### PR TITLE
Remove -Dmetals.documentSymbol in favor of client capabilities

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -396,4 +396,20 @@ object MetalsEnrichments extends DecorateAsJava with DecorateAsScala {
 
   }
 
+  implicit class XtensionClientCapabilities(
+      initializeParams: Option[l.InitializeParams]
+  ) {
+    val supportsHierarchicalDocumentSymbols =
+      (for {
+        params <- initializeParams
+        capabilities <- Option(params.getCapabilities)
+        textDocument <- Option(capabilities.getTextDocument)
+        documentSymbol <- Option(textDocument.getDocumentSymbol)
+        hierarchicalDocumentSymbolSupport <- Option(
+          documentSymbol.getHierarchicalDocumentSymbolSupport
+        )
+      } yield hierarchicalDocumentSymbolSupport.booleanValue).getOrElse(false)
+
+  }
+
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -538,13 +538,13 @@ class MetalsLanguageServer(
   ] =
     CompletableFutures.computeAsync { _ =>
       val result = documentSymbolResult(params)
-      if (config.documentSymbol.isSymbolInformation) {
+      if (initializeParams.supportsHierarchicalDocumentSymbols) {
+        JEither.forLeft(result)
+      } else {
         val infos = result.asScala
           .toSymbolInformation(params.getTextDocument.getUri)
           .asJava
         JEither.forRight(infos)
-      } else {
-        JEither.forLeft(result)
       }
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -29,7 +29,6 @@ final case class MetalsServerConfig(
     showMessage: ShowMessageConfig = ShowMessageConfig.default,
     showMessageRequest: ShowMessageRequestConfig =
       ShowMessageRequestConfig.default,
-    documentSymbol: DocumentSymbolConfig = DocumentSymbolConfig.default,
     isNoInitialized: Boolean = MetalsServerConfig.binaryOption(
       "metals.no-initialized",
       default = false
@@ -62,7 +61,6 @@ final case class MetalsServerConfig(
       s"execute-client-command=$executeClientCommand",
       s"show-message=$showMessage",
       s"show-message-request=$showMessageRequest",
-      s"document-symbol=$documentSymbol",
       s"no-initialized=$isNoInitialized",
       s"http=$isHttpEnabled",
       s"icons=$icons",
@@ -92,7 +90,6 @@ object MetalsServerConfig {
         base.copy(
           // window/logMessage output is always visible and non-invasive in vim-lsc
           statusBar = StatusBarConfig.logMessage,
-          documentSymbol = DocumentSymbolConfig.symbolInformation,
           // Not strictly needed, but helpful while this integration matures.
           isHttpEnabled = true,
           icons = Icons.unicode


### PR DESCRIPTION
In #424 we introduced a custom option for determining whether to return `SymbolInformation[]` or `DocumentSymbol[]`.

It turns out that clients already specify whether they support hierarchical document symbols (i.e. `DocumentSymbol[]`) or not.

This PR removes `-Dmetals.documentSymbol` and respects client capabilities instead.

Tested locally with VSCode, Emacs, vim and Sublime Text.