### PR TITLE
Add link to new Discord server in the website footer.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -159,6 +159,12 @@ object ServerCommands {
     "Open the Metals channel on Gitter to discuss with other Metals users."
   )
 
+  val ChatOnDiscord = Command(
+    OpenBrowser("https://discord.gg/RFpSVth"),
+    "Chat on Discord",
+    "Open the Scalameta server on Discord to discuss with other Metals users."
+  )
+
   val ReadVscodeDocumentation = Command(
     OpenBrowser("https://scalameta.org/metals/docs/editors/vscode.html"),
     "Read Metals documentation",

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -204,6 +204,7 @@ class MetalsTreeViewProvider(
           echoCommand(ServerCommands.ReadVscodeDocumentation, "book"),
           echoCommand(ServerCommands.ReadBloopDocumentation, "book"),
           echoCommand(ServerCommands.ChatOnGitter, "gitter"),
+          echoCommand(ServerCommands.ChatOnDiscord, "discord"),
           echoCommand(ServerCommands.OpenIssue, "issue-opened"),
           echoCommand(ServerCommands.MetalsGithub, "github"),
           echoCommand(ServerCommands.BloopGithub, "github"),

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -20,9 +20,7 @@ class Footer extends React.Component {
           {this.props.config.footerIcon && (
             <a href={this.props.config.baseUrl} className="nav-home">
               <img
-                src={`${this.props.config.baseUrl}${
-                  this.props.config.footerIcon
-                }`}
+                src={`${this.props.config.baseUrl}${this.props.config.footerIcon}`}
                 alt={this.props.config.title}
                 width="66"
                 height="58"
@@ -53,6 +51,13 @@ class Footer extends React.Component {
             <h5>Social</h5>
             <a href="https://github.com/scalameta/metals" target="_blank">
               <img src="https://img.shields.io/github/stars/scalameta/metals.svg?color=%23087e8b&label=stars&logo=github&style=social" />
+            </a>
+            <a href="https://scala-lang-slack.herokuapp.com/" target="_blank">
+              <script
+                async
+                defer
+                src="https://scala-lang-slack.herokuapp.com/slackin.js"
+              ></script>
             </a>
             <a href="https://gitter.im/scalameta/metals" target="_blank">
               <img src="https://img.shields.io/gitter/room/scalameta/metals.svg?logo=gitter&style=social" />

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -52,12 +52,8 @@ class Footer extends React.Component {
             <a href="https://github.com/scalameta/metals" target="_blank">
               <img src="https://img.shields.io/github/stars/scalameta/metals.svg?color=%23087e8b&label=stars&logo=github&style=social" />
             </a>
-            <a href="https://scala-lang-slack.herokuapp.com/" target="_blank">
-              <script
-                async
-                defer
-                src="https://scala-lang-slack.herokuapp.com/slackin.js"
-              ></script>
+            <a href="https://discord.gg/RFpSVth" target="_blank">
+              <img src="https://img.shields.io/discord/632642981228314653?logo=discord&style=social" />
             </a>
             <a href="https://gitter.im/scalameta/metals" target="_blank">
               <img src="https://img.shields.io/gitter/room/scalameta/metals.svg?logo=gitter&style=social" />


### PR DESCRIPTION
The Gitter UX is quite bad to the point where I don't enjoy using it
much anymore. I suspect GitHub will sooner or later release a community
chat solution judging by
https://spectrum.chat/spectrum/general/spectrum-is-joining-github~1d3eb8ee-4c99-46c0-8daf-ca35a96be6ce/
However, until then I think it's worth a try to keep the conversation
going on Slack under the #scalameta-metals channel in the new
"scala-lang" organization.

Live demo is here https://olafurpg.github.io/metals/ I'm unable to make the Slack badge clickable however 🤔 any idea how to fix it? Docs are here https://github.com/rauchg/slackin