### PR TITLE
Avoid redundant didFocus compiles, fixes #483.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DidFocusResult.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DidFocusResult.scala
@@ -1,0 +1,6 @@
+package scala.meta.internal.metals
+
+object DidFocusResult extends Enumeration {
+  type DidFocusResult = Value
+  val NoBuildTarget, RecentlyActive, AlreadyCompiled, Compiled = Value
+}

--- a/tests/unit/src/main/scala/tests/BaseSlowSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseSlowSuite.scala
@@ -11,6 +11,7 @@ import scala.meta.internal.metals.ExecuteClientCommandConfig
 import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.RecursivelyDelete
+import scala.meta.internal.metals.Time
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.io.AbsolutePath
 import scala.util.control.NonFatal
@@ -23,6 +24,7 @@ abstract class BaseSlowSuite(suiteName: String) extends BaseSuite {
   def icons: Icons = Icons.default
   def userConfig: UserConfiguration = UserConfiguration()
   def serverConfig: MetalsServerConfig = MetalsServerConfig.default
+  def time: Time = Time.system
   implicit val ex: ExecutionContextExecutorService =
     ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
   private val sh = Executors.newSingleThreadScheduledExecutor()
@@ -66,7 +68,8 @@ abstract class BaseSlowSuite(suiteName: String) extends BaseSuite {
       buffers,
       config,
       bspGlobalDirectories,
-      sh
+      sh,
+      time
     )(ex)
     server.server.userConfig = this.userConfig
   }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -46,11 +46,13 @@ import scala.meta.internal.io.FileIO
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.Debug
+import scala.meta.internal.metals.DidFocusResult
 import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsLanguageServer
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.ProgressTicks
+import scala.meta.internal.metals.Time
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.mtags.Semanticdbs
@@ -80,7 +82,8 @@ final class TestingServer(
     buffers: Buffers,
     config: MetalsServerConfig,
     bspGlobalDirectories: List[AbsolutePath],
-    sh: ScheduledExecutorService
+    sh: ScheduledExecutorService,
+    time: Time
 )(implicit ex: ExecutionContextExecutorService) {
   val server = new MetalsLanguageServer(
     ex,
@@ -89,7 +92,8 @@ final class TestingServer(
     config = config,
     progressTicks = ProgressTicks.none,
     bspGlobalDirectories = bspGlobalDirectories,
-    sh = sh
+    sh = sh,
+    time = time
   )
   server.connectToLanguageClient(client)
   private val readonlySources = TrieMap.empty[String, AbsolutePath]
@@ -245,7 +249,7 @@ final class TestingServer(
       .asScala
       .ignoreValue
   }
-  def didFocus(filename: String): Future[Unit] = {
+  def didFocus(filename: String): Future[DidFocusResult.Value] = {
     server.didFocus(toPath(filename).toURI.toString).asScala
   }
   def didSave(filename: String)(fn: String => String): Future[Unit] = {

--- a/tests/unit/src/test/scala/tests/DidFocusSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/DidFocusSlowSuite.scala
@@ -1,0 +1,69 @@
+package tests
+
+import scala.meta.internal.metals.DidFocusResult._
+import scala.meta.internal.metals.Time
+
+object DidFocusSlowSuite extends BaseSlowSuite("did-focus") {
+  var fakeTime: FakeTime = _
+  override def time: Time = fakeTime
+  override def utestBeforeEach(path: Seq[String]): Unit = {
+    fakeTime = new FakeTime()
+    super.utestBeforeEach(path)
+  }
+  testAsync("is-compiled") {
+    for {
+      _ <- server.initialize(
+        """
+          |/metals.json
+          |{
+          |  "a": {},
+          |  "b": {
+          |    "dependsOn": ["a"]
+          |  }
+          |}
+          |/a/src/main/scala/a/A.scala
+          |package a
+          |object A {
+          |  val x = 1
+          |}
+          |/a/src/main/scala/a/A2.scala
+          |package a
+          |object A2 {
+          |  val y = 1
+          |}
+          |/b/src/main/scala/b/B.scala
+          |package b
+          |object C {
+          |  val z: Int = a.A.x
+          |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ <- server.didOpen("b/src/main/scala/b/B.scala")
+      _ = assertNoDiagnostics()
+      _ = fakeTime.elapseSeconds(10)
+      didCompile <- server.didFocus("a/src/main/scala/a/A2.scala")
+      _ = assert(didCompile == AlreadyCompiled)
+      didCompile <- server.didFocus("b/src/main/scala/b/B.scala")
+      _ = assert(didCompile == AlreadyCompiled)
+      _ <- server.didSave("a/src/main/scala/a/A.scala")(
+        _.replaceAllLiterally("val x = 1", "val x = \"string\"")
+      )
+      _ = fakeTime.elapseSeconds(10)
+      _ = assertNoDiagnostics()
+      didCompile <- server.didFocus("a/src/main/scala/a/A2.scala")
+      _ = assert(didCompile == AlreadyCompiled)
+      didCompile <- server.didFocus("b/src/main/scala/b/B.scala")
+      _ = assert(didCompile == Compiled)
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|b/src/main/scala/b/B.scala:3:16: error: type mismatch;
+           | found   : String
+           | required: Int
+           |  val z: Int = a.A.x
+           |               ^^^^^
+           |""".stripMargin
+      )
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/InverseDependenciesSuite.scala
+++ b/tests/unit/src/test/scala/tests/InverseDependenciesSuite.scala
@@ -23,7 +23,7 @@ object InverseDependenciesSuite extends BaseSuite {
   ): Unit = {
     test(name) {
       val obtained = BuildTargets.inverseDependencies(
-        new BuildTargetIdentifier(original.root), { key =>
+        List(new BuildTargetIdentifier(original.root)), { key =>
           original.inverseDependencies
             .get(key.getUri)
             .map(_.map(new BuildTargetIdentifier(_)))


### PR DESCRIPTION
Previously, we always triggered a compile on didFocus events. With this
commit, we only trigger a compile on didFocus if the focused path may be
affected by the last compilation.