### PR TITLE
Fix off-by-one for parameter hints.

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -316,7 +316,17 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
             val end =
               if (lastArgument.contains(arg)) tree.pos.end
               else arg.pos.end
-            val isEnclosed = start <= pos.start && pos.end <= end
+            val extraEndOffset = unit.source.content(pos.point - 1) match {
+              case ')' | ']' => 0
+              case _ =>
+                // NOTE(olafur) Add one extra character for missing closing paren/bracket.
+                // This happens in the example "List(1, 2@@" and the compiler inferred a closing
+                // parenthesis.
+                1
+            }
+            val isEnclosed =
+              start <= pos.start &&
+                pos.end < (end + extraEndOffset)
             if (isEnclosed) {
               activeCallsite = Some(call -> Arg(arg, i, j))
             }

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -711,4 +711,60 @@ object SignatureHelpSuite extends BaseSignatureHelpSuite {
     ""
   )
 
+  check(
+    "off-by-one",
+    """
+      |object a {
+      |  identity(42)@@
+      |}
+      |""".stripMargin,
+    ""
+  )
+
+  check(
+    "off-by-one2",
+    """
+      |object a {
+      |  identity(42@@)
+      |}
+      |""".stripMargin,
+    """|identity[A](x: A): A
+       |            ^^^^
+       |""".stripMargin
+  )
+
+  check(
+    "between-parens",
+    """
+      |object a {
+      |  Option(1).fold(2)@@(_ + 1)
+      |}
+      |""".stripMargin,
+    ""
+  )
+
+  check(
+    "between-parens2",
+    """
+      |object a {
+      |  Option(1).fold(2@@)(_ + 1)
+      |}
+      |""".stripMargin,
+    """|fold[B](ifEmpty: => B)(f: Int => B): B
+       |        ^^^^^^^^^^^^^
+       |""".stripMargin
+  )
+
+  check(
+    "between-parens3",
+    """
+      |object a {
+      |  Option(1).fold(2)(@@_ + 1)
+      |}
+      |""".stripMargin,
+    """|fold[B](ifEmpty: => B)(f: Int => B): B
+       |                       ^^^^^^^^^^^
+       |""".stripMargin
+  )
+
 }


### PR DESCRIPTION
Previously, running parameter hints after the closing parenthesis in
`List(1)@@` or between curried arguments `Option(1).fold(1)@@(_ + 1)`
would trigger a false-positive signature help (resulting in noisy
popups). Now, we exclude the last characters such as closing `)` and
`]` to avoid returning parameter hints when the cursor is not inside
the argument position.

Thanks to Sébastien Doeraene (@sjrd) for catching this bug!