### PR TITLE
Add snippets only for supported clients

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -345,10 +345,21 @@ class MetalsLanguageServer(
       interactiveSemanticdbs.toFileOnDisk
     )
     foldingRangeProvider = FoldingRangeProvider(trees, buffers, params)
+
+    val snippetsSupported = params
+      .getCapabilities()
+      .getTextDocument()
+      .getCompletion()
+      .getCompletionItem()
+      .getSnippetSupport()
+
+    val updatedCompilerConfig =
+      config.compilers.copy(isCompletionItemSnippetEnabled = snippetsSupported)
+
     compilers = register(
       new Compilers(
         workspace,
-        config,
+        config.copy(compilers = updatedCompilerConfig),
         () => userConfig,
         buildTargets,
         buffers,

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -65,6 +65,11 @@ public interface PresentationCompilerConfig {
     boolean isSignatureHelpDocumentationEnabled();
 
     /**
+     * Returns true if snippet syntax for completions is supported.
+     */
+    boolean isCompletionItemSnippetEnabled();
+    
+    /**
      * The maximum delay for requests to respond.
      *
      * After the given delay, every request to completions/hover/signatureHelp

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -19,6 +19,7 @@ case class PresentationCompilerConfigImpl(
     isHoverDocumentationEnabled: Boolean = true,
     isSignatureHelpDocumentationEnabled: Boolean = true,
     isCompletionItemResolve: Boolean = true,
+    isCompletionItemSnippetEnabled: Boolean = true,
     timeoutDelay: Long = 20,
     timeoutUnit: TimeUnit = TimeUnit.SECONDS
 ) extends PresentationCompilerConfig {


### PR DESCRIPTION
Previously, we would use snippet syntax for all clients and now we make sure that the client has that capability.

I'm thinking we could separate the compiler config since it might be dependent on server capabilities and we would be able to create it after the initialize request. I don't think it needs to be in the server config? What do you think @olafurpg ?

Either way we could merge this as a fix before the release and separate the configuration while refactoring MetalsLanguageServer.