### PR TITLE
Add unit tests and benchmark suite for LSP base protocol parser

### DIFF
--- a/benchmarks/src/main/scala/benchmarks/HotBaseProtocolMessageParserBench.scala
+++ b/benchmarks/src/main/scala/benchmarks/HotBaseProtocolMessageParserBench.scala
@@ -1,0 +1,37 @@
+package benchmarks
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import com.typesafe.scalalogging.Logger
+import io.circe.Json
+import monix.execution.schedulers.TestScheduler
+import monix.reactive.Observable
+import org.langmeta.jsonrpc._
+import org.openjdk.jmh.annotations._
+
+/**
+ * benchmarks/jmh:run -i 10 -wi 10 -f1 -t1 benchmarks.HotBaseProtocolMessageParserBench
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class HotBaseProtocolMessageParserBench {
+
+  @Benchmark
+  def parse_1000_messages_in_increasing_size(): Unit = {
+    val requests = 1.to(1000).map { i =>
+      BaseProtocolMessage(
+        Request("method", Some(Json.fromString(i.toString)), RequestId(i))
+      )
+    }
+    val messages = BaseProtocolMessage.fromByteBuffers(
+      Observable(requests: _*).map(MessageWriter.write),
+      Logger("bench")
+    )
+    val s = TestScheduler()
+    val f = messages.runAsyncGetLast(s)
+    while (s.tickOne()) ()
+    Await.result(f, Duration("10s"))
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,10 @@ inThisBuild(
     )
 )
 
+lazy val benchmarks = project
+  .dependsOn(metaserver)
+  .enablePlugins(JmhPlugin)
+
 lazy val V = new {
   val scala212 = "2.12.4"
   val scalameta = "2.1.5"

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val V = new {
   val enumeratum = "1.5.12"
   val circe = "0.9.0"
   val cats = "1.0.1"
-  val monix = "2.3.0"
+  val monix = "3.0.0-RC3"
 }
 
 lazy val noPublish = List(

--- a/jsonrpc/src/main/scala/org/langmeta/jsonrpc/MessageWriter.scala
+++ b/jsonrpc/src/main/scala/org/langmeta/jsonrpc/MessageWriter.scala
@@ -31,7 +31,7 @@ class MessageWriter(out: Observer[ByteBuffer], logger: Logger) {
   /** Lock protecting the output stream, so multiple writes don't mix message chunks. */
   private val lock = new Object
 
