### PR TITLE
Add basic support for the Pants build tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,14 @@ jobs:
       - uses: olafurpg/setup-scala@v7
       - name: Run Mill tests
         run: bin/test.sh 'slow/testOnly -- tests.mill'
+  pants:
+    name: Pants integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: olafurpg/setup-scala@v5
+      - name: Run Pants tests
+        run: bin/test.sh 'slow/testOnly -- tests.pants'
   feature:
     name: Slow tests
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -282,6 +282,9 @@ lazy val metals = project
       "com.outr" %% "scribe-slf4j" % "2.7.10", // needed for flyway database migrations
       // for debugging purposes, not strictly needed but nice for productivity
       "com.lihaoyi" %% "pprint" % "0.5.6",
+      // For exporting Pants builds.
+      "com.lihaoyi" %% "ujson" % "0.7.5",
+      "ch.epfl.scala" %% "bloop-config" % V.bloop,
       // for producing SemanticDB from Scala source files
       "org.scalameta" %% "scalameta" % V.scalameta,
       "org.scalameta" % "semanticdb-scalac-core" % V.scalameta cross CrossVersion.full

--- a/metals/src/main/resources/pants
+++ b/metals/src/main/resources/pants
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# =============================== NOTE ===============================
+# This ./pants bootstrap script comes from the pantsbuild/setup
+# project and is intended to be checked into your code repository so
+# that any developer can check out your code and be building it with
+# Pants with no prior setup needed.
+#
+# You can learn more here: https://www.pantsbuild.org/install.html
+# ====================================================================
+
+set -eou pipefail
+
+PYTHON_BIN_NAME="${PYTHON:-unspecified}"
+
+PANTS_HOME="${PANTS_HOME:-${XDG_CACHE_HOME:-$HOME/.cache}/pants/setup}"
+PANTS_BOOTSTRAP="${PANTS_HOME}/bootstrap-$(uname -s)-$(uname -m)"
+
+VENV_VERSION=${VENV_VERSION:-16.4.3}
+
+VENV_PACKAGE=virtualenv-${VENV_VERSION}
+VENV_TARBALL=${VENV_PACKAGE}.tar.gz
+
+COLOR_RED="\x1b[31m"
+COLOR_GREEN="\x1b[32m"
+COLOR_RESET="\x1b[0m"
+
+function log() {
+  echo -e "$@" 1>&2
+}
+
+function die() {
+  (($# > 0)) && log "${COLOR_RED}$*${COLOR_RESET}"
+  exit 1
+}
+
+function green() {
+  (($# > 0)) && log "${COLOR_GREEN}$*${COLOR_RESET}"
+}
+
+function tempdir {
+  mktemp -d "$1"/pants.XXXXXX
+}
+
+function get_exe_path_or_die {
+  exe="$1"
+  if ! command -v "${exe}"; then
+    die "Could not find ${exe}. Please ensure ${exe} is on your PATH."
+  fi
+}
+
+function get_pants_ini_config_value {
+  if [[ ! -f 'pants.ini' ]]; then
+    return 0
+  fi
+  config_key="$1"
+  valid_delimiters="[:=]"
+  optional_space="[[:space:]]*"
+  prefix="^${config_key}${optional_space}${valid_delimiters}${optional_space}"
+  sed -ne "/${prefix}/ s#${prefix}##p" pants.ini
+}
+
+function get_python_major_minor_version {
+  python_exe="$1"
+  "$python_exe" <<EOF
+import sys
+major_minor_version = ''.join(str(version_num) for version_num in sys.version_info[0:2])
+print(major_minor_version)
+EOF
+}
+
+# The high-level flow:
+# 1.) Resolve the Pants version from pants.ini or from the latest stable
+#     release to PyPi, so that we know what to name the venv folder and which
+#     Python versions we can use.
+# 2.) Resolve the Python interpreter, first reading from the env var $PYTHON,
+#     then reading from pants.ini, then determining the default based off of
+#     which Python versions the Pants version supports.
+# 3.) Check if the venv (virtual environment) already exists via a naming/path convention,
+#     and create the venv if not found.
+# 4.) Execute Pants with the resolved Python interpreter and venv.
+#
+# After that, Pants itself will handle making sure any requested plugins
+# are installed and up to date.
+
+function determine_pants_version {
+  pants_version="$(get_pants_ini_config_value 'pants_version')"
+  if [[ -n "${pants_version}" ]]; then
+    echo "${pants_version}"
+  else
+    curl -sSL https://pypi.python.org/pypi/pantsbuild.pants/json |
+      python -c "import json, sys; print(json.load(sys.stdin)['info']['version'])"
+  fi
+}
+
+function determine_default_python_exe {
+  pants_version="$1"
+  pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
+  pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
+  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 14 ]]; then
+    supported_python_versions=('2.7')
+    supported_message='2.7'
+  elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 15 ]]; then
+    supported_python_versions=('3.6' '2.7')
+    supported_message='2.7 or 3.6'
+  elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 16 ]]; then
+    supported_python_versions=('3.6' '3.7' '2.7')
+    supported_message='2.7, 3.6, or 3.7'
+  elif [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -eq 17 ]]; then
+    supported_python_versions=('3.6' '3.7' '3.8' '3.9')
+    supported_message='3.6+'
+  else
+    supported_python_versions=('3.9' '3.8' '3.7' '3.6')
+    supported_message='3.6+'
+  fi
+  for version in "${supported_python_versions[@]}"; do
+    command -v "python${version}" && return 0
+  done
+  die "No valid Python interpreter found. For this Pants version, Pants requires Python ${supported_message}."
+}
+
+function determine_python_exe {
+  pants_version="$1"
+  if [[ "${PYTHON_BIN_NAME}" != 'unspecified' ]]; then
+    python_bin_name="${PYTHON_BIN_NAME}"
+  else
+    interpreter_version="$(get_pants_ini_config_value 'pants_runtime_python_version')"
+    if [[ -n "${interpreter_version}" ]]; then
+      python_bin_name="python${interpreter_version}"
+    else
+      python_bin_name="$(determine_default_python_exe "${pants_version}")"
+    fi
+  fi
+  get_exe_path_or_die "${python_bin_name}"
+}
+
+# TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX
+# functions.  Any tmp dir w/o a symlink pointing to it can go.
+
+function bootstrap_venv {
+  if [[ ! -d "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}" ]]; then
+    (
+      mkdir -p "${PANTS_BOOTSTRAP}"
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      cd "${staging_dir}"
+      curl -LO "https://pypi.io/packages/source/v/virtualenv/${VENV_TARBALL}"
+      tar -xzf "${VENV_TARBALL}"
+      ln -s "${staging_dir}/${VENV_PACKAGE}" "${staging_dir}/latest"
+      mv "${staging_dir}/latest" "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"
+    ) 1>&2
+  fi
+  echo "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"
+}
+
+function bootstrap_pants {
+  pants_version="$1"
+  python="$2"
+
+  pants_requirement="pantsbuild.pants==${pants_version}"
+  python_major_minor_version="$(get_python_major_minor_version "${python}")"
+  target_folder_name="${pants_version}_py${python_major_minor_version}"
+
+  if [[ ! -d "${PANTS_BOOTSTRAP}/${target_folder_name}" ]]; then
+    (
+      venv_path="$(bootstrap_venv)"
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      "${python}" "${venv_path}/virtualenv.py" --no-download "${staging_dir}/install"
+      "${staging_dir}/install/bin/pip" install -U pip
+      "${staging_dir}/install/bin/pip" install "${pants_requirement}"
+      ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}"
+      mv "${staging_dir}/${target_folder_name}" "${PANTS_BOOTSTRAP}/${target_folder_name}"
+      green "New virtual environment successfully created at ${PANTS_BOOTSTRAP}/${target_folder_name}."
+    ) 1>&2
+  fi
+  echo "${PANTS_BOOTSTRAP}/${target_folder_name}"
+}
+
+# Ensure we operate from the context of the ./pants buildroot.
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+pants_version="$(determine_pants_version)"
+python="$(determine_python_exe "${pants_version}")"
+pants_dir="$(bootstrap_pants "${pants_version}" "${python}")"
+
+
+# We set the env var no_proxy to '*', to work around an issue with urllib using non
+# async-signal-safe syscalls after we fork a process that has already spawned threads.
+#
+# See https://blog.phusion.nl/2017/10/13/why-ruby-app-servers-break-on-macos-high-sierra-and-what-can-be-done-about-it/
+export no_proxy='*'
+
+exec "${pants_dir}/bin/python" "${pants_dir}/bin/pants" "$@"

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -67,7 +67,8 @@ final class BuildTools(
       SbtBuildTool(version = "", userConfig, config),
       GradleBuildTool(userConfig),
       MavenBuildTool(userConfig),
-      MillBuildTool(userConfig)
+      MillBuildTool(userConfig),
+      PantsBuildTool(userConfig)
     )
   }
 
