### PR TITLE
Honor metals.scalafix.confPath

### DIFF
--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -43,8 +43,11 @@ object Configuration {
   }
   @JsonCodec case class Scalafix(
       enabled: Boolean = true,
-      confPath: RelativePath = RelativePath(".scalafix.conf")
+      confPath: Option[RelativePath] = None
   )
+  object Scalafix {
+    lazy val defaultConfPath = RelativePath(".scalafix.conf")
+  }
   @JsonCodec case class Search(
       indexJDK: Boolean = true,
       indexClasspath: Boolean = true

--- a/metals/src/main/scala/scala/meta/metals/Linter.scala
+++ b/metals/src/main/scala/scala/meta/metals/Linter.scala
@@ -15,14 +15,28 @@ import scalafix.rule.RuleCtx
 import scalafix.util.SemanticdbIndex
 import com.typesafe.scalalogging.LazyLogging
 import org.langmeta.io.AbsolutePath
+import org.langmeta.inputs.Input
+import org.langmeta.jsonrpc.JsonRpcClient
+import org.langmeta.jsonrpc.Response
+import org.langmeta.lsp.Window.showMessage
+import cats.syntax.bifunctor._
+import cats.instances.either._
+import monix.execution.Scheduler
+import monix.reactive.Observable
+import monix.eval.Task
+import org.langmeta.lsp.MonixEnrichments._
+import java.nio.file.Files
 
-class Linter(cwd: AbsolutePath) extends LazyLogging {
+class Linter(configuration: Observable[Configuration], cwd: AbsolutePath)(
+    implicit client: JsonRpcClient,
+    s: Scheduler
+) extends LazyLogging {
 
   // Simple method to run syntactic scalafix rules on a string.
   def onSyntacticInput(
       filename: String,
       contents: String
-  ): Seq[Diagnostic] = {
+  ): Task[Either[Response.Error, Seq[Diagnostic]]] = {
     val mdoc = m.Document(
       m.Input.VirtualFile(filename, contents),
       "scala212",
@@ -41,7 +55,9 @@ class Linter(cwd: AbsolutePath) extends LazyLogging {
     )
   }
 
-  def linterMessages(mdoc: m.Document): Seq[Diagnostic] =
+  def linterMessages(
+      mdoc: m.Document
+  ): Task[Either[Response.Error, Seq[Diagnostic]]] =
     analyzeIndex(
       mdoc,
       EagerInMemorySemanticdbIndex(
@@ -51,30 +67,63 @@ class Linter(cwd: AbsolutePath) extends LazyLogging {
       )
     )
 
+  private val config: () => Either[String, Option[Input]] =
+    configuration
+      .focus(_.scalafix.confPath)
+      .map[Either[String, Option[Input]]] {
+        case None =>
+          val default = cwd.resolve(Configuration.Scalafix.defaultConfPath)
+          if (Files.isRegularFile(default.toNIO))
+            Right(Some(Input.File(default)))
+          else Right(None)
+        case Some(relpath) =>
+          val custom = cwd.resolve(relpath)
+          if (Files.isRegularFile(custom.toNIO))
+            Right(Some(Input.File(custom)))
+          else if (relpath == Configuration.Scalafix.defaultConfPath)
+            Right(None)
+          else
+            Left(s"metals.scalafix.confPath=$relpath is not a file")
+      }
+      .toFunction0()
+
   private def analyzeIndex(
       document: m.Document,
       index: SemanticdbIndex
-  ): Seq[Diagnostic] =
-    withConfig { configInput =>
-      val lazyIndex = lazySemanticdbIndex(index)
-      val configDecoder = ScalafixReflect.fromLazySemanticdbIndex(lazyIndex)
-      val (rule, config) =
-        ScalafixConfig.fromInput(configInput, lazyIndex)(configDecoder).get
-      val results: Seq[Diagnostic] = Parser.parse(document.input) match {
-        case Parsed.Error(_, _, _) => Nil
-        case Parsed.Success(tree) =>
-          val ctx = RuleCtx.applyInternal(tree, config)
-          val patches = rule.fixWithNameInternal(ctx)
-          Patch.lintMessagesInternal(patches, ctx).map(_.toLSP)
+  ): Task[Either[Response.Error, Seq[Diagnostic]]] = Task {
+    val linterResult = for {
+      scalafixConfig <- config()
+    } yield
+      scalafixConfig match {
+        case None => Nil // no scalafix config, nothing to do
+        case Some(configInput) =>
+          val lazyIndex = lazySemanticdbIndex(index)
+          val configDecoder = ScalafixReflect.fromLazySemanticdbIndex(lazyIndex)
+          val (rule, config) =
+            ScalafixConfig.fromInput(configInput, lazyIndex)(configDecoder).get
+          val results: Seq[Diagnostic] = Parser.parse(document.input) match {
+            case Parsed.Error(_, _, _) => Nil
+            case Parsed.Success(tree) =>
+              val ctx = RuleCtx.applyInternal(tree, config)
+              val patches = rule.fixWithNameInternal(ctx)
+              Patch.lintMessagesInternal(patches, ctx).map(_.toLSP)
+          }
+
+          // megaCache needs to die, if we forget this we will read stale
+          // snapshots of filenames if using m.Input.File.slurp
+          // https://github.com/scalameta/scalameta/issues/1068
+          PlatformTokenizerCache.megaCache.clear()
+
+          results
       }
-
-      // megaCache needs to die, if we forget this we will read stale
-      // snapshots of filenames if using m.Input.File.slurp
-      // https://github.com/scalameta/scalameta/issues/1068
-      PlatformTokenizerCache.megaCache.clear()
-
-      results
+    linterResult.leftMap { message =>
+      // We show a message here to be sure the message is
+      // reported in the UI. invalidParams responses don't
+      // get reported in vscode at least.
+      showMessage.error(message)
+      Response.invalidParams(message)
     }
+  }
 
   private def withConfig[T](f: m.Input => Seq[T]): Seq[T] =
     configFile match {
@@ -84,7 +133,12 @@ class Linter(cwd: AbsolutePath) extends LazyLogging {
         f(configInput)
     }
 
-  private def configFile: Option[m.Input] = ScalafixConfig.auto(cwd)
+  private def configFile: Option[m.Input] = {
+    val file = cwd.resolve(".scalafix.conf")
+    if (file.isFile && file.toFile.exists())
+      Some(Input.File(file))
+    else None
+  }
 
   private def lazySemanticdbIndex(index: SemanticdbIndex): LazySemanticdbIndex =
     new LazySemanticdbIndex(_ => Some(index), ScalafixReporter.default)

--- a/metals/src/main/scala/scala/meta/metals/Linter.scala
+++ b/metals/src/main/scala/scala/meta/metals/Linter.scala
@@ -125,21 +125,6 @@ class Linter(configuration: Observable[Configuration], cwd: AbsolutePath)(
     }
   }
 
-  private def withConfig[T](f: m.Input => Seq[T]): Seq[T] =
-    configFile match {
-      case None =>
-        Nil
-      case Some(configInput) =>
-        f(configInput)
-    }
-
-  private def configFile: Option[m.Input] = {
-    val file = cwd.resolve(".scalafix.conf")
-    if (file.isFile && file.toFile.exists())
-      Some(Input.File(file))
-    else None
-  }
-
   private def lazySemanticdbIndex(index: SemanticdbIndex): LazySemanticdbIndex =
     new LazySemanticdbIndex(_ => Some(index), ScalafixReporter.default)
 

--- a/metals/src/main/scala/scala/meta/metals/providers/SquiggliesProvider.scala
+++ b/metals/src/main/scala/scala/meta/metals/providers/SquiggliesProvider.scala
@@ -7,6 +7,7 @@ import scala.{meta => m}
 import scala.meta.metals.ScalametaEnrichments._
 import org.langmeta.lsp.MonixEnrichments._
 import org.langmeta.lsp.PublishDiagnostics
+import org.langmeta.jsonrpc.JsonRpcClient
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
@@ -15,24 +16,27 @@ import org.langmeta.AbsolutePath
 class SquiggliesProvider(
     configuration: Observable[Configuration],
     cwd: AbsolutePath
-)(implicit s: Scheduler)
+)(implicit s: Scheduler, client: JsonRpcClient)
     extends LazyLogging {
   private val isEnabled: () => Boolean =
     configuration.map(_.scalafix.enabled).toFunction0()
 
-  lazy val linter = new Linter(cwd)
+  lazy val linter = new Linter(configuration, cwd)
 
   def squigglies(doc: m.Document): Task[Seq[PublishDiagnostics]] =
     squigglies(m.Database(doc :: Nil))
-  def squigglies(db: m.Database): Task[Seq[PublishDiagnostics]] = Task.eval {
-    if (!isEnabled()) Nil
-    else {
-      db.documents.map { document =>
-        val uri = document.input.syntax
-        val compilerErrors = document.messages.map(_.toLSP)
-        val scalafixErrors = linter.linterMessages(document)
-        PublishDiagnostics(uri, compilerErrors ++ scalafixErrors)
+  def squigglies(db: m.Database): Task[Seq[PublishDiagnostics]] = {
+    if (!isEnabled()) Task(Nil)
+    else
+      Task.sequence {
+        db.documents.map { document =>
+          val uri = document.input.syntax
+          val compilerErrors = document.messages.map(_.toLSP)
+          linter.linterMessages(document).map { scalafixResult =>
+            val scalafixErrors = scalafixResult.getOrElse(Nil)
+            PublishDiagnostics(uri, compilerErrors ++ scalafixErrors)
+          }
+        }
       }
-    }
   }
 }

--- a/metals/src/test/scala/tests/compiler/SquiggliesTest.scala
+++ b/metals/src/test/scala/tests/compiler/SquiggliesTest.scala
@@ -29,7 +29,8 @@ object SquiggliesTest extends CompilerSuite with LazyLogging {
   val scalafixConfPath = ".customScalafixConfPath"
   val config = Observable.now(
     Configuration(
-      scalafix = Configuration.Scalafix(confPath = Some(RelativePath(scalafixConfPath)))
+      scalafix =
+        Configuration.Scalafix(confPath = Some(RelativePath(scalafixConfPath)))
     )
   )
   val stdout = new PipedOutputStream()

--- a/metals/src/test/scala/tests/compiler/SquiggliesTest.scala
+++ b/metals/src/test/scala/tests/compiler/SquiggliesTest.scala
@@ -34,7 +34,7 @@ object SquiggliesTest extends CompilerSuite with LazyLogging {
     )
   )
   val stdout = new PipedOutputStream()
-  implicit val client = new LanguageClient(stdout, logger)
+  implicit val client: LanguageClient = new LanguageClient(stdout, logger)
   val squiggliesProvider = new SquiggliesProvider(config, AbsolutePath(tmp))
   Files.write(
     tmp.resolve(scalafixConfPath),


### PR DESCRIPTION
This is another step towards #161.

Not strictly necessary, but I took the opportunity to make Linter expose a `Task` directly.