### PR TITLE
Use git fetch --unshallow to restore version number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v7
       - uses: actions/setup-node@v1
+      - run: git fetch --depth=10000
+      - run: git fetch --tags
       - name: Scalafmt & Scalafix & Docusaurus
         run: |
           ./bin/scalafmt --test


### PR DESCRIPTION
On advice from https://github.com/dwijnand/sbt-dynver/issues/133#issuecomment-561585983