### PR TITLE
Revert "Update directory-watcher to 0.8.3"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,23 +5,20 @@ on:
       - master
   pull_request:
 jobs:
-  windows:
-    name: Windows unit tests
-    runs-on: windows-latest
+  unit:
+    name: ${{ matrix.os }} tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v1
-      - uses: olafurpg/setup-scala@v7
-      - name: Run unit tests
-        run: bin/test.sh "unit/test"
-        shell: bash
-  linux:
-    name: Linux unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
+
       - uses: olafurpg/setup-scala@v7
       - name: Run unit tests
         run: bin/test.sh unit/test
+        shell: bash
   sbt:
     name: Sbt integration
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -240,7 +240,7 @@ lazy val metals = project
       // for measuring memory footprint
       "org.openjdk.jol" % "jol-core" % "0.9",
       // for file watching
-      "io.methvin" % "directory-watcher" % "0.8.3",
+      "io.methvin" % "directory-watcher" % "0.8.0",
       // for http client
       "io.undertow" % "undertow-core" % "2.0.28.Final",
       "org.jboss.xnio" % "xnio-nio" % "3.6.5.Final",

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -85,6 +85,7 @@ import org.eclipse.lsp4j.RenameParams
 import scala.meta.internal.metals.TextEdits
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.RenameFile
+import scala.util.Properties
 
 /**
  * Wrapper around `MetalsLanguageServer` with helpers methods for testing purpopses.
@@ -117,7 +118,8 @@ final class TestingServer(
     progressTicks = ProgressTicks.none,
     bspGlobalDirectories = bspGlobalDirectories,
     sh = sh,
-    time = time
+    time = time,
+    isReliableFileWatcher = Properties.isLinux
   )
   server.connectToLanguageClient(client)
   private val readonlySources = TrieMap.empty[String, AbsolutePath]
@@ -748,8 +750,7 @@ final class TestingServer(
           file -> path.readText
         } else {
           val code = buffers.get(path).get
-          if (renames
-              .getDocumentChanges() == null) {
+          if (renames.getDocumentChanges() == null) {
             file -> code
           } else {
             val renamed = renameFile(file, renames)


### PR DESCRIPTION
The PR #1108 introduced an uncaught regression on macOS. 

```
Exception in thread "pool-2-thread-2" java.lang.NoSuchFieldError: SIZE
	at com.zaxxer.nuprocess.osx.OsxProcess.createPosixSpawnFileActions(OsxProcess.java:191)
	at com.zaxxer.nuprocess.osx.OsxProcess.createPosixPipes(OsxProcess.java:150)
	at com.zaxxer.nuprocess.osx.OsxProcess.start(OsxProcess.java:58)
	at com.zaxxer.nuprocess.osx.OsxProcessFactory.createProcess(OsxProcessFactory.java:34)
	at com.zaxxer.nuprocess.NuProcessBuilder.start(NuProcessBuilder.java:266)
	at scala.meta.internal.process.SystemProcess$.run(SystemProcess.scala:27)
	at scala.meta.internal.pantsbuild.Filemap$.fromPants(Filemap.scala:40)
	at scala.meta.internal.pantsbuild.BloopPants$.$anonfun$bloopInstall$1(BloopPants.scala:133)
	at scala.runtime.java8.JFunction0$mcI$sp.apply(JFunction0$mcI$sp.java:23)
	at scala.meta.internal.pantsbuild.BloopPants$.interruptedTry(BloopPants.scala:109)
```

Now, we run tests on macOS to prevent further regressions.
