### PR TITLE
Update scalafmt to 2.0.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "2.0.0-RC4"
+version = "2.0.1"
 project.git = true
 align = none
 docstrings = javadoc

--- a/build.sbt
+++ b/build.sbt
@@ -145,8 +145,7 @@ lazy val V = new {
   val bloop = "1.3.2"
   val sbtBloop = bloop
   val gradleBloop = bloop
-  val scalafmt = "2.0.0"
-  val scalafmtDynamic = "2.0.0-RC4" // Not v2.0.0 because it has a regression https://github.com/scalameta/scalafmt/issues/1442
+  val scalafmt = "2.0.1"
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.
   def supportedScalaVersions =
@@ -239,7 +238,7 @@ lazy val metals = project
       // Scala dependencies
       // ==================
       "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0",
-      "org.scalameta" %% "scalafmt-dynamic" % V.scalafmtDynamic,
+      "org.scalameta" %% "scalafmt-dynamic" % V.scalafmt,
       // For reading classpaths.
       // for fetching ch.epfl.scala:bloop-frontend and other library dependencies
       "com.geirsson" %% "coursier-small" % "1.3.3",

--- a/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/FormattingSlowSuite.scala
@@ -316,7 +316,7 @@ object FormattingSlowSuite extends BaseSlowSuite("formatting") {
         )
         assertNoDiff(
           client.workspaceDiagnostics,
-          """|.scalafmt.conf:1:1: error: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.0'.
+          """|.scalafmt.conf:1:1: error: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=2.0.1'.
              |maxColumn=40
              |^^^^^^^^^^^^
              |""".stripMargin


### PR DESCRIPTION
I just released scalafmt v2.0.1 that contains the [change](https://github.com/scalameta/scalafmt/pull/1467) which fixes https://github.com/scalameta/scalafmt/issues/1442
Some tests are failing, but they seem to have nothing to do with this change.