### PR TITLE
Implement textDocument/codeLens to run main function

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -1,10 +1,5 @@
 package scala.meta.internal.metals
 
-import ch.epfl.scala.bsp4j.BuildClientCapabilities
-import ch.epfl.scala.bsp4j.CompileParams
-import ch.epfl.scala.bsp4j.CompileResult
-import ch.epfl.scala.bsp4j.InitializeBuildParams
-import ch.epfl.scala.bsp4j.InitializeBuildResult
 import java.io.InputStream
 import java.io.OutputStream
 import java.util.Collections
@@ -12,13 +7,20 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
+import ch.epfl.scala.bsp4j.BuildClientCapabilities
+import ch.epfl.scala.bsp4j.CompileParams
+import ch.epfl.scala.bsp4j.CompileResult
+import ch.epfl.scala.bsp4j.InitializeBuildParams
+import ch.epfl.scala.bsp4j.InitializeBuildResult
+import ch.epfl.scala.bsp4j.ScalaMainClassesParams
+import ch.epfl.scala.bsp4j.ScalaMainClassesResult
 import org.eclipse.lsp4j.jsonrpc.Launcher
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Future
+import scala.meta.internal.pc.InterruptException
 import scala.meta.io.AbsolutePath
 import scala.util.Try
-import scala.meta.internal.pc.InterruptException
 
 /**
  * An actively running and initialized BSP connection.
@@ -67,6 +69,15 @@ case class BuildServerConnection(
 
   def compile(params: CompileParams): CompletableFuture[CompileResult] = {
     register(server.buildTargetCompile(params))
+  }
+
+  def mainClasses(
+      params: ScalaMainClassesParams
+  ): CompletableFuture[ScalaMainClassesResult] = {
+    // TODO use server.buildTargetScalaMainClasses when bloop releases version supporting mainClasses
+    CompletableFuture.completedFuture(
+      new ScalaMainClassesResult(Collections.emptyList())
+    )
   }
 
   private val cancelled = new AtomicBoolean(false)

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClasses.scala
@@ -1,0 +1,75 @@
+package scala.meta.internal.metals
+
+import ch.epfl.scala.{bsp4j => b}
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.semanticdb.Scala.Descriptor
+import scala.meta.internal.semanticdb.Scala.Symbols
+
+/**
+ * In-memory index of main class symbols grouped by their enclosing build target
+ */
+final class BuildTargetClasses(
+    buildServer: () => Option[BuildServerConnection]
+)(implicit val ec: ExecutionContext) {
+  private val index = new TrieMap[b.BuildTargetIdentifier, Classes]()
+
+  def main(target: b.BuildTargetIdentifier): TrieMap[String, b.ScalaMainClass] =
+    classesOf(target).main
+
+  val onCompiled: BatchedFunction[b.BuildTargetIdentifier, Unit] =
+    BatchedFunction.fromFuture(fetchMainClassesFor)
+
+  private def fetchMainClassesFor(
+      targets: Seq[b.BuildTargetIdentifier]
+  ): Future[Unit] = {
+    targets.foreach { target =>
+      classesOf(target).clear()
+    }
+
+    buildServer() match {
+      case Some(connection) =>
+        val parameters = new b.ScalaMainClassesParams(targets.asJava)
+        val task = for {
+          result <- connection.mainClasses(parameters).asScala
+          _ = cacheMainClasses(result)
+        } yield ()
+
+        task
+      case None =>
+        Future.successful(())
+    }
+  }
+
+  private def classesOf(target: b.BuildTargetIdentifier): Classes =
+    index.getOrElseUpdate(target, new Classes)
+
+  private def cacheMainClasses(result: b.ScalaMainClassesResult): Unit = {
+    def createObjectSymbol(className: String): String = {
+      val symbol = className.replaceAll("\\.", "/")
+      val isInsideEmptyPackage = !className.contains(".")
+      if (isInsideEmptyPackage) {
+        Symbols.Global(Symbols.EmptyPackage, Descriptor.Term(symbol))
+      } else {
+        symbol
+      }
+    }
+
+    for {
+      item <- result.getItems.asScala
+      target = item.getTarget
+      aClass <- item.getClasses.asScala
+      objectSymbol = createObjectSymbol(aClass.getClassName)
+    } classesOf(target).main.put(objectSymbol, aClass)
+  }
+
+  final class Classes {
+    val main = new TrieMap[String, b.ScalaMainClass]()
+
+    def clear(): Unit = {
+      main.clear()
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -39,6 +39,17 @@ object ClientCommands {
        |""".stripMargin
   )
 
+  val RunMain = Command(
+    "metals-main-run",
+    "run",
+    "Runs main method",
+    """|Array of strings of length 2 where
+       |- first array element is a build target identifier URI
+       |- second array element is the name of the class containing the main method 
+       |Example: `["mybuild://workspace/foo/?id=foo", "com.app.Main"]`
+    """.stripMargin
+  )
+
   def all: List[Command] = List(
     RunDoctor,
     ToggleLogs,

--- a/metals/src/main/scala/scala/meta/internal/metals/CodeLensProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeLensProvider.scala
@@ -1,0 +1,50 @@
+package scala.meta.internal.metals
+import java.util
+import java.util.Collections._
+import ch.epfl.scala.{bsp4j => b}
+import org.eclipse.{lsp4j => l}
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.mtags.Semanticdbs
+import scala.meta.io.AbsolutePath
+
+final class CodeLensProvider(
+    classes: BuildTargetClasses,
+    buffers: Buffers,
+    buildTargets: BuildTargets,
+    semanticdbs: Semanticdbs
+) {
+  def findLenses(path: AbsolutePath): util.List[l.CodeLens] = {
+    buildTargets.inverseSources(path) match {
+      case Some(buildTarget) if classes.main(buildTarget).nonEmpty =>
+        findLenses(path, buildTarget).asJava
+      case _ =>
+        emptyList[l.CodeLens]()
+    }
+  }
+
+  private def findLenses(
+      path: AbsolutePath,
+      buildTarget: b.BuildTargetIdentifier
+  ): List[l.CodeLens] = {
+    semanticdbs.textDocument(path).documentIncludingStale match {
+      case Some(textDocument) =>
+        val distance =
+          TokenEditDistance.fromBuffer(path, textDocument.text, buffers)
+        val mainClasses = classes.main(buildTarget)
+
+        val lenses = for {
+          occurrence <- textDocument.occurrences
+          if mainClasses.contains(occurrence.symbol)
+          mainClass = mainClasses(occurrence.symbol)
+          range <- occurrence.range
+            .flatMap(r => distance.toRevised(r.toLSP))
+            .toList
+          arguments = List(buildTarget.getUri, mainClass.getClassName)
+        } yield
+          new l.CodeLens(range, ClientCommands.RunMain.toLSP(arguments), null)
+        lenses.toList
+      case _ =>
+        Nil
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/Command.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Command.scala
@@ -1,5 +1,8 @@
 package scala.meta.internal.metals
 
+import org.eclipse.{lsp4j => l}
+import scala.meta.internal.metals.MetalsEnrichments._
+
 case class Command(
     id: String,
     title: String,
@@ -7,4 +10,7 @@ case class Command(
     arguments: String = "`null`"
 ) {
   def unapply(string: String): Boolean = string == id
+
+  def toLSP(arguments: List[AnyRef]): l.Command =
+    new l.Command(title, id, arguments.asJava)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -1,0 +1,99 @@
+package scala.meta.internal.metals
+import ch.epfl.scala.{bsp4j => b}
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+
+final class Compilations(
+    buildTargets: BuildTargets,
+    classes: BuildTargetClasses,
+    workspace: () => AbsolutePath,
+    buildServer: () => Option[BuildServerConnection]
+)(implicit ec: ExecutionContext) {
+
+  // we are maintaining a separate queue for cascade compilation since those must happen ASAP
+  private val compileBatch =
+    new BatchedFunction[b.BuildTargetIdentifier, b.CompileResult](compile)
+  private val cascadeBatch =
+    new BatchedFunction[b.BuildTargetIdentifier, b.CompileResult](compile)
+
+  private val isCompiling = TrieMap.empty[b.BuildTargetIdentifier, Boolean]
+  private var lastCompile: collection.Set[b.BuildTargetIdentifier] = Set.empty
+
+  def currentlyCompiling: Iterable[b.BuildTargetIdentifier] = isCompiling.keys
+  def isCurrentlyCompiling(buildTarget: b.BuildTargetIdentifier): Boolean =
+    isCompiling.contains(buildTarget)
+
+  def previouslyCompiled: Iterable[b.BuildTargetIdentifier] = lastCompile
+  def wasPreviouslyCompiled(buildTarget: b.BuildTargetIdentifier): Boolean =
+    lastCompile.contains(buildTarget)
+
+  def compileFiles(paths: Seq[AbsolutePath]): Future[b.CompileResult] = {
+    val targets = expand(paths)
+    compileBatch(targets)
+  }
+
+  def cascadeCompileFiles(paths: Seq[AbsolutePath]): Future[b.CompileResult] = {
+    val targets =
+      expand(paths).flatMap(buildTargets.inverseDependencies).distinct
+    cascadeBatch(targets)
+  }
+
+  def cancel(): Unit = {
+    compileBatch.cancelCurrentRequest()
+    cascadeBatch.cancelCurrentRequest()
+  }
+
+  def expand(paths: Seq[AbsolutePath]): Seq[b.BuildTargetIdentifier] = {
+    def isCompilable(path: AbsolutePath): Boolean =
+      path.isScalaOrJava && !path.isDependencySource(workspace())
+
+    val targets =
+      paths.filter(isCompilable).flatMap(buildTargets.inverseSources).distinct
+
+    if (targets.isEmpty) {
+      scribe.warn(s"no build target: ${paths.mkString("\n  ")}")
+    }
+
+    targets
+  }
+
+  private def compile(
+      targets: Seq[b.BuildTargetIdentifier]
+  ): CancelableFuture[b.CompileResult] = {
+    val result = for {
+      connection <- buildServer()
+      if targets.nonEmpty
+    } yield compile(connection, targets)
+
+    result.getOrElse {
+      val result = new b.CompileResult(b.StatusCode.CANCELLED)
+      Future.successful(result).asCancelable
+    }
+  }
+
+  private def compile(
+      connection: BuildServerConnection,
+      targets: Seq[b.BuildTargetIdentifier]
+  ): CancelableFuture[b.CompileResult] = {
+    val params = new b.CompileParams(targets.asJava)
+    targets.foreach(target => isCompiling(target) = true)
+    val compilation = connection.compile(params)
+    val task = for {
+      result <- compilation.asScala
+      _ <- {
+        lastCompile = isCompiling.keySet
+        isCompiling.clear()
+        if (result.isOK) classes.onCompiled(targets)
+        else Future.successful(())
+      }
+    } yield result
+
+    CancelableFuture(
+      task,
+      Cancelable(() => compilation.cancel(false))
+    )
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -76,6 +76,11 @@ object MetalsEnrichments
     }
   }
 
+  implicit class XtensionCompileResult(result: b.CompileResult) {
+    def isOK: Boolean = result.getStatusCode == b.StatusCode.OK
+    def isError: Boolean = result.getStatusCode == b.StatusCode.ERROR
+  }
+
   implicit class XtensionEditDistance(result: Either[EmptyResult, m.Position]) {
     def toPosition(dirty: l.Position): Option[l.Position] =
       foldResult(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -3,7 +3,6 @@ package scala.meta.internal.metals
 import java.net.URI
 import java.net.URLClassLoader
 import java.nio.charset.Charset
-import scala.meta.pc.CancelToken
 import java.nio.charset.StandardCharsets
 import java.nio.file._
 import java.util
@@ -13,8 +12,6 @@ import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
-import ch.epfl.scala.bsp4j.BuildTargetIdentifier
-import ch.epfl.scala.bsp4j.CompileParams
 import ch.epfl.scala.bsp4j.DependencySourcesParams
 import ch.epfl.scala.bsp4j.DependencySourcesResult
 import ch.epfl.scala.bsp4j.ScalacOptionsParams
@@ -27,15 +24,14 @@ import org.eclipse.lsp4j._
 import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
-import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.HashSet
 import scala.concurrent.Await
-import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.TimeoutException
+import scala.concurrent.duration.Duration
 import scala.meta.internal.builds.BuildTool
 import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.io.FileIO
@@ -44,6 +40,7 @@ import scala.meta.internal.mtags._
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.io.AbsolutePath
 import scala.meta.parsers.ParseException
+import scala.meta.pc.CancelToken
 import scala.meta.tokenizers.TokenizeException
 import scala.util.control.NonFatal
 
@@ -99,6 +96,7 @@ class MetalsLanguageServer(
   private val definitionIndex = newSymbolIndex()
   private val symbolDocs = new Docstrings(definitionIndex)
   var buildServer = Option.empty[BuildServerConnection]
+  private val buildTargetClasses = new BuildTargetClasses(() => buildServer)
   private val openTextDocument = new AtomicReference[AbsolutePath]()
   private val savedFiles = new ActiveFiles(time)
   private val openedFiles = new ActiveFiles(time)
@@ -107,6 +105,12 @@ class MetalsLanguageServer(
     new DelegatingLanguageClient(NoopLanguageClient, config)
   var userConfig = UserConfiguration()
   val buildTargets: BuildTargets = new BuildTargets()
+  val compilations: Compilations = new Compilations(
+    buildTargets,
+    buildTargetClasses,
+    () => workspace,
+    () => buildServer
+  )
   private val fileWatcher = register(
     new FileWatcher(
       buildTargets,
@@ -128,6 +132,7 @@ class MetalsLanguageServer(
   private var buildClient: ForwardingMetalsBuildClient = _
   private var bloopServers: BloopServers = _
   private var bspServers: BspServers = _
+  private var codeLensProvider: CodeLensProvider = _
   private var definitionProvider: DefinitionProvider = _
   private var documentHighlightProvider: DocumentHighlightProvider = _
   private var formattingProvider: FormattingProvider = _
@@ -193,7 +198,7 @@ class MetalsLanguageServer(
       statusBar,
       config.icons,
       buildTools,
-      isCompiling.contains
+      compilations.isCurrentlyCompiling
     )
     diagnostics = new Diagnostics(
       buildTargets,
@@ -250,6 +255,12 @@ class MetalsLanguageServer(
         fileSystemSemanticdbs,
         interactiveSemanticdbs
       )
+    )
+    codeLensProvider = new CodeLensProvider(
+      buildTargetClasses,
+      buffers,
+      buildTargets,
+      semanticdbs
     )
     definitionProvider = new DefinitionProvider(
       workspace,
@@ -550,7 +561,7 @@ class MetalsLanguageServer(
       }
     } else {
       compilers.load(List(path))
-      compileSourceFiles(List(path)).asJava
+      compilations.compileFiles(List(path)).ignoreValue.asJava
     }
   }
 
@@ -567,13 +578,20 @@ class MetalsLanguageServer(
       buildTargets.inverseSources(path) match {
         case Some(target) =>
           val isAffectedByCurrentCompilation =
-            buildTargets.isInverseDependency(target, isCompiling.keys.toList)
+            buildTargets.isInverseDependency(
+              target,
+              compilations.currentlyCompiling.toList
+            )
           def isAffectedByLastCompilation: Boolean =
-            !lastCompile(target) &&
-              buildTargets.isInverseDependency(target, lastCompile.toList)
+            !compilations.wasPreviouslyCompiled(target) &&
+              buildTargets.isInverseDependency(
+                target,
+                compilations.previouslyCompiled.toList
+              )
           val needsCompile = isAffectedByCurrentCompilation || isAffectedByLastCompilation
           if (needsCompile) {
-            compileSourceFiles(List(path))
+            compilations
+              .compileFiles(List(path))
               .map(_ => DidFocusResult.Compiled)
               .asJava
           } else {
@@ -683,7 +701,7 @@ class MetalsLanguageServer(
       .sequence(
         List(
           Future(reindexWorkspaceSources(paths)),
-          compileSourceFiles(paths).ignoreValue,
+          compilations.compileFiles(paths).ignoreValue,
           onBuildChanged(paths).ignoreValue
         )
       )
@@ -804,7 +822,7 @@ class MetalsLanguageServer(
   ): Unit = {
     val path = params.getTextDocument.getUri.toAbsolutePath
     val old = path.toInputFromBuffers(buffers)
-    cascadeCompileSourceFiles(Seq(path)).foreach { _ =>
+    compilations.cascadeCompileFiles(Seq(path)).foreach { _ =>
       val newBuffer = path.toInputFromBuffers(buffers)
       val newParams: Option[ReferenceParams] =
         if (newBuffer.text == old.text) Some(params)
@@ -951,19 +969,20 @@ class MetalsLanguageServer(
       case ServerCommands.OpenBrowser(url) =>
         Future.successful(Urls.openBrowser(url)).asJavaObject
       case ServerCommands.CascadeCompile() =>
-        cascadeCompileSourceFiles(buffers.open.toSeq).asJavaObject
+        compilations
+          .cascadeCompileFiles(buffers.open.toSeq)
+          .asJavaObject
       case ServerCommands.CancelCompile() =>
         Future {
-          compileSourceFiles.cancelCurrentRequest()
-          cascadeCompileSourceFiles.cancelCurrentRequest()
+          compilations.cancel()
           scribe.info("compilation cancelled")
         }.asJavaObject
       case ServerCommands.PresentationCompilerRestart() =>
         Future {
           compilers.restartAll()
         }.asJavaObject
-      case els =>
-        scribe.error(s"Unknown command '$els'")
+      case cmd =>
+        scribe.error(s"Unknown command '$cmd'")
         Future.successful(()).asJavaObject
     }
 
@@ -1116,7 +1135,9 @@ class MetalsLanguageServer(
       }
       _ = indexingPromise.trySuccess(())
       _ <- Future.sequence[Unit, List](
-        cascadeCompileSourceFiles(buffers.open.toSeq) ::
+        compilations
+          .cascadeCompileFiles(buffers.open.toSeq)
+          .ignoreValue ::
           compilers.load(buffers.open.toSeq) ::
           Nil
       )
@@ -1365,53 +1386,6 @@ class MetalsLanguageServer(
         }
       }
     )
-  }
-
-  private val isCompiling = TrieMap.empty[BuildTargetIdentifier, Boolean]
-  private var lastCompile: collection.Set[BuildTargetIdentifier] = Set.empty
-  val cascadeCompileSourceFiles =
-    new BatchedFunction[AbsolutePath, Unit](
-      paths => compileSourceFilesUnbatched(paths, isCascade = true)
-    )
-  val compileSourceFiles =
-    new BatchedFunction[AbsolutePath, Unit](
-      paths => compileSourceFilesUnbatched(paths, isCascade = false)
-    )
-  private def compileSourceFilesUnbatched(
-      paths: Seq[AbsolutePath],
-      isCascade: Boolean
-  ): CancelableFuture[Unit] = {
-    val scalaPaths = paths.filter { path =>
-      path.isScalaOrJava &&
-      !path.isDependencySource(workspace)
-    }
-    buildServer match {
-      case Some(build) if scalaPaths.nonEmpty =>
-        val targets = scalaPaths.flatMap(buildTargets.inverseSources).distinct
-        if (targets.isEmpty) {
-          scribe.warn(s"no build target: ${scalaPaths.mkString("\n  ")}")
-          Future.successful(()).asCancelable
-        } else {
-          val allTargets =
-            if (isCascade) {
-              targets.flatMap(buildTargets.inverseDependencies).distinct
-            } else {
-              targets
-            }
-          val params = new CompileParams(allTargets.asJava)
-          targets.foreach(target => isCompiling(target) = true)
-          val completableFuture = build.compile(params)
-          CancelableFuture(
-            completableFuture.asScala.map { _ =>
-              lastCompile = isCompiling.keySet
-              isCompiling.clear()
-            }.ignoreValue,
-            Cancelable(() => completableFuture.cancel(false))
-          )
-        }
-      case _ =>
-        Future.successful(()).asCancelable
-    }
   }
 
   /**

--- a/tests/unit/src/main/scala/tests/CodeLensesTextEdits.scala
+++ b/tests/unit/src/main/scala/tests/CodeLensesTextEdits.scala
@@ -1,0 +1,20 @@
+package tests
+
+import org.eclipse.{lsp4j => l}
+
+object CodeLensesTextEdits {
+  def apply(ranges: Seq[l.CodeLens]): List[l.TextEdit] = {
+    ranges.map(convert).toList
+  }
+
+  private def convert(lens: l.CodeLens): l.TextEdit = {
+    val range = lens.getRange
+    val pos = new l.Position(range.getStart.getLine, 0)
+    new l.TextEdit(new l.Range(pos, pos), print(lens))
+  }
+
+  private def print(lens: l.CodeLens): String = {
+    val command = lens.getCommand
+    s"<<${command.getTitle}>>\n"
+  }
+}

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -15,6 +15,7 @@ import java.util.Collections
 import java.util.concurrent.ScheduledExecutorService
 import com.google.gson.JsonParser
 import org.eclipse.lsp4j.ClientCapabilities
+import org.eclipse.lsp4j.CodeLensParams
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.CompletionParams
 import org.eclipse.lsp4j.DidChangeConfigurationParams
@@ -377,6 +378,16 @@ final class TestingServer(
     for {
       ranges <- server.foldingRange(params).asScala
       textEdits = FoldingRangesTextEdits(ranges)
+    } yield TextEdits.applyEdits(textContents(filename), textEdits)
+  }
+
+  def codeLenses(filename: String): Future[String] = {
+    val path = toPath(filename)
+    val uri = path.toURI.toString
+    val params = new CodeLensParams(new TextDocumentIdentifier(uri))
+    for {
+      lenses <- server.codeLens(params).asScala
+      textEdits = CodeLensesTextEdits(lenses.asScala)
     } yield TextEdits.applyEdits(textContents(filename), textEdits)
   }
 

--- a/tests/unit/src/test/scala/tests/CodeLensesSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeLensesSlowSuite.scala
@@ -1,0 +1,109 @@
+package tests
+import scala.concurrent.Future
+
+object CodeLensesSlowSuite extends BaseSlowSuite("codeLenses") {
+  override def isTestSuiteEnabled: Boolean =
+    false // TODO enable once bloop supports main class request
+
+  testAsync("run") {
+    for {
+      _ <- server.initialize(
+        """|/metals.json
+           |{
+           |  "a": { }
+           |}
+           |
+           |/a/src/main/scala/Main.scala
+           |object Main {
+           |  def main(args: Array[String]): Unit = {}
+           |}""".stripMargin
+      )
+      _ <- assertCodeLenses(
+        "a/src/main/scala/Main.scala",
+        """<<run>>
+          |object Main {
+          |  def main(args: Array[String]): Unit = {}
+          |}
+          |""".stripMargin
+      )
+    } yield ()
+  }
+
+  testAsync("run-many-main-files") {
+    for {
+      _ <- server.initialize(
+        """|/metals.json
+           |{
+           |  "a": { }
+           |}
+           |
+           |/a/src/main/scala/Foo.scala
+           |object Foo {
+           |  def main(args: Array[String]): Unit = {}
+           |}
+           |
+           |/a/src/main/scala/Bar.scala
+           |object Bar {
+           |  def main(args: Array[String]): Unit = {}
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Foo.scala") // compile `a` to populate its cache
+      _ <- assertCodeLenses(
+        "a/src/main/scala/Foo.scala",
+        """<<run>>
+          |object Foo {
+          |  def main(args: Array[String]): Unit = {}
+          |}
+          |""".stripMargin
+      )
+      _ <- assertCodeLenses(
+        "a/src/main/scala/Bar.scala",
+        """<<run>>
+          |object Bar {
+          |  def main(args: Array[String]): Unit = {}
+          |}
+          |""".stripMargin
+      )
+    } yield ()
+  }
+
+  // Tests, whether main class in one project does not affect other class with same name in other project
+  testAsync("run-multi-module") {
+    for {
+      _ <- server.initialize(
+        """|/metals.json
+           |{
+           |  "a": { },
+           |  "b": { }
+           |}
+           |
+           |/a/src/main/scala/Main.scala
+           |object Main {
+           |  def main(args: Array[String]): Unit = {}
+           |}
+           |
+           |/b/src/main/scala/Main.scala
+           |object Main {}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala") // compile `a` to populate its cache
+      _ <- assertCodeLenses(
+        "b/src/main/scala/Main.scala",
+        """|object Main {}
+           |""".stripMargin
+      )
+    } yield ()
+  }
+
+  private def assertCodeLenses(
+      filename: String,
+      expected: String
+  ): Future[Unit] =
+    for {
+      _ <- server.didOpen(filename)
+      obtained <- server.codeLenses(filename)
+    } yield {
+      assertNoDiff(obtained, expected)
+    }
+}


### PR DESCRIPTION
Previously, metals did not provide any code lens for running the main classes.

Now, we have the whole infrastructure for providing those code lenses set up. We will just have to enable them once we can actually run the main classes.

When this is merged, #652 should be updated to reflect the need of enabling this feature