### PR TITLE
Fix 404 links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing
 
 Please refer to the documentation for contributors
-[on our website](https://scalameta.org/metals/docs/getting-started-contributors.html).
+[on our website](https://scalameta.org/metals/docs/contributors/getting-started.html).

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ instructions are primarily intended for project contributors.
 
 ## Contributing
 
-See the [contributing guide](https://scalameta.org/metals/docs/getting-started-contributors.html).
+See the [contributing guide](https://scalameta.org/metals/docs/contributors/getting-started.html).
 
 ## Overview
 
-See [here](https://scalameta.org/metals/docs/overview.html) for an overview of a what features are supported or
+See [here](https://scalameta.org/metals/docs/editors/overview.html) for an overview of a what features are supported or
 not supported by Metals.
 
 ### Team


### PR DESCRIPTION
Fixes #349 

This is a super lazy fix, I think generally the README could use some refactoring, but at least links are not broken now.