### PR TITLE
Trigger didFocus when current compile may affect focused buffer.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -489,8 +489,12 @@ class MetalsLanguageServer(
     } else {
       buildTargets.inverseSources(path) match {
         case Some(target) =>
-          val needsCompile = !lastCompile(target) &&
-            buildTargets.isInverseDependency(target, lastCompile.toList)
+          val isAffectedByCurrentCompilation =
+            buildTargets.isInverseDependency(target, isCompiling.keys.toList)
+          def isAffectedByLastCompilation: Boolean =
+            !lastCompile(target) &&
+              buildTargets.isInverseDependency(target, lastCompile.toList)
+          val needsCompile = isAffectedByCurrentCompilation || isAffectedByLastCompilation
           if (needsCompile) {
             compileSourceFiles(List(path))
               .map(_ => DidFocusResult.Compiled)

--- a/tests/unit/src/test/scala/tests/DidFocusSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/DidFocusSlowSuite.scala
@@ -66,4 +66,72 @@ object DidFocusSlowSuite extends BaseSlowSuite("did-focus") {
       )
     } yield ()
   }
+
+  testAsync("497") {
+    for {
+      _ <- server.initialize(
+        """
+          |/metals.json
+          |{
+          |  "a": {},
+          |  "b": {
+          |    "dependsOn": ["a"]
+          |  }
+          |}
+          |/a/src/main/scala/a/A.scala
+          |package a
+          |object A {
+          |  val x: Int = 1
+          |}
+          |/b/src/main/scala/b/B.scala
+          |package b
+          |object B {
+          |  val y: Int = 2
+          |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ <- server.didOpen("b/src/main/scala/b/B.scala")
+      _ = assertNoDiagnostics()
+      xMismatch = {
+        """|a/src/main/scala/a/A.scala:3:16: error: type mismatch;
+           | found   : String("")
+           | required: Int
+           |  val x: Int = ""
+           |               ^^
+           |""".stripMargin
+      }
+      _ = fakeTime.elapseSeconds(10)
+      _ <- server.didSave("a/src/main/scala/a/A.scala")(
+        _.replaceAllLiterally("1", "\"\"")
+      )
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        xMismatch
+      )
+      _ <- server.didSave("b/src/main/scala/b/B.scala")(
+        _.replaceAllLiterally("2", "\"\"")
+      )
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        xMismatch
+      )
+      didSaveA = server.didSave("a/src/main/scala/a/A.scala")(
+        _.replaceAllLiterally("Int", "String")
+      )
+      // Focus before compilation of A.scala is complete.
+      didCompile <- server.didFocus("b/src/main/scala/b/B.scala")
+      _ <- didSaveA
+      _ = assert(didCompile == Compiled)
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|b/src/main/scala/b/B.scala:3:16: error: type mismatch;
+           | found   : String("")
+           | required: Int
+           |  val y: Int = ""
+           |               ^^
+           |""".stripMargin
+      )
+    } yield ()
+  }
 }


### PR DESCRIPTION
Fixes #497. Previously, we did not trigger didFocus compiles if there
was an ongoing compilation that might affect the focused buffer. This
could results in missing compilation when fixing an error in main and
then instantly focus on a file in tests before the main compilation
finished.