### PR TITLE
Include method signature in completion item label.

### DIFF
--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -1,3 +1,5 @@
 package example
 
-object Main {}
+object Main {
+  val `type` = 42
+}

--- a/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
@@ -47,9 +47,7 @@ object CancelCompletionSuite extends BaseCompletionSuite {
         CompilerOffsetParams("A.scala", code, offset, EmptyCancelToken)
       )
       val obtained = completion.getItems.asScala
-        .map { item =>
-          s"${item.getLabel}${item.getDetail}"
-        }
+        .map(_.getLabel)
         .mkString("\n")
       assertNoDiff(obtained, expected)
     }


### PR DESCRIPTION
Previously, we only showed the method signature as "detail", which is
not always visible in editors. This commit moves the method signature
into the label so that it's more prominently displayed. This change
makes it easier to read the completion results, especially for
overloaded methods.

Before:
![Screenshot 2019-03-20 at 12 41 02](https://user-images.githubusercontent.com/1408093/54681767-79b3df00-4b0d-11e9-8ada-69276f2d80c0.png)

After:
![Screenshot 2019-03-20 at 12 16 08](https://user-images.githubusercontent.com/1408093/54681765-77ea1b80-4b0d-11e9-9218-0c21efe288f5.png)
