### PR TITLE
Trigger parameter hints command after completion, if supported.

### DIFF
--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -238,6 +238,28 @@ Possible values:
 
 ```
 
+### `-Dmetals.signature-help-command`
+
+An optional string value for a command identifier to trigger parameter hints
+(`textDocument/signatureHelp`) in the editor. Metals uses this setting to
+populate `CompletionItem.command` for completion items that move the cursor
+inside an argument list. For example, when completing `"".stripSu@@` into
+`"".stripSuffix(@@)`, Metals will automatically trigger parameter hints if this
+setting is provided by the editor.
+
+Default value:
+
+- `"editor.action.triggerParameterHints"`: when editor is Visual Studio Code.
+- empty: for all other editors.
+
+### `-Dmetals.pc.debug`
+
+Possible values:
+
+- `off` (default): do not log verbose debugging information for the presentation
+  compiler.
+- `on`: log verbose debugging information for the presentation compiler.
+
 ## Metals user configuration
 
 Users can customize the Metals server through the LSP

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -75,7 +75,7 @@ class Compilers(
   }
 
   def log: List[String] =
-    if (config.pcLog) {
+    if (config.compilers.debug) {
       List(
         "-Ypresentation-debug",
         "-Ypresentation-verbose",
@@ -166,6 +166,7 @@ class Compilers(
     pc.withSearch(search)
       .withExecutorService(ec)
       .withScheduledExecutorService(sh)
+      .withConfiguration(config.compilers)
       .newInstance(
         scalac.getTarget.getUri,
         classpath.asJava,

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -1,9 +1,12 @@
 package scala.meta.internal.metals
 
+import java.util.Optional
+import java.util.Properties
 import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions
 import org.eclipse.lsp4j.FileSystemWatcher
 import scala.meta.io.AbsolutePath
 import scala.collection.JavaConverters._
+import scala.meta.pc.PresentationCompilerConfig
 
 object Configs {
 
@@ -33,6 +36,21 @@ object Configs {
     def default = new GlobSyntaxConfig(
       System.getProperty("metals.glob-syntax", uri.value)
     )
+  }
+
+  case class CompilersConfig(debug: Boolean, parameterHint: Option[String])
+      extends PresentationCompilerConfig {
+    def parameterHintsCommand: Optional[String] =
+      Optional.ofNullable(parameterHint.orNull)
+  }
+
+  object CompilersConfig {
+    def apply(props: Properties = System.getProperties): CompilersConfig = {
+      CompilersConfig(
+        MetalsServerConfig.binaryOption("pc.debug", default = false),
+        Option(props.getProperty("metals.signature-help-command"))
+      )
+    }
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -59,10 +59,7 @@ final case class MetalsServerConfig(
     ),
     icons: Icons = Icons.default,
     statistics: StatisticsConfig = StatisticsConfig.default,
-    pcLog: Boolean = MetalsServerConfig.binaryOption(
-      "metals.pc-log",
-      default = false
-    )
+    compilers: CompilersConfig = CompilersConfig()
 ) {
   override def toString: String =
     List[String](
@@ -82,7 +79,7 @@ final case class MetalsServerConfig(
 }
 object MetalsServerConfig {
   def isTesting: Boolean = "true" == System.getProperty("metals.testing")
-  private def binaryOption(key: String, default: Boolean): Boolean =
+  def binaryOption(key: String, default: Boolean): Boolean =
     System.getProperty(key) match {
       case "true" | "on" => true
       case "false" | "off" => false
@@ -98,7 +95,10 @@ object MetalsServerConfig {
           slowTask = SlowTaskConfig.on,
           icons = Icons.vscode,
           executeClientCommand = ExecuteClientCommandConfig.on,
-          globSyntax = GlobSyntaxConfig.vscode
+          globSyntax = GlobSyntaxConfig.vscode,
+          compilers = CompilersConfig().copy(
+            parameterHint = Some("editor.action.triggerParameterHints")
+          )
         )
       case "vim-lsc" =>
         base.copy(

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -7,6 +7,7 @@ import org.eclipse.lsp4j.SignatureHelp;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -74,6 +75,11 @@ public abstract class PresentationCompiler {
      * Provide a custom scheduled executor service to schedule `Thread.stop()` for unresponsive compiler instances.
      */
     public abstract PresentationCompiler withScheduledExecutorService(ScheduledExecutorService scheduledExecutorService);
+
+    /**
+     * Provide custom configuration for features like signature help and completions.
+     */
+    public abstract PresentationCompiler withConfiguration(PresentationCompilerConfig config);
 
     /**
      * Construct a new presentation compiler with the given parameters.

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -1,0 +1,18 @@
+package scala.meta.pc;
+
+import java.util.Optional;
+
+/**
+ * Configuration options used by the Metals presentation compiler.
+ */
+public interface PresentationCompilerConfig {
+
+    /**
+     * Command ID to trigger parameter hints (textDocument/signatureHelp) in the editor.
+     *
+     * See https://scalameta.org/metals/docs/editors/new-editor.html#dmetalssignature-help-command
+     * for details.
+     */
+    Optional<String> parameterHintsCommand();
+
+}

--- a/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util
+import java.util.Optional
 import java.util.logging.Level
 import java.util.logging.Logger
 import org.eclipse.lsp4j.CompletionItem
@@ -252,6 +253,11 @@ trait MtagsEnrichments {
       )
   }
 
+  implicit class XtensionOptionalJava[T](opt: Optional[T]) {
+    def asScala: Option[T] =
+      if (opt.isPresent) Some(opt.get())
+      else None
+  }
   implicit class XtensionPositionLsp(pos: m.Position) {
     def toSemanticdb: s.Range = {
       new s.Range(

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.pc
 
 import java.nio.file.Path
+import scala.meta.internal.mtags.MtagsEnrichments._
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionItemKind
 import org.eclipse.lsp4j.CompletionList
@@ -70,6 +71,14 @@ class CompletionProvider(
                   item.setInsertText(label + "()")
                 case _ =>
                   item.setInsertText(label + "($0)")
+                  metalsConfig
+                    .parameterHintsCommand()
+                    .asScala
+                    .foreach { command =>
+                      item.setCommand(
+                        new l.Command("", command)
+                      )
+                    }
               }
             } else if (!suffix.isEmpty) {
               item.setInsertTextFormat(InsertTextFormat.Snippet)

--- a/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
@@ -5,6 +5,7 @@ import java.util.logging.Logger
 import org.eclipse.{lsp4j => l}
 import scala.language.implicitConversions
 import scala.meta.internal.semanticdb.scalac.SemanticdbOps
+import scala.meta.pc.PresentationCompilerConfig
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 import scala.reflect.internal.{Flags => gf}
@@ -19,7 +20,8 @@ class MetalsGlobal(
     settings: Settings,
     reporter: Reporter,
     val search: SymbolSearch,
-    val buildTargetIdentifier: String
+    val buildTargetIdentifier: String,
+    val metalsConfig: PresentationCompilerConfig
 ) extends Global(settings, reporter)
     with Completions
     with Signatures

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -1,0 +1,8 @@
+package scala.meta.internal.pc
+
+import java.util.Optional
+import scala.meta.pc.PresentationCompilerConfig
+
+case class PresentationCompilerConfigImpl(
+    parameterHintsCommand: Optional[String] = Optional.empty()
+) extends PresentationCompilerConfig

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -18,6 +18,7 @@ import scala.meta.pc.SymbolSearch
 import scala.reflect.io.VirtualDirectory
 import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.StoreReporter
+import scala.meta.pc.PresentationCompilerConfig
 import scala.util.Properties
 
 case class ScalaPresentationCompiler(
@@ -26,7 +27,8 @@ case class ScalaPresentationCompiler(
     options: List[String] = Nil,
     search: SymbolSearch = EmptySymbolSearch,
     ec: ExecutionContext = ExecutionContext.global,
-    sh: Option[ScheduledExecutorService] = None
+    sh: Option[ScheduledExecutorService] = None,
+    config: PresentationCompilerConfig = PresentationCompilerConfigImpl()
 ) extends PresentationCompiler {
   val logger = Logger.getLogger(classOf[ScalaPresentationCompiler].getName)
   override def withSearch(search: SymbolSearch): PresentationCompiler =
@@ -39,6 +41,11 @@ case class ScalaPresentationCompiler(
       sh: ScheduledExecutorService
   ): PresentationCompiler =
     copy(sh = Some(sh))
+
+  override def withConfiguration(
+      config: PresentationCompilerConfig
+  ): PresentationCompiler =
+    copy(config = config)
   def this() = this(buildTargetIdentifier = "")
 
   val access = new CompilerAccess(sh, () => newCompiler())(ec)
@@ -111,7 +118,8 @@ case class ScalaPresentationCompiler(
       settings,
       new StoreReporter,
       search,
-      buildTargetIdentifier
+      buildTargetIdentifier,
+      config
     )
   }
 

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -1,9 +1,5 @@
 package example
-object User {
-  val name = "John"
-  def greeting = """Hello
-   $name! This is goodbye
-   """
 
-  def message = "Hello $name, this is goodbye!"
+object User {
+    "".stripSuffix()
 }

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -32,6 +32,16 @@ abstract class BaseCompletionSuite extends BasePCSuite {
     result.getItems.asScala.sortBy(_.getSortText)
   }
 
+  def checkItems(
+      name: String,
+      original: String,
+      fn: Seq[CompletionItem] => Unit
+  ): Unit = {
+    test(name) {
+      fn(getItems(original))
+    }
+  }
+
   def checkEdit(
       name: String,
       original: String,

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -16,8 +16,10 @@ import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.metals.Docstrings
 import scala.meta.internal.metals.RecursivelyDelete
 import scala.meta.internal.mtags.OnDemandSymbolIndex
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.internal.pc.ScalaPresentationCompiler
 import scala.meta.io.AbsolutePath
+import scala.meta.pc.PresentationCompilerConfig
 import scala.util.Properties
 
 abstract class BasePCSuite extends BaseSuite {
@@ -36,6 +38,7 @@ abstract class BasePCSuite extends BaseSuite {
       .toSeq
   def extraClasspath: Seq[Path] = Nil
   def scalacOptions: Seq[String] = Nil
+  def config: PresentationCompilerConfig = PresentationCompilerConfigImpl()
   val myclasspath: Seq[Path] = extraClasspath ++ scalaLibrary.toList
   val index = OnDemandSymbolIndex()
   val indexer = new Docstrings(index)
@@ -47,6 +50,7 @@ abstract class BasePCSuite extends BaseSuite {
   )
   val pc = new ScalaPresentationCompiler()
     .withSearch(search)
+    .withConfiguration(config)
     .newInstance("", myclasspath.asJava, scalacOptions.asJava)
   val tmp = AbsolutePath(Files.createTempDirectory("metals"))
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionParameterHintSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionParameterHintSuite.scala
@@ -1,0 +1,36 @@
+package tests.pc
+
+import java.util.Optional
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
+import scala.meta.pc.PresentationCompilerConfig
+import tests.BaseCompletionSuite
+
+object CompletionParameterHintSuite extends BaseCompletionSuite {
+
+  override def config: PresentationCompilerConfig =
+    PresentationCompilerConfigImpl(Optional.of("hello"))
+  checkItems(
+    "command",
+    """
+      |object Main {
+      |  "".stripSuffi@@
+      |}
+    """.stripMargin, {
+      case Seq(item) =>
+        assert(item.getCommand.getCommand == "hello")
+    }
+  )
+
+  checkItems(
+    "command",
+    """
+      |object Main {
+      |  println@@
+      |}
+    """.stripMargin, {
+      case Seq(item1, item2) =>
+        assert(item1.getCommand == null)
+        assert(item2.getCommand.getCommand == "hello")
+    }
+  )
+}


### PR DESCRIPTION
Previously, completing a method like `println($0)` didn't automatically
trigger parameter hints, which would be really nice in my opinion. This
commit implements infrastructure to allow editors to opt-into triggering
parameter hints after selecting a completion item. We make it work out
of the box with VS Code.

Fixes #551 