### PR TITLE
Sort symbols defined in the current file to the top, fixes #618.

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -110,6 +110,9 @@ trait Completions { this: MetalsGlobal =>
     var relevance = 0
     // local symbols are more relevant
     if (!sym.isLocalToBlock) relevance |= IsNotLocalByBlock
+    // symbols defined in this file are more relevant
+    if (!sym.pos.isDefined || sym.hasPackageFlag)
+      relevance |= IsNotDefinedInFile
     // fields are more relevant than non fields
     if (!sym.hasGetter) relevance |= IsNotGetter
     // non-inherited members are more relevant
@@ -209,7 +212,8 @@ trait Completions { this: MetalsGlobal =>
         new SignaturePrinter(m, history, info, includeDocs = false)
           .defaultMethodSignature()
       case _ =>
-        def fullName(s: Symbol): String = " " + s.owner.fullName
+        def fullName(s: Symbol): String =
+          " " + s.owner.fullNameSyntax
         dealiasedValForwarder(sym) match {
           case dealiased :: _ =>
             fullName(dealiased)

--- a/mtags/src/main/scala/scala/meta/internal/pc/MemberOrdering.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MemberOrdering.scala
@@ -6,13 +6,14 @@ object MemberOrdering {
   val IsImplicitConversion = 1 << 28
   val IsInherited = 1 << 27
   val IsNotLocalByBlock = 1 << 26
-  val IsNotGetter = 1 << 25
-  val IsPackage = 1 << 24
-  val IsNotCaseAccessor = 1 << 23
-  val IsNotPublic = 1 << 22
-  val IsSynthetic = 1 << 21
-  val IsDeprecated = 1 << 20
-  val IsEvilMethod = 1 << 19 // example: clone() and finalize()
+  val IsNotDefinedInFile = 1 << 25
+  val IsNotGetter = 1 << 24
+  val IsPackage = 1 << 23
+  val IsNotCaseAccessor = 1 << 22
+  val IsNotPublic = 1 << 21
+  val IsSynthetic = 1 << 20
+  val IsDeprecated = 1 << 19
+  val IsEvilMethod = 1 << 18 // example: clone() and finalize()
 
   // OverrideDefMember
   val IsNotAbstract = 1 << 30

--- a/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
@@ -436,7 +436,11 @@ class MetalsGlobal(
       val out = new java.lang.StringBuilder
       def loop(s: Symbol): Unit = {
         if (s.isRoot || s.isRootPackage || s == NoSymbol || s.owner.isEffectiveRoot) {
-          out.append(Identifier(s.name))
+          val name =
+            if (s.isEmptyPackage || s.isEmptyPackageClass) TermName("_empty_")
+            else if (s.isRootPackage || s.isRoot) TermName("_root_")
+            else s.name
+          out.append(Identifier(name))
         } else {
           loop(s.effectiveOwner.enclClass)
           out.append('.').append(Identifier(s.name))

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -133,7 +133,10 @@ abstract class BaseCompletionSuite extends BasePCSuite {
   )(implicit file: sourcecode.File, line: sourcecode.Line): Unit = {
     test(name) {
       val out = new StringBuilder()
-      val baseItems = getItems(original, filename)
+      val withPkg =
+        if (original.contains("package")) original
+        else s"package ${scala.meta.Term.Name(name)}\n$original"
+      val baseItems = getItems(withPkg, filename)
       val items = topLines match {
         case Some(top) => baseItems.take(top)
         case None => baseItems

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -10,8 +10,8 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|assertion = : Boolean
+       |Main arg
        |:: scala.collection.immutable
-       |:+ scala.collection
        |""".stripMargin,
     topLines = Option(3)
   )
@@ -23,8 +23,8 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|message = : => Any
+       |Main arg1
        |:: scala.collection.immutable
-       |:+ scala.collection
        |""".stripMargin,
     topLines = Option(3)
   )
@@ -36,8 +36,8 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|message = : => Any
+       |Main arg2
        |:: scala.collection.immutable
-       |:+ scala.collection
        |""".stripMargin,
     topLines = Option(3)
   )
@@ -60,7 +60,7 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|age = : Int
        |followers = : Int
-       |:: scala.collection.immutable
+       |Main arg3
        |""".stripMargin,
     topLines = Option(3)
   )
@@ -75,7 +75,7 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|age = : Int
        |followers = : Int
-       |:: scala.collection.immutable
+       |Main arg4
        |""".stripMargin,
     topLines = Option(3)
   )
@@ -90,9 +90,10 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|address = : String
        |followers = : Int
-       |:: scala.collection.immutable
+       |Main arg5
+       |User arg5
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(4)
   )
 
   check(
@@ -118,8 +119,8 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|x = : Int
+       |Main arg7
        |:: scala.collection.immutable
-       |:+ scala.collection
        |""".stripMargin,
     topLines = Option(3)
   )
@@ -132,8 +133,8 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|suffix = : String
+       |Main arg8
        |:: scala.collection.immutable
-       |:+ scala.collection
        |""".stripMargin,
     topLines = Option(3)
   )
@@ -147,8 +148,8 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|end = : Int
+       |Main arg9
        |:: scala.collection.immutable
-       |:+ scala.collection
        |""".stripMargin,
     topLines = Option(3)
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -66,7 +66,7 @@ object CompletionCaseSuite extends BaseCompletionSuite {
 
   check(
     "case",
-    """
+    """package kase
       |object A {
       |  Option(1) match {
       |    cas@@
@@ -147,7 +147,7 @@ object CompletionCaseSuite extends BaseCompletionSuite {
       |  }
       |}""".stripMargin,
     // Assert we don't include AdtTwo in the results.
-    """|case Cls(a, b) => Outer
+    """|case Cls(a, b) => `sealed-two`.Outer
        |""".stripMargin,
     compat = Map(
       // known-direct subclasses doesn't work well in 2.11 apparently.

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -521,7 +521,7 @@ object CompletionSuite extends BaseCompletionSuite {
       |  incrementThisType@@
       |}
     """.stripMargin,
-    """|incrementThisType(): A.this.type (with underlying type A)
+    """|incrementThisType(): A.this.type (with underlying type singleton.A)
        |""".stripMargin
   )
 
@@ -808,13 +808,32 @@ object CompletionSuite extends BaseCompletionSuite {
   check(
     "error",
     s"""|object Main {
-        |  def foo(file: String): String = {
-        |    println(fil@@)
+        |  def foo(myError: String): String = {
+        |    println(myErr@@)
         |    // type mismatch: obtained Unit, expected String
         |  }
         |}
         |""".stripMargin,
-    "file: String"
+    "myError: String"
+  )
+
+  check(
+    "sort",
+    s"""|object Main {
+        |  def printnnn = ""
+        |  def printmmm = ""
+        |  locally {
+        |    val printxxx = ""
+        |    print@@
+        |  }
+        |}
+        |""".stripMargin,
+    """|printxxx: String
+       |printmmm: String
+       |printnnn: String
+       |print(x: Any): Unit
+       |""".stripMargin,
+    topLines = Some(4)
   )
 
 }


### PR DESCRIPTION
Previously, we sorted global symbols defined in the current file in the
same group as global symbols from the root scope. Now, we priotize
symbols in the current file.

This change has the nice side-effect that `::` no longer appears at the
top of all completions in an empty scope without a prefix.