### PR TITLE
Make bloop server startup more robust, reuse sockets wherever possible.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -137,7 +137,7 @@ final class BloopServers(
     callBloopMain(
       args,
       isOk = { () =>
-       Try {
+        Try {
           val socket = new Socket()
           socket.setReuseAddress(true)
           socket.setTcpNoDelay(true)
@@ -160,7 +160,9 @@ final class BloopServers(
     callBloopMain(
       args,
       isOk = { () =>
-        Try(BloopSocket.Unix(new UnixDomainSocket(socket.toFile.getCanonicalPath)))
+        Try(
+          BloopSocket.Unix(new UnixDomainSocket(socket.toFile.getCanonicalPath))
+        )
       }
     )
   }
@@ -260,7 +262,9 @@ final class BloopServers(
       socket = new Socket()
       socket.setReuseAddress(true)
       socket.setTcpNoDelay(true)
-      socket.connect(new InetSocketAddress(InetAddress.getLoopbackAddress, port))
+      socket.connect(
+        new InetSocketAddress(InetAddress.getLoopbackAddress, port)
+      )
       socket.isConnected
     } catch {
       case NonFatal(_) => false
@@ -276,7 +280,9 @@ final class BloopServers(
 
   case object NoResponse extends Exception("no response: bloop bsp")
 
-  private def waitUntilSuccess(isOk: () => Try[BloopSocket]): Future[Try[BloopSocket]] = {
+  private def waitUntilSuccess(
+      isOk: () => Try[BloopSocket]
+  ): Future[Try[BloopSocket]] = {
     val retryDelayMillis: Long = 200
     val maxRetries: Int = 40
     val promise = Promise[Try[BloopSocket]]()
@@ -285,9 +291,9 @@ final class BloopServers(
       new Runnable {
         override def run(): Unit = {
           isOk() match {
-            case s@Success(_) =>
+            case s @ Success(_) =>
               promise.complete(Success(s))
-            case f@Failure(ex) if (remainingRetries < 0) =>
+            case f @ Failure(ex) if (remainingRetries < 0) =>
               promise.complete(Success(f))
             case _ =>
               remainingRetries -= 1


### PR DESCRIPTION
Two main changes:
1. When connecting to the bsp server the isOk and onSuccess method have been merged. We try to open the socket and reuse it if the socket is ok. This alleviates the instability issue on Windows and makes the startup faster.
2. When checking if we have an installed bloop we connect to the bloop port instead of firing up the python script. This saves startup time especially on Windows.

There's also a bug fix in the logic of picking the socket type. Previously if we had chosen windows domain socket the code would also try connecting to a unix socket, now it will pick one of the three; windows , tcp or unix socket.

Question, should we add the bloop server port to configuration? Currently it's hard-coded to 8212.
