### PR TITLE
Coursier resolve to validate serverVersion, log to console if correct/incorrect

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -128,8 +128,10 @@ export async function activate(context: ExtensionContext) {
   spawn('java', resolveArgs)
     .on('exit', code => {
       if (code !== 0) {
-        const msg =  `Could not find Metals server artifact, ensure that metals.serverVersion setting is correct.
-                      Coursier resolve failed on:${artifact} with exit code:${code}.`.replace(/^(\s{2})+/gm, '');
+        const msg = [
+          'Could not find Metals server artifact, ensure that metals.serverVersion setting is correct.',
+          `Coursier resolve failed on:${artifact} with exit code:${code}.`
+        ].join('\n')
         window.showErrorMessage(msg);
         console.error(msg);
       } else {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,6 +1,7 @@
 "use strict";
 
 import * as path from "path";
+import * as cp from 'child_process';
 import { workspace, ExtensionContext, window, commands } from "vscode";
 import {
   LanguageClient,
@@ -23,22 +24,35 @@ export async function activate(context: ExtensionContext) {
 
   const serverVersion = workspace.getConfiguration("metals").get("serverVersion")
 
-  const coursierArgs = [
+  const javaArgs = [
+    `-XX:+UseG1GC`,
+    `-XX:+UseStringDeduplication`,
+    "-jar", coursierPath
+  ]
+
+  const artifact = `org.scalameta:metals_2.12:${serverVersion}`
+
+  //Validate the serverVersion resolves OK before attempting to launch it
+  const coursierResolveArgs = [
+      "resolve",
+      "-r", "bintray:scalameta/maven",
+      artifact,
+    ];
+
+  const resolveArgs = javaArgs.concat(coursierResolveArgs)
+
+  const coursierLaunchArgs = [
     "launch",
     "-r", "bintray:scalameta/maven",
     `org.scalameta:metals_2.12:${serverVersion}`,
     "-M", "scala.meta.metals.Main"
   ];
 
-  const javaArgs = [
-    `-XX:+UseG1GC`,
-    `-XX:+UseStringDeduplication`,
-    "-jar", coursierPath
-  ].concat(coursierArgs);
+  const launchArgs = javaArgs.concat(coursierLaunchArgs);
 
   const serverOptions: ServerOptions = {
-    run: { command: "java", args: javaArgs },
-    debug: { command: "java", args: debugOptions.concat(javaArgs) }
+    run: { command: "java", args: launchArgs },
+    debug: { command: "java", args: debugOptions.concat(launchArgs) }
   };
 
   const clientOptions: LanguageClientOptions = {
@@ -110,5 +124,18 @@ export async function activate(context: ExtensionContext) {
     );
   });
 
-  context.subscriptions.push(client.start(), restartServerCommand);
+
+  cp.spawn('java', resolveArgs)
+    .on('exit', function(code) {
+      if (code !== 0) {
+        console.error(
+          `Could not find Metals server artifact, ensure that metals.serverVersion setting is correct
+           Coursier resolve failed on:${artifact} with exit code:${code}.`
+        );
+      } else {
+        console.log(`Successfully resolved Metals server artifact: ${artifact}. Starting LanguageClient.`);
+        context.subscriptions.push(client.start(), restartServerCommand);
+      }
+    });
+
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -128,10 +128,10 @@ export async function activate(context: ExtensionContext) {
   spawn('java', resolveArgs)
     .on('exit', code => {
       if (code !== 0) {
-        console.error(
-          `Could not find Metals server artifact, ensure that metals.serverVersion setting is correct
-           Coursier resolve failed on:${artifact} with exit code:${code}.`
-        );
+        const msg =  `Could not find Metals server artifact, ensure that metals.serverVersion setting is correct.
+                      Coursier resolve failed on:${artifact} with exit code:${code}.`.replace(/^(\s{2})+/gm, '');
+        window.showErrorMessage(msg);
+        console.error(msg);
       } else {
         console.log(`Successfully resolved Metals server artifact: ${artifact}. Starting LanguageClient.`);
         context.subscriptions.push(client.start(), restartServerCommand);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import * as path from "path";
-import * as cp from 'child_process';
+import { spawn } from 'child_process';
 import { workspace, ExtensionContext, window, commands } from "vscode";
 import {
   LanguageClient,
@@ -125,8 +125,8 @@ export async function activate(context: ExtensionContext) {
   });
 
 
-  cp.spawn('java', resolveArgs)
-    .on('exit', function(code) {
+  spawn('java', resolveArgs)
+    .on('exit', code => {
       if (code !== 0) {
         console.error(
           `Could not find Metals server artifact, ensure that metals.serverVersion setting is correct


### PR DESCRIPTION
I'm not particularly fluent with JS nor VSCode APIs so this is a fairly basic implementation. It can definitely be refined further, such as @laughedelic suggestion of a progress bar. 

However I would say that its an improvement vs status quo; definitely better to have some feedback to user whether the metals server has been resolved successfully or not.

I have manually tested both the Happy and Unhappy paths.

Fixes #303 