### PR TITLE
Enable hover by default.

### DIFF
--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -38,7 +38,7 @@ object Configuration {
   @JsonCodec case class ScalacCompletions(enabled: Boolean = false)
   @JsonCodec case class ScalacDiagnostics(enabled: Boolean = false)
 
-  @JsonCodec case class Hover(enabled: Boolean = false)
+  @JsonCodec case class Hover(enabled: Boolean = true)
   @JsonCodec case class Highlight(enabled: Boolean = false)
   @JsonCodec case class Rename(enabled: Boolean = false)
 


### PR DESCRIPTION
Hover uses SemanticDB and token-edit-distance (same as definition)
so it should be fairly robust. The only known caveat of hover is that it
shows generic types of symbols (not expressions), which can be annoying
when working with generic code (tuples, collections, ...).