### PR TITLE
Eagerly load Scalafmt during initialized

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/EmptyScalafmtReporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/EmptyScalafmtReporter.scala
@@ -1,0 +1,20 @@
+package scala.meta.internal.metals
+
+import org.scalafmt.interfaces.ScalafmtReporter
+import java.io.PrintWriter
+import java.io.OutputStream
+import java.nio.file.Path
+
+/**
+ * A Scalafmt reporter that ignores all messages
+ */
+object EmptyScalafmtReporter extends ScalafmtReporter {
+  def error(file: Path, message: String): Unit = ()
+  def error(file: Path, e: Throwable): Unit = ()
+  def excluded(file: Path): Unit = ()
+  def parsedConfig(config: Path, scalafmtVersion: String): Unit = ()
+  def downloadWriter(): PrintWriter =
+    new PrintWriter(new OutputStream() {
+      def write(b: Int): Unit = ()
+    })
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.metals
 import java.io.PrintWriter
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.nio.file.Paths
 import java.nio.file.Path
 import java.util
 import java.util.Collections
@@ -137,6 +138,18 @@ final class FormattingProvider(
     reporterPromise.get().foreach(_.trySuccess(false))
     reporterPromise.set(None)
     cancelToken.set(Some(token))
+  }
+
+  // Warms up the Scalafmt instance so that the first formatting request responds faster.
+  // Does nothing if there is no .scalafmt.conf or there is no configured version setting.
+  def load(): Unit = {
+    if (scalafmtConf.isFile) {
+      scalafmt.format(
+        scalafmtConf.toNIO,
+        Paths.get("Main.scala"),
+        "object Main  {}"
+      )
+    }
   }
 
   def format(

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -40,6 +40,142 @@ final class FormattingProvider(
     scalafmt.clear()
   }
 
+  private def clearDiagnostics(config: AbsolutePath): Unit = {
+    client.publishDiagnostics(
+      new l.PublishDiagnosticsParams(
+        config.toURI.toString,
+        Collections.emptyList()
+      )
+    )
+  }
+
+  private var scalafmt = Scalafmt
+    .create(this.getClass.getClassLoader)
+    .withReporter(EmptyScalafmtReporter)
+    .withDefaultVersion(BuildInfo.scalafmtVersion)
+  private val reporterPromise =
+    new AtomicReference[Option[Promise[Boolean]]](None)
+  private val cancelToken = new AtomicReference[Option[CancelChecker]](None)
+  private def isCancelled: Boolean = cancelToken.get().exists(_.isCancelled)
+  private def reset(token: CancelChecker): Unit = {
+    reporterPromise.get().foreach(_.trySuccess(false))
+    reporterPromise.set(None)
+    cancelToken.set(Some(token))
+  }
+
+  // Warms up the Scalafmt instance so that the first formatting request responds faster.
+  // Does nothing if there is no .scalafmt.conf or there is no configured version setting.
+  def load(): Unit = {
+    if (scalafmtConf.isFile && !Testing.isEnabled) {
+      scalafmt.format(
+        scalafmtConf.toNIO,
+        Paths.get("Main.scala"),
+        "object Main  {}"
+      )
+    }
+  }
+
+  def format(
+      path: AbsolutePath,
+      token: CancelChecker
+  ): Future[util.List[l.TextEdit]] = {
+    scalafmt = scalafmt.withReporter(activeReporter)
+    reset(token)
+    val input = path.toInputFromBuffers(buffers)
+    if (!scalafmtConf.isFile) {
+      handleMissingFile(scalafmtConf).map {
+        case true =>
+          runFormat(path, input).asJava
+        case false =>
+          Collections.emptyList[l.TextEdit]()
+      }
+    } else {
+      val result = runFormat(path, input)
+      if (token.isCancelled) {
+        statusBar.addMessage(
+          s"${icons.info}Scalafmt cancelled by editor, try saving file again"
+        )
+      }
+      reporterPromise.get() match {
+        case Some(promise) =>
+          // Wait until "update .scalafmt.conf" dialogue has completed
+          // before returning future.
+          promise.future.map {
+            case true if !token.isCancelled => runFormat(path, input).asJava
+            case _ => result.asJava
+          }
+        case None =>
+          Future.successful(result.asJava)
+      }
+    }
+  }
+
+  private def runFormat(path: AbsolutePath, input: Input): List[l.TextEdit] = {
+    val fullDocumentRange = Position.Range(input, 0, input.chars.length).toLSP
+    val formatted = scalafmt.format(scalafmtConf.toNIO, path.toNIO, input.text)
+    if (formatted != input.text) {
+      List(new l.TextEdit(fullDocumentRange, formatted))
+    } else {
+      Nil
+    }
+  }
+
+  private def handleMissingVersion(config: AbsolutePath): Future[Boolean] = {
+    askScalafmtVersion().map {
+      case Some(version) =>
+        val text = config.toInputFromBuffers(buffers).text
+        val newText =
+          s"""version = "$version"
+             |""".stripMargin + text
+        Files.write(config.toNIO, newText.getBytes(StandardCharsets.UTF_8))
+        clearDiagnostics(config)
+        client.showMessage(
+          MissingScalafmtVersion.fixedVersion(isCancelled)
+        )
+        true
+      case None =>
+        scribe.info("scalafmt: no version provided for .scalafmt.conf")
+        false
+    }
+  }
+
+  private def askScalafmtVersion(): Future[Option[String]] = {
+    if (serverConfig.isInputBoxEnabled) {
+      client
+        .metalsInputBox(MissingScalafmtVersion.inputBox())
+        .asScala
+        .map(response => Option(response.value))
+    } else {
+      client
+        .showMessageRequest(MissingScalafmtVersion.messageRequest())
+        .asScala
+        .map { item =>
+          if (item == MissingScalafmtVersion.changeVersion) {
+            Some(BuildInfo.scalafmtVersion)
+          } else {
+            None
+          }
+        }
+    }
+  }
+
+  private def handleMissingFile(path: AbsolutePath): Future[Boolean] = {
+    val params = MissingScalafmtConf.params(path)
+    client.showMessageRequest(params).asScala.map { item =>
+      if (item == MissingScalafmtConf.createFile) {
+        val text =
+          s"""version = "${BuildInfo.scalafmtVersion}"
+             |""".stripMargin
+        Files.createDirectories(path.toNIO.getParent)
+        Files.write(path.toNIO, text.getBytes(StandardCharsets.UTF_8))
+        client.showMessage(MissingScalafmtConf.fixedParams(isCancelled))
+        true
+      } else {
+        false
+      }
+    }
+  }
+
   private def scalafmtConf: AbsolutePath = {
     val configpath = userConfig().scalafmtConfigPath
     (workspace :: workspaceFolders).iterator
@@ -47,7 +183,8 @@ final class FormattingProvider(
       .collectFirst { case path if path.isFile => path }
       .getOrElse(workspace.resolve(configpath))
   }
-  private val reporter: ScalafmtReporter = new ScalafmtReporter {
+
+  private val activeReporter: ScalafmtReporter = new ScalafmtReporter {
     private var downloadingScalafmt = Promise[Unit]()
     override def error(file: Path, message: String): Unit = {
       scribe.error(s"scalafmt: $file: $message")
@@ -115,140 +252,6 @@ final class FormattingProvider(
         downloadingScalafmt.future
       )
       new PrintWriter(System.out)
-    }
-  }
-  private def clearDiagnostics(config: AbsolutePath): Unit = {
-    client.publishDiagnostics(
-      new l.PublishDiagnosticsParams(
-        config.toURI.toString,
-        Collections.emptyList()
-      )
-    )
-  }
-
-  private val scalafmt = Scalafmt
-    .create(this.getClass.getClassLoader)
-    .withReporter(reporter)
-    .withDefaultVersion(BuildInfo.scalafmtVersion)
-  private val reporterPromise =
-    new AtomicReference[Option[Promise[Boolean]]](None)
-  private val cancelToken = new AtomicReference[Option[CancelChecker]](None)
-  private def isCancelled: Boolean = cancelToken.get().exists(_.isCancelled)
-  private def reset(token: CancelChecker): Unit = {
-    reporterPromise.get().foreach(_.trySuccess(false))
-    reporterPromise.set(None)
-    cancelToken.set(Some(token))
-  }
-
-  // Warms up the Scalafmt instance so that the first formatting request responds faster.
-  // Does nothing if there is no .scalafmt.conf or there is no configured version setting.
-  def load(): Unit = {
-    if (scalafmtConf.isFile) {
-      scalafmt.format(
-        scalafmtConf.toNIO,
-        Paths.get("Main.scala"),
-        "object Main  {}"
-      )
-    }
-  }
-
-  def format(
-      path: AbsolutePath,
-      token: CancelChecker
-  ): Future[util.List[l.TextEdit]] = {
-    reset(token)
-    val input = path.toInputFromBuffers(buffers)
-    if (!scalafmtConf.isFile) {
-      handleMissingFile(scalafmtConf).map {
-        case true =>
-          runFormat(path, input).asJava
-        case false =>
-          Collections.emptyList[l.TextEdit]()
-      }
-    } else {
-      val result = runFormat(path, input)
-      if (token.isCancelled) {
-        statusBar.addMessage(
-          s"${icons.info}Scalafmt cancelled by editor, try saving file again"
-        )
-      }
-      reporterPromise.get() match {
-        case Some(promise) =>
-          // Wait until "update .scalafmt.conf" dialogue has completed
-          // before returning future.
-          promise.future.map {
-            case true if !token.isCancelled => runFormat(path, input).asJava
-            case _ => result.asJava
-          }
-        case None =>
-          Future.successful(result.asJava)
-      }
-    }
-  }
-
-  private def runFormat(path: AbsolutePath, input: Input): List[l.TextEdit] = {
-    val fullDocumentRange = Position.Range(input, 0, input.chars.length).toLSP
-    val formatted = scalafmt.format(scalafmtConf.toNIO, path.toNIO, input.text)
-    if (formatted != input.text) {
-      List(new l.TextEdit(fullDocumentRange, formatted))
-    } else {
-      Nil
-    }
-  }
-
-  def handleMissingVersion(config: AbsolutePath): Future[Boolean] = {
-    askScalafmtVersion().map {
-      case Some(version) =>
-        val text = config.toInputFromBuffers(buffers).text
-        val newText =
-          s"""version = "$version"
-             |""".stripMargin + text
-        Files.write(config.toNIO, newText.getBytes(StandardCharsets.UTF_8))
-        clearDiagnostics(config)
-        client.showMessage(
-          MissingScalafmtVersion.fixedVersion(isCancelled)
-        )
-        true
-      case None =>
-        scribe.info("scalafmt: no version provided for .scalafmt.conf")
-        false
-    }
-  }
-
-  def askScalafmtVersion(): Future[Option[String]] = {
-    if (serverConfig.isInputBoxEnabled) {
-      client
-        .metalsInputBox(MissingScalafmtVersion.inputBox())
-        .asScala
-        .map(response => Option(response.value))
-    } else {
-      client
-        .showMessageRequest(MissingScalafmtVersion.messageRequest())
-        .asScala
-        .map { item =>
-          if (item == MissingScalafmtVersion.changeVersion) {
-            Some(BuildInfo.scalafmtVersion)
-          } else {
-            None
-          }
-        }
-    }
-  }
-
-  def handleMissingFile(path: AbsolutePath): Future[Boolean] = {
-    val params = MissingScalafmtConf.params(path)
-    client.showMessageRequest(params).asScala.map { item =>
-      if (item == MissingScalafmtConf.createFile) {
-        val text =
-          s"""version = "${BuildInfo.scalafmtVersion}"
-             |""".stripMargin
-        Files.createDirectories(path.toNIO.getParent)
-        Files.write(path.toNIO, text.getBytes(StandardCharsets.UTF_8))
-        client.showMessage(MissingScalafmtConf.fixedParams(isCancelled))
-        true
-      } else {
-        false
-      }
     }
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -445,7 +445,8 @@ class MetalsLanguageServer(
           List[Future[Unit]](
             quickConnectToBuildServer().ignoreValue,
             slowConnectToBuildServer(forceImport = false).ignoreValue,
-            Future(startHttpServer())
+            Future(startHttpServer()),
+            Future(formattingProvider.load())
           )
         )
         .ignoreValue

--- a/mtags/src/main/scala/scala/meta/internal/metals/Testing.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/Testing.scala
@@ -1,0 +1,10 @@
+package scala.meta.internal.metals
+
+object Testing {
+  def enable(): Unit = {
+    System.setProperty("metals.testing", "true")
+  }
+  def isEnabled: Boolean = {
+    "true" == System.getProperty("metals.testing")
+  }
+}

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -15,15 +15,13 @@ import utest.framework.TestCallTree
 import utest.framework.Tree
 import utest.ufansi.Attrs
 import utest.ufansi.Str
+import scala.meta.internal.metals.Testing
 
 /**
  * Test suite that replace utest DSL with FunSuite-style syntax from ScalaTest.
- *
- * Exposes
- *
  */
 class BaseSuite extends TestSuite {
-  System.setProperty("metals.testing", "true")
+  Testing.enable()
   def isScala211: Boolean =
     Properties.versionNumberString.startsWith("2.11")
   def isWindows: Boolean =


### PR DESCRIPTION
This lowers the risk of timing out for the first "format on save" request.

Fixes #544 