### PR TITLE
Implement `override def` completions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ project/plugins/project/
 .ensime
 
 .metals/
+metals.sbt
 
 .vscode/
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ inThisBuild(
     scalaVersion := V.scala212,
     crossScalaVersions := List(V.scala212),
     scalacOptions ++= List(
+      "-target:jvm-1.8",
       "-Yrangepos",
       "-deprecation",
       // -Xlint is unusable because of

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -31,6 +31,7 @@ import scala.tools.nsc.Properties
 class Compilers(
     workspace: AbsolutePath,
     config: MetalsServerConfig,
+    userConfig: () => UserConfiguration,
     buildTargets: BuildTargets,
     buffers: Buffers,
     search: SymbolSearch,
@@ -166,7 +167,9 @@ class Compilers(
     pc.withSearch(search)
       .withExecutorService(ec)
       .withScheduledExecutorService(sh)
-      .withConfiguration(config.compilers)
+      .withConfiguration(
+        config.compilers.copy(_symbolPrefixes = userConfig().symbolPrefixes)
+      )
       .newInstance(
         scalac.getTarget.getUri,
         classpath.asJava,

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -1,12 +1,11 @@
 package scala.meta.internal.metals
 
-import java.util.Optional
 import java.util.Properties
 import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions
 import org.eclipse.lsp4j.FileSystemWatcher
-import scala.meta.io.AbsolutePath
 import scala.collection.JavaConverters._
-import scala.meta.pc.PresentationCompilerConfig
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
+import scala.meta.io.AbsolutePath
 
 object Configs {
 
@@ -38,15 +37,11 @@ object Configs {
     )
   }
 
-  case class CompilersConfig(debug: Boolean, parameterHint: Option[String])
-      extends PresentationCompilerConfig {
-    def parameterHintsCommand: Optional[String] =
-      Optional.ofNullable(parameterHint.orNull)
-  }
-
   object CompilersConfig {
-    def apply(props: Properties = System.getProperties): CompilersConfig = {
-      CompilersConfig(
+    def apply(
+        props: Properties = System.getProperties
+    ): PresentationCompilerConfigImpl = {
+      PresentationCompilerConfigImpl(
         MetalsServerConfig.binaryOption("pc.debug", default = false),
         Option(props.getProperty("metals.signature-help-command"))
       )

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.metals
 
 import scala.meta.internal.metals.Configs._
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
 
 /**
  * Configuration parameters for the Metals language server.
@@ -59,7 +60,7 @@ final case class MetalsServerConfig(
     ),
     icons: Icons = Icons.default,
     statistics: StatisticsConfig = StatisticsConfig.default,
-    compilers: CompilersConfig = CompilersConfig()
+    compilers: PresentationCompilerConfigImpl = CompilersConfig()
 ) {
   override def toString: String =
     List[String](
@@ -71,6 +72,7 @@ final case class MetalsServerConfig(
       s"show-message=$showMessage",
       s"show-message-request=$showMessageRequest",
       s"no-initialized=$isNoInitialized",
+      s"compilers=$compilers",
       s"http=$isHttpEnabled",
       s"input-box=$isInputBoxEnabled",
       s"icons=$icons",
@@ -97,7 +99,7 @@ object MetalsServerConfig {
           executeClientCommand = ExecuteClientCommandConfig.on,
           globSyntax = GlobSyntaxConfig.vscode,
           compilers = CompilersConfig().copy(
-            parameterHint = Some("editor.action.triggerParameterHints")
+            _parameterHintsCommand = Some("editor.action.triggerParameterHints")
           )
         )
       case "vim-lsc" =>

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -1,5 +1,7 @@
 package scala.meta.pc;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -14,5 +16,14 @@ public interface PresentationCompilerConfig {
      * for details.
      */
     Optional<String> parameterHintsCommand();
+
+    Map<String, String> symbolPrefixes();
+
+    static Map<String, String> defaultSymbolPrefixes() {
+        HashMap<String, String> map = new HashMap<>();
+        map.put("scala/collection/mutable/", "mutable.");
+        map.put("java/util/", "ju.");
+        return map;
+    }
 
 }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -180,6 +180,11 @@ trait MtagsEnrichments {
       }
   }
   implicit class XtensionStringDoc(doc: String) {
+    def endsWithAt(value: String, offset: Int): Boolean = {
+      val start = offset - value.length
+      start >= 0 &&
+      doc.startsWith(value, start)
+    }
     def toMarkupContent: l.MarkupContent = {
       val content = new MarkupContent
       content.setKind("markdown")

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerThrowable.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerThrowable.scala
@@ -9,14 +9,15 @@ object CompilerThrowable {
    * Removes stacktraces that are unrelated to the
    * @param e
    */
-  def trimStackTrace(e: Throwable): Unit = {
+  def trimStackTrace(e: Throwable): e.type = {
     val isVisited = Collections.newSetFromMap(
       new java.util.IdentityHashMap[Throwable, java.lang.Boolean]
     )
     @tailrec def loop(ex: Throwable): Unit = {
       isVisited.add(ex)
-      val stacktrace =
-        ex.getStackTrace.takeWhile(!_.getClassName.contains("ScalaPC"))
+      val stacktrace = ex.getStackTrace.takeWhile(
+        !_.getClassName.contains("ScalaPresentationCompiler")
+      )
       ex.setStackTrace(stacktrace)
       // avoid infinite loop when traversing exceptions cyclic dependencies between causes.
       if (e.getCause != null && !isVisited.contains(e.getCause)) {
@@ -24,5 +25,6 @@ object CompilerThrowable {
       }
     }
     loop(e)
+    e
   }
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionItemData.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionItemData.scala
@@ -4,11 +4,25 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 
-case class CompletionItemData(symbol: String, target: String) {
+case class CompletionItemData(
+    symbol: String,
+    target: String,
+    // The kind of the completion item, for example `override def`
+    kind: java.lang.Integer = null
+) {
   def toJson: JsonElement = {
     val obj = new JsonObject()
     obj.add("symbol", new JsonPrimitive(symbol))
     obj.add("target", new JsonPrimitive(target))
+    if (kind != null) {
+      obj.add("kind", new JsonPrimitive(kind))
+    }
     obj
   }
+}
+
+object CompletionItemData {
+  def empty: CompletionItemData = CompletionItemData("", "")
+  // This is an `override def` completion item.
+  val OverrideKind: java.lang.Integer = 1
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionItemResolver.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionItemResolver.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.pc
 import org.eclipse.lsp4j.CompletionItem
 import scala.collection.JavaConverters._
 import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.pc.SymbolDocumentation
 
 class CompletionItemResolver(
     val compiler: MetalsGlobal
@@ -14,19 +15,15 @@ class CompletionItemResolver(
       symbolDocumentation(gsym).orElse(symbolDocumentation(gsym.companion)) match {
         case Some(info) if item.getDetail != null =>
           if (isJavaSymbol(gsym)) {
-            val newDetail = info
-              .parameters()
-              .asScala
-              .iterator
-              .zipWithIndex
-              .foldLeft(item.getDetail) {
-                case (detail, (param, i)) =>
-                  detail.replaceAllLiterally(
-                    s"x$$${i + 1}",
-                    param.displayName()
-                  )
-              }
+            val data = item.data.getOrElse(CompletionItemData.empty)
+            val newDetail = replaceJavaParameters(info, item.getDetail)
             item.setDetail(newDetail)
+            if (item.getTextEdit != null && data.kind == CompletionItemData.OverrideKind) {
+              item.getTextEdit.setNewText(
+                replaceJavaParameters(info, item.getTextEdit.getNewText)
+              )
+              item.setLabel(replaceJavaParameters(info, item.getLabel))
+            }
           } else {
             val defaults = info
               .parameters()
@@ -52,6 +49,30 @@ class CompletionItemResolver(
     } else {
       item
     }
+  }
+
+  // NOTE(olafur): it's hacky to use `String.replaceAllLiterally("x$1", paramName)`, ideally we would use the
+  // signature printer to pretty-print the signature from scratch with parameter names. However, that approach
+  // is tricky because it would require us to JSON serialize/deserialize Scala compiler types. The reason
+  // we don't print Java parameter names in `textDocument/completions` is because that requires parsing the
+  // library dependency sources which is slow and `Thread.interrupt` cancellation triggers the `*-sources.jar`
+  // to close causing other problems.
+  private def replaceJavaParameters(
+      info: SymbolDocumentation,
+      detail: String
+  ): String = {
+    info
+      .parameters()
+      .asScala
+      .iterator
+      .zipWithIndex
+      .foldLeft(detail) {
+        case (accum, (param, i)) =>
+          accum.replaceAllLiterally(
+            s"x$$${i + 1}",
+            param.displayName()
+          )
+      }
   }
 
   def fullDocstring(gsym: Symbol): String = {

--- a/mtags/src/main/scala/scala/meta/internal/pc/Identifier.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Identifier.scala
@@ -4,7 +4,11 @@
 // Original author: Li Haoyi
 package scala.meta.internal.pc
 
+import scala.tools.nsc.Global
+
 object Identifier {
+  def apply(name: Global#Name): String = backtickWrap(name)
+  def apply(name: String): String = backtickWrap(name)
   private val alphaKeywords = Set(
     "abstract", "case", "catch", "class", "def", "do", "else", "extends",
     "false", "finally", "final", "finally", "forSome", "for", "if", "implicit",
@@ -53,6 +57,9 @@ object Identifier {
     !valid
   }
 
+  def backtickWrap(name: Global#Name): String = {
+    backtickWrap(name.decoded.trim)
+  }
   def backtickWrap(s: String): String = {
     if (s.isEmpty) "``"
     else if (s(0) == '`' && s.last == '`') s

--- a/mtags/src/main/scala/scala/meta/internal/pc/MemberOrdering.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MemberOrdering.scala
@@ -12,4 +12,8 @@ object MemberOrdering {
   val IsNotPublic = 1 << 22
   val IsSynthetic = 1 << 21
   val IsDeprecated = 1 << 20
+  val IsEvilMethod = 1 << 19 // example: clone() and finalize()
+
+  // OverrideDefMember
+  val IsNotAbstract = 1 << 30
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -1,8 +1,18 @@
 package scala.meta.internal.pc
 
+import java.util
 import java.util.Optional
 import scala.meta.pc.PresentationCompilerConfig
+import scala.collection.JavaConverters._
 
 case class PresentationCompilerConfigImpl(
-    parameterHintsCommand: Optional[String] = Optional.empty()
-) extends PresentationCompilerConfig
+    debug: Boolean = false,
+    _parameterHintsCommand: Option[String] = None,
+    _symbolPrefixes: collection.Map[String, String] =
+      PresentationCompilerConfig.defaultSymbolPrefixes().asScala
+) extends PresentationCompilerConfig {
+  override def symbolPrefixes(): util.Map[String, String] =
+    _symbolPrefixes.asJava
+  override def parameterHintsCommand: Optional[String] =
+    Optional.ofNullable(_parameterHintsCommand.orNull)
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/Signatures.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Signatures.scala
@@ -5,31 +5,140 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.meta.pc
 import scala.meta.pc.SymbolDocumentation
+import org.eclipse.{lsp4j => l}
 
 trait Signatures { this: MetalsGlobal =>
 
-  class ShortenedNames(history: mutable.Map[Name, Symbol] = mutable.Map.empty) {
-    def tryShortenName(name: Option[Name], sym: Symbol): Boolean =
-      name match {
-        case Some(n) =>
-          history.get(n) match {
-            case Some(other) =>
-              if (other == sym) true
-              else false
-            case _ =>
-              history(n) = sym
+  case class ShortName(
+      name: Name,
+      symbol: Symbol
+  ) {
+    def isRename: Boolean = symbol.name != name
+    def asImport: String = {
+      val ident = Identifier(name)
+      if (isRename) s"${Identifier(symbol.name)} => ${ident}"
+      else ident
+    }
+    def owner: Symbol = symbol.owner
+  }
+  object ShortName {
+    def apply(sym: Symbol): ShortName =
+      ShortName(sym.name, sym)
+  }
+
+  class ShortenedNames(
+      val history: mutable.Map[Name, ShortName] = mutable.Map.empty,
+      val lookupSymbol: Name => NameLookup = _ => LookupNotFound,
+      val config: collection.Map[Symbol, Name] = Map.empty,
+      val renames: collection.Map[Symbol, Name] = Map.empty,
+      val owners: collection.Set[Symbol] = Set.empty
+  ) {
+
+    def fullname(sym: Symbol): String = {
+      if (topSymbolResolves(sym)) sym.fullName
+      else s"_root_.${sym.fullName}"
+    }
+    def topSymbolResolves(sym: Symbol): Boolean = {
+      // Returns the package `a` for the symbol `_root_.a.b.c`
+      def topPackage(s: Symbol): Symbol = {
+        val owner = s.owner
+        if (owner.isEffectiveRoot || owner.isEmptyPackageClass) s
+        else topPackage(owner)
+      }
+      val top = topPackage(sym)
+      nameResolvesToSymbol(top.name.toTermName, top)
+    }
+
+    def nameResolvesToSymbol(name: Name, sym: Symbol): Boolean = {
+      lookupSymbol(name) match {
+        case LookupNotFound => true
+        case l => sym.isKindaTheSameAs(l.symbol)
+      }
+    }
+    def tryShortenName(short: ShortName): Boolean = {
+      val ShortName(name, sym) = short
+      history.get(name) match {
+        case Some(ShortName(_, other)) =>
+          if (other.isKindaTheSameAs(sym)) true
+          else false
+        case _ =>
+          val isOk = lookupSymbol(name) match {
+            case LookupSucceeded(_, symbol) =>
+              symbol.isKindaTheSameAs(sym)
+            case LookupNotFound =>
               true
+            case _ =>
+              false
           }
+          if (isOk) {
+            history(name) = short
+            true
+          } else {
+            false // conflict, do not shorten name.
+          }
+      }
+    }
+    def tryShortenName(name: Option[ShortName]): Boolean =
+      name match {
+        case Some(short) =>
+          tryShortenName(short)
         case _ =>
           false
       }
+
+    // Returns the list of text edits to insert imports for symbols that got shortened.
+    def autoImports(
+        pos: Position,
+        context: Context,
+        lineStart: Int,
+        inferIndent: => Int
+    ): List[l.TextEdit] = {
+      val toImport = mutable.Map.empty[Symbol, List[ShortName]]
+      val isRootSymbol = Set[Symbol](
+        rootMirror.RootClass,
+        rootMirror.RootPackage
+      )
+      for {
+        (name, sym) <- history.iterator
+        owner = sym.owner
+        if !isRootSymbol(owner)
+        if !context.lookupSymbol(name, _ => true).isSuccess
+      } {
+        toImport(owner) = sym :: toImport.getOrElse(owner, Nil)
+      }
+      if (toImport.nonEmpty) {
+        val indent = " " * inferIndent
+        val formatted = toImport.toSeq
+          .sortBy {
+            case (owner, _) => owner.fullName
+          }
+          .map {
+            case (owner, names) =>
+              val isGroup =
+                names.lengthCompare(1) > 0 ||
+                  names.exists(_.isRename)
+              val importNames = names.map(_.asImport).sorted
+              val name =
+                if (isGroup) importNames.mkString("{", ", ", "}")
+                else importNames.mkString
+              s"${indent}import ${fullname(owner)}.${name}"
+          }
+          .mkString("", "\n", "\n")
+        val startPos = pos.withPoint(lineStart).focus
+        new l.TextEdit(startPos.toLSP, formatted) :: Nil
+      } else {
+        Nil
+      }
+    }
   }
 
   class SignaturePrinter(
       gsym: Symbol,
       shortenedNames: ShortenedNames,
       gtpe: Type,
-      includeDocs: Boolean
+      includeDocs: Boolean,
+      includeDefaultParam: Boolean = true,
+      printLongType: Boolean = true
   ) {
     private val info: Option[SymbolDocumentation] =
       if (includeDocs) {
@@ -47,8 +156,11 @@ trait Signatures { this: MetalsGlobal =>
     private val infoParams =
       infoParamsA.lift
     private val returnType =
-      metalsToLongString(gtpe.finalResultType, shortenedNames)
+      printType(shortType(gtpe.finalResultType, shortenedNames))
 
+    def printType(tpe: Type): String =
+      if (printLongType) tpe.toLongString
+      else tpe.toString()
     def methodDocstring: String = {
       if (isDocs) info.fold("")(_.docstring())
       else ""
@@ -56,6 +168,7 @@ trait Signatures { this: MetalsGlobal =>
     def isTypeParameters: Boolean = gtpe.typeParams.nonEmpty
     def implicitParams: Option[List[Symbol]] =
       gtpe.paramss.lastOption.filter(_.headOption.exists(_.isImplicit))
+    val implicitEvidenceTermParams = mutable.Set.empty[Symbol]
     val implicitEvidencesByTypeParam
         : collection.Map[Symbol, ListBuffer[String]] = {
       val result = mutable.Map.empty[Symbol, ListBuffer[String]]
@@ -68,6 +181,7 @@ trait Signatures { this: MetalsGlobal =>
           TypeRef(NoPrefix, tparam, Nil) :: Nil
         ) <- List(param.info)
       } {
+        implicitEvidenceTermParams += param
         val buf = result.getOrElseUpdate(tparam, ListBuffer.empty)
         buf += sym.name.toString
       }
@@ -79,7 +193,7 @@ trait Signatures { this: MetalsGlobal =>
         case Nil => gtpe.paramss
         case tparams => tparams :: gtpe.paramss
       }
-    def defaultMethodSignature: String = {
+    def defaultMethodSignature(name: String = ""): String = {
       var i = 0
       val paramss = gtpe.typeParams match {
         case Nil => gtpe.paramss
@@ -87,7 +201,7 @@ trait Signatures { this: MetalsGlobal =>
       }
       val params = paramss.iterator.flatMap { params =>
         val labels = params.flatMap { param =>
-          if (param.name.startsWith(termNames.EVIDENCE_PARAM_PREFIX)) {
+          if (implicitEvidenceTermParams.contains(param)) {
             Nil
           } else {
             val result = paramLabel(param, i)
@@ -98,7 +212,7 @@ trait Signatures { this: MetalsGlobal =>
         if (labels.isEmpty && params.nonEmpty) Nil
         else labels.iterator :: Nil
       }
-      methodSignature(params, name = "")
+      methodSignature(params, name)
     }
 
     def methodSignature(
@@ -134,7 +248,7 @@ trait Signatures { this: MetalsGlobal =>
       else ""
     }
     def paramLabel(param: Symbol, index: Int): String = {
-      val paramTypeString = metalsToLongString(param.info, shortenedNames)
+      val paramTypeString = printType(shortType(param.info, shortenedNames))
       val name = infoParams(index) match {
         case Some(value) if param.name.startsWith("x$") =>
           value.displayName()
@@ -150,7 +264,7 @@ trait Signatures { this: MetalsGlobal =>
         s"$name$paramTypeString$contextBounds"
       } else {
         val default =
-          if (param.isParamWithDefault) {
+          if (includeDefaultParam && param.isParamWithDefault) {
             val defaultValue = infoParams(index).map(_.defaultValue()) match {
               case Some(value) if !value.isEmpty => value
               case _ => "{}"

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -1,9 +1,5 @@
 package example
 
-object User {
-  val member = ""
-  val myName = "name"
-  def foo = s"""
-  ${User.member}
-  """
+// class Foo
+class Main {
 }

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -43,6 +43,22 @@ abstract class BaseCompletionSuite extends BasePCSuite {
     }
   }
 
+  def checkEditLine(
+      name: String,
+      template: String,
+      original: String,
+      expected: String,
+      filterText: String = "",
+      assertSingleItem: Boolean = true
+  )(implicit filename: sourcecode.File, line: sourcecode.Line): Unit = {
+    checkEdit(
+      name,
+      template.replaceAllLiterally("___", original),
+      template.replaceAllLiterally("___", expected),
+      filterText,
+      assertSingleItem
+    )
+  }
   def checkEdit(
       name: String,
       original: String,
@@ -92,7 +108,8 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       stableOrder: Boolean = true,
       postAssert: () => Unit = () => (),
       topLines: Option[Int] = None,
-      filterText: String = ""
+      filterText: String = "",
+      includeDetail: Boolean = true
   )(implicit filename: sourcecode.File, line: sourcecode.Line): Unit = {
     test(name) {
       val out = new StringBuilder()
@@ -116,7 +133,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
         }
         out
           .append(label)
-          .append(item.getDetail)
+          .append(if (includeDetail) item.getDetail else "")
           .append(commitCharacter)
           .append("\n")
       }

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
@@ -1,0 +1,49 @@
+package tests.pc
+
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
+import scala.meta.pc.PresentationCompilerConfig
+import tests.BaseCompletionSuite
+
+object CompletionOverrideConfigSuite extends BaseCompletionSuite {
+
+  override def config: PresentationCompilerConfig =
+    PresentationCompilerConfigImpl().copy(
+      _symbolPrefixes = Map(
+        "a/Weekday." -> "w",
+        "java/util/function/" -> "f"
+      )
+    )
+
+  checkEditLine(
+    "object",
+    """|package a
+       |object Weekday {
+       |  case class Monday()
+       |}
+       |class Super {
+       |  def weekday: Weekday.Monday
+       |}
+       |class Main extends Super {
+       |___
+       |}
+       |""".stripMargin,
+    "  def weekday@@",
+    """  import a.{Weekday => w}
+      |  def weekday: w.Monday = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "package",
+    """|package b
+       |class Package {
+       |  def function: java.util.function.Function[Int, String]
+       |}
+       |class Main extends Package {
+       |___
+       |}
+       |""".stripMargin,
+    "  def function@@",
+    """  import java.util.{function => f}
+      |  def function: f.Function[Int,String] = ${0:???}""".stripMargin
+  )
+}

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -1,0 +1,695 @@
+package tests.pc
+
+import tests.BaseCompletionSuite
+
+object CompletionOverrideSuite extends BaseCompletionSuite {
+
+  override def beforeAll(): Unit = {
+    indexJDK()
+  }
+
+  checkEdit(
+    "basic",
+    """
+      |object Main extends AutoCloseable {
+      |  def close@@
+      |}
+    """.stripMargin,
+    """
+      |object Main extends AutoCloseable {
+      |  def close(): Unit = ${0:???}
+      |}
+      |""".stripMargin
+  )
+
+  checkEdit(
+    "overload",
+    """
+      |trait Interface {
+      |  def foo(a: Int): Unit
+      |  def foo(a: String): Unit
+      |}
+      |object Main extends Interface {
+      |  override def foo(a: Int): Unit = ()
+      |  override def foo@@
+      |}
+    """.stripMargin,
+    """
+      |trait Interface {
+      |  def foo(a: Int): Unit
+      |  def foo(a: String): Unit
+      |}
+      |object Main extends Interface {
+      |  override def foo(a: Int): Unit = ()
+      |  override def foo(a: String): Unit = ${0:???}
+      |}
+      |""".stripMargin
+  )
+
+  checkEdit(
+    "seen-from",
+    """
+      |object Main {
+      |  new Iterable[Int] {
+      |    def iterato@@
+      |  }
+      |}
+    """.stripMargin,
+    """
+      |object Main {
+      |  new Iterable[Int] {
+      |    def iterator: Iterator[Int] = ${0:???}
+      |  }
+      |}
+      |""".stripMargin
+  )
+
+  checkEdit(
+    "generic",
+    """
+      |object Main {
+      |  new scala.Traversable[Int] {
+      |    def foreach@@
+      |  }
+      |}
+    """.stripMargin,
+    """
+      |object Main {
+      |  new scala.Traversable[Int] {
+      |    def foreach[U](f: Int => U): Unit = ${0:???}
+      |  }
+      |}
+      |""".stripMargin
+  )
+
+  checkEdit(
+    "context-bound",
+    """
+      |trait Context {
+      |   def add[T:Ordering]: T
+      |}
+      |object Main {
+      |  new Context {
+      |    override def ad@@
+      |  }
+      |}
+    """.stripMargin,
+    """
+      |trait Context {
+      |   def add[T:Ordering]: T
+      |}
+      |object Main {
+      |  new Context {
+      |    override def add[T: Ordering]: T = ${0:???}
+      |  }
+      |}
+      |""".stripMargin
+  )
+
+  checkEdit(
+    "import",
+    """
+      |object Main {
+      |  new java.nio.file.SimpleFileVisitor[java.nio.file.Path] {
+      |    def visitFil@@
+      |  }
+      |}
+    """.stripMargin,
+    """
+      |object Main {
+      |  new java.nio.file.SimpleFileVisitor[java.nio.file.Path] {
+      |    import java.nio.file.{FileVisitResult, Path}
+      |    import java.nio.file.attribute.BasicFileAttributes
+      |    override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = ${0:???}
+      |  }
+      |}
+      |""".stripMargin,
+    assertSingleItem = false
+  )
+
+  check(
+    "empty",
+    """
+      |trait SuperAbstract {
+      |  def aaa: Int = 2
+      |}
+      |trait Abstract extends SuperAbstract {
+      |  def bbb: Int = 2
+      |  type TypeAlias = String // should be ignored
+      |}
+      |object Main {
+      |  new Abstract {
+      |    def @@
+      |  }
+      |}
+    """.stripMargin,
+    // assert that `isInstanceOf` and friends are not included
+    """|override def aaa: Int
+       |override def bbb: Int
+       |override def equals(obj: Any): Boolean
+       |override def hashCode(): Int
+       |override def toString(): String
+       |override def clone(): Object
+       |override def finalize(): Unit
+       |""".stripMargin,
+    includeDetail = false
+  )
+
+  def implement(completion: String): String =
+    s"""
+       |trait Abstract {
+       |  def implementMe: Int
+       |}
+       |object Main {
+       |  new Abstract {
+       |    $completion
+       |  }
+       |}
+    """.stripMargin
+
+  checkEdit(
+    "implement",
+    // assert that `override` is not inserted.
+    implement("def implement@@"),
+    implement("def implementMe: Int = ${0:???}")
+  )
+  checkEdit(
+    "implement-override",
+    // assert that `override` is inserted.
+    implement("override def implement@@"),
+    implement("override def implementMe: Int = ${0:???}")
+  )
+
+  checkEdit(
+    "error",
+    """
+      |object Main {
+      |  new scala.Iterable[Unknown] {
+      |    def iterato@@
+      |  }
+      |}
+    """.stripMargin,
+    // Replace error types with type parameter name `A`. IntelliJ converts the unknown type
+    // into `Any`, which is less helpful IMO.
+    """
+      |object Main {
+      |  new scala.Iterable[Unknown] {
+      |    def iterator: Iterator[A] = ${0:???}
+      |  }
+      |}
+    """.stripMargin
+  )
+
+  check(
+    "sort",
+    """
+      |trait Super {
+      |  def a: Int = 2
+      |  def b: Int
+      |}
+      |object Main {
+      |  new Super {
+      |    def @@
+      |  }
+      |}
+    """.stripMargin,
+    // assert that `isInstanceOf` and friends are not included
+    """|def b: Int
+       |override def a: Int
+       |""".stripMargin,
+    topLines = Some(2),
+    includeDetail = false
+  )
+
+  checkEditLine(
+    "conflict",
+    s"""package a.b
+       |abstract class Conflict {
+       |  def self: Conflict
+       |}
+       |object Main {
+       |  class Conflict
+       |  new a.b.Conflict {
+       |    ___
+       |  }
+       |}
+       |""".stripMargin,
+    "def self@@",
+    "def self: a.b.Conflict = ${0:???}"
+  )
+
+  check(
+    "conflict2",
+    s"""package a.c
+       |abstract class Conflict {
+       |  type Inner
+       |  def self: Conflict
+       |  def selfArg: Option[Conflict]
+       |  def selfPath: Conflict#Inner
+       |}
+       |object Main {
+       |  class Conflict
+       |  val a = 2
+       |  new _root_.a.c.Conflict {
+       |    def self@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|def self: _root_.a.c.Conflict
+       |def selfArg: Option[_root_.a.c.Conflict]
+       |def selfPath: Inner
+       |""".stripMargin,
+    includeDetail = false
+  )
+
+  checkEditLine(
+    "mutable",
+    s"""|abstract class Mutable {
+        |  def foo: scala.collection.mutable.Set[Int]
+        |}
+        |object Main {
+        |  new Mutable {
+        |___
+        |  }
+        |}
+        |""".stripMargin,
+    "    def foo@@",
+    """    import scala.collection.mutable
+      |    def foo: mutable.Set[Int] = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "mutable-conflict",
+    s"""|abstract class Mutable {
+        |  def foo: scala.collection.mutable.Set[Int]
+        |}
+        |object Main {
+        |  new Mutable {
+        |    val mutable = 42
+        |___
+        |  }
+        |}
+        |""".stripMargin,
+    "    def foo@@",
+    """    def foo: scala.collection.mutable.Set[Int] = ${0:???}"""
+  )
+
+  checkEditLine(
+    "jutil",
+    s"""|abstract class JUtil {
+        |  def foo: java.util.List[Int]
+        |}
+        |class Main extends JUtil {
+        |___
+        |}
+        |""".stripMargin,
+    "  def foo@@",
+    """  import java.{util => ju}
+      |  def foo: ju.List[Int] = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "jutil-conflict",
+    s"""|package jutil
+        |abstract class JUtil {
+        |  def foo: java.util.List[Int]
+        |}
+        |class Main extends JUtil {
+        |  val java = 42
+        |___
+        |}
+        |""".stripMargin,
+    "  def foo@@",
+    // Ensure we insert `_root_` prefix for import because `val java = 42`
+    """  import _root_.java.{util => ju}
+      |  def foo: ju.List[Int] = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "jutil-conflict2",
+    s"""|package jutil2
+        |abstract class JUtil {
+        |  def foo: java.util.List[Int]
+        |}
+        |class Main extends JUtil {
+        |  val ju = 42
+        |___
+        |}
+        |""".stripMargin,
+    "  def foo@@",
+    // Can't use `import java.{util => ju}` because `val ju = 42` is in scope.
+    """  def foo: java.util.List[Int] = ${0:???}"""
+  )
+
+  checkEditLine(
+    "jlang",
+    s"""|abstract class Mutable {
+        |  def foo: java.lang.StringBuilder
+        |}
+        |class Main extends Mutable {
+        |  ___
+        |}
+        |""".stripMargin,
+    "  def foo@@",
+    """  def foo: java.lang.StringBuilder = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "alias",
+    s"""|
+        |abstract class Abstract {
+        |  def foo: scala.collection.immutable.List[Int]
+        |}
+        |class Main extends Abstract {
+        |  ___
+        |}
+        |
+        |""".stripMargin,
+    "  def foo@@",
+    """  def foo: List[Int] = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "alias2",
+    s"""|package alias
+        |abstract class Alias {
+        |  type Foobar = List[Int]
+        |  def foo: Foobar
+        |}
+        |class Main extends Alias {
+        |  ___
+        |}
+        |
+        |""".stripMargin,
+    "  def foo@@",
+    // NOTE(olafur) I am not sure this is desirable behavior, we might want to
+    // consider not dealiasing here.
+    """  def foo: List[Int] = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "rename",
+    s"""|import java.lang.{Boolean => JBoolean}
+        |abstract class Abstract {
+        |  def foo: JBoolean
+        |}
+        |class Main extends Abstract {
+        |___
+        |}
+        |
+        |""".stripMargin,
+    "  def foo@@",
+    """  def foo: JBoolean = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "path",
+    s"""|package path
+        |abstract class Path {
+        |  type Out
+        |  def foo: Out
+        |}
+        |class Main extends Path {
+        |___
+        |}
+        |
+        |""".stripMargin,
+    "  def foo@@",
+    """  def foo: Out = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "path-alias",
+    s"""|package paththis
+        |abstract class Path {
+        |  type Out
+        |  def foo: Out
+        |}
+        |class Main extends Path {
+        |  type Out = String
+        |___
+        |}
+        |
+        |""".stripMargin,
+    "  def foo@@",
+    """  def foo: String = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "path-this",
+    """|package paththis
+       |abstract class Path {
+       |  type Out
+       |}
+       |class Main extends Path {
+       |  trait Conflict {
+       |    def conflict: Out
+       |  }
+       |  object Conflict extends Conflict {
+       |    type Out = Int
+       |___
+       |  }
+       |}
+       |""".stripMargin,
+    "    def conflict@@",
+    """    def conflict: Main.this.Out = ${0:???}""".stripMargin
+  )
+
+  check(
+    "final",
+    """|package f
+       |abstract class Final {
+       |  def hello1: Int = 42
+       |  final def hello2: Int = 42
+       |}
+       |class Main extends Final {
+       |  def hello@@
+       |}
+       |""".stripMargin,
+    """override def hello1: Int
+      |""".stripMargin,
+    includeDetail = false
+  )
+
+  check(
+    "default",
+    """|package g
+       |abstract class Final {
+       |  def hello1: Int
+       |  final def hello2(hello2: Int = 42)
+       |}
+       |class Main extends Final {
+       |  def hello@@
+       |}
+       |""".stripMargin,
+    """def hello1: Int
+      |""".stripMargin,
+    includeDetail = false
+  )
+
+  checkEditLine(
+    "default2",
+    """|package h
+       |abstract class Final {
+       |  def hello(arg: Int = 42): Unit
+       |}
+       |class Main extends Final {
+       |  ___
+       |}
+       |""".stripMargin,
+    "def hello@@",
+    """def hello(arg: Int): Unit = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "existential",
+    """|package i
+       |abstract class Exist {
+       |  def exist: Set[_]
+       |}
+       |class Main extends Exist {
+       |  ___
+       |}
+       |""".stripMargin,
+    "def exist@@",
+    """def exist: Set[_] = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "cake",
+    """|package i
+       |trait Trees { this: Global =>
+       |  case class Tree()
+       |  def Apply(tree: Tree): Tree = ???
+       |}
+       |class Global extends Trees  {
+       |  ___
+       |}
+       |""".stripMargin,
+    "def Apply@@",
+    """override def Apply(tree: Tree): Tree = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "cake2",
+    """|package i2
+       |trait Trees { this: Global =>
+       |  case class Tree()
+       |  def Apply(tree: Tree): Tree = ???
+       |}
+       |class Global extends Trees  {
+       |}
+       |class MyGlobal extends Global  {
+       |  ___
+       |}
+       |""".stripMargin,
+    "def Apply@@",
+    """override def Apply(tree: Tree): Tree = ${0:???}""".stripMargin
+  )
+
+  checkEditLine(
+    "cake-generic",
+    """|package i
+       |trait Trees[T] { this: Global =>
+       |  case class Tree()
+       |  def Apply(tree: T): Tree = ???
+       |}
+       |class Global extends Trees[Int] {
+       |  ___
+       |}
+       |""".stripMargin,
+    "def Apply@@",
+    """override def Apply(tree: Int): Tree = ${0:???}""".stripMargin
+  )
+
+  check(
+    "val-negative",
+    """|package j
+       |abstract class Val {
+       |  val hello1: Int = 42
+       |  var hello2: Int = 42
+       |}
+       |class Main extends Val {
+       |  def hello@@
+       |}
+       |""".stripMargin,
+    ""
+  )
+
+  checkEditLine(
+    "val",
+    """|package k
+       |abstract class Val {
+       |  val hello1: Int = 42
+       |}
+       |class Main extends Val {
+       |  ___
+       |}
+       |""".stripMargin,
+    "val hello@@",
+    "override val hello1: Int = ${0:???}"
+  )
+
+  check(
+    "var",
+    """|package l
+       |abstract class Val {
+       |  var hello1: Int = 42
+       |}
+       |class Main extends Val {
+       |   override var hello@@
+       |}
+       |""".stripMargin,
+    // NOTE(olafur) assert completion items are empty because it's not possible to
+    // override vars.
+    ""
+  )
+
+  check(
+    "val-var",
+    """|package m
+       |abstract class Val {
+       |  var hello1: Int = 42
+       |}
+       |class Main extends Val {
+       |   override val hello@@
+       |}
+       |""".stripMargin,
+    // NOTE(olafur) assert completion items are empty because it's not possible to
+    // override vars.
+    ""
+  )
+
+  check(
+    "private",
+    """|package n
+       |abstract class Val {
+       |  private def hello: Int = 2
+       |}
+       |class Main extends Val {
+       |   override val hello@@
+       |}
+       |""".stripMargin,
+    ""
+  )
+
+  check(
+    "protected",
+    """|package o
+       |abstract class Val {
+       |  protected def hello: Int = 2
+       |}
+       |class Main extends Val {
+       |   override def hello@@
+       |}
+       |""".stripMargin,
+    "override def hello: Int",
+    includeDetail = false
+  )
+
+  check(
+    "filter",
+    """|package p
+       |abstract class Val {
+       |  def hello: Int = 2
+       |}
+       |class Main extends Val {
+       |   override def hel@@
+       |}
+       |""".stripMargin,
+    "override def hello: Int",
+    includeDetail = false,
+    filterText = "override def hello"
+  )
+
+  checkEditLine(
+    "lazy",
+    """|package q
+       |abstract class Val {
+       |  lazy val hello: Int = 2
+       |}
+       |class Main extends Val {
+       |   ___
+       |}
+       |""".stripMargin,
+    "override val hel@@",
+    "override lazy val hello: Int = ${0:???}"
+  )
+
+  checkEditLine(
+    "early-init",
+    """|package r
+       |abstract class Global {
+       |  lazy val analyzer = new {
+       |    val global: Global.this.type = Global.this
+       |  }
+       |}
+       |class Main extends Global {
+       |   ___
+       |}
+       |""".stripMargin,
+    "val analyz@@",
+    "override lazy val analyzer: Object{val global: r.Main} = ${0:???}"
+  )
+
+}

--- a/tests/cross/src/test/scala/tests/pc/CompletionParameterHintSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionParameterHintSuite.scala
@@ -1,6 +1,5 @@
 package tests.pc
 
-import java.util.Optional
 import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.pc.PresentationCompilerConfig
 import tests.BaseCompletionSuite
@@ -8,7 +7,9 @@ import tests.BaseCompletionSuite
 object CompletionParameterHintSuite extends BaseCompletionSuite {
 
   override def config: PresentationCompilerConfig =
-    PresentationCompilerConfigImpl(Optional.of("hello"))
+    PresentationCompilerConfigImpl(
+      _parameterHintsCommand = Some("hello")
+    )
   checkItems(
     "command",
     """

--- a/tests/cross/src/test/scala/tests/pc/PrettyPrintSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PrettyPrintSuite.scala
@@ -1,0 +1,155 @@
+package tests.pc
+
+import tests.BaseCompletionSuite
+
+object PrettyPrintSuite extends BaseCompletionSuite {
+
+  def checkSignature(
+      name: String,
+      original: String,
+      expected: String
+  ): Unit = {
+    val signature = original.replaceAllLiterally("@@", "")
+    val completion = original.replaceFirst("@@.*", "@@")
+    checkEditLine(
+      name,
+      s"""package ${scala.meta.Term.Name(name)}
+         |abstract class Abstract {
+         |  ${signature}
+         |}
+         |class Main extends Abstract {
+         |  ___
+         |}
+      """.stripMargin,
+      completion,
+      expected + " = ${0:???}"
+    )
+  }
+
+  checkSignature(
+    "this-type",
+    "def foo@@(): this.type",
+    // NOTE(olafur): this expected output is undesirable, we widen the type too aggressively.
+    // It would be nice to fix this if possible.
+    "def foo(): Main"
+  )
+
+  checkSignature(
+    "single-type",
+    "def foo@@(x: Int): x.type",
+    // NOTE(olafur): this expected output is undesirable, I couldn't get this working because
+    // `sym.info` on the supermethod has an error result type.
+    "def foo(x: Int): Any"
+  )
+
+  checkSignature(
+    "structural",
+    "def foo@@(duck: {def quack(): Unit}): Unit",
+    // NOTE(olafur): the ideal output would be without the redunant `AnyRef` but we need to implement
+    // our own pretty-printer to fix that.
+    "def foo(duck: AnyRef{def quack(): Unit}): Unit"
+  )
+
+  checkSignature(
+    "int-literal",
+    "def foo@@ = 42",
+    "override def foo: Int"
+  )
+
+  checkSignature(
+    "string-literal",
+    "def foo@@ = \"foo\"",
+    "override def foo: String"
+  )
+
+  checkSignature(
+    "int-val-literal",
+    "val foo@@ = 42",
+    "override val foo: Int"
+  )
+
+  checkSignature(
+    "int-val-literal",
+    "def foo@@: Int with String",
+    "def foo: Int with String"
+  )
+
+  checkSignature(
+    "annotated",
+    "def foo@@: Int @deprecated(\"\", \"\") ",
+    "def foo: Int"
+  )
+
+  checkSignature(
+    "by-name",
+    "def foo@@(x: => Int): Unit",
+    "def foo(x: => Int): Unit"
+  )
+
+  checkSignature(
+    "vararg",
+    "def foo@@(x: Int*): Unit",
+    "def foo(x: Int*): Unit"
+  )
+
+  checkSignature(
+    "forSome",
+    "def foo@@: Option[T] forSome { type T }",
+    "def foo: Option[_]"
+  )
+
+  checkSignature(
+    "forSome2",
+    "def foo@@: Option[T] forSome { type T <: Int }",
+    "def foo: Option[_ <: Int]"
+  )
+
+  checkSignature(
+    "forSome3",
+    "def foo@@: Map[T, T] forSome { type T <: Int }",
+    "def foo: Map[T,T] forSome { type T <: Int }"
+  )
+
+  checkSignature(
+    "function",
+    "def foo@@(fn: Int => String): Unit",
+    "def foo(fn: Int => String): Unit"
+  )
+
+  checkSignature(
+    "tuple",
+    "def foo@@(tuple: (Int, String)): Unit",
+    "def foo(tuple: (Int, String)): Unit"
+  )
+
+  checkSignature(
+    "upper-bound",
+    "def foo@@[T <: CharSequence](arg: T): T",
+    "def foo[T <: CharSequence](arg: T): T"
+  )
+
+  checkSignature(
+    "lower-bound",
+    "def foo@@[T >: CharSequence](arg: T): T",
+    "def foo[T >: CharSequence](arg: T): T"
+  )
+
+  checkSignature(
+    "upper-lower-bound",
+    "def foo@@[T >: String <: CharSequence](arg: T): T",
+    "def foo[T >: String <: CharSequence](arg: T): T"
+  )
+
+  checkSignature(
+    "context-bound",
+    "def foo@@[T:Ordering](arg: T): T",
+    "def foo[T: Ordering](arg: T): T"
+  )
+
+  checkSignature(
+    "view-bound",
+    "def foo@@[T <% String](arg: T): T",
+    // View bounds are not resugared into `<% String` because they're considered a bad practice.
+    "def foo[T](arg: T)(implicit evidence$1: T => String): T"
+  )
+}

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -133,4 +133,18 @@ object UserConfigurationSuite extends BaseSuite {
     """.stripMargin
   )
 
+  checkError(
+    "symbol-prefixes",
+    """
+      |{
+      | "symbol-prefixes": {
+      |   "a.b": "c"
+      | }
+      |}
+    """.stripMargin,
+    "invalid SemanticDB symbol 'a.b': missing descriptor, " +
+      "did you mean `a.b/` or `a.b.`? " +
+      "(to learn the syntax see https://scalameta.org/docs/semanticdb/specification.html#symbol-1)"
+  )
+
 }


### PR DESCRIPTION
This commit implements a new completion feature to override methods from
a supertype.

```scala
new Iterable[Int] {
  // before completion
  def iterat<COMPLETE>
  // after completion
  def iterator: Iterator[Int] = ???
}
```

Fixes #540

![2019-03-18 12 48 11](https://user-images.githubusercontent.com/1408093/54528084-25c5c080-497c-11e9-95d3-7634c04bd1dd.gif)
