### PR TITLE
Fix wrong windows SemanticDB file path

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -62,7 +62,7 @@ case class GradleBuildTool() extends BuildTool {
        |          dependencies {
        |              scalaCompilerPlugin 'org.scalameta:semanticdb-scalac_' + scalaLib.version + ':4.1.4'
        |          }
-       |          String semanticDb = configurations.scalaCompilerPlugin.asPath.split(':').find{it.contains('semanticdb')}
+       |          String semanticDb = configurations.scalaCompilerPlugin.files.find { it.name.contains('semanticdb') }.toString()
        |          if (!semanticDb) {
        |              throw new RuntimeException("SemanticDB plugin not found!")
        |          }


### PR DESCRIPTION
Previously we searched classpath for plugin splitting on ':', which didn't work on Windows.
    
Now, we use the files collection on the configuration and search it.