### PR TITLE
Fix issue with missing completions after comment and newline.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,12 +11,12 @@ install:
 
 environment:
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: "-t7z -m0=lzma -mx=9"
-  JAVA_OPTS: -Xss2m -Xmx1024m -XX:-TieredCompilation -XX:ReservedCodeCacheSize=48m -Dfile.encoding=UTF-8 -Djna.nosys=true
+  JAVA_OPTS: -Xss2m -Xmx4096m -XX:-TieredCompilation -XX:ReservedCodeCacheSize=48m -Dfile.encoding=UTF-8 -Djna.nosys=true
 before_build:
   - ps: |
       @"
       -Xss2m
-      -Xmx1024m
+      -Xmx4096m
       -XX:ReservedCodeCacheSize=48m
       -XX:-TieredCompilation
       -Dfile.encoding=UTF-8

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -106,4 +106,61 @@ object CompletionIssueSuite extends BaseCompletionSuite {
       |  val allCountries = Sweden + Norway + France + USA
       |}""".stripMargin
   )
+
+  check(
+    "issue-813-empty",
+    """|package a
+       |
+       |object Main {
+       |  (1 to 10).toList
+       |  .map(_ + 1) // comment breaks completions
+       |  .@@
+       |}
+       |""".stripMargin,
+    """|::[B >: Int](x: B): List[B]
+       |:::[B >: Int](prefix: List[B]): List[B]
+       |""".stripMargin,
+    topLines = Some(2)
+  )
+
+  check(
+    "issue-813",
+    """|package a
+       |
+       |object Main {
+       |  Array(1, 1,10)
+       |  .map(_ + 1)
+       |  .fil@@ 
+       |}
+       |""".stripMargin,
+    """|filter(p: Int => Boolean): Array[Int]
+       |filterNot(p: Int => Boolean): Array[Int]
+       |""".stripMargin,
+    topLines = Some(2)
+  )
+
+  check(
+    "issue-813-space",
+    """|package a
+       |
+       |object Main {
+       |  Array(1, 1,10)
+       |  .map(_ + 1)
+       |  . fil@@ 
+       |}
+       |""".stripMargin,
+    """|filter(p: Int => Boolean): Array[Int]
+       |filterNot(p: Int => Boolean): Array[Int]
+       |""".stripMargin,
+    topLines = Some(2)
+  )
+
+  override val compatProcess: Map[String, String => String] = Map(
+    "2.13" -> { s =>
+      s.replaceAllLiterally(
+        "::[B >: Int](x: B): List[B]",
+        "::[B >: Int](elem: B): List[B]"
+      )
+    }
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -129,7 +129,7 @@ object CompletionIssueSuite extends BaseCompletionSuite {
        |
        |object Main {
        |  Array(1, 1,10)
-       |  .map(_ + 1)
+       |  .map(_ + 1) // comment breaks completions
        |  .fil@@ 
        |}
        |""".stripMargin,
@@ -145,8 +145,24 @@ object CompletionIssueSuite extends BaseCompletionSuite {
        |
        |object Main {
        |  Array(1, 1,10)
-       |  .map(_ + 1)
+       |  .map(_ + 1) // comment breaks completions
        |  . fil@@ 
+       |}
+       |""".stripMargin,
+    """|filter(p: Int => Boolean): Array[Int]
+       |filterNot(p: Int => Boolean): Array[Int]
+       |""".stripMargin,
+    topLines = Some(2)
+  )
+
+  check(
+    "issue-813-multi",
+    """|package a
+       |
+       |object Main {
+       |  Array(1, 1,10)
+       |  .map(_ + 1) /* comment breaks completions */
+       |  .fil@@ 
        |}
        |""".stripMargin,
     """|filter(p: Int => Boolean): Array[Int]


### PR DESCRIPTION
Previously, completions after a comment and newline would yield no results.

Now we remove the comment from the name that PC gives us and this causes us to get all completions.

This is connected to a presentation compiler bug that would include comment as a legal identifier. We will try to fix that inside the compiler - the implementation here might not be most efficient, but it only happens in case of comments.

Fixes https://github.com/scalameta/metals/issues/813