### PR TITLE
Insert local import when completing workspace symbol.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1025,6 +1025,7 @@ class MetalsLanguageServer(
       build: BuildServerConnection
   ): Future[BuildChange] = {
     cancelables.add(build)
+    compilers.cancel()
     buildServer = Some(build)
     val importedBuild = timed("imported build") {
       for {

--- a/mtags/src/main/scala/scala/meta/internal/metals/ClasspathSearch.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/ClasspathSearch.scala
@@ -42,7 +42,9 @@ class ClasspathSearch(
       classfiles.add(classfile)
     }
     var nonExactMatches = 0
-    var searchResult = SymbolSearch.Result.COMPLETE
+    var searchResult =
+      if (query.isExact) SymbolSearch.Result.INCOMPLETE
+      else SymbolSearch.Result.COMPLETE
     for {
       hit <- classfiles.pollingIterator
       if {

--- a/mtags/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolQuery.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolQuery.scala
@@ -19,6 +19,7 @@ case class WorkspaceSymbolQuery(
     alternatives: Array[AlternativeQuery],
     isTrailingDot: Boolean
 ) {
+  def isExact: Boolean = query.length < Fuzzy.ExactSearchLimit
   def matches(bloom: BloomFilter[CharSequence]): Boolean =
     alternatives.exists(_.matches(bloom))
   def matches(symbol: CharSequence): Boolean =

--- a/test-workspace/build.sbt
+++ b/test-workspace/build.sbt
@@ -5,6 +5,4 @@ inThisBuild(
 )
 
 libraryDependencies ++= List(
-  "com.lihaoyi" %% "pprint" % "0.5.2",
-  "com.chuusai" %% "shapeless" % "2.3.3"
-)
+  )

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -1,12 +1,3 @@
 package example
 
-trait Samda {
-  def foobar(a: Int, b: Double): String
-}
-
-object Main {
-  def foobar(fn: Samda): Unit = ()
-  foobar {
-    case (a, b) => ""
-  }
-}
+object Main {}

--- a/test-workspace/src/test/scala/example/UserTest.scala
+++ b/test-workspace/src/test/scala/example/UserTest.scala
@@ -1,8 +1,5 @@
 package example
 
-class UserTest {
-  // val basic: Int = User.foo
-  // User("John")
-  val basic = 1
-  assert(basic == 42)
-}
+import java.nio.file.Path
+
+class UserTest {}

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -398,7 +398,7 @@ object CompletionDocSuite extends BaseCompletionSuite {
        |- `rethrow`: Predicate on throwables determining when to rethrow a caught Throwable
        |- `pf`: Partial function used when applying catch logic to determine result value
        |- `fin`: Finally logic which if defined will be invoked after catch logic
-       |scala.util.control.Exception.Catch scala.util.control.Exception
+       |Catch - scala.util.control.Exception
        |""".stripMargin,
     includeDocs = true
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -86,7 +86,7 @@ object CompletionSnippetSuite extends BaseCompletionSuite {
         |  def foo(param: ArrayDeque@@)
         |}
         |""".stripMargin,
-    """|java.util.ArrayDeque[$0]
+    """|ju.ArrayDeque[$0]
        |""".stripMargin
   )
 
@@ -96,7 +96,7 @@ object CompletionSnippetSuite extends BaseCompletionSuite {
         |  new SimpleFileVisitor@@
         |}
         |""".stripMargin,
-    """|java.nio.file.SimpleFileVisitor[$0]
+    """|SimpleFileVisitor[$0]
        |""".stripMargin
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -14,16 +14,16 @@ object CompletionSuite extends BaseCompletionSuite {
       |  Lis@@
       |}""".stripMargin,
     """|List scala.collection.immutable
-       |java.awt.List java.awt
-       |java.util.List java.util
-       |scala.collection.immutable.ListMap scala.collection.immutable
-       |scala.collection.mutable.ListMap scala.collection.mutable
-       |scala.collection.immutable.ListSet scala.collection.immutable
-       |java.awt.peer.ListPeer java.awt.peer
-       |org.w3c.dom.NameList org.w3c.dom
-       |org.w3c.dom.NodeList org.w3c.dom
-       |java.util.ArrayList java.util
-       |org.w3c.dom.stylesheets.MediaList org.w3c.dom.stylesheets
+       |List - java.awt
+       |List - java.util
+       |ListMap - scala.collection.immutable
+       |ListMap - scala.collection.mutable
+       |ListSet - scala.collection.immutable
+       |ListPeer - java.awt.peer
+       |NameList - org.w3c.dom
+       |NodeList - org.w3c.dom
+       |ArrayList - java.util
+       |MediaList - org.w3c.dom.stylesheets
        |""".stripMargin
   )
 
@@ -211,14 +211,14 @@ object CompletionSuite extends BaseCompletionSuite {
       |  new PBuil@@
       |}""".stripMargin,
     """|ProcessBuilder java.lang
-       |scala.sys.process.ProcessBuilder scala.sys.process
-       |java.security.cert.CertPathBuilder java.security.cert
-       |java.security.cert.CertPathBuilderSpi java.security.cert
-       |scala.sys.process.ProcessBuilderImpl scala.sys.process
-       |java.security.cert.CertPathBuilderResult java.security.cert
-       |java.security.cert.PKIXBuilderParameters java.security.cert
-       |java.security.cert.CertPathBuilderException java.security.cert
-       |java.security.cert.PKIXCertPathBuilderResult java.security.cert
+       |ProcessBuilder - scala.sys.process
+       |CertPathBuilder - java.security.cert
+       |CertPathBuilderSpi - java.security.cert
+       |ProcessBuilderImpl - scala.sys.process
+       |CertPathBuilderResult - java.security.cert
+       |PKIXBuilderParameters - java.security.cert
+       |CertPathBuilderException - java.security.cert
+       |PKIXCertPathBuilderResult - java.security.cert
        |""".stripMargin
   )
 
@@ -230,11 +230,11 @@ object CompletionSuite extends BaseCompletionSuite {
       |  TrieMap@@
       |}""".stripMargin,
     """|TrieMap scala.collection.concurrent
-       |scala.collection.parallel.mutable.ParTrieMap scala.collection.parallel.mutable
-       |scala.collection.immutable.HashMap.HashTrieMap scala.collection.immutable.HashMap
-       |scala.collection.parallel.mutable.ParTrieMapCombiner scala.collection.parallel.mutable
-       |scala.collection.parallel.mutable.ParTrieMapSplitter scala.collection.parallel.mutable
-       |scala.collection.concurrent.TrieMapSerializationEnd scala.collection.concurrent
+       |ParTrieMap - scala.collection.parallel.mutable
+       |HashTrieMap - scala.collection.immutable.HashMap
+       |ParTrieMapCombiner - scala.collection.parallel.mutable
+       |ParTrieMapSplitter - scala.collection.parallel.mutable
+       |TrieMapSerializationEnd - scala.collection.concurrent
        |""".stripMargin
   )
 
@@ -252,15 +252,15 @@ object CompletionSuite extends BaseCompletionSuite {
     """
       |import JavaCon@@
       |""".stripMargin,
-    """|scala.collection.JavaConverters scala.collection
-       |scala.collection.JavaConversions scala.collection
-       |scala.concurrent.JavaConversions scala.concurrent
-       |scala.collection.convert.AsJavaConverters scala.collection.convert
+    """|JavaConverters - scala.collection
+       |JavaConversions - scala.collection
+       |JavaConversions - scala.concurrent
+       |AsJavaConverters - scala.collection.convert
        |""".stripMargin,
     compat = Map(
-      "2.11" -> """|scala.collection.JavaConverters scala.collection
-                   |scala.collection.JavaConversions scala.collection
-                   |scala.concurrent.JavaConversions scala.concurrent
+      "2.11" -> """|JavaConverters - scala.collection
+                   |JavaConversions - scala.collection
+                   |JavaConversions - scala.concurrent
                    |""".stripMargin
     )
   )
@@ -270,7 +270,7 @@ object CompletionSuite extends BaseCompletionSuite {
     """
       |import Paths@@
       |""".stripMargin,
-    """|java.nio.file.Paths java.nio.file
+    """|Paths - java.nio.file
        |""".stripMargin
   )
 
@@ -279,7 +279,7 @@ object CompletionSuite extends BaseCompletionSuite {
     """
       |import Catch@@
       |""".stripMargin,
-    """|scala.util.control.Exception.Catch scala.util.control.Exception
+    """|Catch - scala.util.control.Exception
        |""".stripMargin
   )
 
@@ -288,17 +288,17 @@ object CompletionSuite extends BaseCompletionSuite {
     """
       |import Path@@
       |""".stripMargin,
-    """|java.nio.file.Path java.nio.file
-       |java.nio.file.Paths java.nio.file
-       |java.awt.geom.Path2D java.awt.geom
-       |java.security.cert.CertPath java.security.cert
-       |java.awt.font.LayoutPath java.awt.font
-       |java.awt.geom.GeneralPath java.awt.geom
-       |java.nio.file.PathMatcher java.nio.file
-       |org.w3c.dom.xpath.XPathResult org.w3c.dom.xpath
-       |java.awt.geom.PathIterator java.awt.geom
-       |org.w3c.dom.xpath.XPathEvaluator org.w3c.dom.xpath
-       |org.w3c.dom.xpath.XPathException org.w3c.dom.xpath
+    """|Path - java.nio.file
+       |Paths - java.nio.file
+       |Path2D - java.awt.geom
+       |CertPath - java.security.cert
+       |LayoutPath - java.awt.font
+       |GeneralPath - java.awt.geom
+       |PathMatcher - java.nio.file
+       |XPathResult - org.w3c.dom.xpath
+       |PathIterator - java.awt.geom
+       |XPathEvaluator - org.w3c.dom.xpath
+       |XPathException - org.w3c.dom.xpath
        |""".stripMargin
   )
 
@@ -308,9 +308,9 @@ object CompletionSuite extends BaseCompletionSuite {
       |package a
       |import MetaData@@
       |""".stripMargin,
-    """|java.sql.DatabaseMetaData java.sql
-       |java.sql.ParameterMetaData java.sql
-       |java.sql.ResultSetMetaData java.sql
+    """|DatabaseMetaData - java.sql
+       |ParameterMetaData - java.sql
+       |ResultSetMetaData - java.sql
        |""".stripMargin
   )
 
@@ -325,7 +325,7 @@ object CompletionSuite extends BaseCompletionSuite {
       |  class Inner
       |}
       |""".stripMargin,
-    """|a.Outer.Inner a.Outer
+    """|Inner - a.Outer
        |""".stripMargin
   )
 
@@ -359,7 +359,7 @@ object CompletionSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """Files java.nio.file
-      |a.Outer.Files a.Outer
+      |Files - a.Outer
       |""".stripMargin
   )
 
@@ -621,7 +621,7 @@ object CompletionSuite extends BaseCompletionSuite {
         |  val foo: ListBuffe@@
         |}
         |""".stripMargin,
-    """|scala.collection.mutable.ListBuffer scala.collection.mutable
+    """|ListBuffer - scala.collection.mutable
        |""".stripMargin
   )
 
@@ -631,7 +631,7 @@ object CompletionSuite extends BaseCompletionSuite {
         |  val foo: Map[Int, ListBuffe@@]
         |}
         |""".stripMargin,
-    """|scala.collection.mutable.ListBuffer scala.collection.mutable
+    """|ListBuffer - scala.collection.mutable
        |""".stripMargin
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -1,0 +1,295 @@
+package tests.pc
+
+import tests.BaseCompletionSuite
+
+object CompletionWorkspaceSuite extends BaseCompletionSuite {
+
+  checkEditLine(
+    "files",
+    """package pkg
+      |object Main {
+      |___
+      |}
+      |""".stripMargin,
+    "  Files@@",
+    """  import java.nio.file.Files
+      |  Files""".stripMargin
+  )
+
+  checkEditLine(
+    "import",
+    """package pkg
+      |object Main {
+      |  ___
+      |}
+      |""".stripMargin,
+    "import Files@@",
+    "import java.nio.file.Files"
+  )
+
+  checkEdit(
+    "conflict",
+    """package pkg
+      |trait Serializable
+      |object Main extends Serializable@@
+      |""".stripMargin,
+    """package pkg
+      |trait Serializable
+      |object Main extends java.io.Serializable
+      |""".stripMargin,
+    filter = _ == "Serializable - java.io"
+  )
+
+  checkEdit(
+    "extends",
+    """package pkg
+      |object Main extends CompletableFutur@@
+      |""".stripMargin,
+    """package pkg
+      |import java.util.concurrent.CompletableFuture
+      |object Main extends CompletableFuture
+      |""".stripMargin
+  )
+
+  checkEdit(
+    "replace",
+    """package pkg
+      |object Main extends CompletableFu@@ture
+      |""".stripMargin,
+    """package pkg
+      |import java.util.concurrent.CompletableFuture
+      |object Main extends CompletableFuture
+      |""".stripMargin
+  )
+
+  checkEdit(
+    "block1",
+    """|object Main {
+       |  def foo(): Unit = {
+       |    Files@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|object Main {
+       |  import java.nio.file.Files
+       |  def foo(): Unit = {
+       |    Files
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "block2",
+    """|object Main {
+       |  def foo(): Unit = {
+       |    val x = 1
+       |    Files@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|object Main {
+       |  def foo(): Unit = {
+       |    val x = 1
+       |    import java.nio.file.Files
+       |    Files
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "block3",
+    """|object Main {
+       |  def foo(): Unit = {
+       |    val x = 1
+       |    println("".substring(Files@@))
+       |  }
+       |}
+       |""".stripMargin,
+    """|object Main {
+       |  def foo(): Unit = {
+       |    val x = 1
+       |    import java.nio.file.Files
+       |    println("".substring(Files))
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "match",
+    """|object Main {
+       |  def foo(): Unit = 1 match {
+       |    case 2 =>
+       |      Files@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|object Main {
+       |  import java.nio.file.Files
+       |  def foo(): Unit = 1 match {
+       |    case 2 =>
+       |      Files
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "case-if",
+    """|object Main {
+       |  def foo(): Unit = 1 match {
+       |    case 2 if {
+       |      Files@@
+       |     } =>
+       |  }
+       |}
+       |""".stripMargin,
+    """|object Main {
+       |  import java.nio.file.Files
+       |  def foo(): Unit = 1 match {
+       |    case 2 if {
+       |      Files
+       |     } =>
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "match-typed",
+    """|object Main {
+       |  def foo(): Unit = null match {
+       |    case x: ArrayDeque@@ =>
+       |  }
+       |}
+       |""".stripMargin,
+    """|object Main {
+       |  import java.{util => ju}
+       |  def foo(): Unit = null match {
+       |    case x: ju.ArrayDeque =>
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "type",
+    """|object Main {
+       |  def foo(): Unit = {
+       |    val x: Failure@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|object Main {
+       |  def foo(): Unit = {
+       |    import scala.util.Failure
+       |    val x: Failure
+       |  }
+       |}
+       |""".stripMargin,
+    filter = _.contains("scala.util")
+  )
+
+  checkEdit(
+    "partial-function",
+    """package pkg
+      |object Main {
+      |  List(1).collect {
+      |    case 2 =>
+      |      Files@@
+      |  }
+      |}
+      |""".stripMargin,
+    """package pkg
+      |object Main {
+      |  import java.nio.file.Files
+      |  List(1).collect {
+      |    case 2 =>
+      |      Files
+      |  }
+      |}
+      |""".stripMargin
+  )
+
+  checkEdit(
+    "for",
+    """package pkg
+      |object Main {
+      |  for {
+      |    x <- List(1)
+      |    y = x + 1
+      |    if y > 2
+      |    _ = Files@@
+      |  } yield x
+      |}
+      |""".stripMargin,
+    """package pkg
+      |object Main {
+      |  import java.nio.file.Files
+      |  for {
+      |    x <- List(1)
+      |    y = x + 1
+      |    if y > 2
+      |    _ = Files
+      |  } yield x
+      |}
+      |""".stripMargin
+  )
+
+  checkEdit(
+    "for2",
+    """package pkg
+      |object Main {
+      |  for {
+      |    x <- List(1)
+      |    _ = {
+      |      println(1)
+      |      Files@@
+      |    }
+      |  } yield x
+      |}
+      |""".stripMargin,
+    """package pkg
+      |object Main {
+      |  for {
+      |    x <- List(1)
+      |    _ = {
+      |      println(1)
+      |      import java.nio.file.Files
+      |      Files
+      |    }
+      |  } yield x
+      |}
+      |""".stripMargin
+  )
+
+  checkEdit(
+    "for3",
+    """package pkg
+      |object Main {
+      |  for {
+      |    x <- List(1)
+      |    if {
+      |      println(x)
+      |      Files@@
+      |    }
+      |  } yield x
+      |}
+      |""".stripMargin,
+    """package pkg
+      |object Main {
+      |  for {
+      |    x <- List(1)
+      |    if {
+      |      println(x)
+      |      import java.nio.file.Files
+      |      Files
+      |    }
+      |  } yield x
+      |}
+      |""".stripMargin
+  )
+
+}

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -119,6 +119,7 @@ object SignatureHelpSuite extends BaseSignatureHelpSuite {
        |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
        |""".stripMargin
   )
+
   check(
     "nested",
     """

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -96,7 +96,7 @@ class BaseSuite extends TestSuite {
       title: String = ""
   )(implicit filename: sourcecode.File, line: sourcecode.Line): Unit = {
     DiffAssertions.colored {
-      DiffAssertions.assertNoDiffOrPrintExpected(obtained, expected, title)
+      DiffAssertions.assertNoDiff(obtained, expected, title, title)
     }
   }
   override def utestAfterAll(): Unit = afterAll()

--- a/tests/mtest/src/main/scala/tests/TestCompletions.scala
+++ b/tests/mtest/src/main/scala/tests/TestCompletions.scala
@@ -18,11 +18,12 @@ object TestCompletions {
     if (item.getInsertText == null) {
       item.getLabel
     } else {
-      val fullyQualifiedPrefix = item.getInsertText.substring(
-        0,
-        item.getInsertText.indexOf(item.getLabel)
-      )
-      fullyQualifiedPrefix + item.getLabel
+      val idx = item.getInsertText.indexOf(item.getLabel)
+      if (idx < 0) item.getLabel
+      else {
+        val fullyQualifiedPrefix = item.getInsertText.substring(0, idx)
+        fullyQualifiedPrefix + item.getLabel
+      }
     }
   }
 }

--- a/tests/unit/src/main/scala/tests/BaseCompletionSlowSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionSlowSuite.scala
@@ -71,29 +71,29 @@ abstract class BaseCompletionSlowSuite(name: String)
       _ <- assertCompletion(
         "Stream@@",
         """|Stream scala.collection.immutable
-           |java.util.stream.Stream java.util.stream
-           |java.util.stream.IntStream java.util.stream
-           |java.rmi.server.LogStream java.rmi.server
-           |java.util.stream.BaseStream java.util.stream
-           |java.util.stream.LongStream java.util.stream
-           |scala.collection.immutable.StreamView scala.collection.immutable
-           |java.io.InputStream java.io
-           |java.io.PrintStream java.io
-           |java.util.stream.DoubleStream java.util.stream
-           |java.io.OutputStream java.io
-           |scala.collection.immutable.Stream.StreamBuilder scala.collection.immutable.Stream
-           |java.util.logging.StreamHandler java.util.logging
-           |scala.collection.immutable.Stream.StreamCanBuildFrom scala.collection.immutable.Stream
+           |Stream - java.util.stream
+           |IntStream - java.util.stream
+           |LogStream - java.rmi.server
+           |BaseStream - java.util.stream
+           |LongStream - java.util.stream
+           |StreamView - scala.collection.immutable
+           |InputStream - java.io
+           |PrintStream - java.io
+           |DoubleStream - java.util.stream
+           |OutputStream - java.io
+           |StreamBuilder - scala.collection.immutable.Stream
+           |StreamHandler - java.util.logging
+           |StreamCanBuildFrom - scala.collection.immutable.Stream
            |""".stripMargin
       )
       _ <- assertCompletion(
         "TrieMap@@",
-        """|scala.collection.concurrent.TrieMap scala.collection.concurrent
-           |scala.collection.parallel.mutable.ParTrieMap scala.collection.parallel.mutable
-           |scala.collection.immutable.HashMap.HashTrieMap scala.collection.immutable.HashMap
-           |scala.collection.parallel.mutable.ParTrieMapCombiner scala.collection.parallel.mutable
-           |scala.collection.parallel.mutable.ParTrieMapSplitter scala.collection.parallel.mutable
-           |scala.collection.concurrent.TrieMapSerializationEnd scala.collection.concurrent
+        """|TrieMap - scala.collection.concurrent
+           |ParTrieMap - scala.collection.parallel.mutable
+           |HashTrieMap - scala.collection.immutable.HashMap
+           |ParTrieMapCombiner - scala.collection.parallel.mutable
+           |ParTrieMapSplitter - scala.collection.parallel.mutable
+           |TrieMapSerializationEnd - scala.collection.concurrent
            |""".stripMargin
       )
       _ <- assertCompletion(

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -359,10 +359,11 @@ final class TestingServer(
       completion.getItems.asScala.map(server.completionItemResolveSync)
     items.iterator
       .map { item =>
+        val label = TestCompletions.getFullyQualifiedLabel(item)
         val detail =
-          if (includeDetail) item.getDetail
+          if (includeDetail && !label.contains(item.getDetail)) item.getDetail
           else ""
-        TestCompletions.getFullyQualifiedLabel(item) + detail
+        label + detail
       }
       .mkString("\n")
   }

--- a/tests/unit/src/test/scala/tests/CompletionSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompletionSlowSuite.scala
@@ -43,8 +43,8 @@ object CompletionSlowSuite extends BaseCompletionSlowSuite("completion") {
       _ = assertNoDiagnostics()
       _ <- assertCompletion(
         "DefinedIn@@",
-        """|a.Outer.DefinedInA a.Outer
-           |c.DefinedInC c
+        """|DefinedInA - a.Outer
+           |DefinedInC - c
            |""".stripMargin
       )
     } yield ()


### PR DESCRIPTION
Previously, Metals inserted a fully qualified name at the completion
position. With this commit, we now insert a local import in the nearest
enclosing block. Down the road, we can add a code action to "Move import
to global scope" to clean up local imports inserted by Metals.

Other improvements in this commit:

- we render the package name in the completion item label so that it's
  more visible what you are importing.
- we no longer use insert text, which is a deprected LSP feature and
  has unclear semantics between editors. Instead, we only use `textEdit`.