### PR TITLE
Clear diagnostics on build import, fixes #644.

### DIFF
--- a/metals-bench/src/main/scala/bench/CompletionBench.scala
+++ b/metals-bench/src/main/scala/bench/CompletionBench.scala
@@ -99,8 +99,6 @@ abstract class CompletionBench {
   def complete(): CompletionList = {
     val pc = presentationCompiler()
     val result = currentCompletion.complete(pc)
-//    val diagnosticsForDebuggingPurposes = pc.diagnosticsForDebuggingPurposes()
-//    require(diagnosticsForDebuggingPurposes.isEmpty, diagnosticsForDebuggingPurposes.asScala.mkString("\n", "\n", "\n")) require(!result.getItems.isEmpty, result)
     result
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -31,9 +31,9 @@ object ClientCommands {
   )
 
   val FocusDiagnostics = Command(
-    "metals-diagnosticsForDebuggingPurposes-focus",
+    "metals-diagnostics-focus",
     "Open problems",
-    """|Focus on the window that lists all published diagnosticsForDebuggingPurposes.
+    """|Focus on the window that lists all published diagnostics.
        |
        |In VS Code, this opens the "problems" window.
        |""".stripMargin

--- a/metals/src/main/scala/scala/meta/internal/metals/CompilerPlugins.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CompilerPlugins.scala
@@ -16,7 +16,7 @@ import scala.xml.XML
  * - hover
  * - parameter hints
  * Compiler plugins that don't affect those features can be disabled, for example
- * WartRemover that only reports diagnosticsForDebuggingPurposes. Diagnostics are already published from
+ * WartRemover that only reports diagnostics. Diagnostics are already published from
  * the build, where all compiler plugins are enabled by default.
  *
  * Some compiler plugins change the semantics of the Scala language. Metals officially

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -51,6 +51,14 @@ final class Diagnostics(
   private val compileTimer =
     TrieMap.empty[BuildTargetIdentifier, Timer]
 
+  def reset(): Unit = {
+    val keys = diagnostics.keys
+    diagnostics.clear()
+    keys.foreach { key =>
+      publishDiagnostics(key)
+    }
+  }
+
   def onStartCompileBuildTarget(target: BuildTargetIdentifier): Unit = {
     if (statistics.isDiagnostics) {
       compileTimer(target) = new Timer(Time.system)

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -19,10 +19,10 @@ import scala.meta.io.AbsolutePath
 import scala.{meta => m}
 
 /**
- * Converts diagnosticsForDebuggingPurposes from the build server and Scalameta parser into LSP diagnosticsForDebuggingPurposes.
+ * Converts diagnostics from the build server and Scalameta parser into LSP diagnostics.
  *
- * BSP diagnosticsForDebuggingPurposes have different semantics from LSP diagnosticsForDebuggingPurposes with regards to how they
- * are published. BSP diagnosticsForDebuggingPurposes can be accumulated when `reset=false`, meaning the client
+ * BSP diagnostics have different semantics from LSP diagnostics with regards to how they
+ * are published. BSP diagnostics can be accumulated when `reset=false`, meaning the client
  * (Metals) is responsible for aggregating multiple `build/publishDiagnostics` notifications
  * into a single `textDocument/publishDiagnostics` notification.
  *
@@ -118,9 +118,9 @@ final class Diagnostics(
       queue.add(buildDiagnostic.toLSP)
     }
 
-    // NOTE(olafur): we buffer up several diagnosticsForDebuggingPurposes for the same path before forwarding
+    // NOTE(olafur): we buffer up several diagnostics for the same path before forwarding
     // them to the editor client. Without buffering, we risk publishing an exponential number
-    // notifications for a file with N number of diagnosticsForDebuggingPurposes:
+    // notifications for a file with N number of diagnostics:
     // Notification 1: [1]
     // Notification 2: [1, 2]
     // Notification 3: [1, 2, 3]

--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -99,7 +99,7 @@ final class InteractiveSemanticdbs(
   }
 
   /**
-   * Unpublish diagnosticsForDebuggingPurposes for un-focused dependency source, if any, and publish diagnosticsForDebuggingPurposes
+   * Unpublish diagnostics for un-focused dependency source, if any, and publish diagnostics
    * for the currently focused source, if any.
    */
   def didFocus(path: AbsolutePath): Unit = {
@@ -116,7 +116,7 @@ final class InteractiveSemanticdbs(
           if diag.severity.isError
           range <- diag.range
         } yield {
-          // Use INFO instead of ERROR severity because these diagnosticsForDebuggingPurposes are published for readonly
+          // Use INFO instead of ERROR severity because these diagnostics are published for readonly
           // files of external dependencies so the user cannot fix them.
           val severity = DiagnosticSeverity.Information
           new l.Diagnostic(range.toLSP, diag.message, severity, "scala")

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -535,7 +535,7 @@ class MetalsLanguageServer(
       CancelTokens { _ =>
         // trigger compilation in preparation for definition requests
         interactiveSemanticdbs.textDocument(path)
-        // publish diagnosticsForDebuggingPurposes
+        // publish diagnostics
         interactiveSemanticdbs.didFocus(path)
         ()
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -922,6 +922,10 @@ class MetalsLanguageServer(
         slowConnectToBuildServer(forceImport = true).asJavaObject
       case ServerCommands.ConnectBuildServer() =>
         quickConnectToBuildServer().asJavaObject
+      case ServerCommands.DisconnectBuildServer() =>
+        Future {
+          disconnectOldBuildServer()
+        }.asJavaObject
       case ServerCommands.RunDoctor() =>
         Future {
           doctor.executeRunDoctor()
@@ -1054,21 +1058,29 @@ class MetalsLanguageServer(
     } yield result
   }.recover {
     case NonFatal(e) =>
+      disconnectOldBuildServer()
       val message =
         "Failed to connect with build server, no functionality will work."
       val details = " See logs for more details."
-      buildServer.foreach(_.shutdown())
-      buildServer = None
-      scribe.error(message, e)
       languageClient.showMessage(
         new MessageParams(MessageType.Error, message + details)
       )
+      scribe.error(message, e)
       BuildChange.Failed
   }
 
+  private def disconnectOldBuildServer(): Unit = {
+    if (buildServer.isDefined) {
+      scribe.info("disconnected: build server")
+    }
+    buildServer.foreach(_.shutdown())
+    buildServer = None
+    diagnostics.reset()
+  }
   private def connectToNewBuildServer(
       build: BuildServerConnection
   ): Future[BuildChange] = {
+    disconnectOldBuildServer()
     cancelables.add(build)
     compilers.cancel()
     buildServer = Some(build)

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -28,6 +28,12 @@ object ServerCommands {
       |""".stripMargin
   )
 
+  val DisconnectBuildServer = Command(
+    "build-disconnect",
+    "Disconnect to build server",
+    """Unconditionally cancel existing build server connection without reconnecting"""
+  )
+
   val ScanWorkspaceSources = Command(
     "sources-scan",
     "Scan sources",

--- a/metals/src/main/scala/scala/meta/internal/metals/StatisticsConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatisticsConfig.scala
@@ -4,9 +4,7 @@ final case class StatisticsConfig(value: String) {
   val isAll: Boolean = value == "all"
   val isMemory: Boolean = isAll || value.contains("memory")
   val isDefinition: Boolean = isAll || value.contains("definition")
-  val isDiagnostics: Boolean = isAll || value.contains(
-    "diagnosticsForDebuggingPurposes"
-  )
+  val isDiagnostics: Boolean = isAll || value.contains("diagnostics")
   val isReferences: Boolean = isAll || value.contains("references")
   val isWorkspaceSymbol: Boolean = isAll || value.contains("workspace-symbol")
   val isIndex: Boolean = isAll || value.contains("index")

--- a/metals/src/main/scala/scala/meta/internal/metals/Trees.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Trees.scala
@@ -11,7 +11,7 @@ import scala.meta.parsers.Parsed
  *
  * - provides the latest good Scalameta tree for a given source file
  *   similar as `Buffers` provides the current text content.
- * - publishes diagnosticsForDebuggingPurposes for syntax errors.
+ * - publishes diagnostics for syntax errors.
  */
 final class Trees(buffers: Buffers, diagnostics: Diagnostics) {
   private val trees = TrieMap.empty[AbsolutePath, Tree]

--- a/tests/unit/src/main/scala/bill/Bill.scala
+++ b/tests/unit/src/main/scala/bill/Bill.scala
@@ -49,7 +49,7 @@ import scala.meta.io.AbsolutePath
  * of interest to you:
  *
  * - server discovery installation of `.bsp/bill.json` files
- * - custom Scala compiler reporter to produce BSP diagnosticsForDebuggingPurposes
+ * - custom Scala compiler reporter to produce BSP diagnostics.
  *
  * You can try bill by running the main method:
  *

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -32,7 +32,7 @@ import tests.TestOrderings._
  * Fake LSP client that responds to notifications/requests initiated by the server.
  *
  * - Can customize how to respond to window/showMessageRequest
- * - Aggregates published diagnosticsForDebuggingPurposes and pretty-prints them as strings
+ * - Aggregates published diagnostics and pretty-prints them as strings
  */
 final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
     extends MetalsLanguageClient {

--- a/tests/unit/src/test/scala/tests/BillSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/BillSlowSuite.scala
@@ -40,7 +40,7 @@ object BillSlowSuite extends BaseSlowSuite("bill") {
     } yield ()
   }
 
-  testAsync("diagnosticsForDebuggingPurposes") {
+  testAsync("diagnostics") {
     Bill.installWorkspace(workspace.toNIO)
     testRoundtripCompilation()
   }

--- a/tests/unit/src/test/scala/tests/DefinitionSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionSlowSuite.scala
@@ -8,7 +8,7 @@ import scala.meta.internal.metals.StatisticsConfig
 object DefinitionSlowSuite extends BaseSlowSuite("definition") {
   override def serverConfig: MetalsServerConfig =
     super.serverConfig.copy(
-      statistics = new StatisticsConfig("diagnosticsForDebuggingPurposes")
+      statistics = new StatisticsConfig("diagnostics")
     )
 
   override def testAsync(
@@ -226,7 +226,7 @@ object DefinitionSlowSuite extends BaseSlowSuite("definition") {
            |""".stripMargin
       )
       _ <- server.didFocus("a/src/main/scala/a/Main.scala")
-      // dependency diagnosticsForDebuggingPurposes are unpublished.
+      // dependency diagnostics are unpublished.
       _ = assertNoDiff(client.workspaceDiagnostics, "")
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/DiagnosticsSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/DiagnosticsSlowSuite.scala
@@ -1,16 +1,8 @@
 package tests
 
-import scala.meta.internal.metals.MetalsServerConfig
-import scala.meta.internal.metals.StatisticsConfig
+object DiagnosticsSlowSuite extends BaseSlowSuite("diagnostics") {
 
-object DiagnosticsSlowSuite
-    extends BaseSlowSuite("diagnosticsForDebuggingPurposes") {
-
-  override def serverConfig: MetalsServerConfig = super.serverConfig.copy(
-    statistics = StatisticsConfig("diagnosticsForDebuggingPurposes-clear")
-  )
-
-  testAsync("diagnosticsForDebuggingPurposes") {
+  testAsync("diagnostics") {
     cleanCompileCache("a")
     cleanCompileCache("b")
     for {
@@ -117,7 +109,7 @@ object DiagnosticsSlowSuite
       )
       _ = assertNoDiff(
         client.workspaceDiagnostics,
-        // Duplicate diagnosticsForDebuggingPurposes are expected, the scala compiler reports them.
+        // Duplicate diagnostics are expected, the scala compiler reports them.
         """|a/src/main/scala/Main.scala:3:7: error: a is already defined as value a
            |  val a = 2
            |      ^


### PR DESCRIPTION
Previously, we could occasionally get in a state where Metals published
stale diagnostics from an old build server.  Now, when we disconnect
from a build server we unpublish the diagnostics from that server. If we
connect to a new server, the errors will get re-published if they are
still relevant.