### PR TITLE
Upgrade to latest Scalameta.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,7 @@ lazy val V = new {
   val scala210 = "2.10.7"
   val scala211 = "2.11.12"
   val scala212 = "2.12.8"
-  val scalameta = "4.1.4"
+  val scalameta = "4.1.9"
   val semanticdb = scalameta
   val bsp = "2.0.0-M3"
   val bloop = "1.2.5"
@@ -118,9 +118,10 @@ lazy val V = new {
   val scalafmt = "2.0.0-RC4"
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.
-  def supportedScalaVersions = Seq(
-    "2.12.8", "2.12.7", "2.12.6", "2.12.5", "2.12.4", "2.11.12", "2.11.11",
-    "2.11.10", "2.11.9"
+  def supportedScalaVersions =
+    Seq("2.12.8", "2.12.7", "2.11.12") ++ deprecatedScalaVersions
+  def deprecatedScalaVersions = Seq(
+    "2.12.6", "2.12.5", "2.12.4", "2.11.11", "2.11.10", "2.11.9"
   )
 }
 
@@ -144,7 +145,6 @@ lazy val mtags = project
     crossScalaVersions := V.supportedScalaVersions,
     libraryDependencies ++= List(
       "com.thoughtworks.qdox" % "qdox" % "2.0-M9", // for java mtags
-      "org.scalameta" %% "contrib" % V.scalameta,
       "org.jsoup" % "jsoup" % "1.11.3",
       "org.scalameta" % "semanticdb-scalac-core" % V.scalameta cross CrossVersion.full
     ),
@@ -198,7 +198,6 @@ lazy val metals = project
       "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0",
       "org.scalameta" %% "scalafmt-dynamic" % V.scalafmt,
       // For reading classpaths.
-      "org.scalameta" %% "symtab" % V.scalameta,
       // for fetching ch.epfl.scala:bloop-frontend and other library dependencies
       "com.geirsson" %% "coursier-small" % "1.3.3",
       // undeclared transitive dependency of coursier-small
@@ -210,7 +209,7 @@ lazy val metals = project
       "com.lihaoyi" %% "pprint" % "0.5.3",
       // for producing SemanticDB from Scala source files
       "org.scalameta" %% "scalameta" % V.scalameta,
-      "org.scalameta" % "interactive" % V.scalameta cross CrossVersion.full
+      "org.scalameta" % "semanticdb-scalac-core" % V.scalameta cross CrossVersion.full
     ),
     buildInfoPackage := "scala.meta.internal.metals",
     buildInfoKeys := Seq[BuildInfoKey](
@@ -223,6 +222,7 @@ lazy val metals = project
       "semanticdbVersion" -> V.semanticdb,
       "scalafmtVersion" -> V.scalafmt,
       "supportedScalaVersions" -> V.supportedScalaVersions,
+      "deprecatedScalaVersions" -> V.deprecatedScalaVersions,
       "scala211" -> V.scala211,
       "scala212" -> V.scala212
     )

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -60,6 +60,21 @@ sbt
 > test
 ```
 
+### Manually testing a `SlowSuite`
+
+Every test suite that extends `SlowSuite` generates a workspace directory under
+`tests/unit/target/e2e/$suitename/$testname`.  To debug why a `SlowSuite` might
+be failing, run the test once and then open it directly in your editor.  For
+example, for the test case `"deprecated-scala"` in `WarningsSlowSuite` run the
+following command:
+
+```
+code tests/unit/target/e2e/warnings/deprecated-scala
+```
+
+If you are using VS Code, make sure to update the "Server Version" setting to
+use your locally published version of Metals.
+
 ## Manual tests
 
 Some functionality is best to manually test through an editor. A common workflow

--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -196,8 +196,8 @@ pattern matches and more.
 
 ![2019-04-12 14 19 39](https://user-images.githubusercontent.com/1408093/56036958-725bac00-5d2e-11e9-9cf7-46249125494a.gif)
 
-- **Auto-import**: symbols that are not in scope are automatically imported
-  locally. Imports still need to be organized manually, we are exploring ways to
+- **Auto-import**: imports are inserted at the bottom of the global import list.
+  Imports still need to be sorted and grouped manually, we are exploring ways to
   automate this workflow in the future.
 - **Override def**: implement methods from the super class.
 - **Exhaustive match**: generate an exhaustive pattern match for sealed types.

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -195,9 +195,7 @@ class Compilers(
     for {
       info <- buildTargets.info(target)
       scala <- info.asScalaBuildTarget
-      isSupported = ScalaVersions.isSupportedScalaVersion(
-        ScalaVersions.dropVendorSuffix(scala.getScalaVersion)
-      )
+      isSupported = ScalaVersions.isSupportedScalaVersion(scala.getScalaVersion)
       _ = {
         if (!isSupported) {
           scribe.warn(s"unsupported Scala ${scala.getScalaVersion}")

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -284,4 +284,21 @@ class Messages(icons: Icons) {
          |The library dependencies are automatically searched when no results are found in the workspace.
          |""".stripMargin
   }
+
+  object DeprecatedScalaVersion {
+    def message(
+        usingNow: Iterable[String],
+        shouldBeUsing: Iterable[String]
+    ): String = {
+      val using =
+        if (usingNow.size == 1)
+          s"a legacy Scala version ${usingNow.head}"
+        else usingNow.mkString("legacy Scala versions ", ", ", "")
+      val recommended =
+        if (shouldBeUsing.size == 1) shouldBeUsing.head
+        else shouldBeUsing.mkString(" and ")
+      s"You are using $using, which will not be supported in future versions of Metals. " +
+        s"Please upgrade to Scala $recommended."
+    }
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -324,7 +324,8 @@ class MetalsLanguageServer(
       config,
       languageClient,
       () => httpServer,
-      tables
+      tables,
+      messages
     )
   }
   def setupJna(): Unit = {

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -6,8 +6,14 @@ object ScalaVersions {
   def dropVendorSuffix(version: String): String =
     version.replaceAll("-bin-.*", "")
 
-  val isSupportedScalaVersion: Set[String] =
+  private val _isDeprecatedScalaVersion: Set[String] =
+    BuildInfo.deprecatedScalaVersions.toSet
+  private val _isSupportedScalaVersion: Set[String] =
     BuildInfo.supportedScalaVersions.toSet
+  def isSupportedScalaVersion(version: String): Boolean =
+    _isSupportedScalaVersion(dropVendorSuffix(version))
+  def isDeprecatedScalaVersion(version: String): Boolean =
+    _isDeprecatedScalaVersion(dropVendorSuffix(version))
   def isSupportedScalaBinaryVersion(scalaVersion: String): Boolean =
     Set("2.12", "2.11").exists { binaryVersion =>
       scalaVersion.startsWith(binaryVersion)

--- a/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
@@ -36,9 +36,7 @@ final class Warnings(
       scalacOptions <- buildTargets.scalacOptions(buildTarget)
     } yield {
       if (!scalacOptions.isSemanticdbEnabled) {
-        if (isSupportedScalaVersion(
-            ScalaVersions.dropVendorSuffix(scala.getScalaVersion)
-          )) {
+        if (isSupportedScalaVersion(scala.getScalaVersion)) {
           logger.error(
             s"$doesntWorkBecause the SemanticDB compiler plugin is not enabled for the build target ${info.getDisplayName}."
           )

--- a/tests/unit/src/main/scala/tests/BaseSlowSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseSlowSuite.scala
@@ -81,7 +81,10 @@ abstract class BaseSlowSuite(suiteName: String) extends BaseSuite {
     server.server.userConfig = this.userConfig
   }
 
-  def assertNoDiagnostics(): Unit = {
+  def assertNoDiagnostics()(
+      implicit file: sourcecode.File,
+      line: sourcecode.Line
+  ): Unit = {
     assertNoDiff(client.workspaceDiagnostics, "")
   }
 

--- a/tests/unit/src/test/resources/semanticdb/example/StructuralTypes.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/StructuralTypes.scala
@@ -13,7 +13,7 @@ object StructuralTypes/*example.StructuralTypes.*/ {
   val V/*example.StructuralTypes.V.*/: Object/*java.lang.Object#*/ {
     def scalameta/*local2*/: String/*scala.Predef.String#*/
   } = new {
-    def scalameta/*local3*/ = "4.0"
+    def scalameta/*local4*/ = "4.0"
   }
   V/*example.StructuralTypes.V.*/.scalameta
 }

--- a/tests/unit/src/test/resources/semanticdb/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/nested/LocalDeclarations.scala
@@ -14,10 +14,10 @@ object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
       val x/*local2*/ = 2
     }
 
-    val y/*local3*/ = new Foo/*example.nested.Foo#*/ /*java.lang.Object#`<init>`().*/{}
+    val y/*local4*/ = new Foo/*example.nested.Foo#*/ /*java.lang.Object#`<init>`().*/{}
 
     new LocalDeclarations/*example.nested.LocalDeclarations#*/ /*java.lang.Object#`<init>`().*/with Foo/*example.nested.Foo#*/ {
-      override def foo/*local4*/(): Unit/*scala.Unit#*/ = bar/*local0*/()
+      override def foo/*local7*/(): Unit/*scala.Unit#*/ = bar/*local0*/()
     }
 
   }

--- a/tests/unit/src/test/scala/tests/CancelCompileSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/CancelCompileSlowSuite.scala
@@ -41,15 +41,6 @@ object CancelCompileSlowSuite extends BaseSlowSuite("compile-cancel") {
           "If this assertion is flaky, feel free to remove it until it's refactored."
       )
       _ <- server.executeCommand(ServerCommands.CascadeCompile.id)
-      _ = assertNoDiff(
-        client.workspaceDiagnostics,
-        """|c/src/main/scala/c/C.scala:2:28: error: type mismatch;
-           | found   : Int
-           | required: String
-           |object C { val x: String = b.B.x }
-           |                           ^^^^^
-           |""".stripMargin
-      )
     } yield ()
   }
 }

--- a/tests/unit/src/test/scala/tests/DidFocusSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/DidFocusSlowSuite.scala
@@ -69,6 +69,7 @@ object DidFocusSlowSuite extends BaseSlowSuite("did-focus") {
   }
 
   testAsync("497") {
+    cleanWorkspace()
     for {
       _ <- server.initialize(
         """

--- a/tests/unit/src/test/scala/tests/WarningsSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/WarningsSlowSuite.scala
@@ -1,0 +1,34 @@
+package tests
+
+import scala.meta.internal.metals.{BuildInfo => V}
+import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.metals.Messages
+
+object WarningsSlowSuite extends BaseSlowSuite("warnings") {
+  testAsync("deprecated-scala") {
+    cleanWorkspace()
+    val using = V.deprecatedScalaVersions.head
+    val recommended = ScalaVersions.recommendedVersion(using)
+    for {
+      _ <- server.initialize(
+        s"""/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "${using}"
+           |  }
+           |}
+           |/a/src/main/scala/a/Main.scala
+           |package a
+           |object Main
+           |""".stripMargin
+      )
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        Messages.DeprecatedScalaVersion.message(
+          Set(using),
+          Set(recommended)
+        )
+      )
+    } yield ()
+  }
+}


### PR DESCRIPTION
- Fixes #699
- Fixes #697

While improving the warning messages for deprecated Scala versions I
additionally improved the output of the doctor to show more helpful
information:

- add new columns to table of features: completions, find references
- show custom message if there are no build targets in the workspace