### PR TITLE
Specify a custom directory for Bloop to emit classfiles.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.metals
 
 import java.io.InputStream
 import java.io.OutputStream
+import java.nio.file.Files
 import java.net.URI
 import java.util.Collections
 import java.util.concurrent.CompletableFuture
@@ -143,6 +144,7 @@ object BuildServerConnection {
   }
 
   final case class BloopExtraBuildParams(
+      clientClassesRootDir: String,
       semanticdbVersion: String,
       supportedScalaVersions: java.util.List[String]
   )
@@ -152,7 +154,10 @@ object BuildServerConnection {
       workspace: AbsolutePath,
       server: MetalsBuildServer
   ): InitializeBuildResult = {
+    val clientClassesDirectory =
+      workspace.resolve(Directories.bloopClientClasses)
     val extraParams = BloopExtraBuildParams(
+      Files.createDirectories(clientClassesDirectory.toNIO).toUri.toString,
       BuildInfo.scalametaVersion,
       BuildInfo.supportedScalaVersions.asJava
     )

--- a/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
@@ -2,6 +2,8 @@ package scala.meta.internal.metals
 import scala.meta.io.RelativePath
 
 object Directories {
+  def bloopClientClassesDirectory: RelativePath =
+    RelativePath(".metals").resolve("bloop-out")
   def database: RelativePath =
     RelativePath(".metals").resolve("metals.h2.db")
   def readonly: RelativePath =


### PR DESCRIPTION
Previously, Bloop would allocate a new directory for every new BSP
session with Metals. This introduced runtime overhead fromdeleting/copying large amounts of classfiles+semanticdb on Metals startup. This also introduced unpredicability:
* SemanticDB indexing was only triggered by file watching because
  classes directory was empty on a fresh BSP session.
* tree view displayed empty package view for build targets that hadn't
  finished copying classfiles over.

Now, Bloop will always write classfiles to the same stable directory
under `.metals/`. This means that Metals will always index SemanticDB
files on startup when starting in a directory with an existing build
that has already been compiled.