### PR TITLE
Revert "Update jna, jna-platform to 5.5.0"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -249,8 +249,8 @@ lazy val metals = project
       "com.h2database" % "h2" % "1.4.197",
       // for starting `sbt bloopInstall` process
       "com.zaxxer" % "nuprocess" % "1.2.4",
-      "net.java.dev.jna" % "jna" % "5.5.0",
-      "net.java.dev.jna" % "jna-platform" % "5.5.0",
+      "net.java.dev.jna" % "jna" % "4.5.2",
+      "net.java.dev.jna" % "jna-platform" % "4.5.2",
       // for token edit-distance used by goto definition
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       // for BSP


### PR DESCRIPTION
This reverts commit a99afaf97204e1710d334c85dd8abec2f9072770.

This upgrade caused the same regression on macOS as the directory-watcher upgrade. The PR https://github.com/scalameta/metals/pull/1131 was merged this morning before we enabled the macOS CI.