### PR TITLE
Disable EOL Conversion On /.jvmopts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/.jvmopts eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-    env:
-      JAVA_OPTS: -Xss4m -Xms1G -Xmx8G -XX:ReservedCodeCacheSize=1024m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -Dfile.encoding=UTF-8 -Djna.nosys=true
     steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v7
       - name: Run unit tests
         run: |
-          rm .jvmopts
           bin/test.sh unit/test
         shell: bash
   sbt:


### PR DESCRIPTION
Add a `.gitattributes` file to prevent end of line (EOL) conversion on the `/.jvmopts` file. This was the causing windows based CI failures as the JVM options were being parsed with a carriage return at the end of them.

This commit also re-enables use of the `.jvmopts` file in the Windows CI environment.


----

#