### PR TITLE
Improve compilation tracking in the status bar.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -1,19 +1,51 @@
 package scala.meta.internal.metals
 
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import ch.epfl.scala.bsp4j.CompileReport
+import ch.epfl.scala.bsp4j.TaskDataKind
 import ch.epfl.scala.bsp4j.TaskFinishParams
 import ch.epfl.scala.bsp4j.TaskStartParams
 import ch.epfl.scala.{bsp4j => b}
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.{lsp4j => l}
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.Promise
+import scala.meta.internal.metals.MetalsEnrichments._
 
 /**
  * A build client that forwards notifications from the build server to the language client.
  */
 final class ForwardingMetalsBuildClient(
     languageClient: LanguageClient,
-    diagnostics: Diagnostics
-) extends MetalsBuildClient {
+    diagnostics: Diagnostics,
+    buildTargets: BuildTargets,
+    config: MetalsServerConfig,
+    statusBar: StatusBar,
+    time: Time
+) extends MetalsBuildClient
+    with Cancelable {
+
+  private case class Compilation(
+      timer: Timer,
+      promise: Promise[CompileReport]
+  )
+
+  private val compilations = TrieMap.empty[BuildTargetIdentifier, Compilation]
+  private val hasReportedError = Collections.newSetFromMap(
+    new ConcurrentHashMap[BuildTargetIdentifier, java.lang.Boolean]()
+  )
+
+  def reset(): Unit = {
+    cancel()
+  }
+  override def cancel(): Unit = {
+    compilations.values.foreach { compilation =>
+      compilation.promise.cancel()
+    }
+  }
 
   def onBuildShowMessage(params: l.MessageParams): Unit =
     languageClient.showMessage(params)
@@ -40,9 +72,66 @@ final class ForwardingMetalsBuildClient(
 
   def onBuildTargetCompileReport(params: b.CompileReport): Unit = {}
 
-  // We ignore task{Start,Finish} notifications for now.
   @JsonNotification("build/taskStart")
-  def buildTaskStart(params: TaskStartParams): Unit = {}
+  def buildTaskStart(params: TaskStartParams): Unit = {
+    params.getDataKind match {
+      case TaskDataKind.COMPILE_TASK =>
+        for {
+          task <- params.asCompileTask
+          info <- buildTargets.info(task.getTarget)
+        } {
+          // cancel ongoing compilation for the current target, if any.
+          compilations.get(task.getTarget).foreach(_.promise.cancel())
+
+          val name = info.getDisplayName
+          val promise = Promise[CompileReport]()
+          val compilation = Compilation(new Timer(time), promise)
+
+          compilations(task.getTarget) = compilation
+          statusBar.trackFuture(
+            s"Compiling $name",
+            promise.future,
+            showTimer = true
+          )
+        }
+      case _ =>
+    }
+  }
+
   @JsonNotification("build/taskFinish")
-  def buildTaskEnd(params: TaskFinishParams): Unit = {}
+  def buildTaskEnd(params: TaskFinishParams): Unit = {
+    params.getDataKind match {
+      case TaskDataKind.COMPILE_REPORT =>
+        for {
+          report <- params.asCompileReport
+          compilation <- compilations.get(report.getTarget)
+        } {
+          val target = report.getTarget
+          compilation.promise.trySuccess(report)
+          val name = buildTargets.info(report.getTarget) match {
+            case Some(i) => i.getDisplayName
+            case None => report.getTarget.getUri
+          }
+          val isSuccess = report.getErrors == 0
+          val icon = if (isSuccess) config.icons.check else config.icons.alert
+          val message = s"${icon}Compiled $name (${compilation.timer})"
+          if (isSuccess) {
+            if (hasReportedError.contains(target)) {
+              // Only report success compilation if it fixes a previous compile error.
+              statusBar.addMessage(message)
+            }
+            hasReportedError.remove(target)
+          } else {
+            hasReportedError.add(target)
+            statusBar.addMessage(
+              MetalsStatusParams(
+                message,
+                command = ClientCommands.FocusDiagnostics.id
+              )
+            )
+          }
+        }
+      case _ =>
+    }
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
@@ -136,6 +136,7 @@ final class StatusBar(
   }
 
   private val items = new ConcurrentLinkedQueue[Item]()
+  def pendingItems: Iterable[String] = items.asScala.map(_.formattedMessage)
   private def garbageCollect(): Unit = {
     items.removeIf(_.isStale)
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -38,19 +38,6 @@ object UserConfiguration {
 
   def options: List[UserConfigurationOption] = List(
     UserConfigurationOption(
-      "compile-on-save",
-      s""" `"${default.compileOnSave}"` """,
-      CascadeCompile,
-      "Compile on save",
-      """What compilation mode to use for file save events.
-        |Possible values:
-        |
-        |- `"cascade"` (default): compile the build target that contains the saved file
-        |  along other build targets that depend on that build target.
-        |- `"current-project"`: compile only the build target that contains the saved file.
-      """.stripMargin
-    ),
-    UserConfigurationOption(
       "java-home",
       "`JAVA_HOME` environment variable with fallback to `user.home` system property.",
       "/Library/Java/JavaVirtualMachines/jdk1.8.0_192.jdk/Contents/Home",
@@ -121,16 +108,10 @@ object UserConfiguration {
         .getOrElse(default.scalafmtConfigPath)
     val sbtScript =
       getStringKey("sbt-script")
-    val cascadeCompile = getStringKey("compile-on-save") match {
-      case None => default.compileOnSave
-      case Some(value) =>
-        value match {
-          case CascadeCompile | CurrentProjectCompile => value
-          case unknown =>
-            errors += s"unknown compile-on-save: '$unknown'. Expected one of: ${allCompile.mkString(", ")}."
-            default.compileOnSave
-        }
-    }
+    // NOTE(olafur) Not configurable because we should not expose configuration options for
+    // experimental features. I was tempted to remove the cascade implementation but
+    // decided to keep it instead because I suspect we will need it soon for rename/references.
+    val cascadeCompile = default.compileOnSave
 
     if (errors.isEmpty) {
       Right(

--- a/tests/unit/src/main/scala/tests/BaseSlowSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseSlowSuite.scala
@@ -7,8 +7,10 @@ import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.BloopProtocol
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.ExecuteClientCommandConfig
+import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.RecursivelyDelete
+import scala.meta.internal.metals.UserConfiguration
 import scala.meta.io.AbsolutePath
 
 /**
@@ -16,6 +18,8 @@ import scala.meta.io.AbsolutePath
  */
 abstract class BaseSlowSuite(suiteName: String) extends BaseSuite {
   def protocol: BloopProtocol = BloopProtocol.auto
+  def icons: Icons = Icons.default
+  def userConfig: UserConfiguration = UserConfiguration()
   implicit val ex: ExecutionContextExecutorService =
     ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
   def bspGlobalDirectories: List[AbsolutePath] = Nil
@@ -49,7 +53,8 @@ abstract class BaseSlowSuite(suiteName: String) extends BaseSuite {
     val buffers = Buffers()
     val config = MetalsServerConfig.default.copy(
       bloopProtocol = protocol,
-      executeClientCommand = ExecuteClientCommandConfig.on
+      executeClientCommand = ExecuteClientCommandConfig.on,
+      icons = this.icons
     )
     client = new TestingClient(workspace, buffers)
     server = new TestingServer(
@@ -59,6 +64,7 @@ abstract class BaseSlowSuite(suiteName: String) extends BaseSuite {
       config,
       bspGlobalDirectories
     )(ex)
+    server.server.userConfig = this.userConfig
   }
 
   def cleanCompileCache(project: String): Unit = {

--- a/tests/unit/src/main/scala/tests/BaseSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseSuite.scala
@@ -4,6 +4,8 @@ import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.language.experimental.macros
+import scala.meta.internal.metals.MetalsLogger
+import scala.meta.io.AbsolutePath
 import scala.reflect.ClassTag
 import utest.TestSuite
 import utest.Tests
@@ -11,10 +13,8 @@ import utest.asserts.Asserts
 import utest.framework.Formatter
 import utest.framework.TestCallTree
 import utest.framework.Tree
-import utest.ufansi.Str
-import scala.meta.internal.metals.MetalsLogger
-import scala.meta.io.AbsolutePath
 import utest.ufansi.Attrs
+import utest.ufansi.Str
 
 /**
  * Test suite that replace utest DSL with FunSuite-style syntax from ScalaTest.
@@ -28,6 +28,20 @@ class BaseSuite extends TestSuite {
   def beforeAll(): Unit = ()
   def afterAll(): Unit = ()
   def intercept[T: ClassTag](exprs: Unit): T = macro Asserts.interceptProxy[T]
+  def assertNotEmpty(string: String): Unit = {
+    if (string.isEmpty) {
+      fail(
+        s"expected non-empty string, obtained empty string."
+      )
+    }
+  }
+  def assertEmpty(string: String): Unit = {
+    if (!string.isEmpty) {
+      fail(
+        s"expected empty string, obtained: $string"
+      )
+    }
+  }
   def assertContains(string: String, substring: String): Unit = {
     assert(string.contains(substring))
   }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -39,7 +39,6 @@ import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.Debug
 import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.internal.metals.MetalsLanguageServer
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.ProgressTicks
@@ -69,7 +68,7 @@ import tests.MetalsTestEnrichments._
  */
 final class TestingServer(
     workspace: AbsolutePath,
-    client: MetalsLanguageClient,
+    client: TestingClient,
     buffers: Buffers,
     config: MetalsServerConfig,
     bspGlobalDirectories: List[AbsolutePath]
@@ -84,6 +83,14 @@ final class TestingServer(
   )
   server.connectToLanguageClient(client)
   private val readonlySources = TrieMap.empty[String, AbsolutePath]
+  def statusBarHistory: String = {
+    // collect both published items in the client and pending items from the server.
+    val all = List(
+      server.statusBar.pendingItems,
+      client.statusParams.asScala.map(_.text)
+    ).flatten
+    all.distinct.mkString("\n")
+  }
 
   private def write(layout: String): Unit = {
     FileLayout.fromString(layout, root = workspace)

--- a/tests/unit/src/test/scala/tests/CascadeSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/CascadeSlowSuite.scala
@@ -1,0 +1,50 @@
+package tests
+
+import scala.meta.internal.metals.UserConfiguration
+
+object CascadeSlowSuite extends BaseSlowSuite("cascade") {
+  override def userConfig: UserConfiguration = super.userConfig.copy(
+    compileOnSave = UserConfiguration.CascadeCompile
+  )
+  testAsync("basic") {
+    for {
+      _ <- server.initialize(
+        """
+          |/metals.json
+          |{
+          |  "a": { },
+          |  "b": { "dependsOn": ["a"] },
+          |  "c": { }
+          |}
+          |/a/src/main/scala/a/A.scala
+          |package a
+          |object A {
+          |  val n = 42
+          |}
+          |/b/src/main/scala/b/B.scala
+          |package b
+          |object B {
+          |  val n: String = a.A.n
+          |}
+          |/c/src/main/scala/c/C.scala
+          |package c
+          |object C {
+          |  val n: String = 42
+          |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      // Check that opening file A.scala triggers compile in dependent project "b"
+      // but not independent project "c".
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|b/src/main/scala/b/B.scala:3:23: error: type mismatch;
+           | found   : Int
+           | required: String
+           |  val n: String = a.A.n
+           |                      ^
+          """.stripMargin
+      )
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/CurrentProjectCompileSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/CurrentProjectCompileSlowSuite.scala
@@ -1,0 +1,30 @@
+package tests
+import scala.meta.internal.metals.UserConfiguration
+
+object CurrentProjectCompileSlowSuite extends BaseSlowSuite("current-project") {
+  override def userConfig: UserConfiguration = super.userConfig.copy(
+    compileOnSave = UserConfiguration.CurrentProjectCompile
+  )
+  testAsync("basic") {
+    for {
+      _ <- server.initialize(
+        """
+          |/metals.json
+          |{
+          |  "a": { },
+          |  "b": { "dependsOn": ["a"] }
+          |}
+          |/a/src/main/scala/a/A.scala
+          |object A {}
+          |/b/src/main/scala/b/B.scala
+          |object B {
+          |  val n: String = 42
+          |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      // Assert that we don't trigger compilation in "b" even if it depends on "a".
+      _ = assertNoDiff(client.workspaceDiagnostics, "")
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/InverseDependenciesSuite.scala
+++ b/tests/unit/src/test/scala/tests/InverseDependenciesSuite.scala
@@ -1,0 +1,82 @@
+package tests
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+import scala.meta.internal.metals.BuildTargets
+
+object InverseDependenciesSuite extends BaseSuite {
+  class Graph(val root: String) {
+    val inverseDependencies = mutable.Map.empty[String, ListBuffer[String]]
+    def dependsOn(project: String, dependency: String): this.type = {
+      val dependencies =
+        inverseDependencies.getOrElseUpdate(dependency, ListBuffer.empty)
+      dependencies += project
+      this
+    }
+  }
+  def root(x: String): Graph = new Graph(x)
+  def check(
+      name: String,
+      original: Graph,
+      expected: String
+  ): Unit = {
+    test(name) {
+      val obtained = BuildTargets.inverseDependencies(
+        new BuildTargetIdentifier(original.root), { key =>
+          original.inverseDependencies
+            .get(key.getUri)
+            .map(_.map(new BuildTargetIdentifier(_)))
+        }
+      )
+      assertNoDiff(
+        obtained.toSeq.map(_.getUri).sorted.mkString("\n"),
+        expected
+      )
+    }
+  }
+
+  check(
+    "basic",
+    root("a")
+      .dependsOn("b", "a"),
+    "b"
+  )
+
+  check(
+    "transitive",
+    root("a")
+      .dependsOn("b", "a")
+      .dependsOn("c", "b"),
+    "c"
+  )
+
+  check(
+    "branch",
+    root("a")
+      .dependsOn("b", "a")
+      .dependsOn("d", "a")
+      .dependsOn("c", "b"),
+    """
+      |c
+      |d
+      |""".stripMargin
+  )
+
+  check(
+    "alone",
+    root("a"),
+    "a"
+  )
+
+  check(
+    "diamond",
+    root("a")
+      .dependsOn("b", "a")
+      .dependsOn("c", "a")
+      .dependsOn("d", "b")
+      .dependsOn("d", "c"),
+    "d"
+  )
+
+}

--- a/tests/unit/src/test/scala/tests/StatusBarSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/StatusBarSlowSuite.scala
@@ -1,0 +1,47 @@
+package tests
+import scala.meta.internal.metals.Icons
+
+object StatusBarSlowSuite extends BaseSlowSuite("status-bar") {
+  override def icons: Icons = Icons.vscode
+  testAsync("compile-success") {
+    for {
+      _ <- server.initialize(
+        """
+          |/metals.json
+          |{ "a": {} }
+          |/a/src/main/scala/A.scala
+          |object A {
+          |  val x = 42
+          |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/A.scala")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        ""
+      )
+      // Successful compilation is not reported in the status bar if there was no prior compile error.
+      _ = assertNotContains(
+        server.statusBarHistory,
+        s"${icons.check}Compiled a"
+      )
+      _ <- server.didSave("a/src/main/scala/A.scala")(
+        _.replaceFirst("val x = 42", "val x: String = 42")
+      )
+      _ = assertNotEmpty(client.workspaceDiagnostics)
+      // Failed compilation is always reported in the status bar.
+      _ = assertContains(
+        server.statusBarHistory,
+        s"${icons.alert}Compiled a"
+      )
+      _ <- server.didSave("a/src/main/scala/A.scala")(
+        _.replaceFirst("val x: String = 42", "val x = 42")
+      )
+      // Successful compilation is reported in the status bar when following a failed compilation.
+      _ = assertContains(
+        server.statusBarHistory,
+        s"${icons.check}Compiled a"
+      )
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -138,15 +138,4 @@ object UserConfigurationSuite extends BaseSuite {
     """.stripMargin
   )
 
-  checkError(
-    "cascade",
-    """
-      |{
-      | "compile-on-save": "foobar"
-      |}
-    """.stripMargin,
-    """
-      |unknown compile-on-save: 'foobar'. Expected one of: cascade, current-project.
-    """.stripMargin
-  )
 }

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -52,12 +52,14 @@ object UserConfigurationSuite extends BaseSuite {
     """
       |{
       | "java-home": "home",
+      | "compile-on-save": "current-project",
       | "sbt-script": "script"
       |}
     """.stripMargin
   ) { obtained =>
     assert(obtained.javaHome == Some("home"))
     assert(obtained.sbtScript == Some("script"))
+    assert(obtained.isCurrentProject)
   }
 
   checkOK(
@@ -66,6 +68,14 @@ object UserConfigurationSuite extends BaseSuite {
   ) { obtained =>
     assert(obtained.javaHome.isEmpty)
     assert(obtained.sbtScript.isEmpty)
+    assert(
+      obtained.scalafmtConfigPath ==
+        UserConfiguration.default.scalafmtConfigPath
+    )
+    assert(
+      obtained.compileOnSave ==
+        UserConfiguration.default.compileOnSave
+    )
   }
 
   checkOK(
@@ -125,6 +135,18 @@ object UserConfigurationSuite extends BaseSuite {
     """.stripMargin,
     """
       |json error: key 'sbt-script' should have value of type string but obtained []
+    """.stripMargin
+  )
+
+  checkError(
+    "cascade",
+    """
+      |{
+      | "compile-on-save": "foobar"
+      |}
+    """.stripMargin,
+    """
+      |unknown compile-on-save: 'foobar'. Expected one of: cascade, current-project.
     """.stripMargin
   )
 }


### PR DESCRIPTION
Previously, we showed a single "Compiling $project" message when
compiling a project regardless if that project triggered compilation
in other projects in the workspace. With this commit, we now add
a "Compiling $project" status bar message for each unique project
that's compiled.

For example, if you open `core-test` with one transitive dependency you
get two status bar updates.

- "Compiling core": the main sources.
- "Compiling core-test": the test sources.