### PR TITLE
LSP logging improvements

### DIFF
--- a/lsp4s/src/main/scala/org/langmeta/lsp/Endpoints.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/Endpoints.scala
@@ -79,8 +79,17 @@ trait Window {
       showMessage.notify(ShowMessageParams(MessageType.Warning, message))
     def info(message: String)(implicit client: JsonRpcClient): Unit =
       showMessage.notify(ShowMessageParams(MessageType.Info, message))
+    def log(message: String)(implicit client: JsonRpcClient): Unit =
+      showMessage.notify(ShowMessageParams(MessageType.Log, message))
+  }
   }
   object logMessage extends Endpoint[LogMessageParams, Unit]("window/logMessage") {
+    def error(message: String)(implicit client: JsonRpcClient): Unit =
+      super.notify(LogMessageParams(MessageType.Error, message))
+    def warn(message: String)(implicit client: JsonRpcClient): Unit =
+      super.notify(LogMessageParams(MessageType.Warning, message))
+    def info(message: String)(implicit client: JsonRpcClient): Unit =
+      super.notify(LogMessageParams(MessageType.Info, message))
     def log(message: String)(implicit client: JsonRpcClient): Unit =
       super.notify(LogMessageParams(MessageType.Log, message))
   }

--- a/lsp4s/src/main/scala/org/langmeta/lsp/Endpoints.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/Endpoints.scala
@@ -5,6 +5,8 @@ import org.langmeta.jsonrpc.Endpoint
 import org.langmeta.jsonrpc.Endpoint._
 import io.circe.Json
 import org.langmeta.jsonrpc.JsonRpcClient
+import org.langmeta.jsonrpc.Response.Error
+import monix.eval.Task
 
 object Lifecycle extends Lifecycle
 trait Lifecycle {
@@ -82,6 +84,28 @@ trait Window {
     def log(message: String)(implicit client: JsonRpcClient): Unit =
       showMessage.notify(ShowMessageParams(MessageType.Log, message))
   }
+  object showMessageRequest
+      extends Endpoint[ShowMessageRequestParams, Option[MessageActionItem]]("window/showMessageRequest") {
+    def error(message: String)(actionItems: MessageActionItem*)(
+        implicit client: JsonRpcClient): Task[Either[Error, Option[MessageActionItem]]] =
+      showMessageRequest.request(
+        ShowMessageRequestParams(MessageType.Error, message, actionItems)
+      )
+    def warn(message: String)(actionItems: MessageActionItem*)(
+        implicit client: JsonRpcClient): Task[Either[Error, Option[MessageActionItem]]] =
+      showMessageRequest.request(
+        ShowMessageRequestParams(MessageType.Warning, message, actionItems)
+      )
+    def info(message: String)(actionItems: MessageActionItem*)(
+        implicit client: JsonRpcClient): Task[Either[Error, Option[MessageActionItem]]] =
+      showMessageRequest.request(
+        ShowMessageRequestParams(MessageType.Info, message, actionItems)
+      )
+    def log(message: String)(actionItems: MessageActionItem*)(
+        implicit client: JsonRpcClient): Task[Either[Error, Option[MessageActionItem]]] =
+      showMessageRequest.request(
+        ShowMessageRequestParams(MessageType.Log, message, actionItems)
+      )
   }
   object logMessage extends Endpoint[LogMessageParams, Unit]("window/logMessage") {
     def error(message: String)(implicit client: JsonRpcClient): Unit =

--- a/metals/src/main/resources/logback.groovy
+++ b/metals/src/main/resources/logback.groovy
@@ -8,7 +8,7 @@ appender("STDOUT", ch.qos.logback.core.ConsoleAppender) {
 
 appender("LSP", scala.meta.metals.LSPLogger) {
   encoder(PatternLayoutEncoder) {
-    pattern = defaultPattern
+    pattern = "%msg%n"
   }
 }
 

--- a/metals/src/main/scala/scala/meta/metals/LSPLogger.scala
+++ b/metals/src/main/scala/scala/meta/metals/LSPLogger.scala
@@ -6,6 +6,7 @@ import org.langmeta.lsp.Window._
 import org.langmeta.jsonrpc.JsonRpcClient
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder
 import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.Level
 import ch.qos.logback.core.AppenderBase
 
 class LSPLogger(@BeanProperty var encoder: PatternLayoutEncoder)
@@ -17,7 +18,12 @@ class LSPLogger(@BeanProperty var encoder: PatternLayoutEncoder)
       if (encoder != null) new String(encoder.encode(event), UTF_8)
       else event.getFormattedMessage
     notifications.foreach { implicit client =>
-      logMessage.log(message)
+      event.getLevel match {
+        case Level.ERROR => logMessage.error(message)
+        case Level.WARN => logMessage.warn(message)
+        case Level.INFO => logMessage.info(message)
+        case _ => logMessage.log(message)
+      }
     }
   }
 }


### PR DESCRIPTION
This does not address https://github.com/scalameta/metals/issues/227. It only
* adds missing log levels to the `showMessage`/`logMessage` notifications
* adds `showMessageRequest` request
* fixes log levels and simplifies formatting of the messages that are sent to the LSP client:
    <img width="689" alt="screen shot 2018-04-21 at 19 12 24" src="https://user-images.githubusercontent.com/766656/39086982-c89659ce-4599-11e8-8e22-e6414236f2b6.png">

    (before all these messages were sent with the `log` level)
