### PR TITLE
Update sample Emacs configuration to avoid AutoSave files in src dir

### DIFF
--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -33,8 +33,11 @@ To use Metals in Emacs, place this snippet in your Emacs configuration (for exam
 (require 'use-package)
 
 ;; Enable defer and ensure by default for use-package
+;; Keep auto-save/backup files separate from source code:  https://github.com/scalameta/metals/issues/1027
 (setq use-package-always-defer t
-      use-package-always-ensure t)
+      use-package-always-ensure t
+      backup-directory-alist `((".*" . ,temporary-file-directory))
+      auto-save-file-transforms `((".*" ,temporary-file-directory t)))
 
 ;; Enable scala-mode and sbt-mode
 (use-package scala-mode
@@ -48,7 +51,10 @@ To use Metals in Emacs, place this snippet in your Emacs configuration (for exam
   (substitute-key-definition
    'minibuffer-complete-word
    'self-insert-command
-   minibuffer-local-completion-map))
+   minibuffer-local-completion-map)
+   ;; sbt-supershell kills sbt-mode:  https://github.com/hvesalai/emacs-sbt-mode/issues/152
+   (setq sbt:program-options '("-Dsbt.supershell=false"))
+)
 
 ;; Enable nice rendering of diagnostics like compile errors.
 (use-package flycheck

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -37,7 +37,7 @@ To use Metals in Emacs, place this snippet in your Emacs configuration (for exam
 (setq use-package-always-defer t
       use-package-always-ensure t
       backup-directory-alist `((".*" . ,temporary-file-directory))
-      auto-save-file-transforms `((".*" ,temporary-file-directory t)))
+      auto-save-file-name-transforms `((".*" ,temporary-file-directory t)))
 
 ;; Enable scala-mode and sbt-mode
 (use-package scala-mode


### PR DESCRIPTION
See issue #1027. AutoSave files in source directories break the
compile and in Emacs can cause error highlighting to vanish in some
sourc files.

This change also shows a work-around to prevent the SBT 1.3 supershell
from killing sbt-mode.