### PR TITLE
Enforce correct scala version for the embedded bloop server.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -151,6 +151,21 @@ object Embedded {
         "ch.epfl.scala",
         "bloop-frontend_2.12",
         bloopVersion
+      ),
+      new Dependency(
+        "org.scala-lang",
+        "scala-library",
+        BuildInfo.scala212
+      ),
+      new Dependency(
+        "org.scala-lang",
+        "scala-compiler",
+        BuildInfo.scala212
+      ),
+      new Dependency(
+        "org.scala-lang",
+        "scala-reflect",
+        BuildInfo.scala212
       )
     ).addRepositories(
       List(


### PR DESCRIPTION
Previously we could download a wrong version of scala-compiler as a transitive dependency, now we make sure we have the right one.