### PR TITLE
Implement build server discovery

### DIFF
--- a/docs/build-tools/new-build-tool.md
+++ b/docs/build-tools/new-build-tool.md
@@ -76,11 +76,29 @@ There are two available libraries to implement a BSP server:
 Both libraries are compatible with each other. For example, it's OK to implement
 a server with bsp4j and a client in bsp4s.
 
-### Testing
+### Manual tests
+
+You can manually test your build server integration by running Metals with your
+editor of choice.
+
+Create the following trace files to spy on incoming/outgoing JSON communication
+between Metals and your build tool.
+
+```
+# macOS
+touch ~/Library/Caches/org.scalameta.metals/bsp.trace.json
+# Linux
+touch ~/.cache/metals/bsp.trace.json
+```
+
+Metals must re-start to pick up the trace file.
+
+### Automated tests
 
 The Metals repository has infrastructure for running end-to-end integration
 tests with build servers. To test your build server integration, you can to
-clone the repository and write custom tests.
+clone the repository and write custom tests under
+`tests/unit/src/test/scala/tests`.
 
 If there is interest, we can publish a Metals `testkit` module to make it
 possible to write tests outside the Metals repository.

--- a/metals/src/main/resources/db/migration/V2__Server_discovery.sql
+++ b/metals/src/main/resources/db/migration/V2__Server_discovery.sql
@@ -1,0 +1,9 @@
+-- For each unique combination of installed build servers we select one server.
+-- The md5 checksum is computed from the names of the installed build servers, and
+-- the selected server is the server which the user chose for this workspace.
+create table chosen_build_server(
+  md5 varchar primary key,
+  selected_server varchar,
+  when_recorded timestamp
+);
+

