### PR TITLE
Fix handling of didChangeConfiguration payload

### DIFF
--- a/metals-docs/src/main/scala/docs/UserConfigurationModifier.scala
+++ b/metals-docs/src/main/scala/docs/UserConfigurationModifier.scala
@@ -41,10 +41,8 @@ class UserConfigurationModifier extends StringModifier {
                |**Example**:
                |```json
                |{
-               |  "settings": {
-               |    "metals": {
-               |      "${option.key}": "${option.example}"
-               |    }
+               |  "metals": {
+               |    "${option.key}": "${option.example}"
                |  }
                |}
                |```

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -67,8 +67,7 @@ object UserConfiguration {
     val errors = ListBuffer.empty[String]
     val base: JsonObject =
       (for {
-        settings <- Option(json.getAsJsonObject("settings"))
-        metals <- Option(settings.getAsJsonObject("metals"))
+        metals <- Option(json.getAsJsonObject("metals"))
       } yield metals).getOrElse(new JsonObject)
 
     def getKey(key: String): Option[String] = {
@@ -117,5 +116,5 @@ object UserConfiguration {
   }
 
   def toWrappedJson(config: String): String =
-    s"""{"settings":{"metals": $config}}"""
+    s"""{"metals": $config}"""
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -66,9 +66,7 @@ object UserConfiguration {
   ): Either[List[String], UserConfiguration] = {
     val errors = ListBuffer.empty[String]
     val base: JsonObject =
-      (for {
-        metals <- Option(json.getAsJsonObject("metals"))
-      } yield metals).getOrElse(new JsonObject)
+      Option(json.getAsJsonObject("metals")).getOrElse(new JsonObject)
 
     def getKey(key: String): Option[String] = {
       def option[T](fn: String => T): Option[T] =


### PR DESCRIPTION
Fix for https://github.com/scalameta/metals/pull/387#discussion_r240047421

The `"settings"` key is part of the protocol, so it's already de-serialized by lsp4j.