### PR TITLE
Use BuildInfo.scalaCompilerVersion over Properties.versionNumberString

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,6 @@ inThisBuild(
     scalacOptions ++= List(
       "-target:jvm-1.8",
       "-Yrangepos",
-      "-deprecation",
       // -Xlint is unusable because of
       // https://github.com/scala/bug/issues/10448
       "-Ywarn-unused:imports"
@@ -198,7 +197,7 @@ lazy val mtags = project
     },
     buildInfoPackage := "scala.meta.internal.mtags",
     buildInfoKeys := Seq[BuildInfoKey](
-      "scalaCompilerVersion" -> V.scala212
+      "scalaCompilerVersion" -> scalaVersion.value
     )
   )
   .dependsOn(interfaces)

--- a/build.sbt
+++ b/build.sbt
@@ -195,9 +195,14 @@ lazy val mtags = project
           if211 = List("com.lihaoyi" %% "pprint" % "0.5.4"),
           otherwise = List("com.lihaoyi" %% "pprint" % "0.5.5")
         )
-    }
+    },
+    buildInfoPackage := "scala.meta.internal.mtags",
+    buildInfoKeys := Seq[BuildInfoKey](
+      "scalaCompilerVersion" -> V.scala212
+    )
   )
   .dependsOn(interfaces)
