### PR TITLE
Force sequential publishLocal for mtags 2.11/2.13.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -441,20 +441,8 @@ lazy val slow = project
   .in(file("tests/slow"))
   .settings(
     testSettings,
-    testOnly.in(Test) := testOnly
-      .in(Test)
-      .dependsOn(
-        crossPublishLocal(V.scala211),
-        crossPublishLocal(V.scala213)
-      )
-      .evaluated,
-    test.in(Test) := test
-      .in(Test)
-      .dependsOn(
-        crossPublishLocal(V.scala211),
-        crossPublishLocal(V.scala213)
-      )
-      .value
+    testOnly.in(Test) := testOnly.in(Test).dependsOn(publishMtags).evaluated,
+    test.in(Test) := test.in(Test).dependsOn(publishMtags).value
   )
   .dependsOn(unit)
 


### PR DESCRIPTION
Previously, the CI would occasionally fail with a "could not copy ..."
error during compilation caused by
https://github.com/sbt/sbt-buildinfo/issues/152. This commit changes the
`publishLocal` step for mtags so that 2.13 and 2.11 publish sequentially
instead of in parallel.