### PR TITLE
Fix semanticdb version and prepare for 0.4.3 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-def localSnapshotVersion = "0.4.0-SNAPSHOT"
+def localSnapshotVersion = "0.5.0-SNAPSHOT"
 inThisBuild(
   List(
     version ~= { dynVer =>

--- a/build.sbt
+++ b/build.sbt
@@ -90,10 +90,10 @@ lazy val V = new {
   val scala211 = "2.11.12"
   val scala212 = "2.12.8"
   val scalameta = "4.1.3"
-  val semanticdb = "4.1.0"
+  val semanticdb = scalameta
   val bsp = "2.0.0-M3"
-  val sbtBloop = "1.2.5"
   val bloop = "1.2.5"
+  val sbtBloop = bloop
   val scalafmt = "2.0.0-RC4"
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.

--- a/metals/src/main/scala/scala/meta/internal/metals/SbtDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SbtDigest.scala
@@ -23,7 +23,7 @@ object SbtDigest {
    * Bump up this version if parameters outside of the sbt sources themselves require
    * re-running `bloopInstall`. For example a SemanticDB or Bloop version upgrade.
    */
-  val version: String = "v3"
+  val version: String = "v4"
   sealed abstract class Status(val value: Int)
       extends Product
       with Serializable {
@@ -60,7 +60,11 @@ object SbtDigest {
     if (!workspace.isDirectory) None
     else {
       val digest = MessageDigest.getInstance("MD5")
-      digest.update(version.getBytes(StandardCharsets.UTF_8))
+      // we skip the version in tests, so that we don't have to manually update the digests in tests
+      // when changing the version
+      if (System.getProperty("metals.testing") == null) {
+        digest.update(version.getBytes(StandardCharsets.UTF_8))
+      }
       val project = workspace.resolve("project")
       val isSuccess =
         digestDirectory(workspace, digest) &&

--- a/tests/unit/src/test/scala/tests/SbtDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtDigestSuite.scala
@@ -49,7 +49,7 @@ object SbtDigestSuite extends BaseSuite {
     }
   }
 
-  val solo = "E247CC8F123CD16AAF03EB8A42B47115"
+  val solo = "62E46F71242E515912BE6814C9356D63"
   check(
     "solo build.sbt",
     """
@@ -69,7 +69,7 @@ object SbtDigestSuite extends BaseSuite {
     Some(solo)
   )
 
-  val project = "46BBD8C6B3B8B0189969309BA8E8DF0A"
+  val project = "08E20CE98E81FAB7388686CCADFC2F64"
   check(
     "metabuild",
     """

--- a/website/blog/2019-02-01-tin.md
+++ b/website/blog/2019-02-01-tin.md
@@ -1,6 +1,6 @@
 ---
 author: Ólafur Páll Geirsson
-title: Metals v0.4.2
+title: Metals v0.4.3
 authorURL: https://twitter.com/olafurpg
 authorImageURL: https://avatars2.githubusercontent.com/u/1408093?s=460&v=4
 ---


### PR DESCRIPTION
Semanticdb was out of sync with the scalameta version, causing the 0.4.1 (and 0.4.2) releases not to benefit from the recent semanticdb improvements.

This PR defaults the semanticdb version to the scalameta version, and it does the same for sbt-bloop to bloop following the same logic.

We still keep them separated since it makes it easier to test latest changes while developing.