### PR TITLE
Use default scalafmt conf is .scalafmt.conf file is missing

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/providers/DocumentFormattingProvider.scala
@@ -54,10 +54,12 @@ class DocumentFormattingProvider(
           else Right(None)
         case Some(relpath) =>
           val custom = cwd.resolve(relpath)
-          if (Files.isRegularFile(custom.toNIO)) Right(Some(custom))
-          else {
+          if (Files.isRegularFile(custom.toNIO))
+            Right(Some(custom))
+          else if (relpath == Configuration.Scalafmt.defaultConfPath)
+            Right(None)
+          else
             Left(s"scalameta.scalafmt.confPath=$relpath is not a file")
-          }
       }
       .toFunction0()
 


### PR DESCRIPTION
Fix #185 

We have three cases to handle:

1) a. user specified a custom path and it exists, or
   b. user didn't specify a path and the default path .scalafmt.conf exists
2) user specified a custom path and it doesn't exist
3) user didn't specify a custom path and .scalafmt.conf doesn't exists

---

1. and 3. should not return an error and fallback to the default
Scalafmt configuration is .scalafmt.conf doesn't exist

2. should return an error

This PR handles 3., which currently returns an error

## Test plan
Tested locally with `publishLocal`