### PR TITLE
Fix blogpost typo

### DIFF
--- a/website/blog/2019-04-26-mercury.md
+++ b/website/blog/2019-04-26-mercury.md
@@ -61,7 +61,7 @@ Previously, deleting a file with compile errors would result in the stale
 diagnostics to stay until you restarted the Metals server. Now, diagnostics are
 cleared when a source file is deleted.
 
-## Fuzzy symbol sarch gracefully handles deleted files
+## Fuzzy symbol search gracefully handles deleted files
 
 Previously, fuzzy searching for a symbol could return results from deleted
 files. Now, fuzzy symbol search only shows results from files that exist on


### PR DESCRIPTION
`s/sarch/search`