### PR TITLE
update sbt-protoc version

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.0.0")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin(
-  "com.thesamet" % "sbt-protoc" % "0.99.13" exclude ("com.trueaccord.scalapb", "protoc-bridge_2.12")
+  "com.thesamet" % "sbt-protoc" % "0.99.18" exclude ("com.trueaccord.scalapb", "protoc-bridge_2.12")
 )
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin-shaded" % "0.6.6"


### PR DESCRIPTION
This version does not depend on python to integrate protobuff on Windows