### PR TITLE
Add automatic Mill import to metals

### DIFF
--- a/metals/src/main/resources/millw
+++ b/metals/src/main/resources/millw
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+
+# This is a wrapper script, that automatically download mill from GitHub release pages
+# You can give the required mill version with --mill-version parameter
+# If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
+
+DEFAULT_MILL_VERSION=0.3.6
+
+set -e
+
+if [ -f ".mill-version" ] ; then
+  MILL_VERSION="$(head -n 1 .mill-version 2> /dev/null)"
+fi
+
+if [ "x$1" = "x--mill-version" ] ; then
+  shift
+  if [ "x$1" != "x" ] ; then
+    MILL_VERSION="$1"
+    shift
+  else
+    echo "You specified --mill-version without a version."
+    echo "Please provide a version that matches one provided on"
+    echo "https://github.com/lihaoyi/mill/releases"
+    false
+  fi
+fi
+
+if [ "x${MILL_VERSION}" = "x" ] ; then
+  MILL_VERSION="${DEFAULT_MILL_VERSION}"
+fi
+
+MILL_DOWNLOAD_PATH="${HOME}/.mill/download"
+
+MILL="${MILL_DOWNLOAD_PATH}/${MILL_VERSION}"
+
+if [ ! -x "${MILL}" ] ; then
+  DOWNLOAD_FILE=$(mktemp mill.XXXX)
+  # TODO: handle command not found
+  curl -L -o "${DOWNLOAD_FILE}" "https://github.com/lihaoyi/mill/releases/download/${MILL_VERSION%%-*}/${MILL_VERSION}"
+  chmod +x "${DOWNLOAD_FILE}"
+  mkdir -p "${MILL_DOWNLOAD_PATH}"
+  mv "${DOWNLOAD_FILE}" "${MILL}"
+  unset DOWNLOAD_FILE
+fi
+
+unset MILL_DOWNLOAD_PATH
+unset MILL_VERSION
+
+exec $MILL "$@"

--- a/metals/src/main/resources/millw.bat
+++ b/metals/src/main/resources/millw.bat
@@ -1,0 +1,58 @@
+@echo off
+
+rem This is a wrapper script, that automatically download mill from GitHub release pages
+rem You can give the required mill version with --mill-version parameter
+rem If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
+
+rem setlocal seems to be unavailable on Windows 95/98/ME
+rem but I don't think we need to support them in 2019
+setlocal enabledelayedexpansion
+
+set DEFAULT_MILL_VERSION=0.3.6
+
+if exist .mill-version (
+    set /p MILL_VERSION= < .mill-version
+)
+
+rem %~1% removes surrounding quotes
+if "%~1%"=="--mill-version" (
+    rem shift command doesn't work within parentheses
+    if not "%~2%"=="" (
+        set MILL_VERSION=%~2%
+    ) else (
+        echo You specified --mill-version without a version.
+        echo Please provide a version that matches one provided on
+        echo https://github.com/lihaoyi/mill/releases
+        exit /b 1
+    )
+)
+
+if "%MILL_VERSION%"=="" (
+    set MILL_VERSION=%DEFAULT_MILL_VERSION%
+)
+
+set MILL_DOWNLOAD_PATH=%USERPROFILE%\.mill\download
+
+rem without bat file extension, cmd doesn't seem to be able to run it
+set MILL=%MILL_DOWNLOAD_PATH%\%MILL_VERSION%.bat
+
+if not exist "%MILL%" (
+    rem there seems to be no way to generate a unique temporary file path (on native Windows)
+    set DOWNLOAD_FILE=%MILL%.tmp
+
+    rem curl is bundled with recent Windows 10
+    rem but I don't think we can expect all the users to have it in 2019
+    rem bitadmin seems to be available on Windows 7
+    rem without /dynamic, github returns 403
+    rem bitadmin is sometimes needlessly slow but it looks better with /priority foreground
+    if not exist "%MILL_DOWNLOAD_PATH%" mkdir "%MILL_DOWNLOAD_PATH%"
+    bitsadmin /transfer millDownloadJob /dynamic /priority foreground "https://github.com/lihaoyi/mill/releases/download/%MILL_VERSION%/%MILL_VERSION%" "!DOWNLOAD_FILE!"
+
+    move /y "!DOWNLOAD_FILE!" "%MILL%"
+    set DOWNLOAD_FILE=
+)
+
+set MILL_DOWNLOAD_PATH=
+set MILL_VERSION=
+
+%MILL% %*

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
@@ -23,6 +23,8 @@ abstract class BuildTool {
     dir.toFile.deleteOnExit()
     dir
   }
