### PR TITLE
Fix importing nested objects

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
@@ -236,12 +236,8 @@ class MetalsGlobal(
             }
           }
         case ThisType(sym) =>
-          if (sym.hasPackageFlag) {
-            if (history.tryShortenName(name)) NoPrefix
-            else new PrettyType(history.fullname(sym))
-          } else {
-            TypeRef(NoPrefix, sym, Nil)
-          }
+          if (history.tryShortenName(name)) NoPrefix
+          else new PrettyType(history.fullname(sym))
         case ConstantType(Constant(sym: TermSymbol))
             if sym.hasFlag(gf.JAVA_ENUM) =>
           loop(SingleType(sym.owner.thisPrefix, sym), None)

--- a/tests/cross/src/test/scala/tests/hover/HoverNamedArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverNamedArgSuite.scala
@@ -56,7 +56,7 @@ object HoverNamedArgSuite extends BaseHoverSuite {
       |  println(<<new User(age = 42, n@@ame = "")>>)
       |}
       |""".stripMargin,
-    "def this(name: String, age: Int): e.User".hover
+    "def this(name: String, age: Int): User".hover
   )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -38,4 +38,30 @@ object CompletionIssueSuite extends BaseCompletionSuite {
     "Self[+T] = Main.this.stream.Self",
     topLines = Some(1)
   )
+
+  checkEdit(
+    "issue-753",
+    """
+      |package a
+      |object A {
+      |  object Nested{
+      |    object NestedLeaf
+      |  }
+      |}
+      |object B {
+      |  NestedLea@@
+      |}""".stripMargin,
+    """
+      |package a
+      |import a.A.Nested.NestedLeaf
+      |object A {
+      |  object Nested{
+      |    object NestedLeaf
+      |  }
+      |}
+      |object B {
+      |  NestedLeaf
+      |}""".stripMargin
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -188,7 +188,7 @@ object CompletionSuite extends BaseCompletionSuite {
       |  }
       |  Xtension@@
       |}""".stripMargin,
-    """|XtensionMethod(a: Int): A.XtensionMethod
+    """|XtensionMethod(a: Int): XtensionMethod
        |""".stripMargin
   )
 


### PR DESCRIPTION
Working on https://github.com/scalameta/metals/issues/753

`TypeRef(NoPrefix, sym, Nil)` cuases us to include parent object, which i turn breaks auto importing. Checking if I didn't break anything in the process.

@gabro Did you mean something like this?