### PR TITLE
Update links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ instructions are primarily intended for project contributors.
 
 ## Contributing
 
-See the [installation instructions](docs/installation.md) and
-[contributing guide](CONTRIBUTING.md).
+See the [contributing guide](https://scalameta.org/metals/docs/getting-started-contributors.html).
 
 ## Overview
 
-See [here](docs/overview.md) for an overview of a what features are supported or
+See [here](https://scalameta.org/metals/docs/overview.html) for an overview of a what features are supported or
 not supported by Metals.
 
 ### Team


### PR DESCRIPTION
The installation link was broken and I've simply removed it.

I've updated the contributing and the overview links to point to the website (the content is exactly the same, so this is just for consistency)