### PR TITLE
Change manual instalation section for sbt, gradle and maven

### DIFF
--- a/docs/build-tools/gradle.md
+++ b/docs/build-tools/gradle.md
@@ -4,10 +4,9 @@ title: Gradle
 ---
 
 Gradle is a build tool that can be used easily with a large number of
-programming languages including Scala. With it you can easily define your
-builds for Groovy or Kotlin, which enables for a high degree of customization.
-You can look up all the possible features on the
-[Gradle website](https://gradle.org/).
+programming languages including Scala. With it you can easily define your builds
+for Groovy or Kotlin, which enables for a high degree of customization. You can
+look up all the possible features on the [Gradle website](https://gradle.org/).
 
 ## Automatic installation
 
@@ -45,9 +44,15 @@ allprojects {
 ```
 
 Now we can run `gradle bloopInstall`, which will create a Bloop configuration
-files. This will enable us to work with Metals and most features will work, but
-for everything to work properly we need to also add the SemanticDB plugin. This
-can be done by adding a couple of options to the scala compiler:
+files.
+
+This will enable us to work with Metals and all features should work.
+
+However, for all versions before and including 0.7.6 we need a couple more
+steps.
+
+First, we need to add the SemanticDB plugin. This can be done by adding a couple
+of options to the Scala compiler:
 
 ```groovy
 allprojects {
@@ -93,5 +98,6 @@ plugin in Bloop config.
 
 This is much more complex than in case of the automatic installation, so it is
 recommended to only do manual installation when having problems with the
-automatic one. You can also always try to reach us on the [Metals gitter channel](https://gitter.im/scalameta/metals)
-in case of any problems.
+automatic one. You can also always try to reach us on the
+[Metals gitter channel](https://gitter.im/scalameta/metals) in case of any
+problems.

--- a/docs/build-tools/maven.md
+++ b/docs/build-tools/maven.md
@@ -7,7 +7,8 @@ Maven is one of the most common build tools in the JVM ecosystem and it also
 allows for using scala through the
 [scala-maven-plugin](https://davidb.github.io/scala-maven-plugin/usage.html).
 The [scalor-maven-plugin](https://github.com/random-maven/scalor-maven-plugin)
-is not currently supported and requires a new plugin for bloop to be implemented.
+is not currently supported and requires a new plugin for bloop to be
+implemented.
 
 ## Automatic installation
 
@@ -20,7 +21,14 @@ be added later. Most features should work without it, however some require
 SemanticDB files to be provided alongside compiled data. To do that we need a
 couple of steps that are explained in the manual installation section.
 
-## Manual instalation
+## Manual installation
+
+For current Metals snapshots all you need to run the manual installation is:
+
+`mvn ch.epfl.scala:maven-bloop_2.10:@BLOOP_VERSION@:bloopInstall -DdownloadSources=true`
+
+However, for all versions before and including 0.7.6 we need a couple more
+steps.
 
 First, we need to add a couple of options to the Scala compiler in the
 configuration section:

--- a/docs/build-tools/mill.md
+++ b/docs/build-tools/mill.md
@@ -16,7 +16,7 @@ finished you should be able edit and compile your code.
 
 ## Manual installation
 
-Manual instalation is not recommended, but it's pretty easy to do. There are
+Manual installation is not recommended, but it's pretty easy to do. There are
 only two steps involved.
 
 First add one import line to your `build.sc` file or in any other file it

--- a/docs/build-tools/sbt.md
+++ b/docs/build-tools/sbt.md
@@ -34,7 +34,7 @@ generate the Bloop JSON files directly from your sbt shell. This approach may
 speed up build import by avoiding Metals from starting sbt in a separate
 process.
 
-### For current snapshots
+### For latest SNAPSHOT
 
 First, install the Bloop plugin globally or inside your `project` directory:
 

--- a/docs/build-tools/sbt.md
+++ b/docs/build-tools/sbt.md
@@ -29,10 +29,38 @@ sbt builds without Bloop.
 > manual installation requires several independent steps that makes it harder to
 > stay up-to-date with the latest Metals version.
 
-Instead of using automatic build import, you can manually install sbt-metals and
+Instead of using automatic build import, you can manually install sbt-bloop and
 generate the Bloop JSON files directly from your sbt shell. This approach may
 speed up build import by avoiding Metals from starting sbt in a separate
 process.
+
+### For current snapshots
+
+First, install the Bloop plugin globally or inside your `project` directory:
+
+```scala
+// One of:
+//   ~/.sbt/0.13/plugins/plugins.sbt
+//   ~/.sbt/1.0/plugins/plugins.sbt
+resolvers += Resolver.sonatypeRepo("snapshots")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "@BLOOP_VERSION@")
+```
+
+Next, run:
+
+```
+sbt "set bloopExportJarClassifiers := Some(Set(\"source\"))" bloopInstall
+```
+
+to generate the Bloop JSON configuration files. You can also set
+`bloopExportJarClassifiers` setting inside your main build.sbt file, but using
+the above command will do it automatically for you in the current sbt session.
+
+Finally, once `bloopInstall` is finished, execute the "Connect to build server"
+command (id: `build.connect`) command to tell Metals to establish a connections
+with the Bloop build server.
+
+### For versions up to 0.7.6
 
 First, install the Bloop and Metals plugins globally
 
@@ -48,9 +76,9 @@ addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "@BLOOP_VERSION@")
 Next, run `sbt metalsEnable bloopInstall` to generate the Bloop JSON
 configuration files.
 
-Finally, once `bloopInstall` is finished, execute the "Import build" command
-(id: `build.import`) command to tell Metals to establish a connections with the
-Bloop build server.
+Finally, once `bloopInstall` is finished, execute the "Connect to build server"
+command (id: `build.connect`) command to tell Metals to establish a connections
+with the Bloop build server.
 
 For more information about sbt-bloop, consult the
 [Bloop website](https://scalacenter.github.io/bloop/docs/build-tools/sbt).


### PR DESCRIPTION
After the next release I will remove the old instructions, since they will no longer be needed.

However, currently the instructions differ if you use snapshots.

Fixes https://github.com/scalameta/metals/issues/958