### PR TITLE
Improve sbt server configuration

### DIFF
--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -16,32 +16,28 @@ import Configuration._
     scalafmt: Scalafmt = Scalafmt(),
     scalafix: Scalafix = Scalafix(),
     search: Search = Search(),
-    hover: Hover = Hover(),
-    highlight: Highlight = Highlight(),
-    rename: Rename = Rename(),
+    hover: Enabled = Enabled(true),
+    highlight: Enabled = Enabled(false),
+    rename: Enabled = Enabled(false),
 )
 
 object Configuration {
   implicit val circeConfiguration: CirceConfiguration =
     CirceConfiguration.default.withDefaults
 
+  @JsonCodec case class Enabled(enabled: Boolean)
+
   @JsonCodec case class Sbt(
       enabled: Boolean = false,
-      diagnostics: Diagnostics = Diagnostics(enabled = true),
+      diagnostics: Enabled = Enabled(true),
       command: String = "test:compile",
   )
   @JsonCodec case class Scalac(
-      completions: Completions = Completions(enabled = false),
-      diagnostics: Diagnostics = Diagnostics(enabled = false),
+      completions: Enabled = Enabled(false),
+      diagnostics: Enabled = Enabled(false),
   ) {
     def enabled: Boolean = completions.enabled || diagnostics.enabled
   }
-  @JsonCodec case class Completions(enabled: Boolean = false)
-  @JsonCodec case class Diagnostics(enabled: Boolean = false)
-
-  @JsonCodec case class Hover(enabled: Boolean = true)
-  @JsonCodec case class Highlight(enabled: Boolean = false)
-  @JsonCodec case class Rename(enabled: Boolean = false)
 
   @JsonCodec case class Scalafmt(
       enabled: Boolean = true,

--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -42,7 +42,7 @@ object Configuration {
   @JsonCodec case class Scalafmt(
       enabled: Boolean = true,
       onSave: Boolean = false,
-      version: String = "1.3.0",
+      version: String = "1.4.0",
       confPath: Option[RelativePath] = None
   )
   object Scalafmt {

--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -43,14 +43,14 @@ object Configuration {
       enabled: Boolean = true,
       onSave: Boolean = false,
       version: String = "1.4.0",
-      confPath: Option[RelativePath] = None
+      confPath: Option[RelativePath] = Some(Scalafmt.defaultConfPath)
   )
   object Scalafmt {
     lazy val defaultConfPath = RelativePath(".scalafmt.conf")
   }
   @JsonCodec case class Scalafix(
       enabled: Boolean = true,
-      confPath: Option[RelativePath] = None
+      confPath: Option[RelativePath] = Some(Scalafix.defaultConfPath)
   )
   object Scalafix {
     lazy val defaultConfPath = RelativePath(".scalafix.conf")

--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -28,9 +28,8 @@ object Configuration {
   @JsonCodec case class Enabled(enabled: Boolean)
 
   @JsonCodec case class Sbt(
-      enabled: Boolean = false,
       diagnostics: Enabled = Enabled(true),
-      command: String = "test:compile",
+      command: String = "",
   )
   @JsonCodec case class Scalac(
       completions: Enabled = Enabled(false),

--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -30,13 +30,13 @@ object Configuration {
       command: String = "test:compile"
   )
   @JsonCodec case class Scalac(
-      completions: ScalacCompletions = ScalacCompletions(),
-      diagnostics: ScalacDiagnostics = ScalacDiagnostics(),
+      completions: Completions = Completions(enabled = false),
+      diagnostics: Diagnostics = Diagnostics(enabled = false),
   ) {
     def enabled: Boolean = completions.enabled || diagnostics.enabled
   }
-  @JsonCodec case class ScalacCompletions(enabled: Boolean = false)
-  @JsonCodec case class ScalacDiagnostics(enabled: Boolean = false)
+  @JsonCodec case class Completions(enabled: Boolean = false)
+  @JsonCodec case class Diagnostics(enabled: Boolean = false)
 
   @JsonCodec case class Hover(enabled: Boolean = true)
   @JsonCodec case class Highlight(enabled: Boolean = false)

--- a/metals/src/main/scala/scala/meta/metals/Configuration.scala
+++ b/metals/src/main/scala/scala/meta/metals/Configuration.scala
@@ -27,7 +27,8 @@ object Configuration {
 
   @JsonCodec case class Sbt(
       enabled: Boolean = false,
-      command: String = "test:compile"
+      diagnostics: Diagnostics = Diagnostics(enabled = true),
+      command: String = "test:compile",
   )
   @JsonCodec case class Scalac(
       completions: Completions = Completions(enabled = false),

--- a/metals/src/main/scala/scala/meta/metals/MetalsServices.scala
+++ b/metals/src/main/scala/scala/meta/metals/MetalsServices.scala
@@ -121,17 +121,6 @@ class MetalsServices(
         Effects.PublishDiagnostics
       }
     }
-  val sbtServerEnabled: () => Boolean =
-    configurationPublisher
-      .focus(_.sbt.enabled)
-      .doOnNext {
-        case true =>
-          connectToSbtServer()
-        case false =>
-          sbtServer.foreach(_.runningServer.cancel())
-          sbtServer = None
-      }
-      .toFunction0()
   private var cancelEffects = List.empty[Cancelable]
   val effects: List[Observable[Effects]] = List(
     configurationPublisher.map(_ => Effects.UpdateBuffers),
@@ -272,9 +261,8 @@ class MetalsServices(
       }
     }
     .notification(td.didSave) { _ =>
-      if (sbtServerEnabled()) {
-        sbtCompile()
-      }
+      // if sbt is not connected or the command is empty it won't do anything
+      sbtExec()
     }
     .notification(ws.didChangeConfiguration) { params =>
       params.settings.hcursor.downField("metals").as[Configuration] match {
@@ -423,34 +411,28 @@ class MetalsServices(
       response
     case SbtConnect =>
       Task {
-        if (!sbtServerEnabled()) {
-          showMessage.error("Set metals.sbt.enabled=true to use sbt server.")
-        } else {
-          connectToSbtServer()
-        }
+        connectToSbtServer()
         Right(Json.Null)
       }
   }
 
-  private def sbtCompile(): Unit = sbtServer match {
-    case None => ()
-    case Some(sbt) =>
-      // TODO(olafur) support running other commands than "compile"
-      // running top-level "compile" is sub-optimal for large builds
-      // especially cross-built builds with scala.js/native
-      Sbt
-        .exec(latestConfig().sbt.command)(sbt.client)
-        .onErrorRecover {
-          case NonFatal(err) =>
-            // TODO(olafur) figure out why this "broken pipe" is not getting
-            // caught here.
-            logger.error("Failed to send sbt compile", err)
-            showMessage.warn(
-              "Lost connection to sbt server. " +
-                "Restart the sbt session and run the 'Re-connect to sbt server' command"
-            )
-        }
-        .runAsync
+  private def sbtExec(): Unit = sbtServer.foreach { sbt =>
+    // TODO(olafur) support running other commands than "compile"
+    // running top-level "compile" is sub-optimal for large builds
+    // especially cross-built builds with scala.js/native
+    Sbt
+      .exec(latestConfig().sbt.command)(sbt.client)
+      .onErrorRecover {
+        case NonFatal(err) =>
+          // TODO(olafur) figure out why this "broken pipe" is not getting
+          // caught here.
+          logger.error("Failed to send sbt compile", err)
+          showMessage.warn(
+            "Lost connection to sbt server. " +
+              "Restart the sbt session and run the 'Re-connect to sbt server' command"
+          )
+      }
+      .runAsync
   }
 
   private def connectToSbtServer(): Unit = {
@@ -472,7 +454,7 @@ class MetalsServices(
             sbtServer = None
             showMessage.warn("Disconnected from sbt server")
         }
-        sbtCompile() // run compile right away.
+        sbtExec() // run compile right away.
     }
   }
 

--- a/metals/src/main/scala/scala/meta/metals/MetalsServices.scala
+++ b/metals/src/main/scala/scala/meta/metals/MetalsServices.scala
@@ -417,9 +417,6 @@ class MetalsServices(
   }
 
   private def sbtExec(): Unit = sbtServer.foreach { sbt =>
-    // TODO(olafur) support running other commands than "compile"
-    // running top-level "compile" is sub-optimal for large builds
-    // especially cross-built builds with scala.js/native
     Sbt
       .exec(latestConfig().sbt.command)(sbt.client)
       .onErrorRecover {

--- a/metals/src/main/scala/scala/meta/metals/MetalsServices.scala
+++ b/metals/src/main/scala/scala/meta/metals/MetalsServices.scala
@@ -455,7 +455,7 @@ class MetalsServices(
 
   private def connectToSbtServer(): Unit = {
     sbtServer.foreach(_.runningServer.cancel())
-    val services = SbtServer.forwardingServices(client)
+    val services = SbtServer.forwardingServices(client, latestConfig)
     SbtServer.connect(cwd, services)(s.sbt).foreach {
       case Left(err) => showMessage.error(err)
       case Right(server) =>

--- a/metals/src/main/scala/scala/meta/metals/sbtserver/Sbt.scala
+++ b/metals/src/main/scala/scala/meta/metals/sbtserver/Sbt.scala
@@ -24,7 +24,7 @@ trait Sbt {
     def apply(
         commandLine: String
     )(implicit client: JsonRpcClient): Task[Unit] = {
-      if (commandLine.isEmpty) Task(())
+      if (commandLine.trim.isEmpty) Task.now(())
       // NOTE(olafur) sbt/exec is a request that never responds
       else super.request(SbtExecParams(commandLine)).map(_ => Unit)
     }

--- a/metals/src/main/scala/scala/meta/metals/sbtserver/Sbt.scala
+++ b/metals/src/main/scala/scala/meta/metals/sbtserver/Sbt.scala
@@ -24,8 +24,9 @@ trait Sbt {
     def apply(
         commandLine: String
     )(implicit client: JsonRpcClient): Task[Unit] = {
+      if (commandLine.isEmpty) Task(())
       // NOTE(olafur) sbt/exec is a request that never responds
-      super.request(SbtExecParams(commandLine)).map(_ => Unit)
+      else super.request(SbtExecParams(commandLine)).map(_ => Unit)
     }
   }
 }

--- a/metals/src/main/scala/scala/meta/metals/sbtserver/SbtServer.scala
+++ b/metals/src/main/scala/scala/meta/metals/sbtserver/SbtServer.scala
@@ -68,7 +68,7 @@ object SbtServer extends LazyLogging {
       case Left(_: IOException) =>
         fail(
           s"Unable to establish connection with sbt server. " +
-            s"Do you have an active sbt 1.1.0 session?"
+            s"Do you have an active sbt 1.1+ session?"
         )
       case Left(err) =>
         val msg = s"Unexpected error opening connection to sbt server"

--- a/metals/src/main/scala/scala/meta/metals/sbtserver/SbtServer.scala
+++ b/metals/src/main/scala/scala/meta/metals/sbtserver/SbtServer.scala
@@ -7,6 +7,7 @@ import java.nio.file.Files
 import scala.meta.metals.ActiveJson
 import scala.meta.metals.MissingActiveJson
 import scala.meta.metals.SbtInitializeParams
+import scala.meta.metals.Configuration
 import scala.util.Try
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.jawn.parseByteBuffer
@@ -95,13 +96,18 @@ object SbtServer extends LazyLogging {
    * @param editorClient the LSP editor client to forward the notifications
    *                     from the sbt server.
    */
-  def forwardingServices(editorClient: JsonRpcClient): Services =
+  def forwardingServices(
+      editorClient: JsonRpcClient,
+      config: () => Configuration
+  ): Services =
     Services.empty
       .notification(Window.logMessage) { msg =>
         editorClient.notify(Window.logMessage, msg)
       }
       .notification(TextDocument.publishDiagnostics) { msg =>
-        editorClient.notify(TextDocument.publishDiagnostics, msg)
+        if (config().sbt.diagnostics.enabled) {
+          editorClient.notify(TextDocument.publishDiagnostics, msg)
+        }
       }
 
   /**

--- a/metals/src/test/scala/tests/compiler/DiagnosticsTest.scala
+++ b/metals/src/test/scala/tests/compiler/DiagnosticsTest.scala
@@ -30,9 +30,7 @@ object DiagnosticsTest extends CompilerSuite with LazyLogging {
   val config = Observable.now(
     Configuration(
       scalac = Configuration.Scalac(
-        diagnostics = Configuration.Diagnostics(
-          enabled = true
-        )
+        diagnostics = Configuration.Enabled(true)
       ),
       scalafix = Configuration.Scalafix(
         enabled = true,

--- a/metals/src/test/scala/tests/compiler/DiagnosticsTest.scala
+++ b/metals/src/test/scala/tests/compiler/DiagnosticsTest.scala
@@ -30,7 +30,7 @@ object DiagnosticsTest extends CompilerSuite with LazyLogging {
   val config = Observable.now(
     Configuration(
       scalac = Configuration.Scalac(
-        diagnostics = Configuration.ScalacDiagnostics(
+        diagnostics = Configuration.Diagnostics(
           enabled = true
         )
       ),

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -49,20 +49,15 @@
     "configuration": {
       "title": "Metals",
       "properties": {
-        "metals.sbt.enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "EXPERIMENTAL. Use sbt language server to compile on file save and report diagnostics. Requires sbt 1.1+."
-        },
         "metals.sbt.diagnostics.enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Enable diagnostics from the sbt server."
+          "description": "EXPERIMENTAL. Enable diagnostics from the sbt server. Requires a running sbt 1.1+ instance."
         },
         "metals.sbt.command": {
           "type": "string",
-          "default": "test:compile",
-          "description": "Which sbt command to run on file save."
+          "default": "",
+          "description": "EXPERIMENTAL. Which sbt command to run on file save. Requires a running sbt 1.1+ instance."
         },
         "metals.scalac.completions.enabled": {
           "type": "boolean",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -52,12 +52,12 @@
         "metals.sbt.diagnostics.enabled": {
           "type": "boolean",
           "default": true,
-          "description": "EXPERIMENTAL. Enable diagnostics from the sbt server. Requires a running sbt 1.1+ instance."
+          "description": "Enable diagnostics from the sbt server. Requires a running sbt 1.1+ instance."
         },
         "metals.sbt.command": {
           "type": "string",
           "default": "",
-          "description": "EXPERIMENTAL. Which sbt command to run on file save. Requires a running sbt 1.1+ instance."
+          "description": "Which sbt command to run on file save. Requires a running sbt 1.1+ instance."
         },
         "metals.scalac.completions.enabled": {
           "type": "boolean",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -52,7 +52,12 @@
         "metals.sbt.enabled": {
           "type": "boolean",
           "default": false,
-          "description": "EXPERIMENTAL. Use sbt language server to compile on file save and report diagnostics. Requires sbt 1.1.0"
+          "description": "EXPERIMENTAL. Use sbt language server to compile on file save and report diagnostics. Requires sbt 1.1+."
+        },
+        "metals.sbt.diagnostics.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable diagnostics from the sbt server."
         },
         "metals.sbt.command": {
           "type": "string",


### PR DESCRIPTION
Fixes #228, #250:

* add `sbt.diagnostics.enabled = true`, ~~while keeping general `sbt.enabled = false` (as suggested by @gabro in https://github.com/scalameta/metals/issues/228#issuecomment-379285363)~~ (see discussion below: https://github.com/scalameta/metals/pull/263#discussion_r179914418)
* set `sbt.command = ""`
* simply skip `sbt/exec` if the passed command is empty
* don't autoconnect to the sbt server