### PR TITLE
Implement cascade compilation.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -1,19 +1,51 @@
 package scala.meta.internal.metals
 
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import ch.epfl.scala.bsp4j.CompileReport
+import ch.epfl.scala.bsp4j.TaskDataKind
 import ch.epfl.scala.bsp4j.TaskFinishParams
 import ch.epfl.scala.bsp4j.TaskStartParams
 import ch.epfl.scala.{bsp4j => b}
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.{lsp4j => l}
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.Promise
+import scala.meta.internal.metals.MetalsEnrichments._
 
 /**
  * A build client that forwards notifications from the build server to the language client.
  */
 final class ForwardingMetalsBuildClient(
     languageClient: LanguageClient,
-    diagnostics: Diagnostics
-) extends MetalsBuildClient {
+    diagnostics: Diagnostics,
+    buildTargets: BuildTargets,
+    config: MetalsServerConfig,
+    statusBar: StatusBar,
+    time: Time
+) extends MetalsBuildClient
+    with Cancelable {
+
+  private case class Compilation(
+      timer: Timer,
+      promise: Promise[CompileReport]
+  )
+
+  private val compilations = TrieMap.empty[BuildTargetIdentifier, Compilation]
+  private val hasReportedError = Collections.newSetFromMap(
+    new ConcurrentHashMap[BuildTargetIdentifier, java.lang.Boolean]()
+  )
+
+  def reset(): Unit = {
+    cancel()
+  }
+  override def cancel(): Unit = {
+    compilations.values.foreach { compilation =>
+      compilation.promise.cancel()
+    }
+  }
 
   def onBuildShowMessage(params: l.MessageParams): Unit =
     languageClient.showMessage(params)
@@ -40,9 +72,66 @@ final class ForwardingMetalsBuildClient(
 
   def onBuildTargetCompileReport(params: b.CompileReport): Unit = {}
 
-  // We ignore task{Start,Finish} notifications for now.
   @JsonNotification("build/taskStart")
-  def buildTaskStart(params: TaskStartParams): Unit = {}
+  def buildTaskStart(params: TaskStartParams): Unit = {
+    params.getDataKind match {
+      case TaskDataKind.COMPILE_TASK =>
+        for {
+          task <- params.asCompileTask
+          info <- buildTargets.info(task.getTarget)
+        } {
+          // cancel ongoing compilation for the current target, if any.
+          compilations.get(task.getTarget).foreach(_.promise.cancel())
+
+          val name = info.getDisplayName
+          val promise = Promise[CompileReport]()
+          val compilation = Compilation(new Timer(time), promise)
+
+          compilations(task.getTarget) = compilation
+          statusBar.trackFuture(
+            s"Compiling $name",
+            promise.future,
+            showTimer = true
+          )
+        }
+      case _ =>
+    }
+  }
+
   @JsonNotification("build/taskFinish")
-  def buildTaskEnd(params: TaskFinishParams): Unit = {}
+  def buildTaskEnd(params: TaskFinishParams): Unit = {
+    params.getDataKind match {
+      case TaskDataKind.COMPILE_REPORT =>
+        for {
+          report <- params.asCompileReport
+          compilation <- compilations.get(report.getTarget)
+        } {
+          val target = report.getTarget
+          compilation.promise.trySuccess(report)
+          val name = buildTargets.info(report.getTarget) match {
+            case Some(i) => i.getDisplayName
+            case None => report.getTarget.getUri
+          }
+          val isSuccess = report.getErrors == 0
+          val icon = if (isSuccess) config.icons.check else config.icons.alert
+          val message = s"${icon}Compiled $name (${compilation.timer})"
+          if (isSuccess) {
+            if (hasReportedError.contains(target)) {
+              // Only report success compilation if it fixes a previous compile error.
+              statusBar.addMessage(message)
+            }
+            hasReportedError.remove(target)
+          } else {
+            hasReportedError.add(target)
+            statusBar.addMessage(
+              MetalsStatusParams(
+                message,
+                command = ClientCommands.FocusDiagnostics.id
+              )
+            )
+          }
+        }
+      case _ =>
+    }
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -12,6 +12,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 import java.util
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import org.eclipse.lsp4j.TextDocumentIdentifier
@@ -21,6 +22,7 @@ import scala.collection.convert.DecorateAsScala
 import scala.compat.java8.FutureConverters
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.Promise
 import scala.meta.inputs.Input
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.mtags.MtagsEnrichments._
@@ -29,7 +31,7 @@ import scala.meta.internal.semanticdb.Scala.Symbols
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.AbsolutePath
 import scala.util.Properties
-import scala.util.Try
+import scala.util.control.NonFatal
 import scala.{meta => m}
 
 /**
@@ -53,24 +55,38 @@ import scala.{meta => m}
  */
 object MetalsEnrichments extends DecorateAsJava with DecorateAsScala {
 
-  implicit class XtensionBuildTarget(buildTarget: b.BuildTarget) {
-
-    /**
-     * Reads BSP `BuildTarget.data` field into a `ScalaBuildTarget`.
-     */
-    def asScalaBuildTarget: Option[b.ScalaBuildTarget] = {
-      for {
-        data <- Option(buildTarget.getData)
-        if data.isInstanceOf[JsonElement]
-        info <- Try(
-          new Gson().fromJson[b.ScalaBuildTarget](
+  private def decodeJson[T](obj: AnyRef, cls: Class[T]): Option[T] =
+    for {
+      data <- Option(obj)
+      value <- try {
+        Some(
+          new Gson().fromJson[T](
             data.asInstanceOf[JsonElement],
-            classOf[b.ScalaBuildTarget]
+            cls
           )
-        ).toOption
-      } yield info
-    }
+        )
+      } catch {
+        case NonFatal(e) =>
+          scribe.error(s"decode error: $cls", e)
+          None
+      }
+    } yield value
 
+  implicit class XtensionBuildTarget(buildTarget: b.BuildTarget) {
+    def asScalaBuildTarget: Option[b.ScalaBuildTarget] = {
+      decodeJson(buildTarget.getData, classOf[b.ScalaBuildTarget])
+    }
+  }
+  implicit class XtensionTaskStart(task: b.TaskStartParams) {
+    def asCompileTask: Option[b.CompileTask] = {
+      decodeJson(task.getData, classOf[b.CompileTask])
+    }
+  }
+
+  implicit class XtensionTaskFinish(task: b.TaskFinishParams) {
+    def asCompileReport: Option[b.CompileReport] = {
+      decodeJson(task.getData, classOf[b.CompileReport])
+    }
   }
 
   implicit class XtensionEditDistance(result: Either[EmptyResult, m.Position]) {
@@ -396,4 +412,8 @@ object MetalsEnrichments extends DecorateAsJava with DecorateAsScala {
 
   }
 
+  implicit class XtensionPromise[T](promise: Promise[T]) {
+    def cancel(): Unit =
+      promise.tryFailure(new CancellationException())
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -5,7 +5,6 @@ import ch.epfl.scala.bsp4j.CompileParams
 import ch.epfl.scala.bsp4j.DependencySourcesParams
 import ch.epfl.scala.bsp4j.ScalacOptionsParams
 import ch.epfl.scala.bsp4j.SourcesParams
-import ch.epfl.scala.bsp4j.StatusCode
 import com.google.gson.JsonElement
 import io.methvin.watcher.DirectoryChangeEvent
 import io.undertow.server.HttpServerExchange
@@ -84,7 +83,7 @@ class MetalsLanguageServer(
   private var interactiveSemanticdbs: InteractiveSemanticdbs = _
   private var buildTools: BuildTools = _
   private var semanticdbs: Semanticdbs = _
-  private var buildClient: MetalsBuildClient = _
+  private var buildClient: ForwardingMetalsBuildClient = _
   private var bloopServers: BloopServers = _
   private var bspServers: BspServers = _
   private var definitionProvider: DefinitionProvider = _
@@ -92,7 +91,7 @@ class MetalsLanguageServer(
     new DocumentSymbolProvider(buffers)
   private var initializeParams: Option[InitializeParams] = None
   var tables: Tables = _
-  private var statusBar: StatusBar = _
+  var statusBar: StatusBar = _
   private var embedded: Embedded = _
   private var doctor: Doctor = _
   var httpServer: Option[MetalsHttpServer] = None
@@ -129,7 +128,14 @@ class MetalsLanguageServer(
       )
     )
     diagnostics = new Diagnostics(buildTargets, languageClient)
-    buildClient = new ForwardingMetalsBuildClient(languageClient, diagnostics)
+    buildClient = new ForwardingMetalsBuildClient(
+      languageClient,
+      diagnostics,
+      buildTargets,
+      config,
+      statusBar,
+      time
+    )
     bloopInstall = register(
       new BloopInstall(
         workspace,
@@ -389,7 +395,9 @@ class MetalsLanguageServer(
     val path = uri.toAbsolutePath
     // unpublish diagnostic for dependencies
     interactiveSemanticdbs.didFocus(path)
-    if (openedFiles.isRecentlyActive(path)) {
+    // Don't trigger compilation on didFocus events under cascade compilation
+    // because save events already trigger compile in inverse dependencies.
+    if (userConfig.isCascadeCompile || openedFiles.isRecentlyActive(path)) {
       CompletableFuture.completedFuture(())
     } else {
       compileSourceFiles(List(path)).asJava
@@ -802,6 +810,7 @@ class MetalsLanguageServer(
       _ = {
         buildTargets.reset()
         interactiveSemanticdbs.reset()
+        buildClient.reset()
         buildTargets.addWorkspaceBuildTargets(workspaceBuildTargets)
       }
       ids = workspaceBuildTargets.getTargets.map(_.getId)
@@ -886,39 +895,14 @@ class MetalsLanguageServer(
           scribe.warn(s"no build target: ${scalaPaths.mkString("\n  ")}")
           Future.successful(())
         } else {
-          val params = new CompileParams(targets.asJava)
-          val name =
-            targets.headOption
-              .flatMap(buildTargets.info)
-              .map(info => " " + info.getDisplayName)
-              .getOrElse("")
-          for {
-            (elapsed, status) <- withTimer(
-              s"compiled$name",
-              reportStatus = true
-            ) {
-              statusBar.trackFuture(
-                s"${config.icons.sync}Compiling$name",
-                build.compile(params).asScala,
-                showTimer = true
-              )
+          val allTargets =
+            if (userConfig.isCascadeCompile) {
+              targets.flatMap(buildTargets.inverseDependencies).distinct
+            } else {
+              targets
             }
-          } yield {
-            status.getStatusCode match {
-              case StatusCode.OK =>
-                statusBar.addMessage(
-                  s"${config.icons.check}Compiled$name ($elapsed)"
-                )
-              case StatusCode.ERROR =>
-                statusBar.addMessage(
-                  MetalsStatusParams(
-                    s"${config.icons.alert}Compile error ($elapsed)",
-                    command = ClientCommands.FocusDiagnostics.id
-                  )
-                )
-              case StatusCode.CANCELLED =>
-            }
-          }
+          val params = new CompileParams(allTargets.asJava)
+          build.compile(params).asScala.ignoreValue
         }
       case _ =>
         Future.successful(())

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
@@ -136,6 +136,7 @@ final class StatusBar(
   }
 
   private val items = new ConcurrentLinkedQueue[Item]()
+  def pendingItems: Iterable[String] = items.asScala.map(_.formattedMessage)
   private def garbageCollect(): Unit = {
     items.removeIf(_.isStale)
   }

--- a/tests/unit/src/main/scala/tests/BaseSlowSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseSlowSuite.scala
@@ -7,6 +7,7 @@ import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.BloopProtocol
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.ExecuteClientCommandConfig
+import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.RecursivelyDelete
 import scala.meta.io.AbsolutePath
@@ -16,6 +17,7 @@ import scala.meta.io.AbsolutePath
  */
 abstract class BaseSlowSuite(suiteName: String) extends BaseSuite {
   def protocol: BloopProtocol = BloopProtocol.auto
+  def icons: Icons = Icons.default
   implicit val ex: ExecutionContextExecutorService =
     ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
   def bspGlobalDirectories: List[AbsolutePath] = Nil
@@ -49,7 +51,8 @@ abstract class BaseSlowSuite(suiteName: String) extends BaseSuite {
     val buffers = Buffers()
     val config = MetalsServerConfig.default.copy(
       bloopProtocol = protocol,
-      executeClientCommand = ExecuteClientCommandConfig.on
+      executeClientCommand = ExecuteClientCommandConfig.on,
+      icons = this.icons
     )
     client = new TestingClient(workspace, buffers)
     server = new TestingServer(

--- a/tests/unit/src/main/scala/tests/BaseSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseSuite.scala
@@ -4,6 +4,8 @@ import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.language.experimental.macros
+import scala.meta.internal.metals.MetalsLogger
+import scala.meta.io.AbsolutePath
 import scala.reflect.ClassTag
 import utest.TestSuite
 import utest.Tests
@@ -11,10 +13,8 @@ import utest.asserts.Asserts
 import utest.framework.Formatter
 import utest.framework.TestCallTree
 import utest.framework.Tree
-import utest.ufansi.Str
-import scala.meta.internal.metals.MetalsLogger
-import scala.meta.io.AbsolutePath
 import utest.ufansi.Attrs
+import utest.ufansi.Str
 
 /**
  * Test suite that replace utest DSL with FunSuite-style syntax from ScalaTest.
@@ -28,6 +28,20 @@ class BaseSuite extends TestSuite {
   def beforeAll(): Unit = ()
   def afterAll(): Unit = ()
   def intercept[T: ClassTag](exprs: Unit): T = macro Asserts.interceptProxy[T]
+  def assertNotEmpty(string: String): Unit = {
+    if (string.isEmpty) {
+      fail(
+        s"expected non-empty string, obtained empty string."
+      )
+    }
+  }
+  def assertEmpty(string: String): Unit = {
+    if (!string.isEmpty) {
+      fail(
+        s"expected empty string, obtained: $string"
+      )
+    }
+  }
   def assertContains(string: String, substring: String): Unit = {
     assert(string.contains(substring))
   }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -35,7 +35,6 @@ import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.Debug
 import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.internal.metals.MetalsLanguageServer
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.ProgressTicks
@@ -63,7 +62,7 @@ import tests.MetalsTestEnrichments._
  */
 final class TestingServer(
     workspace: AbsolutePath,
-    client: MetalsLanguageClient,
+    client: TestingClient,
     buffers: Buffers,
     config: MetalsServerConfig,
     bspGlobalDirectories: List[AbsolutePath]
@@ -78,6 +77,14 @@ final class TestingServer(
   )
   server.connectToLanguageClient(client)
   private val readonlySources = TrieMap.empty[String, AbsolutePath]
+  def statusBarHistory: String = {
+    // collect both published items in the client and pending items from the server.
+    val all = List(
+      server.statusBar.pendingItems,
+      client.statusParams.asScala.map(_.text)
+    ).flatten
+    all.distinct.mkString("\n")
+  }
 
   private def write(layout: String): Unit = {
     FileLayout.fromString(layout, root = workspace)

--- a/tests/unit/src/test/scala/tests/CascadeSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/CascadeSlowSuite.scala
@@ -1,0 +1,45 @@
+package tests
+
+object CascadeSlowSuite extends BaseSlowSuite("cascade") {
+  testAsync("basic") {
+    for {
+      _ <- server.initialize(
+        """
+          |/metals.json
+          |{
+          |  "a": { },
+          |  "b": { "dependsOn": ["a"] },
+          |  "c": { }
+          |}
+          |/a/src/main/scala/a/A.scala
+          |package a
+          |object A {
+          |  val n = 42
+          |}
+          |/b/src/main/scala/b/B.scala
+          |package b
+          |object B {
+          |  val n: String = a.A.n
+          |}
+          |/c/src/main/scala/c/C.scala
+          |package c
+          |object C {
+          |  val n: String = 42
+          |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      // Check that opening file A.scala triggers compile in dependent project "b"
+      // but not independent project "c".
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|b/src/main/scala/b/B.scala:3:23: error: type mismatch;
+           | found   : Int
+           | required: String
+           |  val n: String = a.A.n
+           |                      ^
+          """.stripMargin
+      )
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/InverseDependenciesSuite.scala
+++ b/tests/unit/src/test/scala/tests/InverseDependenciesSuite.scala
@@ -1,0 +1,82 @@
+package tests
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+import scala.meta.internal.metals.BuildTargets
+
+object InverseDependenciesSuite extends BaseSuite {
+  class Graph(val root: String) {
+    val inverseDependencies = mutable.Map.empty[String, ListBuffer[String]]
+    def dependsOn(project: String, dependency: String): this.type = {
+      val dependencies =
+        inverseDependencies.getOrElseUpdate(dependency, ListBuffer.empty)
+      dependencies += project
+      this
+    }
+  }
+  def root(x: String): Graph = new Graph(x)
+  def check(
+      name: String,
+      original: Graph,
+      expected: String
+  ): Unit = {
+    test(name) {
+      val obtained = BuildTargets.inverseDependencies(
+        new BuildTargetIdentifier(original.root), { key =>
+          original.inverseDependencies
+            .get(key.getUri)
+            .map(_.map(new BuildTargetIdentifier(_)))
+        }
+      )
+      assertNoDiff(
+        obtained.toSeq.map(_.getUri).sorted.mkString("\n"),
+        expected
+      )
+    }
+  }
+
+  check(
+    "basic",
+    root("a")
+      .dependsOn("b", "a"),
+    "b"
+  )
+
+  check(
+    "transitive",
+    root("a")
+      .dependsOn("b", "a")
+      .dependsOn("c", "b"),
+    "c"
+  )
+
+  check(
+    "branch",
+    root("a")
+      .dependsOn("b", "a")
+      .dependsOn("d", "a")
+      .dependsOn("c", "b"),
+    """
+      |c
+      |d
+      |""".stripMargin
+  )
+
+  check(
+    "alone",
+    root("a"),
+    "a"
+  )
+
+  check(
+    "diamond",
+    root("a")
+      .dependsOn("b", "a")
+      .dependsOn("c", "a")
+      .dependsOn("d", "b")
+      .dependsOn("d", "c"),
+    "d"
+  )
+
+}

--- a/tests/unit/src/test/scala/tests/StatusBarSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/StatusBarSlowSuite.scala
@@ -1,0 +1,47 @@
+package tests
+import scala.meta.internal.metals.Icons
+
+object StatusBarSlowSuite extends BaseSlowSuite("status-bar") {
+  override def icons: Icons = Icons.vscode
+  testAsync("compile-success") {
+    for {
+      _ <- server.initialize(
+        """
+          |/metals.json
+          |{ "a": {} }
+          |/a/src/main/scala/A.scala
+          |object A {
+          |  val x = 42
+          |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/A.scala")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        ""
+      )
+      // Successful compilation is not reported in the status bar if there was no prior compile error.
+      _ = assertNotContains(
+        server.statusBarHistory,
+        s"${icons.check}Compiled a"
+      )
+      _ <- server.didSave("a/src/main/scala/A.scala")(
+        _.replaceFirst("val x = 42", "val x: String = 42")
+      )
+      _ = assertNotEmpty(client.workspaceDiagnostics)
+      // Failed compilation is always reported in the status bar.
+      _ = assertContains(
+        server.statusBarHistory,
+        s"${icons.alert}Compiled a"
+      )
+      _ <- server.didSave("a/src/main/scala/A.scala")(
+        _.replaceFirst("val x: String = 42", "val x = 42")
+      )
+      // Successful compilation is reported in the status bar when following a failed compilation.
+      _ = assertContains(
+        server.statusBarHistory,
+        s"${icons.check}Compiled a"
+      )
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -52,12 +52,14 @@ object UserConfigurationSuite extends BaseSuite {
     """
       |{
       | "java-home": "home",
+      | "compile-on-save": "current-project",
       | "sbt-script": "script"
       |}
     """.stripMargin
   ) { obtained =>
     assert(obtained.javaHome == Some("home"))
     assert(obtained.sbtScript == Some("script"))
+    assert(obtained.isCurrentProject)
   }
 
   checkOK(
@@ -66,6 +68,7 @@ object UserConfigurationSuite extends BaseSuite {
   ) { obtained =>
     assert(obtained.javaHome.isEmpty)
     assert(obtained.sbtScript.isEmpty)
+    assert(obtained.isCascadeCompile)
   }
 
   checkOK(
@@ -125,6 +128,18 @@ object UserConfigurationSuite extends BaseSuite {
     """.stripMargin,
     """
       |json error: key 'sbt-script' should have value of type string but obtained []
+    """.stripMargin
+  )
+
+  checkError(
+    "cascade",
+    """
+      |{
+      | "compile-on-save": "foobar"
+      |}
+    """.stripMargin,
+    """
+      |unknown compile-on-save: 'foobar'. Expected one of: cascade, current-project.
     """.stripMargin
   )
 }


### PR DESCRIPTION
So far, we have triggere only compilation for the build targets
containing saved filed. This commit introduces a new default compilation
mode "cascade" that additionally triggeres compilation in downstream
build targets.

Example: when we change an API in main sources we get compile errors in
test sources with cascade compilation. Without cascade, we only see
compile errors in main sources.

Cascade compilation is needed for other features like "Find references"
and "Rename symbol" to funcion properly. However, for very large builds
it may be preferable to enable the old behavior by setting the user
option `-Dmetals.compile-on-save=curren-project`.

This PR improves how we report compilation progress in the status bar.
Before, we added one "Compiling $name" status for the current project
but now we add a "Compiling $project" for all compiled targets making
it easier to track what project has an error.

Example status bar: ![2018-12-20 14 35 19](https://user-images.githubusercontent.com/1408093/50287895-94ba7880-0464-11e9-9e1a-59d94012a150.gif)
