### PR TITLE
Miscellaneous improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-def localSnapshotVersion = "0.5.1-SNAPSHOT"
+def localSnapshotVersion = "0.6.0-SNAPSHOT"
 def isCI = System.getenv("CI") != null
 inThisBuild(
   List(
@@ -120,9 +120,7 @@ lazy val V = new {
   // for every SemanticDB upgrade.
   def supportedScalaVersions =
     Seq("2.12.8", "2.12.7", "2.11.12") ++ deprecatedScalaVersions
-  def deprecatedScalaVersions = Seq(
-    "2.12.6", "2.12.5", "2.12.4", "2.11.11", "2.11.10", "2.11.9"
-  )
+  def deprecatedScalaVersions = Seq[String]()
 }
 
 skip.in(publish) := true
@@ -133,7 +131,7 @@ lazy val interfaces = project
     moduleName := "mtags-interfaces",
     autoScalaLibrary := false,
     libraryDependencies ++= List(
-      "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.5.0"
+      "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.7.1"
     ),
     crossVersion := CrossVersion.disabled
   )

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -65,7 +65,7 @@ final class BloopServers(
     if (config.bloopProtocol.isTcp) {
       10
     } else {
-      0
+      2
     }
 
   private def newServerUnsafe(): Future[BuildServerConnection] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
@@ -38,6 +38,7 @@ final class FileWatcher(
 ) extends Cancelable {
 
   private val executor = Executors.newFixedThreadPool(1)
+  ThreadPools.discardRejectedRunnables("FileWatcher.executor", executor)
   private var activeWatcher: Option[DirectoryWatcher] = None
   private var watching: CompletableFuture[Void] = new CompletableFuture()
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -61,7 +61,7 @@ class MetalsLanguageServer(
     newBloopClassloader: () => URLClassLoader = () =>
       Embedded.newBloopClassloader()
 ) extends Cancelable {
-
+  ThreadPools.discardRejectedRunnables("MetalsLanguageServer.sh", sh)
   private val cancelables = new MutableCancelable()
   val isCancelled = new AtomicBoolean(false)
   override def cancel(): Unit = {

--- a/metals/src/main/scala/scala/meta/internal/metals/ThreadPools.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ThreadPools.scala
@@ -1,0 +1,21 @@
+package scala.meta.internal.metals
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.RejectedExecutionHandler
+
+object ThreadPools {
+  def discardRejectedRunnables(where: String, executor: ExecutorService): Unit =
+    executor match {
+      case t: ThreadPoolExecutor =>
+        t.setRejectedExecutionHandler(new RejectedExecutionHandler {
+          def rejectedExecution(
+              r: Runnable,
+              executor: ThreadPoolExecutor
+          ): Unit = {
+            scribe.info(s"rejected runnable: $where")
+          }
+        })
+      case _ =>
+    }
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/InterruptException.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/InterruptException.scala
@@ -12,6 +12,10 @@ object InterruptException {
         _: CancellationException =>
       true
     case _ =>
-      false
+      if (e.getCause() != null) {
+        unapply(e.getCause())
+      } else {
+        false
+      }
   }
 }

--- a/tests/cross/src/main/scala/tests/BaseSignatureHelpSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseSignatureHelpSuite.scala
@@ -40,7 +40,7 @@ abstract class BaseSignatureHelpSuite extends BasePCSuite {
               .append("\n")
             if (result.getActiveSignature == i && result.getActiveParameter != null) {
               val param = signature.getParameters.get(result.getActiveParameter)
-              val column = signature.getLabel.indexOf(param.getLabel)
+              val column = signature.getLabel.indexOf(param.getLabel.getLeft())
               if (column < 0) {
                 fail(s"""invalid parameter label
                         |  param.label    : ${param.getLabel}
@@ -50,7 +50,7 @@ abstract class BaseSignatureHelpSuite extends BasePCSuite {
               val indent = " " * column
               out
                 .append(indent)
-                .append("^" * param.getLabel.length)
+                .append("^" * param.getLabel.getLeft().length)
                 .append("\n")
               signature.getParameters.asScala.foreach { param =>
                 val pdoc = doc(param.getDocumentation)
@@ -60,7 +60,7 @@ abstract class BaseSignatureHelpSuite extends BasePCSuite {
                 if (includeDocs && pdoc.nonEmpty) {
                   out
                     .append("  @param ")
-                    .append(param.getLabel.replaceFirst(":.*", ""))
+                    .append(param.getLabel.getLeft().replaceFirst(":.*", ""))
                     .append(" ")
                     .append(pdoc)
                     .append("\n")

--- a/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
+++ b/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
@@ -259,7 +259,7 @@ object SbtSlowSuite extends BaseSlowSuite("import") {
       _ = assertStatus(_.isInstalled)
       _ = assertNoDiff(
         client.messageRequests.peekLast(),
-        CheckDoctor.multipleMisconfiguredProjects(6)
+        CheckDoctor.multipleMisconfiguredProjects(8)
       )
       _ <- Future.sequence(
         ('a' to 'f')

--- a/tests/unit/src/main/scala/tests/QuickBuild.scala
+++ b/tests/unit/src/main/scala/tests/QuickBuild.scala
@@ -285,8 +285,6 @@ object QuickBuild {
     if (json.isFile) {
       newDigest(workspace) match {
         case None =>
-          // do nothing
-          scribe.info("quick-build is cached")
         case Some((digestFile, digest)) =>
           val timer = new Timer(Time.system)
           val gson = new Gson()

--- a/tests/unit/src/test/scala/tests/BuildServerConnectionSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/BuildServerConnectionSlowSuite.scala
@@ -1,0 +1,43 @@
+package tests
+
+import scala.meta.internal.metals.ServerCommands
+
+object BuildServerConnectionSlowSuite
+    extends BaseSlowSuite("build-server-connection") {
+  testAsync("basic") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        """
+          |/metals.json
+          |{
+          |  "a": { }
+          |}
+          |/a/src/main/scala/a/A.scala
+          |package a
+          |object A {
+          |  val n = 42
+          |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ = assertNoDiagnostics()
+      _ = server.server.buildServer.get.cancel()
+      _ = assertNoDiagnostics()
+      _ <- server.executeCommand(ServerCommands.ConnectBuildServer.id)
+      _ <- server.didSave("a/src/main/scala/a/A.scala")(
+        _.replaceAllLiterally("val n = 42", "val n: String = 42")
+      )
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|a/src/main/scala/a/A.scala:3:19: error: type mismatch;
+           | found   : Int(42)
+           | required: String
+           |  val n: String = 42
+           |                  ^^
+           |""".stripMargin
+      )
+    } yield ()
+  }
+
+}

--- a/tests/unit/src/test/scala/tests/ReferenceSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceSlowSuite.scala
@@ -39,7 +39,7 @@ object ReferenceSlowSuite extends BaseSlowSuite("reference") {
         }
       )
       _ = assertNoDiagnostics()
-      _ = server.didOpen("a/src/main/scala/a/A.scala")
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
       _ = server.assertReferenceDefinitionBijection()
     } yield ()
   }
@@ -71,7 +71,7 @@ object ReferenceSlowSuite extends BaseSlowSuite("reference") {
         }
       )
       _ = assertNoDiagnostics()
-      _ = server.didOpen("a/src/main/scala/a/A.scala")
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
       _ = server.assertReferenceDefinitionDiff(
         """|--- references
            |+++ definition

--- a/tests/unit/src/test/scala/tests/WarningsSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/WarningsSlowSuite.scala
@@ -5,7 +5,9 @@ import scala.meta.internal.metals.ScalaVersions
 import scala.meta.internal.metals.Messages
 
 object WarningsSlowSuite extends BaseSlowSuite("warnings") {
-  testAsync("deprecated-scala") {
+  // NOTE(olafur) Ignored because at the time of this writing we have no deprecated
+  // Scala versions.
+  ignore("deprecated-scala") {
     cleanWorkspace()
     val using = V.deprecatedScalaVersions.head
     val recommended = ScalaVersions.recommendedVersion(using)


### PR DESCRIPTION
- bump local publish version to 0.6.0-SNAPSHOT
- upgrade lsp4j dependency
- make "connect to build server" more robust to errors
- drop support for deprecated Scala versions
- avoid log messages with noisy stack traces when running full test
suite.
- fix potential flakiness issues in ReferenceSlowSuite