### PR TITLE
Don't return workspace/symbol results for deleted files.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -653,6 +653,7 @@ class MetalsLanguageServer(
       CompletableFuture.completedFuture {
         event.eventType() match {
           case EventType.DELETE =>
+            diagnostics.didDelete(AbsolutePath(event.path()))
             referencesProvider.onDelete(event.path())
           case EventType.CREATE | EventType.MODIFY =>
             referencesProvider.onChange(event.path())

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -5,6 +5,7 @@ import com.google.common.hash.BloomFilter
 import com.google.common.hash.Funnels
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
+import java.nio.file.Files
 import java.util.concurrent.CancellationException
 import org.eclipse.lsp4j.jsonrpc.CancelChecker
 import org.eclipse.{lsp4j => l}
@@ -114,6 +115,9 @@ final class WorkspaceSymbolProvider(
           } yield (source.toNIO, index)
       }
       if query.matches(index.bloom)
+      isDeleted = !Files.isRegularFile(path)
+      _ = if (isDeleted) inWorkspace.remove(path)
+      if !isDeleted
       symbol <- index.symbols
       if query.matches(symbol.symbol)
     } {

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -2,6 +2,7 @@ package tests
 
 import java.io.IOException
 import java.net.URLClassLoader
+import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
@@ -132,7 +133,7 @@ final class TestingServer(
           else ""
         val filename =
           if (includeFilename) {
-            val path = Paths.get(info.getLocation().getUri())
+            val path = Paths.get(URI.create(info.getLocation().getUri()))
             s" ${path.getFileName()}"
           } else ""
         val container = Option(info.getContainerName()).getOrElse("")

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 import java.util
@@ -118,15 +119,24 @@ final class TestingServer(
     FileLayout.fromString(layout, root = workspace)
   }
 
-  def workspaceSymbol(query: String, includeKind: Boolean = false): String = {
+  def workspaceSymbol(
+      query: String,
+      includeKind: Boolean = false,
+      includeFilename: Boolean = false
+  ): String = {
     val infos = server.workspaceSymbol(query)
     infos
       .map { info =>
         val kind =
           if (includeKind) s" ${info.getKind}"
           else ""
+        val filename =
+          if (includeFilename) {
+            val path = Paths.get(info.getLocation().getUri())
+            s" ${path.getFileName()}"
+          } else ""
         val container = Option(info.getContainerName()).getOrElse("")
-        s"${container}${info.getName}$kind"
+        s"${container}${info.getName}$kind$filename"
       }
       .mkString("\n")
   }
@@ -256,7 +266,7 @@ final class TestingServer(
     require(server.buildServer.isDefined, "Build server did not initialize")
   }
 
-  private def toPath(filename: String): AbsolutePath =
+  def toPath(filename: String): AbsolutePath =
     TestingServer.toPath(workspace, filename)
 
   def executeCommand(command: String): Future[Unit] = {


### PR DESCRIPTION
Fixes #693.

Previously, renaming a file would cause workspace/symbol to return
duplicate results: one result for the new file and one result for the
deleted file. Now, we filter out results for deleted files.