### PR TITLE
Migrate Java converters to 2.13

### DIFF
--- a/metals-bench/src/main/scala/bench/CompletionBench.scala
+++ b/metals-bench/src/main/scala/bench/CompletionBench.scala
@@ -1,6 +1,6 @@
 package bench
 
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import org.eclipse.lsp4j.CompletionList

--- a/metals-docs/src/main/scala/docs/Snapshot.scala
+++ b/metals-docs/src/main/scala/docs/Snapshot.scala
@@ -3,7 +3,7 @@ package docs
 import java.time._
 import java.time.format.DateTimeFormatter
 import org.jsoup.Jsoup
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.BuildInfo
 import scala.util.control.NonFatal
 import scala.util.Try

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -2,7 +2,7 @@ package scala.meta.internal.builds
 
 import java.nio.file.Files
 import java.util.Properties
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.io.AbsolutePath
 
 /**

--- a/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
@@ -11,7 +11,7 @@ import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.io.AbsolutePath
 import scala.meta.tokens.Token
 import scala.util.control.NonFatal
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.xml.Node
 
 case class Digest(

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleDigest.scala
@@ -4,7 +4,7 @@ import java.security.MessageDigest
 import java.nio.file.Files
 import java.util.stream.Collectors
 import java.nio.file.Path
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 
 object GradleDigest extends Digestable {
   override protected def digestWorkspace(

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -37,7 +37,7 @@ case class MillBuildTool() extends BuildTool {
       predefScriptPath.toString,
       "mill.contrib.Bloop/install"
     )
-    import scala.collection.JavaConverters._
+    import scala.meta.internal.jdk.CollectionConverters._
     val millVersionPath = workspace.resolve(".mill-version")
     val millVersion = if (millVersionPath.isFile) {
       Files

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtDigest.scala
@@ -3,7 +3,7 @@ package scala.meta.internal.builds
 import java.nio.file.{Files, Path}
 import java.security.MessageDigest
 
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.builds.Digest.digestScala
 import scala.meta.internal.io.PathIO
 import scala.meta.io.AbsolutePath

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -3,7 +3,7 @@ package scala.meta.internal.metals
 import java.util.Properties
 import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions
 import org.eclipse.lsp4j.FileSystemWatcher
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -5,7 +5,7 @@ import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.MessageType
 import org.eclipse.lsp4j.ShowMessageRequestParams
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.meta.internal.builds.BuildTool
 import scala.meta.io.AbsolutePath

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -46,7 +46,7 @@ import scala.{meta => m}
  *
  * Includes the following converters from the standard library: {{{
  *  import scala.compat.java8.FutureConverters._
- *  import scala.collection.JavaConverters._
+ *  import scala.meta.internal.jdk.CollectionConverters._
  * }}}
  *
  * If this doesn't scale because we have too many unrelated extension methods

--- a/metals/src/main/scala/scala/meta/internal/metals/MutableCancelable.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MutableCancelable.scala
@@ -1,7 +1,7 @@
 package scala.meta.internal.metals
 
 import java.util.concurrent.ConcurrentLinkedQueue
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 
 /** Open collection of cancelables that should cancel together */
 final class MutableCancelable extends Cancelable {

--- a/metals/src/main/scala/scala/meta/internal/metals/MutableMd5Fingerprints.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MutableMd5Fingerprints.scala
@@ -2,7 +2,7 @@ package scala.meta.internal.metals
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.mtags.MD5
 import scala.meta.internal.mtags.Md5Fingerprints
 import scala.meta.io.AbsolutePath

--- a/metals/src/main/scala/scala/meta/internal/metals/TokenEditDistance.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/TokenEditDistance.scala
@@ -252,7 +252,7 @@ object TokenEditDistance {
       }
     }
     val deltas = {
-      import scala.collection.JavaConverters._
+      import scala.meta.internal.jdk.CollectionConverters._
       DiffUtils
         .diff(original.asJava, revised.asJava, TokenEqualizer)
         .getDeltas

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -4,7 +4,7 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import java.util.Properties
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.collection.mutable.ListBuffer
 import scala.meta.RelativePath
 import scala.meta.internal.mtags.Symbol

--- a/mtags/src/main/scala-2.11/scala/meta/internal/jdk/CollectionConverters.scala
+++ b/mtags/src/main/scala-2.11/scala/meta/internal/jdk/CollectionConverters.scala
@@ -1,0 +1,5 @@
+package scala.meta.internal.jdk
+
+import scala.collection.convert.{DecorateAsJava, DecorateAsScala}
+
+object CollectionConverters extends DecorateAsJava with DecorateAsScala

--- a/mtags/src/main/scala-2.12/scala/meta/internal/jdk/CollectionConverters.scala
+++ b/mtags/src/main/scala-2.12/scala/meta/internal/jdk/CollectionConverters.scala
@@ -1,0 +1,5 @@
+package scala.meta.internal.jdk
+
+import scala.collection.convert.{DecorateAsJava, DecorateAsScala}
+
+object CollectionConverters extends DecorateAsJava with DecorateAsScala

--- a/mtags/src/main/scala-2.13/scala/meta/internal/jdk/CollectionConverters.scala
+++ b/mtags/src/main/scala-2.13/scala/meta/internal/jdk/CollectionConverters.scala
@@ -1,0 +1,5 @@
+package scala.meta.internal
+
+package object jdk {
+  val CollectionConverters = scala.jdk.CollectionConverters
+}

--- a/mtags/src/main/scala/scala/meta/internal/docstrings/HtmlConverter.scala
+++ b/mtags/src/main/scala/scala/meta/internal/docstrings/HtmlConverter.scala
@@ -6,7 +6,7 @@ import org.jsoup.nodes.{Element, Node, TextNode}
 import org.jsoup.safety.{Cleaner, Whitelist}
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.util.matching.Regex
 
 // TODO - Add conversion of tables

--- a/mtags/src/main/scala/scala/meta/internal/metals/CompressedPackageIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/CompressedPackageIndex.scala
@@ -1,6 +1,6 @@
 package scala.meta.internal.metals
 
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import java.{util => ju}
 
 /**

--- a/mtags/src/main/scala/scala/meta/internal/metals/JavadocIndexer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JavadocIndexer.scala
@@ -8,7 +8,7 @@ import com.thoughtworks.qdox.model.JavaMethod
 import com.thoughtworks.qdox.model.JavaParameter
 import com.thoughtworks.qdox.model.JavaTypeVariable
 import java.util
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import scala.meta.internal.docstrings.MarkdownGenerator

--- a/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
@@ -1,7 +1,7 @@
 package scala.meta.internal.metals
 
 import java.nio.file.Files
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import java.nio.file.Paths
 import scala.meta.io.AbsolutePath
 

--- a/mtags/src/main/scala/scala/meta/internal/metals/MetalsSymbolDocumentation.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/MetalsSymbolDocumentation.scala
@@ -1,7 +1,7 @@
 package scala.meta.internal.metals
 
 import java.util
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.pc.SymbolDocumentation
 
 case class MetalsSymbolDocumentation(

--- a/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
@@ -13,7 +13,7 @@ import java.util.logging.Logger
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.mtags.ClasspathLoader
 import scala.meta.internal.mtags.MtagsEnrichments._
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.io.AbsolutePath
 import scala.meta.io.Classpath
 import scala.util.control.NonFatal

--- a/mtags/src/main/scala/scala/meta/internal/metals/ScaladocIndexer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/ScaladocIndexer.scala
@@ -1,6 +1,6 @@
 package scala.meta.internal.metals
 
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.meta._
 import scala.meta.internal.docstrings._

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ClasspathLoader.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ClasspathLoader.scala
@@ -2,7 +2,7 @@ package scala.meta.internal.mtags
 
 import java.net.{URL, URLClassLoader}
 import java.util
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.io.AbsolutePath
 import scala.meta.io.Classpath
 import scala.meta.io.RelativePath

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
@@ -10,7 +10,7 @@ import com.thoughtworks.qdox.model.JavaModel
 import com.thoughtworks.qdox.parser.ParseException
 import java.io.StringReader
 import java.util.Comparator
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import scala.meta.internal.mtags.MtagsEnrichments._

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionItemResolver.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionItemResolver.scala
@@ -1,7 +1,7 @@
 package scala.meta.internal.pc
 
 import org.eclipse.lsp4j.CompletionItem
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.SymbolDocumentation
 

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -6,7 +6,7 @@ import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionItemKind
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.InsertTextFormat
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.SymbolSearch

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -7,7 +7,7 @@ import scala.meta.internal.semanticdb.Scala._
 import scala.collection.mutable
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.util.control.NonFatal
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.collection.mutable.ListBuffer
 import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
 import java.nio.file.Paths

--- a/mtags/src/main/scala/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/HoverProvider.scala
@@ -6,7 +6,7 @@ import org.eclipse.lsp4j.MarkedString
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.OffsetParams
 import scala.reflect.internal.{Flags => gf}
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 
 class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
   import compiler._

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -4,7 +4,7 @@ import java.util
 import java.util.Optional
 import java.util.concurrent.TimeUnit
 import scala.meta.pc.PresentationCompilerConfig
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
 
 case class PresentationCompilerConfigImpl(

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -11,7 +11,7 @@ import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.SignatureHelp
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
 import scala.meta.internal.metals.EmptyCancelToken

--- a/mtags/src/main/scala/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -3,7 +3,7 @@ package scala.meta.internal.pc
 import org.eclipse.lsp4j.ParameterInformation
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.SignatureInformation
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.pc.OffsetParams
 import scala.meta.internal.mtags.MtagsEnrichments._
 

--- a/mtags/src/main/scala/scala/meta/internal/pc/Signatures.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Signatures.scala
@@ -1,6 +1,6 @@
 package scala.meta.internal.pc
 
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.collection.Seq
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -3,7 +3,7 @@ package tests
 import java.util.Collections
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionList
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.CompilerOffsetParams
 import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.mtags.MtagsEnrichments._

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -7,7 +7,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import org.eclipse.lsp4j.MarkupContent
 import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.ClasspathSearch
 import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.metals.Docstrings

--- a/tests/cross/src/main/scala/tests/BaseSignatureHelpSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseSignatureHelpSuite.scala
@@ -1,6 +1,6 @@
 package tests
 
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.CompilerOffsetParams
 
 abstract class BaseSignatureHelpSuite extends BasePCSuite {

--- a/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
@@ -5,7 +5,7 @@ import scala.meta.internal.metals.CompilerOffsetParams
 import org.eclipse.lsp4j.TextEdit
 import org.eclipse.{lsp4j => l}
 import tests.TextEdits
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.mtags.MtagsEnrichments._
 
 abstract class BasePcDefinitionSuite extends BasePCSuite {

--- a/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
@@ -1,7 +1,7 @@
 package tests.pc
 
 import java.lang
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.atomic.AtomicBoolean

--- a/tests/mtest/src/main/scala/tests/DiffAssertions.scala
+++ b/tests/mtest/src/main/scala/tests/DiffAssertions.scala
@@ -3,7 +3,7 @@ package tests
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import org.scalactic.source.Position
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 import utest.ufansi.Color
 

--- a/tests/mtest/src/main/scala/tests/TestHovers.scala
+++ b/tests/mtest/src/main/scala/tests/TestHovers.scala
@@ -4,7 +4,7 @@ import org.eclipse.lsp4j.Hover
 import scala.meta.inputs.Input
 import scala.meta.internal.pc.HoverMarkup
 import scala.meta.internal.mtags.MtagsEnrichments._
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 
 object TestHovers extends TestHovers
 trait TestHovers {

--- a/tests/mtest/src/main/scala/tests/TextEdits.scala
+++ b/tests/mtest/src/main/scala/tests/TextEdits.scala
@@ -4,7 +4,7 @@ import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.TextEdit
 import scala.meta.inputs.Input
 import scala.meta.internal.mtags.MtagsEnrichments._
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 
 /**
  * Client implementation of how to interpret `TextEdit` from LSP, used for testing purposes.

--- a/tests/unit/src/main/scala/tests/FoldingRangesTextEdits.scala
+++ b/tests/unit/src/main/scala/tests/FoldingRangesTextEdits.scala
@@ -3,7 +3,7 @@ package tests
 import java.util
 import org.eclipse.lsp4j.TextEdit
 import org.eclipse.{lsp4j => l}
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 
 object FoldingRangesTextEdits {
   def apply(ranges: util.List[l.FoldingRange]): List[l.TextEdit] = {

--- a/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
@@ -5,7 +5,7 @@ import com.google.gson.JsonPrimitive
 import scala.meta.internal.metals.Messages.MissingScalafmtConf
 import scala.meta.internal.metals.Messages.MissingScalafmtVersion
 import scala.meta.internal.metals.{BuildInfo => V}
-import scala.collection.JavaConverters._
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.Messages
 
 object FormattingSlowSuite extends BaseSlowSuite("formatting") {


### PR DESCRIPTION
This PR migrates the deprecated `scala.collection.JavaConverters` to the newer `scala.jdk.CollectionConverters`, using `scala-collection-compat` for cross-compatibility.

This removes a bunch of deprecations warnings when cross-building for Scala 2.13.

Note: we don't technically need to do this for the `metals` main module, since it doesn't cross-compile, but I figured it doesn't harm and it's one fewer thing to do when we'll migrate the codebase to 2.13. The `scala-collection-compat` dep can dropped from the `metals` module when this happens.

This is still WIP because `scala-collection-compat` 2.1.0 artifacts are not on Maven Central yet (should be there soon)