### PR TITLE
Re-enable indexJDK

### DIFF
--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -45,9 +45,8 @@ object Configuration {
       enabled: Boolean = true,
       confPath: RelativePath = RelativePath(".scalafix.conf")
   )
-  // TODO(olafur): re-enable indexJDK after https://github.com/scalameta/metals/issues/43 is fixed
   @JsonCodec case class Search(
-      indexJDK: Boolean = false,
+      indexJDK: Boolean = true,
       indexClasspath: Boolean = true
   )
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -70,8 +70,8 @@
         },
         "metals.search.indexJDK": {
           "type": "boolean",
-          "default": false,
-          "description": "EXPERIMENTAL. Enable indexing of the JDK"
+          "default": true,
+          "description": "Enable indexing of the JDK"
         },
         "metals.hover.enabled": {
           "type": "boolean",


### PR DESCRIPTION
Fixes #43 

I've tried turning the option back on and it just seems to work.

Tested locally by:

- enabling the `index JDK` test (currently ignored because it's slow)
- publishing locally and successfully jumping to a JDK file. 