### PR TITLE
Issue 259: use enhanced (CompletionItem|Symbol)Kinds

### DIFF
--- a/lsp4s/src/main/scala/org/langmeta/lsp/Enums.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/Enums.scala
@@ -46,7 +46,7 @@ case object CompletionItemKind
   case object Event extends CompletionItemKind(23)
   case object Operator extends CompletionItemKind(24)
   case object TypeParameter extends CompletionItemKind(25)
-  
+
   val values = findValues
 }
 
@@ -92,7 +92,7 @@ case object SymbolKind
   case object Number extends SymbolKind(16)
   case object Boolean extends SymbolKind(17)
   case object Array extends SymbolKind(18)
-	case object Object extends SymbolKind(19)
+  case object Object extends SymbolKind(19)
   case object Key extends SymbolKind(20)
   case object Null extends SymbolKind(21)
   case object EnumMember extends SymbolKind(22)
@@ -100,7 +100,7 @@ case object SymbolKind
   case object Event extends SymbolKind(24)
   case object Operator extends SymbolKind(25)
   case object TypeParameter extends SymbolKind(26)
-  
+
   val values = findValues
 }
 

--- a/lsp4s/src/main/scala/org/langmeta/lsp/Enums.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/Enums.scala
@@ -39,7 +39,14 @@ case object CompletionItemKind
   case object Color extends CompletionItemKind(16)
   case object File extends CompletionItemKind(17)
   case object Reference extends CompletionItemKind(18)
-
+  case object Folder extends CompletionItemKind(19)
+  case object EnumMember extends CompletionItemKind(20)
+  case object Constant extends CompletionItemKind(21)
+  case object Struct extends CompletionItemKind(22)
+  case object Event extends CompletionItemKind(23)
+  case object Operator extends CompletionItemKind(24)
+  case object TypeParameter extends CompletionItemKind(25)
+  
   val values = findValues
 }
 
@@ -85,7 +92,15 @@ case object SymbolKind
   case object Number extends SymbolKind(16)
   case object Boolean extends SymbolKind(17)
   case object Array extends SymbolKind(18)
-
+	case object Object extends SymbolKind(19)
+  case object Key extends SymbolKind(20)
+  case object Null extends SymbolKind(21)
+  case object EnumMember extends SymbolKind(22)
+  case object Struct extends SymbolKind(23)
+  case object Event extends SymbolKind(24)
+  case object Operator extends SymbolKind(25)
+  case object TypeParameter extends SymbolKind(26)
+  
   val values = findValues
 }
 

--- a/metals/src/main/scala/org/langmeta/semanticdb/SemanticdbEnrichments.scala
+++ b/metals/src/main/scala/org/langmeta/semanticdb/SemanticdbEnrichments.scala
@@ -9,6 +9,8 @@ object SemanticdbEnrichments {
     def toSymbolKind: SymbolKind =
       if (isClass) SymbolKind.Class
       else if (isTrait) SymbolKind.Interface
+      else if (isTypeParam) SymbolKind.TypeParameter
+      else if (isObject) SymbolKind.Object
       else SymbolKind.Module
   }
 }

