### PR TITLE
Remove metals.scalafmt.onSave option from VSCode extension

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -74,11 +74,6 @@
           "default": true,
           "description": "Enable formatting with scalafmt"
         },
-        "metals.scalafmt.onSave": {
-          "type": "boolean",
-          "default": false,
-          "description": "Format file before saving it"
-        },
         "metals.scalafmt.version": {
           "type": "string",
           "default": "1.4.0",


### PR DESCRIPTION
[VSCode extensions should rely on the integrated DocumentFormatting API](https://code.visualstudio.com/blogs/2016/11/15/formatters-best-practices), which include the `editor.formatOnSave` settings.

Note that it's fine to keep the option on the server, as other editors without integrated support for formatting can use it.