### PR TITLE
Upgrade to Bloop v1.2.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,9 +91,9 @@ lazy val V = new {
   val scala212 = "2.12.8"
   val scalameta = "4.1.0"
   val semanticdb = "4.1.0"
-  val bsp = "2.0.0-M2"
-  val sbtBloop = "1.1.2"
-  val bloop = "1.1.2"
+  val bsp = "2.0.0-M3"
+  val sbtBloop = "1.2.4"
+  val bloop = "1.2.4"
   val scalafmt = "2.0.0-RC4"
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -61,6 +61,9 @@ case class BuildServerConnection(
       ongoingRequests.cancel()
     }
   }
+
+  def isBloop: Boolean =
+    initializeResult.getDisplayName.compareToIgnoreCase("Bloop") == 0
 }
 
 object BuildServerConnection {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1167,12 +1167,15 @@ class MetalsLanguageServer(
           Future.successful(()).asCancelable
         } else {
           val allTargets =
-            if (isCascade) {
+            if (isCascade && !build.isBloop) {
               targets.flatMap(buildTargets.inverseDependencies).distinct
             } else {
               targets
             }
           val params = new CompileParams(allTargets.asJava)
+          if (isCascade && build.isBloop) {
+            params.setArguments(List("--cascade").asJava)
+          }
           targets.foreach(target => isCompiling(target) = true)
           val completableFuture = build.compile(params)
           CancelableFuture(

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
@@ -122,7 +122,7 @@ final class StatusBar(
             s"$message   "
           } else {
             maybeProgress match {
-              case Some(TaskProgress(percentage)) if seconds > 5 =>
+              case Some(TaskProgress(percentage)) if seconds > 3 =>
                 s"$message ${Timer.readableSeconds(seconds)} ($percentage%)"
               case _ =>
                 s"$message ${Timer.readableSeconds(seconds)}"

--- a/metals/src/main/scala/scala/meta/internal/metals/TaskProgress.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/TaskProgress.scala
@@ -1,5 +1,11 @@
 package scala.meta.internal.metals
 
+/**
+ * Denotes how much of a task has been completed.
+ *
+ * @param progress must be greater or equal to 0 and smaller than total.
+ * @param total the task is complete when progress == total.
+ */
 class TaskProgress(
     var progress: Long,
     var total: Long
@@ -12,6 +18,7 @@ class TaskProgress(
     if (total == 0) 0
     else ((progress.toDouble / total) * 100).toInt
   }
+  override def toString: String = s"TaskProgress($progress, $total)"
 }
 
 object TaskProgress {

--- a/metals/src/main/scala/scala/meta/internal/metals/TaskProgress.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/TaskProgress.scala
@@ -1,0 +1,24 @@
+package scala.meta.internal.metals
+
+class TaskProgress(
+    var progress: Long,
+    var total: Long
+) {
+  def update(newProgress: Long, newTotal: Long): Unit = {
+    progress = newProgress
+    total = newTotal
+  }
+  def percentage: Int = {
+    if (total == 0) 0
+    else ((progress.toDouble / total) * 100).toInt
+  }
+}
+
+object TaskProgress {
+  def unapply(p: TaskProgress): Option[Long] = {
+    val percentage = p.percentage
+    if (percentage >= 0 && percentage <= 100) Some(percentage)
+    else None
+  }
+  def empty: TaskProgress = new TaskProgress(0, 0)
+}

--- a/metals/src/main/scala/scala/meta/metals/Main.scala
+++ b/metals/src/main/scala/scala/meta/metals/Main.scala
@@ -44,7 +44,7 @@ object Main {
         e.printStackTrace(systemOut)
         sys.exit(1)
     } finally {
-      exec.shutdown()
+      server.cancelAll()
     }
   }
 

--- a/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
+++ b/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
@@ -384,9 +384,9 @@ object SbtSlowSuite extends BaseSlowSuite("import") {
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """
-          |src/main/scala/warning/Warning.scala:1:25: warning: Unused import
+          |src/main/scala/warning/Warning.scala:1:1: warning: Unused import
           |import scala.concurrent.Future // unused
-          |                        ^^^^^^
+          |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         """.stripMargin
       )
     } yield ()

--- a/tests/unit/src/test/scala/tests/CancelCompileSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/CancelCompileSlowSuite.scala
@@ -43,11 +43,11 @@ object CancelCompileSlowSuite extends BaseSlowSuite("compile-cancel") {
       _ <- server.executeCommand(ServerCommands.CascadeCompile.id)
       _ = assertNoDiff(
         client.workspaceDiagnostics,
-        """|c/src/main/scala/c/C.scala:2:32: error: type mismatch;
+        """|c/src/main/scala/c/C.scala:2:28: error: type mismatch;
            | found   : Int
            | required: String
            |object C { val x: String = b.B.x }
-           |                               ^
+           |                           ^^^^^
            |""".stripMargin
       )
     } yield ()

--- a/tests/unit/src/test/scala/tests/CascadeSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/CascadeSlowSuite.scala
@@ -37,11 +37,11 @@ object CascadeSlowSuite extends BaseSlowSuite("cascade") {
       // but not independent project "c".
       _ = assertNoDiff(
         client.workspaceDiagnostics,
-        """|b/src/main/scala/b/B.scala:3:23: error: type mismatch;
+        """|b/src/main/scala/b/B.scala:3:19: error: type mismatch;
            | found   : Int
            | required: String
            |  val n: String = a.A.n
-           |                      ^
+           |                  ^^^^^
           """.stripMargin
       )
     } yield ()

--- a/tests/unit/src/test/scala/tests/DiagnosticsSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/DiagnosticsSlowSuite.scala
@@ -48,22 +48,21 @@ object DiagnosticsSlowSuite extends BaseSlowSuite("diagnostics") {
       _ = assertNoDiff(client.workspaceDiagnostics, "")
       _ <- server.didOpen("a/src/main/scala/a/Main.scala")
       exampleDiagnostics = {
-        """
-          |a/src/main/scala/a/Example.scala:2:29: warning: Unused import
-          |import java.util.concurrent.Future // unused
-          |                            ^^^^^^
-          |a/src/main/scala/a/Example.scala:3:19: warning: Unused import
-          |import scala.util.Failure // unused
-          |                  ^^^^^^^
-          |""".stripMargin
+        """|a/src/main/scala/a/Example.scala:2:1: warning: Unused import
+           |import java.util.concurrent.Future // unused
+           |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+           |a/src/main/scala/a/Example.scala:3:1: warning: Unused import
+           |import scala.util.Failure // unused
+           |^^^^^^^^^^^^^^^^^^^^^^^^^
+           |""".stripMargin
       }
       mainDiagnostics = {
-        """|a/src/main/scala/a/Main.scala:2:29: warning: Unused import
+        """|a/src/main/scala/a/Main.scala:2:1: warning: Unused import
            |import java.util.concurrent.Future // unused
-           |                            ^^^^^^
-           |a/src/main/scala/a/Main.scala:3:19: warning: Unused import
+           |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+           |a/src/main/scala/a/Main.scala:3:1: warning: Unused import
            |import scala.util.Failure // unused
-           |                  ^^^^^^^
+           |^^^^^^^^^^^^^^^^^^^^^^^^^
            |""".stripMargin
       }
       _ = assertNoDiff(
@@ -72,14 +71,13 @@ object DiagnosticsSlowSuite extends BaseSlowSuite("diagnostics") {
       )
       _ <- server.didOpen("b/src/main/scala/a/MainSuite.scala")
       testDiagnostics = {
-        """
-          |b/src/main/scala/a/MainSuite.scala:2:29: warning: Unused import
-          |import java.util.concurrent.Future // unused
-          |                            ^^^^^^
-          |b/src/main/scala/a/MainSuite.scala:3:19: warning: Unused import
-          |import scala.util.Failure // unused
-          |                  ^^^^^^^
-        """.stripMargin
+        """|b/src/main/scala/a/MainSuite.scala:2:1: warning: Unused import
+           |import java.util.concurrent.Future // unused
+           |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+           |b/src/main/scala/a/MainSuite.scala:3:1: warning: Unused import
+           |import scala.util.Failure // unused
+           |^^^^^^^^^^^^^^^^^^^^^^^^^
+           |""".stripMargin
       }
       _ = assertNoDiff(
         client.pathDiagnostics("b/src/main/scala/a/MainSuite.scala"),
@@ -155,11 +153,10 @@ object DiagnosticsSlowSuite extends BaseSlowSuite("diagnostics") {
       _ <- server.didOpen("a/src/main/scala/a/Post.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
-        """
-          |a/src/main/scala/a/Post.scala:5:8: error: object creation impossible, since method post in trait Post of type => Int is not defined
-          |object Post extends Post
-          |       ^^^^^^^^^^^^^^^^^
-          |""".stripMargin
+        """|a/src/main/scala/a/Post.scala:5:1: error: object creation impossible, since method post in trait Post of type => Int is not defined
+           |object Post extends Post
+           |^^^^^^^^^^^^^^^^^^^^^^^^
+           |""".stripMargin
       )
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
+++ b/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
@@ -43,10 +43,9 @@ object QuickBuildSuite extends BaseSlowSuite("quick-build") {
       _ <- server.didOpen("b/src/main/scala/b/B.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
-        """
-          |b/src/main/scala/b/B.scala:3:19: warning: Unused import
-          |import scala.util.Success
-          |                  ^^^^^^^
+        """|b/src/main/scala/b/B.scala:3:1: warning: Unused import
+           |import scala.util.Success
+           |^^^^^^^^^^^^^^^^^^^^^^^^^
         """.stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/a/A.scala")

--- a/tests/unit/src/test/scala/tests/SyntaxErrorSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/SyntaxErrorSlowSuite.scala
@@ -1,5 +1,6 @@
 package tests
 
+import org.scalactic.source.Position
 import scala.concurrent.Future
 
 object SyntaxErrorSlowSuite extends BaseSlowSuite("syntax-error") {
@@ -9,7 +10,7 @@ object SyntaxErrorSlowSuite extends BaseSlowSuite("syntax-error") {
       name: String,
       code: String,
       asserts: Assert*
-  ): Unit = {
+  )(implicit pos: Position): Unit = {
     testAsync(name) {
       def runAsserts(as: List[Assert]): Future[Unit] = as match {
         case Nil => Future.successful(())
@@ -252,10 +253,10 @@ object SyntaxErrorSlowSuite extends BaseSlowSuite("syntax-error") {
        |""".stripMargin,
     Assert(
       _.replaceAllLiterally("object A", "object B"),
-      """|a/src/main/scala/A.scala:2:19: error: not enough arguments for method lengthCompare: (len: Int)Int.
+      """|a/src/main/scala/A.scala:2:3: error: not enough arguments for method lengthCompare: (len: Int)Int.
          |Unspecified value parameter len.
          |  "".lengthCompare()
-         |                  ^^
+         |  ^^^^^^^^^^^^^^^^^^
          |""".stripMargin
     )
   )
@@ -285,11 +286,11 @@ object SyntaxErrorSlowSuite extends BaseSlowSuite("syntax-error") {
        |""".stripMargin,
     Assert(
       _.replaceAllLiterally("\"b\"", "\"c\""),
-      """|a/src/main/scala/A.scala:2:20: error: type mismatch;
+      """|a/src/main/scala/A.scala:2:16: error: type mismatch;
          | found   : String("ab")
          | required: Int
          |  val x: Int = "a" + "c"
-         |                   ^^^^^
+         |               ^^^^^^^^^
          |""".stripMargin
     )
   )


### PR DESCRIPTION
This Bloop release has many improvements:
- no-op compilation still clears fixed errors
- fixed errors cleared faster
- range positions have correct start offsets
- compile progress is reported at 5% intervals
- new --cascade compile option for native cascade compilation

Fixes #470.
Fixes #468.

The new compilation progress for long-running compiles.

![2019-01-21 21 27 49](https://user-images.githubusercontent.com/1408093/51497833-b0e36980-1dc4-11e9-971f-bb0eb1041f60.gif)
