### PR TITLE
Remove sbt-coursier

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -395,7 +395,6 @@ lazy val unit = project
     testSettings,
     libraryDependencies ++= List(
       "io.get-coursier" %% "coursier" % V.coursier, // for jars
-      "io.get-coursier" %% "coursier-cache" % V.coursier,
       "org.scalameta" %% "testkit" % V.scalameta,
       "ch.epfl.scala" %% "bloop-config" % V.bloop,
       "com.lihaoyi" %% "utest" % "0.6.0"

--- a/build.sbt
+++ b/build.sbt
@@ -163,7 +163,7 @@ lazy val V = new {
   def lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.8.0"
   def dap4j =
     "org.eclipse.lsp4j" % "org.eclipse.lsp4j.debug" % "0.8.0"
-  val coursier = "2.0.0-RC2-2"
+  val coursier = "2.0.0-RC5-2"
 }
 
 skip.in(publish) := true

--- a/build.sbt
+++ b/build.sbt
@@ -393,8 +393,8 @@ lazy val unit = project
   .settings(
     testSettings,
     libraryDependencies ++= List(
-      "io.get-coursier" %% "coursier" % coursier.util.Properties.version, // for jars
-      "io.get-coursier" %% "coursier-cache" % coursier.util.Properties.version,
+      "io.get-coursier" %% "coursier" % "2.0.0-RC2-2", // for jars
+      "io.get-coursier" %% "coursier-cache" % "2.0.0-RC2-2",
       "org.scalameta" %% "testkit" % V.scalameta,
       "ch.epfl.scala" %% "bloop-config" % V.bloop,
       "com.lihaoyi" %% "utest" % "0.6.0"

--- a/build.sbt
+++ b/build.sbt
@@ -163,6 +163,7 @@ lazy val V = new {
   def lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.8.0"
   def dap4j =
     "org.eclipse.lsp4j" % "org.eclipse.lsp4j.debug" % "0.8.0"
+  val coursier = "2.0.0-RC2-2"
 }
 
 skip.in(publish) := true
@@ -335,7 +336,7 @@ lazy val mtest = project
     skip.in(publish) := true,
     crossScalaVersions := V.supportedScalaVersions,
     libraryDependencies ++= List(
-      "io.get-coursier" %% "coursier" % "2.0.0-RC2-2",
+      "io.get-coursier" %% "coursier" % V.coursier,
       "org.scalameta" %% "testkit" % V.scalameta
     ) ++ crossSetting(
       scalaVersion.value,
@@ -393,8 +394,8 @@ lazy val unit = project
   .settings(
     testSettings,
     libraryDependencies ++= List(
-      "io.get-coursier" %% "coursier" % "2.0.0-RC2-2", // for jars
-      "io.get-coursier" %% "coursier-cache" % "2.0.0-RC2-2",
+      "io.get-coursier" %% "coursier" % V.coursier, // for jars
+      "io.get-coursier" %% "coursier-cache" % V.coursier,
       "org.scalameta" %% "testkit" % V.scalameta,
       "ch.epfl.scala" %% "bloop-config" % V.bloop,
       "com.lihaoyi" %% "utest" % "0.6.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,6 @@ addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.3.1")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.0.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
-addSbtCoursier
-
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
 resolvers += Resolver.sonatypeRepo("public")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-4")


### PR DESCRIPTION
It's not necessary since sbt 1.3.x, that uses coursier automatically.