### PR TITLE
Replace foreach workaround with geny foreach.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -168,6 +168,11 @@ lazy val interfaces = project
     crossVersion := CrossVersion.disabled
   )
 
+val genyVersion = Def.setting {
+  if (scalaVersion.value.startsWith("2.11")) "0.1.6"
+  else "0.1.8"
+}
+
 lazy val mtags = project
   .settings(
     moduleName := "mtags",
@@ -185,6 +190,7 @@ lazy val mtags = project
       "com.thoughtworks.qdox" % "qdox" % "2.0-M9", // for java mtags
       "org.jsoup" % "jsoup" % "1.11.3", // for extracting HTML from javadocs
       "org.lz4" % "lz4-java" % "1.6.0", // for streaming hashing when indexing classpaths
+      "com.lihaoyi" %% "geny" % genyVersion.value,
       "org.scalameta" % "semanticdb-scalac-core" % V.scalameta cross CrossVersion.full
     ),
     libraryDependencies ++= {

--- a/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
@@ -13,7 +13,7 @@ import scala.meta.tokens.Token
 import scala.util.control.NonFatal
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.xml.Node
-import scala.meta.internal.mtags.ListFiles
+import scala.meta.internal.mtags.JFiles
 
 case class Digest(
     md5: String,
@@ -63,11 +63,9 @@ object Digest {
   ): Boolean = {
     if (!path.isDirectory) true
     else {
-      var success = true
-      ListFiles.foreach(path) { file =>
-        success &= digestFile(file, digest)
+      JFiles.list(path).forall { file =>
+        digestFile(file, digest)
       }
-      success
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleDigest.scala
@@ -1,12 +1,12 @@
 package scala.meta.internal.builds
 
 import scala.meta.io.AbsolutePath
-import scala.meta.internal.mtags.WalkFiles
 import scala.meta.internal.jdk.CollectionConverters._
 import java.security.MessageDigest
 import java.nio.file.Files
 import java.util.stream.Collectors
 import java.nio.file.Path
+import scala.meta.internal.mtags.JFiles
 
 object GradleDigest extends Digestable {
   override protected def digestWorkspace(
@@ -26,10 +26,9 @@ object GradleDigest extends Digestable {
   }
 
   def digestBuildSrc(path: AbsolutePath, digest: MessageDigest): Boolean = {
-    WalkFiles.foreach(path) { file =>
+    JFiles.walk(path).forall { file =>
       Digest.digestFile(file, digest)
     }
-    true
   }
 
   def digestSubProjects(

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenDigest.scala
@@ -2,8 +2,8 @@ package scala.meta.internal.builds
 
 import java.security.MessageDigest
 import scala.meta.io.AbsolutePath
-import scala.meta.internal.mtags.WalkFiles
 import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.internal.mtags.JFiles
 
 object MavenDigest extends Digestable {
   override protected def digestWorkspace(
@@ -11,11 +11,12 @@ object MavenDigest extends Digestable {
       digest: MessageDigest
   ): Boolean = {
     Digest.digestFile(workspace.resolve("pom.xml"), digest)
-    WalkFiles.foreach(workspace) { file =>
+    JFiles.walk(workspace).forall { file =>
       if (file.filename == "pom.xml") {
         Digest.digestFile(file, digest)
+      } else {
+        true
       }
     }
-    true
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtDigest.scala
@@ -5,7 +5,7 @@ import java.security.MessageDigest
 import scala.meta.internal.builds.Digest.digestScala
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
-import scala.meta.internal.mtags.ListFiles
+import scala.meta.internal.mtags.JFiles
 
 object SbtDigest extends Digestable {
 
@@ -27,9 +27,7 @@ object SbtDigest extends Digestable {
     if (!path.isDirectory) {
       true
     } else {
-      var success = true
-      ListFiles.foreach(path)(file => success &= digestSbtFile(digest)(file))
-      success
+      JFiles.list(path).forall(file => digestSbtFile(digest)(file))
     }
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JFiles.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JFiles.scala
@@ -1,0 +1,63 @@
+package scala.meta.internal.mtags
+
+import geny.Generator
+import scala.meta.io.AbsolutePath
+import java.nio.file.Files
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.Path
+import java.nio.file.FileVisitResult
+import java.nio.file.attribute.BasicFileAttributes
+
+object JFiles {
+  def walk(path: AbsolutePath): Generator[AbsolutePath] =
+    new Generator[AbsolutePath] {
+      def generate(
+          handleItem: AbsolutePath => Generator.Action
+      ): Generator.Action = {
+        var result: Generator.Action = Generator.Continue
+        def toResult(action: Generator.Action): FileVisitResult = action match {
+          case Generator.Continue => FileVisitResult.CONTINUE
+          case Generator.End =>
+            result = Generator.End
+            FileVisitResult.TERMINATE
+        }
+        Files.walkFileTree(
+          path.toNIO,
+          new SimpleFileVisitor[Path] {
+            override def preVisitDirectory(
+                dir: Path,
+                attrs: BasicFileAttributes
+            ): FileVisitResult = {
+              toResult(handleItem(AbsolutePath(dir)))
+            }
+            override def visitFile(
+                file: Path,
+                attrs: BasicFileAttributes
+            ): FileVisitResult = {
+              toResult(handleItem(AbsolutePath(file)))
+            }
+          }
+        )
+        result
+      }
+    }
+
+  def list(path: AbsolutePath): Generator[AbsolutePath] =
+    new Generator[AbsolutePath] {
+      def generate(
+          handleItem: AbsolutePath => Generator.Action
+      ): Generator.Action = {
+        val ds = Files.newDirectoryStream(path.toNIO)
+        val iter = ds.iterator()
+        var currentAction: Generator.Action = Generator.Continue
+        try {
+          while (iter.hasNext && currentAction == Generator.Continue) {
+            currentAction = handleItem(AbsolutePath(iter.next().toAbsolutePath))
+          }
+        } finally {
+          ds.close()
+        }
+        currentAction
+      }
+    }
+}


### PR DESCRIPTION
Previously, we implemented a `forall` combinator using a mutable
variable `success` and a `ListFiles.foreach` helper method. Now, we use
the library geny to implement a `JFiles.list(path): Generator[Path]`
method, which exposes a `forall` combinator that safely closes the returned
`DirectoryStream`.