### PR TITLE
Pause compile-on-save while the editor window is not focused

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BatchedFunction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BatchedFunction.scala
@@ -43,13 +43,13 @@ final class BatchedFunction[A, B](
   /**
    * Pauses applications of the arguments to the fn but allows to accumulate requests
    */
-  def accumulate: Unit =
+  def pause(): Unit =
     paused.set(true)
 
   /**
    * Restarts appliation of the accumulated requests to the fn
    */
-  def restart: Unit = {
+  def unpause(): Unit = {
     paused.set(false)
     unlock()
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClasses.scala
@@ -22,10 +22,6 @@ final class BuildTargetClasses(
   val onCompiled: BatchedFunction[b.BuildTargetIdentifier, Unit] =
     BatchedFunction.fromFuture(fetchMainClassesFor)
 
-  def pause(): Unit = onCompiled.pause()
-
-  def unpause(): Unit = onCompiled.unpause()
-
   private def fetchMainClassesFor(
       targets: Seq[b.BuildTargetIdentifier]
   ): Future[Unit] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClasses.scala
@@ -22,9 +22,9 @@ final class BuildTargetClasses(
   val onCompiled: BatchedFunction[b.BuildTargetIdentifier, Unit] =
     BatchedFunction.fromFuture(fetchMainClassesFor)
 
-  def pause(): Unit = onCompiled.accumulate
+  def pause(): Unit = onCompiled.pause()
 
-  def unpause(): Unit = onCompiled.restart
+  def unpause(): Unit = onCompiled.unpause()
 
   private def fetchMainClassesFor(
       targets: Seq[b.BuildTargetIdentifier]

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClasses.scala
@@ -22,6 +22,10 @@ final class BuildTargetClasses(
   val onCompiled: BatchedFunction[b.BuildTargetIdentifier, Unit] =
     BatchedFunction.fromFuture(fetchMainClassesFor)
 
+  def pause(): Unit = onCompiled.accumulate
+
+  def unpause(): Unit = onCompiled.restart
+
   private def fetchMainClassesFor(
       targets: Seq[b.BuildTargetIdentifier]
   ): Future[Unit] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/CancelableFuture.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CancelableFuture.scala
@@ -6,3 +6,8 @@ case class CancelableFuture[T](
     future: Future[T],
     cancelable: Cancelable = Cancelable.empty
 )
+
+object CancelableFuture {
+  def successful[T](value: T): CancelableFuture[T] =
+    CancelableFuture(Future.successful(value))
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/CancelableFuture.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CancelableFuture.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.metals
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
 
 case class CancelableFuture[T](
     future: Future[T],
@@ -8,6 +9,11 @@ case class CancelableFuture[T](
 )
 
 object CancelableFuture {
+  def apply[T](
+      thunk: => T
+  )(implicit ec: ExecutionContext): CancelableFuture[T] = {
+    CancelableFuture(Future(thunk), Cancelable.empty)
+  }
   def successful[T](value: T): CancelableFuture[T] =
     CancelableFuture(Future.successful(value))
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -18,19 +18,10 @@ final class Compilations(
     new BatchedFunction[b.BuildTargetIdentifier, b.CompileResult](compile)
   private val cascadeBatch =
     new BatchedFunction[b.BuildTargetIdentifier, b.CompileResult](compile)
+  def pauseables: List[Pauseable] = List(compileBatch, cascadeBatch)
 
   private val isCompiling = TrieMap.empty[b.BuildTargetIdentifier, Boolean]
   private var lastCompile: collection.Set[b.BuildTargetIdentifier] = Set.empty
-
-  def pause(): Unit = {
-    compileBatch.pause()
-    cascadeBatch.pause()
-  }
-
-  def unpause(): Unit = {
-    compileBatch.unpause()
-    cascadeBatch.unpause()
-  }
 
   def currentlyCompiling: Iterable[b.BuildTargetIdentifier] = isCompiling.keys
   def isCurrentlyCompiling(buildTarget: b.BuildTargetIdentifier): Boolean =

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -22,6 +22,16 @@ final class Compilations(
   private val isCompiling = TrieMap.empty[b.BuildTargetIdentifier, Boolean]
   private var lastCompile: collection.Set[b.BuildTargetIdentifier] = Set.empty
 
+  def pause(): Unit = {
+    compileBatch.accumulate
+    cascadeBatch.accumulate
+  }
+
+  def unpause(): Unit = {
+    compileBatch.restart
+    cascadeBatch.restart
+  }
+
   def currentlyCompiling: Iterable[b.BuildTargetIdentifier] = isCompiling.keys
   def isCurrentlyCompiling(buildTarget: b.BuildTargetIdentifier): Boolean =
     isCompiling.contains(buildTarget)

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -23,13 +23,13 @@ final class Compilations(
   private var lastCompile: collection.Set[b.BuildTargetIdentifier] = Set.empty
 
   def pause(): Unit = {
-    compileBatch.accumulate
-    cascadeBatch.accumulate
+    compileBatch.pause()
+    cascadeBatch.pause()
   }
 
   def unpause(): Unit = {
-    compileBatch.restart
-    cascadeBatch.restart
+    compileBatch.unpause()
+    cascadeBatch.unpause()
   }
 
   def currentlyCompiling: Iterable[b.BuildTargetIdentifier] = isCompiling.keys

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -604,15 +604,15 @@ class MetalsLanguageServer(
   }
 
   @JsonNotification("metals/windowStateDidChange")
-  def windowStateDidChane(params: WindowStateDidChangeParams): Unit = {
+  def windowStateDidChange(params: WindowStateDidChangeParams): Unit = {
     if (params.focused) {
       compilations.unpause()
-      onBuildChanged.restart
-      parseTrees.restart
+      onBuildChanged.unpause()
+      parseTrees.unpause()
     } else {
       compilations.pause()
-      onBuildChanged.accumulate
-      parseTrees.accumulate
+      onBuildChanged.pause()
+      parseTrees.pause()
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -339,6 +339,19 @@ class MetalsLanguageServer(
       messages
     )
   }
+
+  private def pauseComputations(): Unit = {
+    onBuildChanged.pause()
+    parseTrees.pause()
+    compilations.pause()
+  }
+
+  private def unpauseComputations(): Unit = {
+    onBuildChanged.unpause()
+    parseTrees.unpause()
+    compilations.unpause()
+  }
+
   def setupJna(): Unit = {
     // This is required to avoid the following error:
     //   java.lang.NoClassDefFoundError: Could not initialize class com.sun.jna.platform.win32.Kernel32
@@ -606,13 +619,9 @@ class MetalsLanguageServer(
   @JsonNotification("metals/windowStateDidChange")
   def windowStateDidChange(params: WindowStateDidChangeParams): Unit = {
     if (params.focused) {
-      compilations.unpause()
-      onBuildChanged.unpause()
-      parseTrees.unpause()
+      pauseComputations()
     } else {
-      compilations.pause()
-      onBuildChanged.pause()
-      parseTrees.pause()
+      unpauseComputations()
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -603,6 +603,17 @@ class MetalsLanguageServer(
     }
   }
 
+  @JsonNotification("metals/windowStateDidChange")
+  def windowStateDidChane(params: WindowStateDidChangeParams): Unit = {
+    CompletableFuture.completedFuture {
+      if(params.focused) {
+        compileSourceFiles.unpause
+      } else {
+        compileSourceFiles.pause
+      }
+    }
+  }
+
   @JsonNotification("textDocument/didChange")
   def didChange(
       params: DidChangeTextDocumentParams

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1407,6 +1407,7 @@ class MetalsLanguageServer(
       paths =>
         CancelableFuture.successful(paths.distinct.foreach(trees.didChange))
     )
+
   /**
    * Re-imports the build if build files have changed.
    */

--- a/metals/src/main/scala/scala/meta/internal/metals/Pauseable.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Pauseable.scala
@@ -1,0 +1,32 @@
+package scala.meta.internal.metals
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Interface for something that can be paused and unpaused, for example a stream of compile requests.
+ */
+trait Pauseable {
+  final val isPaused = new AtomicBoolean(false)
+
+  final def pause(): Unit = {
+    isPaused.set(true)
+    doPause()
+  }
+  final def unpause(): Unit = {
+    isPaused.set(false)
+    doUnpause()
+  }
+
+  def doPause(): Unit = {}
+  def doUnpause(): Unit = {}
+}
+
+object Pauseable {
+
+  /** Merges a list of Pausables into a single Pauseable. */
+  def fromPausables(all: Iterable[Pauseable]): Pauseable = new Pauseable {
+    override def doPause(): Unit = Cancelable.cancelEach(all)(_.pause())
+    override def doUnpause(): Unit = Cancelable.cancelEach(all)(_.unpause())
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/WindowStateDidChangeParams.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WindowStateDidChangeParams.scala
@@ -1,0 +1,3 @@
+package scala.meta.internal.metals
+
+case class WindowStateDidChangeParams(focused: java.lang.Boolean)

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -57,6 +57,7 @@ import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.Debug
 import scala.meta.internal.metals.DidFocusResult
+import scala.meta.internal.metals.WindowStateDidChangeParams
 import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsLanguageServer
@@ -283,6 +284,11 @@ final class TestingServer(
   def didFocus(filename: String): Future[DidFocusResult.Value] = {
     server.didFocus(toPath(filename).toURI.toString).asScala
   }
+
+  def windowStateDidChange(focused: Boolean): Unit = {
+    server.windowStateDidChane(WindowStateDidChangeParams(focused))
+  }
+
   def didSave(filename: String)(fn: String => String): Future[Unit] = {
     Debug.printEnclosing()
     val abspath = toPath(filename)

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -286,7 +286,7 @@ final class TestingServer(
   }
 
   def windowStateDidChange(focused: Boolean): Unit = {
-    server.windowStateDidChane(WindowStateDidChangeParams(focused))
+    server.windowStateDidChange(WindowStateDidChangeParams(focused))
   }
 
   def didSave(filename: String)(fn: String => String): Future[Unit] = {

--- a/tests/unit/src/test/scala/tests/BatchedFunctionSuite.scala
+++ b/tests/unit/src/test/scala/tests/BatchedFunctionSuite.scala
@@ -2,10 +2,13 @@ package tests
 
 import scala.concurrent.Future
 import scala.meta.internal.metals.BatchedFunction
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
+import scala.util.Success
 
 object BatchedFunctionSuite extends BaseSuite {
   testAsync("batch") {
+    import ExecutionContext.Implicits.global
+
     val lock = new Object
     val mkString = BatchedFunction.fromFuture[String, String]({ numbers =>
       Future {
@@ -36,39 +39,31 @@ object BatchedFunctionSuite extends BaseSuite {
     }
   }
 
-  testAsync("accumulate") {
-    val lock = new Object
-    val mkString = BatchedFunction.fromFuture[String, String]({ numbers =>
-      Future {
-        lock.synchronized {
-          numbers.mkString
-        }
+  test("pause") {
+    implicit val ec = new ExecutionContext {
+      def execute(runnable: Runnable): Unit = runnable.run()
+      def reportFailure(cause: Throwable): Unit = cause.printStackTrace()
+    }
+
+    val mkString = BatchedFunction.fromFuture[String, String]{ numbers =>
+      Future.successful {
+        numbers.mkString
       }
-    })
-    val results = lock.synchronized {
-      mkString.accumulate
-
-      val strings = List(
-        mkString(List("a")),
-        mkString(List("b")),
-        mkString(List("c"))
-      )
-
-      mkString.restart
-
-      strings
     }
 
-    Future.sequence(results).map { results =>
-      assertNoDiff(
-        results.mkString("\n"),
-        """
-          |abc
-          |abc
-          |abc
-        """.stripMargin
-      )
-    }
+    val unpaused = mkString(List("a"))
+    assertEquals(unpaused.value, Some(Success("a")))
+
+    mkString.pause()
+
+    val paused = mkString("b")
+    assert(!paused.isCompleted)
+    val paused2 = mkString("c")
+    assert(!paused2.isCompleted)
+
+    mkString.unpause()
+
+    assertEquals(paused.value, Some(Success("bc")))
+    assertEquals(paused2.value, Some(Success("bc")))
   }
-
 }

--- a/tests/unit/src/test/scala/tests/BatchedFunctionSuite.scala
+++ b/tests/unit/src/test/scala/tests/BatchedFunctionSuite.scala
@@ -7,7 +7,7 @@ import scala.util.Success
 
 object BatchedFunctionSuite extends BaseSuite {
   testAsync("batch") {
-    import ExecutionContext.Implicits.global
+    implicit val ec = ExecutionContext.global
 
     val lock = new Object
     val mkString = BatchedFunction.fromFuture[String, String]({ numbers =>

--- a/tests/unit/src/test/scala/tests/BatchedFunctionSuite.scala
+++ b/tests/unit/src/test/scala/tests/BatchedFunctionSuite.scala
@@ -45,7 +45,7 @@ object BatchedFunctionSuite extends BaseSuite {
       def reportFailure(cause: Throwable): Unit = cause.printStackTrace()
     }
 
-    val mkString = BatchedFunction.fromFuture[String, String]{ numbers =>
+    val mkString = BatchedFunction.fromFuture[String, String] { numbers =>
       Future.successful {
         numbers.mkString
       }

--- a/tests/unit/src/test/scala/tests/WindowStateDidChangeSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/WindowStateDidChangeSlowSuite.scala
@@ -16,13 +16,15 @@ object WindowStateDidChangeSlowSuite
         """.stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ = Thread.sleep(100)
       _ = assertNoDiagnostics()
-      _ = server.windowStateDidChange(false)
+      _ = server.windowStateDidChange(focused = false)
       didSave = server.didSave("a/src/main/scala/a/A.scala")(
         _.replaceAllLiterally("val x", "x")
       )
+      _ = Thread.sleep(100)
       _ = assertNoDiagnostics()
-      _ = server.windowStateDidChange(true)
+      _ = server.windowStateDidChange(focused = true)
       _ <- didSave
       _ = assertNoDiff(
         client.workspaceDiagnostics,

--- a/tests/unit/src/test/scala/tests/WindowStateDidChangeSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/WindowStateDidChangeSlowSuite.scala
@@ -1,0 +1,36 @@
+package tests
+
+object WindowStateDidChangeSlowSuite
+    extends BaseSlowSuite("window-state-did-change") {
+  testAsync("compile-after-focus") {
+    for {
+      _ <- server.initialize(
+        """
+          |/metals.json
+          |{ "a": {} }
+          |/a/src/main/scala/a/A.scala
+          |package a
+          |object A {
+          |  val x = 42
+          |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ = assertNoDiagnostics()
+      _ = server.windowStateDidChange(false)
+      didSave = server.didSave("a/src/main/scala/a/A.scala")(
+        _.replaceAllLiterally("val x", "x")
+      )
+      _ = assertNoDiagnostics()
+      _ = server.windowStateDidChange(true)
+      _ <- didSave
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|a/src/main/scala/a/A.scala:3:3: error: not found: value x
+           |  x = 42
+           |  ^
+        """.stripMargin
+      )
+    } yield ()
+  }
+}


### PR DESCRIPTION
Closes #668. Previously, Metals would continue to run compile-on-save even if the editor application window was not focused. For example, checking out a different branch in the terminal would immediately trigger compilation in Metals.

Now, editors can send a new `metals/windowStateDidChange` notification to express when the editor window is in focus and out of focus. When the editor window is out of focus, Metals pauses compile-on-save changes until the window is re-focused.