### PR TITLE
Make completions work on overr<COMPLETE> and def<COMPLETE>

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -248,7 +248,12 @@ class CompletionProvider(
         if (head.sym.isClass || head.sym.isModule) {
           head.sym.fullName
         } else {
-          semanticdbSymbol(head.sym)
+          head match {
+            case o: OverrideDefMember =>
+              o.label
+            case _ =>
+              semanticdbSymbol(head.sym)
+          }
         }
       def isIgnoredWorkspace: Boolean =
         head.isInstanceOf[WorkspaceMember] &&

--- a/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
@@ -57,7 +57,7 @@ object CancelCompletionSuite extends BaseCompletionSuite {
     "basic",
     """
       |object A {
-      |  asser@@
+      |  val x = asser@@
       |}
     """.stripMargin,
     """|assert(assertion: Boolean): Unit

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
@@ -60,8 +60,8 @@ object CompletionOverrideConfigSuite extends BaseCompletionSuite {
        |  def number@@
        |}
        |""".stripMargin,
-    """numberAbstract: Int
-      |🔼 number: Int
+    """🔼 numberAbstract: Int
+      |⏫ number: Int
       |""".stripMargin
   )
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -97,6 +97,11 @@ object CompletionSuite extends BaseCompletionSuite {
       |  def@@
       |}""".stripMargin,
     """|default: Int
+       |override def equals(obj: Any): Boolean
+       |override def hashCode(): Int
+       |override def toString(): String
+       |override def clone(): Object
+       |override def finalize(): Unit
        |""".stripMargin
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -11,9 +11,9 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |___
       |}
       |""".stripMargin,
-    "  Files@@",
+    "  val x = Files@@",
     """  import java.nio.file.Files
-      |  Files""".stripMargin
+      |  val x = Files""".stripMargin
   )
 
   checkEditLine(
@@ -63,14 +63,14 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
     """package `import-conflict`
       |object Main {
       |  val java = 42
-      |  Files@@
+      |  val x = Files@@
       |}
       |""".stripMargin,
     """package `import-conflict`
       |object Main {
       |  val java = 42
       |  import _root_.java.nio.file.Files
-      |  Files
+      |  val x = Files
       |}
       |""".stripMargin,
     filter = _ == "Files - java.nio.file"


### PR DESCRIPTION
Fixes #631. Previously, we needed to write def <COMPLETE> to autocomplete an override, now we can write a start of the 'override' word or a combination of letters in the def/val name and it will trigger the proper completion. When starting with override word it will add it to method even if overriding abstract methods.

Also fixes a bug with not autocompleting when overriding vals from traits.