### PR TITLE
Prioritize build targets with supported Scala versions.

### DIFF
--- a/tests/unit/src/test/scala/tests/BuildTargetsSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/BuildTargetsSlowSuite.scala
@@ -1,0 +1,36 @@
+package tests
+
+object BuildTargetsSlowSuite
+    extends BaseSlowSuite("build-targets")
+    with TestHovers {
+
+  testAsync("scala-priority") {
+    for {
+      _ <- server.initialize(
+        s"""/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "2.10.6",
+           |    "libraryDependencies": ["com.lihaoyi::sourcecode:0.1.7"],
+           |    "additionalSources": [ "shared/Main.scala" ]
+           |  },
+           |  "b": {
+           |    "scalaVersion": "${BuildInfo.scalaVersion}",
+           |    "libraryDependencies": ["com.lihaoyi::sourcecode:0.1.7"],
+           |    "additionalSources": [ "shared/Main.scala" ]
+           |  }
+           |}
+        """.stripMargin
+      )
+      // Assert that a supported Scala version target is picked over 2.10.
+      _ <- server.assertHover(
+        "shared/Main.scala",
+        """
+          |object Main {
+          |  sourcecode.Line(1).val@@ue
+          |}""".stripMargin,
+        """val value: Int""".hover
+      )
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/DiagnosticsSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/DiagnosticsSlowSuite.scala
@@ -304,7 +304,7 @@ object DiagnosticsSlowSuite extends BaseSlowSuite("diagnostics") {
           |/metals.json
           |{
           |  "a": { 
-          |    "additionalSources" : [ "weird/path/A.scala" ] 
+          |    "additionalSources" : [ "a/weird/path/A.scala" ]
           |  }
           |}
           |/a/weird/path/A.scala

--- a/tests/unit/src/test/scala/tests/FileWatcherSlowSuite.scala
+++ b/tests/unit/src/test/scala/tests/FileWatcherSlowSuite.scala
@@ -24,7 +24,7 @@ object FileWatcherSlowSuite extends BaseSlowSuite("file-watcher") {
         """
           |/metals.json
           |{
-          |  "a": { "additionalSources" : ["weird/path/d/D.scala", "non/existent/one/e/E.scala"] },
+          |  "a": { "additionalSources" : ["a/weird/path/d/D.scala", "non/existent/one/e/E.scala"] },
           |  "b": { },
           |  "c": { "dependsOn": [ "a" ] }
           |}


### PR DESCRIPTION
Previously, if two build targets in the repo were eligible for a source
file, Metals would sometimes prioritize a target with an unsupported
Scala version over a target with a supported Scala version. This
resulted in completions/hover/parameterHints not to work while editing
cross-built sources.

This PR introduces a change to the logic where we select a build target
for a given source file. Now we sort the elibible candidates by two
criteria: the Scala version and the platform (JVM/JS/Native). This
change takes the first step towards
https://github.com/scalameta/metals-feature-requests/issues/13, which is
about making this logic configurable.