### PR TITLE
Only run tests on master branch or in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 on:
   push:
+    branches:
+      - master
   pull_request:
 jobs:
   windows:


### PR DESCRIPTION
Only run tests on master branch or in PRs, previously it would run twice on a push to forked branch.

Finally figured out why we were getting 2x test notifications. Noticed that when upgrading to new sbt. I think it makes sense to still run tests on master - we can track any issues - and obviously on PRs.