### PR TITLE
Change behavior of FileWatcher so that it doesn't create non-existing source directories

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
@@ -89,10 +89,14 @@ final class FileWatcher(
     // Used to filter out any events not occuring in the
     // source directories
     private def isInSourceDirectory(path: Path): Boolean = {
-      buildTargets.sourceDirectories.exists(dir => path.toString().startsWith(dir.toString()))
+      buildTargets.sourceDirectories.exists(
+        dir => path.toString.startsWith(dir.toString())
+      )
     }
     override def onEvent(event: DirectoryChangeEvent): Unit = {
-      if (Files.isRegularFile(event.path()) && isInSourceDirectory(event.path())) {
+      if (Files.isRegularFile(event.path()) && isInSourceDirectory(
+          event.path()
+        )) {
         didChangeWatchedFiles(event)
       }
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
@@ -49,24 +49,25 @@ final class FileWatcher(
 
   def restart(): Unit = {
     val directoriesToWatch = new util.ArrayList[Path]()
-    def watch(dir: AbsolutePath): Unit = {
+    val createdSourceDirectories = new util.ArrayList[AbsolutePath]()
+    def watch(dir: AbsolutePath, isSourceDirectory: Boolean): Unit = {
       if (!dir.isDirectory) {
         dir.createDirectories()
+        if (isSourceDirectory) createdSourceDirectories.add(dir)
       }
       directoriesToWatch.add(dir.toNIO)
     }
-    // Watch the parents of source directories for "goto definition" index.
-    // We watch the parents so that we get events if the actual source directories
-    // get deleted and/or created
-    buildTargets.sourceDirectories
-      .groupBy(ap => AbsolutePath(ap.toNIO.getParent))
-      .keys
-      .foreach(watch)
+    // Watch the source directories for "goto definition" index.
+    buildTargets.sourceDirectories.foreach(watch(_, isSourceDirectory = true))
     buildTargets.scalacOptions.foreach { item =>
       // Watch META-INF/semanticdb directories for "find references" index.
-      watch(item.targetroot.resolve(Directories.semanticdb))
+      watch(
+        item.targetroot.resolve(Directories.semanticdb),
+        isSourceDirectory = false
+      )
     }
     startWatching(directoriesToWatch)
+    createdSourceDirectories.asScala.foreach(_.delete())
   }
 
   private def startWatching(paths: util.List[Path]): Unit = {
@@ -86,17 +87,8 @@ final class FileWatcher(
   }
 
   class Listener extends DirectoryChangeListener {
-    // Used to filter out any events not occuring in the
-    // source directories
-    private def isInSourceDirectory(path: Path): Boolean = {
-      buildTargets.sourceDirectories.exists(
-        dir => path.toString.startsWith(dir.toString())
-      )
-    }
     override def onEvent(event: DirectoryChangeEvent): Unit = {
-      if (Files.isRegularFile(event.path()) && isInSourceDirectory(
-          event.path()
-        )) {
+      if (Files.isRegularFile(event.path())) {
         didChangeWatchedFiles(event)
       }
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -322,6 +322,10 @@ object MetalsEnrichments extends DecorateAsJava with DecorateAsScala {
       AbsolutePath(Files.createDirectories(dealias.toNIO))
     }
 
+    def delete(): Unit = {
+      Files.delete(dealias.toNIO)
+    }
+
   }
 
   implicit class XtensionStringUriProtocol(value: String) {

--- a/tests/unit/src/main/scala/tests/BaseSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseSuite.scala
@@ -74,6 +74,11 @@ class BaseSuite extends TestSuite {
       fail(s"no such file: $path", stackBump = 1)
     }
   }
+  def assertIsNotDirectory(path: AbsolutePath): Unit = {
+    if (path.isDirectory) {
+      fail(s"directory exists: $path", stackBump = 1)
+    }
+  }
   def assertNoDiff(
       obtained: String,
       expected: String,

--- a/tests/unit/src/test/scala/tests/FileWatcherSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/FileWatcherSlowSuite.scala
@@ -59,8 +59,8 @@ object FileWatcherSlowSuite extends BaseSlowSuite("file-watcher") {
         FileWrites.write(
           CFileEvent,
           s"""
-             |import "stdio.h"
-             |void main(char **args) { println("Hello World!"); }s
+             |#include <stdio.h>
+             |void main(char **args) { printf("Hello World!\n"); }
              |""".stripMargin
         )
       }

--- a/tests/unit/src/test/scala/tests/FileWatcherSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/FileWatcherSlowSuite.scala
@@ -9,6 +9,14 @@ object FileWatcherSlowSuite extends BaseSlowSuite("file-watcher") {
     cleanCompileCache("b")
     cleanCompileCache("c")
     RecursivelyDelete(workspace.resolve("a"))
+    RecursivelyDelete(workspace.resolve("b"))
+    RecursivelyDelete(workspace.resolve("c"))
+    val JavaFileEvent =
+      workspace.resolve("a/src/main/java/a/JavaFileEvent.java")
+    Files.createDirectories(JavaFileEvent.toNIO.getParent)
+    Files.createDirectories(workspace.resolve("a/src/main/scala").toNIO)
+    Files.createDirectories(workspace.resolve("b/src/main/scala").toNIO)
+    Files.createDirectories(workspace.resolve("c/src/main/scala").toNIO)
     for {
       _ <- server.initialize(
         """
@@ -41,9 +49,7 @@ object FileWatcherSlowSuite extends BaseSlowSuite("file-watcher") {
            |""".stripMargin
       )
       _ = {
-        val JavaFileEvent =
-          workspace.resolve("a/src/main/java/a/JavaFileEvent.java")
-        Files.createDirectories(JavaFileEvent.toNIO.getParent)
+        // Should generate an event
         FileWrites.write(
           JavaFileEvent,
           s"""
@@ -53,6 +59,7 @@ object FileWatcherSlowSuite extends BaseSlowSuite("file-watcher") {
         )
       }
       _ = {
+        // Should not generate a event
         val CFileEvent =
           workspace.resolve("a/src/main/c/a/main.c")
         Files.createDirectories(CFileEvent.toNIO.getParent)

--- a/tests/unit/src/test/scala/tests/FileWatcherSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/FileWatcherSlowSuite.scala
@@ -52,6 +52,18 @@ object FileWatcherSlowSuite extends BaseSlowSuite("file-watcher") {
              |""".stripMargin
         )
       }
+      _ = {
+        val CFileEvent =
+          workspace.resolve("a/src/main/c/a/main.c")
+        Files.createDirectories(CFileEvent.toNIO.getParent)
+        FileWrites.write(
+          CFileEvent,
+          s"""
+             |import "stdio.h"
+             |void main(char **args) { println("Hello World!"); }s
+             |""".stripMargin
+        )
+      }
       _ <- server.didOpen("b/src/main/scala/B.scala")
       _ <- server.didOpen("c/src/main/scala/C.scala")
       _ = assertNoDiff(client.workspaceDiagnostics, "")
@@ -69,6 +81,11 @@ object FileWatcherSlowSuite extends BaseSlowSuite("file-watcher") {
           |}
           |""".stripMargin
       )
+      _ = assertIsNotDirectory(workspace.resolve("a/src/main/scala-2.12"))
+      _ = assertIsNotDirectory(workspace.resolve("b/src/main/scala-2.12"))
+      _ = assertIsNotDirectory(workspace.resolve("c/src/main/scala-2.12"))
+      _ = assertIsNotDirectory(workspace.resolve("b/src/main/java"))
+      _ = assertIsNotDirectory(workspace.resolve("c/src/main/java"))
     } yield ()
   }
 }


### PR DESCRIPTION
The original behavior of the FileWatcher is to create all directories defined in unmanagedSourceDirectories so that it can monitor them for file changes. For example if the project has only a src/main/scala directory, the FileWatcher will create src/main/scala-2.12 and src/main/java. The reason it does this is that it can't monitor changes underneath those directories if they don't exist.
This PR changes that behavior so that it monitors all parents of directories defined in unmanagedSourceDirectories, the events generated arefiltered out if they did not occur under any of the directories in unmanagedSourceDirectories. This way source directories can get created and/or removed we still receive notifications for file changes in them.