### PR TITLE
Provide fuzzier type member matching and more polished sorting.

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/metals/Fuzzy.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/Fuzzy.scala
@@ -334,4 +334,35 @@ class Fuzzy {
     }
   }
 
+  /**
+   * Returns true if all characters in the query have a case in-sensitive matching character in the symbol, in-order
+   *
+   * Matching examples:
+   * - int       toInt
+   * - int       instance  // Because `in` and `t`
+   * - int       intNumber
+   *
+   * Non-matching examples:
+   * - int       inSub // missing t
+   *
+   * @param query the query string, like "int"
+   * @param sym the symbol to test for matching against the query string, like "toInt".
+   */
+  def matchesSubCharacters(query: CharSequence, sym: CharSequence): Boolean = {
+    val A = query.length()
+    val B = sym.length()
+    def loop(a: Int, b: Int): Boolean = {
+      if (a >= A) true
+      else if (b >= B) false
+      else {
+        val ca = query.charAt(a).toLower
+        val cb = sym.charAt(b).toLower
+        if (ca == cb) loop(a + 1, b + 1)
+        else if (cb == '$') false
+        else loop(a, b + 1)
+      }
+    }
+    loop(0, 0)
+  }
+
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -358,7 +358,13 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
         qual <- applyQualifier(tree)
         completions = completionsAt(qual.pos.focus).results
           .filter(_.sym.name == qual.name)
-          .sorted(memberOrdering(new ShortenedNames(), CompletionPosition.None))
+          .sorted(
+            memberOrdering(
+              qual.name.toString(),
+              new ShortenedNames(),
+              CompletionPosition.None
+            )
+          )
           .map(_.sym)
           .distinct
         completion <- completions match {

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -128,7 +128,7 @@ object CompletionDocSuite extends BaseCompletionSuite {
       |  Predef@@
       |}
     """.stripMargin,
-    """|DeprecatedPredef scala
+    """|
        |> The `Predef` object provides definitions that are accessible in all Scala
        | compilation units without explicit qualification.
        |
@@ -176,6 +176,7 @@ object CompletionDocSuite extends BaseCompletionSuite {
        | Short value to a Long value as required, and to add additional higher-order
        | functions to Array values. These are described in more detail in the documentation of [scala.Array](scala.Array).
        |Predef scala
+       |DeprecatedPredef scala
        |""".stripMargin,
     includeDocs = true
   )
@@ -186,11 +187,7 @@ object CompletionDocSuite extends BaseCompletionSuite {
       |  scala.collection.Iterator@@
       |}
     """.stripMargin,
-    """|> Explicit instantiation of the `Iterator` trait to reduce class file size in subclasses.
-       |AbstractIterator scala.collection
-       |> Buffered iterators are iterators which provide a method `head`
-       | that inspects the next element without discarding it.
-       |BufferedIterator scala.collection
+    """|
        |> ### class Iterator
        |Iterators are data structures that allow to iterate over a sequence
        | of elements. They have a `hasNext` method for checking
@@ -225,6 +222,11 @@ object CompletionDocSuite extends BaseCompletionSuite {
        |### object Iterator
        |The `Iterator` object provides various functions for creating specialized iterators.
        |Iterator scala.collection
+       |> Explicit instantiation of the `Iterator` trait to reduce class file size in subclasses.
+       |AbstractIterator scala.collection
+       |> Buffered iterators are iterators which provide a method `head`
+       | that inspects the next element without discarding it.
+       |BufferedIterator scala.collection
        |""".stripMargin,
     includeDocs = true
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -11,6 +11,7 @@ object CompletionSnippetSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|apply($0)
+       |unapplySeq($0)
        |""".stripMargin
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -286,8 +286,8 @@ object CompletionSuite extends BaseCompletionSuite {
        |Path2D - java.awt.geom
        |CertPath - java.security.cert
        |LayoutPath - java.awt.font
-       |GeneralPath - java.awt.geom
        |PathMatcher - java.nio.file
+       |GeneralPath - java.awt.geom
        |XPathResult - org.w3c.dom.xpath
        |PathIterator - java.awt.geom
        |XPathEvaluator - org.w3c.dom.xpath
@@ -690,9 +690,6 @@ object CompletionSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|None scala
        |NoManifest scala.reflect
-       |ClassNotFoundException java.lang
-       |CloneNotSupportedException java.lang
-       |EnumConstantNotPresentException java.lang
        |NoClassDefFoundError java.lang
        |NoSuchFieldError java.lang
        |NoSuchFieldException java.lang
@@ -700,6 +697,9 @@ object CompletionSuite extends BaseCompletionSuite {
        |NoSuchMethodException java.lang
        |NotImplementedError scala
        |NotNull scala
+       |ClassNotFoundException java.lang
+       |CloneNotSupportedException java.lang
+       |EnumConstantNotPresentException java.lang
        |TypeNotPresentException java.lang
        |""".stripMargin
   )
@@ -712,8 +712,8 @@ object CompletionSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|Some scala
-       |IndexedSeq scala.collection
        |Seq scala.collection
+       |Set scala.collection.immutable
        |""".stripMargin,
     topLines = Some(3)
   )
@@ -726,8 +726,8 @@ object CompletionSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|Some scala
-       |IndexedSeq scala.collection
        |Seq scala.collection
+       |Set scala.collection.immutable
        |""".stripMargin,
     topLines = Some(3)
   )
