### PR TITLE
Setup git hooks for scalafmt and scalafix.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -96,22 +96,21 @@ inThisBuild(
 )
 
 onLoad.in(Global) ~= { old =>
-  import java.nio.file._
-  val sh =
-    if (scala.util.Properties.isWin) "#!C:/Program\\ Files/Git/usr/bin/sh.exe"
-    else "#!/bin/sh"
-  val prePush = Paths.get(".git", "hooks", "pre-push")
-  Files.createDirectories(prePush.getParent)
-  Files.write(
-    prePush,
-    s"""$sh
-       |set -eux
-       |sbt -client 'all compile:scalafix test:scalafix'
-       |bin/scalafmt --diff
-       |git diff --exit-code
-       |""".stripMargin.getBytes()
-  )
-  prePush.toFile.setExecutable(true)
+  if (!scala.util.Properties.isWin) {
+    import java.nio.file._
+    val prePush = Paths.get(".git", "hooks", "pre-push")
+    Files.createDirectories(prePush.getParent)
+    Files.write(
+      prePush,
+      """#!/bin/sh
+        |set -eux
+        |sbt -client 'all compile:scalafix test:scalafix'
+        |bin/scalafmt --diff
+        |git diff --exit-code
+        |""".stripMargin.getBytes()
+    )
+    prePush.toFile.setExecutable(true)
+  }
   old
 }
 cancelable.in(Global) := true

--- a/build.sbt
+++ b/build.sbt
@@ -95,6 +95,25 @@ inThisBuild(
   )
 )
 
+onLoad.in(Global) ~= { old =>
+  import java.nio.file._
+  val sh =
+    if (scala.util.Properties.isWin) "#!C:/Program\\ Files/Git/usr/bin/sh.exe"
+    else "#!/bin/sh"
+  val prePush = Paths.get(".git", "hooks", "pre-push")
+  Files.createDirectories(prePush.getParent)
+  Files.write(
+    prePush,
+    s"""$sh
+       |set -eux
+       |sbt -client 'all compile:scalafix test:scalafix'
+       |bin/scalafmt --diff
+       |git diff --exit-code
+       |""".stripMargin.getBytes()
+  )
+  prePush.toFile.setExecutable(true)
+  old
+}
 cancelable.in(Global) := true
 crossScalaVersions := Nil
 

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -26,6 +26,13 @@ You will need the following applications installed:
 - `tests/slow` slow integration tests.
 - `test-workspace` demo project for manually testing Metals through an editor.
 
+## Git hooks
+
+This git repository has a pre-push hook to run Scalafmt and Scalafix.
+
+Pro tip: keep an sbt session open in a separate terminal when running `git
+push` in order to speed up the `sbt scalafix` pre-push hook.
+
 ## Related projects
 
 The improvement you are looking to contribute may belong in a separate


### PR DESCRIPTION
Previously, contributors needed to manually run scalafmt and scalafix
when opening pull requests in order to make the CI green. Now, we
automatically install git hooks so that scalafmt and scalafix are always
run before pushing a commit.

To speed up the `sbt scalafixAll` command, we use the experimental
`-client` flag which delegates the command to a running sbt server
instance if one exists. In my local experiments, this makes the pre-push
hooks run in ~5 seconds if the project is already compiled.

Related to #672