### PR TITLE
use sbt-ensime for the heavy lifting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -208,6 +208,7 @@ lazy val `sbt-metals` = project
     },
     publishMavenStyle := false,
     libraryDependencies --= libraryDependencies.in(ThisBuild).value,
+    libraryDependencies += "org.ensime" %% "sbt-ensime" % "2.6.0",
     scalacOptions --= Seq("-Yrangepos", "-Ywarn-unused-import"),
     scriptedBufferLog := !sys.env.contains("CI"),
     scriptedLaunchOpts ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.1.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.2")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.7")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.10")
 addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.0.0")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin(
   "com.thesamet" % "sbt-protoc" % "0.99.18" exclude ("com.trueaccord.scalapb", "protoc-bridge_2.12")

--- a/test-workspace/project/build.properties
+++ b/test-workspace/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.1.4


### PR DESCRIPTION
close #291 by reusing `ensime-sbt` instead of reinventing the wheel.

This only requires one small piece of code to be implemented. I think it's best if somebody from Metals does that.

You will benefit from 5+ years of industry hardening and an extensive test suite.

The ADT you are handed, for free, by calling this task is defined in https://github.com/ensime/ensime-sbt/blob/v2.6.0/src/main/scala/EnsimePlugin.scala#L756-L808

I recommend ignoring the 1.0 legacy fields.

You can disable the ensime server downloading by defining the task to return `Nil` but it's probably not worth the hassle.