### PR TITLE
Remove Unused `packagePriority` Parameter From ClasspathSearch

### DIFF
--- a/metals-bench/src/main/scala/bench/ClasspathIndexingBench.scala
+++ b/metals-bench/src/main/scala/bench/ClasspathIndexingBench.scala
@@ -29,7 +29,7 @@ class ClasspathIndexingBench {
   @BenchmarkMode(Array(Mode.SingleShotTime))
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   def run(): Unit = {
-    ClasspathSearch.fromClasspath(classpath, _ => 1)
+    ClasspathSearch.fromClasspath(classpath)
   }
 
 }

--- a/metals-bench/src/main/scala/bench/CompletionBench.scala
+++ b/metals-bench/src/main/scala/bench/CompletionBench.scala
@@ -110,7 +110,7 @@ abstract class CompletionBench {
 
   def newSearch(): SymbolSearch = {
     require(libraries.nonEmpty)
-    new TestingSymbolSearch(ClasspathSearch.fromClasspath(classpath, _ => 0))
+    new TestingSymbolSearch(ClasspathSearch.fromClasspath(classpath))
   }
 
   def newPC(search: SymbolSearch = newSearch()): PresentationCompiler = {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -377,11 +377,6 @@ class MetalsLanguageServer(
       config.statistics,
       buildTargets,
       definitionIndex,
-      pkg => {
-        val mightContain =
-          referencesProvider.referencedPackages.mightContain(pkg)
-        if (mightContain) 0 else 1
-      },
       interactiveSemanticdbs.toFileOnDisk
     )
     foldingRangeProvider = FoldingRangeProvider(trees, buffers, params)

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -23,14 +23,13 @@ final class WorkspaceSymbolProvider(
     statistics: StatisticsConfig,
     val buildTargets: BuildTargets,
     val index: OnDemandSymbolIndex,
-    isReferencedPackage: String => Int,
     fileOnDisk: AbsolutePath => AbsolutePath,
     bucketSize: Int = CompressedPackageIndex.DefaultBucketSize
 )(implicit ec: ExecutionContext) {
   val inWorkspace: TrieMap[Path, WorkspaceSymbolsIndex] =
     TrieMap.empty[Path, WorkspaceSymbolsIndex]
   var inDependencies: ClasspathSearch =
-    ClasspathSearch.fromClasspath(Nil, isReferencedPackage, bucketSize)
+    ClasspathSearch.fromClasspath(Nil, bucketSize)
 
   def search(query: String): Seq[l.SymbolInformation] = {
     search(query, () => ())
@@ -94,8 +93,7 @@ final class WorkspaceSymbolProvider(
     } {
       packages.visit(classpathEntry)
     }
-    inDependencies =
-      ClasspathSearch.fromPackages(packages, isReferencedPackage, bucketSize)
+    inDependencies = ClasspathSearch.fromPackages(packages, bucketSize)
   }
 
   private def workspaceSearch(

--- a/mtags/src/main/scala/scala/meta/internal/metals/ClasspathSearch.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/ClasspathSearch.scala
@@ -7,8 +7,7 @@ import scala.meta.pc.SymbolSearchVisitor
 import scala.meta.internal.mtags.MtagsEnrichments._
 
 class ClasspathSearch(
-    val packages: Array[CompressedPackageIndex],
-    packagePriority: String => Int
+    val packages: Array[CompressedPackageIndex]
 ) {
   // The maximum number of non-exact matches that we return for classpath queries.
   // Generic queries like "Str" can returns several thousand results, so we need
@@ -77,21 +76,19 @@ class ClasspathSearch(
 
 object ClasspathSearch {
   def empty: ClasspathSearch =
-    new ClasspathSearch(Array.empty, _ => 0)
+    new ClasspathSearch(Array.empty)
   def fromPackages(
       packages: PackageIndex,
-      packagePriority: String => Int,
       bucketSize: Int = CompressedPackageIndex.DefaultBucketSize
   ): ClasspathSearch = {
     val map = CompressedPackageIndex.fromPackages(packages, bucketSize)
-    new ClasspathSearch(map, packagePriority)
+    new ClasspathSearch(map)
   }
   def fromClasspath(
       classpath: collection.Seq[Path],
-      packagePriority: String => Int,
       bucketSize: Int = CompressedPackageIndex.DefaultBucketSize
   ): ClasspathSearch = {
     val packages = PackageIndex.fromClasspath(classpath)
-    fromPackages(packages, packagePriority, bucketSize)
+    fromPackages(packages, bucketSize)
   }
 }

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -43,7 +43,7 @@ abstract class BasePCSuite extends BaseSuite {
   val indexer = new Docstrings(index)
   val workspace = new TestingWorkspaceSearch
   val search = new TestingSymbolSearch(
-    ClasspathSearch.fromClasspath(myclasspath, _ => 0),
+    ClasspathSearch.fromClasspath(myclasspath),
     new Docstrings(index),
     workspace,
     index

--- a/tests/unit/src/main/scala/tests/TestingWorkspaceSymbolProvider.scala
+++ b/tests/unit/src/main/scala/tests/TestingWorkspaceSymbolProvider.scala
@@ -15,7 +15,6 @@ object TestingWorkspaceSymbolProvider {
       buildTargets: BuildTargets = new BuildTargets,
       statistics: StatisticsConfig = StatisticsConfig.default,
       index: OnDemandSymbolIndex = OnDemandSymbolIndex(),
-      isReferencedPackage: String => Int = _ => 0,
       bucketSize: Int = CompressedPackageIndex.DefaultBucketSize
   ): WorkspaceSymbolProvider = {
     new WorkspaceSymbolProvider(
@@ -23,7 +22,6 @@ object TestingWorkspaceSymbolProvider {
       statistics = statistics,
       buildTargets = new BuildTargets,
       index = index,
-      isReferencedPackage,
       _.toFileOnDisk(workspace),
       bucketSize = bucketSize
     )


### PR DESCRIPTION
The parameter `packagePriority` in `ClasspathSearch` is unused.