### PR TITLE
Improve Emacs docs

### DIFF
--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -60,7 +60,7 @@ dependencies
   :pin melpa-stable
   :hook (lsp-mode . lsp-ui-mode))
 
-(use-package 'lsp-scala
+(use-package lsp-scala
   :load-path "~/path/to/lsp-scala"
   :hook (scala-mode . lsp-scala-enable))
 ```

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -29,7 +29,7 @@ dependencies
 
 ```el
 ;; Add melpa-stable to your packages repositories
-(add-to-list 'package-archives '("melpa-stable" . "http://stable.melpa.org/packages/") t)
+(add-to-list 'package-archives '("melpa-stable" . "https://stable.melpa.org/packages/") t)
 
 ;; Enable defer and ensure by default for use-package
 (setq use-package-always-defer t

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -51,19 +51,18 @@ dependencies
 
 ;; Enable nice rendering of diagnostics like compile errors.
 (use-package flycheck
-  :ensure t
   :init (global-flycheck-mode))
-(use-package lsp-ui)
-(require 'lsp-ui)
 
-(use-package lsp-mode)
-(add-hook 'lsp-mode-hook 'lsp-ui-mode )
-(require 'lsp-mode)
-(require 'sbt-mode)
+(use-package lsp-mode
+  :pin melpa-stable)
 
-(add-to-list 'load-path "~/path/to/lsp-scala")
-(require 'lsp-scala)
-(add-hook 'scala-mode-hook #'lsp-scala-enable)
+(use-package lsp-ui
+  :pin melpa-stable
+  :hook (lsp-mode . lsp-ui-mode))
+
+(use-package 'lsp-scala
+  :load-path "~/path/to/lsp-scala"
+  :hook (scala-mode . lsp-scala-enable))
 ```
 
 > You may need to disable other packages like `ensime` or sbt server to prevent

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -28,6 +28,9 @@ Next, update your Emacs configuration to load `lsp-scala` along with its
 dependencies
 
 ```el
+;; Add melpa-stable to your packages repositories
+(add-to-list 'package-archives '("melpa-stable" . "http://stable.melpa.org/packages/") t)
+
 ;; Enable scala-mode and sbt-mode
 (use-package scala-mode
   :interpreter

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -37,8 +37,8 @@ dependencies
 
 ;; Enable scala-mode and sbt-mode
 (use-package scala-mode
-  :interpreter
-  ("scala" . scala-mode))
+  :mode "\\.s\\(cala\\|bt\\)$")
+
 (use-package sbt-mode
   :commands sbt-start sbt-command
   :config

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -31,6 +31,10 @@ dependencies
 ;; Add melpa-stable to your packages repositories
 (add-to-list 'package-archives '("melpa-stable" . "http://stable.melpa.org/packages/") t)
 
+;; Enable defer and ensure by default for use-package
+(setq use-package-always-defer t
+      use-package-always-ensure t)
+
 ;; Enable scala-mode and sbt-mode
 (use-package scala-mode
   :interpreter


### PR DESCRIPTION
This PR makes a refactor of Emacs Editor documentation.
- [x] Add `melpa-stable` explicitly
- [x] Pin `lsp-mode` and `lsp-ui` to `melpa-stable`, since `lsp-scala` only works with stable versions.
- [x] Use `use-package` power:
   - Avoid using `require`.
   - Enable `defer` by default for `use-package`.
   - Enable `ensure` by default for `use-package`.
   - Use `:hook` instead of `add-hook` function.
   - Use `:load-path` for `lsp-scala`.
- [x] Improve regex to enable `scala-mode`