+
+  def redirectErrorOutput: Boolean = false
 }
 
 object BuildTool {

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -80,6 +80,7 @@ final class BuildTools(
     if (isSbt) Some(SbtBuildTool(workspace))
     else if (isGradle) Some(GradleBuildTool())
     else if (isMaven) Some(MavenBuildTool())
+    else if (isMill) Some(MillBuildTool())
     else None
   }
   override def toString: String = {
@@ -91,6 +92,7 @@ final class BuildTools(
     if (isSbt) SbtBuildTool.isSbtRelatedPath(workspace, path)
     else if (isGradle) GradleBuildTool.isGradleRelatedPath(workspace, path)
     else if (isMaven) MavenBuildTool.isMavenRelatedPath(workspace, path)
+    else if (isMill) MillBuildTool.isMillRelatedPath(workspace, path)
     else false
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleDigest.scala
@@ -1,0 +1,66 @@
+package scala.meta.internal.builds
+import scala.meta.io.AbsolutePath
+import java.security.MessageDigest
+import java.nio.file.Files
+import java.util.stream.Collectors
+import java.nio.file.Path
+import scala.collection.JavaConverters._
+
+object GradleDigest extends Digestable {
+  override protected def digestWorkspace(
+      workspace: AbsolutePath,
+      digest: MessageDigest
+  ): Boolean = {
+    val buildSrc = workspace.resolve("buildSrc")
+    val buildSrcDigest = if (buildSrc.isDirectory) {
+      digestBuildSrc(buildSrc, digest)
+    } else {
+      true
+    }
+    buildSrcDigest && Digest.digestDirectory(workspace, digest) && digestSubProjects(
+      workspace,
+      digest
+    )
+  }
+
+  def digestBuildSrc(path: AbsolutePath, digest: MessageDigest): Boolean = {
+    Files.walk(path.toNIO).iterator().asScala.forall { file =>
+      Digest.digestFile(AbsolutePath(file), digest)
+    }
+  }
+
+  def digestSubProjects(
+      workspace: AbsolutePath,
+      digest: MessageDigest
+  ): Boolean = {
+    val (subprojects, dirs) = Files
+      .list(workspace.toNIO)
+      .filter(Files.isDirectory(_))
+      .collect(Collectors.toList[Path])
+      .asScala
+      .partition { file =>
+        Files
+          .list(file)
+          .anyMatch { path =>
+            val stringPath = path.toString
+            stringPath.endsWith(".gradle") || stringPath.endsWith("gradle.kts")
+          }
+      }
+    /*
+       If a dir contains a gradle file we need to treat is as a workspace
+     */
+    val isSuccessful = subprojects.forall { file =>
+      digestWorkspace(
+        AbsolutePath(file),
+        digest
+      )
+    }
+
+    /*
+       If it's a dir we need to keep searching since gradle can have non trivial workspace layouts
+     */
+    isSuccessful && dirs.forall { file =>
+      digestSubProjects(AbsolutePath(file), digest)
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -1,0 +1,64 @@
+package scala.meta.internal.builds
+import scala.meta.internal.metals.{MetalsServerConfig, UserConfiguration}
+import scala.meta.io.AbsolutePath
+import scala.util.Properties
+import java.nio.file.Files
+import java.nio.file.Path
+
+case class MillBuildTool() extends BuildTool {
+
+  private val predefScript =
+    s"import $$ivy.`com.lihaoyi::mill-contrib-bloop:$version`".getBytes()
+
+  private val predefScriptName = "predef.sc"
+
+  private lazy val predefScriptPath: Path = {
+    Files.write(tempDir.resolve(predefScriptName), predefScript)
+  }
+
+  private lazy val embeddedMillWrapper: AbsolutePath = {
+    val millWrapper =
+      if (Properties.isWin) "millw.bat"
+      else "millw"
+    val out = BuildTool.copyFromResource(tempDir, millWrapper)
+    out.toFile.setExecutable(true)
+    AbsolutePath(out)
+  }
+
+  override def redirectErrorOutput: Boolean = true
+
+  override def args(
+      workspace: AbsolutePath,
+      userConfig: () => UserConfiguration,
+      config: MetalsServerConfig
+  ): List[String] = {
+    val cmd = List(
+      "--predef",
+      predefScriptPath.toString,
+      "mill.contrib.Bloop/install"
+    )
+    userConfig().millScript match {
+      case Some(script) =>
+        script :: cmd
+      case None =>
+        embeddedMillWrapper.toString() :: "--mill-version" :: version :: cmd
+    }
+  }
+
+  override def digest(workspace: AbsolutePath): Option[String] =
+    MillDigest.current(workspace)
+
+  override def minimumVersion: String = "0.4.0"
+
+  override def version: String = "0.4.0"
+
+  override def toString(): String = "mill"
+
+}
+
+object MillBuildTool {
+  def isMillRelatedPath(workspace: AbsolutePath, path: AbsolutePath) = {
+    val filename = path.toNIO.getFileName.toString
+    filename.endsWith(".sc")
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/builds/MillDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillDigest.scala
@@ -1,0 +1,96 @@
+package scala.meta.internal.builds
+import scala.util.control.NonFatal
+import scala.meta.tokens.Token
+import java.nio.file.Paths
+import scala.meta.io.AbsolutePath
+import scala.collection.mutable
+import java.security.MessageDigest
+import scala.meta.internal.mtags.MtagsEnrichments._
+
+object MillDigest extends Digestable {
+  override protected def digestWorkspace(
+      workspace: AbsolutePath,
+      digest: MessageDigest
+  ): Boolean = {
+    def analyzeBuildScript(file: AbsolutePath): Boolean = {
+      val imported = findImportedScripts(file)
+      imported.forall(script => analyzeBuildScript(script)) && Digest
+        .digestFile(file, digest)
+    }
+    val buildFile = workspace.resolve("build.sc")
+    analyzeBuildScript(buildFile)
+  }
+
+  private case class ImportLinesAcc(
+      var hadImport: Boolean = false,
+      var hadFile: Boolean = false,
+      var insideBraces: Boolean = false,
+      var skip: Boolean = false,
+      var allPaths: mutable.ListBuffer[AbsolutePath] = new mutable.ListBuffer,
+      var current: String = "",
+      var prefix: String = ""
+  ) {
+    def processingFileImport = hadFile && hadImport
+  }
+
+  // find all `import $file.path`
+  private def findImportedScripts(
+      file: AbsolutePath
+  ): List[AbsolutePath] = {
+    try {
+      val input = file.toInput
+      val tokens = input.tokenize.get.tokens
+      val acc = ImportLinesAcc()
+      tokens.foreach { token =>
+        token match {
+          // recognize line with import statement
+          case _: Token.KwImport =>
+            acc.hadImport = true
+          // end import either with newline or `,` or `}`
+          case _: Token.LF | _: Token.LFLF | _: Token.Comma |
+              _: Token.RightBrace if acc.processingFileImport =>
+            val newPath = Paths.get(acc.prefix).resolve(acc.current + ".sc")
+            val relative = file.toNIO.resolveSibling(newPath)
+            acc.allPaths.append(AbsolutePath(relative))
+            acc.current = ""
+            acc.skip = false
+            if (token.isInstanceOf[Token.RightBrace]) {
+              acc.insideBraces = false
+              acc.prefix = ""
+            }
+            if (!acc.insideBraces) {
+              acc.hadFile = false
+            }
+            if (token.isInstanceOf[Token.LF] || token
+                .isInstanceOf[Token.LFLF]) {
+              acc.hadImport = false
+            }
+          // if we are after => and haven't encountered `,`, `}` or newline
+          case other if acc.skip =>
+          // recognize $file import
+          case ident: Token.Ident if ident.pos.text == "$file" =>
+            acc.hadFile = true
+          // add another token to path
+          case ident: Token.Ident if acc.processingFileImport =>
+            val toAdd = if (ident.pos.text == "^") ".." else ident.pos.text
+            acc.current += (if (acc.current.nonEmpty) "/" + toAdd else toAdd)
+          // we don't care about anything after =>, which is jsut a rename
+          case _: Token.RightArrow =>
+            acc.skip = true
+          // open braces, we need to save the prefix
+          case _: Token.LeftBrace if acc.processingFileImport =>
+            acc.insideBraces = true
+            acc.prefix = acc.current
+            acc.current = ""
+          // don't care about anything else
+          case _ =>
+        }
+
+      }
+      acc.allPaths.toList
+    } catch {
+      case NonFatal(e) =>
+        Nil
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtDigest.scala
@@ -1,0 +1,17 @@
+package scala.meta.internal.builds
+
+import scala.meta.io.AbsolutePath
+import java.security.MessageDigest
+
+object SbtDigest extends Digestable {
+  override protected def digestWorkspace(
+      workspace: AbsolutePath,
+      digest: MessageDigest
+  ): Boolean = {
+    val project = workspace.resolve("project")
+    Digest.digestDirectory(workspace, digest) &&
+    Digest.digestFileBytes(project.resolve("build.properties"), digest) &&
+    Digest.digestDirectory(project, digest) &&
+    Digest.digestDirectory(project.resolve("project"), digest)
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -23,6 +23,7 @@ object Configs {
       new DidChangeWatchedFilesRegistrationOptions(
         List(
           new FileSystemWatcher(s"$root/*.sbt"),
+          new FileSystemWatcher(s"$root/*.sc"),
           new FileSystemWatcher(s"$root/*?.gradle"),
           new FileSystemWatcher(s"$root/*.gradle.kts"),
           new FileSystemWatcher(s"$root/project/*.{scala,sbt}"),

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -21,6 +21,7 @@ case class UserConfiguration(
     sbtScript: Option[String] = None,
     gradleScript: Option[String] = None,
     mavenScript: Option[String] = None,
+    millScript: Option[String] = None,
     scalafmtConfigPath: RelativePath =
       UserConfiguration.default.scalafmtConfigPath,
     symbolPrefixes: Map[String, String] =
@@ -70,6 +71,15 @@ object UserConfiguration {
       "maven script",
       """Optional absolute path to a `maven` executable to use for generating bloop config.
         |By default, Metals uses mvnw maven wrapper with 3.6.1 maven version. Update this setting if your `maven` script requires more customizations
+        |""".stripMargin
+    ),
+    UserConfigurationOption(
+      "mill-script",
+      """empty string `""`.""",
+      "/usr/local/bin/mill",
+      "mill script",
+      """Optional absolute path to a `mill` executable to use for running `mill mill.contrib.Bloop/install`.
+        |By default, Metals uses mill wrapper script with 0.4.0 mill version. Update this setting if your `mill` script requires more customizations
         |like using environment variables.
         |""".stripMargin
     ),
@@ -148,6 +158,8 @@ object UserConfiguration {
       getStringKey("gradle-script")
     val mavenScript =
       getStringKey("maven-script")
+    val millScript =
+      getStringKey("mill-script")
     val symbolPrefixes =
       getStringMap("symbol-prefixes")
         .getOrElse(default.symbolPrefixes)
@@ -162,6 +174,7 @@ object UserConfiguration {
           sbtScript,
           gradleScript,
           mavenScript,
+          millScript,
           scalafmtConfigPath,
           symbolPrefixes
         )

--- a/tests/slow/src/test/scala/tests/MillSlowSuite.scala
+++ b/tests/slow/src/test/scala/tests/MillSlowSuite.scala
@@ -1,0 +1,239 @@
+package tests
+import scala.meta.io.AbsolutePath
+import scala.meta.internal.builds.MillDigest
+import scala.meta.internal.metals.Messages._
+import scala.meta.internal.metals.ServerCommands
+import java.util.concurrent.TimeUnit
+import scala.meta.internal.metals.MetalsSlowTaskResult
+
+object MillSlowSuite extends BaseImportSuite("mill-import") {
+
+  override def currentDigest(
+      workspace: AbsolutePath
+  ): Option[String] = MillDigest.current(workspace)
+
+  testAsync("basic") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        """
+          |/build.sc
+          |import mill._, scalalib._
+          |object foo extends ScalaModule {
+          |  def scalaVersion = "2.12.8"
+          |}
+        """.stripMargin
+      )
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          // Project has no .bloop directory so user is asked to "import via bloop"
+          ImportBuild.params("mill").getMessage,
+          bloopInstallProgress("mill").message
+        ).mkString("\n")
+      )
+      _ = client.messageRequests.clear() // restart
+      _ = assertStatus(_.isInstalled)
+      _ <- server.didChange("build.sc")(_ + "\n// comment")
+      _ = assertNoDiff(client.workspaceMessageRequests, "")
+      _ <- server.didSave("build.sc")(identity)
+      // Comment changes do not trigger "re-import project" request
+      _ = assertNoDiff(client.workspaceMessageRequests, "")
+      _ <- server.didChange("build.sc") { text =>
+        text + """
+          |object bar extends ScalaModule {
+          |  def scalaVersion = "2.12.8"
+         |}
+        """
+      }
+      _ = assertNoDiff(client.workspaceMessageRequests, "")
+      _ <- server.didSave("build.sc")(identity)
+    } yield {
+      assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          // Project has .bloop directory so user is asked to "re-import project"
+          ImportBuildChanges.params("mill").getMessage,
+          bloopInstallProgress("mill").message
+        ).mkString("\n")
+      )
+    }
+  }
+
+  testAsync("force-command") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        """
+          |/build.sc
+          |import mill._, scalalib._
+          |object foo extends ScalaModule {
+          |  def scalaVersion = "2.12.8"
+          |}
+        """.stripMargin
+      )
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          // Project has no .bloop directory so user is asked to "import via bloop"
+          ImportBuild.params("mill").getMessage,
+          bloopInstallProgress("mill").message
+        ).mkString("\n")
+      )
+      _ = client.messageRequests.clear() // restart
+      _ <- server.executeCommand(ServerCommands.ImportBuild.id)
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          bloopInstallProgress("mill").message
+        ).mkString("\n")
+      )
+    } yield ()
+  }
+
+  testAsync("new-dependency") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        """
+          |/build.sc
+          |import mill._, scalalib._
+          |object foo extends ScalaModule {
+          |  def scalaVersion = "2.12.8"
+          |  def compileIvyDeps = Agg(
+          |    ivy"org.scala-lang:scala-reflect:${scalaVersion()}"
+          |  )
+          |  /*DEPS*/
+          |}
+          |/foo/src/reload/Main.scala
+          |package reload
+          |object Main extends App {
+          |  println("sourcecode.Line(42)")
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didOpen("foo/src/reload/Main.scala")
+      _ = assertNoDiff(client.workspaceDiagnostics, "")
+      _ <- server.didSave("build.sc") { text =>
+        text.replace(
+          "/*DEPS*/",
+          "def ivyDeps = Agg(ivy\"com.lihaoyi::sourcecode::0.1.4\")"
+        )
+      }
+      _ <- server
+        .didSave("foo/src/reload/Main.scala") { text =>
+          text.replaceAll("\"", "")
+        }
+        .recover { case e => scribe.error("compile", e) }
+      _ = assertNoDiff(client.workspaceDiagnostics, "")
+    } yield ()
+  }
+
+  testAsync("cancel") {
+    client.slowTaskHandler = params => {
+      if (params == bloopInstallProgress("mill")) {
+        Thread.sleep(TimeUnit.SECONDS.toMillis(2))
+        Some(MetalsSlowTaskResult(cancel = true))
+      } else {
+        None
+      }
+    }
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        """
+          |/build.sc
+          |import mill._, scalalib._
+          |object foo extends ScalaModule {
+          |  def scalaVersion = "2.12.8"
+          |  /*DIFF*/
+          |}
+        """.stripMargin,
+        expectError = true
+      )
+      _ = assertStatus(!_.isInstalled)
+      _ = client.slowTaskHandler = _ => None
+      _ <- server.didSave("build.sc")(_ + "\n// comment \n")
+      _ = assertNoDiff(client.workspaceShowMessages, "")
+      _ = assertStatus(!_.isInstalled)
+      _ <- server.didSave("build.sc") { text =>
+        val a = text.replace("/*DIFF*/", "def test = 123"); println(a); a
+      }
+      _ = assertNoDiff(client.workspaceShowMessages, "")
+      _ = assertStatus(_.isInstalled)
+    } yield ()
+  }
+
+  testAsync("error") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        """|/build.sc
+           |, syntax error
+           |""".stripMargin,
+        expectError = true
+      )
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          ImportBuild.params("mill").getMessage,
+          bloopInstallProgress("mill").message
+        ).mkString("\n")
+      )
+      _ = assertNoDiff(
+        client.workspaceShowMessages,
+        ImportProjectFailed.getMessage
+      )
+      _ = assertStatus(!_.isInstalled)
+      _ = client.messageRequests.clear()
+      _ <- server.didSave("build.sc") { _ =>
+        """
+          |import mill._, scalalib._
+          |object foo extends ScalaModule {
+          |  def scalaVersion = "2.12.8"
+          |}
+        """.stripMargin,
+      }
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          ImportBuild.params("mill").getMessage,
+          bloopInstallProgress("mill").message
+        ).mkString("\n")
+      )
+      _ = assertStatus(_.isInstalled)
+    } yield ()
+  }
+
+  testAsync("fatal-warnings") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        """
+          |/build.sc
+          |import mill._, scalalib._
+          |object foo extends ScalaModule {
+          |  def scalaVersion = "2.12.8"
+          |  def compileIvyDeps = Agg(
+          |    ivy"org.scala-lang:scala-reflect:${scalaVersion()}"
+          |  )
+          |  def scalacOptions = Seq("-Xfatal-warnings", "-Ywarn-unused")
+          |}
+          |/foo/src/Warning.scala
+          |import scala.concurrent.Future // unused
+          |object Warning
+          |""".stripMargin
+      )
+      _ = assertStatus(_.isInstalled)
+      _ <- server.didOpen("foo/src/Warning.scala")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """
+          |foo/src/Warning.scala:1:1: error: Unused import
+          |import scala.concurrent.Future // unused
+          |^^^^^^^
+        """.stripMargin
+      )
+    } yield ()
+  }
+}

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -169,7 +169,9 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
     def isSameMessage(
         createParams: String => ShowMessageRequestParams
     ): Boolean = {
-      Set("gradle", "sbt", "maven").map(createParams).exists(_ == params)
+      Set("gradle", "sbt", "maven", "mill")
+        .map(createParams)
+        .contains(params)
     }
     CompletableFuture.completedFuture {
       messageRequests.addLast(params.getMessage)

--- a/tests/unit/src/test/scala/tests/MillDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/MillDigestSuite.scala
@@ -1,0 +1,284 @@
+package tests
+
+import scala.meta.io.AbsolutePath
+import scala.meta.internal.builds.MillDigest
+
+object MillDigestSuite extends BaseDigestSuite {
+
+  override def digestCurrent(
+      root: AbsolutePath
+  ): Option[String] = MillDigest.current(root)
+
+  checkSame(
+    "solo-build.sc",
+    """
+      |/build.sc
+      |import mill._, scalalib._
+      |object foo extends ScalaModule {
+      |  def scalaVersion = "2.12.8"
+      |}
+    """.stripMargin,
+    """
+      |/build.sc
+      |import mill._, scalalib._
+      |object foo extends ScalaModule {
+      |  def scalaVersion = "2.12.8"
+      |}
+    """.stripMargin
+  )
+
+  checkSame(
+    "multiline-comment",
+    """
+      |/build.sc
+      |import mill._, scalalib._
+      |object foo extends ScalaModule {
+      |  def scalaVersion = "2.12.8"
+      |}
+    """.stripMargin,
+    """
+      |/build.sc
+      |import mill._, scalalib._
+      | /* This is a multi
+      | line comment */
+      |object foo extends ScalaModule {
+      |  def scalaVersion = "2.12.8"
+      |}
+    """.stripMargin
+  )
+
+  checkSame(
+    "comment",
+    """
+      |/build.sc
+      |import mill._, scalalib._
+      |object foo extends ScalaModule {
+      |  def scalaVersion = "2.12.8"
+      |}
+    """.stripMargin,
+    """
+      |/build.sc
+      |import mill._, scalalib._
+      | // thi sis a comment
+      |object foo extends ScalaModule {
+      |  def scalaVersion = "2.12.8"
+      |}
+    """.stripMargin
+  )
+
+  checkSame(
+    "whitespace",
+    """
+      |/build.sc
+      |import mill._, scalalib._
+      |object foo extends ScalaModule {
+      |  def scalaVersion = "2.12.8"
+      |}
+    """.stripMargin,
+    """
+      |/build.sc
+      |import mill._, scalalib._
+      | 
+      |object foo extends ScalaModule {
+      |  
+      | def scalaVersion =    "2.12.8"
+      |}
+    """.stripMargin
+  )
+
+  checkDiff(
+    "significant-tokens",
+    """
+      |/build.sc
+      |import mill._, scalalib._
+      |object foo extends ScalaModule {
+      |  def scalaVersion = "2.12.8"
+      |}
+    """.stripMargin,
+    """
+      |/build.sc
+      |import mill._, scalalib._
+      |object foo extends ScalaModule {
+      |  def scalaVersion = "2.12.7"
+      |}
+    """.stripMargin
+  )
+
+  def project(name: String) =
+    s"""
+       |import mill._, scalalib._
+       |object $name extends ScalaModule {
+       | def scalaVersion = "2.12.8"
+       |}
+      """.stripMargin
+
+  checkDiff(
+    "subproject",
+    s"""
+       |/build.sc
+       |import $$file.sub.other
+       |${project("foo")}
+       |/sub/other.sc
+       |${project("other")}
+    """.stripMargin,
+    s"""
+       |/build.sc
+       |import $$file.sub.other
+       |${project("foo")}
+       |/sub/other.sc
+       |${project("renamed")}
+    """.stripMargin
+  )
+
+  checkDiff(
+    "subproject-^",
+    s"""
+       |/build.sc
+       |import $$file.sub.^.sub.other
+       |${project("foo")}
+       |/sub/other.sc
+       |${project("other")}
+    """.stripMargin,
+    s"""
+       |/build.sc
+       |import $$file.sub.^.sub.other
+       |${project("foo")}
+       |/sub/other.sc
+       |${project("renamed")}
+    """.stripMargin
+  )
+
+  checkDiff(
+    "subproject-rename",
+    s"""
+       |/build.sc
+       |import $$file.sub.{other => EasierName}
+       |${project("foo")}
+       |/sub/other.sc
+       |${project("other")}
+    """.stripMargin,
+    s"""
+       |/build.sc
+       |import $$file.sub.{other => EasierName}
+       |${project("foo")}
+       |/sub/other.sc
+       |${project("renamed")}
+    """.stripMargin
+  )
+
+  checkDiff(
+    "multiple-subprojects",
+    s"""
+       |/build.sc
+       |import $$file.sub.other
+       |import $$file.sub.sub.other
+       |${project("foo")}
+       |/sub/other.sc
+       |${project("bar")}
+       |/sub/sub/other.sc
+       |${project("man")}
+    """.stripMargin,
+    s"""
+       |/build.sc
+       |import $$file.sub.other
+       |import $$file.sub.sub.other
+       |${project("foo")}
+       |/sub/other.sc
+       |${project("bar")}
+       |/sub/sub/other.sc
+       |${project("tender")}
+    """.stripMargin
+  )
+
+  checkDiff(
+    "line-import",
+    s"""
+       |/build.sc
+       |import $$file.sub.other, $$file.sub.sub.other
+       |${project("foo")}
+       |/sub/other.sc
+       |import mill._, scalalib._
+       |${project("bar")}
+       |/sub/sub/other.sc
+       |${project("man")}
+    """.stripMargin,
+    s"""
+       |/build.sc
+       |import $$file.sub.other, $$file.sub.sub.other
+       |${project("foo")}
+       |/sub/other.sc
+       |import mill._, scalalib._
+       |${project("bar")}
+       |/sub/sub/other.sc
+       |${project("tender")}
+    """.stripMargin
+  )
+
+  checkDiff(
+    "line-import-coma",
+    s"""
+       |/build.sc
+       |import mill._, scalalib._
+       |import $$file.sub1.{other, sub2.other}
+       |${project("foo")}
+       |/sub1/other.sc
+       |${project("bar")}
+       |/sub1/sub2/other.sc
+       |${project("man")}
+    """.stripMargin,
+    s"""
+       |/build.sc
+       |import mill._, scalalib._
+       |import $$file.sub1.{other, sub2.other}
+       |${project("foo")}
+       |/sub1/other.sc
+       |${project("bar")}
+       |/sub1/sub2/other.sc
+       |${project("tender")}
+    """.stripMargin
+  )
+
+  checkDiff(
+    "line-import-no-prefix",
+    s"""
+       |/build.sc
+       |import $$file.{other, sub2.other}
+       |${project("foo")}
+       |/other.sc
+       |${project("bar")}
+       |/sub2/other.sc
+       |${project("man")}
+    """.stripMargin,
+    s"""
+       |/build.sc
+       |import $$file.{other, sub2.other}
+       |${project("foo")}
+       |/other.sc
+       |${project("bar")}
+       |/sub2/other.sc
+       |${project("tender")}
+    """.stripMargin
+  )
+
+  checkDiff(
+    "line-import-coma-rename",
+    s"""
+       |/build.sc
+       |import $$file.sub1.{other => betterName, sub2.other}
+       |${project("foo")}
+       |/sub1/other.sc
+       |${project("bar")}
+       |/sub1/sub2/other.sc
+       |${project("man")}
+    """.stripMargin,
+    s"""
+       |/build.sc
+       |import $$file.sub1.{other => betterName, sub2.other}
+       |${project("foo")}
+       |/sub1/other.sc
+       |${project("bar")}
+       |/sub1/sub2/other.sc
+       |${project("tender")}
+    """.stripMargin
+  )
+}

--- a/tests/unit/src/test/scala/tests/RelatedSuite.scala
+++ b/tests/unit/src/test/scala/tests/RelatedSuite.scala
@@ -5,6 +5,7 @@ import scala.meta.internal.builds.SbtBuildTool
 import scala.meta.internal.io.PathIO
 import scala.meta.io.AbsolutePath
 import scala.meta.internal.builds.MavenBuildTool
+import scala.meta.internal.builds.MillBuildTool
 
 object RelatedSuite extends BaseSuite {
   private def addNot(flag: Boolean) =
@@ -75,4 +76,19 @@ object RelatedSuite extends BaseSuite {
   checkIsMavenRelated("a/b/c/pom.xml")
   checkIsNotMavenRelated("a/b/c/settings.xml")
   checkIsNotMavenRelated("other.xml")
+
+  /**------------ Mill ------------**/
+  def checkIsNotMillRelated(relpath: String): Unit = {
+    checkIsMillRelated(relpath, isTrue = false)
+  }
+  def checkIsMillRelated(relpath: String, isTrue: Boolean = true): Unit = {
+    test(s"is${addNot(isTrue)}MillRelated - $relpath") {
+      checkRelated(relpath, MillBuildTool.isMillRelatedPath, isTrue)
+    }
+  }
+  checkIsMillRelated("build.sc")
+  checkIsMillRelated("a/b/c/other.sc")
+  checkIsNotMillRelated("/ab/c/A.groovy")
+  checkIsNotMillRelated("/ab/c/A.kts")
+  checkIsNotMillRelated("/ab/c/A.scala")
 }


### PR DESCRIPTION
Previously mill builds would have to be imported manually via bloop and now we add automatic mill import to metals whenever the workspace is detected.

Also, moved build tools digest calculation to separate files.