### PR TITLE
Upgrade to h2 v1.4.200.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -246,7 +246,7 @@ lazy val metals = project
       "org.jboss.xnio" % "xnio-nio" % "3.6.9.Final",
       // for persistent data like "dismissed notification"
       "org.flywaydb" % "flyway-core" % "5.2.4",
-      "com.h2database" % "h2" % "1.4.197",
+      "com.h2database" % "h2" % "1.4.200",
       // for starting `sbt bloopInstall` process
       "com.zaxxer" % "nuprocess" % "1.2.4",
       "net.java.dev.jna" % "jna" % "5.5.0",

--- a/metals/src/main/resources/db/migration/V3__Jar_symbols.sql
+++ b/metals/src/main/resources/db/migration/V3__Jar_symbols.sql
@@ -1,7 +1,7 @@
 -- Indexed jars, the MD5 digest of path, modified time and size as key
 create table indexed_jar(
   id int auto_increment,
-  md5 varchar primary key,
+  md5 varchar primary key
 );
 -- Top Level Symbols per jar, allow for multiple jars with same symbols and paths
 create table toplevel_symbol(


### PR DESCRIPTION
Followup of #1101 fixing a trailing comma syntax error.

Sadly, this change means that the flyway migration will fail for all users when they upgrade and `.metals/metals.h2.db` will be dropped and recreated from scratch 😟 