### PR TITLE
Suppress model-refresh if debugging is unsupported

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -100,8 +100,6 @@ final class ConfiguredLanguageClient(
   ): Unit = {
     if (config.executeClientCommand.isOn) {
       params.getCommand match {
-        case _ if config.executeClientCommand.isOff =>
-        // ignore
         case ClientCommands.RefreshModel() if !debuggingSupported =>
         // ignore
         case _ =>

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -18,10 +18,16 @@ import scala.meta.internal.metals.MetalsEnrichments._
  * from window/logMessage are always visible in the UI while in VS Code the logs are hidden by default.
  */
 final class ConfiguredLanguageClient(
-    _underlying: MetalsLanguageClient,
+    initial: MetalsLanguageClient,
     config: MetalsServerConfig
 )(implicit ec: ExecutionContext)
-    extends DelegatingLanguageClient(_underlying, config) {
+    extends DelegatingLanguageClient(initial) {
+
+  @volatile private var debuggingSupported = true
+
+  def configure(capabilities: ClientExperimentalCapabilities): Unit = {
+    debuggingSupported = capabilities.debuggingProvider
+  }
 
   override def shutdown(): Unit = {
     underlying = NoopLanguageClient
@@ -93,7 +99,14 @@ final class ConfiguredLanguageClient(
       params: ExecuteCommandParams
   ): Unit = {
     if (config.executeClientCommand.isOn) {
-      underlying.metalsExecuteClientCommand(params)
+      params.getCommand match {
+        case _ if config.executeClientCommand.isOff =>
+        // ignore
+        case ClientCommands.RefreshModel.id if !debuggingSupported =>
+        // ignore
+        case _ =>
+          underlying.metalsExecuteClientCommand(params)
+      }
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -25,8 +25,9 @@ final class ConfiguredLanguageClient(
 
   @volatile private var debuggingSupported = true
 
-  def configure(capabilities: ClientExperimentalCapabilities): Unit = {
+  override def configure(capabilities: ClientExperimentalCapabilities): Unit = {
     debuggingSupported = capabilities.debuggingProvider
+    super.configure(capabilities)
   }
 
   override def shutdown(): Unit = {

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -102,7 +102,7 @@ final class ConfiguredLanguageClient(
       params.getCommand match {
         case _ if config.executeClientCommand.isOff =>
         // ignore
-        case ClientCommands.RefreshModel.id if !debuggingSupported =>
+        case ClientCommands.RefreshModel() if !debuggingSupported =>
         // ignore
         case _ =>
           underlying.metalsExecuteClientCommand(params)

--- a/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
@@ -12,10 +12,8 @@ import org.eclipse.lsp4j.ShowMessageRequestParams
 import org.eclipse.lsp4j.UnregistrationParams
 import scala.meta.internal.tvp._
 
-class DelegatingLanguageClient(
-    var underlying: MetalsLanguageClient,
-    config: MetalsServerConfig
-) extends MetalsLanguageClient {
+class DelegatingLanguageClient(var underlying: MetalsLanguageClient)
+    extends MetalsLanguageClient {
 
   override def shutdown(): Unit = {
     underlying.shutdown()

--- a/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
@@ -37,6 +37,10 @@ class DelegatingLanguageClient(var underlying: MetalsLanguageClient)
     underlying.applyEdit(params)
   }
 
+  override def configure(capabilities: ClientExperimentalCapabilities): Unit = {
+    underlying.configure(capabilities)
+  }
+
   override def metalsStatus(params: MetalsStatusParams): Unit = {
     underlying.metalsStatus(params)
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
@@ -41,7 +41,7 @@ import scala.util.Try
 final class MetalsHttpClient(
     workspace: AbsolutePath,
     url: () => String,
-    _underlying: MetalsLanguageClient,
+    initial: MetalsLanguageClient,
     triggerReload: () => Unit,
     charset: Charset,
     icons: Icons,
@@ -49,7 +49,7 @@ final class MetalsHttpClient(
     sh: ScheduledExecutorService,
     config: MetalsServerConfig
 )(implicit ec: ExecutionContext)
-    extends DelegatingLanguageClient(_underlying, config) {
+    extends DelegatingLanguageClient(initial) {
 
   override def metalsInputBox(
       params: MetalsInputBoxParams

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
@@ -12,19 +12,6 @@ import scala.meta.internal.tvp._
 import scala.meta.internal.metals.MetalsEnrichments._
 
 trait MetalsLanguageClient extends LanguageClient with TreeViewClient {
-  @volatile private var debuggingSupported = true
-
-  final def configure(capabilities: ClientExperimentalCapabilities): Unit = {
-    debuggingSupported = capabilities.debuggingProvider
-  }
-
-  final def refreshModel(): Unit = {
-    if (debuggingSupported) {
-      val command = ClientCommands.RefreshModel.id
-      val params = new ExecuteCommandParams(command, Nil.asJava)
-      metalsExecuteClientCommand(params)
-    }
-  }
 
   /**
    * Display message in the editor "status bar", which should be displayed somewhere alongside the buffer.
@@ -49,6 +36,12 @@ trait MetalsLanguageClient extends LanguageClient with TreeViewClient {
 
   @JsonNotification("metals/executeClientCommand")
   def metalsExecuteClientCommand(params: ExecuteCommandParams): Unit
+
+  final def refreshModel(): Unit = {
+    val command = ClientCommands.RefreshModel.id
+    val params = new ExecuteCommandParams(command, Nil.asJava)
+    metalsExecuteClientCommand(params)
+  }
 
   /**
    * Opens an input box to ask the user for input.

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
@@ -13,6 +13,8 @@ import scala.meta.internal.metals.MetalsEnrichments._
 
 trait MetalsLanguageClient extends LanguageClient with TreeViewClient {
 
+  def configure(capabilities: ClientExperimentalCapabilities): Unit
+
   /**
    * Display message in the editor "status bar", which should be displayed somewhere alongside the buffer.
    *

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -200,6 +200,8 @@ class MetalsLanguageServer(
     MetalsLogger.setupLspLogger(workspace, redirectSystemOut)
     val clientExperimentalCapabilities =
       ClientExperimentalCapabilities.from(params.getCapabilities)
+
+    languageClient.configure(clientExperimentalCapabilities)
     buildTargets.setWorkspaceDirectory(workspace)
     tables = register(new Tables(workspace, time, config))
     buildTargets.setTables(tables)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -200,13 +200,7 @@ class MetalsLanguageServer(
     val clientExperimentalCapabilities =
       ClientExperimentalCapabilities.from(params.getCapabilities)
 
-    languageClient.underlying match {
-      case client: ConfiguredLanguageClient =>
-        client.configure(clientExperimentalCapabilities)
-      case _ =>
-        scribe.debug("Client proxy is not configurable")
-    }
-
+    languageClient.configure(clientExperimentalCapabilities)
     buildTargets.setWorkspaceDirectory(workspace)
     tables = register(new Tables(workspace, time, config))
     buildTargets.setTables(tables)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -105,8 +105,7 @@ class MetalsLanguageServer(
   private val savedFiles = new ActiveFiles(time)
   private val openedFiles = new ActiveFiles(time)
   private val messages = new Messages(config.icons)
-  private val languageClient =
-    new DelegatingLanguageClient(NoopLanguageClient, config)
+  private val languageClient = new DelegatingLanguageClient(NoopLanguageClient)
   var userConfig = UserConfiguration()
   val buildTargets: BuildTargets = new BuildTargets()
   val compilations: Compilations = new Compilations(
@@ -171,7 +170,7 @@ class MetalsLanguageServer(
   var treeView: TreeViewProvider = NoopTreeViewProvider
 
   def connectToLanguageClient(client: MetalsLanguageClient): Unit = {
-    languageClient.underlying = client
+    languageClient.underlying = new ConfiguredLanguageClient(client, config)(ec)
     statusBar = new StatusBar(
       () => languageClient,
       time,
@@ -201,7 +200,13 @@ class MetalsLanguageServer(
     val clientExperimentalCapabilities =
       ClientExperimentalCapabilities.from(params.getCapabilities)
 
-    languageClient.configure(clientExperimentalCapabilities)
+    languageClient.underlying match {
+      case client: ConfiguredLanguageClient =>
+        client.configure(clientExperimentalCapabilities)
+      case _ =>
+        scribe.debug("Client proxy is not configurable")
+    }
+
     buildTargets.setWorkspaceDirectory(workspace)
     tables = register(new Tables(workspace, time, config))
     buildTargets.setTables(tables)

--- a/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
@@ -15,6 +15,8 @@ import scala.meta.internal.tvp._
  * or log messages are published during shutdown.
  */
 abstract class NoopLanguageClient extends MetalsLanguageClient {
+  override def configure(capabilities: ClientExperimentalCapabilities): Unit =
+    ()
   override def metalsStatus(params: MetalsStatusParams): Unit = ()
   override def metalsSlowTask(
       params: MetalsSlowTaskParams

--- a/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
@@ -39,9 +39,6 @@ abstract class NoopLanguageClient extends MetalsLanguageClient {
   override def metalsTreeViewDidChange(
       params: TreeViewDidChangeParams
   ): Unit = ()
-  // override def metalsTreeViewNodeReveal(
-  //     params: TreeViewNodeRevealResult
-  // ): Unit = ()
 }
 
 object NoopLanguageClient extends NoopLanguageClient

--- a/metals/src/main/scala/scala/meta/metals/Main.scala
+++ b/metals/src/main/scala/scala/meta/metals/Main.scala
@@ -8,7 +8,6 @@ import scala.meta.internal.metals.GlobalTrace
 import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.internal.metals.MetalsLanguageServer
 import scala.meta.internal.metals.MetalsServerConfig
-import scala.meta.internal.metals.ConfiguredLanguageClient
 import scala.util.control.NonFatal
 
 object Main {
@@ -35,9 +34,8 @@ object Main {
         .setRemoteInterface(classOf[MetalsLanguageClient])
         .setLocalService(server)
         .create()
-      val underlyingClient = launcher.getRemoteProxy
-      val client = new ConfiguredLanguageClient(underlyingClient, config)(ec)
-      server.connectToLanguageClient(client)
+      val clientProxy = launcher.getRemoteProxy
+      server.connectToLanguageClient(clientProxy)
       launcher.startListening().get()
     } catch {
       case NonFatal(e) =>

--- a/tests/slow/src/test/scala/tests/BaseImportSuite.scala
+++ b/tests/slow/src/test/scala/tests/BaseImportSuite.scala
@@ -6,9 +6,15 @@ import scala.meta.internal.builds.Digest
 import scala.meta.io.AbsolutePath
 import scala.meta.internal.builds.BuildTool
 import scala.meta.internal.metals.Messages._
+import scala.meta.internal.metals.SlowTaskConfig
 
 abstract class BaseImportSuite(suiteName: String)
     extends BaseLspSuite(suiteName) {
+
+  // enables support for bloop install (a slow task)
+  override val serverConfig = {
+    super.serverConfig.copy(slowTask = SlowTaskConfig.on)
+  }
 
   def buildTool: BuildTool
 

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -6,6 +6,7 @@ import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Future
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.Buffers
+import scala.meta.internal.metals.ClientExperimentalCapabilities
 import scala.meta.internal.metals.ExecuteClientCommandConfig
 import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.MetalsLogger
@@ -32,6 +33,9 @@ abstract class BaseLspSuite(suiteName: String) extends BaseSuite {
   var server: TestingServer = _
   var client: TestingClient = _
   var workspace: AbsolutePath = _
+
+  protected def experimentalCapabilities
+      : Option[ClientExperimentalCapabilities] = None
 
   override def afterAll(): Unit = {
     if (server != null) {
@@ -69,7 +73,8 @@ abstract class BaseLspSuite(suiteName: String) extends BaseSuite {
       config,
       bspGlobalDirectories,
       sh,
-      time
+      time,
+      experimentalCapabilities
     )(ex)
     server.server.userConfig = this.userConfig
   }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -12,7 +12,6 @@ import java.nio.file.attribute.BasicFileAttributes
 import java.util
 import java.util.Collections
 import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
 import ch.epfl.scala.{bsp4j => b}
 import org.eclipse.lsp4j.ClientCapabilities
 import org.eclipse.lsp4j.CodeLensParams
@@ -498,7 +497,7 @@ final class TestingServer(
       _ = client.refreshModelHandler = handler
       // first compilation, to trigger the handler
       _ <- server.compilations.compileFiles(List(path))
-      lenses <- codeLenses.future.withTimeout(30, TimeUnit.SECONDS)
+      lenses <- codeLenses.future
       textEdits = CodeLensesTextEdits(lenses)
     } yield TextEdits.applyEdits(textContents(filename), textEdits)
   }

--- a/tests/unit/src/test/scala/tests/UnsupportedDebuggingLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/UnsupportedDebuggingLspSuite.scala
@@ -1,0 +1,68 @@
+package tests
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.TimeoutException
+import scala.meta.internal.metals.ClientCommands
+import scala.meta.internal.metals.ClientExperimentalCapabilities
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.util.Failure
+import scala.util.Success
+
+object UnsupportedDebuggingLspSuite
+    extends BaseLspSuite("unsupported-debugging") {
+
+  override val experimentalCapabilities = Some(
+    new ClientExperimentalCapabilities(
+      debuggingProvider = false,
+      treeViewProvider = false
+    )
+  )
+
+  testAsync("no-code-lenses") {
+    for {
+      _ <- server.initialize(
+        """|/metals.json
+           |{ "a": { } }
+           |
+           |/a/src/main/scala/Main.scala
+           |object Main {
+           |  def main(args: Array[String]): Unit = ???
+           |}
+           |""".stripMargin
+      )
+      codeLenses <- server
+        .codeLenses("a/src/main/scala/Main.scala")(maxRetries = 3)
+        .withTimeout(5, TimeUnit.SECONDS)
+        .transform(Success(_))
+    } yield {
+      codeLenses match {
+        case Failure(_: TimeoutException) =>
+        // success
+        case result =>
+          fail(
+            s"Expected timeout when retrieving code lenses. Obtained [$result]"
+          )
+      }
+    }
+  }
+
+  testAsync("suppress-model-refresh") {
+    for {
+      _ <- server.initialize(
+        """|/metals.json
+           |{ "a": { } }
+           |
+           |/a/src/main/scala/Main.scala
+           |object Main {
+           |  def main(args: Array[String]): Unit = ???
+           |}
+           |""".stripMargin
+      )
+      _ <- server.server.compilations
+        .compileFiles(List(server.toPath("a/src/main/scala/Main.scala")))
+    } yield {
+      val clientCommands = client.clientCommands.asScala.map(_.getCommand).toSet
+      assert(!clientCommands.contains(ClientCommands.RefreshModel.id))
+    }
+  }
+}


### PR DESCRIPTION
closes #1016 

Previously, model-refresh command was sent to the client even though it didn't support debugging.
Now, metals will refrain from sending in in such cases.