### PR TITLE
Upgrade to mdoc v1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -276,7 +276,7 @@ lazy val docs = project
   .settings(
     skip.in(publish) := true,
     moduleName := "metals-docs",
-    mainClass.in(Compile) := Some("docs.Docs"),
+    mdoc := run.in(Compile).evaluated,
     libraryDependencies ++= List(
       "org.jsoup" % "jsoup" % "1.11.3"
     )

--- a/docs/build-tools/new-build-tool.md
+++ b/docs/build-tools/new-build-tool.md
@@ -25,7 +25,7 @@ There are two options for integrating Metals with a new build tool:
 Consult the
 [Bloop configuration format](https://scalacenter.github.io/bloop/docs/configuration-format/)
 to learn how to emit Bloop JSON files. Once the JSON files have been generated,
-use "[Connect to build server](../editors/new-editor.html#import-build)" server
+use "[Connect to build server](../editors/new-editor.md#import-build)" server
 command in Metals to establish a connection with Bloop.
 
 ## Custom build server

--- a/docs/build-tools/overview.md
+++ b/docs/build-tools/overview.md
@@ -44,4 +44,4 @@ are populated with `*-sources.jar`.
 Metals works with any build tool that supports the
 [Build Server Protocol](https://github.com/scalacenter/bsp/blob/master/docs/bsp.md).
 For more information, see the
-[guide to integrate new build tools](new-build-tool.html).
+[guide to integrate new build tools](new-build-tool.md).

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -85,7 +85,7 @@ When you make changes in the Metals Scala codebase
 
 ### Vim
 
-First, follow the [`vim` installation instruction](../editors/vim.html).
+First, follow the [`vim` installation instruction](../editors/vim.md).
 
 Next, write a `new-metals-vim` script that builds a new `metals-vim` bootstrap
 script using the locally published version.

--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -177,7 +177,7 @@ https://scalameta.org/scalafmt/docs/configuration.html.
 The Metals language server supports custom extensions that are not part of the
 Language Server Protocol (LSP). These extensions are not necessary for Metals to
 function but they improve the user experience. To learn more about Metals
-extensions, see [integrating a new editor](new-editor.html).
+extensions, see [integrating a new editor](new-editor.md).
 
 ## Unsupported features
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
-addSbtPlugin("com.geirsson" % "sbt-docusaurus" % "0.3.5")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.0.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 
 addSbtCoursier

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.0.0")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.2.7")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 
 addSbtCoursier

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,6 @@
     "rename-version": "docusaurus-rename-version"
   },
   "devDependencies": {
-    "docusaurus": "1.5.1"
+    "docusaurus": "1.6.2"
   }
 }


### PR DESCRIPTION
It seems that relative `.md` links works now after the docusaurus upgrade, no more dead link warnings 🎉 