### PR TITLE
load-plugin integration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -135,7 +135,8 @@ lazy val metals = project
     fork in Test := true, // required for jni interrop with leveldb.
     buildInfoKeys := Seq[BuildInfoKey](
       "testWorkspaceBaseDirectory" ->
-        baseDirectory.in(testWorkspace).value
+        baseDirectory.in(testWorkspace).value,
+      version,
     ),
     buildInfoPackage := "scala.meta.metals.internal",
     libraryDependencies ++= List(

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -44,7 +44,7 @@ sbt
 
 The command will create the necessary metadata in the `.metals` directory
 (which you should not checkout into version control) and setup the `semanticdb-scalac` compiler
-plugin for the current sbt ession.
+plugin for the current sbt session.
 
 You should not checkout the `.metals` directory into version control. We recommend to add it to your
 project's `.gitignore` or/and to your global `.gitignore`:
@@ -53,8 +53,9 @@ project's `.gitignore` or/and to your global `.gitignore`:
 echo ".metals/" >> .gitignore
 ```
 
-Note that you will need to invoke `metalsSetup` (or `semanticdbEnable`) whenever you close and
-re-open sbt. For a more persistent setup, keep reading.
+Note that in sbt 0.13 you will need to invoke `metalsSetup` (or `semanticdbEnable`) whenever you close and
+re-open sbt. For a more persistent setup, keep reading. In sbt 1 you don't need to do it because Metals will
+automatically invoke `semanticdbEnable` every time it connects to the sbt server.
 
 ## Persisting the semanticdb-scalac compiler plugin
 Some features like definition/references/hover rely on artifacts produced by a compiler plugin

--- a/metals/src/main/scala/scala/meta/metals/MetalsServices.scala
+++ b/metals/src/main/scala/scala/meta/metals/MetalsServices.scala
@@ -448,8 +448,11 @@ class MetalsServices(
   }
 
   private def sbtExecWithMetalsPlugin(commands: String*): Unit = {
-    val metalsPluginModule =
-      ModuleID("org.scalameta", "sbt-metals", "0.1.0-M1+84-a3ffb91c")
+    val metalsPluginModule = ModuleID(
+      "org.scalameta",
+      "sbt-metals",
+      scala.meta.metals.internal.BuildInfo.version
+    )
     val metalsPluginRef = "scala.meta.sbt.MetalsPlugin"
     val loadPluginClasspath = loadPluginJars.value.mkString(File.pathSeparator)
     val loadCommands = Seq(

--- a/metals/src/main/scala/scala/meta/metals/MetalsServices.scala
+++ b/metals/src/main/scala/scala/meta/metals/MetalsServices.scala
@@ -1,6 +1,7 @@
 package scala.meta.metals
 
 import java.io.IOException
+import java.io.File
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
@@ -450,7 +451,7 @@ class MetalsServices(
     val metalsPluginModule =
       ModuleID("org.scalameta", "sbt-metals", "0.1.0-M1+84-a3ffb91c")
     val metalsPluginRef = "scala.meta.sbt.MetalsPlugin"
-    val loadPluginClasspath = loadPluginJars.value.mkString(":")
+    val loadPluginClasspath = loadPluginJars.value.mkString(File.pathSeparator)
     val loadCommands = Seq(
       s"apply -cp ${loadPluginClasspath} ch.epfl.scala.loadplugin.LoadPlugin",
       s"""if-absent ${metalsPluginRef} "load-plugin ${metalsPluginModule} ${metalsPluginRef}"""",

--- a/metals/src/main/scala/scala/meta/metals/sbtserver/SbtServer.scala
+++ b/metals/src/main/scala/scala/meta/metals/sbtserver/SbtServer.scala
@@ -4,7 +4,6 @@ import java.io.IOException
 import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.file.Files
-import java.nio.file.Path
 import java.util.Properties
 import scala.meta.metals.ActiveJson
 import scala.meta.metals.MissingActiveJson
@@ -144,8 +143,8 @@ object SbtServer extends LazyLogging {
     def apply(cwd: AbsolutePath): AbsolutePath =
       cwd.resolve(relativePath)
 
-    def unapply(path: Path): Boolean =
-      path.endsWith(relativePath.toNIO)
+    def unapply(path: RelativePath): Boolean =
+      path == relativePath
   }
 
   /**


### PR DESCRIPTION
This is a proof-of-concept integration with [load-plugin](https://github.com/scalacenter/load-plugin).

It eliminates the need to add global sbt-metals in case of sbt 1. On every connection to the sbt server Metals will load sbt-metals and run `semanticdbEnable` automatically.


Next steps:
- [x] retrieve load-plugin somehow (it currently just runs `coursier fetch --classpath` 😬)
- [ ] if the project doesn't have `.metals/buildinfo` send a `showMessageRequest` suggesting to setup the project with a confirmation button (see #284)
- [ ] watch `.sbt` files and do the same when they change
- [ ] update the docs: explicit sbt-metals setup is needed _only_ for sbt 0.13
