### PR TITLE
Fix concurrent modification

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -155,7 +155,6 @@ final class InteractiveSemanticdbs(
         .semanticdbTextDocument(uri, text)
         .get(config.compilers.timeoutDelay, config.compilers.timeoutUnit)
       val textDocument = TextDocument.parseFrom(bytes)
-      textDocumentCache.put(source, textDocument)
       PlatformTokenizerCache.megaCache.clear() // :facepalm:
       textDocument
     }


### PR DESCRIPTION
in `def textDocument`, `textDocumentCache.computeIfAbsent` calls `compile` which modifies `textDocumentCache`, java 8 fails to detect this but java 11 detects correctly.