--- a/metals/src/main/scala/scala/meta/internal/metals/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BspServers.scala
@@ -1,0 +1,177 @@
+package scala.meta.internal.metals
+
+import ch.epfl.scala.bsp4j.BspConnectionDetails
+import com.google.gson.Gson
+import io.github.soc.directories.ProjectDirectories
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.security.MessageDigest
+import scala.concurrent.ExecutionContextExecutorService
+import scala.concurrent.Future
+import scala.meta.internal.io.FileIO
+import scala.meta.internal.io.PathIO
+import scala.meta.internal.metals.Messages.BspSwitch
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.mtags.MD5
+import scala.meta.io.AbsolutePath
+import scala.util.Try
+
+/**
+ * Implements BSP server discovery, named "BSP Connection Protocol" in the spec.
+ *
+ * See https://github.com/scalacenter/bsp/blob/master/docs/bsp.md#bsp-connection-protocol
+ */
+class BspServers(
+    workspace: AbsolutePath,
+    charset: Charset,
+    client: MetalsLanguageClient,
+    buildClient: MetalsBuildClient,
+    tables: Tables,
+    bspGlobalInstallDirectories: List[AbsolutePath]
+)(implicit ec: ExecutionContextExecutorService) {
+
+  def newServer(): Future[Option[BuildServerConnection]] = {
+    findServer().map(_.map(newServer))
+  }
+
+  private def newServer(
+      details: BspConnectionDetails
+  ): BuildServerConnection = {
+    val process = new ProcessBuilder(details.getArgv)
+      .directory(workspace.toFile)
+      .start()
+
+    val output = new QuietOutputStream(
+      process.getOutputStream,
+      s"${details.getName} output stream"
+    )
+    val input = new QuietInputStream(
+      process.getInputStream,
+      s"${details.getName} input stream"
+    )
+
+    BuildServerConnection.fromStreams(
+      workspace,
+      buildClient,
+      output,
+      input,
+      List(
+        Cancelable(() => process.destroy())
+      ),
+      details.getName
+    )
+  }
+
+  def findServer(): Future[Option[BspConnectionDetails]] = {
+    findAvailableServers() match {
+      case Nil =>
+        Future.successful(None)
+      case head :: Nil =>
+        Future.successful(Some(head))
+      case availableServers =>
+        val md5 = digestServerDetails(availableServers)
+        val selectedServer = for {
+          name <- tables.buildServers.selectedServer(md5)
+          server <- availableServers.find(_.getName == name)
+        } yield server
+        selectedServer match {
+          case Some(value) =>
+            scribe.info(
+              s"pre-selected build server: ${value.getName} (run 'Switch build server' command to pick a new server)"
+            )
+            Future.successful(Some(value))
+          case None =>
+            askUser(md5, availableServers)
+        }
+    }
+  }
+
+  def switchBuildServer(): Future[Boolean] = {
+    findAvailableServers() match {
+      case Nil =>
+        client.showMessage(BspSwitch.noInstalledServer)
+        Future.successful(false)
+      case head :: Nil =>
+        client.showMessage(BspSwitch.onlyOneServer(head.getName))
+        Future.successful(false)
+      case availableServers =>
+        val md5 = digestServerDetails(availableServers)
+        askUser(md5, availableServers).map(_ => true)
+    }
+  }
+
+  def findJsonFiles(): List[AbsolutePath] = {
+    val buf = List.newBuilder[AbsolutePath]
+    def visit(dir: AbsolutePath): Unit =
+      if (dir.isDirectory) {
+        Files.list(dir.toNIO).iterator().asScala.foreach { p =>
+          if (PathIO.extension(p) == "json") {
+            buf += AbsolutePath(p)
+          }
+        }
+      }
+    visit(workspace.resolve(".bsp"))
+    bspGlobalInstallDirectories.foreach(visit)
+    buf.result()
+  }
+
+  private def findAvailableServers(): List[BspConnectionDetails] = {
+    val jsonFiles = findJsonFiles()
+    val gson = new Gson()
+    for {
+      candidate <- jsonFiles
+      text = FileIO.slurp(candidate, charset)
+      details <- Try(gson.fromJson(text, classOf[BspConnectionDetails])).fold(
+        e => {
+          scribe.error(s"parse error: $jsonFiles", e)
+          List()
+        },
+        details => {
+          List(details)
+        }
+      )
+    } yield {
+      details
+    }
+  }
+
+  private def askUser(
+      md5: String,
+      availableServers: List[BspConnectionDetails]
+  ): Future[Option[BspConnectionDetails]] = {
+    val query = Messages.SelectBspServer.request(availableServers)
+    for {
+      item <- client.showMessageRequest(query.params).asScala
+    } yield {
+      val chosen =
+        if (item == null) {
+          None
+        } else {
+          query.details.get(item.getTitle)
+        }
+      val name = chosen.fold("<none>")(_.getName)
+      tables.buildServers.chooseServer(md5, name)
+      scribe.info(s"selected build server: $name")
+      chosen
+    }
+  }
+
+  private def digestServerDetails(
+      candidates: List[BspConnectionDetails]
+  ): String = {
+    val md5 = MessageDigest.getInstance("MD5")
+    candidates.foreach { details =>
+      md5.update(details.getName.getBytes(StandardCharsets.UTF_8))
+    }
+    MD5.bytesToHex(md5.digest())
+  }
+
+}
+
+object BspServers {
+  def globalInstallDirectories: List[AbsolutePath] = {
+    val dirs = ProjectDirectories.fromPath("bsp")
+    List(dirs.dataLocalDir, dirs.dataDir).distinct.map(AbsolutePath(_))
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -91,7 +91,6 @@ object BuildServerConnection {
       .create()
     val listening = launcher.startListening()
     val server = launcher.getRemoteProxy
-    localClient.onConnect(server)
     val result = BuildServerConnection.initialize(workspace, server)
     val stopListening =
       Cancelable(() => listening.cancel(true))

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -5,12 +5,16 @@ import ch.epfl.scala.bsp4j.CompileParams
 import ch.epfl.scala.bsp4j.CompileResult
 import ch.epfl.scala.bsp4j.InitializeBuildParams
 import ch.epfl.scala.bsp4j.InitializeBuildResult
+import java.io.InputStream
+import java.io.OutputStream
 import java.util.Collections
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
+import org.eclipse.lsp4j.jsonrpc.Launcher
 import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Future
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
@@ -24,7 +28,8 @@ case class BuildServerConnection(
     client: MetalsBuildClient,
     server: MetalsBuildServer,
     cancelables: List[Cancelable],
-    initializeResult: InitializeBuildResult
+    initializeResult: InitializeBuildResult,
+    name: String
 )(implicit ec: ExecutionContext)
     extends Cancelable {
 
@@ -59,6 +64,39 @@ case class BuildServerConnection(
 }
 
 object BuildServerConnection {
+
+  def fromStreams(
+      workspace: AbsolutePath,
+      localClient: MetalsBuildClient,
+      output: OutputStream,
+      input: InputStream,
+      cancelables: List[Cancelable],
+      name: String
+  )(implicit ec: ExecutionContextExecutorService): BuildServerConnection = {
+    val tracePrinter = GlobalTrace.setupTracePrinter("BSP")
+    val launcher = new Launcher.Builder[MetalsBuildServer]()
+      .traceMessages(tracePrinter)
+      .setOutput(output)
+      .setInput(input)
+      .setLocalService(localClient)
+      .setRemoteInterface(classOf[MetalsBuildServer])
+      .setExecutorService(ec)
+      .create()
+    val listening = launcher.startListening()
+    val server = launcher.getRemoteProxy
+    localClient.onConnect(server)
+    val result = BuildServerConnection.initialize(workspace, server)
+    val stopListening =
+      Cancelable(() => listening.cancel(true))
+    BuildServerConnection(
+      workspace,
+      localClient,
+      server,
+      stopListening :: cancelables,
+      result,
+      name
+    )
+  }
 
   /** Run build/initialize handshake */
   def initialize(

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTool.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.metals
 sealed abstract class BuildTool extends Product with Serializable
 
 object BuildTool {
+  case object Bsp extends BuildTool
   case object Bazel extends BuildTool
   case object Bloop extends BuildTool
   case object Gradle extends BuildTool

--- a/metals/src/main/scala/scala/meta/internal/metals/ChosenBuildServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ChosenBuildServers.scala
@@ -1,0 +1,30 @@
+package scala.meta.internal.metals
+
+import java.sql.Connection
+import JdbcEnrichments._
+import java.sql.Timestamp
+
+class ChosenBuildServers(conn: () => Connection, time: Time) {
+  def selectedServer(md5: String): Option[String] = {
+    conn()
+      .query(
+        "select selected_server from chosen_build_server where md5 = ?;"
+      )(
+        _.setString(1, md5)
+      ) { rs =>
+        rs.getString(1)
+      }
+      .headOption
+  }
+
+  def chooseServer(md5: String, server: String): Int = {
+    conn().update(
+      s"merge into chosen_build_server key(md5) values (?, ?, ?);"
+    ) { stmt =>
+      val timestamp = new Timestamp(time.millis())
+      stmt.setString(1, md5)
+      stmt.setString(2, server)
+      stmt.setTimestamp(3, timestamp)
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -40,8 +40,6 @@ final class ForwardingMetalsBuildClient(
 
   def onBuildTargetCompileReport(params: b.CompileReport): Unit = {}
 
-  def onConnect(server: b.BuildServer): Unit = {}
-
   // We ignore task{Start,Finish} notifications for now.
   @JsonNotification("build/taskStart")
   def buildTaskStart(params: TaskStartParams): Unit = {}

--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -15,7 +15,6 @@ final class ForwardingMetalsBuildClient(
     diagnostics: Diagnostics
 ) extends MetalsBuildClient {
 
-  private var buildServer: Option[b.BuildServer] = None
   def onBuildShowMessage(params: l.MessageParams): Unit =
     languageClient.showMessage(params)
 
@@ -41,9 +40,7 @@ final class ForwardingMetalsBuildClient(
 
   def onBuildTargetCompileReport(params: b.CompileReport): Unit = {}
 
-  def onConnect(server: b.BuildServer): Unit = {
-    this.buildServer = Some(server)
-  }
+  def onConnect(server: b.BuildServer): Unit = {}
 
   // We ignore task{Start,Finish} notifications for now.
   @JsonNotification("build/taskStart")

--- a/metals/src/main/scala/scala/meta/internal/metals/Memory.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Memory.scala
@@ -30,6 +30,7 @@ object Memory {
 
   def footprint(iterable: sourcecode.Text[Object]): Footprint = {
     val layout = GraphLayout.parseInstance(iterable.value)
+
     val size = layout.totalSize()
     val linesOfCode: Option[Long] = iterable.value match {
       case index: OnDemandSymbolIndex =>

--- a/metals/src/main/scala/scala/meta/internal/metals/Memory.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Memory.scala
@@ -30,7 +30,6 @@ object Memory {
 
   def footprint(iterable: sourcecode.Text[Object]): Footprint = {
     val layout = GraphLayout.parseInstance(iterable.value)
-
     val size = layout.totalSize()
     val linesOfCode: Option[Long] = iterable.value match {
       case index: OnDemandSymbolIndex =>

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -180,6 +180,13 @@ class Messages(icons: Icons) {
       params.setMessage(message)
       params.setType(MessageType.Warning)
       val details = mutable.Map.empty[String, BspConnectionDetails]
+      // The logic for choosing item names is a bit tricky because we want
+      // the following characteristics:
+      // - all options must be unique, we get a title string back from the
+      //   editor for which server the user chose.
+      // - happy path: title is build server name without noisy version number.
+      // - name conflicts: disambiguate conflicting names by version number
+      // - name+version conflicts: append random characters to the title.
       val items = candidates.map { candidate =>
         val nameConflicts = candidates.count(_.getName == candidate.getName)
         val title: String = if (nameConflicts < 2) {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsBuildClient.scala
@@ -29,6 +29,4 @@ trait MetalsBuildClient {
   @JsonNotification("buildTarget/compileReport")
   def onBuildTargetCompileReport(params: b.CompileReport): Unit
 
-  def onConnect(remoteServer: BuildServer): Unit
-
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsBuildClient.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.metals
 
-import ch.epfl.scala.bsp4j.BuildServer
 import ch.epfl.scala.{bsp4j => b}
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.{lsp4j => l}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -278,6 +278,14 @@ object MetalsEnrichments extends DecorateAsJava with DecorateAsScala {
   }
 
   implicit class XtensionRangeBsp(range: b.Range) {
+    def toMeta(input: m.Input): m.Position =
+      m.Position.Range(
+        input,
+        range.getStart.getLine,
+        range.getStart.getCharacter,
+        range.getEnd.getLine,
+        range.getEnd.getCharacter
+      )
     def toLSP: l.Range =
       new l.Range(range.getStart.toLSP, range.getEnd.toLSP)
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -676,7 +676,6 @@ class MetalsLanguageServer(
     } yield change
 
   private def quickConnectToBuildServer(): Future[BuildChange] = {
-    Debug.printEnclosing()
     if (!buildTools.isAutoConnectable) {
       scribe.warn("Unable to automatically connect to build server.")
       Future.successful(BuildChange.None)

--- a/metals/src/main/scala/scala/meta/internal/metals/QuietInputStream.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/QuietInputStream.scala
@@ -1,0 +1,29 @@
+package scala.meta.internal.metals
+
+import java.io.FilterInputStream
+import java.io.IOException
+import java.io.InputStream
+
+/**
+ * A delegate input stream that gracefully fails when the underlying stream is closed.
+ *
+ * This class exists to suppress lsp4j logs like this: {{{
+ *   WARNING: Failed to send notification message.
+ * org.eclipse.lsp4j.jsonrpc.JsonRpcException: java.io.IOException: Stream Closed
+ * 	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer.consume(StreamMessageConsumer.java:72)
+ * 	at org.eclipse.lsp4j.jsonrpc.Launcher$Builder.lambda$wrapMessageConsumer$0(Launcher.java:312)
+ * 	at or
+ * }}}
+ */
+class QuietInputStream(underlying: InputStream, name: String)
+    extends FilterInputStream(underlying) {
+  override def read(): Int = {
+    try {
+      underlying.read()
+    } catch {
+      case e: IOException =>
+        scribe.debug(s"closed: $name", e)
+        -1
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/QuietOutputStream.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/QuietOutputStream.scala
@@ -1,0 +1,41 @@
+package scala.meta.internal.metals
+
+import java.io.FilterOutputStream
+import java.io.IOException
+import java.io.OutputStream
+
+/**
+ * A delegate output stream that gracefully fails when the underlying stream is closed.
+ *
+ * This class exists to suppress lsp4j logs like this: {{{
+ *   WARNING: Failed to send notification message.
+ * org.eclipse.lsp4j.jsonrpc.JsonRpcException: java.io.IOException: Stream Closed
+ * 	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer.consume(StreamMessageConsumer.java:72)
+ * 	at org.eclipse.lsp4j.jsonrpc.Launcher$Builder.lambda$wrapMessageConsumer$0(Launcher.java:312)
+ * 	at or
+ * }}}
+ */
+class QuietOutputStream(underlying: OutputStream, name: String)
+    extends FilterOutputStream(underlying) {
+  private var isClosed = false
+
+  override def flush(): Unit = {
+    try {
+      super.flush()
+    } catch {
+      case _: IOException =>
+    }
+  }
+
+  override def write(b: Int): Unit = {
+    try {
+      if (!isClosed) {
+        underlying.write(b)
+      }
+    } catch {
+      case e: IOException =>
+        scribe.debug(s"closed: $name", e)
+        isClosed = true
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -48,6 +48,17 @@ object ServerCommands {
        |""".stripMargin
   )
 
+  val BspSwitch = Command(
+    "bsp-switch",
+    "Switch build server",
+    """|Prompt the user to select a new build server to connect to.
+       |
+       |This command does nothing in case there are less than two installed build
+       |servers on the computer. In case the user has multiple BSP servers installed
+       |then Metals will prompt the user to select which server to use.
+       |""".stripMargin
+  )
+
   /**
    * Open the browser at the given url.
    */

--- a/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
@@ -9,6 +9,15 @@ import scala.meta.io.AbsolutePath
 
 final class Tables(workspace: AbsolutePath, time: Time) extends Cancelable {
   var connection: Connection = _
+  val sbtDigests =
+    new SbtDigests(() => connection, time)
+  val dependencySources =
+    new DependencySources(() => connection)
+  val dismissedNotifications =
+    new DismissedNotifications(() => connection, time)
+  val buildServers =
+    new ChosenBuildServers(() => connection, time)
+
   def start(): Unit = {
     val dbfile = workspace.resolve(".metals").resolve("metals")
     Files.createDirectories(dbfile.toNIO.getParent)
@@ -18,10 +27,7 @@ final class Tables(workspace: AbsolutePath, time: Time) extends Cancelable {
     Tables.migrateOrRestart(flyway, dbfile.resolveSibling(_ + ".h2.db"))
     this.connection = DriverManager.getConnection(url, user, null)
   }
-  val sbtDigests = new SbtDigests(() => connection, time)
-  val dependencySources = new DependencySources(() => connection)
-  val dismissedNotifications =
-    new DismissedNotifications(() => connection, time)
+
   def cancel(): Unit = connection.close()
 }
 

--- a/test-workspace/build.sbt
+++ b/test-workspace/build.sbt
@@ -1,7 +1,7 @@
 inThisBuild(Vector(
   scalaVersion := "2.12.8",
   scalacOptions ++= List(
-    "-Yrangepos", "-Ywarn-unused"
+    "-Ywarn-unused"
   ),
 ))
 

--- a/tests/unit/src/main/scala/bill/Bill.scala
+++ b/tests/unit/src/main/scala/bill/Bill.scala
@@ -1,0 +1,492 @@
+package bill
+
+import ch.epfl.scala.bsp4j._
+import ch.epfl.scala.{bsp4j => b}
+import com.geirsson.coursiersmall.CoursierSmall
+import com.geirsson.coursiersmall.Dependency
+import com.geirsson.coursiersmall.Settings
+import com.google.gson.GsonBuilder
+import java.io.File
+import java.io.PrintStream
+import java.io.PrintWriter
+import java.net.URI
+import java.net.URLClassLoader
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardOpenOption
+import java.util
+import java.util.Collections
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.stream.Collectors
+import org.eclipse.lsp4j.jsonrpc.Launcher
+import scala.collection.mutable
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.PositionSyntax._
+import scala.reflect.internal.util.BatchSourceFile
+import scala.reflect.internal.{util => r}
+import scala.reflect.io.AbstractFile
+import scala.reflect.io.VirtualFile
+import scala.tools.nsc
+import scala.tools.nsc.reporters.StoreReporter
+import scala.util.Properties
+import scala.util.control.NonFatal
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import scala.meta.internal.metals.MetalsLogger
+import scala.meta.io.AbsolutePath
+import tests.RecursivelyDelete
+
+/**
+ * Bill is a basic build tool that implements BSP server discovery for testing purposes.
+ *
+ * If you are looking to implement a build server, then some parts of Bill might
+ * of interest to you:
+ *
+ * - server discovery installation of `.bsp/bill.json` files
+ * - custom Scala compiler reporter to produce BSP diagnostics
+ *
+ * You can try bill by running the main method:
+ *
+ * {{{
+ *  $ bill help
+ *  usage: bill install (create server discovery file in .bsp/bill.json)
+ *         bill bsp     (start BSP server)
+ *         bill help    (print this help)
+ *         bill compile (start BSP client and run a single compilation request)
+ * }}}
+ *
+ * Bill is otherwise a pretty crappy build tool:
+ *
+ * - only one target with `src/` source directory and `out/` class directory
+ * - no incremental compilation, every compilation is a clean compile.
+ */
+object Bill {
+  class Server() extends BuildServer with ScalaBuildServer {
+    val languages = Collections.singletonList("scala")
+    var client: BuildClient = _
+    override def onConnectWithClient(server: BuildClient): Unit =
+      client = server
+    var workspace: Path = Paths.get(".").toAbsolutePath.normalize()
+    def src: Path = workspace.resolve("src")
+    def scalaJars: util.List[String] =
+      myClasspath
+        .filter(_.getFileName.toString.startsWith("scala-"))
+        .map(_.toUri.toString)
+        .toList
+        .asJava
+    val target: BuildTarget = {
+      val scalaTarget = new ScalaBuildTarget(
+        "org.scala-lang",
+        Properties.versionNumberString,
+        "2.12",
+        ScalaPlatform.JVM,
+        scalaJars
+      )
+      val id = new BuildTargetIdentifier("id")
+      val capabilities = new BuildTargetCapabilities(true, false, false)
+      val result = new BuildTarget(
+        id,
+        Collections.singletonList("tag"),
+        languages,
+        Collections.emptyList(),
+        capabilities
+      )
+      result.setDisplayName("id")
+      result.setData(scalaTarget)
+      result
+    }
+    val reporter = new StoreReporter
+    val out = AbsolutePath(workspace.resolve("out"))
+    Files.createDirectories(out.toNIO)
+    lazy val g = {
+      val settings = new nsc.Settings()
+      settings.classpath.value =
+        myClasspath.map(_.toString).mkString(File.pathSeparator)
+      settings.Yrangepos.value = true
+      settings.d.value = out.toString
+      new nsc.Global(settings, reporter)
+    }
+
+    override def buildInitialize(
+        params: InitializeBuildParams
+    ): CompletableFuture[InitializeBuildResult] = {
+      Future {
+        workspace = Paths.get(URI.create(params.getRootUri))
+        MetalsLogger.setupLspLogger(AbsolutePath(workspace), true)
+        val capabilities = new BuildServerCapabilities
+        capabilities.setCompileProvider(new CompileProvider(languages))
+        new InitializeBuildResult("Bill", "1.0", "2.0.0-M2", capabilities)
+      }.logError("initialize").asJava
+    }
+    override def onBuildInitialized(): Unit = {}
+    override def buildShutdown(): CompletableFuture[AnyRef] = {
+      CompletableFuture.completedFuture(null)
+    }
+    override def onBuildExit(): Unit = {
+      System.exit(0)
+    }
+    override def workspaceBuildTargets()
+      : CompletableFuture[WorkspaceBuildTargetsResult] = {
+      CompletableFuture.completedFuture {
+        new WorkspaceBuildTargetsResult(Collections.singletonList(target))
+      }
+    }
+    override def buildTargetSources(
+        params: SourcesParams
+    ): CompletableFuture[SourcesResult] = {
+      Files.createDirectories(src)
+      CompletableFuture.completedFuture {
+        new SourcesResult(
+          List(
+            new SourcesItem(
+              target.getId,
+              List(
+                new SourceItem(src.toUri.toString, false)
+              ).asJava
+            )
+          ).asJava
+        )
+      }
+    }
+    override def buildTargetInverseSources(
+        params: InverseSourcesParams
+    ): CompletableFuture[InverseSourcesResult] = ???
+    override def buildTargetDependencySources(
+        params: DependencySourcesParams
+    ): CompletableFuture[DependencySourcesResult] = {
+      CompletableFuture.completedFuture {
+        val sources = CoursierSmall.fetch(
+          new Settings().withDependencies(
+            List(
+              new Dependency(
+                "org.scala-lang",
+                "scala-library",
+                Properties.versionNumberString
+              )
+            )
+          )
+        )
+        new DependencySourcesResult(
+          List(
+            new DependencySourcesItem(
+              target.getId,
+              sources.map(_.toUri.toString).asJava
+            )
+          ).asJava
+        )
+      }
+    }
+    override def buildTargetResources(
+        params: ResourcesParams
+    ): CompletableFuture[ResourcesResult] = ???
+
+    private val hasError = mutable.Set.empty[AbstractFile]
+    def publishDiagnostics(): Unit = {
+      val byFile = reporter.infos.groupBy(_.pos.source.file)
+      val fixedErrors = hasError.filterNot(byFile.contains)
+      fixedErrors.foreach { file =>
+        client.onBuildPublishDiagnostics(
+          new PublishDiagnosticsParams(
+            new TextDocumentIdentifier(file.name),
+            target.getId,
+            List().asJava,
+            true
+          )
+        )
+      }
+      hasError --= fixedErrors
+      byFile.foreach {
+        case (file, infos) =>
+          def toBspPos(pos: r.Position, offset: Int): b.Position = {
+            val line = pos.source.offsetToLine(offset)
+            val column0 = pos.source.lineToOffset(line)
+            val column = offset - column0
+            new b.Position(line, column)
+          }
+          val diagnostics = infos.iterator
+            .filter(_.pos.isDefined)
+            .map { info =>
+              val p = info.pos
+              val start =
+                toBspPos(info.pos, if (p.isRange) p.start else p.point)
+              val end =
+                toBspPos(info.pos, if (p.isRange) p.end else p.point)
+              val severity = info.severity match {
+                case reporter.ERROR => DiagnosticSeverity.ERROR
+                case reporter.WARNING => DiagnosticSeverity.WARNING
+                case reporter.INFO => DiagnosticSeverity.INFORMATION
+                case _ => DiagnosticSeverity.HINT
+              }
+              val diagnostic = new Diagnostic(new b.Range(start, end), info.msg)
+              diagnostic.setSeverity(severity)
+              diagnostic
+            }
+            .toList
+          val uri = file.name
+          val params =
+            new PublishDiagnosticsParams(
+              new TextDocumentIdentifier(uri),
+              target.getId,
+              diagnostics.asJava,
+              true
+            )
+          client.onBuildPublishDiagnostics(params)
+          hasError += file
+      }
+    }
+
+    override def buildTargetCompile(
+        params: CompileParams
+    ): CompletableFuture[CompileResult] = {
+      CompletableFuture.completedFuture {
+        reporter.reset()
+        val run = new g.Run()
+        val sources: List[BatchSourceFile] =
+          if (Files.isDirectory(src)) {
+            Files
+              .walk(src)
+              .collect(Collectors.toList())
+              .asScala
+              .iterator
+              .filter(_.getFileName.toString.endsWith(".scala"))
+              .map(path => {
+                val text =
+                  new String(Files.readAllBytes(path), StandardCharsets.UTF_8)
+                val chars = text.toCharArray
+                new BatchSourceFile(new VirtualFile(path.toUri.toString), chars)
+              })
+              .toList
+          } else {
+            Nil
+          }
+        run.compileSources(sources)
+        publishDiagnostics()
+        val exit =
+          if (reporter.hasErrors) StatusCode.ERROR
+          else StatusCode.OK
+        new CompileResult(exit)
+      }
+    }
+    override def buildTargetTest(
+        params: TestParams
+    ): CompletableFuture[TestResult] = ???
+    override def buildTargetRun(
+        params: RunParams
+    ): CompletableFuture[RunResult] = ???
+    override def buildTargetCleanCache(
+        params: CleanCacheParams
+    ): CompletableFuture[CleanCacheResult] = {
+      CompletableFuture.completedFuture {
+        val count = RecursivelyDelete(out)
+        val plural = if (count != 1) "s" else ""
+        new CleanCacheResult(s"deleted $count file$plural", true)
+      }
+    }
+
+    override def buildTargetScalacOptions(
+        params: ScalacOptionsParams
+    ): CompletableFuture[ScalacOptionsResult] = {
+      CompletableFuture.completedFuture {
+        new ScalacOptionsResult(
+          List(
+            new ScalacOptionsItem(
+              target.getId,
+              List().asJava,
+              scalaJars,
+              out.toURI.toASCIIString
+            )
+          ).asJava
+        )
+      }
+    }
+    override def buildTargetScalaTestClasses(
+        params: ScalaTestClassesParams
+    ): CompletableFuture[ScalaTestClassesResult] = ???
+    override def buildTargetScalaMainClasses(
+        params: ScalaMainClassesParams
+    ): CompletableFuture[ScalaMainClassesResult] = ???
+  }
+
+  def myClassLoader: URLClassLoader =
+    this.getClass.getClassLoader.asInstanceOf[URLClassLoader]
+  def myClasspath: Iterator[Path] =
+    myClassLoader.getURLs.iterator
+      .map(url => Paths.get(url.toURI))
+
+  def cwd: Path = Paths.get(System.getProperty("user.dir"))
+
+  def handleBsp(): Unit = {
+    val stdout = System.out
+    val stdin = System.in
+    val home = Paths.get(".bill").toAbsolutePath
+    Files.createDirectories(home)
+    val executor = Executors.newCachedThreadPool()
+    val log = home.resolve("bill.log")
+    val trace = home.resolve("bill.trace.json")
+    val logStream = new PrintStream(
+      Files.newOutputStream(
+        log,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING
+      )
+    )
+    System.setOut(logStream)
+    System.setErr(logStream)
+    try {
+      val server = new Server()
+      val traceWrites = new PrintWriter(
+        Files.newOutputStream(
+          trace,
+          StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING
+        )
+      )
+      val launcher = new Launcher.Builder[BuildClient]()
+        .traceMessages(traceWrites)
+        .setOutput(stdout)
+        .setInput(stdin)
+        .setLocalService(server)
+        .setRemoteInterface(classOf[BuildClient])
+        .setExecutorService(executor)
+        .create()
+      server.client = launcher.getRemoteProxy
+      val listening = launcher.startListening()
+      pprint.log("listening...")
+      listening.get()
+    } catch {
+      case NonFatal(e) =>
+        e.printStackTrace(stdout)
+        e.printStackTrace(logStream)
+        System.exit(1)
+    } finally {
+      executor.shutdown()
+    }
+    stdout.println("error: abnormal exit path")
+    println(s"error: abnormal exit path")
+  }
+
+  /** Installed this build tool only for the local workspace */
+  def installWorkspace(
+      directory: Path,
+      name: String = "Bill"
+  ): Unit = {
+    handleInstall(directory.resolve(".bsp"), name)
+  }
+
+  /** Installed this build server globally for the machine */
+  def installGlobal(
+      directory: Path,
+      name: String = "Bill"
+  ): Unit = {
+    handleInstall(directory.resolve("bsp"), name)
+  }
+
+  private def handleInstall(directory: Path, name: String = "Bill"): Unit = {
+    val java =
+      Paths.get(System.getProperty("java.home")).resolve("bin").resolve("java")
+    val classpath = myClasspath.mkString(File.pathSeparator)
+    val details = new BspConnectionDetails(
+      name,
+      List(
+        java.toString,
+        "-classpath",
+        classpath,
+        "bill.Bill",
+        "bsp"
+      ).asJava,
+      BuildInfo.metalsVersion,
+      BuildInfo.bspVersion,
+      List("scala").asJava
+    )
+    val json = new GsonBuilder().setPrettyPrinting().create().toJson(details)
+    val bspJson = directory.resolve(s"${name.toLowerCase()}.json")
+    Files.createDirectories(directory)
+    Files.write(bspJson, json.getBytes(StandardCharsets.UTF_8))
+    println(s"installed: $bspJson")
+  }
+
+  def handleCompile(wd: Path): Unit = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    import scala.meta.internal.metals.MetalsEnrichments._
+    import scala.meta.internal.mtags.MtagsEnrichments._
+    val server = new Server()
+    val client = new BuildClient {
+      override def onBuildShowMessage(params: ShowMessageParams): Unit = ???
+      override def onBuildLogMessage(params: LogMessageParams): Unit = ???
+      override def onBuildTaskStart(params: TaskStartParams): Unit = ???
+      override def onBuildTaskProgress(params: TaskProgressParams): Unit = ???
+      override def onBuildTaskFinish(params: TaskFinishParams): Unit = ???
+      override def onBuildPublishDiagnostics(
+          params: PublishDiagnosticsParams
+      ): Unit = {
+        val path = params.getTextDocument.getUri.toAbsolutePath
+        val input = path.toInput
+        params.getDiagnostics.asScala.foreach { diag =>
+          val pos = diag.getRange.toMeta(input)
+          val message = pos.formatMessage(
+            diag.getSeverity.toString.toLowerCase(),
+            diag.getMessage
+          )
+          println(message)
+        }
+      }
+      override def onBuildTargetDidChange(params: DidChangeBuildTarget): Unit =
+        ???
+    }
+    server.onConnectWithClient(client)
+    val result = for {
+      _ <- server
+        .buildInitialize(
+          new InitializeBuildParams(
+            "Metals",
+            BuildInfo.metalsVersion,
+            BuildInfo.bspVersion,
+            wd.toUri.toString,
+            new BuildClientCapabilities(
+              Collections.singletonList("scala")
+            )
+          )
+        )
+        .asScala
+      _ = server.onBuildInitialized()
+      buildTargets <- server.workspaceBuildTargets().asScala
+      _ <- server
+        .buildTargetCompile(
+          new CompileParams(buildTargets.getTargets.map(_.getId))
+        )
+        .asScala
+    } yield ()
+    Await.result(result, Duration("1min"))
+  }
+
+  def handleHelp(): Unit = {
+    println(
+      s"""bill v${BuildInfo.metalsVersion}
+         |usage: bill install (create server discovery file in .bsp/bill.json)
+         |       bill bsp     (start BSP server)
+         |       bill help    (print this help)
+         |       bill compile (start BSP client and run a single compilation request)
+       """.stripMargin
+    )
+  }
+
+  def main(args: Array[String]): Unit = {
+    args.toList match {
+      case List("help" | "--help" | "-help" | "-h") => handleHelp()
+      case List("install") => handleInstall(cwd)
+      case List("bsp") => handleBsp()
+      case List("compile") => handleCompile(cwd)
+      case List("compile", wd) => handleCompile(Paths.get(wd))
+      case unknown =>
+        println(s"Invalid arguments: ${unknown.mkString(" ")}")
+        handleHelp()
+        System.exit(1)
+    }
+  }
+}

--- a/tests/unit/src/main/scala/tests/RecursivelyDelete.scala
+++ b/tests/unit/src/main/scala/tests/RecursivelyDelete.scala
@@ -9,9 +9,12 @@ import java.nio.file.attribute.BasicFileAttributes
 import scala.meta.io.AbsolutePath
 
 object RecursivelyDelete {
-  def apply(root: AbsolutePath): Unit = {
-    if (root.isFile) Files.delete(root.toNIO)
-    else if (root.isDirectory) {
+  def apply(root: AbsolutePath): Int = {
+    if (root.isFile) {
+      Files.delete(root.toNIO)
+      1
+    } else if (root.isDirectory) {
+      var count = 0
       Files.walkFileTree(
         root.toNIO,
         new SimpleFileVisitor[Path] {
@@ -19,6 +22,7 @@ object RecursivelyDelete {
               file: Path,
               attrs: BasicFileAttributes
           ): FileVisitResult = {
+            count += 1
             Files.delete(file)
             super.visitFile(file, attrs)
           }
@@ -35,6 +39,9 @@ object RecursivelyDelete {
           }
         }
       )
+      count
+    } else {
+      0
     }
   }
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -62,14 +62,16 @@ final class TestingServer(
     workspace: AbsolutePath,
     client: MetalsLanguageClient,
     buffers: Buffers,
-    config: MetalsServerConfig
+    config: MetalsServerConfig,
+    bspGlobalDirectories: List[AbsolutePath]
 )(implicit ex: ExecutionContextExecutorService) {
   val server = new MetalsLanguageServer(
     ex,
     buffers = buffers,
     redirectSystemOut = false,
     config = config,
-    progressTicks = ProgressTicks.none
+    progressTicks = ProgressTicks.none,
+    bspGlobalDirectories = bspGlobalDirectories
   )
   server.connectToLanguageClient(client)
   private val readonlySources = TrieMap.empty[String, AbsolutePath]

--- a/tests/unit/src/test/scala/tests/BillSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/BillSlowSuite.scala
@@ -1,0 +1,85 @@
+package tests
+
+import bill._
+import scala.concurrent.Future
+import scala.meta.internal.metals.Messages
+import scala.meta.io.AbsolutePath
+
+object BillSlowSuite extends BaseSlowSuite("bill") {
+
+  def globalBsp: AbsolutePath = workspace.resolve("global-bsp")
+  override def bspGlobalDirectories: List[AbsolutePath] =
+    List(globalBsp.resolve("bsp"))
+
+  def testRoundtripCompilation(): Future[Unit] = {
+    for {
+      _ <- server.initialize(
+        """
+          |/src/com/App.scala
+          |object App {
+          |  val x: Int = ""
+          |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("src/com/App.scala")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """
+          |src/com/App.scala:2:16: error: type mismatch;
+          | found   : String("")
+          | required: Int
+          |  val x: Int = ""
+          |               ^^
+        """.stripMargin
+      )
+      _ <- server.didSave("src/com/App.scala")(_ => "object App")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        ""
+      )
+    } yield ()
+  }
+
+  testAsync("diagnostics") {
+    Bill.installWorkspace(workspace.toNIO)
+    testRoundtripCompilation()
+  }
+
+  testAsync("global") {
+    Bill.installGlobal(globalBsp.toNIO)
+    testRoundtripCompilation()
+  }
+
+  def testSelectServerDialogue(): Future[Unit] = {
+    for {
+      _ <- server.initialize(
+        """
+          |/src/App.scala
+          |object App {}
+        """.stripMargin
+      )
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          Messages.SelectBspServer.message,
+          Messages.CheckDoctor.allProjectsMisconfigured
+        ).mkString("\n")
+      )
+    } yield ()
+  }
+
+  testAsync("conflict") {
+    cleanDatabase()
+    Bill.installWorkspace(workspace.toNIO, "Bill")
+    Bill.installWorkspace(workspace.toNIO, "Bob")
+    testSelectServerDialogue()
+  }
+
+  testAsync("mix") {
+    cleanDatabase()
+    Bill.installWorkspace(workspace.toNIO, "Bill")
+    Bill.installGlobal(globalBsp.toNIO, "Bob")
+    testSelectServerDialogue()
+  }
+
+}

--- a/tests/unit/src/test/scala/tests/BspCli.scala
+++ b/tests/unit/src/test/scala/tests/BspCli.scala
@@ -1,6 +1,5 @@
 package tests
 
-import ch.epfl.scala.bsp4j.BuildServer
 import ch.epfl.scala.bsp4j.CompileParams
 import ch.epfl.scala.bsp4j.CompileReport
 import ch.epfl.scala.bsp4j.DidChangeBuildTarget

--- a/tests/unit/src/test/scala/tests/BspCli.scala
+++ b/tests/unit/src/test/scala/tests/BspCli.scala
@@ -123,7 +123,7 @@ object BspCli {
       targets: List[String]
   )(implicit ec: ExecutionContextExecutorService): Future[Unit] = {
     for {
-      bloop <- bloopServers.newServer()
+      bloop <- bloopServers.newServer().map(_.get)
       buildTargets <- bloop.server.workspaceBuildTargets().asScala
       ids = buildTargets.getTargets.asScala
         .filter(target => targets.contains(target.getDisplayName))

--- a/tests/unit/src/test/scala/tests/BspCli.scala
+++ b/tests/unit/src/test/scala/tests/BspCli.scala
@@ -114,8 +114,6 @@ object BspCli {
     ): Unit = pprint.log(params)
     override def onBuildTargetCompileReport(params: CompileReport): Unit =
       pprint.log(params)
-    override def onConnect(remoteServer: BuildServer): Unit =
-      pprint.log(remoteServer)
   }
 
   private def compile(

--- a/tests/unit/src/test/scala/tests/BspSwitchSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/BspSwitchSlowSuite.scala
@@ -1,0 +1,40 @@
+package tests
+
+import bill.Bill
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.metals.Messages._
+
+object BspSwitchSlowSuite extends BaseSlowSuite("bsp-switch") {
+  testAsync("switch") {
+    cleanWorkspace()
+    Bill.installWorkspace(workspace.toNIO)
+    for {
+      _ <- server.initialize("")
+      _ = {
+        client.messageRequests.clear()
+        assertConnectedToBuildServer("Bill")
+        Bill.installWorkspace(workspace.toNIO, "Bob")
+      }
+      _ <- server.executeCommand(ServerCommands.ConnectBuildServer.id)
+      _ = {
+        assertConnectedToBuildServer("Bob")
+        assertNoDiff(
+          client.workspaceMessageRequests,
+          SelectBspServer.message
+        )
+        assertNoDiff(client.workspaceShowMessages, "")
+
+        client.messageRequests.clear()
+        client.showMessageRequestHandler = { params =>
+          params.getActions.asScala.find(_.getTitle == "Bill")
+        }
+      }
+      _ <- server.executeCommand(ServerCommands.BspSwitch.id)
+      _ = {
+        assertNoDiff(client.workspaceShowMessages, "")
+        assertConnectedToBuildServer("Bill")
+      }
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/ChosenBuildServerSuite.scala
+++ b/tests/unit/src/test/scala/tests/ChosenBuildServerSuite.scala
@@ -1,0 +1,15 @@
+package tests
+
+import scala.meta.internal.metals.ChosenBuildServers
+
+object ChosenBuildServerSuite extends BaseTablesSuite {
+  def buildServers: ChosenBuildServers = tables.buildServers
+  test("basic") {
+    assert(buildServers.selectedServer("a").isEmpty)
+    assertEquals(buildServers.chooseServer("a", "bill"), 1)
+    assertEquals(
+      buildServers.selectedServer("a").get,
+      "bill"
+    )
+  }
+}

--- a/tests/unit/src/test/scala/tests/SbtDetectionSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtDetectionSuite.scala
@@ -10,7 +10,7 @@ object SbtDetectionSuite extends BaseSuite {
     test(name) {
       val workspace = FileLayout.fromString(layout)
       workspace.toFile.deleteOnExit()
-      val isSbt = new BuildTools(workspace).isSbt
+      val isSbt = new BuildTools(workspace, Nil).isSbt
       if (isTrue) assert(isSbt)
       else assert(!isSbt)
     }

--- a/tests/unit/src/test/scala/tests/SelectBspServerSuite.scala
+++ b/tests/unit/src/test/scala/tests/SelectBspServerSuite.scala
@@ -1,0 +1,60 @@
+package tests
+
+import ch.epfl.scala.bsp4j.BspConnectionDetails
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.MetalsEnrichments._
+
+object SelectBspServerSuite extends BaseSuite {
+  def check(
+      name: String,
+      candidates: List[BspConnectionDetails],
+      expected: String
+  ): Unit = {
+    test(name) {
+      val query = Messages.SelectBspServer.request(candidates)
+      val obtained =
+        query.params.getActions.asScala.map(_.getTitle).mkString("\n")
+      assertNoDiff(obtained, expected)
+    }
+  }
+
+  def name(n: String, version: String = "1.0.0"): BspConnectionDetails = {
+    new BspConnectionDetails(n, List().asJava, version, "2.0.0", List().asJava)
+  }
+
+  check(
+    "basic",
+    List(
+      name("Bloop"),
+      name("Mill")
+    ),
+    """
+      |Bloop
+      |Mill
+      |""".stripMargin
+  )
+
+  check(
+    "version",
+    List(
+      name("Bloop", "1.0"),
+      name("Bloop", "2.0")
+    ),
+    """
+      |Bloop v1.0
+      |Bloop v2.0
+      |""".stripMargin
+  )
+
+  check(
+    "conflict",
+    List(
+      name("Bloop", "1.0"),
+      name("Bloop", "1.0")
+    ),
+    """
+      |Bloop v1.0 (a)
+      |Bloop v1.0 (b)
+      |""".stripMargin
+  )
+}


### PR DESCRIPTION
This commit makes it possible for Metals to communicate with other build
tools than Bloop. New build tools need to implement "BSP connection protocol" documented here:
https://github.com/scalacenter/bsp/blob/master/docs/bsp.md#bsp-connection-protocol

The "Integrating a new build tool" docs have been updated to explain the
steps to implement server discovery.

The long-term plan is to communicate with Bloop via server discovery,
instead of the current custom integration in Metals.

This commit implements a new build tool called "Bill" that implements
BSP server discovery. Bill is used internally to test server discovery.
However, Bill can also be used an inspiration for other 3rd party build
server implementations.

When there are multiple build servers installed on the computer, users
are asked to select which server to connect to. The user choice is
persisted for each unique combination of server names. To override a
persisted server choice, users can run the "Switch build server"
command.