### PR TITLE
(Spac)Emacs continuously crashing due to compilation of swap files

### DIFF
--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -120,7 +120,7 @@ To configure Eglot with Metals:
 
 ;; Enable scala-mode and sbt-mode
 (use-package scala-mode
-  :mode "\\.s\\(cala\\|bt\\)$")
+  :mode "^\w+\\.s\\(cala\\|bt\\)$")
 
 (use-package sbt-mode
   :commands sbt-start sbt-command


### PR DESCRIPTION
it seems that the regex of the docu for the scala-mode is too much general for emacs so swap files (starting with .#) are compiled by metals and this one crashes, throwing a runtime exception, when the swap file is not there

this new regex is maybe too restrictive but seems to be valid for most of usecases