### PR TITLE
Refactor from OutputStream to Observer[ByteBuffer].

### DIFF
--- a/jsonrpc/src/main/scala/org/langmeta/jsonrpc/JsonRpcClient.scala
+++ b/jsonrpc/src/main/scala/org/langmeta/jsonrpc/JsonRpcClient.scala
@@ -1,14 +1,18 @@
 package org.langmeta.jsonrpc
 
+import scala.concurrent.Future
 import io.circe.Decoder
 import io.circe.Encoder
 import monix.eval.Task
+import monix.execution.Ack
 
 trait JsonRpcClient {
-  final def notify[A](endpoint: Endpoint[A, Unit], notification: A): Unit =
-    notify[A](endpoint.method, notification)(endpoint.encoderA)
-  def notify[A: Encoder](method: String, notification: A): Unit
-  def serverRespond(response: Response): Unit
+  final def notify[A](
+      endpoint: Endpoint[A, Unit],
+      notification: A
+  ): Future[Ack] = notify[A](endpoint.method, notification)(endpoint.encoderA)
+  def notify[A: Encoder](method: String, notification: A): Future[Ack]
+  def serverRespond(response: Response): Future[Ack]
   def clientRespond(response: Response): Unit
   final def request[A, B](
       endpoint: Endpoint[A, B],
@@ -23,8 +27,11 @@ trait JsonRpcClient {
 
 object JsonRpcClient {
   val empty: JsonRpcClient = new JsonRpcClient {
-    override def notify[A: Encoder](method: String, notification: A): Unit = ()
-    override def serverRespond(response: Response): Unit = ()
+    override def notify[A: Encoder](
+        method: String,
+        notification: A
+    ): Future[Ack] = Ack.Continue
+    override def serverRespond(response: Response): Future[Ack] = Ack.Continue
     override def clientRespond(response: Response): Unit = ()
     override def request[A: Encoder, B: Decoder](
         method: String,

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaServices.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaServices.scala
@@ -18,7 +18,7 @@ import org.langmeta.lsp.{
   Workspace => ws,
   _
 }
-import scala.meta.languageserver.MonixEnrichments._
+import MonixEnrichments._
 import org.langmeta.jsonrpc.Response
 import org.langmeta.jsonrpc.Services
 import scala.meta.languageserver.providers._

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
@@ -4,7 +4,7 @@ import java.nio.file.Files
 import scala.meta.languageserver.Configuration
 import scala.meta.languageserver.Configuration.Scalafmt
 import scala.meta.languageserver.Formatter
-import scala.meta.languageserver.MonixEnrichments._
+import org.langmeta.lsp.MonixEnrichments._
 import org.langmeta.lsp.Position
 import org.langmeta.lsp.TextEdit
 import org.langmeta.jsonrpc.JsonRpcClient

--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/SquiggliesProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/SquiggliesProvider.scala
@@ -5,7 +5,7 @@ import scala.meta.languageserver.Configuration
 import com.typesafe.scalalogging.LazyLogging
 import scala.{meta => m}
 import scala.meta.languageserver.ScalametaEnrichments._
-import scala.meta.languageserver.MonixEnrichments._
+import org.langmeta.lsp.MonixEnrichments._
 import org.langmeta.lsp.PublishDiagnostics
 import monix.eval.Task
 import monix.execution.Scheduler

--- a/metaserver/src/main/scala/scala/meta/languageserver/search/InMemorySymbolIndex.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/search/InMemorySymbolIndex.scala
@@ -11,7 +11,7 @@ import scala.meta.languageserver.compiler.CompilerConfig
 import scala.meta.languageserver.index.SymbolData
 import scala.meta.languageserver.mtags.Mtags
 import scala.meta.languageserver.storage.LevelDBMap
-import scala.meta.languageserver.MonixEnrichments._
+import org.langmeta.lsp.MonixEnrichments._
 import org.langmeta.lsp.SymbolInformation
 import org.langmeta.jsonrpc.JsonRpcClient
 import scala.meta.languageserver.{index => i}


### PR DESCRIPTION
This refactoring makes it easier to emit jsonrpc
requests/response/notifications to consumers such as nuprocess
that don't operate on java.io.OutputStream