### PR TITLE
Update emacs docs to include yasnippet

### DIFF
--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -67,6 +67,11 @@ To use Metals in Emacs, place this snippet in your Emacs configuration (for exam
 
 (use-package lsp-ui)
 
+;; lsp-mode supports snippets, but in order for them to work you need to use yasnippet
+;; If you don't want to use snippets set lsp-enable-snippet to nil in your lsp-mode settings
+::   to avoid odd behavior with snippets and indentation
+(use-package yasnippet)
+
 ;; Add company-lsp backend for metals
 (use-package company-lsp)
 ```


### PR DESCRIPTION
This will close #1045 which was an inaccurate description of what was actually happening. It was bugging me since I know we came across the "magic" indentation of some editors, but with emacs, it seemed odd that the last `}` was never being indented correctly. Plus, after @gabro made the  #1057 fix, I didn't understand why it seemed that emacs lsp-mode was saying it supported snippets, when they obviously weren't working right. Turns out lsp-mode has a configuration option `lsp-enable-snippet` which is on by default. This then requires you to use the `yasnippet` package, or snippets won't work correctly, and also some of the indentations will be wrong. An emacs buff may have known this, but I am anything but an emacs buff. Either way, I think we should mention this in the docs as it may save someone time trying to set Metals up with emacs.

This PR gives extra info in the docs to make sure your snippets go from looking like this...
![old](https://user-images.githubusercontent.com/13974112/68974751-c31a1280-07f1-11ea-8690-a68b00ffcd91.gif)

to working and looking correctly like this...
![2019-11-15 21 32 07](https://user-images.githubusercontent.com/13974112/68974798-e04ee100-07f1-11ea-9f14-b6396b5e692c.gif)
