### PR TITLE
Remove old roadmap.md document

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -1,1 +1,0 @@
-This document has moved to [here](docs/overview.md).


### PR DESCRIPTION
`roadmap.md` points to a 404, as reported by @lambdista on Twitter.

In general, we had a few markdown files scattered around before we had a website and we subsequently added pointers to them for retro-compatibility.

I think this specific document can go, users can refer to the website for up-to-date information.