### PR TITLE
Ensure build server shuts down before starting new build connection.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -951,9 +951,7 @@ class MetalsLanguageServer(
       case ServerCommands.ConnectBuildServer() =>
         quickConnectToBuildServer().asJavaObject
       case ServerCommands.DisconnectBuildServer() =>
-        Future {
-          disconnectOldBuildServer()
-        }.asJavaObject
+        disconnectOldBuildServer().asJavaObject
       case ServerCommands.RunDoctor() =>
         Future {
           doctor.executeRunDoctor()
@@ -1063,10 +1061,7 @@ class MetalsLanguageServer(
 
   private def autoConnectToBuildServer(): Future[BuildChange] = {
     for {
-      _ <- buildServer match {
-        case Some(old) => old.shutdown()
-        case None => Future.successful(())
-      }
+      _ <- disconnectOldBuildServer()
       maybeBuild <- timed("connected to build server") {
         if (buildTools.isBloop) bloopServers.newServer()
         else bspServers.newServer()
@@ -1091,18 +1086,21 @@ class MetalsLanguageServer(
       BuildChange.Failed
   }
 
-  private def disconnectOldBuildServer(): Unit = {
+  private def disconnectOldBuildServer(): Future[Unit] = {
     if (buildServer.isDefined) {
       scribe.info("disconnected: build server")
     }
-    buildServer.foreach(_.shutdown())
-    buildServer = None
-    diagnostics.reset()
+    buildServer match {
+      case None => Future.successful(())
+      case Some(value) =>
+        buildServer = None
+        diagnostics.reset()
+        value.shutdown()
+    }
   }
   private def connectToNewBuildServer(
       build: BuildServerConnection
   ): Future[BuildChange] = {
-    disconnectOldBuildServer()
     cancelables.add(build)
     compilers.cancel()
     buildServer = Some(build)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.metals
 
 import java.io.PrintStream
 import java.nio.file.Files
+import java.nio.file.StandardOpenOption
 import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
 import scribe._
@@ -26,7 +27,11 @@ object MetalsLogger {
 
   def redirectSystemOut(logfile: AbsolutePath): Unit = {
     Files.createDirectories(logfile.toNIO.getParent)
-    val logStream = Files.newOutputStream(logfile.toNIO)
+    val logStream = Files.newOutputStream(
+      logfile.toNIO,
+      StandardOpenOption.APPEND,
+      StandardOpenOption.CREATE
+    )
     val out = new PrintStream(logStream)
     System.setOut(out)
     System.setErr(out)

--- a/tests/unit/src/test/scala/tests/BillSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/BillSlowSuite.scala
@@ -2,15 +2,17 @@ package tests
 
 import bill._
 import scala.concurrent.Future
-import scala.meta.internal.metals.Messages
 import scala.meta.io.AbsolutePath
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.metals.Directories
+import scala.meta.internal.metals.MetalsEnrichments._
 
 object BillSlowSuite extends BaseSlowSuite("bill") {
 
   def globalBsp: AbsolutePath = workspace.resolve("global-bsp")
   override def bspGlobalDirectories: List[AbsolutePath] =
     List(globalBsp.resolve("bsp"))
-
   def testRoundtripCompilation(): Future[Unit] = {
     for {
       _ <- server.initialize(
@@ -43,6 +45,44 @@ object BillSlowSuite extends BaseSlowSuite("bill") {
   testAsync("diagnostics") {
     Bill.installWorkspace(workspace.toNIO)
     testRoundtripCompilation()
+  }
+
+  testAsync("reconnect") {
+    cleanWorkspace()
+    Bill.installWorkspace(workspace.toNIO)
+    for {
+      _ <- server.initialize(
+        """
+          |/src/com/App.scala
+          |object App {
+          |  val x: Int = ""
+          |}
+          |/shutdown-trace
+          |true
+        """.stripMargin
+      )
+      _ <- server.executeCommand(ServerCommands.ConnectBuildServer.id)
+      _ <- server.executeCommand(ServerCommands.ConnectBuildServer.id)
+      _ = {
+        val logs = workspace
+          .resolve(Directories.log)
+          .readText
+          .linesIterator
+          .filter(_.startsWith("trace:"))
+          .mkString("\n")
+        assertNoDiff(
+          logs,
+          // Assert that "Connect to build server" waits for the shutdown
+          // response from the build server before sending "initialize".
+          """|trace: initialize
+             |trace: shutdown
+             |trace: initialize
+             |trace: shutdown
+             |trace: initialize
+             |""".stripMargin
+        )
+      }
+    } yield ()
   }
 
   testAsync("global") {


### PR DESCRIPTION
Previously, we risked connecting to a new build server before completing
the shutdown for the old build connection resulting in the following
sequence of requests:

```
metals ---shutdown----> bloop (old connection)
metals ---initialize--> bloop (new connection)
metals <--shutdown----- bloop (old connection)
```

Now, Metals waits for the `shutdown` response from the old connection
before sending `initialize` for the new connection.

This bug was introduced by a recent refactoring of how we shut down
the build server connection. This commit adds a new test case to
prevent similar regressions in the future.