### PR TITLE
Add "Cascade compile" and "Cancel compile" tasks.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CancelableFuture.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CancelableFuture.scala
@@ -1,0 +1,8 @@
+package scala.meta.internal.metals
+
+import scala.concurrent.Future
+
+case class CancelableFuture[T](
+    future: Future[T],
+    cancelable: Cancelable = Cancelable.empty
+)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -107,6 +107,8 @@ object MetalsEnrichments extends DecorateAsJava with DecorateAsScala {
   }
 
   implicit class XtensionScalaFuture[A](future: Future[A]) {
+    def asCancelable: CancelableFuture[A] =
+      CancelableFuture(future)
     def asJava: CompletableFuture[A] =
       FutureConverters.toJava(future).toCompletableFuture
     def asJavaObject: CompletableFuture[Object] =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -138,7 +138,7 @@ class MetalsLanguageServer(
       statusBar,
       config.icons,
       buildTools,
-      isCompiling
+      isCompiling.contains
     )
     diagnostics = new Diagnostics(
       buildTargets,
@@ -432,7 +432,7 @@ class MetalsLanguageServer(
     interactiveSemanticdbs.didFocus(path)
     // Don't trigger compilation on didFocus events under cascade compilation
     // because save events already trigger compile in inverse dependencies.
-    if (userConfig.isCascadeCompile || openedFiles.isRecentlyActive(path)) {
+    if (openedFiles.isRecentlyActive(path)) {
       CompletableFuture.completedFuture(())
     } else {
       compileSourceFiles(List(path)).asJava
@@ -673,6 +673,13 @@ class MetalsLanguageServer(
         } yield ()).asJavaObject
       case ServerCommands.OpenBrowser(url) =>
         Future.successful(Urls.openBrowser(url)).asJavaObject
+      case ServerCommands.CascadeCompile() =>
+        cascadeCompileSourceFiles(buffers.open.toSeq).asJavaObject
+      case ServerCommands.CancelCompile() =>
+        Future {
+          compileSourceFiles.cancelCurrentRequest()
+          cascadeCompileSourceFiles.cancelCurrentRequest()
+        }.asJavaObject
       case els =>
         scribe.error(s"Unknown command '$els'")
         Future.successful(()).asJavaObject
@@ -783,7 +790,7 @@ class MetalsLanguageServer(
             scribe.info(s"memory: ${Memory.footprint(index)}")
           }
         }
-        _ <- compileSourceFiles(buffers.open.toSeq)
+        _ <- cascadeCompileSourceFiles(buffers.open.toSeq)
       } yield BuildChange.Reconnected
     }
   }.recover {
@@ -943,35 +950,44 @@ class MetalsLanguageServer(
     }
   }
   private val isCompiling = TrieMap.empty[BuildTargetIdentifier, Boolean]
+  private val cascadeCompileSourceFiles =
+    new BatchedFunction[AbsolutePath, Unit](
+      paths => compileSourceFilesUnbatched(paths, isCascade = true)
+    )
   private val compileSourceFiles =
