### PR TITLE
Avoid inifinite loop when shortening types, fixes #749.

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
@@ -167,95 +167,103 @@ class MetalsGlobal(
    * making sure to not convert two different symbols into same short name.
    */
   def shortType(longType: Type, history: ShortenedNames): Type = {
-    def loop(tpe: Type, name: Option[ShortName]): Type = tpe match {
-      case TypeRef(pre, sym, args) =>
-        val ownerSymbol = pre.termSymbol
-        history.config.get(ownerSymbol) match {
-          case Some(rename)
-              if history.tryShortenName(ShortName(rename, ownerSymbol)) =>
-            TypeRef(
-              new PrettyType(rename.toString),
-              sym,
-              args.map(arg => loop(arg, None))
-            )
-          case _ =>
-            history.renames.get(sym) match {
-              case Some(rename) if history.nameResolvesToSymbol(rename, sym) =>
-                TypeRef(
-                  NoPrefix,
-                  sym.newErrorSymbol(rename),
-                  args.map(arg => loop(arg, None))
-                )
-              case _ =>
-                if (sym.isAliasType &&
-                  (sym.isAbstract ||
-                  sym.overrides.lastOption.exists(_.isAbstract))) {
-                  // Always dealias abstract type aliases but leave concrete aliases alone.
-                  // trait Generic { type Repr /* dealias */ }
-                  // type Catcher[T] = PartialFunction[Throwable, T] // no dealias
-                  loop(tpe.dealias, name)
-                } else if (history.owners(pre.typeSymbol)) {
-                  if (history.nameResolvesToSymbol(sym.name, sym)) {
-                    TypeRef(NoPrefix, sym, args.map(arg => loop(arg, None)))
+    val isVisited = mutable.Set.empty[(Type, Option[ShortName])]
+    def loop(tpe: Type, name: Option[ShortName]): Type = {
+      // NOTE(olafur) Prevent infinite recursion, see https://github.com/scalameta/metals/issues/749
+      if (isVisited(tpe -> name)) return tpe
+      isVisited += (tpe -> name)
+      tpe match {
+        case TypeRef(pre, sym, args) =>
+          val ownerSymbol = pre.termSymbol
+          history.config.get(ownerSymbol) match {
+            case Some(rename)
+                if history.tryShortenName(ShortName(rename, ownerSymbol)) =>
+              TypeRef(
+                new PrettyType(rename.toString),
+                sym,
+                args.map(arg => loop(arg, None))
+              )
+            case _ =>
+              history.renames.get(sym) match {
+                case Some(rename)
+                    if history.nameResolvesToSymbol(rename, sym) =>
+                  TypeRef(
+                    NoPrefix,
+                    sym.newErrorSymbol(rename),
+                    args.map(arg => loop(arg, None))
+                  )
+                case _ =>
+                  if (sym.isAliasType &&
+                    (sym.isAbstract ||
+                    sym.overrides.lastOption.exists(_.isAbstract))) {
+
+                    // Always dealias abstract type aliases but leave concrete aliases alone.
+                    // trait Generic { type Repr /* dealias */ }
+                    // type Catcher[T] = PartialFunction[Throwable, T] // no dealias
+                    loop(tpe.dealias, name)
+                  } else if (history.owners(pre.typeSymbol)) {
+                    if (history.nameResolvesToSymbol(sym.name, sym)) {
+                      TypeRef(NoPrefix, sym, args.map(arg => loop(arg, None)))
+                    } else {
+                      TypeRef(
+                        ThisType(pre.typeSymbol),
+                        sym,
+                        args.map(arg => loop(arg, None))
+                      )
+                    }
                   } else {
                     TypeRef(
-                      ThisType(pre.typeSymbol),
+                      loop(pre, Some(ShortName(sym))),
                       sym,
                       args.map(arg => loop(arg, None))
                     )
                   }
-                } else {
-                  TypeRef(
-                    loop(pre, Some(ShortName(sym))),
-                    sym,
-                    args.map(arg => loop(arg, None))
-                  )
-                }
-            }
-        }
-      case SingleType(pre, sym) =>
-        if (sym.hasPackageFlag) {
-          if (history.tryShortenName(name)) NoPrefix
-          else tpe
-        } else {
-          pre match {
-            case ThisType(psym) if history.nameResolvesToSymbol(psym) =>
-              SingleType(NoPrefix, sym)
-            case _ =>
-              SingleType(loop(pre, Some(ShortName(sym))), sym)
+              }
           }
-        }
-      case ThisType(sym) =>
-        if (sym.hasPackageFlag) {
-          if (history.tryShortenName(name)) NoPrefix
-          else new PrettyType(history.fullname(sym))
-        } else {
-          TypeRef(NoPrefix, sym, Nil)
-        }
-      case ConstantType(Constant(sym: TermSymbol))
-          if sym.hasFlag(gf.JAVA_ENUM) =>
-        loop(SingleType(sym.owner.thisPrefix, sym), None)
-      case ConstantType(Constant(tpe: Type)) =>
-        ConstantType(Constant(loop(tpe, None)))
-      case SuperType(thistpe, supertpe) =>
-        SuperType(loop(thistpe, None), loop(supertpe, None))
-      case RefinedType(parents, decls) =>
-        RefinedType(parents.map(parent => loop(parent, None)), decls)
-      case AnnotatedType(annotations, underlying) =>
-        AnnotatedType(annotations, loop(underlying, None))
-      case ExistentialType(quantified, underlying) =>
-        ExistentialType(quantified, loop(underlying, None))
-      case PolyType(tparams, resultType) =>
-        PolyType(tparams, resultType.map(t => loop(t, None)))
-      case NullaryMethodType(resultType) =>
-        loop(resultType, None)
-      case TypeBounds(lo, hi) =>
-        TypeBounds(loop(lo, None), loop(hi, None))
-      case MethodType(params, resultType) =>
-        MethodType(params, loop(resultType, None))
-      case ErrorType =>
-        definitions.AnyTpe
-      case t => t
+        case SingleType(pre, sym) =>
+          if (sym.hasPackageFlag) {
+            if (history.tryShortenName(name)) NoPrefix
+            else tpe
+          } else {
+            pre match {
+              case ThisType(psym) if history.nameResolvesToSymbol(psym) =>
+                SingleType(NoPrefix, sym)
+              case _ =>
+                SingleType(loop(pre, Some(ShortName(sym))), sym)
+            }
+          }
+        case ThisType(sym) =>
+          if (sym.hasPackageFlag) {
+            if (history.tryShortenName(name)) NoPrefix
+            else new PrettyType(history.fullname(sym))
+          } else {
+            TypeRef(NoPrefix, sym, Nil)
+          }
+        case ConstantType(Constant(sym: TermSymbol))
+            if sym.hasFlag(gf.JAVA_ENUM) =>
+          loop(SingleType(sym.owner.thisPrefix, sym), None)
+        case ConstantType(Constant(tpe: Type)) =>
+          ConstantType(Constant(loop(tpe, None)))
+        case SuperType(thistpe, supertpe) =>
+          SuperType(loop(thistpe, None), loop(supertpe, None))
+        case RefinedType(parents, decls) =>
+          RefinedType(parents.map(parent => loop(parent, None)), decls)
+        case AnnotatedType(annotations, underlying) =>
+          AnnotatedType(annotations, loop(underlying, None))
+        case ExistentialType(quantified, underlying) =>
+          ExistentialType(quantified, loop(underlying, None))
+        case PolyType(tparams, resultType) =>
+          PolyType(tparams, resultType.map(t => loop(t, None)))
+        case NullaryMethodType(resultType) =>
+          loop(resultType, None)
+        case TypeBounds(lo, hi) =>
+          TypeBounds(loop(lo, None), loop(hi, None))
+        case MethodType(params, resultType) =>
+          MethodType(params, loop(resultType, None))
+        case ErrorType =>
+          definitions.AnyTpe
+        case t => t
+      }
     }
 
     longType match {

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -20,4 +20,22 @@ object CompletionIssueSuite extends BaseCompletionSuite {
     """.stripMargin,
     ""
   )
+
+  check(
+    "issue-749",
+    """package a
+      |trait Observable[+A] {
+      |  type Self[+T] <: Observable[T]
+      |}
+      |trait EventStream[+A] extends Observable[A] {
+      |  override type Self[+T] = EventStream[T]
+      |}
+      |class Main {
+      |  val stream: EventStream[Int] = ???
+      |  stream.@@
+      |}
+      |""".stripMargin,
+    "Self[+T] = Main.this.stream.Self",
+    topLines = Some(1)
+  )
 }


### PR DESCRIPTION
Previously, triggering completions on a type that had recursive type
aliases would make Metals get stuck in an infinite loop. Now, we prevent
infinite loops by adding a cache to what types we have tried to shorten.