### PR TITLE
Resolve problem with coc.nvim installation

### DIFF
--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -73,7 +73,7 @@ following settings.
 
 " Configuration for vim-plug
 Plug 'derekwyatt/vim-scala'
-Plug 'neoclide/coc.nvim', {'do': { -> coc#util#install()}}
+Plug 'neoclide/coc.nvim', {'branch': 'release'}
 
 " Configuration for vim-scala
 au BufRead,BufNewFile *.sbt set filetype=scala


### PR DESCRIPTION
This pull request is intended to resolve problem I've stumbled upon - after installing this plugin it didn't load coc-settings.json from ~/.config/nvim/coc-settings.json. Upon further inspection it turns out that this tutorial was outdated. For reference: https://github.com/neoclide/coc.nvim/wiki/Install-coc.nvim.