### PR TITLE
Gracefully handle jvm-directories failures, fixes #1085.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BspServers.scala
@@ -169,6 +169,8 @@ final class BspServers(
 object BspServers {
   def globalInstallDirectories: List[AbsolutePath] = {
     val dirs = ProjectDirectories.fromPath("bsp")
-    List(dirs.dataLocalDir, dirs.dataDir).distinct.map(AbsolutePath(_))
+    List(dirs.dataLocalDir, dirs.dataDir).distinct
+      .map(path => Try(AbsolutePath(path)).toOption)
+      .flatten
   }
 }


### PR DESCRIPTION
Previously, we used `Paths.get(..)` directly on the path returned by the
jvm-directories libraries, which could crash on some Windows
installations. Now, we fallback to silently ignoring the issue.  It's
fine to silently ignore this issue since users can still configure
custom BSP servers via the local directory. The BSP server discovery
spec says that KNOWNFOLDERID should be used on Windows to determine the
global directory, if the running computer does not support that feature
then we can't support it in Metals.