### PR TITLE
Use fallback presentation compiler for missing build target.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -450,6 +450,7 @@ class MetalsLanguageServer(
           List[Future[Unit]](
             quickConnectToBuildServer().ignoreValue,
             slowConnectToBuildServer(forceImport = false).ignoreValue,
+            Future(workspaceSymbols.indexClasspath()),
             Future(startHttpServer()),
             Future(formattingProvider.load())
           )

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -95,10 +95,7 @@ final class WorkspaceSymbolProvider(
     } {
       packages.visit(classpathEntry)
     }
-    inDependencies = ClasspathSearch.fromPackages(
-      packages,
-      isReferencedPackage
-    )
+    inDependencies = ClasspathSearch.fromPackages(packages, isReferencedPackage)
   }
 
   private def workspaceSearch(

--- a/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
@@ -5,6 +5,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
+import java.net.URLClassLoader
+import java.nio.file.Paths
 import java.util
 import java.util.jar.JarFile
 import java.util.logging.Level
@@ -112,6 +114,9 @@ class PackageIndex() {
 
   def visitBootClasspath(): Unit = {
     PackageIndex.bootClasspath.foreach(visit)
+    PackageIndex.scalaLibrary.foreach { scalaLibrary =>
+      visit(AbsolutePath(scalaLibrary))
+    }
   }
 
 }
@@ -126,4 +131,14 @@ object PackageIndex {
       entry <- entries
       if entry.isFile
     } yield entry
+
+  def scalaLibrary: Seq[Path] = {
+    this.getClass.getClassLoader
+      .asInstanceOf[URLClassLoader]
+      .getURLs
+      .iterator
+      .filter(_.getPath.contains("scala-library"))
+      .map(url => Paths.get(url.toURI))
+      .toSeq
+  }
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -20,8 +20,6 @@ class CompletionProvider(
 ) {
   import compiler._
 
-  val maxWorkspaceSymbolResults = 10
-
   def completions(): CompletionList = {
     val unit = addCompilationUnit(
       code = params.text,

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -18,6 +18,7 @@ import scala.meta.internal.metals.RecursivelyDelete
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.internal.pc.ScalaPresentationCompiler
+import scala.meta.internal.metals.PackageIndex
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.PresentationCompilerConfig
 import scala.util.Properties
@@ -29,14 +30,7 @@ abstract class BasePCSuite extends BaseSuite {
       .asInstanceOf[URLClassLoader]
       .getURLs
       .map(url => Paths.get(url.toURI))
-  val scalaLibrary: Seq[Path] =
-    this.getClass.getClassLoader
-      .asInstanceOf[URLClassLoader]
-      .getURLs
-      .iterator
-      .filter(_.getPath.contains("scala-library"))
-      .map(url => Paths.get(url.toURI))
-      .toSeq
+  val scalaLibrary: Seq[Path] = PackageIndex.scalaLibrary
   def extraClasspath: Seq[Path] = Nil
   def scalacOptions: Seq[String] = Nil
   def config: PresentationCompilerConfig = PresentationCompilerConfigImpl()

--- a/tests/unit/src/main/scala/tests/BaseCompletionSlowSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionSlowSuite.scala
@@ -25,10 +25,11 @@ abstract class BaseCompletionSlowSuite(name: String)
       query: String,
       expected: String,
       project: Char = 'a',
-      includeDetail: Boolean = true
+      includeDetail: Boolean = true,
+      filter: String => Boolean = _ => true
   )(implicit file: sourcecode.File, line: sourcecode.Line): Future[Unit] = {
     withCompletion(query, project) { list =>
-      val completion = server.formatCompletion(list, includeDetail)
+      val completion = server.formatCompletion(list, includeDetail, filter)
       val obtained =
         if (isWindows) {
           // HACK(olafur) we don't have access to the JDK sources on Appveyor

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -354,11 +354,13 @@ final class TestingServer(
 
   def formatCompletion(
       completion: CompletionList,
-      includeDetail: Boolean
+      includeDetail: Boolean,
+      filter: String => Boolean = _ => true
   ): String = {
     val items =
       completion.getItems.asScala.map(server.completionItemResolveSync)
     items.iterator
+      .filter(item => filter(item.getLabel()))
       .map { item =>
         val label = TestCompletions.getFullyQualifiedLabel(item)
         val detail =

--- a/tests/unit/src/test/scala/tests/CompletionSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompletionSlowSuite.scala
@@ -198,4 +198,26 @@ object CompletionSlowSuite extends BaseCompletionSlowSuite("completion") {
       )
     } yield ()
   }
+
+  testAsync("rambo") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        """|/a/src/main/scala/a/A.scala
+           |object Main extends App {
+           |  // @@
+           |}
+           |""".stripMargin,
+        expectError = true
+      )
+      _ <- assertCompletion(
+        "Properties@@",
+        // Assert both JDK and scala-library are indexed.
+        """|Properties - java.util
+           |Properties - scala.util
+           |""".stripMargin,
+        filter = _.startsWith("Properties -")
+      )
+    } yield ()
+  }
 }


### PR DESCRIPTION
Previously, completions/hover/signatureHelp didn't work in source files
that didn't belong to any build target. Now, we fallback to a 2.12.8
presentation compiler that only has scala-library on the classpath. This
makes it possible to user Metals on source files without a build tool.

Fixes #613