### PR TITLE
Refine doctor messages.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -75,11 +75,12 @@ class Messages(icons: Icons) {
     def singleMisconfiguredProject(name: String): String =
       s"Navigation will not work in project '$name' since SemanticDB is not configured."
     def multipleMisconfiguredProjects(count: Int): String =
-      s"SemanticDB is not configured for $count projects for which navigation will not work."
+      s"Code navigation will not work for $count build targets in this workspace. " +
+        s"Select 'More information' to learn how to fix this problem."
     def isDoctor(params: ShowMessageRequestParams): Boolean =
-      params.getActions.asScala.contains(runDoctor)
-    def runDoctor: MessageActionItem =
-      new MessageActionItem("Run doctor to fix this problem")
+      params.getActions.asScala.contains(moreInformation)
+    def moreInformation: MessageActionItem =
+      new MessageActionItem("More information")
     def dismissForever: MessageActionItem =
       new MessageActionItem("Don't show again")
     def params(problem: String): ShowMessageRequestParams = {
@@ -88,7 +89,7 @@ class Messages(icons: Icons) {
       params.setType(MessageType.Warning)
       params.setActions(
         List(
-          runDoctor,
+          moreInformation,
           dismissForever
         ).asJava
       )

--- a/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
+++ b/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
@@ -2,6 +2,7 @@ package tests
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Future
+import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.MetalsSlowTaskResult
 import scala.meta.internal.metals.SbtDigest
@@ -263,6 +264,10 @@ object SbtSlowSuite extends BaseSlowSuite("import") {
           |package a/*<no symbol>*/
           |object A/*<no symbol>*/ // 2.10.7
           |""".stripMargin
+      )
+      _ = assertNoDiff(
+        client.workspaceClientCommands,
+        ClientCommands.RunDoctor.id
       )
     } yield ()
   }

--- a/tests/unit/src/main/scala/tests/BaseSlowSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseSlowSuite.scala
@@ -6,6 +6,7 @@ import scala.concurrent.ExecutionContextExecutorService
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.BloopProtocol
 import scala.meta.internal.metals.Buffers
+import scala.meta.internal.metals.ExecuteClientCommandConfig
 import scala.meta.internal.metals.FileWatcherConfig
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.io.AbsolutePath
@@ -39,8 +40,11 @@ abstract class BaseSlowSuite(suiteName: String) extends BaseSuite {
       .resolve(name.replace(' ', '-'))
     Files.createDirectories(workspace.toNIO)
     val buffers = Buffers()
-    val config = MetalsServerConfig.default
-      .copy(bloopProtocol = protocol, fileWatcher = FileWatcherConfig.auto)
+    val config = MetalsServerConfig.default.copy(
+      bloopProtocol = protocol,
+      fileWatcher = FileWatcherConfig.auto,
+      executeClientCommand = ExecuteClientCommandConfig.on
+    )
     client = new TestingClient(workspace, buffers)
     server = new TestingServer(workspace, client, buffers, config)(ex)
   }

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -40,6 +40,7 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
   val showMessages = new ConcurrentLinkedQueue[MessageParams]()
   val statusParams = new ConcurrentLinkedQueue[MetalsStatusParams]()
   val logMessages = new ConcurrentLinkedQueue[MessageParams]()
+  val clientCommands = new ConcurrentLinkedDeque[ExecuteCommandParams]()
   var slowTaskHandler: MetalsSlowTaskParams => Option[MetalsSlowTaskResult] = {
     _: MetalsSlowTaskParams =>
       None
@@ -47,8 +48,12 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
 
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams
-  ): Unit = {}
-
+  ): Unit = {
+    clientCommands.addLast(params)
+  }
+  def workspaceClientCommands: String = {
+    clientCommands.asScala.map(_.getCommand).mkString("\n")
+  }
   def statusBarHistory: String = {
     statusParams.asScala
       .map { params =>
@@ -159,7 +164,7 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
       } else if (params == Only212Navigation.params("2.11.12")) {
         Only212Navigation.dismissForever
       } else if (CheckDoctor.isDoctor(params)) {
-        null
+        CheckDoctor.moreInformation
       } else {
         throw new IllegalArgumentException(params.toString)
       }


### PR DESCRIPTION
- Add "Diagnostics" and "Goto definition" columns to Doctor table,
  remove "SemanticDB". This is more helpful for users trying to
  understand the implications of the warning sign. Also makes it clear
  that diagnostics still work for 2.10/2.13.
- Explain what the table lists, previously it was just a raw html table
  with no explanation.
- Use `th` for header row and align icons in the center, makes it more
  readable.
- Use clearer language in the import build warning message.
- Add test for `executeClientCommand`.


![screenshot 2018-12-01 at 15 02 59](https://user-images.githubusercontent.com/1408093/49329191-c03ff680-f57b-11e8-8a82-33c798a00a15.png)
![screenshot 2018-12-01 at 15 03 03](https://user-images.githubusercontent.com/1408093/49329192-c0d88d00-f57b-11e8-96f0-730e73dfa4e5.png)
