### PR TITLE
Disable macro-paradise compiler plugin, fixes #622.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CompilerPlugins.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CompilerPlugins.scala
@@ -23,9 +23,10 @@ import scala.xml.XML
  * only supports a hardcoded list of such compiler plugins:
  * - kind-projector, introduces new syntax for anonymous type lambdas
  * - better-monadic-for, changes for comprehension desugaring
- * - macro-paradise-plugin, adds support for macro annotations. Has been
- *   merged into the compiler for 2.13.
- * The IntelliJ Scala plugin has custom support for these three plugins.
+ * The IntelliJ Scala plugin has custom support for these plugins.
+ *
+ * Notably, macro-paradise-plugin id disabled because it does not work with the -Ymacro-expand:discard
+ * setting making completions always fail when inside an expanded tree.
  *
  * The process for adding support for other compiler plugins is the following,
  * send a PR to Metals adding integration tests to demonstrate thee compiler plugin
@@ -50,9 +51,10 @@ class CompilerPlugins {
   }
 
   private val isSupportedPlugin = Set(
-    "macro-paradise-plugin", // https://github.com/scalamacros/paradise/
     "kind-projector", // https://github.com/non/kind-projector
     "bm4" // https://github.com/oleg-py/better-monadic-for
+    // Intentionally not supported:
+    // "macro-paradise-plugin", see https://github.com/scalameta/metals/issues/622
   )
 
   private def isSupportedPlugin(path: AbsolutePath): Boolean = {

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
@@ -100,6 +100,8 @@ class CompilerAccess(
           e.getClassName.startsWith("scala.reflect")
         }
         if (isParadiseRelated) {
+          // NOTE(olafur) Metals disables macroparadise by default but other library
+          // clients of mtags may enable it.
           // Testing shows that the scalamacro paradise plugin tends to crash
           // easily in long-running sessions. We retry with a fresh compiler
           // to see if that fixes the issue. This is a hacky solution that is

--- a/tests/cross/src/test/scala/tests/pc/MacroCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/MacroCompletionSuite.scala
@@ -10,7 +10,6 @@ object MacroCompletionSuite extends BaseCompletionSuite {
     thisClasspath
       .filter { path =>
         val filename = path.getFileName.toString
-        filename.contains("paradise") ||
         filename.contains("better-monadic-for") ||
         filename.contains("kind-projector")
       }
@@ -92,27 +91,14 @@ object MacroCompletionSuite extends BaseCompletionSuite {
     "import",
     """|import Semigroup.op@@
        |""".stripMargin,
-    """|ops x.Semigroup
-       |""".stripMargin
+    ""
   )
   simulacrum(
     "object",
     """|Semigroup.apply@@
        |""".stripMargin,
-    """|apply[A](implicit instance: Semigroup[A]): Semigroup[A]
-       |""".stripMargin
+    ""
   )
-  1.to(5).foreach { i =>
-    val name = "generatedMethod".dropRight(i)
-    simulacrum(
-      s"member-$i",
-      s"""|import Semigroup.ops._
-          |1.$name@@
-          |""".stripMargin,
-      """|generatedMethod(y: Int): Int
-         |""".stripMargin
-    )
-  }
 
   check(
     "kind-projector",


### PR DESCRIPTION
Previously, we tried to expand macro annotations so that
completions/hover/signatureHelp would take the expanded code in the
current source file into account. This approach didn't work:

- the presentation compiler crashed frequently in macro-paradise
  on the second request for completions.
- completions/hover/signatureHelp don't work at all inside macro
  expanded code because macroparadise doesn't respect
  -Ymacro-expand:discard.

Now with macroparadise disabled, completions work as expected inside a
class with the `@react` annotation in https://github.com/shadaj/slinky.

Note that completions/hover/signatureHelp will continue to take macro
expanded code into account from other source files. It is only for
expanded code in the current open buffer where we won't take macro
expanded signatures into account.