### PR TITLE
Polish snippets when completing with existing parentheses and braces

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -615,6 +615,7 @@ trait Completions { this: MetalsGlobal =>
       val offset = if (lit.pos.focusEnd.line == pos.line) CURSOR.length else 0
       val litpos = lit.pos.withEnd(lit.pos.end - offset)
       val lrange = litpos.toLSP
+      val hasClosingBrace = text.charAt(pos.point) == '}'
       def write(out: StringBuilder, from: Int, to: Int): Unit = {
         var i = from
         while (i < to) {
@@ -644,7 +645,7 @@ trait Completions { this: MetalsGlobal =>
         }
         out.append(identifier)
         out.append(sym.snippetCursor)
-        if (symbolNeedsBraces) {
+        if (symbolNeedsBraces && !hasClosingBrace) {
           out.append('}')
         }
         write(out, pos.point, lit.pos.end - CURSOR.length)

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -1,14 +1,6 @@
 package example
 
-package app {
-  import example.`type`.Banana
-  object Main {
-    val `type` = 42
-    def foobar(x: Int): String = x.toString()
-    // Main.foobar()
-  }
-}
-
-package `type` {
-  object Banana
+object Main {
+  val hello = 42
+  s"Hello ${hello}"
 }

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -49,14 +49,16 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       original: String,
       expected: String,
       filterText: String = "",
-      assertSingleItem: Boolean = true
+      assertSingleItem: Boolean = true,
+      filter: String => Boolean = _ => true
   )(implicit filename: sourcecode.File, line: sourcecode.Line): Unit = {
     checkEdit(
       name,
       template.replaceAllLiterally("___", original),
       template.replaceAllLiterally("___", expected),
       filterText,
-      assertSingleItem
+      assertSingleItem,
+      filter
     )
   }
   def checkEdit(

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -408,4 +408,26 @@ object CompletionInterpolatorSuite extends BaseCompletionSuite {
     filterText = "$Main.member"
   )
 
+  checkEditLine(
+    "closing-brace",
+    """|object Main {
+       |  val hello = ""
+       |  ___
+       |}
+       |""".stripMargin,
+    """"Hello ${hell@@}"""".stripMargin,
+    """s"Hello \${hello$0}"""".stripMargin
+  )
+
+  checkEditLine(
+    "closing-brace-negative",
+    """|object Main {
+       |  val hello = ""
+       |  ___
+       |}
+       |""".stripMargin,
+    """"Hello ${hell@@o}"""".stripMargin,
+    """s"Hello \${hello$0}o}"""".stripMargin
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -133,4 +133,48 @@ object CompletionSnippetSuite extends BaseCompletionSuite {
        |""".stripMargin
   )
 
+  checkEditLine(
+    "trailing-paren",
+    s"""|object Main {
+        |  def trailing(a: Int) = ()
+        |  ___
+        |}
+        |""".stripMargin,
+    "trailing@@()",
+    "trailing($0)"
+  )
+
+  checkEditLine(
+    "trailing-brace",
+    s"""|object Main {
+        |  def trailing(a: Int) = ()
+        |  ___
+        |}
+        |""".stripMargin,
+    "trailing@@ { }",
+    "trailing {$0 }"
+  )
+
+  checkEditLine(
+    "trailing-brace1",
+    s"""|object Main {
+        |  def trailing(a: Int) = ()
+        |  ___
+        |}
+        |""".stripMargin,
+    "trailing@@{ }",
+    "trailing{$0 }"
+  )
+
+  checkEditLine(
+    "trailing-eta",
+    s"""|object Main {
+        |  def trailing(a: Int) = ()
+        |  ___
+        |}
+        |""".stripMargin,
+    "trailing@@ _",
+    "trailing _$0"
+  )
+
 }


### PR DESCRIPTION
See individual commits. We now try to reuse existing braces `{` and parens `(` when possible.

![2019-03-22 08 58 21](https://user-images.githubusercontent.com/1408093/54808910-ed76f880-4c81-11e9-94da-06f184b4f292.gif)
![2019-03-22 08 57 32](https://user-images.githubusercontent.com/1408093/54808911-ed76f880-4c81-11e9-89e1-dff2bc0310d6.gif)
