### PR TITLE
Eagerly load presentation compiler for open buffers.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-def localSnapshotVersion = "0.5.0-SNAPSHOT"
+def localSnapshotVersion = "0.5.1-SNAPSHOT"
 def isCI = System.getenv("CI") != null
 inThisBuild(
   List(

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -23,6 +23,7 @@ import scala.meta.pc.CancelToken
 import scala.meta.pc.PresentationCompiler
 import scala.meta.pc.SymbolSearch
 import scala.tools.nsc.Properties
+import scala.concurrent.Future
 
 /**
  * Manages lifecycle for presentation compilers in all build targets.
@@ -62,6 +63,23 @@ class Compilers(
     scribe.info(
       s"restarted ${count} presentation compiler${LogMessages.plural(count)}"
     )
+  }
+
+  def load(paths: Seq[AbsolutePath]): Future[Unit] = Future {
+    val targets = paths
+      .flatMap(path => buildTargets.inverseSources(path).toList)
+      .distinct
+    targets.foreach { target =>
+      loadCompiler(target).foreach { pc =>
+        pc.hover(
+          CompilerOffsetParams(
+            "Main.scala",
+            "object Ma\n",
+            "object Ma".length()
+          )
+        )
+      }
+    }
   }
 
   def didCompile(report: CompileReport): Unit = {
@@ -140,6 +158,7 @@ class Compilers(
         .orElse(interactiveSemanticdbs.flatMap(_.getBuildTarget(path)))
       compiler <- loadCompiler(target)
     } yield compiler
+
   def loadCompiler(
       target: BuildTargetIdentifier
   ): Option[PresentationCompiler] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -247,8 +247,8 @@ final class FormattingProvider(
     override def downloadWriter(): PrintWriter = {
       downloadingScalafmt.trySuccess(())
       downloadingScalafmt = Promise()
-      statusBar.trackFuture(
-        s"${icons.sync}Loading Scalafmt",
+      statusBar.trackSlowFuture(
+        "Loading Scalafmt",
         downloadingScalafmt.future
       )
       new PrintWriter(System.out)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -516,6 +516,7 @@ class MetalsLanguageServer(
         ()
       }
     } else {
+      compilers.load(List(path))
       compileSourceFiles(List(path)).asJava
     }
   }
@@ -1062,7 +1063,11 @@ class MetalsLanguageServer(
         indexWorkspace(i)
       }
       _ = indexingPromise.trySuccess(())
-      _ <- cascadeCompileSourceFiles(buffers.open.toSeq)
+      _ <- Future.sequence[Unit, List](
+        cascadeCompileSourceFiles(buffers.open.toSeq) ::
+          compilers.load(buffers.open.toSeq) ::
+          Nil
+      )
     } yield {
       BuildChange.Reconnected
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -141,8 +141,13 @@ class MetalsLanguageServer(
 
   def connectToLanguageClient(client: MetalsLanguageClient): Unit = {
     languageClient.underlying = client
-    statusBar =
-      new StatusBar(() => languageClient, time, progressTicks, config.icons)
+    statusBar = new StatusBar(
+      () => languageClient,
+      time,
+      progressTicks,
+      config.icons,
+      config.statusBar
+    )
     embedded = register(
       new Embedded(
         config.icons,

--- a/test-workspace/build.sbt
+++ b/test-workspace/build.sbt
@@ -3,4 +3,3 @@ inThisBuild(
     scalaVersion := "2.12.8"
   )
 )
-

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -1,6 +1,8 @@
 package example
 
 object Main {
-  Option(1).map(_.toString)
-  List(1).flatten
+  Option(1).map(_.toString())
+  import java.nio.file.Files
+  import java.nio.file.Paths
+  Files.readAllBytes(Paths.get(""))
 }

--- a/test-workspace/src/test/scala/example/UserTest.scala
+++ b/test-workspace/src/test/scala/example/UserTest.scala
@@ -2,4 +2,7 @@ package example
 
 import java.nio.file.Path
 
-class UserTest {}
+class UserTest {
+  val abc = 2
+  println(abc + abc)
+}

--- a/tests/unit/src/test/scala/tests/StatusBarSuite.scala
+++ b/tests/unit/src/test/scala/tests/StatusBarSuite.scala
@@ -6,6 +6,7 @@ import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.ProgressTicks
 import scala.meta.internal.metals.StatusBar
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object StatusBarSuite extends BaseSuite {
   val time = new FakeTime

--- a/tests/unit/src/test/scala/tests/StatusBarSuite.scala
+++ b/tests/unit/src/test/scala/tests/StatusBarSuite.scala
@@ -11,8 +11,14 @@ import scala.concurrent.ExecutionContext.Implicits.global
 object StatusBarSuite extends BaseSuite {
   val time = new FakeTime
   val client = new TestingClient(PathIO.workingDirectory, Buffers())
-  var status =
-    new StatusBar(() => client, time, ProgressTicks.dots, Icons.default)
+  import scala.meta.internal.metals.StatusBarConfig
+  var status = new StatusBar(
+    () => client,
+    time,
+    ProgressTicks.dots,
+    Icons.default,
+    StatusBarConfig.default
+  )
   override def utestBeforeEach(path: Seq[String]): Unit = {
     client.statusParams.clear()
     status.cancel()


### PR DESCRIPTION
Previously, we waited until the first completion/hover/signatureHelp
request to load the presentation compiler. After this commit, we load
the compiler eagerly and display a "slow task" status with timer so that
it's more clear that we're downloading artifacts from the internet.
Scalafmt also uses slow tasks now, for consistency.

Fixes #543