### PR TITLE
A documentation change in support of Java 11 configuration

### DIFF
--- a/docs/editors/vscode.md
+++ b/docs/editors/vscode.md
@@ -42,26 +42,20 @@ variables.
 
 ## Configure Java version
 
-The VS Code plugin uses by default the `JAVA_HOME` environment variable (via
-[`find-java-home`](https://www.npmjs.com/package/find-java-home)) to locate the
-`java` executable. Metals only works with Java 8 so this executable cannot point
-to another version such as Java 11.
-
-To override the default Java home location, update the "Java Home" variable to
+The VS Code plugin uses by default the `JAVA_HOME` environment variable (via [`find-java-home`](https://www.npmjs.com/package/find-java-home)) to locate the `java` executable. To override the default Java home location, update the "Java Home" variable to
 in the settings menu.
 
 ![Java Home setting](https://i.imgur.com/sKrPKk2.png)
 
-If this setting is defined, the VS Code plugin uses the custom path instead of
-the `JAVA_HOME` environment variable.
+If this setting is defined, the VS Code plugin uses the custom path instead of the `JAVA_HOME` environment variable.
+
+**Note:** Metals only tries to find by default Java 8. For Java 11 support, you need to specify the path in Metals settings.
 
 ### macOS
 
-To globally configure `$JAVA_HOME` for all GUI applications, see
-[this Stackoverflow answer](https://stackoverflow.com/questions/135688/setting-environment-variables-on-os-x).
+To globally configure `$JAVA_HOME` for all GUI applications, see [this Stackoverflow answer](https://stackoverflow.com/questions/135688/setting-environment-variables-on-os-x).
 
-If you prefer to manually configure Java home through VS Code, run the following
-command to copy the Java 8 home path.
+If you prefer to manually configure Java home through VS Code, run the following command to copy the Java 8 home path.
 
 ```sh
 /usr/libexec/java_home -v 1.8 | pbcopy
@@ -154,7 +148,7 @@ Install the
 extension to use default IntelliJ shortcuts with VS Code.
 
 | IntelliJ         | VS Code                   |
-| ---------------- | ------------------------- |
+|------------------|---------------------------|
 | Go to class      | Go to symbol in workspace |
 | Parameter info   | Trigger parameter hints   |
 | Basic completion | Trigger suggest           |


### PR DESCRIPTION
The current documentation suggests that Java 11 is supported, but it actually needs to be manually configured at the moment. This PR hopefully makes that more clear.

See https://github.com/scalameta/metals/issues/762 and https://twitter.com/andyczerwonka/status/1184560663215034369 for details.