### PR TITLE
Use scalafmt-dynamic module to simplify formatting implementation.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,6 +152,7 @@ lazy val metals = project
       // Scala dependencies
       // ==================
       // for fetching ch.epfl.scala:bloop-frontend and other library dependencies
+      "org.scalameta" %% "scalafmt-dynamic" % "2.0.0-RC4",
       "com.geirsson" %% "coursier-small" % "1.3.1",
       // undeclared transitive dependency of coursier-small
       "org.scala-lang.modules" %% "scala-xml" % "1.1.1",

--- a/build.sbt
+++ b/build.sbt
@@ -94,6 +94,7 @@ lazy val V = new {
   val bsp = "2.0.0-M2"
   val sbtBloop = "1.1.2"
   val bloop = "1.1.2"
+  val scalafmt = "2.0.0-RC4"
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.
   def supportedScalaVersions = Seq(
@@ -146,13 +147,11 @@ lazy val metals = project
       "com.thoughtworks.qdox" % "qdox" % "2.0-M9",
       // for finding paths of global log/cache directories
       "io.github.soc" % "directories" % "11",
-      // for reading Scalafmt conf
-      "com.typesafe" % "config" % "1.3.2",
       // ==================
       // Scala dependencies
       // ==================
+      "org.scalameta" %% "scalafmt-dynamic" % V.scalafmt,
       // for fetching ch.epfl.scala:bloop-frontend and other library dependencies
-      "org.scalameta" %% "scalafmt-dynamic" % "2.0.0-RC4",
       "com.geirsson" %% "coursier-small" % "1.3.1",
       // undeclared transitive dependency of coursier-small
       "org.scala-lang.modules" %% "scala-xml" % "1.1.1",
@@ -176,6 +175,7 @@ lazy val metals = project
       "sbtBloopVersion" -> V.sbtBloop,
       "scalametaVersion" -> V.scalameta,
       "semanticdbVersion" -> V.semanticdb,
+      "scalafmtVersion" -> V.scalafmt,
       "supportedScalaVersions" -> V.supportedScalaVersions,
       "scala211" -> V.scala211,
       "scala212" -> V.scala212

--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -172,6 +172,8 @@ https://scalameta.org/scalafmt/docs/configuration.html.
 
 **Slow task**: Editor client implements the `metals/slowTask` request.
 
+**Input box**: Editor client implements the `metals/inputBox` request.
+
 **✅**: Editor implements all Metals extension endpoints.
 
 The Metals language server supports custom extensions that are not part of the

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -120,4 +120,14 @@ final class ConfiguredLanguageClient(
     }
   }
 
+  override def metalsInputBox(
+      params: MetalsInputBoxParams
+  ): CompletableFuture[MetalsInputBoxResult] = {
+    if (config.isInputBoxEnabled) {
+      underlying.metalsInputBox(params)
+    } else {
+      CompletableFuture.completedFuture(MetalsInputBoxResult(cancelled = true))
+    }
+  }
+
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
@@ -78,4 +78,10 @@ class DelegatingLanguageClient(
     underlying.metalsExecuteClientCommand(params)
   }
 
+  override def metalsInputBox(
+      params: MetalsInputBoxParams
+  ): CompletableFuture[MetalsInputBoxResult] = {
+    underlying.metalsInputBox(params)
+  }
+
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -224,6 +224,43 @@ class Messages(icons: Icons) {
       )
   }
 
+  object MissingScalafmtVersion {
+    def failedToResolve(message: String): MessageParams = {
+      new MessageParams(MessageType.Error, message)
+    }
+    def fixedVersion: MessageParams =
+      new MessageParams(
+        MessageType.Info,
+        "Updated .scalafmt.conf, try formatting again. "
+      )
+    def isMissingScalafmtVersion(params: ShowMessageRequestParams): Boolean =
+      params.getMessage == messageRequestMessage
+    def inputBox(): MetalsInputBoxParams = MetalsInputBoxParams(
+      prompt =
+        "No Scalafmt version is configured for this workspace, what version would you like to use?",
+      value = BuildInfo.scalafmtVersion
+    )
+    def messageRequestMessage: String =
+      s"No Scalafmt version is configured for this workspace. " +
+        s"To fix this problem, update .scalafmt.conf to include 'version=${BuildInfo.scalafmtVersion}'."
+    def changeVersion: MessageActionItem =
+      new MessageActionItem(
+        s"Update .scalafmt.conf to use v${BuildInfo.scalafmtVersion}"
+      )
+    def messageRequest(): ShowMessageRequestParams = {
+      val params = new ShowMessageRequestParams()
+      params.setMessage(messageRequestMessage)
+      params.setType(MessageType.Error)
+      params.setActions(
+        List(
+          changeVersion,
+          notNow
+        ).asJava
+      )
+      params
+    }
+  }
+
   object MissingScalafmtConf {
     def createFile = new MessageActionItem("Create .scalafmt.conf")
     def fixedParams: MessageParams =

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -225,30 +225,6 @@ class Messages(icons: Icons) {
       )
   }
 
