### PR TITLE
Remove root package from completion results.

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -170,7 +170,10 @@ class CompletionProvider(
           TypeName("ArrowAssoc")
         ),
         TermName("→").encode
-      )
+      ),
+      // NOTE(olafur) IntelliJ does not complete the root package and without this filter
+      // then `_root_` would appear as a completion result in the code `foobar(_<COMPLETE>)`
+      rootMirror.RootPackage
     ).flatMap(_.alternatives)
     val isSeen = mutable.Set.empty[String]
     val isIgnored = mutable.Set.empty[Symbol]

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -962,4 +962,14 @@ object CompletionSuite extends BaseCompletionSuite {
     ""
   )
 
+  check(
+    "underscore",
+    s"""|object Main {
+        |  List(1).exists(_@@)
+        |}
+        |""".stripMargin,
+    // assert that `_root_` is not a completion item.
+    ""
+  )
+
 }


### PR DESCRIPTION
This mirrors the behavior in IntelliJ and fixes an annoying situation
where `List(1).map(_<TAB>)` completes to `_root_`.

Thank you @jvican for reporting!