### PR TITLE
Switch shutdownNow to shutdown due to excessive exceptions being logged

### DIFF
--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -40,8 +40,8 @@ abstract class BaseLspSuite(suiteName: String) extends BaseSuite {
     if (server != null) {
       server.server.cancelAll()
     }
-    ex.shutdownNow()
-    sh.shutdownNow()
+    ex.shutdown()
+    sh.shutdown()
   }
 
   def assertConnectedToBuildServer(


### PR DESCRIPTION
Previously, shutdownNow would cause multiple threads to be interrupted, which would show up as a large number of exception. Now, we use shutdown(), so that threads can finish orderly. 