### PR TITLE
Fix Runtime Error In Metals Bench

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -451,6 +451,7 @@ lazy val slow = project
 
 lazy val bench = project
   .in(file("metals-bench"))
+  .enablePlugins(BuildInfoPlugin)
   .settings(
     fork.in(run) := true,
     skip.in(publish) := true,
@@ -458,7 +459,9 @@ lazy val bench = project
     libraryDependencies ++= List(
       // for measuring memory usage
       "org.spire-math" %% "clouseau" % "0.2.2"
-    )
+    ),
+    buildInfoKeys := Seq[BuildInfoKey](scalaVersion),
+    buildInfoPackage := "bench"
   )
   .dependsOn(unit)
   .enablePlugins(JmhPlugin)

--- a/metals-bench/src/main/scala/bench/CompletionBench.scala
+++ b/metals-bench/src/main/scala/bench/CompletionBench.scala
@@ -42,7 +42,7 @@ abstract class CompletionBench {
       "akka-2.5.19/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala"
     val scala = Corpus.scala()
     val typers =
-      "scala-2.12.8/src/compiler/scala/tools/nsc/typechecker/Typers.scala"
+      s"scala-${bench.BuildInfo.scalaVersion}/src/compiler/scala/tools/nsc/typechecker/Typers.scala"
     val fastparse = Corpus.fastparse()
     val exprs =
       "fastparse-2.1.0/scalaparse/src/scalaparse/Exprs.scala"


### PR DESCRIPTION
A path to file needed to run the `CompletionBench` benchmark was hard coded as scala `2.12.8`. Since this is no longer the version of Scala used to compile `metals` this fails at runtime.

This was changed to use sbt-buildinfo to populate the correct version of scala for the given build from the build definition directly.