### PR TITLE
Bump mill version

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -62,7 +62,7 @@ case class MillBuildTool() extends BuildTool {
 
   override def minimumVersion: String = "0.4.0"
 
-  override def version: String = "0.4.1"
+  override def version: String = "0.4.2"
 
   override def toString(): String = "Mill"
 


### PR DESCRIPTION
Mill 0.4.2 is the first version that supports scala 2.13.0.