### PR TITLE
Inform the user when doctor problems have been fixed

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -13,6 +13,14 @@ object ClientCommands {
       """`string`, the HTML to display in the focused window.""".stripMargin
   )
 
+  val ReloadDoctor = Command(
+    "metals-doctor-reload",
+    "Reload doctor",
+    """Reload the HTML contents of an open Doctor window, if any. Should be ignored if there is no open doctor window.""".stripMargin,
+    arguments =
+      """`string`, the HTML to display in the focused window.""".stripMargin
+  )
+
   val ToggleLogs = Command(
     "metals-logs-toggle",
     "Toggle logs",

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -1,7 +1,10 @@
 package scala.meta.internal.metals
 
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.MessageType
 import scala.concurrent.ExecutionContext
 import scala.meta.internal.metals.Messages.CheckDoctor
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -18,11 +21,13 @@ final class Doctor(
     httpServer: () => Option[MetalsHttpServer],
     tables: Tables
 )(implicit ec: ExecutionContext) {
+  private val hasProblems = new AtomicBoolean(false)
 
   /** Returns a full HTML page for the HTTP client. */
-  def problemsHtmlPage: String = {
+  def problemsHtmlPage(url: String): String = {
+    val livereload = Urls.livereload(url)
     new HtmlBuilder()
-      .page("Metals Doctor") { html =>
+      .page("Metals Doctor", livereload) { html =>
         html.section("Build targets", buildTargetsTable)
       }
       .render
@@ -30,17 +35,38 @@ final class Doctor(
 
   /** Executes the "Run doctor" server command. */
   def executeRunDoctor(): Unit = {
+    executeDoctor(ClientCommands.RunDoctor, server => {
+      Urls.openBrowser(server.address + "/doctor")
+    })
+  }
+
+  /** Executes the "Reload doctor" server command. */
+  private def executeReloadDoctor(summary: Option[String]): Unit = {
+    val hasProblemsNow = summary.isDefined
+    if (hasProblems.get() && !hasProblemsNow) {
+      hasProblems.set(false)
+      languageClient.showMessage(CheckDoctor.problemsFixed)
+    }
+    executeDoctor(ClientCommands.ReloadDoctor, server => {
+      server.reload()
+    })
+  }
+
+  private def executeDoctor(
+      clientCommand: Command,
+      onServer: MetalsHttpServer => Unit
+  ): Unit = {
     if (config.executeClientCommand.isOn) {
       val html = buildTargetsHtml()
       val params = new ExecuteCommandParams(
-        ClientCommands.RunDoctor.id,
+        clientCommand.id,
         List(html: AnyRef).asJava
       )
       languageClient.metalsExecuteClientCommand(params)
     } else {
       httpServer() match {
         case Some(server) =>
-          Urls.openBrowser(server.address + "/doctor")
+          onServer(server)
         case None =>
           scribe.warn(
             "Unable to run doctor. To fix this problem enable -Dmetals.http=true"
@@ -51,13 +77,16 @@ final class Doctor(
 
   /** Checks if there are any potential problems and if any, notifies the user. */
   def check(): Unit = {
-    problemSummary match {
+    val summary = problemSummary
+    executeReloadDoctor(summary)
+    summary match {
       case Some(problem) =>
         val notification = tables.dismissedNotifications.DoctorWarning
         if (!notification.isDismissed) {
           notification.dismiss(2, TimeUnit.MINUTES)
           import scala.meta.internal.metals.Messages.CheckDoctor
           val params = CheckDoctor.params(problem)
+          hasProblems.set(true)
           languageClient.showMessageRequest(params).asScala.foreach { item =>
             if (item == CheckDoctor.moreInformation) {
               executeRunDoctor()

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -3,8 +3,6 @@ package scala.meta.internal.metals
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import org.eclipse.lsp4j.ExecuteCommandParams
-import org.eclipse.lsp4j.MessageParams
-import org.eclipse.lsp4j.MessageType
 import scala.concurrent.ExecutionContext
 import scala.meta.internal.metals.Messages.CheckDoctor
 import scala.meta.internal.metals.MetalsEnrichments._

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -70,6 +70,11 @@ class Messages(icons: Icons) {
   )
 
   object CheckDoctor {
+    def problemsFixed: MessageParams =
+      new MessageParams(
+        MessageType.Info,
+        "Build is correctly configured now, navigation will work for all build targets."
+      )
     def moreInfo: String =
       " Select 'More information' to learn how to fix this problem.."
     def allProjectsMisconfigured: String =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
@@ -218,8 +218,8 @@ final class MetalsHttpClient(
   private def nextId(): String = ids.getAndIncrement().toString
 
   def renderHtml: String = {
-    val head = s"""<script src="${url()}/livereload.js"></script>"""
-    val result = new HtmlBuilder().page("Metals", head) { html =>
+    val livereload = Urls.livereload(url())
+    val result = new HtmlBuilder().page("Metals", livereload) { html =>
       html
         .section(
           "metals/status",

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -284,7 +284,7 @@ class MetalsLanguageServer(
           this,
           () => render(),
           e => complete(e),
-          () => doctor.problemsHtmlPage
+          () => doctor.problemsHtmlPage(url)
         )
       )
       httpServer = Some(server)

--- a/metals/src/main/scala/scala/meta/internal/metals/Urls.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Urls.scala
@@ -11,6 +11,9 @@ object Urls {
   def docs(page: String): String =
     s"https://scalameta.org/metals/docs/$page.html"
 
+  def livereload(baseUrl: String): String =
+    s"""<script src="$baseUrl/livereload.js"></script>"""
+
   /**
    * Opens the user's default browser at the provided URL.
    */

--- a/test-workspace/build.sbt
+++ b/test-workspace/build.sbt
@@ -12,3 +12,4 @@ libraryDependencies ++= List(
   "com.lihaoyi" %% "sourcecode" % "0.1.4",
   "org.scalatest" %% "scalatest" % "3.0.5"
 )
+

--- a/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
+++ b/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
@@ -265,10 +265,28 @@ object SbtSlowSuite extends BaseSlowSuite("import") {
           |object A/*<no symbol>*/ // 2.10.7
           |""".stripMargin
       )
-      _ = assertNoDiff(
-        client.workspaceClientCommands,
-        ClientCommands.RunDoctor.id
-      )
+      _ = {
+        assertNoDiff(
+          client.workspaceClientCommands,
+          List(
+            ClientCommands.ReloadDoctor.id,
+            ClientCommands.RunDoctor.id
+          ).mkString("\n")
+        )
+        client.showMessages.clear()
+        client.clientCommands.clear()
+      }
+      _ <- server.didSave("build.sbt")(_ => """scalaVersion := "2.12.7" """)
+      _ = {
+        assertNoDiff(
+          client.workspaceClientCommands,
+          ClientCommands.ReloadDoctor.id
+        )
+        assertNoDiff(
+          client.workspaceShowMessages,
+          CheckDoctor.problemsFixed.getMessage
+        )
+      }
     } yield ()
   }
 


### PR DESCRIPTION
This commit adds two changes:

- `metals-doctor-reload` client command to trigger a reload if a doctor
  window, if such a window exists.
- a new `showMessage` information message to inform the user when build
  mis-configuration has been fixed.

Demo of the auto-reloading doctor window, recorded before the `showMessage` got added.
![2018-12-05 16 46 36](https://user-images.githubusercontent.com/1408093/49530142-ea652180-f8b7-11e8-9b84-062e0634acee.gif)


Thanks to @jvican for the idea!