### PR TITLE
Make sure we add an autoimport in the correct line

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/AutoImports.scala
@@ -54,7 +54,7 @@ trait AutoImports { this: MetalsGlobal =>
               .getOrElse(pkg.pid)
             Some(
               new AutoImportPosition(
-                pos.source.lineToOffset(lastImport.pos.line),
+                pos.source.lineToOffset(lastImport.pos.focusEnd.line),
                 text
               )
             )

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -64,4 +64,46 @@ object CompletionIssueSuite extends BaseCompletionSuite {
       |}""".stripMargin
   )
 
+  checkEdit(
+    "issue-783",
+    """
+      |package all
+      |import all.World.Countries.{
+      |  Sweden,
+      |  Norway
+      |}
+      |
+      |object World {
+      |  object Countries{
+      |    object Sweden
+      |    object Norway
+      |    object France
+      |    object USA
+      |  }
+      |}
+      |import all.World.Countries.France
+      |object B {
+      |  val allCountries = Sweden + Norway + France + USA@@
+      |}""".stripMargin,
+    """
+      |package all
+      |import all.World.Countries.{
+      |  Sweden,
+      |  Norway
+      |}
+      |import all.World.Countries.USA
+      |
+      |object World {
+      |  object Countries{
+      |    object Sweden
+      |    object Norway
+      |    object France
+      |    object USA
+      |  }
+      |}
+      |import all.World.Countries.France
+      |object B {
+      |  val allCountries = Sweden + Norway + France + USA
+      |}""".stripMargin
+  )
 }


### PR DESCRIPTION
Previously when using imports with braces in the last import position auto imports would be added to a wrong place.

Now in case of braces we search for the closing brace and add the import afterwards.

Fixes https://github.com/scalameta/metals/issues/783