### PR TITLE
Add -Dmetals.verbose to enable verbose logging

### DIFF
--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -79,6 +79,13 @@ example, in vim-lsc the `window/logMessage` notification is always displayed in
 the UI so `-Dmetals.status-bar=log-message` can be configured to direct
 higher-priority messages to the logs.
 
+### `-Dmetals.verbose`
+
+Possible values:
+
+- `off` (default): don't log unnecessary details.
+- `on`: emit very detailed logs, should only be used when debugging problems.
+
 ### `-Dmetals.file-watcher`
 
 Possible values:

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -114,6 +114,11 @@ final class BloopServers(
     port
   }
 
+  private def bspCommand: Array[String] = {
+    if (config.isVerbose) Array("bsp", "--verbose")
+    else Array("bsp")
+  }
+
   private def callBSP(): Future[(BloopSocket, Cancelable)] = {
     if (config.bloopProtocol.isNamedPipe) callNamedPipeBsp()
     if (config.bloopProtocol.isTcp) callTcpBsp()
@@ -122,8 +127,7 @@ final class BloopServers(
 
   private def callNamedPipeBsp(): Future[(BloopSocket, Cancelable)] = {
     val pipeName = "\\\\.\\pipe\\metals" + Random.nextInt()
-    val args = Array(
-      "bsp",
+    val args = bspCommand ++ Array(
       "--protocol",
       "local",
       "--pipe-name",
@@ -145,8 +149,7 @@ final class BloopServers(
   private def callTcpBsp(): Future[(BloopSocket, Cancelable)] = {
     val host = "127.0.0.1"
     val port = randomPort(host)
-    val args = Array(
-      "bsp",
+    val args = bspCommand ++ Array(
       "--protocol",
       "tcp",
       "--host",
@@ -173,9 +176,7 @@ final class BloopServers(
 
   private def callUnixBsp(): Future[(BloopSocket, Cancelable)] = {
     val socket = BloopServers.newSocketFile()
-    val args = Array(
-      "bsp",
-      "--verbose",
+    val args = bspCommand ++ Array(
       "--protocol",
       "local",
       "--socket",

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -28,6 +28,7 @@ final case class MetalsServerConfig(
     isNoInitialized: Boolean =
       MetalsServerConfig.binaryOption("metals.no-initialized"),
     isHttpEnabled: Boolean = MetalsServerConfig.binaryOption("metals.http"),
+    isVerbose: Boolean = MetalsServerConfig.binaryOption("metals.verbose"),
     icons: Icons = Icons.default
 ) {
   override def toString: String =


### PR DESCRIPTION
The --verbose flag in bloop produces a lot of logs that are not relevant
unless you are troubleshooting issues. This commit disables --verbose
but allows users to turn it on if something is amiss.

cc/ @coreyoconnor 