### PR TITLE
Add a benchmark for classpath indexing performance.

### DIFF
--- a/metals-bench/readme.md
+++ b/metals-bench/readme.md
@@ -134,3 +134,11 @@ If all went well you should see an output like this in the end.
 ```
 
 Open the `*.svg` files in your browser to see the graphs.
+
+## Classpath indexing
+
+```
+> bench/jmh:run -i 10 -wi 10 -f1 -t1 .*ClasspathIndexingBench
+[info] Benchmark                   Mode  Cnt     Score    Error  Units
+[info] ClasspathIndexingBench.run    ss   10  1809.068 ± 61.461  ms/op
+```

--- a/metals-bench/src/main/scala/bench/ClasspathIndexingBench.scala
+++ b/metals-bench/src/main/scala/bench/ClasspathIndexingBench.scala
@@ -1,0 +1,35 @@
+package bench
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import tests.Library
+import scala.meta.internal.metals.ClasspathSearch
+import java.nio.file.Path
+
+@State(Scope.Benchmark)
+class ClasspathIndexingBench {
+  var classpath: Seq[Path] = _
+
+  @Setup
+  def setup(): Unit = {
+    classpath = Library.all.flatMap(_.classpath.entries.map(_.toNIO))
+  }
+
+  @TearDown
+  def teardown(): Unit = {}
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  def run(): Unit = {
+    ClasspathSearch.fromClasspath(classpath, _ => 1)
+  }
+
+}


### PR DESCRIPTION
Previously, we only benchmarked the performance for responding to search
queries but not the time it took to build the classpath index. Metals
builds the classpath index quite frequently so this commit introduces a
new benchmark to measure the time it takes to index a ~200mb classpath
containing.

Related #792 