### PR TITLE
Add completion to add all abstract members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ project/plugins/project/
 
 .metals/
 metals.sbt
+metals/project/
 
 .vscode/
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -72,9 +72,9 @@ object Configs {
           "metals.hover.documentation",
           default = true
         ),
-        isMagicIndentClient = MetalsServerConfig.binaryOption(
-          "metals.magic-indent-client",
-          default = false
+        snippetVscodeIndent = MetalsServerConfig.binaryOption(
+          "metals.snippet-vscode-indent",
+          default = true
         ),
         isSignatureHelpDocumentationEnabled = MetalsServerConfig.binaryOption(
           "metals.signature-help.documentation",

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -72,8 +72,8 @@ object Configs {
           "metals.hover.documentation",
           default = true
         ),
-        snippetVscodeIndent = MetalsServerConfig.binaryOption(
-          "metals.snippet-vscode-indent",
+        snippetAutoIndent = MetalsServerConfig.binaryOption(
+          "metals.snippet-auto-indent",
           default = true
         ),
         isSignatureHelpDocumentationEnabled = MetalsServerConfig.binaryOption(

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -72,6 +72,10 @@ object Configs {
           "metals.hover.documentation",
           default = true
         ),
+        isMagicIndentClient = MetalsServerConfig.binaryOption(
+          "metals.magic-indent-client",
+          default = false
+        ),
         isSignatureHelpDocumentationEnabled = MetalsServerConfig.binaryOption(
           "metals.signature-help.documentation",
           default = true

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -14,8 +14,8 @@ import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
  * @param slowTask how to handle metals/slowTask requests.
  * @param showMessage how to handle window/showMessage notifications.
  * @param showMessageRequest how to handle window/showMessageRequest requests.
- * @param snippetVscodeIndent if the client defaults to adding the identation of the reference
- *                            line that the operation started on (relevant for multiline textEdits)
+ * @param snippetAutoIndent if the client defaults to adding the identation of the reference
+ *                          line that the operation started on (relevant for multiline textEdits)
  * @param isNoInitialized set true if the editor client doesn't call the `initialized`
  *                        notification for some reason, see https://github.com/natebosch/vim-lsc/issues/113
  * @param isHttpEnabled whether to start the Metals HTTP client interface. This is needed
@@ -32,8 +32,8 @@ final case class MetalsServerConfig(
     showMessage: ShowMessageConfig = ShowMessageConfig.default,
     showMessageRequest: ShowMessageRequestConfig =
       ShowMessageRequestConfig.default,
-    snippetVscodeIndent: Boolean = MetalsServerConfig.binaryOption(
-      "metals.snippet-vscode-indent",
+    snippetAutoIndent: Boolean = MetalsServerConfig.binaryOption(
+      "metals.snippet-auto-indent",
       default = true
     ),
     isNoInitialized: Boolean = MetalsServerConfig.binaryOption(
@@ -127,7 +127,7 @@ object MetalsServerConfig {
           isHttpEnabled = true,
           icons = Icons.unicode,
           compilers = base.compilers.copy(
-            snippetVscodeIndent = false
+            snippetAutoIndent = false
           )
         )
       case "coc.nvim" =>
@@ -153,14 +153,14 @@ object MetalsServerConfig {
           compilers = base.compilers.copy(
             // Avoid showing the method signature twice because it's already visible in the label.
             isCompletionItemDetailEnabled = false,
-            snippetVscodeIndent = false
+            snippetAutoIndent = false
           )
         )
       case "emacs" =>
         base.copy(
           executeClientCommand = ExecuteClientCommandConfig.on,
           compilers = base.compilers.copy(
-            snippetVscodeIndent = false
+            snippetAutoIndent = false
           )
         )
       case _ =>

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -14,6 +14,8 @@ import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
  * @param slowTask how to handle metals/slowTask requests.
  * @param showMessage how to handle window/showMessage notifications.
  * @param showMessageRequest how to handle window/showMessageRequest requests.
+ * @param isMagicIndentClient if the client defaults to adding the identation of the reference
+ *                            line that the operation started on (relevant for multiline textEdits)
  * @param isNoInitialized set true if the editor client doesn't call the `initialized`
  *                        notification for some reason, see https://github.com/natebosch/vim-lsc/issues/113
  * @param isHttpEnabled whether to start the Metals HTTP client interface. This is needed
@@ -30,6 +32,10 @@ final case class MetalsServerConfig(
     showMessage: ShowMessageConfig = ShowMessageConfig.default,
     showMessageRequest: ShowMessageRequestConfig =
       ShowMessageRequestConfig.default,
+    isMagicIndentClient: Boolean = MetalsServerConfig.binaryOption(
+      "metals.magic-indent-client",
+      default = false
+    ),
     isNoInitialized: Boolean = MetalsServerConfig.binaryOption(
       "metals.no-initialized",
       default = false
@@ -105,6 +111,7 @@ object MetalsServerConfig {
           statusBar = StatusBarConfig.on,
           slowTask = SlowTaskConfig.on,
           icons = Icons.vscode,
+          isMagicIndentClient = true,
           executeClientCommand = ExecuteClientCommandConfig.on,
           globSyntax = GlobSyntaxConfig.vscode,
           compilers = base.compilers.copy(
@@ -125,6 +132,7 @@ object MetalsServerConfig {
         base.copy(
           statusBar = StatusBarConfig.showMessage,
           isHttpEnabled = true,
+          isMagicIndentClient = true,
           compilers = base.compilers.copy(
             _parameterHintsCommand = Some("editor.action.triggerParameterHints"),
             _completionCommand = Some("editor.action.triggerSuggest"),
@@ -149,6 +157,10 @@ object MetalsServerConfig {
       case "emacs" =>
         base.copy(
           executeClientCommand = ExecuteClientCommandConfig.on
+        )
+      case "atom" =>
+        base.copy(
+          isMagicIndentClient = true
         )
       case _ =>
         base

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -14,7 +14,7 @@ import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
  * @param slowTask how to handle metals/slowTask requests.
  * @param showMessage how to handle window/showMessage notifications.
  * @param showMessageRequest how to handle window/showMessageRequest requests.
- * @param isMagicIndentClient if the client defaults to adding the identation of the reference
+ * @param snippetVscodeIndent if the client defaults to adding the identation of the reference
  *                            line that the operation started on (relevant for multiline textEdits)
  * @param isNoInitialized set true if the editor client doesn't call the `initialized`
  *                        notification for some reason, see https://github.com/natebosch/vim-lsc/issues/113
@@ -32,9 +32,9 @@ final case class MetalsServerConfig(
     showMessage: ShowMessageConfig = ShowMessageConfig.default,
     showMessageRequest: ShowMessageRequestConfig =
       ShowMessageRequestConfig.default,
-    isMagicIndentClient: Boolean = MetalsServerConfig.binaryOption(
-      "metals.magic-indent-client",
-      default = false
+    snippetVscodeIndent: Boolean = MetalsServerConfig.binaryOption(
+      "metals.snippet-vscode-indent",
+      default = true
     ),
     isNoInitialized: Boolean = MetalsServerConfig.binaryOption(
       "metals.no-initialized",
@@ -111,7 +111,6 @@ object MetalsServerConfig {
           statusBar = StatusBarConfig.on,
           slowTask = SlowTaskConfig.on,
           icons = Icons.vscode,
-          isMagicIndentClient = true,
           executeClientCommand = ExecuteClientCommandConfig.on,
           globSyntax = GlobSyntaxConfig.vscode,
           compilers = base.compilers.copy(
@@ -126,13 +125,15 @@ object MetalsServerConfig {
           statusBar = StatusBarConfig.logMessage,
           // Not strictly needed, but helpful while this integration matures.
           isHttpEnabled = true,
-          icons = Icons.unicode
+          icons = Icons.unicode,
+          compilers = base.compilers.copy(
+            snippetVscodeIndent = false
+          )
         )
       case "coc.nvim" =>
         base.copy(
           statusBar = StatusBarConfig.showMessage,
           isHttpEnabled = true,
-          isMagicIndentClient = true,
           compilers = base.compilers.copy(
             _parameterHintsCommand = Some("editor.action.triggerParameterHints"),
             _completionCommand = Some("editor.action.triggerSuggest"),
@@ -151,16 +152,16 @@ object MetalsServerConfig {
           isExitOnShutdown = true,
           compilers = base.compilers.copy(
             // Avoid showing the method signature twice because it's already visible in the label.
-            isCompletionItemDetailEnabled = false
+            isCompletionItemDetailEnabled = false,
+            snippetVscodeIndent = false
           )
         )
       case "emacs" =>
         base.copy(
-          executeClientCommand = ExecuteClientCommandConfig.on
-        )
-      case "atom" =>
-        base.copy(
-          isMagicIndentClient = true
+          executeClientCommand = ExecuteClientCommandConfig.on,
+          compilers = base.compilers.copy(
+            snippetVscodeIndent = false
+          )
         )
       case _ =>
         base

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -60,6 +60,11 @@ public interface PresentationCompilerConfig {
     boolean isHoverDocumentationEnabled();
 
     /**
+     * Returns true if the client inserts magic indentation on a multline textEdit.
+     */
+    boolean isMagicIndentClient();
+
+    /**
      * Returns true if the <code>SignatureHelp.documentation</code> field should be populated.
      */
     boolean isSignatureHelpDocumentationEnabled();

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -63,7 +63,7 @@ public interface PresentationCompilerConfig {
      * True if the client defaults to adding the identation of the reference
      * line that the operation started on (relevant for multiline textEdits)
      */
-    boolean snippetVscodeIndent();
+    boolean snippetAutoIndent();
 
     /**
      * Returns true if the <code>SignatureHelp.documentation</code> field should be populated.

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -60,9 +60,10 @@ public interface PresentationCompilerConfig {
     boolean isHoverDocumentationEnabled();
 
     /**
-     * Returns true if the client inserts magic indentation on a multline textEdit.
+     * True if the client defaults to adding the identation of the reference
+     * line that the operation started on (relevant for multiline textEdits)
      */
-    boolean isMagicIndentClient();
+    boolean snippetVscodeIndent();
 
     /**
      * Returns true if the <code>SignatureHelp.documentation</code> field should be populated.

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -15,6 +15,7 @@ import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.tokenizers.Chars
 import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
 import scala.util.control.NonFatal
+import scala.collection.immutable.Nil
 
 /**
  * Utility methods for completions.
@@ -1217,6 +1218,7 @@ trait Completions { this: MetalsGlobal =>
           val overrideMembers = typed.tpe.members.iterator.toList
             .filter(isOverridableMethod)
             .map(OverrideCandidate.apply)
+            .map(_.toMember)
 
           val overrideDefMembers: List[OverrideDefMember] =
             overrideMembers
@@ -1226,21 +1228,17 @@ trait Completions { this: MetalsGlobal =>
                   candidate.filterText
                 )
               }
-              .map(_.toMember)
-              .toList
 
           val allAbstractMembers = overrideMembers
-            .map(_.toMember)
             .filter(_.sym.isAbstract)
-            .toList
-            .map(_.edit.getNewText)
+            .map(_.edit)
 
           if (allAbstractMembers.length > 1 && overrideDefMembers.length > 1) {
             val implementAll: TextEditMember = new TextEditMember(
               prefix,
               new l.TextEdit(
                 range,
-                allAbstractMembers.reverse.mkString("\n")
+                allAbstractMembers.map(_.getNewText).reverse.mkString(s"\n")
               ),
               completionsSymbol("implement"),
               label = Some("Implement all members"),

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -1234,7 +1234,7 @@ trait Completions { this: MetalsGlobal =>
             .map(_.edit)
 
           if (allAbstractMembers.length > 1 && overrideDefMembers.length > 1) {
-            val necessaryIndent = if (metalsConfig.snippetVscodeIndent()) {
+            val necessaryIndent = if (metalsConfig.snippetAutoIndent()) {
               ""
             } else {
               val amount =

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -1234,11 +1234,22 @@ trait Completions { this: MetalsGlobal =>
             .map(_.edit)
 
           if (allAbstractMembers.length > 1 && overrideDefMembers.length > 1) {
+            val necessaryIndent = if (metalsConfig.isMagicIndentClient()) {
+              ""
+            } else {
+              val amount =
+                allAbstractMembers.head.getRange.getStart.getCharacter
+              " " * amount
+            }
+
             val implementAll: TextEditMember = new TextEditMember(
               prefix,
               new l.TextEdit(
                 range,
-                allAbstractMembers.map(_.getNewText).reverse.mkString(s"\n")
+                allAbstractMembers
+                  .map(_.getNewText)
+                  .reverse
+                  .mkString(s"\n${necessaryIndent}")
               ),
               completionsSymbol("implement"),
               label = Some("Implement all members"),

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -1234,7 +1234,7 @@ trait Completions { this: MetalsGlobal =>
             .map(_.edit)
 
           if (allAbstractMembers.length > 1 && overrideDefMembers.length > 1) {
-            val necessaryIndent = if (metalsConfig.isMagicIndentClient()) {
+            val necessaryIndent = if (metalsConfig.snippetVscodeIndent()) {
               ""
             } else {
               val amount =

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -17,7 +17,7 @@ case class PresentationCompilerConfigImpl(
     isCompletionItemDetailEnabled: Boolean = true,
     isCompletionItemDocumentationEnabled: Boolean = true,
     isHoverDocumentationEnabled: Boolean = true,
-    snippetVscodeIndent: Boolean = true,
+    snippetAutoIndent: Boolean = true,
     isSignatureHelpDocumentationEnabled: Boolean = true,
     isCompletionItemResolve: Boolean = true,
     timeoutDelay: Long = 20,

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -17,7 +17,7 @@ case class PresentationCompilerConfigImpl(
     isCompletionItemDetailEnabled: Boolean = true,
     isCompletionItemDocumentationEnabled: Boolean = true,
     isHoverDocumentationEnabled: Boolean = true,
-    isMagicIndentClient: Boolean = false,
+    snippetVscodeIndent: Boolean = true,
     isSignatureHelpDocumentationEnabled: Boolean = true,
     isCompletionItemResolve: Boolean = true,
     timeoutDelay: Long = 20,

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -17,6 +17,7 @@ case class PresentationCompilerConfigImpl(
     isCompletionItemDetailEnabled: Boolean = true,
     isCompletionItemDocumentationEnabled: Boolean = true,
     isHoverDocumentationEnabled: Boolean = true,
+    isMagicIndentClient: Boolean = false,
     isSignatureHelpDocumentationEnabled: Boolean = true,
     isCompletionItemResolve: Boolean = true,
     timeoutDelay: Long = 20,

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -36,7 +36,7 @@ abstract class BasePCSuite extends BaseSuite {
   def scalacOptions: Seq[String] = Nil
   def config: PresentationCompilerConfig =
     PresentationCompilerConfigImpl().copy(
-      snippetVscodeIndent = false
+      snippetAutoIndent = false
     )
   val myclasspath: Seq[Path] = extraClasspath ++ scalaLibrary.toList
   val index = new DelegatingGlobalSymbolIndex(OnDemandSymbolIndex())

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -36,7 +36,7 @@ abstract class BasePCSuite extends BaseSuite {
   def scalacOptions: Seq[String] = Nil
   def config: PresentationCompilerConfig =
     PresentationCompilerConfigImpl().copy(
-      isMagicIndentClient = false
+      snippetVscodeIndent = false
     )
   val myclasspath: Seq[Path] = extraClasspath ++ scalaLibrary.toList
   val index = new DelegatingGlobalSymbolIndex(OnDemandSymbolIndex())

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -34,7 +34,10 @@ abstract class BasePCSuite extends BaseSuite {
   val scalaLibrary: Seq[Path] = PackageIndex.scalaLibrary
   def extraClasspath: Seq[Path] = Nil
   def scalacOptions: Seq[String] = Nil
-  def config: PresentationCompilerConfig = PresentationCompilerConfigImpl()
+  def config: PresentationCompilerConfig =
+    PresentationCompilerConfigImpl().copy(
+      isMagicIndentClient = false
+    )
   val myclasspath: Seq[Path] = extraClasspath ++ scalaLibrary.toList
   val index = new DelegatingGlobalSymbolIndex(OnDemandSymbolIndex())
   val indexer = new Docstrings(index)

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideAllSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideAllSuite.scala
@@ -27,10 +27,6 @@ object CompletionOverrideAllSuite extends BaseCompletionSuite {
     filter = _.contains("Implement")
   )
 
-  // Note: ckipp01 the indentation for the completions on the edits
-  // look a bit odd, but it seems the tests aren't respecting the actual
-  // indentation as these all work locally as expected, and when the actual
-  // indent is added, the necessary indent is unnecessarily doubled
   checkEdit(
     "simple-edit",
     """|package example
@@ -54,7 +50,7 @@ object CompletionOverrideAllSuite extends BaseCompletionSuite {
        |object Main {
        |  val x = new Foo {
        |    def foo: Int = ${0:???}
-       |def bar: Int = ${0:???}
+       |    def bar: Int = ${0:???}
        |  }
        |}
        |""".stripMargin,
@@ -107,8 +103,8 @@ object CompletionOverrideAllSuite extends BaseCompletionSuite {
       |object Main {
       |  val x = new Foo {
       |    def foo: Int = ${0:???}
-      |def bar: Int = ${0:???}
-      |def car: Int = ${0:???}
+      |    def bar: Int = ${0:???}
+      |    def car: Int = ${0:???}
       |  }
       |}
       |""".stripMargin,
@@ -163,7 +159,7 @@ object CompletionOverrideAllSuite extends BaseCompletionSuite {
        |  val x = new Foo {
        |    def foo = 2
        |    def bar: Int = ${0:???}
-       |def car: Int = ${0:???}
+       |    def car: Int = ${0:???}
        |  }
        |}
        |""".stripMargin,
@@ -232,7 +228,7 @@ object CompletionOverrideAllSuite extends BaseCompletionSuite {
        |object Main {
        |  val x = new Foo {
        |    def one: a.Foo = ${0:???}
-       |def two: b.Foo = ${0:???}
+       |    def two: b.Foo = ${0:???}
        |  }
        |}
        |""".stripMargin,
@@ -284,8 +280,8 @@ object CompletionOverrideAllSuite extends BaseCompletionSuite {
        |object Main {
        |  val x = new Foo {
        |    def foo: Int = ${0:???}
-       |val bar: Int = ${0:???}
-       |var car: Int = ${0:???}
+       |    val bar: Int = ${0:???}
+       |    var car: Int = ${0:???}
        |  }
        |}
        |""".stripMargin,
@@ -355,12 +351,11 @@ object CompletionOverrideAllSuite extends BaseCompletionSuite {
        |    var bar: int = 2
        |    val car: Int = 1
        |    def foo2: Int = ${0:???}
-       |var bar2: Int = ${0:???}
-       |val car2: Int = ${0:???}
+       |    var bar2: Int = ${0:???}
+       |    val car2: Int = ${0:???}
        |  }
        |}
        |""".stripMargin,
     filter = _.contains("Implement")
   )
-
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideAllSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideAllSuite.scala
@@ -27,6 +27,10 @@ object CompletionOverrideAllSuite extends BaseCompletionSuite {
     filter = _.contains("Implement")
   )
 
+  // Note: ckipp01 the indentation for the completions on the edits
+  // look a bit odd, but it seems the tests aren't respecting the actual
+  // indentation as these all work locally as expected, and when the actual
+  // indent is added, the necessary indent is unnecessarily doubled
   checkEdit(
     "simple-edit",
     """|package example
@@ -328,10 +332,10 @@ object CompletionOverrideAllSuite extends BaseCompletionSuite {
        |}
        |object Main {
        |  val x = new Foo {
-       |   def foo: int = 3
-       |   var bar: int = 2
-       |   val car: Int = 1
-       |   def@@
+       |    def foo: int = 3
+       |    var bar: int = 2
+       |    val car: Int = 1
+       |    def@@
        |  }
        |}
        |""".stripMargin,
@@ -347,10 +351,10 @@ object CompletionOverrideAllSuite extends BaseCompletionSuite {
        |}
        |object Main {
        |  val x = new Foo {
-       |   def foo: int = 3
-       |   var bar: int = 2
-       |   val car: Int = 1
-       |   def foo2: Int = ${0:???}
+       |    def foo: int = 3
+       |    var bar: int = 2
+       |    val car: Int = 1
+       |    def foo2: Int = ${0:???}
        |var bar2: Int = ${0:???}
        |val car2: Int = ${0:???}
        |  }

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideAllSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideAllSuite.scala
@@ -1,0 +1,362 @@
+package tests.pc
+
+import tests.BaseCompletionSuite
+
+object CompletionOverrideAllSuite extends BaseCompletionSuite {
+
+  override def beforeAll(): Unit = {
+    indexJDK()
+  }
+
+  check(
+    "simple",
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  def bar: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|Implement all members (2 total)
+       |""".stripMargin,
+    filter = _.contains("Implement")
+  )
+
+  checkEdit(
+    "simple-edit",
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  def bar: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  def bar: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def foo: Int = ${0:???}
+       |def bar: Int = ${0:???}
+       |  }
+       |}
+       |""".stripMargin,
+    filter = _.contains("Implement")
+  )
+
+  check(
+    "simple-three",
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  def bar: Int
+       |  def car: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|Implement all members (3 total)
+       |""".stripMargin,
+    filter = _.contains("Implement")
+  )
+
+  checkEdit(
+    "simple-three-edit",
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  def bar: Int
+       |  def car: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def@@
+       |  }
+       |}
+       |""".stripMargin,
+    """
+      |package example
+      |
+      |trait Foo {
+      |  def foo: Int
+      |  def bar: Int
+      |  def car: Int
+      |}
+      |object Main {
+      |  val x = new Foo {
+      |    def foo: Int = ${0:???}
+      |def bar: Int = ${0:???}
+      |def car: Int = ${0:???}
+      |  }
+      |}
+      |""".stripMargin,
+    filter = _.contains("Implement")
+  )
+
+  check(
+    "two-left",
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  def bar: Int
+       |  def car: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+           def foo = 2
+       |    def@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|Implement all members (2 total)
+       |""".stripMargin,
+    filter = _.contains("Implement")
+  )
+
+  checkEdit(
+    "two-left-edit",
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  def bar: Int
+       |  def car: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def foo = 2
+       |    def@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  def bar: Int
+       |  def car: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def foo = 2
+       |    def bar: Int = ${0:???}
+       |def car: Int = ${0:???}
+       |  }
+       |}
+       |""".stripMargin,
+    filter = _.contains("Implement")
+  )
+
+  check(
+    "none-with-one",
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def@@
+       |  }
+       |}
+       |""".stripMargin,
+    "",
+    filter = _.contains("Implement")
+  )
+
+  check(
+    "same-scope",
+    """|package a { class Foo }
+       |package b { class Foo }
+       |
+       |trait Foo {
+       |  def one: a.Foo
+       |  def two: b.Foo
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|Implement all members (2 total)
+       |""".stripMargin,
+    filter = _.contains("Implement")
+  )
+
+  checkEdit(
+    "same-scope-edit",
+    """|package a { class Foo }
+       |package b { class Foo }
+       |
+       |trait Foo {
+       |  def one: a.Foo
+       |  def two: b.Foo
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|package a { class Foo }
+       |package b { class Foo }
+       |
+       |trait Foo {
+       |  def one: a.Foo
+       |  def two: b.Foo
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def one: a.Foo = ${0:???}
+       |def two: b.Foo = ${0:???}
+       |  }
+       |}
+       |""".stripMargin,
+    filter = _.contains("Implement")
+  )
+
+  check(
+    "include-val-var",
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  val bar: Int
+       |  var car: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|Implement all members (3 total)
+       |""".stripMargin,
+    filter = _.contains("Implement")
+  )
+
+  checkEdit(
+    "include-val-var-edit",
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  val bar: Int
+       |  var car: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  val bar: Int
+       |  var car: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |    def foo: Int = ${0:???}
+       |val bar: Int = ${0:???}
+       |var car: Int = ${0:???}
+       |  }
+       |}
+       |""".stripMargin,
+    filter = _.contains("Implement")
+  )
+
+  check(
+    "mixed-partial",
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  def foo2: Int
+       |  var bar: Int
+       |  var bar2: Int
+       |  val car: Int
+       |  val car2: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |   def foo: int = 3
+       |   var bar: int = 2
+       |   val car: Int = 1
+       |   def@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|Implement all members (3 total)
+       |""".stripMargin,
+    filter = _.contains("Implement")
+  )
+
+  checkEdit(
+    "mixed-partial-edit",
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  def foo2: Int
+       |  var bar: Int
+       |  var bar2: Int
+       |  val car: Int
+       |  val car2: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |   def foo: int = 3
+       |   var bar: int = 2
+       |   val car: Int = 1
+       |   def@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|package example
+       |
+       |trait Foo {
+       |  def foo: Int
+       |  def foo2: Int
+       |  var bar: Int
+       |  var bar2: Int
+       |  val car: Int
+       |  val car2: Int
+       |}
+       |object Main {
+       |  val x = new Foo {
+       |   def foo: int = 3
+       |   var bar: int = 2
+       |   val car: Int = 1
+       |   def foo2: Int = ${0:???}
+       |var bar2: Int = ${0:???}
+       |val car2: Int = ${0:???}
+       |  }
+       |}
+       |""".stripMargin,
+    filter = _.contains("Implement")
+  )
+
+}

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -685,6 +685,7 @@ object CompletionOverrideSuite extends BaseCompletionSuite {
     """|var hello1: Int
        |val hello2: Int
        |def hello3: Int
+       |Implement all members
        |""".stripMargin,
     includeDetail = false
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -271,6 +271,7 @@ object CompletionOverrideSuite extends BaseCompletionSuite {
     """|def self: _root_.a.c.Conflict
        |def selfArg: Option[_root_.a.c.Conflict]
        |def selfPath: Inner
+       |Implement all members
        |""".stripMargin,
     includeDetail = false
   )


### PR DESCRIPTION
![2019-10-30 21 44 17](https://user-images.githubusercontent.com/13974112/67897352-81853880-fb5e-11e9-9563-8cd8f67deb62.gif)

So I believe I have the implemented correctly now that it will work for all abstract members -- defs, vals, and vars. If you have 5, but 2 implemented, then the implement all will implement the remaining 3.

I am not sure about a few things though...
1) The way I did the actual text edit with the strings of the other text edits
2) I wasn't positive about what you mentioned in the issue about this https://github.com/scalameta/metals/issues/1008#issuecomment-544505366, but I made a test with that scenario, and it seems to work as expected?
3) Other tests that I may be missing.

This should close #1029 and also address #1008. However, regarding #1008, I'm not sure if we also want to implement it as well where if you are instantiating a class or something that has the abstract members, it will gives you the option to automatically create the class not just with an empty `{}` but rather with all the members. I wasn't sure if that should be grouped with this PR or not.

