### PR TITLE
Setting h2.bindAddress to avoid exposing open ports

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
@@ -90,6 +90,10 @@ final class Tables(
       else ""
     val dbfile = workspace.resolve(".metals").resolve("metals")
     Files.createDirectories(dbfile.toNIO.getParent)
+    System.setProperty(
+      "h2.bindAddress",
+      System.getProperty("h2.bindAddress", "127.0.0.1")
+    )
     val url = s"jdbc:h2:file:$dbfile;MV_STORE=false$autoServer"
     tryUrl(url)
   }


### PR DESCRIPTION
Not a great style, but the properties API isn't super great.