### PR TITLE
Filter out empty config strings

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -78,12 +78,13 @@ object UserConfiguration {
               .map(new JsonPrimitive(_))
           )
         string <- Try(value.getAsString).fold(
-          e => {
+          _ => {
             errors += s"json error: key '$key' should have value of type string but obtained $value"
             None
           },
           Some(_)
         )
+        if string.nonEmpty
       } yield string
     }
 

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -65,13 +65,20 @@ object UserConfigurationSuite extends BaseSuite {
   }
 
   checkOK(
-    "empty",
+    "empty-object",
     "{}"
   ) { obtained =>
     assert(obtained.javaHome.isEmpty)
     assert(obtained.sbtLauncher.isEmpty)
     assert(obtained.sbtOpts.isEmpty)
     assert(obtained.sbtScript.isEmpty)
+  }
+
+  checkOK(
+    "empty-string",
+    "{'java-home':''}"
+  ) { obtained =>
+    assert(obtained.javaHome.isEmpty)
   }
 
   checkOK(


### PR DESCRIPTION
Previously, we would accept `javaHome=Some("")`, which would
then result in trying to read the empty path directory `""`.