@@ -90,6 +91,7 @@ final class BuildTools(
     else if (isGradle) Some(GradleBuildTool(userConfig))
     else if (isMaven) Some(MavenBuildTool(userConfig))
     else if (isMill) Some(MillBuildTool(userConfig))
+    else if (isPants) Some(PantsBuildTool(userConfig))
     else None
   }
 
@@ -103,6 +105,7 @@ final class BuildTools(
     else if (isGradle) GradleBuildTool.isGradleRelatedPath(workspace, path)
     else if (isMaven) MavenBuildTool.isMavenRelatedPath(workspace, path)
     else if (isMill) MillBuildTool.isMillRelatedPath(workspace, path)
+    else if (isPants) PantsBuildTool.isPantsRelatedPath(workspace, path)
     else false
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
@@ -34,10 +34,7 @@ case class PantsBuildTool(
   }
 
   private def pantsTargets(): List[String] =
-    userConfig().pantsTargets match {
-      case None => Nil
-      case Some(target) => target.split(" ").toList
-    }
+    userConfig().pantsTargets.getOrElse(Nil)
 
   override def onBuildTargets(
       workspace: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
@@ -70,7 +70,8 @@ case class PantsBuildTool(
   def bloopInstall(
       workspace: AbsolutePath,
       languageClient: MetalsLanguageClient,
-      systemProcess: List[String] => Future[BloopInstallResult]
+      // Not used: we call metals/slowTask directly
+      _unused: List[String] => Future[BloopInstallResult]
   ): Future[BloopInstallResult] = {
     pantsTargets() match {
       case Nil =>

--- a/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
@@ -1,0 +1,116 @@
+package scala.meta.internal.builds
+
+import scala.meta.io.AbsolutePath
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.pantsbuild.BloopPants
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.meta.internal.metals.BloopInstallResult
+import scala.meta.internal.metals.Timer
+import scala.meta.internal.metals.Time
+import scala.util.Failure
+import scala.util.Success
+import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.MetalsLanguageClient
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.FutureCancelToken
+import scala.meta.internal.pantsbuild.Args
+import scala.meta.internal.pantsbuild.PantsConfiguration
+
+case class PantsBuildTool(
+    userConfig: () => UserConfiguration
+)(implicit ec: ExecutionContext)
+    extends BuildTool {
+  override def toString(): String = "pants"
+  // NOTE(olafur) Version detection is not supported yet for Pants.
+  def version: String = "1.0.0"
+  def minimumVersion: String = "1.0.0"
+  def recommendedVersion: String = "1.0.0"
+
+  def executableName: String = "pants"
+  def digest(workspace: AbsolutePath): Option[String] = {
+    new PantsDigest(userConfig).current(workspace)
+  }
+
+  private def pantsTargets(): List[String] =
+    userConfig().pantsTargets match {
+      case None => Nil
+      case Some(target) => target.split(" ").toList
+    }
+
+  override def onBuildTargets(
+      workspace: AbsolutePath,
+      buildTargets: BuildTargets
+  ): Unit = {
+    buildTargets.addBuildTargetInference { source =>
+      // Fallback to `./pants --owner-of=$source list` when hitting on "no build target"
+      if (source.isScalaScript) {
+        BloopPants
+          .pantsOwnerOf(
+            workspace,
+            source.resolveSibling(_.stripSuffix(".sc") + ".scala")
+          )
+          .map(
+            target => PantsConfiguration.toBloopBuildTarget(workspace, target)
+          )
+      } else if (source.isScalaOrJava) {
+        BloopPants.bloopAddOwnerOf(workspace, source)
+      } else {
+        Nil
+      }
+    }
+    userConfig().pantsTargets.foreach { pantsTargets =>
+      PantsConfiguration
+        .sourceRoots(workspace, pantsTargets)
+        .foreach(root => buildTargets.addSourceRoot(root))
+    }
+  }
+
+  def bloopInstall(
+      workspace: AbsolutePath,
+      languageClient: MetalsLanguageClient,
+      systemProcess: List[String] => Future[BloopInstallResult]
+  ): Future[BloopInstallResult] = {
+    pantsTargets() match {
+      case Nil =>
+        Future.successful(BloopInstallResult.Failed(1))
+      case targets =>
+        Future {
+          val timer = new Timer(Time.system)
+          val response = languageClient.metalsSlowTask(
+            Messages.bloopInstallProgress(executableName)
+          )
+          val token = FutureCancelToken(response.asScala.map(_.cancel))
+          try {
+            val args = Args().copy(
+              workspace = workspace.toNIO,
+              out = workspace.toNIO,
+              targets = targets,
+              isCache = false,
+              isCompile = true
+            )
+            BloopPants.bloopInstall(args) match {
+              case Failure(error) =>
+                scribe.error(s"pants bloopInstall failed", error)
+                BloopInstallResult.Failed(1)
+              case Success(count) =>
+                scribe.info(s"Exported ${count} Pants targets(s) in $timer")
+                BloopInstallResult.Installed
+            }
+          } finally {
+            response.cancel(false)
+          }
+        }
+    }
+  }
+}
+
+object PantsBuildTool {
+  def isPantsRelatedPath(
+      workspace: AbsolutePath,
+      path: AbsolutePath
+  ): Boolean = {
+    path.toNIO.endsWith("BUILD")
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
@@ -43,6 +43,9 @@ case class PantsBuildTool(
     buildTargets.addBuildTargetInference { source =>
       // Fallback to `./pants --owner-of=$source list` when hitting on "no build target"
       if (source.isScalaScript) {
+        // Convert Scala script name into a `*.scala` filename to find out what
+        // target it should belong to. Pants doesn't support Scala scripts so
+        // using the script name unchanged would return no targets.
         BloopPants
           .pantsOwnerOf(
             workspace,

--- a/metals/src/main/scala/scala/meta/internal/builds/PantsDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/PantsDigest.scala
@@ -1,0 +1,41 @@
+package scala.meta.internal.builds
+
+import scala.meta.io.AbsolutePath
+import java.security.MessageDigest
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.pantsbuild.PantsConfiguration
+
+class PantsDigest(userConfig: () => UserConfiguration) extends Digestable {
+  override protected def digestWorkspace(
+      workspace: AbsolutePath,
+      digest: MessageDigest
+  ): Boolean = {
+    userConfig().pantsTargets match {
+      case None =>
+        scribe.info(
+          "skipping build import for Pants workspace since the setting 'pants-targets' is not defined. " +
+            "To fix this problem, update the 'pants-targets' setting to list what build targets should be imported in this workspace."
+        )
+        false
+      case Some(pantsTargets) =>
+        digestBuildFiles(workspace, digest, pantsTargets)
+    }
+  }
+
+  private def digestBuildFiles(
+      workspace: AbsolutePath,
+      digest: MessageDigest,
+      pantsTargets: String
+  ): Boolean = {
+    var isOk = true
+    for {
+      root <- PantsConfiguration.sourceRoots(workspace, pantsTargets)
+      buildFile <- root.listRecursive.filter(_.toNIO.endsWith("BUILD"))
+    } {
+      isOk &= Digest.digestFile(buildFile, digest)
+    }
+    isOk
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/builds/PantsDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/PantsDigest.scala
@@ -26,7 +26,7 @@ class PantsDigest(userConfig: () => UserConfiguration) extends Digestable {
   private def digestBuildFiles(
       workspace: AbsolutePath,
       digest: MessageDigest,
-      pantsTargets: String
+      pantsTargets: List[String]
   ): Boolean = {
     var isOk = true
     for {

--- a/metals/src/main/scala/scala/meta/internal/builds/PantsDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/PantsDigest.scala
@@ -28,14 +28,11 @@ class PantsDigest(userConfig: () => UserConfiguration) extends Digestable {
       digest: MessageDigest,
       pantsTargets: List[String]
   ): Boolean = {
-    var isOk = true
-    for {
-      root <- PantsConfiguration.sourceRoots(workspace, pantsTargets)
-      buildFile <- root.listRecursive.filter(_.toNIO.endsWith("BUILD"))
-    } {
-      isOk &= Digest.digestFile(buildFile, digest)
+    PantsConfiguration.sourceRoots(workspace, pantsTargets).forall { root =>
+      root.listRecursive.filter(_.toNIO.endsWith("BUILD")).forall { buildFile =>
+        Digest.digestFile(buildFile, digest)
+      }
     }
-    isOk
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -801,14 +801,20 @@ class MetalsLanguageServer(
           errors.foreach { error =>
             scribe.error(s"config error: $error")
           }
+          Future.successful(())
         case Right(value) =>
           val old = userConfig
           userConfig = value
           if (userConfig.symbolPrefixes != old.symbolPrefixes) {
             compilers.restartAll()
           }
+          if (userConfig.pantsTargets != old.pantsTargets) {
+            slowConnectToBuildServer(forceImport = false).ignoreValue
+          } else {
+            Future.successful(())
+          }
       }
-    }.asJava
+    }.flatten.asJava
 
   @JsonNotification("workspace/didChangeWatchedFiles")
   def didChangeWatchedFiles(

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -28,7 +28,8 @@ case class UserConfiguration(
     symbolPrefixes: Map[String, String] =
       PresentationCompilerConfig.defaultSymbolPrefixes().asScala.toMap,
     worksheetScreenWidth: Int = 120,
-    worksheetCancelTimeout: Int = 4
+    worksheetCancelTimeout: Int = 4,
+    pantsTargets: Option[String] = None
 )
 object UserConfiguration {
 
@@ -90,6 +91,18 @@ object UserConfiguration {
       """Optional custom path to the .scalafmt.conf file.
         |Should be relative to the workspace root directory and use forward slashes / for file
         |separators (even on Windows).
+        |""".stripMargin
+    ),
+    UserConfigurationOption(
+      "pants-targets",
+      """empty string `""`.""",
+      "src::",
+      "Pants targets",
+      """The pants targets to export.
+        |
+        |Space separated list of Pants targets to export, for example
+        |`src/main/scala:: src/main/java::`. Syntax such as `src/{main,test}::`
+        |is not supported.
         |""".stripMargin
     )
   )
@@ -181,6 +194,8 @@ object UserConfiguration {
     val worksheetCancelTimeout =
       getIntKey("worksheet-cancel-timeout")
         .getOrElse(default.worksheetCancelTimeout)
+    val pantsTargets =
+      getStringKey("pants-targets")
 
     if (errors.isEmpty) {
       Right(
@@ -193,7 +208,8 @@ object UserConfiguration {
           scalafmtConfigPath,
           symbolPrefixes,
           worksheetScreenWidth,
-          worksheetCancelTimeout
+          worksheetCancelTimeout,
+          pantsTargets
         )
       )
     } else {

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
@@ -45,7 +45,8 @@ private[debug] final class DebugProxy(
       exitStatus.trySuccess(Restarted)
       outputTerminated = true
       server.consume(message)
-
+    case null =>
+      () // do nothing
     case message =>
       server.consume(message)
   }

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/Args.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/Args.scala
@@ -1,0 +1,93 @@
+package scala.meta.internal.pantsbuild
+
+import java.nio.file.Path
+import scala.meta.internal.io.PathIO
+import scala.meta.io.AbsolutePath
+import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.pc.CancelToken
+import scala.util.Try
+import scala.util.Failure
+import scala.util.Success
+
+/**
+ * The command-line argument parser for BloopPants.
+ */
+case class Args(
+    isHelp: Boolean = false,
+    isCompile: Boolean = true,
+    isCache: Boolean = false,
+    isRegenerate: Boolean = false,
+    maxFileCount: Int = 500,
+    workspace: Path = PathIO.workingDirectory.toNIO,
+    out: Path = PathIO.workingDirectory.toNIO,
+    targets: List[String] = Nil,
+    token: CancelToken = EmptyCancelToken,
+    onFilemap: Filemap => Unit = _ => Unit
+) {
+  def helpMessage: String =
+    s"""pants-bloop [option ..] <dir ..>
+       |
+       |Command-line tool to export a Pants build into Bloop JSON config files.
+       |The <dir ..> arguments are directories containing BUILD files to export,
+       |for example "src/main/scala".
+       |
+       |  --help
+       |    Print this help message
+       |  --workspace <dir>
+       |    The directory containing the pants build.
+       |  --out <dir>
+       |    The directory containing the generated Bloop JSON files. Defaults to --workspace if not provided.
+       |  --regenerate (default=false)
+       |    If enabled, only re-expands the source globs to pick up new file creations.
+       |  --[no-]cache (default=false)
+       |    If enabled, cache the result from `./pants export`
+       |  --[no-]compile (default=$isCompile)
+       |    If ena, do not run `./pants compile`
+       |  --max-file-count (default=$maxFileCount)
+       |    The export process fails fast if the number of exported source files exceeds this threshold.
+       |""".stripMargin
+}
+object Args {
+  def parse(args: List[String]): Either[List[String], Args] =
+    args match {
+      case Nil => Right(Args(isHelp = true))
+      case _ => parse(args, Args())
+    }
+  def parse(args: List[String], base: Args): Either[List[String], Args] =
+    args match {
+      case Nil => Right(base)
+      case "--help" :: tail =>
+        Right(Args(isHelp = true))
+      case "--workspace" :: workspace :: tail =>
+        val dir = AbsolutePath(workspace).toNIO
+        val out =
+          if (base.out == base.workspace) dir
+          else base.out
+        parse(tail, base.copy(workspace = dir, out = out))
+      case "--out" :: out :: tail =>
+        parse(tail, base.copy(out = AbsolutePath(out).toNIO))
+      case "--compile" :: tail =>
+        parse(tail, base.copy(isCompile = true))
+      case "--regenerate" :: tail =>
+        parse(tail, base.copy(isRegenerate = true))
+      case "--no-compile" :: tail =>
+        parse(tail, base.copy(isCompile = false))
+      case "--cache" :: tail =>
+        parse(tail, base.copy(isCache = true))
+      case "--no-cache" :: tail =>
+        parse(tail, base.copy(isCache = false))
+      case "--max-file-count" :: count :: tail =>
+        Try(count.toInt) match {
+          case Failure(_) =>
+            Left(
+              List(
+                s"type mismatch: --max-file-count expected a number, got '$count'"
+              )
+            )
+          case Success(value) =>
+            parse(tail, base.copy(maxFileCount = value))
+        }
+      case tail =>
+        Right(base.copy(targets = base.targets ++ tail))
+    }
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/Args.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/Args.scala
@@ -42,7 +42,7 @@ case class Args(
        |  --[no-]cache (default=false)
        |    If enabled, cache the result from `./pants export`
        |  --[no-]compile (default=$isCompile)
-       |    If ena, do not run `./pants compile`
+       |    If enabled, do not run `./pants export-classpath`
        |  --max-file-count (default=$maxFileCount)
        |    The export process fails fast if the number of exported source files exceeds this threshold.
        |""".stripMargin

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -1,0 +1,657 @@
+package scala.meta.internal.pantsbuild
+
+import bloop.config.{Config => C}
+import java.nio.file.Paths
+import java.nio.file.Files
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import scala.collection.mutable
+import ujson.Value
+import scala.util.Success
+import scala.util.Failure
+import scala.util.Try
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.Timer
+import scala.meta.internal.metals.Time
+import java.nio.file.NoSuchFileException
+import scala.meta.internal.mtags.MD5
+import scala.util.Properties
+import coursierapi.Dependency
+import scala.concurrent.ExecutionContext
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.process.SystemProcess
+import scala.meta.pc.CancelToken
+import scala.util.control.NonFatal
+import scala.meta.internal.pc.InterruptException
+import scala.meta.internal.metals.MetalsLogger
+import scala.meta.io.AbsolutePath
+import scala.meta.internal.ansi.LineListener
+import java.util.concurrent.CancellationException
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import scala.sys.process.Process
+
+object BloopPants {
+
+  def main(argStrings: Array[String]): Unit = {
+    MetalsLogger.updateDefaultFormat()
+    Args.parse(argStrings.toList) match {
+      case Left(errors) =>
+        errors.foreach { error =>
+          scribe.error(error)
+        }
+        System.exit(1)
+      case Right(args) =>
+        if (args.isHelp) {
+          println(args.helpMessage)
+        } else if (args.isRegenerate) {
+          bloopRegenerate(
+            AbsolutePath(args.workspace),
+            args.targets
+          )(ExecutionContext.global)
+        } else {
+          val workspace = args.workspace
+          val targets = args.targets
+          val timer = new Timer(Time.system)
+          val installResult = bloopInstall(args)(ExecutionContext.global)
+          installResult match {
+            case Failure(exception) =>
+              scribe.error(s"bloopInstall failed in $timer", exception)
+              sys.exit(1)
+            case Success(count) =>
+              scribe.info(s"time: exported ${count} Pants target(s) in $timer")
+          }
+        }
+    }
+  }
+
+  def bloopAddOwnerOf(
+      workspace: AbsolutePath,
+      source: AbsolutePath
+  ): Seq[BuildTargetIdentifier] = synchronized {
+    val targets = pantsOwnerOf(workspace, source)
+    if (targets.nonEmpty) {
+      val bloopDir = workspace.resolve(".bloop")
+      for {
+        target <- targets
+        jsonFile = bloopDir.resolve(BloopPants.makeJsonFilename(target))
+        if jsonFile.isFile
+      } {
+        val json = ujson.read(jsonFile.readText)
+        val sources = json("project")("sources").arr
+        val sourceStr = Value.Str(source.toString())
+        if (!sources.contains(sourceStr)) {
+          sources += sourceStr
+          jsonFile.writeText(ujson.write(json, indent = 4))
+          scribe.info(s"add source: $jsonFile")
+        }
+      }
+    }
+    targets.map { target =>
+      val baseDirectory = PantsConfiguration.baseDirectory(workspace, target)
+      PantsConfiguration.toBloopBuildTarget(baseDirectory, target)
+    }
+  }
+
+  def pantsOwnerOf(
+      workspace: AbsolutePath,
+      source: AbsolutePath
+  ): Seq[String] = {
+    try {
+      val relpath = source.toRelative(workspace).toString()
+      val output = Process(
+        List[String](
+          workspace.resolve("pants").toString(),
+          s"--owner-of=$relpath",
+          "list"
+        ),
+        cwd = Some(workspace.toFile)
+      ).!!
+      output.linesIterator.toSeq.distinct
+    } catch {
+      case NonFatal(_) =>
+        Nil
+    }
+  }
+
+  private def targetDirectory(target: String): String = {
+    val colon = target.lastIndexOf(':')
+    if (colon < 0) target
+    else target.substring(0, colon)
+  }
+
+  private def interruptedTry[T](thunk: => T): Try[T] =
+    try {
+      Success(thunk)
+    } catch {
+      case NonFatal(e) => Failure(e)
+      case e @ InterruptException() => Failure(e)
+    }
+
+  def bloopInstall(args: Args)(implicit ec: ExecutionContext): Try[Int] =
+    interruptedTry {
+      val cacheDir = Files.createDirectories(
+        args.workspace.resolve(".pants.d").resolve("metals")
+      )
+      val outputFilename = {
+        val processed =
+          args.targets.map(_.replaceAll("[^a-zA-Z0-9]", "")).mkString
+        if (processed.isEmpty()) {
+          MD5.compute(args.targets.mkString) // necessary for targets like "::/"
+        } else {
+          processed
+        }
+      }
+      val outputFile = cacheDir.resolve(s"$outputFilename.json")
+      val bloopDir = Files.createDirectories(args.out.resolve(".bloop"))
+      args.token.checkCanceled()
+
+      val filemap = Filemap.fromPants(args.workspace, args.targets)
+      val fileCount = filemap.fileCount()
+      if (fileCount > args.maxFileCount) {
+        val targetSyntax = args.targets.mkString("'", "' '", "'")
+        scribe.error(
+          s"The target set ${targetSyntax} is too broad, it expands to ${fileCount} source files " +
+            s"when the maximum number of allowed source files is ${args.maxFileCount}. " +
+            s"To fix this problem, configure a smaller set of Pants targets."
+        )
+        throw new CancellationException("too many Pants targets")
+      }
+      args.onFilemap(filemap)
+
+      if (!args.isCache || !Files.isRegularFile(outputFile)) {
+        runPantsExport(args, outputFile)
+      }
+
+      if (Files.isRegularFile(outputFile)) {
+        val text =
+          new String(Files.readAllBytes(outputFile), StandardCharsets.UTF_8)
+        val json = ujson.read(text)
+        new BloopPants(args, bloopDir, json, filemap).run()
+      } else {
+        throw new NoSuchFileException(
+          outputFile.toString(),
+          null,
+          "expected this file to exist after running `./pants export`"
+        )
+      }
+    }
+
+  def bloopRegenerate(
+      workspace: AbsolutePath,
+      targets: List[String]
+  )(implicit ec: ExecutionContext): Unit = {
+    val filemap = Filemap.fromPants(workspace.toNIO, targets)
+    val bloopDir = workspace.resolve(".bloop")
+    for {
+      (target, files) <- filemap.iterator()
+      jsonFile = bloopDir.resolve(BloopPants.makeJsonFilename(target))
+      if jsonFile.isFile
+    } {
+      val json = ujson.read(jsonFile.readText)
+      val newSources =
+        files.iterator.map(file => Value.Str(file.toString)).toBuffer
+      json("project")("sources") = newSources
+      jsonFile.writeText(ujson.write(json, indent = 4))
+    }
+  }
+
+  private def runPantsExport(
+      args: Args,
+      outputFile: Path
+  )(implicit ec: ExecutionContext): Unit = {
+    val pantsBinary = args.workspace.resolve("pants").toString()
+    val command = List[String](
+      pantsBinary,
+      s"--no-quiet",
+      s"--export-libraries-sources",
+      s"--export-output-file=$outputFile",
+      s"export-classpath",
+      s"export"
+    ) ++ args.targets
+    val shortName = "pants export-classpath export"
+    SystemProcess.run(
+      shortName,
+      command,
+      args.workspace,
+      args.token,
+      LineListener.info
+    )
+  }
+
+  private val nonAlphanumeric = "[^a-zA-Z0-9]".r
+  def makeFilename(target: String): String = {
+    nonAlphanumeric.replaceAllIn(target, "")
+  }
+  def makeJsonFilename(target: String): String = {
+    makeReadableFilename(target) + ".json"
+  }
+  def makeReadableFilename(target: String): String = {
+    nonAlphanumeric.replaceAllIn(target, "-")
+  }
+
+}
+
+private class BloopPants(
+    args: Args,
+    bloopDir: Path,
+    json: Value,
+    filemap: Filemap
+)(implicit ec: ExecutionContext) { self =>
+  def token: CancelToken = args.token
+  def workspace: Path = args.workspace
+  def userTargets: List[String] = args.targets
+
+  private val cycles = Cycles.findConnectedComponents(json)
+  private val scalaCompiler = "org.scala-lang:scala-compiler:"
+
+  private val transitiveClasspath = mutable.Map.empty[String, List[Path]]
+  private val isVisited = mutable.Set.empty[String]
+  private val binaryDependencySources = mutable.Set.empty[Path]
+
+  val targets: mutable.LinkedHashMap[String, Value] = json.obj("targets").obj
+  val libraries: mutable.LinkedHashMap[String, Value] =
+    json.obj("libraries").obj
+  val compilerVersion: String = libraries.keysIterator
+    .collectFirst {
+      case module if module.startsWith(scalaCompiler) =>
+        module.stripPrefix(scalaCompiler)
+    }
+    .getOrElse {
+      scribe.warn(
+        s"missing scala-compiler: falling back to ${Properties.versionNumberString}"
+      )
+      Properties.versionNumberString
+    }
+  val allScalaJars: Seq[Path] = {
+    val scalaJars = libraries.collect {
+      case (module, jar) if isScalaJar(module) =>
+        Paths.get(jar.obj("default").str)
+    }.toSeq
+    val hasScalaCompiler =
+      scalaJars.exists(_.getFileName().toString().contains("scala-compiler"))
+    if (hasScalaCompiler) {
+      scalaJars
+    } else {
+      scalaJars ++
+        coursierapi.Fetch
+          .create()
+          .addDependencies(
+            Dependency.of("org.scala-lang", "scala-compiler", compilerVersion)
+          )
+          .fetch()
+          .asScala
+          .map(_.toPath)
+    }
+  }
+
+  def run(): Int = {
+    token.checkCanceled()
+    // Create Bloop projects that only contain the classpath of direct
+    // dependencies but not transitive dependencies.
+    val shallowClasspathProjects = targets.collect {
+      case (id, target) if isSupportedTargetType(target) =>
+        toBloopProject(id, target)
+    }
+    val byName = shallowClasspathProjects.map(p => p.name -> p).toMap
+
+    // Add full transitive classpath to Bloop projects.
+    val fullClasspathProjects = shallowClasspathProjects.map { p =>
+      val children = cycles.children.getOrElse(p.name, Nil)
+      val extraSources = children.flatMap(child => byName(child).sources)
+      val extraDependencies = children
+        .flatMap(child => byName(child).dependencies)
+        .filter(_ != p.name)
+      val dependencies = (p.dependencies ++ extraDependencies).distinct
+      p.copy(
+        classpath = getTransitiveClasspath(p.name, byName),
+        sources = (p.sources ++ extraSources).distinct,
+        dependencies = dependencies.filterNot(_.isBinaryDependency)
+      )
+    }
+
+    val binaryDependenciesToCompile = mutable.Set.empty[String]
+    for {
+      project <- shallowClasspathProjects
+      if !project.name.isBinaryDependency
+      dependency <- project.dependencies.iterator
+      if dependency.isBinaryDependency
+      dependencyProject <- byName.get(dependency)
+      if dependencyProject.sources.nonEmpty
+    } {
+      binaryDependenciesToCompile += dependency
+    }
+
+    val binaryDependencyResolution =
+      binaryDependencySources.iterator.map(newSourceModule)
+    var generatedProjects = Set.empty[Path]
+    fullClasspathProjects.foreach { bloop =>
+      if (cycles.parents.contains(bloop.name) ||
+        bloop.name.isBinaryDependency) {
+        // do nothing
+      } else {
+        val out = bloopDir.resolve(BloopPants.makeJsonFilename(bloop.name))
+        val withBinaryResolution =
+          if (binaryDependencyResolution.hasNext) {
+            val extraResolution =
+              bloop.resolution.map(_.modules).getOrElse(Nil)
+            bloop.copy(
+              resolution = Some(
+                C.Resolution(
+                  binaryDependencyResolution.toList ++ extraResolution
+                )
+              )
+            )
+          } else {
+            bloop
+          }
+        val json = C.File(BuildInfo.bloopVersion, withBinaryResolution)
+        _root_.bloop.config.write(json, out)
+        generatedProjects += out
+      }
+    }
+    cleanStaleBloopFiles(generatedProjects)
+    token.checkCanceled()
+    generatedProjects.size
+  }
+
+  private val unsupportedTargetType = Set(
+    "files", "page", "python_binary", "python_tests", "python_library",
+    "python_requirement_library"
+  )
+
+  implicit class XtensionTargetString(value: String) {
+    def isBinaryDependency: Boolean = {
+      !userTargets.exists(target => value.startsWith(target.stripSuffix("::")))
+    }
+    def baseDirectory: Path =
+      PantsConfiguration.baseDirectory(AbsolutePath(workspace), value).toNIO
+  }
+  implicit class XtensionValue(value: Value) {
+    def pantsTargetType: String = value.obj("pants_target_type").str
+    def targetType: String = value.obj("target_type").str
+    def id: String = value.obj("id").str
+    def isTestTarget: Boolean = targetType == "TEST"
+    def isResourceTarget: Boolean = targetType == "RESOURCE"
+  }
+  private def isSupportedTargetType(target: Value): Boolean =
+    // Instead of whitelisting which target types we support, we hardcode which
+    // known target types we know we don't support. Pants plugins can introduce
+    // new target types that are minor variations of for example `scala_library`
+    // that we may want to support.
+    !unsupportedTargetType.contains(target.pantsTargetType)
+
+  private def toBloopProject(
+      id: String,
+      target: Value
+  ): C.Project = {
+
+    val baseDirectories = for {
+      roots <- target.obj.get("roots").toList
+      root <- roots.arr
+      sourceRoot <- root.obj.get("source_root")
+    } yield Paths.get(sourceRoot.str)
+
+    val baseDirectory = id.baseDirectory
+
+    val sources =
+      if (target.isResourceTarget) Nil
+      else filemap.forTarget(id).toList
+
+    // Extract target dependencies.
+    val dependsOn = (for {
+      dependency <- target.obj("targets").arr
+      acyclicDependency = cycles.acyclicDependency(dependency.str)
+      if acyclicDependency != id
+      if isSupportedTargetType(targets(acyclicDependency))
+    } yield acyclicDependency).toList
+
+    // Extract class directories of direct target dependencies.
+    val dependencyClassdirectories: List[Path] = (for {
+      dependency <- target.obj("targets").arr
+      classDir <- makeClassdirectory(dependency.str)
+    } yield classDir).toList
+
+    // Extract 3rd party library dependencies, and their associated sources.
+    val libraryDependencies = for {
+      dependency <- target.obj("libraries").arr
+      library <- libraries.get(dependency.str)
+    } yield library
+    val libraryDependencyConfigs: List[String] =
+      List("test", "default", "shaded", "linux-x86_64", "thrift9")
+    val libraryDependencyClasspaths =
+      getLibraryDependencies(libraryDependencies, libraryDependencyConfigs)
+    val sourcesConfigs = List("sources")
+    val libraryDependencySources =
+      getLibraryDependencies(libraryDependencies, sourcesConfigs)
+
+    // Warn about unfamiliar configurations.
+    val knownConfigs = sourcesConfigs ::: libraryDependencyConfigs
+    val unknownConfigs = libraryDependencies
+      .flatMap(
+        lib => lib.obj.keys.toSet -- knownConfigs
+      )
+      .distinct
+    if (unknownConfigs.nonEmpty) {
+      val kinds = unknownConfigs.mkString(",")
+      println(
+        s"[warning] Unknown configs for target '${id}' with type '${target.targetType}': ${kinds}"
+      )
+    }
+
+    val out = bloopDir.resolve(BloopPants.makeFilename(id))
+    val classDirectory = out.resolve("classes")
+    val javaHome = Option(System.getProperty("java.home")).map(Paths.get(_))
+
+    val resources =
+      if (target.isResourceTarget) {
+        // Resources are relativized by the directory where the BUILD file exists.
+        Some(List(baseDirectory))
+      } else {
+        None
+      }
+
+    val test = if (target.pantsTargetType.contains("test")) {
+      val scalatest = C.TestFramework(
+        List(
+          "org.scalatest.tools.Framework",
+          "org.scalatest.tools.ScalaTestFramework"
+        )
+      )
+      // These test frameworks are the default output from running `show
+      // testFrameworks` in sbt (excluding spec2). The output from `./pants
+      // export` doesn't include the configured test frameworks.
+      val defaultTestFrameworks = List(
+        scalatest,
+        C.TestFramework(List("org.scalacheck.ScalaCheckFramework")),
+        C.TestFramework(List("com.novocode.junit.JUnitFramework"))
+      )
+      Some(
+        C.Test(
+          frameworks = defaultTestFrameworks,
+          options = C.TestOptions(
+            excludes = Nil,
+            arguments = List(
+              C.TestArgument(
+                List("-o"),
+                Some(scalatest)
+              )
+            )
+          )
+        )
+      )
+    } else {
+      None
+    }
+
+    val resolution: Option[C.Resolution] =
+      if (id.isBinaryDependency) {
+        binaryDependencySources ++= libraryDependencySources
+        binaryDependencySources ++= enclosingSourceDirectory(baseDirectory)
+        None
+      } else {
+        Some(
+          C.Resolution(
+            libraryDependencySources.iterator.map(newSourceModule).toList
+          )
+        )
+      }
+
+    C.Project(
+      name = id,
+      directory = baseDirectory,
+      workspaceDir = Some(workspace),
+      sources,
+      dependencies = dependsOn,
+      classpath = dependencyClassdirectories ++ libraryDependencyClasspaths,
+      out = out,
+      classesDir = classDirectory,
+      resources = resources,
+      scala = Some(
+        C.Scala(
+          "org.scala-lang",
+          "scala-compiler",
+          compilerVersion,
+          List.empty[String],
+          allScalaJars.toList,
+          None,
+          setup = Some(
+            C.CompileSetup(
+              C.Mixed,
+              addLibraryToBootClasspath = true,
+              addCompilerToClasspath = false,
+              addExtraJarsToClasspath = false,
+              manageBootClasspath = true,
+              filterLibraryFromClasspath = true
+            )
+          )
+        )
+      ),
+      java = Some(C.Java(Nil)),
+      sbt = None,
+      test = test,
+      platform = Some(C.Platform.Jvm(C.JvmConfig(javaHome, Nil), None)),
+      resolution = resolution
+    )
+  }
+
+  lazy val dist: mutable.Buffer[Path] = Files
+    .list(
+      workspace.resolve("dist").resolve("export-classpath")
+    )
+    .asScala
+    .toBuffer
+
+  def enclosingSourceDirectory(file: Path): Option[Path] = {
+    def loop(p: Path): Option[Path] = {
+      if (p == workspace) None
+      else if (p.endsWith("java") || p.endsWith("scala")) Some(p)
+      else {
+        Option(p.getParent()) match {
+          case None => None
+          case Some(parent) => loop(parent)
+        }
+      }
+    }
+    loop(file)
+  }
+
+  private def makeClassdirectory(target: String): List[Path] =
+    if (target.isBinaryDependency) {
+      if (targets(target).isResourceTarget) {
+        List(target.baseDirectory)
+      } else {
+        dist.iterator.filter { p =>
+          val filename = p.filename
+          filename.startsWith(targets(target).id) &&
+          filename.endsWith(".jar")
+        }.toList
+      }
+    } else {
+      List(bloopDir.resolve(BloopPants.makeFilename(target)).resolve("classes"))
+    }
+
+  private def getLibraryDependencies(
+      libraryDependencies: Seq[Value],
+      keys: List[String]
+  ): Seq[Path] =
+    for {
+      lib <- libraryDependencies
+      path <- keys.collectFirst {
+        case key if lib.obj.contains(key) => lib.obj(key)
+      }
+    } yield Paths.get(path.str)
+
+  private def newSourceModule(source: Path) =
+    C.Module(
+      "",
+      "",
+      "",
+      None,
+      artifacts = List(
+        C.Artifact(
+          "",
+          classifier = Some("sources"),
+          None,
+          path = source
+        )
+      )
+    )
+
+  private def getTransitiveClasspath(
+      name: String,
+      byName: Map[String, C.Project]
+  ): List[Path] = {
+    def computeTransitiveClasspath(): List[Path] = {
+      val buf = mutable.Set.empty[Path]
+      buf ++= byName(name).classpath
+      byName(name).dependencies.foreach { dep =>
+        buf ++= getTransitiveClasspath(dep, byName)
+      }
+      val children = cycles.children.getOrElse(name, Nil)
+      children.foreach { child =>
+        buf ++= getTransitiveClasspath(child, byName)
+      }
+
+      // NOTE: Pants automatically includes the compiler classpath for all
+      // targets causing some targets to have an undeclared dependency on
+      // scala-compiler even if they don't compile without scala-compiler on the
+      // classpath.
+      buf ++= allScalaJars
+
+      buf.toList.sorted
+    }
+    if (isVisited(name)) {
+      transitiveClasspath.getOrElse(name, Nil)
+    } else {
+      isVisited += name
+      transitiveClasspath.getOrElseUpdate(name, computeTransitiveClasspath())
+    }
+  }
+
+  private def isScalaJar(module: String): Boolean =
+    module.startsWith(scalaCompiler) ||
+      module.startsWith("org.scala-lang:scala-reflect:") ||
+      module.startsWith("org.scala-lang:scala-library:") ||
+      module.startsWith("org.scala-lang:scala-library:") ||
+      module.startsWith("org.fursesource:jansi:") ||
+      module.startsWith("jline:jline:")
+
+  private def cleanStaleBloopFiles(
+      generatedProjects: Set[Path]
+  ): Unit = {
+    val ls = Files.list(bloopDir)
+    try {
+      ls.filter { path =>
+          Files.isRegularFile(path) &&
+          path.getFileName().toString().endsWith(".json") &&
+          !generatedProjects(path)
+        }
+        .forEach { path =>
+          Files.delete(path)
+        }
+    } finally {
+      ls.close()
+    }
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/Cycles.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/Cycles.scala
@@ -1,0 +1,32 @@
+package scala.meta.internal.pantsbuild
+
+import ujson.Value
+import scala.collection.mutable
+
+case class Cycles(
+    children: collection.Map[String, List[String]],
+    parents: collection.Map[String, String]
+) {
+  def acyclicDependency(target: String): String =
+    parents.getOrElse(target, target)
+}
+object Cycles {
+  def findConnectedComponents(js: Value): Cycles = {
+    val graph = Graph.fromExport(js)
+    val ccs = Tarjans.fromGraph(graph.graph)
+    val children = mutable.Map.empty[String, List[String]]
+    val parents = mutable.Map.empty[String, String]
+    ccs.foreach { cc =>
+      if (cc.lengthCompare(1) > 0) {
+        val it = cc.iterator.map(graph.rindex)
+        val head = it.next()
+        val tail = it.toList
+        children(head) = tail
+        tail.foreach { child =>
+          parents(child) = head
+        }
+      }
+    }
+    Cycles(children, parents)
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/Filemap.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/Filemap.scala
@@ -1,0 +1,52 @@
+package scala.meta.internal.pantsbuild
+
+import java.nio.file.Path
+import scala.collection.mutable
+import scala.meta.internal.process.SystemProcess
+import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.internal.ansi.LineListener
+import scala.concurrent.ExecutionContext
+
+class Filemap(
+    map: mutable.Map[String, mutable.ArrayBuffer[Path]] = mutable.Map.empty
+) {
+  override def toString(): String =
+    pprint.tokenize(map).mkString("Filemap(", "", ")")
+  def fileCount(): Int =
+    map.valuesIterator.foldLeft(0)(_ + _.length)
+  def iterator(): Iterator[(String, collection.Seq[Path])] =
+    map.iterator
+  private[Filemap] def addPath(target: String, path: Path): Unit = {
+    val value =
+      map.getOrElseUpdate(target, mutable.ArrayBuffer.empty[Path])
+    value += path
+  }
+  def forTarget(key: String): List[Path] = map.getOrElse(key, Nil).toList
+}
+
+object Filemap {
+  def fromPants(workspace: Path, targets: List[String])(
+      implicit ec: ExecutionContext
+  ): Filemap = {
+    val filemap = new Filemap()
+    val lines = new LineListener(line => {
+      val split = line.split(" ", 2)
+      if (split.length == 2) {
+        val path = workspace.resolve(split(0))
+        val target = split(1)
+        filemap.addPath(target, path)
+      }
+    })
+    SystemProcess.run(
+      "pants filemap",
+      workspace.resolve("pants").toString() ::
+        "--print-exception-stacktrace=true" ::
+        "filemap" ::
+        targets,
+      workspace,
+      EmptyCancelToken,
+      lines
+    )
+    filemap
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/Graph.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/Graph.scala
@@ -1,0 +1,39 @@
+package scala.meta.internal.pantsbuild
+
+import ujson.Value
+import bloop.config.Config.Project
+
+case class Graph(
+    export: Value,
+    index: String => Int,
+    rindex: Int => String,
+    graph: Array[Array[Int]]
+)
+object Graph {
+  def fromSeq(graph: Seq[Seq[Int]]): Graph = {
+    Graph(Value.Str(""), _.toInt, _.toString, graph.map(_.toArray).toArray)
+  }
+  def fromProjects(projects: Seq[Project]): Graph = {
+    val edges = new Array[Array[Int]](projects.length)
+    val index = projects.map(_.name).zipWithIndex.toMap
+    val rindex = index.map(_.swap).toMap
+    projects.zipWithIndex.foreach {
+      case (project, i) =>
+        edges(i) = project.dependencies.iterator.map(index).toArray
+    }
+    Graph(Value.Str(""), index.apply _, rindex.apply _, edges)
+  }
+  def fromExport(export: Value): Graph = {
+    val targets = export.obj("targets").obj
+    val index = targets.keysIterator.zipWithIndex.toMap
+    val rindex = index.iterator.map(_.swap).toMap
+    val edges = new Array[Array[Int]](index.size)
+    index.foreach {
+      case (key, i) =>
+        val ts = targets(key).obj("targets").arr
+        val deps = ts.iterator.map(dep => index(dep.str)).toArray
+        edges(i) = deps
+    }
+    Graph(export, index.apply _, rindex.apply _, edges)
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsConfiguration.scala
@@ -1,0 +1,65 @@
+package scala.meta.internal.pantsbuild
+
+import scala.meta.io.AbsolutePath
+import scala.collection.mutable
+import java.net.URI
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+
+object PantsConfiguration {
+
+  /**
+   * Converts a Pants target into a Bloop BSP target URI.
+   *
+   * Copy-pasted from https://github.com/scalacenter/bloop/blob/0bb8e1c2750c555f6414165d90f769dd52d105b8/frontend/src/main/scala/bloop/bsp/ProjectUris.scala#L32
+   */
+  def toBloopBuildTarget(
+      projectBaseDir: AbsolutePath,
+      id: String
+  ): BuildTargetIdentifier = {
+    val existingUri = projectBaseDir.toNIO.toUri
+    val uri = new URI(
+      existingUri.getScheme,
+      existingUri.getUserInfo,
+      existingUri.getHost,
+      existingUri.getPort,
+      existingUri.getPath,
+      s"id=${id}",
+      existingUri.getFragment
+    )
+    new BuildTargetIdentifier(uri.toString())
+  }
+
+  /** Returns the nearest enclosing directory of a Pants target */
+  def baseDirectory(workspace: AbsolutePath, target: String): AbsolutePath = {
+    workspace.resolve(target.substring(0, target.lastIndexOf(':')))
+  }
+
+  /**
+   * Returns the toplevel directories that enclose all of the target.
+   *
+   * For example, this method returns the directories `a/src` and `b` given the
+   * targets below:
+   *
+   * - a/src:foo
+   * - a/src/inner:bar
+   * - b:b
+   * - b/inner:c
+   */
+  def sourceRoots(
+      workspace: AbsolutePath,
+      pantsTargets: String
+  ): List[AbsolutePath] = {
+    val parts = pantsTargets.split(" ").map(_.replaceFirst("/?:.*", "")).sorted
+    if (parts.isEmpty) return Nil
+    val buf = mutable.ListBuffer.empty[String]
+    var current = parts(0)
+    buf += current
+    parts.iterator.drop(1).foreach { target =>
+      if (!target.startsWith(current)) {
+        current = target
+        buf += current
+      }
+    }
+    buf.result().map(workspace.resolve)
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/Tarjans.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/Tarjans.scala
@@ -1,0 +1,57 @@
+package scala.meta.internal.pantsbuild
+
+import scala.collection.mutable
+
+// Adapted from:
+// https://github.com/indy256/codelibrary/blob/c52247216258e84aac442a23273b7d8306ef757b/java/src/SCCTarjan.java
+// https://github.com/lihaoyi/mill/blob/bc71cdb7d3f806ca5eeee2a9782ec6e2e5cf6bff/main/core/src/eval/Tarjans.scala
+object Tarjans {
+  def fromGraph(edges: Array[Array[Int]]): Seq[Seq[Int]] = {
+    val n = edges.length
+    val visited = new Array[Boolean](n)
+    val onStack = new Array[Boolean](n)
+    var stack = List.empty[Int]
+    var time = 0
+    val index = new Array[Int](n)
+    val lowlink = new Array[Int](n)
+    val components = mutable.ArrayBuffer.empty[Seq[Int]]
+
+    for (v <- 0 until n) {
+      if (!visited(v)) {
+        strongconnect(v)
+      }
+    }
+
+    def strongconnect(v: Int): Unit = {
+      index(v) = time
+      lowlink(v) = time
+      time += 1
+      visited(v) = true
+      stack ::= v
+      onStack(v) = true
+      for (w <- edges(v)) {
+        if (!visited(w)) {
+          strongconnect(w)
+          lowlink(v) = math.min(lowlink(v), lowlink(w))
+        } else if (onStack(w)) {
+          lowlink(v) = math.min(lowlink(v), index(w))
+        }
+      }
+      if (lowlink(v) == index(v)) {
+        val component = mutable.Buffer.empty[Int]
+        var continue = true
+        while (continue) {
+          val w = stack.head
+          stack = stack.tail
+          onStack(w) = false
+          component.append(w)
+          if (w == v) {
+            continue = false
+          }
+        }
+        components.append(component)
+      }
+    }
+    components
+  }
+}

--- a/tests/slow/src/test/scala/tests/pants/PantsLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/pants/PantsLspSuite.scala
@@ -34,7 +34,7 @@ object PantsLspSuite extends BaseImportSuite("pants") {
       workspace: AbsolutePath
   ): Option[String] = {
     new PantsDigest(
-      () => UserConfiguration(pantsTargets = Option(s"src::"))
+      () => UserConfiguration(pantsTargets = Option(List("src::")))
     ).current(workspace)
   }
 

--- a/tests/slow/src/test/scala/tests/pants/PantsLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/pants/PantsLspSuite.scala
@@ -1,0 +1,210 @@
+package tests.pants
+
+import scala.meta.internal.builds.{PantsBuildTool, PantsDigest}
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.io.AbsolutePath
+import tests.BaseImportSuite
+import scala.meta.internal.builds.BuildTool
+import tests.FileLayout
+import java.nio.file.Files
+import scala.meta.internal.metals.BuildInfo
+import java.nio.file.StandardOpenOption
+import scala.util.control.NonFatal
+import scala.sys.process._
+
+object PantsLspSuite extends BaseImportSuite("pants") {
+
+  val buildTool: PantsBuildTool = PantsBuildTool(() => userConfig)
+
+  override def utestAfterEach(path: Seq[String]): Unit = {
+    try {
+      List(workspace.resolve("pants").toString(), "clean-all", "--async").!
+      super.utestAfterEach(path)
+    } catch {
+      case NonFatal(_) =>
+    }
+  }
+
+  override def utestBeforeEach(path: Seq[String]): Unit = {
+    super.utestBeforeEach(path)
+    installPants()
+  }
+
+  override def currentDigest(
+      workspace: AbsolutePath
+  ): Option[String] = {
+    new PantsDigest(
+      () => UserConfiguration(pantsTargets = Option(s"src::"))
+    ).current(workspace)
+  }
+
+  private def preInitialized = {
+    val pants_targets_config =
+      s"""
+         |{
+         |  "pants-targets": "src::"
+         |}
+         |""".stripMargin
+    server.didChangeConfiguration(pants_targets_config)
+  }
+
+  def installPants(): Unit = {
+    cleanWorkspace()
+    val pants = BuildTool.copyFromResource(workspace.toNIO, "pants")
+    pants.toFile().setExecutable(true)
+    val exit = List(pants.toString(), "generate-pants-ini").!
+    require(exit == 0, "failed to generate pants.ini")
+    Files.write(
+      workspace.resolve("pants.ini").toNIO,
+      """|[scala]
+         |version: custom
+         |suffix_version: 2.12
+         |strict_deps: False
+         |scala_repl: //:scala-repl
+         |""".stripMargin.getBytes(),
+      StandardOpenOption.APPEND
+    )
+    Files.write(
+      workspace.resolve("BUILD.tools").toNIO,
+      s"""|SCALA_VERSION='${BuildInfo.scala212}'
+          |jar_library(
+          |  name = 'scalac',
+          |  jars = [
+          |    jar(org = 'org.scala-lang', name = 'scala-compiler', rev = SCALA_VERSION),
+          |  ],
+          |  dependencies=[
+          |    ':scala-reflect',
+          |    ':scala-library',
+          |  ])
+          |jar_library(name = 'scala-library', jars = [jar(org = 'org.scala-lang', name = 'scala-library', rev = SCALA_VERSION)], scope='force')
+          |jar_library(name = 'scala-reflect', jars = [jar(org = 'org.scala-lang', name = 'scala-reflect', rev = SCALA_VERSION, intransitive=True)])
+          |target(name = 'scala-repl', dependencies=[ ':scalac', ':scala-reflect', ':scala-library'])
+          |""".stripMargin.getBytes()
+    )
+  }
+
+  testAsync("basic") {
+    for {
+      _ <- server.initialize(
+        s"""
+           |/src/BUILD
+           |scala_library(
+           |  name='math',
+           |  sources=globs('*.scala'),
+           |)
+           |/src/Util.scala
+           |package src
+           |object Util {
+           |  def add(a: Int, b: Int) = a + b
+           |}
+           |/src/Math.scala
+           |package src
+           |class Math {
+           |  def add(a: Int, b: Int): Unit = a + b
+           |}
+           |""".stripMargin,
+        preInitialized = () => preInitialized
+      )
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          importBuildMessage,
+          progressMessage
+        ).mkString("\n")
+      )
+      _ <- server.didOpen("src/Math.scala")
+      _ = client.messageRequests.clear() // restart
+      _ <- server.didSave(s"src/BUILD") { text =>
+        text.replace("'math'", "'math1'")
+      }
+      _ <- server.didOpen("src/Util.scala")
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          importBuildChangesMessage,
+          progressMessage
+        ).mkString("\n")
+      )
+    } yield ()
+  }
+
+  testAsync("regenerate") {
+    for {
+      _ <- server.initialize(
+        s"""
+           |/src/BUILD
+           |scala_library(
+           |  name='math',
+           |  sources=globs('*.scala'),
+           |)
+           |/src/Util.scala
+           |package src
+           |object Util {
+           |  def add(a: Int, b: Int) = a + b
+           |}
+           |""".stripMargin,
+        preInitialized = () => preInitialized
+      )
+      _ <- server.didOpen("src/Util.scala")
+      _ = assertNoDiagnostics()
+      _ = FileLayout.fromString(
+        """
+          |/src/Example.scala
+          |package src
+          |object Example {
+          |  def number = Util.add(1, 2)
+          |  def error: Int = ""
+          |}
+          |""".stripMargin,
+        workspace
+      )
+      _ <- server.didOpen("src/Example.scala")
+      _ <- server.didSave("src/Example.scala")(identity)
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|src/Example.scala:4:20: error: type mismatch;
+           | found   : String("")
+           | required: Int
+           |  def error: Int = ""
+           |                   ^^
+           |""".stripMargin
+      )
+    } yield ()
+  }
+
+  testAsync("binary-dependency") {
+    for {
+      _ <- server.initialize(
+        s"""
+           |/core/BUILD
+           |scala_library(
+           |  sources=globs('*.scala'),
+           |)
+           |/core/Lib.scala
+           |package core
+           |object Lib {
+           |  def greeting = "Hello from lib!"
+           |}
+           |/src/BUILD
+           |scala_library(
+           |  sources=globs('*.scala'),
+           |  dependencies=['core:core']
+           |)
+           |/src/Main.scala
+           |package src
+           |object Main extends App {
+           |  println(core.Lib.greeting)
+           |}
+           |""".stripMargin,
+        preInitialized = () => preInitialized
+      )
+      _ <- server.didOpen("src/Main.scala")
+      _ = assertNoDiagnostics() // "core" was compiled during import
+      _ <- server.didOpen("core/Lib.scala")
+      _ <- server.didSave("core/Lib.scala")(
+        _.replaceAllLiterally("greeting", "greeting: Int")
+      )
+      _ = assertNoDiagnostics() // no errors because "core" is not exported.
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/PantsDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/PantsDigestSuite.scala
@@ -8,7 +8,7 @@ object PantsDigestSuite extends BaseDigestSuite {
   override def digestCurrent(
       root: AbsolutePath
   ): Option[String] = {
-    val userConfig = new UserConfiguration(pantsTargets = Option("::"))
+    val userConfig = new UserConfiguration(pantsTargets = Option(List("::")))
     new PantsDigest(() => userConfig).current(root)
   }
 

--- a/tests/unit/src/test/scala/tests/PantsDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/PantsDigestSuite.scala
@@ -1,0 +1,70 @@
+package tests
+
+import scala.meta.internal.builds.PantsDigest
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.io.AbsolutePath
+
+object PantsDigestSuite extends BaseDigestSuite {
+  override def digestCurrent(
+      root: AbsolutePath
+  ): Option[String] = {
+    val userConfig = new UserConfiguration(pantsTargets = Option("::"))
+    new PantsDigest(() => userConfig).current(root)
+  }
+
+  checkSame(
+    "same-BUILD",
+    """
+      |/BUILD
+      |scala_library(
+      |  name='a',
+      |  sources=globs('*.scala'),
+      |)
+    """.stripMargin,
+    """
+      |/BUILD
+      |scala_library(
+      |  name='a',
+      |  sources=globs('*.scala'),
+      |)
+    """.stripMargin
+  )
+
+  checkDiff(
+    "comments-whitespace",
+    """
+      |/BUILD
+      |scala_library(
+      |  name='a',
+      |  sources=globs('*.scala'),
+      |)
+    """.stripMargin,
+    """
+      |/BUILD
+      |scala_library(
+      |  name='a',
+      |  sources=globs(
+      |   '*.scala'
+      |  ),
+      |)
+    """.stripMargin
+  )
+
+  checkDiff(
+    "diff-BUILD",
+    """
+      |/BUILD
+      |java_library(
+      |  name='a',
+      |  sources=globs('*.java'),
+      |)
+    """.stripMargin,
+    """
+      |/BUILD
+      |scala_library(
+      |  name='a',
+      |  sources=globs('*.scala'),
+      |)
+    """.stripMargin
+  )
+}

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -492,7 +492,6 @@ object TreeViewLspSuite extends BaseLspSuite("tree-view") {
       // Trigger a compilation in an unrelated project to ensure that the
       // background compilation of project "b" has completed.
       _ <- server.didOpen("a/src/main/scala/a/First.scala")
-      _ <- server.didSave("a/src/main/scala/a/First.scala")(identity)
 
       // Assert that the tree view for "b" has been updated due to the triggered
       // background compilation of project "b" has completed, even if it was a

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -145,4 +145,58 @@ object UserConfigurationSuite extends BaseSuite {
       "(to learn the syntax see https://scalameta.org/docs/semanticdb/specification.html#symbol-1)"
   )
 
+  checkOK(
+    "pants-targets-string",
+    """
+      |{
+      | "pants-targets": "a b"
+      |}
+    """.stripMargin
+  ) { ok =>
+    assert(ok.pantsTargets == Some(List("a", "b")))
+  }
+
+  checkOK(
+    "pants-targets-string2",
+    """
+      |{
+      | "pants-targets": "a  b"
+      |}
+    """.stripMargin
+  ) { ok =>
+    assert(ok.pantsTargets == Some(List("a", "b")))
+  }
+
+  checkOK(
+    "pants-targets-list",
+    """
+      |{
+      | "pants-targets": ["a  b"]
+      |}
+    """.stripMargin
+  ) { ok =>
+    assert(ok.pantsTargets == Some(List("a", "b")))
+  }
+
+  checkOK(
+    "pants-targets-list2",
+    """
+      |{
+      | "pants-targets": ["a", "b"]
+      |}
+    """.stripMargin
+  ) { ok =>
+    assert(ok.pantsTargets == Some(List("a", "b")))
+  }
+
+  checkError(
+    "pants-error",
+    """
+      |{
+      | "pants-targets": 42
+      |}
+    """.stripMargin,
+    """Unexpected 'pants-targets' configuration. Expected a string or a list of strings. Obtained: 42"""
+  )
+
 }

--- a/tests/unit/src/test/scala/tests/digest/PantsDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/digest/PantsDigestSuite.scala
@@ -1,10 +1,10 @@
-package tests
+package tests.digest
 
 import scala.meta.internal.builds.PantsDigest
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.io.AbsolutePath
 
-object PantsDigestSuite extends BaseDigestSuite {
+object PantsDigestSuite extends tests.BaseDigestSuite {
   override def digestCurrent(
       root: AbsolutePath
   ): Option[String] = {


### PR DESCRIPTION
Previously, Metals didn't work with the Pants build tool https://www.pantsbuild.org/. This PR adds support for Pants that works similarly to the build tool support with sbt, Gradle, Maven and Mill.

* the user needs to configure the `pants-targets` setting to specify what parts of their Pants build should be exported to Metals/Bloop.
* the user is prompted to import a Pants workspace on first startup
* when `BUILD` files change, Metals will prompt to the user to "import changes"

This PR is still a WIP. There are several issues related to handling large number of individual source files that belong to a Pants target.