### PR TITLE
Respect client capabilities for completion item snippets

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -6,6 +6,7 @@ import ch.epfl.scala.bsp4j.ScalaBuildTarget
 import ch.epfl.scala.bsp4j.ScalacOptionsItem
 import java.util.Collections
 import java.util.concurrent.ScheduledExecutorService
+import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.CompletionParams
@@ -40,7 +41,8 @@ class Compilers(
     search: SymbolSearch,
     embedded: Embedded,
     statusBar: StatusBar,
-    sh: ScheduledExecutorService
+    sh: ScheduledExecutorService,
+    initializeParams: Option[InitializeParams]
 )(implicit ec: ExecutionContextExecutorService)
     extends Cancelable {
   val plugins = new CompilerPlugins()
@@ -247,7 +249,11 @@ class Compilers(
       .withExecutorService(ec)
       .withScheduledExecutorService(sh)
       .withConfiguration(
-        config.compilers.copy(_symbolPrefixes = userConfig().symbolPrefixes)
+        config.compilers.copy(
+          _symbolPrefixes = userConfig().symbolPrefixes,
+          isCompletionSnippetsEnabled =
+            initializeParams.supportsCompletionSnippets
+        )
       )
 
   def newCompiler(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -509,6 +509,16 @@ object MetalsEnrichments
         )
       } yield hierarchicalDocumentSymbolSupport.booleanValue).getOrElse(false)
 
+    def supportsCompletionSnippets: Boolean =
+      (for {
+        params <- initializeParams
+        capabilities <- Option(params.getCapabilities)
+        textDocument <- Option(capabilities.getTextDocument)
+        completion <- Option(textDocument.getCompletion)
+        completionItem <- Option(completion.getCompletionItem)
+        snippetSupport <- Option(completionItem.getSnippetSupport())
+      } yield snippetSupport.booleanValue).getOrElse(false)
+
   }
 
   implicit class XtensionPromise[T](promise: Promise[T]) {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -381,7 +381,8 @@ class MetalsLanguageServer(
         ),
         embedded,
         statusBar,
-        sh
+        sh,
+        Option(params)
       )
     )
     doctor = new Doctor(

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -65,6 +65,11 @@ public interface PresentationCompilerConfig {
     boolean isSignatureHelpDocumentationEnabled();
 
     /**
+     * Returns true if completions can contain snippets.
+     */
+    boolean isCompletionSnippetsEnabled();
+
+    /**
      * The maximum delay for requests to respond.
      *
      * After the given delay, every request to completions/hover/signatureHelp

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -16,8 +16,7 @@ import org.eclipse.{lsp4j => l}
 
 class CompletionProvider(
     val compiler: MetalsGlobal,
-    params: OffsetParams,
-    clientSupportsSnippets: Boolean
+    params: OffsetParams
 ) {
   import compiler._
 
@@ -45,6 +44,8 @@ class CompletionProvider(
     )
     val pos = unit.position(params.offset)
     val isSnippet = isSnippetEnabled(pos, params.text())
+    val clientSupportsSnippets =
+      compiler.metalsConfig.isCompletionSnippetsEnabled()
     val (i, completion, editRange, query) = safeCompletionsAt(pos)
     val start = inferIdentStart(pos, params.text())
     val end = inferIdentEnd(pos, params.text())

--- a/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
@@ -573,11 +573,11 @@ class MetalsGlobal(
 
     def snippetCursor: String = sym.paramss match {
       case Nil =>
-        "$0"
+        if (clientSupportsSnippets) "$0" else ""
       case Nil :: Nil =>
-        "()$0"
+        if (clientSupportsSnippets) "()$0" else "()"
       case _ =>
-        "($0)"
+        if (clientSupportsSnippets) "($0)" else ""
     }
 
     def isDefined: Boolean =

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -18,6 +18,7 @@ case class PresentationCompilerConfigImpl(
     isCompletionItemDocumentationEnabled: Boolean = true,
     isHoverDocumentationEnabled: Boolean = true,
     isSignatureHelpDocumentationEnabled: Boolean = true,
+    isCompletionSnippetsEnabled: Boolean = true,
     isCompletionItemResolve: Boolean = true,
     timeoutDelay: Long = 20,
     timeoutUnit: TimeUnit = TimeUnit.SECONDS

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -85,8 +85,7 @@ case class ScalaPresentationCompiler(
       params: OffsetParams
   ): CompletableFuture[CompletionList] =
     access.withInterruptableCompiler(emptyCompletion, params.token) { global =>
-      new CompletionProvider(global, params, config.isCompletionSnippetsEnabled)
-        .completions()
+      new CompletionProvider(global, params).completions()
     }
 
   // NOTE(olafur): hover and signature help use a "shared" compiler instance because

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -85,7 +85,8 @@ case class ScalaPresentationCompiler(
       params: OffsetParams
   ): CompletableFuture[CompletionList] =
     access.withInterruptableCompiler(emptyCompletion, params.token) { global =>
-      new CompletionProvider(global, params).completions()
+      new CompletionProvider(global, params, config.isCompletionSnippetsEnabled)
+        .completions()
     }
 
   // NOTE(olafur): hover and signature help use a "shared" compiler instance because

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetNegSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetNegSuite.scala
@@ -1,0 +1,76 @@
+package tests.pc
+
+import tests.BaseCompletionSuite
+import scala.meta.pc.PresentationCompilerConfig
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
+
+object CompletionSnippetNegSuite extends BaseCompletionSuite {
+
+  override def config: PresentationCompilerConfig =
+    PresentationCompilerConfigImpl(
+      isCompletionSnippetsEnabled = false
+    )
+
+  checkSnippet(
+    "member",
+    """
+      |object Main {
+      |  List.appl@@
+      |}
+      |""".stripMargin,
+    """|apply
+       |unapplySeq
+       |""".stripMargin,
+    compat = Map(
+      "2.13" ->
+        // the second apply is from scala/collection/BuildFrom#apply(), introduced in 2.13
+        """|apply
+           |unapplySeq
+           |apply
+           |""".stripMargin
+    )
+  )
+
+  checkSnippet(
+    "scope",
+    """
+      |object Main {
+      |  printl@@
+      |
+      |}
+      |""".stripMargin,
+    """|println()
+       |println
+       |""".stripMargin
+  )
+
+  checkSnippet(
+    "java-nullary",
+    """
+      |class Foo {
+      |  override def toString = "Foo"
+      |}
+      |object Main {
+      |  new Foo().toStrin@@
+      |
+      |}
+      |""".stripMargin,
+    // even if `Foo.toString` is nullary, it overrides `Object.toString()`
+    // which is a Java non-nullary method with an empty parameter list.
+    """|toString()
+       |""".stripMargin
+  )
+
+  checkSnippet(
+    "type",
+    s"""|object Main {
+        |  val x: scala.IndexedSe@@
+        |}
+        |""".stripMargin,
+    // It's expected to have two separate results, one for `object IndexedSeq` and one for `type IndexedSeq[T]`.
+    """|IndexedSeq
+       |IndexedSeq
+       |""".stripMargin
+  )
+
+}


### PR DESCRIPTION
Fixes #1055 

Previously we always used snippets in completion items, regardless of whether the client declared that it supported them. Now we respect the capabilities declared by the client.