### PR TITLE
Improve quality and performance of workspace/symbol, fixes #639.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
@@ -12,4 +12,6 @@ object Directories {
     RelativePath("META-INF").resolve("semanticdb")
   def pc: RelativePath =
     RelativePath(".metals").resolve("pc.log")
+  def workspaceSymbol: RelativePath =
+    RelativePath(".metals").resolve("workspace-symbol.md")
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -265,4 +265,23 @@ class Messages(icons: Icons) {
       params
     }
   }
+
+  object WorkspaceSymbolDependencies {
+    def title: String =
+      "Add ';' to search library dependencies"
+    def detail: String =
+      """|The workspace/symbol feature ("Go to symbol in workspace") allows you to search for 
+         |classes, traits and objects that are defined in your workspace as well as library dependencies.
+         |
+         |By default, a query searches only for symbols defined in this workspace. Include a semicolon 
+         |character `;` in the query to search for symbols in library dependencies.
+         |
+         |Examples:
+         |- "Future": workspace only
+         |- "Future;": workspace + library dependencies
+         |- ";Future": workspace + library dependencies
+         |
+         |The library dependencies are automatically searched when no results are found in the workspace.
+         |""".stripMargin
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -324,6 +324,11 @@ object MetalsEnrichments
       Files.delete(dealias.toNIO)
     }
 
+    def writeText(text: String): Unit = {
+      parent.createDirectories()
+      Files.write(path.toNIO, text.getBytes(StandardCharsets.UTF_8))
+    }
+
   }
 
   implicit class XtensionStringUriProtocol(value: String) {

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -131,9 +131,10 @@ final class WorkspaceSymbolProvider(
       token: CancelChecker
   ): Seq[l.SymbolInformation] = {
     val query = WorkspaceSymbolQuery.fromTextQuery(textQuery)
-    val visitor = new WorkspaceSearchVisitor(query, token, index, fileOnDisk)
+    val visitor =
+      new WorkspaceSearchVisitor(workspace, query, token, index, fileOnDisk)
     search(query, visitor, None)
-    visitor.results.sortBy(_.getName.length)
+    visitor.allResults()
   }
 
 }

--- a/mtags/src/main/scala/scala/meta/internal/metals/TrigramSubstrings.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/TrigramSubstrings.scala
@@ -45,9 +45,12 @@ object TrigramSubstrings {
       maxCount: Int = 250
   ): Traversable[String] = new Traversable[String] {
     override def foreach[U](f: String => U): Unit = {
+      if (query.isEmpty()) ()
+      else runForeach(query.head.toUpper, f)
+    }
+    def runForeach[U](first: Char, f: String => U): Unit = {
       var continue = true
       var count = 0
-      val first = query.head.toUpper
       def emit(string: String): Unit = {
         count += 1
         if (count > maxCount) {

--- a/mtags/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolQuery.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolQuery.scala
@@ -17,7 +17,8 @@ import scala.meta.internal.semanticdb.SymbolInformation.Kind
 case class WorkspaceSymbolQuery(
     query: String,
     alternatives: Array[AlternativeQuery],
-    isTrailingDot: Boolean
+    isTrailingDot: Boolean,
+    isClasspath: Boolean = true
 ) {
   def isExact: Boolean = query.length < Fuzzy.ExactSearchLimit
   def matches(bloom: BloomFilter[CharSequence]): Boolean =
@@ -40,13 +41,13 @@ object WorkspaceSymbolQuery {
   }
   def fromTextQuery(query: String): WorkspaceSymbolQuery = {
     val isTrailingDot = query.endsWith(".")
-    val actualQuery =
-      if (isTrailingDot) query.stripSuffix(".")
-      else query
+    val isClasspath = query.contains(";")
+    val actualQuery = query.stripSuffix(".").replaceAllLiterally(";", "")
     WorkspaceSymbolQuery(
       actualQuery,
       AlternativeQuery.all(actualQuery),
-      isTrailingDot
+      isTrailingDot,
+      isClasspath
     )
   }
 

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -123,7 +123,8 @@ final class TestingServer(
         val kind =
           if (includeKind) s" ${info.getKind}"
           else ""
-        s"${info.getContainerName}${info.getName}$kind"
+        val container = Option(info.getContainerName()).getOrElse("")
+        s"${container}${info.getName}$kind"
       }
       .mkString("\n")
   }


### PR DESCRIPTION
Previously, workspace/symbol often showed too many results from library
dependencies when most of the time you are only interested in symbols
defined in the workspace. Now, workspace/symbol searches only in the
workspace by default. Library dependencies are searches only when

- the search query contains a semicolon character `;`, or
- workspace contains no results

To improve discoverability of this new behavior, we include a dummy
result "Add ';' to search library dependencies".