### PR TITLE
Support navigation for library dependencies in Scala versions.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -136,32 +136,6 @@ class Messages(icons: Icons) {
     }
   }
 
-  object Only212Navigation {
-    def statusBar(scalaVersion: String) =
-      MetalsStatusParams(
-        "$(alert) No navigation",
-        tooltip = params(scalaVersion).getMessage
-      )
-    def dismissForever: MessageActionItem =
-      new MessageActionItem("Don't show again")
-    def ok: MessageActionItem =
-      new MessageActionItem("Ok")
-    def params(scalaVersion: String): ShowMessageRequestParams = {
-      val params = new ShowMessageRequestParams()
-      params.setMessage(
-        s"Navigation for external library sources is not supported in Scala $scalaVersion."
-      )
-      params.setType(MessageType.Warning)
-      params.setActions(
-        List(
-          ok,
-          dismissForever
-        ).asJava
-      )
-      params
-    }
-  }
-
   object SelectBspServer {
     case class Request(
         params: ShowMessageRequestParams,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -175,7 +175,8 @@ class MetalsLanguageServer(
         languageClient,
         tables,
         messages,
-        statusBar
+        statusBar,
+        () => compilers
       )
     )
     warnings = new Warnings(
@@ -683,7 +684,7 @@ class MetalsLanguageServer(
   @JsonRequest("textDocument/hover")
   def hover(params: TextDocumentPositionParams): CompletableFuture[Hover] =
     CancelTokens { token =>
-      compilers.hover(params, token) match {
+      compilers.hover(params, token, interactiveSemanticdbs) match {
         case None => null
         case Some(value) =>
           value.orElse(null)
@@ -829,7 +830,7 @@ class MetalsLanguageServer(
       params: TextDocumentPositionParams
   ): CompletableFuture[SignatureHelp] =
     CancelTokens { token =>
-      compilers.signatureHelp(params, token).orNull
+      compilers.signatureHelp(params, token, interactiveSemanticdbs).orNull
     }
 
   @JsonRequest("textDocument/codeAction")

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -55,6 +55,11 @@ public abstract class PresentationCompiler {
      */
     public abstract Optional<Hover> hover(OffsetParams params);
 
+    /**
+     * Returns the Protobuf byte array representation of a SemanticDB <code>TextDocument</code> for the given source.
+     */
+    public abstract byte[] semanticdbTextDocument(String filename, String code);
+
     // =================================
     // Configuration and lifecycle APIs.
     // =================================

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -13,6 +13,7 @@ import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.SignatureHelp
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
+import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.PresentationCompiler
 import scala.meta.pc.SymbolSearch
@@ -112,6 +113,20 @@ case class ScalaPresentationCompiler(
     ) { global =>
       Optional.ofNullable(new HoverProvider(global, params).hover().orNull)
     }
+
+  override def semanticdbTextDocument(
+      filename: String,
+      code: String
+  ): Array[Byte] = {
+    access.withNonCancelableCompiler(
+      Array.emptyByteArray,
+      EmptyCancelToken
+    ) { global =>
+      new SemanticdbTextDocumentProvider(global)
+        .textDocument(filename, code)
+        .toByteArray
+    }
+  }
 
   def newCompiler(): MetalsGlobal = {
     val classpath = this.classpath.mkString(File.pathSeparator)

--- a/mtags/src/main/scala/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
@@ -1,0 +1,32 @@
+package scala.meta.internal.pc
+
+import scala.meta.internal.semanticdb.scalac.SemanticdbConfig
+import scala.meta.internal.{semanticdb => s}
+
+class SemanticdbTextDocumentProvider(val compiler: MetalsGlobal) {
+  import compiler._
+  def textDocument(
+      filename: String,
+      code: String
+  ): s.TextDocument = {
+    val unit = addCompilationUnit(
+      code = code,
+      filename = filename,
+      cursor = None
+    )
+    typeCheck(unit)
+    semanticdbOps.config = SemanticdbConfig.parse(
+      List(
+        "-P:semanticdb:synthetics:on",
+        "-P:semanticdb:symbols:none",
+        "-P:semanticdb:text:on"
+      ),
+      _ => (),
+      compiler.reporter,
+      SemanticdbConfig.default
+    )
+    import semanticdbOps._
+    val document = unit.toTextDocument
+    document.withUri(filename)
+  }
+}

--- a/tests/slow/src/test/scala/tests/DefinitionCrossSlowSuite.scala
+++ b/tests/slow/src/test/scala/tests/DefinitionCrossSlowSuite.scala
@@ -1,0 +1,33 @@
+package tests
+
+object DefinitionCrossSlowSuite
+    extends BaseCompletionSlowSuite("definition-cross") {
+  testAsync("2.11") {
+    cleanDatabase()
+    for {
+      _ <- server.initialize(
+        """
+          |/metals.json
+          |{
+          |  "a": {
+          |    "scalaVersion": "2.11.12"
+          |  }
+          |}
+          |/a/src/main/scala/a/Main.scala
+          |object Main {
+          |  println("hello!")
+          |}
+          |""".stripMargin
+      )
+      _ = client.messageRequests.clear()
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      _ = server.workspaceDefinitions // trigger definition
+      _ <- server.didOpen("scala/Predef.scala")
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        ""
+      )
+      _ = assertNoDiff(client.workspaceDiagnostics, "")
+    } yield ()
+  }
+}

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -166,8 +166,6 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
           ImportBuildChanges.yes
         } else if (params == ImportBuild.params) {
           ImportBuild.yes
-        } else if (params == Only212Navigation.params("2.11.12")) {
-          Only212Navigation.dismissForever
         } else if (CheckDoctor.isDoctor(params)) {
           CheckDoctor.moreInformation
         } else if (SelectBspServer.isSelectBspServer(params)) {

--- a/tests/unit/src/test/scala/tests/DefinitionSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionSlowSuite.scala
@@ -2,7 +2,6 @@ package tests
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
-import scala.meta.internal.metals.Messages.Only212Navigation
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.StatisticsConfig
 
@@ -231,35 +230,6 @@ object DefinitionSlowSuite extends BaseSlowSuite("definition") {
       )
       _ <- server.didFocus("a/src/main/scala/a/Main.scala")
       // dependency diagnosticsForDebuggingPurposes are unpublished.
-      _ = assertNoDiff(client.workspaceDiagnostics, "")
-    } yield ()
-  }
-
-  testAsync("2.11") {
-    cleanDatabase()
-    for {
-      _ <- server.initialize(
-        """
-          |/metals.json
-          |{
-          |  "a": {
-          |    "scalaVersion": "2.11.12"
-          |  }
-          |}
-          |/a/src/main/scala/a/Main.scala
-          |object Main {
-          |  println("hello!")
-          |}
-          |""".stripMargin
-      )
-      _ = client.messageRequests.clear()
-      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
-      _ = server.workspaceDefinitions // trigger definition
-      _ <- server.didOpen("scala/Predef.scala")
-      _ = assertNoDiff(
-        client.workspaceMessageRequests,
-        Only212Navigation.params("2.11.12").getMessage
-      )
       _ = assertNoDiff(client.workspaceDiagnostics, "")
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/HoverSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/HoverSlowSuite.scala
@@ -1,5 +1,7 @@
 package tests
 
+import scala.meta.internal.metals.Directories
+
 object HoverSlowSuite extends BaseSlowSuite("hover") with TestHovers {
 
   testAsync("basic") {
@@ -16,6 +18,32 @@ object HoverSlowSuite extends BaseSlowSuite("hover") with TestHovers {
           |  Option(1).he@@ad
           |}""".stripMargin,
         """override def head: Int""".hover
+      )
+    } yield ()
+  }
+
+  testAsync("dependencies") {
+    for {
+      _ <- server.initialize(
+        """/metals.json
+          |{"a":{}}
+          |/a/src/main/scala/a/Main.scala
+          |package a
+          |object Main {
+          |  println(42)
+          |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      _ = server.workspaceDefinitions // triggers goto definition, creating Predef.scala
+      _ <- server.assertHover(
+        "scala/Predef.scala",
+        """
+          |object Main {
+          |  Option(1).he@@ad
+          |}""".stripMargin,
+        """override def head: Int""".hover,
+        root = workspace.resolve(Directories.readonly)
       )
     } yield ()
   }


### PR DESCRIPTION
Previously, we only supported navigation inside library dependencies
with Scala version 2.12.8, after this commit it works with all Scala
versions including 2.11.x.

- Supported: definition, hover, signature help
- Not supported: completions, references

Fixes #473