### PR TITLE
Give CompletionPosition finer control over sorting, fixes #619.

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -196,4 +196,18 @@ object CompletionArgSuite extends BaseCompletionSuite {
     ""
   )
 
+  check(
+    "priority",
+    s"""|object Main {
+        |  def foo(argument : Int) : Int = argument
+        |  val argument = 5
+        |  foo(argu@@)
+        |}
+        |""".stripMargin,
+    """|argument: Int
+       |argument = : Int
+       |""".stripMargin,
+    topLines = Some(2)
+  )
+
 }


### PR DESCRIPTION
Previously, we sorted named argument `foo =` completions over scope
identifiers with the exact same name as the argument. Now, we sort
exact matching identifiers over named arguments thanks to the new
ability in CompletionPosition to arbitrarily sort completion items.