### PR TITLE
Publish sbt-metals maven style

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -174,6 +174,7 @@ lazy val metals = project
 lazy val `sbt-metals` = project
   .settings(
     sbtPlugin := true,
+    publishMavenStyle := true,
     crossScalaVersions := List(V.scala212, V.scala210),
     addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % V.sbtBloop),
     sbtVersion in pluginCrossBuild := {


### PR DESCRIPTION
This setting is required to publish sbt plugins to Maven Central.
Previously the plugin was published "ivy-style", which results in
resolution errors
```
 :: org.scalameta#sbt-metals;0.2.0+3-82fa2560-SNAPSHOT: not found
```