### PR TITLE
Improve handling of requests that access the presentation compiler.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,6 +145,7 @@ lazy val mtags = project
     crossVersion := CrossVersion.full,
     crossScalaVersions := V.supportedScalaVersions,
     scalacOptions ++= List(
+      // Needed for SAM types on 2.11.
       "-Xexperimental"
     ),
     libraryDependencies ++= List(

--- a/build.sbt
+++ b/build.sbt
@@ -144,6 +144,9 @@ lazy val mtags = project
     moduleName := "mtags",
     crossVersion := CrossVersion.full,
     crossScalaVersions := V.supportedScalaVersions,
+    scalacOptions ++= List(
+      "-Xexperimental"
+    ),
     libraryDependencies ++= List(
       "com.thoughtworks.qdox" % "qdox" % "2.0-M9", // for java mtags
       "org.jsoup" % "jsoup" % "1.11.3",

--- a/metals-bench/src/main/scala/bench/CompletionBench.scala
+++ b/metals-bench/src/main/scala/bench/CompletionBench.scala
@@ -121,7 +121,7 @@ abstract class CompletionBench {
 
   def scopeComplete(pc: PresentationCompiler): CompletionList = {
     val code = "import Java\n"
-    pc.complete(CompilerOffsetParams("A.scala", code, code.length - 2))
+    pc.complete(CompilerOffsetParams("A.scala", code, code.length - 2)).get()
   }
 }
 

--- a/metals-bench/src/main/scala/bench/SourceCompletion.scala
+++ b/metals-bench/src/main/scala/bench/SourceCompletion.scala
@@ -17,6 +17,7 @@ case class SourceCompletion(filename: String, code: String, offset: Int) {
     // Trigger re-typechecking
     val randomSuffix = s"\n/* ${Random.nextInt()} */\n"
     pc.complete(CompilerOffsetParams(filename, code + randomSuffix, offset))
+      .get()
   }
 }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -59,19 +59,7 @@ final class DefinitionProvider(
           DefinitionResult.empty
       }
     if (fromSemanticdb.locations.isEmpty()) {
-      compilers().definition(params, token) match {
-        case None =>
-          Future.successful(DefinitionResult.empty)
-        case Some(fromCompilers) =>
-          fromCompilers.map { c =>
-            DefinitionResult(
-              c.locations(),
-              c.symbol(),
-              None,
-              None
-            )
-          }
-      }
+      compilers().definition(params, token)
     } else {
       Future.successful(fromSemanticdb)
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -14,7 +14,6 @@ import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import org.eclipse.lsp4j.TextDocumentIdentifier
-import org.eclipse.lsp4j.jsonrpc.CancelChecker
 import org.eclipse.{lsp4j => l}
 import scala.collection.convert.DecorateAsJava
 import scala.collection.convert.DecorateAsScala
@@ -479,16 +478,6 @@ object MetalsEnrichments
   implicit class XtensionPromise[T](promise: Promise[T]) {
     def cancel(): Unit =
       promise.tryFailure(new CancellationException())
-  }
-  implicit class XtensionCancelChecker(token: CancelChecker) {
-    def isCancelled: Boolean =
-      try {
-        token.checkCanceled()
-        false
-      } catch {
-        case _: CancellationException =>
-          true
-      }
   }
 
   implicit class XtensionTreeTokenStream(tree: Tree) {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -889,9 +889,7 @@ class MetalsLanguageServer(
   @JsonRequest("textDocument/completion")
   def completion(params: CompletionParams): CompletableFuture[CompletionList] =
     CancelTokens.future { token =>
-      compilers
-        .completions(params, token)
-        .getOrElse(Future.successful(null))
+      compilers.completions(params, token)
     }
 
   @JsonRequest("completionItem/resolve")
@@ -900,9 +898,7 @@ class MetalsLanguageServer(
   ): CompletableFuture[CompletionItem] =
     CancelTokens.future { token =>
       if (config.compilers.isCompletionItemResolve) {
-        compilers
-          .completionItemResolve(item, token)
-          .getOrElse(Future.successful(item))
+        compilers.completionItemResolve(item, token)
       } else {
         Future.successful(item)
       }
@@ -913,9 +909,7 @@ class MetalsLanguageServer(
       params: TextDocumentPositionParams
   ): CompletableFuture[SignatureHelp] =
     CancelTokens.future { token =>
-      compilers
-        .signatureHelp(params, token, interactiveSemanticdbs)
-        .getOrElse(Future.successful(null))
+      compilers.signatureHelp(params, token, interactiveSemanticdbs)
     }
 
   @JsonRequest("textDocument/codeAction")

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1303,6 +1303,7 @@ class MetalsLanguageServer(
       buildTargets.reset()
       interactiveSemanticdbs.reset()
       buildClient.reset()
+      referencesProvider.reset()
       buildTargets.addWorkspaceBuildTargets(i.workspaceBuildTargets)
       buildTargets.addScalacOptions(i.scalacOptions)
       for {

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -42,6 +42,9 @@ final class ReferenceProvider(
       onChangeDirectory(targetroot.resolve(Directories.semanticdb).toNIO)
     }
   }
+  def reset(): Unit = {
+    index.clear()
+  }
   def onDelete(file: Path): Unit = {
     index.remove(file)
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/ThreadPools.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ThreadPools.scala
@@ -2,19 +2,13 @@ package scala.meta.internal.metals
 
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.RejectedExecutionHandler
 
 object ThreadPools {
   def discardRejectedRunnables(where: String, executor: ExecutorService): Unit =
     executor match {
       case t: ThreadPoolExecutor =>
-        t.setRejectedExecutionHandler(new RejectedExecutionHandler {
-          def rejectedExecution(
-              r: Runnable,
-              executor: ThreadPoolExecutor
-          ): Unit = {
-            scribe.info(s"rejected runnable: $where")
-          }
+        t.setRejectedExecutionHandler((_, _) => {
+          scribe.info(s"rejected runnable: $where")
         })
       case _ =>
     }

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -7,6 +7,7 @@ import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.SignatureHelp;
 
 import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -35,36 +36,37 @@ public abstract class PresentationCompiler {
      *
      * @implNote supports cancellation.
      */
-    public abstract CompletionList complete(OffsetParams params);
+    public abstract CompletableFuture<CompletionList> complete(OffsetParams params);
 
     /**
      * Returns a fully resolved completion item with defined fields such as `documentation` and `details` populated.
      *
      * @implNote does not support cancellation.
      */
-    public abstract CompletionItem completionItemResolve(CompletionItem item, String symbol);
+    public abstract CompletableFuture<CompletionItem> completionItemResolve(CompletionItem item, String symbol);
 
     /**
      * Returns the parameter hints at the given source position.
      *
      * @implNote supports cancellation.
      */
-    public abstract SignatureHelp signatureHelp(OffsetParams params);
+    public abstract CompletableFuture<SignatureHelp> signatureHelp(OffsetParams params);
 
     /**
      * Returns the type of the expression at the given position along with the symbol of the referenced symbol.
      */
-    public abstract Optional<Hover> hover(OffsetParams params);
+    public abstract CompletableFuture<Optional<Hover>> hover(OffsetParams params);
 
     /**
      * Returns the definition of the symbol at the given position.
+
      */
-    public abstract DefinitionResult definition(OffsetParams params);
+    public abstract CompletableFuture<DefinitionResult> definition(OffsetParams params);
 
     /**
      * Returns the Protobuf byte array representation of a SemanticDB <code>TextDocument</code> for the given source.
      */
-    public abstract byte[] semanticdbTextDocument(String filename, String code);
+    public abstract CompletableFuture<byte[]> semanticdbTextDocument(String filename, String code);
 
     // =================================
     // Configuration and lifecycle APIs.

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -62,8 +62,7 @@ public abstract class PresentationCompiler {
 
      */
     public abstract CompletableFuture<DefinitionResult> definition(OffsetParams params);
-
-    /**
+/**
      * Returns the Protobuf byte array representation of a SemanticDB <code>TextDocument</code> for the given source.
      */
     public abstract CompletableFuture<byte[]> semanticdbTextDocument(String filename, String code);

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -62,7 +62,8 @@ public abstract class PresentationCompiler {
 
      */
     public abstract CompletableFuture<DefinitionResult> definition(OffsetParams params);
-/**
+
+    /**
      * Returns the Protobuf byte array representation of a SemanticDB <code>TextDocument</code> for the given source.
      */
     public abstract CompletableFuture<byte[]> semanticdbTextDocument(String filename, String code);

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -67,8 +67,8 @@ public interface PresentationCompilerConfig {
     /**
      * The maximum delay for requests to respond.
      *
-     * After the given delay, every request to completions/hover/signatureHelp are automatically
-     * cancelled and the presentation compiler is restarted.
+     * After the given delay, every request to completions/hover/signatureHelp
+     * is automatically cancelled and the presentation compiler is restarted.
      */
     long timeoutDelay();
 

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -66,6 +66,9 @@ public interface PresentationCompilerConfig {
 
     /**
      * The maximum delay for requests to respond.
+     *
+     * After the given delay, every request to completions/hover/signatureHelp are automatically
+     * cancelled and the presentation compiler is restarted.
      */
     long timeoutDelay();
 

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -3,6 +3,7 @@ package scala.meta.pc;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Configuration options used by the Metals presentation compiler.
@@ -62,5 +63,15 @@ public interface PresentationCompilerConfig {
      * Returns true if the <code>SignatureHelp.documentation</code> field should be populated.
      */
     boolean isSignatureHelpDocumentationEnabled();
+
+    /**
+     * The maximum delay for requests to respond.
+     */
+    long timeoutDelay();
+
+    /**
+     * The unit to use for <code>timeoutDelay</code>.
+     */
+    TimeUnit timeoutUnit();
 
 }

--- a/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
@@ -11,13 +11,14 @@ import scala.meta.internal.mtags.SymbolDefinition
 import scala.meta.internal.semanticdb.Language
 import scala.meta.pc.SymbolDocumentation
 import scala.util.control.NonFatal
+import scala.meta.internal.mtags.GlobalSymbolIndex
 
 /**
  * Implementation of the `documentation(symbol: String): Option[SymbolDocumentation]` method in `SymbolSearch`.
  *
  * Handles both javadoc and scaladoc.
  */
-class Docstrings(index: OnDemandSymbolIndex) {
+class Docstrings(index: GlobalSymbolIndex) {
   val cache = TrieMap.empty[String, SymbolDocumentation]
   private val logger = Logger.getLogger(classOf[Docstrings].getName)
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/GlobalSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/GlobalSymbolIndex.scala
@@ -10,8 +10,7 @@ import scala.meta.io.AbsolutePath
 trait GlobalSymbolIndex {
 
   /**
-   * Lookup the definition of a global symbol.
-   *
+   * Lookup the definition of a global symbol. *
    * Returns the path of the file that defines the symbol but does not include
    * the exact position of the definition. Computing the range position of the
    * definition is not handled by this method, it is left for the user and can

--- a/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -7,10 +7,12 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util
 import java.util.Optional
+import java.util.concurrent.CancellationException
 import java.util.logging.Level
 import java.util.logging.Logger
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.MarkupContent
+import org.eclipse.lsp4j.jsonrpc.CancelChecker
 import org.eclipse.{lsp4j => l}
 import scala.annotation.tailrec
 import scala.collection.AbstractIterator
@@ -307,5 +309,15 @@ trait MtagsEnrichments {
       params.offset() >= params.text().length ||
       params.text().charAt(params.offset()).isWhitespace
     }
+  }
+  implicit class XtensionCancelChecker(token: CancelChecker) {
+    def isCancelled: Boolean =
+      try {
+        token.checkCanceled()
+        false
+      } catch {
+        case _: CancellationException =>
+          true
+      }
   }
 }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
@@ -59,7 +59,7 @@ final case class OnDemandSymbolIndex(
               addSourceFile(source, None)
             } catch {
               case NonFatal(e) =>
-                onError(IndexError(source, e))
+                onError.lift(IndexError(source, e))
             }
           }
         }

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerJobQueue.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerJobQueue.scala
@@ -1,0 +1,84 @@
+package scala.meta.internal.pc
+
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.PriorityBlockingQueue
+import java.{util => ju}
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CancellationException
+
+/**
+ * A thread pool executor to execute jobs on a single thread in a last-in-first-out order.
+ *
+ * The last-in-first-out order is important because it's common for Metals
+ * users to send multiple completion/hover/signatureHelp requests in rapid
+ * succession. In these situations, we care most about responding to the latest
+ * request even if it comes at the expense of ignoring older requests.
+ *
+ * To restrict unsafe multi-threaded access to the presentation compiler we
+ * schedule jobs to run on a single thread. We use this executor instead of the
+ * presentation compiler thread (see MetalsGlobalThread) for the following reasons:
+ * - we limit the usage of sleep/notify/wait/synchronized primitives.
+ * - some blocking compiler APIs like `ask[T](op: () => T)` don't seem to work as advertised.
+ * - it's preferable to work on top of CompletableFuture[T] instead of the custom Response[T] from the compiler,
+ *   which is required to execute tasks on the presentation compiler thread:
+ *   - CompletableFuture[T] can be passed via Java-only reflection APIs in mtags-interfaces.
+ *   - CompletableFuture[T] can be returned to lsp4j, for non-blocking JSON-RPC request handling.
+ *   - CompletableFuture[T] can be converted to Scala Futures for easier composition.
+ */
+class CompilerJobQueue(val executor: ThreadPoolExecutor) {
+  override def toString(): String = s"CompilerJobQueue($executor)"
+  def shutdown(): Unit = executor.shutdown()
+  def submit(fn: () => Unit): Unit = {
+    submit(new CompletableFuture[Unit](), fn)
+  }
+  def submit(result: CompletableFuture[_], fn: () => Unit): Unit = {
+    executor.execute(new CompilerJobQueue.Job(result, fn))
+  }
+}
+
+object CompilerJobQueue {
+
+  def apply(): CompilerJobQueue = {
+    val singleThreadExecutor = new ThreadPoolExecutor(
+      1,
+      1,
+      0,
+      TimeUnit.MILLISECONDS,
+      new LastInFirstOutBlockingQueue
+    )
+    singleThreadExecutor.setRejectedExecutionHandler((r, _) => {
+      r match {
+        case j: Job =>
+          j.reject()
+        case _ =>
+      }
+    })
+    new CompilerJobQueue(singleThreadExecutor)
+  }
+
+  /** Runnable with a timestamp and attached completable future. */
+  private class Job(result: CompletableFuture[_], _run: () => Unit)
+      extends Runnable {
+    def reject(): Unit = {
+      result.completeExceptionally(new CancellationException("rejected"))
+    }
+    val start = System.nanoTime()
+    def run(): Unit = {
+      if (!result.isDone()) {
+        _run()
+      }
+    }
+  }
+
+  /** Priority queue that runs the most recently submitted task first. */
+  private class LastInFirstOutBlockingQueue
+      extends PriorityBlockingQueue[Runnable](10, new ju.Comparator[Runnable] {
+        def compare(o1: Runnable, o2: Runnable): Int = {
+          -java.lang.Long.compare(
+            o1.asInstanceOf[Job].start,
+            o2.asInstanceOf[Job].start
+          )
+        }
+      })
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/DefinitionResultImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/DefinitionResultImpl.scala
@@ -10,6 +10,6 @@ case class DefinitionResultImpl(
 ) extends DefinitionResult
 
 object DefinitionResultImpl {
-  def empty: DefinitionResultImpl =
+  def empty: DefinitionResult =
     DefinitionResultImpl("", ju.Collections.emptyList())
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -5,10 +5,11 @@ import org.eclipse.lsp4j.Location
 import scala.meta.pc.OffsetParams
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.pc.DefinitionResult
 
 class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
   import compiler._
-  def definition(): DefinitionResultImpl = {
+  def definition(): DefinitionResult = {
     if (params.isWhitespace || params.isDelimiter || params.offset() == 0) {
       DefinitionResultImpl.empty
     } else {

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -19,7 +19,7 @@ case class PresentationCompilerConfigImpl(
     isHoverDocumentationEnabled: Boolean = true,
     isSignatureHelpDocumentationEnabled: Boolean = true,
     isCompletionItemResolve: Boolean = true,
-    timeoutDelay: Long = 10,
+    timeoutDelay: Long = 20,
     timeoutUnit: TimeUnit = TimeUnit.SECONDS
 ) extends PresentationCompilerConfig {
   override def symbolPrefixes(): util.Map[String, String] =

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.pc
 
 import java.util
 import java.util.Optional
+import java.util.concurrent.TimeUnit
 import scala.meta.pc.PresentationCompilerConfig
 import scala.collection.JavaConverters._
 import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
@@ -17,7 +18,9 @@ case class PresentationCompilerConfigImpl(
     isCompletionItemDocumentationEnabled: Boolean = true,
     isHoverDocumentationEnabled: Boolean = true,
     isSignatureHelpDocumentationEnabled: Boolean = true,
-    isCompletionItemResolve: Boolean = true
+    isCompletionItemResolve: Boolean = true,
+    timeoutDelay: Long = 10,
+    timeoutUnit: TimeUnit = TimeUnit.SECONDS
 ) extends PresentationCompilerConfig {
   override def symbolPrefixes(): util.Map[String, String] =
     _symbolPrefixes.asJava

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -59,7 +59,7 @@ case class ScalaPresentationCompiler(
   }
 
   override def restart(): Unit = {
-    access.restart()
+    access.shutdownCurrentCompiler()
   }
 
   override def newInstance(

--- a/mtags/src/main/scala/scala/tools/nsc/interactive/MetalsGlobalThread.scala
+++ b/mtags/src/main/scala/scala/tools/nsc/interactive/MetalsGlobalThread.scala
@@ -6,6 +6,8 @@ import scala.meta.internal.pc.InterruptException
  * Adapation of PresentationCompilerThread from scala/scala.
  *
  * Changes are marked with "+- scalac deviation" comments.
+ * Note that most of the work with the presentation compiler does not happen on
+ * this thread, see CompilerJobQueue.
  */
 final class MetalsGlobalThread(var compiler: Global, name: String = "")
     extends Thread("Scala Presentation Compiler [" + name + "]") {

--- a/test-workspace/src/main/scala/example/User.scala
+++ b/test-workspace/src/main/scala/example/User.scala
@@ -1,6 +1,10 @@
 package example
 
 import java.util.concurrent.CompletableFuture
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.Path
+import java.nio.file.FileVisitResult
+import java.nio.file.attribute.BasicFileAttributes
 
 object Main extends CompletableFuture[Int] {
   println(Option(1).map(_.toString()))
@@ -9,4 +13,9 @@ object Main extends CompletableFuture[Int] {
   List(1).map(identity _)
   System.out.println(identity(), identity(), identity())
   Files.readAllBytes(Paths.get(""))
+  new SimpleFileVisitor[Path] {
+    override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+      FileVisitResult.CONTINUE
+    }
+  }
 }

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -16,10 +16,10 @@ abstract class BaseCompletionSuite extends BasePCSuite {
   private def resolvedCompletions(
       params: CompilerOffsetParams
   ): CompletionList = {
-    val result = pc.complete(params)
+    val result = pc.complete(params).get()
     val newItems = result.getItems.asScala.map { item =>
       val symbol = item.data.get.symbol
-      pc.completionItemResolve(item, symbol)
+      pc.completionItemResolve(item, symbol).get()
     }
     result.setItems(newItems.asJava)
     result

--- a/tests/cross/src/main/scala/tests/BaseSignatureHelpSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseSignatureHelpSuite.scala
@@ -24,7 +24,7 @@ abstract class BaseSignatureHelpSuite extends BasePCSuite {
       val pkg = scala.meta.Term.Name(name).syntax
       val (code, offset) = params(s"package $pkg\n" + original)
       val result =
-        pc.signatureHelp(CompilerOffsetParams("A.scala", code, offset))
+        pc.signatureHelp(CompilerOffsetParams("A.scala", code, offset)).get()
       val out = new StringBuilder()
       if (result != null) {
         result.getSignatures.asScala.zipWithIndex.foreach {

--- a/tests/cross/src/main/scala/tests/pc/BaseHoverSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BaseHoverSuite.scala
@@ -29,9 +29,11 @@ abstract class BaseHoverSuite
         else ""
       val codeOriginal = packagePrefix + noRange
       val (code, offset) = params(codeOriginal, filename)
-      val hover = pc.hover(
-        CompilerOffsetParams(filename, code, offset)
-      )
+      val hover = pc
+        .hover(
+          CompilerOffsetParams(filename, code, offset)
+        )
+        .get()
       val obtained: String = renderAsString(code, hover.asScala, includeRange)
       assertNoDiff(obtained, expected)
       for {

--- a/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
@@ -22,9 +22,7 @@ abstract class BasePcDefinitionSuite extends BasePCSuite {
       import scala.meta.inputs.Position
       import scala.meta.inputs.Input
       val offsetRange = Position.Range(Input.String(code), offset, offset).toLSP
-      val defn = pc.definition(
-        CompilerOffsetParams(uri, code, offset)
-      )
+      val defn = pc.definition(CompilerOffsetParams(uri, code, offset)).get()
       val edits = defn.locations().asScala.toList.flatMap { location =>
         if (location.getUri() == uri) {
           List(

--- a/tests/cross/src/test/scala/tests/pc/CompilerJobQueueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompilerJobQueueSuite.scala
@@ -50,10 +50,10 @@ object CompilerJobQueueSuite extends BaseSuite {
 
     Await.result(all, Duration("1s"))
 
-    // Assert that the jobs don't run in the default order.
+    // Assert all submitted non-cancelled jobs completed.
     assertEquals(obtained.length, size)
 
-    // Assert all submitted non-cancelled jobs completed.
+    // Assert that the jobs don't run in the default order.
     assertNotEquals(obtained.toList, original)
   }
 }

--- a/tests/cross/src/test/scala/tests/pc/CompilerJobQueueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompilerJobQueueSuite.scala
@@ -1,0 +1,59 @@
+package tests.pc
+
+import tests.BaseSuite
+import scala.meta.internal.pc.CompilerJobQueue
+import scala.concurrent.Promise
+import scala.concurrent.Future
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.collection.mutable
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+object CompilerJobQueueSuite extends BaseSuite {
+  var jobs: CompilerJobQueue = null
+
+  override def utestBeforeEach(path: Seq[String]): Unit = {
+    jobs = CompilerJobQueue()
+    super.utestBeforeEach(path)
+  }
+  override def utestAfterEach(path: Seq[String]): Unit = {
+    jobs.shutdown()
+    super.utestAfterEach(path)
+  }
+
+  test("cancel") {
+    val cancelled = new CompletableFuture[Unit]()
+    cancelled.cancel(false)
+    jobs.submit(cancelled, () => {
+      Thread.sleep(50)
+    })
+    jobs.executor.shutdown()
+    // Assert that cancelled task never execute.
+    jobs.executor.awaitTermination(10, TimeUnit.MILLISECONDS)
+  }
+
+  test("order") {
+    val obtained = mutable.ListBuffer.empty[Int]
+    val size = 10
+    val original = 1.to(size).toList
+    val all = Future.traverse(original) { i =>
+      val promise = Promise[Unit]()
+      jobs.submit(() => {
+        Thread.sleep(i * 5)
+        obtained += i
+        promise.success(())
+      })
+      promise.future
+    }
+
+    Await.result(all, Duration("1s"))
+
+    // Assert that the jobs don't run in the default order.
+    assertEquals(obtained.length, size)
+
+    // Assert all submitted non-cancelled jobs completed.
+    assertNotEquals(obtained.toList, original)
+  }
+}

--- a/tests/cross/src/test/scala/tests/pc/InterruptPresentationCompilerSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InterruptPresentationCompilerSuite.scala
@@ -1,0 +1,93 @@
+package tests.pc
+
+import java.util.concurrent.CompletableFuture
+import scala.meta.internal.metals.CompilerOffsetParams
+import tests.CompletableCancelToken
+import tests.DelegatingGlobalSymbolIndex
+import tests.BasePCSuite
+import scala.meta.internal.mtags.SymbolDefinition
+import scala.meta.internal.mtags.Symbol
+import java.util.concurrent.CancellationException
+import scala.meta.internal.mtags.OnDemandSymbolIndex
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.meta.pc.PresentationCompiler
+import scala.meta.pc.OffsetParams
+import java.util.concurrent.atomic.AtomicReference
+
+object InterruptPresentationCompilerSuite extends BasePCSuite {
+  class InterruptSymbolIndex
+      extends DelegatingGlobalSymbolIndex(OnDemandSymbolIndex()) {
+    val token = new AtomicReference(new CompletableCancelToken())
+    val isInterrupted = new AtomicBoolean(false)
+    def reset(): Unit = {
+      token.set(new CompletableCancelToken())
+      isInterrupted.set(false)
+    }
+    override def definition(symbol: Symbol): Option[SymbolDefinition] = {
+      token.get().cancel()
+      isInterrupted.set(Thread.interrupted())
+      super.definition(symbol)
+    }
+  }
+
+  val interrupt = new InterruptSymbolIndex()
+
+  override def utestBeforeEach(path: Seq[String]): Unit = {
+    interrupt.reset()
+    super.utestBeforeEach(path)
+  }
+
+  override def beforeAll(): Unit = {
+    index.underlying = interrupt
+    indexScalaLibrary()
+  }
+
+  def check(
+      name: String,
+      original: String,
+      act: (PresentationCompiler, OffsetParams) => CompletableFuture[_]
+  ): Unit = {
+    test(name) {
+      val (code, offset) = this.params(original)
+      try {
+        val result = act(
+          pc,
+          CompilerOffsetParams("A.scala", code, offset, interrupt.token.get())
+        ).get()
+        fail(s"Expected cancellation exception. Obtained $result")
+      } catch {
+        case _: CancellationException => () // OK
+      }
+      val isInterrupted = interrupt.isInterrupted.get()
+      Predef.assert(
+        !isInterrupted,
+        "thread was interrupted, expected no interruption."
+      )
+    }
+  }
+
+  check(
+    "hover",
+    """
+      |object A {
+      |  val x = "".stripS@@uffix("")
+      |}
+      |""".stripMargin,
+    (pc, params) => {
+      pc.hover(params)
+    }
+  )
+
+  check(
+    "signature-help",
+    """
+      |object A {
+      |  assert(@@)
+      |}
+      |""".stripMargin,
+    (pc, params) => {
+      pc.signatureHelp(params)
+    }
+  )
+
+}

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -160,15 +160,14 @@ class BaseSuite extends TestSuite {
     throw ex
   }
 
-  override def tests: Tests = {
+  lazy val tests: Tests = {
     if (myTests.isEmpty) {
       myTests += FlatTest("empty", () => ())
     }
+    this.beforeAll()
     val names = Tree("", myTests.map(x => Tree(x.name)): _*)
-    val thunks = new TestCallTree({
-      this.beforeAll()
-      Right(myTests.map(x => new TestCallTree(Left(x.thunk()))))
-    })
+    val inner = Right(myTests.map(x => new TestCallTree(Left(x.thunk()))))
+    val thunks = new TestCallTree(inner)
     Tests(names, thunks)
   }
 }

--- a/tests/mtest/src/main/scala/tests/CompletableCancelToken.scala
+++ b/tests/mtest/src/main/scala/tests/CompletableCancelToken.scala
@@ -1,0 +1,17 @@
+package tests
+
+import java.util.concurrent.CompletableFuture
+import scala.meta.pc.CancelToken
+import java.util.concurrent.CancellationException
+
+/** Cancel token that can be cancelled by calling `cancel()`. */
+class CompletableCancelToken extends CancelToken {
+  val onCancel = new CompletableFuture[java.lang.Boolean]()
+  def cancel(): Unit = onCancel.complete(true)
+  def isCancelled: Boolean = onCancel.getNow(false)
+  def checkCanceled(): Unit = {
+    if (isCancelled) {
+      throw new CancellationException
+    }
+  }
+}

--- a/tests/mtest/src/main/scala/tests/DelegatingGlobalSymbolIndex.scala
+++ b/tests/mtest/src/main/scala/tests/DelegatingGlobalSymbolIndex.scala
@@ -1,0 +1,23 @@
+package tests
+
+import scala.meta.io.AbsolutePath
+import scala.meta.internal.mtags.GlobalSymbolIndex
+import scala.meta.internal.mtags.SymbolDefinition
+import scala.meta.internal.mtags.Symbol
+
+/** Symbol index that delegates all methods to an underlying implementation */
+class DelegatingGlobalSymbolIndex(var underlying: GlobalSymbolIndex)
+    extends GlobalSymbolIndex {
+  def definition(symbol: Symbol): Option[SymbolDefinition] = {
+    underlying.definition(symbol)
+  }
+  def addSourceFile(
+      file: AbsolutePath,
+      sourceDirectory: Option[AbsolutePath]
+  ): Unit = {
+    underlying.addSourceFile(file, sourceDirectory)
+  }
+  def addSourceJar(jar: AbsolutePath): Unit = {
+    underlying.addSourceJar(jar)
+  }
+}

--- a/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
+++ b/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
@@ -10,6 +10,8 @@ import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 import scala.meta.pc.SymbolSearchVisitor
 import scala.meta.internal.mtags.OnDemandSymbolIndex
+import scala.meta.internal.mtags.GlobalSymbolIndex
+import scala.meta.internal.mtags.Symbol
 
 /**
  * Implementation of `SymbolSearch` for testing purposes.
@@ -20,13 +22,12 @@ class TestingSymbolSearch(
     classpath: ClasspathSearch = ClasspathSearch.empty,
     docs: Docstrings = Docstrings.empty,
     workspace: TestingWorkspaceSearch = TestingWorkspaceSearch.empty,
-    index: OnDemandSymbolIndex = OnDemandSymbolIndex()
+    index: GlobalSymbolIndex = OnDemandSymbolIndex()
 ) extends SymbolSearch {
   override def documentation(symbol: String): Optional[SymbolDocumentation] = {
     docs.documentation(symbol)
   }
 
-  import scala.meta.internal.mtags.Symbol
   override def definition(symbol: String): ju.List[Location] = {
     index.definition(Symbol(symbol)) match {
       case None =>

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -195,7 +195,7 @@ final class TestingServer(
       token <- input.tokenize.get
       if token.isIdentifier
       params = token.toPositionParams(identifier)
-      definition = server.definitionResult(params)
+      definition = server.definitionResult(params).asJava.get()
       if !definition.symbol.isPackage
       if !definition.definition.exists(_.isDependencySource(workspace))
       location <- definition.locations.asScala
@@ -403,7 +403,8 @@ final class TestingServer(
       filter: String => Boolean = _ => true
   ): String = {
     val items =
-      completion.getItems.asScala.map(server.completionItemResolveSync)
+      completion.getItems.asScala
+        .map(item => server.completionItemResolve(item).get())
     items.iterator
       .filter(item => filter(item.getLabel()))
       .map { item =>
@@ -579,7 +580,7 @@ final class TestingServer(
     val occurrences = ListBuffer.empty[s.SymbolOccurrence]
     input.tokenize.get.foreach { token =>
       val params = token.toPositionParams(identifier)
-      val definition = server.definitionResult(params)
+      val definition = server.definitionResult(params).asJava.get()
       definition.definition.foreach { path =>
         if (path.isDependencySource(workspace)) {
           readonlySources(path.toNIO.getFileName.toString) = path

--- a/tests/unit/src/main/scala/tests/WorkspaceSymbolReferences.scala
+++ b/tests/unit/src/main/scala/tests/WorkspaceSymbolReferences.scala
@@ -26,11 +26,15 @@ case class WorkspaceSymbolReferences(
   def referencesFormat: String = format(references)
   def definitionFormat: String = format(definition)
   def diff: String = {
-    DiffAssertions.unifiedDiff(
-      referencesFormat,
-      definitionFormat,
-      "references",
-      "definition"
-    )
+    DiffAssertions
+      .unifiedDiff(
+        referencesFormat,
+        definitionFormat,
+        "references",
+        "definition"
+      )
+      .linesIterator
+      .filterNot(_.startsWith("@@"))
+      .mkString("\n")
   }
 }

--- a/tests/unit/src/test/scala/tests/ReferenceSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceSlowSuite.scala
@@ -77,13 +77,11 @@ object ReferenceSlowSuite extends BaseSlowSuite("reference") {
       _ = server.assertReferenceDefinitionDiff(
         """|--- references
            |+++ definition
-           |@@ -18,5 +18,2 @@
            |       ^^^^^
            |-a/src/main/scala/a/B.scala:4:11: a/A.apply().
            |-  val a = A(1)
            |-          ^
            | =================
-           |@@ -45,5 +42,2 @@
            |          ^^^^^^
            |-a/src/main/scala/a/B.scala:4:11: a/A.horror().
            |-  val a = A(1)
@@ -133,7 +131,6 @@ object ReferenceSlowSuite extends BaseSlowSuite("reference") {
       _ = server.assertReferenceDefinitionDiff(
         """|--- references
            |+++ definition
-           |@@ -33,1 +33,7 @@
            |        ^
            |+=============
            |+= b/B.number.

--- a/tests/unit/src/test/scala/tests/ReferenceSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceSlowSuite.scala
@@ -1,5 +1,7 @@
 package tests
 
+import scala.meta.internal.metals.ServerCommands
+
 object ReferenceSlowSuite extends BaseSlowSuite("reference") {
   testAsync("case-class") {
     cleanWorkspace()
@@ -127,6 +129,7 @@ object ReferenceSlowSuite extends BaseSlowSuite("reference") {
       _ <- server.didChange("b/src/main/scala/b/B.scala")(
         _.replaceAllLiterally("val b", "\n  val number")
       )
+      _ <- server.executeCommand(ServerCommands.ConnectBuildServer.id)
       _ = server.assertReferenceDefinitionDiff(
         """|--- references
            |+++ definition


### PR DESCRIPTION
Fixes #723. Previously, we used `.synchronized` to limit multi-threaded
access to the presentation compiler. This approach had several issues,
of which most critically we risked blocking threads forever preventing
the Metals process from exiting.

Now, the APIs that access the presentation compiler return
`CompletableFuture` and the implementation no longer uses
`.synchronized`. This change had a nice side-effect that Metals now
prioritizes the most recently submitted request when choosing between
competing hover/signatureHelp/completion requests