### PR TITLE
Use exact match when computing file renames

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -32,7 +32,6 @@ import org.eclipse.lsp4j.TextDocumentEdit
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
 import org.eclipse.lsp4j.ResourceOperation
 import org.eclipse.lsp4j.RenameFile
-import java.io.File
 
 final class RenameProvider(
     referenceProvider: ReferenceProvider,
@@ -149,7 +148,7 @@ final class RenameProvider(
       .find { file =>
         isOccurence(str => {
           (str.desc.isType || str.desc.isTerm) &&
-            new File(file).getName() == str.desc.name.value + ".scala"
+            Paths.get(file).filename == str.desc.name.value + ".scala"
         })
       }
       .map { file =>

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -323,7 +323,7 @@ final class RenameProvider(
   ): MessageParams = {
     val renamed = name.map(n => s"to $n").getOrElse("")
     val message =
-      s"""|Cannot rename $old $renamed since it will change the semantics and
+      s"""|Cannot rename from $old to $renamed since it will change the semantics
           |and might break your code""".stripMargin
     new MessageParams(MessageType.Error, message)
   }
@@ -341,7 +341,7 @@ final class RenameProvider(
   ): MessageParams = {
     val renamed = name.map(n => s"to $n").getOrElse("")
     val message =
-      s"""|Cannot rename from $old $renamed since it will change the semantics and
+      s"""|Cannot rename from $old to $renamed since it will change the semantics and
           |and might break your code.
           |Only rename to names ending with `:` is allowed.""".stripMargin
     new MessageParams(MessageType.Error, message)

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -148,7 +148,7 @@ final class RenameProvider(
       .find { file =>
         isOccurence(str => {
           (str.desc.isType || str.desc.isTerm) &&
-            Paths.get(file).filename == str.desc.name.value + ".scala"
+            Paths.get(new URI(file)).filename == str.desc.name.value + ".scala"
         })
       }
       .map { file =>

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -148,7 +148,7 @@ final class RenameProvider(
       .find { file =>
         isOccurence(str => {
           (str.desc.isType || str.desc.isTerm) &&
-            Paths.get(new URI(file)).filename == str.desc.name.value + ".scala"
+            file.endsWith(s"/${str.desc.name.value}.scala")
         })
       }
       .map { file =>

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -32,6 +32,7 @@ import org.eclipse.lsp4j.TextDocumentEdit
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
 import org.eclipse.lsp4j.ResourceOperation
 import org.eclipse.lsp4j.RenameFile
+import java.io.File
 
 final class RenameProvider(
     referenceProvider: ReferenceProvider,
@@ -147,9 +148,8 @@ final class RenameProvider(
     fileChanges
       .find { file =>
         isOccurence(str => {
-          (str.desc.isType || str.desc.isTerm) && file.endsWith(
-            str.desc.name.value + ".scala"
-          )
+          (str.desc.isType || str.desc.isTerm) &&
+            new File(file).getName() == str.desc.name.value + ".scala"
         })
       }
       .map { file =>
@@ -324,14 +324,14 @@ final class RenameProvider(
   ): MessageParams = {
     val renamed = name.map(n => s"to $n").getOrElse("")
     val message =
-      s"""|Cannot rename $old $renamed since it will change the semantics and 
+      s"""|Cannot rename $old $renamed since it will change the semantics and
           |and might break your code""".stripMargin
     new MessageParams(MessageType.Error, message)
   }
 
   private def isCompiling: MessageParams = {
     val message =
-      s"""|Cannot rename while the code is compiling 
+      s"""|Cannot rename while the code is compiling
           |since it could produce incorrect results.""".stripMargin
     new MessageParams(MessageType.Error, message)
   }
@@ -342,8 +342,8 @@ final class RenameProvider(
   ): MessageParams = {
     val renamed = name.map(n => s"to $n").getOrElse("")
     val message =
-      s"""|Cannot rename from $old $renamed since it will change the semantics and 
-          |and might break your code. 
+      s"""|Cannot rename from $old $renamed since it will change the semantics and
+          |and might break your code.
           |Only rename to names ending with `:` is allowed.""".stripMargin
     new MessageParams(MessageType.Error, message)
   }

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -1,7 +1,7 @@
 package tests
 import scala.concurrent.Future
 
-object RenameSuite extends BaseLspSuite("rename") {
+object RenameLspSuite extends BaseLspSuite("rename") {
 
   renamed(
     "basic",

--- a/tests/unit/src/test/scala/tests/RenameSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameSuite.scala
@@ -280,6 +280,29 @@ object RenameSuite extends BaseLspSuite("rename") {
   )
 
   renamed(
+    "filename-exact-match",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object <<Ma@@in>>
+       |object TheMain
+       |""".stripMargin,
+    newName = "Tree",
+    fileRenames =
+      Map("a/src/main/scala/a/Main.scala" -> "a/src/main/scala/a/Tree.scala")
+  )
+
+  renamed(
+    "filename-exact-match-2",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main
+       |object <<The@@Main>>
+       |""".stripMargin,
+    newName = "Tree",
+    fileRenames = Map.empty
+  )
+
+  renamed(
     "many-files",
     """|/a/src/main/scala/a/A.scala
        |package a


### PR DESCRIPTION
Fixes #1074 

Previously we would rename files whose name partially matched the symbol being renamed. Now we compute those renames using an exact match, to avoid e.g. renaming a file named `FooBar.scala` when renaming the symbol `Bar` in that file.