### PR TITLE
Improve sbt launcher.

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,203 @@
+# License notice for the IntelliJ Scala plugin
+
+Metals contains parts which are derived from
+[the IntelliJ Scala project](https://github.com/JetBrains/intellij-scala).
+We include the text of the original license below:
+
+```
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+   Copyright 2007-2017 JetBrains s.r.o.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   
+```
+

--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -177,6 +177,27 @@ Possible values:
   on Windows for communicating with the Bloop build server.
 - `tcp`: use TCP sockets for communicating with the Bloop build server.
 
+```scala mdoc:user-config:system-property
+
+```
+
+## Metals user configuration
+
+Users can customize the Metals server through the LSP
+`workspace/didChangeConfiguration` notification. Unlike server properties, it is
+normal for regular Metals users to configure these options.
+
+User configuration options can optionally be provided via server properties
+using the `-Dmetals.` prefix. System properties may be helpful for editor
+clients that don't support `workspace/didChangeConfiguration`. In case user
+configuration is defined both via system properties and
+`workspace/didChangeConfiguration`, then `workspace/didChangeConfiguration`
+takes precedence.
+
+```scala mdoc:user-config:lsp-config
+
+```
+
 ## Metals server commands
 
 The client can trigger one of the following commands through the
@@ -423,6 +444,10 @@ outside of the editor such as during `git checkout`.
 ### `workspace/executeCommands`
 
 Used to trigger a [Metals server command](#metals-server-commands).
+
+### `workspace/didChangeConfiguration`
+
+Used to update [Metals user configuration](#metals-user-configuration).
 
 ### `window/logMessage`
 

--- a/metals-docs/src/main/resources/META-INF/services/mdoc.StringModifier
+++ b/metals-docs/src/main/resources/META-INF/services/mdoc.StringModifier
@@ -1,3 +1,4 @@
+docs.UserConfigurationModifier
 docs.CustomizeBloopModifier
 docs.TextEditorModifier
 docs.CommandsModifiers

--- a/metals-docs/src/main/scala/docs/UserConfigurationModifier.scala
+++ b/metals-docs/src/main/scala/docs/UserConfigurationModifier.scala
@@ -1,0 +1,55 @@
+package docs
+
+import mdoc.Reporter
+import mdoc.StringModifier
+import scala.meta.inputs.Input
+import scala.meta.internal.metals.UserConfiguration
+
+class UserConfigurationModifier extends StringModifier {
+  val name = "user-config"
+
+  override def process(
+      info: String,
+      code: Input,
+      reporter: Reporter
+  ): String = {
+    info match {
+      case "system-property" =>
+        UserConfiguration.options
+          .map { option =>
+            s"""
+               |### `-Dmetals.${option.key}`
+               |
+               |${option.description}
+               |
+               |Default: ${option.default}
+               |
+               |See also [user configuration `"${option.key}"`](#${option.key}).
+               |""".stripMargin
+          }
+          .mkString("\n")
+      case "lsp-config" =>
+        UserConfiguration.options
+          .map { option =>
+            s"""
+               |### `"${option.key}"`
+               |
+               |${option.description}
+               |
+               |**Default**: ${option.default}
+               |
+               |**Example**:
+               |```json
+               |{
+               |  "${option.key}": "${option.example}"
+               |}
+               |```
+               |""".stripMargin
+          }
+          .mkString("\n")
+      case els =>
+        reporter.error(s"unknown user-config '$els'")
+        ""
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
@@ -1,0 +1,17 @@
+package scala.meta.internal.metals
+
+import scala.meta.io.AbsolutePath
+
+object JavaBinary {
+
+  /**
+   * Returns absolute path to the `java` binary of the configured Java Home directory.
+   */
+  def apply(javaHome: Option[String]): String = {
+    javaHome
+      .orElse(JdkSources.defaultJavaHome)
+      .map(AbsolutePath(_).resolve("bin").resolve("java").toString())
+      .getOrElse("java")
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/JvmOpts.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JvmOpts.scala
@@ -1,0 +1,26 @@
+package scala.meta.internal.metals
+// See NOTICE.md, this file contains parts that are derived from
+// IntelliJ Scala, in particular JvmOpts.scala:
+// https://github.com/JetBrains/intellij-scala/blob/e2c57778bb302a6f2f93e2628f6762ecbf76fb3a/scala/scala-impl/src/org/jetbrains/sbt/project/structure/JvmOpts.scala
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import scala.meta.internal.io.FileIO
+import scala.meta.io.AbsolutePath
+
+/**
+ * Support for the .jvmopts file loaded by the sbt launcher script as alternative to command line options.
+ */
+object JvmOpts {
+
+  def loadFrom(workspace: AbsolutePath): List[String] = {
+    val jvmOpts = workspace.resolve(".jvmopts")
+    if (jvmOpts.isFile && Files.isReadable(jvmOpts.toNIO)) {
+      val text = FileIO.slurp(jvmOpts, StandardCharsets.UTF_8)
+      text.lines.map(_.trim).filter(_.startsWith("-")).toList
+    } else {
+      Nil
+    }
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -87,7 +87,7 @@ class MetalsLanguageServer(
   def connectToLanguageClient(client: MetalsLanguageClient): Unit = {
     languageClient = client
     statusBar = new StatusBar(() => languageClient, time, progressTicks)
-    embedded = register(new Embedded(config.icons, statusBar))
+    embedded = register(new Embedded(config.icons, statusBar, () => userConfig))
     LanguageClientLogger.languageClient = Some(client)
     cancelables
       .add(() => languageClient.shutdown())
@@ -134,7 +134,8 @@ class MetalsLanguageServer(
         messages,
         config,
         embedded,
-        statusBar
+        statusBar,
+        () => userConfig
       )
     )
     bloopServers = new BloopServers(
@@ -433,7 +434,7 @@ class MetalsLanguageServer(
   @JsonNotification("workspace/didChangeConfiguration")
   def didChangeConfiguration(params: DidChangeConfigurationParams): Unit = {
     val json = params.getSettings.asInstanceOf[JsonElement].getAsJsonObject
-    UserConfiguration.fromJson(userConfig, json) match {
+    UserConfiguration.fromJson(json) match {
       case Left(errors) =>
         errors.foreach { error =>
           scribe.error(s"config error: $error")

--- a/metals/src/main/scala/scala/meta/internal/metals/SbtOpts.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SbtOpts.scala
@@ -1,0 +1,63 @@
+package scala.meta.internal.metals
+// See NOTICE.md, this file contains parts that are derived from
+// IntelliJ Scala, in particular SbtOpts.scala:
+// https://github.com/JetBrains/intellij-scala/blob/e2c57778bb302a6f2f93e2628f6762ecbf76fb3a/scala/scala-impl/src/org/jetbrains/sbt/project/structure/SbtOpts.scala
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import scala.meta.internal.io.FileIO
+import scala.meta.io.AbsolutePath
+
+/**
+ * Support for the .sbtopts file loaded by the sbt launcher script as alternative to command line options.
+ */
+object SbtOpts {
+
+  def loadFrom(workspace: AbsolutePath): List[String] = {
+    val sbtOpts = workspace.resolve(".sbtopts")
+    if (sbtOpts.isFile && Files.isReadable(sbtOpts.toNIO)) {
+      val text = FileIO.slurp(sbtOpts, StandardCharsets.UTF_8)
+      process(text.lines.map(_.trim).toList)
+    } else {
+      Nil
+    }
+  }
+
+  private val noShareOpts =
+    "-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
+  private val noGlobalOpts = "-Dsbt.global.base=project/.sbtboot"
+  private val debuggerOpts =
+    "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address="
+
+  private val sbtToJdkOpts: Map[String, String] = Map(
+    "-sbt-boot" -> "-Dsbt.boot.directory=",
+    "-sbt-dir" -> "-Dsbt.global.base=",
+    "-ivy" -> "-Dsbt.ivy.home=",
+    "-jvm-debug" -> debuggerOpts
+  )
+
+  private def process(opts: List[String]): List[String] = {
+    opts.flatMap { opt =>
+      if (opt.startsWith("-no-share"))
+        Some(noShareOpts)
+      else if (opt.startsWith("-no-global"))
+        Some(noGlobalOpts)
+      else if (sbtToJdkOpts.exists { case (k, _) => opt.startsWith(k) })
+        processOptWithArg(opt)
+      else if (opt.startsWith("-J"))
+        Some(opt.substring(2))
+      else if (opt.startsWith("-D"))
+        Some(opt)
+      else
+        None
+    }
+  }
+
+  private def processOptWithArg(opt: String): Option[String] = {
+    sbtToJdkOpts.find { case (k, _) => opt.startsWith(k) }.flatMap {
+      case (k, x) =>
+        val v = opt.replace(k, "").trim
+        if (v.isEmpty) None else Some(x + v)
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/StringCase.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StringCase.scala
@@ -1,0 +1,29 @@
+package scala.meta.internal.metals
+
+object StringCase {
+  private val Kebab = "-([a-z])".r
+  private val Camel = "([A-Z])".r
+  def kebabToCamel(kebab: String): String = {
+    val m = Kebab.pattern.matcher(kebab)
+    val sb = new StringBuffer
+    while (m.find()) {
+      m.appendReplacement(
+        sb,
+        m.group().charAt(1).toUpper + m.group().substring(2)
+      )
+    }
+    m.appendTail(sb)
+    sb.toString
+  }
+
+  def camelToKebab(camel: String): String = {
+    val m = Camel.pattern.matcher(camel)
+    val sb = new StringBuffer
+    while (m.find()) {
+      m.appendReplacement(sb, "-" + m.group().toLowerCase())
+    }
+    m.appendTail(sb)
+    sb.toString
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -1,8 +1,10 @@
 package scala.meta.internal.metals
 
 import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import java.util.Properties
 import scala.collection.mutable.ListBuffer
-import scala.util.control.NonFatal
+import scala.util.Try
 
 /**
  * Configuration that the user can override via workspace/didChangeConfiguration.
@@ -10,35 +12,81 @@ import scala.util.control.NonFatal
  * @param javaHome The Java home location used to detect src.zip for JDK sources.
  */
 case class UserConfiguration(
-    javaHome: Option[String] = None
+    javaHome: Option[String] = None,
+    sbtLauncher: Option[String] = None,
+    sbtOpts: List[String] = Nil
 )
 
 object UserConfiguration {
+  def options: List[UserConfigurationOption] = List(
+    UserConfigurationOption(
+      "java-home",
+      "`JAVA_HOME` environment variable with fallback to `user.home` system property.",
+      "/Library/Java/JavaVirtualMachines/jdk1.8.0_192.jdk/Contents/Home",
+      "Java Home directory",
+      "The Java Home directory used for indexing JDK sources and locating the `java` binary."
+    ),
+    UserConfigurationOption(
+      "sbt-launcher",
+      "Metals embedded sbt-launch.jar.",
+      "/usr/local/Cellar/sbt/1.2.6/libexec/bin/sbt-launch.jar",
+      "sbt launcher jar",
+      "Optional sbt-launch.jar launcher to use when running `sbt bloopInstall`."
+    ),
+    UserConfigurationOption(
+      "sbt-options",
+      """empty string `""`.""",
+      "-Dsbt.override.build.repos=true -Divy.home=/home/ivy-cache",
+      "sbt JVM options",
+      """Additional space separated JVM options used for the `sbt bloopInstall` step.
+        |By default, Metals respects custom options in `.jvmopts` and `.sbtopts` of the workspace root directory,
+        |it's recommended to use those instead of customizing this setting. The benefit of `.jvmopts` and `.sbtopts`
+        |is that it's respected by other tools such as IntelliJ.
+        |""".stripMargin
+    )
+  )
+
   def fromJson(
-      base: UserConfiguration,
-      json: JsonObject
+      json: JsonObject,
+      properties: Properties = System.getProperties
   ): Either[List[String], UserConfiguration] = {
     val errors = ListBuffer.empty[String]
 
-    val javaHome: Option[String] =
-      if (json.has("javaHome")) {
-        try {
-          val string = json.get("javaHome").getAsString
-          if (string.isEmpty) None
-          else Some(string)
-        } catch {
-          case NonFatal(e) =>
-            errors += e.getMessage
-            base.javaHome
-        }
-      } else {
-        base.javaHome
+    def getKey(key: String): Option[String] = {
+      def option[T](fn: String => T): Option[T] =
+        Option(fn(key)).orElse(Option(fn(StringCase.kebabToCamel(key))))
+      for {
+        value <- option(json.get)
+          .orElse(
+            option(k => properties.getProperty(s"metals.$k"))
+              .map(new JsonPrimitive(_))
+          )
+        string <- Try(value.getAsString).fold(
+          e => {
+            errors += s"json error: key '$key' should have value of type string but obtained $value"
+            None
+          },
+          Some(_)
+        )
+      } yield string
+    }
+
+    val javaHome =
+      getKey("java-home")
+    val sbtLauncher =
+      getKey("sbt-launcher")
+    val sbtOpts =
+      getKey("sbt-options") match {
+        case Some(value) => value.split(" ").toList
+        case None => Nil
       }
 
     if (errors.isEmpty) {
       Right(
         UserConfiguration(
-          javaHome
+          javaHome,
+          sbtLauncher,
+          sbtOpts
         )
       )
     } else {

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfigurationOption.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfigurationOption.scala
@@ -1,0 +1,14 @@
+package scala.meta.internal.metals
+
+/**
+ * A setting that users can configure via LSP workspace/didChangeConfiguration.
+ *
+ * @see `UserConfiguration.options` for available options.
+ */
+case class UserConfigurationOption(
+    key: String,
+    default: String,
+    example: String,
+    title: String,
+    description: String
+)

--- a/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
+++ b/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
@@ -298,4 +298,30 @@ object SbtSlowSuite extends BaseSlowSuite("import") {
     } yield ()
   }
 
+  testAsync("sbtopts") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        """
+          |/project/build.properties
+          |sbt.version=1.2.6
+          |/build.sbt
+          |scalaVersion := "2.12.7"
+          |libraryDependencies +=
+          |  // dependency won't resolve without the `bintray:scalacenter/releases` resolver
+          |  // that is defined in the `custom-repositories` file.
+          |  "ch.epfl.scala" %% "bloop-config" % "1.0.0-RC1+4-c5e24b66"
+          |/.sbtopts
+          |-Dsbt.repository.config=custom-repositories
+          |/custom-repositories
+          |[repositories]
+          |  local
+          |  maven: https://repo1.maven.org/maven2/
+          |  scalacenter-releases: https://dl.bintray.com/scalacenter/releases
+          |""".stripMargin
+      )
+      _ = assertStatus(_.isInstalled)
+    } yield ()
+  }
+
 }

--- a/tests/unit/src/test/scala/tests/BspCli.scala
+++ b/tests/unit/src/test/scala/tests/BspCli.scala
@@ -30,6 +30,7 @@ import scala.meta.internal.metals.MetalsStatusParams
 import scala.meta.internal.metals.ProgressTicks
 import scala.meta.internal.metals.StatusBar
 import scala.meta.internal.metals.Time
+import scala.meta.internal.metals.UserConfiguration
 import scala.meta.io.AbsolutePath
 
 object BspCli {
@@ -53,7 +54,7 @@ object BspCli {
         val time = Time.system
         val statusBar: StatusBar =
           new StatusBar(() => loggingLangaugeClient, time, ProgressTicks.none)
-        val embedded = new Embedded(icons, statusBar)
+        val embedded = new Embedded(icons, statusBar, () => UserConfiguration())
         val server = new BloopServers(
           sh,
           workspace,

--- a/tests/unit/src/test/scala/tests/SbtOptsSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtOptsSuite.scala
@@ -1,0 +1,47 @@
+package tests
+
+import scala.meta.internal.metals.JvmOpts
+import scala.meta.internal.metals.SbtOpts
+
+object SbtOptsSuite extends BaseSuite {
+  def check(name: String, original: String, expected: String): Unit = {
+    test(name) {
+      val root = FileLayout.fromString(original)
+      val obtained =
+        SbtOpts.loadFrom(root).mkString("\n") ++
+          JvmOpts.loadFrom(root).mkString("\n")
+      assertNoDiff(obtained, expected)
+    }
+  }
+  check(
+    "sbtopts",
+    """
+      |/.sbtopts
+      |-sbt-boot /some/where/sbt/boot
+      |-sbt-dir /some/where/else/sbt
+      |-ivy /some/where/ivy
+      |-jvm-debug 4711
+      |
+    """.stripMargin,
+    """
+      |-Dsbt.boot.directory=/some/where/sbt/boot
+      |-Dsbt.global.base=/some/where/else/sbt
+      |-Dsbt.ivy.home=/some/where/ivy
+      |-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=4711
+    """.stripMargin
+  )
+
+  check(
+    "jvmopts",
+    """
+      |/.jvmopts
+      |-Xmx2G
+      |-Dhoodlump=bloom
+    """.stripMargin,
+    """
+      |-Xmx2G
+      |-Dhoodlump=bloom
+    """.stripMargin
+  )
+
+}

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -1,0 +1,127 @@
+package tests
+
+import com.google.gson.JsonParser
+import java.util.Properties
+import scala.meta.internal.metals.UserConfiguration
+import scala.collection.JavaConverters._
+
+object UserConfigurationSuite extends BaseSuite {
+  def check(
+      name: String,
+      original: String,
+      props: Map[String, String] = Map.empty
+  )(fn: Either[List[String], UserConfiguration] => Unit): Unit = {
+    test(name) {
+      val json = new JsonParser().parse(original).getAsJsonObject
+      val jprops = new Properties()
+      jprops.putAll(props.asJava)
+      val obtained = UserConfiguration.fromJson(json, jprops)
+      fn(obtained)
+    }
+  }
+
+  def checkOK(
+      name: String,
+      original: String,
+      props: Map[String, String] = Map.empty
+  )(fn: UserConfiguration => Unit): Unit = {
+    check(name, original, props) {
+      case Left(errs) =>
+        fail(s"Expected success. Obtained error: $errs")
+      case Right(obtained) =>
+        fn(obtained)
+    }
+  }
+  def checkError(
+      name: String,
+      original: String,
+      expected: String
+  ): Unit = {
+    check(name, original) {
+      case Right(ok) =>
+        fail(s"Expected error. Obtained successful value $ok")
+      case Left(errs) =>
+        val obtained = errs.mkString("\n")
+        assertNoDiff(obtained, expected)
+    }
+  }
+
+  checkOK(
+    "basic",
+    """
+      |{
+      | "sbt-launcher": "launch",
+      | "java-home": "home",
+      | "sbt-options": "a b"
+      |}
+    """.stripMargin
+  ) { obtained =>
+    assert(obtained.javaHome == Some("home"))
+    assert(obtained.sbtLauncher == Some("launch"))
+    assert(obtained.sbtOpts == List("a", "b"))
+  }
+
+  checkOK(
+    "empty",
+    "{}"
+  ) { obtained =>
+    assert(obtained.javaHome.isEmpty)
+    assert(obtained.sbtLauncher.isEmpty)
+    assert(obtained.sbtOpts.isEmpty)
+  }
+
+  checkOK(
+    "sys-props",
+    """
+      |{
+      |}
+    """.stripMargin,
+    Map(
+      "metals.sbt-launcher" -> "launch",
+      "metals.java-home" -> "home",
+      "metals.sbt-options" -> "a b"
+    )
+  ) { obtained =>
+    assert(obtained.javaHome == Some("home"))
+    assert(obtained.sbtLauncher == Some("launch"))
+    assert(obtained.sbtOpts == List("a", "b"))
+  }
+
+  // we support camel case to not break existing clients using `javaHome`.
+  checkOK(
+    "camel",
+    """
+      |{
+      |  "javaHome": "home"
+      |}
+    """.stripMargin
+  ) { obtained =>
+    assert(obtained.javaHome == Some("home"))
+  }
+
+  checkOK(
+    "conflict",
+    """
+      |{
+      |  "java-home": "a"
+      |}
+    """.stripMargin,
+    Map(
+      "metals.java-home" -> "b"
+    )
+  ) { obtained =>
+    assert(obtained.javaHome == Some("a"))
+  }
+
+  checkError(
+    "type-mismatch",
+    """
+      |{
+      | "sbt-launcher": []
+      |}
+    """.stripMargin,
+    """
+      |json error: key 'sbt-launcher' should have value of type string but obtained []
+    """.stripMargin
+  )
+}


### PR DESCRIPTION
This commit improves how the `sbt bloopInstall` step reproduces
the user's `sbt` command.

- Respect .sbtopts and .jvmopts
- Use fully-qualified `java` binary
- Allow users to pass in custom sbt JVM options via
  `workspace/didChangeConfiguration` or system properties.

We borrow some code from IntelliJ Scala to ensure our handling of
`.sbtopts` is not a blind guess of how it's interpreted normally.

We don't system process to an `sbt` command because that failed CI on
Windows. We might end up having to go that route if this doesn't work
but I want to first try and use the same approach as IntelliJ here.

Towards #383