### PR TITLE
Update editor installation instructions based on feedback

### DIFF
--- a/docs/editors/atom.md
+++ b/docs/editors/atom.md
@@ -37,3 +37,7 @@ features.
 
 Run the "Reload Window" command after updating the setting for the new version
 to take effect.
+
+```scala mdoc:generic
+
+```

--- a/docs/editors/atom.md
+++ b/docs/editors/atom.md
@@ -25,3 +25,15 @@ apm install ide-scala
 ```scala mdoc:editor:atom
 
 ```
+
+## Using latest Metals SNAPSHOT
+
+Update the "Metals version" setting to try out the latest pending Metals
+features.
+
+```scala mdoc:releases
+
+```
+
+Run the "Reload Window" command after updating the setting for the new version
+to take effect.

--- a/docs/editors/sublime.md
+++ b/docs/editors/sublime.md
@@ -98,3 +98,7 @@ sources with "Goto definition" by pressing `F12`.
   it necessary to import the build via the browser instead of inside the editor.
 - The Sublime Text client uses an invasive alert window for
   `window/showMessage`, so Metals uses `window/logMessage` instead.
+
+```scala mdoc:generic
+
+```

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -21,9 +21,9 @@ First, install the following plugins
 - [`derekwyatt/vim-scala`](https://github.com/derekwyatt/vim-scala): for syntax
   highlighting Scala and sbt source files.
 
-Assuming [`vim-plug`](https://github.com/junegunn/vim-plug) is used for
-installing plugin (another plugin manager like vundle works too), update
-`~/.vimrc` to include the following settings.
+Assuming [`vim-plug`](https://github.com/junegunn/vim-plug) is used (another
+plugin manager like vundle works too), update `~/.vimrc` to include the
+following settings.
 
 ```vim
 " ~/.vimrc

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -21,34 +21,21 @@ First, install the following plugins
 - [`derekwyatt/vim-scala`](https://github.com/derekwyatt/vim-scala): for syntax
   highlighting Scala and sbt source files.
 
-If you use [`vim-plug`](https://github.com/junegunn/vim-plug)
+Assuming [`vim-plug`](https://github.com/junegunn/vim-plug) is used for
+installing plugin (another plugin manager like vundle works too), update
+`~/.vimrc` to include the following settings.
 
 ```vim
 " ~/.vimrc
+
+" Configuration for vim-plug
 Plug 'derekwyatt/vim-scala'
 Plug 'natebosch/vim-lsc'
-```
 
-Run `:PlugInstall` to install the plugin. If you already have `vim-lsc`
-installed, be sure to update to the latest version with `:PlugUpdate`.
-
-```scala mdoc:bootstrap:metals-vim vim-lsc
-
-```
-
-The `-Dmetals.client=vim-lsc` flag configures Metals for usage with the
-`vim-lsc` client.
-
-Next, update `~/.vimrc` to tell `vim-lsc` to use `metals-vim` for Scala sources
-and map `gd` to run "Goto definition".
-
-```vim
-" ~/.vimrc
-
-" vim-scala
+" Configuration for vim-scala
 au BufRead,BufNewFile *.sbt set filetype=scala
 
-" vim-lsc
+" Configuration for vim-lsc
 let g:lsc_enable_autocomplete = v:false
 let g:lsc_server_commands = {
   \ 'scala': 'metals-vim'
@@ -57,6 +44,19 @@ let g:lsc_auto_map = {
     \ 'GoToDefinition': 'gd',
     \}
 ```
+
+Run `:PlugInstall` to install the plugin. If you already have `vim-lsc`
+installed, be sure to update to the latest version with `:PlugUpdate`.
+
+If you start Vim now then it will fail since the `metals-vim` binary does not
+exist yet.
+
+```scala mdoc:bootstrap:metals-vim vim-lsc
+
+```
+
+The `-Dmetals.client=vim-lsc` flag is important since it configures Metals for
+usage with the `vim-lsc` client.
 
 ## Importing a build
 

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -203,3 +203,7 @@ client for the following reasons:
 - Installation is more complicated compared to vim-lsc
 - `LanguageClient-neovim` does not implement `window/showMessageRequest`
 - `LanguageClient-neovim` does not implement `window/logMessage`
+
+```scala mdoc:generic
+
+```

--- a/docs/editors/vscode.md
+++ b/docs/editors/vscode.md
@@ -57,3 +57,15 @@ command to copy the Java 8 home path.
 ```sh
 /usr/libexec/java_home -v 1.8 | pbcopy
 ```
+
+## Using latest Metals SNAPSHOT
+
+Update the "Server Version" setting to try out the latest pending Metals
+features.
+
+```scala mdoc:releases
+
+```
+
+Run the "Reload Window" command after updating the setting for the new version
+to take effect.

--- a/docs/editors/vscode.md
+++ b/docs/editors/vscode.md
@@ -15,6 +15,15 @@ Install the Metals extension from the Marketplace, search for "Metals".
 
 [![Install Metals extension](https://img.shields.io/badge/metals-vscode-blue.png)](vscode:extension/scalameta.metals)
 
+> Make sure to disable the extensions
+> [Scala Language Server](https://marketplace.visualstudio.com/items?itemName=dragos.scala-lsp)
+> and
+> [Scala (sbt)](https://marketplace.visualstudio.com/items?itemName=lightbend.vscode-sbt-scala)
+> if they are installed. The
+> [Dotty Language Server](https://marketplace.visualstudio.com/items?itemName=lampepfl.dotty)
+> does **not** need to be disabled because the Metals and Dotty extensions don't
+> conflict with each other.
+
 Next, open a directory containing a `build.sbt` file. The extension activates
 when a `*.scala` or `*.sbt` file is opened.
 

--- a/docs/editors/vscode.md
+++ b/docs/editors/vscode.md
@@ -69,3 +69,7 @@ features.
 
 Run the "Reload Window" command after updating the setting for the new version
 to take effect.
+
+```scala mdoc:generic
+
+```

--- a/metals-docs/src/main/resources/META-INF/services/mdoc.StringModifier
+++ b/metals-docs/src/main/resources/META-INF/services/mdoc.StringModifier
@@ -1,3 +1,4 @@
+docs.GenericModifier
 docs.ReleasesModifier
 docs.UserConfigurationModifier
 docs.CustomizeBloopModifier

--- a/metals-docs/src/main/resources/META-INF/services/mdoc.StringModifier
+++ b/metals-docs/src/main/resources/META-INF/services/mdoc.StringModifier
@@ -1,3 +1,4 @@
+docs.ReleasesModifier
 docs.UserConfigurationModifier
 docs.CustomizeBloopModifier
 docs.TextEditorModifier

--- a/metals-docs/src/main/scala/docs/BootstrapModifier.scala
+++ b/metals-docs/src/main/scala/docs/BootstrapModifier.scala
@@ -6,7 +6,6 @@ import scala.meta.inputs.Input
 
 class BootstrapModifier extends StringModifier {
   override val name: String = "bootstrap"
-  val snapshot = Snapshot.latest()
   override def process(
       info: String,
       code: Input,
@@ -15,8 +14,13 @@ class BootstrapModifier extends StringModifier {
     info.split(" ") match {
       case Array(binary, client) =>
         s"""
-           |Next, build a `$binary` binary using the
+           |Next, build a `$binary` binary for the latest Metals release using the
            |[Coursier](https://github.com/coursier/coursier) command-line interface.
+           |
+           || Version                   | Published             | Resolver                |
+           || ---                       | ---                   | ---                     |
+           ||  ${Docs.release.version}  | ${Docs.release.date}  | `-r sonatype:releases`  |
+           ||  ${Docs.snapshot.version} | ${Docs.snapshot.date} | `-r sonatype:snapshots` |
            |
            |```sh
            |# Make sure to use coursier v1.1.0-M9 or newer.
@@ -29,19 +33,12 @@ class BootstrapModifier extends StringModifier {
            |  --java-opt -Xms1G \\
            |  --java-opt -Xmx4G  \\
            |  --java-opt -Dmetals.client=$client \\
-           |  org.scalameta:metals_2.12:${snapshot.version} \\
+           |  org.scalameta:metals_2.12:${Docs.release.version} \\
            |  -r bintray:scalacenter/releases \\
            |  -r sonatype:snapshots \\
-           |  -o $binary -f
+           |  -o /usr/local/bin/$binary -f
            |```
-           |
-           |(optional) Feel free to place this binary anywhere on your `$$PATH`, for example
-           |adapt the `-o` flag like this:
-           |
-           |```diff
-           |-  -o $binary -f
-           |+  -o /usr/local/bin/$binary -f
-           |```
+           |Make sure the generated `$binary` binary is available on your `$$PATH`.
            |""".stripMargin
       case _ =>
         reporter.error(s"Invalid info '$info'. Expected '<binary> <client>'")

--- a/metals-docs/src/main/scala/docs/BootstrapModifier.scala
+++ b/metals-docs/src/main/scala/docs/BootstrapModifier.scala
@@ -17,10 +17,7 @@ class BootstrapModifier extends StringModifier {
            |Next, build a `$binary` binary for the latest Metals release using the
            |[Coursier](https://github.com/coursier/coursier) command-line interface.
            |
-           || Version                   | Published             | Resolver                |
-           || ---                       | ---                   | ---                     |
-           ||  ${Docs.release.version}  | ${Docs.release.date}  | `-r sonatype:releases`  |
-           ||  ${Docs.snapshot.version} | ${Docs.snapshot.date} | `-r sonatype:snapshots` |
+           |${Docs.releasesResolverTable}
            |
            |```sh
            |# Make sure to use coursier v1.1.0-M9 or newer.

--- a/metals-docs/src/main/scala/docs/Docs.scala
+++ b/metals-docs/src/main/scala/docs/Docs.scala
@@ -4,13 +4,19 @@ import java.nio.file.Paths
 import scala.meta.internal.metals.{BuildInfo => V}
 
 object Docs {
+  lazy val snapshot = Snapshot.latest("snapshots")
+  lazy val release = Snapshot.latest("releases")
+  lazy val stableVersion = V.metalsVersion.replaceFirst("\\+.*", "")
   def main(args: Array[String]): Unit = {
     val out = Paths.get("website", "target", "docs")
     val settings = mdoc
       .MainSettings()
       .withSiteVariables(
-        Map(
+        Map[String, String](
           "VERSION" -> V.metalsVersion,
+          "STABLE_VERSION" -> stableVersion,
+          "SNAPSHOT_VERSION" -> snapshot.version,
+          "SNAPSHOT_DATE" -> snapshot.lastModified.toString,
           "LOCAL_VERSION" -> V.localSnapshotVersion,
           "BLOOP_VERSION" -> V.bloopVersion,
           "SCALAMETA_VERSION" -> V.scalametaVersion,

--- a/metals-docs/src/main/scala/docs/Docs.scala
+++ b/metals-docs/src/main/scala/docs/Docs.scala
@@ -6,20 +6,46 @@ import scala.meta.internal.metals.{BuildInfo => V}
 object Docs {
   lazy val snapshot = Snapshot.latest("snapshots")
   lazy val release = Snapshot.latest("releases")
-  def releasesResolverTable: String =
-    s"""
-       || Version              | Published        | Resolver                |
-       || ---                  | ---              | ---                     |
-       ||  ${release.version}  | ${release.date}  | `-r sonatype:releases`  |
-       ||  ${snapshot.version} | ${snapshot.date} | `-r sonatype:snapshots` |
-       |""".stripMargin
-  def releasesTable: String =
-    s"""
-       || Version              | Published        |
-       || ---                  | ---              |
-       ||  ${release.version}  | ${release.date}  |
-       ||  ${snapshot.version} | ${snapshot.date} |
-       |""".stripMargin
+  def releasesResolverTable: String = {
+    <table>
+      <thead>
+        <th>Version</th>
+        <th>Published</th>
+        <th>Resolver</th>
+      </thead>
+      <tbody>
+        <tr>
+          <td>{release.version}</td>
+          <td>{release.date}</td>
+          <td><code>-r sonatype:releases</code></td>
+        </tr>
+        <tr>
+          <td>{snapshot.version}</td>
+          <td>{snapshot.date}</td>
+          <td><code>-r sonatype:snapshots</code></td>
+        </tr>
+      </tbody>
+    </table>
+  }.toString
+
+  def releasesTable: String = {
+    <table>
+      <thead>
+        <th>Version</th>
+        <th>Published</th>
+      </thead>
+      <tbody>
+        <tr>
+          <td>{release.version}</td>
+          <td>{release.date}</td>
+        </tr>
+        <tr>
+          <td>{snapshot.version}</td>
+          <td>{snapshot.date}</td>
+        </tr>
+      </tbody>
+    </table>
+  }.toString
 
   lazy val stableVersion = V.metalsVersion.replaceFirst("\\+.*", "")
   def main(args: Array[String]): Unit = {

--- a/metals-docs/src/main/scala/docs/Docs.scala
+++ b/metals-docs/src/main/scala/docs/Docs.scala
@@ -6,6 +6,21 @@ import scala.meta.internal.metals.{BuildInfo => V}
 object Docs {
   lazy val snapshot = Snapshot.latest("snapshots")
   lazy val release = Snapshot.latest("releases")
+  def releasesResolverTable: String =
+    s"""
+       || Version              | Published        | Resolver                |
+       || ---                  | ---              | ---                     |
+       ||  ${release.version}  | ${release.date}  | `-r sonatype:releases`  |
+       ||  ${snapshot.version} | ${snapshot.date} | `-r sonatype:snapshots` |
+       |""".stripMargin
+  def releasesTable: String =
+    s"""
+       || Version              | Published        |
+       || ---                  | ---              |
+       ||  ${release.version}  | ${release.date}  |
+       ||  ${snapshot.version} | ${snapshot.date} |
+       |""".stripMargin
+
   lazy val stableVersion = V.metalsVersion.replaceFirst("\\+.*", "")
   def main(args: Array[String]): Unit = {
     val out = Paths.get("website", "target", "docs")

--- a/metals-docs/src/main/scala/docs/GenericModifier.scala
+++ b/metals-docs/src/main/scala/docs/GenericModifier.scala
@@ -1,0 +1,26 @@
+package docs
+
+import mdoc.Reporter
+import mdoc.StringModifier
+import scala.meta.inputs.Input
+
+class GenericModifier extends StringModifier {
+  override val name: String = "generic"
+
+  override def process(info: String, code: Input, reporter: Reporter): String =
+    s"""
+       |## Gitignore `.metals/` and `.bloop/`
+       |
+       |The Metals server places logs and other files in the `.metals/` directory. The
+       |Bloop compile server places logs and compilation artifacts in the `.bloop`
+       |directory. It's recommended to ignore these directories from version control
+       |systems like git.
+       |
+       |```sh
+       |# ~/.gitignore
+       |.metals/
+       |.bloop/
+       |```
+       |
+     """.stripMargin
+}

--- a/metals-docs/src/main/scala/docs/ReleasesModifier.scala
+++ b/metals-docs/src/main/scala/docs/ReleasesModifier.scala
@@ -1,0 +1,11 @@
+package docs
+
+import mdoc.Reporter
+import mdoc.StringModifier
+import scala.meta.inputs.Input
+
+class ReleasesModifier extends StringModifier {
+  override val name: String = "releases"
+  override def process(info: String, code: Input, reporter: Reporter): String =
+    Docs.releasesTable
+}

--- a/metals-docs/src/main/scala/docs/Snapshot.scala
+++ b/metals-docs/src/main/scala/docs/Snapshot.scala
@@ -7,13 +7,18 @@ import scala.collection.JavaConverters._
 import scala.meta.internal.metals.BuildInfo
 import scala.util.control.NonFatal
 
-case class Snapshot(version: String, lastModified: Date)
+case class Snapshot(version: String, lastModified: Date) {
+  def date: String = {
+    val pattern = new SimpleDateFormat("dd MMM yyyy HH:mm")
+    pattern.format(lastModified)
+  }
+}
 
 object Snapshot {
-  def latest(): Snapshot = {
+  def latest(repo: String): Snapshot = {
     if (System.getenv("CI") != null) {
       try {
-        fetchLatest()
+        fetchLatest(repo)
       } catch {
         case NonFatal(e) =>
           scribe.error("unexpected error fetching SNAPSHOT version", e)
@@ -27,12 +32,12 @@ object Snapshot {
   private def current: Snapshot = Snapshot(BuildInfo.metalsVersion, new Date())
 
   /** Returns the latest published snapshot release, or the current release if. */
-  private def fetchLatest(): Snapshot = {
+  private def fetchLatest(repo: String): Snapshot = {
     // maven-metadata.xml is consistently outdated so we scrape the "Last modified" column
     // of the HTML page that lists all snapshot releases instead.
     val doc = Jsoup
       .connect(
-        "https://oss.sonatype.org/content/repositories/snapshots/org/scalameta/metals_2.12/"
+        s"https://oss.sonatype.org/content/repositories/$repo/org/scalameta/metals_2.12/"
       )
       .get
     val dateTime = new SimpleDateFormat("EEE MMM d H:m:s z yyyy")


### PR DESCRIPTION
Followup on feedback from several people for things that can be clearer in the docs.

I'm not too happy about the readability of the markdown sources with the `mdoc:generic` modifiers. I can live with it however, since it avoids copy-pasting a lot of text. I want to try and have each editor page be fully self-contained even if it comes at the price of duplicated content.