### PR TITLE
Update the list of supported Scala binary versions

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -15,12 +15,12 @@ object ScalaVersions {
   def isDeprecatedScalaVersion(version: String): Boolean =
     _isDeprecatedScalaVersion(dropVendorSuffix(version))
   def isSupportedScalaBinaryVersion(scalaVersion: String): Boolean =
-    Set("2.12", "2.11").exists { binaryVersion =>
+    Set("2.13", "2.12", "2.11").exists { binaryVersion =>
       scalaVersion.startsWith(binaryVersion)
     }
 
   val isLatestScalaVersion: Set[String] =
-    Set(BuildInfo.scala212, BuildInfo.scala211)
+    Set(BuildInfo.scala213, BuildInfo.scala212, BuildInfo.scala211)
 
   def recommendedVersion(scalaVersion: String): String = BuildInfo.scala212
 


### PR DESCRIPTION
This fixes incorrect messaging in Metals Doctor. When Scala version is 2.13.0, it currently recommends "Upgrade to Scala 2.12.8 to enjoy the latest compiler improvements".