### PR TITLE
Add type annotations for public members with Scalafix

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,3 +1,6 @@
 rules = [
-  RemoveUnused
+  RemoveUnused,
+  ExplicitResultTypes,
 ]
+
+ExplicitResultTypes.rewriteStructuralTypesToNamedSubclass = false

--- a/build.sbt
+++ b/build.sbt
@@ -315,6 +315,7 @@ lazy val input = project
       "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full
     )
   )
+  .disablePlugins(ScalafixPlugin)
 
 lazy val testSettings: Seq[Def.Setting[_]] = List(
   skip.in(publish) := true,

--- a/metals-bench/src/main/scala/bench/MetalsBench.scala
+++ b/metals-bench/src/main/scala/bench/MetalsBench.scala
@@ -20,12 +20,13 @@ import scala.reflect.internal.util.BatchSourceFile
 import scala.reflect.io.VirtualFile
 import tests.InputProperties
 import tests.Library
+import scala.tools.nsc.interactive.Global
 
 @State(Scope.Benchmark)
 class MetalsBench {
 
   MetalsLogger.updateDefaultFormat()
-  val inputs = InputProperties.default()
+  val inputs: InputProperties = InputProperties.default()
   val classpath = new SemanticdbClasspath(inputs.sourceroot, inputs.classpath)
   val documents: List[(AbsolutePath, TextDocument)] =
     inputs.scalaFiles.map { input =>
@@ -40,10 +41,10 @@ class MetalsBench {
       )
     }
 
-  val jdk = Classpath(JdkSources().toList)
-  val fullClasspath = jdk ++ inputs.dependencySources
+  val jdk: Classpath = Classpath(JdkSources().toList)
+  val fullClasspath: Classpath = jdk ++ inputs.dependencySources
 
-  val inflated = Inflated.jars(fullClasspath)
+  val inflated: Inflated = Inflated.jars(fullClasspath)
 
   val scalaDependencySources: Inflated = {
     val result = inflated.filter(_.path.endsWith(".scala"))
@@ -57,7 +58,7 @@ class MetalsBench {
     result
   }
 
-  val megaSources = Classpath(
+  val megaSources: Classpath = Classpath(
     Library.all
       .flatMap(_.sources.entries)
       .filter(_.toNIO.getFileName.toString.endsWith(".jar"))
@@ -113,7 +114,7 @@ class MetalsBench {
     }
   }
 
-  lazy val global = InteractiveSemanticdb.newCompiler()
+  lazy val global: Global = InteractiveSemanticdb.newCompiler()
 
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))

--- a/metals-docs/src/main/scala/docs/Docs.scala
+++ b/metals-docs/src/main/scala/docs/Docs.scala
@@ -4,8 +4,8 @@ import java.nio.file.Paths
 import scala.meta.internal.metals.{BuildInfo => V}
 
 object Docs {
-  lazy val snapshot = Snapshot.latest("snapshots")
-  lazy val release = Snapshot.latest("releases")
+  lazy val snapshot: Snapshot = Snapshot.latest("snapshots")
+  lazy val release: Snapshot = Snapshot.latest("releases")
   def releasesResolverTable: String = {
     <table>
       <thead>
@@ -47,7 +47,7 @@ object Docs {
     </table>
   }.toString
 
-  lazy val stableVersion = V.metalsVersion.replaceFirst("\\+.*", "")
+  lazy val stableVersion: String = V.metalsVersion.replaceFirst("\\+.*", "")
   def main(args: Array[String]): Unit = {
     val out = Paths.get("website", "target", "docs")
     val settings = mdoc

--- a/metals-docs/src/main/scala/docs/RequirementsModifier.scala
+++ b/metals-docs/src/main/scala/docs/RequirementsModifier.scala
@@ -8,7 +8,7 @@ import scala.meta.internal.metals.BuildInfo
 class RequirementsModifier extends StringModifier {
   override val name: String = "requirements"
 
-  def supportedScalaVersions =
+  def supportedScalaVersions: String =
     BuildInfo.supportedScalaVersions.dropRight(1).mkString(", ") +
       s" and ${BuildInfo.supportedScalaVersions.last}"
 

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
@@ -20,7 +20,7 @@ abstract class BuildTool {
 
   def recommendedVersion: String
 
-  protected lazy val tempDir = {
+  protected lazy val tempDir: Path = {
     val dir = Files.createTempDirectory("metals")
     dir.toFile.deleteOnExit()
     dir

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -99,7 +99,10 @@ case class GradleBuildTool() extends BuildTool {
 }
 
 object GradleBuildTool {
-  def isGradleRelatedPath(workspace: AbsolutePath, path: AbsolutePath) = {
+  def isGradleRelatedPath(
+      workspace: AbsolutePath,
+      path: AbsolutePath
+  ): Boolean = {
     val buildSrc = workspace.toNIO.resolve("buildSrc")
     val filename = path.toNIO.getFileName.toString
     path.toNIO.startsWith(buildSrc) ||

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -67,7 +67,10 @@ case class MavenBuildTool() extends BuildTool {
 }
 
 object MavenBuildTool {
-  def isMavenRelatedPath(workspace: AbsolutePath, path: AbsolutePath) = {
+  def isMavenRelatedPath(
+      workspace: AbsolutePath,
+      path: AbsolutePath
+  ): Boolean = {
     path.toNIO.startsWith(workspace.toNIO) && path.filename == "pom.xml"
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -73,7 +73,10 @@ case class MillBuildTool() extends BuildTool {
 }
 
 object MillBuildTool {
-  def isMillRelatedPath(workspace: AbsolutePath, path: AbsolutePath) = {
+  def isMillRelatedPath(
+      workspace: AbsolutePath,
+      path: AbsolutePath
+  ): Boolean = {
     val filename = path.toNIO.getFileName.toString
     filename.endsWith(".sc")
   }

--- a/metals/src/main/scala/scala/meta/internal/builds/MillDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillDigest.scala
@@ -30,7 +30,7 @@ object MillDigest extends Digestable {
       var current: String = "",
       var prefix: String = ""
   ) {
-    def processingFileImport = hadFile && hadImport
+    def processingFileImport: Boolean = hadFile && hadImport
   }
 
   // find all `import $file.path`

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -104,7 +104,7 @@ case class SbtBuildTool(version: String) extends BuildTool {
 
 object SbtBuildTool {
 
-  def isSbtRelatedPath(workspace: AbsolutePath, path: AbsolutePath) = {
+  def isSbtRelatedPath(workspace: AbsolutePath, path: AbsolutePath): Boolean = {
     val project = workspace.toNIO.resolve("project")
     val isToplevel = Set(
       workspace.toNIO,

--- a/metals/src/main/scala/scala/meta/internal/implementation/ClassLocation.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ClassLocation.scala
@@ -88,7 +88,7 @@ private[implementation] object ClassLocation {
   def calculateAsSeenFrom(
       parentType: TypeRef,
       typeParameters: Option[Scope]
-  ) = {
+  ): Map[String, String] = {
     parentType.typeArguments.zipWithIndex.flatMap {
       case (arg: TypeRef, ind) =>
         // create mapping dependent on order - this way we don't need parent information here

--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -384,7 +384,7 @@ object ImplementationProvider {
       )
   }
 
-  def isClassLike(info: SymbolInformation) =
+  def isClassLike(info: SymbolInformation): Boolean =
     info.isObject || info.isClass || info.isTrait || info.isType
 
   def addParameterSignatures(

--- a/metals/src/main/scala/scala/meta/internal/implementation/MethodImplementation.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/MethodImplementation.scala
@@ -198,7 +198,7 @@ object MethodImplementation {
       findSymbolInParent: String => Option[SymbolInformation],
       asSeenFrom: Map[String, String]
   ) {
-    def addAsSeenFrom(asSeenFrom: Map[String, String]) = {
+    def addAsSeenFrom(asSeenFrom: Map[String, String]): Context = {
       this.copy(asSeenFrom = this.asSeenFrom ++ asSeenFrom)
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
@@ -222,9 +222,10 @@ object BloopInstall {
       joinErrorWithInfo: Boolean
   ) extends NuAbstractProcessHandler {
     var response: Option[CompletableFuture[_]] = None
-    val completeProcess = Promise[BloopInstallResult]()
+    val completeProcess: Promise[BloopInstallResult] =
+      Promise[BloopInstallResult]()
     val stdout = new LineListener(line => scribe.info(line))
-    val stderr =
+    val stderr: LineListener =
       if (joinErrorWithInfo) stdout
       else new LineListener(line => scribe.error(line))
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -7,7 +7,7 @@ import ch.epfl.scala.{bsp4j => b}
  */
 object ClientCommands {
 
-  val EchoCommand: Command = Command(
+  val EchoCommand = new Command(
     "metals-echo-command",
     "Echo command",
     """A client command that should be forwarded back to the Metals server.
@@ -19,7 +19,7 @@ object ClientCommands {
       """`string`, the command ID to execute on the client.""".stripMargin
   )
 
-  val RunDoctor: Command = Command(
+  val RunDoctor = new Command(
     "metals-doctor-run",
     "Run doctor",
     """Focus on a window displaying troubleshooting help from the Metals doctor.""".stripMargin,
@@ -27,7 +27,7 @@ object ClientCommands {
       """`string`, the HTML to display in the focused window.""".stripMargin
   )
 
-  val ReloadDoctor: Command = Command(
+  val ReloadDoctor = new Command(
     "metals-doctor-reload",
     "Reload doctor",
     """Reload the HTML contents of an open Doctor window, if any. Should be ignored if there is no open doctor window.""".stripMargin,
@@ -35,7 +35,7 @@ object ClientCommands {
       """`string`, the HTML to display in the focused window.""".stripMargin
   )
 
-  val ToggleLogs: Command = Command(
+  val ToggleLogs = new Command(
     "metals-logs-toggle",
     "Toggle logs",
     """|Focus or remove focus on the output logs reported by the server via `window/logMessage`.
@@ -44,7 +44,7 @@ object ClientCommands {
        |""".stripMargin
   )
 
-  val FocusDiagnostics: Command = Command(
+  val FocusDiagnostics = new Command(
     "metals-diagnostics-focus",
     "Open problems",
     """|Focus on the window that lists all published diagnostics.
@@ -53,7 +53,7 @@ object ClientCommands {
        |""".stripMargin
   )
 
-  val StartDebugSession: Command = Command(
+  val StartDebugSession = new Command(
     "metals-debug-session-start",
     "Start debug session",
     s"""|Starts a debug session. The address of a new Debug Adapter can be obtained 
@@ -75,7 +75,7 @@ object ClientCommands {
     """.stripMargin
   )
 
-  val RefreshModel: Command = Command(
+  val RefreshModel = new Command(
     "metals-model-refresh",
     "Refresh model",
     """|Notifies the client that the model has been updated and it 
@@ -83,7 +83,7 @@ object ClientCommands {
        |""".stripMargin
   )
 
-  val GotoLocation: Command = Command(
+  val GotoLocation = new Command(
     "metals-goto-location",
     "Goto location",
     "Move the cursor focus to the provided location",

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -7,7 +7,7 @@ import ch.epfl.scala.{bsp4j => b}
  */
 object ClientCommands {
 
-  val EchoCommand = Command(
+  val EchoCommand: Command = Command(
     "metals-echo-command",
     "Echo command",
     """A client command that should be forwarded back to the Metals server.
@@ -19,7 +19,7 @@ object ClientCommands {
       """`string`, the command ID to execute on the client.""".stripMargin
   )
 
-  val RunDoctor = Command(
+  val RunDoctor: Command = Command(
     "metals-doctor-run",
     "Run doctor",
     """Focus on a window displaying troubleshooting help from the Metals doctor.""".stripMargin,
@@ -27,7 +27,7 @@ object ClientCommands {
       """`string`, the HTML to display in the focused window.""".stripMargin
   )
 
-  val ReloadDoctor = Command(
+  val ReloadDoctor: Command = Command(
     "metals-doctor-reload",
     "Reload doctor",
     """Reload the HTML contents of an open Doctor window, if any. Should be ignored if there is no open doctor window.""".stripMargin,
@@ -35,7 +35,7 @@ object ClientCommands {
       """`string`, the HTML to display in the focused window.""".stripMargin
   )
 
-  val ToggleLogs = Command(
+  val ToggleLogs: Command = Command(
     "metals-logs-toggle",
     "Toggle logs",
     """|Focus or remove focus on the output logs reported by the server via `window/logMessage`.
@@ -44,7 +44,7 @@ object ClientCommands {
        |""".stripMargin
   )
 
-  val FocusDiagnostics = Command(
+  val FocusDiagnostics: Command = Command(
     "metals-diagnostics-focus",
     "Open problems",
     """|Focus on the window that lists all published diagnostics.
@@ -53,7 +53,7 @@ object ClientCommands {
        |""".stripMargin
   )
 
-  val StartDebugSession = Command(
+  val StartDebugSession: Command = Command(
     "metals-debug-session-start",
     "Start debug session",
     s"""|Starts a debug session. The address of a new Debug Adapter can be obtained 
@@ -75,7 +75,7 @@ object ClientCommands {
     """.stripMargin
   )
 
-  val RefreshModel = Command(
+  val RefreshModel: Command = Command(
     "metals-model-refresh",
     "Refresh model",
     """|Notifies the client that the model has been updated and it 
@@ -83,7 +83,7 @@ object ClientCommands {
        |""".stripMargin
   )
 
-  val GotoLocation = Command(
+  val GotoLocation: Command = Command(
     "metals-goto-location",
     "Goto location",
     "Move the cursor focus to the provided location",

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -23,6 +23,7 @@ import scala.meta.pc.CancelToken
 import scala.meta.pc.PresentationCompiler
 import scala.meta.pc.SymbolSearch
 import scala.concurrent.Future
+import java.{util => ju}
 
 /**
  * Manages lifecycle for presentation compilers in all build targets.
@@ -47,9 +48,10 @@ class Compilers(
   // Not a TrieMap because we want to avoid loading duplicate compilers for the same build target.
   // Not a `j.u.c.ConcurrentHashMap` because it can deadlock in `computeIfAbsent` when the absent
   // function is expensive, which is the case here.
-  val jcache = Collections.synchronizedMap(
-    new java.util.HashMap[BuildTargetIdentifier, PresentationCompiler]
-  )
+  val jcache: ju.Map[BuildTargetIdentifier, PresentationCompiler] =
+    Collections.synchronizedMap(
+      new java.util.HashMap[BuildTargetIdentifier, PresentationCompiler]
+    )
   private val cache = jcache.asScala
 
   // The "rambo" compiler is used for source files that don't belong to a build target.

--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -14,6 +14,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Promise
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.tvp._
+import java.{util => ju}
 
 /**
  * A build client that forwards notifications from the build server to the language client.
@@ -46,7 +47,8 @@ final class ForwardingMetalsBuildClient(
     new ConcurrentHashMap[BuildTargetIdentifier, java.lang.Boolean]()
   )
 
-  val updatedTreeViews = ConcurrentHashSet.empty[BuildTargetIdentifier]
+  val updatedTreeViews: ju.Set[BuildTargetIdentifier] =
+    ConcurrentHashSet.empty[BuildTargetIdentifier]
 
   def reset(): Unit = {
     cancel()

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -26,7 +26,7 @@ class Messages(icons: Icons) {
       "See the logs for more details. "
   )
 
-  def bloopInstallProgress(buildToolExecName: String) =
+  def bloopInstallProgress(buildToolExecName: String): MetalsSlowTaskParams =
     MetalsSlowTaskParams(s"$buildToolExecName bloopInstall")
   def dontShowAgain: MessageActionItem =
     new MessageActionItem("Don't show again")
@@ -70,7 +70,7 @@ class Messages(icons: Icons) {
 
   }
 
-  val PartialNavigation = MetalsStatusParams(
+  val PartialNavigation: MetalsStatusParams = MetalsStatusParams(
     "$(info) Partial navigation",
     tooltip =
       "This external library source has compile errors. " +

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -26,8 +26,8 @@ class Messages(icons: Icons) {
       "See the logs for more details. "
   )
 
-  def bloopInstallProgress(buildToolExecName: String): MetalsSlowTaskParams =
-    MetalsSlowTaskParams(s"$buildToolExecName bloopInstall")
+  def bloopInstallProgress(buildToolExecName: String) =
+    new MetalsSlowTaskParams(s"$buildToolExecName bloopInstall")
   def dontShowAgain: MessageActionItem =
     new MessageActionItem("Don't show again")
   def notNow: MessageActionItem =
@@ -70,7 +70,7 @@ class Messages(icons: Icons) {
 
   }
 
-  val PartialNavigation: MetalsStatusParams = MetalsStatusParams(
+  val PartialNavigation = new MetalsStatusParams(
     "$(info) Partial navigation",
     tooltip =
       "This external library source has compile errors. " +

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -369,7 +369,7 @@ object MetalsEnrichments
         char: Char,
         lowerBound: Int = 0,
         upperBound: Int = value.size
-    ) = {
+    ): Int = {
       var index = upperBound
       while (index > lowerBound && value(index) != char) {
         index -= 1
@@ -517,7 +517,7 @@ object MetalsEnrichments
   }
 
   implicit class XtensionToken(token: Token) {
-    def isWhiteSpaceOrComment = token match {
+    def isWhiteSpaceOrComment: Boolean = token match {
       case _: Token.Space | _: Token.Tab | _: Token.CR | _: Token.LF |
           _: Token.LFLF | _: Token.FF | _: Token.Comment | _: Token.BOF |
           _: Token.EOF =>

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -94,7 +94,7 @@ class MetalsLanguageServer(
   private val fingerprints = new MutableMd5Fingerprints
   private val mtags = new Mtags
   var workspace: AbsolutePath = _
-  var focusedDocument: Option[AbsolutePath] = Option.empty[AbsolutePath]
+  var focusedDocument: Option[AbsolutePath] = None
   private val focusedDocumentBuildTarget =
     new AtomicReference[b.BuildTargetIdentifier]()
   private val definitionIndex = newSymbolIndex()

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -94,19 +94,20 @@ class MetalsLanguageServer(
   private val fingerprints = new MutableMd5Fingerprints
   private val mtags = new Mtags
   var workspace: AbsolutePath = _
-  var focusedDocument = Option.empty[AbsolutePath]
+  var focusedDocument: Option[AbsolutePath] = Option.empty[AbsolutePath]
   private val focusedDocumentBuildTarget =
     new AtomicReference[b.BuildTargetIdentifier]()
   private val definitionIndex = newSymbolIndex()
   private val symbolDocs = new Docstrings(definitionIndex)
-  var buildServer = Option.empty[BuildServerConnection]
+  var buildServer: Option[BuildServerConnection] =
+    Option.empty[BuildServerConnection]
   private val buildTargetClasses = new BuildTargetClasses(() => buildServer)
   private val openTextDocument = new AtomicReference[AbsolutePath]()
   private val savedFiles = new ActiveFiles(time)
   private val openedFiles = new ActiveFiles(time)
   private val messages = new Messages(config.icons)
   private val languageClient = new DelegatingLanguageClient(NoopLanguageClient)
-  var userConfig = UserConfiguration()
+  var userConfig: UserConfiguration = UserConfiguration()
   val buildTargets: BuildTargets = new BuildTargets()
   val compilations: Compilations = new Compilations(
     buildTargets,
@@ -130,7 +131,7 @@ class MetalsLanguageServer(
     BatchedFunction.fromFuture[AbsolutePath, BuildChange](
       onBuildChangedUnbatched
     )
-  val pauseables = Pauseable.fromPausables(
+  val pauseables: Pauseable = Pauseable.fromPausables(
     onBuildChanged :: parseTrees :: compilations.pauseables
   )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
@@ -12,7 +12,8 @@ import scribe.writer.FileWriter
 
 object MetalsLogger {
 
-  val workspaceLogPath = RelativePath(".metals").resolve("metals.log")
+  val workspaceLogPath: RelativePath =
+    RelativePath(".metals").resolve("metals.log")
 
   def updateDefaultFormat(): Unit = {
     Logger.root
@@ -98,7 +99,7 @@ object MetalsLogger {
   def newFileWriter(logfile: AbsolutePath): FileWriter =
     FileWriter().path(_ => logfile.toNIO).autoFlush
 
-  def defaultFormat = formatter"$levelPaddedRight $message$newLine"
+  def defaultFormat: Formatter = formatter"$levelPaddedRight $message$newLine"
 
   def silent: LoggerSupport = new LoggerSupport {
     override def log[M](record: LogRecord[M]): Unit = ()

--- a/metals/src/main/scala/scala/meta/internal/metals/ProgressTicks.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProgressTicks.scala
@@ -16,7 +16,7 @@ object ProgressTicks {
   }
 
   object dots extends ProgressTicks {
-    val value = Array(
+    val value: Array[String] = Array(
       "   ",
       ".  ",
       ".. ",

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -27,8 +27,9 @@ final class ReferenceProvider(
     buffers: Buffers,
     definition: DefinitionProvider
 ) {
-  var referencedPackages = BloomFilters.create(10000)
-  val index = TrieMap.empty[Path, BloomFilter[CharSequence]]
+  var referencedPackages: BloomFilter[CharSequence] = BloomFilters.create(10000)
+  val index: TrieMap[Path, BloomFilter[CharSequence]] =
+    TrieMap.empty[Path, BloomFilter[CharSequence]]
 
   def reset(): Unit = {
     index.clear()

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -3,13 +3,14 @@ package scala.meta.internal.metals
 import ch.epfl.scala.bsp4j.BuildTarget
 import ch.epfl.scala.bsp4j.ScalacOptionsItem
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
 
 case class ScalaTarget(info: BuildTarget, scalac: ScalacOptionsItem) {
   def isSemanticdbEnabled: Boolean = scalac.isSemanticdbEnabled
 
-  def isScalaTarget = info.getLanguageIds().contains("scala")
+  def isScalaTarget: Boolean = info.getLanguageIds().contains("scala")
 
-  def classpath = {
+  def classpath: List[AbsolutePath] = {
     scalac
       .getClasspath()
       .asScala

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -8,7 +8,7 @@ import ch.epfl.scala.{bsp4j => b}
  */
 object ServerCommands {
 
-  val ImportBuild = Command(
+  val ImportBuild: Command = Command(
     "build-import",
     "Import build",
     """Import the latest changes from the build to for example pick up new library dependencies.
@@ -18,7 +18,7 @@ object ServerCommands {
       |""".stripMargin
   )
 
-  val ConnectBuildServer = Command(
+  val ConnectBuildServer: Command = Command(
     "build-connect",
     "Connect to build server",
     """Establish a new connection to the build server and reindex the workspace.
@@ -28,13 +28,13 @@ object ServerCommands {
       |""".stripMargin
   )
 
-  val DisconnectBuildServer = Command(
+  val DisconnectBuildServer: Command = Command(
     "build-disconnect",
     "Disconnect to build server",
     """Unconditionally cancel existing build server connection without reconnecting"""
   )
 
-  val ScanWorkspaceSources = Command(
+  val ScanWorkspaceSources: Command = Command(
     "sources-scan",
     "Scan sources",
     """|Walk all files in the workspace and index where symbols are defined.
@@ -47,7 +47,7 @@ object ServerCommands {
        |""".stripMargin
   )
 
-  val RunDoctor = Command(
+  val RunDoctor: Command = Command(
     "doctor-run",
     "Run doctor",
     """|Open the Metals doctor to troubleshoot potential problems with the build.
@@ -57,7 +57,7 @@ object ServerCommands {
        |""".stripMargin
   )
 
-  val CascadeCompile = Command(
+  val CascadeCompile: Command = Command(
     "compile-cascade",
     "Cascade compile",
     """|Compile the current open files along with all build targets in this workspace that depend on those files.
@@ -69,13 +69,13 @@ object ServerCommands {
        |""".stripMargin
   )
 
-  val CancelCompile = Command(
+  val CancelCompile: Command = Command(
     "compile-cancel",
     "Cancel compilation",
     """Cancel the currently ongoing compilation, if any."""
   )
 
-  val BspSwitch = Command(
+  val BspSwitch: Command = Command(
     "bsp-switch",
     "Switch build server",
     """|Prompt the user to select a new build server to connect to.
@@ -86,7 +86,7 @@ object ServerCommands {
        |""".stripMargin
   )
 
-  val StartDebugAdapter = Command(
+  val StartDebugAdapter: Command = Command(
     "debug-adapter-start",
     "Start debug adapter",
     "Start debug adapter",
@@ -103,7 +103,7 @@ object ServerCommands {
     """.stripMargin
   )
 
-  val PresentationCompilerRestart = Command(
+  val PresentationCompilerRestart: Command = Command(
     "presentation-compiler-restart",
     "Restart presentation compiler",
     """|Restart running presentation compiler instances.
@@ -114,7 +114,7 @@ object ServerCommands {
        |""".stripMargin
   )
 
-  val GotoLocation = Command(
+  val GotoLocation: Command = Command(
     "goto",
     "Goto location",
     """|Move the cursor to the definition of the argument symbol.
@@ -129,55 +129,55 @@ object ServerCommands {
   val OpenBrowser: Regex = "browser-open-url:(.*)".r
   def OpenBrowser(url: String): String = s"browser-open-url:$url"
 
-  val GotoLog = Command(
+  val GotoLog: Command = Command(
     "goto-log",
     "Check logs",
     "Open the Metals logs to troubleshoot issues."
   )
 
-  val OpenIssue = Command(
+  val OpenIssue: Command = Command(
     OpenBrowser("https://github.com/scalameta/metals/issues/new/choose"),
     "Open issue on GitHub",
     "Open the Metals repository on GitHub to ask a question, report a bug or request a new feature."
   )
 
-  val MetalsGithub = Command(
+  val MetalsGithub: Command = Command(
     OpenBrowser("https://github.com/scalameta/metals"),
     "Metals on GitHub",
     "Open the Metals repository on GitHub"
   )
 
-  val BloopGithub = Command(
+  val BloopGithub: Command = Command(
     OpenBrowser("https://github.com/scalacenter/bloop"),
     "Bloop on GitHub",
     "Open the Metals repository on GitHub"
   )
 
-  val ChatOnGitter = Command(
+  val ChatOnGitter: Command = Command(
     OpenBrowser("https://gitter.im/scalameta/metals"),
     "Chat on Gitter",
     "Open the Metals channel on Gitter to discuss with other Metals users."
   )
 
-  val ChatOnDiscord = Command(
+  val ChatOnDiscord: Command = Command(
     OpenBrowser("https://discord.gg/RFpSVth"),
     "Chat on Discord",
     "Open the Scalameta server on Discord to discuss with other Metals users."
   )
 
-  val ReadVscodeDocumentation = Command(
+  val ReadVscodeDocumentation: Command = Command(
     OpenBrowser("https://scalameta.org/metals/docs/editors/vscode.html"),
     "Read Metals documentation",
     "Open the Metals website to read the full instructions on how to use Metals with VS Code."
   )
 
-  val ReadBloopDocumentation = Command(
+  val ReadBloopDocumentation: Command = Command(
     OpenBrowser("https://scalacenter.github.io/bloop/"),
     "Read Bloop documentation",
     "Open the Bloop website to read the full instructions on how to install and use Bloop."
   )
 
-  val ScalametaTwitter = Command(
+  val ScalametaTwitter: Command = Command(
     OpenBrowser("https://twitter.com/scalameta"),
     "Scalameta on Twitter",
     "Stay up to date with the latest release announcements and learn new Scala code editing tricks."

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -8,7 +8,7 @@ import ch.epfl.scala.{bsp4j => b}
  */
 object ServerCommands {
 
-  val ImportBuild: Command = Command(
+  val ImportBuild = new Command(
     "build-import",
     "Import build",
     """Import the latest changes from the build to for example pick up new library dependencies.
@@ -18,7 +18,7 @@ object ServerCommands {
       |""".stripMargin
   )
 
-  val ConnectBuildServer: Command = Command(
+  val ConnectBuildServer = new Command(
     "build-connect",
     "Connect to build server",
     """Establish a new connection to the build server and reindex the workspace.
@@ -28,13 +28,13 @@ object ServerCommands {
       |""".stripMargin
   )
 
-  val DisconnectBuildServer: Command = Command(
+  val DisconnectBuildServer = new Command(
     "build-disconnect",
     "Disconnect to build server",
     """Unconditionally cancel existing build server connection without reconnecting"""
   )
 
-  val ScanWorkspaceSources: Command = Command(
+  val ScanWorkspaceSources = new Command(
     "sources-scan",
     "Scan sources",
     """|Walk all files in the workspace and index where symbols are defined.
@@ -47,7 +47,7 @@ object ServerCommands {
        |""".stripMargin
   )
 
-  val RunDoctor: Command = Command(
+  val RunDoctor = new Command(
     "doctor-run",
     "Run doctor",
     """|Open the Metals doctor to troubleshoot potential problems with the build.
@@ -57,7 +57,7 @@ object ServerCommands {
        |""".stripMargin
   )
 
-  val CascadeCompile: Command = Command(
+  val CascadeCompile = new Command(
     "compile-cascade",
     "Cascade compile",
     """|Compile the current open files along with all build targets in this workspace that depend on those files.
@@ -69,13 +69,13 @@ object ServerCommands {
        |""".stripMargin
   )
 
-  val CancelCompile: Command = Command(
+  val CancelCompile = new Command(
     "compile-cancel",
     "Cancel compilation",
     """Cancel the currently ongoing compilation, if any."""
   )
 
-  val BspSwitch: Command = Command(
+  val BspSwitch = new Command(
     "bsp-switch",
     "Switch build server",
     """|Prompt the user to select a new build server to connect to.
@@ -86,7 +86,7 @@ object ServerCommands {
        |""".stripMargin
   )
 
-  val StartDebugAdapter: Command = Command(
+  val StartDebugAdapter = new Command(
     "debug-adapter-start",
     "Start debug adapter",
     "Start debug adapter",
@@ -103,7 +103,7 @@ object ServerCommands {
     """.stripMargin
   )
 
-  val PresentationCompilerRestart: Command = Command(
+  val PresentationCompilerRestart = new Command(
     "presentation-compiler-restart",
     "Restart presentation compiler",
     """|Restart running presentation compiler instances.
@@ -114,7 +114,7 @@ object ServerCommands {
        |""".stripMargin
   )
 
-  val GotoLocation: Command = Command(
+  val GotoLocation = new Command(
     "goto",
     "Goto location",
     """|Move the cursor to the definition of the argument symbol.
@@ -129,55 +129,55 @@ object ServerCommands {
   val OpenBrowser: Regex = "browser-open-url:(.*)".r
   def OpenBrowser(url: String): String = s"browser-open-url:$url"
 
-  val GotoLog: Command = Command(
+  val GotoLog = new Command(
     "goto-log",
     "Check logs",
     "Open the Metals logs to troubleshoot issues."
   )
 
-  val OpenIssue: Command = Command(
+  val OpenIssue = new Command(
     OpenBrowser("https://github.com/scalameta/metals/issues/new/choose"),
     "Open issue on GitHub",
     "Open the Metals repository on GitHub to ask a question, report a bug or request a new feature."
   )
 
-  val MetalsGithub: Command = Command(
+  val MetalsGithub = new Command(
     OpenBrowser("https://github.com/scalameta/metals"),
     "Metals on GitHub",
     "Open the Metals repository on GitHub"
   )
 
-  val BloopGithub: Command = Command(
+  val BloopGithub = new Command(
     OpenBrowser("https://github.com/scalacenter/bloop"),
     "Bloop on GitHub",
     "Open the Metals repository on GitHub"
   )
 
-  val ChatOnGitter: Command = Command(
+  val ChatOnGitter = new Command(
     OpenBrowser("https://gitter.im/scalameta/metals"),
     "Chat on Gitter",
     "Open the Metals channel on Gitter to discuss with other Metals users."
   )
 
-  val ChatOnDiscord: Command = Command(
+  val ChatOnDiscord = new Command(
     OpenBrowser("https://discord.gg/RFpSVth"),
     "Chat on Discord",
     "Open the Scalameta server on Discord to discuss with other Metals users."
   )
 
-  val ReadVscodeDocumentation: Command = Command(
+  val ReadVscodeDocumentation = new Command(
     OpenBrowser("https://scalameta.org/metals/docs/editors/vscode.html"),
     "Read Metals documentation",
     "Open the Metals website to read the full instructions on how to use Metals with VS Code."
   )
 
-  val ReadBloopDocumentation: Command = Command(
+  val ReadBloopDocumentation = new Command(
     OpenBrowser("https://scalacenter.github.io/bloop/"),
     "Read Bloop documentation",
     "Open the Bloop website to read the full instructions on how to install and use Bloop."
   )
 
-  val ScalametaTwitter: Command = Command(
+  val ScalametaTwitter = new Command(
     OpenBrowser("https://twitter.com/scalameta"),
     "Scalameta on Twitter",
     "Stay up to date with the latest release announcements and learn new Scala code editing tricks."

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSearchVisitor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSearchVisitor.scala
@@ -77,7 +77,7 @@ class WorkspaceSearchVisitor(
       Integer.compare(x.getName().length(), y.getName().length())
     }
   }
-  val isVisited = mutable.Set.empty[AbsolutePath]
+  val isVisited: mutable.Set[AbsolutePath] = mutable.Set.empty[AbsolutePath]
   def definition(
       pkg: String,
       filename: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -27,8 +27,9 @@ final class WorkspaceSymbolProvider(
     fileOnDisk: AbsolutePath => AbsolutePath,
     bucketSize: Int = CompressedPackageIndex.DefaultBucketSize
 )(implicit ec: ExecutionContext) {
-  val inWorkspace = TrieMap.empty[Path, WorkspaceSymbolsIndex]
-  var inDependencies =
+  val inWorkspace: TrieMap[Path, WorkspaceSymbolsIndex] =
+    TrieMap.empty[Path, WorkspaceSymbolsIndex]
+  var inDependencies: ClasspathSearch =
     ClasspathSearch.fromClasspath(Nil, isReferencedPackage, bucketSize)
 
   def search(query: String): Seq[l.SymbolInformation] = {

--- a/metals/src/main/scala/scala/meta/internal/tvp/ClasspathSymbols.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/ClasspathSymbols.scala
@@ -32,8 +32,10 @@ import scala.collection.concurrent.TrieMap
  * Extracts SemanticDB symbols from `*.class` files in jars.
  */
 class ClasspathSymbols(isStatisticsEnabled: Boolean = false) {
-  val cache = TrieMap
-    .empty[AbsolutePath, TrieMap[String, Array[TreeViewSymbolInformation]]]
+  private val cache = TrieMap.empty[
+    AbsolutePath,
+    TrieMap[String, Array[TreeViewSymbolInformation]]
+  ]
 
   def clearCache(path: AbsolutePath): Unit = {
     cache.remove(path)

--- a/metals/src/main/scala/scala/meta/internal/tvp/ClasspathTreeView.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/ClasspathTreeView.scala
@@ -27,8 +27,8 @@ class ClasspathTreeView[Value, Key](
     toplevels: () => Iterator[Value],
     loadSymbols: (Key, String) => Iterator[TreeViewSymbolInformation]
 ) {
-  val rootUri = scheme + ":"
-  def root = TreeViewNode(
+  val rootUri: String = scheme + ":"
+  def root: TreeViewNode = TreeViewNode(
     viewId,
     rootUri,
     title + s" (${toplevels().size})",
@@ -175,7 +175,7 @@ class ClasspathTreeView[Value, Key](
     override def toString(): String = toUri
     def withSymbol(newSymbol: String): NodeUri =
       copy(symbol = newSymbol)
-    val isRoot = symbol == Symbols.RootPackage
+    val isRoot: Boolean = symbol == Symbols.RootPackage
     def isDescendent(child: String): Boolean =
       if (isRoot) true
       else child.startsWith(symbol)

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -25,7 +25,8 @@ class MetalsTreeViewProvider(
     doCompile: BuildTargetIdentifier => Unit,
     sh: ScheduledExecutorService
 ) extends TreeViewProvider {
-  val ticks = TrieMap.empty[String, ScheduledFuture[_]]
+  private val ticks =
+    TrieMap.empty[String, ScheduledFuture[_]]
   private val isVisible = TrieMap.empty[String, Boolean].withDefaultValue(false)
   private val isCollapsed = TrieMap.empty[BuildTargetIdentifier, Boolean]
   private val pendingProjectUpdates =

--- a/metals/src/main/scala/scala/meta/internal/tvp/ScalacpCopyPaste.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/ScalacpCopyPaste.scala
@@ -231,10 +231,10 @@ class ScalacpCopyPaste(node: ScalaSigNode) {
     def isConstructor: Boolean =
       sym.isMethod && (sym.name == "<init>" || sym.name == "$init$")
     def isPackageObject: Boolean = sym.name == "package"
-    def isTypeParam = sym.isType && sym.isParam
-    def isAnonymousClass = sym.name.contains("$anon")
-    def isAnonymousFunction = sym.name.contains("$anonfun")
-    def isSyntheticConstructor = sym match {
+    def isTypeParam: Boolean = sym.isType && sym.isParam
+    def isAnonymousClass: Boolean = sym.name.contains("$anon")
+    def isAnonymousFunction: Boolean = sym.name.contains("$anonfun")
+    def isSyntheticConstructor: Boolean = sym match {
       case sym: SymbolInfoSymbol =>
         val owner = sym.symbolInfo.owner
         sym.isConstructor && (owner.isModuleClass || owner.isTrait)

--- a/metals/src/main/scala/scala/meta/internal/tvp/TreeViewNode.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/TreeViewNode.scala
@@ -16,9 +16,11 @@ case class TreeViewNode(
     @Nullable collapseState: String = null
 ) {
   def isDirectory: Boolean = label.endsWith("/")
-  def isCollapsed = collapseState == MetalsTreeItemCollapseState.collapsed
-  def isExpanded = collapseState == MetalsTreeItemCollapseState.expanded
-  def isNoCollapse = collapseState == MetalsTreeItemCollapseState.none
+  def isCollapsed: Boolean =
+    collapseState == MetalsTreeItemCollapseState.collapsed
+  def isExpanded: Boolean =
+    collapseState == MetalsTreeItemCollapseState.expanded
+  def isNoCollapse: Boolean = collapseState == MetalsTreeItemCollapseState.none
 }
 
 object TreeViewNode {

--- a/mtags/src/main/scala/scala/meta/internal/docstrings/Body.scala
+++ b/mtags/src/main/scala/scala/meta/internal/docstrings/Body.scala
@@ -61,9 +61,9 @@ final case class ColumnOption(option: Char) {
   require(option == 'L' || option == 'C' || option == 'R')
 }
 object ColumnOption {
-  val ColumnOptionLeft = ColumnOption('L')
-  val ColumnOptionCenter = ColumnOption('C')
-  val ColumnOptionRight = ColumnOption('R')
+  val ColumnOptionLeft: ColumnOption = ColumnOption('L')
+  val ColumnOptionCenter: ColumnOption = ColumnOption('C')
+  val ColumnOptionRight: ColumnOption = ColumnOption('R')
 }
 final case class Row(cells: Seq[Cell])
 final case class Cell(blocks: Seq[Block])
@@ -96,11 +96,11 @@ final case class HtmlTag(data: String) extends Inline {
       (false, None)
   }
 
-  def canClose(open: HtmlTag) = {
+  def canClose(open: HtmlTag): Boolean = {
     isEnd && tagName == open.tagName
   }
 
-  def close = tagName collect {
+  def close: Option[HtmlTag] = tagName collect {
     case name if !HtmlTag.TagsNotToClose(name) && !data.endsWith(s"</$name>") =>
       HtmlTag(s"</$name>")
   }

--- a/mtags/src/main/scala/scala/meta/internal/docstrings/Comment.scala
+++ b/mtags/src/main/scala/scala/meta/internal/docstrings/Comment.scala
@@ -126,7 +126,7 @@ abstract class Comment {
   /** A short description used in the entity-view and search results */
   def shortDescription: Option[Text]
 
-  override def toString =
+  override def toString: String =
     body.toString + "\n" +
       (authors map ("@author " + _.toString)).mkString("\n") +
       (result map ("@return " + _.toString)).mkString("\n") +

--- a/mtags/src/main/scala/scala/meta/internal/docstrings/ScaladocParser.scala
+++ b/mtags/src/main/scala/scala/meta/internal/docstrings/ScaladocParser.scala
@@ -657,7 +657,7 @@ object ScaladocParser {
 
     /** listStyle ::= '-' spc | '1.' spc | 'I.' spc | 'i.' spc | 'A.' spc | 'a.' spc
      * Characters used to build lists and their constructors */
-    val listStyles =
+    val listStyles: Map[String, Seq[Block] => Block] =
       Map[String, (Seq[Block] => Block)]( // TODO Should this be defined at some list companion?
         "- " -> (UnorderedList(_)),
         "1. " -> (OrderedList(_, "decimal")),
@@ -668,7 +668,7 @@ object ScaladocParser {
       )
 
     /** Checks if the current line is formed with more than one space and one the listStyles */
-    def checkList =
+    def checkList: Boolean =
       (countWhitespace > 0) && (listStyles.keys exists {
         checkSkipInitWhitespace(_)
       })
@@ -1063,8 +1063,8 @@ object ScaladocParser {
 
     /* INLINES */
 
-    val OPEN_TAG = "^<([A-Za-z]+)( [^>]*)?(/?)>$".r
-    val CLOSE_TAG = "^</([A-Za-z]+)>$".r
+    val OPEN_TAG: Regex = "^<([A-Za-z]+)( [^>]*)?(/?)>$".r
+    val CLOSE_TAG: Regex = "^</([A-Za-z]+)>$".r
     private def readHTMLFrom(begin: HtmlTag): String = {
       val list = mutable.ListBuffer.empty[String]
       val stack = mutable.ListBuffer.empty[String]
@@ -1417,9 +1417,9 @@ object ScaladocParser {
       count
     }
 
-    def jumpWhitespace() = jumpUntil(!isWhitespace(char))
+    def jumpWhitespace(): Int = jumpUntil(!isWhitespace(char))
 
-    def jumpWhitespaceOrNewLine() = jumpUntil(!isWhitespaceOrNewLine(char))
+    def jumpWhitespaceOrNewLine(): Int = jumpUntil(!isWhitespaceOrNewLine(char))
 
     /* READERS */
 
@@ -1458,9 +1458,9 @@ object ScaladocParser {
 
     /* CHARS CLASSES */
 
-    def isWhitespace(c: Char) = c == ' ' || c == '\t'
+    def isWhitespace(c: Char): Boolean = c == ' ' || c == '\t'
 
-    def isWhitespaceOrNewLine(c: Char) = isWhitespace(c) || c == '\n'
+    def isWhitespaceOrNewLine(c: Char): Boolean = isWhitespace(c) || c == '\n'
   }
 
 }

--- a/mtags/src/main/scala/scala/meta/internal/docstrings/ScaladocUtils.scala
+++ b/mtags/src/main/scala/scala/meta/internal/docstrings/ScaladocUtils.scala
@@ -132,7 +132,7 @@ object ScaladocUtils {
   /** The first start tag of a list of tag intervals,
    *  or the end of the whole comment string - 2 if list is empty
    */
-  def startTag(str: String, sections: List[(Int, Int)]) = sections match {
+  def startTag(str: String, sections: List[(Int, Int)]): Int = sections match {
     case Nil => str.length - 2
     case (start, _) :: _ => start
   }
@@ -229,7 +229,7 @@ object ScaladocUtils {
   }
 
   /** Cleanup section text */
-  def cleanupSectionText(str: String) = {
+  def cleanupSectionText(str: String): String = {
     var result = str.trim.replaceAll("\n\\s+\\*\\s+", " \n")
     while (result.endsWith("\n")) result = result.substring(0, str.length - 1)
     result

--- a/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
@@ -19,7 +19,8 @@ import scala.meta.internal.mtags.GlobalSymbolIndex
  * Handles both javadoc and scaladoc.
  */
 class Docstrings(index: GlobalSymbolIndex) {
-  val cache = TrieMap.empty[String, SymbolDocumentation]
+  val cache: TrieMap[String, SymbolDocumentation] =
+    TrieMap.empty[String, SymbolDocumentation]
   private val logger = Logger.getLogger(classOf[Docstrings].getName)
 
   def documentation(symbol: String): Optional[SymbolDocumentation] = {

--- a/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
@@ -19,8 +19,7 @@ import scala.meta.internal.mtags.GlobalSymbolIndex
  * Handles both javadoc and scaladoc.
  */
 class Docstrings(index: GlobalSymbolIndex) {
-  val cache: TrieMap[String, SymbolDocumentation] =
-    TrieMap.empty[String, SymbolDocumentation]
+  val cache = new TrieMap[String, SymbolDocumentation]()
   private val logger = Logger.getLogger(classOf[Docstrings].getName)
 
   def documentation(symbol: String): Optional[SymbolDocumentation] = {

--- a/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
@@ -25,7 +25,7 @@ import java.net.URI
  * An index to lookup classfiles contained in a given classpath.
  */
 class PackageIndex() {
-  val logger = Logger.getLogger(classOf[PackageIndex].getName)
+  val logger: Logger = Logger.getLogger(classOf[PackageIndex].getName)
   val packages = new util.HashMap[String, util.Set[String]]()
   private val isVisited = new util.HashSet[AbsolutePath]()
   private val enterPackage =

--- a/mtags/src/main/scala/scala/meta/internal/metals/ScaladocIndexer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/ScaladocIndexer.scala
@@ -19,7 +19,7 @@ class ScaladocIndexer(
     input: Input.VirtualFile,
     fn: SymbolDocumentation => Unit
 ) extends ScalaMtags(input) {
-  val defines = mutable.Map.empty[String, String]
+  val defines: mutable.Map[String, String] = mutable.Map.empty[String, String]
   override def visitOccurrence(
       occ: SymbolOccurrence,
       sinfo: SymbolInformation,

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerJobQueue.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerJobQueue.scala
@@ -67,7 +67,7 @@ object CompilerJobQueue {
     def reject(): Unit = {
       result.completeExceptionally(new CancellationException("rejected"))
     }
-    val start = System.nanoTime()
+    val start: Long = System.nanoTime()
     def run(): Unit = {
       if (!result.isDone()) {
         _run()

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -48,7 +48,8 @@ trait Completions { this: MetalsGlobal =>
       val detail: String
   ) extends ScopeMember(sym, NoType, true, EmptyTree)
 
-  val packageSymbols = mutable.Map.empty[String, Option[Symbol]]
+  val packageSymbols: mutable.Map[String, Option[Symbol]] =
+    mutable.Map.empty[String, Option[Symbol]]
   def packageSymbolFromString(symbol: String): Option[Symbol] = {
     packageSymbols.getOrElseUpdate(symbol, {
       val fqn = symbol.stripSuffix("/").replace('/', '.')
@@ -144,7 +145,7 @@ trait Completions { this: MetalsGlobal =>
     relevance
   }
 
-  lazy val isEvilMethod = Set[Name](
+  lazy val isEvilMethod: Set[Name] = Set[Name](
     termNames.notifyAll_,
     termNames.notify_,
     termNames.wait_,
@@ -354,7 +355,8 @@ trait Completions { this: MetalsGlobal =>
 
     // Default implementation for `compare` delegates to the `isPrioritized` method
     // which groups prioritized members with first and non-prioritized second.
-    final lazy val cache = mutable.Map.empty[Symbol, Boolean]
+    final lazy val cache: mutable.Map[Symbol, Boolean] =
+      mutable.Map.empty[Symbol, Boolean]
     final def isPrioritizedCached(m: Member): Boolean =
       cache.getOrElseUpdate(m.sym, isPrioritized(m))
 
@@ -699,7 +701,7 @@ trait Completions { this: MetalsGlobal =>
         cursor: Position,
         text: String
     ) extends CompletionPosition {
-      val pos = ident.pos.withEnd(cursor.point).toLSP
+      val pos: l.Range = ident.pos.withEnd(cursor.point).toLSP
       def newText(sym: Symbol): String = {
         new StringBuilder()
           .append('{')
@@ -710,7 +712,7 @@ trait Completions { this: MetalsGlobal =>
           .append('}')
           .toString
       }
-      val filter =
+      val filter: String =
         text.substring(ident.pos.start - 1, cursor.point - query.length)
       override def contribute: List[Member] = {
         metalsTypeMembers(ident.pos).collect {
@@ -748,11 +750,15 @@ trait Completions { this: MetalsGlobal =>
         text: String
     ) extends CompletionPosition {
 
-      val offset = if (lit.pos.focusEnd.line == pos.line) CURSOR.length else 0
-      val nameStart = pos.withStart(pos.start - interpolator.name.size)
+      val offset: Int =
+        if (lit.pos.focusEnd.line == pos.line) CURSOR.length else 0
+      val nameStart: Position =
+        pos.withStart(pos.start - interpolator.name.size)
       val nameRange = nameStart.toLSP
-      val hasClosingBrace = text.charAt(pos.point) == '}'
-      val hasOpeningBrace = text.charAt(pos.start - interpolator.name.size - 1) == '{'
+      val hasClosingBrace: Boolean = text.charAt(pos.point) == '}'
+      val hasOpeningBrace: Boolean = text.charAt(
+        pos.start - interpolator.name.size - 1
+      ) == '{'
 
       def additionalEdits(): List[l.TextEdit] = {
         val interpolatorEdit =
@@ -785,7 +791,7 @@ trait Completions { this: MetalsGlobal =>
         out.toString
       }
 
-      val filter =
+      val filter: String =
         text.substring(lit.pos.start, pos.point - interpolator.name.length)
       override def contribute: List[Member] = {
         metalsScopeMembers(pos).collect {
@@ -822,7 +828,7 @@ trait Completions { this: MetalsGlobal =>
         pos: Position,
         editRange: l.Range
     ) extends CompletionPosition {
-      val query = toplevel.name.toString().stripSuffix(CURSOR)
+      val query: String = toplevel.name.toString().stripSuffix(CURSOR)
       override def contribute: List[Member] = {
         try {
           val name = Paths
@@ -881,8 +887,9 @@ trait Completions { this: MetalsGlobal =>
         text: String,
         completions: CompletionResult
     ) extends CompletionPosition {
-      val editRange = pos.withStart(ident.pos.start).withEnd(pos.start).toLSP
-      val method = typedTreeAt(apply.fun.pos)
+      val editRange: l.Range =
+        pos.withStart(ident.pos.start).withEnd(pos.start).toLSP
+      val method: Tree = typedTreeAt(apply.fun.pos)
       val methodSym = method.symbol
       lazy val baseParams: List[Symbol] =
         if (method.tpe == null) Nil
@@ -890,7 +897,7 @@ trait Completions { this: MetalsGlobal =>
           method.tpe.paramss.headOption
             .getOrElse(methodSym.paramss.flatten)
         }
-      lazy val isNamed = apply.args.iterator
+      lazy val isNamed: Set[Name] = apply.args.iterator
         .filterNot(_ == ident)
         .zip(baseParams.iterator)
         .map {
@@ -900,15 +907,16 @@ trait Completions { this: MetalsGlobal =>
             param.name
         }
         .toSet
-      val prefix = ident.name.toString.stripSuffix(CURSOR)
+      val prefix: String = ident.name.toString.stripSuffix(CURSOR)
       lazy val allParams: List[Symbol] = {
         baseParams.iterator.filterNot { param =>
           isNamed(param.name) ||
           param.name.containsChar('$') // exclude synthetic parameters
         }.toList
       }
-      lazy val params = allParams.filter(param => param.name.startsWith(prefix))
-      lazy val isParamName = params.iterator
+      lazy val params: List[Symbol] =
+        allParams.filter(param => param.name.startsWith(prefix))
+      lazy val isParamName: Set[String] = params.iterator
         .map(_.name)
         .filterNot(isNamed)
         .map(_.toString().trim())
@@ -1035,11 +1043,11 @@ trait Completions { this: MetalsGlobal =>
         start: Int,
         isCandidate: Symbol => Boolean
     ) extends CompletionPosition {
-      val prefix = name.toString.stripSuffix(CURSOR)
-      val typed = typedTreeAt(t.pos)
+      val prefix: String = name.toString.stripSuffix(CURSOR)
+      val typed: Tree = typedTreeAt(t.pos)
       val isDecl = typed.tpe.decls.toSet
-      val range = pos.withStart(start).withEnd(pos.point).toLSP
-      val lineStart = pos.source.lineToOffset(pos.line - 1)
+      val range: l.Range = pos.withStart(start).withEnd(pos.point).toLSP
+      val lineStart: Int = pos.source.lineToOffset(pos.line - 1)
 
       // Returns all the symbols of all transitive supertypes in the enclosing scope.
       // For example:
@@ -1084,21 +1092,22 @@ trait Completions { this: MetalsGlobal =>
         isCandidate(sym)
       }
 
-      val context = doLocateContext(pos)
-      val baseAutoImport = autoImportPosition(pos, text)
-      val autoImport = baseAutoImport.getOrElse(
+      val context: Context = doLocateContext(pos)
+      val baseAutoImport: Option[AutoImportPosition] =
+        autoImportPosition(pos, text)
+      val autoImport: AutoImportPosition = baseAutoImport.getOrElse(
         AutoImportPosition(lineStart, inferIndent(lineStart, text))
       )
-      val importContext =
+      val importContext: Context =
         if (baseAutoImport.isDefined)
           doLocateImportContext(pos, baseAutoImport)
         else context
-      val re = renamedSymbols(context)
-      val owners = this.parentSymbols(context)
+      val re: scala.collection.Map[Symbol, Name] = renamedSymbols(context)
+      val owners: scala.collection.Set[Symbol] = this.parentSymbols(context)
 
       private case class OverrideCandidate(sym: Symbol) {
-        val memberType = typed.tpe.memberType(sym)
-        val info =
+        val memberType: Type = typed.tpe.memberType(sym)
+        val info: Type =
           if (memberType.isErroneous) sym.info
           else {
             memberType match {
@@ -1127,34 +1136,34 @@ trait Completions { this: MetalsGlobal =>
           printLongType = false
         )
 
-        val overrideKeyword =
+        val overrideKeyword: String =
           if (!sym.isAbstract || text.startsWith("o", start)) "override "
           // Don't insert `override` keyword if the supermethod is abstract and the
           // user did not explicitly type starting with o . See:
           // https://github.com/scalameta/metals/issues/565#issuecomment-472761240
           else ""
 
-        val lzy =
+        val lzy: String =
           if (sym.isLazy) "lazy "
           else ""
 
-        val keyword = if (sym.isStable) "val " else "def "
+        val keyword: String = if (sym.isStable) "val " else "def "
 
-        val asciOverrideDef = {
+        val asciOverrideDef: String = {
           if (sym.isAbstract) s"${keyword}"
           else s"${overrideKeyword}${keyword}"
         }
 
-        val overrideDef = metalsConfig.overrideDefFormat() match {
+        val overrideDef: String = metalsConfig.overrideDefFormat() match {
           case OverrideDefFormat.Unicode =>
             if (sym.isAbstract) "🔼 "
             else "⏫ "
           case _ => asciOverrideDef
         }
 
-        val name = Identifier(sym.name)
+        val name: String = Identifier(sym.name)
 
-        val filterText = s"${overrideKeyword}${lzy}${keyword}${name}"
+        val filterText: String = s"${overrideKeyword}${lzy}${keyword}${name}"
 
         // if we had no val or def then filter will be empty
         def toMember = new OverrideDefMember(
@@ -1289,8 +1298,8 @@ trait Completions { this: MetalsGlobal =>
         text: String,
         parent: Tree
     ) extends CompletionPosition {
-      val context = doLocateContext(pos)
-      val parents = selector match {
+      val context: Context = doLocateContext(pos)
+      val parents: Parents = selector match {
         case EmptyTree =>
           val typedParent = typedTreeAt(parent.pos)
           typedParent match {
@@ -1662,9 +1671,10 @@ trait Completions { this: MetalsGlobal =>
         case _ => definitions.tupleType(tpes)
       }
     )
-    val isParent = Set(selector.typeSymbol, selector.typeSymbol.companion)
-      .filterNot(_ == NoSymbol)
-    val isBottom = Set[Symbol](
+    val isParent: Set[Symbol] =
+      Set(selector.typeSymbol, selector.typeSymbol.companion)
+        .filterNot(_ == NoSymbol)
+    val isBottom: Set[Symbol] = Set[Symbol](
       definitions.NullClass,
       definitions.NothingClass
     )

--- a/mtags/src/main/scala/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/HoverProvider.scala
@@ -255,7 +255,7 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
     }
   }
 
-  lazy val isForName = Set[Name](
+  lazy val isForName: Set[Name] = Set[Name](
     nme.map,
     nme.withFilter,
     nme.flatMap,

--- a/mtags/src/main/scala/scala/meta/internal/pc/MemberOrdering.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MemberOrdering.scala
@@ -1,20 +1,20 @@
 package scala.meta.internal.pc
 
 object MemberOrdering {
-  val IsWorkspaceSymbol = 1 << 30
-  val IsInheritedBaseMethod = 1 << 29
-  val IsImplicitConversion = 1 << 28
-  val IsInherited = 1 << 27
-  val IsNotLocalByBlock = 1 << 26
-  val IsNotDefinedInFile = 1 << 25
-  val IsNotGetter = 1 << 24
-  val IsPackage = 1 << 23
-  val IsNotCaseAccessor = 1 << 22
-  val IsNotPublic = 1 << 21
-  val IsSynthetic = 1 << 20
-  val IsDeprecated = 1 << 19
-  val IsEvilMethod = 1 << 18 // example: clone() and finalize()
+  val IsWorkspaceSymbol: Int = 1 << 30
+  val IsInheritedBaseMethod: Int = 1 << 29
+  val IsImplicitConversion: Int = 1 << 28
+  val IsInherited: Int = 1 << 27
+  val IsNotLocalByBlock: Int = 1 << 26
+  val IsNotDefinedInFile: Int = 1 << 25
+  val IsNotGetter: Int = 1 << 24
+  val IsPackage: Int = 1 << 23
+  val IsNotCaseAccessor: Int = 1 << 22
+  val IsNotPublic: Int = 1 << 21
+  val IsSynthetic: Int = 1 << 20
+  val IsDeprecated: Int = 1 << 19
+  val IsEvilMethod: Int = 1 << 18 // example: clone() and finalize()
 
   // OverrideDefMember
-  val IsNotAbstract = 1 << 30
+  val IsNotAbstract: Int = 1 << 30
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -36,7 +36,8 @@ case class ScalaPresentationCompiler(
     sh: Option[ScheduledExecutorService] = None,
     config: PresentationCompilerConfig = PresentationCompilerConfigImpl()
 ) extends PresentationCompiler {
-  val logger = Logger.getLogger(classOf[ScalaPresentationCompiler].getName)
+  val logger: Logger =
+    Logger.getLogger(classOf[ScalaPresentationCompiler].getName)
   override def withSearch(search: SymbolSearch): PresentationCompiler =
     copy(search = search)
   override def withExecutorService(

--- a/mtags/src/main/scala/scala/meta/internal/pc/Signatures.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Signatures.scala
@@ -253,7 +253,8 @@ trait Signatures { this: MetalsGlobal =>
     def isTypeParameters: Boolean = gtpe.typeParams.nonEmpty
     def implicitParams: Option[List[Symbol]] =
       gtpe.paramss.lastOption.filter(_.headOption.exists(_.isImplicit))
-    val implicitEvidenceTermParams = mutable.Set.empty[Symbol]
+    private val implicitEvidenceTermParams =
+      mutable.Set.empty[Symbol]
     val implicitEvidencesByTypeParam
         : collection.Map[Symbol, ListBuffer[String]] = {
       val result = mutable.Map.empty[Symbol, ListBuffer[String]]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.8")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.3.1")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.2.7")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -24,6 +24,7 @@ import scala.util.control.NonFatal
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import scala.collection.Seq
+import scala.meta.pc.PresentationCompiler
 
 abstract class BasePCSuite extends BaseSuite {
   def thisClasspath: Seq[Path] =
@@ -46,13 +47,13 @@ abstract class BasePCSuite extends BaseSuite {
   )
   val executorService: ScheduledExecutorService =
     Executors.newSingleThreadScheduledExecutor()
-  val pc = new ScalaPresentationCompiler()
+  val pc: PresentationCompiler = new ScalaPresentationCompiler()
     .withSearch(search)
     .withConfiguration(config)
     .withExecutorService(executorService)
     .withScheduledExecutorService(executorService)
     .newInstance("", myclasspath.asJava, scalacOptions.asJava)
-  val tmp = AbsolutePath(Files.createTempDirectory("metals"))
+  val tmp: AbsolutePath = AbsolutePath(Files.createTempDirectory("metals"))
   override def utestAfterAll(): Unit = {
     executorService.shutdown()
   }

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -6,7 +6,7 @@ import tests.BaseCompletionSuite
 
 object CompletionCaseSuite extends BaseCompletionSuite {
 
-  def paramHint = Some("param-hint")
+  def paramHint: Option[String] = Some("param-hint")
 
   override def config: PresentationCompilerConfig =
     PresentationCompilerConfigImpl().copy(

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -142,7 +142,7 @@ object CompletionDocSuite extends BaseCompletionSuite {
        |""".stripMargin,
     includeDocs = true
   )
-  def predefDocString =
+  def predefDocString: String =
     """|
        |> The `Predef` object provides definitions that are accessible in all Scala
        | compilation units without explicit qualification.
@@ -602,7 +602,7 @@ object CompletionDocSuite extends BaseCompletionSuite {
     includeDocs = true
   )
 
-  val isDefinedLatestDocs =
+  val isDefinedLatestDocs: String =
     """|> Returns true if the option is an instance of [scala.Some](scala.Some), false otherwise.
        |
        |This is equivalent to:
@@ -616,7 +616,7 @@ object CompletionDocSuite extends BaseCompletionSuite {
        |isDefined: Boolean
        |""".stripMargin
 
-  val isDefinedOlderDocs =
+  val isDefinedOlderDocs: String =
     """|> Returns true if the option is an instance of [scala.Some](scala.Some), false otherwise.
        |isDefined: Boolean
        |""".stripMargin

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpDocSuite.scala
@@ -9,7 +9,7 @@ object SignatureHelpDocSuite extends BaseSignatureHelpSuite {
     indexScalaLibrary()
   }
 
-  val foldLatestDocs =
+  val foldLatestDocs: String =
     """|Returns the result of applying `f` to this [scala.Option](scala.Option)'s
        | value if the [scala.Option](scala.Option) is nonempty.  Otherwise, evaluates
        | expression `ifEmpty`.
@@ -28,7 +28,7 @@ object SignatureHelpDocSuite extends BaseSignatureHelpSuite {
        |option map f getOrElse ifEmpty
        |```""".stripMargin
 
-  val foldOlderDocs1 =
+  val foldOlderDocs1: String =
     """|Returns the result of applying `f` to this [scala.Option](scala.Option)'s
        | value if the [scala.Option](scala.Option) is nonempty.  Otherwise, evaluates
        | expression `ifEmpty`.
@@ -78,7 +78,7 @@ object SignatureHelpDocSuite extends BaseSignatureHelpSuite {
     )
   )
 
-  val foldOlderDocs2 =
+  val foldOlderDocs2: String =
     """|Returns the result of applying `f` to this [scala.Option](scala.Option)'s
        | value if the [scala.Option](scala.Option) is nonempty.  Otherwise, evaluates
        | expression `ifEmpty`.

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -186,7 +186,8 @@ class BaseSuite extends TestSuite {
     Properties.versionNumberString
   private def scalaBinary(scalaVersion: String): String =
     scalaVersion.split("\\.").take(2).mkString(".")
-  val compatProcess = Map.empty[String, String => String]
+  val compatProcess: Map[String, String => String] =
+    Map.empty[String, String => String]
 
   def getExpected(
       default: String,

--- a/tests/mtest/src/main/scala/tests/TestingWorkspaceSearch.scala
+++ b/tests/mtest/src/main/scala/tests/TestingWorkspaceSearch.scala
@@ -12,7 +12,7 @@ object TestingWorkspaceSearch {
 }
 
 class TestingWorkspaceSearch {
-  val inputs = mutable.Map.empty[String, String]
+  val inputs: mutable.Map[String, String] = mutable.Map.empty[String, String]
   def search(query: WorkspaceSymbolQuery, visitor: SymbolSearchVisitor): Unit =
     for {
       (path, text) <- inputs

--- a/tests/slow/src/test/scala/tests/BaseImportSuite.scala
+++ b/tests/slow/src/test/scala/tests/BaseImportSuite.scala
@@ -5,23 +5,26 @@ import scala.meta.io.AbsolutePath
 import scala.meta.internal.builds.BuildTool
 import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.SlowTaskConfig
+import scala.meta.internal.metals.MetalsServerConfig
 
 abstract class BaseImportSuite(suiteName: String)
     extends BaseLspSuite(suiteName) {
 
   // enables support for bloop install (a slow task)
-  override val serverConfig = {
+  override val serverConfig: MetalsServerConfig = {
     super.serverConfig.copy(slowTask = SlowTaskConfig.on)
   }
 
   def buildTool: BuildTool
 
-  def importBuildMessage = ImportBuild.params(buildTool.toString()).getMessage
+  def importBuildMessage: String =
+    ImportBuild.params(buildTool.toString()).getMessage
 
-  def importBuildChangesMessage =
+  def importBuildChangesMessage: String =
     ImportBuildChanges.params(buildTool.toString()).getMessage
 
-  def progressMessage = bloopInstallProgress(buildTool.executableName).message
+  def progressMessage: String =
+    bloopInstallProgress(buildTool.executableName).message
 
   def currentDigest(workspace: AbsolutePath): Option[String]
 

--- a/tests/slow/src/test/scala/tests/feature/ClasspathSymbolRegressionSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/ClasspathSymbolRegressionSuite.scala
@@ -7,7 +7,7 @@ import tests.BaseWorkspaceSymbolSuite
 import tests.Library
 
 object ClasspathSymbolRegressionSuite extends BaseWorkspaceSymbolSuite {
-  var tmp = AbsolutePath(Files.createTempDirectory("metals"))
+  var tmp: AbsolutePath = AbsolutePath(Files.createTempDirectory("metals"))
   override def libraries: List[Library] = Library.all
   def workspace: AbsolutePath = tmp
   override def afterAll(): Unit = {

--- a/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
@@ -2,6 +2,7 @@ package tests.feature
 
 import tests.BaseCompletionLspSuite
 import scala.meta.internal.metals.BuildInfo
+import scala.concurrent.Future
 
 object DefinitionCrossLspSuite
     extends BaseCompletionLspSuite("definition-cross") {
@@ -14,7 +15,7 @@ object DefinitionCrossLspSuite
     basicDefinitionTest(BuildInfo.scala213)
   }
 
-  def basicDefinitionTest(scalaVersion: String) = {
+  def basicDefinitionTest(scalaVersion: String): Future[Unit] = {
     cleanDatabase()
     for {
       _ <- server.initialize(

--- a/tests/slow/src/test/scala/tests/gradle/GradleLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/gradle/GradleLspSuite.scala
@@ -12,7 +12,7 @@ import tests.BaseImportSuite
 
 object GradleLspSuite extends BaseImportSuite("gradle-import") {
 
-  val buildTool = GradleBuildTool()
+  val buildTool: GradleBuildTool = GradleBuildTool()
 
   override def currentDigest(
       workspace: AbsolutePath

--- a/tests/slow/src/test/scala/tests/maven/MavenLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/maven/MavenLspSuite.scala
@@ -11,7 +11,7 @@ import tests.BaseImportSuite
 
 object MavenLspSuite extends BaseImportSuite("maven-import") {
 
-  val buildTool = MavenBuildTool()
+  val buildTool: MavenBuildTool = MavenBuildTool()
 
   val defaultPom = new String(
     InputStreamIO.readBytes(
@@ -173,7 +173,7 @@ object MavenLspSuite extends BaseImportSuite("maven-import") {
     } yield ()
   }
 
-  val scalacArgs =
+  val scalacArgs: String =
     """|<arg>-Xfatal-warnings</arg>
        |<arg>-Ywarn-unused</arg>
        |""".stripMargin

--- a/tests/slow/src/test/scala/tests/mill/MillLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/mill/MillLspSuite.scala
@@ -8,7 +8,7 @@ import tests.BaseImportSuite
 
 object MillLspSuite extends BaseImportSuite("mill-import") {
 
-  val buildTool = MillBuildTool()
+  val buildTool: MillBuildTool = MillBuildTool()
 
   override def currentDigest(
       workspace: AbsolutePath

--- a/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
@@ -16,7 +16,7 @@ import scala.meta.io.AbsolutePath
 
 object SbtLspSuite extends BaseImportSuite("sbt-import") {
 
-  val buildTool = SbtBuildTool("")
+  val buildTool: SbtBuildTool = SbtBuildTool("")
 
   override def currentDigest(
       workspace: AbsolutePath

--- a/tests/unit/src/main/scala/bill/Bill.scala
+++ b/tests/unit/src/main/scala/bill/Bill.scala
@@ -66,7 +66,7 @@ import scala.meta.io.AbsolutePath
  */
 object Bill {
   class Server() extends BuildServer with ScalaBuildServer {
-    val languages = Collections.singletonList("scala")
+    val languages: util.List[String] = Collections.singletonList("scala")
     var client: BuildClient = _
     override def onConnectWithClient(server: BuildClient): Unit =
       client = server
@@ -104,9 +104,9 @@ object Bill {
       result
     }
     val reporter = new StoreReporter
-    val out = AbsolutePath(workspace.resolve("out.jar"))
+    val out: AbsolutePath = AbsolutePath(workspace.resolve("out.jar"))
     Files.createDirectories(out.toNIO.getParent())
-    lazy val g = {
+    lazy val g: nsc.Global = {
       val settings = new nsc.Settings()
       settings.classpath.value =
         myClasspath.map(_.toString).mkString(File.pathSeparator)

--- a/tests/unit/src/main/scala/tests/BaseDigestSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseDigestSuite.scala
@@ -11,14 +11,14 @@ trait BaseDigestSuite extends BaseSuite {
       name: String,
       layout: String,
       altLayout: String
-  )(implicit file: sourcecode.File, line: sourcecode.Line) =
+  )(implicit file: sourcecode.File, line: sourcecode.Line): Unit =
     check(name, layout, altLayout, isEqual = true)
 
   def checkDiff(
       name: String,
       layout: String,
       altLayout: String
-  )(implicit file: sourcecode.File, line: sourcecode.Line) =
+  )(implicit file: sourcecode.File, line: sourcecode.Line): Unit =
     check(name, layout, altLayout, isEqual = false)
 
   private def check(

--- a/tests/unit/src/main/scala/tests/BaseExpectSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseExpectSuite.scala
@@ -10,9 +10,9 @@ import scala.meta.io.Classpath
  * Exposes useful methods to lookup metadata about the input project.
  */
 abstract class BaseExpectSuite(val suiteName: String) extends BaseSuite {
-  lazy val input = InputProperties.default()
+  lazy val input: InputProperties = InputProperties.default()
 
-  lazy val symtab = {
+  lazy val symtab: GlobalSymbolTable = {
     val bootClasspath =
       sys.props
         .collectFirst {

--- a/tests/unit/src/main/scala/tests/PrettyPrintTree.scala
+++ b/tests/unit/src/main/scala/tests/PrettyPrintTree.scala
@@ -4,7 +4,7 @@ case class PrettyPrintTree(
     value: String,
     children: List[PrettyPrintTree] = Nil
 ) {
-  def isEmpty = value.isEmpty() && children.isEmpty
+  def isEmpty: Boolean = value.isEmpty() && children.isEmpty
   def render(indent: String, sb: StringBuilder): Unit = {
     if (!isEmpty) {
       sb.append(indent)
@@ -24,5 +24,5 @@ case class PrettyPrintTree(
 }
 
 object PrettyPrintTree {
-  def empty = PrettyPrintTree("")
+  def empty: PrettyPrintTree = PrettyPrintTree("")
 }

--- a/tests/unit/src/main/scala/tests/QuickBuild.scala
+++ b/tests/unit/src/main/scala/tests/QuickBuild.scala
@@ -215,7 +215,7 @@ case class QuickBuild(
 }
 
 object QuickBuild {
-  val supportedTestFrameworks = Map(
+  val supportedTestFrameworks: Map[String, C.TestFramework] = Map(
     "org.scalatest::scalatest" -> Config.TestFramework.ScalaTest,
     "com.lihaoyi::utest" -> Config.TestFramework(List("utest.runner.Framework"))
   )

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -47,8 +47,10 @@ import scala.meta.internal.tvp.TreeViewDidChangeParams
  */
 final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
     extends NoopLanguageClient {
-  val diagnostics = TrieMap.empty[AbsolutePath, Seq[Diagnostic]]
-  val diagnosticsCount = TrieMap.empty[AbsolutePath, AtomicInteger]
+  val diagnostics: TrieMap[AbsolutePath, Seq[Diagnostic]] =
+    TrieMap.empty[AbsolutePath, Seq[Diagnostic]]
+  val diagnosticsCount: TrieMap[AbsolutePath, AtomicInteger] =
+    TrieMap.empty[AbsolutePath, AtomicInteger]
   val messageRequests = new ConcurrentLinkedDeque[String]()
   val showMessages = new ConcurrentLinkedQueue[MessageParams]()
   val statusParams = new ConcurrentLinkedQueue[MetalsStatusParams]()

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -80,6 +80,7 @@ import scala.meta.internal.metals.ClientExperimentalCapabilities
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.debug.TestDebugger
 import scala.meta.internal.metals.DebugSession
+import scala.util.matching.Regex
 
 /**
  * Wrapper around `MetalsLanguageServer` with helpers methods for testing purpopses.
@@ -815,7 +816,7 @@ final class TestingServer(
     )
   }
 
-  val Docstring = " *\\/?\\*.*".r
+  val Docstring: Regex = " *\\/?\\*.*".r
   def workspaceDefinitions: String = {
     buffers.open.toSeq
       .sortBy(_.toURI.toString)

--- a/tests/unit/src/test/scala/tests/DetectionSuite.scala
+++ b/tests/unit/src/test/scala/tests/DetectionSuite.scala
@@ -8,7 +8,7 @@ object DetectionSuite extends BaseSuite {
       layout: String,
       testFunction: AbsolutePath => Boolean,
       isTrue: Boolean = true
-  ) = {
+  ): Unit = {
     val workspace = FileLayout.fromString(layout)
     workspace.toFile.deleteOnExit()
     val isSbt = testFunction(workspace)

--- a/tests/unit/src/test/scala/tests/InverseDependenciesSuite.scala
+++ b/tests/unit/src/test/scala/tests/InverseDependenciesSuite.scala
@@ -7,7 +7,8 @@ import scala.meta.internal.metals.BuildTargets
 
 object InverseDependenciesSuite extends BaseSuite {
   class Graph(val root: String) {
-    val inverseDependencies = mutable.Map.empty[String, ListBuffer[String]]
+    val inverseDependencies: mutable.Map[String, ListBuffer[String]] =
+      mutable.Map.empty[String, ListBuffer[String]]
     def dependsOn(project: String, dependency: String): this.type = {
       val dependencies =
         inverseDependencies.getOrElseUpdate(dependency, ListBuffer.empty)

--- a/tests/unit/src/test/scala/tests/PrettyPrintTreeSuite.scala
+++ b/tests/unit/src/test/scala/tests/PrettyPrintTreeSuite.scala
@@ -9,7 +9,7 @@ object PrettyPrintTreeSuite extends BaseSuite {
   def t(
       value: String,
       children: PrettyPrintTree*
-  ) = PrettyPrintTree(value, children.toList)
+  ): PrettyPrintTree = PrettyPrintTree(value, children.toList)
 
   check(
     "shallow",

--- a/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
@@ -3,12 +3,13 @@ package tests
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.mtags.Mtags
+import scala.meta.io.AbsolutePath
 
 /**
  * Assert the symbols emitted by ScalaToplevelMtags is a subset of ScalaMtags
  */
 class ScalaToplevelSuite extends BaseSuite {
-  val testClasspath = Library.all.flatMap(_.sources.entries)
+  val testClasspath: List[AbsolutePath] = Library.all.flatMap(_.sources.entries)
   testClasspath.foreach { entry =>
     test(entry.toNIO.getFileName.toString) {
       FileIO.withJarFileSystem(entry, create = false) { root =>

--- a/tests/unit/src/test/scala/tests/UnsupportedDebuggingLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/UnsupportedDebuggingLspSuite.scala
@@ -11,12 +11,13 @@ import scala.util.Success
 object UnsupportedDebuggingLspSuite
     extends BaseLspSuite("unsupported-debugging") {
 
-  override val experimentalCapabilities = Some(
-    new ClientExperimentalCapabilities(
-      debuggingProvider = false,
-      treeViewProvider = false
+  override val experimentalCapabilities: Some[ClientExperimentalCapabilities] =
+    Some(
+      new ClientExperimentalCapabilities(
+        debuggingProvider = false,
+        treeViewProvider = false
+      )
     )
-  )
 
   testAsync("no-code-lenses") {
     for {

--- a/tests/unit/src/test/scala/tests/digest/MavenDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/digest/MavenDigestSuite.scala
@@ -145,13 +145,14 @@ object MavenDigestSuite extends BaseDigestSuite {
     """.stripMargin
   )
 
-  def projectString = """
-                        |<project>
-                        |<modelVersion>4.0.0</modelVersion>
-                        |<groupId>com.mycompany.app</groupId>
-                        |<artifactId>my-app</artifactId>
-                        |<version>1</version>
-                        |</project>
+  def projectString: String =
+    """
+      |<project>
+      |<modelVersion>4.0.0</modelVersion>
+      |<groupId>com.mycompany.app</groupId>
+      |<artifactId>my-app</artifactId>
+      |<version>1</version>
+      |</project>
   """.stripMargin
 
   checkDiff(

--- a/tests/unit/src/test/scala/tests/digest/MillDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/digest/MillDigestSuite.scala
@@ -105,7 +105,7 @@ object MillDigestSuite extends BaseDigestSuite {
     """.stripMargin
   )
 
-  def project(name: String) =
+  def project(name: String): String =
     s"""
        |import mill._, scalalib._
        |object $name extends ScalaModule {


### PR DESCRIPTION
Previously, Scalafix only checked for unused imports. Now, it also adds
type annotations for public members.