-  object ScalafmtError {
-    def configParseError(
-        path: RelativePath,
-        message: String
-    ): MessageParams =
-      new MessageParams(
-        MessageType.Error,
-        s"Failed to parse config $path with error message '$message'"
-      )
-    def formatError(e: Throwable): MessageParams = {
-      new MessageParams(
-        MessageType.Error,
-        s"Scalafmt error: ${e.getMessage}"
-      )
-    }
-    def downloadError(version: String): MessageParams = {
-      new MessageParams(
-        MessageType.Error,
-        s"Failed to download Scalafmt v$version. " +
-          "Make sure you have a working internet connection and this version exists on Maven Central."
-      )
-    }
-  }
-
   object MissingScalafmtConf {
     def createFile = new MessageActionItem("Create .scalafmt.conf")
     def fixedParams: MessageParams =

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -9,7 +9,6 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.meta.internal.metals.BuildTool.Sbt
 import scala.meta.io.AbsolutePath
-import scala.meta.io.RelativePath
 
 /**
  * Constants for requests/dialogues via LSP window/showMessage and window/showMessageRequest.

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -16,6 +16,7 @@ import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.jsonrpc.CancelChecker
 import org.eclipse.{lsp4j => l}
 import scala.collection.convert.DecorateAsJava
 import scala.collection.convert.DecorateAsScala
@@ -431,5 +432,15 @@ object MetalsEnrichments extends DecorateAsJava with DecorateAsScala {
   implicit class XtensionPromise[T](promise: Promise[T]) {
     def cancel(): Unit =
       promise.tryFailure(new CancellationException())
+  }
+  implicit class XtensionCancelChecker(token: CancelChecker) {
+    def isCancelled: Boolean =
+      try {
+        token.checkCanceled()
+        false
+      } catch {
+        case _: CancellationException =>
+          true
+      }
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
@@ -50,6 +50,13 @@ final class MetalsHttpClient(
     sh: ScheduledExecutorService
 )(implicit ec: ExecutionContext)
     extends MetalsLanguageClient {
+
+  override def metalsInputBox(
+      params: MetalsInputBoxParams
+  ): CompletableFuture[MetalsInputBoxResult] = {
+    CompletableFuture.completedFuture(MetalsInputBoxResult(cancelled = true))
+  }
+
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams
   ): Unit = {}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
@@ -33,6 +33,17 @@ trait MetalsLanguageClient extends LanguageClient {
   @JsonNotification("metals/executeClientCommand")
   def metalsExecuteClientCommand(params: ExecuteCommandParams): Unit
 
+  /**
+   * Opens an input box to ask the user for input.
+   *
+   * @return the user provided input. The future can be cancelled, meaning
+   *         the input box should be dismissed in the editor.
+   */
+  @JsonRequest("metals/inputBox")
+  def metalsInputBox(
+      params: MetalsInputBoxParams
+  ): CompletableFuture[MetalsInputBoxResult]
+
   def shutdown(): Unit = {}
 
 }
