### PR TITLE
Implement textDocument/formatting using Scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -11,7 +11,7 @@ To fix this problem:
 """
 
 project.excludeFilters = [
-  test-workspace
-  tests/unit/src/test/resources
-  sbt-metals/src/sbt-test
+  "test-workspace"
+  "tests/unit/src/test/resources"
+  "sbt-metals/src/sbt-test"
 ]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+version = "1.6.0-RC4"
 project.git = true
 align = none
 docstrings = javadoc

--- a/build.sbt
+++ b/build.sbt
@@ -146,6 +146,8 @@ lazy val metals = project
       "com.thoughtworks.qdox" % "qdox" % "2.0-M9",
       // for finding paths of global log/cache directories
       "io.github.soc" % "directories" % "11",
+      // for reading Scalafmt conf
+      "com.typesafe" % "config" % "1.3.2",
       // ==================
       // Scala dependencies
       // ==================

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -125,7 +125,7 @@ final class DefinitionProvider(
                   new l.Position(pos.endLine, pos.endColumn)
                 )
               )
-          ),
+            ),
           () => Some(location),
           () => None
         )

--- a/metals/src/main/scala/scala/meta/internal/metals/FilterMatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FilterMatcher.scala
@@ -24,7 +24,10 @@ object FilterMatcher {
   private def fixSeparatorsInPathPattern(unixSpecificPattern: String): String =
     unixSpecificPattern.replace('/', File.separatorChar)
 
-  def apply(includeFilters: Seq[String], excludeFilters: Seq[String]): FilterMatcher = {
+  def apply(
+      includeFilters: Seq[String],
+      excludeFilters: Seq[String]
+  ): FilterMatcher = {
     val includes = includeFilters.map(fixSeparatorsInPathPattern)
     val excludes = excludeFilters.map(fixSeparatorsInPathPattern)
     new FilterMatcher(mkRegexp(includes), mkRegexp(excludes))

--- a/metals/src/main/scala/scala/meta/internal/metals/FilterMatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FilterMatcher.scala
@@ -14,9 +14,9 @@ case class FilterMatcher(include: Regex, exclude: Regex) {
 }
 
 object FilterMatcher {
-  private def mkRegexp(filters: Seq[String], ifEmpty: String): Regex =
+  private def mkRegexp(filters: Seq[String]): Regex =
     filters match {
-      case Nil => ifEmpty.r
+      case Nil => "$a".r // will never match anything
       case head :: Nil => head.r
       case _ => filters.mkString("(", "|", ")").r
     }
@@ -27,6 +27,6 @@ object FilterMatcher {
   def apply(includeFilters: Seq[String], excludeFilters: Seq[String]): FilterMatcher = {
     val includes = includeFilters.map(fixSeparatorsInPathPattern)
     val excludes = excludeFilters.map(fixSeparatorsInPathPattern)
-    new FilterMatcher(mkRegexp(includes, ".*"), mkRegexp(excludes, "$a"))
+    new FilterMatcher(mkRegexp(includes), mkRegexp(excludes))
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/FilterMatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FilterMatcher.scala
@@ -1,0 +1,32 @@
+package scala.meta.internal.metals
+// This file contains parts that are derived from
+// Scalafmt, in particular FilterMatcher.scala and OsSpecific.scala:
+// - https://github.com/scalameta/scalafmt/blob/64bedcc8f6eed7b9912589ae6cdace86bef974b5/scalafmt-core/shared/src/main/scala/org/scalafmt/config/FilterMatcher.scala#L7
+// - https://github.com/scalameta/scalafmt/blob/08c6798a40188ce69b3287e3026becfbd540a847/scalafmt-core/shared/src/main/scala/org/scalafmt/util/OsSpecific.scala
+
+import scala.util.matching.Regex
+import java.io.File
+
+case class FilterMatcher(include: Regex, exclude: Regex) {
+  def matches(input: String): Boolean =
+    include.findFirstIn(input).isDefined &&
+      exclude.findFirstIn(input).isEmpty
+}
+
+object FilterMatcher {
+  private def mkRegexp(filters: Seq[String], ifEmpty: String): Regex =
+    filters match {
+      case Nil => ifEmpty.r
+      case head :: Nil => head.r
+      case _ => filters.mkString("(", "|", ")").r
+    }
+
+  private def fixSeparatorsInPathPattern(unixSpecificPattern: String): String =
+    unixSpecificPattern.replace('/', File.separatorChar)
+
+  def apply(includeFilters: Seq[String], excludeFilters: Seq[String]): FilterMatcher = {
+    val includes = includeFilters.map(fixSeparatorsInPathPattern)
+    val excludes = excludeFilters.map(fixSeparatorsInPathPattern)
+    new FilterMatcher(mkRegexp(includes, ".*"), mkRegexp(excludes, "$a"))
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -17,6 +17,7 @@ import org.eclipse.{lsp4j => l}
 import org.eclipse.lsp4j.PublishDiagnosticsParams
 import scala.concurrent.ExecutionContext
 import scala.meta.internal.metals.Messages.MissingScalafmtConf
+import scala.meta.internal.metals.Messages.ScalafmtError
 import scala.util.control.NonFatal
 
 /**
@@ -70,7 +71,7 @@ final class FormattingProvider(
         .fold(
           e => {
             scribe.error(s"scalafmt error: ${e.getMessage}")
-            client.showMessage(MissingScalafmtConf.formatError(e))
+            client.showMessage(ScalafmtError.formatError(e))
             None
           },
           Some(_)
@@ -126,7 +127,7 @@ final class FormattingProvider(
       case _ =>
         e.getMessage
     }
-    val params = MissingScalafmtConf.configParseError(
+    val params = ScalafmtError.configParseError(
       path.toRelative(workspace),
       message
     )
@@ -134,7 +135,7 @@ final class FormattingProvider(
   }
 
   def handleMissingFile(path: AbsolutePath): Unit = {
-    val params = Messages.MissingScalafmtConf.params(path)
+    val params = MissingScalafmtConf.params(path)
     client.showMessageRequest(params).asScala.foreach { item =>
       if (item == MissingScalafmtConf.createFile) {
         val text =
@@ -189,7 +190,7 @@ final class FormattingProvider(
         })
       case None =>
         val params =
-          MissingScalafmtConf.downloadError(version)
+          ScalafmtError.downloadError(version)
         client.showMessage(params)
         None
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -51,6 +51,18 @@ final class FormattingProvider(
         if (config.hasPath("version")) config.getString("version")
         else defaultScalafmtVersion
       }
+      (includeFilters, excludeFilters) = {
+        val excludeFilters =
+          if (config.hasPath("project.excludeFilters"))
+            config.getStringList("project.excludeFilters").asScala
+          else Nil
+        val includeFilters =
+          if (config.hasPath("project.includeFilters"))
+            config.getStringList("project.includeFilters").asScala
+          else Nil
+        (includeFilters, excludeFilters)
+      }
+      if FilterMatcher(includeFilters, excludeFilters).matches(path.toString)
       scalafmt <- classloadScalafmt(version)
       formatted <- scalafmt
         .format(input.text, scalafmtConf.toString(), input.path)

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -3,12 +3,21 @@ package scala.meta.internal.metals
 import scala.meta._
 import org.eclipse.{lsp4j => l}
 import MetalsEnrichments._
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigException
 import scala.language.reflectiveCalls
 import java.util
 import java.nio.file.Files
 import scala.util.Try
 import scala.meta.internal.tokenizers.PlatformTokenizerCache
 import com.typesafe.config.ConfigFactory
+import java.nio.charset.StandardCharsets
+import java.util.Collections
+import org.eclipse.{lsp4j => l}
+import org.eclipse.lsp4j.PublishDiagnosticsParams
+import scala.concurrent.ExecutionContext
+import scala.meta.internal.metals.Messages.MissingScalafmtConf
+import scala.util.control.NonFatal
 
 /**
  * Implement text formatting using Scalafmt
@@ -17,41 +26,113 @@ final class FormattingProvider(
     workspace: AbsolutePath,
     buffers: Buffers,
     embedded: Embedded,
-    userConfig: () => UserConfiguration
-) {
+    userConfig: () => UserConfiguration,
+    client: MetalsLanguageClient,
+    statusBar: StatusBar,
+    icons: Icons
+)(implicit ec: ExecutionContext) {
 
+  private def defaultScalafmtVersion = "1.5.1"
   def format(path: AbsolutePath): util.List[l.TextEdit] = {
     val input = path.toInputFromBuffers(buffers)
     val fullDocumentRange = Position.Range(input, 0, input.chars.length).toLSP
-    val defaultScalafmtVersion = "1.5.1"
-    (for {
-      scalafmt <- scalafmtConfigPath match {
-        case Some(configPath) =>
-          val scalafmtConf = ConfigFactory.parseFile(configPath.toNIO.toFile)
-          val scalafmtVersion = Try(scalafmtConf.getString("version")).toOption
-            .getOrElse(defaultScalafmtVersion)
-          classloadScalafmt(scalafmtVersion)
-        case _ =>
-          scribe.info(
-            "Skipping formatting request because no Scalafmt config file is present"
-          )
+    val scalafmtConf = workspace.resolve(userConfig().scalafmtConfigPath)
+    val edits = for {
+      confPath <- {
+        if (scalafmtConf.isFile) {
+          Some(scalafmtConf)
+        } else {
+          handleMissingFile(scalafmtConf)
           None
+        }
       }
-      configPath <- scalafmtConfigPath
+      config <- parseConfig(confPath)
+      version = {
+        if (config.hasPath("version")) config.getString("version")
+        else defaultScalafmtVersion
+      }
+      scalafmt <- classloadScalafmt(version)
       formatted <- scalafmt
-        .format(input.text, configPath.toString, input.path)
-        .fold(e => {
-          scribe.error(s"Scalafmt error: ${e.getMessage}")
-          None
-        }, Some(_))
-    } yield {
-      List(new l.TextEdit(fullDocumentRange, formatted))
-    }).getOrElse(Nil).asJava
+        .format(input.text, scalafmtConf.toString(), input.path)
+        .fold(
+          e => {
+            scribe.error(s"scalafmt error: ${e.getMessage}")
+            client.showMessage(MissingScalafmtConf.formatError(e))
+            None
+          },
+          Some(_)
+        )
+    } yield List(new l.TextEdit(fullDocumentRange, formatted))
+    edits.getOrElse(Nil).asJava
   }
 
-  private def scalafmtConfigPath: Option[AbsolutePath] = {
-    Some(workspace.resolve(userConfig().scalafmtConfigPath))
-      .filter(path => Files.isRegularFile(path.toNIO))
+  def parseConfig(path: AbsolutePath): Option[Config] = {
+    try {
+      val result = ConfigFactory.parseFile(path.toFile)
+      client.publishDiagnostics(
+        new PublishDiagnosticsParams(
+          path.toURI.toString,
+          Collections.emptyList()
+        )
+      )
+      Some(result)
+    } catch {
+      case e: ConfigException =>
+        handleConfigError(path, e)
+        None
+    }
+  }
+
+  def handleConfigError(path: AbsolutePath, e: ConfigException): Unit = {
+    val message = e match {
+      case e: ConfigException.Parse if e.origin().lineNumber() >= 0 =>
+        val line = e.origin().lineNumber() - 1
+        val message = e.getMessage.stripPrefix(s"$path: ${line + 1}: ")
+        val diagnostic = new l.Diagnostic(
+          new l.Range(
+            new l.Position(line, 0),
+            new l.Position(line, 0)
+          ),
+          message,
+          l.DiagnosticSeverity.Error,
+          "hocon"
+        )
+        client.publishDiagnostics(
+          new PublishDiagnosticsParams(
+            path.toURI.toString,
+            Collections.singletonList(diagnostic)
+          )
+        )
+        statusBar.addMessage(
+          MetalsStatusParams(
+            s"${icons.alert}.scalafmt.conf parse error",
+            command = ClientCommands.FocusDiagnostics.id
+          )
+        )
+        message
+      case _ =>
+        e.getMessage
+    }
+    val params = MissingScalafmtConf.configParseError(
+      path.toRelative(workspace),
+      message
+    )
+    client.showMessage(params)
+  }
+
+  def handleMissingFile(path: AbsolutePath): Unit = {
+    val params = Messages.MissingScalafmtConf.params(path)
+    client.showMessageRequest(params).asScala.foreach { item =>
+      if (item == MissingScalafmtConf.createFile) {
+        val text =
+          s"""version = "$defaultScalafmtVersion"
+             |""".stripMargin
+
+        Files.createDirectories(path.toNIO.getParent)
+        Files.write(path.toNIO, text.getBytes(StandardCharsets.UTF_8))
+        client.showMessage(MissingScalafmtConf.fixedParams)
+      }
+    }
   }
 
   private def classloadScalafmt(version: String): Option[Scalafmt] = {
@@ -64,6 +145,24 @@ final class FormattingProvider(
           .loadClass("org.scalafmt.cli.Scalafmt210")
           .newInstance()
           .asInstanceOf[Scalafmt210]
+        // See https://github.com/scalameta/scalameta/issues/1068
+        def clearMegaCache(): Unit = {
+          try {
+            val cls =
+              classloader.loadClass(PlatformTokenizerCache.getClass.getName)
+            val module = cls.getField("MODULE$")
+            module.setAccessible(true)
+            val megacache = cls.getMethod("megaCache")
+            megacache.setAccessible(true)
+            val instance = module.get(null)
+            val map =
+              megacache.invoke(instance).asInstanceOf[java.util.Map[_, _]]
+            map.clear()
+          } catch {
+            case NonFatal(e) =>
+              scribe.error("megaCache error", e)
+          }
+        }
         Some(new Scalafmt {
           def format(
               code: String,
@@ -71,15 +170,14 @@ final class FormattingProvider(
               filename: String
           ): Try[String] = {
             val r = Try(scalafmt210.format(code, configFile, filename))
-            // See https://github.com/scalameta/scalameta/issues/1068
-            PlatformTokenizerCache.megaCache.clear()
+            clearMegaCache()
             r
           }
         })
       case None =>
-        scribe.error(
-          "not found: Scalafmt classloader. Make sure you have specified an existing version of Scalafmt in the settings"
-        )
+        val params =
+          MissingScalafmtConf.downloadError(version)
+        client.showMessage(params)
         None
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -7,6 +7,8 @@ import scala.language.reflectiveCalls
 import java.util
 import java.nio.file.Files
 import scala.util.Try
+import scala.meta.internal.tokenizers.PlatformTokenizerCache
+import com.typesafe.config.ConfigFactory
 
 /**
  * Implement text formatting using Scalafmt
@@ -21,47 +23,42 @@ final class FormattingProvider(
   def format(path: AbsolutePath): util.List[l.TextEdit] = {
     val input = path.toInputFromBuffers(buffers)
     val fullDocumentRange = Position.Range(input, 0, input.chars.length).toLSP
+    val defaultScalafmtVersion = "1.5.1"
     (for {
-      scalafmt <- classloadedScalafmt
-      formatted <- scalafmtConfigPath match {
+      scalafmt <- scalafmtConfigPath match {
         case Some(configPath) =>
-          scalafmt
-            .format(input.text, configPath.toString, input.path)
-            .fold(e => {
-              scribe.error("Error while running Scalafmt", e)
-              None
-            }, Some(_))
-        case None if !userConfig().scalafmtRequireConfigFile =>
-          scalafmt
-            .format(input.text, input.path)
-            .fold(e => {
-              scribe.error("Error while running Scalafmt", e)
-              None
-            }, Some(_))
+          val scalafmtConf = ConfigFactory.parseFile(configPath.toNIO.toFile)
+          val scalafmtVersion = Try(scalafmtConf.getString("version")).toOption
+            .getOrElse(defaultScalafmtVersion)
+          classloadScalafmt(scalafmtVersion)
         case _ =>
           scribe.info(
             "Skipping formatting request because no Scalafmt config file is present"
           )
           None
       }
+      configPath <- scalafmtConfigPath
+      formatted <- scalafmt
+        .format(input.text, configPath.toString, input.path)
+        .fold(e => {
+          scribe.error(s"Scalafmt error: ${e.getMessage}")
+          None
+        }, Some(_))
     } yield {
       List(new l.TextEdit(fullDocumentRange, formatted))
     }).getOrElse(Nil).asJava
   }
 
   private def scalafmtConfigPath: Option[AbsolutePath] = {
-    val relativePath =
-      userConfig().scalafmtConfigPath.getOrElse(".scalafmt.conf")
-    Some(workspace.resolve(relativePath))
+    Some(workspace.resolve(userConfig().scalafmtConfigPath))
       .filter(path => Files.isRegularFile(path.toNIO))
   }
 
-  private val classloadedScalafmt: Option[Scalafmt] = {
-    embedded.scalafmtJars match {
+  private def classloadScalafmt(version: String): Option[Scalafmt] = {
+    embedded.scalafmtJars(version) match {
       case Some(classloader) =>
         type Scalafmt210 = {
           def format(code: String, configFile: String, filename: String): String
-          def format(code: String, filename: String): String
         }
         val scalafmt210 = classloader
           .loadClass("org.scalafmt.cli.Scalafmt210")
@@ -72,14 +69,16 @@ final class FormattingProvider(
               code: String,
               configFile: String,
               filename: String
-          ): Try[String] =
-            Try(scalafmt210.format(code, configFile, filename))
-          def format(code: String, filename: String): Try[String] =
-            Try(scalafmt210.format(code, filename))
+          ): Try[String] = {
+            val r = Try(scalafmt210.format(code, configFile, filename))
+            // See https://github.com/scalameta/scalameta/issues/1068
+            PlatformTokenizerCache.megaCache.clear()
+            r
+          }
         })
       case None =>
         scribe.error(
-          "not found: scalafmt classloader. Make sure you have specified an existing version of Scalafmt in the settings"
+          "not found: Scalafmt classloader. Make sure you have specified an existing version of Scalafmt in the settings"
         )
         None
     }
@@ -89,5 +88,4 @@ final class FormattingProvider(
 
 private trait Scalafmt {
   def format(code: String, configFile: String, filename: String): Try[String]
-  def format(code: String, filename: String): Try[String]
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -1,0 +1,93 @@
+package scala.meta.internal.metals
+
+import scala.meta._
+import org.eclipse.{lsp4j => l}
+import MetalsEnrichments._
+import scala.language.reflectiveCalls
+import java.util
+import java.nio.file.Files
+import scala.util.Try
+
+/**
+ * Implement text formatting using Scalafmt
+ */
+final class FormattingProvider(
+    workspace: AbsolutePath,
+    buffers: Buffers,
+    embedded: Embedded,
+    userConfig: () => UserConfiguration
+) {
+
+  def format(path: AbsolutePath): util.List[l.TextEdit] = {
+    val input = path.toInputFromBuffers(buffers)
+    val fullDocumentRange = Position.Range(input, 0, input.chars.length).toLSP
+    (for {
+      scalafmt <- classloadedScalafmt
+      formatted <- scalafmtConfigPath match {
+        case Some(configPath) =>
+          scalafmt
+            .format(input.text, configPath.toString, input.path)
+            .fold(e => {
+              scribe.error("Error while running Scalafmt", e)
+              None
+            }, Some(_))
+        case None if !userConfig().scalafmtRequireConfigFile =>
+          scalafmt
+            .format(input.text, input.path)
+            .fold(e => {
+              scribe.error("Error while running Scalafmt", e)
+              None
+            }, Some(_))
+        case _ =>
+          scribe.info(
+            "Skipping formatting request because no Scalafmt config file is present"
+          )
+          None
+      }
+    } yield {
+      List(new l.TextEdit(fullDocumentRange, formatted))
+    }).getOrElse(Nil).asJava
+  }
+
+  private def scalafmtConfigPath: Option[AbsolutePath] = {
+    val relativePath =
+      userConfig().scalafmtConfigPath.getOrElse(".scalafmt.conf")
+    Some(workspace.resolve(relativePath))
+      .filter(path => Files.isRegularFile(path.toNIO))
+  }
+
+  private val classloadedScalafmt: Option[Scalafmt] = {
+    embedded.scalafmtJars match {
+      case Some(classloader) =>
+        type Scalafmt210 = {
+          def format(code: String, configFile: String, filename: String): String
+          def format(code: String, filename: String): String
+        }
+        val scalafmt210 = classloader
+          .loadClass("org.scalafmt.cli.Scalafmt210")
+          .newInstance()
+          .asInstanceOf[Scalafmt210]
+        Some(new Scalafmt {
+          def format(
+              code: String,
+              configFile: String,
+              filename: String
+          ): Try[String] =
+            Try(scalafmt210.format(code, configFile, filename))
+          def format(code: String, filename: String): Try[String] =
+            Try(scalafmt210.format(code, filename))
+        })
+      case None =>
+        scribe.error(
+          "not found: scalafmt classloader. Make sure you have specified an existing version of Scalafmt in the settings"
+        )
+        None
+    }
+  }
+
+}
+
+private trait Scalafmt {
+  def format(code: String, configFile: String, filename: String): Try[String]
+  def format(code: String, filename: String): Try[String]
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -33,7 +33,7 @@ final class FormattingProvider(
     icons: Icons
 )(implicit ec: ExecutionContext) {
 
-  private val defaultScalafmtVersion = "1.5.1"
+  private def defaultScalafmtVersion = "1.5.1"
 
   def format(path: AbsolutePath): util.List[l.TextEdit] = {
     val input = path.toInputFromBuffers(buffers)
@@ -53,16 +53,15 @@ final class FormattingProvider(
         if (config.hasPath("version")) config.getString("version")
         else defaultScalafmtVersion
       }
-      (includeFilters, excludeFilters) = {
-        val excludeFilters =
-          if (config.hasPath("project.excludeFilters"))
-            config.getStringList("project.excludeFilters").asScala
-          else Nil
-        val includeFilters =
-          if (config.hasPath("project.includeFilters"))
-            config.getStringList("project.includeFilters").asScala
-          else List(".*\\.scala$", ".*\\.sbt$", ".*\\.sc$")
-        (includeFilters, excludeFilters)
+      includeFilters = {
+        if (config.hasPath("project.includeFilters"))
+          config.getStringList("project.includeFilters").asScala
+        else List(".*\\.scala$", ".*\\.sbt$", ".*\\.sc$")
+      }
+      excludeFilters = {
+        if (config.hasPath("project.excludeFilters"))
+          config.getStringList("project.excludeFilters").asScala
+        else Nil
       }
       if FilterMatcher(includeFilters, excludeFilters).matches(path.toString)
       scalafmt <- classloadScalafmt(version)

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -32,7 +32,8 @@ final class FormattingProvider(
     icons: Icons
 )(implicit ec: ExecutionContext) {
 
-  private def defaultScalafmtVersion = "1.5.1"
+  private val defaultScalafmtVersion = "1.5.1"
+
   def format(path: AbsolutePath): util.List[l.TextEdit] = {
     val input = path.toInputFromBuffers(buffers)
     val fullDocumentRange = Position.Range(input, 0, input.chars.length).toLSP

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -60,7 +60,7 @@ final class FormattingProvider(
         val includeFilters =
           if (config.hasPath("project.includeFilters"))
             config.getStringList("project.includeFilters").asScala
-          else Nil
+          else List(".*\\.scala$", ".*\\.sbt$", ".*\\.sc$")
         (includeFilters, excludeFilters)
       }
       if FilterMatcher(includeFilters, excludeFilters).matches(path.toString)

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -230,13 +230,7 @@ class Messages(icons: Icons) {
       )
   }
 
-  object MissingScalafmtConf {
-    def createFile = new MessageActionItem("Create .scalafmt.conf")
-    def fixedParams: MessageParams =
-      new MessageParams(
-        MessageType.Info,
-        "Created a .scalafmt.conf, formatting should work now. "
-      )
+  object ScalafmtError {
     def configParseError(
         path: RelativePath,
         message: String
@@ -258,6 +252,15 @@ class Messages(icons: Icons) {
           "Make sure you have a working internet connection and this version exists on Maven Central."
       )
     }
+  }
+
+  object MissingScalafmtConf {
+    def createFile = new MessageActionItem("Create .scalafmt.conf")
+    def fixedParams: MessageParams =
+      new MessageParams(
+        MessageType.Info,
+        "Created a .scalafmt.conf, formatting should work now. "
+      )
     def isCreateScalafmtConf(params: ShowMessageRequestParams): Boolean =
       params.getMessage == createScalafmtConfMessage
     def createScalafmtConfMessage: String =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -83,6 +83,7 @@ class MetalsLanguageServer(
   private var definitionProvider: DefinitionProvider = _
   private val documentSymbolProvider: DocumentSymbolProvider =
     new DocumentSymbolProvider(buffers)
+  private var formattingProvider: FormattingProvider = _
   private var initializeParams: Option[InitializeParams] = None
   var tables: Tables = _
   private var statusBar: StatusBar = _
@@ -172,6 +173,12 @@ class MetalsLanguageServer(
       config.icons,
       statusBar
     )
+    formattingProvider = new FormattingProvider(
+      workspace,
+      buffers,
+      embedded,
+      () => userConfig
+    )
     doctor = new Doctor(
       buildTargets,
       config,
@@ -208,6 +215,7 @@ class MetalsLanguageServer(
       )
       capabilities.setDefinitionProvider(true)
       capabilities.setDocumentSymbolProvider(true)
+      capabilities.setDocumentFormattingProvider(true)
       capabilities.setTextDocumentSync(TextDocumentSyncKind.Full)
       if (config.isNoInitialized) {
         sh.schedule(
@@ -552,8 +560,7 @@ class MetalsLanguageServer(
       params: DocumentFormattingParams
   ): CompletableFuture[util.List[TextEdit]] =
     CompletableFutures.computeAsync { _ =>
-      scribe.warn("textDocument/formatting is not supported.")
-      null
+      formattingProvider.format(params.getTextDocument.getUri.toAbsolutePath)
     }
 
   @JsonRequest("textDocument/rename")

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -177,7 +177,10 @@ class MetalsLanguageServer(
       workspace,
       buffers,
       embedded,
-      () => userConfig
+      () => userConfig,
+      languageClient,
+      statusBar,
+      config.icons
     )
     doctor = new Doctor(
       buildTargets,

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -49,7 +49,10 @@ object UserConfiguration {
       default.scalafmtConfigPath.toString,
       "project/.scalafmt.conf",
       "Scalafmt config path",
-      "Optional Scalafmt config file path, relative to the workspace root"
+      """Optional custom path to the .scalafmt.conf file.
+        |Should be relative to the workspace root directory and use forward slashes / for file
+        |separators (even on Windows).
+        |""".stripMargin
     )
   )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.metals
 
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
+import com.google.gson.JsonElement
 import java.util.Properties
 import scala.collection.mutable.ListBuffer
 import scala.util.Try
@@ -13,7 +14,10 @@ import scala.util.Try
  */
 case class UserConfiguration(
     javaHome: Option[String] = None,
-    sbtScript: Option[String] = None
+    sbtScript: Option[String] = None,
+    scalafmtVersion: Option[String] = None,
+    scalafmtRequireConfigFile: Boolean = true,
+    scalafmtConfigPath: Option[String] = None
 )
 
 object UserConfiguration {
@@ -35,6 +39,31 @@ object UserConfiguration {
         |`.jvmopts` and `.sbtopts`. Update this setting if your `sbt` script requires more customizations
         |like using environment variables.
         |""".stripMargin
