### PR TITLE
Avoid duplicate classpath indexing.

### DIFF
--- a/metals-bench/src/main/scala/bench/Inflated.scala
+++ b/metals-bench/src/main/scala/bench/Inflated.scala
@@ -11,7 +11,7 @@ case class Inflated(inputs: List[Input.VirtualFile], linesOfCode: Long) {
     val newInputs = inputs.filter(input => f(input))
     val newLinesOfCode = newInputs.foldLeft(0) {
       case (accum, input) =>
-        accum + input.text.lines.length
+        accum + input.text.linesIterator.length
     }
     Inflated(newInputs, newLinesOfCode)
   }
@@ -38,7 +38,7 @@ object Inflated {
       FileIO.listAllFilesRecursively(root).foreach { file =>
         val path = file.toString()
         val text = FileIO.slurp(file, StandardCharsets.UTF_8)
-        lines += text.lines.length
+        lines += text.linesIterator.length
         buf += Input.VirtualFile(path, text)
       }
       val inputs = buf.result()

--- a/metals-bench/src/main/scala/bench/ServerInitializeBench.scala
+++ b/metals-bench/src/main/scala/bench/ServerInitializeBench.scala
@@ -1,0 +1,48 @@
+package bench
+
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.eclipse.lsp4j.InitializeParams
+import org.eclipse.lsp4j.InitializedParams
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import scala.concurrent.ExecutionContext
+import scala.meta.internal.metals.Buffers
+import scala.meta.internal.metals.MetalsLanguageServer
+import scala.meta.internal.metals.MetalsLogger
+import scala.meta.io.AbsolutePath
+import tests.TestingClient
+
+@State(Scope.Benchmark)
+class ServerInitializeBench {
+
+  // Replace with path to local directory that you want to benchmark.
+  @Param(Array("/Users/olafurpg/dev/prisma/server"))
+  var workspace: String = _
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def run(): Unit = {
+    val path = AbsolutePath(workspace)
+    val buffers = Buffers()
+    val client = new TestingClient(path, buffers)
+    MetalsLogger.updateDefaultFormat()
+    var server: MetalsLanguageServer = _
+    val ex = Executors.newCachedThreadPool()
+    val ec = ExecutionContext.fromExecutorService(ex)
+    server = new MetalsLanguageServer(ec)
+    server.connectToLanguageClient(client)
+    val initialize = new InitializeParams
+    initialize.setRootUri(path.toURI.toString)
+    server.initialize(initialize).get()
+    server.initialized(new InitializedParams).get()
+    server.shutdown().get()
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/JvmOpts.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JvmOpts.scala
@@ -17,7 +17,7 @@ object JvmOpts {
     val jvmOpts = workspace.resolve(".jvmopts")
     if (jvmOpts.isFile && Files.isReadable(jvmOpts.toNIO)) {
       val text = FileIO.slurp(jvmOpts, StandardCharsets.UTF_8)
-      text.lines.map(_.trim).filter(_.startsWith("-")).toList
+      text.linesIterator.map(_.trim).filter(_.startsWith("-")).toList
     } else {
       Nil
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -61,6 +61,9 @@ class MetalsLanguageServer(
 
   private implicit val executionContext: ExecutionContextExecutorService = ec
   private val sh = Executors.newSingleThreadScheduledExecutor()
+  cancelables
+    .add(() => sh.shutdown())
+    .add(() => ec.shutdown())
   private val fingerprints = new MutableMd5Fingerprints
   private val mtags = new Mtags
   var workspace: AbsolutePath = _

--- a/metals/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
@@ -28,6 +28,7 @@ class PackageIndex {
   def visit(entry: AbsolutePath): Unit = {
     if (isVisited.contains(entry)) ()
     else {
+      isVisited.add(entry)
       try {
         if (entry.isDirectory) {
           visitDirectoryEntry(entry)

--- a/metals/src/main/scala/scala/meta/internal/metals/SbtOpts.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SbtOpts.scala
@@ -17,7 +17,7 @@ object SbtOpts {
     val sbtOpts = workspace.resolve(".sbtopts")
     if (sbtOpts.isFile && Files.isReadable(sbtOpts.toNIO)) {
       val text = FileIO.slurp(sbtOpts, StandardCharsets.UTF_8)
-      process(text.lines.map(_.trim).toList)
+      process(text.linesIterator.map(_.trim).toList)
     } else {
       Nil
     }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/Mtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/Mtags.scala
@@ -51,9 +51,9 @@ final class Mtags {
   private var scalaLines: Long = 0L
   private def addLines(language: Language, text: String): Unit = {
     if (language.isJava) {
-      javaLines += text.lines.length
+      javaLines += text.linesIterator.length
     } else if (language.isScala) {
-      scalaLines += text.lines.length
+      scalaLines += text.linesIterator.length
     }
   }
 }

--- a/tests/unit/src/main/scala/tests/DiffAssertions.scala
+++ b/tests/unit/src/main/scala/tests/DiffAssertions.scala
@@ -89,7 +89,7 @@ object DiffAssertions extends scala.meta.testkit.DiffAssertions {
       thunk
     } catch {
       case NonFatal(e) =>
-        val message = e.getMessage.lines
+        val message = e.getMessage.linesIterator
           .map { line =>
             if (line.startsWith("+")) Color.Green(line)
             else if (line.startsWith("-")) Color.LightRed(line)


### PR DESCRIPTION
Previously, we indexed the same jars multiple times for
workspace/symbol causing significant slowdown when importing
multi-module builds with large classpaths. With this change indexing the
prisma/server sbt build takes 11.5s instead of 23s.