### PR TITLE
Fix JdkSources not to ignore JAVA_HOME environment variable

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
@@ -14,7 +14,7 @@ object JdkSources {
   }
 
   def defaultJavaHome: Option[String] = {
-    Option(System.getProperty("JAVA_HOME")).orElse(
+    Option(System.getenv("JAVA_HOME")).orElse(
       Option(System.getProperty("java.home"))
     )
   }


### PR DESCRIPTION
`JAVA_HOME` is an environment variable and `System.getProperty("JAVA_HOME")` seems always return `null`.
`JdkSources` had been working correctly because `candidates` [deals with `java.home` system property properly](https://github.com/scalameta/metals/blob/cee748a957645b2e0b6ad8ae5762624754631069/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala#L30-L32).

- https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html
- https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#getProperty-java.lang.String-