### PR TITLE
Lower recommended memory settings.

### DIFF
--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -27,8 +27,7 @@ coursier bootstrap \
   --java-opt -XX:+UseG1GC \
   --java-opt -XX:+UseStringDeduplication  \
   --java-opt -Xss4m \
-  --java-opt -Xms1G \
-  --java-opt -Xmx4G \
+  --java-opt -Xms100m \
   org.scalameta:metals_2.12:@VERSION@ -o metals -f
 ```
 

--- a/metals-docs/src/main/scala/docs/BootstrapModifier.scala
+++ b/metals-docs/src/main/scala/docs/BootstrapModifier.scala
@@ -27,8 +27,7 @@ class BootstrapModifier extends StringModifier {
            |  --java-opt -XX:+UseG1GC \\
            |  --java-opt -XX:+UseStringDeduplication  \\
            |  --java-opt -Xss4m \\
-           |  --java-opt -Xms1G \\
-           |  --java-opt -Xmx4G  \\
+           |  --java-opt -Xms100m \\
            |  --java-opt -Dmetals.client=$client \\
            |  org.scalameta:metals_2.12:${Docs.release.version} \\
            |  -r bintray:scalacenter/releases \\


### PR DESCRIPTION
Fixes #454.

I don't think Metals will need more than 100mb even for very large
projects, even after we implement "find references". We remove the
maximum heap size so it can fit the computer's configuration.
