### PR TITLE
Don't eagerly load presentation compiler during tests.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -65,22 +65,26 @@ class Compilers(
     )
   }
 
-  def load(paths: Seq[AbsolutePath]): Future[Unit] = Future {
-    val targets = paths
-      .flatMap(path => buildTargets.inverseSources(path).toList)
-      .distinct
-    targets.foreach { target =>
-      loadCompiler(target).foreach { pc =>
-        pc.hover(
-          CompilerOffsetParams(
-            "Main.scala",
-            "object Ma\n",
-            "object Ma".length()
-          )
-        )
+  def load(paths: Seq[AbsolutePath]): Future[Unit] =
+    if (Testing.isEnabled) Future.successful(())
+    else {
+      Future {
+        val targets = paths
+          .flatMap(path => buildTargets.inverseSources(path).toList)
+          .distinct
+        targets.foreach { target =>
+          loadCompiler(target).foreach { pc =>
+            pc.hover(
+              CompilerOffsetParams(
+                "Main.scala",
+                "object Ma\n",
+                "object Ma".length()
+              )
+            )
+          }
+        }
       }
     }
-  }
 
   def didCompile(report: CompileReport): Unit = {
     if (report.getErrors > 0) {


### PR DESCRIPTION
Previously, we always eagerly loaded the presentation compiler to
improve the out-of-the-box experience for new Metals users. However,
this behavior is undesirable for tests because it triggers a lot
of unnecessary computation on every test.

It's generally undesirable to customize the runtime for running tests
but in this particular case I feel it's justified.