### PR TITLE
Filter out ensuring and -> extension methods from Predef.

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -230,6 +230,7 @@ class CompletionProvider(
           !head.sym.pos.isAfter(pos)
       if (!isSeen(id) &&
         !isUninterestingSymbol(head.sym) &&
+        !isUninterestingSymbolOwner(head.sym.owner) &&
         !isIgnoredWorkspace &&
         completion.isCandidate(head) &&
         !head.sym.name.containsName(CURSOR) &&

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -1002,10 +1002,18 @@ trait Completions { this: MetalsGlobal =>
       termNames.equals_
     )
 
+  lazy val isUninterestingSymbolOwner: Set[Symbol] = Set[Symbol](
+    // The extension methods in these classes are noisy because they appear on every completion.
+    definitions.getMemberClass(
+      definitions.PredefModule,
+      TypeName("ArrowAssoc")
+    ),
+    definitions.getMemberClass(
+      definitions.PredefModule,
+      TypeName("Ensuring")
+    )
+  )
   lazy val isUninterestingSymbol: Set[Symbol] = Set[Symbol](
-    // the methods == != ## are arguably "interesting" but they're here becuase
-    // - they're short so completing them doesn't save you keystrokes
-    // - they're available on everything so you
     definitions.Any_==,
     definitions.Any_!=,
     definitions.Any_##,
@@ -1021,13 +1029,6 @@ trait Completions { this: MetalsGlobal =>
     definitions.Object_notifyAll,
     definitions.Object_notify,
     definitions.getMemberMethod(definitions.ObjectClass, termNames.wait_),
-    definitions.getMemberMethod(
-      definitions.getMemberClass(
-        definitions.PredefModule,
-        TypeName("ArrowAssoc")
-      ),
-      TermName("→").encode
-    ),
     // NOTE(olafur) IntelliJ does not complete the root package and without this filter
     // then `_root_` would appear as a completion result in the code `foobar(_<COMPLETE>)`
     rootMirror.RootPackage

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -124,12 +124,7 @@ object CompletionSuite extends BaseCompletionSuite {
        |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): List[List[List[List[A]]]]
        |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): List[List[List[List[List[A]]]]]
        |unapplySeq[A](x: List[A]): Some[List[A]]
-       |->[B](y: B): (List.type, B)
        |+(other: String): String
-       |ensuring(cond: Boolean): List.type
-       |ensuring(cond: List.type => Boolean): List.type
-       |ensuring(cond: Boolean, msg: => Any): List.type
-       |ensuring(cond: List.type => Boolean, msg: => Any): List.type
        |formatted(fmtstr: String): String
        |asInstanceOf[T0]: T0
        |equals(obj: Any): Boolean
@@ -162,12 +157,7 @@ object CompletionSuite extends BaseCompletionSuite {
            |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): List[List[List[List[A]]]]
            |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): List[List[List[List[List[A]]]]]
            |unapplySeq[A](x: List[A]): Some[List[A]]
-           |->[B](y: B): (List.type, B)
            |+(other: String): String
-           |ensuring(cond: Boolean): List.type
-           |ensuring(cond: List.type => Boolean): List.type
-           |ensuring(cond: Boolean, msg: => Any): List.type
-           |ensuring(cond: List.type => Boolean, msg: => Any): List.type
            |formatted(fmtstr: String): String
            |asInstanceOf[T0]: T0
            |equals(obj: Any): Boolean


### PR DESCRIPTION
These methods are noisy because they appear on everything.