### PR TITLE
Retry on error when reading source jar

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1611,8 +1611,8 @@ class MetalsLanguageServer(
           case None =>
             // Nothing in cache, read top level symbols and store them in cache
             val tempIndex = OnDemandSymbolIndex(onError = {
-              case NonFatal(e) =>
-                scribe.warn(s"Error when reading source jar [$path]", e)
+              case NonFatal(_) =>
+                scribe.warn(s"Error when reading source jar [$path]")
             })
             tempIndex.addSourceJar(path)
             tables.jarSymbols.putTopLevels(path, tempIndex.toplevels)


### PR DESCRIPTION
Previously, in case of issues with source jar an exception was thrown and logged, which caused extremely large logs on CI. Now, we retry on exception with a maximum retry of 3.