+  .enablePlugins(BuildInfoPlugin)
 
 lazy val metals = project
   .settings(

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -22,7 +22,6 @@ import scala.meta.io.AbsolutePath
 import scala.meta.pc.CancelToken
 import scala.meta.pc.PresentationCompiler
 import scala.meta.pc.SymbolSearch
-import scala.tools.nsc.Properties
 import scala.concurrent.Future
 
 /**

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -23,7 +23,6 @@ import scala.reflect.io.VirtualDirectory
 import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.StoreReporter
 import scala.meta.pc.PresentationCompilerConfig
-import scala.util.Properties
 import java.util.concurrent.CompletableFuture
 import scala.meta.pc.DefinitionResult
 import scala.collection.Seq

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -15,6 +15,7 @@ import scala.meta.internal.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
 import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.internal.mtags.BuildInfo
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.PresentationCompiler
 import scala.meta.pc.SymbolSearch
@@ -151,8 +152,8 @@ case class ScalaPresentationCompiler(
     settings.outputDirs.setSingleOutput(vd)
     settings.classpath.value = classpath
     settings.YpresentationAnyThread.value = true
-    if (!Properties.versionNumberString.startsWith("2.11") &&
-      Properties.versionNumberString != "2.12.4") {
+    if (!BuildInfo.scalaCompilerVersion.startsWith("2.11") &&
+      BuildInfo.scalaCompilerVersion != "2.12.4") {
       settings.processArguments(
         List("-Ycache-plugin-class-loader:last-modified"),
         processAll = true

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -12,7 +12,7 @@ import scala.meta.internal.metals.ClasspathSearch
 import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.metals.Docstrings
 import scala.meta.internal.metals.RecursivelyDelete
-import scala.meta.internal.mtags
+import scala.meta.internal.mtags.BuildInfo
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.mtags.ClasspathLoader
 import scala.meta.internal.pc.PresentationCompilerConfigImpl
@@ -24,7 +24,6 @@ import scala.util.control.NonFatal
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import scala.collection.Seq
-import scala.meta.internal.mtags.BuildInfo
 
 abstract class BasePCSuite extends BaseSuite {
   def thisClasspath: Seq[Path] =
@@ -71,7 +70,7 @@ abstract class BasePCSuite extends BaseSuite {
     else {
       val testName =
         if (isCI && BuildInfo.scalaCompilerVersion != BuildInfoVersions.scala212)
-          s"${mtags.BuildInfo.scalaCompilerVersion}-$name"
+          s"${BuildInfo.scalaCompilerVersion}-$name"
         else name
       super.test(testName) {
         try {

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -12,6 +12,7 @@ import scala.meta.internal.metals.ClasspathSearch
 import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.metals.Docstrings
 import scala.meta.internal.metals.RecursivelyDelete
+import scala.meta.internal.mtags
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.mtags.ClasspathLoader
 import scala.meta.internal.pc.PresentationCompilerConfigImpl
@@ -19,11 +20,11 @@ import scala.meta.internal.pc.ScalaPresentationCompiler
 import scala.meta.internal.metals.PackageIndex
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.PresentationCompilerConfig
-import scala.util.Properties
 import scala.util.control.NonFatal
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import scala.collection.Seq
+import scala.meta.internal.mtags.BuildInfo
 
 abstract class BasePCSuite extends BaseSuite {
   def thisClasspath: Seq[Path] =
@@ -69,8 +70,8 @@ abstract class BasePCSuite extends BaseSuite {
     if (isWindows || (requiresJdkSources && !hasJdkSources)) ignore(name)(())
     else {
       val testName =
-        if (isCI && Properties.versionNumberString != BuildInfoVersions.scala212)
-          s"${Properties.versionNumberString}-$name"
+        if (isCI && BuildInfo.scalaCompilerVersion != BuildInfoVersions.scala212)
+          s"${mtags.BuildInfo.scalaCompilerVersion}-$name"
         else name
       super.test(testName) {
         try {

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -5,6 +5,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.language.experimental.macros
 import scala.meta.io.AbsolutePath
+import scala.meta.internal.mtags
 import scala.reflect.ClassTag
 import scala.util.Properties
 import utest.TestSuite
@@ -27,7 +28,7 @@ class BaseSuite extends TestSuite {
   def isJava8: Boolean =
     !Properties.isJavaAtLeast("9")
   def isScala211: Boolean =
-    Properties.versionNumberString.startsWith("2.11")
+    mtags.BuildInfo.scalaCompilerVersion.startsWith("2.11")
   def isWindows: Boolean =
     isAppveyor || isAzureWindows
   def hasJdkSources: Boolean = JdkSources().isDefined
@@ -179,7 +180,7 @@ class BaseSuite extends TestSuite {
   }
 
   private def scalaVersion: String =
-    Properties.versionNumberString
+    mtags.BuildInfo.scalaCompilerVersion
   private def scalaBinary(scalaVersion: String): String =
     scalaVersion.split("\\.").take(2).mkString(".")
   val compatProcess = Map.empty[String, String => String]

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -180,7 +180,7 @@ class BaseSuite extends TestSuite {
   }
 
   private def scalaVersion: String =
-    mtags.BuildInfo.scalaCompilerVersion
+    Properties.versionNumberString
   private def scalaBinary(scalaVersion: String): String =
     scalaVersion.split("\\.").take(2).mkString(".")
   val compatProcess = Map.empty[String, String => String]

--- a/tests/unit/src/main/scala/bill/Bill.scala
+++ b/tests/unit/src/main/scala/bill/Bill.scala
@@ -33,10 +33,10 @@ import scala.reflect.io.AbstractFile
 import scala.reflect.io.VirtualFile
 import scala.tools.nsc
 import scala.tools.nsc.reporters.StoreReporter
-import scala.util.Properties
 import scala.util.control.NonFatal
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
+import scala.meta.internal.mtags
 import scala.meta.internal.mtags.ClasspathLoader
 import scala.meta.io.AbsolutePath
 
@@ -85,7 +85,7 @@ object Bill {
     val target: BuildTarget = {
       val scalaTarget = new ScalaBuildTarget(
         "org.scala-lang",
-        Properties.versionNumberString,
+        mtags.BuildInfo.scalaCompilerVersion,
         "2.12",
         ScalaPlatform.JVM,
         scalaJars
@@ -183,7 +183,7 @@ object Bill {
               new Dependency(
                 "org.scala-lang",
                 "scala-library",
-                Properties.versionNumberString
+                mtags.BuildInfo.scalaCompilerVersion
               )
             )
           )

--- a/tests/unit/src/main/scala/tests/Library.scala
+++ b/tests/unit/src/main/scala/tests/Library.scala
@@ -5,9 +5,9 @@ import com.geirsson.coursiersmall.Dependency
 import com.geirsson.coursiersmall.Settings
 import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.metals.PackageIndex
+import scala.meta.internal.mtags
 import scala.meta.io.AbsolutePath
 import scala.meta.io.Classpath
-import scala.util.Properties
 
 case class Library(
     name: String,
@@ -86,7 +86,7 @@ object Library {
           new Dependency(
             "org.scala-lang",
             "scala-compiler",
-            Properties.versionNumberString
+            mtags.BuildInfo.scalaCompilerVersion
           ),
           new Dependency(
             "io.buoyant",


### PR DESCRIPTION
Previously, we used `scala.util.Properties.versionNumberString`
to find the current Scala version of the running classloader. This
approach had the problem where we would pick up a more recent Scala
version than expected. For example, the Metals server depended on an
`mtags_2.12.8.jar` and `scala-library_2.12.jar` (compiled by 2.12.9)
causing `Properties.versionNumberString` to return "2.12.9" instead of
the expected "2.12.8".

Now, we use a `BuildInfo.scalaCompilerVersion` that is generated by the
build to ensure we get "2.12.8" even if scala-library.jar on the
classpath comes from 2.12.9.

Fixes #868.