### PR TITLE
Parameter processId to initialize is optional

### DIFF
--- a/lsp4s/src/main/scala/org/langmeta/lsp/Commands.scala
+++ b/lsp4s/src/main/scala/org/langmeta/lsp/Commands.scala
@@ -11,7 +11,7 @@ import io.circe.generic.JsonCodec
      * The process Id of the parent process that started
      * the server.
      */
-    processId: Long,
+    processId: Option[Long],
     /**
      * The rootPath of the workspace. Is null
      * if no folder is open.

--- a/metals/src/test/scala/tests/search/SymbolIndexTest.scala
+++ b/metals/src/test/scala/tests/search/SymbolIndexTest.scala
@@ -63,7 +63,7 @@ object SymbolIndexTest extends MegaSuite with LazyLogging {
   val client = new LanguageClient(stdout, logger)
   val metals = new MetalsServices(cwd, client, mscheduler)
   metals
-    .initialize(InitializeParams(0L, cwd.toString(), ClientCapabilities()))
+    .initialize(InitializeParams(None, cwd.toString(), ClientCapabilities()))
     .runAsync(s)
   while (s.tickOne()) () // Trigger indexing
   val index: SymbolIndex = metals.symbolIndex


### PR DESCRIPTION
According to the specification, the processId parameter is optional.

Some LSP clients (for example, vim-lsp) do not provide this parameter.
Currently, Metals fails to initialize for those clients. Making this
parameter optional allows initialization to continue.

This parameter appears to be unused, so only the type has been changed.

https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-2-x.md#initialize