### PR TITLE
Refine sbt build detection

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTools.scala
@@ -25,15 +25,18 @@ final class BuildTools(workspace: AbsolutePath) {
       hasJsonFile
     }
   }
+  // Returns true if there's a build.sbt file or project/build.properties with sbt.version
   def isSbt: Boolean = {
-    val buildProperties =
-      workspace.resolve("project").resolve("build.properties")
-    buildProperties.isFile && {
-      val props = new Properties()
-      val in = Files.newInputStream(buildProperties.toNIO)
-      try props.load(in)
-      finally in.close()
-      props.getProperty("sbt.version") != null
+    workspace.resolve("build.sbt").isFile || {
+      val buildProperties =
+        workspace.resolve("project").resolve("build.properties")
+      buildProperties.isFile && {
+        val props = new Properties()
+        val in = Files.newInputStream(buildProperties.toNIO)
+        try props.load(in)
+        finally in.close()
+        props.getProperty("sbt.version") != null
+      }
     }
   }
   def isMill: Boolean = workspace.resolve("build.sc").isFile

--- a/tests/unit/src/test/scala/tests/SbtDetectionSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtDetectionSuite.scala
@@ -24,29 +24,41 @@ object SbtDetectionSuite extends BaseSuite {
   )
 
   checkSbt(
-    "sbt.version",
-    """|/project/build.properties
-       |sbt.version = 0.13
-       |/build.sbt
-       |lazy val a = project
-       |""".stripMargin
-  )
-
-  checkSbt(
     "build.scala",
     """|/project/build.properties
        |sbt.version = 0.13
-       |/project/Build.scala
+       |/project/build.scala
        |import sbt._
        |""".stripMargin
   )
 
   checkSbt(
-    "gradle-property",
+    "sbt.version",
     """|/project/build.properties
-       |gradle.version = 0.13
-       |/build.sbt
-       |lazy val a = project
+       |sbt.version = 0.13
+       |""".stripMargin
+  )
+
+  checkNotSbt(
+    "no-properties",
+    """|/project/build.scala
+       |import sbt._
+       |/project/plugins.sbt
+       |addSbtPlugin(plugin)
+       |""".stripMargin
+  )
+
+  checkNotSbt(
+    "mill",
+    """|/mill.sc
+       |import mill._
+       |""".stripMargin
+  )
+
+  checkNotSbt(
+    "gradle",
+    """|/build.gradle
+       |import gradle._
        |""".stripMargin
   )
 

--- a/tests/unit/src/test/scala/tests/SbtDetectionSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtDetectionSuite.scala
@@ -16,7 +16,7 @@ object SbtDetectionSuite extends BaseSuite {
     }
   }
 
-  checkNotSbt(
+  checkSbt(
     "build.sbt",
     """|/build.sbt
        |lazy val a = project
@@ -41,7 +41,7 @@ object SbtDetectionSuite extends BaseSuite {
        |""".stripMargin
   )
 
-  checkNotSbt(
+  checkSbt(
     "gradle-property",
     """|/project/build.properties
        |gradle.version = 0.13

--- a/tests/unit/src/test/scala/tests/SbtDetectionSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtDetectionSuite.scala
@@ -1,0 +1,53 @@
+package tests
+
+import scala.meta.internal.metals.BuildTools
+
+object SbtDetectionSuite extends BaseSuite {
+  def checkNotSbt(name: String, layout: String): Unit = {
+    checkSbt(name, layout, isTrue = false)
+  }
+  def checkSbt(name: String, layout: String, isTrue: Boolean = true): Unit = {
+    test(name) {
+      val workspace = FileLayout.fromString(layout)
+      workspace.toFile.deleteOnExit()
+      val isSbt = new BuildTools(workspace).isSbt
+      if (isTrue) assert(isSbt)
+      else assert(!isSbt)
+    }
+  }
+
+  checkNotSbt(
+    "build.sbt",
+    """|/build.sbt
+       |lazy val a = project
+       |""".stripMargin
+  )
+
+  checkSbt(
+    "sbt.version",
+    """|/project/build.properties
+       |sbt.version = 0.13
+       |/build.sbt
+       |lazy val a = project
+       |""".stripMargin
+  )
+
+  checkSbt(
+    "build.scala",
+    """|/project/build.properties
+       |sbt.version = 0.13
+       |/project/Build.scala
+       |import sbt._
+       |""".stripMargin
+  )
+
+  checkNotSbt(
+    "gradle-property",
+    """|/project/build.properties
+       |gradle.version = 0.13
+       |/build.sbt
+       |lazy val a = project
+       |""".stripMargin
+  )
+
+}


### PR DESCRIPTION
The previous logic assumed all sbt builds have `build.sbt` but that is
not correct. This commit changes the logic to guard against
`project/build.properties` with a `sbt.version` key. This key is
used by the sbt launcher and the sbt launcher generates this file
when `project/build.properties` is missing.