### PR TITLE
Avoid renaming synthetic occurrences

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -67,7 +67,7 @@ final class ReferenceProvider(
   def references(
       params: ReferenceParams,
       checkMatchesText: Boolean = false,
-      includeSynthetics: Boolean = true
+      includeSynthetics: SymbolOccurrence => Boolean = _ => true
   ): ReferencesResult = {
     val source = params.getTextDocument.getUri.toAbsolutePath
     semanticdbs.textDocument(source).documentIncludingStale match {
@@ -86,7 +86,7 @@ final class ReferenceProvider(
               alternatives,
               params.getContext.isIncludeDeclaration,
               checkMatchesText,
-              includeSynthetics
+              includeSynthetics(occurrence)
             )
             ReferencesResult(occurrence.symbol, locations)
           case None =>

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -82,7 +82,7 @@ final class RenameProvider(
 
       def includeSynthetic(syn: Synthetic) = {
         syn.tree match {
-          case SelectTree(qualifier, id) =>
+          case SelectTree(_, id) =>
             id.exists(_.symbol.desc.name.toString == "apply")
           case _ => false
         }

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -93,7 +93,8 @@ final class RenameProvider(
             // we can't get definition by name for local symbols
             toReferenceParams(txtParams, includeDeclaration = isLocal),
             // local symbol will not contain a proper name
-            checkMatchesText = !isLocal
+            checkMatchesText = !isLocal,
+            includeSynthetics = false
           )
           .locations
         definitionLocation = {

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -83,7 +83,7 @@ final class RenameProvider(
       def includeSynthetic(syn: Synthetic) = {
         syn.tree match {
           case SelectTree(qualifier, id) =>
-            id.exists(_.symbol.contains(".apply()"))
+            id.exists(_.symbol.desc.name.toString == "apply")
           case _ => false
         }
       }

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -94,7 +94,7 @@ final class RenameProvider(
             toReferenceParams(txtParams, includeDeclaration = isLocal),
             // local symbol will not contain a proper name
             checkMatchesText = !isLocal,
-            includeSynthetics = false
+            includeSynthetics = _.symbol.desc.name.value == "apply"
           )
           .locations
         definitionLocation = {

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -169,6 +169,7 @@ object RenameLspSuite extends BaseLspSuite("rename") {
        |package a
        |object User{
        |  def <<ap@@ply>>(name : String) = name
+       |  def apply(name : String, age: Int) = name
        |}
        |object Main{
        |  val toRename = User##.##<<>>("abc")

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -472,6 +472,18 @@ object RenameLspSuite extends BaseLspSuite("rename") {
     newName = "Animal"
   )
 
+  renamed(
+    "implicit-param",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object A {
+       |  implicit val <<some@@Name>>: Int = 1
+       |  def m[A](implicit a: A): A = a
+       |  m[Int]
+       |}""".stripMargin,
+    newName = "anotherName"
+  )
+
   def renamed(
       name: String,
       input: String,


### PR DESCRIPTION
Fixes #1072 

Previously we would rename all references of a symbol, including synthetic ones. This resulted in bugs such as #1072. Now we ignore synthetics references when performing a rename.