### PR TITLE
trace the debug adapter protocol messages

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/EndpointLogger.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/EndpointLogger.scala
@@ -1,0 +1,72 @@
+package scala.meta.internal.metals.debug
+
+import java.io.PrintWriter
+import java.time.Clock
+import java.time.format.DateTimeFormatter
+import java.util.Collections
+import java.util.function.Consumer
+import com.google.gson.GsonBuilder
+import org.eclipse.lsp4j.jsonrpc.MessageConsumer
+import org.eclipse.lsp4j.jsonrpc.debug.json.DebugMessageJsonHandler
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler
+import org.eclipse.lsp4j.jsonrpc.messages.Message
+import org.eclipse.lsp4j.jsonrpc.messages.NotificationMessage
+import org.eclipse.lsp4j.jsonrpc.messages.RequestMessage
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
+import scala.meta.internal.metals.debug.EndpointLogger.Direction
+import scala.meta.internal.metals.debug.EndpointLogger.Received
+import scala.meta.internal.metals.debug.EndpointLogger.Sent
+import scala.meta.internal.metals.debug.EndpointLogger.time
+
+final class EndpointLogger(endpoint: RemoteEndpoint, logger: PrintWriter)
+    extends RemoteEndpoint {
+  private val writer: MessageJsonHandler = EndpointLogger.serializer
+
+  override def consume(message: Message): Unit = {
+    try log(Sent, message)
+    finally endpoint.consume(message)
+  }
+
+  override def listen(messageConsumer: MessageConsumer): Unit = {
+    endpoint.listen { message =>
+      try log(Received, message)
+      finally messageConsumer.consume(message)
+    }
+  }
+
+  override def cancel(): Unit = endpoint.cancel()
+
+  private def log(direction: Direction, message: Message): Unit = {
+    logger.println(s"[Trace][$time] $direction ${typeOf(message)}:")
+    writer.serialize(message, logger)
+    logger.println()
+    logger.flush()
+  }
+
+  private def typeOf(message: Message): String = {
+    message match {
+      case _: RequestMessage => "request"
+      case _: ResponseMessage => "response"
+      case _: NotificationMessage => "notification"
+    }
+  }
+}
+
+object EndpointLogger {
+  sealed trait Direction
+  final case object Received extends Direction
+  final case object Sent extends Direction
+
+  private def serializer: MessageJsonHandler = {
+    val configure: Consumer[GsonBuilder] = { gson =>
+      gson.setPrettyPrinting()
+    }
+    new DebugMessageJsonHandler(Collections.emptyMap(), configure)
+  }
+
+  private val clock = Clock.systemDefaultZone()
+  private val timeFormat =
+    DateTimeFormatter.ofPattern("KK:mm:ss a").withZone(clock.getZone)
+
+  def time: String = timeFormat.format(clock.instant())
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/RemoteEndpoint.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/RemoteEndpoint.scala
@@ -1,45 +1,10 @@
 package scala.meta.internal.metals.debug
 
-import java.net.Socket
-import java.util.Collections
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer
 import org.eclipse.lsp4j.jsonrpc.MessageProducer
-import org.eclipse.lsp4j.jsonrpc.debug.json.DebugMessageJsonHandler
-import org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer
-import org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer
-import org.eclipse.lsp4j.jsonrpc.messages.Message
 import scala.meta.internal.metals.Cancelable
-import scala.meta.internal.metals.debug.RemoteEndpoint._
 
-private[debug] final class RemoteEndpoint(socket: Socket)
+trait RemoteEndpoint
     extends MessageConsumer
     with MessageProducer
-    with Cancelable {
-  private val source = messageSource(socket)
-  private val target = messageTarget(socket)
-
-  override def consume(message: Message): Unit = {
-    target.consume(message)
-  }
-
-  override def listen(consumer: MessageConsumer): Unit = {
-    source.listen(consumer)
-  }
-
-  override def cancel(): Unit = {
-    source.close()
-    socket.close()
-  }
-}
-
-private[debug] object RemoteEndpoint {
-  private val handler = new DebugMessageJsonHandler(Collections.emptyMap())
-
-  private def messageSource(socket: Socket): StreamMessageProducer = {
-    new StreamMessageProducer(socket.getInputStream, handler)
-  }
-
-  private def messageTarget(socket: Socket): MessageConsumer = {
-    new StreamMessageConsumer(socket.getOutputStream, handler)
-  }
-}
+    with Cancelable

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/SocketEndpoint.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/SocketEndpoint.scala
@@ -1,0 +1,41 @@
+package scala.meta.internal.metals.debug
+
+import java.net.Socket
+import java.util.Collections
+import org.eclipse.lsp4j.jsonrpc.MessageConsumer
+import org.eclipse.lsp4j.jsonrpc.debug.json.DebugMessageJsonHandler
+import org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer
+import org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer
+import org.eclipse.lsp4j.jsonrpc.messages.Message
+import scala.meta.internal.metals.debug.SocketEndpoint._
+
+private[debug] final class SocketEndpoint(socket: Socket)
+    extends RemoteEndpoint {
+  private val source = messageSource(socket)
+  private val target = messageTarget(socket)
+
+  override def consume(message: Message): Unit = {
+    target.consume(message)
+  }
+
+  override def listen(consumer: MessageConsumer): Unit = {
+    source.listen(consumer)
+  }
+
+  override def cancel(): Unit = {
+    source.close()
+    socket.close()
+  }
+}
+
+private[debug] object SocketEndpoint {
+  private val handler = new DebugMessageJsonHandler(Collections.emptyMap())
+
+  private def messageSource(socket: Socket): StreamMessageProducer = {
+    new StreamMessageProducer(socket.getInputStream, handler)
+  }
+
+  private def messageTarget(socket: Socket): MessageConsumer = {
+    new StreamMessageConsumer(socket.getOutputStream, handler)
+  }
+}

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/RemoteServer.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/RemoteServer.scala
@@ -32,7 +32,7 @@ private[debug] final class RemoteServer(
     extends IDebugProtocolServer
     with Cancelable {
 
-  private val remote = new RemoteEndpoint(socket)
+  private val remote = new SocketEndpoint(socket)
   private val ongoing = new TrieMap[String, Response => Unit]()
   private val id = new AtomicInteger(0)
   lazy val listening: Future[Unit] = Future(listen())


### PR DESCRIPTION
closes #1022

Previously the dap messages were were not being traced.
Now, we trace them on both ends in: `dap-client.trace.json` and `tap-server.trace.json` files