--- a/metals/src/main/scala/scala/meta/metals/ScalametaEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/metals/ScalametaEnrichments.scala
@@ -66,6 +66,8 @@ object ScalametaEnrichments {
       case _: Defn.Object => SymbolKind.Module
       case _: Pkg.Object => SymbolKind.Namespace
       case _: Pkg => SymbolKind.Package
+      case _: Type.Param => SymbolKind.TypeParameter
+      case _: Lit.Null => SymbolKind.Null
       // TODO(alexey) are these kinds useful?
       // case ??? => SymbolKind.Enum
       // case ??? => SymbolKind.String

--- a/metals/src/main/scala/scala/meta/metals/providers/CompletionProvider.scala
+++ b/metals/src/main/scala/scala/meta/metals/providers/CompletionProvider.scala
@@ -19,16 +19,25 @@ object CompletionProvider extends LazyLogging {
   ): CompletionList = {
     import compiler._
 
+    def isFunction(symbol: Symbol): Boolean = {
+      val functionTraitRegex = """^scala\.Function([0-9]|1[0-9]|2[0-2])$""".r
+      val typeSymbolFullName = symbol.info.finalResultType.typeSymbol.fullName
+      functionTraitRegex.findFirstIn(typeSymbolFullName).isDefined
+    }
+
     def completionItemKind(r: CompletionResult#M): CompletionItemKind = {
-      if (r.sym.hasPackageFlag) CompletionItemKind.Module
-      else if (r.sym.isPackageObject) CompletionItemKind.Module
-      else if (r.sym.isModuleOrModuleClass) CompletionItemKind.Module
-      else if (r.sym.isTraitOrInterface) CompletionItemKind.Interface
-      else if (r.sym.isClass) CompletionItemKind.Class
-      else if (r.sym.isMethod) CompletionItemKind.Method
-      else if (r.sym.isCaseAccessor) CompletionItemKind.Field
-      else if (r.sym.isVal) CompletionItemKind.Value
-      else if (r.sym.isVar) CompletionItemKind.Variable
+      val symbol = r.sym
+      if (symbol.hasPackageFlag) CompletionItemKind.Module
+      else if (symbol.isPackageObject) CompletionItemKind.Module
+      else if (symbol.isModuleOrModuleClass) CompletionItemKind.Module
+      else if (symbol.isTraitOrInterface) CompletionItemKind.Interface
+      else if (symbol.isClass) CompletionItemKind.Class
+      else if (symbol.isMethod) CompletionItemKind.Method
+      else if (symbol.isCaseAccessor) CompletionItemKind.Field
+      else if (symbol.isVal) CompletionItemKind.Value
+      else if (symbol.isVar) CompletionItemKind.Variable
+      else if (symbol.isTypeParameterOrSkolem) CompletionItemKind.TypeParameter
+      else if (isFunction(symbol)) CompletionItemKind.Function
       else CompletionItemKind.Value
     }
 

--- a/metals/src/main/scala/scala/meta/metals/providers/CompletionProvider.scala
+++ b/metals/src/main/scala/scala/meta/metals/providers/CompletionProvider.scala
@@ -19,10 +19,10 @@ object CompletionProvider extends LazyLogging {
   ): CompletionList = {
     import compiler._
 
-    val functionTraitRegex = """^scala\.Function([0-9]|1[0-9]|2[0-2])$""".r
     def isFunction(symbol: Symbol): Boolean = {
-      val typeSymbolFullName = symbol.info.finalResultType.typeSymbol.fullName
-      functionTraitRegex.findFirstIn(typeSymbolFullName).isDefined
+      compiler.definitions.isFunctionSymbol(
+        symbol.info.finalResultType.typeSymbol
+      )
     }
 
     def completionItemKind(r: CompletionResult#M): CompletionItemKind = {

--- a/metals/src/main/scala/scala/meta/metals/providers/CompletionProvider.scala
+++ b/metals/src/main/scala/scala/meta/metals/providers/CompletionProvider.scala
@@ -19,14 +19,15 @@ object CompletionProvider extends LazyLogging {
   ): CompletionList = {
     import compiler._
 
+    val functionTraitRegex = """^scala\.Function([0-9]|1[0-9]|2[0-2])$""".r
     def isFunction(symbol: Symbol): Boolean = {
-      val functionTraitRegex = """^scala\.Function([0-9]|1[0-9]|2[0-2])$""".r
       val typeSymbolFullName = symbol.info.finalResultType.typeSymbol.fullName
       functionTraitRegex.findFirstIn(typeSymbolFullName).isDefined
     }
 
     def completionItemKind(r: CompletionResult#M): CompletionItemKind = {
       val symbol = r.sym
+      val symbolIsFunction = isFunction(symbol)
       if (symbol.hasPackageFlag) CompletionItemKind.Module
       else if (symbol.isPackageObject) CompletionItemKind.Module
       else if (symbol.isModuleOrModuleClass) CompletionItemKind.Module
@@ -34,10 +35,10 @@ object CompletionProvider extends LazyLogging {
       else if (symbol.isClass) CompletionItemKind.Class
       else if (symbol.isMethod) CompletionItemKind.Method
       else if (symbol.isCaseAccessor) CompletionItemKind.Field
-      else if (symbol.isVal) CompletionItemKind.Value
-      else if (symbol.isVar) CompletionItemKind.Variable
+      else if (symbol.isVal && !symbolIsFunction) CompletionItemKind.Value
+      else if (symbol.isVar && !symbolIsFunction) CompletionItemKind.Variable
       else if (symbol.isTypeParameterOrSkolem) CompletionItemKind.TypeParameter
-      else if (isFunction(symbol)) CompletionItemKind.Function
+      else if (symbolIsFunction) CompletionItemKind.Function
       else CompletionItemKind.Value
     }
 

--- a/metals/src/test/scala/tests/compiler/CompletionsTest.scala
+++ b/metals/src/test/scala/tests/compiler/CompletionsTest.scala
@@ -166,6 +166,31 @@ object CompletionsTest extends CompilerSuite {
   )
 
   check(
+    "type parameter",
+    """
+      |trait Hmm[ABC] {
+      |  val a: AB<<>>
+      |}
+    """.stripMargin,
+    label = "ABC",
+    kind = CompletionItemKind.TypeParameter,
+    detail = ""
+  )
+
+  check(
+    "function",
+    """
+      |object a {
+      |  val xyz: Int => String => Boolean = _ => _ => false
+      |  xy<<>>
+      |}
+    """.stripMargin,
+    label = "xyz",
+    kind = CompletionItemKind.Function,
+    detail = ": Int => (String => Boolean)"
+  )
+
+  check(
     "sorting",
     """
       |case class User(name: String, age: Int) {

--- a/metals/src/test/scala/tests/compiler/CompletionsTest.scala
+++ b/metals/src/test/scala/tests/compiler/CompletionsTest.scala
@@ -178,10 +178,23 @@ object CompletionsTest extends CompilerSuite {
   )
 
   check(
-    "function",
+    "function val",
     """
       |object a {
       |  val xyz: Int => String => Boolean = _ => _ => false
+      |  xy<<>>
+      |}
+    """.stripMargin,
+    label = "xyz",
+    kind = CompletionItemKind.Function,
+    detail = ": Int => (String => Boolean)"
+  )
+
+  check(
+    "function var",
+    """
+      |object a {
+      |  var xyz: Int => String => Boolean = _ => _ => false
       |  xy<<>>
       |}
     """.stripMargin,


### PR DESCRIPTION
Closes #259

I added the new lsp CompletionItemKinds and SymbolKinds.

For CompletionItemKinds I only mapped TypeParameter and Function, but I'm not sure if you want Function mapped because it's not a new CompletionItemKind, and it wasn't previously mapped. I also think the Function case is dead-code cause when trying to complete a symbol that's a function it'll probably go into the val case.

For SymbolKinds I'm not convinced that I did the additions to ScalametaEnrichments correctly. I'm not sure if documentSymbol() adds Type.Param and Lit.Null to the list that it builds, so those additional cases might be pointless.

Finally the issue mentions Constant in CompletionItemKind. I'm not sure how to map that cause doesn't CompletionItemKind.Value cover that, or does Constant mean something else?