### PR TITLE
Miscellaneous polish fixes

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -40,7 +40,7 @@ final class Embedded(
    * Fetches jars for bloop-frontend and creates a new orphan classloader.
    */
   lazy val bloopJars: Option[URLClassLoader] = {
-    statusBar.trackSlowTask(s"${icons.sync}Downloading Bloop") {
+    statusBar.trackSlowTask("Downloading Bloop") {
       try {
         Some(newBloopClassloader())
       } catch {

--- a/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
@@ -89,7 +89,7 @@ final class FileWatcher(
 
   class Listener extends DirectoryChangeListener {
     override def onEvent(event: DirectoryChangeEvent): Unit = {
-      if (Files.isRegularFile(event.path())) {
+      if (!Files.isDirectory(event.path())) {
         didChangeWatchedFiles(event)
       }
     }

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -1604,12 +1604,14 @@ trait Completions { this: MetalsGlobal =>
   }
 
   def isSnippetEnabled(pos: Position, text: String): Boolean = {
-    text.charAt(pos.point) match {
-      case ')' | ']' | '}' | ',' | '\n' => true
-      case _ =>
-        !text.startsWith(" _", pos.point) && {
-          text.startsWith("\r\n", pos.point)
-        }
+    pos.point < text.length() && {
+      text.charAt(pos.point) match {
+        case ')' | ']' | '}' | ',' | '\n' => true
+        case _ =>
+          !text.startsWith(" _", pos.point) && {
+            text.startsWith("\r\n", pos.point)
+          }
+      }
     }
   }
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionFilenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionFilenameSuite.scala
@@ -124,4 +124,11 @@ object CompletionFilenameSuite extends BaseCompletionSuite {
     "",
     filename = "User.scala"
   )
+
+  check(
+    "end-of-file",
+    "object Use@@",
+    "object User",
+    filename = "User.scala"
+  )
 }


### PR DESCRIPTION
- clear diagnostics on file delete events
- don't crash completions when editing the last character in a file
- don't display "$(sync)" for "Downloading Bloop" message