### PR TITLE
Re-introduce Azure pipelines for more stable CI.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,6 @@
+jobs:
+- job: Linux
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  steps:
+  - script: ./sbt unit/test


### PR DESCRIPTION
GitHub Actions seems to be timing out once-in-a-while. This commit adds
back Azure Pipelines to run the same tests in parallel with Github Actions.