### PR TITLE
Escape keyword identifier in packag prefixes.

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -99,7 +99,7 @@ class CompletionProvider(
             importPosition match {
               case None =>
                 // No import position, fully qualify the name in-place.
-                item.setTextEdit(textEdit(w.sym.fullName + suffix))
+                item.setTextEdit(textEdit(w.sym.fullNameSyntax + suffix))
               case Some(value) =>
                 val (short, edits) = ShortenedNames.synthesize(
                   TypeRef(

--- a/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
@@ -398,6 +398,19 @@ class MetalsGlobal(
   }
 
   implicit class XtensionSymbolMetals(sym: Symbol) {
+    def fullNameSyntax: String = {
+      val out = new java.lang.StringBuilder
+      def loop(s: Symbol): Unit = {
+        if (s.isRoot || s.isRootPackage || s == NoSymbol || s.owner.isEffectiveRoot) {
+          out.append(Identifier(s.name))
+        } else {
+          loop(s.effectiveOwner.enclClass)
+          out.append('.').append(Identifier(s.name))
+        }
+      }
+      loop(sym)
+      out.toString
+    }
     def isLocallyDefinedSymbol: Boolean = {
       sym.isLocalToBlock && sym.pos.isDefined
     }

--- a/mtags/src/main/scala/scala/meta/internal/pc/Signatures.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Signatures.scala
@@ -73,8 +73,8 @@ trait Signatures { this: MetalsGlobal =>
   ) {
 
     def fullname(sym: Symbol): String = {
-      if (topSymbolResolves(sym)) sym.fullName
-      else s"_root_.${sym.fullName}"
+      if (topSymbolResolves(sym)) sym.fullNameSyntax
+      else s"_root_.${sym.fullNameSyntax}"
     }
 
     def topSymbolResolves(sym: Symbol): Boolean = {

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -1,5 +1,12 @@
 package example
 
-object Main {
-  val `type` = 42
+package app {
+  import example.`type`.Banana
+  object Main {
+    val `type` = 42
+  }
+}
+
+package `type` {
+  object Banana
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -27,6 +27,23 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
     "import java.nio.file.Files"
   )
 
+  checkEditLine(
+    "import-escape",
+    """package pkg
+      |
+      |package app {
+      |  object Main {
+      |    ___
+      |  }
+      |}
+      |package `type` {
+      |  object Banana
+      |}
+      |""".stripMargin,
+    "import Banana@@",
+    "import pkg.`type`.Banana"
+  )
+
   checkEdit(
     "conflict",
     """package pkg
@@ -290,6 +307,21 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |  } yield x
       |}
       |""".stripMargin
+  )
+
+  checkEditLine(
+    "backtick",
+    """package `type`
+      |abstract class Foo {
+      |  def backtick: Foo
+      |}
+      |object Main extends Foo {
+      |  class Foo // conflict
+      |  ___
+      |}
+      |""".stripMargin,
+    "def backtick@@",
+    "def backtick: `type`.Foo = ${0:???}"
   )
 
 }


### PR DESCRIPTION
Previously, auto-import and completions could generate non-compiling
code due to lack of backtick escaping in qualifier paths. With this
commit, we properly escape package names like `type` in backticks
so that the generated code compiles.


![2019-03-20 15 16 34](https://user-images.githubusercontent.com/1408093/54691255-349aa780-4b23-11e9-8207-71d758d76dcc.gif)