### PR TITLE
Feature/appveyor memory limits

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,16 +5,33 @@ install:
   - cmd: SET PATH=%JAVA_HOME%\bin;%PATH%
   - cmd: choco install sbt -ia "INSTALLDIR=""C:\sbt"""
   - cmd: SET PATH=C:\sbt\bin;%JAVA_HOME%\bin;%PATH%
-  - cmd: SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g
+  # disable dynVer
+  - ps: Remove-Item Env:\CI
   - cmd: sbt version & exit 0
-  - cmd: sbt version & exit 0
+
 environment:
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: "-t7z -m0=lzma -mx=9"
-  JAVA_OPTS: -Djna.nosys=true
+  JAVA_OPTS: -Xss2m -Xmx1024m -XX:-TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:ReservedCodeCacheSize=96m -Dfile.encoding=UTF-8 -Djna.nosys=true
+before_build:
+  - ps: |
+      @"
+      -Xss2m
+      -Xmx1024m
+      -XX:+CMSClassUnloadingEnabled
+      -XX:ReservedCodeCacheSize=96m
+      -XX:-TieredCompilation
+      -Dfile.encoding=UTF-8
+      "@ > ".jvmopts"
 build_script:
   - sbt publishLocal
 test_script:
   - sbt test
+after_test:
+  - ps: |
+      Get-ChildItem C:\Users\appveyor\.ivy2\* -Include "ivydata-*.properties" -Recurse | Remove-Item
+      Remove-Item C:\Users\appveyor\.ivy2\.sbt.ivy.lock -Force
+      Remove-Item C:\Users\appveyor\.ivy2\local -Recurse
+      Get-ChildItem C:\Users\appveyor\.sbt\* -Include "*.lock" -Recurse | Remove-Item -Force
 cache:
   - C:\sbt\
   - C:\Users\appveyor\.ivy2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,14 +11,13 @@ install:
 
 environment:
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: "-t7z -m0=lzma -mx=9"
-  JAVA_OPTS: -Xss2m -Xmx1024m -XX:-TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:ReservedCodeCacheSize=96m -Dfile.encoding=UTF-8 -Djna.nosys=true
+  JAVA_OPTS: -Xss2m -Xmx1024m -XX:-TieredCompilation -XX:ReservedCodeCacheSize=48m -Dfile.encoding=UTF-8 -Djna.nosys=true
 before_build:
   - ps: |
       @"
       -Xss2m
       -Xmx1024m
-      -XX:+CMSClassUnloadingEnabled
-      -XX:ReservedCodeCacheSize=96m
+      -XX:ReservedCodeCacheSize=48m
       -XX:-TieredCompilation
       -Dfile.encoding=UTF-8
       "@ > ".jvmopts"


### PR DESCRIPTION
Hi,
I've reduced the global memory limit to 1Gb using `JAVA_OPTS`, also I had to override `.jvmopts`. Because `dynVer` would generate two versions, with two different timestamps for `publishLocal` and `test` I had turned it off. Also I'm cleaning cached folders, as recommended in the sbt travis guide. Looks like "-XX:+CMSClassUnloadingEnabled" doesn't do much in jdk8, as classes are stored in metaspace, removed that option.

Regarding Travis build, it has slightly more memory - 7Gb, so maybe the build doesn't hit the limit there. 




Related #435 