### PR TITLE
Add automatic value completions on named arguments

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -10,11 +10,10 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|assertion = : Boolean
-       |assertion = false : Boolean
        |Main arg
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(4)
+    topLines = Option(3)
   )
 
   check(
@@ -24,11 +23,10 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|message = : => Any
-       |message = ??? : => Any
        |Main arg1
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(4)
+    topLines = Option(3)
   )
 
   check(
@@ -38,11 +36,10 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|message = : => Any
-       |message = ??? : => Any
        |Main arg2
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(4)
+    topLines = Option(3)
   )
 
   def user: String =
@@ -63,12 +60,10 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|age = : Int
        |followers = : Int
-       |age = 0 : Int
-       |followers = 0 : Int
        |Main arg3
        |User arg3
        |""".stripMargin,
-    topLines = Option(6)
+    topLines = Option(4)
   )
 
   check(
@@ -81,11 +76,9 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|age = : Int
        |followers = : Int
-       |age = 0 : Int
-       |followers = 0 : Int
        |Main arg4
        |""".stripMargin,
-    topLines = Option(5)
+    topLines = Option(3)
   )
 
   check(
@@ -98,12 +91,10 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|address = : String
        |followers = : Int
-       |address = "" : String
-       |followers = 0 : Int
        |Main arg5
        |User arg5
        |""".stripMargin,
-    topLines = Option(6)
+    topLines = Option(4)
   )
 
   check(
@@ -129,10 +120,9 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|x = : Int
-       |x = 0 : Int
        |Main arg7
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(2)
   )
 
   check(
@@ -143,11 +133,10 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|suffix = : String
-       |suffix = "" : String
        |Main arg8
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(4)
+    topLines = Option(3)
   )
 
   check(
@@ -159,11 +148,10 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|end = : Int
-       |end = 0 : Int
        |Main arg9
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(4)
+    topLines = Option(3)
   )
 
   check(
@@ -174,9 +162,8 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|address = : String
-       |address = "" : String
        |""".stripMargin,
-    topLines = Option(2)
+    topLines = Option(1)
   )
 
   check(
@@ -187,7 +174,6 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|banana = : Int
-       |banana = 0 : Int
        |""".stripMargin
   )
 
@@ -274,14 +260,15 @@ object CompletionArgSuite extends BaseCompletionSuite {
   )
 
   checkEditLine(
-    "auto-default",
+    "auto-not-found",
     s"""|object Main {
-        |  def foo(argument : Int, other : String, isTrue: Boolean, opt : Option[String]) : Int = argument
+        |  val number = 234
+        |  def foo(argument : Int = 123, other : String = "", isTrue: Boolean, opt : Option[String]) : Int = argument
         |  ___
         |}
         |""".stripMargin,
     "foo(auto@@)",
-    "foo(argument = ${1:0}, other = ${2:\"\"}, isTrue = ${3:false}, opt = ${4:None})"
+    "foo(argument = ${1:number}, other = ${2:???}, isTrue = ${3:???}, opt = ${4:???})"
   )
 
   checkEditLine(

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -67,9 +67,8 @@ object CompletionArgSuite extends BaseCompletionSuite {
        |followers = 0 : Int
        |Main arg3
        |User arg3
-       |Autofill with default valuesage = 0, followers = 0
        |""".stripMargin,
-    topLines = Option(7)
+    topLines = Option(6)
   )
 
   check(
@@ -176,8 +175,8 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|address = : String
        |address = "" : String
-       |Autofill with default valuesname = "", age = 0, address = "", followers = 0
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Option(2)
   )
 
   check(
@@ -228,40 +227,7 @@ object CompletionArgSuite extends BaseCompletionSuite {
   )
 
   check(
-    "auto",
-    s"""|object Main {
-        |  def foo(argument : Int, other : String) : Int = argument
-        |  val number = 5
-        |  val hello = "" 
-        |  foo(argu@@)
-        |}
-        |""".stripMargin,
-    """|argument = : Int
-       |argument = number : Int
-       |Autofill with default valuesargument = number, other = hello
-       |""".stripMargin,
-    topLines = Some(3)
-  )
-
-  check(
-    "auto-same-name",
-    s"""|object Main {
-        |  def foo(argument : Int, other : String) : Int = argument
-        |  val number = 5
-        |  val argument = 123
-        |  val hello = "" 
-        |  foo(ot@@)
-        |}
-        |""".stripMargin,
-    """|other = : String
-       |other = hello : String
-       |Autofill with default valuesargument = argument, other = hello
-       |""".stripMargin,
-    topLines = Some(3)
-  )
-
-  check(
-    "auto-multiple",
+    "named-multiple",
     s"""|object Main {
         |  def foo(argument : Int) : Int = argument
         |  val number = 1
@@ -280,17 +246,57 @@ object CompletionArgSuite extends BaseCompletionSuite {
     topLines = Some(5)
   )
 
-  check(
+  checkEditLine(
+    "auto",
+    s"""|object Main {
+        |  def foo(argument : Int, other : String) : Int = argument
+        |  val number = 5
+        |  val hello = "" 
+        |  ___ 
+        |}
+        |""".stripMargin,
+    "foo(auto@@)",
+    "foo(argument = ${1:number}, other = ${2:hello})"
+  )
+
+  checkEditLine(
+    "auto-multiple-type",
+    s"""|object Main {
+        |  def foo(argument : Int, other : String) : Int = argument
+        |  val number = 5
+        |  val argument = 123
+        |  val hello = "" 
+        |  ___
+        |}
+        |""".stripMargin,
+    "foo(auto@@)",
+    "foo(argument = ${1|argument,number|}, other = ${2:hello})"
+  )
+
+  checkEditLine(
     "auto-default",
     s"""|object Main {
         |  def foo(argument : Int, other : String, isTrue: Boolean, opt : Option[String]) : Int = argument
-        |  foo(argu@@)
+        |  ___
         |}
         |""".stripMargin,
-    """|argument = : Int
-       |argument = 0 : Int
-       |Autofill with default valuesargument = 0, other = "", isTrue = false, opt = None
-       |""".stripMargin
+    "foo(auto@@)",
+    "foo(argument = ${1:0}, other = ${2:\"\"}, isTrue = ${3:false}, opt = ${4:None})"
+  )
+
+  checkEditLine(
+    "auto-list",
+    s"""|object Main {
+        |  def foo(argument : List[String], other : List[Int]) : Int = 0
+        |  val list1 = List(1,2,3)
+        |  val list2 = List(3,2,1)
+        |  val list3 = List("")
+        |  val list4 = List("")
+        |  ___
+        |}
+        |""".stripMargin,
+    "foo(auto@@)",
+    "foo(argument = ${1|list4,list3|}, other = ${2|list2,list1|})"
   )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -10,10 +10,11 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|assertion = : Boolean
+       |assertion = false : Boolean
        |Main arg
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(4)
   )
 
   check(
@@ -23,10 +24,11 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|message = : => Any
+       |message = ??? : => Any
        |Main arg1
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(4)
   )
 
   check(
@@ -36,10 +38,11 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|message = : => Any
+       |message = ??? : => Any
        |Main arg2
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(4)
   )
 
   def user: String =
@@ -60,9 +63,13 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|age = : Int
        |followers = : Int
+       |age = 0 : Int
+       |followers = 0 : Int
        |Main arg3
+       |User arg3
+       |Autofill with default valuesage = 0, followers = 0
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(7)
   )
 
   check(
@@ -75,9 +82,11 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|age = : Int
        |followers = : Int
+       |age = 0 : Int
+       |followers = 0 : Int
        |Main arg4
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(5)
   )
 
   check(
@@ -90,10 +99,12 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|address = : String
        |followers = : Int
+       |address = "" : String
+       |followers = 0 : Int
        |Main arg5
        |User arg5
        |""".stripMargin,
-    topLines = Option(4)
+    topLines = Option(6)
   )
 
   check(
@@ -119,8 +130,8 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|x = : Int
+       |x = 0 : Int
        |Main arg7
-       |:: scala.collection.immutable
        |""".stripMargin,
     topLines = Option(3)
   )
@@ -133,10 +144,11 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|suffix = : String
+       |suffix = "" : String
        |Main arg8
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(4)
   )
 
   check(
@@ -148,10 +160,11 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|end = : Int
+       |end = 0 : Int
        |Main arg9
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(4)
   )
 
   check(
@@ -162,6 +175,8 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|address = : String
+       |address = "" : String
+       |Autofill with default valuesname = "", age = 0, address = "", followers = 0
        |""".stripMargin
   )
 
@@ -173,6 +188,7 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|banana = : Int
+       |banana = 0 : Int
        |""".stripMargin
   )
 
@@ -206,8 +222,75 @@ object CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|argument: Int
        |argument = : Int
+       |argument = argument : Int
        |""".stripMargin,
-    topLines = Some(2)
+    topLines = Some(3)
+  )
+
+  check(
+    "auto",
+    s"""|object Main {
+        |  def foo(argument : Int, other : String) : Int = argument
+        |  val number = 5
+        |  val hello = "" 
+        |  foo(argu@@)
+        |}
+        |""".stripMargin,
+    """|argument = : Int
+       |argument = number : Int
+       |Autofill with default valuesargument = number, other = hello
+       |""".stripMargin,
+    topLines = Some(3)
+  )
+
+  check(
+    "auto-same-name",
+    s"""|object Main {
+        |  def foo(argument : Int, other : String) : Int = argument
+        |  val number = 5
+        |  val argument = 123
+        |  val hello = "" 
+        |  foo(ot@@)
+        |}
+        |""".stripMargin,
+    """|other = : String
+       |other = hello : String
+       |Autofill with default valuesargument = argument, other = hello
+       |""".stripMargin,
+    topLines = Some(3)
+  )
+
+  check(
+    "auto-multiple",
+    s"""|object Main {
+        |  def foo(argument : Int) : Int = argument
+        |  val number = 1
+        |  val number2 = 2
+        |  val number4 = 4
+        |  val number8 = 8
+        |  foo(ar@@)
+        |}
+        |""".stripMargin,
+    """|argument = : Int
+       |argument = number : Int
+       |argument = number2 : Int
+       |argument = number4 : Int
+       |argument = number8 : Int
+       |""".stripMargin,
+    topLines = Some(5)
+  )
+
+  check(
+    "auto-default",
+    s"""|object Main {
+        |  def foo(argument : Int, other : String, isTrue: Boolean, opt : Option[String]) : Int = argument
+        |  foo(argu@@)
+        |}
+        |""".stripMargin,
+    """|argument = : Int
+       |argument = 0 : Int
+       |Autofill with default valuesargument = 0, other = "", isTrue = false, opt = None
+       |""".stripMargin
   )
 
 }


### PR DESCRIPTION
I talked around in the office and someone said it would be useful to have something that autofills named parameters. After tinkering a bit with possibilities I come up with:

![current-auto](https://user-images.githubusercontent.com/3807253/61727694-16b0ae00-ad74-11e9-998e-d18b96a907e8.gif)

What does anyone think? I was pretty easy to implement, but not sure about the ideal functionality.  I am not sure about default arguments.

All suggestions are welcome.