### PR TITLE
Improve eglot documentation

### DIFF
--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -151,10 +151,11 @@ sections from the config above with the settings below.
    minibuffer-local-completion-map))
 
 (use-package eglot
-  :pin melpa-stable)
-;; (optional) Automatically start Metals for Scala files.
-(add-to-list 'eglot-server-programs '(scala-mode . ("metals-emacs")))
-(add-hook 'scala-mode-hook 'eglot-ensure)
+  :pin melpa-stable
+  ;; (optional) Automatically start metals for Scala files.
+  :config
+  (add-to-list 'eglot-server-programs '(scala-mode . ("metals-emacs")))
+  :hook (scala-mode . eglot-ensure))
 ```
 
 ```scala mdoc:generic

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -125,8 +125,7 @@ There is an alternative LSP client called
 [eglot](https://github.com/joaotavora/eglot) that might be worth trying out to
 see if it addresses the issues of lsp-mode.
 
-To configure Eglot with Metals, replace the `lsp-mode`, `lsp-ui`, `lsp-scala`
-sections from the config above with the settings below.
+To configure Eglot with Metals:
 
 ```el
 ;; Add melpa-stable to your packages repositories

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -129,7 +129,27 @@ To configure Eglot with Metals, replace the `lsp-mode`, `lsp-ui`, `lsp-scala`
 sections from the config above with the settings below.
 
 ```el
-;; Eglot
+;; Add melpa-stable to your packages repositories
+(add-to-list 'package-archives '("melpa-stable" . "https://stable.melpa.org/packages/") t)
+
+;; Enable defer and ensure by default for use-package
+(setq use-package-always-defer t
+      use-package-always-ensure t)
+
+;; Enable scala-mode and sbt-mode
+(use-package scala-mode
+  :mode "\\.s\\(cala\\|bt\\)$")
+
+(use-package sbt-mode
+  :commands sbt-start sbt-command
+  :config
+  ;; WORKAROUND: https://github.com/ensime/emacs-sbt-mode/issues/31
+  ;; allows using SPACE when in the minibuffer
+  (substitute-key-definition
+   'minibuffer-complete-word
+   'self-insert-command
+   minibuffer-local-completion-map))
+
 (use-package eglot
   :pin melpa-stable)
 ;; (optional) Automatically start Metals for Scala files.


### PR DESCRIPTION
This PR improves `eglot` documentation for metals. It has been tested locally, to make sure it works.

- Add `scala-mode` setup in `eglot` section.
- Add `sbt-mode` setup in `eglot` section.
- Set `scala-mode` server for `eglot` in `:config` section.
- Use `:hook` feature of `use-package` instead of `add-hook` to automatically start `metals`.