### PR TITLE
Fallback to "show usages" from "Goto definition" if the symbol represents a definition itself

### DIFF
--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -580,7 +580,7 @@ final class TestingServer(
     val occurrences = ListBuffer.empty[s.SymbolOccurrence]
     input.tokenize.get.foreach { token =>
       val params = token.toPositionParams(identifier)
-      val definition = server.definitionResult(params).asJava.get()
+      val definition = server.definitionOrReferences(params).asJava.get()
       definition.definition.foreach { path =>
         if (path.isDependencySource(workspace)) {
           readonlySources(path.toNIO.getFileName.toString) = path
@@ -601,10 +601,10 @@ final class TestingServer(
       val occurrence = if (token.isIdentifier) {
         if (definition.symbol.isPackage) None // ignore packages
         else if (symbols.isEmpty) Some("<no symbol>")
-        else Some(Symbols.Multi(symbols))
+        else Some(Symbols.Multi(symbols.sorted))
       } else {
         if (symbols.isEmpty) None // OK, expected
-        else Some(s"unexpected: ${Symbols.Multi(symbols)}")
+        else Some(s"unexpected: ${Symbols.Multi(symbols.sorted)}")
       }
       occurrences ++= occurrence.map { symbol =>
         s.SymbolOccurrence(Some(token.pos.toSemanticdb), symbol)

--- a/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
+++ b/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
@@ -55,8 +55,8 @@ object QuickBuildSuite extends BaseSlowSuite("quick-build") {
            |package a
            |import com.geirsson.coursiersmall._
            |import scala.util.Success/*Try.scala*/
-           |object A/*L3*/ {
-           |  val settings/*L4*/ = new Settings/*Settings.scala*/()
+           |object A/*B.scala:6*/ {
+           |  val settings/*B.scala:6*/ = new Settings/*Settings.scala*/()
            |}
            |/b/src/main/scala/b/B.scala
            |package b


### PR DESCRIPTION
This PR adds a feature that fallbacks to "show usages" from "goto definition" if the symbol at the given text document position represents a definition itself, which is proposed in https://github.com/scalameta/metals/issues/755.

Now, Metals returns the reference locations instead of definition location for `textDocument/definition` if the symbol at the given text document position represents the definition itself.

## VSCode example
In this recording, I used only "go to definition".

![Peek 2019-06-17 18-41](https://user-images.githubusercontent.com/9353584/59673980-3d237c80-91fd-11e9-9302-2f351c8eb192.gif)

<details>
<summary>Here's the pieces of JSON RPC logs while recording</summary>

### When `textDocument/definition` returns `definitonOrReferences`'s reference locations'

```
{
  "jsonrpc": "2.0",
  "id": 51,
  "method": "textDocument/definition",
  "params": {
    "textDocument": {
      "uri": "file:///home/tanishiking/dev/src/github.com/tanishiking/metals/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala"
    },
    "position": {
      "line": 1430,
      "character": 6
    }
  }
}
{
  "jsonrpc": "2.0",
  "id": 51,
  "result": [
    {
      "uri": "file:///home/tanishiking/dev/src/github.com/tanishiking/metals/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala",
      "range": {
        "start": {
          "line": 742,
          "character": 6
        },
        "end": {
          "line": 742,
          "character": 28
        }
      }
    },
    {
      "uri": "file:///home/tanishiking/dev/src/github.com/tanishiking/metals/tests/unit/src/main/scala/tests/TestingServer.scala",
      "range": {
        "start": {
          "line": 582,
          "character": 30
        },
        "end": {
          "line": 582,
          "character": 52
        }
      }
    }
  ]
}
```

### When `textDocument/definition` returns the location of its definition

```
{
  "jsonrpc": "2.0",
  "id": 49,
  "method": "textDocument/definition",
  "params": {
    "textDocument": {
      "uri": "file:///home/tanishiking/dev/src/github.com/tanishiking/metals/tests/unit/src/main/scala/tests/TestingServer.scala"
    },
    "position": {
      "line": 582,
      "character": 33
    }
  }
}
{
  "jsonrpc": "2.0",
  "id": 49,
  "result": [
    {
      "uri": "file:///home/tanishiking/dev/src/github.com/tanishiking/metals/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala",
      "range": {
        "start": {
          "line": 1430,
          "character": 6
        },
        "end": {
          "line": 1430,
          "character": 28
        }
      }
    }
  ]
}
```

</details>

## nvim + coc.nvim example

![Peek 2019-06-19 01-50](https://user-images.githubusercontent.com/9353584/59709801-8fd35780-9242-11e9-95a1-a5f9efdd4db9.gif)
