### PR TITLE
Add automatic formatting of multi-line `stripMargin` strings on paste

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ website/yarn.lock
 website/node_modules
 website/i18n/*
 !website/i18n/en.json
+
+project/metals.sbt
+.bloop/*
+.metals/*

--- a/metals/src/main/scala/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
@@ -20,19 +20,21 @@ import org.eclipse.lsp4j.Position
 you'll have to set editor.formatOnType = true
 and editor.formatOnPaste = true in settings*/
 final class MultilineStringFormattingProvider(
-  semanticdbs: Semanticdbs,
-  buffer: Buffers
+    semanticdbs: Semanticdbs,
+    buffer: Buffers
 )(implicit ec: ExecutionContext) {
 
   private val quote = '"'
   private val space = " "
   private val stripMargin = "stripMargin"
 
-  private def hasStripMarginSuffix(stringTokenIndex: Int,
-                                   tokens: Tokens): Boolean = {
+  private def hasStripMarginSuffix(
+      stringTokenIndex: Int,
+      tokens: Tokens
+  ): Boolean = {
     var methodIndex = stringTokenIndex + 1
     while (tokens(methodIndex).isWhiteSpaceOrComment ||
-           tokens(methodIndex).isInstanceOf[Token.Dot]) methodIndex += 1
+      tokens(methodIndex).isInstanceOf[Token.Dot]) methodIndex += 1
     tokens(methodIndex) match {
       case token: Token.Ident if token.value == stripMargin =>
         true
@@ -41,18 +43,18 @@ final class MultilineStringFormattingProvider(
     }
   }
 
-  private def charIsPipe(charToCheck: Char): Boolean = charToCheck == '|'
-
-  private def indent(sourceText: String, start: Int): String = {
+  private def determineDefaultIndent(sourceText: String, start: Int): String = {
     val lastPipe = sourceText.lastIndexBetween('|', upperBound = start)
     val lastNewline = sourceText.lastIndexBetween('\n', upperBound = lastPipe)
     space * (lastPipe - lastNewline - 1)
   }
 
-  private def indent(sourceText: String,
-                     start: Int,
-                     position: Position): TextEdit = {
-    val defaultIndent = indent(sourceText, start)
+  private def indent(
+      sourceText: String,
+      start: Int,
+      position: Position
+  ): TextEdit = {
+    val defaultIndent = determineDefaultIndent(sourceText, start)
     val existingSpaces = position.getCharacter()
     val addedSpaces = defaultIndent.drop(existingSpaces)
     val startChar = defaultIndent.size - addedSpaces.size
@@ -73,9 +75,11 @@ final class MultilineStringFormattingProvider(
     pos.start >= token.start && pos.end <= token.end
   }
 
-  private def pipeInScope(pos: meta.Position,
-                          text: String,
-                          newlineAdded: Boolean): Boolean = {
+  private def pipeInScope(
+      pos: meta.Position,
+      text: String,
+      newlineAdded: Boolean
+  ): Boolean = {
     val newLineBeforePos =
       text.lastIndexBetween('\n', upperBound = pos.start - 1)
     val pipeSearchStop =
@@ -86,9 +90,11 @@ final class MultilineStringFormattingProvider(
     lastPipe > pipeSearchStop
   }
 
-  private def multilineStringInTokens(tokens: Tokens,
-                                      pos: meta.Position,
-                                      sourceText: String): Boolean = {
+  private def multilineStringInTokens(
+      tokens: Tokens,
+      pos: meta.Position,
+      sourceText: String
+  ): Boolean = {
     var tokenIndex = 0
     var stringFound = false
     var shouldAddPipes = false
@@ -101,7 +107,7 @@ final class MultilineStringFormattingProvider(
         case start: Interpolation.Start if start.start < pos.start =>
           var endIndex = tokenIndex + 1
           while (!tokens(endIndex)
-                   .isInstanceOf[Interpolation.End]) endIndex += 1
+              .isInstanceOf[Interpolation.End]) endIndex += 1
           val end = tokens(endIndex)
           stringFound = end.end > pos.end
           shouldAddPipes = stringFound && isMultilineString(sourceText, start) &&
@@ -114,9 +120,9 @@ final class MultilineStringFormattingProvider(
   }
 
   private def withToken(
-    textId: TextDocumentIdentifier,
-    range: Range,
-    newlineAdded: Boolean
+      textId: TextDocumentIdentifier,
+      range: Range,
+      newlineAdded: Boolean
   )(fn: (String, meta.Position) => List[TextEdit]): Future[List[TextEdit]] =
     Future {
       val source = textId.getUri.toAbsolutePath
@@ -135,6 +141,35 @@ final class MultilineStringFormattingProvider(
       } else Nil
     }
 
+  private def formatPipeLine(
+      line: Int,
+      lines: Array[String],
+      defaultIndent: String
+  ): TextEdit = {
+    val zeroPos = new Position(line, 0)
+    val lineText = lines(line)
+    val firstChar = lineText.trim.headOption
+
+    firstChar match {
+      case Some('|') =>
+        val firstPipeIndex = lineText.indexOf('|')
+        val firstCharAfterPipe = lineText.trim.tail.trim.headOption
+
+        firstCharAfterPipe match {
+          case Some('|') =>
+            val secondPipeIndex = lineText.indexOf('|', firstPipeIndex + 1)
+            val secondPipePos = new Position(line, secondPipeIndex)
+            new TextEdit(new Range(zeroPos, secondPipePos), defaultIndent)
+          case _ =>
+            val pipePos = new Position(line, firstPipeIndex)
+            new TextEdit(new Range(zeroPos, pipePos), defaultIndent)
+        }
+      case _ =>
+        val newText = defaultIndent + "|"
+        new TextEdit(new Range(zeroPos, zeroPos), newText)
+    }
+  }
+
   def format(params: DocumentOnTypeFormattingParams): Future[List[TextEdit]] = {
     val range = new Range(params.getPosition, params.getPosition)
     val doc = params.getTextDocument()
@@ -150,34 +185,13 @@ final class MultilineStringFormattingProvider(
     val doc = params.getTextDocument()
     withToken(doc, range, newlineAdded = false) { (sourceText, position) =>
       val splitLines = sourceText.split('\n')
-      val defaultIndent = indent(sourceText, position.start)
-      val linesToFormat = (range.getStart().getLine()) to range.getEnd().getLine()
+      val defaultIndent = determineDefaultIndent(sourceText, position.start)
+      val linesToFormat =
+        range.getStart().getLine().to(range.getEnd().getLine())
 
-      linesToFormat.map { line =>
-        val zeroPos = new Position(line, 0)
-        val lineText = splitLines(line)
-        val firstChar = lineText.trim.head
-        if (charIsPipe(firstChar)) {
-          val firstPipeIndex = lineText.indexOf('|')
-
-          /* There may be an existing pipe on the line the text
-           was pasted into. We need to see if the first char after
-           the initial pipe is also a pipe confirming a multilineString
-           being pasted into another multilineString*/
-          val firstCharAfterPipe = lineText.trim.tail.trim.head
-          if (charIsPipe(firstCharAfterPipe)) {
-            val secondPipeIndex = lineText.indexOf('|', firstPipeIndex + 1)
-            val secondPipePos = new Position(line, secondPipeIndex)
-            new TextEdit(new Range(zeroPos, secondPipePos), defaultIndent)
-          } else {
-            val pipePos = new Position(line, firstPipeIndex)
-            new TextEdit(new Range(zeroPos, pipePos), defaultIndent)
-          }
-        } else {
-          val newText = defaultIndent + "|"
-          new TextEdit(new Range(zeroPos, zeroPos), newText)
-        }
-      }.toList
+      linesToFormat
+        .map(line => formatPipeLine(line, splitLines, defaultIndent))
+        .toList
     }
   }
 

--- a/tests/unit/src/test/scala/tests/RangeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/RangeFormattingSuite.scala
@@ -82,6 +82,67 @@ object RangeFormattingSuite extends BaseSlowSuite("rangeFormatting") {
        |}""".stripMargin
   )
 
+  check(
+    "with-pipe",
+    s"""
+       |object Main {
+       |  val str = '''
+       |  |@@
+       |  '''.stripMargin
+       |}""".stripMargin,
+    s"""| |single line
+        |""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = '''
+       |  |single line
+       |  |
+       |  '''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
+    "with-pipes",
+    s"""
+       |object Main {
+       |  val str = '''
+       |  |@@
+       |  '''.stripMargin
+       |}""".stripMargin,
+    s"""| |first line
+        | |second line
+        | | different indent""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = '''
+       |  |first line
+       |  |second line
+       |  | different indent
+       |  '''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
+    "with-pipes-skip-line",
+    s"""
+       |object Main {
+       |  val str = '''
+       |  |@@
+       |  '''.stripMargin
+       |}""".stripMargin,
+    s"""| |first line
+        |
+        | |second line""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = '''
+       |  |first line
+       |  |
+       |  |second line
+       |  '''.stripMargin
+       |}""".stripMargin
+  )
+
   def check(
       name: String,
       testCase: String,


### PR DESCRIPTION
Fixes #952 

![metals](https://user-images.githubusercontent.com/13974112/66270945-11cea700-e859-11e9-9531-2577c01c3308.gif)

I left a comment on the issue as I wasn't sure the way to go about testing this -- mainly where to put the test or if I should tack it on to another. Any pointers there would be helpful. I also may have missed some helper methods or ways I could have reused stuff, so please let me know! I figured I'd make the pr right away in order to get some feedback.

