### PR TITLE
Don't file watch inside jar files.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
@@ -84,11 +84,14 @@ final class FileWatcher(
     // Watch the source directories for "goto definition" index.
     buildTargets.sourceItems.foreach(watch(_, isSource = true))
     buildTargets.scalacOptions.foreach { item =>
-      // Watch META-INF/semanticdb directories for "find references" index.
-      watch(
-        item.targetroot.resolve(Directories.semanticdb),
-        isSource = false
-      )
+      val targetroot = item.targetroot
+      if (!targetroot.isJar) {
+        // Watch META-INF/semanticdb directories for "find references" index.
+        watch(
+          targetroot.resolve(Directories.semanticdb),
+          isSource = false
+        )
+      }
     }
     startWatching(sourceFilesToWatch, sourceDirectoriesToWatch)
     createdSourceDirectories.asScala.foreach(_.delete())

--- a/tests/unit/src/main/scala/bill/Bill.scala
+++ b/tests/unit/src/main/scala/bill/Bill.scala
@@ -104,8 +104,8 @@ object Bill {
       result
     }
     val reporter = new StoreReporter
-    val out = AbsolutePath(workspace.resolve("out"))
-    Files.createDirectories(out.toNIO)
+    val out = AbsolutePath(workspace.resolve("out.jar"))
+    Files.createDirectories(out.toNIO.getParent())
     lazy val g = {
       val settings = new nsc.Settings()
       settings.classpath.value =


### PR DESCRIPTION
The Scala compiler supports a feature where it compiles the output
classfiles directly to `*.jar` files. This feature is used in build
tools like Pants and Bazel.

Previously, Metals would crash on build targets that used this feature
of the compiler. Now, we don't do anything even if it means missing file
watching notifications that are needed for the "find symbol references"
index.

Thank you @illicitonion for reporting this issue!