### PR TITLE
[DAP-tests] Adapt new lines to the underlying OS

### DIFF
--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/DebuggeeOutput.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/DebuggeeOutput.scala
@@ -1,0 +1,47 @@
+package scala.meta.internal.metals.debug
+
+import scala.collection.mutable
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.meta.internal.metals.debug.DebuggeeOutput.PrefixPattern
+
+final class DebuggeeOutput {
+  private val output = new StringBuilder
+  @volatile private var listeners = mutable.Buffer.empty[PrefixPattern]
+
+  def apply(): String = synchronized(output.toString())
+
+  def append(message: String): Unit = synchronized {
+    output.append(message)
+
+    val remaining = listeners.filterNot(_.matches(output.toString()))
+    listeners = remaining
+  }
+
+  def awaitPrefix(prefix: String): Future[Unit] = synchronized {
+    if (output.startsWith(prefix)) {
+      Future.unit
+    } else {
+      val promise = Promise[Unit]()
+      listeners.append(new PrefixPattern(prefix, promise))
+      promise.future
+    }
+  }
+}
+
+object DebuggeeOutput {
+  protected final class PrefixPattern(prefix: String, promise: Promise[Unit]) {
+    def matches(output: String): Boolean = {
+      if (output.startsWith(prefix)) {
+        promise.success(())
+        true
+      } else {
+        false
+      }
+    }
+
+    def foo(): Unit = {
+      promise.success(())
+    }
+  }
+}

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Debugger.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Debugger.scala
@@ -1,0 +1,55 @@
+package scala.meta.internal.metals.debug
+
+import java.util.Collections
+import java.util.concurrent.TimeUnit
+import org.eclipse.lsp4j.debug.Capabilities
+import org.eclipse.lsp4j.debug.ConfigurationDoneArguments
+import org.eclipse.lsp4j.debug.DisconnectArguments
+import org.eclipse.lsp4j.debug.InitializeRequestArguments
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.meta.internal.metals.MetalsEnrichments._
+
+/**
+ * Provides simple facade over the Debug Adapter Protocol
+ * by hiding the implementation details of how to build the
+ * request arguments
+ */
+final class Debugger(server: RemoteServer)(implicit ec: ExecutionContext) {
+
+  def initialize: Future[Capabilities] = {
+    val arguments = new InitializeRequestArguments
+    arguments.setAdapterID("test-adapter")
+    server.initialize(arguments).asScala
+  }
+
+  def launch: Future[Unit] = {
+    server.launch(Collections.emptyMap()).asScala.ignoreValue
+  }
+
+  def configurationDone: Future[Unit] = {
+    server
+      .configurationDone(new ConfigurationDoneArguments)
+      .asScala
+      .ignoreValue
+  }
+
+  def restart: Future[Unit] = {
+    val args = new DisconnectArguments
+    args.setRestart(true)
+    server.disconnect(args).asScala.ignoreValue
+  }
+
+  def disconnect: Future[Unit] = {
+    val args = new DisconnectArguments
+    args.setRestart(false)
+    args.setTerminateDebuggee(false)
+    server.disconnect(args).asScala.ignoreValue
+  }
+
+  def shutdown: Future[Unit] = {
+    server.listening.withTimeout(20, TimeUnit.SECONDS).andThen {
+      case _ => server.cancel()
+    }
+  }
+}

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/TestDebugger.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/TestDebugger.scala
@@ -59,7 +59,7 @@ final class TestDebugger(connect: RemoteServer.Listener => Debugger)(
   def awaitOutput(prefix: String, seconds: Int = 5): Future[Unit] = {
     ifNotFailed {
       output
-        .awaitPrefix(prefix)
+        .awaitPrefix(prefix.replaceAll("\n", System.lineSeparator()))
         .withTimeout(seconds, TimeUnit.SECONDS)
         .recoverWith {
           case timeout: TimeoutException =>

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/TestDebugger.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/TestDebugger.scala
@@ -3,106 +3,120 @@ package scala.meta.internal.metals.debug
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.net.URI
-import java.util.Collections
 import java.util.concurrent.TimeUnit
 import org.eclipse.lsp4j.debug.Capabilities
-import org.eclipse.lsp4j.debug.ConfigurationDoneArguments
-import org.eclipse.lsp4j.debug.DisconnectArguments
-import org.eclipse.lsp4j.debug.InitializeRequestArguments
 import org.eclipse.lsp4j.debug.OutputEventArguments
-import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
+import scala.concurrent.TimeoutException
 import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.internal.metals.debug.TestDebugger.Prefix
 
-final class TestDebugger(connect: RemoteServer.Listener => RemoteServer)(
+final class TestDebugger(connect: RemoteServer.Listener => Debugger)(
     implicit ec: ExecutionContext
 ) extends RemoteServer.Listener {
+  @volatile private var debugger = connect(this)
+  @volatile private var terminated: Promise[Unit] = Promise()
+  @volatile private var output = new DebuggeeOutput
 
-  @volatile private var server: RemoteServer = connect(this)
-  private var terminationPromise = Promise[Unit]()
-  private val outputBuffer = new StringBuilder
-  private val prefixes = mutable.Set.empty[Prefix]
+  @volatile private var failure: Option[Throwable] = None
 
   def initialize: Future[Capabilities] = {
-    val arguments = new InitializeRequestArguments
-    arguments.setAdapterID("test-adapter")
-    server.initialize(arguments).asScala
+    ifNotFailed(debugger.initialize)
   }
 
   def launch: Future[Unit] = {
-    for {
-      _ <- server.launch(Collections.emptyMap()).asScala
-      _ <- server.configurationDone(new ConfigurationDoneArguments).asScala
-    } yield ()
+    ifNotFailed(debugger.launch)
+  }
+
+  def configurationDone: Future[Unit] = {
+    ifNotFailed(debugger.configurationDone)
   }
 
   def restart: Future[Unit] = {
-    val args = new DisconnectArguments
-    args.setRestart(true)
-    for {
-      _ <- server.disconnect(args).asScala
-      _ <- awaitCompletion
-    } yield {
-      terminationPromise = Promise()
-      server = connect(this)
-      outputBuffer.clear()
+    ifNotFailed(debugger.restart).andThen {
+      case _ =>
+        debugger = connect(this)
+        terminated = Promise()
+        output = new DebuggeeOutput
     }
   }
 
   def disconnect: Future[Unit] = {
-    val args = new DisconnectArguments
-    args.setRestart(false)
-    args.setTerminateDebuggee(false)
-    server.disconnect(args).asScala.ignoreValue
+    ifNotFailed(debugger.disconnect)
   }
 
   /**
    * Not waiting for exited because it might not be sent
    */
-  def awaitCompletion: Future[Unit] = {
+  def shutdown: Future[Unit] = {
     for {
-      _ <- terminationPromise.future
-      _ <- server.listening.onTimeout(20, TimeUnit.SECONDS)(this.close())
+      _ <- terminated.future
+      _ <- debugger.shutdown
     } yield ()
   }
 
-  def awaitOutput(expected: String): Future[Unit] = {
-    val prefix = Prefix(expected, Promise())
-    prefixes += prefix
-
-    if (output.startsWith(expected)) {
-      prefix.promise.success(())
-      prefixes -= prefix
+  def awaitOutput(prefix: String, seconds: Int = 5): Future[Unit] = {
+    ifNotFailed {
+      output
+        .awaitPrefix(prefix)
+        .withTimeout(seconds, TimeUnit.SECONDS)
+        .recoverWith {
+          case timeout: TimeoutException =>
+            val error = s"No prefix [$prefix] in [${output()}]"
+            Future.failed(new Exception(error, timeout))
+        }
     }
-
-    prefix.promise.future
   }
 
-  def output: String = outputBuffer.toString()
-
-  def close(): Unit = {
-    server.cancel()
-    prefixes.foreach { prefix =>
-      val message = s"Output did not start with ${prefix.pattern}"
-      prefix.promise.failure(new IllegalStateException(message))
-    }
+  def allOutput: Future[String] = {
+    terminated.future.map(_ => output())
   }
 
   override def onOutput(event: OutputEventArguments): Unit = {
-    outputBuffer.append(event.getOutput)
-    val out = output
-    val matched = prefixes.filter(prefix => out.startsWith(prefix.pattern))
-    matched.foreach { prefix =>
-      prefixes.remove(prefix)
-      prefix.promise.success(())
+    import org.eclipse.lsp4j.debug.{OutputEventArgumentsCategory => Category}
+    event.getCategory match {
+      case Category.STDOUT =>
+        output.append(event.getOutput)
+      case Category.STDERR =>
+        fail(new IllegalStateException(event.getOutput))
+      case _ =>
+      // ignore
     }
   }
 
   override def onTerminated(): Unit = {
-    terminationPromise.trySuccess(())
+    terminated.trySuccess(()) // might already be completed in [[fail]]
+  }
+
+  private def ifNotFailed[A](action: => Future[A]): Future[A] = {
+    import scala.util.{Failure, Success}
+    failure match {
+      case Some(error) => // don't start the action if already failed
+        Future.failed(error)
+      case None =>
+        action.andThen {
+          case Failure(error) => // fail when the action fails
+            failure.foreach(error.addSuppressed)
+            fail(error)
+            Future.failed(error)
+          case Success(value) =>
+            failure match {
+              case Some(error) => // propagate failure that occurred while processing action
+                Future.failed(error)
+              case None =>
+                Future.successful(value)
+            }
+        }
+    }
+  }
+
+  private def fail(error: Throwable): Unit = {
+    if (failure.isEmpty) {
+      failure = Some(error)
+      terminated.tryFailure(error)
+      disconnect.andThen { case _ => debugger.shutdown }
+    }
   }
 }
 
@@ -110,14 +124,13 @@ object TestDebugger {
   private val timeout = TimeUnit.SECONDS.toMillis(60).toInt
 
   def apply(uri: URI)(implicit ec: ExecutionContext): TestDebugger = {
-    def connect(listener: RemoteServer.Listener): RemoteServer = {
+    def connect(listener: RemoteServer.Listener): Debugger = {
       val socket = new Socket()
       socket.connect(new InetSocketAddress(uri.getHost, uri.getPort), timeout)
-      RemoteServer(socket, listener)
+      val server = RemoteServer(socket, listener)
+      new Debugger(server)
     }
 
     new TestDebugger(connect)
   }
-
-  final case class Prefix(pattern: String, promise: Promise[Unit])
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -329,16 +329,18 @@ final class TestingServer(
   }
 
   def startDebugging(
-      a: String,
+      target: String,
       kind: String,
       parameter: AnyRef
   ): Future[TestDebugger] = {
-    val targets = List(new b.BuildTargetIdentifier(buildTarget(a)))
+    val targets = List(new b.BuildTargetIdentifier(buildTarget(target)))
     val params =
       new b.DebugSessionParams(targets.asJava, kind, parameter.toJson)
 
-    executeCommand(ServerCommands.StartDebugAdapter.id, params)
-      .collect { case DebugSession(_, uri) => TestDebugger(URI.create(uri)) }
+    executeCommand(ServerCommands.StartDebugAdapter.id, params).collect {
+      case DebugSession(_, uri) =>
+        TestDebugger(URI.create(uri))
+    }
   }
 
   def didFocus(filename: String): Future[DidFocusResult.Value] = {

--- a/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
@@ -10,18 +10,6 @@ import scala.concurrent.Future
 
 object DebugProtocolSuite extends BaseLspSuite("debug-protocol") {
 
-  override def testAsync(
-      name: String,
-      maxDuration: Duration = Duration("3min")
-  )(run: => Future[Unit]): Unit = {
-    if (BaseSuite.isWindows) {
-      // Currently not working on Windows
-      ignore(name) {}
-    } else {
-      super.testAsync(name, maxDuration)(run)
-    }
-  }
-
   testAsync("start") {
     for {
       _ <- server.initialize(


### PR DESCRIPTION
Previously, waiting for output containing new lines was system dependent - we were expecting `\n` even on windows. Now, we are automatically adapting unix new lines to the underlying OS.