### PR TITLE
Delay renaming in closed files until the first save is run 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -750,7 +750,13 @@ class MetalsLanguageServer(
     // read file from disk, we only remove files from buffers on didClose.
     buffers.put(path, path.toInput.text)
     Future
-      .sequence(List(parseTrees(path), onChange(List(path))))
+      .sequence(
+        List(
+          Future(renameProvider.runSave()),
+          parseTrees(path),
+          onChange(List(path))
+        )
+      )
       .ignoreValue
       .asJava
   }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -739,6 +739,8 @@ final class TestingServer(
       } else {
         Future.successful(new WorkspaceEdit)
       }
+      // save current file to simulate user saving in the editor
+      _ <- didSave(filename)(identity)
     } yield {
       files.map { file =>
         val path = workspace.resolve(file)


### PR DESCRIPTION
Previously, all closed files would be updated just during the rename, which could produce false positive compiler errors while the opened files are not saved. Now, we delay changing the close files until the first save is hit.