### PR TITLE
Fix signature help bug for tuple patterns.

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
@@ -1,0 +1,19 @@
+package tests.pc
+
+import tests.BaseSignatureHelpSuite
+
+object SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
+  check(
+    "case",
+    """
+      |object Main {
+      |  List(1 -> 2).map {
+      |    case (a, @@) =>
+      |  }
+      |}
+      |""".stripMargin,
+    """|map[B, That](f: ((Int, Int)) => B)(implicit bf: CanBuildFrom[List[(Int, Int)],B,That]): That
+       |             ^^^^^^^^^^^^^^^^^^^^
+       |""".stripMargin
+  )
+}


### PR DESCRIPTION
Previously, signature help (parameter hints) didn't work when
deconstructing a tuple. This commit fixes that bug. The bug happened
because we first perform a syntactic pass where we narrowed to the
synthetic `TupleN.apply(...)` tree node. We now guard against that
pattern so that we show the signature of the enclosing method call.