+    ),
+    UserConfigurationOption(
+      "scalafmt-version",
+      "1.5.1",
+      "1.3.0",
+      "Scalafmt version",
+      """Optional Scalafmt version"""
+    ),
+    UserConfigurationOption(
+      "scalafmt-require-config-file",
+      "true",
+      "false",
+      "Scalafmt require config file",
+      """|Whether a Scalafmt config file is required for formatting to work.
+         |By default, Metals ignores textFormatting/requests if no Scalafmt config file is found.
+         |Update this setting to `true` if you prefer to run Scalafmt with its default configuration
+         |when no Scalafmt config file is present.
+      """.stripMargin
+    ),
+    UserConfigurationOption(
+      "scalafmt-require-config-path",
+      ".scalafmt.conf",
+      "path/to/my/scalafmt.conf",
+      "Scalafmt config path",
+      "Optional Scalafmt config file path, relative to the workspace root"
     )
   )
 
@@ -46,36 +75,60 @@ object UserConfiguration {
     val base: JsonObject =
       Option(json.getAsJsonObject("metals")).getOrElse(new JsonObject)
 
-    def getKey(key: String): Option[String] = {
+    def getKey[A](key: String, f: JsonElement => Option[A]): Option[A] = {
       def option[T](fn: String => T): Option[T] =
         Option(fn(key)).orElse(Option(fn(StringCase.kebabToCamel(key))))
       for {
-        value <- option(base.get)
+        jsonValue <- option(base.get)
           .orElse(
             option(k => properties.getProperty(s"metals.$k"))
               .map(new JsonPrimitive(_))
           )
-        string <- Try(value.getAsString).fold(
-          _ => {
-            errors += s"json error: key '$key' should have value of type string but obtained $value"
-            None
-          },
-          Some(_)
-        )
-        if string.nonEmpty
-      } yield string
+        value <- f(jsonValue)
+      } yield value
     }
 
+    def getStringKey(key: String): Option[String] =
+      getKey(
+        key,
+        value =>
+          Try(value.getAsString)
+            .fold(_ => {
+              errors += s"json error: key '$key' should have value of type string but obtained $value"
+              None
+            }, Some(_))
+            .filter(_.nonEmpty)
+      )
+
+    def getBooleanKey(key: String): Option[Boolean] =
+      getKey(
+        key,
+        value =>
+          Try(value.getAsBoolean).fold(_ => {
+            errors += s"json error: key '$key' should have value of type boolean but obtained $value"
+            None
+          }, Some(_))
+      )
+
     val javaHome =
-      getKey("java-home")
+      getStringKey("java-home")
     val sbtScript =
-      getKey("sbt-script")
+      getStringKey("sbt-script")
+    val scalafmtVersion =
+      getStringKey("scalafmt-version")
+    val scalafmtRequireConfigFile =
+      getBooleanKey("scalafmt-require-config-file").getOrElse(true)
+    val scalafmtConfigPath =
+      getStringKey("scalafmt-config-path")
 
     if (errors.isEmpty) {
       Right(
         UserConfiguration(
           javaHome,
-          sbtScript
+          sbtScript,
+          scalafmtVersion,
+          scalafmtRequireConfigFile,
+          scalafmtConfigPath
         )
       )
     } else {

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals
 
+import scala.meta.RelativePath
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import com.google.gson.JsonElement
@@ -15,12 +16,15 @@ import scala.util.Try
 case class UserConfiguration(
     javaHome: Option[String] = None,
     sbtScript: Option[String] = None,
-    scalafmtVersion: Option[String] = None,
-    scalafmtRequireConfigFile: Boolean = true,
-    scalafmtConfigPath: Option[String] = None
+    scalafmtConfigPath: RelativePath =
+      UserConfiguration.default.scalafmtConfigPath
 )
 
 object UserConfiguration {
+  object default {
+    val scalafmtConfigPath = RelativePath(".scalafmt.conf")
+  }
+
   def options: List[UserConfigurationOption] = List(
     UserConfigurationOption(
       "java-home",
@@ -41,27 +45,9 @@ object UserConfiguration {
         |""".stripMargin
     ),
     UserConfigurationOption(
-      "scalafmt-version",
-      "1.5.1",
-      "1.3.0",
-      "Scalafmt version",
-      """Optional Scalafmt version"""
-    ),
-    UserConfigurationOption(
-      "scalafmt-require-config-file",
-      "true",
-      "false",
-      "Scalafmt require config file",
-      """|Whether a Scalafmt config file is required for formatting to work.
-         |By default, Metals ignores textFormatting/requests if no Scalafmt config file is found.
-         |Update this setting to `true` if you prefer to run Scalafmt with its default configuration
-         |when no Scalafmt config file is present.
-      """.stripMargin
-    ),
-    UserConfigurationOption(
-      "scalafmt-require-config-path",
-      ".scalafmt.conf",
-      "path/to/my/scalafmt.conf",
+      "scalafmt-config-path",
+      default.scalafmtConfigPath.toString,
+      "project/.scalafmt.conf",
       "Scalafmt config path",
       "Optional Scalafmt config file path, relative to the workspace root"
     )
@@ -100,34 +86,20 @@ object UserConfiguration {
             .filter(_.nonEmpty)
       )
 
-    def getBooleanKey(key: String): Option[Boolean] =
-      getKey(
-        key,
-        value =>
-          Try(value.getAsBoolean).fold(_ => {
-            errors += s"json error: key '$key' should have value of type boolean but obtained $value"
-            None
-          }, Some(_))
-      )
-
     val javaHome =
       getStringKey("java-home")
     val sbtScript =
       getStringKey("sbt-script")
-    val scalafmtVersion =
-      getStringKey("scalafmt-version")
-    val scalafmtRequireConfigFile =
-      getBooleanKey("scalafmt-require-config-file").getOrElse(true)
     val scalafmtConfigPath =
       getStringKey("scalafmt-config-path")
+        .map(RelativePath(_))
+        .getOrElse(default.scalafmtConfigPath)
 
     if (errors.isEmpty) {
       Right(
         UserConfiguration(
           javaHome,
           sbtScript,
-          scalafmtVersion,
-          scalafmtRequireConfigFile,
           scalafmtConfigPath
         )
       )

--- a/test-workspace/.scalafmt.conf
+++ b/test-workspace/.scalafmt.conf
@@ -1,1 +1,1 @@
-align = none
+version = "1.5.1"

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -2,9 +2,12 @@ package example
 
 import java.nio.file.Paths
 
-case class User(name: String, age: Int)
+case class User(
+    name: String,
+    age: Int
+)
 
 object User {
-  val sum: Int = ""
+  val x: Int = 42
   val path = Paths.get("build.sbt")
 }

--- a/tests/unit/src/main/scala/tests/InputFile.scala
+++ b/tests/unit/src/main/scala/tests/InputFile.scala
@@ -11,7 +11,7 @@ import scala.meta.internal.mtags.MtagsEnrichments._
 case class InputFile(
     file: AbsolutePath,
     sourceDirectory: AbsolutePath,
-    semanticdbRelativePath: RelativePath,
+    semanticdbRelativePath: RelativePath
 ) {
   def sourceDirectoryRelativePath: RelativePath =
     file.toRelative(sourceDirectory)

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -173,6 +173,8 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
           CheckDoctor.moreInformation
         } else if (SelectBspServer.isSelectBspServer(params)) {
           params.getActions.asScala.find(_.getTitle == "Bob").get
+        } else if (MissingScalafmtConf.isCreateScalafmtConf(params)) {
+          null
         } else {
           throw new IllegalArgumentException(params.toString)
         }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -8,6 +8,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
+import java.util
 import java.util.Collections
 import org.eclipse.lsp4j.ClientCapabilities
 import org.eclipse.lsp4j.DidChangeConfigurationParams
@@ -16,7 +17,9 @@ import org.eclipse.lsp4j.DidCloseTextDocumentParams
 import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.DidSaveTextDocumentParams
 import org.eclipse.lsp4j.DocumentSymbolParams
+import org.eclipse.lsp4j.DocumentFormattingParams
 import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.FormattingOptions
 import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.InitializedParams
 import org.eclipse.lsp4j.TextDocumentClientCapabilities
@@ -24,6 +27,7 @@ import org.eclipse.lsp4j.TextDocumentContentChangeEvent
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentItem
 import org.eclipse.lsp4j.TextDocumentPositionParams
+import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
 import org.eclipse.lsp4j.WorkspaceClientCapabilities
 import scala.collection.concurrent.TrieMap
@@ -200,6 +204,18 @@ final class TestingServer(
       val json = new JsonParser().parse(wrapped)
       server.didChangeConfiguration(new DidChangeConfigurationParams(json))
     }
+  }
+
+  def formatting(filename: String): Future[util.List[TextEdit]] = {
+    val abspath = toPath(filename)
+    server
+      .formatting(
+        new DocumentFormattingParams(
+          new TextDocumentIdentifier(abspath.toURI.toString),
+          new FormattingOptions
+        )
+      )
+      .asScala
   }
 
   private def toSemanticdbTextDocument(path: AbsolutePath): s.TextDocument = {

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -221,17 +221,23 @@ final class TestingServer(
       .map(textEdits => applyTextEdits(path, textEdits))
   }
 
-  private def applyTextEdits(path: AbsolutePath, textEdits: util.List[TextEdit]): Unit = {
+  private def applyTextEdits(
+      path: AbsolutePath,
+      textEdits: util.List[TextEdit]
+  ): Unit = {
     for {
       buffer <- buffers.get(path)
     } yield {
       val input = Input.String(buffer)
-      val newBuffer = textEdits.asScala.foldLeft(buffer) { case (buf, edit) =>
-        val startPosition = edit.getRange.getStart
-        val endPosition = edit.getRange.getEnd
-        val startOffset = input.toOffset(startPosition.getLine, startPosition.getCharacter)
-        val endOffset = input.toOffset(endPosition.getLine, endPosition.getCharacter)
-        buf.patch(startOffset, edit.getNewText, endOffset)
+      val newBuffer = textEdits.asScala.foldLeft(buffer) {
+        case (buf, edit) =>
+          val startPosition = edit.getRange.getStart
+          val endPosition = edit.getRange.getEnd
+          val startOffset =
+            input.toOffset(startPosition.getLine, startPosition.getCharacter)
+          val endOffset =
+            input.toOffset(endPosition.getLine, endPosition.getCharacter)
+          buf.patch(startOffset, edit.getNewText, endOffset)
       }
       buffers.put(path, newBuffer)
     }
@@ -314,8 +320,10 @@ final class TestingServer(
     Semanticdbs.printTextDocument(textDocument)
   }
 
-  def bufferContent(filename: String): Option[String] =
-    buffers.get(toPath(filename))
+  def bufferContent(filename: String): String =
+    buffers
+      .get(toPath(filename))
+      .getOrElse(throw new NoSuchElementException(filename))
 
   def cancel(): Unit = {
     server.cancel()

--- a/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
@@ -3,6 +3,7 @@ package tests
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import scala.meta.internal.metals.Messages.MissingScalafmtConf
+import scala.meta.internal.metals.Messages.ScalafmtError
 
 object FormattingSlowSuite extends BaseSlowSuite("formatting") {
 
@@ -124,7 +125,7 @@ object FormattingSlowSuite extends BaseSlowSuite("formatting") {
       _ <- server.formatting("Main.scala")
       _ = assertNoDiff(
         client.workspaceShowMessages,
-        MissingScalafmtConf.downloadError("does-not-exist").getMessage
+        ScalafmtError.downloadError("does-not-exist").getMessage
       )
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
@@ -2,6 +2,7 @@ package tests
 
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
+import scala.meta.internal.metals.Messages.MissingScalafmtConf
 
 object FormattingSlowSuite extends BaseSlowSuite("formatting") {
 
@@ -20,7 +21,7 @@ object FormattingSlowSuite extends BaseSlowSuite("formatting") {
       _ <- server.formatting("a/src/main/scala/a/Main.scala")
       // check that the file has been formatted
       _ = assertNoDiff(
-        server.bufferContent("a/src/main/scala/a/Main.scala").get,
+        server.bufferContent("a/src/main/scala/a/Main.scala"),
         """|object FormatMe {
            |  val x = 1
            |}""".stripMargin
@@ -39,9 +40,13 @@ object FormattingSlowSuite extends BaseSlowSuite("formatting") {
       )
       _ <- server.didOpen("a/src/main/scala/a/Main.scala")
       _ <- server.formatting("a/src/main/scala/a/Main.scala")
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        MissingScalafmtConf.createScalafmtConfMessage
+      )
       // check that the formatting request has been ignored
       _ = assertNoDiff(
-        server.bufferContent("a/src/main/scala/a/Main.scala").get,
+        server.bufferContent("a/src/main/scala/a/Main.scala"),
         """|object FormatMe {
            | val x = 1  }
            |""".stripMargin
@@ -71,7 +76,7 @@ object FormattingSlowSuite extends BaseSlowSuite("formatting") {
       }
       _ <- server.formatting("a/src/main/scala/a/Main.scala")
       _ = assertNoDiff(
-        server.bufferContent("a/src/main/scala/a/Main.scala").get,
+        server.bufferContent("a/src/main/scala/a/Main.scala"),
         """|object FormatMe {
            |  val x = 1
            |}""".stripMargin
@@ -97,11 +102,54 @@ object FormattingSlowSuite extends BaseSlowSuite("formatting") {
       _ <- server.formatting("a/src/main/scala/a/Main.scala")
       // check that the file has been formatted respecting the trailing comma config (new in 1.6.0)
       _ = assertNoDiff(
-        server.bufferContent("a/src/main/scala/a/Main.scala").get,
+        server.bufferContent("a/src/main/scala/a/Main.scala"),
         """|case class User(
            |    name: String,
            |    age: Int
            |)""".stripMargin
+      )
+    } yield ()
+  }
+
+  testAsync("download-error") {
+    for {
+      _ <- server.initialize(
+        """|.scalafmt.conf
+           |version="does-not-exist"
+           |/Main.scala
+           |object  Main
+           |""".stripMargin,
+        expectError = true
+      )
+      _ <- server.formatting("Main.scala")
+      _ = assertNoDiff(
+        client.workspaceShowMessages,
+        MissingScalafmtConf.downloadError("does-not-exist").getMessage
+      )
+    } yield ()
+  }
+
+  testAsync("config-error") {
+    for {
+      _ <- server.initialize(
+        """|.scalafmt.conf
+           |align=none
+           |version=
+           |maxColumn=80
+           |/Main.scala
+           |object  Main
+           |""".stripMargin,
+        expectError = true
+      )
+      _ <- server.didOpen(".scalafmt.conf")
+      _ <- server.formatting("Main.scala")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """
+          |.scalafmt.conf:3:1: error: Expecting end of input or a comma, got '=' (if you intended '=' to be part of a key or string value, try enclosing the key or value in double quotes, or you may be able to rename the file .properties rather than .conf)
+          |maxColumn=80
+          |^
+        """.stripMargin
       )
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
@@ -199,4 +199,24 @@ object FormattingSlowSuite extends BaseSlowSuite("formatting") {
     } yield ()
   }
 
+  testAsync(".sbt") {
+    for {
+      _ <- server.initialize(
+        """|/.scalafmt.conf
+           |
+           |/project/plugins.sbt
+           |  object   Plugins
+           |""".stripMargin,
+        expectError = true
+      )
+      _ <- server.didOpen("project/plugins.sbt")
+      _ <- server.formatting("project/plugins.sbt")
+      // check plugins.sbt has been formatted
+      _ = assertNoDiff(
+        server.bufferContent("project/plugins.sbt"),
+        "object Plugins"
+      )
+    } yield ()
+  }
+
 }

--- a/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
@@ -17,10 +17,10 @@ object FormattingSlowSuite extends BaseSlowSuite("formatting") {
         expectError = true
       )
       _ <- server.didOpen("a/src/main/scala/a/Main.scala")
-      textEdits <- server.formatting("a/src/main/scala/a/Main.scala")
+      _ <- server.formatting("a/src/main/scala/a/Main.scala")
       // check that the file has been formatted
       _ = assertNoDiff(
-        textEdits.get(0).getNewText,
+        server.bufferContent("a/src/main/scala/a/Main.scala").get,
         """|object FormatMe {
            |  val x = 1
            |}""".stripMargin
@@ -38,9 +38,14 @@ object FormattingSlowSuite extends BaseSlowSuite("formatting") {
         expectError = true
       )
       _ <- server.didOpen("a/src/main/scala/a/Main.scala")
-      textEdits <- server.formatting("a/src/main/scala/a/Main.scala")
+      _ <- server.formatting("a/src/main/scala/a/Main.scala")
       // check that the formatting request has been ignored
-      _ = assert(textEdits.isEmpty)
+      _ = assertNoDiff(
+        server.bufferContent("a/src/main/scala/a/Main.scala").get,
+        """|object FormatMe {
+           | val x = 1  }
+           |""".stripMargin
+      )
     } yield ()
   }
 
@@ -64,10 +69,9 @@ object FormattingSlowSuite extends BaseSlowSuite("formatting") {
         )
         server.didChangeConfiguration(config.toString)
       }
-      textEdits <- server.formatting("a/src/main/scala/a/Main.scala")
-      // check that the file has been formatted
+      _ <- server.formatting("a/src/main/scala/a/Main.scala")
       _ = assertNoDiff(
-        textEdits.get(0).getNewText,
+        server.bufferContent("a/src/main/scala/a/Main.scala").get,
         """|object FormatMe {
            |  val x = 1
            |}""".stripMargin
@@ -90,10 +94,10 @@ object FormattingSlowSuite extends BaseSlowSuite("formatting") {
         expectError = true
       )
       _ <- server.didOpen("a/src/main/scala/a/Main.scala")
-      textEdits <- server.formatting("a/src/main/scala/a/Main.scala")
+      _ <- server.formatting("a/src/main/scala/a/Main.scala")
       // check that the file has been formatted respecting the trailing comma config (new in 1.6.0)
       _ = assertNoDiff(
-        textEdits.get(0).getNewText,
+        server.bufferContent("a/src/main/scala/a/Main.scala").get,
         """|case class User(
            |    name: String,
            |    age: Int

--- a/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
@@ -1,0 +1,120 @@
+package tests
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+
+object FormattingSlowSuite extends BaseSlowSuite("formatting") {
+
+  testAsync("basic") {
+    for {
+      _ <- server.initialize(
+        """|
+           |/metals.json
+           |{
+           |  "a": { }
+           |}
+           |/.scalafmt.conf
+           |maxColumn = 100
+           |/a/src/main/scala/a/Main.scala
+           |object FormatMe {
+           | val x = 1  }
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      textEdits <- server.formatting("a/src/main/scala/a/Main.scala")
+      // check that the file has been formatted
+      _ = assertNoDiff(
+        textEdits.get(0).getNewText,
+        """|object FormatMe {
+           |  val x = 1
+           |}""".stripMargin
+      )
+    } yield ()
+  }
+
+  testAsync("require-config-true") {
+    for {
+      _ <- server.initialize(
+        """|
+           |/metals.json
+           |{
+           |  "a": { }
+           |}
+           |/a/src/main/scala/a/Main.scala
+           |object FormatMe {
+           | val x = 1  }
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      textEdits <- server.formatting("a/src/main/scala/a/Main.scala")
+      // check that the formatting request has been ignored
+      _ = assert(textEdits.isEmpty)
+    } yield ()
+  }
+
+  testAsync("require-config-false") {
+    for {
+      _ <- server.initialize(
+        """|
+           |/metals.json
+           |{
+           |  "a": { }
+           |}
+           |/a/src/main/scala/a/Main.scala
+           |object FormatMe {
+           | val x = 1  }
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      _ <- {
+        val config = new JsonObject
+        config.add("scalafmt-require-config-file", new JsonPrimitive(false))
+        server.didChangeConfiguration(config.toString)
+      }
+      textEdits <- server.formatting("a/src/main/scala/a/Main.scala")
+      // check that the file has been formatted
+      _ = assertNoDiff(
+        textEdits.get(0).getNewText,
+        """|object FormatMe {
+           |  val x = 1
+           |}""".stripMargin
+      )
+    } yield ()
+  }
+
+  testAsync("custom-config-path") {
+    for {
+      _ <- server.initialize(
+        """|
+           |/metals.json
+           |{
+           |  "a": { }
+           |}
+           |/customconfig.conf
+           |maxColumn=100
+           |/a/src/main/scala/a/Main.scala
+           |object FormatMe {
+           | val x = 1  }
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      _ <- {
+        val config = new JsonObject
+        config.add(
+          "scalafmt-config-path",
+          new JsonPrimitive("customconfig.conf")
+        )
+        server.didChangeConfiguration(config.toString)
+      }
+      textEdits <- server.formatting("a/src/main/scala/a/Main.scala")
+      // check that the file has been formatted
+      _ = assertNoDiff(
+        textEdits.get(0).getNewText,
+        """|object FormatMe {
+           |  val x = 1
+           |}""".stripMargin
+      )
+    } yield ()
+  }
+
+}


### PR DESCRIPTION
This PR implements `textDocument/formatting` using Scalafmt.

Notable points:

- Scalafmt is classloaded, so that users can choose a version
- By default, Scalafmt won't run if no config file is found. This prevents users from accidentally formatting a file with the default config, although they can opt-in to this behavior
- Users can specify a custom Scalafmt config path