### PR TITLE
Limit classpath search to jars.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -128,6 +128,7 @@ final class WorkspaceSymbolProvider(
     for {
       target <- buildTargets.all
       classpathEntry <- target.scalac.classpath
+      if classpathEntry.extension == "jar"
     } {
       packages.visit(classpathEntry)
     }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -102,9 +102,16 @@ final class TestingServer(
     FileLayout.fromString(layout, root = workspace)
   }
 
-  def workspaceSymbol(query: String): String = {
+  def workspaceSymbol(query: String, includeKind: Boolean = false): String = {
     val infos = server.workspaceSymbol(query)
-    infos.map(info => s"${info.getContainerName}${info.getName}").mkString("\n")
+    infos
+      .map { info =>
+        val kind =
+          if (includeKind) s" ${info.getKind}"
+          else ""
+        s"${info.getContainerName}${info.getName}$kind"
+      }
+      .mkString("\n")
   }
   def workspaceSources: Seq[AbsolutePath] = {
     for {

--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolSlowSuite.scala
@@ -97,4 +97,29 @@ object WorkspaceSymbolSlowSuite extends BaseSlowSuite("workspace-symbol") {
     } yield ()
   }
 
+  testAsync("duplicate") {
+    for {
+      _ <- server.initialize(
+        """
+          |/metals.json
+          |{
+          |  "a": {},
+          |  "b": {"dependsOn":["a"]}
+          |}
+          |/a/src/main/scala/a/A.scala
+          |package a
+          |
+          |case class User(name: String, age: Int)
+          |object User
+          |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ = assertNoDiff(
+        server.workspaceSymbol("User", includeKind = true),
+        """a.User Class
+          |a.User Object
+          |""".stripMargin
+      )
+    } yield ()
+  }
 }


### PR DESCRIPTION
Previously, the classpath search included duplicate results for project
sources that were depended on by other build targets in the workspace.