### PR TITLE
Add support for non-directory sources

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -286,7 +286,7 @@ final class BuildTargets() {
       .getOrElse(Iterable.empty)
   }
 
-  def inverseSourceDirectory(source: AbsolutePath): Option[AbsolutePath] =
+  def inverseSourceItem(source: AbsolutePath): Option[AbsolutePath] =
     sourceItems.find(dir => source.toNIO.startsWith(dir.toNIO))
 
   def isInverseDependency(

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -91,11 +91,11 @@ final class BuildTargets() {
   }
 
   def addSourceItem(
-      sourceItemPath: AbsolutePath,
+      sourceItem: AbsolutePath,
       buildTarget: BuildTargetIdentifier
   ): Unit = {
     val queue = sourceItemsToBuildTarget.getOrElseUpdate(
-      sourceItemPath,
+      sourceItem,
       new ConcurrentLinkedQueue()
     )
     queue.add(buildTarget)
@@ -275,19 +275,19 @@ final class BuildTargets() {
   }
 
   def sourceBuildTargets(
-      source: AbsolutePath
+      sourceItem: AbsolutePath
   ): Iterable[BuildTargetIdentifier] = {
     sourceItemsToBuildTarget
       .collectFirst {
-        case (sourceItem, buildTargets)
-            if source.toNIO.startsWith(sourceItem.toNIO) =>
+        case (source, buildTargets)
+            if sourceItem.toNIO.startsWith(source.toNIO) =>
           buildTargets.asScala
       }
       .getOrElse(Iterable.empty)
   }
 
   def inverseSourceItem(source: AbsolutePath): Option[AbsolutePath] =
-    sourceItems.find(dir => source.toNIO.startsWith(dir.toNIO))
+    sourceItems.find(item => source.toNIO.startsWith(item.toNIO))
 
   def isInverseDependency(
       query: BuildTargetIdentifier,

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -31,7 +31,7 @@ final class BuildTargets() {
     workspace = newWorkspace
   }
   private var tables: Option[Tables] = None
-  private val sourceDirectoriesToBuildTarget =
+  private val sourceItemsToBuildTarget =
     TrieMap.empty[AbsolutePath, ConcurrentLinkedQueue[BuildTargetIdentifier]]
   private val buildTargetInfo =
     TrieMap.empty[BuildTargetIdentifier, BuildTarget]
@@ -49,19 +49,19 @@ final class BuildTargets() {
   }
 
   def reset(): Unit = {
-    sourceDirectoriesToBuildTarget.values.foreach(_.clear())
-    sourceDirectoriesToBuildTarget.clear()
+    sourceItemsToBuildTarget.values.foreach(_.clear())
+    sourceItemsToBuildTarget.clear()
     buildTargetInfo.clear()
     scalacTargetInfo.clear()
     inverseDependencies.clear()
     buildTargetSources.clear()
     inverseDependencySources.clear()
   }
-  def sourceDirectories: Iterable[AbsolutePath] =
-    sourceDirectoriesToBuildTarget.keys
-  def sourceDirectoriesToBuildTargets
+  def sourceItems: Iterable[AbsolutePath] =
+    sourceItemsToBuildTarget.keys
+  def sourceItemsToBuildTargets
       : Iterator[(AbsolutePath, JIterable[BuildTargetIdentifier])] =
-    sourceDirectoriesToBuildTarget.iterator
+    sourceItemsToBuildTarget.iterator
   def scalacOptions: Iterable[ScalacOptionsItem] =
     scalacTargetInfo.values
 
@@ -90,12 +90,12 @@ final class BuildTargets() {
     ).flatten
   }
 
-  def addSourceDirectory(
-      directory: AbsolutePath,
+  def addSourceItem(
+      sourceItemPath: AbsolutePath,
       buildTarget: BuildTargetIdentifier
   ): Unit = {
-    val queue = sourceDirectoriesToBuildTarget.getOrElseUpdate(
-      directory,
+    val queue = sourceItemsToBuildTarget.getOrElseUpdate(
+      sourceItemPath,
       new ConcurrentLinkedQueue()
     )
     queue.add(buildTarget)
@@ -277,17 +277,17 @@ final class BuildTargets() {
   def sourceBuildTargets(
       source: AbsolutePath
   ): Iterable[BuildTargetIdentifier] = {
-    sourceDirectoriesToBuildTarget
+    sourceItemsToBuildTarget
       .collectFirst {
-        case (sourceDirectory, buildTargets)
-            if source.toNIO.startsWith(sourceDirectory.toNIO) =>
+        case (sourceItem, buildTargets)
+            if source.toNIO.startsWith(sourceItem.toNIO) =>
           buildTargets.asScala
       }
       .getOrElse(Iterable.empty)
   }
 
   def inverseSourceDirectory(source: AbsolutePath): Option[AbsolutePath] =
-    sourceDirectories.find(dir => source.toNIO.startsWith(dir.toNIO))
+    sourceItems.find(dir => source.toNIO.startsWith(dir.toNIO))
 
   def isInverseDependency(
       query: BuildTargetIdentifier,

--- a/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
@@ -49,25 +49,25 @@ final class FileWatcher(
   }
 
   def restart(): Unit = {
-    val directoriesToWatch = new util.ArrayList[Path]()
+    val sourcesItemsToWatch = new util.ArrayList[Path]()
     val createdSourceDirectories = new util.ArrayList[AbsolutePath]()
-    def watch(dir: AbsolutePath, isSourceDirectory: Boolean): Unit = {
-      if (!dir.isDirectory) {
-        dir.createDirectories()
-        if (isSourceDirectory) createdSourceDirectories.add(dir)
+    def watch(path: AbsolutePath, isSourceItem: Boolean): Unit = {
+      if (!path.isDirectory && !path.isFile) {
+        path.createDirectories()
+        if (isSourceItem) createdSourceDirectories.add(path)
       }
-      directoriesToWatch.add(dir.toNIO)
+      sourcesItemsToWatch.add(path.toNIO)
     }
     // Watch the source directories for "goto definition" index.
-    buildTargets.sourceDirectories.foreach(watch(_, isSourceDirectory = true))
+    buildTargets.sourceItems.foreach(watch(_, isSourceItem = true))
     buildTargets.scalacOptions.foreach { item =>
       // Watch META-INF/semanticdb directories for "find references" index.
       watch(
         item.targetroot.resolve(Directories.semanticdb),
-        isSourceDirectory = false
+        isSourceItem = false
       )
     }
-    startWatching(directoriesToWatch)
+    startWatching(sourcesItemsToWatch)
     createdSourceDirectories.asScala.foreach(_.delete())
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ListFiles.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ListFiles.scala
@@ -39,8 +39,12 @@ object ListFiles {
       }
     }
 
-    val buf = ArrayBuffer.empty[AbsolutePath]
-    runForeach(trigram => { buf += trigram })
-    buf
+    if (root.isFile) {
+      ArrayBuffer(root)
+    } else {
+      val buf = ArrayBuffer.empty[AbsolutePath]
+      runForeach(file => { buf += file })
+      buf
+    }
   }
 }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -74,10 +74,14 @@ trait MtagsEnrichments {
     }
   }
   implicit class XtensionAbsolutePathMetals(file: AbsolutePath) {
-    def toIdeallyRelativeURI(directory: Option[AbsolutePath]): String =
-      directory match {
-        case Some(dir) =>
-          file.toRelative(dir).toURI(false).toString
+    def toIdeallyRelativeURI(sourceItemOpt: Option[AbsolutePath]): String =
+      sourceItemOpt match {
+        case Some(sourceItem) =>
+          if (sourceItem.isScalaOrJava) {
+            sourceItem.toNIO.getFileName().toString()
+          } else {
+            file.toRelative(sourceItem).toURI(false).toString
+          }
         case None =>
           file.toURI.toString
       }

--- a/tests/unit/src/main/scala/tests/QuickBuild.scala
+++ b/tests/unit/src/main/scala/tests/QuickBuild.scala
@@ -61,7 +61,8 @@ case class QuickBuild(
     libraryDependencies: Array[String],
     compilerPlugins: Array[String],
     scalacOptions: Array[String],
-    dependsOn: Array[String]
+    dependsOn: Array[String],
+    additionalSources: Array[String]
 ) {
   def withId(id: String): QuickBuild =
     QuickBuild(
@@ -71,7 +72,8 @@ case class QuickBuild(
       orEmpty(libraryDependencies),
       orEmpty(compilerPlugins),
       orEmpty(scalacOptions),
-      orEmpty(dependsOn)
+      orEmpty(dependsOn),
+      orEmpty(additionalSources)
     )
   private def orEmpty(array: Array[String]): Array[String] =
     if (array == null) new Array(0) else array
@@ -88,12 +90,12 @@ case class QuickBuild(
         .resolve(s"scala-$binaryVersion")
         .resolve(s"${testPrefix}classes")
     }
-    val sources = List(
+    val sources = (List(
       "src/main/java",
       "src/main/scala",
       s"src/main/scala-$binaryVersion",
       s"src/main/scala-$binaryVersion"
-    ).map(relpath => baseDirectory.resolve(relpath))
+    ) ++ additionalSources).map(relpath => baseDirectory.resolve(relpath))
     val allDependencies = Array(
       s"org.scala-lang:scala-library:$scalaVersion",
       s"org.scala-lang:scala-reflect:$scalaVersion"

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -149,9 +149,11 @@ final class TestingServer(
   }
   def workspaceSources: Seq[AbsolutePath] = {
     for {
-      sourceDirectory <- server.buildTargets.sourceDirectories.toSeq
-      if sourceDirectory.isDirectory
-      source <- FileIO.listAllFilesRecursively(sourceDirectory)
+      sourceItem <- server.buildTargets.sourceItems.toSeq
+      sources = if (sourceItem.isDirectory)
+        FileIO.listAllFilesRecursively(sourceItem)
+      else Seq(sourceItem)
+      source <- sources
     } yield source
   }
 

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -150,10 +150,10 @@ final class TestingServer(
   def workspaceSources: Seq[AbsolutePath] = {
     for {
       sourceItem <- server.buildTargets.sourceItems.toSeq
-      sources = if (sourceItem.isDirectory)
-        FileIO.listAllFilesRecursively(sourceItem)
-      else Seq(sourceItem)
-      source <- sources
+      if sourceItem.exists
+      source <- if (sourceItem.isScalaOrJava)
+        Seq(sourceItem)
+      else FileIO.listAllFilesRecursively(sourceItem)
     } yield source
   }
 


### PR DESCRIPTION
Fixes #770

Reopened the PR here. I fixed the suggestions:
- added a file watcher which only reports on the specific file
- if a source file item does not exist we then create the parent dir and watch it then delete it afterwards as with the source directories
- renamed isSourceItem to isSource