### PR TITLE
Don't infer build target for non-readonly files.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -18,6 +18,7 @@ import scala.meta.io.AbsolutePath
 import scala.meta.internal.mtags.Symbol
 import scala.util.Try
 import scala.meta.internal.mtags.Mtags
+import scala.meta.internal.io.PathIO
 import java.net.URLClassLoader
 import scala.util.control.NonFatal
 
@@ -25,6 +26,10 @@ import scala.util.control.NonFatal
  * In-memory cache for looking up build server metadata.
  */
 final class BuildTargets() {
+  private var workspace = PathIO.workingDirectory
+  def setWorkspaceDirectory(newWorkspace: AbsolutePath): Unit = {
+    workspace = newWorkspace
+  }
   private var tables: Option[Tables] = None
   private val sourceDirectoriesToBuildTarget =
     TrieMap.empty[AbsolutePath, ConcurrentLinkedQueue[BuildTargetIdentifier]]
@@ -213,7 +218,8 @@ final class BuildTargets() {
   def inferBuildTarget(
       source: AbsolutePath
   ): Option[BuildTargetIdentifier] =
-    Try(unsafeInferBuildTarget(source)).getOrElse(None)
+    if (!source.isDependencySource(workspace)) None
+    else Try(unsafeInferBuildTarget(source)).getOrElse(None)
   private def unsafeInferBuildTarget(
       source: AbsolutePath
   ): Option[BuildTargetIdentifier] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -194,6 +194,7 @@ class MetalsLanguageServer(
   private def updateWorkspaceDirectory(params: InitializeParams): Unit = {
     workspace = AbsolutePath(Paths.get(URI.create(params.getRootUri)))
     MetalsLogger.setupLspLogger(workspace, redirectSystemOut)
+    buildTargets.setWorkspaceDirectory(workspace)
     tables = register(new Tables(workspace, time, config))
     buildTargets.setTables(tables)
     buildTools = new BuildTools(workspace, bspGlobalDirectories)


### PR DESCRIPTION
A last minute change in the Tree View PR to fix a navigation bug when
browsing library dependenency sources from the tree view resulted in a
performance regression when editing standalone Scala files.
Previously, we tried to infer the build target using an expensive
classloading technique on every completion/hover/signatureHelp request
in standalone files. Now, the expensive technique is only used for files
in the `.metals/readonly` directory.