### PR TITLE
Update build tools overview

### DIFF
--- a/docs/build-tools/overview.md
+++ b/docs/build-tools/overview.md
@@ -11,9 +11,9 @@ functionality.
 | ---------- | :----------: | :-----------------------: |
 | sbt        |  Automatic   |            ✅             |
 | Bloop      |  Automatic   |  If configured correctly  |
-| Maven      |    Manual    |                           |
-| Gradle     |    Manual    |                           |
-| Mill       |    Manual    |                           |
+| Maven      |  Automatic   |                           |
+| Gradle     |  Automatic   |                           |
+| Mill       |  Automatic   |                           |
 
 ## Installation
 


### PR DESCRIPTION
to reflect changes made in https://github.com/scalameta/metals/pull/737, https://github.com/scalameta/metals/pull/722 and https://github.com/scalameta/metals/pull/694

Should we add specific pages per build tool ?