### PR TITLE
Move provider tests into provider package

### DIFF
--- a/metals/src/test/scala/tests/CompilerSuite.scala
+++ b/metals/src/test/scala/tests/CompilerSuite.scala
@@ -1,12 +1,11 @@
-package tests.compiler
+package tests
+
+import org.langmeta.semanticdb.Document
 
 import scala.meta.interactive.InteractiveSemanticdb
 import scala.meta.metals.Uri
-import scala.meta.metals.compiler.Cursor
-import scala.meta.metals.compiler.ScalacProvider
+import scala.meta.metals.compiler.{Cursor, ScalacProvider}
 import scala.tools.nsc.interactive.Global
-import org.langmeta.semanticdb.Document
-import tests.MegaSuite
 
 class CompilerSuite extends MegaSuite {
   val compiler: Global = ScalacProvider.newCompiler(

--- a/metals/src/test/scala/tests/provider/BaseHoverProviderTest.scala
+++ b/metals/src/test/scala/tests/provider/BaseHoverProviderTest.scala
@@ -1,13 +1,14 @@
-package tests.hover
+package tests.provider
+
+import io.circe.syntax._
+import org.langmeta.lsp.Hover
+import tests.search.BaseIndexTest
 
 import scala.meta.metals.Uri
-import org.langmeta.lsp.Hover
 import scala.meta.metals.providers.HoverProvider
 import scala.{meta => m}
-import tests.search.BaseIndexTest
-import io.circe.syntax._
 
-abstract class BaseHoverTest extends BaseIndexTest {
+abstract class BaseHoverProviderTest extends BaseIndexTest {
 
   def check(
       filename: String,

--- a/metals/src/test/scala/tests/provider/CompletionsProviderTest.scala
+++ b/metals/src/test/scala/tests/provider/CompletionsProviderTest.scala
@@ -1,11 +1,12 @@
-package tests.compiler
+package tests.provider
 
-import org.langmeta.lsp.CompletionList
-import scala.meta.metals.providers.CompletionProvider
-import org.langmeta.lsp.CompletionItemKind
 import io.circe.syntax._
+import org.langmeta.lsp.{CompletionItemKind, CompletionList}
+import tests.CompilerSuite
 
-object CompletionsTest extends CompilerSuite {
+import scala.meta.metals.providers.CompletionProvider
+
+object CompletionsProviderTest extends CompilerSuite {
 
   def check(
       filename: String,

--- a/metals/src/test/scala/tests/provider/DiagnosticsProviderTest.scala
+++ b/metals/src/test/scala/tests/provider/DiagnosticsProviderTest.scala
@@ -1,28 +1,24 @@
-package tests.compiler
+package tests.provider
 
-import java.io.FileOutputStream
-import java.io.PipedOutputStream
-import java.io.PrintStream
-import java.nio.file.Files
-import java.nio.file.Path
-import scala.meta.internal.inputs._
-import scala.meta.metals.Configuration
-import scala.meta.metals.Linter
-import scala.meta.metals.Semanticdbs
-import org.langmeta.lsp.PublishDiagnostics
-import scala.meta.metals.providers.DiagnosticsProvider
+import java.io.{FileOutputStream, PipedOutputStream, PrintStream}
+import java.nio.file.{Files, Path}
+
+import com.typesafe.scalalogging.LazyLogging
 import monix.execution.Scheduler.Implicits.global
 import monix.reactive.Observable
 import org.langmeta.inputs.Input
-import org.langmeta.io.AbsolutePath
-import org.langmeta.io.RelativePath
+import org.langmeta.io.{AbsolutePath, RelativePath}
 import org.langmeta.languageserver.InputEnrichments._
-import org.langmeta.lsp.LanguageClient
-import com.typesafe.scalalogging.LazyLogging
+import org.langmeta.lsp.{LanguageClient, PublishDiagnostics}
+import tests.CompilerSuite
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.meta.internal.inputs._
+import scala.meta.metals.{Configuration, Linter, Semanticdbs}
+import scala.meta.metals.providers.DiagnosticsProvider
 
-object DiagnosticsTest extends CompilerSuite with LazyLogging {
+object DiagnosticsProviderTest extends CompilerSuite with LazyLogging {
   val tmp: Path = Files.createTempDirectory("metals")
   val logFile = tmp.resolve("metals.log").toFile
   val out = new PrintStream(new FileOutputStream(logFile))

--- a/metals/src/test/scala/tests/provider/HoverProviderTest.scala
+++ b/metals/src/test/scala/tests/provider/HoverProviderTest.scala
@@ -1,6 +1,6 @@
-package tests.hover
+package tests.provider
 
-object HoverTest extends BaseHoverTest {
+object HoverProviderTest extends BaseHoverProviderTest {
 
   check(
     "val assignment",

--- a/metals/src/test/scala/tests/provider/SignatureHelpProviderTest.scala
+++ b/metals/src/test/scala/tests/provider/SignatureHelpProviderTest.scala
@@ -1,10 +1,12 @@
-package tests.compiler
+package tests.provider
 
-import org.langmeta.lsp.SignatureHelp
-import scala.meta.metals.providers.SignatureHelpProvider
 import io.circe.syntax._
+import org.langmeta.lsp.SignatureHelp
+import tests.CompilerSuite
 
-object SignatureHelpTest extends CompilerSuite {
+import scala.meta.metals.providers.SignatureHelpProvider
+
+object SignatureHelpProviderTest extends CompilerSuite {
 
   def check(
       filename: String,

--- a/metals/src/test/scala/tests/refactoring/RemoveUnusedImportsTest.scala
+++ b/metals/src/test/scala/tests/refactoring/RemoveUnusedImportsTest.scala
@@ -4,7 +4,7 @@ import scala.meta.metals.Uri
 import scala.meta.metals.refactoring.OrganizeImports
 import scala.meta.metals.refactoring.TextEdits
 import org.langmeta.inputs.Input
-import tests.compiler.CompilerSuite
+import tests.CompilerSuite
 
 // This test suite is not supposed to test the actual scalafix implementation,
 // it is only supposed to check that the conversion from scalafix.Patch to

--- a/metals/src/test/scala/tests/search/BaseIndexTest.scala
+++ b/metals/src/test/scala/tests/search/BaseIndexTest.scala
@@ -7,13 +7,14 @@ import scala.meta.metals.Configuration
 import scala.meta.metals.Effects
 import scala.meta.metals.Uri
 import org.langmeta.jsonrpc.JsonRpcClient
+
 import scala.meta.metals.search.SymbolIndex
 import scala.{meta => m}
 import monix.execution.Scheduler.Implicits.global
 import monix.reactive.Observable
 import org.langmeta.internal.io.PathIO
 import org.langmeta.internal.semanticdb._
-import tests.compiler.CompilerSuite
+import tests.CompilerSuite
 
 abstract class BaseIndexTest extends CompilerSuite {
   val buffers = Buffers()


### PR DESCRIPTION
This pr just updates test file locations to match code under test packages along with the associated import changes (some import orders are changed due to IJ organize import functionality).