### PR TITLE
Fix an issue with wrong deprecation warning for 2.11 and update snapshot version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-def localSnapshotVersion = "0.6.2-SNAPSHOT"
+def localSnapshotVersion = "0.7.1-SNAPSHOT"
 def isCI = System.getenv("CI") != null
 
 def crossSetting[A](

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -129,7 +129,7 @@ final class Doctor(
     } else {
       val messages = ListBuffer.empty[String]
       if (ScalaVersions.isDeprecatedScalaVersion(scalaVersion)) {
-        messages += s"This Scala version will not be supported in upcoming versions of Metals, " +
+        messages += s"This Scala version might not be supported in upcoming versions of Metals, " +
           s"please upgrade to Scala ${recommendedVersion(scalaVersion)}."
       } else if (!isLatestScalaVersion(scalaVersion)) {
         messages += s"Upgrade to Scala ${recommendedVersion(scalaVersion)} to enjoy the latest compiler improvements."

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -299,7 +299,7 @@ class Messages(icons: Icons) {
       val recommended =
         if (shouldBeUsing.size == 1) shouldBeUsing.head
         else shouldBeUsing.mkString(" and ")
-      s"You are using $using, which will not be supported in future versions of Metals. " +
+      s"You are using $using, might not be supported in future versions of Metals. " +
         s"Please upgrade to Scala $recommended."
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -22,8 +22,6 @@ object ScalaVersions {
   val isLatestScalaVersion: Set[String] =
     Set(BuildInfo.scala212, BuildInfo.scala211)
 
-  def recommendedVersion(scalaVersion: String): String = {
-    if (scalaVersion.startsWith("2.11")) BuildInfo.scala211
-    else BuildInfo.scala212
-  }
+  def recommendedVersion(scalaVersion: String): String = BuildInfo.scala212
+
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3807253/60359778-533df380-99da-11e9-9476-7eba142cce05.png)

Added `might` in order not to scare 2.11 people too much.