### PR TITLE
Respect more configuration options

### DIFF
--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -30,8 +30,8 @@ object Configuration {
       command: String = "test:compile"
   )
   @JsonCodec case class Scalac(
-    completions: ScalacCompletions = ScalacCompletions(),
-    diagnostics: ScalacDiagnostics = ScalacDiagnostics(),
+      completions: ScalacCompletions = ScalacCompletions(),
+      diagnostics: ScalacDiagnostics = ScalacDiagnostics(),
   )
   @JsonCodec case class ScalacCompletions(enabled: Boolean = false)
   @JsonCodec case class ScalacDiagnostics(enabled: Boolean = false)

--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -32,7 +32,9 @@ object Configuration {
   @JsonCodec case class Scalac(
       completions: ScalacCompletions = ScalacCompletions(),
       diagnostics: ScalacDiagnostics = ScalacDiagnostics(),
-  )
+  ) {
+    def enabled: Boolean = completions.enabled || diagnostics.enabled
+  }
   @JsonCodec case class ScalacCompletions(enabled: Boolean = false)
   @JsonCodec case class ScalacDiagnostics(enabled: Boolean = false)
 

--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -17,6 +17,7 @@ import Configuration._
     scalafix: Scalafix = Scalafix(),
     search: Search = Search(),
     hover: Hover = Hover(),
+    highlight: Highlight = Highlight(),
     rename: Rename = Rename(),
 )
 
@@ -30,6 +31,7 @@ object Configuration {
   )
   @JsonCodec case class Scalac(enabled: Boolean = false)
   @JsonCodec case class Hover(enabled: Boolean = false)
