### PR TITLE
Remove Two More Usages Of Deprecated `lines` Method

### DIFF
--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -303,7 +303,7 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
             .append("\n")
         }
         val input = path.toInputFromBuffers(buffers)
-        input.text.lines.zipWithIndex.foreach {
+        input.text.linesIterator.zipWithIndex.foreach {
           case (line, i) =>
             out.append(line)
             decorations

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1000,7 +1000,7 @@ final class TestingServer(
       isIgnored: String => Boolean = _ => true
   )(implicit sourcecodeLine: sourcecode.Line, file: sourcecode.File): String = {
     val path = toPath(filename)
-    val line = path.toInput.value.lines.zipWithIndex
+    val line = path.toInput.value.linesIterator.zipWithIndex
       .collectFirst {
         case (text, line) if text.contains(linePattern) =>
           line


### PR DESCRIPTION
In 4d78f9cf5a2e6c49d8a6e2474a49a8bbb99e216c a usage of the deprecated method `lines` on `StringOps` was changed to `linesIterator` to allow for compilation on JDK>=11. Two other invocations were also present in the code, but missed in that PR.