### PR TITLE
Remove Deprecated Usage Of String#lines Method

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1181,7 +1181,7 @@ class MetalsLanguageServer(
       case ServerCommands.GotoLog() =>
         Future {
           val log = workspace.resolve(Directories.log)
-          val linesCount = log.readText.lines.size
+          val linesCount = log.readText.linesIterator.size
           val pos = new l.Position(linesCount, 0)
           languageClient.metalsExecuteClientCommand(
             new ExecuteCommandParams(


### PR DESCRIPTION
In JDK11 a method on `String` was added named `lines` which returned a `java.util.stream.Stream`. This collided with the enrichment method from Scala's `StringOps` class by the same name which returned an `Iterator`. The result, for metals, is that it was not possible to build metals using JDK11 or greater.

This commit uses the new enrichment method `linesIterator` which was added to the Scala standard library as a replacement. This now enables metals to compile on JDK11.

See: https://github.com/scala/bug/issues/11125