### PR TITLE
Improve "No SemanticDB" error message

### DIFF
--- a/docs/build-tools/new-build-tool.md
+++ b/docs/build-tools/new-build-tool.md
@@ -20,6 +20,32 @@ There are two options for integrating Metals with a new build tool:
   environment as your current workflow. The downside of this approach is that it
   most likely requires more effort compared to emitting Bloop JSON files.
 
+## Enable SemanticDB
+
+Regardless if you use the Bloop build server or implement a custom build server,
+the [SemanticDB](https://scalameta.org/docs/semanticdb/guide.html) compiler
+plugin is required for Metals code navigation to work. Only limited Metals
+features like diagnostics and code formatting work without the SemanticDB
+compiler plugin enabled.
+
+Make sure to declare the compiler option `"-P:semanticdb:sourceroot:$WORKSPACE"`
+where `$WORKSPACE` is the absolute path to the workspace root directory. By
+default, the sourceroot is inferred from the working directory of the compiler
+process but it's better to explicitly declare it. If the sourceroot is
+misconfigured, then Metals is unable to find the SemanticDB files created by the
+compiler plugin.
+
+## Recommended compiler options
+
+We recommend you update the following compiler options when using Metals:
+
+- `-Xlint`: these warnings are helpful in the editor even if you don't have them
+  enabled in your main build. Consult `scalac -Xlint:help` for a full list of
+  available warnings.
+- `-Xfatal-warnings`: disable this setting even if you have it enabled in your
+  main build. Fatal warnings prevent code navigation from working when there are
+  warnings like 'unused import'.
+
 ## Bloop build server
 
 Consult the

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTools.scala
@@ -73,6 +73,9 @@ final class BuildTools(
     if (isBazel) buf += Bazel
     buf.result()
   }
+  def isEmpty: Boolean = {
+    all.isEmpty
+  }
   override def toString: String = {
     val names = all.mkString("+")
     if (names.isEmpty) "<no build tool>"

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -37,7 +37,8 @@ final class DefinitionProvider(
     index: GlobalSymbolIndex,
     semanticdbs: Semanticdbs,
     icons: Icons,
-    statusBar: StatusBar
+    statusBar: StatusBar,
+    warnings: Warnings
 ) {
 
   def definition(
@@ -49,7 +50,7 @@ final class DefinitionProvider(
       case Some(doc) =>
         definitionFromSnapshot(path, params, doc)
       case _ =>
-        statusBar.addMessage(s"${icons.alert} No SemanticDB")
+        warnings.noSemanticdb(path)
         DefinitionResult.empty
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -198,6 +198,8 @@ object MetalsEnrichments extends DecorateAsJava with DecorateAsScala {
 
   implicit class XtensionAbsolutePathBuffers(path: AbsolutePath) {
 
+    def sourcerootOption: String = s""""-P:semanticdb:sourceroot:$path""""
+
     /**
      * Resolve each path segment individually to prevent jjkjjk
      */
@@ -416,6 +418,16 @@ object MetalsEnrichments extends DecorateAsJava with DecorateAsScala {
       Option(exchange.getQueryParameters.get(key)).flatMap(_.asScala.headOption)
   }
   implicit class XtensionScalacOptions(item: b.ScalacOptionsItem) {
+    def isSemanticdbEnabled: Boolean =
+      item.getOptions.asScala.exists { opt =>
+        opt.startsWith("-Xplugin:") && opt
+          .contains("semanticdb-scalac")
+      }
+    def isSourcerootDeclared: Boolean = {
+      item.getOptions.asScala.exists { option =>
+        option.startsWith("-P:semanticdb:sourceroot")
+      }
+    }
     def isJVM: Boolean = {
       // FIXME: https://github.com/scalacenter/bloop/issues/700
       !item.getOptions.asScala.exists(_.isNonJVMPlatformOption)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -137,6 +137,7 @@ class MetalsLanguageServer(
       buildTargets,
       statusBar,
       config.icons,
+      buildTools,
       isCompiling
     )
     diagnostics = new Diagnostics(
@@ -683,9 +684,7 @@ class MetalsLanguageServer(
     buildTools.asSbt match {
       case None =>
         if (!buildTools.isAutoConnectable) {
-          scribe.warn(
-            s"Skipping build import for unsupported build tool $buildTools"
-          )
+          warnings.noBuildTool()
         }
         Future.successful(BuildChange.None)
       case Some(sbt) =>
@@ -753,7 +752,6 @@ class MetalsLanguageServer(
 
   private def quickConnectToBuildServer(): Future[BuildChange] = {
     if (!buildTools.isAutoConnectable) {
-      scribe.warn("Unable to automatically connect to build server.")
       Future.successful(BuildChange.None)
     } else if (isUnsupportedJavaVersion) {
       Future.successful(BuildChange.None)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
@@ -95,4 +95,11 @@ object MetalsLogger {
 
   def defaultFormat = formatter"$levelPaddedRight $message$newLine"
 
+  def silent: LoggerSupport = new LoggerSupport {
+    override def log[M](record: LogRecord[M]): Unit = ()
+  }
+  def default: LoggerSupport = scribe.Logger.root
+  def silentInTests: LoggerSupport =
+    if (MetalsServerConfig.isTesting) silent
+    else default
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -53,6 +53,10 @@ final case class MetalsServerConfig(
       "metals.h2.auto-server",
       default = true
     ),
+    isWarningsEnabled: Boolean = MetalsServerConfig.binaryOption(
+      "metals.warnings",
+      default = true
+    ),
     icons: Icons = Icons.default,
     statistics: StatisticsConfig = StatisticsConfig.default
 ) {
@@ -73,6 +77,7 @@ final case class MetalsServerConfig(
     ).mkString("MetalsServerConfig(\n  ", ",\n  ", "\n)")
 }
 object MetalsServerConfig {
+  def isTesting: Boolean = "true" == System.getProperty("metals.testing")
   private def binaryOption(key: String, default: Boolean): Boolean =
     System.getProperty(key) match {
       case "true" | "on" => true

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -5,10 +5,5 @@ import ch.epfl.scala.bsp4j.ScalacOptionsItem
 import scala.meta.internal.metals.MetalsEnrichments._
 
 case class ScalaTarget(info: BuildTarget, scalac: ScalacOptionsItem) {
-  def isSemanticdbEnabled: Boolean = {
-    scalac.getOptions.asScala.exists { opt =>
-      opt.startsWith("-Xplugin:") && opt
-        .contains("semanticdb-scalac")
-    }
-  }
+  def isSemanticdbEnabled: Boolean = scalac.isSemanticdbEnabled
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -1,0 +1,18 @@
+package scala.meta.internal.metals
+
+object ScalaVersions {
+  val isSupportedScalaVersion: Set[String] =
+    BuildInfo.supportedScalaVersions.toSet
+  def isSupportedScalaBinaryVersion(scalaVersion: String): Boolean =
+    Set("2.12", "2.11").exists { binaryVersion =>
+      scalaVersion.startsWith(binaryVersion)
+    }
+
+  val isLatestScalaVersion: Set[String] =
+    Set(BuildInfo.scala212, BuildInfo.scala211)
+
+  def recommendedVersion(scalaVersion: String): String = {
+    if (scalaVersion.startsWith("2.11")) BuildInfo.scala211
+    else BuildInfo.scala212
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
@@ -1,0 +1,83 @@
+package scala.meta.internal.metals
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ScalaVersions._
+import scala.meta.internal.mtags.SemanticdbClasspath
+import scala.meta.io.AbsolutePath
+
+/**
+ * A helper to construct clear and actionable warning messages.
+ */
+final class Warnings(
+    workspace: AbsolutePath,
+    buildTargets: BuildTargets,
+    statusBar: StatusBar,
+    icons: Icons,
+    isCompiling: BuildTargetIdentifier => Boolean
+) {
+  def noSemanticdb(path: AbsolutePath): Unit = {
+    def doesntWorkBecause =
+      s"no navigation: code navigation does not work for the file '$path' because"
+    def buildMisconfiguration(): Unit = {
+      statusBar.addMessage(
+        MetalsStatusParams(
+          s"${icons.alert}Build misconfiguration",
+          command = ClientCommands.RunDoctor.id
+        )
+      )
+    }
+    val isReported: Option[Unit] = for {
+      buildTarget <- buildTargets.inverseSources(path)
+      info <- buildTargets.info(buildTarget)
+      scala <- info.asScalaBuildTarget
+      scalacOptions <- buildTargets.scalacOptions(buildTarget)
+    } yield {
+      if (!scalacOptions.isSemanticdbEnabled) {
+        if (isSupportedScalaVersion(scala.getScalaVersion)) {
+          scribe.error(
+            s"$doesntWorkBecause the SemanticDB compiler plugin is not enabled for the build target ${info.getDisplayName}."
+          )
+          buildMisconfiguration()
+        } else {
+          scribe.error(
+            s"$doesntWorkBecause the Scala version ${scala.getScalaVersion} is not supported. " +
+              s"To fix this problem, change the Scala version to ${isLatestScalaVersion.mkString(" or ")}."
+          )
+          statusBar.addMessage(
+            s"${icons.alert}Unsupported Scala ${scala.getScalaVersion}"
+          )
+        }
+      } else {
+        if (!scalacOptions.isSourcerootDeclared) {
+          val option = workspace.sourcerootOption
+          scribe.error(
+            s"$doesntWorkBecause the build target ${info.getDisplayName} is missing the compiler option $option. " +
+              s"To fix this problems, update the build settings to include this compiler option."
+          )
+          buildMisconfiguration()
+        } else if (isCompiling(buildTarget)) {
+          val tryAgain = "Wait until compilation is finished and try again"
+          scribe.error(
+            s"$doesntWorkBecause the build target ${info.getDisplayName} is being compiled. $tryAgain."
+          )
+          statusBar.addMessage(icons.info + tryAgain)
+        } else {
+          val targetfile = scalacOptions.getClassDirectory.toAbsolutePath
+            .resolve(SemanticdbClasspath.fromScala(path.toRelative(workspace)))
+          scribe.error(
+            s"$doesntWorkBecause the SemanticDB file '$targetfile' doesn't exist. " +
+              s"There can be many reasons for this error. "
+          )
+          statusBar.addMessage(s"${icons.alert}No SemanticDB")
+        }
+      }
+    }
+    isReported match {
+      case Some(()) =>
+      case None =>
+        scribe.warn(s"$doesntWorkBecause it doesn't belong to a build target.")
+        statusBar.addMessage(s"${icons.alert}No build target")
+    }
+  }
+}

--- a/tests/unit/src/main/scala/tests/BaseSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseSuite.scala
@@ -24,6 +24,7 @@ import utest.ufansi.Str
  */
 class BaseSuite extends TestSuite {
   MetalsLogger.updateDefaultFormat()
+  System.setProperty("metals.testing", "true")
   def isAppveyor: Boolean = "True" == System.getenv("APPVEYOR")
   def beforeAll(): Unit = ()
   def afterAll(): Unit = ()


### PR DESCRIPTION
Fixes #425. Fixes #415.

This error can happen for several reasons. Previously, we only reported
a "No SemanticDB" warning but now we try to automatically detect the
most common cases and report more specific advice if possible.