### PR TITLE
resolve symlinks from client requests

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -286,12 +286,15 @@ object MetalsEnrichments
       }
     }
 
-    def dealias: AbsolutePath =
-      if (Files.isSymbolicLink(path.toNIO)) {
-        AbsolutePath(Files.readSymbolicLink(path.toNIO))
+    // Using [[Files.isSymbolicLink]] is not enough.
+    // It will be false when one of the parents is a symlink (e.g. /dir/link/file.txt)
+    def dealias: AbsolutePath = {
+      if (path.exists) { // cannot dealias non-existing path
+        AbsolutePath(path.toNIO.toRealPath())
       } else {
         path
       }
+    }
 
     def exists: Boolean = {
       Files.exists(path.toNIO)
@@ -342,7 +345,7 @@ object MetalsEnrichments
     }
 
     def toAbsolutePath: AbsolutePath =
-      AbsolutePath(Paths.get(URI.create(value.stripPrefix("metals:"))))
+      AbsolutePath(Paths.get(URI.create(value.stripPrefix("metals:")))).dealias
   }
 
   implicit class XtensionTextDocumentSemanticdb(textDocument: s.TextDocument) {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -192,7 +192,7 @@ class MetalsLanguageServer(
   }
 
   private def updateWorkspaceDirectory(params: InitializeParams): Unit = {
-    workspace = AbsolutePath(Paths.get(URI.create(params.getRootUri)))
+    workspace = AbsolutePath(Paths.get(URI.create(params.getRootUri))).dealias
     MetalsLogger.setupLspLogger(workspace, redirectSystemOut)
     buildTargets.setWorkspaceDirectory(workspace)
     tables = register(new Tables(workspace, time, config))

--- a/tests/slow/src/test/scala/tests/SymlinkedProjectSuite.scala
+++ b/tests/slow/src/test/scala/tests/SymlinkedProjectSuite.scala
@@ -1,0 +1,48 @@
+package tests
+import java.nio.file.Files
+import java.util.UUID
+import scala.meta.io.AbsolutePath
+
+object SymlinkedProjectSuite extends BaseSlowSuite("symlinked-project") {
+  testAsync("definitions-from-other-file") {
+    for {
+      _ <- server.initialize(
+        """|/project/build.properties
+           |sbt.version=1.2.6
+           |
+           |/build.sbt
+           |scalaVersion := "2.12.8"
+           |
+           |/src/main/scala/Foo.scala
+           |class Foo
+           |
+           |/src/main/scala/Bar.scala
+           |object Bar{
+           |  val foo = new Foo
+           |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("src/main/scala/Bar.scala")
+    } yield {
+      assertNoDiagnostics()
+      assertNoDiff(
+        server.workspaceDefinitions,
+        """|/../original/src/main/scala/Bar.scala
+           |object Bar/*L0*/{
+           |  val foo/*L1*/ = new Foo/*Foo.scala:0*/
+           |}
+           |        
+           |""".stripMargin
+      )
+    }
+  }
+
+  override protected def createWorkspace(name: String): AbsolutePath = {
+    val directory =
+      super.createWorkspace(name).resolve(UUID.randomUUID().toString)
+
+    val target = Files.createDirectories(directory.resolve("original").toNIO)
+    val link = Files.createSymbolicLink(directory.resolve("link").toNIO, target)
+    AbsolutePath(link)
+  }
+}

--- a/tests/unit/src/main/scala/tests/FileLayout.scala
+++ b/tests/unit/src/main/scala/tests/FileLayout.scala
@@ -20,7 +20,9 @@ object FileLayout {
             val file =
               path.stripPrefix("/").split("/").foldLeft(root)(_ resolve _)
             val parent = file.toNIO.getParent
-            Files.createDirectories(parent)
+            if (!Files.exists(parent)) { // cannot create directories when parent is a symlink
+              Files.createDirectories(parent)
+            }
             Files.deleteIfExists(file.toNIO)
             Files.write(
               file.toNIO,


### PR DESCRIPTION
Previously, we were using paths from the clients without resolving symlinks to real paths. 
This made resolving build targets impossible whenever workspace or one of its ancestors were a symlink.

Now, we dealias paths coming from the client.

closes #823 