### PR TITLE
Handle generic unapply signatures in signature help.

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
@@ -16,4 +16,66 @@ object SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
        |             ^^^^^^^^^^^^^^^^^^^^
        |""".stripMargin
   )
+
+  check(
+    "generic1",
+    """
+      |object Main {
+      |  Option(1) match {
+      |    case Some(@@) =>
+      |  }
+      |}
+      |""".stripMargin,
+    """|unapply(value: A): Some[A]
+       |        ^^^^^^^^
+       |""".stripMargin
+  )
+
+  check(
+    "generic2",
+    """
+      |case class Two[T](a: T, b: T)
+      |object Main {
+      |  (null: Any) match {
+      |    case Two(@@) =>
+      |  }
+      |}
+      |""".stripMargin,
+    """|unapply(a: T, b: T): Two[T]
+       |        ^^^^
+       |""".stripMargin
+  )
+
+  check(
+    "generic3",
+    """
+      |case class HKT[C[_], T](a: C[T])
+      |object Main {
+      |  (null: Any) match {
+      |    case HKT(@@) =>
+      |  }
+      |}
+      |""".stripMargin,
+    """|unapply(a: C[T]): HKT[C,T]
+       |        ^^^^^^^
+       |""".stripMargin
+  )
+
+  check(
+    "negative",
+    """
+      |class HKT[C[_], T](a: C[T])
+      |object HKT {
+      |  def unapply(a: Int): Option[(Int, Int)] = Some(2 -> 2)
+      |}
+      |object Main {
+      |  (null: Any) match {
+      |    case HKT(@@) =>
+      |  }
+      |}
+      |""".stripMargin,
+    """|unapply(a: Int): Option[(Int, Int)]
+       |        ^^^^^^
+       |""".stripMargin
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
@@ -28,7 +28,13 @@ object SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
       |""".stripMargin,
     """|unapply(value: A): Some[A]
        |        ^^^^^^^^
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "2.11" ->
+        """|unapply(x: A): Some[A]
+           |        ^^^^
+           |""".stripMargin
+    )
   )
 
   check(


### PR DESCRIPTION
Previously, we showed `unapply[A, B](x$1: Left[A, B]): Option[A]`
and now we show `unapply(value: A): Some[A]` where `value: A` is the
field on the `Left` case class.

We can still do much better for custom extractors but that can be left
for a separate PR. This is a bugfix.