### PR TITLE
Add support for non-Lightbend compilers

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -132,7 +132,9 @@ class Compilers(
       target <- buildTargets.inverseSources(path)
       info <- buildTargets.info(target)
       scala <- info.asScalaBuildTarget
-      isSupported = ScalaVersions.isSupportedScalaVersion(scala.getScalaVersion)
+      isSupported = ScalaVersions.isSupportedScalaVersion(
+        ScalaVersions.dropVendorSuffix(scala.getScalaVersion)
+      )
       _ = {
         if (!isSupported) {
           scribe.warn(s"unsupported Scala ${scala.getScalaVersion}")
@@ -171,7 +173,7 @@ class Compilers(
   ): PresentationCompiler = {
     val classpath = scalac.classpath.map(_.toNIO).toSeq
     val pc: PresentationCompiler =
-      if (info.getScalaVersion == Properties.versionNumberString) {
+      if (ScalaVersions.dropVendorSuffix(info.getScalaVersion) == Properties.versionNumberString) {
         new ScalaPresentationCompiler()
       } else {
         embedded.presentationCompiler(info, scalac)

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -90,7 +90,7 @@ final class Embedded(
       scalac: ScalacOptionsItem
   ): PresentationCompiler = {
     val classloader = presentationCompilers.getOrElseUpdate(
-      info.getScalaVersion,
+      ScalaVersions.dropVendorSuffix(info.getScalaVersion),
       statusBar.trackBlockingTask(
         s"${icons.sync}Downloading presentation compiler"
       ) {
@@ -130,7 +130,7 @@ object Embedded {
   ): URLClassLoader = {
     val pc = new Dependency(
       "org.scalameta",
-      s"mtags_${info.getScalaVersion}",
+      s"mtags_${ScalaVersions.dropVendorSuffix(info.getScalaVersion)}",
       BuildInfo.metalsVersion
     )
     val needsFullClasspath = !scalac.isSemanticdbEnabled

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -1,6 +1,11 @@
 package scala.meta.internal.metals
 
 object ScalaVersions {
+
+  /** Non-Lightbend compilers often use a suffix, such as `-bin-typelevel-4` */
+  def dropVendorSuffix(version: String): String =
+    version.replaceAll("-bin-.*", "")
+
   val isSupportedScalaVersion: Set[String] =
     BuildInfo.supportedScalaVersions.toSet
   def isSupportedScalaBinaryVersion(scalaVersion: String): Boolean =

--- a/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
@@ -36,7 +36,9 @@ final class Warnings(
       scalacOptions <- buildTargets.scalacOptions(buildTarget)
     } yield {
       if (!scalacOptions.isSemanticdbEnabled) {
-        if (isSupportedScalaVersion(scala.getScalaVersion)) {
+        if (isSupportedScalaVersion(
+            ScalaVersions.dropVendorSuffix(scala.getScalaVersion)
+          )) {
           logger.error(
             s"$doesntWorkBecause the SemanticDB compiler plugin is not enabled for the build target ${info.getDisplayName}."
           )

--- a/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
@@ -1,0 +1,30 @@
+package tests
+
+import scala.meta.internal.metals.ScalaVersions
+
+object ScalaVersionsSuite extends BaseSuite {
+  test("Idempotent minor release") {
+    assert(
+      ScalaVersions.dropVendorSuffix("2.12.4") ==
+        "2.12.4"
+    )
+  }
+
+  test("Retain pre-release version") {
+    assert(
+      ScalaVersions.dropVendorSuffix("2.13.0-RC1") ==
+        "2.13.0-RC1"
+    )
+    assert(
+      ScalaVersions.dropVendorSuffix("2.13.0-M5") ==
+        "2.13.0-M5"
+    )
+  }
+
+  test("Drop Typelevel vendor suffix") {
+    assert(
+      ScalaVersions.dropVendorSuffix("2.12.4-bin-typelevel-4") ==
+        "2.12.4"
+    )
+  }
+}


### PR DESCRIPTION
Drop the vendor suffix since unofficial Scala versions are typically
compatible. If there are syntactic incompatibilities as seen with
Typelevel Scala, support for these must be added to SemanticDB.

See also https://github.com/scalameta/scalameta/pull/1846