### PR TITLE
Use 2.13 dialect for syntax errors

### DIFF
--- a/metals-bench/src/main/scala/bench/MetalsBench.scala
+++ b/metals-bench/src/main/scala/bench/MetalsBench.scala
@@ -82,7 +82,7 @@ class MetalsBench {
   @BenchmarkMode(Array(Mode.SingleShotTime))
   def scalaTokenize(): Unit = {
     scalaDependencySources.inputs.foreach { input =>
-      val scanner = new LegacyScanner(input, meta.dialects.Scala212)
+      val scanner = new LegacyScanner(input, meta.dialects.Scala213)
       var i = 0
       scanner.foreach(_ => i += 1)
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/Trees.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Trees.scala
@@ -50,7 +50,7 @@ final class Trees(buffers: Buffers, diagnostics: Diagnostics) {
   }
   private def dialect(path: AbsolutePath): Option[Dialect] = {
     Option(PathIO.extension(path.toNIO)).collect {
-      case "scala" => dialects.Scala212
+      case "scala" => dialects.Scala213
       case "sbt" => dialects.Sbt
       case "sc" => dialects.Sbt
     }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
@@ -38,7 +38,7 @@ class ScalaToplevelMtags(
     val input: Input.VirtualFile,
     includeInnerClasses: Boolean
 ) extends MtagsIndexer {
-  private val scanner = new LegacyScanner(input, dialects.Scala212)
+  private val scanner = new LegacyScanner(input, dialects.Scala213)
   scanner.reader.nextChar()
   def isDone: Boolean = scanner.curr.token == EOF
   def isNewline: Boolean =

--- a/tests/unit/src/test/scala/tests/SyntaxErrorSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/SyntaxErrorSlowSuite.scala
@@ -312,4 +312,22 @@ object SyntaxErrorSlowSuite extends BaseSlowSuite("syntax-error") {
     )
   )
 
+  testAsync("literal-types") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{"a": { "scalaVersion": "2.13.0" }}
+           |/a/src/main/scala/A.scala
+           |object A {
+           |  val x: Option["literal"] = Some("literal")
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/A.scala")
+      _ = assertEmpty(client.workspaceDiagnostics)
+    } yield ()
+  }
+
 }


### PR DESCRIPTION
Fixes #787 

This PR switches to the 2.13 Scalameta dialect for parsing buffers.

It's important to notice that we always the 2.13 dialect even for 2.12 or 2.11 builds, which means that in this case:

```scala
val x: Option["lit"] = Some("lit")
```

we won't be reporting an error as you type for 2.12 / 2.11 builds.

The error is still reported after compilation (i.e. on file save) so this should be an acceptable compromise.