### PR TITLE
Support navigation for visited dependency sources via workspace/symbol.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -24,6 +24,8 @@ final class BuildTargets() {
     TrieMap.empty[BuildTargetIdentifier, ScalacOptionsItem]
   private val inverseDependencies =
     TrieMap.empty[BuildTargetIdentifier, ListBuffer[BuildTargetIdentifier]]
+  private val inverseDependencySources =
+    TrieMap.empty[AbsolutePath, BuildTargetIdentifier]
 
   def reset(): Unit = {
     sourceDirectoriesToBuildTarget.values.foreach(_.clear())
@@ -31,15 +33,16 @@ final class BuildTargets() {
     buildTargetInfo.clear()
     scalacTargetInfo.clear()
     inverseDependencies.clear()
+    inverseDependencySources.clear()
   }
   def sourceDirectories: Iterable[AbsolutePath] =
     sourceDirectoriesToBuildTarget.keys
   def scalacOptions: Iterable[ScalacOptionsItem] =
     scalacTargetInfo.values
 
-  def all: List[ScalaTarget] =
+  def all: Iterator[ScalaTarget] =
     for {
-      (id, target) <- buildTargetInfo.toList
+      (id, target) <- buildTargetInfo.iterator
       scalac <- scalacTargetInfo.get(id)
     } yield ScalaTarget(target, scalac)
 
@@ -103,6 +106,19 @@ final class BuildTargets() {
       target: BuildTargetIdentifier
   ): Iterable[BuildTargetIdentifier] = {
     BuildTargets.inverseDependencies(target, inverseDependencies.get)
+  }
+
+  def addDependencySource(
+      sourcesJar: AbsolutePath,
+      target: BuildTargetIdentifier
+  ): Unit = {
+    inverseDependencySources(sourcesJar) = target
+  }
+
+  def inverseDependencySource(
+      sourceJar: AbsolutePath
+  ): Option[BuildTargetIdentifier] = {
+    inverseDependencySources.get(sourceJar)
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -137,9 +137,10 @@ final class Doctor(
   }
 
   private def problemSummary: Option[String] = {
-    val isMissingSemanticdb = buildTargets.all.filter(!_.isSemanticdbEnabled)
+    val targets = buildTargets.all.toList
+    val isMissingSemanticdb = targets.filter(!_.isSemanticdbEnabled)
     val count = isMissingSemanticdb.length
-    val isAllProjects = count == buildTargets.all.size
+    val isAllProjects = count == targets.size
     if (isMissingSemanticdb.isEmpty) {
       None
     } else if (isAllProjects) {
@@ -182,7 +183,7 @@ final class Doctor(
   }
 
   private def buildTargetRows(html: HtmlBuilder): Unit = {
-    buildTargets.all.sortBy(_.info.getBaseDirectory).foreach { target =>
+    buildTargets.all.toList.sortBy(_.info.getBaseDirectory).foreach { target =>
       val scala = target.info.asScalaBuildTarget
       val scalaVersion =
         scala.fold("<unknown>")(_.getScalaVersion)

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -34,7 +34,8 @@ final class WorkspaceSymbolProvider(
     statistics: StatisticsConfig,
     val buildTargets: BuildTargets,
     val index: OnDemandSymbolIndex,
-    isReferencedPackage: String => Boolean
+    isReferencedPackage: String => Boolean,
+    fileOnDisk: AbsolutePath => AbsolutePath
 )(implicit ec: ExecutionContext) {
   private val files = new WorkspaceSources(workspace)
   private val inWorkspace = TrieMap.empty[Path, BloomFilter[CharSequence]]
@@ -290,7 +291,7 @@ final class WorkspaceSymbolProvider(
           nonExactMatches += 1
         }
         val input = defn.path.toInput
-        lazy val uri = defn.path.toFileOnDisk(workspace).toURI.toString
+        lazy val uri = fileOnDisk(defn.path).toURI.toString
         SemanticdbDefinition.foreach(input) { defn =>
           if (matches(defn.info)) {
             classpathEntries += defn.toLSP(uri)

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -8,6 +8,5 @@ case class User(
 )
 
 object User {
-  val x: Int = 42
   val path = Paths.get("build.sbt")
 }

--- a/tests/unit/src/main/scala/tests/TestingWorkspaceSymbolProvider.scala
+++ b/tests/unit/src/main/scala/tests/TestingWorkspaceSymbolProvider.scala
@@ -2,6 +2,7 @@ package tests
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.StatisticsConfig
 import scala.meta.internal.metals.WorkspaceSymbolProvider
 import scala.meta.internal.mtags.OnDemandSymbolIndex
@@ -20,7 +21,8 @@ object TestingWorkspaceSymbolProvider {
       statistics = statistics,
       buildTargets = new BuildTargets,
       index = index,
-      isReferencedPackage
+      isReferencedPackage,
+      _.toFileOnDisk(workspace)
     )
   }
 }


### PR DESCRIPTION
Fixed #474.  Previously, if you navigated to a library dependency source
via workspace/symbol then you couldn't use "goto definition" from that
source. With this change, we keep track of where workspace/symbol
dependency sources origin from so we can query what build target it came
from.