### PR TITLE
Factor out a ClasspathLoader.getURLs(classLoader) helper for java9+ compatability, update usages

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -180,9 +180,18 @@ object Embedded {
           )
         )
       )
+
+    // java9+ compatability
+    val parent: ClassLoader = try {
+      val parentClassLoaderMethod =
+        classOf[ClassLoader].getMethod("getPlatformClassLoader")
+      parentClassLoaderMethod.invoke(null).asInstanceOf[ClassLoader]
+    } catch {
+      case _: NoSuchMethodException => null
+    }
+
     val jars = CoursierSmall.fetch(settings)
-    // Don't make Bloop classloader a child or our classloader.
-    val parent: ClassLoader = null
+    // Don't make Bloop classloader a child of our classloader.
     val classloader =
       new URLClassLoader(jars.iterator.map(_.toUri.toURL).toArray, parent)
     classloader

--- a/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
@@ -5,13 +5,13 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
-import java.net.URLClassLoader
 import java.nio.file.Paths
 import java.util
 import java.util.jar.JarFile
 import java.util.logging.Level
 import java.util.logging.Logger
 import scala.meta.internal.io.PathIO
+import scala.meta.internal.mtags.ClasspathLoader
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.io.AbsolutePath
 import scala.meta.io.Classpath
@@ -133,9 +133,7 @@ object PackageIndex {
     } yield entry
 
   def scalaLibrary: Seq[Path] = {
-    this.getClass.getClassLoader
-      .asInstanceOf[URLClassLoader]
-      .getURLs
+    ClasspathLoader.getURLs(this.getClass.getClassLoader)
       .iterator
       .filter(_.getPath.contains("scala-library"))
       .map(url => Paths.get(url.toURI))

--- a/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
@@ -133,7 +133,8 @@ object PackageIndex {
     } yield entry
 
   def scalaLibrary: Seq[Path] = {
-    ClasspathLoader.getURLs(this.getClass.getClassLoader)
+    ClasspathLoader
+      .getURLs(this.getClass.getClassLoader)
       .iterator
       .filter(_.getPath.contains("scala-library"))
       .map(url => Paths.get(url.toURI))

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ClasspathLoader.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ClasspathLoader.scala
@@ -9,6 +9,7 @@ import scala.meta.io.RelativePath
 import sun.misc.Unsafe
 
 object ClasspathLoader {
+
   /**
    * Utility to get SystemClassLoader/ClassLoader urls in java8 and java9+
    *   Based upon: https://gist.github.com/hengyunabc/644f8e84908b7b405c532a51d8e34ba9
@@ -17,7 +18,10 @@ object ClasspathLoader {
     if (classLoader.isInstanceOf[URLClassLoader]) {
       classLoader.asInstanceOf[URLClassLoader].getURLs()
       // java9+
-    } else if (classLoader.getClass().getName().startsWith("jdk.internal.loader.ClassLoaders$")) {
+    } else if (classLoader
+        .getClass()
+        .getName()
+        .startsWith("jdk.internal.loader.ClassLoaders$")) {
       try {
         val field = classOf[Unsafe].getDeclaredField("theUnsafe")
         field.setAccessible(true)
@@ -31,7 +35,10 @@ object ClasspathLoader {
         // jdk.internal.loader.URLClassPath.path
         val pathField = ucpField.getType().getDeclaredField("path")
         val pathFieldOffset = unsafe.objectFieldOffset(pathField)
-        val paths: Seq[URL] = unsafe.getObject(ucpObject, pathFieldOffset).asInstanceOf[util.ArrayList[URL]].asScala
+        val paths: Seq[URL] = unsafe
+          .getObject(ucpObject, pathFieldOffset)
+          .asInstanceOf[util.ArrayList[URL]]
+          .asScala
 
         paths
       } catch {

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ClasspathLoader.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ClasspathLoader.scala
@@ -1,8 +1,49 @@
 package scala.meta.internal.mtags
 
+import java.net.{URL, URLClassLoader}
+import java.util
+import scala.collection.JavaConverters._
 import scala.meta.io.AbsolutePath
 import scala.meta.io.Classpath
 import scala.meta.io.RelativePath
+import sun.misc.Unsafe
+
+object ClasspathLoader {
+  /**
+   * Utility to get SystemClassLoader/ClassLoader urls in java8 and java9+
+   *   Based upon: https://gist.github.com/hengyunabc/644f8e84908b7b405c532a51d8e34ba9
+   */
+  def getURLs(classLoader: ClassLoader): Seq[URL] = {
+    if (classLoader.isInstanceOf[URLClassLoader]) {
+      classLoader.asInstanceOf[URLClassLoader].getURLs()
+      // java9+
+    } else if (classLoader.getClass().getName().startsWith("jdk.internal.loader.ClassLoaders$")) {
+      try {
+        val field = classOf[Unsafe].getDeclaredField("theUnsafe")
+        field.setAccessible(true)
+        val unsafe = field.get(null).asInstanceOf[Unsafe]
+
+        // jdk.internal.loader.ClassLoaders.AppClassLoader.ucp
+        val ucpField = classLoader.getClass().getDeclaredField("ucp")
+        val ucpFieldOffset: Long = unsafe.objectFieldOffset(ucpField)
+        val ucpObject = unsafe.getObject(classLoader, ucpFieldOffset)
+
+        // jdk.internal.loader.URLClassPath.path
+        val pathField = ucpField.getType().getDeclaredField("path")
+        val pathFieldOffset = unsafe.objectFieldOffset(pathField)
+        val paths: Seq[URL] = unsafe.getObject(ucpObject, pathFieldOffset).asInstanceOf[util.ArrayList[URL]].asScala
+
+        paths
+      } catch {
+        case ex: Exception =>
+          ex.printStackTrace()
+          Nil
+      }
+    } else {
+      Nil
+    }
+  }
+}
 
 /**
  * Utility to load relative paths from a classpath.

--- a/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
@@ -213,7 +213,8 @@ final case class OnDemandSymbolIndex(
     val noExtension = toplevel.value.stripSuffix(".").stripSuffix("#")
     List(
       noExtension + ".scala",
-      noExtension + ".java"
+      noExtension + ".java",
+      "java.base/" + noExtension + ".java" // For Java 11.
     )
   }
 

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -3,7 +3,6 @@ package tests
 import com.geirsson.coursiersmall.CoursierSmall
 import com.geirsson.coursiersmall.Dependency
 import com.geirsson.coursiersmall.Settings
-import java.net.URLClassLoader
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
@@ -16,6 +15,7 @@ import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.metals.Docstrings
 import scala.meta.internal.metals.RecursivelyDelete
 import scala.meta.internal.mtags.OnDemandSymbolIndex
+import scala.meta.internal.mtags.ClasspathLoader
 import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.internal.pc.ScalaPresentationCompiler
 import scala.meta.internal.metals.PackageIndex
@@ -28,7 +28,8 @@ import java.util.concurrent.ScheduledExecutorService
 
 abstract class BasePCSuite extends BaseSuite {
   def thisClasspath: Seq[Path] =
-    ClasspathLoader.getURLs(this.getClass.getClassLoader)
+    ClasspathLoader
+      .getURLs(this.getClass.getClassLoader)
       .map(url => Paths.get(url.toURI))
   val scalaLibrary: Seq[Path] = PackageIndex.scalaLibrary
   def extraClasspath: Seq[Path] = Nil

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -28,9 +28,7 @@ import java.util.concurrent.ScheduledExecutorService
 
 abstract class BasePCSuite extends BaseSuite {
   def thisClasspath: Seq[Path] =
-    this.getClass.getClassLoader
-      .asInstanceOf[URLClassLoader]
-      .getURLs
+    ClasspathLoader.getURLs(this.getClass.getClassLoader)
       .map(url => Paths.get(url.toURI))
   val scalaLibrary: Seq[Path] = PackageIndex.scalaLibrary
   def extraClasspath: Seq[Path] = Nil

--- a/tests/cross/src/test/scala/tests/pc/HKSignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/HKSignatureHelpSuite.scala
@@ -7,9 +7,7 @@ import tests.BaseSignatureHelpSuite
 
 object HKSignatureHelpSuite extends BaseSignatureHelpSuite {
   override def extraClasspath: List[Path] =
-    this.getClass.getClassLoader
-      .asInstanceOf[URLClassLoader]
-      .getURLs
+    ClasspathLoader.getURLs(this.getClass.getClassLoader)
       .map(url => Paths.get(url.toURI))
       .toList
 

--- a/tests/cross/src/test/scala/tests/pc/HKSignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/HKSignatureHelpSuite.scala
@@ -1,13 +1,14 @@
 package tests.pc
 
-import java.net.URLClassLoader
 import java.nio.file.Path
 import java.nio.file.Paths
 import tests.BaseSignatureHelpSuite
+import scala.meta.internal.mtags.ClasspathLoader
 
 object HKSignatureHelpSuite extends BaseSignatureHelpSuite {
   override def extraClasspath: List[Path] =
-    ClasspathLoader.getURLs(this.getClass.getClassLoader)
+    ClasspathLoader
+      .getURLs(this.getClass.getClassLoader)
       .map(url => Paths.get(url.toURI))
       .toList
 

--- a/tests/unit/src/main/scala/bill/Bill.scala
+++ b/tests/unit/src/main/scala/bill/Bill.scala
@@ -10,7 +10,6 @@ import java.io.File
 import java.io.PrintStream
 import java.io.PrintWriter
 import java.net.URI
-import java.net.URLClassLoader
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
@@ -25,7 +24,7 @@ import org.eclipse.lsp4j.jsonrpc.Launcher
 import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.Future
-import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.{BuildInfo, MetalsLogger, RecursivelyDelete}
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.PositionSyntax._
 import scala.reflect.internal.util.BatchSourceFile
@@ -38,8 +37,7 @@ import scala.util.Properties
 import scala.util.control.NonFatal
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
-import scala.meta.internal.metals.MetalsLogger
-import scala.meta.internal.metals.RecursivelyDelete
+import scala.meta.internal.mtags.ClasspathLoader
 import scala.meta.io.AbsolutePath
 
 /**
@@ -331,10 +329,10 @@ object Bill {
     ): CompletableFuture[ScalaMainClassesResult] = ???
   }
 
-  def myClassLoader: URLClassLoader =
-    this.getClass.getClassLoader.asInstanceOf[URLClassLoader]
-  def myClasspath: Iterator[Path] =
-    myClassLoader.getURLs.iterator
+  def myClassLoader: ClassLoader =
+    this.getClass.getClassLoader
+  def myClasspath: Seq[Path] =
+    ClasspathLoader.getURLs(myClassLoader)
       .map(url => Paths.get(url.toURI))
 
   def cwd: Path = Paths.get(System.getProperty("user.dir"))

--- a/tests/unit/src/main/scala/bill/Bill.scala
+++ b/tests/unit/src/main/scala/bill/Bill.scala
@@ -332,7 +332,8 @@ object Bill {
   def myClassLoader: ClassLoader =
     this.getClass.getClassLoader
   def myClasspath: Seq[Path] =
-    ClasspathLoader.getURLs(myClassLoader)
+    ClasspathLoader
+      .getURLs(myClassLoader)
       .map(url => Paths.get(url.toURI))
 
   def cwd: Path = Paths.get(System.getProperty("user.dir"))

--- a/tests/unit/src/main/scala/tests/BaseExpectSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseExpectSuite.scala
@@ -20,7 +20,8 @@ abstract class BaseExpectSuite(val suiteName: String) extends BaseSuite {
         }
         .getOrElse(Classpath(Nil))
     GlobalSymbolTable(
-      input.classpath ++ bootClasspath
+      input.classpath ++ bootClasspath,
+      includeJdk = true
     )
   }
   final lazy val sourceroot: AbsolutePath =


### PR DESCRIPTION
This updates https://github.com/scalameta/metals/pull/739, tests still fail on java11, but no longer from  `Caused by: java.lang.NoClassDefFoundError: javax/tools/ToolProvider`



```
sbt:default-40f014> unit/testOnly -- tests.DocumentHighlightSlowSuite.single
[info] Compiling 1 Scala source to /c/Users/Eric Peters/IdeaProjects/metals/metals/target/scala-2.12/classes ...
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil (file:/c/Users/Eric%20Peters/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalameta/semanticdb-scalac_2.12.8/4.1.9/semanticdb-scalac_2.12.8-4.1.9.jar) to field java.nio.Buffer.address
WARNING: Please consider reporting this to the maintainers of com.google.protobuf.UnsafeUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[info] Done compiling.
------------ Running Tests tests.DocumentHighlightSlowSuite.single ------------
------------ Running Tests tests.DocumentHighlightSlowSuite.single ------------
INFO  tests.TestingServer#initialize
INFO  time: generated quick build in 1.3s
INFO  logging to file /c/Users/Eric Peters/IdeaProjects/metals/tests/unit/target/e2e/documentHighlight/single/.metals/metals.log
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil (file:/c/Users/Eric%20Peters/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalameta/semanticdb-scalac_2.12.8/4.1.9/semanticdb-scalac_2.12.8-4.1.9.jar) to field java.nio.Buffer.address
WARNING: Please consider reporting this to the maintainers of com.google.protobuf.UnsafeUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
INFO  time: initialize in 0.28s
INFO  running embedded 'bloop bsp --protocol local --socket /tmp/bsp13549952426963183349/-9uxbm22vm0b.socket'
The server is listening for incoming connections at local:///tmp/bsp13549952426963183349/-9uxbm22vm0b.socket...
Accepted incoming BSP client connection at local:///tmp/bsp13549952426963183349/-9uxbm22vm0b.socket
INFO  tracing is disabled for protocol BSP, to enable tracing of incoming and outgoing JSON messages create an empty file at /c/Users/Eric Peters/.cache/metals/bsp.trace.json
request received: build/initialize
INFO  time: connected to build server in 3.55s
BSP initialization handshake complete.
INFO  time: indexed workspace in 0.53s
WARN  no build target:
INFO  tests.TestingServer#didOpen
INFO  tests.TestingServer#didChange
+ tests.DocumentHighlightSlowSuite.single 8959ms
shutdown request received: build/shutdown
[E] BSP server cancelled, closing socket...
Client in /c/Users/Eric Peters/IdeaProjects/metals/tests/unit/target/e2e/documentHighlight/single/.bloop triggered cancellation. Cancelling tasks...
INFO  bloop exit: 0
Tests: 1, Passed: 1, Failed: 0
[info]
[success] Total time: 20 s, completed Jun 13, 2019, 8:48:10 PM
```