### PR TITLE
Strip "metals." prefix from `workspace/executeCommand` requests.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1055,7 +1055,8 @@ class MetalsLanguageServer(
       params: ExecuteCommandParams
   ): CompletableFuture[Object] = {
     import JsonParser._
-    params.getCommand match {
+    val command = Option(params.getCommand).getOrElse("")
+    command.stripPrefix("metals.") match {
       case ServerCommands.ScanWorkspaceSources() =>
         Future {
           indexWorkspaceSources()


### PR DESCRIPTION
This allows clients to optionally choose whether to include a
`"metals."` prefix or not. Fixes #838.