### PR TITLE
Fix not closing streams when using Files.list

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtDigest.scala
@@ -27,9 +27,7 @@ object SbtDigest extends Digestable {
     if (!path.isDirectory) {
       true
     } else {
-      var success = true
-      ListFiles.foreach(path)(file => success &= digestSbtFile(digest)(file))
-      success
+      ListFiles.forall(path)(file => digestSbtFile(digest)(file))
     }
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ListFiles.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ListFiles.scala
@@ -3,6 +3,8 @@ package scala.meta.internal.mtags
 import java.nio.file.Files
 import scala.meta.io.AbsolutePath
 import scala.collection.mutable
+import java.util.stream.{Stream => JStream}
+import java.nio.file.Path
 
 object ListFiles {
   def apply(root: AbsolutePath): mutable.ArrayBuffer[AbsolutePath] = {
@@ -10,10 +12,28 @@ object ListFiles {
     foreach(root)(file => buf += file)
     buf
   }
-  def foreach(root: AbsolutePath)(fn: AbsolutePath => Unit): Unit = {
+
+  def exists(root: AbsolutePath)(fn: AbsolutePath => Boolean) =
+    closing(root) {
+      _.anyMatch(file => fn(AbsolutePath(file)))
+    }
+
+  def forall(root: AbsolutePath)(fn: AbsolutePath => Boolean) =
+    closing(root) {
+      _.allMatch(file => fn(AbsolutePath(file)))
+    }
+
+  def foreach(root: AbsolutePath)(fn: AbsolutePath => Unit) =
+    closing(root) {
+      _.forEach(file => fn(AbsolutePath(file)))
+    }
+
+  private def closing[T](
+      root: AbsolutePath
+  )(fn: JStream[Path] => T): T = {
     val ls = Files.list(root.toNIO)
     try {
-      ls.forEach(file => fn(AbsolutePath(file)))
+      fn(ls)
     } finally {
       ls.close()
     }


### PR DESCRIPTION
This fixes the issue that we had when not closing streams when looking for subdirectories. 

We might add same method to WalkFiles and simplify a lot of the code. I don't really think we need a whole new library here.