### PR TITLE
Restart the presentation compile more aggressively.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -27,7 +27,7 @@ final class ForwardingMetalsBuildClient(
     config: MetalsServerConfig,
     statusBar: StatusBar,
     time: Time,
-    didCompileSuccessfully: BuildTargetIdentifier => Unit
+    didCompileSuccessfully: CompileReport => Unit
 ) extends MetalsBuildClient
     with Cancelable {
 
@@ -119,7 +119,7 @@ final class ForwardingMetalsBuildClient(
         } {
           diagnostics.onFinishCompileBuildTarget(report.getTarget)
           if (!compilation.isNoOp && report.getErrors == 0) {
-            didCompileSuccessfully(report.getTarget)
+            didCompileSuccessfully(report)
           }
           val target = report.getTarget
           compilation.promise.trySuccess(report)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -200,7 +200,7 @@ class MetalsLanguageServer(
       config,
       statusBar,
       time,
-      id => compilers.didCompileSuccessfully(id)
+      report => compilers.didCompile(report)
     )
     trees = new Trees(buffers, diagnostics)
     documentSymbolProvider = new DocumentSymbolProvider(trees)
@@ -580,7 +580,9 @@ class MetalsLanguageServer(
   }
 
   @JsonNotification("workspace/didChangeConfiguration")
-  def didChangeConfiguration(params: DidChangeConfigurationParams): Unit =
+  def didChangeConfiguration(
+      params: DidChangeConfigurationParams
+  ): CompletableFuture[Unit] =
     Future {
       val json = params.getSettings.asInstanceOf[JsonElement].getAsJsonObject
       UserConfiguration.fromJson(json) match {
@@ -595,7 +597,7 @@ class MetalsLanguageServer(
             compilers.restartAll()
           }
       }
-    }
+    }.asJava
 
   @JsonNotification("workspace/didChangeWatchedFiles")
   def didChangeWatchedFiles(

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -58,8 +58,15 @@ public abstract class PresentationCompiler {
      *
      * It is necessary to call this method in order to for example stop the presentation compiler thread.
      * If this method is not called, then the JVM may not shut exit cleanly.
+     *
+     * This presentation compiler instance should no longer be used after calling this method.
      */
     public abstract void shutdown();
+
+    /**
+     * Clean the symbol table and other mutable state in the compiler.
+     */
+    public abstract void restart();
 
     /**
      * Provide a SymbolSearch to extract docstrings, java parameter names and Scala default parameter values.

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -53,6 +53,12 @@ case class ScalaPresentationCompiler(
     access.shutdown()
   }
 
+  override def restart(): Unit = {
+    // NOTE(olafur) turns out that `shutdown()` has the same effect as `restart()`
+    // implementation-wise.
+    shutdown()
+  }
+
   override def newInstance(
       buildTargetIdentifier: String,
       classpath: util.List[Path],

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -326,11 +326,11 @@ final class TestingServer(
   }
 
   def didChangeConfiguration(config: String): Future[Unit] = {
-    Future {
-      val wrapped = UserConfiguration.toWrappedJson(config)
-      val json = new JsonParser().parse(wrapped)
-      server.didChangeConfiguration(new DidChangeConfigurationParams(json))
-    }
+    val wrapped = UserConfiguration.toWrappedJson(config)
+    val json = new JsonParser().parse(wrapped)
+    server
+      .didChangeConfiguration(new DidChangeConfigurationParams(json))
+      .asScala
   }
 
   def completionList(


### PR DESCRIPTION
Previously, we only restarted the presentation compiler for build
targets that successfully compiled. After this commit, we also restart
the pc in the following situations:

- if a transitive dependency build target compiled successfully
- if the current build target failed to compile

This commit also fixes a regression we introduced in a recent PR that
made the tests around configuration flaky.