### PR TITLE
Add log when skipping formatting of a file due to Scalafmt configuration

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -68,8 +68,9 @@ final class FormattingProvider(
           FilterMatcher(includeFilters, excludeFilters).matches(path.toString)
         if (shouldSkip) {
           scribe.info(
-            s"skipping format request for ${path.toRelative(workspace)}. To fix this, update project.excludeFilters or project.includeFilters in ${confPath
-              .toRelative(workspace)}"
+            s"skipping format request for ${path.toRelative(workspace)}. " +
+              "To fix this, update project.excludeFilters or project.includeFilters in " +
+              confPath.toRelative(workspace)
           )
         }
         shouldSkip

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -63,7 +63,17 @@ final class FormattingProvider(
           config.getStringList("project.excludeFilters").asScala
         else Nil
       }
-      if FilterMatcher(includeFilters, excludeFilters).matches(path.toString)
+      if {
+        val shouldSkip =
+          FilterMatcher(includeFilters, excludeFilters).matches(path.toString)
+        if (shouldSkip) {
+          scribe.info(
+            s"skipping format request for ${path.toRelative(workspace)}. To fix this, update project.excludeFilters or project.includeFilters in ${confPath
+              .toRelative(workspace)}"
+          )
+        }
+        shouldSkip
+      }
       scalafmt <- classloadScalafmt(version)
       formatted <- scalafmt
         .format(input.text, scalafmtConf.toString(), input.path)


### PR DESCRIPTION
Minor follow up of #429 

Example:

![image](https://user-images.githubusercontent.com/691940/50374087-d542ff00-05e8-11e9-92e4-6b28db2d675e.png)
