### PR TITLE
Make scalafmt.format.onSave off by default

### DIFF
--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -44,7 +44,7 @@ object Configuration {
 
   @JsonCodec case class Scalafmt(
       enabled: Boolean = true,
-      onSave: Boolean = true,
+      onSave: Boolean = false,
       version: String = "1.3.0",
       confPath: Option[RelativePath] = None
   )


### PR DESCRIPTION
I think `scalafmt.format.onSave` should be off by default. It's a pretty opinionated feature and I also have no way of turning it off in VS Code.