### PR TITLE
Make test-release.sh script check that artifacts have synced to Maven

### DIFF
--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -2,15 +2,17 @@
 set -eux
 
 version=$1
+argumentsRest=${@:2}
+suffix=${argumentsRest:-}
 
 coursier fetch \
   org.scalameta:metals_2.12:$version \
   org.scalameta:mtags_2.13.0:$version \
   org.scalameta:mtags_2.12.8:$version \
   org.scalameta:mtags_2.12.7:$version \
-  org.scalameta:mtags_2.11.12:$version \
-  -r sonatype:public
+  org.scalameta:mtags_2.11.12:$version $suffix
+
 coursier fetch \
     "org.scalameta:sbt-metals;sbtVersion=1.0;scalaVersion=2.12:$version" \
     "org.scalameta:sbt-metals;sbtVersion=0.13;scalaVersion=2.10:$version" \
-    --sbt-plugin-hack -r sonatype:public
+    --sbt-plugin-hack $suffix

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -41,7 +41,12 @@ title: Making a release
   - Make sure that the release shows up at
     https://oss.sonatype.org/content/repositories/releases/org/scalameta/.
   - Run `./bin/test-release.sh $VERSION` to ensure that all artifacts have
-    successfully been released.
+    successfully been released. It's important to ensure that this script passes
+    before announcing the release since it takes a while for all published
+    artifacts to sync with Maven Central.
+  - To check that the release to Sonatype succeed even if the artifacts are not
+    yet available on Maven Central run:
+    `./bin/test-release.sh $VERSION -r sonatype:public`
 
 - Upgrade downstream projects:
 


### PR DESCRIPTION
Previously, we used the `-r sonatype:public` resolver by default which
passed even if the artifacts hadn't synced t Maven Centra. This resulted
in many users getting resolution errors if they updated Metals right
after the release announcement (which is easy to do with VS Code
auto-update).