### PR TITLE
Documenting coc.nvim as the recommended LSP client for Vim

### DIFF
--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -113,6 +113,8 @@ Possible values:
 - `on`: the `metals/status` notification is supported.
 - `log-message`: translate `metals/status` notifications to `window/logMessage`
   notifications. Used by vim-lsc at the moment.
+- `show-message`: translate `metals/status` notifications to
+  `window/showMessage` notifications. Used by coc.nvim at the moment.
 
 ### `-Dmetals.slow-task`
 
@@ -249,7 +251,8 @@ setting is provided by the editor.
 
 Default value:
 
-- `"editor.action.triggerParameterHints"`: when editor is Visual Studio Code.
+- `"editor.action.triggerParameterHints"`: when editor client is Visual Studio
+  Code or coc.nvim.
 - empty: for all other editors.
 
 ### `-Dmetals.completion.command`
@@ -259,7 +262,8 @@ An optional string value for a command identifier to trigger completion
 
 Default value:
 
-- `"editor.action.triggerSuggest"`: when editor is Visual Studio Code.
+- `"editor.action.triggerSuggest"`: when editor client is Visual Studio Code or
+  coc.nvim.
 - empty: for all other editors.
 
 ### `-Dmetals.pc.debug`

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -28,13 +28,16 @@ clients.
 
 ## Installing Vim
 
-The coc.nvim plugin requires either **Vim >= 8.1** or **neovim >= 0.3.1**. Make
+The coc.nvim plugin requires either **Vim >= 8.1** or **Neovim >= 0.3.1**. Make
 sure you have the correct version installed.
 
 ```sh
-$ vim --version | head
+# If using Vim
+vim --version | head
 VIM - Vi IMproved 8.1
-$ nvim --version | head
+
+# If using Neovim
+nvim --version | head
 NVIM v0.3.4
 ```
 
@@ -46,12 +49,12 @@ extensions but you could opt-out of it and use `vim-plug` instead for example.
 
 For convenience we recommend installing both:
 
-```
+```sh
 curl -sL install-node.now.sh/lts | sh
 curl --compressed -o- -L https://yarnpkg.com/install.sh | bash
 ```
 
-## Installing the plugin
+## Installing coc.nvim
 
 Once the requirements are satisfied, we can now proceed to install the following
 plugins:
@@ -79,7 +82,7 @@ au BufRead,BufNewFile *.sbt set filetype=scala
 Run `:PlugInstall` to install the plugin. If you already have `coc.nvim`
 installed, be sure to update to the latest version with `:PlugUpdate`.
 
-### COC Configuration
+### Configuration
 
 We need to tell `coc.nvim` that our LSP server is going to be `metals`. In order
 to do so, we need to run `:CocConfig` and input our configuration. Here's the
@@ -119,14 +122,6 @@ binary does not exist yet.
 
 The `-Dmetals.client=coc.nvim` flag is important since it configures Metals for
 usage with the `coc.nvim` client.
-
-You might also want to include the following properties to better understand
-what's happening under the hood:
-
-```
--Dmetals.status-bar=log-message
--Dmetals.status-bar=show-message
-```
 
 ```scala mdoc:editor:vim
 

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -29,7 +29,7 @@ same steps can be adapted to use Metals with other LSP clients.
 
 ## Installing the plugin
 
