### PR TITLE
Insert pipe character when editing multiline strings

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DocumentHighlightProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DocumentHighlightProvider.scala
@@ -131,7 +131,7 @@ final class DocumentHighlightProvider(
       areParamsInObject: Boolean
   ): Set[String] = {
     val setterSuffix = "_="
-    val paramsDecriptor =
+    val paramsDescriptor =
       if (areParamsInObject) Descriptor.Term(className)
       else Descriptor.Type(className)
     Set(
@@ -154,11 +154,11 @@ final class DocumentHighlightProvider(
         Descriptor.Parameter(paramName)
       ),
       Symbols.Global(
-        Symbols.Global(packageName, paramsDecriptor),
+        Symbols.Global(packageName, paramsDescriptor),
         Descriptor.Method(paramName, "()")
       ),
       Symbols.Global(
-        Symbols.Global(packageName, paramsDecriptor),
+        Symbols.Global(packageName, paramsDescriptor),
         Descriptor.Method(paramName + setterSuffix, "()")
       )
     )

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -848,7 +848,7 @@ class MetalsLanguageServer(
         token
       )
     }
-
+  /*in order to use onTypeFormatting in vscode, you'll have to set editor.formatOnType = true in settings*/
   @JsonRequest("textDocument/onTypeFormatting")
   def onTypeFormatting(
       params: DocumentOnTypeFormattingParams

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -153,6 +153,7 @@ class MetalsLanguageServer(
   private var definitionProvider: DefinitionProvider = _
   private var documentHighlightProvider: DocumentHighlightProvider = _
   private var formattingProvider: FormattingProvider = _
+  private var onTypeFormattingProvider: OnTypeFormattingProvider = _
   private var initializeParams: Option[InitializeParams] = None
   private var referencesProvider: ReferenceProvider = _
   private var workspaceSymbols: WorkspaceSymbolProvider = _
@@ -317,6 +318,10 @@ class MetalsLanguageServer(
           Nil
       }
     )
+    onTypeFormattingProvider = new OnTypeFormattingProvider(
+      semanticdbs,
+      buffers
+    )
     referencesProvider = new ReferenceProvider(
       workspace,
       semanticdbs,
@@ -409,6 +414,9 @@ class MetalsLanguageServer(
       capabilities.setHoverProvider(true)
       capabilities.setReferencesProvider(true)
       capabilities.setDocumentHighlightProvider(true)
+      capabilities.setDocumentOnTypeFormattingProvider(
+        new DocumentOnTypeFormattingOptions("\n")
+      )
       capabilities.setSignatureHelpProvider(
         new SignatureHelpOptions(List("(", "[").asJava)
       )
@@ -838,6 +846,16 @@ class MetalsLanguageServer(
       formattingProvider.format(
         params.getTextDocument.getUri.toAbsolutePath,
         token
+      )
+    }
+
+  @JsonRequest("textDocument/onTypeFormatting")
+  def onTypeFormatting(
+      params: DocumentOnTypeFormattingParams
+  ): CompletableFuture[util.List[TextEdit]] =
+    CancelTokens.future { _ =>
+      onTypeFormattingProvider.format(
+        params
       )
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/OnTypeFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/OnTypeFormattingProvider.scala
@@ -1,0 +1,75 @@
+package scala.meta.internal.metals
+
+import org.eclipse.lsp4j.{DocumentOnTypeFormattingParams, Range, TextEdit}
+
+import scala.meta.internal.mtags.Semanticdbs
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.meta.inputs.Input
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.tokens.Token
+import scala.meta.tokens.Token.Constant
+
+final class OnTypeFormattingProvider(
+    semanticdbs: Semanticdbs,
+    buffer: Buffers
+)(implicit ec: ExecutionContext) {
+
+  val tripleQuote = """\u0022\u0022\u0022"""
+  val space = " "
+
+  private def indent(toInput: String, pos: meta.Position): String = {
+    val beforePos = toInput.substring(0, pos.start)
+    val lastPipe = beforePos.lastIndexOf("|")
+    val lastNewline = beforePos.lastIndexOf("\n", lastPipe)
+    val indent = beforePos.substring(beforePos.lastIndexOf("\n")).length
+    val length = toInput.substring(lastNewline, lastPipe).length
+    space * (length - indent)
+  }
+
+  private def isMultilineString(text: String, token: Token) = {
+    text.substring(token.start, token.start + 3).equals(tripleQuote)
+  }
+
+  private def inToken(pos: meta.Position, token: Token): Boolean = {
+    pos.start >= token.start && pos.end <= token.end
+  }
+
+  private def pipeInScope(pos: meta.Position, text: String): Boolean = {
+    val firstNewline = text.substring(0, pos.start).lastIndexOf("\n")
+    val lastNewline =
+      text.substring(0, firstNewline).lastIndexOf("\n")
+    text
+      .substring(lastNewline + 1, pos.start)
+      .contains("|")
+  }
+
+  def format(
+      params: DocumentOnTypeFormattingParams
+  ): Future[java.util.List[TextEdit]] = {
+    val source = params.getTextDocument.getUri.toAbsolutePath
+    val range = new Range(params.getPosition, params.getPosition)
+
+    val edit = if (source.exists) {
+      val sourceText = buffer.get(source).getOrElse("")
+      val pos = params.getPosition.toMeta(
+        Input.VirtualFile(source.toString(), sourceText)
+      )
+      if (pipeInScope(pos, sourceText)) {
+        val tokens =
+          Input.VirtualFile(source.toString(), sourceText).tokenize.toOption
+        tokens.flatMap { tokens =>
+          tokens.collectFirst {
+            case token: Constant.String
+                if inToken(pos, token) && isMultilineString(
+                  sourceText,
+                  token
+                ) =>
+              new TextEdit(range, indent(sourceText, pos) + "|")
+          }
+        }
+      } else None
+    } else None
+    Future.successful(List(edit.orNull).asJava)
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/OnTypeFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/OnTypeFormattingProvider.scala
@@ -9,6 +9,9 @@ import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token.Constant
 
+/*in order to use onTypeFormatting in vscode,
+you'll have to set editor.formatOnType = true in settings*/
+
 final class OnTypeFormattingProvider(
     semanticdbs: Semanticdbs,
     buffer: Buffers

--- a/tests/unit/src/main/scala/tests/TestMultilineStrings.scala
+++ b/tests/unit/src/main/scala/tests/TestMultilineStrings.scala
@@ -1,0 +1,38 @@
+package tests
+
+import org.eclipse.lsp4j.{DocumentOnTypeFormattingParams, TextEdit}
+
+import scala.meta.inputs.Input
+import scala.meta.internal.metals.MetalsEnrichments._
+
+object TestMultilineStrings extends TestMultilineStrings
+trait TestMultilineStrings {
+
+  def renderAsString(
+      code: String,
+      params: DocumentOnTypeFormattingParams,
+      edit: List[TextEdit]
+  ): String = {
+    edit.foldLeft(code) { (base, smallEdit) =>
+      replaceInRange(base, params, smallEdit)
+    }
+  }
+
+  protected def replaceInRange(
+      base: String,
+      params: DocumentOnTypeFormattingParams,
+      edit: TextEdit
+  ): String = {
+    val input = Input.String(base)
+    val text =
+      if (edit != null) edit.getNewText
+      else ""
+    val pos = params.getPosition.toMeta(input)
+    new java.lang.StringBuilder()
+      .append(base, 0, pos.start)
+      .append(text)
+      .append(base, pos.start, base.length)
+      .toString
+  }
+
+}

--- a/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
@@ -1,0 +1,100 @@
+package tests
+
+object OnTypeFormattingSuite extends BaseSlowSuite("onTypeFormatting") {
+
+  val quot = """\u0022\u0022\u0022"""
+
+  check(
+    "correct-string",
+    s"""
+       |object Main {
+       |  val str = $quot
+       |  #@@word
+       |$quot
+       |}""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = $quot
+       |  #
+       |  #word
+       |$quot
+       |}""".stripMargin
+  )
+
+  check(
+    "after-string",
+    s"""
+       |object Main {
+       |val a = $quot
+       |# this is
+       |# a multiline
+       |# string
+       |$quot@@
+       |}""".stripMargin,
+    s"""
+       |object Main {
+       |val a = $quot
+       |# this is
+       |# a multiline
+       |# string
+       |$quot
+       |
+       |}""".stripMargin
+  )
+
+  check(
+    "no-pipe-string",
+    s"""
+       |object Main {
+       |  val abc = 123
+       |  val s = $quot example
+       |  word@@$quot
+       |  abc.toInt
+       |}""".stripMargin,
+    s"""
+       object Main {
+       |  val abc = 123
+       |  val s = $quot example
+       |  word
+       |  $quot
+       |  abc.toInt
+       |}""".stripMargin
+  )
+
+  check(
+    "far-indent-string",
+    s"""
+       |object Main {
+       |  val str = $quot#@@
+       |$quot
+       |}""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = $quot#
+       |               #
+       |$quot
+       |}""".stripMargin
+  )
+
+  def check(name: String, testCase: String, expectedCase: String): Unit = {
+    val test = testCase.replaceAll("#", "|")
+    val base = test.replaceAll("(@@)", "")
+    val expected = expectedCase.replaceAll("#", "|")
+    testAsync(name) {
+      for {
+        _ <- server.initialize(
+          s"""/metals.json
+             |{"a":{}}
+             |/a/src/main/scala/a/Main.scala
+      """.stripMargin + base
+        )
+        _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+        _ <- server.onTypeFormatting(
+          "a/src/main/scala/a/Main.scala",
+          test, // bez @@
+          expected
+        )
+      } yield ()
+    }
+  }
+}


### PR DESCRIPTION
Partially solves #859. Doesn't work for copypasted strings yet, though.

The behaviour isn't identical to that demonstrated in gifs under issue #859. For now, before making a TextEdit, Provider checks whether there was a pipe in the last line, even, if it's the first line of the string. It doesn't yet add .stripMargin after the end of the string, either. So we might want to expand on that. 