### PR TITLE
Update sbt version to 1.3.2

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.2


### PR DESCRIPTION
After removing metals-plugin we can finally switch to the newest sbt version.