### PR TITLE
Reference pluginCrossBuild via reflection to support older sbt 0.13.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
@@ -257,7 +257,7 @@ object BloopInstall {
         |  if (System.getenv("METALS_ENABLED") == "true") {
         |    val bloopModule = "ch.epfl.scala" % "sbt-bloop" % "${BuildInfo.sbtBloopVersion}"
         |    val metalsModule = "org.scalameta" % "sbt-metals" % "${BuildInfo.metalsVersion}"
-        |    val sbtVersion = Keys.sbtBinaryVersion.in(pluginCrossBuild).value
+        |    val sbtVersion = Keys.sbtBinaryVersion.in(TaskKey[Unit]("pluginCrossBuild")).value
         |    val scalaVersion = Keys.scalaBinaryVersion.in(update).value
         |    val bloopPlugin = sbtPluginExtra(bloopModule, sbtVersion, scalaVersion)
         |    val metalsPlugin = sbtPluginExtra(metalsModule, sbtVersion, scalaVersion)


### PR DESCRIPTION
Fixes #504. The `pluginCrossBuild` setting came in 0.13.17, so currently users get a
compile error when opening older sbt builds on their machine as long as
they have used Metals in at least one sbt 0.13 build. After this commit,
users no longer get a compile error even if they're on an older sbt version. Instead, they the following runtime exception in case they start `sbt` with the environment variable `METALS_ENABLED=true`.
```
[error] java.lang.NoSuchMethodError: sbt.Keys$.pluginCrossBuild()Lsbt/TaskKey;
```