### PR TITLE
Timestamps should use currentTimeMillis 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/Digests.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/Digests.scala
@@ -15,7 +15,7 @@ final class Digests(conn: () => Connection, time: Time) {
     conn().update(
       s"insert into sbt_digest values (?, ?, ?);"
     ) { stmt =>
-      val timestamp = new Timestamp(time.millis())
+      val timestamp = new Timestamp(time.currentMillis())
       stmt.setString(1, md5Digest)
       stmt.setByte(2, status.value.toByte)
       stmt.setTimestamp(3, timestamp)

--- a/metals/src/main/scala/scala/meta/internal/metals/ChosenBuildServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ChosenBuildServers.scala
@@ -21,7 +21,7 @@ class ChosenBuildServers(conn: () => Connection, time: Time) {
     conn().update(
       s"merge into chosen_build_server key(md5) values (?, ?, ?);"
     ) { stmt =>
-      val timestamp = new Timestamp(time.millis())
+      val timestamp = new Timestamp(time.currentMillis())
       stmt.setString(1, md5)
       stmt.setString(2, server)
       stmt.setTimestamp(3, timestamp)

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -23,6 +23,7 @@ object Configs {
       new DidChangeWatchedFilesRegistrationOptions(
         List(
           new FileSystemWatcher(s"$root/*.sbt"),
+          new FileSystemWatcher(s"$root/pom.xml"),
           new FileSystemWatcher(s"$root/*.sc"),
           new FileSystemWatcher(s"$root/*?.gradle"),
           new FileSystemWatcher(s"$root/*.gradle.kts"),

--- a/metals/src/main/scala/scala/meta/internal/metals/DismissedNotifications.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DismissedNotifications.scala
@@ -15,7 +15,7 @@ final class DismissedNotifications(conn: () => Connection, time: Time) {
   class Notification(val id: Int)(implicit name: sourcecode.Name) {
     override def toString: String = s"Notification(${name.value}, $id)"
     def isDismissed: Boolean = {
-      val now = new Timestamp(time.millis())
+      val now = new Timestamp(time.currentMillis())
       conn().query {
         "select * from dismissed_notification where id = ? and when_expires > ? limit 1;"
       } { stmt =>
@@ -29,12 +29,12 @@ final class DismissedNotifications(conn: () => Connection, time: Time) {
       dismiss(10000, TimeUnit.DAYS)
     }
     def dismiss(count: Long, unit: TimeUnit): Unit = {
-      val sum = time.millis() + unit.toMillis(count)
+      val sum = time.currentMillis() + unit.toMillis(count)
       if (sum < 0) dismissForever()
       else dismiss(new Timestamp(sum))
     }
     def dismiss(whenExpire: Timestamp): Unit = {
-      val now = new Timestamp(time.millis())
+      val now = new Timestamp(time.currentMillis())
       conn().update {
         "insert into dismissed_notification values (?, ?, ?);"
       } { stmt =>

--- a/metals/src/main/scala/scala/meta/internal/metals/Time.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Time.scala
@@ -1,17 +1,17 @@
 package scala.meta.internal.metals
 
-import java.util.concurrent.TimeUnit
-
 /**
- * Wrapper around `System.nanoTime` to allow easier testing.
+ * Wrapper around `System.nanoTime` and `System.currentTimeMillis`
+ * to allow easier testing.
  */
 trait Time {
   def nanos(): Long
-  final def millis(): Long = TimeUnit.NANOSECONDS.toMillis(nanos())
+  def currentMillis(): Long
 }
 
 object Time {
   object system extends Time {
     def nanos(): Long = System.nanoTime()
+    def currentMillis(): Long = System.currentTimeMillis()
   }
 }

--- a/tests/unit/src/main/scala/tests/FakeTime.scala
+++ b/tests/unit/src/main/scala/tests/FakeTime.scala
@@ -13,4 +13,6 @@ class FakeTime extends Time {
     elapse(n, TimeUnit.SECONDS)
   }
   override def nanos(): Long = elapsed
+
+  override def currentMillis(): Long = TimeUnit.NANOSECONDS.toMillis(elapsed)
 }

--- a/tests/unit/src/test/scala/tests/DigestsSuite.scala
+++ b/tests/unit/src/test/scala/tests/DigestsSuite.scala
@@ -9,14 +9,14 @@ object DigestsSuite extends BaseTablesSuite {
     assertEquals(digests.setStatus("a", Requested), 1)
     assertEquals(
       digests.last().get,
-      Digest("a", Requested, time.millis())
+      Digest("a", Requested, time.currentMillis())
     )
     time.elapseSeconds(1)
     assertEquals(digests.getStatus("a").get, Requested)
     assertEquals(digests.setStatus("a", Installed), 1)
     assertEquals(
       digests.last().get,
-      Digest("a", Installed, time.millis())
+      Digest("a", Installed, time.currentMillis())
     )
     time.elapseSeconds(1)
     assertEquals(digests.getStatus("a").get, Installed)


### PR DESCRIPTION
`nanoTime` is not actually time in nanos from 1970, but is used to measure difference. So all timestamps would be quite random since they can repeat themselves. We can't use them as timestamps for sure.

Also add pom.xml to be watched, since I must have forgot about it previously.