### PR TITLE
Add an empty line after the package declaration before import

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/AutoImports.scala
@@ -10,7 +10,7 @@ trait AutoImports { this: MetalsGlobal =>
    * @param offset the offset where to place the import.
    * @param indent the indentation at which to place the import.
    * @param padTop whether the import needs to be padded on top
-   *               in the case that it is the first one after the pacage def
+   *               in the case that it is the first one after the package def
    */
   case class AutoImportPosition(
       offset: Int,
@@ -54,20 +54,22 @@ trait AutoImports { this: MetalsGlobal =>
           case Some(pkg)
               if pkg.symbol != rootMirror.EmptyPackage ||
                 pkg.stats.headOption.exists(_.isInstanceOf[Import]) =>
-            val lastImport: (Tree, Boolean) = pkg.stats
+            val lastImport = pkg.stats
               .takeWhile(_.isInstanceOf[Import])
-              .lastOption // if there are no imports, return true to pad top of import
-              .fold[(Tree, Boolean)]((pkg.pid, true))((tree => (tree, false)))
+              .lastOption
+
+            val padTop = lastImport.isEmpty
+            val lastImportOrPkg = lastImport.getOrElse(pkg.pid)
 
             Some(
               new AutoImportPosition(
-                pos.source.lineToOffset(lastImport._1.pos.focusEnd.line),
+                pos.source.lineToOffset(lastImportOrPkg.pos.focusEnd.line),
                 text,
-                lastImport._2
+                padTop
               )
             )
           case _ =>
-            Some(AutoImportPosition(0, 0, false))
+            Some(AutoImportPosition(0, 0, padTop = false))
         }
     }
   }

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -1096,7 +1096,7 @@ trait Completions { this: MetalsGlobal =>
       val baseAutoImport: Option[AutoImportPosition] =
         autoImportPosition(pos, text)
       val autoImport: AutoImportPosition = baseAutoImport.getOrElse(
-        AutoImportPosition(lineStart, inferIndent(lineStart, text))
+        AutoImportPosition(lineStart, inferIndent(lineStart, text), false)
       )
       val importContext: Context =
         if (baseAutoImport.isDefined)
@@ -1175,7 +1175,8 @@ trait Completions { this: MetalsGlobal =>
             pos,
             importContext,
             autoImport.offset,
-            autoImport.indent
+            autoImport.indent,
+            autoImport.padTop
           ),
           details
         )

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -1096,7 +1096,11 @@ trait Completions { this: MetalsGlobal =>
       val baseAutoImport: Option[AutoImportPosition] =
         autoImportPosition(pos, text)
       val autoImport: AutoImportPosition = baseAutoImport.getOrElse(
-        AutoImportPosition(lineStart, inferIndent(lineStart, text), false)
+        AutoImportPosition(
+          lineStart,
+          inferIndent(lineStart, text),
+          padTop = false
+        )
       )
       val importContext: Context =
         if (baseAutoImport.isDefined)

--- a/mtags/src/main/scala/scala/meta/internal/pc/Signatures.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Signatures.scala
@@ -59,7 +59,8 @@ trait Signatures { this: MetalsGlobal =>
         pos,
         scope,
         importPosition.offset,
-        importPosition.indent
+        importPosition.indent,
+        importPosition.padTop
       )
       (tpeString, edits)
     }
