### PR TITLE
Hook goto definition fallback with compiler into LSP.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -4,11 +4,9 @@ import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import ch.epfl.scala.bsp4j.CompileReport
 import ch.epfl.scala.bsp4j.ScalaBuildTarget
 import ch.epfl.scala.bsp4j.ScalacOptionsItem
-import java.{util => ju}
 import java.util.Collections
 import java.util.Optional
 import java.util.concurrent.ScheduledExecutorService
-import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.CompletionParams
@@ -21,6 +19,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.pc.LogMessages
 import scala.meta.internal.pc.ScalaPresentationCompiler
 import scala.meta.io.AbsolutePath
+import scala.meta.pc
 import scala.meta.pc.CancelToken
 import scala.meta.pc.PresentationCompiler
 import scala.meta.pc.SymbolSearch
@@ -158,7 +157,7 @@ class Compilers(
   def definition(
       params: TextDocumentPositionParams,
       token: CancelToken
-  ): Option[ju.List[Location]] =
+  ): Option[pc.DefinitionResult] =
     withPC(params, None) { (pc, pos) =>
       pc.definition(
         CompilerOffsetParams(pos.input.syntax, pos.input.text, pos.start, token)

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -15,6 +15,7 @@ import scala.meta.internal.mtags.SymbolDefinition
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.semanticdb.TextDocument
 import scala.meta.io.AbsolutePath
+import scala.meta.internal.pc.DefinitionResultImpl
 
 /**
  * Implements goto definition that works even in code that doesn't parse.
@@ -60,10 +61,10 @@ final class DefinitionProvider(
       val fromCompilers =
         compilers()
           .definition(params, token)
-          .getOrElse(Collections.emptyList())
+          .getOrElse(DefinitionResultImpl.empty)
       DefinitionResult(
-        fromCompilers,
-        "",
+        fromCompilers.locations(),
+        fromCompilers.symbol(),
         None,
         None
       )

--- a/mtags-interfaces/src/main/java/scala/meta/pc/DefinitionResult.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/DefinitionResult.java
@@ -1,0 +1,9 @@
+package scala.meta.pc;
+
+import java.util.List;
+import org.eclipse.lsp4j.Location;
+
+public interface DefinitionResult {
+    String symbol();
+    List<Location> locations();
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -59,7 +59,7 @@ public abstract class PresentationCompiler {
     /**
      * Returns the definition of the symbol at the given position.
      */
-    public abstract List<Location> definition(OffsetParams params);
+    public abstract DefinitionResult definition(OffsetParams params);
 
     /**
      * Returns the Protobuf byte array representation of a SemanticDB <code>TextDocument</code> for the given source.

--- a/mtags/src/main/scala/scala/meta/internal/pc/DefinitionResultImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/DefinitionResultImpl.scala
@@ -1,0 +1,15 @@
+package scala.meta.internal.pc
+
+import java.{util => ju}
+import org.eclipse.lsp4j.Location
+import scala.meta.pc.DefinitionResult
+
+case class DefinitionResultImpl(
+    symbol: String,
+    locations: ju.List[Location]
+) extends DefinitionResult
+
+object DefinitionResultImpl {
+  def empty: DefinitionResultImpl =
+    DefinitionResultImpl("", ju.Collections.emptyList())
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.pc
 
-import java.{util => ju}
 import java.io.File
 import java.nio.file.Path
 import java.util
@@ -8,7 +7,6 @@ import java.util.Optional
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
 import java.util.logging.Logger
-import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.Hover
@@ -116,9 +114,9 @@ case class ScalaPresentationCompiler(
       Optional.ofNullable(new HoverProvider(global, params).hover().orNull)
     }
 
-  def definition(params: OffsetParams): ju.List[Location] = {
+  def definition(params: OffsetParams): DefinitionResultImpl = {
     access.withNonCancelableCompiler(
-      ju.Collections.emptyList[Location](),
+      DefinitionResultImpl.empty,
       params.token
     ) { global =>
       new PcDefinitionProvider(global, params).definition()

--- a/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
@@ -22,10 +22,10 @@ abstract class BasePcDefinitionSuite extends BasePCSuite {
       import scala.meta.inputs.Position
       import scala.meta.inputs.Input
       val offsetRange = Position.Range(Input.String(code), offset, offset).toLSP
-      val locations = pc.definition(
+      val defn = pc.definition(
         CompilerOffsetParams(uri, code, offset)
       )
-      val edits = locations.asScala.toList.flatMap { location =>
+      val edits = defn.locations().asScala.toList.flatMap { location =>
         if (location.getUri() == uri) {
           List(
             new TextEdit(

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -123,19 +123,28 @@ object PcDefinitionSuite extends BasePcDefinitionSuite {
        |""".stripMargin
   )
 
-  // NOTE(olafur): we don't provide navigation in imports for now.
   check(
     "import1",
     """|
-       |import scala.concurrent.@@Future
+       |import scala.concurrent./*scala/concurrent/Future. Future.scala*/@@Future
        |object Main {
        |}
        |""".stripMargin
   )
+
   check(
     "import2",
     """|
        |imp@@ort scala.concurrent.Future
+       |object Main {
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "import3",
+    """|
+       |import scala.co@@ncurrent.Future
        |object Main {
        |}
        |""".stripMargin
@@ -168,6 +177,33 @@ object PcDefinitionSuite extends BasePcDefinitionSuite {
     """|
        |object Main {
        |  val lst = 1 /*scala/collection/immutable/List#`::`(). List.scala*/@@:: Nil
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "colon",
+    """|
+       |object Main {
+       |  val number@@: Int = 1
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "package",
+    """|
+       |object Main {
+       |  val n = ma@@th.max(1, 2)
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "eta",
+    """|
+       |object Main {
+       |  List(1).map(@@_ + 2)
        |}
        |""".stripMargin
   )

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -97,7 +97,12 @@ class BaseSuite extends TestSuite {
       title: String = ""
   )(implicit filename: sourcecode.File, line: sourcecode.Line): Unit = {
     DiffAssertions.colored {
-      DiffAssertions.assertNoDiff(obtained, expected, title, title)
+      DiffAssertions.assertNoDiffOrPrintObtained(
+        obtained,
+        expected,
+        title,
+        title
+      )
     }
   }
   override def utestAfterAll(): Unit = afterAll()

--- a/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
+++ b/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
@@ -267,29 +267,6 @@ object SbtSlowSuite extends BaseSlowSuite("import") {
           .map(file => server.didOpen(file))
       )
       _ = assertNoDiff(client.workspaceDiagnostics, "")
-      _ = assertNoDiff(
-        server.workspaceDefinitions,
-        s"""
-           |/a/src/main/scala/a/A.scala
-           |package a
-           |object A/*L1*/ // 2.12.4
-           |/b/src/main/scala/a/A.scala
-           |package a/*<no symbol>*/ // 2.12.3
-           |object A/*<no symbol>*/
-           |/c/src/main/scala/a/A.scala
-           |package a
-           |object A/*L1*/ // 2.11.12
-           |/d/src/main/scala/a/A.scala
-           |package a/*<no symbol>*/
-           |object A/*<no symbol>*/ // 2.11.8
-           |/e/src/main/scala/a/A.scala
-           |package a/*<no symbol>*/
-           |object A/*<no symbol>*/ // 2.10.7
-           |/f/src/main/scala/a/A.scala
-           |package a
-           |object A/*L1*/ // ${V.scala212}
-           |""".stripMargin
-      )
       _ = {
         assertNoDiff(
           client.workspaceClientCommands,

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -209,7 +209,10 @@ final class TestingServer(
         l => newRef(ref.symbol, l)
       )
     }
-    WorkspaceSymbolReferences(references.result(), definition.result())
+    WorkspaceSymbolReferences(
+      references.result().distinct,
+      definition.result().distinct
+    )
   }
 
   def initialize(

--- a/tests/unit/src/test/scala/tests/DefinitionSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionSlowSuite.scala
@@ -174,10 +174,10 @@ object DefinitionSlowSuite extends BaseSlowSuite("definition") {
            |  def contramap/*L6*/[A/*L6*/, B/*L6*/](fa/*L6*/: F/*L5*/[A/*L6*/])(f/*L6*/: B/*L6*/ => A/*L6*/): F/*L5*/[B/*L6*/]
            |  override def imap/*L7*/[A/*L7*/, B/*L7*/](fa/*L7*/: F/*L5*/[A/*L7*/])(f/*L7*/: A/*L7*/ => B/*L7*/)(fi/*L7*/: B/*L7*/ => A/*L7*/): F/*L5*/[B/*L7*/] = contramap/*L6*/(fa/*L7*/)(fi/*L7*/)
            |
-           |  def compose/*L9*/[G/*L9*/[_]: Contravariant/*L5*/]: Functor/*Functor.scala*/[λ/*<no symbol>*/[α/*<no symbol>*/ => F/*<no symbol>*/[G/*<no symbol>*/[α/*<no symbol>*/]]]] =
+           |  def compose/*L9*/[G/*L9*/[_]:/*unexpected: L5*/ Contravariant/*L5*/]: Functor/*Functor.scala*/[λ/*<no symbol>*/[α/*<no symbol>*/ => F/*<no symbol>*/[G/*<no symbol>*/[α/*<no symbol>*/]]]] =
            |    new ComposedContravariant/*Composed.scala*/[F/*L5*/, G/*L9*/] {
            |      val F/*L11*/ = self/*L5*/
-           |      val G/*L12*/ = Contravariant/*<no symbol>*/[G/*L9*/]
+           |      val G/*L12*/ = Contravariant/*L5*/[G/*L9*/]
            |    }
            |
            |  /**
@@ -217,9 +217,6 @@ object DefinitionSlowSuite extends BaseSlowSuite("definition") {
            |.metals/readonly/cats/Contravariant.scala:10:45: information: <error> takes no type parameters, expected: one
            |  def compose[G[_]: Contravariant]: Functor[λ[α => F[G[α]]]] =
            |                                            ^
-           |.metals/readonly/cats/Contravariant.scala:13:15: information: not found: value Contravariant
-           |      val G = Contravariant[G]
-           |              ^^^^^^^^^^^^^
            |.metals/readonly/cats/Contravariant.scala:24:61: information: not found: type λ
            |  override def composeFunctor[G[_]: Functor]: Contravariant[λ[α => F[G[α]]]] =
            |                                                            ^

--- a/tests/unit/src/test/scala/tests/ReferenceSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceSlowSuite.scala
@@ -127,7 +127,19 @@ object ReferenceSlowSuite extends BaseSlowSuite("reference") {
       _ <- server.didChange("b/src/main/scala/b/B.scala")(
         _.replaceAllLiterally("val b", "\n  val number")
       )
-      _ = server.assertReferenceDefinitionBijection()
+      _ = server.assertReferenceDefinitionDiff(
+        """|--- references
+           |+++ definition
+           |@@ -33,1 +33,7 @@
+           |        ^
+           |+=============
+           |+= b/B.number.
+           |+=============
+           |+b/src/main/scala/b/B.scala:4:7: b/B.number.
+           |+  val number = new a.A().bar(2)
+           |+      ^^^^^^
+           |""".stripMargin
+      )
     } yield ()
   }
 


### PR DESCRIPTION
A last-minute change in 6c501e51b9d0d0937646e01fdc8a25c26372ed2a made
the goto definition fallback integration with LSP no longer work.  This
PR fixes the issue and adds a test to prevent further regressions.