### PR TITLE
Use Thread#interrupt instead of Thread#stop for pc threads

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
@@ -55,7 +55,7 @@ class CompilerAccess(
       sh.foreach { scheduler =>
         scheduler.schedule[Unit](() => {
           if (compiler.presentationCompilerThread.isAlive) {
-            compiler.presentationCompilerThread.stop()
+            compiler.presentationCompilerThread.interrupt()
           }
         }, 2, TimeUnit.SECONDS)
       }

--- a/mtags/src/main/scala/scala/tools/nsc/interactive/MetalsGlobalThread.scala
+++ b/mtags/src/main/scala/scala/tools/nsc/interactive/MetalsGlobalThread.scala
@@ -44,7 +44,7 @@ final class MetalsGlobalThread(var compiler: Global, name: String = "")
         ex match {
           // + scalac deviation
           case InterruptException() =>
-            Thread.interrupted()
+            compiler = null
           case _: ThreadDeath =>
             compiler = null
           // - scalac deviation


### PR DESCRIPTION
Though [Thread#stop() still survives in Java11](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Thread.html#stop()), this long time deprecated method maybe removed in the recent future (actually, `Thread#destroy()`and `Thread#stop(Throwable)`have dropped in Java11).
Maybe it's worth stopping relying on `Thread#stop()` and use `Thread#interrupt()` instead.

## Why we are relying on `Thread#stop()`
- Normally, metals terminate presentation compiler threads using [askShutdown()](https://www.scala-lang.org/api/2.12.10/scala-compiler/scala/tools/nsc/interactive/CompilerControl.html) which send `ShutdownReq`, then presentation compiler thread receive `ShutdownReq` in [pollForWork](https://github.com/scalameta/metals/blob/d0abb62e7439d76217299e121927873560a368a6/mtags/src/main/scala/scala/tools/nsc/interactive/MetalsGlobalThread.scala#L24) and [terminate the thread](https://github.com/scalameta/metals/blob/d0abb62e7439d76217299e121927873560a368a6/mtags/src/main/scala/scala/tools/nsc/interactive/MetalsGlobalThread.scala#L35-L40) by assigning `null` to compiler.
- In case the thread didn't stop immediately for some reasons, metals [check that the thread is dead or not 2 secs later](https://github.com/scalameta/metals/blob/2c5a6193cb1509f11fc387d2f4d57df0e99d6c86/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala#L55-L61). And if it is still alive, metals will kill the thread using `Thread#stop()` which kills the thread immediately.

(Correct me if it is wrong)

## Alternative solution (for killing the thread ASAP)
Use [Thread#interrupt()](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#interrupt--) instead.

> If this thread is blocked in an invocation of the wait(), wait(long), or wait(long, int) methods of the Object class, or of the join(), join(long), join(long, int), sleep(long), or sleep(long, int), methods of this class, then its interrupt status will be cleared and it will receive an InterruptedException.
> If this thread is blocked in an I/O operation upon an InterruptibleChannel then the channel will be closed, the thread's interrupt status will be set, and the thread will receive a ClosedByInterruptException.
> If this thread is blocked in a Selector then the thread's interrupt status will be set and it will return immediately from the selection operation, possibly with a non-zero value, just as if the selector's wakeup method were invoked.

So, as long as metals handle `InterruptedException` properly (catch the exception and terminate the thread), metals can make sure the thread is killed in most cases.

## Or should we keep to use `Thread#stop()` ?
Though metals can terminate pc thread ASAP using `Thread#interrupt`, in minor cases, `Thread#interrupt` can't terminate the thread ASAP and wait until the next poll.

> If none of the previous conditions hold then this thread's interrupt status will be set

If it is safe to terminate threads using `Thread.stop()` for pc threads, maybe we can continue to use it.

---

If you want to stay in `Thread#stop()` or don't wanna take the risk of this change this time, feel free to close this PR :+1: 
(because my motivation for this PR is just studying the metals codebase around presentation compiler stuff).