### PR TITLE
Add "Coming from IntelliJ" section to VS Code docs.

### DIFF
--- a/docs/editors/vscode.md
+++ b/docs/editors/vscode.md
@@ -11,7 +11,8 @@ title: Visual Studio Code
 
 ## Installation
 
-Install the Metals extension from the [Marketplace](https://marketplace.visualstudio.com/items?itemName=scalameta.metals).
+Install the Metals extension from the
+[Marketplace](https://marketplace.visualstudio.com/items?itemName=scalameta.metals).
 
 [![Install Metals extension](https://img.shields.io/badge/metals-vscode-blue.png)](vscode:extension/scalameta.metals)
 
@@ -110,3 +111,18 @@ without opening the sidebar.
 
 As you type, the symbol outline is also visible at the top of the file.
 ![Document Symbols Outline](https://i.imgur.com/L217n4q.png)
+
+## Coming from IntelliJ
+
+Install the
+[IntelliJ IDEA Keybindings](https://marketplace.visualstudio.com/items?itemName=k--kato.intellij-idea-keybindings)
+extension to use default IntelliJ shortcuts with VS Code.
+
+| IntelliJ         | VS Code                   |
+| ---------------- | ------------------------- |
+| Go to class      | Go to symbol in workspace |
+| Parameter info   | Trigger parameter hints   |
+| Basic completion | Trigger suggest           |
+| Type info        | Show hover                |
+| Expand           | Fold                      |
+| Extend Selection | Expand selection          |


### PR DESCRIPTION
Fixes #673. We can add more details to this section, this is just a basic start.