### PR TITLE
Fix indentation when adding pipes in multiline string.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-def localSnapshotVersion = "0.7.5-SNAPSHOT"
+def localSnapshotVersion = "0.7.6-SNAPSHOT"
 def isCI = System.getenv("CI") != null
 
 def crossSetting[A](

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -400,10 +400,11 @@ final class TestingServer(
       filename: String,
       query: String,
       expected: String,
+      autoIndent: String,
       root: AbsolutePath = workspace
   ): Future[Unit] = {
     for {
-      (text, params) <- onTypeParams(filename, query, root)
+      (text, params) <- onTypeParams(filename, query, root, autoIndent)
       multiline <- server.onTypeFormatting(params).asScala
       format = TextEdits.applyEdits(
         textContents(filename),
@@ -512,12 +513,18 @@ final class TestingServer(
   private def onTypeParams(
       filename: String,
       original: String,
-      root: AbsolutePath
+      root: AbsolutePath,
+      autoIndent: String
   ): Future[(String, DocumentOnTypeFormattingParams)] = {
-    positionFromString(filename, original, root, replaceWith = "\n") {
+    positionFromString(
+      filename,
+      original,
+      root,
+      replaceWith = "\n" + autoIndent
+    ) {
       case (text, textId, start) =>
         start.setLine(start.getLine() + 1) // + newline
-        start.setCharacter(0)
+        start.setCharacter(autoIndent.size)
         val params = new DocumentOnTypeFormattingParams(start, "\n")
         params.setTextDocument(textId)
         (text, params)

--- a/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
@@ -80,7 +80,7 @@ object OnTypeFormattingSuite extends BaseSlowSuite("onTypeFormatting") {
        |object Main {
        |  val number = 102
        |  val str = s"|
-       |$$number".stripMargin
+       |  $$number".stripMargin
        |}""".stripMargin
   )
 
@@ -118,7 +118,7 @@ object OnTypeFormattingSuite extends BaseSlowSuite("onTypeFormatting") {
        |  | a multiline
        |  | string
        |  '''.stripMargin
-       |
+       |  
        |}""".stripMargin
   )
 
@@ -136,7 +136,7 @@ object OnTypeFormattingSuite extends BaseSlowSuite("onTypeFormatting") {
        |  val abc = 123
        |  val s = ''' example
        |  word
-       |'''.stripMargin
+       |  '''.stripMargin
        |  abc.toInt
        |}""".stripMargin
   )
@@ -146,17 +146,41 @@ object OnTypeFormattingSuite extends BaseSlowSuite("onTypeFormatting") {
     s"""
        |object Main {
        |  val str = '''|@@
-       |'''.stripMargin
+       |  '''.stripMargin
        |}""".stripMargin,
     s"""
        |object Main {
        |  val str = '''|
        |               |
-       |'''.stripMargin
+       |  '''.stripMargin
        |}""".stripMargin
   )
 
-  def check(name: String, testCase: String, expectedCase: String): Unit = {
+  // this can be caused by the client if scala syntax is recognized inside a string
+  check(
+    "weird-indent",
+    s"""
+       |object Main {
+       |  val str = '''
+       |  |object A{@@
+       |  '''.stripMargin
+       |}""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = '''
+       |  |object A{
+       |  |
+       |  '''.stripMargin
+       |}""".stripMargin,
+    " " * 4
+  )
+
+  def check(
+      name: String,
+      testCase: String,
+      expectedCase: String,
+      autoIndent: String = "  "
+  ): Unit = {
     val tripleQuote = """\u0022\u0022\u0022"""
     def unmangle(string: String): String =
       string.replaceAll("'''", tripleQuote)
@@ -176,7 +200,8 @@ object OnTypeFormattingSuite extends BaseSlowSuite("onTypeFormatting") {
         _ <- server.onTypeFormatting(
           "a/src/main/scala/a/Main.scala",
           test,
-          expected
+          expected,
+          autoIndent
         )
       } yield ()
     }


### PR DESCRIPTION
Seems this got a bit broken in the last PR when used in VS Code. Should work properly now.