### PR TITLE
Improve handling of the java sources

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1462,9 +1462,14 @@ class MetalsLanguageServer(
     // remove cached symbols from Jars
     // that are not used
     val usedJars = mutable.HashSet.empty[AbsolutePath]
-    JdkSources(userConfig.javaHome).foreach { zip =>
-      usedJars += zip
-      addSourceJarSymbols(zip)
+    JdkSources(userConfig.javaHome) match {
+      case Some(zip) =>
+        usedJars += zip
+        addSourceJarSymbols(zip)
+      case None =>
+        scribe.warn(
+          s"Could not find java sources in ${userConfig.javaHome}. Java symbols will not be available."
+        )
     }
     for {
       item <- dependencySources.getItems.asScala

--- a/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
@@ -3,8 +3,6 @@ package scala.meta.internal.metals
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.Comparator
-import java.util.Comparator.comparing
 import scala.meta.io.AbsolutePath
 
 /**

--- a/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
@@ -1,16 +1,21 @@
 package scala.meta.internal.metals
 
 import java.nio.file.Files
-import scala.meta.internal.jdk.CollectionConverters._
+import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.Comparator
+import java.util.Comparator.comparing
 import scala.meta.io.AbsolutePath
 
 /**
  * Locates zip file on disk that contains the source code for the JDK.
  */
 object JdkSources {
+  private val sources = Paths.get("src.zip")
+  private val libSources = Paths.get("lib").resolve(sources)
+
   def apply(userJavaHome: Option[String] = None): Option[AbsolutePath] = {
-    candidates(userJavaHome).find(_.isFile)
+    candidates(userJavaHome).headOption
   }
 
   def defaultJavaHome: Option[String] = {
@@ -19,36 +24,33 @@ object JdkSources {
     )
   }
 
-  def candidates(userJavaHome: Option[String]): List[AbsolutePath] = {
+  private def candidates(userJavaHome: Option[String]): List[AbsolutePath] = {
+    def isJdkCandidate(path: Path): Boolean = {
+      def containsJre = Files.exists(path.resolve("jre"))
+      val name = path.getFileName.toString
+      name.contains("jdk") || containsJre //e.g. jdk-8, java-openjdk-11
+    }
+
     for {
       javaHomeString <- userJavaHome.orElse(defaultJavaHome).toList
       javaHome = Paths.get(javaHomeString)
       jdkHome = {
-        if (javaHome.getFileName.toString.startsWith("jdk")) {
+        if (isJdkCandidate(javaHome)) {
           Nil
         } else {
-          // In case java.home points to the JRE instead of the JDK, try
-          // to pick a sibling directory that starts with jdk*.
-          val ls = Files.list(javaHome.getParent)
-          try {
-            ls.iterator()
-              .asScala
-              .filter(_.getFileName.toString.startsWith("jdk"))
-              .toArray
-              .sortBy(_.getFileName.toString)
-              .toList
-          } finally ls.close()
+          // In case java.home points to the JRE instead of the JDK,
+          // try to find jdk among its siblings
+          Files
+            .list(javaHome.getParent)
+            .filter(isJdkCandidate)
+            .toArray[Path](size => new Array(size))
+            .sortBy(_.getFileName)
+            .toList
         }
       }
-      src <- jdkHome ++ List(
-        javaHome.getParent,
-        javaHome
-      ).flatMap { dir =>
-        List(
-          dir.resolve("src.zip"),
-          dir.resolve("lib").resolve("src.zip")
-        )
-      }
+      jdk <- jdkHome ++ List(javaHome.getParent, javaHome)
+      src <- List(sources, libSources).map(jdk.resolve)
+      if Files.isRegularFile(src)
     } yield AbsolutePath(src)
   }
 


### PR DESCRIPTION
Previously Metals was directories with names starting with `jdk` as proper jdk home candidates.
Now, we consider those **containing** `jdk`, since java-8-openjdk would obviously fail the test.
Also, we notify the user that the sources were not found and that the java symbols will not be available.