### PR TITLE
Explicitly set filter text for all completions.

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -84,9 +84,9 @@ class CompletionProvider(
           case i: OverrideDefMember =>
             item.setFilterText(i.filterText)
           case _ =>
-            if (ident.startsWith("`")) {
-              item.setFilterText(symbolName)
-            }
+            // Explicitly set filter text because the label has method signature and
+            // fully qualified name.
+            item.setFilterText(symbolName)
         }
 
         item.setInsertTextFormat(InsertTextFormat.Snippet)

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -790,4 +790,16 @@ object CompletionSuite extends BaseCompletionSuite {
     ""
   )
 
+  check(
+    "filterText",
+    s"""|object Main {
+        |  "".substring@@
+        |}
+        |""".stripMargin,
+    """substring(beginIndex: Int): String
+      |substring(beginIndex: Int, endIndex: Int): String
+      |""".stripMargin,
+    filterText = "substring"
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -24,7 +24,8 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     "import Files@@",
-    "import java.nio.file.Files"
+    "import java.nio.file.Files",
+    filterText = "Files"
   )
 
   checkEditLine(


### PR DESCRIPTION


Now that we include method signatures and fully qualified names in
completion items we need to explicitly set the filter text to avoid
undesirable client-side filter behavior.


Before:
![2019-03-21 14 26 16](https://user-images.githubusercontent.com/1408093/54755054-4f355500-4be5-11e9-9a97-a74781245159.gif)

After:
![2019-03-21 14 17 05](https://user-images.githubusercontent.com/1408093/54755007-2e6cff80-4be5-11e9-982b-0eeab102d8ed.gif)


Big thanks to @jvican for reporting!