@@ -175,7 +176,8 @@ trait Signatures { this: MetalsGlobal =>
         pos: Position,
         context: Context,
         lineStart: Int,
-        inferIndent: => Int
+        inferIndent: => Int,
+        padTop: Boolean
     ): List[l.TextEdit] = {
       val toImport = mutable.Map.empty[Symbol, List[ShortName]]
       val isRootSymbol = Set[Symbol](
@@ -192,6 +194,9 @@ trait Signatures { this: MetalsGlobal =>
       }
       if (toImport.nonEmpty) {
         val indent = " " * inferIndent
+        val topPadding =
+          if (padTop) "\n"
+          else ""
         val scope = new ShortenedNames(context)
         val formatted = toImport.toSeq
           .sortBy {
@@ -208,7 +213,7 @@ trait Signatures { this: MetalsGlobal =>
                 else importNames.mkString
               s"${indent}import ${scope.fullname(owner)}.${name}"
           }
-          .mkString("", "\n", "\n")
+          .mkString(topPadding, "\n", "\n")
         val startPos = pos.withPoint(lineStart).focus
         new l.TextEdit(startPos.toLSP, formatted) :: Nil
       } else {

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -53,6 +53,7 @@ object CompletionIssueSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """
       |package a
+      |
       |import a.A.Nested.NestedLeaf
       |object A {
       |  object Nested{
@@ -130,7 +131,7 @@ object CompletionIssueSuite extends BaseCompletionSuite {
        |object Main {
        |  Array(1, 1,10)
        |  .map(_ + 1) // comment breaks completions
-       |  .fil@@ 
+       |  .fil@@
        |}
        |""".stripMargin,
     """|filter(p: Int => Boolean): Array[Int]
@@ -146,7 +147,7 @@ object CompletionIssueSuite extends BaseCompletionSuite {
        |object Main {
        |  Array(1, 1,10)
        |  .map(_ + 1) // comment breaks completions
-       |  . fil@@ 
+       |  . fil@@
        |}
        |""".stripMargin,
     """|filter(p: Int => Boolean): Array[Int]
@@ -162,7 +163,7 @@ object CompletionIssueSuite extends BaseCompletionSuite {
        |object Main {
        |  Array(1, 1,10)
        |  .map(_ + 1) /* comment breaks completions */
-       |  .fil@@ 
+       |  .fil@@
        |}
        |""".stripMargin,
     """|filter(p: Int => Boolean): Array[Int]

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
@@ -30,6 +30,7 @@ object CompletionOverrideConfigSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|package a
+       |
        |import a.{Weekday => w}
        |object Weekday {
        |  case class Monday()
@@ -54,6 +55,7 @@ object CompletionOverrideConfigSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|package b
+       |
        |import java.util.{function => f}
        |class Package {
        |  def function: java.util.function.Function[Int, String]

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -346,6 +346,7 @@ object CompletionOverrideSuite extends BaseCompletionSuite {
        |""".stripMargin,
     // Ensure we don't insert `_root_` prefix for import because `val java = 42` is local.
     """|package jutil
+       |
        |import java.{util => ju}
        |abstract class JUtil {
        |  def foo: java.util.List[Int]

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -12,6 +12,7 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|package pkg
+       |
        |import java.nio.file.Files
        |object Main {
        |  val x = Files
@@ -70,6 +71,7 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|package `import-conflict`
+       |
        |import java.nio.file.Files
        |object Main {
        |  val java = 42
@@ -88,6 +90,7 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|package `import-conflict2`
+       |
        |import _root_.java.nio.file.Files
        |object java
        |object Main {
@@ -103,6 +106,7 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |object Main extends CompletableFutur@@
       |""".stripMargin,
     """package pkg
+      |
       |import java.util.concurrent.CompletableFuture
       |object Main extends CompletableFuture
       |""".stripMargin
@@ -114,6 +118,7 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |object Main extends CompletableFu@@ture
       |""".stripMargin,
     """package pkg
+      |
       |import java.util.concurrent.CompletableFuture
       |object Main extends CompletableFuture
       |""".stripMargin
@@ -261,6 +266,7 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|package pkg
+       |
        |import java.nio.file.Files
        |object Main {
        |  List(1).collect {
@@ -284,6 +290,7 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|package pkg
+       |
        |import java.nio.file.Files
        |object Main {
        |  for {
@@ -310,6 +317,7 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|package pkg
+       |
        |import java.nio.file.Files
        |object Main {
        |  for {
@@ -337,6 +345,7 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|package pkg
+       |
        |import java.nio.file.Files
        |object Main {
        |  for {
@@ -392,6 +401,7 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|package annotationclass
+       |
        |import scala.collection.mutable
        |object Main {
        |  @deprecated("", "")
@@ -410,6 +420,7 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|package annotationtrait
+       |
        |import scala.collection.mutable
        |object Main {
        |  @deprecated("", "")
@@ -427,6 +438,7 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |)
        |""".stripMargin,
     """|package classparam
+       |
        |import scala.concurrent.Future
        |case class Foo(
        |  name: Future[String]
@@ -446,6 +458,7 @@ object CompletionWorkspaceSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|package docstring
+       |
        |import scala.concurrent.Future
        |/**
        | * Hello


### PR DESCRIPTION
This will close #1054

Checks to see if there are any imports and if not, but there is a package declaration, it will add an extra new line to add padding between the package declaration and the first import.

![2019-11-08 14 03 05](https://user-images.githubusercontent.com/13974112/68478631-9fbef880-0230-11ea-9451-a3858567c3a2.gif)
