### PR TITLE
Fix renames in case of macro annotations

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -87,7 +87,7 @@ final class DefinitionProvider(
         currentDocument
       )
       symbolOccurrence <- {
-        lazy val mtagsOccurrence =
+        def mtagsOccurrence =
           fromMtags(source, dirtyPosition.getPosition())
         posOcc.occurrence.orElse(mtagsOccurrence)
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -18,6 +18,7 @@ import scala.meta.io.AbsolutePath
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
 import scala.meta.internal.semanticdb.SymbolOccurrence
+import org.eclipse.lsp4j.Position
 
 /**
  * Implements goto definition that works even in code that doesn't parse.
@@ -86,10 +87,8 @@ final class DefinitionProvider(
         currentDocument
       )
       symbolOccurrence <- {
-        lazy val mtagsOccurrence = Mtags
-          .allToplevels(source.toInput)
-          .occurrences
-          .find(_.encloses(dirtyPosition.getPosition))
+        lazy val mtagsOccurrence =
+          fromMtags(source, dirtyPosition.getPosition())
         posOcc.occurrence.orElse(mtagsOccurrence)
       }
     } yield (symbolOccurrence, currentDocument)
@@ -115,7 +114,11 @@ final class DefinitionProvider(
         .find(_.encloses(queryPosition, true))
     } yield occurrence
 
-    ResolvedSymbolOccurrence(sourceDistance, occurrence)
+    // In case of macros we might need to get the postion from the presentation compiler
+    val sureOccurence =
+      occurrence.orElse(fromMtags(source, dirtyPosition.getPosition()))
+
+    ResolvedSymbolOccurrence(sourceDistance, sureOccurence)
   }
 
   def definitionFromSnapshot(
@@ -144,6 +147,13 @@ final class DefinitionProvider(
     }
 
     result.getOrElse(DefinitionResult.empty(occurrence.fold("")(_.symbol)))
+  }
+
+  private def fromMtags(source: AbsolutePath, dirtyPos: Position) = {
+    Mtags
+      .allToplevels(source.toInput)
+      .occurrences
+      .find(_.encloses(dirtyPos))
   }
 
   private case class DefinitionDestination(

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -66,7 +66,7 @@ final class ReferenceProvider(
 
   def references(
       params: ReferenceParams,
-      strictCheck: Boolean = false
+      checkMatchesText: Boolean = false
   ): ReferencesResult = {
     val source = params.getTextDocument.getUri.toAbsolutePath
     semanticdbs.textDocument(source).documentIncludingStale match {
@@ -84,7 +84,7 @@ final class ReferenceProvider(
               occurrence,
               alternatives,
               params.getContext.isIncludeDeclaration,
-              strictCheck
+              checkMatchesText
             )
             ReferencesResult(occurrence.symbol, locations)
           case None =>
@@ -197,7 +197,7 @@ final class ReferenceProvider(
       occ: SymbolOccurrence,
       alternatives: Set[String],
       isIncludeDeclaration: Boolean,
-      strictCheck: Boolean
+      checkMatchesText: Boolean
   ): Seq[Location] = {
     val isSymbol = alternatives + occ.symbol
     if (occ.symbol.isLocal) {
@@ -207,7 +207,7 @@ final class ReferenceProvider(
         distance,
         params.getTextDocument.getUri,
         isIncludeDeclaration,
-        strictCheck
+        checkMatchesText
       )
     } else {
       val results: Iterator[Location] = for {
@@ -233,7 +233,7 @@ final class ReferenceProvider(
             semanticdbDistance,
             uri,
             isIncludeDeclaration,
-            strictCheck
+            checkMatchesText
           )
         } catch {
           case NonFatal(e) =>
@@ -252,7 +252,7 @@ final class ReferenceProvider(
       distance: TokenEditDistance,
       uri: String,
       isIncludeDeclaration: Boolean,
-      strictCheck: Boolean
+      checkMatchesText: Boolean
   ): Seq[Location] = {
     val buf = Seq.newBuilder[Location]
     def add(range: s.Range): Unit = {
@@ -270,7 +270,7 @@ final class ReferenceProvider(
       if isSymbol(reference.symbol)
       if !reference.role.isDefinition || isIncludeDeclaration
       range <- reference.range.toList
-      if !strictCheck || reference.symbol.contains(
+      if !checkMatchesText || reference.symbol.contains(
         findName(range, snapshot.text)
       )
     } {

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -83,23 +83,27 @@ final class RenameProvider(
         if canRenameSymbol(occurence.symbol, Option(params.getNewName()))
         parentSymbols = implementationProvider
           .topMethodParents(occurence.symbol, semanticDb)
-        txtParams <- if (parentSymbols.isEmpty) List(textParams)
-        else parentSymbols.map(toTextParams)
+        txtParams <- {
+          if (parentSymbols.isEmpty) List(textParams)
+          else parentSymbols.map(toTextParams)
+        }
         isLocal = occurence.symbol.isLocal
         currentReferences = referenceProvider
           .references(
             // we can't get definition by name for local symbols
             toReferenceParams(txtParams, includeDeclaration = isLocal),
             // local symbol will not contain a proper name
-            strictCheck = !isLocal
+            checkMatchesText = !isLocal
           )
           .locations
-        definitionLocation = if (parentSymbols.isEmpty)
-          definitionProvider
-            .fromSymbol(occurence.symbol)
-            .asScala
-            .filter(_.getUri().isScalaFilename)
-        else parentSymbols
+        definitionLocation = {
+          if (parentSymbols.isEmpty)
+            definitionProvider
+              .fromSymbol(occurence.symbol)
+              .asScala
+              .filter(_.getUri().isScalaFilename)
+          else parentSymbols
+        }
         companionRefs = companionReferences(occurence.symbol)
         implReferences = implementations(
           txtParams,

--- a/tests/unit/src/test/scala/tests/ImplementationLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ImplementationLspSuite.scala
@@ -1,7 +1,7 @@
 package tests
 import scala.concurrent.Future
 
-object ImplementationSuite extends BaseLspSuite("implementation") {
+object ImplementationLspSuite extends BaseLspSuite("implementation") {
 
   check(
     "basic",

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -391,6 +391,36 @@ object RenameLspSuite extends BaseLspSuite("rename") {
     breakingChange = (str: String) => str.replaceAll("Int", "String")
   )
 
+  renamed(
+    "macro-annotation",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |import io.circe.generic.JsonCodec
+       |trait LivingBeing
+       |@JsonCodec sealed trait <<An@@imal>> extends LivingBeing
+       |object <<Animal>> {
+       |  case object Dog extends <<Animal>>
+       |  case object Cat extends <<Animal>>
+       |}
+       |""".stripMargin,
+    "Tree"
+  )
+
+  renamed(
+    "macro-annotation2",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |import io.circe.generic.JsonCodec
+       |trait <<LivingBeing>>
+       |@JsonCodec sealed trait Animal extends <<Livi@@ngBeing>>
+       |object Animal {
+       |  case object Dog extends Animal
+       |  case object Cat extends Animal
+       |}
+       |""".stripMargin,
+    "Tree"
+  )
+
   // tests currently not working correctly due to issues in SemanticDB
   // issue https://github.com/scalameta/scalameta/issues/1636
   renamed(
@@ -406,20 +436,6 @@ object RenameLspSuite extends BaseLspSuite("rename") {
        |}
        |""".stripMargin,
     newName = "name"
-  )
-
-  same(
-    "macro-annotation",
-    """|/a/src/main/scala/a/Main.scala
-       |package a
-       |import io.circe.generic.JsonCodec
-       |trait LivingBeing
-       |@JsonCodec sealed trait <<An@@imal>> extends LivingBeing
-       |object Animal {
-       |  case object Dog extends <<Animal>>
-       |  case object Cat extends <<Animal>>
-       |}
-       |""".stripMargin
   )
 
   renamed(

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -392,7 +392,7 @@ object RenameLspSuite extends BaseLspSuite("rename") {
   )
 
   renamed(
-    "macro-annotation",
+    "macro",
     """|/a/src/main/scala/a/Main.scala
        |package a
        |import io.circe.generic.JsonCodec
@@ -407,7 +407,7 @@ object RenameLspSuite extends BaseLspSuite("rename") {
   )
 
   renamed(
-    "macro-annotation2",
+    "macro2",
     """|/a/src/main/scala/a/Main.scala
        |package a
        |import io.circe.generic.JsonCodec
@@ -421,8 +421,27 @@ object RenameLspSuite extends BaseLspSuite("rename") {
     "Tree"
   )
 
+  renamed(
+    "macro3",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |import io.circe.generic.JsonCodec
+       |trait LivingBeing
+       |@JsonCodec sealed trait <<Animal>> extends LivingBeing
+       |case object Dog extends <<Animal>>
+       |case object Cat extends <<Animal>>
+       |/a/src/main/scala/a/Use.scala
+       |package a
+       |object Use {
+       |  val dog : <<An@@imal>> = Dog
+       |}
+       |""".stripMargin,
+    "Tree"
+  )
+
   // tests currently not working correctly due to issues in SemanticDB
-  // issue https://github.com/scalameta/scalameta/issues/1636
+  // issue https://github.com/scalameta/scalameta/issues/1169
+  // possibly issue https://github.com/scalameta/scalameta/issues/1845
   renamed(
     "params",
     """|/a/src/main/scala/a/Main.scala
@@ -438,6 +457,7 @@ object RenameLspSuite extends BaseLspSuite("rename") {
     newName = "name"
   )
 
+  // https://github.com/scalameta/scalameta/issues/1909
   renamed(
     "type-params",
     """|/a/src/main/scala/a/Main.scala


### PR DESCRIPTION
Previously, renames would not work correctly in case of macro annotations - it would not find annotated classes definition and create an additional reference pointing to the annotation itself.

Now, we always try to find the definition separately for non local symbols and we check all references to be at the right names.