### PR TITLE
Make detail view in override not show unicode character.

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/metals/JavadocIndexer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JavadocIndexer.scala
@@ -65,12 +65,13 @@ class JavadocIndexer(
   }
 
   def markdown(e: JavaAnnotatedElement): String = {
-    try MarkdownGenerator.fromDocstring(s"/**${e.getComment}\n*/", Map.empty)
+    val comment = Option(e.getComment).getOrElse("")
+    try MarkdownGenerator.fromDocstring(s"/**$comment\n*/", Map.empty)
     catch {
       case NonFatal(_) =>
         // The Scaladoc parser implementation uses fragile regexp processing which
         // sometimes causes exceptions.
-        e.getComment
+        comment
     }
   }
   def fromMethod(symbol: String, method: JavaMethod): SymbolDocumentation = {

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -63,7 +63,7 @@ class CompletionProvider(
         val symbolName = r.symNameDropLocal.decoded
         val ident = Identifier.backtickWrap(symbolName)
         val detail = r match {
-          case o: OverrideDefMember => o.label
+          case o: OverrideDefMember => o.detail
           case t: TextEditMember if t.detail.isDefined => t.detail.get
           case _ => detailString(r, history)
         }

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -44,7 +44,8 @@ trait Completions { this: MetalsGlobal =>
       val edit: l.TextEdit,
       val filterText: String,
       sym: Symbol,
-      val autoImports: List[l.TextEdit]
+      val autoImports: List[l.TextEdit],
+      val detail: String
   ) extends ScopeMember(sym, NoType, true, EmptyTree)
 
   val packageSymbols = mutable.Map.empty[String, Option[Symbol]]
@@ -1094,13 +1095,16 @@ trait Completions { this: MetalsGlobal =>
 
         val keyword = if (sym.isStable) "val " else "def "
 
+        val asciOverrideDef = {
+          if (sym.isAbstract) s"${keyword}"
+          else s"${overrideKeyword}${keyword}"
+        }
+
         val overrideDef = metalsConfig.overrideDefFormat() match {
           case OverrideDefFormat.Unicode =>
             if (sym.isAbstract) "🔼 "
             else "⏫ "
-          case _ =>
-            if (sym.isAbstract) s"${keyword}"
-            else s"${overrideKeyword}${keyword}"
+          case _ => asciOverrideDef
         }
 
         val name = Identifier(sym.name)
@@ -1118,10 +1122,13 @@ trait Completions { this: MetalsGlobal =>
             context,
             lineStart,
             inferIndent(lineStart, text)
-          )
+          ),
+          details
         )
 
         private def label = overrideDef + name + signature
+
+        private def details = asciOverrideDef + name + signature
 
         private def signature = printer.defaultMethodSignature()
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
@@ -60,8 +60,8 @@ object CompletionOverrideConfigSuite extends BaseCompletionSuite {
        |  def number@@
        |}
        |""".stripMargin,
-    """🔼 numberAbstract: Int
-      |⏫ number: Int
+    """🔼 numberAbstract: Intdef numberAbstract: Int
+      |⏫ number: Intoverride def number: Int
       |""".stripMargin
   )
 }


### PR DESCRIPTION
Previously when showing details for overriding it showed unicode mode if it was enabled. Now it shows the full signature to override. The unicode character should only be shown in the list, so that it is easier to read it.

Previously:
![image](https://user-images.githubusercontent.com/3807253/56038230-b00e0400-5d31-11e9-96e2-cb177774c617.png)

Now:
![image](https://user-images.githubusercontent.com/3807253/56038248-bf8d4d00-5d31-11e9-8037-4fdc041bcbc6.png)
