### PR TITLE
Remove colors from metals.log

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
@@ -94,17 +94,5 @@ object MetalsLogger {
     FileWriter().path(_ => logfile.toNIO).autoFlush
 
   def defaultFormat = formatter"$levelPaddedRight $message$newLine"
-  implicit def AnyLoggable[T]: Loggable[T] = _AnyLoggable
-  private val _AnyLoggable = new Loggable[Any] {
-    override def apply(value: Any): String =
-      value match {
-        case s: String =>
-          s
-        case e: Throwable =>
-          Loggable.ThrowableLoggable(e)
-        case _ =>
-          pprint.PPrinter.Color.tokenize(value).mkString
-      }
-  }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
@@ -93,11 +93,7 @@ object MetalsLogger {
   def newFileWriter(logfile: AbsolutePath): FileWriter =
     FileWriter().path(_ => logfile.toNIO).autoFlush
 
-  // Example format: "MyProgram.scala:14 trace foo"
-  def defaultFormat =
-    formatter"$prettyLevel $message$newLine"
-  def debugFormat =
-    formatter"$prettyLevel $fileName:$line$newLine$prettyLevel $message$newLine"
+  def defaultFormat = formatter"$levelPaddedRight $message$newLine"
   implicit def AnyLoggable[T]: Loggable[T] = _AnyLoggable
   private val _AnyLoggable = new Loggable[Any] {
     override def apply(value: Any): String =
@@ -109,21 +105,6 @@ object MetalsLogger {
         case _ =>
           pprint.PPrinter.Color.tokenize(value).mkString
       }
-  }
-
-  private object prettyLevel extends FormatBlock {
-    import scribe.Level._
-    override def format[M](record: LogRecord[M]): String = {
-      val color = record.level match {
-        case Trace => Console.MAGENTA
-        case Debug => Console.GREEN
-        case Info => Console.BLUE
-        case Warn => Console.YELLOW
-        case Error => Console.RED
-        case _ => ""
-      }
-      color + record.level.namePaddedRight.toLowerCase + Console.RESET
-    }
   }
 
 }


### PR DESCRIPTION
A lot of stack traces that have been reported in issues
include ansi escape codes
```
23 ^[[0m^[[31m[E]^
```

The logs are still readable without color so let's remove them.
The logs look like this now
```
INFO  tests.TestingServer#didOpen
INFO  time: compiled a in 0.51s
INFO  time: compiled c in 0.5s
```