### PR TITLE
Update Atom info

### DIFF
--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -43,9 +43,9 @@ functionality.
   <td align=center>✅</td>
   <td align=center>✅</td>
   <td align=center>✅</td>
-  <td align=center>✅</td>
-  <td align=center>✅</td>
   <td align=center></td>
+  <td align=center>✅</td>
+  <td align=center>Status bar</td>
 </tr>
 <tr>
   <td>Vim</td>


### PR DESCRIPTION
Atom IDE doesn't have UI for `workspace/symbol`. Metals extensions are partially supported.