### PR TITLE
Rename doctor-run server command for consistency

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -6,7 +6,7 @@ package scala.meta.internal.metals
 object ClientCommands {
 
   val RunDoctor = Command(
-    "metals-run-doctor",
+    "metals-doctor-run",
     "Run Doctor",
     """Focus on a window displaying troubleshooting help from the Metals doctor.""".stripMargin,
     arguments =


### PR DESCRIPTION
All other commands use `<noun>-<verb>` so that the commands line
up nicely
```
doctor-run
doctor-disable
doctor-foobar
...
```
Not a big deal really, but consistency is good.