### PR TITLE
Improve the status bar redirection to window/logMessage

### DIFF
--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -38,11 +38,14 @@ au BufRead,BufNewFile *.sbt set filetype=scala
 " Configuration for vim-lsc
 let g:lsc_enable_autocomplete = v:false
 let g:lsc_server_commands = {
-  \ 'scala': 'metals-vim'
+  \  'scala': {
+  \    'command': 'metals-vim',
+  \    'log_level': 'Log'
+  \  }
   \}
 let g:lsc_auto_map = {
-    \ 'GoToDefinition': 'gd',
-    \}
+  \  'GoToDefinition': 'gd',
+  \}
 ```
 
 Run `:PlugInstall` to install the plugin. If you already have `vim-lsc`

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -54,9 +54,7 @@ final class ConfiguredLanguageClient(
     if (config.statusBar.isOn) {
       underlying.metalsStatus(params)
     } else if (config.statusBar.isLogMessage && !pendingShowMessage.get()) {
-      if (params.text.nonEmpty) {
-        logMessage(new MessageParams(MessageType.Info, params.text))
-      }
+      underlying.logMessage(new MessageParams(MessageType.Log, params.text))
     } else {
       ()
     }


### PR DESCRIPTION
Fixes #463

- clear status bar with empty text to avoid hanging "Compiling core"
- use 'Log' level to avoid colorful info background
- recommend vim-lsc users to configure log_level `Log`, will be
  required once https://github.com/natebosch/vim-lsc/pull/135 is merged.