@@ -57,3 +68,24 @@ case class MetalsStatusParams(
 
 case class MetalsSlowTaskParams(message: String)
 case class MetalsSlowTaskResult(cancel: Boolean)
+
+case class MetalsInputBoxParams(
+    // The value to prefill in the input box
+    @Nullable value: String = null,
+    // The text to display underneath the input box.
+    @Nullable prompt: String = null,
+    // An optional string to show as place holder in the input box to guide the user what to type.
+    @Nullable placeholder: String = null,
+    // Set to `true` to show a password prompt that will not show the typed value.
+    @Nullable password: java.lang.Boolean = null,
+    // Set to `true` to keep the input box open when focus moves to another
+    // part of the editor or to another window.
+    @Nullable ignoreFocusOut: java.lang.Boolean = null,
+    @Nullable valueSelection: Array[Int] = null
+)
+
+case class MetalsInputBoxResult(
+    // value=null when cancelled=true
+    @Nullable value: String = null,
+    @Nullable cancelled: java.lang.Boolean = null
+)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -189,6 +189,7 @@ class MetalsLanguageServer(
       workspace,
       buffers,
       embedded,
+      config,
       () => userConfig,
       languageClient,
       statusBar,
@@ -560,8 +561,11 @@ class MetalsLanguageServer(
   def formatting(
       params: DocumentFormattingParams
   ): CompletableFuture[util.List[TextEdit]] =
-    CompletableFutures.computeAsync { _ =>
-      formattingProvider.format(params.getTextDocument.getUri.toAbsolutePath)
+    CompletableFutures.computeAsync { token =>
+      formattingProvider.format(
+        params.getTextDocument.getUri.toAbsolutePath,
+        token
+      )
     }
 
   @JsonRequest("textDocument/rename")

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -41,6 +41,10 @@ final case class MetalsServerConfig(
       "metals.http",
       default = false
     ),
+    isInputBoxEnabled: Boolean = MetalsServerConfig.binaryOption(
+      "metals.input-box",
+      default = false
+    ),
     isVerbose: Boolean = MetalsServerConfig.binaryOption(
       "metals.verbose",
       default = false
@@ -63,6 +67,7 @@ final case class MetalsServerConfig(
       s"show-message-request=$showMessageRequest",
       s"no-initialized=$isNoInitialized",
       s"http=$isHttpEnabled",
+      s"input-box=$isInputBoxEnabled",
       s"icons=$icons",
       s"statistics=$statistics"
     ).mkString("MetalsServerConfig(\n  ", ",\n  ", "\n)")
@@ -84,7 +89,8 @@ object MetalsServerConfig {
           slowTask = SlowTaskConfig.on,
           icons = Icons.vscode,
           executeClientCommand = ExecuteClientCommandConfig.on,
-          globSyntax = GlobSyntaxConfig.vscode
+          globSyntax = GlobSyntaxConfig.vscode,
+          isInputBoxEnabled = true
         )
       case "vim-lsc" =>
         base.copy(

--- a/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
@@ -30,4 +30,9 @@ object NoopLanguageClient extends MetalsLanguageClient {
   override def logMessage(message: MessageParams): Unit = ()
   override def metalsExecuteClientCommand(params: ExecuteCommandParams): Unit =
     ()
+  override def metalsInputBox(
+      params: MetalsInputBoxParams
+  ): CompletableFuture[MetalsInputBoxResult] = {
+    CompletableFuture.completedFuture(MetalsInputBoxResult(cancelled = true))
+  }
 }

--- a/test-workspace/.scalafmt.conf
+++ b/test-workspace/.scalafmt.conf
@@ -1,1 +1,2 @@
-version = "1.5.1"
+version = "2.0.0-RC4"
+

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -19,6 +19,8 @@ import scala.meta.inputs.Position
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MetalsInputBoxParams
+import scala.meta.internal.metals.MetalsInputBoxResult
 import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.internal.metals.MetalsSlowTaskParams
 import scala.meta.internal.metals.MetalsSlowTaskResult
@@ -199,5 +201,11 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
 
   override def metalsStatus(params: MetalsStatusParams): Unit = {
     statusParams.add(params)
+  }
+
+  override def metalsInputBox(
+      params: MetalsInputBoxParams
+  ): CompletableFuture[MetalsInputBoxResult] = {
+    CompletableFuture.completedFuture(MetalsInputBoxResult(cancelled = true))
   }
 }

--- a/tests/unit/src/test/scala/tests/BspCli.scala
+++ b/tests/unit/src/test/scala/tests/BspCli.scala
@@ -21,6 +21,8 @@ import scala.meta.internal.metals.Embedded
 import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.MetalsBuildClient
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MetalsInputBoxParams
+import scala.meta.internal.metals.MetalsInputBoxResult
 import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.MetalsSlowTaskParams
@@ -80,6 +82,13 @@ object BspCli {
   }
   private def loggingLangaugeClient: MetalsLanguageClient =
     new MetalsLanguageClient {
+      override def metalsInputBox(
+          params: MetalsInputBoxParams
+      ): CompletableFuture[MetalsInputBoxResult] = {
+        CompletableFuture.completedFuture(
+          MetalsInputBoxResult(cancelled = true)
+        )
+      }
       override def metalsExecuteClientCommand(
           params: ExecuteCommandParams
       ): Unit = {}

--- a/tests/unit/src/test/scala/tests/StatusBarSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/StatusBarSlowSuite.scala
@@ -4,6 +4,7 @@ import scala.meta.internal.metals.Icons
 object StatusBarSlowSuite extends BaseSlowSuite("status-bar") {
   override def icons: Icons = Icons.vscode
   testAsync("compile-success") {
+    cleanCompileCache("a")
     for {
       _ <- server.initialize(
         """


### PR DESCRIPTION
The classloading parts have been merged into Scalafmt so they
can be used by all build tools and editor plugins:
https://scalameta.org/scalafmt/docs/installation.html#standalone-library