### PR TITLE
Update sublime doc regarding autoimport

### DIFF
--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -85,7 +85,7 @@ functionality.
   <td align=center>✅</td>
   <td align=center>✅</td>
   <td align=center>✅</td>
-  <td align=center>✅*</td>
+  <td align=center>✅</td>
   <td align=center>✅</td>
   <td align=center>✅</td>
   <td align=center>✅</td>
@@ -188,8 +188,6 @@ code.
 
 **✅ Vim**: auto-import and snippets require
 [coc.nvim](https://github.com/neoclide/coc.nvim) client.
-
-**✅ Sublime**: no auto-import.
 
 Use code completions to explore APIs, implement interfaces, generate exhaustive
 pattern matches and more.


### PR DESCRIPTION
With the new [release](https://github.com/tomv564/LSP/releases/tag/0.8.5) of LSP, auto import for sublime now works thanks to @tomv564