### PR TITLE
Respect workspace folders for Scalafmt formatting, fixes #509.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -249,7 +249,8 @@ class MetalsLanguageServer(
       () => userConfig,
       languageClient,
       statusBar,
-      config.icons
+      config.icons,
+      params.getWorkspaceFolders.asScala.map(_.getUri.toAbsolutePath).toList
     )
     referencesProvider = new ReferenceProvider(
       workspace,

--- a/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
@@ -325,4 +325,29 @@ object FormattingSlowSuite extends BaseSlowSuite("formatting") {
     } yield ()
   }
 
+  testAsync("workspace-folder") {
+    for {
+      _ <- server.initialize(
+        """|/a/.scalafmt.conf
+           |version="2.0.0-RC4"
+           |maxColumn=10
+           |/Main.scala
+           |object   Main { val x = 2 }
+           |""".stripMargin,
+        expectError = true,
+        workspaceFolders = List("a")
+      )
+      _ <- server.didOpen("Main.scala")
+      _ <- server.formatting("Main.scala")
+      _ = assertNoDiff(
+        server.bufferContent("Main.scala"),
+        """object Main {
+          |  val x =
+          |    2
+          |}
+          |""".stripMargin
+      )
+    } yield ()
+  }
+
 }


### PR DESCRIPTION
Previously, we only looked for `.scalafmt.conf` in the `rootUri`
directory. After this fix, we fallback to `workspaceFolders` if we don't
find a `.scalafmt.conf` file. In the case of formatting, it's not big
trouble to support multiple workspace roots. In the general case it may
be tricker, for example I have no idea how we would handle two separate
sbt builds. We can take it case-by-case.