### PR TITLE
Implement goto definition fallback with the presentation compiler.

### DIFF
--- a/metals-bench/src/main/scala/bench/ClasspathOnlySymbolSearch.scala
+++ b/metals-bench/src/main/scala/bench/ClasspathOnlySymbolSearch.scala
@@ -1,6 +1,8 @@
 package bench
 
+import java.{util => ju}
 import java.util.Optional
+import org.eclipse.lsp4j.Location
 import scala.meta.internal.metals.ClasspathSearch
 import scala.meta.internal.metals.WorkspaceSymbolQuery
 import scala.meta.pc.SymbolDocumentation
@@ -16,6 +18,8 @@ class ClasspathOnlySymbolSearch(classpath: ClasspathSearch)
     extends SymbolSearch {
   override def documentation(symbol: String): Optional[SymbolDocumentation] =
     Optional.empty()
+
+  def definition(symbol: String): ju.List[Location] = ju.Collections.emptyList()
 
   override def search(
       query: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsSymbolSearch.scala
@@ -1,7 +1,9 @@
 package scala.meta.internal.metals
 
-import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import java.{util => ju}
+import org.eclipse.lsp4j.Location
 import java.util.Optional
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 import scala.meta.pc.SymbolSearchVisitor
@@ -11,10 +13,15 @@ import scala.meta.pc.SymbolSearchVisitor
  */
 class MetalsSymbolSearch(
     docs: Docstrings,
-    wsp: WorkspaceSymbolProvider
+    wsp: WorkspaceSymbolProvider,
+    defn: DefinitionProvider
 ) extends SymbolSearch {
   override def documentation(symbol: String): Optional[SymbolDocumentation] =
     docs.documentation(symbol)
+
+  def definition(symbol: String): ju.List[Location] = {
+    defn.fromSymbol(symbol)
+  }
 
   override def search(
       query: String,

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -1,5 +1,6 @@
 package scala.meta.pc;
 
+import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.Hover;
@@ -54,6 +55,11 @@ public abstract class PresentationCompiler {
      * Returns the type of the expression at the given position along with the symbol of the referenced symbol.
      */
     public abstract Optional<Hover> hover(OffsetParams params);
+
+    /**
+     * Returns the definition of the symbol at the given position.
+     */
+    public abstract List<Location> definition(OffsetParams params);
 
     /**
      * Returns the Protobuf byte array representation of a SemanticDB <code>TextDocument</code> for the given source.

--- a/mtags-interfaces/src/main/java/scala/meta/pc/SymbolSearch.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/SymbolSearch.java
@@ -1,5 +1,7 @@
 package scala.meta.pc;
 
+import org.eclipse.lsp4j.Location;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -11,6 +13,11 @@ public interface SymbolSearch {
      * Returns the documentation of this symbol, if any.
      */
     Optional<SymbolDocumentation> documentation(String symbol);
+
+    /**
+     * Returns the definition of this symbol, if any.
+     */
+    List<Location> definition(String symbol);
 
     /**
      * Runs fuzzy symbol search for the given query.

--- a/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -14,6 +14,7 @@ import org.eclipse.lsp4j.MarkupContent
 import org.eclipse.{lsp4j => l}
 import scala.annotation.tailrec
 import scala.collection.AbstractIterator
+import scala.meta.pc.OffsetParams
 import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import scala.meta.internal.io.FileIO
@@ -290,6 +291,21 @@ trait MtagsEnrichments {
         new l.Position(pos.startLine, pos.startColumn),
         new l.Position(pos.endLine, pos.endColumn)
       )
+    }
+  }
+  implicit class XtensionOffsetParams(params: OffsetParams) {
+    def isDelimiter: Boolean = {
+      params.offset() < 0 ||
+      params.offset() >= params.text().length ||
+      (params.text().charAt(params.offset()) match {
+        case '(' | ')' | '{' | '}' | '[' | ']' | ',' | '=' | '.' => true
+        case _ => false
+      })
+    }
+    def isWhitespace: Boolean = {
+      params.offset() < 0 ||
+      params.offset() >= params.text().length ||
+      params.text().charAt(params.offset()).isWhitespace
     }
   }
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.pc
 
+import java.net.URI
 import java.lang.StringBuilder
 import org.eclipse.{lsp4j => l}
 import scala.meta.internal.semanticdb.Scala._
@@ -874,9 +875,10 @@ trait Completions { this: MetalsGlobal =>
       override def contribute: List[Member] = {
         try {
           val name = Paths
-            .get(pos.source.file.name.stripSuffix(".scala"))
+            .get(URI.create(pos.source.file.name))
             .getFileName()
             .toString()
+            .stripSuffix(".scala")
           val isTermName = toplevel.name.isTermName
           val siblings = pkg.stats.count {
             case d: DefTree =>

--- a/mtags/src/main/scala/scala/meta/internal/pc/EmptySymbolSearch.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/EmptySymbolSearch.scala
@@ -1,6 +1,8 @@
 package scala.meta.internal.pc
 
 import java.util.Optional
+import java.{util => ju}
+import org.eclipse.lsp4j.Location
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 import scala.meta.pc.SymbolSearchVisitor
@@ -12,6 +14,10 @@ object EmptySymbolSearch extends SymbolSearch {
       visitor: SymbolSearchVisitor
   ): SymbolSearch.Result = {
     SymbolSearch.Result.COMPLETE
+  }
+
+  def definition(symbol: String): ju.List[Location] = {
+    ju.Collections.emptyList()
   }
 
   override def documentation(symbol: String): Optional[SymbolDocumentation] =

--- a/mtags/src/main/scala/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/HoverProvider.scala
@@ -12,9 +12,7 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
   import compiler._
 
   def hover(): Option[Hover] = {
-    if (params.offset() < 0 ||
-      params.offset() >= params.text().length ||
-      params.text().charAt(params.offset()).isWhitespace) {
+    if (params.isWhitespace) {
       None
     } else {
       val unit = addCompilationUnit(
@@ -236,7 +234,7 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
     }
     val typedTree = typedTreeAt(pos)
     typedTree match {
-      case Import(qual, _) if qual.pos.includes(pos) =>
+      case Import(qual, se) if qual.pos.includes(pos) =>
         loop(qual)
       case Apply(fun, args)
           if !fun.pos.includes(pos) &&

--- a/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
@@ -89,17 +89,21 @@ class MetalsGlobal(
   }
 
   def printPretty(pos: sourcecode.Text[Position]): Unit = {
-    import scala.meta.internal.metals.PositionSyntax._
-    val input = scala.meta.Input.String(new String(pos.value.source.content))
-    val (start, end) =
-      if (pos.value.isRange) {
-        (pos.value.start, pos.value.end)
-      } else {
-        (pos.value.point, pos.value.point)
-      }
-    val range =
-      scala.meta.Position.Range(input, start, end)
-    println(range.formatMessage("info", pos.source))
+    if (pos.value == null || pos.value == NoPosition) {
+      println(pos.value.toString())
+    } else {
+      import scala.meta.internal.metals.PositionSyntax._
+      val input = scala.meta.Input.String(new String(pos.value.source.content))
+      val (start, end) =
+        if (pos.value.isRange) {
+          (pos.value.start, pos.value.end)
+        } else {
+          (pos.value.point, pos.value.point)
+        }
+      val range =
+        scala.meta.Position.Range(input, start, end)
+      println(range.formatMessage("info", pos.source))
+    }
   }
 
   def pretty(pos: Position): String = {

--- a/mtags/src/main/scala/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -1,0 +1,112 @@
+package scala.meta.internal.pc
+
+import java.{util => ju}
+import org.eclipse.lsp4j.Location
+import scala.meta.pc.OffsetParams
+import scala.meta.internal.semanticdb.Scala._
+import scala.meta.internal.mtags.MtagsEnrichments._
+
+class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
+  import compiler._
+  def definition(): ju.List[Location] = {
+    if (params.isWhitespace || params.isDelimiter) {
+      ju.Collections.emptyList()
+    } else {
+      val unit = addCompilationUnit(
+        params.text(),
+        params.filename(),
+        None
+      )
+      val pos = unit.position(params.offset())
+      val tree = definitionTypedTreeAt(pos)
+      if (tree.symbol == null ||
+        tree.symbol == NoSymbol ||
+        tree.symbol.hasPackageFlag ||
+        tree.symbol.isErroneous) {
+        ju.Collections.emptyList()
+      } else if (tree.symbol.pos != null &&
+        tree.symbol.pos.isDefined &&
+        tree.symbol.pos.source.eq(unit.source)) {
+        ju.Collections.singletonList(
+          new Location(params.filename(), tree.symbol.pos.toLSP)
+        )
+      } else {
+        val res = new ju.ArrayList[Location]()
+        tree.symbol.alternatives.foreach { alternative =>
+          val sym = semanticdbSymbol(alternative)
+          if (sym.isGlobal) {
+            res.addAll(search.definition(sym))
+          }
+        }
+        res
+      }
+    }
+  }
+
+  def definitionTypedTreeAt(pos: Position): Tree = {
+    def loop(tree: Tree): Tree = {
+      tree match {
+        case Select(qualifier, name) =>
+          if (name == termNames.apply &&
+            qualifier.pos.includes(pos)) {
+            if (definitions.isFunctionSymbol(tree.symbol.owner)) loop(qualifier)
+            else if (definitions.isTupleSymbol(tree.symbol.owner)) {
+              EmptyTree
+            } else {
+              tree
+            }
+          } else {
+            tree
+          }
+        case Apply(sel @ Select(New(_), termNames.CONSTRUCTOR), args)
+            if sel.pos != null &&
+              sel.pos.isRange &&
+              !sel.pos.includes(pos) =>
+          // Position is on `new` keyword
+          EmptyTree
+        case TreeApply(fun, _)
+            if fun.pos != null &&
+              fun.pos.isDefined &&
+              fun.pos.point == tree.pos.point &&
+              definitions.isTupleSymbol(tree.symbol.owner.companionClass) =>
+          EmptyTree
+        case _ => tree
+      }
+    }
+    val typedTree = typedTreeAt(pos)
+    val tree0 = typedTree match {
+      case sel @ Select(qual, _) if sel.tpe == ErrorType => qual
+      case Import(expr, _) => expr
+      case t => t
+    }
+    val context = doLocateContext(pos)
+    val shouldTypeQualifier = tree0.tpe match {
+      case null => true
+      case mt: MethodType => mt.isImplicit
+      case pt: PolyType => isImplicitMethodType(pt.resultType)
+      case _ => false
+    }
+    def selectQual(tree: Tree): Tree = tree match {
+      case Select(qual, _) if qual.pos.includes(pos) => loop(qual)
+      case t => t
+    }
+    // TODO: guard with try/catch to deal with ill-typed qualifiers.
+    val tree =
+      if (shouldTypeQualifier) analyzer.newTyper(context).typedQualifier(tree0)
+      else tree0
+    typedTree match {
+      case Import(expr, selectors) =>
+        EmptyTree
+      case sel @ Select(qualifier, name) if sel.tpe == ErrorType =>
+        val symbols = tree.tpe.member(name)
+        typedTree.setSymbol(symbols)
+      case defn: DefTree if !defn.namePos.includes(pos) =>
+        EmptyTree
+      case _: Template =>
+        EmptyTree
+      case _ =>
+        loop(tree)
+
+    }
+  }
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.pc
 
+import java.{util => ju}
 import java.io.File
 import java.nio.file.Path
 import java.util
@@ -7,6 +8,7 @@ import java.util.Optional
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
 import java.util.logging.Logger
+import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.Hover
@@ -113,6 +115,15 @@ case class ScalaPresentationCompiler(
     ) { global =>
       Optional.ofNullable(new HoverProvider(global, params).hover().orNull)
     }
+
+  def definition(params: OffsetParams): ju.List[Location] = {
+    access.withNonCancelableCompiler(
+      ju.Collections.emptyList[Location](),
+      params.token
+    ) { global =>
+      new PcDefinitionProvider(global, params).definition()
+    }
+  }
 
   override def semanticdbTextDocument(
       filename: String,

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-2")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-4")

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -31,7 +31,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
   ): Seq[CompletionItem] = {
     val (code, offset) = params(original)
     val result = resolvedCompletions(
-      CompilerOffsetParams(filename, code, offset, cancelToken)
+      CompilerOffsetParams("file:/" + filename, code, offset, cancelToken)
     )
     result.getItems.asScala.sortBy(_.getSortText)
   }

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -41,7 +41,8 @@ abstract class BasePCSuite extends BaseSuite {
   val search = new TestingSymbolSearch(
     ClasspathSearch.fromClasspath(myclasspath, _ => 0),
     new Docstrings(index),
-    workspace
+    workspace,
+    index
   )
   val pc = new ScalaPresentationCompiler()
     .withSearch(search)

--- a/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
@@ -1,0 +1,61 @@
+package tests.pc
+
+import tests.BasePCSuite
+import scala.meta.internal.metals.CompilerOffsetParams
+import org.eclipse.lsp4j.TextEdit
+import org.eclipse.{lsp4j => l}
+import tests.TextEdits
+import scala.collection.JavaConverters._
+import scala.meta.internal.mtags.MtagsEnrichments._
+
+abstract class BasePcDefinitionSuite extends BasePCSuite {
+  def check(
+      name: String,
+      original: String
+  ): Unit = {
+    test(name) {
+      val noRange = original
+        .replaceAllLiterally("<<", "")
+        .replaceAllLiterally(">>", "")
+      val uri = "A.scala"
+      val (code, offset) = params(noRange, uri)
+      import scala.meta.inputs.Position
+      import scala.meta.inputs.Input
+      val offsetRange = Position.Range(Input.String(code), offset, offset).toLSP
+      val locations = pc.definition(
+        CompilerOffsetParams(uri, code, offset)
+      )
+      val edits = locations.asScala.toList.flatMap { location =>
+        if (location.getUri() == uri) {
+          List(
+            new TextEdit(
+              new l.Range(
+                location.getRange().getStart(),
+                location.getRange().getStart()
+              ),
+              "<<"
+            ),
+            new TextEdit(
+              new l.Range(
+                location.getRange().getEnd(),
+                location.getRange().getEnd()
+              ),
+              ">>"
+            )
+          )
+        } else {
+          val filename = location.getUri()
+          val comment = s"/*$filename*/"
+          if (code.contains(comment)) {
+            Nil
+          } else {
+            List(new TextEdit(offsetRange, comment))
+          }
+        }
+      }
+      val obtained = TextEdits.applyEdits(code, edits)
+      val expected = original.replaceAllLiterally("@@", "")
+      assertNoDiff(obtained, expected)
+    }
+  }
+}

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -1,0 +1,174 @@
+package tests.pc
+
+object PcDefinitionSuite extends BasePcDefinitionSuite {
+
+  override def beforeAll(): Unit = {
+    indexJDK()
+    indexScalaLibrary()
+  }
+
+  check(
+    "basic",
+    """|
+       |object Main {
+       |  val <<>>abc = 42
+       |  println(a@@bc)
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "for",
+    """|
+       |object Main {
+       |  for {
+       |    <<x>> <- List(1)
+       |    y <- 1.to(x)
+       |    z = y + x
+       |    if y < @@x
+       |  } yield y
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "for-flatMap",
+    """|
+       |object Main {
+       |  for {
+       |    x /*scala/Option#flatMap(). Option.scala*/@@<- Option(1)
+       |    y <- Option(x)
+       |  } yield y
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "for-map",
+    """|
+       |object Main {
+       |  for {
+       |    x <- Option(1)
+       |    y /*scala/Option#map(). Option.scala*/@@<- Option(x)
+       |  } yield y
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "for-withFilter",
+    """|
+       |object Main {
+       |  for {
+       |    x <- Option(1)
+       |    y <- Option(x)
+       |    /*scala/Option#withFilter(). Option.scala*/@@if y > 2
+       |  } yield y
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "function",
+    """|
+       |object Main {
+       |  val <<>>increment: Int => Int = _ + 2
+       |  incre@@ment(1)
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "tuple",
+    // assert we don't go to `Tuple2.scala`
+    """|
+       |object Main {
+       |  @@(1, 2)
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "apply",
+    """|
+       |object Main {
+       |  /*scala/collection/immutable/List.apply(). List.scala*/@@List(1)
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "error",
+    """|
+       |object Main {
+       |  /*scala/Predef.assert(+1). Predef.scala*//*scala/Predef.assert(). Predef.scala*/@@assert
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "new",
+    """|
+       |object Main {
+       |  ne@@w java.io.File("")
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "extends",
+    """|
+       |object Main ex@@tends java.io.Serializable {
+       |}
+       |""".stripMargin
+  )
+
+  // NOTE(olafur): we don't provide navigation in imports for now.
+  check(
+    "import1",
+    """|
+       |import scala.concurrent.@@Future
+       |object Main {
+       |}
+       |""".stripMargin
+  )
+  check(
+    "import2",
+    """|
+       |imp@@ort scala.concurrent.Future
+       |object Main {
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "named-arg-local",
+    """|
+       |object Main {
+       |  <<def foo(arg: Int): Unit = ()>>
+       |
+       |  foo(a@@rg = 42)
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "named-arg-global",
+    // NOTE(olafur) ideally we should navigate to the parameter symbol instead of the
+    // enclosing method symbol, but I can live with this behavior.
+    """|
+       |object Main {
+       |  assert(/*scala/Predef.assert(). Predef.scala*/@@assertion = true)
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "symbolic-infix",
+    """|
+       |object Main {
+       |  val lst = 1 /*scala/collection/immutable/List#`::`(). List.scala*/@@:: Nil
+       |}
+       |""".stripMargin
+  )
+}

--- a/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
+++ b/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
@@ -1,5 +1,7 @@
 package tests
 
+import java.{util => ju}
+import org.eclipse.lsp4j.Location
 import java.util.Optional
 import scala.meta.internal.metals.ClasspathSearch
 import scala.meta.internal.metals.Docstrings
@@ -7,6 +9,7 @@ import scala.meta.internal.metals.WorkspaceSymbolQuery
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 import scala.meta.pc.SymbolSearchVisitor
+import scala.meta.internal.mtags.OnDemandSymbolIndex
 
 /**
  * Implementation of `SymbolSearch` for testing purposes.
@@ -16,10 +19,30 @@ import scala.meta.pc.SymbolSearchVisitor
 class TestingSymbolSearch(
     classpath: ClasspathSearch = ClasspathSearch.empty,
     docs: Docstrings = Docstrings.empty,
-    workspace: TestingWorkspaceSearch = TestingWorkspaceSearch.empty
+    workspace: TestingWorkspaceSearch = TestingWorkspaceSearch.empty,
+    index: OnDemandSymbolIndex = OnDemandSymbolIndex()
 ) extends SymbolSearch {
   override def documentation(symbol: String): Optional[SymbolDocumentation] = {
     docs.documentation(symbol)
+  }
+
+  import scala.meta.internal.mtags.Symbol
+  override def definition(symbol: String): ju.List[Location] = {
+    index.definition(Symbol(symbol)) match {
+      case None =>
+        ju.Collections.emptyList()
+      case Some(value) =>
+        import org.eclipse.lsp4j.Range
+        import org.eclipse.lsp4j.Position
+        val filename = value.path.toNIO.getFileName().toString()
+        val uri = s"$symbol $filename"
+        ju.Collections.singletonList(
+          new Location(
+            uri,
+            new Range(new Position(0, 0), new Position(0, 0))
+          )
+        )
+    }
   }
 
   override def search(


### PR DESCRIPTION
Fixes #548. Previously, goto definition worked only for identifiers that
had successfully compiled in the build. Now, goto definition also works
for identifiers that you just typed in the buffer even if you haven't
saved the file.