### PR TITLE
Disable file hashing for improved startup performance.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
@@ -106,6 +106,7 @@ final class FileWatcher(
       .builder()
       .paths(directories)
       .listener(new DirectoryListener())
+      .fileHashing(false)
       .build()
     activeDirectoryWatcher = Some(directoryWatcher)
     directoryWatching = directoryWatcher.watchAsync(directoryExecutor)


### PR DESCRIPTION
Opening a separate PR for this change (it's currently part of #1145 ) to see whether it impacts the CI.

The file hashing feature in the directory watcher makes file watching very expensive to start in large directories.
See http://scalameta.org/metals/blog/2019/01/22/bloom-filters.html#indexing-time for more details on how expensive this step is.
We can safely disable the file hashing feature because it's fine if we get duplicate file watching notifications.
Our mtags indexer is fast enough that it's not a big deal if we end up tokenizing the same file twice.