### PR TITLE
Remove automatic gitignoring.

### DIFF
--- a/metals-docs/src/main/scala/docs/GenericModifier.scala
+++ b/metals-docs/src/main/scala/docs/GenericModifier.scala
@@ -9,17 +9,19 @@ class GenericModifier extends StringModifier {
 
   override def process(info: String, code: Input, reporter: Reporter): String =
     s"""
-       |## Gitignore `.metals/` and `.bloop/`
+       |## Gitignore `project/metals.sbt` `.metals/` and `.bloop/`
        |
        |The Metals server places logs and other files in the `.metals/` directory. The
        |Bloop compile server places logs and compilation artifacts in the `.bloop`
-       |directory. It's recommended to ignore these directories from version control
-       |systems like git.
+       |directory. Bloop plugin that generates Bloop configuration is added in the 
+       |`project/metals.sbt` file. It's recommended to ignore these directories and file
+       |from version control systems like git.
        |
        |```sh
        |# ~/.gitignore
        |.metals/
        |.bloop/
+       |project/metals.sbt
        |```
        |
      """.stripMargin

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
@@ -4,7 +4,6 @@ import java.nio.file.{Files, Path}
 import scala.meta.internal.metals._
 import scala.meta.io.AbsolutePath
 import scala.util.Try
-import scala.meta.internal.metals.MetalsEnrichments._
 
 abstract class BuildTool {
   def args(
@@ -30,15 +29,6 @@ abstract class BuildTool {
   def redirectErrorOutput: Boolean = false
 
   def executableName: String
-
-  def gitignore(workspace: AbsolutePath, paths: List[String]): Unit = {
-    val gitignore = workspace.resolve(".gitignore")
-    if (gitignore.exists) {
-      paths
-        .filterNot(gitignore.readText.contains)
-        .foreach(path => gitignore.appendText(s"\n$path"))
-    }
-  }
 
 }
 

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -52,7 +52,6 @@ case class SbtBuildTool(version: String) extends BuildTool {
     }
     removeLegacyGlobalPlugin()
     writeSbtMetalsPlugin(workspace, config)
-    gitignore(workspace, List("project/metals.sbt"))
     allArgs
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
@@ -82,7 +82,6 @@ final class BloopInstall(
     // window/showMessageRequest, meaning the "cancel build import" button
     // stays forever in view even after successful build import. In newer
     // VS Code versions the message is hidden after a delay.
-    buildTool.gitignore(workspace, List(".bloop/*", ".metals/*"))
     val taskResponse =
       languageClient.metalsSlowTask(
         Messages.bloopInstallProgress(buildTool.executableName)

--- a/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
@@ -13,7 +13,6 @@ import scala.meta.internal.metals.MetalsSlowTaskResult
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.{BuildInfo => V}
 import scala.meta.io.AbsolutePath
-import scala.meta.internal.metals.MetalsEnrichments._
 
 object SbtLspSuite extends BaseImportSuite("sbt-import") {
 
@@ -387,71 +386,6 @@ object SbtLspSuite extends BaseImportSuite("sbt-import") {
       _ = assertNoDiff(
         client.workspaceShowMessages,
         IncompatibleBuildToolVersion.params(SbtBuildTool("0.13.15")).getMessage
-      )
-    } yield ()
-  }
-
-  testAsync("gitignore") {
-    cleanWorkspace()
-    for {
-      _ <- server.initialize(
-        """|/project/build.properties
-           |sbt.version=1.2.6
-           |/build.sbt
-           |scalaVersion := "2.12.8"
-           |/.gitignore
-           |.iml
-           |""".stripMargin
-      )
-      _ = assertNoDiff(
-        client.workspaceMessageRequests,
-        List(
-          importBuildMessage,
-          progressMessage
-        ).mkString("\n")
-      )
-      _ = client.messageRequests.clear()
-      _ = assertStatus(_.isInstalled)
-      _ = assertNoDiff(
-        workspace.resolve(".gitignore").readText,
-        """|.iml
-           |
-           |project/metals.sbt
-           |.bloop/*
-           |.metals/*
-           |""".stripMargin
-      )
-    } yield ()
-  }
-
-  testAsync("gitignore-existing") {
-    cleanWorkspace()
-    for {
-      _ <- server.initialize(
-        """|/project/build.properties
-           |sbt.version=1.2.6
-           |/build.sbt
-           |scalaVersion := "2.12.8"
-           |/.gitignore
-           |project/metals.sbt
-           |""".stripMargin
-      )
-      _ = assertNoDiff(
-        client.workspaceMessageRequests,
-        List(
-          importBuildMessage,
-          progressMessage
-        ).mkString("\n")
-      )
-      _ = client.messageRequests.clear()
-      _ = assertStatus(_.isInstalled)
-      _ = assertNoDiff(
-        workspace.resolve(".gitignore").readText,
-        """|project/metals.sbt
-
-           |.bloop/*
-           |.metals/*
-          """.stripMargin
       )
     } yield ()
   }


### PR DESCRIPTION
Previously, we automatically added metals files to gitignore, now we leave it to the user to decide.

Turns out most people are either opposed to this change or have a different opinion on how it should work, so we decided not to introduce this altogether.

Fixes https://github.com/scalameta/metals/issues/966