+  @JsonCodec case class Highlight(enabled: Boolean = false)
   @JsonCodec case class Rename(enabled: Boolean = false)
 
   @JsonCodec case class Scalafmt(

--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -29,7 +29,13 @@ object Configuration {
       enabled: Boolean = false,
       command: String = "test:compile"
   )
-  @JsonCodec case class Scalac(enabled: Boolean = false)
+  @JsonCodec case class Scalac(
+    completions: ScalacCompletions = ScalacCompletions(),
+    diagnostics: ScalacDiagnostics = ScalacDiagnostics(),
+  )
+  @JsonCodec case class ScalacCompletions(enabled: Boolean = false)
+  @JsonCodec case class ScalacDiagnostics(enabled: Boolean = false)
+
   @JsonCodec case class Hover(enabled: Boolean = false)
   @JsonCodec case class Highlight(enabled: Boolean = false)
   @JsonCodec case class Rename(enabled: Boolean = false)

--- a/metals/src/main/scala/scala/meta/metals/Effects.scala
+++ b/metals/src/main/scala/scala/meta/metals/Effects.scala
@@ -15,10 +15,8 @@ object Effects {
   final val IndexSourcesClasspath = new IndexSourcesClasspath
   final class InstallPresentationCompiler extends Effects
   final val InstallPresentationCompiler = new InstallPresentationCompiler
-  final class PublishSquigglies extends Effects
-  final val PublishSquigglies = new PublishSquigglies
-  final class PublishScalacDiagnostics extends Effects
-  final val PublishScalacDiagnostics = new PublishScalacDiagnostics
+  final class PublishDiagnostics extends Effects
+  final val PublishDiagnostics = new PublishDiagnostics
   final class UpdateBuffers extends Effects
   final val UpdateBuffers = new UpdateBuffers
 }

--- a/metals/src/main/scala/scala/meta/metals/ScalacErrorReporter.scala
+++ b/metals/src/main/scala/scala/meta/metals/ScalacErrorReporter.scala
@@ -15,10 +15,10 @@ class ScalacErrorReporter()(implicit connection: JsonRpcClient) {
 
   def reportErrors(
       mdb: m.Database
-  ): Effects.PublishScalacDiagnostics = {
+  ): Effects.PublishDiagnostics = {
     val messages = analyzeIndex(mdb)
     messages.foreach(publishDiagnostics.notify)
-    Effects.PublishScalacDiagnostics
+    Effects.PublishDiagnostics
   }
   private def analyzeIndex(mdb: m.Database): Seq[PublishDiagnostics] =
     analyzeIndex(

--- a/metals/src/main/scala/scala/meta/metals/ScalametaServices.scala
+++ b/metals/src/main/scala/scala/meta/metals/ScalametaServices.scala
@@ -313,11 +313,13 @@ class MetalsServices(
       ()
     }
     .request(td.documentHighlight) { params =>
-      DocumentHighlightProvider.highlight(
-        symbolIndex,
-        Uri(params.textDocument.uri),
-        params.position
-      )
+      if (latestConfig().highlight.enabled) {
+        DocumentHighlightProvider.highlight(
+          symbolIndex,
+          Uri(params.textDocument.uri),
+          params.position
+        )
+      } else DocumentHighlightProvider.empty
     }
     .request(td.documentSymbol) { params =>
       val uri = Uri(params.textDocument.uri)

--- a/metals/src/main/scala/scala/meta/metals/ScalametaServices.scala
+++ b/metals/src/main/scala/scala/meta/metals/ScalametaServices.scala
@@ -89,16 +89,15 @@ class MetalsServices(
     new SquiggliesProvider(configurationPublisher, cwd)
   val scalacProvider = new ScalacProvider
   val interactiveSemanticdbs: Observable[semanticdb.Database] =
-    if (latestConfig().scalac.completions.enabled ||
-      latestConfig().scalac.diagnostics.enabled) {
-      sourceChangePublisher
-        .debounce(FiniteDuration(1, "s"))
-        .flatMap { input =>
+    sourceChangePublisher
+      .debounce(FiniteDuration(1, "s"))
+      .flatMap { input =>
+        if (latestConfig().scalac.enabled) {
           Observable
             .fromIterable(Semanticdbs.toSemanticdb(input, scalacProvider))
             .executeOn(presentationCompilerScheduler)
-        }
-    } else Observable.empty
+        } else Observable.empty
+      }
   val interactiveSchemaSemanticdbs: Observable[schema.Database] =
     interactiveSemanticdbs.flatMap(db => Observable(db.toSchema(cwd)))
   val metaSemanticdbs: Observable[semanticdb.Database] =

--- a/metals/src/main/scala/scala/meta/metals/ScalametaServices.scala
+++ b/metals/src/main/scala/scala/meta/metals/ScalametaServices.scala
@@ -323,12 +323,14 @@ class MetalsServices(
       documentFormattingProvider.format(uri.toInput(buffers))
     }
     .request(td.hover) { params =>
-      HoverProvider.hover(
-        symbolIndex,
-        Uri(params.textDocument),
-        params.position.line,
-        params.position.character
-      )
+      if (latestConfig().hover.enabled) {
+        HoverProvider.hover(
+          symbolIndex,
+          Uri(params.textDocument),
+          params.position.line,
+          params.position.character
+        )
+      } else HoverProvider.empty
     }
     .request(td.references) { params =>
       ReferencesProvider.references(

--- a/metals/src/main/scala/scala/meta/metals/ScalametaServices.scala
+++ b/metals/src/main/scala/scala/meta/metals/ScalametaServices.scala
@@ -89,10 +89,8 @@ class MetalsServices(
     new SquiggliesProvider(configurationPublisher, cwd)
   val scalacProvider = new ScalacProvider
   val interactiveSemanticdbs: Observable[semanticdb.Database] =
-    if (
-      latestConfig().scalac.completions.enabled ||
-      latestConfig().scalac.diagnostics.enabled
-    ) {
+    if (latestConfig().scalac.completions.enabled ||
+      latestConfig().scalac.diagnostics.enabled) {
       sourceChangePublisher
         .debounce(FiniteDuration(1, "s"))
         .flatMap { input =>
@@ -120,17 +118,17 @@ class MetalsServices(
     )
   val installedCompilers: Observable[Effects.InstallPresentationCompiler] =
     compilerConfigPublisher.map(scalacProvider.loadNewCompilerGlobals)
-  val publishDiagnostics: Observable[Effects.PublishSquigglies] =
+  val publishDiagnostics: Observable[Effects.PublishDiagnostics] =
     metaSemanticdbs.mapTask { db =>
       squiggliesProvider.squigglies(db).map { diagnostics =>
         diagnostics.foreach(td.publishDiagnostics.notify)
-        Effects.PublishSquigglies
+        Effects.PublishDiagnostics
       }
     }
-  val scalacErrors: Observable[Effects.PublishScalacDiagnostics] =
+  val scalacErrors: Observable[Effects.PublishDiagnostics] =
     if (latestConfig().scalac.diagnostics.enabled) {
       metaSemanticdbs.map(scalacErrorReporter.reportErrors)
-    } else Observable(Effects.PublishScalacDiagnostics)
+    } else Observable(Effects.PublishDiagnostics)
   val sbtServerEnabled: () => Boolean =
     configurationPublisher
       .focus(_.sbt.enabled)

--- a/metals/src/main/scala/scala/meta/metals/providers/DocumentHighlightProvider.scala
+++ b/metals/src/main/scala/scala/meta/metals/providers/DocumentHighlightProvider.scala
@@ -8,6 +8,7 @@ import org.langmeta.lsp.DocumentHighlight
 import org.langmeta.lsp.Position
 
 object DocumentHighlightProvider extends LazyLogging {
+  def empty: List[DocumentHighlight] = Nil
 
   def highlight(
       symbolIndex: SymbolIndex,

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -78,6 +78,11 @@
           "default": true,
           "description": "Enable tooltips on hover"
         },
+        "metals.highlight.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "EXPERIMENTAL. Enable symbol highlights"
+        },
         "metals.rename.enabled": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
This fixes some points in #161:
- respect hover.enabled for tooltips on hover
- respect scalac.enabled for diagnostics, completions and signature help
- add an option to control symbol highlights (`textDocument.documentHighlight`)

Some things for discussion:
- I think that the features provided by presentation compiler should have their own switches. Although their stability depends on the state of PC, even if they do work, they may work differently and have different value for the user. So user may want to enable only some of them. 
- I got confused by the `PublishSquigglies` vs. `PublishScalacDiagnostics`. Isn't it all just diagnostics? Also I'm not sure I handled `scalac.enabled` for the diagnostics well. If I disable `sbt.enabled` and `scalac.enabled`, but enable `scalafix.enabled`, I still get "squigglies" on save — where do they come from? Does it mean that PC still generates semanticdb for scalafix?
- I disabled symbol highlights by default because it works well in read-only mode, but breaks immediately once I start changing code. This is something to be diagnosed and addressed separately, but I think this feature is not stable enough to be enabled by default.