### PR TITLE
Fix renames for edited companion objects and case class apply/c…

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -112,13 +112,11 @@ final class DefinitionProvider(
       queryPosition <- snapshotPosition.toPosition(dirtyPosition.getPosition)
       occurrence <- snapshot.occurrences
         .find(_.encloses(queryPosition, true))
+        // In case of macros we might need to get the postion from the presentation compiler
+        .orElse(fromMtags(source, queryPosition))
     } yield occurrence
 
-    // In case of macros we might need to get the postion from the presentation compiler
-    val sureOccurence =
-      occurrence.orElse(fromMtags(source, dirtyPosition.getPosition()))
-
-    ResolvedSymbolOccurrence(sourceDistance, sureOccurence)
+    ResolvedSymbolOccurrence(sourceDistance, occurrence)
   }
 
   def definitionFromSnapshot(

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -113,24 +113,6 @@ final class ReferenceProvider(
           info.symbol.owner,
           Descriptor.Type(info.displayName)
         )
-    // Returns true if `info` is a synthetic `copy` or `apply` of the occurrence class symbol.
-    def isCopyOrApplyMethod(info: SymbolInformation): Boolean =
-      info.isMethod &&
-        isCopyOrApply(info.displayName) &&
-        occ.symbol == (Symbol(info.symbol) match {
-          case GlobalSymbol(
-              GlobalSymbol(owner, Descriptor.Term(obj)),
-              Descriptor.Method("apply", _)
-              ) =>
-            Symbols.Global(owner.value, Descriptor.Type(obj))
-          case GlobalSymbol(
-              GlobalSymbol(owner, Descriptor.Type(obj)),
-              Descriptor.Method("copy", _)
-              ) =>
-            Symbols.Global(owner.value, Descriptor.Type(obj))
-          case _ =>
-            ""
-        })
     // Returns true if `info` is a parameter of a synthetic `copy` or `apply` matching the occurrence field symbol.
     def isCopyOrApplyParam(info: SymbolInformation): Boolean =
       info.isParameter &&
@@ -180,8 +162,7 @@ final class ReferenceProvider(
       if {
         isVarSetter(info) ||
         isCompanionObject(info) ||
-        isCopyOrApplyParam(info) ||
-        isCopyOrApplyMethod(info)
+        isCopyOrApplyParam(info)
       }
     } yield info.symbol
     val isCandidate = candidates.toSet

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -42,7 +42,27 @@ object ReferenceLspSuite extends BaseLspSuite("reference") {
       )
       _ = assertNoDiagnostics()
       _ <- server.didOpen("a/src/main/scala/a/A.scala")
-      _ = server.assertReferenceDefinitionBijection()
+      _ = server.assertReferenceDefinitionDiff(
+        """|--- references
+           |+++ definition
+           |                              ^
+           |+a/src/main/scala/a/A.scala:4:36: a/A#
+           |+  def apply(a: Int, b: Int): A = A.apply(a) // overloaded non-synthetic apply
+           |+                                   ^^^^^
+           |+a/src/main/scala/a/A.scala:9:6: a/A#
+           |+    .apply(a = 1)
+           |+     ^^^^^
+           |+a/src/main/scala/a/A.scala:10:6: a/A#
+           |+    .copy(a = 2)
+           |+     ^^^^
+           | b/src/main/scala/b/B.scala:4:12: a/A#
+           |            ^
+           |+b/src/main/scala/b/B.scala:4:20: a/A#
+           |+  val y: a.A = a.A.apply(1)
+           |+                   ^^^^^
+           | b/src/main/scala/b/B.scala:5:13: a/A#
+           |""".stripMargin
+      )
     } yield ()
   }
 

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -423,21 +423,35 @@ object RenameLspSuite extends BaseLspSuite("rename") {
   )
 
   renamed(
-    "macro3",
+    "macro",
     """|/a/src/main/scala/a/Main.scala
        |package a
        |import io.circe.generic.JsonCodec
        |trait LivingBeing
        |@JsonCodec sealed trait <<Animal>> extends LivingBeing
-       |case object Dog extends <<Animal>>
-       |case object Cat extends <<Animal>>
+       |object <<Animal>>{
+       |  case object Dog extends <<Animal>>
+       |  case object Cat extends <<Animal>>
+       |}
        |/a/src/main/scala/a/Use.scala
        |package a
        |object Use {
-       |  val dog : <<An@@imal>> = Dog
+       |  val dog : <<An@@imal>> = <<Animal>>.Dog
        |}
        |""".stripMargin,
     "Tree"
+  )
+
+  renamed(
+    "implicit-param",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object A {
+       |  implicit val <<some@@Name>>: Int = 1
+       |  def m[A](implicit a: A): A = a
+       |  m[Int]
+       |}""".stripMargin,
+    newName = "anotherName"
   )
 
   // tests currently not working correctly due to issues in SemanticDB
@@ -471,18 +485,6 @@ object RenameLspSuite extends BaseLspSuite("rename") {
        |}
        |""".stripMargin,
     newName = "Animal"
-  )
-
-  renamed(
-    "implicit-param",
-    """|/a/src/main/scala/a/Main.scala
-       |package a
-       |object A {
-       |  implicit val <<some@@Name>>: Int = 1
-       |  def m[A](implicit a: A): A = a
-       |  m[Int]
-       |}""".stripMargin,
-    newName = "anotherName"
   )
 
   def renamed(

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -20,6 +20,20 @@ object RenameLspSuite extends BaseLspSuite("rename") {
   )
 
   renamed(
+    "case",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |case class <<User>>(name : String)
+       |object Main{
+       |  val user = <<U@@ser>>.apply("James")
+       |  val user2 = <<U@@ser>>(name = "Roger")
+       |  user.copy(name = "")
+       |}
+       |""".stripMargin,
+    newName = "Login"
+  )
+
+  renamed(
     "across-targets",
     """|/a/src/main/scala/a/Main.scala
        |package a


### PR DESCRIPTION
*Fix renames for edited companion objects*
Previously, when renaming in a workspace with edited files with macro annotated classes some symbols would not be renamed properly. Now, we make sure that token distance is taken into account in those files. 

*Fix renaming copy/apply occurrence*
Previously, all copy/apply occurences for case classes would be renamed to the new class name. Now, we do not rename those symbols and additionally `textDocument/references` don't return them.