### PR TITLE
Fix names to be uppercase when needed

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
@@ -25,6 +25,9 @@ abstract class BuildTool {
   }
 
   def redirectErrorOutput: Boolean = false
+
+  def executableName: String
+
 }
 
 object BuildTool {

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -65,7 +65,7 @@ final class BuildTools(
   def all: List[String] = {
     val buf = List.newBuilder[String]
     if (isBloop) buf += "Bloop"
-    if (isSbt) buf += "Sbt"
+    if (isSbt) buf += "sbt"
     if (isMill) buf += "Mill"
     if (isGradle) buf += "Gradle"
     if (isMaven) buf += "Maven"

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -102,8 +102,6 @@ case class GradleBuildTool() extends BuildTool {
     AbsolutePath(out)
   }
 
-  override def toString: String = "gradle"
-
   override def digest(
       workspace: AbsolutePath
   ): Option[String] = GradleDigest.current(workspace)
@@ -134,6 +132,9 @@ case class GradleBuildTool() extends BuildTool {
 
   override def minimumVersion: String = "3.0.0"
 
+  override def toString: String = "Gradle"
+
+  def executableName = "gradle"
 }
 
 object GradleBuildTool {

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -53,7 +53,9 @@ case class MavenBuildTool() extends BuildTool {
 
   def version: String = "3.6.1"
 
-  override def toString(): String = "maven"
+  override def toString(): String = "Maven"
+
+  def executableName = "mvn"
 }
 
 object MavenBuildTool {

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -52,8 +52,9 @@ case class MillBuildTool() extends BuildTool {
 
   override def version: String = "0.4.0"
 
-  override def toString(): String = "mill"
+  override def toString(): String = "Mill"
 
+  def executableName = "mill"
 }
 
 object MillBuildTool {

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -8,8 +8,6 @@ import scala.meta.internal.metals.MetalsEnrichments._
 
 case class SbtBuildTool(version: String) extends BuildTool {
 
-  override def toString: String = "sbt"
-
   /**
    * Returns path to a local copy of sbt-launch.jar.
    *
@@ -80,6 +78,10 @@ case class SbtBuildTool(version: String) extends BuildTool {
       Files.write(destination.toNIO, bytes)
     }
   }
+
+  override def toString: String = "sbt"
+
+  def executableName = "sbt"
 }
 
 object SbtBuildTool {

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
@@ -84,15 +84,20 @@ final class BloopInstall(
     // VS Code versions the message is hidden after a delay.
     val taskResponse =
       languageClient.metalsSlowTask(
-        Messages.bloopInstallProgress(buildTool.toString())
+        Messages.bloopInstallProgress(buildTool.executableName)
       )
     handler.response = Some(taskResponse)
     val processFuture = handler.completeProcess.future.map { result =>
       taskResponse.cancel(false)
-      scribe.info(s"time: ran '$buildTool bloopInstall' in $elapsed")
+      scribe.info(
+        s"time: ran '${buildTool.executableName} bloopInstall' in $elapsed"
+      )
       result
     }
-    statusBar.trackFuture(s"Running $buildTool bloopInstall", processFuture)
+    statusBar.trackFuture(
+      s"Running ${buildTool.executableName} bloopInstall",
+      processFuture
+    )
     taskResponse.asScala.foreach { item =>
       if (item.cancel) {
         scribe.info("user cancelled build import")

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -26,8 +26,8 @@ class Messages(icons: Icons) {
       "See the logs for more details. "
   )
 
-  def bloopInstallProgress(buildToolName: String) =
-    MetalsSlowTaskParams(s"$buildToolName bloopInstall")
+  def bloopInstallProgress(buildToolExecName: String) =
+    MetalsSlowTaskParams(s"$buildToolExecName bloopInstall")
   def dontShowAgain: MessageActionItem =
     new MessageActionItem("Don't show again")
   def notNow: MessageActionItem =

--- a/tests/slow/src/test/scala/tests/BaseImportSuite.scala
+++ b/tests/slow/src/test/scala/tests/BaseImportSuite.scala
@@ -4,9 +4,20 @@ import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.meta.internal.builds.Digest
 import scala.meta.io.AbsolutePath
+import scala.meta.internal.builds.BuildTool
+import scala.meta.internal.metals.Messages._
 
 abstract class BaseImportSuite(suiteName: String)
     extends BaseSlowSuite(suiteName) {
+
+  def buildTool: BuildTool
+
+  def importBuildMessage = ImportBuild.params(buildTool.toString()).getMessage
+
+  def importBuildChangesMessage =
+    ImportBuildChanges.params(buildTool.toString()).getMessage
+
+  def progressMessage = bloopInstallProgress(buildTool.executableName).message
 
   def currentDigest(workspace: AbsolutePath): Option[String]
 

--- a/tests/slow/src/test/scala/tests/GradleSlowSuite.scala
+++ b/tests/slow/src/test/scala/tests/GradleSlowSuite.scala
@@ -7,8 +7,11 @@ import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.{BuildInfo => V}
 import scala.meta.io.AbsolutePath
+import scala.meta.internal.builds.GradleBuildTool
 
 object GradleSlowSuite extends BaseImportSuite("gradle-import") {
+
+  val buildTool = GradleBuildTool()
 
   override def currentDigest(
       workspace: AbsolutePath
@@ -34,8 +37,8 @@ object GradleSlowSuite extends BaseImportSuite("gradle-import") {
         client.workspaceMessageRequests,
         List(
           // Project has no .bloop directory so user is asked to "import via bloop"
-          ImportBuild.params("gradle").getMessage,
-          bloopInstallProgress("gradle").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = client.messageRequests.clear() // restart
@@ -55,8 +58,8 @@ object GradleSlowSuite extends BaseImportSuite("gradle-import") {
         client.workspaceMessageRequests,
         List(
           // Project has .bloop directory so user is asked to "re-import project"
-          ImportBuildChanges.params("gradle").getMessage,
-          bloopInstallProgress("gradle").message
+          importBuildChangesMessage,
+          progressMessage
         ).mkString("\n")
       )
     }
@@ -82,8 +85,8 @@ object GradleSlowSuite extends BaseImportSuite("gradle-import") {
         client.workspaceMessageRequests,
         List(
           // Project has no .bloop directory so user is asked to "import via bloop"
-          ImportBuild.params("gradle").getMessage,
-          bloopInstallProgress("gradle").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = client.messageRequests.clear()
@@ -111,8 +114,8 @@ object GradleSlowSuite extends BaseImportSuite("gradle-import") {
         client.workspaceMessageRequests,
         List(
           // Project has no .bloop directory so user is asked to "import via bloop"
-          ImportBuild.params("gradle").getMessage,
-          bloopInstallProgress("gradle").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = client.messageRequests.clear() // restart
@@ -120,7 +123,7 @@ object GradleSlowSuite extends BaseImportSuite("gradle-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          bloopInstallProgress("gradle").message
+          progressMessage
         ).mkString("\n")
       )
     } yield ()
@@ -177,8 +180,8 @@ object GradleSlowSuite extends BaseImportSuite("gradle-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          ImportBuild.params("gradle").getMessage,
-          bloopInstallProgress("gradle").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = assertNoDiff(
@@ -202,8 +205,8 @@ object GradleSlowSuite extends BaseImportSuite("gradle-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          ImportBuild.params("gradle").getMessage,
-          bloopInstallProgress("gradle").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = assertStatus(_.isInstalled)

--- a/tests/slow/src/test/scala/tests/MavenSlowSuite.scala
+++ b/tests/slow/src/test/scala/tests/MavenSlowSuite.scala
@@ -6,8 +6,11 @@ import scala.meta.internal.builds.MavenDigest
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.io.InputStreamIO
 import java.nio.charset.StandardCharsets
+import scala.meta.internal.builds.MavenBuildTool
 
 object MavenSlowSuite extends BaseImportSuite("maven-import") {
+
+  val buildTool = MavenBuildTool()
 
   val defaultPom = new String(
     InputStreamIO.readBytes(
@@ -31,8 +34,8 @@ object MavenSlowSuite extends BaseImportSuite("maven-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          ImportBuild.params("maven").getMessage,
-          bloopInstallProgress("maven").message,
+          importBuildMessage,
+          progressMessage,
           // we don't have semanticDB plugin yet
           CheckDoctor.allProjectsMisconfigured
         ).mkString("\n")
@@ -58,8 +61,8 @@ object MavenSlowSuite extends BaseImportSuite("maven-import") {
         client.workspaceMessageRequests,
         List(
           // Project has .bloop directory so user is asked to "re-import project"
-          ImportBuildChanges.params("maven").getMessage,
-          bloopInstallProgress("maven").message
+          importBuildChangesMessage,
+          progressMessage
         ).mkString("\n")
       )
     }
@@ -76,8 +79,8 @@ object MavenSlowSuite extends BaseImportSuite("maven-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          ImportBuild.params("maven").getMessage,
-          bloopInstallProgress("maven").message,
+          importBuildMessage,
+          progressMessage,
           // we don't have semanticDB plugin yet
           CheckDoctor.allProjectsMisconfigured
         ).mkString("\n")
@@ -87,7 +90,7 @@ object MavenSlowSuite extends BaseImportSuite("maven-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          bloopInstallProgress("maven").message
+          progressMessage
         ).mkString("\n")
       )
     } yield ()
@@ -151,8 +154,8 @@ object MavenSlowSuite extends BaseImportSuite("maven-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          ImportBuild.params("maven").getMessage,
-          bloopInstallProgress("maven").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = assertNoDiff(
@@ -165,8 +168,8 @@ object MavenSlowSuite extends BaseImportSuite("maven-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          ImportBuild.params("maven").getMessage,
-          bloopInstallProgress("maven").message,
+          importBuildMessage,
+          progressMessage,
           // we don't have semanticDB plugin yet
           CheckDoctor.allProjectsMisconfigured
         ).mkString("\n")

--- a/tests/slow/src/test/scala/tests/MillSlowSuite.scala
+++ b/tests/slow/src/test/scala/tests/MillSlowSuite.scala
@@ -5,8 +5,11 @@ import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.ServerCommands
 import java.util.concurrent.TimeUnit
 import scala.meta.internal.metals.MetalsSlowTaskResult
+import scala.meta.internal.builds.MillBuildTool
 
 object MillSlowSuite extends BaseImportSuite("mill-import") {
+
+  val buildTool = MillBuildTool()
 
   override def currentDigest(
       workspace: AbsolutePath
@@ -28,8 +31,8 @@ object MillSlowSuite extends BaseImportSuite("mill-import") {
         client.workspaceMessageRequests,
         List(
           // Project has no .bloop directory so user is asked to "import via bloop"
-          ImportBuild.params("mill").getMessage,
-          bloopInstallProgress("mill").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = client.messageRequests.clear() // restart
@@ -53,8 +56,8 @@ object MillSlowSuite extends BaseImportSuite("mill-import") {
         client.workspaceMessageRequests,
         List(
           // Project has .bloop directory so user is asked to "re-import project"
-          ImportBuildChanges.params("mill").getMessage,
-          bloopInstallProgress("mill").message
+          importBuildChangesMessage,
+          progressMessage
         ).mkString("\n")
       )
     }
@@ -76,8 +79,8 @@ object MillSlowSuite extends BaseImportSuite("mill-import") {
         client.workspaceMessageRequests,
         List(
           // Project has no .bloop directory so user is asked to "import via bloop"
-          ImportBuild.params("mill").getMessage,
-          bloopInstallProgress("mill").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = client.messageRequests.clear() // restart
@@ -85,7 +88,7 @@ object MillSlowSuite extends BaseImportSuite("mill-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          bloopInstallProgress("mill").message
+          progressMessage
         ).mkString("\n")
       )
     } yield ()
@@ -176,8 +179,8 @@ object MillSlowSuite extends BaseImportSuite("mill-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          ImportBuild.params("mill").getMessage,
-          bloopInstallProgress("mill").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = assertNoDiff(
@@ -197,8 +200,8 @@ object MillSlowSuite extends BaseImportSuite("mill-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          ImportBuild.params("mill").getMessage,
-          bloopInstallProgress("mill").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = assertStatus(_.isInstalled)

--- a/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
+++ b/tests/slow/src/test/scala/tests/SbtSlowSuite.scala
@@ -16,6 +16,8 @@ import scala.meta.io.AbsolutePath
 
 object SbtSlowSuite extends BaseImportSuite("sbt-import") {
 
+  val buildTool = SbtBuildTool("")
+
   override def currentDigest(
       workspace: AbsolutePath
   ): Option[String] = SbtDigest.current(workspace)
@@ -34,8 +36,8 @@ object SbtSlowSuite extends BaseImportSuite("sbt-import") {
         client.workspaceMessageRequests,
         List(
           // Project has no .bloop directory so user is asked to "import via bloop"
-          ImportBuild.params("sbt").getMessage,
-          bloopInstallProgress("sbt").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = client.messageRequests.clear() // restart
@@ -55,8 +57,8 @@ object SbtSlowSuite extends BaseImportSuite("sbt-import") {
         client.workspaceMessageRequests,
         List(
           // Project has .bloop directory so user is asked to "re-import project"
-          ImportBuildChanges.params("sbt").getMessage,
-          bloopInstallProgress("sbt").message
+          importBuildChangesMessage,
+          progressMessage
         ).mkString("\n")
       )
     }
@@ -76,8 +78,8 @@ object SbtSlowSuite extends BaseImportSuite("sbt-import") {
         client.workspaceMessageRequests,
         List(
           // Project has no .bloop directory so user is asked to "import via bloop"
-          ImportBuild.params("sbt").getMessage,
-          bloopInstallProgress("sbt").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = client.messageRequests.clear() // restart
@@ -85,7 +87,7 @@ object SbtSlowSuite extends BaseImportSuite("sbt-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          bloopInstallProgress("sbt").message
+          progressMessage
         ).mkString("\n")
       )
     } yield ()
@@ -167,8 +169,8 @@ object SbtSlowSuite extends BaseImportSuite("sbt-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          ImportBuild.params("sbt").getMessage,
-          bloopInstallProgress("sbt").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = assertNoDiff(
@@ -183,8 +185,8 @@ object SbtSlowSuite extends BaseImportSuite("sbt-import") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          ImportBuild.params("sbt").getMessage,
-          bloopInstallProgress("sbt").message
+          importBuildMessage,
+          progressMessage
         ).mkString("\n")
       )
       _ = assertStatus(_.isInstalled)

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -29,6 +29,10 @@ import scala.meta.io.AbsolutePath
 import tests.MetalsTestEnrichments._
 import tests.TestOrderings._
 import scala.meta.inputs.Input
+import scala.meta.internal.builds.GradleBuildTool
+import scala.meta.internal.builds.SbtBuildTool
+import scala.meta.internal.builds.MavenBuildTool
+import scala.meta.internal.builds.MillBuildTool
 
 /**
  * Fake LSP client that responds to notifications/requests initiated by the server.
@@ -169,8 +173,12 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
     def isSameMessage(
         createParams: String => ShowMessageRequestParams
     ): Boolean = {
-      Set("gradle", "sbt", "maven", "mill")
-        .map(createParams)
+      Set(
+        GradleBuildTool(),
+        SbtBuildTool(""),
+        MavenBuildTool(),
+        MillBuildTool()
+      ).map(tool => createParams(tool.toString()))
         .contains(params)
     }
     CompletableFuture.completedFuture {


### PR DESCRIPTION
Previously tool names and executable names were not differentiated, now we make sure they are correctly written.

I think this is the last PR I want to merge before release.