### PR TITLE
Improve completion snippets, fixes #610.

### DIFF
--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -1,8 +1,12 @@
 package example
 
-object Main {
-  Option(1).map(_.toString())
+import java.util.concurrent.CompletableFuture
+
+object Main extends CompletableFuture[Int] {
+  println(Option(1).map(_.toString()))
   import java.nio.file.Files
   import java.nio.file.Paths
+  List(1).map(identity _)
+  System.out.println(identity(), identity(), identity())
   Files.readAllBytes(Paths.get(""))
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -141,7 +141,7 @@ object CompletionSnippetSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "trailing@@()",
-    "trailing($0)"
+    "trailing()"
   )
 
   checkEditLine(
@@ -152,7 +152,7 @@ object CompletionSnippetSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "trailing@@ { }",
-    "trailing {$0 }"
+    "trailing { }"
   )
 
   checkEditLine(
@@ -163,7 +163,7 @@ object CompletionSnippetSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "trailing@@{ }",
-    "trailing{$0 }"
+    "trailing{ }"
   )
 
   checkEditLine(
@@ -174,7 +174,7 @@ object CompletionSnippetSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "trailing@@ _",
-    "trailing _$0"
+    "trailing _"
   )
 
   checkEditLine(
@@ -185,6 +185,28 @@ object CompletionSnippetSuite extends BaseCompletionSuite {
         |""".stripMargin,
     "List(1).flatte@@",
     "List(1).flatten"
+  )
+
+  checkEditLine(
+    "bug1",
+    s"""|object Main {
+        |  ___
+        |}
+        |""".stripMargin,
+    "scala.util.Try@@(1)",
+    "scala.util.Try(1)"
+  )
+
+  checkEditLine(
+    "symbol",
+    s"""|object Main {
+        |  val out = new StringBuilder()
+        |  ___
+        |}
+        |""".stripMargin,
+    "out.+@@=('a')",
+    "out.++==('a')",
+    filter = _.contains("++=(s: String)")
   )
 
 }


### PR DESCRIPTION
Previously, selecting a completion item would remove the trailing
identifier.

```scala
// before
List(1).m@@flatMap { x => Nil }
// after
List(1).map$0 { x => Nil }
```

This behavior was at best buggy and at worst surprising in cases where
it was working as intended.

Now, completions never strip the suffix unless the completed identifier
is identical to the suffix.

```scala
// before
object Foo extends Fut@@ure[Int]
// after
import scala.concurrent.Future
object Foo extends Future$0[Int]
```

Additionally, snippets like `($0)` and `[$0]` are now disabled
when editing inside an existing expression. For example,

```
// before
Syst@@println()
// old behavior
System$0()
// new behavior
System.$0println()
```