### PR TITLE
Encode the workspace path directory in build digests

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
@@ -24,7 +24,7 @@ object Digest {
    * Bump up this version if parameters outside of the sbt sources themselves require
    * re-running `bloopInstall`. For example a SemanticDB or Bloop version upgrade.
    */
-  val version: String = "v4"
+  val version: String = "v5"
   sealed abstract class Status(val value: Int)
       extends Product
       with Serializable {
@@ -182,6 +182,8 @@ trait Digestable {
       if (System.getProperty("metals.testing") == null) {
         digest.update(Digest.version.getBytes(StandardCharsets.UTF_8))
       }
+
+      digest.update(workspace.toString.getBytes(StandardCharsets.UTF_8))
 
       val isSuccess = digestWorkspace(workspace, digest)
       if (isSuccess) Some(MD5.bytesToHex(digest.digest()))

--- a/tests/unit/src/main/scala/tests/BaseDigestSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseDigestSuite.scala
@@ -42,7 +42,7 @@ trait BaseDigestSuite extends BaseSuite {
       )
       val rootDigest = digestCurrent(root)
       RecursivelyDelete(root)
-      val altDigest = digestCurrent(FileLayout.fromString(altLayout))
+      val altDigest = digestCurrent(FileLayout.fromString(altLayout, root))
       (rootDigest, altDigest) match {
         case (None, None) => ()
         case (Some(x), Some(y)) =>

--- a/tests/unit/src/test/scala/tests/digest/DigestsSuite.scala
+++ b/tests/unit/src/test/scala/tests/digest/DigestsSuite.scala
@@ -1,4 +1,5 @@
 package tests
+package digest
 import scala.meta.internal.builds.Digest
 import scala.meta.internal.builds.Digest.Status._
 import scala.meta.internal.builds.Digests

--- a/tests/unit/src/test/scala/tests/digest/GradleDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/digest/GradleDigestSuite.scala
@@ -1,4 +1,5 @@
 package tests
+package digest
 
 import scala.meta.internal.builds.GradleDigest
 import scala.meta.io.AbsolutePath

--- a/tests/unit/src/test/scala/tests/digest/MavenDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/digest/MavenDigestSuite.scala
@@ -1,4 +1,5 @@
 package tests
+package digest
 
 import scala.meta.internal.builds.MavenDigest
 import scala.meta.io.AbsolutePath

--- a/tests/unit/src/test/scala/tests/digest/MillDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/digest/MillDigestSuite.scala
@@ -1,4 +1,5 @@
 package tests
+package digest
 
 import scala.meta.io.AbsolutePath
 import scala.meta.internal.builds.MillDigest

--- a/tests/unit/src/test/scala/tests/digest/SbtDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/digest/SbtDigestSuite.scala
@@ -1,4 +1,5 @@
 package tests
+package digest
 
 import scala.meta.internal.builds.SbtDigest
 import scala.meta.io.AbsolutePath


### PR DESCRIPTION
Fixes #1009. Previously, when the user loaded the workspace to a docker
container then Metals would fail to connect to the Bloop build server
without providing an explanation what might be wrong. Now, Metals will
prompt the user to re-import the build.