### PR TITLE
Add server property config to disable features.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -43,14 +43,26 @@ object Configs {
         props: Properties = System.getProperties
     ): PresentationCompilerConfigImpl = {
       PresentationCompilerConfigImpl(
-        MetalsServerConfig.binaryOption("pc.debug", default = false),
+        MetalsServerConfig.binaryOption("metals.pc.debug", default = false),
         Option(props.getProperty("metals.signature-help-command")),
         overrideDefFormat =
           Option(props.getProperty("metals.override-def-format")) match {
             case Some("unicode") => OverrideDefFormat.Unicode
             case Some("ascii") => OverrideDefFormat.Ascii
             case _ => OverrideDefFormat.Ascii
-          }
+          },
+        isCompletionItemDetailEnabled = MetalsServerConfig.binaryOption(
+          "metals.completion-item.detail",
+          default = true
+        ),
+        isCompletionItemDocumentationEnabled = MetalsServerConfig.binaryOption(
+          "metals.completion-item.documentation",
+          default = true
+        ),
+        isSignatureHelpDocumentationEnabled = MetalsServerConfig.binaryOption(
+          "metals.signature-help.documentation",
+          default = true
+        )
       )
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -100,7 +100,7 @@ object MetalsServerConfig {
           executeClientCommand = ExecuteClientCommandConfig.on,
           globSyntax = GlobSyntaxConfig.vscode,
           compilers =
-            CompilersConfig().copy(
+            base.compilers.copy(
               _parameterHintsCommand =
                 Some("editor.action.triggerParameterHints"),
               overrideDefFormat = OverrideDefFormat.Unicode
@@ -122,7 +122,11 @@ object MetalsServerConfig {
           showMessage = ShowMessageConfig.logMessage,
           showMessageRequest = ShowMessageRequestConfig.on,
           icons = Icons.unicode,
-          isExitOnShutdown = true
+          isExitOnShutdown = true,
+          compilers = base.compilers.copy(
+            // Avoid showing the method signature twice because it's already visible in the label.
+            isCompletionItemDetailEnabled = false
+          )
         )
       case "emacs" =>
         base.copy(

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -38,4 +38,19 @@ public interface PresentationCompilerConfig {
         Unicode
     }
 
+    /**
+     * Returns true if the <code>CompletionItem.detail</code> field should be populated.
+     */
+    boolean isCompletionItemDetailEnabled();
+
+    /**
+     * Returns true if the <code>CompletionItem.documentation</code> field should be populated.
+     */
+    boolean isCompletionItemDocumentationEnabled();
+
+    /**
+     * Returns true if the <code>SignatureHelp.documentation</code> field should be populated.
+     */
+    boolean isSignatureHelpDocumentationEnabled();
+
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionItemResolver.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionItemResolver.scala
@@ -17,7 +17,9 @@ class CompletionItemResolver(
           if (isJavaSymbol(gsym)) {
             val data = item.data.getOrElse(CompletionItemData.empty)
             item.setLabel(replaceJavaParameters(info, item.getLabel))
-            item.setDetail(replaceJavaParameters(info, item.getDetail))
+            if (metalsConfig.isCompletionItemDetailEnabled) {
+              item.setDetail(replaceJavaParameters(info, item.getDetail))
+            }
             if (item.getTextEdit != null && data.kind == CompletionItemData.OverrideKind) {
               item.getTextEdit.setNewText(
                 replaceJavaParameters(info, item.getTextEdit.getNewText)
@@ -33,10 +35,16 @@ class CompletionItemResolver(
               .filterNot(_.isEmpty)
               .toSeq
             item.setLabel(replaceScalaDefaultParams(item.getLabel, defaults))
-            item.setDetail(replaceScalaDefaultParams(item.getDetail, defaults))
+            if (metalsConfig.isCompletionItemDetailEnabled) {
+              item.setDetail(
+                replaceScalaDefaultParams(item.getDetail, defaults)
+              )
+            }
           }
-          val docstring = fullDocstring(gsym)
-          item.setDocumentation(docstring.toMarkupContent)
+          if (metalsConfig.isCompletionItemDocumentationEnabled) {
+            val docstring = fullDocstring(gsym)
+            item.setDocumentation(docstring.toMarkupContent)
+          }
         case _ =>
       }
       item

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -65,7 +65,9 @@ class CompletionProvider(
             }
         }
         val item = new CompletionItem(label)
-        item.setDetail(detail)
+        if (metalsConfig.isCompletionItemDetailEnabled) {
+          item.setDetail(detail)
+        }
         val templateSuffix =
           if (completion.isNew &&
             r.sym.dealiased.requiresTemplateCurlyBraces) " {}"

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -11,7 +11,10 @@ case class PresentationCompilerConfigImpl(
     _parameterHintsCommand: Option[String] = None,
     _symbolPrefixes: collection.Map[String, String] =
       PresentationCompilerConfig.defaultSymbolPrefixes().asScala,
-    overrideDefFormat: OverrideDefFormat = OverrideDefFormat.Ascii
+    overrideDefFormat: OverrideDefFormat = OverrideDefFormat.Ascii,
+    isCompletionItemDetailEnabled: Boolean = true,
+    isCompletionItemDocumentationEnabled: Boolean = true,
+    isSignatureHelpDocumentationEnabled: Boolean = true
 ) extends PresentationCompilerConfig {
   override def symbolPrefixes(): util.Map[String, String] =
     _symbolPrefixes.asJava

--- a/mtags/src/main/scala/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -494,15 +494,18 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
               val byNameLabel =
                 if (isByNamedOrdered) s"<$label>"
                 else label
-              val lparam =
-                new ParameterInformation(byNameLabel, docstring.toMarkupContent)
+              val lparam = new ParameterInformation(byNameLabel)
+              if (metalsConfig.isSignatureHelpDocumentationEnabled) {
+                lparam.setDocumentation(docstring.toMarkupContent)
+              }
               // TODO(olafur): use LSP 3.14.0 ParameterInformation.label offsets instead of strings
               // once this issue is fixed https://github.com/eclipse/lsp4j/issues/300
               if (isActiveSignature && t.activeArg.matches(param, i, j)) {
                 arg(i, j) match {
                   case Some(a) if a.tpe != null && !a.tpe.isErroneous =>
                     val tpe = metalsToLongString(a.tpe.widen, shortenedNames)
-                    if (!lparam.getLabel.endsWith(tpe)) {
+                    if (!lparam.getLabel.endsWith(tpe) &&
+                      metalsConfig.isSignatureHelpDocumentationEnabled) {
                       lparam.setDocumentation(
                         ("```scala\n" + tpe + "\n```\n" + docstring).toMarkupContent
                       )
@@ -516,13 +519,20 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
         if (labels.isEmpty && sortedByName.nonEmpty) Nil
         else labels :: Nil
     }
-    new SignatureInformation(
+    val signatureInformation = new SignatureInformation(
       printer.methodSignature(
         paramLabels.iterator.map(_.iterator.map(_.getLabel))
-      ),
-      printer.methodDocstring.toMarkupContent,
+      )
+    )
+    if (metalsConfig.isSignatureHelpDocumentationEnabled) {
+      signatureInformation.setDocumentation(
+        printer.methodDocstring.toMarkupContent
+      )
+    }
+    signatureInformation.setParameters(
       paramLabels.iterator.flatten.toSeq.asJava
     )
+    signatureInformation
   }
 
 }

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -4,6 +4,8 @@ package app {
   import example.`type`.Banana
   object Main {
     val `type` = 42
+    def foobar(x: Int): String = x.toString()
+    // Main.foobar()
   }
 }
 


### PR DESCRIPTION
This commits adds three server property settings to disable the features
- `CompletionItem.detail`: because the detail contains duplicate
  information from the completion label, which can be annoying in editors
  like Sublime where both are displayed next to each other.
- `CompletionItem.documentation`: if the docstring is rendered in noisy
  way for some reason.
- `SignatureHelp.documentation`: if the docstring is rendered in noisy
  way for some reason.

Here's how the new completions look in Sublime

![Screenshot 2019-03-21 at 12 01 24](https://user-images.githubusercontent.com/1408093/54748277-73873680-4bd1-11e9-8f7a-19d25abb2f35.png)


Previously, the signature was duplicated. Thanks @ayoub-benali for reporting!