### PR TITLE
Implement textDocument/rename

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/implementation/MethodImplementation.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/MethodImplementation.scala
@@ -28,7 +28,7 @@ object MethodImplementation {
 
   import ImplementationProvider._
 
-  def findParent(
+  def findParentSymbol(
       childSymbol: SymbolInformation,
       childClassSig: ClassSignature,
       parentClassSig: ClassSignature,

--- a/metals/src/main/scala/scala/meta/internal/metals/Buffers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Buffers.scala
@@ -11,4 +11,5 @@ case class Buffers(map: TrieMap[AbsolutePath, String] = TrieMap.empty) {
   def put(key: AbsolutePath, value: String): Unit = map.put(key, value)
   def get(key: AbsolutePath): Option[String] = map.get(key)
   def remove(key: AbsolutePath): Unit = map.remove(key)
+  def contains(key: AbsolutePath): Boolean = map.contains(key)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -255,12 +255,13 @@ object MetalsEnrichments
 
     def isWorkspaceSource(workspace: AbsolutePath): Boolean =
       isLocalFileSystem(workspace) &&
-        !isInReadonlyDirectory(workspace)
+        !isInReadonlyDirectory(workspace) &&
+        path.toNIO.startsWith(workspace.toNIO)
 
-    def isLocalFileSystem(workspace: AbsolutePath) =
+    def isLocalFileSystem(workspace: AbsolutePath): Boolean =
       workspace.toNIO.getFileSystem == path.toNIO.getFileSystem
 
-    def isInReadonlyDirectory(workspace: AbsolutePath) =
+    def isInReadonlyDirectory(workspace: AbsolutePath): Boolean =
       path.toNIO.startsWith(
         workspace.resolve(Directories.readonly).toNIO
       )

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -250,10 +250,20 @@ object MetalsEnrichments
       }
     }
     def isDependencySource(workspace: AbsolutePath): Boolean =
-      workspace.toNIO.getFileSystem == path.toNIO.getFileSystem &&
-        path.toNIO.startsWith(
-          workspace.resolve(Directories.readonly).toNIO
-        )
+      isLocalFileSystem(workspace) &&
+        isInReadonlyDirectory(workspace)
+
+    def isWorkspaceSource(workspace: AbsolutePath): Boolean =
+      isLocalFileSystem(workspace) &&
+        !isInReadonlyDirectory(workspace)
+
+    def isLocalFileSystem(workspace: AbsolutePath) =
+      workspace.toNIO.getFileSystem == path.toNIO.getFileSystem
+
+    def isInReadonlyDirectory(workspace: AbsolutePath) =
+      path.toNIO.startsWith(
+        workspace.resolve(Directories.readonly).toNIO
+      )
 
     /**
      * Writes zip file contents to disk under $workspace/.metals/readonly.

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -48,6 +48,7 @@ import com.google.gson.JsonPrimitive
 import scala.meta.internal.worksheets.WorksheetProvider
 import scala.meta.internal.worksheets.WorksheetProvider
 import scala.meta.internal.decorations.PublishDecorationsParams
+import scala.meta.internal.rename.RenameProvider
 
 class MetalsLanguageServer(
     ec: ExecutionContextExecutorService,
@@ -158,6 +159,7 @@ class MetalsLanguageServer(
   private var definitionProvider: DefinitionProvider = _
   private var semanticDBIndexer: SemanticdbIndexer = _
   private var implementationProvider: ImplementationProvider = _
+  private var renameProvider: RenameProvider = _
   private var documentHighlightProvider: DocumentHighlightProvider = _
   private var formattingProvider: FormattingProvider = _
   private var multilineStringFormattingProvider
@@ -348,6 +350,17 @@ class MetalsLanguageServer(
       buffers,
       definitionProvider
     )
+    renameProvider = new RenameProvider(
+      referencesProvider,
+      implementationProvider,
+      definitionProvider,
+      semanticdbs,
+      definitionIndex,
+      workspace,
+      languageClient,
+      buffers,
+      compilations
+    )
     semanticDBIndexer =
       new SemanticdbIndexer(referencesProvider, implementationProvider)
     documentHighlightProvider = new DocumentHighlightProvider(
@@ -452,6 +465,7 @@ class MetalsLanguageServer(
       capabilities.setImplementationProvider(true)
       capabilities.setHoverProvider(true)
       capabilities.setReferencesProvider(true)
+      capabilities.setRenameProvider(true)
       capabilities.setDocumentHighlightProvider(true)
       capabilities.setDocumentOnTypeFormattingProvider(
         new DocumentOnTypeFormattingOptions("\n")
@@ -909,8 +923,7 @@ class MetalsLanguageServer(
       params: RenameParams
   ): CompletableFuture[WorkspaceEdit] =
     CancelTokens { _ =>
-      scribe.warn("textDocument/rename is not supported.")
-      null
+      renameProvider.rename(params)
     }
 
   @JsonRequest("textDocument/references")

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -465,7 +465,9 @@ class MetalsLanguageServer(
       capabilities.setImplementationProvider(true)
       capabilities.setHoverProvider(true)
       capabilities.setReferencesProvider(true)
-      capabilities.setRenameProvider(true)
+      val renameOptions = new RenameOptions()
+      renameOptions.setPrepareProvider(true)
+      capabilities.setRenameProvider(renameOptions)
       capabilities.setDocumentHighlightProvider(true)
       capabilities.setDocumentOnTypeFormattingProvider(
         new DocumentOnTypeFormattingOptions("\n")
@@ -916,6 +918,14 @@ class MetalsLanguageServer(
       multilineStringFormattingProvider
         .format(params)
         .map(_.asJava)
+    }
+
+  @JsonRequest("textDocument/prepareRename")
+  def prepareRename(
+      params: TextDocumentPositionParams
+  ): CompletableFuture[l.Range] =
+    CancelTokens { _ =>
+      renameProvider.prepareRename(params).getOrElse(null)
     }
 
   @JsonRequest("textDocument/rename")

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -1,0 +1,275 @@
+package scala.meta.internal.rename
+import scala.meta.internal.metals.ReferenceProvider
+import org.eclipse.lsp4j.RenameParams
+import org.eclipse.lsp4j.WorkspaceEdit
+import scala.meta.internal.implementation.ImplementationProvider
+import org.eclipse.lsp4j.TextDocumentPositionParams
+import org.eclipse.lsp4j.ReferenceParams
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextEdit
+import scala.meta.internal.metals.MetalsEnrichments._
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.ReferenceContext
+import scala.meta.internal.metals.DefinitionProvider
+import scala.meta.internal.mtags.{Symbol => MSymbol}
+import scala.meta.internal.mtags.Semanticdbs
+import scala.meta.internal.semanticdb.Scala._
+import scala.meta.internal.mtags.GlobalSymbolIndex
+import scala.meta.io.AbsolutePath
+import scala.meta.internal.metals.Directories
+import org.eclipse.lsp4j.Location
+import scala.meta.internal.metals.MetalsLanguageClient
+import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.MessageType
+import scala.meta.internal.metals.Buffers
+import java.net.URI
+import java.nio.file.Paths
+import scala.meta.internal.metals.TextEdits
+import scala.meta.internal.metals.Compilations
+import scala.meta.internal.metals.ReferencesResult
+
+final class RenameProvider(
+    referenceProvider: ReferenceProvider,
+    implementationProvider: ImplementationProvider,
+    definitionProvider: DefinitionProvider,
+    semanticdbs: Semanticdbs,
+    index: GlobalSymbolIndex,
+    workspace: AbsolutePath,
+    client: MetalsLanguageClient,
+    buffers: Buffers,
+    compilations: Compilations
+) {
+
+  def rename(params: RenameParams): WorkspaceEdit = {
+    if (!compilations.currentlyCompiling.isEmpty) {
+      client.showMessage(isCompiling)
+      new WorkspaceEdit()
+    } else {
+      val source = params.getTextDocument.getUri.toAbsolutePath
+      val textParams = new TextDocumentPositionParams(
+        params.getTextDocument(),
+        params.getPosition()
+      )
+
+      val refParams =
+        toReferenceParams(params.getTextDocument(), params.getPosition())
+
+      val symbolOccurence =
+        definitionProvider.symbolOccurence(source, textParams)
+
+      val allReferences = for {
+        (occurence, semanticDb) <- symbolOccurence.toIterable
+        if canRenameSymbol(occurence.symbol, params.getNewName())
+        parentSymbols = implementationProvider
+          .symbolParent(occurence.symbol, semanticDb)
+        txtParams <- if (parentSymbols.isEmpty) List(textParams)
+        else parentSymbols.map(toTextParams)
+        currentReferences = referenceProvider.references(
+          toReferenceParams(txtParams)
+        )
+        companionRefs = companionReferences(occurence.symbol)
+        implReferences = implementations(
+          txtParams,
+          !occurence.symbol.desc.isType
+        )
+        refResult <- currentReferences +: (implReferences ++ companionRefs)
+        loc <- refResult.locations
+      } yield loc
+
+      val isApply =
+        symbolOccurence.exists(occ => occ._1.symbol.desc.name.value == "apply")
+
+      val allChanges = for {
+        (uri, locs) <- allReferences.toList.distinct.groupBy(_.getUri())
+      } yield {
+        val textEdits = for (loc <- locs) yield {
+          textEdit(isApply, loc, params.getNewName())
+        }
+        Seq(uri -> textEdits.toList)
+      }
+      val fileChanges = allChanges.flatten.toMap
+
+      val (openedEdits, closedEdits) = fileChanges.partition {
+        case (file, edits) =>
+          val path = AbsolutePath(Paths.get(new URI(file)))
+          buffers.contains(path)
+      }
+
+      changeClosedFiles(closedEdits)
+
+      new WorkspaceEdit(
+        openedEdits.map {
+          case (file, edits) => file -> edits.asJava
+        }.asJava
+      )
+    }
+  }
+
+  private def companionReferences(sym: String): List[ReferencesResult] = {
+    val results = for {
+      companionSymbol <- companion(sym).toIterable
+      loc <- definitionProvider.fromSymbol(companionSymbol).asScala
+    } yield referenceProvider.references(toReferenceParams(loc))
+    results.toList
+  }
+
+  private def companion(sym: String) = {
+    val termOrType = sym.desc match {
+      case Descriptor.Type(name) =>
+        Some(Descriptor.Term(name))
+      case Descriptor.Term(name) =>
+        Some(Descriptor.Type(name))
+      case other =>
+        None
+    }
+
+    termOrType.map(
+      name =>
+        Symbols.Global(
+          sym.owner,
+          name
+        )
+    )
+  }
+
+  private def changeClosedFiles(fileEdits: Map[String, List[TextEdit]]) = {
+    fileEdits.toArray.par.foreach {
+      case (file, changes) =>
+        val path = AbsolutePath(Paths.get(new URI(file)))
+        val text = path.readText
+        val newText = TextEdits.applyEdits(text, changes)
+        path.writeText(newText)
+    }
+  }
+
+  private def implementations(
+      textParams: TextDocumentPositionParams,
+      shouldCheckImplementation: Boolean
+  ) = {
+    if (shouldCheckImplementation) {
+      for (loc <- implementationProvider.implementations(textParams))
+        yield {
+          val locParams = toReferenceParams(loc)
+          referenceProvider.references(locParams)
+        }
+    } else {
+      Nil
+    }
+  }
+
+  private def canRenameSymbol(symbol: String, newName: String) = {
+    val forbiddenMethods = Set("equals", "hashCode", "unapply", "unary_!", "!")
+    val desc = symbol.desc
+    val name = desc.name.value
+    val isForbidden = forbiddenMethods(name)
+    if (isForbidden) {
+      client.logMessage(forbiddenRename(name, newName))
+    }
+    val colonNotAllowed = name.endsWith(":") && !newName.endsWith(":")
+    if (colonNotAllowed) {
+      forbiddenColonRename(name, newName)
+    }
+    symbolIsLocal(symbol) && (!desc.isMethod || (!colonNotAllowed && !isForbidden))
+  }
+
+  private def symbolIsLocal(symbol: String): Boolean = {
+
+    lazy val isFromWorkspace = index
+      .definition(MSymbol(symbol))
+      .exists { definition =>
+        workspace.toNIO.getFileSystem == definition.path.toNIO.getFileSystem &&
+        !definition.path.toNIO
+          .startsWith(
+            workspace.resolve(Directories.readonly).toNIO
+          )
+      }
+
+    symbol.startsWith("local") || isFromWorkspace
+  }
+
+  private def textEdit(
+      isApply: Boolean,
+      loc: Location,
+      newName: String
+  ): TextEdit = {
+    lazy val default = new TextEdit(
+      loc.getRange(),
+      newName
+    )
+    if (isApply) {
+      val locSource = loc.getUri.toAbsolutePath
+      val textParams = new TextDocumentPositionParams
+      textParams.setPosition(loc.getRange().getStart())
+      val isImplicitApply =
+        definitionProvider
+          .symbolOccurence(locSource, textParams)
+          .exists(_._1.symbol.desc.name.value != "apply")
+      if (isImplicitApply) {
+        val range = loc.getRange()
+        range.setStart(range.getEnd())
+        new TextEdit(
+          range,
+          "." + newName
+        )
+      } else {
+        default
+      }
+    } else {
+      default
+    }
+  }
+
+  private def toReferenceParams(
+      textDoc: TextDocumentIdentifier,
+      pos: Position
+  ): ReferenceParams = {
+    val referenceParams = new ReferenceParams()
+    referenceParams.setPosition(pos)
+    referenceParams.setTextDocument(textDoc)
+    val context = new ReferenceContext()
+    context.setIncludeDeclaration(true)
+    referenceParams.setContext(context)
+    referenceParams
+  }
+
+  private def toReferenceParams(location: Location): ReferenceParams = {
+    val textDoc = new TextDocumentIdentifier()
+    textDoc.setUri(location.getUri())
+    toReferenceParams(textDoc, location.getRange().getStart())
+  }
+
+  private def toReferenceParams(
+      params: TextDocumentPositionParams
+  ): ReferenceParams = {
+    toReferenceParams(params.getTextDocument(), params.getPosition())
+  }
+
+  private def toTextParams(location: Location): TextDocumentPositionParams = {
+    new TextDocumentPositionParams(
+      new TextDocumentIdentifier(location.getUri()),
+      location.getRange().getStart()
+    )
+  }
+
+  private def forbiddenRename(old: String, name: String): MessageParams = {
+    val message =
+      s"""|Cannot rename to $name since it will change the semantics and 
+          |and might break your code""".stripMargin
+    new MessageParams(MessageType.Error, message)
+  }
+
+  private def isCompiling: MessageParams = {
+    val message =
+      s"""|Cannot rename while the code is compiling 
+          |since it could produce incorrect results.""".stripMargin
+    new MessageParams(MessageType.Error, message)
+  }
+
+  private def forbiddenColonRename(old: String, name: String): MessageParams = {
+    val message =
+      s"""|Cannot rename from $old to $name since it will change the semantics and 
+          |and might break your code. 
+          |Only rename to names ending with `:` is allowed.""".stripMargin
+    new MessageParams(MessageType.Error, message)
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -16,7 +16,6 @@ import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.mtags.GlobalSymbolIndex
 import scala.meta.io.AbsolutePath
-import scala.meta.internal.metals.Directories
 import org.eclipse.lsp4j.Location
 import scala.meta.internal.metals.MetalsLanguageClient
 import org.eclipse.lsp4j.MessageParams
@@ -235,11 +234,7 @@ final class RenameProvider(
       index
         .definition(MSymbol(symbol))
         .exists { definition =>
-          workspace.toNIO.getFileSystem == definition.path.toNIO.getFileSystem &&
-          !definition.path.toNIO
-            .startsWith(
-              workspace.resolve(Directories.readonly).toNIO
-            )
+          definition.path.isWorkspaceSource(workspace)
         }
 
     symbol.startsWith("local") || isFromWorkspace

--- a/mtags/src/main/scala/scala/meta/internal/metals/TextEdits.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/TextEdits.scala
@@ -1,4 +1,4 @@
-package tests
+package scala.meta.internal.metals
 
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.TextEdit

--- a/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -110,6 +110,9 @@ trait MtagsEnrichments {
     def isScala: Boolean = {
       toLanguage == Language.SCALA
     }
+    def isJava: Boolean = {
+      toLanguage == Language.JAVA
+    }
     def isSemanticdb: Boolean = {
       file.toNIO.getFileName.toString.endsWith(".semanticdb")
     }

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -9,6 +9,7 @@ import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.CancelToken
 import scala.collection.Seq
+import scala.meta.internal.metals.TextEdits
 
 abstract class BaseCompletionSuite extends BasePCSuite {
 

--- a/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
@@ -4,9 +4,9 @@ import tests.BasePCSuite
 import scala.meta.internal.metals.CompilerOffsetParams
 import org.eclipse.lsp4j.TextEdit
 import org.eclipse.{lsp4j => l}
-import tests.TextEdits
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.internal.metals.TextEdits
 
 abstract class BasePcDefinitionSuite extends BasePCSuite {
   def check(

--- a/tests/unit/src/main/scala/tests/TestRanges.scala
+++ b/tests/unit/src/main/scala/tests/TestRanges.scala
@@ -2,6 +2,9 @@ package tests
 
 import org.eclipse.lsp4j.DocumentHighlight
 import org.eclipse.lsp4j.Location
+import org.eclipse.lsp4j.WorkspaceEdit
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.TextEdits
 
 object TestRanges extends RangeReplace {
 
@@ -26,5 +29,19 @@ object TestRanges extends RangeReplace {
         replaceInRange(base, location.getRange)
       }
     resolved.toMap
+  }
+
+  def renderEditAsStrings(
+      sourceFiles: Map[String, String],
+      workspaceEdit: WorkspaceEdit
+  ): Map[String, String] = {
+    val resolved = for {
+      (file, code) <- sourceFiles.toSeq
+      (_, validLocations) <- workspaceEdit
+        .getChanges()
+        .asScala
+        .find(_._1.contains(file))
+    } yield file -> TextEdits.applyEdits(code, validLocations.asScala.toList)
+    sourceFiles ++ resolved.toMap
   }
 }

--- a/tests/unit/src/main/scala/tests/TestRanges.scala
+++ b/tests/unit/src/main/scala/tests/TestRanges.scala
@@ -42,11 +42,14 @@ object TestRanges extends RangeReplace {
         .asScala
         .find(
           change =>
-            change.isLeft && change.getLeft.getTextDocument.getUri
-              .contains(file)
+            change.isLeft &&
+              change.getLeft.getTextDocument.getUri.contains(file)
         )
     } yield
-      TextEdits.applyEdits(code, validLocations.getLeft.getEdits.asScala.toList)
+      TextEdits.applyEdits(
+        code,
+        validLocations.getLeft.getEdits.asScala.toList
+      )
 
   }
 }

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -41,6 +41,7 @@ import scala.meta.internal.tvp.TreeViewDidChangeParams
 import java.util.concurrent.ConcurrentHashMap
 import scala.meta.internal.decorations.DecorationOptions
 import scala.meta.internal.decorations.PublishDecorationsParams
+import scala.meta.internal.metals.TextEdits
 
 /**
  * Fake LSP client that responds to notifications/requests initiated by the server.
@@ -110,6 +111,7 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
   def workspaceClientCommands: List[String] = {
     clientCommands.asScala.toList.map(_.getCommand)
   }
+
   def statusBarHistory: String = {
     statusParams.asScala
       .map { params =>

--- a/tests/unit/src/test/scala/tests/FoldingRangeSuite.scala
+++ b/tests/unit/src/test/scala/tests/FoldingRangeSuite.scala
@@ -8,6 +8,7 @@ import tests.BuildInfo.testResourceDirectory
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.FoldingRangeProvider
 import scala.meta.io.AbsolutePath
+import scala.meta.internal.metals.TextEdits
 
 object FoldingRangeSuite extends DirectoryExpectSuite("foldingRange/expect") {
   private val buffers = Buffers()

--- a/tests/unit/src/test/scala/tests/RenameSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameSuite.scala
@@ -3,7 +3,7 @@ import scala.concurrent.Future
 
 object RenameSuite extends BaseLspSuite("rename") {
 
-  check(
+  renamed(
     "basic",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -19,7 +19,39 @@ object RenameSuite extends BaseLspSuite("rename") {
     newName = "otherRename"
   )
 
-  check(
+  renamed(
+    "unapply",
+    """|/a/src/main/scala/a/Main.scala
+       |object <<F@@oo>> {
+       |  def unapply(s: String): Option[String] = Some("")
+       |}
+       |
+       |object Main{
+       |  "foo" match {
+       |    case <<Foo>>(s) => ()
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "Bar"
+  )
+
+  renamed(
+    "unapply-param",
+    """|/a/src/main/scala/a/Main.scala
+       |object Foo {
+       |  def unapply(<<nam@@e>>: String): Option[String] = Some(<<name>>)
+       |}
+       |
+       |object Main{
+       |  "foo" match {
+       |    case Foo(name) => ()
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "str"
+  )
+
+  renamed(
     "local",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -33,7 +65,7 @@ object RenameSuite extends BaseLspSuite("rename") {
     newName = "otherRename"
   )
 
-  check(
+  renamed(
     "method",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -46,7 +78,7 @@ object RenameSuite extends BaseLspSuite("rename") {
     newName = "truth"
   )
 
-  check(
+  renamed(
     "self-type",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -61,7 +93,7 @@ object RenameSuite extends BaseLspSuite("rename") {
     newName = "Animal"
   )
 
-  check(
+  renamed(
     "method-inheritance",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -76,7 +108,7 @@ object RenameSuite extends BaseLspSuite("rename") {
     newName = "truth"
   )
 
-  check(
+  renamed(
     "long-inheritance",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -95,7 +127,7 @@ object RenameSuite extends BaseLspSuite("rename") {
     newName = "truth"
   )
 
-  check(
+  renamed(
     "multiple-inheritance",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -114,7 +146,7 @@ object RenameSuite extends BaseLspSuite("rename") {
     newName = "truth"
   )
 
-  check(
+  renamed(
     "apply",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -128,7 +160,7 @@ object RenameSuite extends BaseLspSuite("rename") {
     newName = "name"
   )
 
-  check(
+  same(
     "colon-bad",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -139,12 +171,10 @@ object RenameSuite extends BaseLspSuite("rename") {
        |  val user = new User()
        |  "" <<::>> user
        |}
-       |""".stripMargin,
-    newName = "SHOULD_NOT_BE_RENAMED",
-    notRenamed = true
+       |""".stripMargin
   )
 
-  check(
+  renamed(
     "colon-good",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -159,7 +189,7 @@ object RenameSuite extends BaseLspSuite("rename") {
     newName = "method:"
   )
 
-  check(
+  same(
     "unary-bad",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -168,14 +198,12 @@ object RenameSuite extends BaseLspSuite("rename") {
        |}
        |object Main{
        |  val user = new User()
-       |  "" <<@@!>> user
+       |  <<@@!>>user
        |}
-       |""".stripMargin,
-    newName = "SHOULD_NOT_BE_RENAMED",
-    notRenamed = true
+       |""".stripMargin
   )
 
-  check(
+  same(
     "unary-bad2",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -184,26 +212,22 @@ object RenameSuite extends BaseLspSuite("rename") {
        |}
        |object Main{
        |  val user = new User()
-       |  "" <<!>> user
+       |  <<!>>user
        |}
-       |""".stripMargin,
-    newName = "SHOULD_NOT_BE_RENAMED",
-    notRenamed = true
+       |""".stripMargin
   )
 
-  check(
+  same(
     "java-classes",
     """|/a/src/main/scala/a/Main.scala
        |package a
        |class MyException extends Exce@@ption
        |class NewException extends RuntimeException
        |class NewException2 extends RuntimeException
-       |""".stripMargin,
-    newName = "SHOULD_NOT_BE_RENAMED",
-    notRenamed = true
+       |""".stripMargin
   )
 
-  check(
+  renamed(
     "inheritance",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -214,7 +238,7 @@ object RenameSuite extends BaseLspSuite("rename") {
     newName = "Tree"
   )
 
-  check(
+  renamed(
     "companion",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -224,7 +248,7 @@ object RenameSuite extends BaseLspSuite("rename") {
     newName = "Tree"
   )
 
-  check(
+  renamed(
     "companion2",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -234,7 +258,7 @@ object RenameSuite extends BaseLspSuite("rename") {
     newName = "Tree"
   )
 
-  check(
+  renamed(
     "many-files",
     """|/a/src/main/scala/a/A.scala
        |package a
@@ -270,7 +294,7 @@ object RenameSuite extends BaseLspSuite("rename") {
     )
   )
 
-  check(
+  renamed(
     "anon",
     """|/a/src/main/scala/a/Main.scala
        |trait Methodable[T] {
@@ -291,7 +315,7 @@ object RenameSuite extends BaseLspSuite("rename") {
   )
 
   // currently not working due to issues in SemanticDB
-  // check(
+  // renamed(
   //   "macro-annotation",
   //   """|/a/src/main/scala/a/Main.scala
   //      |package a
@@ -305,8 +329,7 @@ object RenameSuite extends BaseLspSuite("rename") {
   //      |""".stripMargin,
   //   newName = "Tree"
   // )
-
-  // check(
+  // renamed(
   //   "classof",
   //   """|/a/src/main/scala/a/Main.scala
   //      |package a
@@ -317,6 +340,25 @@ object RenameSuite extends BaseLspSuite("rename") {
   //      |""".stripMargin,
   //   newName = "Animal"
   // )
+
+  def renamed(
+      name: String,
+      input: String,
+      newName: String,
+      nonOpened: Set[String] = Set.empty
+  ): Unit =
+    check(name, input, newName, notRenamed = false, nonOpened = nonOpened)
+
+  def same(
+      name: String,
+      input: String
+  ): Unit =
+    check(
+      name,
+      input,
+      "SHOULD_NOT_BE_RENAMED",
+      notRenamed = true
+    )
 
   def check(
       name: String,
@@ -331,7 +373,9 @@ object RenameSuite extends BaseLspSuite("rename") {
       case (file, code) =>
         file -> {
           if (!notRenamed) {
-            code.replaceAll("<<.*>>", newName).replaceAll("##", "")
+            code
+              .replaceAll("\\<\\<\\S*\\>\\>", newName)
+              .replaceAll("##", "")
           } else {
             code.replaceAll(allMarkersRegex, "")
           }

--- a/tests/unit/src/test/scala/tests/RenameSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameSuite.scala
@@ -1,0 +1,388 @@
+package tests
+import scala.concurrent.Future
+
+object RenameSuite extends BaseLspSuite("rename") {
+
+  check(
+    "basic",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main{
+       |  val <<toRename>> = 123
+       |}
+       |/a/src/main/scala/a/Main2.scala
+       |package a
+       |object Main2{
+       |  val toRename = Main.<<toR@@ename>>
+       |}
+       |""".stripMargin,
+    newName = "otherRename"
+  )
+
+  check(
+    "local",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main{
+       |  def hello() = {
+       |    val <<toRen@@ame>> = 123
+       |    <<toRename>>
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "otherRename"
+  )
+
+  check(
+    "method",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main{
+       |  def <<met@@hod>>(abc : String) = true
+       |
+       |  if(<<method>>("")) println("Is true!")
+       |}
+       |""".stripMargin,
+    newName = "truth"
+  )
+
+  check(
+    "self-type",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |trait <<A@@BC>>
+       |trait Alphabet{
+       |  this: <<ABC>> =>
+       |}
+       |object Main{
+       |  val a = new Alphabet with <<ABC>>
+       |}
+       |""".stripMargin,
+    newName = "Animal"
+  )
+
+  check(
+    "method-inheritance",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |trait Hello{
+       |  def <<method>>(abc : String) : Boolean
+       |}
+       |
+       |class GoodMorning extends Hello {
+       |  def <<met@@hod>>(abc : String) = true
+       |}
+       |""".stripMargin,
+    newName = "truth"
+  )
+
+  check(
+    "long-inheritance",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |trait A[T, S] {
+       |  def <<method>>(abc : T) : S
+       |}
+       |
+       |abstract class B[T] extends A[T, Boolean] {
+       |  def <<method>>(abc : T) : Boolean
+       |}
+       |
+       |abstract class C extends B[String] {
+       |  def <<meth@@od>>(abc : String) : Boolean = false
+       |}
+       |""".stripMargin,
+    newName = "truth"
+  )
+
+  check(
+    "multiple-inheritance",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |trait A {
+       |  def <<method>>(abc : String) : Boolean
+       |}
+       |
+       |trait B {
+       |  def <<method>>(abc : String) : Boolean = true
+       |}
+       |
+       |abstract class C extends B with A {
+       |  override def <<meth@@od>>(abc : String) : Boolean = false
+       |}
+       |""".stripMargin,
+    newName = "truth"
+  )
+
+  check(
+    "apply",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object User{
+       |  def <<ap@@ply>>(name : String) = name
+       |}
+       |object Main{
+       |  val toRename = User##.##<<>>("abc")
+       |}
+       |""".stripMargin,
+    newName = "name"
+  )
+
+  check(
+    "colon-bad",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |class User{
+       |  def <<:@@:>>(name : String) = name
+       |}
+       |object Main{
+       |  val user = new User()
+       |  "" <<::>> user
+       |}
+       |""".stripMargin,
+    newName = "SHOULD_NOT_BE_RENAMED",
+    notRenamed = true
+  )
+
+  check(
+    "colon-good",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |class User{
+       |  def <<:@@:>>(name : String) = name
+       |}
+       |object Main{
+       |  val user = new User()
+       |  "" <<::>> user
+       |}
+       |""".stripMargin,
+    newName = "method:"
+  )
+
+  check(
+    "unary-bad",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |class User{
+       |  def <<unary_!>> = false
+       |}
+       |object Main{
+       |  val user = new User()
+       |  "" <<@@!>> user
+       |}
+       |""".stripMargin,
+    newName = "SHOULD_NOT_BE_RENAMED",
+    notRenamed = true
+  )
+
+  check(
+    "unary-bad2",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |class User{
+       |  def <<u@@nary_!>> = false
+       |}
+       |object Main{
+       |  val user = new User()
+       |  "" <<!>> user
+       |}
+       |""".stripMargin,
+    newName = "SHOULD_NOT_BE_RENAMED",
+    notRenamed = true
+  )
+
+  check(
+    "java-classes",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |class MyException extends Exce@@ption
+       |class NewException extends RuntimeException
+       |class NewException2 extends RuntimeException
+       |""".stripMargin,
+    newName = "SHOULD_NOT_BE_RENAMED",
+    notRenamed = true
+  )
+
+  check(
+    "inheritance",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |abstract class <<An@@imal>>
+       |class Dog extends <<Animal>>
+       |class Cat extends <<Animal>>
+       |""".stripMargin,
+    newName = "Tree"
+  )
+
+  check(
+    "companion",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |class <<Main>>{}
+       |object <<M@@ain>>
+       |""".stripMargin,
+    newName = "Tree"
+  )
+
+  check(
+    "companion2",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |class <<Ma@@in>>{}
+       |object <<Main>>
+       |""".stripMargin,
+    newName = "Tree"
+  )
+
+  check(
+    "many-files",
+    """|/a/src/main/scala/a/A.scala
+       |package a
+       |object A {
+       |  def <<ren@@ameIt>>(a : String) = ""
+       |}
+       |/a/src/main/scala/a/B.scala
+       |package a
+       |object B {
+       |  val str = A.<<renameIt>>("")
+       |}
+       |/a/src/main/scala/a/C.scala
+       |package a
+       |object C {
+       |  val str = A.<<renameIt>>("")
+       |}
+       |/a/src/main/scala/a/D.scala
+       |package a
+       |object D {
+       |  val str = A.<<renameIt>>("")
+       |}
+       |/a/src/main/scala/a/E.scala
+       |package a
+       |object E {
+       |  val str = A.<<renameIt>>("")
+       |}
+       |""".stripMargin,
+    newName = "iAmRenamed",
+    nonOpened = Set(
+      "a/src/main/scala/a/C.scala",
+      "a/src/main/scala/a/D.scala",
+      "a/src/main/scala/a/E.scala"
+    )
+  )
+
+  check(
+    "anon",
+    """|/a/src/main/scala/a/Main.scala
+       |trait Methodable[T] {
+       |  def <<method>>(asf: T): Int
+       |}
+       |
+       |trait Alphabet extends Methodable[String] {
+       |  def <<method>>(adf: String) = 123
+       |}
+       |
+       |object Main {
+       |  val a = new Alphabet {
+       |    override def <<me@@thod>>(adf: String): Int = 321
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "renamed"
+  )
+
+  // currently not working due to issues in SemanticDB
+  // check(
+  //   "macro-annotation",
+  //   """|/a/src/main/scala/a/Main.scala
+  //      |package a
+  //      |import io.circe.generic.JsonCodec
+  //      |trait LivingBeing
+  //      |@JsonCodec sealed trait <<An@@imal>> extends LivingBeing
+  //      |object Animal {
+  //      |  case object Dog extends <<Animal>>
+  //      |  case object Cat extends <<Animal>>
+  //      |}
+  //      |""".stripMargin,
+  //   newName = "Tree"
+  // )
+
+  // check(
+  //   "classof",
+  //   """|/a/src/main/scala/a/Main.scala
+  //      |package a
+  //      |trait <<A@@BC>>
+  //      |object Main{
+  //      |  val a = classOf[<<A@@BC>>]
+  //      |}
+  //      |""".stripMargin,
+  //   newName = "Animal"
+  // )
+
+  def check(
+      name: String,
+      input: String,
+      newName: String,
+      notRenamed: Boolean = false,
+      nonOpened: Set[String] = Set.empty
+  ): Unit = {
+    val allMarkersRegex = "(<<|>>|@@|##.*##)"
+    val files = FileLayout.mapFromString(input)
+    val expectedFiles = files.map {
+      case (file, code) =>
+        file -> {
+          if (!notRenamed) {
+            code.replaceAll("<<.*>>", newName).replaceAll("##", "")
+          } else {
+            code.replaceAll(allMarkersRegex, "")
+          }
+        }
+    }
+    val base = files.map {
+      case (fileName, code) =>
+        fileName -> code.replaceAll(allMarkersRegex, "")
+    }
+
+    val (filename, edit) = files
+      .find(_._2.contains("@@"))
+      .getOrElse {
+        throw new IllegalArgumentException(
+          "No `@@` was defined that specifies cursor position"
+        )
+      }
+
+    testAsync(name) {
+      cleanWorkspace()
+      for {
+        _ <- server.initialize(
+          s"""/metals.json
+             |{"a":
+             |  {
+             |    "compilerPlugins": [
+             |      "org.scalamacros:::paradise:2.1.1"
+             |    ],
+             |    "libraryDependencies": [
+             |      "org.scalatest::scalatest:3.0.5",
+             |      "io.circe::circe-generic:0.12.0"
+             |    ]
+             |  }
+             |}
+             |${input.replaceAll(allMarkersRegex, "")}""".stripMargin
+        )
+        _ <- Future.sequence(
+          files
+            .filterNot(file => nonOpened.contains(file._1))
+            .map { file =>
+              server.didOpen(s"${file._1}")
+            }
+        )
+        _ <- server.assertRename(
+          filename,
+          edit.replaceAll("(<<|>>)", ""),
+          expectedFiles,
+          base.toMap,
+          newName
+        )
+      } yield ()
+    }
+  }
+}

--- a/tests/unit/src/test/scala/tests/RenameSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameSuite.scala
@@ -368,32 +368,50 @@ object RenameSuite extends BaseLspSuite("rename") {
     breakingChange = (str: String) => str.replaceAll("Int", "String")
   )
 
-  // currently not working due to issues in SemanticDB
-  // renamed(
-  //   "macro-annotation",
-  //   """|/a/src/main/scala/a/Main.scala
-  //      |package a
-  //      |import io.circe.generic.JsonCodec
-  //      |trait LivingBeing
-  //      |@JsonCodec sealed trait <<An@@imal>> extends LivingBeing
-  //      |object Animal {
-  //      |  case object Dog extends <<Animal>>
-  //      |  case object Cat extends <<Animal>>
-  //      |}
-  //      |""".stripMargin,
-  //   newName = "Tree"
-  // )
-  // renamed(
-  //   "classof",
-  //   """|/a/src/main/scala/a/Main.scala
-  //      |package a
-  //      |trait <<A@@BC>>
-  //      |object Main{
-  //      |  val a = classOf[<<A@@BC>>]
-  //      |}
-  //      |""".stripMargin,
-  //   newName = "Animal"
-  // )
+  // tests currently not working correctly due to issues in SemanticDB
+  // issue https://github.com/scalameta/scalameta/issues/1636
+  renamed(
+    "params",
+    """|/a/src/main/scala/a/Main.scala
+       |case class Name(<<va@@lue>>: String)
+       |
+       |object Main {
+       |  val name1 = Name(value = "42")
+       |   .copy(<<value>> = "43")
+       |   .<<value>>
+       |  val name2 = new Name(value = "44")
+       |}
+       |""".stripMargin,
+    newName = "name"
+  )
+
+  same(
+    "macro-annotation",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |import io.circe.generic.JsonCodec
+       |trait LivingBeing
+       |@JsonCodec sealed trait <<An@@imal>> extends LivingBeing
+       |object Animal {
+       |  case object Dog extends <<Animal>>
+       |  case object Cat extends <<Animal>>
+       |}
+       |""".stripMargin
+  )
+
+  renamed(
+    "type-params",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |trait <<A@@BC>>
+       |class CBD[T <: <<AB@@C>>]
+       |object Main{
+       |  val a = classOf[ABC]
+       |  val b = new CBD[<<ABC>>]
+       |}
+       |""".stripMargin,
+    newName = "Animal"
+  )
 
   def renamed(
       name: String,


### PR DESCRIPTION
Previously, rename was not supported in any way. User would have to manually rename everything by hand and that could prove really tedious. Now, we offer renaming of any symbol with a small number of exclusions:
- unapply
- equals
- hashCode
- unary_!
- !

We can also add/remove other exclusions if needed.

There are also some special cases and several approaches that need to be mentioned:

1. When apply is renamed we add full name to each invocation

![renamed](https://user-images.githubusercontent.com/3807253/68298589-0eb61900-009a-11ea-8e61-e5c00141896b.gif)

2. Symbols can't be renamed while compiling, since we need full and correct semanticDB information - an error will pop up as a message.
3. Methods ending with colon can only be renamed to another name ending with colon. 
4. Renaming an overriden method will rename both parent symbol and current symbol:
![rename-inherit](https://user-images.githubusercontent.com/3807253/68299380-df081080-009b-11ea-8da9-177ece31d530.gif)

5. Symbols from outside workspace cannot be renamed.
6. Companion objects and classes are renamed.
![companion](https://user-images.githubusercontent.com/3807253/68310441-4fb92800-00b0-11ea-9357-7e4529743973.gif)

Currently not working:
- type reference such as `classOf[MyClass]` or `[T <: MyClass]`
- we don't check operator precedence when they are renamed
- we rename all parent's overriden methods by default - we might want to ask about that, however MessageRequest doesn't seem a pretty way to do it (might be mistaken).

Fixes https://github.com/scalameta/metals/issues/679