### PR TITLE
Make H2 database connection establishment more robust

### DIFF
--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -189,6 +189,24 @@ with a comma separated list of the following supported values:
 
 Set the value to `-Dmetals.statistics=all` to enable all statistics.
 
+### `-Dmetals.h2.auto-server`
+
+Possible values:
+
+- `on` (default): use
+  [H2 `AUTO_SERVER=TRUE` mode](http://www.h2database.com/html/features.html#auto_mixed_mode)
+  to support multiple concurrent Metals servers in the same workspace. If this
+  option is enabled, the Metals H2 database communicate to other concurrently
+  running Metals servers via TCP through a free port. In case of failure to
+  establish a `AUTO_SERVER=TRUE` connection, Metals falls back to
+  `AUTO_SERVER=FALSE`.
+- `off`: do not use use `AUTO_SERVER=TRUE`. By disabling this option, it's not
+  possible to run concurrent Metals servers in the same workspace directory. For
+  example, it's not possible to have both VS Code and Vim installed with Metals
+  running in the same directory. In case there are multiple Metals servers
+  running in the same workspace directory, Metals falls back to using an
+  in-memory database resulting in a degraded user experience.
+
 ```scala mdoc:user-config:system-property
 
 ```

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -104,7 +104,7 @@ class MetalsLanguageServer(
   private def updateWorkspaceDirectory(params: InitializeParams): Unit = {
     workspace = AbsolutePath(Paths.get(URI.create(params.getRootUri)))
     MetalsLogger.setupLspLogger(workspace, redirectSystemOut)
-    tables = register(Tables.forWorkspace(workspace, time))
+    tables = register(new Tables(workspace, time, config))
     buildTools = new BuildTools(workspace, bspGlobalDirectories)
     buildTargets = new BuildTargets()
     fileSystemSemanticdbs =
@@ -323,7 +323,7 @@ class MetalsLanguageServer(
     // enabled.
     if (isInitialized.compareAndSet(false, true)) {
       statusBar.start(sh, 0, 1, TimeUnit.SECONDS)
-      tables.start()
+      tables.connect()
       registerFileWatchers()
       Future
         .sequence(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -28,9 +28,13 @@ final case class MetalsServerConfig(
     showMessageRequest: ShowMessageRequestConfig =
       ShowMessageRequestConfig.default,
     isNoInitialized: Boolean =
-      MetalsServerConfig.binaryOption("metals.no-initialized"),
-    isHttpEnabled: Boolean = MetalsServerConfig.binaryOption("metals.http"),
-    isVerbose: Boolean = MetalsServerConfig.binaryOption("metals.verbose"),
+      MetalsServerConfig.binaryOption("metals.no-initialized", default = false),
+    isHttpEnabled: Boolean =
+      MetalsServerConfig.binaryOption("metals.http", default = false),
+    isVerbose: Boolean =
+      MetalsServerConfig.binaryOption("metals.verbose", default = false),
+    isAutoServer: Boolean =
+      MetalsServerConfig.binaryOption("metals.h2.auto-server", default = true),
     icons: Icons = Icons.default,
     statistics: StatisticsConfig = StatisticsConfig.default
 ) {
@@ -50,10 +54,12 @@ final case class MetalsServerConfig(
     ).mkString("MetalsServerConfig(\n  ", ",\n  ", "\n)")
 }
 object MetalsServerConfig {
-  private def binaryOption(key: String): Boolean =
-    Set("true", "on").contains(
-      System.getProperty(key)
-    )
+  private def binaryOption(key: String, default: Boolean): Boolean =
+    System.getProperty(key) match {
+      case "true" | "on" => true
+      case "false" | "off" => false
+      case _ => default
+    }
 
   def base: MetalsServerConfig = MetalsServerConfig()
   def default: MetalsServerConfig = {

--- a/metals/src/main/scala/scala/meta/internal/metals/RecursivelyDelete.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/RecursivelyDelete.scala
@@ -1,4 +1,4 @@
-package tests
+package scala.meta.internal.metals
 
 import java.io.IOException
 import java.nio.file.FileVisitResult

--- a/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
@@ -6,9 +6,13 @@ import java.sql.DriverManager
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.FlywayException
 import scala.meta.io.AbsolutePath
+import scala.util.control.NonFatal
 
-final class Tables(workspace: AbsolutePath, time: Time) extends Cancelable {
-  var connection: Connection = _
+final class Tables(
+    workspace: AbsolutePath,
+    time: Time,
+    config: MetalsServerConfig
+) extends Cancelable {
   val sbtDigests =
     new SbtDigests(() => connection, time)
   val dependencySources =
@@ -18,30 +22,86 @@ final class Tables(workspace: AbsolutePath, time: Time) extends Cancelable {
   val buildServers =
     new ChosenBuildServers(() => connection, time)
 
-  def start(): Unit = {
+  def connect(): Unit = {
+    this._connection =
+      if (config.isAutoServer) tryAutoServer()
+      else tryAutoServer()
+  }
+  def cancel(): Unit = connection.close()
+  private var _connection: Connection = _
+  private def connection: Connection = {
+    if (_connection == null || _connection.isClosed) {
+      connect()
+    }
+    _connection
+  }
+
+  // The try/catch dodge-ball court in these methods is not glamorous, I'm sure it can be refactored for more
+  // readability and extensibility but it seems to get the job done for now. The most important goals are:
+  // 1. Never fail to establish a connection, even if that means using an in-memory database with degraded UX.
+  // 2. Log helpful error message with actionable advice on how to fix the problem.
+  private def tryAutoServer(): Connection = {
+    try persistentConnection(isAutoServer = true)
+    catch {
+      case NonFatal(e) =>
+        scribe.error(
+          s"unable to setup persistent H2 database with AUTO_SERVER=true, falling back to AUTO_SERVER=false.",
+          e
+        )
+        tryNoAutoServer()
+    }
+  }
+
+  private def tryNoAutoServer(): Connection = {
+    try {
+      persistentConnection(isAutoServer = true)
+    } catch {
+      case NonFatal(e) =>
+        scribe.error(
+          s"unable to setup persistent H2 database with AUTO_SERVER=false, falling back to in-memory database. " +
+            s"This means you may be redundantly asked to execute 'Import build', even if it's not needed. " +
+            s"Also, code navigation will not work for existing files in the .metals/readonly/ directory. " +
+            s"To fix this problem, make sure you only have one running Metals server in the directory '$workspace'.",
+          e
+        )
+
+        RecursivelyDelete(workspace.resolve(Directories.readonly))
+        inMemoryConnection()
+    }
+  }
+
+  private def databasePath: AbsolutePath =
+    workspace.resolve(Directories.database)
+
+  private def inMemoryConnection(): Connection = {
+    tryUrl("jdbc:h2:mem:metals;DB_CLOSE_DELAY=-1")
+  }
+
+  private def persistentConnection(isAutoServer: Boolean): Connection = {
+    val autoServer =
+      if (isAutoServer) ";AUTO_SERVER=TRUE"
+      else ""
     val dbfile = workspace.resolve(".metals").resolve("metals")
     Files.createDirectories(dbfile.toNIO.getParent)
-    val url = s"jdbc:h2:file:$dbfile;MV_STORE=false;AUTO_SERVER=true"
+    val url = s"jdbc:h2:file:$dbfile;MV_STORE=false$autoServer"
+    tryUrl(url)
+  }
+
+  private def tryUrl(url: String): Connection = {
     val user = "sa"
-    val flyway = Flyway.configure.dataSource(url, user, null).load
-    Tables.migrateOrRestart(flyway, dbfile.resolveSibling(_ + ".h2.db"))
-    this.connection = DriverManager.getConnection(url, user, null)
+    val flyway = Flyway.configure.dataSource(url, user, null).load()
+    migrateOrRestart(flyway)
+    DriverManager.getConnection(url, user, null)
   }
 
-  def cancel(): Unit = connection.close()
-}
-
-object Tables {
-  def forWorkspace(workspace: AbsolutePath, time: Time): Tables = {
-    new Tables(workspace, time)
-  }
-
-  private def migrateOrRestart(flyway: Flyway, path: AbsolutePath): Unit = {
+  private def migrateOrRestart(
+      flyway: Flyway
+  ): Unit = {
     try {
       flyway.migrate()
     } catch {
-      case _: FlywayException if path.isFile =>
-        scribe.warn(s"Resetting Metals database $path")
+      case _: FlywayException =>
+        scribe.warn(s"resetting database: $databasePath")
         flyway.clean()
         flyway.migrate()
     }

--- a/tests/unit/src/main/scala/bill/Bill.scala
+++ b/tests/unit/src/main/scala/bill/Bill.scala
@@ -39,8 +39,8 @@ import scala.util.control.NonFatal
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.meta.internal.metals.MetalsLogger
+import scala.meta.internal.metals.RecursivelyDelete
 import scala.meta.io.AbsolutePath
-import tests.RecursivelyDelete
 
 /**
  * Bill is a basic build tool that implements BSP server discovery for testing purposes.

--- a/tests/unit/src/main/scala/tests/BaseSlowSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseSlowSuite.scala
@@ -9,6 +9,7 @@ import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.ExecuteClientCommandConfig
 import scala.meta.internal.metals.FileWatcherConfig
 import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.RecursivelyDelete
 import scala.meta.io.AbsolutePath
 
 /**

--- a/tests/unit/src/main/scala/tests/DirectoryExpectSuite.scala
+++ b/tests/unit/src/main/scala/tests/DirectoryExpectSuite.scala
@@ -2,6 +2,7 @@ package tests
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import scala.meta.internal.metals.RecursivelyDelete
 import scala.meta.io.AbsolutePath
 
 /**

--- a/tests/unit/src/test/scala/tests/BaseTablesSuite.scala
+++ b/tests/unit/src/test/scala/tests/BaseTablesSuite.scala
@@ -1,6 +1,8 @@
 package tests
 
 import java.nio.file.Files
+import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.RecursivelyDelete
 import scala.meta.internal.metals.Tables
 import scala.meta.io.AbsolutePath
 
@@ -11,8 +13,8 @@ abstract class BaseTablesSuite extends BaseSuite {
   override def utestBeforeEach(path: Seq[String]): Unit = {
     workspace = AbsolutePath(Files.createTempDirectory("metals"))
     time.reset()
-    tables = Tables.forWorkspace(workspace, time)
-    tables.start()
+    tables = new Tables(workspace, time, MetalsServerConfig())
+    tables.connect()
   }
   override def utestAfterEach(path: Seq[String]): Unit = {
     tables.cancel()

--- a/tests/unit/src/test/scala/tests/FileWatcherSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/FileWatcherSlowSuite.scala
@@ -1,6 +1,7 @@
 package tests
 
 import java.nio.file.Files
+import scala.meta.internal.metals.RecursivelyDelete
 
 object FileWatcherSlowSuite extends BaseSlowSuite("file-watcher") {
   testAsync("basic") {


### PR DESCRIPTION
Fixes #406.

- first try `AUTO_SERVER=true`
- in case of errors, try `AUTO_SERVER=false`
- in case of errors (due to multiple servers in the same workspace), use
  in-memory database.

This commit adds a new `-Dmetals.h2.auto-server=false` option to disable
`AUTO_SERVER=true`, for users who do not want H2 to speak via TCP to
concurrent Metals servers.