### PR TITLE
Fix navigation bug for var setters.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -197,10 +197,24 @@ final class ReferenceProvider(
           case _ =>
             ""
         })
+    // Returns true if `info` is companion var setter method for occ.symbol var getter.
+    def isVarSetter(info: SymbolInformation): Boolean =
+      info.displayName.endsWith("_=") &&
+        info.displayName.startsWith(name) &&
+        occ.symbol == (Symbol(info.symbol) match {
+          case GlobalSymbol(owner, Descriptor.Method(setter, disambiguator)) =>
+            Symbols.Global(
+              owner.value,
+              Descriptor.Method(setter.stripSuffix("_="), disambiguator)
+            )
+          case _ =>
+            ""
+        })
     val candidates = for {
       info <- doc.symbols.iterator
       if info.symbol != name
       if {
+        isVarSetter(info) ||
         isCompanionObject(info) ||
         isCopyOrApplyParam(info) ||
         isCopyOrApplyMethod(info)

--- a/mtags/src/main/scala/scala/meta/internal/mtags/DefinitionAlternatives.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/DefinitionAlternatives.scala
@@ -10,6 +10,7 @@ object DefinitionAlternatives {
       caseClassCompanionToType(symbol),
       caseClassApplyOrCopy(symbol),
       caseClassApplyOrCopyParams(symbol),
+      varGetter(symbol),
       methodOwner(symbol)
     ).flatten
   }
@@ -62,6 +63,17 @@ object DefinitionAlternatives {
           Descriptor.Method("apply" | "copy", _)
           ) =>
         GlobalSymbol(owner, Descriptor.Type(signature.name.value))
+    }
+
+  /** Convert reference to var setter to var getter. */
+  private def varGetter(symbol: Symbol): Option[Symbol] =
+    Option(symbol).collect {
+      case GlobalSymbol(owner, Descriptor.Method(name, disambiguator))
+          if name.endsWith("_=") =>
+        GlobalSymbol(
+          owner,
+          Descriptor.Method(name.stripSuffix("_="), disambiguator)
+        )
     }
 
   /**

--- a/tests/input/src/main/scala/example/Vars.scala
+++ b/tests/input/src/main/scala/example/Vars.scala
@@ -1,0 +1,9 @@
+package example
+
+object Vars {
+  var a = 2
+
+  a = 2
+
+  Vars.a = 3
+}

--- a/tests/unit/src/test/resources/definition/example/Vars.scala
+++ b/tests/unit/src/test/resources/definition/example/Vars.scala
@@ -1,0 +1,9 @@
+package example
+
+object Vars/*Vars.scala*/ {
+  var a/*Vars.scala*/ = 2
+
+  a/*Vars.scala fallback to example.Vars.a().*/ = 2
+
+  Vars/*Vars.scala*/.a/*Vars.scala fallback to example.Vars.a().*/ = 3
+}

--- a/tests/unit/src/test/resources/documentSymbol/example/Vars.scala
+++ b/tests/unit/src/test/resources/documentSymbol/example/Vars.scala
@@ -1,0 +1,9 @@
+/*example(Package):9*/package example
+
+/*example.Vars(Module):9*/object Vars {
+  /*example.Vars.a(Variable):4*/var a = 2
+
+  a = 2
+
+  Vars.a = 3
+}

--- a/tests/unit/src/test/resources/expect/toplevels.expect
+++ b/tests/unit/src/test/resources/expect/toplevels.expect
@@ -27,6 +27,7 @@ example/Scalalib.scala -> example/Scalalib#
 example/StructuralTypes.scala -> example/StructuralTypes.
 example/TypeParameters.scala -> example/TypeParameters#
 example/VarArgs.scala -> example/VarArgs#
+example/Vars.scala -> example/Vars.
 example/nested/DoublePackage.scala -> example/nested/x/DoublePackage#
 example/nested/DoublePackage.scala -> example/nested2/y/DoublePackage#
 example/nested/ExampleNested.scala -> example/nested/ExampleNested#

--- a/tests/unit/src/test/resources/mtags/example/Vars.scala
+++ b/tests/unit/src/test/resources/mtags/example/Vars.scala
@@ -1,0 +1,9 @@
+package example
+
+object Vars/*example.Vars.*/ {
+  var a/*example.Vars.a().*/ = 2
+
+  a = 2
+
+  Vars.a = 3
+}

--- a/tests/unit/src/test/resources/semanticdb/example/Vars.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/Vars.scala
@@ -1,0 +1,9 @@
+package example
+
+object Vars/*example.Vars.*/ {
+  var a/*example.Vars.a().*/ = 2
+
+  a/*example.Vars.`a_=`().*/ = 2
+
+  Vars/*example.Vars.*/.a/*example.Vars.`a_=`().*/ = 3
+}

--- a/tests/unit/src/test/resources/workspace-symbol/example/Vars.scala
+++ b/tests/unit/src/test/resources/workspace-symbol/example/Vars.scala
@@ -1,0 +1,9 @@
+package example
+
+object Vars/*example.Vars.*/ {
+  var a = 2
+
+  a = 2
+
+  Vars.a = 3
+}

--- a/tests/unit/src/test/scala/tests/ReferenceSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceSlowSuite.scala
@@ -129,4 +129,27 @@ object ReferenceSlowSuite extends BaseSlowSuite("reference") {
       _ = server.assertReferenceDefinitionBijection()
     } yield ()
   }
+
+  testAsync("var") {
+    for {
+      _ <- server.initialize(
+        """
+          |/metals.json
+          |{
+          |  "a": {}
+          |}
+          |/a/src/main/scala/a/A.scala
+          |package a
+          |object A {
+          |  var a = 1
+          |  a = 2
+          |  A.a = 2
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ = assertNoDiagnostics()
+      _ = server.assertReferenceDefinitionBijection()
+    } yield ()
+  }
 }


### PR DESCRIPTION
Previously, "goto definition" for var setters would jump to the
enclosing class of the var instead of the var itself. Find references
on vars also didn't include locations where the setter was referenced.