### PR TITLE
Resolve mtags from Sonatype Snapshots, fixes #554.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -118,6 +118,12 @@ object Embedded {
     new coursiersmall.Settings()
       .withTtl(Some(Duration.Inf))
       .withDependencies(List(dependency))
+      .addRepositories(
+        List(
+          coursiersmall.Repository.SonatypeReleases,
+          coursiersmall.Repository.SonatypeSnapshots
+        )
+      )
   def newPresentationCompilerClassLoader(
       info: ScalaBuildTarget,
       scalac: ScalacOptionsItem
@@ -161,7 +167,6 @@ object Embedded {
       )
     ).addRepositories(
       List(
-        coursiersmall.Repository.SonatypeReleases,
         new coursiersmall.Repository.Maven(
           "https://dl.bintray.com/scalacenter/releases"
         )


### PR DESCRIPTION
I tried to manually validate the fix by publishing 0.5.0-SNAPSHOT to
sonatype but wasn't able to get it working for some reason. Let's
merge this commit and see if it did the trick after CI has released a
fresh snapshot.