-  private val baos = new OpenByteArrayOutputStream()
+  private val baos = new ByteArrayOutputStream()
   private val headerOut = MessageWriter.headerWriter(baos)
 
   /**
@@ -48,10 +48,6 @@ class MessageWriter(out: Observer[ByteBuffer], logger: Logger) {
   }
 }
 
-class OpenByteArrayOutputStream extends ByteArrayOutputStream {
-  def getByteArray: Array[Byte] = buf
-}
-
 object MessageWriter {
 
   def headerWriter(out: OutputStream): PrintWriter = {
@@ -59,14 +55,14 @@ object MessageWriter {
   }
 
   def write(message: BaseProtocolMessage): ByteBuffer = {
-    val out = new OpenByteArrayOutputStream()
+    val out = new ByteArrayOutputStream()
     val header = headerWriter(out)
     write(message, out, header)
   }
 
   def write(
       message: BaseProtocolMessage,
-      out: OpenByteArrayOutputStream,
+      out: ByteArrayOutputStream,
       headerOut: PrintWriter
   ): ByteBuffer = {
     message.header.foreach {
@@ -79,7 +75,7 @@ object MessageWriter {
     headerOut.write("\r\n")
     headerOut.flush()
     out.write(message.content)
-    val buffer = ByteBuffer.wrap(out.getByteArray, 0, out.size())
+    val buffer = ByteBuffer.wrap(out.toByteArray, 0, out.size())
     buffer
   }
 }

--- a/lsp4s/src/main/scala/org/langmeta/lsp/LanguageServer.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/LanguageServer.scala
@@ -1,13 +1,14 @@
 package org.langmeta.lsp
 
+import java.nio.ByteBuffer
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 import com.typesafe.scalalogging.Logger
 import io.circe.Json
-import io.circe.parser.parse
 import io.circe.syntax._
+import io.circe.jawn.parseByteBuffer
 import monix.eval.Task
 import monix.execution.Cancelable
 import monix.execution.Scheduler
@@ -96,7 +97,7 @@ final class LanguageServer(
   }
 
   def handleMessage(message: BaseProtocolMessage): Task[Response] =
-    parse(message.content) match {
+    parseByteBuffer(ByteBuffer.wrap(message.content)) match {
       case Left(err) => Task.now(Response.parseError(err.toString))
       case Right(json) =>
         json.as[Message] match {

--- a/metaserver/src/main/scala/scala/meta/languageserver/MSchedulers.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/MSchedulers.scala
@@ -1,0 +1,23 @@
+package scala.meta.languageserver
+
+import java.util.concurrent.Executors
+import monix.execution.Scheduler
+import monix.execution.schedulers.SchedulerService
+
+/**
+ * Utility to manage monix schedulers.
+ *
+ * @param global The default scheduler when you are unsure which one to use.
+ * @param lsp to communicate with LSP editor client.
+ * @param sbt to communicate with sbt server.
+ */
+case class MSchedulers(global: Scheduler, lsp: Scheduler, sbt: Scheduler)
+object MSchedulers {
+  def apply(): MSchedulers = new MSchedulers(main, lsp, sbt)
+  lazy val main: SchedulerService =
+    Scheduler(Executors.newFixedThreadPool(4))
+  lazy val lsp: SchedulerService =
+    Scheduler(Executors.newFixedThreadPool(1))
+  lazy val sbt: SchedulerService =
+    Scheduler(Executors.newFixedThreadPool(3))
+}

--- a/metaserver/src/main/scala/scala/meta/languageserver/sbtserver/Sbt.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/sbtserver/Sbt.scala
@@ -6,7 +6,6 @@ import scala.meta.languageserver.SbtInitializeResult
 import scala.meta.languageserver.SettingParams
 import scala.meta.languageserver.SettingResult
 import monix.eval.Task
-import monix.execution.Scheduler
 import org.langmeta.jsonrpc.Endpoint
 import org.langmeta.jsonrpc.JsonRpcClient
 import org.langmeta.jsonrpc.Response
