### PR TITLE
Update Sublime Text doc regarding Goto symbol in workspace

### DIFF
--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -67,7 +67,7 @@ functionality.
   <td align=center>✅</td>
   <td align=center>✅</td>
   <td align=center>Flat</td>
-  <td align=center></td>
+  <td align=center>✅</td>
   <td align=center>✅</td>
   <td align=center></td>
 </tr>

--- a/docs/editors/sublime.md
+++ b/docs/editors/sublime.md
@@ -92,6 +92,12 @@ in insert-mode.
 
 ![Find references](https://i.imgur.com/BJDkczD.gif)
 
+## Goto symbol in workspace
+
+You can search for symbols in dependency source using the command palette   
+
+![workspace symbols](https://i.imgur.com/8X0XNi2.gif)
+
 ## Manually trigger build import
 
 You can configure a custom command "Metals: Import Build" to manually trigger
@@ -122,7 +128,7 @@ in this location.
 ~/.config/sublime-text-3/Packages/Metals.sublime-commands
 ```
 
-Once configured, the command can be called from the command pallette.
+Once configured, the command can be called from the command palette.
 
 ![Import build command](https://i.imgur.com/LViPc95.png)
 


### PR DESCRIPTION
Support for `workspace/symbol` is released for the LSP plugin ([0.8.2](https://github.com/tomv564/LSP/releases/tag/0.8.2))

@olafurpg feel free to change the gif if you like