-`coc.nvim` requires [node](https://nodejs.org/en/download/) in order to work. It also uses [yarn](https://yarnpkg.com/en/docs/install#debian-stable) to manage extensions but you could opt-out of it and use `vim-plug` instead for example.
+`coc.nvim` requires [Node.js](https://nodejs.org/en/download/) in order to work. It also uses [Yarn](https://yarnpkg.com/en/docs/install#debian-stable) to manage extensions but you could opt-out of it and use `vim-plug` instead for example.
 
 For convenience we recommend installing both:
 
@@ -71,7 +71,7 @@ input our configuration. Here's the recommended default:
 ```jsonc
 {
   "languageserver": {
-    "scalametals": {
+    "metals": {
       "command": "metals-vim",
       "rootPatterns": ["build.sbt"],
       "trace.server": "verbose",
@@ -94,12 +94,19 @@ autocmd FileType json syntax match Comment +\/\/.\+$+
 If you now start Vim in a Scala project then it will fail since the `metals-vim` binary does not
 exist yet.
 
-```scala mdoc:bootstrap:metals-vim coc
+```scala mdoc:bootstrap:metals-vim coc.nvim
 
 ```
 
-The `-Dmetals.client=coc` flag is important since it configures Metals for
+The `-Dmetals.client=coc.nvim` flag is important since it configures Metals for
 usage with the `coc.nvim` client.
+
+You might also want to include the following properties to better understand what's happening under the hood:
+
+```
+-Dmetals.status-bar=log-message
+-Dmetals.status-bar=show-message
+```
 
 ```scala mdoc:editor:vim
 
@@ -193,16 +200,6 @@ For comprehensive documentation about `coc.nvim`, run the following command.
 :help coc-contents
 ```
 
-## Customize goto definition
-
-Configure `~/.vimrc` to use a different command than `gd` for triggering "goto
-definition".
-
-```vim
-" ~/.vimrc
-nmap <silent> gd <Plug>(coc-definition)
-```
-
 ## List all workspace compile errors
 
 To list all compilation errors and warnings in the workspace, run the following
@@ -244,7 +241,7 @@ To troubleshoot problems with your build workspace execute the following
 command.
 
 ```vim
-:call CocRequest('scalametals', 'workspace/executeCommand', { 'command': 'doctor-run' })
+:call CocRequest('metals', 'workspace/executeCommand', { 'command': 'doctor-run' })
 ```
 
 This command opens your browser with a table like this.
@@ -259,7 +256,7 @@ To manually start the `sbt bloopInstall` step, call the following command below.
 This command works only for sbt builds at the moment.
 
 ```vim
-:call CocRequest('scalametals', 'workspace/executeCommand', { 'command': 'build-import' })
+:call CocRequest('metals', 'workspace/executeCommand', { 'command': 'build-import' })
 ```
 
 ## Manually connect with build server
@@ -269,7 +266,7 @@ the command below. This command works only at the moment if there is a `.bloop/`
 directory containing JSON files.
 
 ```vim
-:call CocRequest('scalametals', 'workspace/executeCommand', { 'command': 'build-connect' })
+:call CocRequest('metals', 'workspace/executeCommand', { 'command': 'build-connect' })
 ```
 
 ## Show document symbols

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -16,8 +16,9 @@ Metals works with most LSP clients for Vim:
   but limited functionality (no auto-import, cancellation and no prompt for
   build import).
 
-In this page, we use `coc.nvim` (Conquer Of Completion) since it offers a richer user experience but the
-same steps can be adapted to use Metals with other LSP clients.
+In this page, we use `coc.nvim` (Conquer Of Completion) since it offers a richer
+user experience but the same steps can be adapted to use Metals with other LSP
+clients.
 
 ![Vim demo](https://i.imgur.com/jMMEmCC.gif)
 
@@ -25,11 +26,23 @@ same steps can be adapted to use Metals with other LSP clients.
 
 ```
 
-**vim >= 8.1 and neovim >= 0.3.1**: Make sure you have the correct supported version.
+## Installing Vim
 
-## Installing the plugin
+The coc.nvim plugin requires either **Vim >= 8.1** or **neovim >= 0.3.1**. Make
+sure you have the correct version installed.
 
-`coc.nvim` requires [Node.js](https://nodejs.org/en/download/) in order to work. It also uses [Yarn](https://yarnpkg.com/en/docs/install#debian-stable) to manage extensions but you could opt-out of it and use `vim-plug` instead for example.
+```sh
+$ vim --version | head
+VIM - Vi IMproved 8.1
+$ nvim --version | head
+NVIM v0.3.4
+```
+
+## Installing yarn
+
+`coc.nvim` requires [Node.js](https://nodejs.org/en/download/) in order to work.
+It also uses [Yarn](https://yarnpkg.com/en/docs/install#debian-stable) to manage
+extensions but you could opt-out of it and use `vim-plug` instead for example.
 
 For convenience we recommend installing both:
 
@@ -38,7 +51,10 @@ curl -sL install-node.now.sh/lts | sh
 curl --compressed -o- -L https://yarnpkg.com/install.sh | bash
 ```
 
-Once the requirements are satisfied, we can now proceed to install the following plugins:
+## Installing the plugin
+
+Once the requirements are satisfied, we can now proceed to install the following
+plugins:
 
 - [`neoclide/coc.nvim`](https://github.com/neoclide/coc.nvim/): Language Server
   Protocol client to communicate with the Metals language server.
@@ -65,22 +81,26 @@ installed, be sure to update to the latest version with `:PlugUpdate`.
 
 ### COC Configuration
 
-We need to tell `coc.nvim` that our LSP server is going to be `metals`. In order to do so, we need to run `:CocConfig` and
-input our configuration. Here's the recommended default:
+We need to tell `coc.nvim` that our LSP server is going to be `metals`. In order
+to do so, we need to run `:CocConfig` and input our configuration. Here's the
+recommended default:
 
 ```jsonc
+// vim:    ~/.vim/coc-settings.json
+// neovim: ~/.config/nvim/coc-settings.json
 {
   "languageserver": {
     "metals": {
       "command": "metals-vim",
       "rootPatterns": ["build.sbt"],
-      "filetypes": ["scala"]
+      "filetypes": ["scala", "sbt"]
     }
   }
 }
 ```
 
-`coc.nvim` uses [jsonc](https://code.visualstudio.com/docs/languages/json) as configuration file format. It's basically json with comments support.
+`coc.nvim` uses [jsonc](https://code.visualstudio.com/docs/languages/json) as
+configuration file format. It's basically json with comments support.
 
 In order to get comments highlighting, please add:
 
@@ -90,8 +110,8 @@ autocmd FileType json syntax match Comment +\/\/.\+$+
 
 ### Generating metals binary
 
-If you now start Vim in a Scala project then it will fail since the `metals-vim` binary does not
-exist yet.
+If you now start Vim in a Scala project then it will fail since the `metals-vim`
+binary does not exist yet.
 
 ```scala mdoc:bootstrap:metals-vim coc.nvim
 
@@ -100,7 +120,8 @@ exist yet.
 The `-Dmetals.client=coc.nvim` flag is important since it configures Metals for
 usage with the `coc.nvim` client.
 
-You might also want to include the following properties to better understand what's happening under the hood:
+You might also want to include the following properties to better understand
+what's happening under the hood:
 
 ```
 -Dmetals.status-bar=log-message
@@ -113,7 +134,8 @@ You might also want to include the following properties to better understand wha
 
 ### LSP commands key mapping
 
-`coc.nvim` doesn't come with a default key mapping for LSP commands, you need to configure it yourself.
+`coc.nvim` doesn't come with a default key mapping for LSP commands, you need to
+configure it yourself.
 
 Here's a recommended configuration:
 
@@ -247,7 +269,8 @@ This command opens your browser with a table like this.
 
 ![Run Doctor](https://i.imgur.com/yelm0jd.png)
 
-Note: the binary `metals-vim` needs to be built using `-Dmetals.http=true` for this command to work.
+Note: the binary `metals-vim` needs to be built using `-Dmetals.http=true` for
+this command to work.
 
 ## Manually start build import
 
@@ -270,7 +293,8 @@ directory containing JSON files.
 
 ## Show document symbols
 
-Run `:CocList outline` to show a symbol outline for the current file or use the default key `<space> o`.
+Run `:CocList outline` to show a symbol outline for the current file or use the
+default key `<space> o`.
 
 ![Document Symbols](https://i.imgur.com/LviFAVm.gif)
 

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -16,7 +16,7 @@ Metals works with most LSP clients for Vim:
   but limited functionality (no auto-import, cancellation and no prompt for
   build import).
 
-In this page, we use vim-lsc since it offers the simplest installation but the
+In this page, we use `coc.nvim` (Conquer Of Completion) since it offers a richer user experience but the
 same steps can be adapted to use Metals with other LSP clients.
 
 ![Vim demo](https://i.imgur.com/jMMEmCC.gif)
@@ -25,11 +25,22 @@ same steps can be adapted to use Metals with other LSP clients.
 
 ```
 
+**vim >= 8.1 and neovim >= 0.3.1**: Make sure you have the correct supported version.
+
 ## Installing the plugin
 
-First, install the following plugins
+`coc.nvim` requires [node](https://nodejs.org/en/download/) in order to work. It also uses [yarn](https://yarnpkg.com/en/docs/install#debian-stable) to manage extensions but you could opt-out of it and use `vim-plug` instead for example.
 
-- [`natebosch/vim-lsc`](https://github.com/natebosch/vim-lsc/): Language Server
+For convenience we recommend installing both:
+
+```
+curl -sL install-node.now.sh/lts | sh
+curl --compressed -o- -L https://yarnpkg.com/install.sh | bash
+```
+
+Once the requirements are satisfied, we can now proceed to install the following plugins:
+
+- [`neoclide/coc.nvim`](https://github.com/neoclide/coc.nvim/): Language Server
   Protocol client to communicate with the Metals language server.
 - [`derekwyatt/vim-scala`](https://github.com/derekwyatt/vim-scala): for syntax
   highlighting Scala and sbt source files.
@@ -43,47 +54,143 @@ following settings.
 
 " Configuration for vim-plug
 Plug 'derekwyatt/vim-scala'
-Plug 'natebosch/vim-lsc'
+Plug 'neoclide/coc.nvim', {'do': { -> coc#util#install()}}
 
 " Configuration for vim-scala
 au BufRead,BufNewFile *.sbt set filetype=scala
-
-" Configuration for vim-lsc
-let g:lsc_enable_autocomplete = v:false
-let g:lsc_server_commands = {
-  \  'scala': {
-  \    'command': 'metals-vim',
-  \    'log_level': 'Log'
-  \  }
-  \}
-let g:lsc_auto_map = {
-  \  'GoToDefinition': 'gd',
-  \}
 ```
 
-Run `:PlugInstall` to install the plugin. If you already have `vim-lsc`
+Run `:PlugInstall` to install the plugin. If you already have `coc.nvim`
 installed, be sure to update to the latest version with `:PlugUpdate`.
 
-If you start Vim now then it will fail since the `metals-vim` binary does not
+### COC Configuration
+
+We need to tell `coc.nvim` that our LSP server is going to be `metals`. In order to do so, we need to run `:CocConfig` and
+input our configuration. Here's the recommended default:
+
+```jsonc
+{
+  "languageserver": {
+    "scalametals": {
+      "command": "metals-vim",
+      "rootPatterns": ["build.sbt"],
+      "trace.server": "verbose",
+      "filetypes": ["scala"]
+    }
+  }
+}
+```
+
+`coc.nvim` uses [jsonc](https://code.visualstudio.com/docs/languages/json) as configuration file format. It's basically json with comments support.
+
+In order to get comments highlighting, please add:
+
+```vim
+autocmd FileType json syntax match Comment +\/\/.\+$+
+```
+
+### Generating metals binary
+
+If you now start Vim in a Scala project then it will fail since the `metals-vim` binary does not
 exist yet.
 
-```scala mdoc:bootstrap:metals-vim vim-lsc
+```scala mdoc:bootstrap:metals-vim coc
 
 ```
 
-The `-Dmetals.client=vim-lsc` flag is important since it configures Metals for
-usage with the `vim-lsc` client.
+The `-Dmetals.client=coc` flag is important since it configures Metals for
+usage with the `coc.nvim` client.
 
 ```scala mdoc:editor:vim
 
 ```
 
-## Learn more about vim-lsc
+### LSP commands key mapping
 
-For comprehensive documentation about vim-lsc, run the following command.
+`coc.nvim` doesn't come with a default key mapping for LSP commands, you need to configure it yourself.
+
+Here's a recommended configuration:
 
 ```vim
-:help lsc
+" ~/.vimrc
+" Configuration for coc.nvim
+
+" Smaller updatetime for CursorHold & CursorHoldI
+set updatetime=300
+
+" don't give |ins-completion-menu| messages.
+set shortmess+=c
+
+" always show signcolumns
+set signcolumn=yes
+
+" Some server have issues with backup files, see #649
+set nobackup
+set nowritebackup
+
+" Better display for messages
+set cmdheight=2
+
+" Use <c-space> for trigger completion.
+inoremap <silent><expr> <c-space> coc#refresh()
+
+" Use <cr> for confirm completion, `<C-g>u` means break undo chain at current position.
+" Coc only does snippet and additional edit on confirm.
+inoremap <expr> <cr> pumvisible() ? "\<C-y>" : "\<C-g>u\<CR>"
+
+" Use `[c` and `]c` for navigate diagnostics
+nmap <silent> [c <Plug>(coc-diagnostic-prev)
+nmap <silent> ]c <Plug>(coc-diagnostic-next)
+
+" Remap keys for gotos
+nmap <silent> gd <Plug>(coc-definition)
+nmap <silent> gy <Plug>(coc-type-definition)
+nmap <silent> gi <Plug>(coc-implementation)
+nmap <silent> gr <Plug>(coc-references)
+
+" Remap for do codeAction of current line
+nmap <leader>ac <Plug>(coc-codeaction)
+
+" Remap for do action format
+nnoremap <silent> F :call CocAction('format')<CR>
+
+" Use K for show documentation in preview window
+nnoremap <silent> K :call <SID>show_documentation()<CR>
+
+function! s:show_documentation()
+  if &filetype == 'vim'
+    execute 'h '.expand('<cword>')
+  else
+    call CocAction('doHover')
+  endif
+endfunction
+
+" Highlight symbol under cursor on CursorHold
+autocmd CursorHold * silent call CocActionAsync('highlight')
+
+" Remap for rename current word
+nmap <leader>rn <Plug>(coc-rename)
+
+" Show all diagnostics
+nnoremap <silent> <space>a  :<C-u>CocList diagnostics<cr>
+" Find symbol of current document
+nnoremap <silent> <space>o  :<C-u>CocList outline<cr>
+" Search workspace symbols
+nnoremap <silent> <space>s  :<C-u>CocList -I symbols<cr>
+" Do default action for next item.
+nnoremap <silent> <space>j  :<C-u>CocNext<CR>
+" Do default action for previous item.
+nnoremap <silent> <space>k  :<C-u>CocPrev<CR>
+" Resume latest coc list
+nnoremap <silent> <space>p  :<C-u>CocListResume<CR>
+```
+
+## Learn more about coc.nvim
+
+For comprehensive documentation about `coc.nvim`, run the following command.
+
+```vim
+:help coc-contents
 ```
 
 ## Customize goto definition
@@ -93,9 +200,7 @@ definition".
 
 ```vim
 " ~/.vimrc
-let g:lsc_auto_map = {
-    \ 'GoToDefinition': 'gd',
-    \}
+nmap <silent> gd <Plug>(coc-definition)
 ```
 
 ## List all workspace compile errors
@@ -104,8 +209,10 @@ To list all compilation errors and warnings in the workspace, run the following
 command.
 
 ```vim
-:LSClientAllDiagnostics
+:CocList diagnostics
 ```
+
+Or use the default recommended mapping `<space> a`.
 
 This is helpful to see compilation errors in different files from your current
 open buffer.
@@ -137,15 +244,14 @@ To troubleshoot problems with your build workspace execute the following
 command.
 
 ```vim
-:call lsc#server#call(&filetype, 'workspace/executeCommand', { 'command': 'doctor-run' }, function('abs'))
+:call CocRequest('scalametals', 'workspace/executeCommand', { 'command': 'doctor-run' })
 ```
 
 This command opens your browser with a table like this.
 
 ![Run Doctor](https://i.imgur.com/yelm0jd.png)
 
-The callback `function('abs')` can be replaced with any function that does
-nothing.
+Note: the binary `metals-vim` needs to be built using `-Dmetals.http=true` for this command to work.
 
 ## Manually start build import
 
@@ -153,11 +259,8 @@ To manually start the `sbt bloopInstall` step, call the following command below.
 This command works only for sbt builds at the moment.
 
 ```vim
-:call lsc#server#call(&filetype, 'workspace/executeCommand', { 'command': 'build-import' }, function('abs'))
+:call CocRequest('scalametals', 'workspace/executeCommand', { 'command': 'build-import' })
 ```
-
-The callback `function('abs')` can be replaced with any function that does
-nothing.
 
 ## Manually connect with build server
 
@@ -166,17 +269,14 @@ the command below. This command works only at the moment if there is a `.bloop/`
 directory containing JSON files.
 
 ```vim
-:call lsc#server#call(&filetype, 'workspace/executeCommand', { 'command': 'build-connect' }, function('abs'))
+:call CocRequest('scalametals', 'workspace/executeCommand', { 'command': 'build-connect' })
 ```
-
-The callback `function('abs')` can be replaced with any function that does
-nothing.
 
 ## Show document symbols
 
-Run `:LSClientDocumentSymbol` to show a symbol outline for the current file.
+Run `:CocList outline` to show a symbol outline for the current file or use the default key `<space> o`.
 
-![Document Symbols](https://i.imgur.com/T8SUD7B.png)
+![Document Symbols](https://i.imgur.com/LviFAVm.gif)
 
 ```scala mdoc:generic
 

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -74,7 +74,6 @@ input our configuration. Here's the recommended default:
     "metals": {
       "command": "metals-vim",
       "rootPatterns": ["build.sbt"],
-      "trace.server": "verbose",
       "filetypes": ["scala"]
     }
   }

--- a/metals-docs/src/main/scala/docs/BootstrapModifier.scala
+++ b/metals-docs/src/main/scala/docs/BootstrapModifier.scala
@@ -24,8 +24,6 @@ class BootstrapModifier extends StringModifier {
            |curl -L -o coursier https://git.io/coursier
            |chmod +x coursier
            |./coursier bootstrap \\
-           |  --java-opt -XX:+UseG1GC \\
-           |  --java-opt -XX:+UseStringDeduplication  \\
            |  --java-opt -Xss4m \\
            |  --java-opt -Xms100m \\
            |  --java-opt -Dmetals.client=$client \\

--- a/metals-docs/src/main/scala/docs/TextEditorModifier.scala
+++ b/metals-docs/src/main/scala/docs/TextEditorModifier.scala
@@ -31,6 +31,7 @@ class TextEditorModifier extends StringModifier {
        |- "Not now" disables this prompt for 2 minutes.
        |- "Don't show again" disables this prompt forever, use `rm -rf .metals/` to re-enable
        |  the prompt.
+       |- Use `tail -f .metals/metals.log` to watch the build import progress.
        |- Behind the scenes, Metals uses [Bloop](https://scalacenter.github.io/bloop/) to
        |  import sbt builds, but you don't need Bloop installed on your machine to run this step.
        |

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -71,6 +71,10 @@ object Configs {
         isSignatureHelpDocumentationEnabled = MetalsServerConfig.binaryOption(
           "metals.signature-help.documentation",
           default = true
+        ),
+        isCompletionItemResolve = MetalsServerConfig.binaryOption(
+          "metals.completion-item.resolve",
+          default = true
         )
       )
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -53,10 +53,14 @@ final class ConfiguredLanguageClient(
   override def metalsStatus(params: MetalsStatusParams): Unit = {
     if (config.statusBar.isOn) {
       underlying.metalsStatus(params)
-    } else if (config.statusBar.isLogMessage && !pendingShowMessage.get()) {
-      underlying.logMessage(new MessageParams(MessageType.Log, params.text))
-    } else if (config.statusBar.isShowMessage && !pendingShowMessage.get()) {
-      underlying.showMessage(new MessageParams(MessageType.Log, params.text))
+    } else if (params.text.nonEmpty && !pendingShowMessage.get()) {
+      if (config.statusBar.isLogMessage) {
+        underlying.logMessage(new MessageParams(MessageType.Log, params.text))
+      } else if (config.statusBar.isShowMessage) {
+        underlying.showMessage(new MessageParams(MessageType.Log, params.text))
+      } else {
+        ()
+      }
     } else {
       ()
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -55,6 +55,8 @@ final class ConfiguredLanguageClient(
       underlying.metalsStatus(params)
     } else if (config.statusBar.isLogMessage && !pendingShowMessage.get()) {
       underlying.logMessage(new MessageParams(MessageType.Log, params.text))
+    } else if (config.statusBar.isShowMessage && !pendingShowMessage.get()) {
+      underlying.showMessage(new MessageParams(MessageType.Log, params.text))
     } else {
       ()
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -361,7 +361,10 @@ class MetalsLanguageServer(
         new SignatureHelpOptions(List("(", "[").asJava)
       )
       capabilities.setCompletionProvider(
-        new CompletionOptions(true, List(".").asJava)
+        new CompletionOptions(
+          config.compilers.isCompletionItemResolve,
+          List(".").asJava
+        )
       )
       capabilities.setWorkspaceSymbolProvider(true)
       capabilities.setDocumentSymbolProvider(true)
@@ -842,7 +845,11 @@ class MetalsLanguageServer(
       item: CompletionItem
   ): CompletableFuture[CompletionItem] =
     CancelTokens { token =>
-      compilers.completionItemResolve(item, token).getOrElse(item)
+      if (config.compilers.isCompletionItemResolve) {
+        compilers.completionItemResolve(item, token).getOrElse(item)
+      } else {
+        item
+      }
     }
   def completionItemResolveSync(item: CompletionItem): CompletionItem =
     compilers.completionItemResolve(item, EmptyCancelToken).getOrElse(item)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -113,6 +113,17 @@ object MetalsServerConfig {
           isHttpEnabled = true,
           icons = Icons.unicode
         )
+      case "coc.nvim" =>
+        base.copy(
+          statusBar = StatusBarConfig.showMessage,
+          isHttpEnabled = true,
+          compilers = base.compilers.copy(
+            _parameterHintsCommand = Some("editor.action.triggerParameterHints"),
+            _completionCommand = Some("editor.action.triggerSuggest"),
+            overrideDefFormat = OverrideDefFormat.Unicode,
+            isCompletionItemResolve = false
+          )
+        )
       case "sublime" =>
         base.copy(
           isHttpEnabled = true,

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBarConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBarConfig.scala
@@ -4,12 +4,14 @@ final case class StatusBarConfig(value: String) {
   def isOff: Boolean = value == "off"
   def isOn: Boolean = value == "on"
   def isLogMessage: Boolean = value == "log-message"
+  def isShowMessage: Boolean = value == "show-message"
 }
 
 object StatusBarConfig {
   def off = new StatusBarConfig("off")
   def on = new StatusBarConfig("on")
   def logMessage = new StatusBarConfig("log-message")
+  def showMessage = new StatusBarConfig("show-message")
   def default = new StatusBarConfig(
     System.getProperty("metals.status-bar", "off")
   )

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -16,7 +16,8 @@ case class PresentationCompilerConfigImpl(
     isCompletionItemDetailEnabled: Boolean = true,
     isCompletionItemDocumentationEnabled: Boolean = true,
     isHoverDocumentationEnabled: Boolean = true,
-    isSignatureHelpDocumentationEnabled: Boolean = true
+    isSignatureHelpDocumentationEnabled: Boolean = true,
+    isCompletionItemResolve: Boolean = true
 ) extends PresentationCompilerConfig {
   override def symbolPrefixes(): util.Map[String, String] =
     _symbolPrefixes.asJava


### PR DESCRIPTION
closes #650 

There are two things that I couldn't figured out yet so any help will be much appreciated:

- LSP logs at the bottom below the status bar. Messages such as "running bloop install", "compiling foo..", "indexing..." , etc. It worked using `vim-lsc` but I don't know yet how to get it working with `coc.nvim.`
- Folding range: I haven't used this feature but there's a related key mapping: `command! -nargs=? Fold :call     CocAction('fold', <f-args>)`. If anyone has got this working please share your config :pray: 

I replaced the static image of searching Document Symbols with a custom gif I made using `coc.nvim`. Let me know if that's okay or if you guys prefer to leave it blank (the instructions might be enough).

### Tab mapping

I also excluded the `<tab>` mapping to navigate completions because I don't think it's a good default but if you want to recommend it as default please let me know and I can add the key mapping:

```vim
" Use tab for trigger completion with characters ahead and navigate.
" Use command ':verbose imap <tab>' to make sure tab is not mapped by other plugin.
inoremap <silent><expr> <TAB>
      \ pumvisible() ? "\<C-n>" :
      \ <SID>check_back_space() ? "\<TAB>" :
      \ coc#refresh()
inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"

function! s:check_back_space() abort
  let col = col('.') - 1
  return !col || getline('.')[col - 1]  =~# '\s'
endfunction
```