### PR TITLE
Insert global imports instead of local imports.

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/AutoImports.scala
@@ -1,0 +1,67 @@
+package scala.meta.internal.pc
+
+import scala.reflect.internal.FatalError
+
+trait AutoImports { this: MetalsGlobal =>
+
+  /**
+   * A position to insert new imports
+   *
+   * @param offset the offset where to place the import.
+   * @param indent the indentation at which to place the import.
+   */
+  case class AutoImportPosition(offset: Int, indent: Int) {
+    def this(offset: Int, text: String) =
+      this(offset, inferIndent(offset, text))
+  }
+
+  def doLocateImportContext(
+      pos: Position,
+      autoImport: Option[AutoImportPosition]
+  ): Context = {
+    try doLocateContext(
+      autoImport.fold(pos)(i => pos.focus.withPoint(i.offset))
+    )
+    catch {
+      case _: FatalError =>
+        (for {
+          unit <- getUnit(pos.source)
+          tree <- unit.contexts.headOption
+        } yield tree.context).getOrElse(NoContext)
+    }
+  }
+
+  def autoImportPosition(
+      pos: Position,
+      text: String
+  ): Option[AutoImportPosition] = {
+    if (lastEnclosing.isEmpty) {
+      locateTree(pos)
+    }
+    lastEnclosing.headOption match {
+      case Some(_: Import) => None
+      case _ =>
+        val enclosingPackage = lastEnclosing.collectFirst {
+          case pkg: PackageDef => pkg
+        }
+        enclosingPackage match {
+          case Some(pkg)
+              if pkg.symbol != rootMirror.EmptyPackage ||
+                pkg.stats.headOption.exists(_.isInstanceOf[Import]) =>
+            val lastImport = pkg.stats
+              .takeWhile(_.isInstanceOf[Import])
+              .lastOption
+              .getOrElse(pkg.pid)
+            Some(
+              new AutoImportPosition(
+                pos.source.lineToOffset(lastImport.pos.line),
+                text
+              )
+            )
+          case _ =>
+            Some(AutoImportPosition(0, 0))
+        }
+    }
+  }
+
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -55,8 +55,8 @@ class CompletionProvider(
     }
     val history = new ShortenedNames()
     val sorted = i.results.sorted(memberOrdering(query, history, completion))
-    lazy val context = doLocateContext(pos)
     lazy val importPosition = autoImportPosition(pos, params.text())
+    lazy val context = doLocateImportContext(pos, importPosition)
     val items = sorted.iterator.zipWithIndex.map {
       case (r, idx) =>
         params.checkCanceled()

--- a/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
@@ -29,8 +29,8 @@ class MetalsGlobal(
     with Completions
     with Signatures
     with Compat
-    with GlobalProxy {
-  compiler =>
+    with GlobalProxy
+    with AutoImports { compiler =>
   hijackPresentationCompilerThread()
 
   val logger: Logger = Logger.getLogger(classOf[MetalsGlobal].getName)
@@ -217,7 +217,12 @@ class MetalsGlobal(
           if (history.tryShortenName(name)) NoPrefix
           else tpe
         } else {
-          SingleType(loop(pre, Some(ShortName(sym))), sym)
+          pre match {
+            case ThisType(psym) if history.nameResolvesToSymbol(psym) =>
+              SingleType(NoPrefix, sym)
+            case _ =>
+              SingleType(loop(pre, Some(ShortName(sym))), sym)
+          }
         }
       case ThisType(sym) =>
         if (sym.hasPackageFlag) {

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -180,9 +180,10 @@ object CompletionCaseSuite extends BaseCompletionSuite {
       |  }
       |}""".stripMargin,
     """
+      |import scala.util.Failure
+      |
       |object A {
       |  val t: scala.util.Try[Int] = ???
-      |  import scala.util.Failure
       |  t match {
       |    case Failure(exception) => $0
       |  }
@@ -193,9 +194,9 @@ object CompletionCaseSuite extends BaseCompletionSuite {
   checkEdit(
     "local-case",
     """
+      |import scala.util.Try
+      |import scala.util.Success
       |object A {
-      |  import scala.util.Try
-      |  import scala.util.Success
       |  Try(1) match {
       |    case Success(x) =>
       |      println(x)
@@ -203,10 +204,10 @@ object CompletionCaseSuite extends BaseCompletionSuite {
       |  }
       |}""".stripMargin,
     """
+      |import scala.util.Try
+      |import scala.util.Success
+      |import scala.util.Failure
       |object A {
-      |  import scala.util.Try
-      |  import scala.util.Success
-      |  import scala.util.Failure
       |  Try(1) match {
       |    case Success(x) =>
       |      println(x)

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -62,14 +62,14 @@ object CompletionMatchSuite extends BaseCompletionSuite {
       // Tab characters are used to indicate user-configured indentation in the editor.
       // For example, in VS Code, the tab characters become 2 space indent by default.
       """|package stale
+         |import stale.Weekday.Workday
+         |import stale.Weekday.Weekend
          |sealed abstract class Weekday
          |object Weekday {
          |  case object Workday extends Weekday
          |  case object Weekend extends Weekday
          |}
          |object App {
-         |  import stale.Weekday.Workday
-         |  import stale.Weekday.Weekend
          |  null.asInstanceOf[Weekday] match {
          |\tcase Workday => $0
          |\tcase Weekend =>

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
@@ -16,7 +16,7 @@ object CompletionOverrideConfigSuite extends BaseCompletionSuite {
       overrideDefFormat = OverrideDefFormat.Unicode
     )
 
-  checkEditLine(
+  checkEdit(
     "object",
     """|package a
        |object Weekday {
@@ -26,27 +26,42 @@ object CompletionOverrideConfigSuite extends BaseCompletionSuite {
        |  def weekday: Weekday.Monday
        |}
        |class Main extends Super {
-       |___
+       |  def weekday@@
        |}
        |""".stripMargin,
-    "  def weekday@@",
-    """  import a.{Weekday => w}
-      |  def weekday: w.Monday = ${0:???}""".stripMargin
+    """|package a
+       |import a.{Weekday => w}
+       |object Weekday {
+       |  case class Monday()
+       |}
+       |class Super {
+       |  def weekday: Weekday.Monday
+       |}
+       |class Main extends Super {
+       |  def weekday: w.Monday = ${0:???}
+       |}
+       |""".stripMargin
   )
 
-  checkEditLine(
+  checkEdit(
     "package",
     """|package b
        |class Package {
        |  def function: java.util.function.Function[Int, String]
        |}
        |class Main extends Package {
-       |___
+       |  def function@@
        |}
        |""".stripMargin,
-    "  def function@@",
-    """  import java.util.{function => f}
-      |  def function: f.Function[Int,String] = ${0:???}""".stripMargin
+    """|package b
+       |import java.util.{function => f}
+       |class Package {
+       |  def function: java.util.function.Function[Int, String]
+       |}
+       |class Main extends Package {
+       |  def function: f.Function[Int,String] = ${0:???}
+       |}
+       |""".stripMargin
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -4,16 +4,19 @@ import tests.BaseCompletionSuite
 
 object CompletionWorkspaceSuite extends BaseCompletionSuite {
 
-  checkEditLine(
+  checkEdit(
     "files",
     """package pkg
       |object Main {
-      |___
+      |  val x = Files@@
       |}
       |""".stripMargin,
-    "  val x = Files@@",
-    """  import java.nio.file.Files
-      |  val x = Files""".stripMargin
+    """|package pkg
+       |import java.nio.file.Files
+       |object Main {
+       |  val x = Files
+       |}
+       |""".stripMargin
   )
 
   checkEditLine(
@@ -66,13 +69,31 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |  val x = Files@@
       |}
       |""".stripMargin,
-    """package `import-conflict`
+    """|package `import-conflict`
+       |import java.nio.file.Files
+       |object Main {
+       |  val java = 42
+       |  val x = Files
+       |}
+       |""".stripMargin,
+    filter = _ == "Files - java.nio.file"
+  )
+
+  checkEdit(
+    "import-conflict2",
+    """package `import-conflict2`
+      |object java
       |object Main {
-      |  val java = 42
-      |  import _root_.java.nio.file.Files
-      |  val x = Files
+      |  val x = Files@@
       |}
       |""".stripMargin,
+    """|package `import-conflict2`
+       |import _root_.java.nio.file.Files
+       |object java
+       |object Main {
+       |  val x = Files
+       |}
+       |""".stripMargin,
     filter = _ == "Files - java.nio.file"
   )
 
@@ -106,8 +127,8 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  }
        |}
        |""".stripMargin,
-    """|object Main {
-       |  import java.nio.file.Files
+    """|import java.nio.file.Files
+       |object Main {
        |  def foo(): Unit = {
        |    Files
        |  }
@@ -124,10 +145,10 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  }
        |}
        |""".stripMargin,
-    """|object Main {
+    """|import java.nio.file.Files
+       |object Main {
        |  def foo(): Unit = {
        |    val x = 1
-       |    import java.nio.file.Files
        |    Files
        |  }
        |}
@@ -143,10 +164,10 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  }
        |}
        |""".stripMargin,
-    """|object Main {
+    """|import java.nio.file.Files
+       |object Main {
        |  def foo(): Unit = {
        |    val x = 1
-       |    import java.nio.file.Files
        |    println("".substring(Files))
        |  }
        |}
@@ -162,8 +183,8 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  }
        |}
        |""".stripMargin,
-    """|object Main {
-       |  import java.nio.file.Files
+    """|import java.nio.file.Files
+       |object Main {
        |  def foo(): Unit = 1 match {
        |    case 2 =>
        |      Files
@@ -182,8 +203,8 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  }
        |}
        |""".stripMargin,
-    """|object Main {
-       |  import java.nio.file.Files
+    """|import java.nio.file.Files
+       |object Main {
        |  def foo(): Unit = 1 match {
        |    case 2 if {
        |      Files
@@ -201,8 +222,8 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  }
        |}
        |""".stripMargin,
-    """|object Main {
-       |  import java.{util => ju}
+    """|import java.{util => ju}
+       |object Main {
        |  def foo(): Unit = null match {
        |    case x: ju.ArrayDeque =>
        |  }
@@ -218,9 +239,9 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  }
        |}
        |""".stripMargin,
-    """|object Main {
+    """|import scala.util.Failure
+       |object Main {
        |  def foo(): Unit = {
-       |    import scala.util.Failure
        |    val x: Failure
        |  }
        |}
@@ -238,15 +259,15 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |  }
       |}
       |""".stripMargin,
-    """package pkg
-      |object Main {
-      |  import java.nio.file.Files
-      |  List(1).collect {
-      |    case 2 =>
-      |      Files
-      |  }
-      |}
-      |""".stripMargin
+    """|package pkg
+       |import java.nio.file.Files
+       |object Main {
+       |  List(1).collect {
+       |    case 2 =>
+       |      Files
+       |  }
+       |}
+       |""".stripMargin
   )
 
   checkEdit(
@@ -261,17 +282,17 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |  } yield x
       |}
       |""".stripMargin,
-    """package pkg
-      |object Main {
-      |  import java.nio.file.Files
-      |  for {
-      |    x <- List(1)
-      |    y = x + 1
-      |    if y > 2
-      |    _ = Files
-      |  } yield x
-      |}
-      |""".stripMargin
+    """|package pkg
+       |import java.nio.file.Files
+       |object Main {
+       |  for {
+       |    x <- List(1)
+       |    y = x + 1
+       |    if y > 2
+       |    _ = Files
+       |  } yield x
+       |}
+       |""".stripMargin
   )
 
   checkEdit(
@@ -287,18 +308,18 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |  } yield x
       |}
       |""".stripMargin,
-    """package pkg
-      |object Main {
-      |  for {
-      |    x <- List(1)
-      |    _ = {
-      |      println(1)
-      |      import java.nio.file.Files
-      |      Files
-      |    }
-      |  } yield x
-      |}
-      |""".stripMargin
+    """|package pkg
+       |import java.nio.file.Files
+       |object Main {
+       |  for {
+       |    x <- List(1)
+       |    _ = {
+       |      println(1)
+       |      Files
+       |    }
+       |  } yield x
+       |}
+       |""".stripMargin
   )
 
   checkEdit(
@@ -314,18 +335,18 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |  } yield x
       |}
       |""".stripMargin,
-    """package pkg
-      |object Main {
-      |  for {
-      |    x <- List(1)
-      |    if {
-      |      println(x)
-      |      import java.nio.file.Files
-      |      Files
-      |    }
-      |  } yield x
-      |}
-      |""".stripMargin
+    """|package pkg
+       |import java.nio.file.Files
+       |object Main {
+       |  for {
+       |    x <- List(1)
+       |    if {
+       |      println(x)
+       |      Files
+       |    }
+       |  } yield x
+       |}
+       |""".stripMargin
   )
 
   checkEditLine(
@@ -351,9 +372,9 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  def foo: ArrayBuffer@@[Int] = ???
        |}
        |""".stripMargin,
-    """|
+    """|import scala.collection.mutable
+       |
        |object Main {
-       |  import scala.collection.mutable
        |  @noinline
        |  def foo: mutable.ArrayBuffer[Int] = ???
        |}
@@ -370,8 +391,8 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|package annotationclass
+       |import scala.collection.mutable
        |object Main {
-       |  import scala.collection.mutable
        |  @deprecated("", "")
        |  class Foo extends mutable.ArrayBuffer[Int]
        |}
@@ -388,8 +409,8 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|package annotationtrait
+       |import scala.collection.mutable
        |object Main {
-       |  import scala.collection.mutable
        |  @deprecated("", "")
        |  trait Foo extends mutable.ArrayBuffer[Int]
        |}
@@ -409,6 +430,68 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |case class Foo(
        |  name: Future[String]
        |)
+       |""".stripMargin,
+    filter = _ == "Future - scala.concurrent"
+  )
+
+  checkEdit(
+    "docstring",
+    """|package docstring
+       |/**
+       | * Hello
+       | */
+       |object Main {
+       |  val x = Future@@
+       |}
+       |""".stripMargin,
+    """|package docstring
+       |import scala.concurrent.Future
+       |/**
+       | * Hello
+       | */
+       |object Main {
+       |  val x = Future
+       |}
+       |""".stripMargin,
+    filter = _ == "Future - scala.concurrent"
+  )
+
+  checkEdit(
+    "docstring-import",
+    """|package docstring
+       |import scala.util._
+       |/**
+       | * Hello
+       | */
+       |object Main {
+       |  val x = Future@@
+       |}
+       |""".stripMargin,
+    """|package docstring
+       |import scala.util._
+       |import scala.concurrent.Future
+       |/**
+       | * Hello
+       | */
+       |object Main {
+       |  val x = Future
+       |}
+       |""".stripMargin,
+    filter = _ == "Future - scala.concurrent"
+  )
+
+  checkEdit(
+    "empty-pkg",
+    """|import scala.util._
+       |object Main {
+       |  val x = Future@@
+       |}
+       |""".stripMargin,
+    """|import scala.util._
+       |import scala.concurrent.Future
+       |object Main {
+       |  val x = Future
+       |}
        |""".stripMargin,
     filter = _ == "Future - scala.concurrent"
   )


### PR DESCRIPTION
Fixes #675. Previously, workspace completions inserted local imports,
which requires a lot of manual work to move local imports into the
toplevel. Now, completions insert imports at the toplevel in the
global scope.

Note that this implementation has the following known limitations:

- inserted imports make no effort to respect the existing coding style
  with respect to blank lines, import ordering or grouping with curly
  braces.
- inserted imports may break code in other scopes where the same
  identifier is referenced via a local wildcard import.