### PR TITLE
Polish before v0.4 release.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -62,8 +62,6 @@ case class BuildServerConnection(
     }
   }
 
-  def isBloop: Boolean =
-    initializeResult.getDisplayName.compareToIgnoreCase("Bloop") == 0
 }
 
 object BuildServerConnection {

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -101,7 +101,6 @@ final class Diagnostics(
       new ConcurrentLinkedQueue[Diagnostic]()
     )
     if (params.getReset) {
-      logStatistics(path, "diagnostics-clear", params.getTextDocument.getUri)
       queue.clear()
       snapshots.remove(path)
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -152,6 +152,7 @@ final class InteractiveSemanticdbs(
           filename = uri,
           timeout = TimeUnit.SECONDS.toMillis(15),
           options = List(
+            "-P:semanticdb:synthetics:on",
             "-P:semanticdb:symbols:none",
             "-P:semanticdb:text:on"
           )

--- a/metals/src/main/scala/scala/meta/internal/metals/Memory.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Memory.scala
@@ -33,8 +33,12 @@ object Memory {
         s" (${format(n)} lines Scala)"
       case i: TrieMap[_, _] =>
         val elements = i.values.foldLeft(0L) {
-          case (n, b: BloomFilter[_]) => n + b.approximateElementCount()
-          case (n, _) => n + 1
+          case (n, b: BloomFilter[_]) =>
+            n + b.approximateElementCount()
+          case (n, c: CompressedPackageIndex) =>
+            n + c.bloom.approximateElementCount()
+          case (n, _) =>
+            n + 1
         }
         s" (${format(elements)} elements)"
       case _ =>

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -72,7 +72,9 @@ class Messages(icons: Icons) {
   val PartialNavigation = MetalsStatusParams(
     "$(info) Partial navigation",
     tooltip =
-      "To fix this problem, update your build settings to use the same compiler plugins and compiler settings as the external library.",
+      "This external library source has compile errors. " +
+        "To fix this problem, update your build settings to use the same compiler plugins and compiler settings as " +
+        "the external library.",
     command = ClientCommands.FocusDiagnostics.id
   )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -94,8 +94,7 @@ object MetalsServerConfig {
           slowTask = SlowTaskConfig.on,
           icons = Icons.vscode,
           executeClientCommand = ExecuteClientCommandConfig.on,
-          globSyntax = GlobSyntaxConfig.vscode,
-          isInputBoxEnabled = true
+          globSyntax = GlobSyntaxConfig.vscode
         )
       case "vim-lsc" =>
         base.copy(

--- a/metals/src/main/scala/scala/meta/internal/metals/SbtDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SbtDigest.scala
@@ -23,7 +23,7 @@ object SbtDigest {
    * Bump up this version if parameters outside of the sbt sources themselves require
    * re-running `bloopInstall`. For example a SemanticDB or Bloop version upgrade.
    */
-  val version: String = "v2"
+  val version: String = "v3"
   sealed abstract class Status(val value: Int)
       extends Product
       with Serializable {

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -171,14 +171,6 @@ final class WorkspaceSymbolProvider(
           falsePositives += 1
         }
       }
-      if (statistics.isWorkspaceSymbol) {
-        val falsePositiveRatio =
-          ((falsePositives.toDouble / visitsCount) * 100).toInt
-        scribe.info(
-          s"workspace-symbol: query '${query.query}' returned ${result.size()} results in $timer from workspace, " +
-            s"visited ${visitsCount} files (${falsePositiveRatio}% false positives)"
-        )
-      }
     }
     def searchDependencySymbols(): Unit = {
       val timer = new Timer(Time.system)
@@ -224,11 +216,6 @@ final class WorkspaceSymbolProvider(
       }
       classpathEntries.foreach { s =>
         result.add(s)
-      }
-      if (statistics.isWorkspaceSymbol) {
-        scribe.info(
-          s"workspace-symbol: query '${query.query}' returned ${classfiles.size} results from classpath in $timer"
-        )
       }
     }
     searchWorkspaceSymbols()

--- a/tests/unit/src/test/scala/tests/SbtDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtDigestSuite.scala
@@ -49,7 +49,7 @@ object SbtDigestSuite extends BaseSuite {
     }
   }
 
-  val solo = "5727878FADFA3FB9EBA4B97CA92440ED"
+  val solo = "E247CC8F123CD16AAF03EB8A42B47115"
   check(
     "solo build.sbt",
     """
@@ -69,7 +69,7 @@ object SbtDigestSuite extends BaseSuite {
     Some(solo)
   )
 
-  val project = "7BDAC1318CFF8DFE816EDEFF5C06F561"
+  val project = "46BBD8C6B3B8B0189969309BA8E8DF0A"
   check(
     "metabuild",
     """


### PR DESCRIPTION
While writing a blog post on bloom filters I enountered several small
nits that are fixed here.
- remove --cascade flag, it breaks persistent incremental compile cache
- give Bloop up to 100ms time to complete shutdown
- cleaner logging output for statistics
- don't block workspace/symbol by compilation, only indexing
- bump sbt checksum version