### PR TITLE
Wrap identifiers in backticks when necessary.

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/metals/Fuzzy.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/Fuzzy.scala
@@ -41,7 +41,8 @@ import scala.collection.mutable
  * - sa, the start index in the symbol string.
  * - sb, the end index in the symbol string.
  */
-object Fuzzy {
+object Fuzzy extends Fuzzy
+class Fuzzy {
   private class Delimiter(
       val isFinished: Boolean,
       val idx: Int
@@ -152,11 +153,10 @@ object Fuzzy {
     var curr = fromIndex - 2
     var continue = true
     while (curr >= 0 && continue) {
-      string.charAt(curr) match {
-        case '.' | '/' | '#' | '$' =>
-          continue = false
-        case _ =>
-          curr -= 1
+      if (isDelimiter(string.charAt(curr))) {
+        continue = false
+      } else {
+        curr -= 1
       }
     }
     if (curr < 0) new Delimiter(true, 0)

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionFuzzy.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionFuzzy.scala
@@ -1,0 +1,13 @@
+package scala.meta.internal.pc
+
+import scala.meta.internal.metals.Fuzzy
+
+/**
+ * A custom version of fuzzy search designed for code completions.
+ */
+object CompletionFuzzy extends Fuzzy {
+
+  // Don't treat classfile `$` or SemanticDB `/` as delimiters.
+  override def isDelimiter(ch: Char): Boolean = false
+
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/Identifier.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Identifier.scala
@@ -1,0 +1,63 @@
+// Sources copy-pasted from Ammonite:
+// https://github.com/lihaoyi/Ammonite/blob/73a874173cd337f953a3edc9fb8cb96556638fdd/amm/util/src/main/scala/ammonite/util/Model.scala#L71-L121
+// Original licence: MIT
+// Original author: Li Haoyi
+package scala.meta.internal.pc
+
+object Identifier {
+  private val alphaKeywords = Set(
+    "abstract", "case", "catch", "class", "def", "do", "else", "extends",
+    "false", "finally", "final", "finally", "forSome", "for", "if", "implicit",
+    "import", "lazy", "match", "new", "null", "object", "override", "package",
+    "private", "protected", "return", "sealed", "super", "this", "throw",
+    "trait", "try", "true", "type", "val", "var", "while", "with", "yield", "_",
+    "macro"
+  )
+  private val symbolKeywords = Set(
+    ":", ";", "=>", "=", "<-", "<:", "<%", ">:", "#", "@", "\u21d2", "\u2190"
+  )
+  private val blockCommentStart = "/*"
+  private val lineCommentStart = "//"
+
+  def needsBacktick(s: String): Boolean = {
+    val chunks = s.split("_", -1)
+    def validOperator(c: Char) = {
+      c.getType == Character.MATH_SYMBOL ||
+      c.getType == Character.OTHER_SYMBOL ||
+      "!#%&*+-/:<=>?@\\^|~".contains(c)
+    }
+    val validChunks = chunks.zipWithIndex.forall {
+      case (chunk, index) =>
+        chunk.forall(c => c.isLetter || c.isDigit || c == '$') ||
+          (chunk.forall(validOperator) &&
+            // operators can only come last
+            index == chunks.length - 1 &&
+            // but cannot be preceded by only a _
+            !(chunks.lift(index - 1).contains("") && index - 1 == 0))
+    }
+
+    val firstLetterValid =
+      s(0).isLetter ||
+        s(0) == '_' ||
+        s(0) == '$' ||
+        validOperator(s(0))
+
+    val valid =
+      validChunks &&
+        firstLetterValid &&
+        !alphaKeywords.contains(s) &&
+        !symbolKeywords.contains(s) &&
+        !s.contains(blockCommentStart) &&
+        !s.contains(lineCommentStart)
+
+    !valid
+  }
+
+  def backtickWrap(s: String): String = {
+    if (s.isEmpty) "``"
+    else if (s(0) == '`' && s.last == '`') s
+    else if (needsBacktick(s)) '`' + s + '`'
+    else s
+  }
+
+}

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -1,5 +1,6 @@
 package example
 
 object User {
-    "".stripSuffix()
+  val `hello world` = "John"
+  "Hello $hello"
 }

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -89,7 +89,8 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       postProcessObtained: String => String = identity,
       stableOrder: Boolean = true,
       postAssert: () => Unit = () => (),
-      topLines: Option[Int] = None
+      topLines: Option[Int] = None,
+      filterText: String = ""
   )(implicit filename: sourcecode.File, line: sourcecode.Line): Unit = {
     test(name) {
       val out = new StringBuilder()
@@ -122,6 +123,15 @@ abstract class BaseCompletionSuite extends BasePCSuite {
         sortLines(stableOrder, getExpected(expected, compat))
       )
       postAssert()
+      if (filterText.nonEmpty) {
+        items.foreach { item =>
+          assertNoDiff(
+            item.getFilterText,
+            filterText,
+            s"Invalid filter text for item:\n$item"
+          )
+        }
+      }
     }
   }
 

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -21,6 +21,7 @@ import scala.meta.internal.pc.ScalaPresentationCompiler
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.PresentationCompilerConfig
 import scala.util.Properties
+import scala.util.control.NonFatal
 
 abstract class BasePCSuite extends BaseSuite {
   def thisClasspath: Seq[Path] =
@@ -101,7 +102,11 @@ abstract class BasePCSuite extends BaseSuite {
     }
     val file = tmp.resolve(filename)
     Files.write(file.toNIO, code2.getBytes(StandardCharsets.UTF_8))
-    index.addSourceFile(file, Some(tmp))
+    try index.addSourceFile(file, Some(tmp))
+    catch {
+      case NonFatal(e) =>
+        println(s"warn: $e")
+    }
     workspace.inputs(filename) = code2
     (code2, offset)
   }

--- a/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
@@ -1,0 +1,111 @@
+package tests.pc
+
+import tests.BaseCompletionSuite
+
+object CompletionBacktickSuite extends BaseCompletionSuite {
+
+  check(
+    "keyword",
+    s"""|object Main {
+        |  val `type` = 42
+        |  Main.typ@@
+        |}
+        |""".stripMargin,
+    """|`type`: Int
+       |""".stripMargin,
+    filterText = "type"
+  )
+
+  check(
+    "space",
+    s"""|object Main {
+        |  val `hello world` = 42
+        |  Main.hello@@
+        |}
+        |""".stripMargin,
+    """|`hello world`: Int
+       |""".stripMargin,
+    filterText = "hello world"
+  )
+
+  check(
+    "comment",
+    s"""|object Main {
+        |  val `///` = 42
+        |  Main./@@
+        |}
+        |""".stripMargin,
+    """|`///`: Int
+       |""".stripMargin,
+    filterText = "///"
+  )
+
+  checkEdit(
+    "interpolator",
+    """|object Main {
+       |  val `type` = 42
+       |  "Hello $type@@"
+       |}
+       |""".stripMargin,
+    """|object Main {
+       |  val `type` = 42
+       |  s"Hello \${`type`$0}"
+       |}
+       |""".stripMargin,
+    filterText = "\"Hello $type"
+  )
+
+  checkEdit(
+    "interpolator2",
+    """|object Main {
+       |  val `hello world` = 42
+       |  "Hello $hello@@"
+       |}
+       |""".stripMargin,
+    """|object Main {
+       |  val `hello world` = 42
+       |  s"Hello \${`hello world`$0}"
+       |}
+       |""".stripMargin,
+    filterText = "\"Hello $hello"
+  )
+
+  check(
+    "named-arg",
+    """|object Main {
+       |  def foo(`type`: Int) = 42
+       |  foo(type@@)
+       |}
+       |""".stripMargin,
+    """`type` = : Int
+      |""".stripMargin,
+    filterText = "type"
+  )
+
+  check(
+    "normal",
+    """|object Main {
+       |  val `spaced` = 42
+       |  spaced@@
+       |}
+       |""".stripMargin,
+    // NOTE(olafur) expected output is not backticked because the compiler symbol does not
+    // distinguish if the symbol was defined with backticks in source.
+    """spaced: Int
+      |""".stripMargin,
+    filterText = ""
+  )
+
+  check(
+    "negative",
+    """|object Main {
+       |  val `type` = 42
+       |  Main.`typ@@
+       |}
+       |""".stripMargin,
+    // NOTE(olafur) expected output is empty because the source does not tokenize due to unclosed identifier.
+    // It would be nice to fix this limitation down the road.
+    ""
+  )
+
+}

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -3,7 +3,6 @@ package tests.pc
 import tests.BaseCompletionSuite
 
 object CompletionSuite extends BaseCompletionSuite {
-
   override def beforeAll(): Unit = {
     indexJDK()
   }


### PR DESCRIPTION
Previously, completions did not correctly handle identifiers that need
to be wrapped in backticks resulting producing code that does not parse.
This commit fixes that issue for all different kinds of completions that
Metals supports, including scope, type members and interpolators.

Fixes #547