### PR TITLE
Handle document symbols for nested declarations

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DocumentSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DocumentSymbolProvider.scala
@@ -93,7 +93,17 @@ class DocumentSymbolProvider(trees: Trees) {
         case t: Pkg =>
           addChild(t.ref.syntax, SymbolKind.Package, t.pos, t.ref.pos, "")
           newOwner()
-        case _: Source | _: Template =>
+        case t: Term.NewAnonymous =>
+          val (name, selection) = t.templ.inits match {
+            case Nil => ("(anonymous)", t.pos)
+            case inits =>
+              (inits.map(_.tpe.syntax).mkString(" with "), inits.head.pos)
+          }
+          if (t.templ.stats.nonEmpty) {
+            addChild(s"new $name", SymbolKind.Interface, t.pos, selection, "")
+            newOwner()
+          } else continue()
+        case _: Source | _: Template | _: Term.Block =>
           continue()
         case t: Defn.Class =>
           addChild(
@@ -139,6 +149,7 @@ class DocumentSymbolProvider(trees: Trees) {
             t.name.pos,
             t.decltpe.fold("")(_.syntax)
           )
+          newOwner()
         case t: Decl.Def =>
           addChild(
             t.name.value,
@@ -147,6 +158,7 @@ class DocumentSymbolProvider(trees: Trees) {
             t.name.pos,
             t.decltpe.syntax
           )
+          newOwner()
         case t: Defn.Val =>
           addPats(
             t.pats,
@@ -154,6 +166,7 @@ class DocumentSymbolProvider(trees: Trees) {
             t.pos,
             t.decltpe.fold("")(_.syntax)
           )
+          newOwner()
         case t: Decl.Val =>
           addPats(
             t.pats,
@@ -161,6 +174,7 @@ class DocumentSymbolProvider(trees: Trees) {
             t.pos,
             t.decltpe.syntax
           )
+          newOwner()
         case t: Defn.Var =>
           addPats(
             t.pats,
@@ -168,6 +182,7 @@ class DocumentSymbolProvider(trees: Trees) {
             t.pos,
             t.decltpe.fold("")(_.syntax)
           )
+          newOwner()
         case t: Decl.Var =>
           addPats(
             t.pats,
@@ -175,6 +190,7 @@ class DocumentSymbolProvider(trees: Trees) {
             t.pos,
             t.decltpe.syntax
           )
+          newOwner()
         case t: Defn.Type =>
           addChild(
             t.name.value,

--- a/tests/input/src/main/scala/example/nested/LocalDeclarations.scala
+++ b/tests/input/src/main/scala/example/nested/LocalDeclarations.scala
@@ -1,0 +1,24 @@
+package example.nested
+
+trait LocalDeclarations {
+  def foo(): Unit
+}
+
+trait Foo {}
+
+object LocalDeclarations {
+  def create(): LocalDeclarations = {
+    def bar(): Unit = ()
+
+    val x = new {
+      val x = 2
+    }
+
+    val y = new Foo {}
+
+    new LocalDeclarations with Foo {
+      override def foo(): Unit = bar()
+    }
+
+  }
+}

--- a/tests/unit/src/test/resources/definition/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/definition/example/nested/LocalDeclarations.scala
@@ -1,0 +1,24 @@
+package example.nested
+
+trait LocalDeclarations/*LocalDeclarations.scala*/ {
+  def foo/*LocalDeclarations.scala*/(): Unit/*Unit.scala*/
+}
+
+trait Foo/*LocalDeclarations.scala*/ {}
+
+object LocalDeclarations/*LocalDeclarations.scala*/ {
+  def create/*LocalDeclarations.scala*/(): LocalDeclarations/*LocalDeclarations.scala*/ = {
+    def bar/*LocalDeclarations.semanticdb*/(): Unit/*Unit.scala*/ = ()
+
+    val x/*LocalDeclarations.semanticdb*/ = new {
+      val x/*LocalDeclarations.semanticdb*/ = 2
+    }
+
+    val y/*LocalDeclarations.semanticdb*/ = new Foo/*LocalDeclarations.scala*/ {}
+
+    new LocalDeclarations/*LocalDeclarations.scala*/ with Foo/*LocalDeclarations.scala*/ {
+      override def foo/*LocalDeclarations.semanticdb*/(): Unit/*Unit.scala*/ = bar/*LocalDeclarations.semanticdb*/()
+    }
+
+  }
+}

--- a/tests/unit/src/test/resources/documentSymbol/example/Locals.scala
+++ b/tests/unit/src/test/resources/documentSymbol/example/Locals.scala
@@ -2,7 +2,7 @@
 
 /*example.Locals(Class):8*/class Locals {
   {
-    val x = 2
+    /*example.Locals#x(Constant):5*/val x = 2
     x + 2
   }
 }

--- a/tests/unit/src/test/resources/documentSymbol/example/PatternMatching.scala
+++ b/tests/unit/src/test/resources/documentSymbol/example/PatternMatching.scala
@@ -17,7 +17,7 @@
   println(number1)
 
   /*example.PatternMatching#localDeconstruction(Method):23*/def localDeconstruction = {
-    val Some(number2) =
+    /*example.PatternMatching#localDeconstruction.number2(Constant):21*/val Some(number2) =
       some
     number2
   }

--- a/tests/unit/src/test/resources/documentSymbol/example/StructuralTypes.scala
+++ b/tests/unit/src/test/resources/documentSymbol/example/StructuralTypes.scala
@@ -12,8 +12,8 @@
 
   /*example.StructuralTypes.V(Constant):17*/val V: Object {
     def scalameta: String
-  } = new {
-    def scalameta = "4.0"
+  } = /*example.StructuralTypes.V.new (anonymous)(Interface):17*/new {
+    /*example.StructuralTypes.V.`new (anonymous)`#scalameta(Method):16*/def scalameta = "4.0"
   }
   V.scalameta
 }

--- a/tests/unit/src/test/resources/documentSymbol/example/nested/LocalClass.scala
+++ b/tests/unit/src/test/resources/documentSymbol/example/nested/LocalClass.scala
@@ -2,6 +2,6 @@
 
 /*example.nested.LocalClass(Class):7*/class LocalClass {
   /*example.nested.LocalClass#foo(Method):6*/def foo(): Unit = {
-    case class LocalClass()
+    /*example.nested.LocalClass#foo.LocalClass(Class):5*/case class LocalClass()
   }
 }

--- a/tests/unit/src/test/resources/documentSymbol/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/documentSymbol/example/nested/LocalDeclarations.scala
@@ -1,0 +1,24 @@
+/*example.nested(Package):24*/package example.nested
+
+/*example.nested.LocalDeclarations(Interface):5*/trait LocalDeclarations {
+  /*example.nested.LocalDeclarations#foo(Method):4*/def foo(): Unit
+}
+
+/*example.nested.Foo(Interface):7*/trait Foo {}
+
+/*example.nested.LocalDeclarations(Module):24*/object LocalDeclarations {
+  /*example.nested.LocalDeclarations.create(Method):23*/def create(): LocalDeclarations = {
+    /*example.nested.LocalDeclarations.create.bar(Method):11*/def bar(): Unit = ()
+
+    /*example.nested.LocalDeclarations.create.x(Constant):15*/val x = /*example.nested.LocalDeclarations.create.x.new (anonymous)(Interface):15*/new {
+      /*example.nested.LocalDeclarations.create.x.`new (anonymous)`#x(Constant):14*/val x = 2
+    }
+
+    /*example.nested.LocalDeclarations.create.y(Constant):17*/val y = new Foo {}
+
+    /*example.nested.LocalDeclarations.create.new LocalDeclarations with Foo(Interface):21*/new LocalDeclarations with Foo {
+      /*example.nested.LocalDeclarations.create.`new LocalDeclarations with Foo`#foo(Method):20*/override def foo(): Unit = bar()
+    }
+
+  }
+}

--- a/tests/unit/src/test/resources/expect/toplevels.expect
+++ b/tests/unit/src/test/resources/expect/toplevels.expect
@@ -33,6 +33,9 @@ example/nested/DoublePackage.scala -> example/nested/x/DoublePackage#
 example/nested/DoublePackage.scala -> example/nested2/y/DoublePackage#
 example/nested/ExampleNested.scala -> example/nested/ExampleNested#
 example/nested/LocalClass.scala -> example/nested/LocalClass#
+example/nested/LocalDeclarations.scala -> example/nested/Foo#
+example/nested/LocalDeclarations.scala -> example/nested/LocalDeclarations#
+example/nested/LocalDeclarations.scala -> example/nested/LocalDeclarations.
 example/nested/package.scala -> example/PackageObjectSibling#
 example/nested/package.scala -> example/nested/package.
 example/package.scala -> example/package.

--- a/tests/unit/src/test/resources/mtags/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/mtags/example/nested/LocalDeclarations.scala
@@ -1,0 +1,24 @@
+package example.nested
+
+trait LocalDeclarations/*example.nested.LocalDeclarations#*/ {
+  def foo/*example.nested.LocalDeclarations#foo().*/(): Unit
+}
+
+trait Foo/*example.nested.Foo#*/ {}
+
+object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
+  def create/*example.nested.LocalDeclarations.create().*/(): LocalDeclarations = {
+    def bar(): Unit = ()
+
+    val x = new {
+      val x = 2
+    }
+
+    val y = new Foo {}
+
+    new LocalDeclarations with Foo {
+      override def foo(): Unit = bar()
+    }
+
+  }
+}

--- a/tests/unit/src/test/resources/semanticdb/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/nested/LocalDeclarations.scala
@@ -1,0 +1,24 @@
+package example.nested
+
+trait LocalDeclarations/*example.nested.LocalDeclarations#*/ {
+  def foo/*example.nested.LocalDeclarations#foo().*/(): Unit/*scala.Unit#*/
+}
+
+trait Foo/*example.nested.Foo#*/ {}
+
+object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
+  def create/*example.nested.LocalDeclarations.create().*/(): LocalDeclarations/*example.nested.LocalDeclarations#*/ = {
+    def bar/*local0*/(): Unit/*scala.Unit#*/ = ()
+
+    val x/*local1*/ = new {
+      val x/*local2*/ = 2
+    }
+
+    val y/*local3*/ = new Foo/*example.nested.Foo#*/ /*java.lang.Object#`<init>`().*/{}
+
+    new LocalDeclarations/*example.nested.LocalDeclarations#*/ /*java.lang.Object#`<init>`().*/with Foo/*example.nested.Foo#*/ {
+      override def foo/*local4*/(): Unit/*scala.Unit#*/ = bar/*local0*/()
+    }
+
+  }
+}

--- a/tests/unit/src/test/resources/workspace-symbol/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/workspace-symbol/example/nested/LocalDeclarations.scala
@@ -1,0 +1,24 @@
+package example.nested
+
+trait LocalDeclarations/*example.nested.LocalDeclarations#*/ {
+  def foo(): Unit
+}
+
+trait Foo/*example.nested.Foo#*/ {}
+
+object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
+  def create(): LocalDeclarations = {
+    def bar(): Unit = ()
+
+    val x = new {
+      val x = 2
+    }
+
+    val y = new Foo {}
+
+    new LocalDeclarations with Foo {
+      override def foo(): Unit = bar()
+    }
+
+  }
+}


### PR DESCRIPTION
Before this PR, we would only consider document symbols defined as children of classes, objects, or traits.

This caused interesting symbols not to appear in the editor outline.

For example, consider this (quite common) pattern:

```scala
trait A {
  def m(): Unit
}
object A {
  def create: A = new A {
    def m(): Unit = ()
  }
}
```

Prior to this PR, we would show a document symbol for the *declaration* of `m`, but not for its *definition*.

![](http://www.livingwithux.pl/wp-content/uploads/2018/10/go-deeper.jpg)

This PR adds document symbols defined in defs, vals, vars, and `new` definitions.

Here's a fairly exhaustive example.

### Before
![image](https://user-images.githubusercontent.com/691940/56455884-dc92d300-6364-11e9-837e-c8aedd13e78d.png)

### After
![image](https://user-images.githubusercontent.com/691940/56455880-cab13000-6364-11e9-910a-4b55854df147.png)


A few things to notice about the anonymous `new` definitions:

- if the template node has >= 1 inits (e.g. `new Foo with Bar {}`) we show `new Foo with Bar` (see the `create` and `createWithLogging` examples in the screenshot above)

- if the template node has 0 inits (e.g. `new {}`) we show `new (anonymous)` (see the `val constants` example in the screenshot above)

- if the template node has no statements e.g. `new Foo {}` we skip it (see the `createDefault` example in the screenshot above)