### PR TITLE
Fix issue with no source dependencies being downloaded by Bloop

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -25,7 +25,7 @@ case class SbtBuildTool(version: String) extends BuildTool {
       config: MetalsServerConfig
   ): List[String] = {
     val sbtArgs = List[String](
-      "set bloopExportJarClassifiers := Some(Set(\"source\"))",
+      "set bloopExportJarClassifiers in Global := Some(Set(\"sources\"))",
       "bloopInstall"
     )
     val allArgs = userConfig().sbtScript match {

--- a/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
@@ -239,6 +239,8 @@ object SbtLspSuite extends BaseImportSuite("sbt-import") {
         client.messageRequests.peekLast(),
         CheckDoctor.multipleMisconfiguredProjects(8)
       )
+      sourceJars <- server.buildTargetSourceJars("a")
+      _ = assert(sourceJars.nonEmpty) // source jars should not be empty
       _ <- Future.sequence(
         ('a' to 'f')
           .map(project => s"$project/src/main/scala/a/A.scala")


### PR DESCRIPTION
Previously, no source dependencies would be downloaded due to a typo and a misconfiguration.

Now, the typo is fixed and proper Bloop settings applied to all projects.