### PR TITLE
Remove debug options from vscode extensions

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -14,11 +14,6 @@ import {
 import { exec } from "child_process";
 
 export async function activate(context: ExtensionContext) {
-  // The debug options for the server
-  const debugOptions = [
-    "-Xdebug",
-    "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000,quiet=y"
-  ];
 
   const coursierPath = path.join(context.extensionPath, "./coursier");
 
@@ -52,7 +47,7 @@ export async function activate(context: ExtensionContext) {
 
   const serverOptions: ServerOptions = {
     run: { command: "java", args: launchArgs },
-    debug: { command: "java", args: debugOptions.concat(launchArgs) }
+    debug: { command: "java", args: launchArgs }
   };
 
   const clientOptions: LanguageClientOptions = {
@@ -123,7 +118,6 @@ export async function activate(context: ExtensionContext) {
       sbtConnectCommand
     );
   });
-
 
   spawn('java', resolveArgs)
     .on('exit', code => {


### PR DESCRIPTION
We've never used these options, they were copy-pasted from dragos' original implementation of the extension, and they've caused me an hour of headache because the JVM tried to bind the port 8000 (which was already bound on my computer) and failing with a cryptic error.