### PR TITLE
Tone down "No SemanticDB" warning

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
@@ -72,7 +72,6 @@ final class Warnings(
             s"$doesntWorkBecause the SemanticDB file '$targetfile' doesn't exist. " +
               s"There can be many reasons for this error. "
           )
-          statusBar.addMessage(s"${icons.alert}No SemanticDB")
         }
       }
     }


### PR DESCRIPTION
Previously, we reported a warning "No SemanticDB" in the status bar when
Metals couldn't find a SemanticDB file for a given source file. Now, we
only log the warning without updating the status bar because this
problem is quite harmless in most situations.

It's difficult to say what the root cause of this problem, my theory is
that it happens in some of the following cases:

- new Bloop BSP connection with an empty class directory
- git checkout to a new branch where new files got added and the file
  hasn't been compiled yet.

Either way, it's not the end of the world when the SemanticDB file
doesn't exist. Most functionality including completions, type at
point,parameter hints and goto definition should continue to work.

cc/ @bishabosha