### PR TITLE
Delegating client should not always call configure for every po…

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -27,7 +27,6 @@ final class ConfiguredLanguageClient(
 
   override def configure(capabilities: ClientExperimentalCapabilities): Unit = {
     debuggingSupported = capabilities.debuggingProvider
-    super.configure(capabilities)
   }
 
   override def shutdown(): Unit = {

--- a/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
@@ -37,8 +37,12 @@ class DelegatingLanguageClient(var underlying: MetalsLanguageClient)
     underlying.applyEdit(params)
   }
 
-  override def configure(capabilities: ClientExperimentalCapabilities): Unit = {
-    underlying.configure(capabilities)
+  def configure(capabilities: ClientExperimentalCapabilities): Unit = {
+    underlying match {
+      case client: ConfiguredLanguageClient =>
+        client.configure(capabilities)
+      case _ =>
+    }
   }
 
   override def metalsStatus(params: MetalsStatusParams): Unit = {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
@@ -13,8 +13,6 @@ import scala.meta.internal.metals.MetalsEnrichments._
 
 trait MetalsLanguageClient extends LanguageClient with TreeViewClient {
 
-  def configure(capabilities: ClientExperimentalCapabilities): Unit
-
   /**
    * Display message in the editor "status bar", which should be displayed somewhere alongside the buffer.
    *

--- a/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
@@ -15,8 +15,6 @@ import scala.meta.internal.tvp._
  * or log messages are published during shutdown.
  */
 abstract class NoopLanguageClient extends MetalsLanguageClient {
-  override def configure(capabilities: ClientExperimentalCapabilities): Unit =
-    ()
   override def metalsStatus(params: MetalsStatusParams): Unit = ()
   override def metalsSlowTask(
       params: MetalsSlowTaskParams


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/1036

Previously, we would invoke `configure` also on remote client which doesn't have this method configured. Now we explicitly check  if it is the proper client.