### PR TITLE
Revert "Update directory watcher to 0.9.6"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -240,7 +240,7 @@ lazy val metals = project
       // for measuring memory footprint
       "org.openjdk.jol" % "jol-core" % "0.9",
       // for file watching
-      "io.methvin" % "directory-watcher" % "0.9.6",
+      "io.methvin" % "directory-watcher" % "0.8.0",
       // for http client
       "io.undertow" % "undertow-core" % "2.0.28.Final",
       "org.jboss.xnio" % "xnio-nio" % "3.7.7.Final",


### PR DESCRIPTION
This reverts commit a6278fbf6cc4e9fb7317b6999f5e6c38ed8b5270.

I'm still hitting on crashes when running the tests locally on my computer
```
Exception in thread "pool-2-thread-2" java.lang.NoSuchFieldError: SIZE
	at com.zaxxer.nuprocess.osx.OsxProcess.createPosixSpawnFileActions(OsxProcess.java:191)
	at com.zaxxer.nuprocess.osx.OsxProcess.createPosixPipes(OsxProcess.java:150)
	at com.zaxxer.nuprocess.osx.OsxProcess.start(OsxProcess.java:58)
	at com.zaxxer.nuprocess.osx.OsxProcessFactory.createProcess(OsxProcessFactory.java:34)
	at com.zaxxer.nuprocess.NuProcessBuilder.start(NuProcessBuilder.java:266)
	at scala.meta.internal.process.SystemProcess$.run(SystemProcess.scala:27)
	at scala.meta.internal.pantsbuild.Filemap$.fromPants(Filemap.scala:40)
	at scala.meta.internal.pantsbuild.BloopPants$.$anonfun$bloopInstall$1(BloopPants.scala:146)
	at scala.runtime.java8.JFunction0$mcI$sp.apply(JFunction0$mcI$sp.java:23)
	at scala.meta.internal.pantsbuild.BloopPants$.interruptedTry(BloopPants.scala:122)
  | => sat scala.meta.internal.pantsbuild.BloopPants$.bloopInstall(BloopPants.scala:129)
	at scala.meta.internal.builds.PantsBuildTool.$anonfun$bloopInstall$1(PantsBuildTool.scala:9
```

I'm on Mojave 10.14.6 (18G95) and I can reproduce with Java 1.8.0_111, adopt@1.8.0-232 and GraalVM 19.3 for JDK 11. It's concerning that the CI still passed on macOS with the upgrade.