### PR TITLE
Preinit sbt on appveyor, because it usually fails the first time

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ install:
   - cmd: choco install sbt -ia "INSTALLDIR=""C:\sbt"""
   - cmd: SET PATH=C:\sbt\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g
+  - cmd: sbt version & exit 0
+  - cmd: sbt version & exit 0
 environment:
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: "-t7z -m0=lzma -mx=9"
   JAVA_OPTS: -Djna.nosys=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,5 @@ test_script:
 cache:
   - C:\sbt\
   - C:\Users\appveyor\.ivy2
-  - C:\Users\appveyor\.coursier
-  - C:\Users\appveyor\.cache
+  - '%LOCALAPPDATA%\Coursier\Cache'
   - C:\Users\appveyor\.sbt


### PR DESCRIPTION
The first time I tried to run sbt on appveyor the build had failed 5 times in a row with the same error `[Not found]file:/C:/Users/appveyor/.sbt/preloaded/org.scala-lang/scala-compiler/2.12.6/jars/scala-compiler.jar`. From the log I can see that `robocopy` task and `sbt publishLocal` were running almost in parallel. I have added a dumb init, so if sbt fails the first time, the robocopy has a chance to catch-up. 

Related: #435