### PR TITLE
Add throw catch for definitions

### DIFF
--- a/tests/unit/src/test/scala/tests/TreeViewSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewSlowSuite.scala
@@ -121,9 +121,9 @@ object TreeViewSlowSuite extends BaseSlowSuite("tree-view") {
              |org.eclipse.lsp4j-0.5.0.jar -
              |org.eclipse.lsp4j.generator-0.5.0.jar -
              |org.eclipse.lsp4j.jsonrpc-0.5.0.jar -
-             |org.eclipse.xtend.lib-2.19.0.M1.jar -
-             |org.eclipse.xtend.lib.macro-2.19.0.M1.jar -
-             |org.eclipse.xtext.xbase.lib-2.19.0.M1.jar -
+             |org.eclipse.xtend.lib-2.19.0.M2.jar -
+             |org.eclipse.xtend.lib.macro-2.19.0.M2.jar -
+             |org.eclipse.xtext.xbase.lib-2.19.0.M2.jar -
              |resources.jar -
              |rt.jar -
              |scala-library-2.12.8.jar -


### PR DESCRIPTION
Seems that each time I run full DefinitionSlowSuite, one of the tests throws ShutdownReq and then hangs. It's never the same one and it most likely hangs because it's a `withNonInterruptableCompiler`. I am not sure this is a proper fix, but tests no longer fail. @olafurpg needs to comment on this once he comes back.

```
INFO  tests.TestingServer#didOpen
Exception in thread "pool-31-thread-1" java.lang.Error: scala.tools.nsc.interactive.ShutdownReq$
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1155)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: scala.tools.nsc.interactive.ShutdownReq$
X tests.DefinitionSlowSuite.definition-fallback-to-show-usages 20825ms 
  java.util.concurrent.CancellationException
  java.util.concurrent.CompletableFuture.cancel(CompletableFuture.java:2263)
  scala.meta.internal.pc.CompilerAccess.$anonfun$onCompilerJobQueue$4(CompilerAccess.scala:206)
  scala.meta.internal.pc.CompilerAccess.$anonfun$onCompilerJobQueue$4$adapted(CompilerAccess.scala:203)
  java.util.concurrent.FutureTask.run(FutureTask.java:266)
  java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
  java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
  java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
  java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
  java.lang.Thread.run(Thread.java:748)
```