### PR TITLE
Fix an issue when `val _ = ()` is the only thing in the block

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DocumentSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DocumentSymbolProvider.scala
@@ -82,7 +82,9 @@ class DocumentSymbolProvider(trees: Trees) {
     override def apply(tree: Tree): Unit = {
       def continue(withNewOwner: Boolean = false): Unit = {
         val oldRoot = owner
-        if (withNewOwner) owner = owner.getChildren.asScala.last
+        val children = owner.getChildren.asScala
+        val hasChildren = children.nonEmpty
+        if (withNewOwner && hasChildren) owner = children.last
         super.apply(tree)
         owner = oldRoot
       }

--- a/tests/input/src/main/scala/example/Miscellaneous.scala
+++ b/tests/input/src/main/scala/example/Miscellaneous.scala
@@ -4,6 +4,10 @@ class Miscellaneous {
   // backtick identifier
   val `a b` = 42
 
+  // block with only wildcard value
+  def apply(): Unit = {
+    val _ = 42
+  }
   // infix + inferred apply/implicits/tparams
   (List(1)
     .map(_ + 1)

--- a/tests/unit/src/test/resources/definition/example/Miscellaneous.scala
+++ b/tests/unit/src/test/resources/definition/example/Miscellaneous.scala
@@ -4,6 +4,10 @@ class Miscellaneous/*Miscellaneous.scala*/ {
   // backtick identifier
   val `a b`/*Miscellaneous.scala*/ = 42
 
+  // block with only wildcard value
+  def apply/*Miscellaneous.scala*/(): Unit/*Unit.scala*/ = {
+    val _ = 42
+  }
   // infix + inferred apply/implicits/tparams
   (List/*List.scala*/(1)
     .map/*List.scala*/(_ +/*Int.scala*/ 1)

--- a/tests/unit/src/test/resources/documentSymbol/example/Miscellaneous.scala
+++ b/tests/unit/src/test/resources/documentSymbol/example/Miscellaneous.scala
@@ -1,9 +1,13 @@
-/*example(Package):12*/package example
+/*example(Package):16*/package example
 
-/*example.Miscellaneous(Class):12*/class Miscellaneous {
+/*example.Miscellaneous(Class):16*/class Miscellaneous {
   // backtick identifier
   /*example.Miscellaneous#a b(Constant):5*/val `a b` = 42
 
+  // block with only wildcard value
+  /*example.Miscellaneous#apply(Method):10*/def apply(): Unit = {
+    val _ = 42
+  }
   // infix + inferred apply/implicits/tparams
   (List(1)
     .map(_ + 1)

--- a/tests/unit/src/test/resources/mtags/example/Miscellaneous.scala
+++ b/tests/unit/src/test/resources/mtags/example/Miscellaneous.scala
@@ -4,6 +4,10 @@ class Miscellaneous/*example.Miscellaneous#*/ {
   // backtick identifier
   val `a b`/*example.Miscellaneous#`a b`.*/ = 42
 
+  // block with only wildcard value
+  def apply/*example.Miscellaneous#apply().*/(): Unit = {
+    val _ = 42
+  }
   // infix + inferred apply/implicits/tparams
   (List(1)
     .map(_ + 1)

--- a/tests/unit/src/test/resources/semanticdb/example/Miscellaneous.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/Miscellaneous.scala
@@ -4,6 +4,10 @@ class Miscellaneous/*example.Miscellaneous#*/ {
   // backtick identifier
   val `a b`/*example.Miscellaneous#`a b`.*/ = 42
 
+  // block with only wildcard value
+  def apply/*example.Miscellaneous#apply().*/(): Unit/*scala.Unit#*/ = {
+    val _ = 42
+  }
   // infix + inferred apply/implicits/tparams
   (List/*scala.collection.immutable.List.*/(1)
     .map/*scala.collection.immutable.List#map().*/(_ +/*scala.Int#`+`(+4).*/ 1)

--- a/tests/unit/src/test/resources/workspace-symbol/example/Miscellaneous.scala
+++ b/tests/unit/src/test/resources/workspace-symbol/example/Miscellaneous.scala
@@ -4,6 +4,10 @@ class Miscellaneous/*example.Miscellaneous#*/ {
   // backtick identifier
   val `a b` = 42
 
+  // block with only wildcard value
+  def apply(): Unit = {
+    val _ = 42
+  }
   // infix + inferred apply/implicits/tparams
   (List(1)
     .map(_ + 1)


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/760.

The issue is that `val _ =` was not added since it has no symbol and the body was actually empty. 