### PR TITLE
Generate exhaustive pattern match for sealed types.

### DIFF
--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -238,7 +238,7 @@ Possible values:
 
 ```
 
-### `-Dmetals.signature-help-command`
+### `-Dmetals.signature-help.command`
 
 An optional string value for a command identifier to trigger parameter hints
 (`textDocument/signatureHelp`) in the editor. Metals uses this setting to
@@ -250,6 +250,16 @@ setting is provided by the editor.
 Default value:
 
 - `"editor.action.triggerParameterHints"`: when editor is Visual Studio Code.
+- empty: for all other editors.
+
+### `-Dmetals.completion.command`
+
+An optional string value for a command identifier to trigger completion
+(`textDocument/signatureHelp`) in the editor.
+
+Default value:
+
+- `"editor.action.triggerSuggest"`: when editor is Visual Studio Code.
 - empty: for all other editors.
 
 ### `-Dmetals.pc.debug`

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -44,8 +44,12 @@ object Configs {
         props: Properties = System.getProperties
     ): PresentationCompilerConfigImpl = {
       PresentationCompilerConfigImpl(
-        MetalsServerConfig.binaryOption("metals.pc.debug", default = false),
-        Option(props.getProperty("metals.signature-help-command")),
+        debug =
+          MetalsServerConfig.binaryOption("metals.pc.debug", default = false),
+        _parameterHintsCommand =
+          Option(props.getProperty("metals.signature-help.command")),
+        _completionCommand =
+          Option(props.getProperty("metals.completion.command")),
         overrideDefFormat =
           Option(props.getProperty("metals.override-def-format")) match {
             case Some("unicode") => OverrideDefFormat.Unicode

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -99,12 +99,11 @@ object MetalsServerConfig {
           icons = Icons.vscode,
           executeClientCommand = ExecuteClientCommandConfig.on,
           globSyntax = GlobSyntaxConfig.vscode,
-          compilers =
-            base.compilers.copy(
-              _parameterHintsCommand =
-                Some("editor.action.triggerParameterHints"),
-              overrideDefFormat = OverrideDefFormat.Unicode
-            )
+          compilers = base.compilers.copy(
+            _parameterHintsCommand = Some("editor.action.triggerParameterHints"),
+            _completionCommand = Some("editor.action.triggerSuggest"),
+            overrideDefFormat = OverrideDefFormat.Unicode
+          )
         )
       case "vim-lsc" =>
         base.copy(

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -12,10 +12,15 @@ public interface PresentationCompilerConfig {
     /**
      * Command ID to trigger parameter hints (textDocument/signatureHelp) in the editor.
      *
-     * See https://scalameta.org/metals/docs/editors/new-editor.html#dmetalssignature-help-command
+     * See https://scalameta.org/metals/docs/editors/new-editor.html#dmetalssignature-helpcommand
      * for details.
      */
     Optional<String> parameterHintsCommand();
+
+    /**
+     * Command ID to trigger completions (textDocument/completion) in the editor.
+     */
+    Optional<String> completionCommand();
 
     Map<String, String> symbolPrefixes();
 

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -64,6 +64,7 @@ class CompletionProvider(
         val ident = Identifier.backtickWrap(symbolName)
         val detail = r match {
           case o: OverrideDefMember => o.label
+          case t: TextEditMember if t.detail.isDefined => t.detail.get
           case _ => detailString(r, history)
         }
         val label = r match {
@@ -317,7 +318,12 @@ class CompletionProvider(
       .toLSP
     val noQuery = "$a"
     def expected(e: Throwable) = {
-      completionPosition(pos, params.text(), editRange) match {
+      completionPosition(
+        pos,
+        params.text(),
+        editRange,
+        CompletionResult.NoResults
+      ) match {
         case CompletionPosition.None =>
           logger.warning(e.getMessage)
           (
@@ -358,7 +364,8 @@ class CompletionProvider(
         if (isTypeMember) CompletionFuzzy.matchesSubCharacters(entered, name)
         else CompletionFuzzy.matches(entered, name)
       }
-      val completion = completionPosition(pos, params.text(), editRange)
+      val completion =
+        completionPosition(pos, params.text(), editRange, completions)
       val query = completions.name.toString
       val items =
         filterInteresting(matchingResults, kind, query, pos, completion)

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -9,6 +9,7 @@ import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
 case class PresentationCompilerConfigImpl(
     debug: Boolean = false,
     _parameterHintsCommand: Option[String] = None,
+    _completionCommand: Option[String] = None,
     _symbolPrefixes: collection.Map[String, String] =
       PresentationCompilerConfig.defaultSymbolPrefixes().asScala,
     overrideDefFormat: OverrideDefFormat = OverrideDefFormat.Ascii,
@@ -21,4 +22,6 @@ case class PresentationCompilerConfigImpl(
     _symbolPrefixes.asJava
   override def parameterHintsCommand: Optional[String] =
     Optional.ofNullable(_parameterHintsCommand.orNull)
+  override def completionCommand: Optional[String] =
+    Optional.ofNullable(_completionCommand.orNull)
 }

--- a/tests/cross/src/main/scala/tests/TextEdits.scala
+++ b/tests/cross/src/main/scala/tests/TextEdits.scala
@@ -21,9 +21,11 @@ object TextEdits {
       val out = new java.lang.StringBuilder()
       positions.foreach {
         case (edit, pos) =>
-          out
-            .append(text, curr, pos.start)
-            .append(edit.getNewText)
+          out.append(text, curr, pos.start)
+          edit.getNewText().foreach {
+            case '\t' => out.append("\\t")
+            case ch => out.append(ch)
+          }
           curr = pos.end
       }
       out.append(text, curr, text.length)

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -1,0 +1,123 @@
+package tests.pc
+
+import tests.BaseCompletionSuite
+
+object CompletionMatchSuite extends BaseCompletionSuite {
+  check(
+    "match",
+    """
+      |object A {
+      |  Option(1) match@@
+      |}""".stripMargin,
+    """|match
+       |match (exhaustive) Option[Int] (2 cases)
+       |""".stripMargin
+  )
+
+  check(
+    "trailing-expression",
+    """
+      |object A {
+      |  Option(1) match@@
+      |  println(1)
+      |}""".stripMargin,
+    """|match
+       |match (exhaustive) Option[Int] (2 cases)
+       |""".stripMargin
+  )
+
+  check(
+    "dot",
+    """
+      |object A {
+      |  Option(1).match@@
+      |}""".stripMargin,
+    ""
+  )
+
+  check(
+    "stale1",
+    """package stale
+      |sealed abstract class Weekday
+      |case object Workday extends Weekday
+      |case object Weekend extends Weekday
+      |@@
+      |""".stripMargin,
+    ""
+  )
+  // Assert that Workday/Weekend symbols from previous test don't appear in result.
+  checkEdit(
+    "stale2",
+    """package stale
+      |sealed abstract class Weekday
+      |object Weekday {
+      |  case object Workday extends Weekday
+      |  case object Weekend extends Weekday
+      |}
+      |object App {
+      |  null.asInstanceOf[Weekday] matc@@
+      |}
+      |""".stripMargin,
+    // Tab characters are used to indicate user-configured indentation in the editor.
+    // For example, in VS Code, the tab characters become 2 space indent by default.
+    """|package stale
+       |sealed abstract class Weekday
+       |object Weekday {
+       |  case object Workday extends Weekday
+       |  case object Weekend extends Weekday
+       |}
+       |object App {
+       |  import stale.Weekday.Workday
+       |  import stale.Weekday.Weekend
+       |  null.asInstanceOf[Weekday] match {
+       |\tcase Workday => $0
+       |\tcase Weekend =>
+       |}
+       |}
+       |""".stripMargin,
+    filter = _.contains("exhaustive")
+  )
+  checkEdit(
+    "stale3",
+    """package stale
+      |sealed abstract class Weekday
+      |case object Workday extends Weekday
+      |case object Weekend extends Weekday
+      |object App {
+      |  null.asInstanceOf[Weekday] matc@@
+      |}
+      |""".stripMargin,
+    """|package stale
+       |sealed abstract class Weekday
+       |case object Workday extends Weekday
+       |case object Weekend extends Weekday
+       |object App {
+       |  null.asInstanceOf[Weekday] match {
+       |\tcase Workday => $0
+       |\tcase Weekend =>
+       |}
+       |}
+       |""".stripMargin,
+    filter = _.contains("exhaustive")
+  )
+
+  check(
+    "inner-class",
+    """
+      |package example
+      |
+      |sealed abstract class Foo
+      |object Foo {
+      |  case object Bar extends Foo
+      |  case class App(a: Int, b: String) extends Foo
+      |}
+      |object Main {
+      |  val foo: Foo = ???
+      |  foo match@@
+      |}
+      |""".stripMargin,
+    """|match
+       |match (exhaustive) Foo (2 cases)
+       |""".stripMargin
+  )
+}


### PR DESCRIPTION
Previously, you had to write on case at a time when pattern matching on
a sealed type. Now, you can complete on the `match` keyword and select
the "match (exhaustive)" completion item to generate all cases.  This
commit also introduces a new "match" completion (non-exhaustive) that
generates a single case and triggers a new completion at the case word,
for editors that support `CompletionItem.command`.

![2019-04-09 08 51 20](https://user-images.githubusercontent.com/1408093/55779042-cce1d780-5aa4-11e9-913a-efe4c29987a5.gif)