-    new BatchedFunction[AbsolutePath, Unit](compileSourceFilesUnbatched)
+    new BatchedFunction[AbsolutePath, Unit](
+      paths => compileSourceFilesUnbatched(paths, isCascade = false)
+    )
   private def compileSourceFilesUnbatched(
-      paths: Seq[AbsolutePath]
-  ): Future[Unit] = {
+      paths: Seq[AbsolutePath],
+      isCascade: Boolean
+  ): CancelableFuture[Unit] = {
     val scalaPaths = paths.filter(_.isScalaOrJava)
     buildServer match {
       case Some(build) if scalaPaths.nonEmpty =>
         val targets = scalaPaths.flatMap(buildTargets.inverseSources).distinct
         if (targets.isEmpty) {
           scribe.warn(s"no build target: ${scalaPaths.mkString("\n  ")}")
-          Future.successful(())
+          Future.successful(()).asCancelable
         } else {
           val allTargets =
-            if (userConfig.isCascadeCompile) {
+            if (isCascade) {
               targets.flatMap(buildTargets.inverseDependencies).distinct
             } else {
               targets
             }
           val params = new CompileParams(allTargets.asJava)
           targets.foreach(target => isCompiling(target) = true)
-          build
-            .compile(params)
-            .asScala
-            .map(_ => isCompiling.clear())
-            .ignoreValue
+          val completableFuture = build.compile(params)
+          CancelableFuture(
+            completableFuture.asScala
+              .map(_ => isCompiling.clear())
+              .ignoreValue,
+            Cancelable(() => completableFuture.cancel(true))
+          )
         }
       case _ =>
-        Future.successful(())
+        Future.successful(()).asCancelable
     }
   }
 
@@ -979,7 +995,9 @@ class MetalsLanguageServer(
    * Re-imports the sbt build if build files have changed.
    */
   private val onSbtBuildChanged =
-    new BatchedFunction[AbsolutePath, BuildChange](onSbtBuildChangedUnbatched)
+    BatchedFunction.fromFuture[AbsolutePath, BuildChange](
+      onSbtBuildChangedUnbatched
+    )
   private def onSbtBuildChangedUnbatched(
       paths: Seq[AbsolutePath]
   ): Future[BuildChange] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -679,6 +679,7 @@ class MetalsLanguageServer(
         Future {
           compileSourceFiles.cancelCurrentRequest()
           cascadeCompileSourceFiles.cancelCurrentRequest()
+          scribe.info("compilation cancelled")
         }.asJavaObject
       case els =>
         scribe.error(s"Unknown command '$els'")
@@ -950,11 +951,11 @@ class MetalsLanguageServer(
     }
   }
   private val isCompiling = TrieMap.empty[BuildTargetIdentifier, Boolean]
-  private val cascadeCompileSourceFiles =
+  val cascadeCompileSourceFiles =
     new BatchedFunction[AbsolutePath, Unit](
       paths => compileSourceFilesUnbatched(paths, isCascade = true)
     )
-  private val compileSourceFiles =
+  val compileSourceFiles =
     new BatchedFunction[AbsolutePath, Unit](
       paths => compileSourceFilesUnbatched(paths, isCascade = false)
     )

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -63,10 +63,7 @@ object ServerCommands {
   val CancelCompile = Command(
     "compile-cancel",
     "Cancel compilation",
-    """|Cancel any ongoing compilation.
-       |
-       |This command
-       |""".stripMargin
+    """Cancel the currently ongoing compilation, if any."""
   )
 
   val BspSwitch = Command(

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -87,7 +87,10 @@ object ServerCommands {
     ImportBuild,
     ConnectBuildServer,
     ScanWorkspaceSources,
-    RunDoctor
+    RunDoctor,
+    CascadeCompile,
+    CancelCompile,
+    BspSwitch
   )
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -48,6 +48,27 @@ object ServerCommands {
        |""".stripMargin
   )
 
+  val CascadeCompile = Command(
+    "compile-cascade",
+    "Cascade compile",
+    """|Compile the current file along with all build targets in this workspace that depend on it.
+       |
+       |By default, Metals compiles only the current build target and its dependencies when saving a file.
+       |Run the cascade compile task to additionally compile the inverse dependencies of the current build target.
+       |For example, if you change the API in main sources and run cascade compile then it will also compile the
+       |test sources that depend on main.
+       |""".stripMargin
+  )
+
+  val CancelCompile = Command(
+    "compile-cancel",
+    "Cancel compilation",
+    """|Cancel any ongoing compilation.
+       |
+       |This command
+       |""".stripMargin
+  )
+
   val BspSwitch = Command(
     "bsp-switch",
     "Switch build server",

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -17,14 +17,8 @@ case class UserConfiguration(
     javaHome: Option[String] = None,
     sbtScript: Option[String] = None,
     scalafmtConfigPath: RelativePath =
-      UserConfiguration.default.scalafmtConfigPath,
-    compileOnSave: String = UserConfiguration.default.compileOnSave
-) {
-  val isCascadeCompile: Boolean =
-    compileOnSave == UserConfiguration.CascadeCompile
-  val isCurrentProject: Boolean =
-    compileOnSave == UserConfiguration.CurrentProjectCompile
-}
+      UserConfiguration.default.scalafmtConfigPath
+)
 object UserConfiguration {
   def CascadeCompile = "cascade"
   def CurrentProjectCompile = "current-project"
@@ -111,18 +105,13 @@ object UserConfiguration {
         .getOrElse(default.scalafmtConfigPath)
     val sbtScript =
       getStringKey("sbt-script")
-    // NOTE(olafur) Not configurable because we should not expose configuration options for
-    // experimental features. I was tempted to remove the cascade implementation but
-    // decided to keep it instead because I suspect we will need it soon for rename/references.
-    val cascadeCompile = default.compileOnSave
 
     if (errors.isEmpty) {
       Right(
         UserConfiguration(
           javaHome,
           sbtScript,
-          scalafmtConfigPath,
-          cascadeCompile
+          scalafmtConfigPath
         )
       )
     } else {

--- a/tests/unit/src/test/scala/tests/BatchedFunctionSuite.scala
+++ b/tests/unit/src/test/scala/tests/BatchedFunctionSuite.scala
@@ -7,7 +7,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 object BatchedFunctionSuite extends BaseSuite {
   testAsync("batch") {
     val lock = new Object
-    val mkString = new BatchedFunction[String, String]({ numbers =>
+    val mkString = BatchedFunction.fromFuture[String, String]({ numbers =>
       Future {
         lock.synchronized {
           numbers.mkString

--- a/tests/unit/src/test/scala/tests/CancelCompileSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/CancelCompileSlowSuite.scala
@@ -1,0 +1,55 @@
+package tests
+
+import java.util.concurrent.CancellationException
+import scala.meta.internal.metals.ServerCommands
+
+object CancelCompileSlowSuite extends BaseSlowSuite("compile-cancel") {
+
+  testAsync("basic") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        """/metals.json
+          |{
+          |  "a": {},
+          |  "b": {"dependsOn": ["a"]},
+          |  "c": {"dependsOn": ["b"]}
+          |}
+          |/a/src/main/scala/a/A.scala
+          |package a
+          |object A { val x = 1 }
+          |/b/src/main/scala/b/B.scala
+          |package b
+          |object B { val x = a.A.x }
+          |/c/src/main/scala/c/C.scala
+          |package c
+          |object C { val x: String = b.B.x }
+          |""".stripMargin
+      )
+      didOpen = server.didOpen("c/src/main/scala/c/C.scala")
+      _ <- server.executeCommand(ServerCommands.CancelCompile.id)
+      _ = assertNoDiff(client.workspaceDiagnostics, "")
+      isCancelled <- didOpen.map(_ => false).recover {
+        case _: CancellationException => true
+      }
+      _ = Predef.assert(
+        isCancelled,
+        // NOTE(olafur): I don't know if this test is flaky, I suspect it might be but want to first give it a
+        // try before we come up with a way to test cancellation more robustly.
+        "expected didOpen future to fail with Cancellation Exception. " +
+          "If this happens frequently for unrelated changes, then this may be a flaky test that needs refactoring. " +
+          "If this assertion is flaky, feel free to remove it until it's refactored."
+      )
+      _ <- server.executeCommand(ServerCommands.CascadeCompile.id)
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|c/src/main/scala/c/C.scala:2:32: error: type mismatch;
+           | found   : Int
+           | required: String
+           |object C { val x: String = b.B.x }
+           |                               ^
+           |""".stripMargin
+      )
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/CascadeSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/CascadeSlowSuite.scala
@@ -1,11 +1,8 @@
 package tests
 
-import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.ServerCommands
 
 object CascadeSlowSuite extends BaseSlowSuite("cascade") {
-  override def userConfig: UserConfiguration = super.userConfig.copy(
-    compileOnSave = UserConfiguration.CascadeCompile
-  )
   testAsync("basic") {
     for {
       _ <- server.initialize(
@@ -34,7 +31,9 @@ object CascadeSlowSuite extends BaseSlowSuite("cascade") {
         """.stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/a/A.scala")
-      // Check that opening file A.scala triggers compile in dependent project "b"
+      _ = assertNoDiff(client.workspaceDiagnostics, "")
+      _ <- server.executeCommand(ServerCommands.CascadeCompile.id)
+      // Check that cascade compile triggers compile in dependent project "b"
       // but not independent project "c".
       _ = assertNoDiff(
         client.workspaceDiagnostics,

--- a/tests/unit/src/test/scala/tests/CurrentProjectCompileSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/CurrentProjectCompileSlowSuite.scala
@@ -1,10 +1,6 @@
 package tests
-import scala.meta.internal.metals.UserConfiguration
 
 object CurrentProjectCompileSlowSuite extends BaseSlowSuite("current-project") {
-  override def userConfig: UserConfiguration = super.userConfig.copy(
-    compileOnSave = UserConfiguration.CurrentProjectCompile
-  )
   testAsync("basic") {
     for {
       _ <- server.initialize(

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -59,7 +59,6 @@ object UserConfigurationSuite extends BaseSuite {
   ) { obtained =>
     assert(obtained.javaHome == Some("home"))
     assert(obtained.sbtScript == Some("script"))
-    assert(obtained.isCurrentProject)
   }
 
   checkOK(
@@ -71,10 +70,6 @@ object UserConfigurationSuite extends BaseSuite {
     assert(
       obtained.scalafmtConfigPath ==
         UserConfiguration.default.scalafmtConfigPath
-    )
-    assert(
-      obtained.compileOnSave ==
-        UserConfiguration.default.compileOnSave
     )
   }
 


### PR DESCRIPTION
- cascade compile compiles inverse dependencies of the open buffers.
  This is both helpful to see if API changes have compile errors in
  downstream projects and is required to implement "find references".
- cancel compile is helpful to clear the compile queue for long-running
  compilations.
- we trigger cascade compile on the first compile after build import
  because users have an expectation that the CPU is busy during this
  period so it's useful to take advantage of it :)

Towards https://github.com/scalameta/metals/issues/338