@@ -24,7 +23,7 @@ trait Sbt {
   object exec extends Endpoint[SbtExecParams, Unit]("sbt/exec") {
     def apply(
         commandLine: String
-    )(implicit client: JsonRpcClient, s: Scheduler): Task[Unit] = {
+    )(implicit client: JsonRpcClient): Task[Unit] = {
       // NOTE(olafur) sbt/exec is a request that never responds
       super.request(SbtExecParams(commandLine)).map(_ => Unit)
     }

--- a/metaserver/src/test/scala/tests/DiffAsserts.scala
+++ b/metaserver/src/test/scala/tests/DiffAsserts.scala
@@ -1,5 +1,7 @@
 package tests
 
+import scala.util.matching.Regex
+
 object DiffAsserts {
 
   def assertNoDiff(
@@ -28,16 +30,17 @@ object DiffAsserts {
         title + "\n" + error2message(obtained, expected)
       )
 
-  private def error2message(obtained: String, expected: String): String = {
+  def error2message(obtained: String, expected: String): String = {
     val sb = new StringBuilder
-    if (obtained.length < 1000) {
-      sb.append(
-        s"""#${header("Obtained")}
-            #${stripTrailingWhitespace(obtained)}
+    val obtainedStr =
+      if (obtained.length < 1000) stripTrailingWhitespace(obtained)
+      else s"<...truncated>"
+    sb.append(
+      s"""#${header("Obtained")}
+            #$obtainedStr
             #
             #""".stripMargin('#')
-      )
-    }
+    )
     sb.append(
       s"""#${header("Diff")}
           #${stripTrailingWhitespace(compareContents(obtained, expected))}"""
@@ -46,11 +49,16 @@ object DiffAsserts {
     sb.toString()
   }
 
+  val linebreak: Regex = "(\n|\r\n|\r)".r
+
   private def stripTrailingWhitespace(str: String): String =
     str.replaceAll(" \n", "∙\n")
 
-  private def compareContents(original: String, revised: String): String =
-    compareContents(original.trim.split("\n"), revised.trim.split("\n"))
+  def compareContents(original: String, revised: String): String =
+    compareContents(
+      linebreak.split(original.trim),
+      linebreak.split(revised.trim)
+    )
 
   private def compareContents(
       original: Seq[String],

--- a/metaserver/src/test/scala/tests/MegaSuite.scala
+++ b/metaserver/src/test/scala/tests/MegaSuite.scala
@@ -28,13 +28,15 @@ class MegaSuite extends TestSuite {
   def afterAll(): Unit = ()
   def intercept[T: ClassTag](exprs: Unit): T = macro Asserts.interceptProxy[T]
   def assert(exprs: Boolean*): Unit = macro Asserts.assertProxy
-  def assertEquals[T](obtained: T, expected: T): Unit = {
+  def assertEquals[T](obtained: T, expected: T, hint: String = ""): Unit = {
     if (obtained != expected) {
+      val hintMsg = if (hint.isEmpty) "" else s" (hint: $hint)"
       // TODO(olafur) handle sequences
       val diff =
         DiffAsserts.error2message(obtained.toString, expected.toString)
-      if (diff.isEmpty) fail(s"obtained=<$obtained> != expected=<$expected>")
-      else fail(diff)
+      if (diff.isEmpty)
+        fail(s"obtained=<$obtained> != expected=<$expected>$hintMsg")
+      else fail(diff + hintMsg)
     }
   }
   def assertNoDiff(

--- a/metaserver/src/test/scala/tests/MegaSuite.scala
+++ b/metaserver/src/test/scala/tests/MegaSuite.scala
@@ -28,9 +28,13 @@ class MegaSuite extends TestSuite {
   def afterAll(): Unit = ()
   def intercept[T: ClassTag](exprs: Unit): T = macro Asserts.interceptProxy[T]
   def assert(exprs: Boolean*): Unit = macro Asserts.assertProxy
-  def assertEquals[T](a: T, b: T): Unit = {
-    if (a != b) {
-      fail(s"$a != $b")
+  def assertEquals[T](obtained: T, expected: T): Unit = {
+    if (obtained != expected) {
+      // TODO(olafur) handle sequences
+      val diff =
+        DiffAsserts.error2message(obtained.toString, expected.toString)
+      if (diff.isEmpty) fail(s"obtained=<$obtained> != expected=<$expected>")
+      else fail(diff)
     }
   }
   def assertNoDiff(

--- a/metaserver/src/test/scala/tests/jsonrpc/BaseProtocolMessageTest.scala
+++ b/metaserver/src/test/scala/tests/jsonrpc/BaseProtocolMessageTest.scala
@@ -1,0 +1,91 @@
+package tests.jsonrpc
+
+import java.nio.ByteBuffer
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.syntax._
+import monix.eval.Task
+import monix.execution.schedulers.TestScheduler
+import monix.reactive.Observable
+import org.langmeta.jsonrpc._
+import tests.MegaSuite
+
+object BaseProtocolMessageTest extends MegaSuite with LazyLogging {
+  val request = Request("method", Some("params".asJson), RequestId(1))
+  val message = BaseProtocolMessage(request)
+  def bytes: ByteBuffer = MessageWriter.write(message)
+
+  test("toString") {
+    assertNoDiff(
+      message.toString,
+      """|Content-Length: 62
+         |
+         |{"method":"method","params":"params","id":"1","jsonrpc":"2.0"}""".stripMargin
+    )
+  }
+
+  val s = TestScheduler()
+
+  def await[T](f: Task[T]): T = {
+    val a = f.runAsync(s)
+    while (s.tickOne()) ()
+    Await.result(a, Duration("5s"))
+  }
+
+  def parse(buffers: List[ByteBuffer]): List[BaseProtocolMessage] = {
+    val buf = List.newBuilder[BaseProtocolMessage]
+    val t = BaseProtocolMessage
+      .fromByteBuffers(Observable(buffers: _*), logger)
+      // NOTE(olafur) toListL will not work as expected here, it will send onComplete
+      // for the first onNext, even when a single ByteBuffer can contain multiple
+      // messages
+      .foreachL(buf += _)
+    await(t)
+    buf.result()
+  }
+
+  def pairs(n: Int): List[(ByteBuffer, BaseProtocolMessage)] =
+    1.to(n).toList.map(_ => bytes -> message)
+
+  0.to(4).foreach { i =>
+    test(s"parse-$i") {
+      val (buffers, messages) = pairs(i).unzip
+      assertEquals(parse(buffers), messages)
+    }
+  }
+
+  def checkTwoMessages(name: String, buffers: List[ByteBuffer]): Unit = {
+    test(name) {
+      val obtained = parse(buffers)
+      val expected = List(message, message)
+      assertEquals(obtained, expected)
+    }
+  }
+  def array: ByteBuffer = ByteBuffer.wrap(bytes.array())
+  def take(n: Int): ByteBuffer = ByteBuffer.wrap(bytes.array().take(n))
+  def drop(n: Int): ByteBuffer = ByteBuffer.wrap(bytes.array().drop(n))
+
+  checkTwoMessages(
+    "combined",
+    ByteBuffer.wrap(bytes.array() ++ bytes.array()) ::
+      Nil
+  )
+
+  checkTwoMessages(
+    "chunked",
+    take(10) ::
+      drop(10) ::
+      array ::
+      Nil
+  )
+
+  checkTwoMessages(
+    "chunked2",
+    take(10) ::
+      ByteBuffer.wrap(drop(10).array() ++ take(10).array()) ::
+      drop(10) ::
+      Nil
+  )
+
+}

--- a/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metaserver/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -3,6 +3,7 @@ package tests.search
 import java.io.PipedOutputStream
 import java.nio.file.Files
 import java.nio.file.Paths
+import scala.meta.languageserver.MSchedulers
 import scala.meta.languageserver.ScalametaEnrichments._
 import scala.meta.languageserver.ScalametaServices
 import scala.meta.languageserver.Uri
@@ -56,10 +57,11 @@ object SymbolIndexTest extends MegaSuite with LazyLogging {
     path.UserTest.toString()
   )
   val s = TestScheduler()
+  val mscheduler = new MSchedulers(s, s, s)
   val stdout = new PipedOutputStream()
   // TODO(olafur) run this as part of utest.runner.Framework.setup()
   val client = new LanguageClient(stdout, logger)
-  val metaserver = new ScalametaServices(cwd, client, s)
+  val metaserver = new ScalametaServices(cwd, client, mscheduler)
   metaserver
     .initialize(InitializeParams(0L, cwd.toString(), ClientCapabilities()))
     .runAsync(s)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.2")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.7")
 addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.0.0")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")


### PR DESCRIPTION
The header parser previously didn't have any unit tests because it just worked with vscode. However, with us relying more on the JSON-RPC implementation for bsp and sbt server integration I feel comfortable with having at least a couple unit tests.

It turned out to be quite tricky to unit test the current implementation because it forced the Observable to run on a custom Scheduler. We replace that with a `.exectuteWithFork` and add a new `MSchedulers` helper to keep track of Schedulers in the application.

The last commit adds a `benchmarks` project to lower the barrier for writing benchmarks, in case someone is interested. I have a hunch that a lot of parts in the codebase are ripe for optimizations, but I don't want to try an optimize anything without bringing accompanying benchmarks. 