### PR TITLE
Fix an issue when named parameters were used before local values when name was the same.

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -109,7 +109,7 @@ trait Completions { this: MetalsGlobal =>
     import MemberOrdering._
     var relevance = 0
     // local symbols are more relevant
-    if (!sym.isLocalToBlock) relevance |= IsNotLocalByBlock
+    if (!sym.isLocalToBlock && !sym.owner.isType) relevance |= IsNotLocalByBlock
     // symbols defined in this file are more relevant
     if (!sym.pos.isDefined || sym.hasPackageFlag)
       relevance |= IsNotDefinedInFile

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -196,4 +196,16 @@ object CompletionArgSuite extends BaseCompletionSuite {
     ""
   )
 
+  check(
+    "arg14",
+    s"""|object Main {
+        |  def foo(argument : Int) : Int = argument
+        |  val argument = 5
+        |  foo(a@@)
+        |}
+        |""".stripMargin,
+    """|argument : Int
+       |argument = : Int
+       |""".stripMargin
+  )
 }


### PR DESCRIPTION

Fix https://github.com/scalameta/metals/issues/619

Previously, when using completion in a method with a same argument name as a local one, named parameter was suggested first. Now local is shown first.

Added a tests - but couldn't run it locally. I think it's ok, so should do alright on CI.