### PR TITLE
Give Bloop more visibility on the website.

### DIFF
--- a/docs/build-tools/overview.md
+++ b/docs/build-tools/overview.md
@@ -7,16 +7,20 @@ sidebar_label: Overview
 Metals works with the following build tools with varying degree of
 functionality.
 
-| Build tool | Installation | Goto library dependencies | Find references      |
-| ---------- | :----------: | :-----------------------: | :------------------: |
-| sbt        |  Automatic   |      Automatic            |     Automatic        |
-| Bloop      |  Automatic   |    Semi-automatic         |   Semi-automatic     |
-| Maven      |  Automatic   |      Automatic            |   Semi-automatic     |
-| Gradle     |  Automatic   |      Automatic            |     Automatic        |
-| Mill       |  Automatic   |      Automatic            |     Automatic        |
-
+| Build tool |    Installation     | Goto library dependencies | Find references |
+| ---------- | :-----------------: | :-----------------------: | :-------------: |
+| sbt        | Automatic via Bloop |         Automatic         |    Automatic    |
+| Maven      | Automatic via Bloop |         Automatic         | Semi-automatic  |
+| Gradle     | Automatic via Bloop |         Automatic         |    Automatic    |
+| Mill       | Automatic via Bloop |         Automatic         |    Automatic    |
+| Bloop      |      Automatic      |      Semi-automatic       | Semi-automatic  |
 
 ## Installation
+
+**Automatic via Bloop**: you can import the build directly from the language
+server without the need for running custom steps in the terminal. The build is
+exported to [Bloop](https://scalacenter.github.io/bloop/), a Scala build server
+that provides fast incremental compilation.
 
 **Automatic**: you can import the build directly from the language server
 without the need for running custom steps in the terminal. To use automatic
@@ -32,11 +36,11 @@ compiler plugin and `-Yrangepos` option enabled.
 
 ## Goto library dependencies
 
-**Automatic**: it is possible to navigate Scala+Java library dependencies using "Goto
-definition".
+**Automatic**: it is possible to navigate Scala+Java library dependencies using
+"Goto definition".
 
-**Semi-automatic**: navigation in library dependency sources works as
-long as the
+**Semi-automatic**: navigation in library dependency sources works as long as
+the
 [Bloop JSON files](https://scalacenter.github.io/bloop/docs/configuration-format/)
 are populated with `*-sources.jar`.
 
@@ -44,7 +48,9 @@ are populated with `*-sources.jar`.
 
 **Automatic**: it is possible to find all references to a symbol in the project
 
-**Semi-automatic**: it is possible to 'Find symbol references' as soon the SemanticDB compiler plugin is manually enabled in the build, check separate build tool pages for details.
+**Semi-automatic**: it is possible to 'Find symbol references' as soon the
+SemanticDB compiler plugin is manually enabled in the build, check separate
+build tool pages for details.
 
 ## Integrating a new build tool
 

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -95,16 +95,25 @@ const Features = props => {
     {
       title: "Accurate diagnostics",
       content:
-        "Compile on file save and see errors from the build tool, no more spurious red squiggles or switching focus to the console.",
+        "Compile on file save and see errors from the build tool inside the editor, no more switching focus to the console.",
       image: "https://i.imgur.com/JYLQGrc.gif",
       imageAlign: "right"
+    },
+    {
+      title: "Rich build tool support",
+      content:
+        `The build tools sbt, Gradle, Maven and Mill are supported thanks to <a href="https://scalacenter.github.io/bloop/">Bloop</a>. ` +
+        `Hot incremental compilation in the Bloop build server ensures compile errors appear as quickly as possible.`,
+      image:
+        "https://user-images.githubusercontent.com/1408093/68486864-dd9f2b00-01f6-11ea-9291-d3a7ce6ef225.png",
+      imageAlign: "left"
     },
     {
       title: "Goto definition",
       content:
         "Jump to symbol definitions in your project sources and Scala/Java library dependencies.",
       image: "https://i.imgur.com/bCIhFof.gif",
-      imageAlign: "left"
+      imageAlign: "right"
     },
     {
       title: "Completions",
@@ -112,33 +121,33 @@ const Features = props => {
         "Explore new library APIs, implement interfaces, generate exhaustive matches and more.",
       image:
         "https://user-images.githubusercontent.com/1408093/56036958-725bac00-5d2e-11e9-9cf7-46249125494a.gif",
-      imageAlign: "right"
+      imageAlign: "left"
     },
     {
       title: "Hover (aka. type at point)",
       content: "See the expression type and symbol signature under the cursor.",
       image: "https://i.imgur.com/2MfQvsM.gif",
-      imageAlign: "left"
+      imageAlign: "right"
     },
     {
       title: "Signature help (aka. parameter hints)",
       content:
         "View a method signature and method overloads as you fill in the arguments.",
       image: "https://i.imgur.com/DAWIrHu.gif",
-      imageAlign: "right"
+      imageAlign: "left"
     },
     {
       title: "Find symbol references",
       content: "Find all usages of a symbol in the workspace.",
       image:
         "https://user-images.githubusercontent.com/1408093/51089190-75fc8880-1769-11e9-819c-95262205e95c.png",
-      imageAlign: "left"
+      imageAlign: "right"
     },
     {
       title: "Fuzzy symbol search",
       content: "Search for symbols in the workspace or library dependencies.",
       image: "https://i.imgur.com/w5yrK1w.gif",
-      imageAlign: "right"
+      imageAlign: "left"
     }
   ];
   return (


### PR DESCRIPTION
Previously, the website made it appear as if Bloop was an implementation
detail of Metals. Now, the website tries to give Bloop more visibility
and advertise it as an essential part of the Metals user experience (low
latency diagnostics, testing, running, soon debugging).

Metals still continues to work with other BSP servers. Nothing changes on the implementation side.

<img width="889" alt="Screenshot 2019-11-08 at 07 11 43" src="https://user-images.githubusercontent.com/1408093/68487474-fc51f180-01f7-11ea-841d-f6ce3cce194b.png">

<img width="554" alt="Screenshot 2019-11-08 at 07 13 18" src="https://user-images.githubusercontent.com/1408093/68487464-f9ef9780-01f7-11ea-95e1-c08769a2012f.png">
