### PR TITLE
Publish status message for compile error

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -852,6 +852,12 @@ class MetalsLanguageServer(
                   s"${config.icons.check}Compiled$name in $elapsed"
                 )
               case StatusCode.ERROR =>
+                statusBar.addMessage(
+                  MetalsStatusParams(
+                    s"${config.icons.alert}Compile error in $elapsed",
+                    command = ClientCommands.FocusDiagnostics.id
+                  )
+                )
               case StatusCode.CANCELLED =>
             }
           }


### PR DESCRIPTION
We already publish status messages on compile success. When there was a
compile error however it looked like "Compiling ..." was frozen. It's
helpful to see this status since the diagnostics may be in a separate
file so you don't see red squiggles in your open buffer.

![2018-11-30 10 29 05](https://user-images.githubusercontent.com/1408093/49280561-cb672980-f48a-11e8-8e7d-3758ed624818.jpg)
