### PR TITLE
Keep code lenses after error until next successful compilation

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CodeLensProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeLensProvider.scala
@@ -5,7 +5,6 @@ import ch.epfl.scala.{bsp4j => b}
 import com.google.gson.JsonElement
 import org.eclipse.{lsp4j => l}
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 import scala.meta.internal.metals.ClientCommands.StartDebugSession
 import scala.meta.internal.metals.CodeLensProvider._
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -20,17 +19,16 @@ final class CodeLensProvider(
     semanticdbs: Semanticdbs
 )(implicit ec: ExecutionContext) {
   // code lenses will be refreshed after compilation or when workspace gets indexed
-  def findLenses(path: AbsolutePath): Future[Seq[l.CodeLens]] = {
+  def findLenses(path: AbsolutePath): Seq[l.CodeLens] = {
     val lenses = buildTargets
       .inverseSources(path)
       .filterNot(compilations.isCurrentlyCompiling)
       .map { buildTarget =>
-        for {
-          classes <- buildTargetClasses.classesOf(buildTarget)
-        } yield codeLenses(path, buildTarget, classes)
+        val classes = buildTargetClasses.classesOf(buildTarget)
+        codeLenses(path, buildTarget, classes)
       }
 
-    lenses.getOrElse(Future.successful(Nil))
+    lenses.getOrElse(Nil)
   }
 
   private def codeLenses(

--- a/metals/src/main/scala/scala/meta/internal/metals/CodeLensProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeLensProvider.scala
@@ -22,7 +22,6 @@ final class CodeLensProvider(
   def findLenses(path: AbsolutePath): Seq[l.CodeLens] = {
     val lenses = buildTargets
       .inverseSources(path)
-      .filterNot(compilations.isCurrentlyCompiling)
       .map { buildTarget =>
         val classes = buildTargetClasses.classesOf(buildTarget)
         codeLenses(path, buildTarget, classes)

--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -27,8 +27,7 @@ final class ForwardingMetalsBuildClient(
     statusBar: StatusBar,
     time: Time,
     didCompile: CompileReport => Unit,
-    treeViewProvider: () => TreeViewProvider,
-    isCurrentlyFocused: b.BuildTargetIdentifier => Boolean
+    treeViewProvider: () => TreeViewProvider
 )(implicit ec: ExecutionContext)
     extends MetalsBuildClient
     with Cancelable {
@@ -141,10 +140,6 @@ final class ForwardingMetalsBuildClient(
             scribe.info(s"time: compiled $name in ${compilation.timer}")
           }
           if (isSuccess) {
-            buildTargetClasses.rebuildIndex(target).foreach { _ =>
-              if (isCurrentlyFocused(target)) languageClient.refreshModel()
-            }
-
             if (hasReportedError.contains(target)) {
               // Only report success compilation if it fixes a previous compile error.
               statusBar.addMessage(message)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -117,7 +117,9 @@ class MetalsLanguageServer(
     buildTargets,
     buildTargetClasses,
     () => workspace,
-    () => buildServer
+    () => buildServer,
+    languageClient,
+    buildTarget => focusedDocumentBuildTarget.get() == buildTarget
   )
   private val fileWatcher = register(
     new FileWatcher(
@@ -248,8 +250,7 @@ class MetalsLanguageServer(
       statusBar,
       time,
       report => compilers.didCompile(report),
-      () => treeView,
-      buildTarget => focusedDocumentBuildTarget.get() == buildTarget
+      () => treeView
     )
     trees = new Trees(buffers, diagnostics)
     documentSymbolProvider = new DocumentSymbolProvider(trees)
@@ -1014,9 +1015,9 @@ class MetalsLanguageServer(
       params: CodeLensParams
   ): CompletableFuture[util.List[CodeLens]] =
     CancelTokens { _ =>
-      codeLensProvider
-        .findLenses(params.getTextDocument.getUri.toAbsolutePath)
-        .asJava
+      val path = params.getTextDocument.getUri.toAbsolutePath
+      val lenses = codeLensProvider.findLenses(path)
+      lenses.asJava
     }
 
   @JsonRequest("textDocument/foldingRange")

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1013,10 +1013,10 @@ class MetalsLanguageServer(
   def codeLens(
       params: CodeLensParams
   ): CompletableFuture[util.List[CodeLens]] =
-    CancelTokens.future { _ =>
+    CancelTokens { _ =>
       codeLensProvider
         .findLenses(params.getTextDocument.getUri.toAbsolutePath)
-        .map(_.asJava)
+        .asJava
     }
 
   @JsonRequest("textDocument/foldingRange")
@@ -1316,6 +1316,7 @@ class MetalsLanguageServer(
   private def connectToNewBuildServer(
       build: BuildServerConnection
   ): Future[BuildChange] = {
+    scribe.info(s"Connected to Build server v${build.version}")
     cancelables.add(build)
     compilers.cancel()
     buildServer = Some(build)

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -1,6 +1,5 @@
 package tests
 import java.nio.file.Files
-import java.util.Comparator
 import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutorService

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -1,5 +1,6 @@
 package tests
 import java.nio.file.Files
+import java.util.Comparator
 import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutorService
@@ -85,6 +86,13 @@ abstract class BaseLspSuite(suiteName: String) extends BaseSuite {
       .resolve("e2e")
       .resolve(suiteName)
       .resolve(name.replace(' ', '-'))
+
+    if (path.isDirectory) {
+      val files = Files.walk(path.toNIO)
+      try files.sorted(Comparator.reverseOrder()).forEach(Files.delete(_))
+      finally files.close()
+    }
+
     Files.createDirectories(path.toNIO)
     path
   }

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -87,12 +87,7 @@ abstract class BaseLspSuite(suiteName: String) extends BaseSuite {
       .resolve(suiteName)
       .resolve(name.replace(' ', '-'))
 
-    if (path.isDirectory) {
-      val files = Files.walk(path.toNIO)
-      try files.sorted(Comparator.reverseOrder()).forEach(Files.delete(_))
-      finally files.close()
-    }
-
+    RecursivelyDelete(path)
     Files.createDirectories(path.toNIO)
     path
   }

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -66,7 +66,7 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
   }
 
   private var refreshedOnIndex = false
-  var refreshModelHandler: Unit => Unit = identity
+  var refreshModelHandler: () => Unit = () => {}
 
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -281,9 +281,3 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
   }
 
 }
-
-object TestingClient {
-  trait Listener {
-    def onRefreshModel(): Unit
-  }
-}

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -35,6 +35,7 @@ import scala.meta.internal.builds.GradleBuildTool
 import scala.meta.internal.builds.SbtBuildTool
 import scala.meta.internal.builds.MavenBuildTool
 import scala.meta.internal.builds.MillBuildTool
+import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.NoopLanguageClient
 import scala.meta.internal.tvp.TreeViewDidChangeParams
 
@@ -64,10 +65,22 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
       None
   }
 
+  private var refreshedOnIndex = false
+  var refreshModelHandler: Unit => Unit = identity
+
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams
   ): Unit = {
     clientCommands.addLast(params)
+    params.getCommand match {
+      case ClientCommands.RefreshModel.id =>
+        if (refreshedOnIndex) {
+          refreshModelHandler()
+        } else {
+          refreshedOnIndex = true
+        }
+      case _ =>
+    }
   }
 
   override def applyEdit(
@@ -267,4 +280,10 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
       .mkString("----\n")
   }
 
+}
+
+object TestingClient {
+  trait Listener {
+    def onRefreshModel(): Unit
+  }
 }

--- a/tests/unit/src/test/scala/tests/CodeLensesLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeLensesLspSuite.scala
@@ -182,7 +182,7 @@ object CodeLensesLspSuite extends BaseLspSuite("codeLenses") {
   }
 
   def check(name: String, library: String = "")(expected: String): Unit = {
-    ignore(name) {
+    testAsync(name) {
       val original = expected.replaceAll("<<.*>>\\W", "")
 
       val sourceFile = {


### PR DESCRIPTION
Closes #992 
Previously, code lens would not disappear when recompilation would fail.
Now, we refresh the code lenses in an open tab also after failure