### PR TITLE
Fix Windows CI Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-    env:
-      JAVA_OPTS: -Xss4m -Xms1G -Xmx8G -XX:ReservedCodeCacheSize=1024m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -Dfile.encoding=UTF-8 -Djna.nosys=true
     steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v7
       - name: Run unit tests
         run: |
-          rm .jvmopts
           bin/test.sh unit/test
         shell: bash
   sbt:

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -7,5 +7,7 @@ function bloop_version {
 curl -Lo coursier https://git.io/coursier-cli && chmod +x coursier
 ./coursier launch ch.epfl.scala:bloopgun-core_2.12:$(bloop_version) -- about
 
+sed -i 's/\r//g' .jvmopts
+
 sbt "$1"
 # sbt must be the last command - its exit code signals if tests passed or not


### PR DESCRIPTION
Windows CI tests are failing because the `.jvmopts` file in the CI environment has DOS style line endings, e.g. `\r\n`. This _is not the case in VSC_ and I am unsure how/why it is getting modified when running in the Windows CI environment.

Nevertheless, the result is that this bash function is reading values in with carriage returns at the end.

https://github.com/paulp/sbt-extras/blob/59a9a1d24b1134587d1512012788421867d690fa/sbt#L495
```bash
readConfigFile() {
  local end=false
  until $end; do
    read -r || end=true
    [[ $REPLY =~ ^# ]] || [[ -z $REPLY ]] || echo "$REPLY"
  done <"$1"
}
```

This, `-Xss4m` becomes `-Xss4m\r`. This is also why the error message looks odd, e.g. `Invalid thread stack size: -Xss4m`. The invalid part of that is the `\r` which is not literally printed.

As work around we run a `sed -i 's/\r//g'` over the `.jvmopts` file before starting the build.

This should be considered a short term work around. One of two different changes should take place long term.

* `sbt-extras` should be updated to handle `\r` in the `.jvmopts` file.
    * This is a pretty small change, but I am unsure if the `sbt-extras` maintainers want this behavior. It would be perfect valid to require Unix line endings.
* `metals` needs to figure out why the Windows CI environment is mangling the files to have DOS line endings.
    * Just because DOS line endings are standard on Windows, doesn't mean that files should be modified _in anyway_.


----

#