### PR TITLE
Update Sublime settings since it does have auto-indent

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -152,8 +152,7 @@ object MetalsServerConfig {
           isExitOnShutdown = true,
           compilers = base.compilers.copy(
             // Avoid showing the method signature twice because it's already visible in the label.
-            isCompletionItemDetailEnabled = false,
-            snippetAutoIndent = false
+            isCompletionItemDetailEnabled = false
           )
         )
       case "emacs" =>


### PR DESCRIPTION
I was doing some testing with this pr https://github.com/tomv564/LSP/pull/772 to see how it would work with the new "implement all memebers" and it seems that Submlime does put in the auto-ident just like VS-Code and Atom does. I originally had this marked to false for Sublime causing it to look like so in Sublime
```
object Main {
	trait Foo {
		def foo: Int
		def bar: Int
		def car: Int
	}

	val x = new Foo {
		def foo: Int = ???
		  def bar: Int = ???
		  def car: Int = ???
	}
}
```
This will fix that.