### PR TITLE
Handle exceptions when computing completion position.

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -805,4 +805,16 @@ object CompletionSuite extends BaseCompletionSuite {
     filterText = "substring"
   )
 
+  check(
+    "error",
+    s"""|object Main {
+        |  def foo(file: String): String = {
+        |    println(fil@@)
+        |    // type mismatch: obtained Unit, expected String
+        |  }
+        |}
+        |""".stripMargin,
+    "file: String"
+  )
+
 }


### PR DESCRIPTION
Previously, we returned no completions in specific cases due to a null
pointer exception caused by a type error. Now we gracefully handle
type errors so that completions are still returned even when `Tree.tpe`
is null.