### PR TITLE
Warn when a source jar is corrupted

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1552,7 +1552,7 @@ class MetalsLanguageServer(
           case None =>
             // Nothing in cache, read top level symbols and store them in cache
             val tempIndex = OnDemandSymbolIndex(onError = {
-              case e: Throwable =>
+              case NonFatal(e) =>
                 scribe.warn(s"Error when reading source jar [$path]", e)
             })
             tempIndex.addSourceJar(path)

--- a/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
@@ -56,7 +56,7 @@ final case class OnDemandSymbolIndex(
       FileIO.withJarFileSystem(jar, create = false) { root =>
         root.listRecursive.foreach {
           case source if source.isScala =>
-            try addSourceFile(source, None )
+            try addSourceFile(source, None)
             catch {
               case NonFatal(e) => onError.lift(IndexError(source, e))
             }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
@@ -51,9 +51,9 @@ final case class OnDemandSymbolIndex(
 
   // Traverses all source files in the given jar file and records
   // all non-trivial toplevel Scala symbols.
-  override def addSourceJar(jar: AbsolutePath): Unit = {
-    FileIO.withJarFileSystem(jar, create = false) { root =>
-      try {
+  override def addSourceJar(jar: AbsolutePath): Unit = tryRun {
+    if (sourceJars.addEntry(jar)) {
+      FileIO.withJarFileSystem(jar, create = false) { root =>
         root.listRecursive.foreach {
           case source if source.isScala =>
             try addSourceFile(source, None)
@@ -62,10 +62,6 @@ final case class OnDemandSymbolIndex(
             }
           case _ =>
         }
-      } catch {
-        case e: NoSuchFileException =>
-          val error = new Exception(s"Corrupted jar [$jar]", e)
-          onError(error)
       }
     }
   }


### PR DESCRIPTION
Previously: In some cases Metals crashed on openhtmltopdf jars if they contain /Users directory or at any other entry without attributes.

Now: It doesn't - it displays warning instead.