### PR TITLE
Change version for local publishing to SNAPSHOT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,10 +56,8 @@ and point it to the local snapshot version of the server you've just published b
 setting (<kbd>CMD</kbd> + <kbd>,</kbd> on macOS):
 
 ```json
-"metals.serverVersion": "<SNAPSHOT_VERSION>"
+"metals.serverVersion": "SNAPSHOT"
 ```
-
-Change `<SNAPSHOT_VERSION>` according to the published snapshot on your machine.
 
 Then open the `test-workspace` project with VSCode (`code test-workspace` from the console)
 and try your changes.

--- a/bin/start-server.sh
+++ b/bin/start-server.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-METALS_VERSION=${1:-"0.1-SNAPSHOT"}
+METALS_VERSION=${1:-"SNAPSHOT"}
 COURSIER_DIR="$HOME/.coursier"
 COURSIER_PATH="$COURSIER_DIR/coursier"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 inThisBuild(
   semanticdbSettings ++
     List(
-      version ~= { old =>
-        if (sys.env.contains("CI")) old
-        else "0.1-SNAPSHOT" // to avoid manually updating extension.js
+      version ~= { dynVer =>
+        if (sys.env.contains("CI")) dynVer
+        else "SNAPSHOT" // only for local publishng
       },
       scalaVersion := V.scala212,
       scalacOptions ++= List(


### PR DESCRIPTION
A minor change to avoid bumping this version after each release. It is used only for local publishing. All artifacts published to Bintray have unique versions based on Git describe.