### PR TITLE
s/scalameta/metals in VSCode extension

### DIFF
--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaServices.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaServices.scala
@@ -252,7 +252,7 @@ class ScalametaServices(
       }
     }
     .notification(ws.didChangeConfiguration) { params =>
-      params.settings.hcursor.downField("scalameta").as[Configuration] match {
+      params.settings.hcursor.downField("metals").as[Configuration] match {
         case Left(err) =>
           showMessage.notify(
             ShowMessageParams(MessageType.Error, err.toString)

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vscode-scalameta",
-  "displayName": "vscode-scalameta",
+  "name": "vscode-metals",
+  "displayName": "Metals",
   "description": "",
   "version": "0.0.1",
   "publisher": "gabro",
@@ -11,68 +11,69 @@
   "activationEvents": ["onLanguage:scala"],
   "contributes": {
     "configuration": {
-      "title": "Scalameta Language Server",
+      "title": "Metals",
       "properties": {
-        "scalameta.sbt.enabled": {
+        "metals.sbt.enabled": {
           "type": "boolean",
           "default": false,
-          "description": "EXPERIMENTAL. Use sbt language server to compile on file save and report squgglies. Requires sbt 1.1.0"
+          "description":
+            "EXPERIMENTAL. Use sbt language server to compile on file save and report squgglies. Requires sbt 1.1.0"
         },
-        "scalameta.sbt.command": {
+        "metals.sbt.command": {
           "type": "string",
           "default": "test:compile",
           "description": "Which sbt command to run on file save."
         },
-        "scalameta.scalac.enabled": {
+        "metals.scalac.enabled": {
           "type": "boolean",
           "default": false,
           "description":
             "EXPERIMENTAL. Enable squigglies and completions as you type with the Scala Presentation Compiler."
         },
-        "scalameta.scalafmt.enabled": {
+        "metals.scalafmt.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Enable formatting with scalafmt"
         },
-        "scalameta.scalafmt.version": {
+        "metals.scalafmt.version": {
           "type": "string",
           "default": "1.3.0",
           "description":
             "Version of scalafmt to use, default to latest stable release."
         },
-        "scalameta.scalafmt.confPath": {
+        "metals.scalafmt.confPath": {
           "type": "string",
           "default": ".scalafmt.conf",
           "description":
             "Path to the Scalafmt configuration, relative to the workspace path"
         },
-        "scalameta.scalafix.enabled": {
+        "metals.scalafix.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Enable Scalafix diagnostics"
         },
-        "scalameta.scalafix.confPath": {
+        "metals.scalafix.confPath": {
           "type": "string",
           "default": ".scalafix.conf",
           "description":
             "Path to the Scalafix configuration, relative to the workspace path"
         },
-        "scalameta.search.indexClasspath": {
+        "metals.search.indexClasspath": {
           "type": "boolean",
           "default": true,
           "description": "Enable indexing of the classpath"
         },
-        "scalameta.search.indexJDK": {
+        "metals.search.indexJDK": {
           "type": "boolean",
           "default": false,
           "description": "EXPERIMENTAL. Enable indexing of the JDK"
         },
-        "scalameta.hover.enabled": {
+        "metals.hover.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Enable tooltips on hover"
         },
-        "scalameta.rename.enabled": {
+        "metals.rename.enabled": {
           "type": "boolean",
           "default": true,
           "description": "Enable renaming symbols"
@@ -81,23 +82,23 @@
     },
     "commands": [
       {
-        "command": "scalameta.restartServer",
-        "category": "Scalameta Language Server",
+        "command": "metals.restartServer",
+        "category": "Metals",
         "title": "Restart server"
       },
       {
-        "command": "scalameta.clearIndexCache",
-        "category": "Scalameta Language Server",
+        "command": "metals.clearIndexCache",
+        "category": "Metals",
         "title": "Clear index cache"
       },
       {
-        "command": "scalameta.sbtConnect",
-        "category": "Scalameta Language Server",
+        "command": "metals.sbtConnect",
+        "category": "Metals",
         "title": "Connect to sbt server"
       },
       {
-        "command": "scalameta.resetPresentationCompiler",
-        "category": "Scalameta Language Server",
+        "command": "metals.resetPresentationCompiler",
+        "category": "Metals",
         "title": "Reset presentation compilers"
       }
     ]

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -59,26 +59,26 @@ export async function activate(context: ExtensionContext) {
         workspace.createFileSystemWatcher("**/*.semanticdb"),
         workspace.createFileSystemWatcher("**/*.compilerconfig")
       ],
-      configurationSection: "scalameta"
+      configurationSection: 'metals'
     },
     revealOutputChannelOn: RevealOutputChannelOn.Never
   };
 
   const client = new LanguageClient(
-    "scalameta",
-    "Scalameta",
+    'metals',
+    'Metals',
     serverOptions,
     clientOptions
   );
 
   const restartServerCommand = commands.registerCommand(
-    "scalameta.restartServer",
+    'metals.restartServer',
     async () => {
       const serverPid = client["_serverProcess"].pid;
       await exec(`kill ${serverPid}`);
       const showLogsAction = "Show server logs";
       const selectedAction = await window.showInformationMessage(
-        "Scalameta Language Server killed, it should restart in a few seconds",
+        'Metals Language Server killed, it should restart in a few seconds',
         showLogsAction
       );
 
@@ -90,7 +90,7 @@ export async function activate(context: ExtensionContext) {
 
   client.onReady().then(() => {
     const clearIndexCacheCommand = commands.registerCommand(
-      "scalameta.clearIndexCache",
+      'metals.clearIndexCache',
       async () => {
         return client.sendRequest(ExecuteCommandRequest.type, {
           command: "clearIndexCache"
@@ -98,7 +98,7 @@ export async function activate(context: ExtensionContext) {
       }
     );
     const resetPresentationCompiler = commands.registerCommand(
-      "scalameta.resetPresentationCompiler",
+      'metals.resetPresentationCompiler',
       async () => {
         return client.sendRequest(ExecuteCommandRequest.type, {
           command: "resetPresentationCompiler"
@@ -106,7 +106,7 @@ export async function activate(context: ExtensionContext) {
       }
     );
     const sbtConnectCommand = commands.registerCommand(
-      "scalameta.sbtConnect",
+      'metals.sbtConnect',
       async () => {
         return client.sendRequest(ExecuteCommandRequest.type, {
           command: "sbtConnect"


### PR DESCRIPTION
This is a continuation of #180

It only takes into account the VSCode extension, but it has one breaking change: the prefix name of the configuration, which is `"metals"` instead of `"scalameta"`.

Other client implementations will potentially break if they implemented the configuration API. @laughedelic does the atom extension support configuration?

