### PR TITLE
Add system property to disable project/metals.sbt generation

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -84,6 +84,7 @@ case class SbtBuildTool(version: String) extends BuildTool {
       workspace: AbsolutePath,
       config: MetalsServerConfig
   ): Unit = {
+    if (!config.bloopGenerateSbt) return
     val bytes = SbtBuildTool
       .sbtPlugin(config.bloopSbtVersion)
       .getBytes(StandardCharsets.UTF_8)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -67,6 +67,8 @@ final case class MetalsServerConfig(
       "bloop.sbt.version",
       BuildInfo.sbtBloopVersion
     ),
+    bloopGenerateSbt: Boolean =
+      "false" != System.getProperty("bloop.generate.sbt"),
     icons: Icons = Icons.default,
     statistics: StatisticsConfig = StatisticsConfig.default,
     compilers: PresentationCompilerConfigImpl = CompilersConfig()


### PR DESCRIPTION
This is intended to be used in the Bloop sbt build that uses a custom
way to install the sbt-bloop plugin.