### PR TITLE
Measure CI times with standard sbt on Azure.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,4 +3,4 @@ jobs:
   pool:
     vmImage: 'Ubuntu-16.04'
   steps:
-  - script: ./sbt -batch unit/test
+  - script: ./sbt -batch -mainline unit/test


### PR DESCRIPTION
We currently use the coursier sbt launcher to speed up CI on Azure,
this commit it only here to measure how long it takes without the
coursier sbt launcher.