@@ -834,6 +834,38 @@ object CompletionSuite extends BaseCompletionSuite {
        |print(x: Any): Unit
        |""".stripMargin,
     topLines = Some(4)
+  )
+
+  check(
+    "fuzzy-member",
+    s"""|class Foo {
+        |  def getTimeStamp: Int = 0
+        |}
+        |object Main {
+        |  new Foo().time@@
+        |}
+        |""".stripMargin,
+    """|getTimeStamp: Int
+       |""".stripMargin
+  )
+
+  check(
+    "fuzzy-member-sort",
+    s"""|class Foo {
+        |  def toInt: Int = 0
+        |  def instance: Int = 42
+        |  def intNumber: Int = 42
+        |}
+        |object Main {
+        |  new Foo().int@@
+        |}
+        |""".stripMargin,
+    """|intNumber: Int
+       |toInt: Int
+       |instance: Int
+       |asInstanceOf[T0]: T0
+       |isInstanceOf[T0]: Boolean
+       |""".stripMargin
   )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/MacroCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/MacroCompletionSuite.scala
@@ -23,16 +23,14 @@ object MacroCompletionSuite extends BaseCompletionSuite {
       |case class Person(name: String, age: Int)
       |object Person {
       |  val gen = Generic[Person]
-      |  gen.to@@
+      |  gen.from@@
       |}
       |""".stripMargin,
-    """|to(t: Person): String :: Int :: HNil
-       |toString(): String
+    """|from(r: String :: Int :: HNil): Person
        |""".stripMargin,
     compat = Map(
       "2.11" ->
-        """|to(t: Person): ::[String,::[Int,HNil]]
-           |toString(): String
+        """|from(r: String :: Int :: HNil): Person
            |""".stripMargin
     )
   )
@@ -49,10 +47,10 @@ object MacroCompletionSuite extends BaseCompletionSuite {
       |    }
       |  }
       |  val x = 42
-      |  fr"$x".righ@@
+      |  fr"$x".fold@@
       |}
       |""".stripMargin,
-    """|right: Either.RightProjection[Int,String]
+    """|fold[C](fa: Int => C, fb: String => C): C
        |""".stripMargin
   )
 
@@ -105,10 +103,10 @@ object MacroCompletionSuite extends BaseCompletionSuite {
     """
       |object a {
       |  def baz[F[_], A]: F[A] = ???
-      |  baz[Either[Int, ?], String].right@@
+      |  baz[Either[Int, ?], String].fold@@
       |}
     """.stripMargin,
-    """|right: Either.RightProjection[Int,String]
+    """|fold[C](fa: Int => C, fb: String => C): C
        |""".stripMargin
   )
 

--- a/tests/cross/src/test/scala/tests/pc/MacroCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/MacroCompletionSuite.scala
@@ -30,7 +30,7 @@ object MacroCompletionSuite extends BaseCompletionSuite {
        |""".stripMargin,
     compat = Map(
       "2.11" ->
-        """|from(r: String :: Int :: HNil): Person
+        """|from(r: ::[String,::[Int,HNil]]): Person
            |""".stripMargin
     )
   )
@@ -51,7 +51,12 @@ object MacroCompletionSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|fold[C](fa: Int => C, fb: String => C): C
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "2.11" ->
+        """|fold[X](fa: Int => X, fb: String => X): X
+           |""".stripMargin
+    )
   )
 
   check(
@@ -107,7 +112,12 @@ object MacroCompletionSuite extends BaseCompletionSuite {
       |}
     """.stripMargin,
     """|fold[C](fa: Int => C, fb: String => C): C
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "2.11" ->
+        """|fold[X](fa: Int => X, fb: String => X): X
+           |""".stripMargin
+    )
   )
 
   check(

--- a/tests/unit/src/main/scala/tests/BaseCompletionSlowSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionSlowSuite.scala
@@ -74,9 +74,9 @@ abstract class BaseCompletionSlowSuite(name: String)
            |Stream - java.util.stream
            |IntStream - java.util.stream
            |LogStream - java.rmi.server
+           |StreamView - scala.collection.immutable
            |BaseStream - java.util.stream
            |LongStream - java.util.stream
-           |StreamView - scala.collection.immutable
            |InputStream - java.io
            |PrintStream - java.io
            |DoubleStream - java.util.stream

--- a/tests/unit/src/test/scala/tests/CompletionSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompletionSlowSuite.scala
@@ -106,9 +106,9 @@ object CompletionSlowSuite extends BaseCompletionSlowSuite("completion") {
     for {
       _ <- assertCompletion(
         """|def baz[F[_], A]: F[A] = ???
-           |baz[Either[Int, ?], String].right@@
+           |baz[Either[Int, ?], String].fold@@
            |""".stripMargin,
-        "right: Either.RightProjection[Int,String]"
+        "fold[C](fa: Int => C, fb: String => C): C"
       )
     } yield ()
   )


### PR DESCRIPTION
Fixes #620 

Previously, the following completion returned empty results
```scala
class Foo { def getTimeStamp: Int = 42 }
new Foo().time@@
```
Now, the completion results include `getTimeStamp`.

Since we started allowing fuzzier results, we needed better sorting of
completion items in the same category. For example, in the following
example
```scala
class Foo {
  def toInt: Int = 42
  def instance: Int = 42
  def intNumber: Int = 42
}
new Foo().int@@
```
we want the results sorted in the following order
```scala
intNumber // because prefix match
toInt     // because literal substring match
instance  // last fallback
```

This improvement in sorting benefitted non-fuzzy non-type members too.
Previously, the query `Iterator` returned the order
`BufferedIterator,Iterator` because they were sorted alphabetically.
Now, the order is `Iterator,BufferedIterator` instead, a big
quality-of-life improvement.