### PR TITLE
Suppress code lenses if debugging is not supported

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
@@ -1,0 +1,27 @@
+package scala.meta.internal.metals
+import com.google.gson.JsonElement
+import org.eclipse.{lsp4j => l}
+
+final case class ClientExperimentalCapabilities(
+    debuggingProvider: java.lang.Boolean,
+    treeViewProvider: java.lang.Boolean
+)
+
+object ClientExperimentalCapabilities {
+  val Default = new ClientExperimentalCapabilities(
+    debuggingProvider = false,
+    treeViewProvider = false
+  )
+
+  def from(
+      capabilities: l.ClientCapabilities
+  ): ClientExperimentalCapabilities = {
+    import scala.meta.internal.metals.JsonParser._
+    capabilities.getExperimental match {
+      case json: JsonElement =>
+        json.as[ClientExperimentalCapabilities].getOrElse(Default)
+      case _ =>
+        Default
+    }
+  }
+}

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -73,11 +73,10 @@ import scala.meta.internal.tvp.TreeViewChildrenParams
 import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
 import scala.{meta => m}
-import com.google.gson.JsonObject
-import com.google.gson.JsonPrimitive
 import scala.meta.internal.tvp.TreeViewProvider
 import org.eclipse.lsp4j.DocumentRangeFormattingParams
 import scala.concurrent.Promise
+import scala.meta.internal.metals.ClientExperimentalCapabilities
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.debug.TestDebugger
 import scala.meta.internal.metals.DebugSession
@@ -250,13 +249,15 @@ final class TestingServer(
     val workspaceCapabilities = new WorkspaceClientCapabilities()
     val textDocumentCapabilities = new TextDocumentClientCapabilities
     textDocumentCapabilities.setFoldingRange(new FoldingRangeCapabilities)
-    val experimental = new JsonObject()
-    experimental.add("treeViewProvider", new JsonPrimitive(true))
+    val experimental = new ClientExperimentalCapabilities(
+      debuggingProvider = true,
+      treeViewProvider = true
+    )
     params.setCapabilities(
       new ClientCapabilities(
         workspaceCapabilities,
         textDocumentCapabilities,
-        experimental
+        experimental.toJson
       )
     )
     params.setWorkspaceFolders(


### PR DESCRIPTION
Closes #1006
Previously, code lenses related to run/test action would be sent to the clients even if it didn't support running the code.
Now, in such case, Metals is not sending those lenses.