### PR TITLE
Added TextDocumentSyncOptions and format on save

### DIFF
--- a/lsp4s/src/main/scala/org/langmeta/lsp/Commands.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/Commands.scala
@@ -25,11 +25,42 @@ import io.circe.generic.JsonCodec
 
 @JsonCodec case class ClientCapabilities()
 
+@JsonCodec case class SaveOptions(
+    /**
+     * The client is supposed to include the content on save.
+     */
+    includeText: Option[Boolean] = None
+)
+
+@JsonCodec case class TextDocumentSyncOptions(
+    /**
+     * Open and close notifications are sent to the server.
+     */
+    openClose: Option[Boolean] = None,
+    /**
+     * Change notifications are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
+     * and TextDocumentSyncKind.Incremental.
+     */
+    change: Option[TextDocumentSyncKind] = None,
+    /**
+     * Will save notifications are sent to the server.
+     */
+    willSave: Option[Boolean] = None,
+    /**
+     * Will save wait until requests are sent to the server.
+     */
+    willSaveWaitUntil: Option[Boolean] = None,
+    /**
+     * Save notifications are sent to the server.
+     */
+    save: Option[SaveOptions] = None
+)
+
 @JsonCodec case class ServerCapabilities(
     /**
      * Defines how text documents are synced.
      */
-    textDocumentSync: TextDocumentSyncKind = TextDocumentSyncKind.Full,
+    textDocumentSync: Option[TextDocumentSyncOptions] = None,
     /**
      * The server provides hover support.
      */

--- a/lsp4s/src/main/scala/org/langmeta/lsp/Commands.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/Commands.scala
@@ -219,6 +219,10 @@ import io.circe.generic.JsonCodec
 @JsonCodec case class DidCloseTextDocumentParams(
     textDocument: TextDocumentIdentifier
 )
+@JsonCodec case class WillSaveTextDocumentParams(
+    textDocument: TextDocumentIdentifier,
+    reason: TextDocumentSaveReason
+)
 @JsonCodec case class DidSaveTextDocumentParams(
     textDocument: TextDocumentIdentifier
 )

--- a/lsp4s/src/main/scala/org/langmeta/lsp/Endpoints.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/Endpoints.scala
@@ -24,6 +24,8 @@ trait TextDocument {
     notification[PublishDiagnostics]("textDocument/publishDiagnostics")
   val didClose: Endpoint[DidCloseTextDocumentParams, Unit] =
     notification[DidCloseTextDocumentParams]("textDocument/didClose")
+  val willSave: Endpoint[WillSaveTextDocumentParams, Unit] =
+    notification[WillSaveTextDocumentParams]("textDocument/willSave")
   val didSave: Endpoint[DidSaveTextDocumentParams, Unit] =
     notification[DidSaveTextDocumentParams]("textDocument/didSave")
   val didOpen: Endpoint[DidOpenTextDocumentParams, Unit] =

--- a/lsp4s/src/main/scala/org/langmeta/lsp/Endpoints.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/Endpoints.scala
@@ -26,6 +26,8 @@ trait TextDocument {
     notification[DidCloseTextDocumentParams]("textDocument/didClose")
   val willSave: Endpoint[WillSaveTextDocumentParams, Unit] =
     notification[WillSaveTextDocumentParams]("textDocument/willSave")
+  val willSaveWaitUntil: Endpoint[WillSaveTextDocumentParams, List[TextEdit]] =
+    request[WillSaveTextDocumentParams, List[TextEdit]]("textDocument/willSaveWaitUntil")
   val didSave: Endpoint[DidSaveTextDocumentParams, Unit] =
     notification[DidSaveTextDocumentParams]("textDocument/didSave")
   val didOpen: Endpoint[DidOpenTextDocumentParams, Unit] =

--- a/lsp4s/src/main/scala/org/langmeta/lsp/Enums.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/Enums.scala
@@ -130,6 +130,31 @@ case object TextDocumentSyncKind
   val values = findValues
 }
 
+/**
+ * Represents reasons why a text document is saved.
+ */
+sealed abstract class TextDocumentSaveReason(val value: Int)
+    extends IntEnumEntry
+
+case object TextDocumentSaveReason
+    extends IntEnum[TextDocumentSaveReason]
+    with IntCirceEnum[TextDocumentSaveReason] {
+
+  /**
+   * Manually triggered, e.g. by the user pressing save, by starting debugging,
+   * or by an API call.
+   */
+  case object Manual extends TextDocumentSaveReason(1)
+
+  /** Automatic after a delay. */
+  case object AfterDelay extends TextDocumentSaveReason(2)
+
+  /** When the editor lost focus. */
+  case object FocusOut extends TextDocumentSaveReason(3)
+
+  val values = findValues
+}
+
 sealed abstract class FileChangeType(val value: Int) extends IntEnumEntry
 
 case object FileChangeType

--- a/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/Configuration.scala
@@ -34,6 +34,7 @@ object Configuration {
 
   @JsonCodec case class Scalafmt(
       enabled: Boolean = true,
+      onSave: Boolean = true,
       version: String = "1.3.0",
       confPath: Option[RelativePath] = None
   )

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaServices.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaServices.scala
@@ -154,6 +154,19 @@ class ScalametaServices(
     loadAllRelevantFilesInThisWorkspace()
     val commands = WorkspaceCommand.values.map(_.entryName)
     val capabilities = ServerCapabilities(
+      textDocumentSync = Some(
+        TextDocumentSyncOptions(
+          openClose = Some(true),
+          change = Some(TextDocumentSyncKind.Full),
+          willSave = Some(false),
+          willSaveWaitUntil = Some(true),
+          save = Some(
+            SaveOptions(
+              includeText = Some(true)
+            )
+          )
+        )
+      ),
       completionProvider = Some(
         CompletionOptions(
           resolveProvider = false,

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaServices.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaServices.scala
@@ -262,6 +262,16 @@ class ScalametaServices(
     .notification(td.willSave) { _ =>
       ()
     }
+    .requestAsync(td.willSaveWaitUntil) { params =>
+      params.reason match {
+        case TextDocumentSaveReason.Manual if latestConfig().scalafmt.onSave =>
+          logger.info(s"Formatting on manual save: $params.textDocument")
+          val uri = Uri(params.textDocument)
+          documentFormattingProvider.format(uri.toInput(buffers))
+        case _ =>
+          Task.now { Right(List()) }
+      }
+    }
     .notification(td.didSave) { _ =>
       if (sbtServerEnabled()) {
         sbtCompile()

--- a/metaserver/src/main/scala/scala/meta/languageserver/ScalametaServices.scala
+++ b/metaserver/src/main/scala/scala/meta/languageserver/ScalametaServices.scala
@@ -246,6 +246,9 @@ class ScalametaServices(
       sourceChangeSubscriber.onNext(input)
       ()
     }
+    .notification(td.willSave) { _ =>
+      ()
+    }
     .notification(td.didSave) { _ =>
       if (sbtServerEnabled()) {
         sbtCompile()

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -35,6 +35,11 @@
           "default": true,
           "description": "Enable formatting with scalafmt"
         },
+        "metals.scalafmt.onSave": {
+          "type": "boolean",
+          "default": false,
+          "description": "Format file before saving it"
+        },
         "metals.scalafmt.version": {
           "type": "string",
           "default": "1.3.0",


### PR DESCRIPTION
Several related changes here:
- added LSP v3 `TextDocumentSyncOptions` (instead of simple `TextDocumentSyncKind`)
- added [`textDocument/willSave`](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md#willsavetextdocument-notification-arrow_right) notification
- added [`textDocument/willSaveWaitUntil`](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md#willsavewaituntiltextdocument-request-leftwards_arrow_with_hook) which is useful to format the file right before it's saved
- added `scalameta.scalafmt.onSave` config parameter (false by default) to control this feature

I hoped to use it in Atom, but unfortunately it doesn't support `willSaveWaitUntil` request yet (although it has "format _after_ saving" feature). So I tried it VSCode and it seems to work well.

P.S. @gabro this overlaps a bit with #187, but probably we can merge it and I'll rebase?