### PR TITLE
Clarify installation docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -260,6 +260,7 @@ lazy val docs = project
     moduleName := "metals-docs",
     mainClass.in(Compile) := Some("docs.Docs"),
     libraryDependencies ++= List(
+      "org.jsoup" % "jsoup" % "1.11.3",
       "com.geirsson" % "mdoc" % "0.6.0" cross CrossVersion.full
     )
   )

--- a/docs/editors/atom.md
+++ b/docs/editors/atom.md
@@ -3,10 +3,7 @@ id: atom
 title: Atom
 ---
 
-The [`ide-scala`](https://atom.io/packages/ide-scala) Atom plugin has
-experimental support for Metals. Please follow the installation instructions of
-the `ide-scala` plugin to setup Metals.
-
-```scala mdoc:requirements
-
-```
+Metals will soon work with Atom thanks to the
+[`ide-scala`](https://atom.io/packages/ide-scala) plugin. The `ide-scala` plugin
+is currently in the process of adding support for latest Metals version. Stay
+tuned for more updates.

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -29,6 +29,9 @@ Plug 'derekwyatt/vim-scala'
 Plug 'natebosch/vim-lsc'
 ```
 
+Run `:PlugInstall` to install the plugin. If you already have `vim-lsc`
+installed, be sure to update to the latest version with `:PlugUpdate`.
+
 ```scala mdoc:bootstrap:metals-vim vim-lsc
 
 ```

--- a/metals-docs/src/main/scala/docs/BootstrapModifier.scala
+++ b/metals-docs/src/main/scala/docs/BootstrapModifier.scala
@@ -3,11 +3,10 @@ package docs
 import mdoc.Reporter
 import mdoc.StringModifier
 import scala.meta.inputs.Input
-import scala.meta.internal.metals.BuildInfo
 
 class BootstrapModifier extends StringModifier {
   override val name: String = "bootstrap"
-
+  val snapshot = Snapshot.latest()
   override def process(
       info: String,
       code: Input,
@@ -20,17 +19,20 @@ class BootstrapModifier extends StringModifier {
            |[Coursier](https://github.com/coursier/coursier) (v1.1+) command-line interface.
            |
            |```sh
+           |# Build bootstrap binary with coursier
            |curl -L -o coursier https://git.io/coursier &&
            |    chmod +x coursier &&
            |./coursier bootstrap \\
+           |  --standalone \\
            |  --java-opt -XX:+UseG1GC \\
            |  --java-opt -XX:+UseStringDeduplication  \\
            |  --java-opt -Xss4m \\
            |  --java-opt -Xms1G \\
            |  --java-opt -Xmx4G  \\
            |  --java-opt -Dmetals.client=$client \\
-           |  org.scalameta:metals_2.12:${BuildInfo.metalsVersion} \\
+           |  org.scalameta:metals_2.12:${snapshot.version} \\
            |  -r bintray:scalacenter/releases \\
+           |  -r sonatype:snapshots \\
            |  -o $binary -f
            |```
            |

--- a/metals-docs/src/main/scala/docs/Docs.scala
+++ b/metals-docs/src/main/scala/docs/Docs.scala
@@ -6,7 +6,6 @@ import scala.meta.internal.metals.{BuildInfo => V}
 object Docs {
   def main(args: Array[String]): Unit = {
     val out = Paths.get("website", "target", "docs")
-    // build arguments for mdoc
     val settings = mdoc
       .MainSettings()
       .withSiteVariables(
@@ -20,9 +19,9 @@ object Docs {
       )
       .withOut(out)
       .withArgs(args.toList)
-    // generate out/readme.md from working directory
     val exitCode = mdoc.Main.process(settings)
-    // (optional) exit the main function with exit code 0 (success) or 1 (error)
-    if (exitCode != 0) sys.exit(exitCode)
+    if (exitCode != 0) {
+      sys.exit(exitCode)
+    }
   }
 }

--- a/metals-docs/src/main/scala/docs/RequirementsModifier.scala
+++ b/metals-docs/src/main/scala/docs/RequirementsModifier.scala
@@ -15,14 +15,12 @@ class RequirementsModifier extends StringModifier {
     s"""
        |## Requirements
        |
-       |**Java 8**. Metals does not yet work with Java 11, see
-       |[scalameta/scalameta#1779](https://github.com/scalameta/scalameta/issues/1779)
+       |**Java 8**. Metals does not work with Java 11 due to [sbt/zinc#602](https://github.com/sbt/zinc/pull/602).
        |
        |**macOS, Linux or Windows**. Metals is developed on macOS and every PR is tested on Ubuntu+Windows.
        |
-       |**Scala 2.12.7 and 2.11.12**. Metals works only with the latest Scala 2.12 and 2.11 versions.
-       |See [scalameta/scalameta#1695](https://github.com/scalameta/scalameta/issues/1695) for updates on
-       |adding support for Scala 2.13 once it's out.
+       |**Scala 2.12 and 2.11**. Metals works only with Scala versions
+       |2.12.{7,6,5,4} and 2.11.{12,11,10,9}. Note that 2.10.x and 2.13.0-M5 are not supported.
        |""".stripMargin
   }
 }

--- a/metals-docs/src/main/scala/docs/Snapshot.scala
+++ b/metals-docs/src/main/scala/docs/Snapshot.scala
@@ -1,0 +1,54 @@
+package docs
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import org.jsoup.Jsoup
+import scala.collection.JavaConverters._
+import scala.meta.internal.metals.BuildInfo
+import scala.util.control.NonFatal
+
+case class Snapshot(version: String, lastModified: Date)
+
+object Snapshot {
+  def latest(): Snapshot = {
+    if (System.getenv("CI") != null) {
+      try {
+        fetchLatest()
+      } catch {
+        case NonFatal(e) =>
+          scribe.error("unexpected error fetching SNAPSHOT version", e)
+          current
+      }
+    } else {
+      current
+    }
+  }
+
+  private def current: Snapshot = Snapshot(BuildInfo.metalsVersion, new Date())
+
+  /** Returns the latest published snapshot release, or the current release if. */
+  private def fetchLatest(): Snapshot = {
+    // maven-metadata.xml is consistently outdated so we scrape the "Last modified" column
+    // of the HTML page that lists all snapshot releases instead.
+    val doc = Jsoup
+      .connect(
+        "https://oss.sonatype.org/content/repositories/snapshots/org/scalameta/metals_2.12/"
+      )
+      .get
+    val dateTime = new SimpleDateFormat("EEE MMM d H:m:s z yyyy")
+    val snapshots: Seq[Snapshot] = doc.select("tr").asScala.flatMap { tr =>
+      val lastModified =
+        tr.select("td:nth-child(2)").text()
+      val version =
+        tr.select("td:nth-child(1)").text().stripSuffix("/")
+      if (lastModified.nonEmpty && !version.contains("maven-metadata")) {
+        val date = dateTime.parse(lastModified)
+        List(Snapshot(version, date))
+      } else {
+        List()
+      }
+    }
+    snapshots.maxBy(_.lastModified.getTime)
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
@@ -120,7 +120,7 @@ final class BloopInstall(
   def runIfApproved(sbt: Sbt, digest: String): Future[BloopInstallResult] = {
     oldInstallResult(digest) match {
       case Some(result) =>
-        scribe.info(s"Skipping build import with status '${result.name}'")
+        scribe.info(s"skipping build import with status '${result.name}'")
         Future.successful(result)
       case None =>
         for {

--- a/metals/src/main/scala/scala/meta/internal/metals/GlobalTrace.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/GlobalTrace.scala
@@ -30,7 +30,7 @@ object GlobalTrace {
     val tracePath = protocolTracePath(protocolName)
     val path = tracePath.toString()
     if (tracePath.isFile) {
-      scribe.info(s"Tracing is enabled: $path")
+      scribe.info(s"tracing is enabled: $path")
       val fos = Files.newOutputStream(
         tracePath.toNIO,
         StandardOpenOption.CREATE,
@@ -39,7 +39,7 @@ object GlobalTrace {
       new PrintWriter(fos)
     } else {
       scribe.info(
-        s"Tracing is disabled for protocol $protocolName, to enable tracing of incoming " +
+        s"tracing is disabled for protocol $protocolName, to enable tracing of incoming " +
           s"and outgoing JSON messages create an empty file at $path"
       )
       null

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -45,16 +45,18 @@ final case class MetalsServerConfig(
     ).mkString("MetalsServerConfig(\n  ", ",\n  ", "\n)")
 }
 object MetalsServerConfig {
+  def base: MetalsServerConfig = MetalsServerConfig()
   def default: MetalsServerConfig = {
     System.getProperty("metals.client", "default") match {
       case "vscode" =>
-        MetalsServerConfig().copy(
+        scribe.info(base.bloopProtocol.toString)
+        base.copy(
           statusBar = StatusBarConfig.on,
           slowTask = SlowTaskConfig.on,
           icons = Icons.octicons
         )
       case "vim-lsc" =>
-        MetalsServerConfig().copy(
+        base.copy(
           fileWatcher = FileWatcherConfig.auto,
           // window/logMessage output is always visible and non-invasive in vim-lsc
           statusBar = StatusBarConfig.logMessage,
@@ -63,7 +65,7 @@ object MetalsServerConfig {
           icons = Icons.unicode
         )
       case "sublime" =>
-        MetalsServerConfig().copy(
+        base.copy(
           fileWatcher = FileWatcherConfig.auto,
           isNoInitialized = true,
           isHttpEnabled = true,
@@ -74,7 +76,7 @@ object MetalsServerConfig {
           icons = Icons.unicode
         )
       case _ =>
-        MetalsServerConfig()
+        base
     }
   }
 }


### PR DESCRIPTION
- use latest published SNAPSHOT version. While Metals is
  changing frequently at every commit I think it's best to advertise
  SNAPSHOT versions instead of stable releases which will be less
  frequent.
- use latest vim-lsc plugin version