### PR TITLE
Cross build lsp4s for Scala 2.11/2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ jobs:
     # default stage is test
     - env: TEST="scalafmt"
       script: ./bin/scalafmt --test
+    - env: TEST="2.11"
+      script:
+        - sbt ++2.11.12 lsp4s/test
+        - sbt ++2.11.12 jsonrpc/test
     - env: TEST="sbt test"
       script:
         - sbt startServer *:scalametaEnableCompletions test scalafixTest

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ inThisBuild(
         "-deprecation",
         // -Xlint is unusable because of
         // https://github.com/scala/bug/issues/10448
-        "-Ywarn-unused:imports"
+        "-Ywarn-unused-import"
       ),
       scalafixEnabled := false,
       organization := "org.scalameta",
@@ -77,6 +77,7 @@ lazy val benchmarks = project
   .enablePlugins(JmhPlugin)
 
 lazy val V = new {
+  val scala211 = "2.11.12"
   val scala212 = "2.12.4"
   val scalameta = "2.1.5"
   val scalafix = "0.5.7"
@@ -104,6 +105,7 @@ lazy val semanticdbSettings = List(
 
 lazy val jsonrpc = project
   .settings(
+    crossScalaVersions := List(V.scala211, V.scala212),
     libraryDependencies ++= List(
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "com.beachape" %% "enumeratum" % V.enumeratum,
@@ -121,7 +123,9 @@ lazy val jsonrpc = project
     )
   )
 
-lazy val lsp4s = project.dependsOn(jsonrpc)
+lazy val lsp4s = project
+  .settings(crossScalaVersions := List(V.scala211, V.scala212))
+  .dependsOn(jsonrpc)
 
 lazy val metaserver = project
   .settings(

--- a/jsonrpc/src/main/scala/org/langmeta/jsonrpc/Services.scala
+++ b/jsonrpc/src/main/scala/org/langmeta/jsonrpc/Services.scala
@@ -81,7 +81,10 @@ object Services {
 class Services private (val services: List[NamedJsonRpcService]) {
 
   def request[A, B](endpoint: Endpoint[A, B])(f: A => B): Services =
-    requestAsync[A, B](endpoint)(params => Task(Right(f(params))))
+    requestAsync[A, B](endpoint)(new Service[A, Either[Response.Error, B]] {
+      def handle(request: A): Task[Either[Response.Error, B]] =
+        Task(Right(f(request)))
+    })
 
   def requestAsync[A, B](
       endpoint: Endpoint[A, B]
@@ -94,7 +97,9 @@ class Services private (val services: List[NamedJsonRpcService]) {
     )
 
   def notification[A](endpoint: Endpoint[A, Unit])(f: A => Unit): Services =
-    notificationAsync[A](endpoint)(request => Task(f(request)))
+    notificationAsync[A](endpoint)(new Service[A, Unit] {
+      def handle(request: A): Task[Unit] = Task(f(request))
+    })
 
   def notificationAsync[A](
       endpoint: Endpoint[A, Unit]

--- a/lsp4s/src/main/scala/org/langmeta/lsp/Types.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/Types.scala
@@ -102,7 +102,7 @@ import io.circe.generic.JsonCodec
 
 sealed trait MarkedString
 object MarkedString {
-  implicit val encoder: Encoder[MarkedString] = {
+  implicit val encoder: Encoder[MarkedString] = Encoder.instance {
     case m: RawMarkedString => Encoder[RawMarkedString].apply(m)
     case m: MarkdownString => Encoder[MarkdownString].apply(m)
   }

--- a/lsp4s/src/main/scala/org/langmeta/lsp/Types.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/Types.scala
@@ -201,7 +201,7 @@ case class CodeLens(
     /**
      * Prefer spaces over tabs.
      */
-    insertSpaces: Boolean,
+    insertSpaces: Boolean
     /**
      * Signature for further properties.
      */


### PR DESCRIPTION
This required:

- using a few explicit trait instantiations instead of SAMs
- removing one dangling comma
- using `-Ywarn-unused-imports` instead of `-Ywarn-unused:imports`