### PR TITLE
Change condition for decrypting env vars for releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_cache:
   - rm -rf $HOME/.ivy2/local
 
 before_install:
-  - if [ $TRAVIS_PULL_REQUEST = 'false'  ]; then
+  - if [ "$TRAVIS_BUILD_STAGE_NAME" = 'Release'  ]; then
       openssl aes-256-cbc -K $encrypted_df92ba612cfd_key -iv $encrypted_df92ba612cfd_iv -in travis/secrets.tar.enc -out travis/secrets.tar -d;
       tar xv -C travis -f travis/secrets.tar;
     fi


### PR DESCRIPTION
I was getting these CI failures on my fork:

```
0.02s$ if [ $TRAVIS_PULL_REQUEST = 'false'  ]; then openssl aes-256-cbc -K $encrypted_df92ba612cfd_key -iv $encrypted_df92ba612cfd_iv -in travis/secrets.tar.enc -out travis/secrets.tar -d; tar xv -C travis -f travis/secrets.tar; fi
iv undefined
tar: This does not look like a tar archive
tar: Exiting with failure status due to previous errors

The command "if [ $TRAVIS_PULL_REQUEST = 'false'  ]; then openssl aes-256-cbc -K $encrypted_df92ba612cfd_key -iv $encrypted_df92ba612cfd_iv -in travis/secrets.tar.enc -out travis/secrets.tar -d; tar xv -C travis -f travis/secrets.tar; fi" failed and exited with 2 during .
```

Because this pre-install script shouldn't run on a fork which doesn't have those encrypted env vars.

I have no idea if this is an appropriate solution for the problem. I just assumed that the `release` stage won't happen on a fork, so it should work.