### PR TITLE
Digest only sbt files at workspace level

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtDigest.scala
@@ -1,17 +1,46 @@
 package scala.meta.internal.builds
 
-import scala.meta.io.AbsolutePath
+import java.nio.file.{Files, Path}
 import java.security.MessageDigest
 
+import scala.collection.JavaConverters._
+import scala.meta.internal.builds.Digest.digestScala
+import scala.meta.internal.io.PathIO
+import scala.meta.io.AbsolutePath
+
 object SbtDigest extends Digestable {
+  val sbtExtension = "sbt"
+
   override protected def digestWorkspace(
       workspace: AbsolutePath,
       digest: MessageDigest
   ): Boolean = {
     val project = workspace.resolve("project")
-    Digest.digestDirectory(workspace, digest) &&
+    digestSbtFiles(workspace, digest) &&
     Digest.digestFileBytes(project.resolve("build.properties"), digest) &&
     Digest.digestDirectory(project, digest) &&
     Digest.digestDirectory(project.resolve("project"), digest)
   }
+
+  def digestSbtFiles(
+      path: AbsolutePath,
+      digest: MessageDigest
+  ): Boolean = {
+    if (!path.isDirectory) {
+      true
+    } else {
+      Files.list(path.toNIO).iterator().asScala.forall(digestSbtFile(digest))
+    }
+  }
+
+  private def digestSbtFile(digest: MessageDigest)(filePath: Path) = {
+    val path = AbsolutePath(filePath)
+    def ext = PathIO.extension(path.toNIO)
+    if (path.isFile && ext == sbtExtension) {
+      digestScala(path, digest)
+    } else {
+      true
+    }
+  }
+
 }

--- a/tests/unit/src/test/scala/tests/SbtDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtDigestSuite.scala
@@ -22,6 +22,25 @@ object SbtDigestSuite extends BaseDigestSuite {
   )
 
   checkSame(
+    "only-sbt-file-at-workspace-level",
+    """
+      |/build.sbt
+      |lazy val x = 2
+      |/test.xml
+      |<tag>
+      |  <inner-tag>test</inner-tag>
+      |</tag>
+      |/Build.scala
+      |package a.b
+      |class A
+    """.stripMargin,
+    """
+      |/build.sbt
+      |lazy val x = 2
+    """.stripMargin
+  )
+
+  checkSame(
     "comments-whitespace",
     """
       |/build.sbt


### PR DESCRIPTION
As agreed on gitter, only .sbt files should be digested at workspace level