### PR TITLE
Add support for 2.13.1

### DIFF
--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -7,6 +7,7 @@ suffix=${argumentsRest:-}
 
 coursier fetch \
   org.scalameta:metals_2.12:$version \
+  org.scalameta:mtags_2.13.1:$version \
   org.scalameta:mtags_2.13.0:$version \
   org.scalameta:mtags_2.12.10:$version \
   org.scalameta:mtags_2.12.9:$version \

--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,7 @@ lazy val V = new {
   val scala210 = "2.10.7"
   val scala211 = "2.11.12"
   val scala212 = "2.12.10"
-  val scala213 = "2.13.0"
+  val scala213 = "2.13.1"
   val scalameta = "4.2.3"
   val semanticdb = scalameta
   val bsp = "2.0.0-M4"
@@ -149,7 +149,7 @@ lazy val V = new {
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.
   def supportedScalaVersions =
-    Seq(scala213, "2.12.8", "2.12.9", scala212) ++ deprecatedScalaVersions
+    Seq("2.13.0", scala213, "2.12.8", "2.12.9", scala212) ++ deprecatedScalaVersions
   def deprecatedScalaVersions = Seq("2.12.7", scala211)
   def guava = "com.google.guava" % "guava" % "28.0-jre"
   def lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.8.0"

--- a/build.sbt
+++ b/build.sbt
@@ -205,7 +205,17 @@ lazy val mtags = project
     buildInfoPackage := "scala.meta.internal.mtags",
     buildInfoKeys := Seq[BuildInfoKey](
       "scalaCompilerVersion" -> scalaVersion.value
-    )
+    ),
+    unmanagedSourceDirectories in Compile ++= {
+      val sourceDir = (sourceDirectory in Compile).value
+      scalaVersion.value.split('.') match {
+        case Array(epic, major, patch) =>
+          List(
+            sourceDir / s"scala-$epic.$major",
+            sourceDir / s"scala-$epic.$major.$patch"
+          )
+      }
+    }
   )
   .dependsOn(interfaces)
   .enablePlugins(BuildInfoPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -205,17 +205,7 @@ lazy val mtags = project
     buildInfoPackage := "scala.meta.internal.mtags",
     buildInfoKeys := Seq[BuildInfoKey](
       "scalaCompilerVersion" -> scalaVersion.value
-    ),
-    unmanagedSourceDirectories in Compile ++= {
-      val sourceDir = (sourceDirectory in Compile).value
-      scalaVersion.value.split('.') match {
-        case Array(epic, major, patch) =>
-          List(
-            sourceDir / s"scala-$epic.$major",
-            sourceDir / s"scala-$epic.$major.$patch"
-          )
-      }
-    }
+    )
   )
   .dependsOn(interfaces)
   .enablePlugins(BuildInfoPlugin)

--- a/mtags/src/main/scala-2.13/scala/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.13/scala/meta/internal/pc/Compat.scala
@@ -2,7 +2,6 @@ package scala.meta.internal.pc
 
 import scala.reflect.internal.Reporter
 import scala.tools.nsc.reporters.StoreReporter
-import scala.tools.nsc.reporters.Reporter.AdaptedReporter
 
 trait Compat { this: MetalsGlobal =>
   def metalsFunctionArgTypes(tpe: Type): List[Type] =
@@ -12,11 +11,6 @@ trait Compat { this: MetalsGlobal =>
 
   def storeReporter(r: Reporter): Option[StoreReporter] = r match {
     case s: StoreReporter => Some(s)
-    case r: AdaptedReporter =>
-      r.delegate match {
-        case s: StoreReporter => Some(s)
-        case _ => None
-      }
     case _ => None
   }
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/Keywords.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Keywords.scala
@@ -78,6 +78,7 @@ trait Keywords { this: MetalsGlobal =>
     enclosing match {
       case Ident(_) :: Template(_, _, _) :: _ => true
       case Ident(_) :: ValOrDefDef(_, _, _, _) :: _ => true
+      case Template(_, _, _) :: _ => true
       case _ => false
     }
 
@@ -115,7 +116,7 @@ trait Keywords { this: MetalsGlobal =>
   private def isBlock(enclosing: List[Tree]): Boolean =
     enclosing match {
       case Ident(_) :: Block(_, _) :: _ => true
-      case _ => false
+      case other => false
     }
 
   private def isExpression(enclosing: List[Tree]): Boolean =

--- a/mtags/src/main/scala/scala/meta/internal/pc/Keywords.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Keywords.scala
@@ -116,7 +116,7 @@ trait Keywords { this: MetalsGlobal =>
   private def isBlock(enclosing: List[Tree]): Boolean =
     enclosing match {
       case Ident(_) :: Block(_, _) :: _ => true
-      case other => false
+      case _ => false
     }
 
   private def isExpression(enclosing: List[Tree]): Boolean =

--- a/sbt
+++ b/sbt
@@ -9,7 +9,7 @@ set -o pipefail
 declare -r sbt_release_version="1.2.8"
 declare -r sbt_unreleased_version="1.2.8"
 
-declare -r latest_213="2.13.0"
+declare -r latest_213="2.13.1"
 declare -r latest_212="2.12.10"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -347,7 +347,7 @@ object CompletionKeywordSuite extends BaseCompletionSuite {
       |package foo
       |
       |class Foo {
-      |  protected def@@
+      |  protected de@@
       |}
     """.stripMargin,
     "def"

--- a/tests/cross/src/test/scala/tests/pc/MacroCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/MacroCompletionSuite.scala
@@ -136,7 +136,7 @@ object MacroCompletionSuite extends BaseCompletionSuite {
     compat = Map(
       // NOTE(olafur): the presentation compiler returns empty results here in 2.12.9 and 2.13.0
       "2.12.9" -> "",
-      "2.13" -> ""
+      "2.13.0" -> ""
     )
   )
 


### PR DESCRIPTION
Getting things ready.

As soon as 2.13.1 is out, we need to merge https://github.com/scalameta/scalameta/pull/1901, backpublish Scalameta 4.2.3 for 2.13.1 and then we can test this one.