### PR TITLE
Upgrade to latest sbt-sonatype for faster and more stable releases

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.2")
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.3.1")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.2.7")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 


### PR DESCRIPTION
Now, `sbt ci-release` will automatically close stale staging
repositories.