### PR TITLE
Implement code action for importing missing symbols

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -1,0 +1,28 @@
+package scala.meta.internal.metals
+
+import org.eclipse.{lsp4j => l}
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.concurrent.Future
+import scala.meta.pc.CancelToken
+import scala.concurrent.ExecutionContext
+
+final class CodeActionProvider(
+    compilers: Compilers
+) extends QuickFixes {
+
+  def codeActions(
+      params: l.CodeActionParams,
+      token: CancelToken
+  )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = {
+    for {
+      quickFixes <- QuickFix.fromDiagnostics(
+        params.getContext().getDiagnostics().asScala.toSeq,
+        params,
+        compilers,
+        token
+      )
+    } yield quickFixes
+
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -1,26 +1,26 @@
 package scala.meta.internal.metals
 
 import org.eclipse.{lsp4j => l}
-import scala.meta.internal.metals.MetalsEnrichments._
-import scala.concurrent.Future
 import scala.meta.pc.CancelToken
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 final class CodeActionProvider(
     compilers: Compilers
-) extends QuickFixes {
+) {
 
   def codeActions(
       params: l.CodeActionParams,
       token: CancelToken
   )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = {
+
     for {
-      quickFixes <- QuickFix.fromDiagnostics(
-        params.getContext().getDiagnostics().asScala.toSeq,
-        params,
-        compilers,
-        token
-      )
+      quickFixes <- Future
+        .sequence(
+          List(QuickFix.ImportMissingSymbol)
+            .map(_.contribute(params, compilers, token))
+        )
+        .map(_.flatten)
     } yield quickFixes
 
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -25,6 +25,8 @@ import scala.meta.pc.PresentationCompiler
 import scala.meta.pc.SymbolSearch
 import scala.concurrent.Future
 import java.{util => ju}
+import org.eclipse.lsp4j.CodeActionParams
+import scala.meta.pc.AutoImportsResult
 
 /**
  * Manages lifecycle for presentation compilers in all build targets.
@@ -150,6 +152,20 @@ class Compilers(
       pc.complete(CompilerOffsetParams.fromPos(pos, token)).asScala
     }.getOrElse(Future.successful(new CompletionList()))
 
+  def autoImports(
+      params: CodeActionParams,
+      name: String,
+      token: CancelToken
+  ): Future[ju.List[AutoImportsResult]] = {
+    val textDocumentPositionParams = new TextDocumentPositionParams(
+      params.getTextDocument(),
+      params.getRange().getEnd()
+    )
+    withPC(textDocumentPositionParams, None) { (pc, pos) =>
+      pc.autoImports(name, CompilerOffsetParams.fromPos(pos, token)).asScala
+    }.getOrElse(Future.successful(new ju.ArrayList))
+  }
+
   def hover(
       params: TextDocumentPositionParams,
       token: CancelToken,
@@ -162,6 +178,7 @@ class Compilers(
     }.getOrElse {
       Future.successful(Option.empty)
     }
+
   def definition(
       params: TextDocumentPositionParams,
       token: CancelToken
@@ -178,6 +195,7 @@ class Compilers(
           )
         }
     }.getOrElse(Future.successful(DefinitionResult.empty))
+
   def signatureHelp(
       params: TextDocumentPositionParams,
       token: CancelToken,

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -25,7 +25,6 @@ import scala.meta.pc.PresentationCompiler
 import scala.meta.pc.SymbolSearch
 import scala.concurrent.Future
 import java.{util => ju}
-import org.eclipse.lsp4j.CodeActionParams
 import scala.meta.pc.AutoImportsResult
 
 /**
@@ -153,15 +152,11 @@ class Compilers(
     }.getOrElse(Future.successful(new CompletionList()))
 
   def autoImports(
-      params: CodeActionParams,
+      params: TextDocumentPositionParams,
       name: String,
       token: CancelToken
   ): Future[ju.List[AutoImportsResult]] = {
-    val textDocumentPositionParams = new TextDocumentPositionParams(
-      params.getTextDocument(),
-      params.getRange().getEnd()
-    )
-    withPC(textDocumentPositionParams, None) { (pc, pos) =>
+    withPC(params, None) { (pc, pos) =>
       pc.autoImports(name, CompilerOffsetParams.fromPos(pos, token)).asScala
     }.getOrElse(Future.successful(new ju.ArrayList))
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/QuickFix.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/QuickFix.scala
@@ -5,7 +5,6 @@ import scala.meta.pc.CancelToken
 import org.eclipse.{lsp4j => l}
 import scala.concurrent.ExecutionContext
 import scala.meta.internal.metals.MetalsEnrichments._
-import org.eclipse.lsp4j.{CodeAction, CodeActionParams}
 
 trait QuickFix {
   def contribute(
@@ -20,17 +19,21 @@ object QuickFix {
   object ImportMissingSymbol extends QuickFix {
 
     override def contribute(
-        params: CodeActionParams,
+        params: l.CodeActionParams,
         compilers: Compilers,
         token: CancelToken
-    )(implicit ec: ExecutionContext): Future[Seq[CodeAction]] = {
+    )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = {
 
       def importMissingSymbol(
           diagnostic: l.Diagnostic,
           name: String
-      ): Future[Seq[CodeAction]] = {
+      ): Future[Seq[l.CodeAction]] = {
+        val textDocumentPositionParams = new l.TextDocumentPositionParams(
+          params.getTextDocument(),
+          diagnostic.getRange.getEnd()
+        )
         compilers
-          .autoImports(params, name, token)
+          .autoImports(textDocumentPositionParams, name, token)
           .map { imports =>
             imports.asScala.map { i =>
               val uri = params.getTextDocument().getUri()

--- a/metals/src/main/scala/scala/meta/internal/metals/QuickFix.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/QuickFix.scala
@@ -17,6 +17,8 @@ trait QuickFix {
 object QuickFix {
 
   object ImportMissingSymbol extends QuickFix {
+    def label(name: String, packageName: String): String =
+      s"Import '$name' from package '$packageName'"
 
     override def contribute(
         params: l.CodeActionParams,
@@ -41,9 +43,7 @@ object QuickFix {
 
               val codeAction = new l.CodeAction()
 
-              codeAction.setTitle(
-                s"Import '$name' from package '${i.packageName}'"
-              )
+              codeAction.setTitle(label(name, i.packageName))
               codeAction.setKind(l.CodeActionKind.QuickFix)
               codeAction.setDiagnostics(List(diagnostic).asJava)
               codeAction.setEdit(edit)

--- a/metals/src/main/scala/scala/meta/internal/metals/QuickFix.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/QuickFix.scala
@@ -55,7 +55,8 @@ object QuickFix {
 
       Future
         .sequence(params.getContext().getDiagnostics().asScala.collect {
-          case d @ ScalacDiagnostic.SymbolNotFound(name) =>
+          case d @ ScalacDiagnostic.SymbolNotFound(name)
+              if d.getRange().encloses(params.getRange().getEnd()) =>
             importMissingSymbol(d, name)
         })
         .map(_.flatten)

--- a/metals/src/main/scala/scala/meta/internal/metals/QuickFixes.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/QuickFixes.scala
@@ -1,0 +1,82 @@
+package scala.meta.internal.metals
+
+import scala.concurrent.Future
+import scala.meta.pc.CancelToken
+import org.eclipse.{lsp4j => l}
+import scala.concurrent.ExecutionContext
+import scala.meta.internal.metals.MetalsEnrichments._
+
+trait QuickFixes {
+  trait QuickFix {
+    def contribute(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]]
+  }
+
+  object QuickFix {
+
+    def fromDiagnostics(
+        diagnostics: Seq[l.Diagnostic],
+        params: l.CodeActionParams,
+        compilers: Compilers,
+        token: CancelToken
+    )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] =
+      Future
+        .sequence(
+          diagnostics
+            .collect {
+              case d @ ScalacDiagnostic.SymbolNotFound(name) =>
+                ImportMissingSymbol(
+                  name,
+                  d,
+                  params,
+                  compilers,
+                  token
+                )
+            }
+            .map(_.contribute)
+        )
+        .map(_.flatten)
+  }
+
+  final case class ImportMissingSymbol(
+      name: String,
+      diagnostic: l.Diagnostic,
+      params: l.CodeActionParams,
+      compilers: Compilers,
+      token: CancelToken
+  ) extends QuickFix {
+
+    override def contribute(
+        implicit ec: ExecutionContext
+    ): Future[Seq[l.CodeAction]] = {
+
+      // TODO(gabro): this is hack. Instead of computing the auto-imports for a name at a range,
+      // we run completions starting from the end of the range, and filter the completions that
+      // match exactly the name we're looking for
+      val completionParams = new l.CompletionParams(
+        params.getTextDocument(),
+        params.getRange().getEnd()
+      )
+      compilers.completions(completionParams, token).map { completions =>
+        scribe.info(completions.getItems().toString())
+        scribe.info(name)
+        completions.getItems().asScala.collect {
+          case completionItem if completionItem.getFilterText() == name =>
+            val pkg = completionItem.getDetail().trim()
+            val edit = new l.WorkspaceEdit()
+            val uri = params.getTextDocument().getUri()
+            val changes = Map(uri -> completionItem.getAdditionalTextEdits())
+
+            val codeAction = new l.CodeAction()
+            codeAction.setTitle(s"Import '$name' from package '$pkg'")
+            codeAction.setKind(l.CodeActionKind.QuickFix)
+            codeAction.setDiagnostics(List(diagnostic).asJava)
+
+            edit.setChanges(changes.asJava)
+            codeAction.setEdit(edit)
+            codeAction
+        }
+      }
+
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
@@ -1,0 +1,13 @@
+package scala.meta.internal.metals
+
+import org.eclipse.{lsp4j => l}
+
+object ScalacDiagnostic {
+  object SymbolNotFound {
+    private val regex = """not found: (value|type) (\w+)""".r
+    def unapply(d: l.Diagnostic): Option[String] = d.getMessage() match {
+      case regex(_, name) => Some(name)
+      case _ => None
+    }
+  }
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/AutoImportsResult.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/AutoImportsResult.java
@@ -1,0 +1,9 @@
+package scala.meta.pc;
+
+import java.util.List;
+import org.eclipse.lsp4j.TextEdit;
+
+public interface AutoImportsResult {
+  public String packageName();
+  public List<TextEdit> edits();
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -64,6 +64,11 @@ public abstract class PresentationCompiler {
     public abstract CompletableFuture<DefinitionResult> definition(OffsetParams params);
 
     /**
+     * Return the necessary imports for a symbol at the given position.
+     */
+    public abstract CompletableFuture<List<AutoImportsResult>> autoImports(String name, OffsetParams params);
+
+    /**
      * Returns the Protobuf byte array representation of a SemanticDB <code>TextDocument</code> for the given source.
      */
     public abstract CompletableFuture<byte[]> semanticdbTextDocument(String filename, String code);

--- a/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -1,0 +1,148 @@
+package scala.meta.internal.pc
+
+import scala.meta.pc.OffsetParams
+import org.eclipse.{lsp4j => l}
+import scala.meta.pc.SymbolSearchVisitor
+import java.nio.file.Path
+import scala.meta.pc.AutoImportsResult
+import scala.collection.mutable
+import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
+
+final class AutoImportsProvider(
+    val compiler: MetalsGlobal,
+    name: String,
+    params: OffsetParams
+) {
+  import compiler._
+
+  def autoImports(): List[AutoImportsResult] = {
+    val unit = addCompilationUnit(
+      code = params.text,
+      filename = params.filename,
+      cursor = Some(params.offset)
+    )
+    val pos = unit.position(params.offset)
+    val importPosition = autoImportPosition(pos, params.text())
+    val context = doLocateImportContext(pos, importPosition)
+    val isSeen = mutable.Set.empty[String]
+    val symbols = List.newBuilder[Symbol]
+
+    def visit(sym: Symbol): Boolean = {
+      val id = sym.fullName
+      if (!isSeen(id)) {
+        isSeen += id
+        symbols += sym
+        true
+      }
+      false
+    }
+
+    val visitor = new CompilerSearchVisitor(name, context, visit)
+
+    search.search(name, buildTargetIdentifier, visitor)
+
+    symbols.result.collect {
+      case sym if sym.name.dropLocal.decoded == name =>
+        val ident = Identifier.backtickWrap(sym.name.dropLocal.decoded)
+        val pkg = sym.owner.fullName
+        val edits = importPosition match {
+          case None => Nil
+          case Some(value) =>
+            val (short, edits) = ShortenedNames.synthesize(
+              TypeRef(ThisType(sym.owner), sym, Nil),
+              pos,
+              context,
+              value
+            )
+            edits
+        }
+        AutoImportsResultImpl(pkg, edits.asJava)
+    }
+  }
+
+  private class CompilerSearchVisitor(
+      query: String,
+      context: Context,
+      visitSymbol: Symbol => Boolean
+  ) extends SymbolSearchVisitor {
+
+    def visit(top: SymbolSearchCandidate): Int = {
+      var added = 0
+      for {
+        sym <- loadSymbolFromClassfile(top)
+        if context.lookupSymbol(sym.name, _ => true).symbol != sym
+      } {
+        if (visitSymbol(sym)) {
+          added += 1
+        }
+      }
+      added
+    }
+
+    def visitClassfile(pkg: String, filename: String): Int = {
+      visit(SymbolSearchCandidate.Classfile(pkg, filename))
+    }
+
+    def visitWorkspaceSymbol(
+        path: Path,
+        symbol: String,
+        kind: l.SymbolKind,
+        range: l.Range
+    ): Int = {
+      visit(SymbolSearchCandidate.Workspace(symbol))
+    }
+
+    def shouldVisitPackage(pkg: String): Boolean =
+      packageSymbolFromString(pkg).isDefined
+
+    override def isCancelled: Boolean =
+      false
+
+  }
+
+  // FIXME(gabro): this is copy-pasted from CompletionProvider, we should de-dupe it
+  private def loadSymbolFromClassfile(
+      classfile: SymbolSearchCandidate
+  ): List[Symbol] = {
+    def isAccessible(sym: Symbol): Boolean = {
+      sym != NoSymbol && {
+        sym.info // needed to fill complete symbol
+        sym.isPublic
+      }
+    }
+    try {
+      classfile match {
+        case SymbolSearchCandidate.Classfile(pkgString, filename) =>
+          val pkg = packageSymbolFromString(pkgString).getOrElse(
+            throw new NoSuchElementException(pkgString)
+          )
+          val names = filename
+            .stripSuffix(".class")
+            .split('$')
+            .iterator
+            .filterNot(_.isEmpty)
+            .toList
+          val members = names.foldLeft(List[Symbol](pkg)) {
+            case (accum, name) =>
+              accum.flatMap { sym =>
+                if (!isAccessible(sym) || !sym.isModuleOrModuleClass) Nil
+                else {
+                  sym.info.member(TermName(name)) ::
+                    sym.info.member(TypeName(name)) ::
+                    Nil
+                }
+              }
+          }
+          members.filter(sym => isAccessible(sym))
+        case SymbolSearchCandidate.Workspace(symbol) =>
+          val gsym = inverseSemanticdbSymbol(symbol)
+          if (isAccessible(gsym)) gsym :: Nil
+          else Nil
+      }
+    } catch {
+      case NonFatal(_) => Nil
+    }
+  }
+
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -62,8 +62,8 @@ final class AutoImportsProvider(
             )
             val namePos =
               pos
-                .withStart(pos.start - name.length() - 1)
-                .withEnd(pos.end - 1)
+                .withStart(pos.start - name.length())
+                .withEnd(pos.end)
                 .toLSP
             val nameEdit = new TextEdit(namePos, short)
             nameEdit :: edits

--- a/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -1,13 +1,9 @@
 package scala.meta.internal.pc
 
 import scala.meta.pc.OffsetParams
-import org.eclipse.{lsp4j => l}
-import scala.meta.pc.SymbolSearchVisitor
-import java.nio.file.Path
 import scala.meta.pc.AutoImportsResult
 import scala.collection.mutable
 import scala.collection.JavaConverters._
-import scala.util.control.NonFatal
 
 final class AutoImportsProvider(
     val compiler: MetalsGlobal,
@@ -58,90 +54,6 @@ final class AutoImportsProvider(
             edits
         }
         AutoImportsResultImpl(pkg, edits.asJava)
-    }
-  }
-
-  private class CompilerSearchVisitor(
-      query: String,
-      context: Context,
-      visitSymbol: Symbol => Boolean
-  ) extends SymbolSearchVisitor {
-
-    def visit(top: SymbolSearchCandidate): Int = {
-      var added = 0
-      for {
-        sym <- loadSymbolFromClassfile(top)
-        if context.lookupSymbol(sym.name, _ => true).symbol != sym
-      } {
-        if (visitSymbol(sym)) {
-          added += 1
-        }
-      }
-      added
-    }
-
-    def visitClassfile(pkg: String, filename: String): Int = {
-      visit(SymbolSearchCandidate.Classfile(pkg, filename))
-    }
-
-    def visitWorkspaceSymbol(
-        path: Path,
-        symbol: String,
-        kind: l.SymbolKind,
-        range: l.Range
-    ): Int = {
-      visit(SymbolSearchCandidate.Workspace(symbol))
-    }
-
-    def shouldVisitPackage(pkg: String): Boolean =
-      packageSymbolFromString(pkg).isDefined
-
-    override def isCancelled: Boolean =
-      false
-
-  }
-
-  // FIXME(gabro): this is copy-pasted from CompletionProvider, we should de-dupe it
-  private def loadSymbolFromClassfile(
-      classfile: SymbolSearchCandidate
-  ): List[Symbol] = {
-    def isAccessible(sym: Symbol): Boolean = {
-      sym != NoSymbol && {
-        sym.info // needed to fill complete symbol
-        sym.isPublic
-      }
-    }
-    try {
-      classfile match {
-        case SymbolSearchCandidate.Classfile(pkgString, filename) =>
-          val pkg = packageSymbolFromString(pkgString).getOrElse(
-            throw new NoSuchElementException(pkgString)
-          )
-          val names = filename
-            .stripSuffix(".class")
-            .split('$')
-            .iterator
-            .filterNot(_.isEmpty)
-            .toList
-          val members = names.foldLeft(List[Symbol](pkg)) {
-            case (accum, name) =>
-              accum.flatMap { sym =>
-                if (!isAccessible(sym) || !sym.isModuleOrModuleClass) Nil
-                else {
-                  sym.info.member(TermName(name)) ::
-                    sym.info.member(TypeName(name)) ::
-                    Nil
-                }
-              }
-          }
-          members.filter(sym => isAccessible(sym))
-        case SymbolSearchCandidate.Workspace(symbol) =>
-          val gsym = inverseSemanticdbSymbol(symbol)
-          if (isAccessible(gsym)) gsym :: Nil
-          else Nil
-      }
-    } catch {
-      case NonFatal(_) => Nil
     }
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -4,6 +4,7 @@ import scala.meta.pc.OffsetParams
 import scala.meta.pc.AutoImportsResult
 import scala.collection.mutable
 import scala.collection.JavaConverters._
+import org.eclipse.lsp4j.TextEdit
 
 final class AutoImportsProvider(
     val compiler: MetalsGlobal,
@@ -59,7 +60,13 @@ final class AutoImportsProvider(
               context,
               value
             )
-            edits
+            val namePos =
+              pos
+                .withStart(pos.start - name.length() - 1)
+                .withEnd(pos.end - 1)
+                .toLSP
+            val nameEdit = new TextEdit(namePos, short)
+            nameEdit :: edits
         }
         AutoImportsResultImpl(pkg, edits.asJava)
     }

--- a/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -14,11 +14,13 @@ final class AutoImportsProvider(
 
   def autoImports(): List[AutoImportsResult] = {
     val unit = addCompilationUnit(
-      code = params.text,
-      filename = params.filename,
-      cursor = Some(params.offset)
+      code = params.text(),
+      filename = params.filename(),
+      cursor = Some(params.offset())
     )
     val pos = unit.position(params.offset)
+    // make sure the compilation unit is loaded
+    typedTreeAt(pos)
     val importPosition = autoImportPosition(pos, params.text())
     val context = doLocateImportContext(pos, importPosition)
     val isSeen = mutable.Set.empty[String]

--- a/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsResultImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsResultImpl.scala
@@ -1,0 +1,8 @@
+package scala.meta.internal.pc
+
+import scala.meta.pc.AutoImportsResult
+import java.{util => ju}
+import org.eclipse.lsp4j.TextEdit
+
+case class AutoImportsResultImpl(packageName: String, edits: ju.List[TextEdit])
+    extends AutoImportsResult

--- a/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
@@ -34,7 +34,8 @@ class MetalsGlobal(
     with Compat
     with GlobalProxy
     with AutoImports
-    with Keywords { compiler =>
+    with Keywords
+    with WorkspaceSymbolSearch { compiler =>
   hijackPresentationCompilerThread()
 
   val logger: Logger = Logger.getLogger(classOf[MetalsGlobal].getName)

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -26,6 +26,8 @@ import scala.meta.pc.PresentationCompilerConfig
 import java.util.concurrent.CompletableFuture
 import scala.meta.pc.DefinitionResult
 import scala.collection.Seq
+import java.{util => ju}
+import scala.meta.pc.AutoImportsResult
 
 case class ScalaPresentationCompiler(
     buildTargetIdentifier: String = "",
@@ -81,11 +83,23 @@ case class ScalaPresentationCompiler(
     items.setIsIncomplete(true)
     items
   }
+
   override def complete(
       params: OffsetParams
   ): CompletableFuture[CompletionList] =
     access.withInterruptableCompiler(emptyCompletion, params.token) { global =>
       new CompletionProvider(global, params).completions()
+    }
+
+  override def autoImports(
+      name: String,
+      params: OffsetParams
+  ): CompletableFuture[ju.List[AutoImportsResult]] =
+    access.withInterruptableCompiler(
+      List.empty[AutoImportsResult].asJava,
+      params.token
+    ) { global =>
+      new AutoImportsProvider(global, name, params).autoImports().asJava
     }
 
   // NOTE(olafur): hover and signature help use a "shared" compiler instance because

--- a/mtags/src/main/scala/scala/meta/internal/pc/WorkspaceSymbolSearch.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/WorkspaceSymbolSearch.scala
@@ -1,0 +1,89 @@
+package scala.meta.internal.pc
+
+import scala.meta.pc.SymbolSearchVisitor
+import java.nio.file.Path
+import org.eclipse.{lsp4j => l}
+import scala.util.control.NonFatal
+
+trait WorkspaceSymbolSearch { this: MetalsGlobal =>
+
+  class CompilerSearchVisitor(
+      query: String,
+      context: Context,
+      visitMember: Symbol => Boolean
+  ) extends SymbolSearchVisitor {
+    def visit(top: SymbolSearchCandidate): Int = {
+      var added = 0
+      for {
+        sym <- loadSymbolFromClassfile(top)
+        if context.lookupSymbol(sym.name, _ => true).symbol != sym
+      } {
+        if (visitMember(sym)) {
+          added += 1
+        }
+      }
+      added
+    }
+    def visitClassfile(pkg: String, filename: String): Int = {
+      visit(SymbolSearchCandidate.Classfile(pkg, filename))
+    }
+    def visitWorkspaceSymbol(
+        path: Path,
+        symbol: String,
+        kind: l.SymbolKind,
+        range: l.Range
+    ): Int = {
+      visit(SymbolSearchCandidate.Workspace(symbol))
+    }
+
+    def shouldVisitPackage(pkg: String): Boolean =
+      packageSymbolFromString(pkg).isDefined
+
+    override def isCancelled: Boolean = {
+      false
+    }
+  }
+
+  private def loadSymbolFromClassfile(
+      classfile: SymbolSearchCandidate
+  ): List[Symbol] = {
+    def isAccessible(sym: Symbol): Boolean = {
+      sym != NoSymbol && {
+        sym.info // needed to fill complete symbol
+        sym.isPublic
+      }
+    }
+    try {
+      classfile match {
+        case SymbolSearchCandidate.Classfile(pkgString, filename) =>
+          val pkg = packageSymbolFromString(pkgString).getOrElse(
+            throw new NoSuchElementException(pkgString)
+          )
+          val names = filename
+            .stripSuffix(".class")
+            .split('$')
+            .iterator
+            .filterNot(_.isEmpty)
+            .toList
+          val members = names.foldLeft(List[Symbol](pkg)) {
+            case (accum, name) =>
+              accum.flatMap { sym =>
+                if (!isAccessible(sym) || !sym.isModuleOrModuleClass) Nil
+                else {
+                  sym.info.member(TermName(name)) ::
+                    sym.info.member(TypeName(name)) ::
+                    Nil
+                }
+              }
+          }
+          members.filter(sym => isAccessible(sym))
+        case SymbolSearchCandidate.Workspace(symbol) =>
+          val gsym = inverseSemanticdbSymbol(symbol)
+          if (isAccessible(gsym)) gsym :: Nil
+          else Nil
+      }
+    } catch {
+      case NonFatal(_) => Nil
+    }
+  }
+}

--- a/tests/cross/src/main/scala/tests/BaseCodeActionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCodeActionSuite.scala
@@ -1,0 +1,36 @@
+package tests
+
+import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.pc.CancelToken
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import scala.util.control.NonFatal
+
+abstract class BaseCodeActionSuite extends BasePCSuite {
+
+  def cancelToken: CancelToken = EmptyCancelToken
+
+  def params(
+      code: String
+  ): (String, String, Int) = {
+    val filename = "test.scala"
+    val targetRegex = "<<(.+)>>".r
+    val target = targetRegex.findAllMatchIn(code).toList match {
+      case Nil => fail("Missing <<target>>")
+      case t :: Nil => t.group(1)
+      case _ => fail("Multiple <<targets>> found")
+    }
+    val code2 = code.replaceAllLiterally("<<", "").replaceAllLiterally(">>", "")
+    val offset = code.indexOf(">>") - 1
+    val file = tmp.resolve(filename)
+    Files.write(file.toNIO, code2.getBytes(StandardCharsets.UTF_8))
+    try index.addSourceFile(file, Some(tmp))
+    catch {
+      case NonFatal(e) =>
+        println(s"warn: $e")
+    }
+    workspace.inputs(filename) = code2
+    (code2, target, offset)
+  }
+
+}

--- a/tests/cross/src/main/scala/tests/BaseCodeActionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCodeActionSuite.scala
@@ -21,7 +21,7 @@ abstract class BaseCodeActionSuite extends BasePCSuite {
       case _ => fail("Multiple <<targets>> found")
     }
     val code2 = code.replaceAllLiterally("<<", "").replaceAllLiterally(">>", "")
-    val offset = code.indexOf(">>") - 1
+    val offset = code.indexOf("<<") + target.length()
     val file = tmp.resolve(filename)
     Files.write(file.toNIO, code2.getBytes(StandardCharsets.UTF_8))
     try index.addSourceFile(file, Some(tmp))

--- a/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
@@ -1,0 +1,66 @@
+package tests.pc
+
+import tests.BaseCodeActionSuite
+import scala.meta.pc.AutoImportsResult
+import scala.meta.internal.metals.CompilerOffsetParams
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.TextEdits
+
+object AutoImportsSuite extends BaseCodeActionSuite {
+
+  check(
+    "basic",
+    """|object A {
+       |  <<Future>>.successful(2)
+       |}
+       |""".stripMargin,
+    """|scala.concurrent
+       |java.util.concurrent
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "basic-edit",
+    """|object A {
+       |  <<Future>>.successful(2)
+       |}
+       |""".stripMargin,
+    """|import scala.concurrent.Future
+       |object A {
+       |  Future.successful(2)
+       |}
+       |""".stripMargin
+  )
+
+  def check(name: String, original: String, expected: String): Unit =
+    test(name) {
+      val imports = getAutoImports(original)
+      val obtained = imports.map(_.packageName()).mkString("\n")
+      assertNoDiff(obtained, expected)
+    }
+
+  def checkEdit(name: String, original: String, expected: String): Unit =
+    test(name) {
+      val imports = getAutoImports(original)
+      if (imports.isEmpty) fail("obtained no imports")
+      val edits = imports.head.edits().asScala.toList
+      val (code, _, _) = params(original)
+      val obtained = TextEdits.applyEdits(code, edits)
+      assertNoDiff(obtained, expected)
+    }
+
+  def getAutoImports(
+      original: String,
+      filename: String = "A.scala"
+  ): List[AutoImportsResult] = {
+    val (code, symbol, offset) = params(original)
+    val result = pc
+      .autoImports(
+        symbol,
+        CompilerOffsetParams("file:/" + filename, code, offset, cancelToken)
+      )
+      .get()
+    result.asScala.toList
+  }
+
+}

--- a/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
@@ -16,7 +16,14 @@ object AutoImportsSuite extends BaseCodeActionSuite {
        |""".stripMargin,
     """|scala.concurrent
        |java.util.concurrent
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "2.11" ->
+        """|scala.concurrent
+           |scala.concurrent.impl
+           |java.util.concurrent
+           |""".stripMargin
+    )
   )
 
   checkEdit(
@@ -73,11 +80,16 @@ object AutoImportsSuite extends BaseCodeActionSuite {
        |""".stripMargin
   )
 
-  def check(name: String, original: String, expected: String): Unit =
+  def check(
+      name: String,
+      original: String,
+      expected: String,
+      compat: Map[String, String] = Map.empty
+  ): Unit =
     test(name) {
       val imports = getAutoImports(original)
       val obtained = imports.map(_.packageName()).mkString("\n")
-      assertNoDiff(obtained, expected)
+      assertNoDiff(obtained, getExpected(expected, compat))
     }
 
   def checkEdit(name: String, original: String, expected: String): Unit =

--- a/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
@@ -21,13 +21,54 @@ object AutoImportsSuite extends BaseCodeActionSuite {
 
   checkEdit(
     "basic-edit",
-    """|object A {
+    """|package a
+       |
+       |object A {
        |  <<Future>>.successful(2)
        |}
        |""".stripMargin,
-    """|import scala.concurrent.Future
+    """|package a
+       |
+       |import scala.concurrent.Future
+       |
        |object A {
        |  Future.successful(2)
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "symbol-prefix-edit",
+    """|package a
+       |
+       |object A {
+       |  val l = new <<ArrayList>>[Int]
+       |}
+       |""".stripMargin,
+    """|package a
+       |
+       |import java.{util => ju}
+       |
+       |object A {
+       |  val l = new ju.ArrayList[Int]
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "interpolator-edit",
+    """|package a
+       |
+       |object A {
+       |  val l = s"${<<ListBuffer>>(2)}"
+       |}
+       |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.mutable
+       |
+       |object A {
+       |  val l = s"${mutable.ListBuffer(2)}"
        |}
        |""".stripMargin
   )

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -86,6 +86,8 @@ import scala.meta.internal.metals.TextEdits
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.RenameFile
 import scala.util.Properties
+import org.eclipse.lsp4j.CodeActionParams
+import org.eclipse.lsp4j.CodeActionContext
 
 /**
  * Wrapper around `MetalsLanguageServer` with helpers methods for testing purpopses.
@@ -648,6 +650,24 @@ final class TestingServer(
     }
   }
 
+  def assertCodeAction(
+      filename: String,
+      query: String,
+      expected: String,
+      root: AbsolutePath = workspace
+  ): Future[List[l.CodeAction]] =
+    for {
+      (codeActions, codeActionString) <- codeAction(filename, query, root)
+    } yield {
+      DiffAssertions.assertNoDiffOrPrintObtained(
+        codeActionString,
+        expected,
+        "obtained",
+        "expected"
+      )
+      codeActions
+    }
+
   def hover(
       filename: String,
       query: String,
@@ -664,6 +684,28 @@ final class TestingServer(
       formatCompletion(c, includeDetail = true)
     }
   }
+
+  def codeAction(
+      filename: String,
+      query: String,
+      root: AbsolutePath
+  ): Future[(List[l.CodeAction], String)] =
+    for {
+      (t, params) <- offsetParams(filename, query, root)
+      codeActionParams = new CodeActionParams(
+        params.getTextDocument(),
+        new l.Range(params.getPosition(), params.getPosition()),
+        new CodeActionContext(
+          client.diagnostics
+            .getOrElse(toPath(filename), Nil)
+            .asJava
+        )
+      )
+      codeActions <- server.codeAction(codeActionParams).asScala
+    } yield (
+      codeActions.asScala.toList,
+      codeActions.map(_.getTitle()).asScala.mkString("\n")
+    )
 
   def assertHighlight(
       filename: String,

--- a/tests/unit/src/test/scala/tests/CodeActionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeActionLspSuite.scala
@@ -45,6 +45,9 @@ object CodeActionLspSuite extends BaseLspSuite("codeAction") {
         _ <- server.didOpen(path)
         codeActions <- server.assertCodeAction(path, input, expectedActions)
         _ <- server.didSave(path) { _ =>
+          if (selectedActionIndex >= codeActions.length) {
+            fail(s"selectedActionIndex ($selectedActionIndex) is out of bounds")
+          }
           client.applyCodeAction(codeActions(selectedActionIndex))
           server.toPath(path).readText
         }

--- a/tests/unit/src/test/scala/tests/CodeActionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeActionLspSuite.scala
@@ -1,0 +1,57 @@
+package tests
+
+import scala.meta.internal.metals.QuickFix.ImportMissingSymbol
+import scala.meta.internal.metals.MetalsEnrichments._
+
+object CodeActionLspSuite extends BaseLspSuite("codeAction") {
+
+  check(
+    "auto-import",
+    """|package a
+       |
+       |object A {
+       |  val f = Fut@@ure.successful(2)
+       |}
+       |""".stripMargin,
+    s"""|${ImportMissingSymbol.label("Future", "scala.concurrent")}
+        |${ImportMissingSymbol.label("Future", "java.util.concurrent")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.concurrent.Future
+       |
+       |object A {
+       |  val f = Future.successful(2)
+       |}
+       |""".stripMargin
+  )
+
+  def check(
+      name: String,
+      input: String,
+      expectedActions: String,
+      expectedCode: String,
+      selectedActionIndex: Int = 0
+  ): Unit = {
+    val path = "a/src/main/scala/a/A.scala"
+    testAsync(name) {
+      cleanWorkspace()
+      for {
+        _ <- server.initialize(s"""/metals.json
+                                  |{"a":{}}
+                                  |/$path
+                                  |${input.replaceAllLiterally("@@", "")}
+                                  |""".stripMargin)
+        _ <- server.didOpen(path)
+        codeActions <- server.assertCodeAction(path, input, expectedActions)
+        _ <- server.didSave(path) { _ =>
+          client.applyCodeAction(codeActions(selectedActionIndex))
+          server.toPath(path).readText
+        }
+        _ = assertNoDiff(server.bufferContents(path), expectedCode)
+        _ = assertNoDiagnostics()
+      } yield ()
+    }
+  }
+
+}


### PR DESCRIPTION
This is draft PR to validate a possible architecture for code actions (aka refactors).

For now, I'm focusing on code actions that resolve existing diagnostics (i.e. quickfixes), but the architecture could be expanded to more general refactors.

This PR implements a working prototype ~(although it's a bit of a hack)~ for the "add missing import" quickfix, which gets triggered by the relevant compiler error.

![2019-11-15 11 38 48](https://user-images.githubusercontent.com/691940/68937367-8839bf80-079c-11ea-8401-4927f6531d24.gif)


If we're happy with the general structure, I can move on with the testing infrastructure for code actions and refining the actual implementation.