### PR TITLE
Remove Unnecessary `asInstanceOf` And Unused Values

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/docstrings/HtmlConverter.scala
+++ b/mtags/src/main/scala/scala/meta/internal/docstrings/HtmlConverter.scala
@@ -71,8 +71,8 @@ object HtmlConverter {
     node match {
       case t: TextNode => t.getWholeText
       case e: Element =>
-        processHtmlElement(node.asInstanceOf[Element])
-      case x =>
+        processHtmlElement(e)
+      case _ =>
         println(s"unknown element - $node")
         ""
     }
@@ -120,7 +120,7 @@ object HtmlConverter {
                 nodeText
           }
           .mkString
-      case x =>
+      case _ =>
         ""
     }
   }


### PR DESCRIPTION
An `asInstanceOf` was being used to case a value to a subtype, but a pattern match had already safely created a typed value.

This commit also removes two unused named variables pattern matches in `HtmlConverter.scala`