### PR TITLE
Remove Usage Of Deprecated `lines` Method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [windows-latest, macOS-latest, ubuntu-latest]
+        java: [8, 11]
+        exclude:
+          - os: windows-latest
+            java: 8
+          - os: macOS-latest
+            java: 8
     steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v7
+        with:
+          java-version: "adopt@1.${{ matrix.java }}"
       - name: Run unit tests
         run: |
           bin/test.sh unit/test
@@ -25,6 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v7
+        with:
+          java-version: "adopt@1.11"
       - name: Run Sbt tests
         run: bin/test.sh 'slow/testOnly -- tests.sbt'
   maven:
@@ -33,6 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v7
+        with:
+          java-version: "adopt@1.11"
       - name: Run Maven tests
         run: bin/test.sh 'slow/testOnly -- tests.maven'
   gradle:
@@ -41,6 +53,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v7
+        with:
+          java-version: "adopt@1.11"
       - name: Run Gradle tests
         run: bin/test.sh 'slow/testOnly -- tests.gradle'
   mill:
@@ -49,6 +63,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v7
+        with:
+          java-version: "adopt@1.11"
       - name: Run Mill tests
         run: bin/test.sh 'slow/testOnly -- tests.mill'
   pants:
@@ -56,7 +72,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: olafurpg/setup-scala@v5
+      - uses: olafurpg/setup-scala@v7
+        with:
+          java-version: "adopt@1.11"
       - name: Run Pants tests
         run: bin/test.sh 'slow/testOnly -- tests.pants'
   feature:
@@ -65,6 +83,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v7
+        with:
+          java-version: "adopt@1.11"
       - name: Run LSP tests
         run: bin/test.sh 'slow/testOnly -- tests.feature'
   cross:
@@ -73,6 +93,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v7
+        with:
+          java-version: "adopt@1.11"
       - name: Run cross tests
         run: sbt +cross/test
   checks:
@@ -81,6 +103,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: olafurpg/setup-scala@v7
+        with:
+          java-version: "adopt@1.11"
       - uses: actions/setup-node@v1
       - run: git fetch --depth=10000
       - run: git fetch --tags

--- a/build.sbt
+++ b/build.sbt
@@ -158,8 +158,9 @@ lazy val V = new {
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.
   def supportedScalaVersions =
-    Seq("2.13.0", scala213, scala212) ++ deprecatedScalaVersions
+    nonDeprecatedScalaVersions ++ deprecatedScalaVersions
   def deprecatedScalaVersions = Seq("2.12.8", "2.12.9", scala211)
+  def nonDeprecatedScalaVersions = Seq("2.13.0", scala213, scala212)
   def guava = "com.google.guava" % "guava" % "28.1-jre"
   def lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.8.1"
   def dap4j =
@@ -384,7 +385,7 @@ lazy val cross = project
         List("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
       case _ => Nil
     }),
-    crossScalaVersions := V.supportedScalaVersions,
+    crossScalaVersions := V.nonDeprecatedScalaVersions,
     scalacOptions ++= crossSetting(
       scalaVersion.value,
       if211 = List("-Xexperimental", "-Ywarn-unused-import")

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
@@ -2,7 +2,6 @@ package scala.meta.internal.builds
 
 import java.nio.file.{Files, Path}
 import scala.meta.io.AbsolutePath
-import scala.util.Try
 import java.nio.file.StandardCopyOption
 import scala.meta.internal.metals.BloopInstallResult
 import scala.concurrent.Future
@@ -47,19 +46,6 @@ abstract class BuildTool {
 }
 
 object BuildTool {
-
-  def isCompatibleVersion(minimumVersion: String, version: String): Boolean = {
-    (minimumVersion.split('.'), version.split('.')) match {
-      case (Array(minMajor, minMinor, minPatch), Array(major, minor, patch)) =>
-        Try {
-          (major > minMajor) ||
-          (major == minMajor && minor > minMinor) ||
-          (major == minMajor && minor == minMinor && patch >= minPatch)
-        }.getOrElse(false)
-      case _ => false
-    }
-  }
-
   def copyFromResource(
       tempDir: Path,
       filePath: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -9,7 +9,7 @@ import scala.meta.internal.metals.Messages.CheckDoctor
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ScalaVersions._
 import scala.meta.io.AbsolutePath
-import scala.meta.internal.builds.BuildTool
+import scala.meta.internal.semver.SemVer
 
 /**
  * Helps the user figure out what is mis-configured in the build through the "Run doctor" command.
@@ -117,7 +117,7 @@ final class Doctor(
     val minimumBloopVersion = "1.3.5"
     def isUnsupportedBloopVersion =
       bspServerVersion.exists(version =>
-        !BuildTool.isCompatibleVersion(
+        !SemVer.isCompatibleVersion(
           minimumBloopVersion,
           version
         )

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -35,9 +35,10 @@ import scala.meta.internal.implementation.ImplementationProvider
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.debug.DebugServer
-import scala.meta.internal.tvp._
 import scala.meta.internal.mtags._
 import scala.meta.internal.semanticdb.Scala._
+import scala.meta.internal.semver.SemVer
+import scala.meta.internal.tvp._
 import scala.meta.io.AbsolutePath
 import scala.meta.parsers.ParseException
 import scala.meta.pc.CancelToken
@@ -1289,7 +1290,7 @@ class MetalsLanguageServer(
   private def supportedBuildTool(): Option[BuildTool] =
     buildTools.loadSupported match {
       case Some(buildTool) =>
-        val isCompatibleVersion = BuildTool.isCompatibleVersion(
+        val isCompatibleVersion = SemVer.isCompatibleVersion(
           buildTool.minimumVersion,
           buildTool.version
         )

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorkspaceEditWorksheetPublisher.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorkspaceEditWorksheetPublisher.scala
@@ -143,7 +143,7 @@ class WorkspaceEditWorksheetPublisher(buffers: Buffers)
   private def updateWithEdits(text: String, edits: List[TextEdit]): String = {
     val editsMap = edits.map(e => e.getRange().getStart().getLine() -> e).toMap
 
-    text.lines.zipWithIndex
+    text.linesIterator.zipWithIndex
       .map {
         case (line, i) =>
           editsMap.get(i) match {

--- a/mtags/src/main/scala/scala/meta/internal/semver/SemVer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/semver/SemVer.scala
@@ -1,0 +1,13 @@
+package scala.meta.internal.semver
+
+object SemVer {
+  def isCompatibleVersion(minimumVersion: String, version: String): Boolean = {
+    (minimumVersion.split('.'), version.split('.')) match {
+      case (Array(minMajor, minMinor, minPatch), Array(major, minor, patch)) =>
+        (major > minMajor) ||
+          (major == minMajor && minor > minMinor) ||
+          (major == minMajor && minor == minMinor && patch >= minPatch)
+      case _ => false
+    }
+  }
+}

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -1,11 +1,15 @@
 package tests
 
+import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.language.experimental.macros
-import scala.meta.io.AbsolutePath
+import scala.meta.internal.metals.JdkSources
+import scala.meta.internal.metals.Testing
 import scala.meta.internal.mtags
+import scala.meta.internal.semver.SemVer
+import scala.meta.io.AbsolutePath
 import scala.reflect.ClassTag
 import scala.util.Properties
 import utest.TestSuite
@@ -16,9 +20,6 @@ import utest.framework.TestCallTree
 import utest.framework.Tree
 import utest.ufansi.Attrs
 import utest.ufansi.Str
-import scala.meta.internal.metals.JdkSources
-import scala.meta.internal.metals.Testing
-import scala.collection.mutable
 
 /**
  * Test suite that replace utest DSL with FunSuite-style syntax from ScalaTest.
@@ -37,6 +38,12 @@ class BaseSuite extends TestSuite {
   def beforeAll(): Unit = ()
   def afterAll(): Unit = ()
   def intercept[T: ClassTag](exprs: Unit): T = macro Asserts.interceptProxy[T]
+  def isValidScalaVersionForEnv(scalaVersion: String): Boolean =
+    this.isJava8 || SemVer.isCompatibleVersion(
+      BaseSuite.minScalaVersionForJDK9OrHigher,
+      scalaVersion
+    )
+
   def assertNotEmpty(string: String): Unit = {
     if (string.isEmpty) {
       fail(
@@ -192,4 +199,8 @@ class BaseSuite extends TestSuite {
       .getOrElse(default)
     postProcess(result)
   }
+}
+
+object BaseSuite {
+  val minScalaVersionForJDK9OrHigher: String = "2.12.10"
 }

--- a/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
@@ -5,11 +5,17 @@ import tests.BaseCompletionLspSuite
 
 object CompletionCrossLspSuite
     extends BaseCompletionLspSuite("completion-cross") {
-  testAsync("basic-211") {
-    basicTest(V.scala211)
+
+  if (super.isValidScalaVersionForEnv(V.scala211)) {
+    testAsync("basic-211") {
+      basicTest(V.scala211)
+    }
   }
-  testAsync("basic-213") {
-    basicTest(V.scala213)
+
+  if (super.isValidScalaVersionForEnv(V.scala213)) {
+    testAsync("basic-213") {
+      basicTest(V.scala213)
+    }
   }
   testAsync("match-211") {
     matchKeywordTest(V.scala213)

--- a/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
@@ -7,12 +7,16 @@ import scala.concurrent.Future
 object DefinitionCrossLspSuite
     extends BaseCompletionLspSuite("definition-cross") {
 
-  testAsync("2.11") {
-    basicDefinitionTest(BuildInfo.scala211)
+  if (super.isValidScalaVersionForEnv(BuildInfo.scala211)) {
+    testAsync("2.11") {
+      basicDefinitionTest(BuildInfo.scala211)
+    }
   }
 
-  testAsync("2.13") {
-    basicDefinitionTest(BuildInfo.scala213)
+  if (super.isValidScalaVersionForEnv(BuildInfo.scala213)) {
+    testAsync("2.13") {
+      basicDefinitionTest(BuildInfo.scala213)
+    }
   }
 
   def basicDefinitionTest(scalaVersion: String): Future[Unit] = {

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -12,6 +12,12 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
     Some(ClientExperimentalCapabilities(decorationProvider = true))
   override def userConfig: UserConfiguration =
     super.userConfig.copy(worksheetScreenWidth = 40, worksheetCancelTimeout = 1)
+
+  override final def test(name: String)(fun: => Any): Unit =
+    if (super.isValidScalaVersionForEnv(this.scalaVersion)) {
+      super.test(name)(fun)
+    }
+
   if (!isWindows)
     testAsync("completion") {
       for {

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -1,8 +1,49 @@
 package tests
 
+import scala.collection.SortedSet
 import scala.meta.internal.tvp.TreeViewProvider
 
 object TreeViewLspSuite extends BaseLspSuite("tree-view") {
+
+  /** The libraries we expect to find for tests in this file.
+   *
+   * @note this value changes depending on the JVM version in use as some JAR
+   *       files have moved to become modules on JVM > 8.
+   */
+  val expectedLibraries: SortedSet[String] = {
+    lazy val jdk8Libraries = SortedSet(
+      "charsets",
+      "jce",
+      "jsse",
+      "resources",
+      "rt"
+    )
+
+    val otherLibraries = SortedSet(
+      "animal-sniffer-annotations", "cats-core_2.12", "cats-kernel_2.12",
+      "cats-macros_2.12", "checker-qual", "circe-core_2.12",
+      "circe-numbers_2.12", "error_prone_annotations", "failureaccess", "gson",
+      "guava", "j2objc-annotations", "jsr305", "listenablefuture",
+      "machinist_2.12", "org.eclipse.lsp4j", "org.eclipse.lsp4j.generator",
+      "org.eclipse.lsp4j.jsonrpc", "org.eclipse.xtend.lib",
+      "org.eclipse.xtend.lib.macro", "org.eclipse.xtext.xbase.lib",
+      "scala-library", "scala-reflect", "sourcecode_2.12"
+    )
+
+    if (scala.util.Properties.isJavaAtLeast(9.toString)) {
+      otherLibraries
+    } else {
+      otherLibraries ++ jdk8Libraries
+    }
+  }
+
+  lazy val expectedLibrariesString: String =
+    this.expectedLibraries.toVector
+      .map((s: String) => s"${s}.jar -")
+      .mkString("\n")
+
+  lazy val expectedLibrariesCount: Int =
+    this.expectedLibraries.size
 
   testAsync("projects") {
     cleanWorkspace()
@@ -100,35 +141,7 @@ object TreeViewLspSuite extends BaseLspSuite("tree-view") {
         )
         server.assertTreeViewChildren(
           s"libraries:",
-          """|animal-sniffer-annotations.jar -
-             |cats-core_2.12.jar -
-             |cats-kernel_2.12.jar -
-             |cats-macros_2.12.jar -
-             |charsets.jar -
-             |checker-qual.jar -
-             |circe-core_2.12.jar -
-             |circe-numbers_2.12.jar -
-             |error_prone_annotations.jar -
-             |failureaccess.jar -
-             |gson.jar -
-             |guava.jar -
-             |j2objc-annotations.jar -
-             |jce.jar -
-             |jsr305.jar -
-             |jsse.jar -
-             |listenablefuture.jar -
-             |machinist_2.12.jar -
-             |org.eclipse.lsp4j.jar -
-             |org.eclipse.lsp4j.generator.jar -
-             |org.eclipse.lsp4j.jsonrpc.jar -
-             |org.eclipse.xtend.lib.jar -
-             |org.eclipse.xtend.lib.macro.jar -
-             |org.eclipse.xtext.xbase.lib.jar -
-             |resources.jar -
-             |rt.jar -
-             |scala-library.jar -
-             |scala-reflect.jar -
-             |sourcecode_2.12.jar -""".stripMargin
+          expectedLibrariesString
         )
         server.assertTreeViewChildren(
           s"libraries:${server.jar("scala-library")}!/scala/Some#",
@@ -182,51 +195,51 @@ object TreeViewLspSuite extends BaseLspSuite("tree-view") {
               !label.contains("sourcecode")
             }
           ),
-          """|root
-             |  Import build command
-             |  Connect to build server command
-             |  Projects (0)
-             |  Libraries (29)
-             |  Libraries (29)
-             |    sourcecode_2.12-0.1.7.jar
-             |    sourcecode_2.12-0.1.7.jar
-             |      sourcecode/
-             |      sourcecode/
-             |        Args class
-             |        Args object
-             |        ArgsMacros trait
-             |        Compat object
-             |        Enclosing class
-             |        Enclosing object
-             |        EnclosingMachineMacros trait
-             |        EnclosingMacros trait
-             |        File class
-             |        File object
-             |        FileMacros trait
-             |        FullName class
-             |        FullName object
-             |        FullNameMachineMacros trait
-             |        FullNameMacros trait
-             |        Line class
-             |        Line object
-             |        LineMacros trait
-             |        Macros object
-             |        Name class
-             |        Name object
-             |        NameMachineMacros trait
-             |        NameMacros trait
-             |        Pkg class
-             |        Pkg object
-             |        PkgMacros trait
-             |        SourceCompanion class
-             |        SourceValue class
-             |        Text class
-             |        Text object
-             |        TextMacros trait
-             |        Util object
-             |        File class
-             |          value val
-             |""".stripMargin
+          s"""|root
+              |  Import build command
+              |  Connect to build server command
+              |  Projects (0)
+              |  Libraries (${expectedLibrariesCount})
+              |  Libraries (${expectedLibrariesCount})
+              |    sourcecode_2.12-0.1.7.jar
+              |    sourcecode_2.12-0.1.7.jar
+              |      sourcecode/
+              |      sourcecode/
+              |        Args class
+              |        Args object
+              |        ArgsMacros trait
+              |        Compat object
+              |        Enclosing class
+              |        Enclosing object
+              |        EnclosingMachineMacros trait
+              |        EnclosingMacros trait
+              |        File class
+              |        File object
+              |        FileMacros trait
+              |        FullName class
+              |        FullName object
+              |        FullNameMachineMacros trait
+              |        FullNameMacros trait
+              |        Line class
+              |        Line object
+              |        LineMacros trait
+              |        Macros object
+              |        Name class
+              |        Name object
+              |        NameMachineMacros trait
+              |        NameMacros trait
+              |        Pkg class
+              |        Pkg object
+              |        PkgMacros trait
+              |        SourceCompanion class
+              |        SourceValue class
+              |        Text class
+              |        Text object
+              |        TextMacros trait
+              |        Util object
+              |        File class
+              |          value val
+              |""".stripMargin
         )
         assertNoDiff(
           server.treeViewReveal(
@@ -237,209 +250,209 @@ object TreeViewLspSuite extends BaseLspSuite("tree-view") {
               !label.contains("lsp4j")
             }
           ),
-          """|root
-             |  Import build command
-             |  Connect to build server command
-             |  Projects (0)
-             |  Libraries (29)
-             |  Libraries (29)
-             |    org.eclipse.lsp4j-0.5.0.jar
-             |    org.eclipse.lsp4j.generator-0.5.0.jar
-             |    org.eclipse.lsp4j.jsonrpc-0.5.0.jar
-             |    org.eclipse.lsp4j-0.5.0.jar
-             |      org/
-             |      org/
-             |        eclipse/
-             |        eclipse/
-             |          lsp4j/
-             |          lsp4j/
-             |            adapters/
-             |            launch/
-             |            services/
-             |            util/
-             |            ApplyWorkspaceEditParams class
-             |            ApplyWorkspaceEditResponse class
-             |            ClientCapabilities class
-             |            CodeAction class
-             |            CodeActionCapabilities class
-             |            CodeActionContext class
-             |            CodeActionKind class
-             |            CodeActionKindCapabilities class
-             |            CodeActionLiteralSupportCapabilities class
-             |            CodeActionParams class
-             |            CodeLens class
-             |            CodeLensCapabilities class
-             |            CodeLensOptions class
-             |            CodeLensParams class
-             |            CodeLensRegistrationOptions class
-             |            Color class
-             |            ColorInformation class
-             |            ColorPresentation class
-             |            ColorPresentationParams class
-             |            ColorProviderCapabilities class
-             |            ColorProviderOptions class
-             |            ColoringInformation class
-             |            ColoringParams class
-             |            ColoringStyle class
-             |            Command class
-             |            CompletionCapabilities class
-             |            CompletionContext class
-             |            CompletionItem class
-             |            CompletionItemCapabilities class
-             |            CompletionItemKind class
-             |            CompletionItemKindCapabilities class
-             |            CompletionList class
-             |            CompletionOptions class
-             |            CompletionParams class
-             |            CompletionRegistrationOptions class
-             |            CompletionTriggerKind class
-             |            ConfigurationItem class
-             |            ConfigurationParams class
-             |            DefinitionCapabilities class
-             |            Diagnostic class
-             |            DiagnosticRelatedInformation class
-             |            DiagnosticSeverity class
-             |            DidChangeConfigurationCapabilities class
-             |            DidChangeConfigurationParams class
-             |            DidChangeTextDocumentParams class
-             |            DidChangeWatchedFilesCapabilities class
-             |            DidChangeWatchedFilesParams class
-             |            DidChangeWatchedFilesRegistrationOptions class
-             |            DidChangeWorkspaceFoldersParams class
-             |            DidCloseTextDocumentParams class
-             |            DidOpenTextDocumentParams class
-             |            DidSaveTextDocumentParams class
-             |            DocumentColorParams class
-             |            DocumentFilter class
-             |            DocumentFormattingParams class
-             |            DocumentHighlight class
-             |            DocumentHighlightCapabilities class
-             |            DocumentHighlightKind class
-             |            DocumentLink class
-             |            DocumentLinkCapabilities class
-             |            DocumentLinkOptions class
-             |            DocumentLinkParams class
-             |            DocumentLinkRegistrationOptions class
-             |            DocumentOnTypeFormattingOptions class
-             |            DocumentOnTypeFormattingParams class
-             |            DocumentOnTypeFormattingRegistrationOptions class
-             |            DocumentRangeFormattingParams class
-             |            DocumentSymbol class
-             |            DocumentSymbolCapabilities class
-             |            DocumentSymbolParams class
-             |            DynamicRegistrationCapabilities class
-             |            ExecuteCommandCapabilities class
-             |            ExecuteCommandOptions class
-             |            ExecuteCommandParams class
-             |            ExecuteCommandRegistrationOptions class
-             |            FileChangeType class
-             |            FileEvent class
-             |            FileSystemWatcher class
-             |            FoldingRange class
-             |            FoldingRangeCapabilities class
-             |            FoldingRangeKind class
-             |            FoldingRangeProviderOptions class
-             |            FoldingRangeRequestParams class
-             |            FormattingCapabilities class
-             |            FormattingOptions class
-             |            Hover class
-             |            HoverCapabilities class
-             |            ImplementationCapabilities class
-             |            InitializeError class
-             |            InitializeErrorCode class
-             |            InitializeParams class
-             |            InitializeResult class
-             |            InitializedParams class
-             |            InsertTextFormat class
-             |            Location class
-             |            MarkedString class
-             |            MarkupContent class
-             |            MarkupKind class
-             |            MessageActionItem class
-             |            MessageParams class
-             |            MessageType class
-             |            OnTypeFormattingCapabilities class
-             |            ParameterInformation class
-             |            Position class
-             |            PublishDiagnosticsCapabilities class
-             |            PublishDiagnosticsParams class
-             |            Range class
-             |            RangeFormattingCapabilities class
-             |            ReferenceContext class
-             |            ReferenceParams class
-             |            ReferencesCapabilities class
-             |            Registration class
-             |            RegistrationParams class
-             |            RenameCapabilities class
-             |            RenameParams class
-             |            ResourceChange class
-             |            ResponseErrorCode class
-             |            SaveOptions class
-             |            SemanticHighlightingCapabilities class
-             |            SemanticHighlightingInformation class
-             |            SemanticHighlightingParams class
-             |            SemanticHighlightingServerCapabilities class
-             |            ServerCapabilities class
-             |            ShowMessageRequestParams class
-             |            SignatureHelp class
-             |            SignatureHelpCapabilities class
-             |            SignatureHelpOptions class
-             |            SignatureHelpRegistrationOptions class
-             |            SignatureInformation class
-             |            SignatureInformationCapabilities class
-             |            StaticRegistrationOptions class
-             |            SymbolCapabilities class
-             |            SymbolInformation class
-             |            SymbolKind class
-             |            SymbolKindCapabilities class
-             |            SynchronizationCapabilities class
-             |            TextDocumentChangeRegistrationOptions class
-             |            TextDocumentClientCapabilities class
-             |            TextDocumentContentChangeEvent class
-             |            TextDocumentEdit class
-             |            TextDocumentIdentifier class
-             |            TextDocumentItem class
-             |            TextDocumentPositionParams class
-             |            TextDocumentRegistrationOptions class
-             |            TextDocumentSaveReason class
-             |            TextDocumentSaveRegistrationOptions class
-             |            TextDocumentSyncKind class
-             |            TextDocumentSyncOptions class
-             |            TextEdit class
-             |            TypeDefinitionCapabilities class
-             |            Unregistration class
-             |            UnregistrationParams class
-             |            VersionedTextDocumentIdentifier class
-             |            WatchKind class
-             |            WillSaveTextDocumentParams class
-             |            WorkspaceClientCapabilities class
-             |            WorkspaceEdit class
-             |            WorkspaceEditCapabilities class
-             |            WorkspaceFolder class
-             |            WorkspaceFoldersChangeEvent class
-             |            WorkspaceFoldersOptions class
-             |            WorkspaceServerCapabilities class
-             |            WorkspaceSymbolParams class
-             |            services/
-             |              LanguageClient class
-             |              LanguageClientAware class
-             |              LanguageClientExtensions class
-             |              LanguageServer class
-             |              TextDocumentService class
-             |              WorkspaceService class
-             |              LanguageClient class
-             |                applyEdit() method
-             |                registerCapability() method
-             |                unregisterCapability() method
-             |                telemetryEvent() method
-             |                publishDiagnostics() method
-             |                showMessage() method
-             |                showMessageRequest() method
-             |                logMessage() method
-             |                workspaceFolders() method
-             |                configuration() method
-             |                semanticHighlighting() method
-             |""".stripMargin
+          s"""|root
+              |  Import build command
+              |  Connect to build server command
+              |  Projects (0)
+              |  Libraries (${expectedLibrariesCount})
+              |  Libraries (${expectedLibrariesCount})
+              |    org.eclipse.lsp4j-0.5.0.jar
+              |    org.eclipse.lsp4j.generator-0.5.0.jar
+              |    org.eclipse.lsp4j.jsonrpc-0.5.0.jar
+              |    org.eclipse.lsp4j-0.5.0.jar
+              |      org/
+              |      org/
+              |        eclipse/
+              |        eclipse/
+              |          lsp4j/
+              |          lsp4j/
+              |            adapters/
+              |            launch/
+              |            services/
+              |            util/
+              |            ApplyWorkspaceEditParams class
+              |            ApplyWorkspaceEditResponse class
+              |            ClientCapabilities class
+              |            CodeAction class
+              |            CodeActionCapabilities class
+              |            CodeActionContext class
+              |            CodeActionKind class
+              |            CodeActionKindCapabilities class
+              |            CodeActionLiteralSupportCapabilities class
+              |            CodeActionParams class
+              |            CodeLens class
+              |            CodeLensCapabilities class
+              |            CodeLensOptions class
+              |            CodeLensParams class
+              |            CodeLensRegistrationOptions class
+              |            Color class
+              |            ColorInformation class
+              |            ColorPresentation class
+              |            ColorPresentationParams class
+              |            ColorProviderCapabilities class
+              |            ColorProviderOptions class
+              |            ColoringInformation class
+              |            ColoringParams class
+              |            ColoringStyle class
+              |            Command class
+              |            CompletionCapabilities class
+              |            CompletionContext class
+              |            CompletionItem class
+              |            CompletionItemCapabilities class
+              |            CompletionItemKind class
+              |            CompletionItemKindCapabilities class
+              |            CompletionList class
+              |            CompletionOptions class
+              |            CompletionParams class
+              |            CompletionRegistrationOptions class
+              |            CompletionTriggerKind class
+              |            ConfigurationItem class
+              |            ConfigurationParams class
+              |            DefinitionCapabilities class
+              |            Diagnostic class
+              |            DiagnosticRelatedInformation class
+              |            DiagnosticSeverity class
+              |            DidChangeConfigurationCapabilities class
+              |            DidChangeConfigurationParams class
+              |            DidChangeTextDocumentParams class
+              |            DidChangeWatchedFilesCapabilities class
+              |            DidChangeWatchedFilesParams class
+              |            DidChangeWatchedFilesRegistrationOptions class
+              |            DidChangeWorkspaceFoldersParams class
+              |            DidCloseTextDocumentParams class
+              |            DidOpenTextDocumentParams class
+              |            DidSaveTextDocumentParams class
+              |            DocumentColorParams class
+              |            DocumentFilter class
+              |            DocumentFormattingParams class
+              |            DocumentHighlight class
+              |            DocumentHighlightCapabilities class
+              |            DocumentHighlightKind class
+              |            DocumentLink class
+              |            DocumentLinkCapabilities class
+              |            DocumentLinkOptions class
+              |            DocumentLinkParams class
+              |            DocumentLinkRegistrationOptions class
+              |            DocumentOnTypeFormattingOptions class
+              |            DocumentOnTypeFormattingParams class
+              |            DocumentOnTypeFormattingRegistrationOptions class
+              |            DocumentRangeFormattingParams class
+              |            DocumentSymbol class
+              |            DocumentSymbolCapabilities class
+              |            DocumentSymbolParams class
+              |            DynamicRegistrationCapabilities class
+              |            ExecuteCommandCapabilities class
+              |            ExecuteCommandOptions class
+              |            ExecuteCommandParams class
+              |            ExecuteCommandRegistrationOptions class
+              |            FileChangeType class
+              |            FileEvent class
+              |            FileSystemWatcher class
+              |            FoldingRange class
+              |            FoldingRangeCapabilities class
+              |            FoldingRangeKind class
+              |            FoldingRangeProviderOptions class
+              |            FoldingRangeRequestParams class
+              |            FormattingCapabilities class
+              |            FormattingOptions class
+              |            Hover class
+              |            HoverCapabilities class
+              |            ImplementationCapabilities class
+              |            InitializeError class
+              |            InitializeErrorCode class
+              |            InitializeParams class
+              |            InitializeResult class
+              |            InitializedParams class
+              |            InsertTextFormat class
+              |            Location class
+              |            MarkedString class
+              |            MarkupContent class
+              |            MarkupKind class
+              |            MessageActionItem class
+              |            MessageParams class
+              |            MessageType class
+              |            OnTypeFormattingCapabilities class
+              |            ParameterInformation class
+              |            Position class
+              |            PublishDiagnosticsCapabilities class
+              |            PublishDiagnosticsParams class
+              |            Range class
+              |            RangeFormattingCapabilities class
+              |            ReferenceContext class
+              |            ReferenceParams class
+              |            ReferencesCapabilities class
+              |            Registration class
+              |            RegistrationParams class
+              |            RenameCapabilities class
+              |            RenameParams class
+              |            ResourceChange class
+              |            ResponseErrorCode class
+              |            SaveOptions class
+              |            SemanticHighlightingCapabilities class
+              |            SemanticHighlightingInformation class
+              |            SemanticHighlightingParams class
+              |            SemanticHighlightingServerCapabilities class
+              |            ServerCapabilities class
+              |            ShowMessageRequestParams class
+              |            SignatureHelp class
+              |            SignatureHelpCapabilities class
+              |            SignatureHelpOptions class
+              |            SignatureHelpRegistrationOptions class
+              |            SignatureInformation class
+              |            SignatureInformationCapabilities class
+              |            StaticRegistrationOptions class
+              |            SymbolCapabilities class
+              |            SymbolInformation class
+              |            SymbolKind class
+              |            SymbolKindCapabilities class
+              |            SynchronizationCapabilities class
+              |            TextDocumentChangeRegistrationOptions class
+              |            TextDocumentClientCapabilities class
+              |            TextDocumentContentChangeEvent class
+              |            TextDocumentEdit class
+              |            TextDocumentIdentifier class
+              |            TextDocumentItem class
+              |            TextDocumentPositionParams class
+              |            TextDocumentRegistrationOptions class
+              |            TextDocumentSaveReason class
+              |            TextDocumentSaveRegistrationOptions class
+              |            TextDocumentSyncKind class
+              |            TextDocumentSyncOptions class
+              |            TextEdit class
+              |            TypeDefinitionCapabilities class
+              |            Unregistration class
+              |            UnregistrationParams class
+              |            VersionedTextDocumentIdentifier class
+              |            WatchKind class
+              |            WillSaveTextDocumentParams class
+              |            WorkspaceClientCapabilities class
+              |            WorkspaceEdit class
+              |            WorkspaceEditCapabilities class
+              |            WorkspaceFolder class
+              |            WorkspaceFoldersChangeEvent class
+              |            WorkspaceFoldersOptions class
+              |            WorkspaceServerCapabilities class
+              |            WorkspaceSymbolParams class
+              |            services/
+              |              LanguageClient class
+              |              LanguageClientAware class
+              |              LanguageClientExtensions class
+              |              LanguageServer class
+              |              TextDocumentService class
+              |              WorkspaceService class
+              |              LanguageClient class
+              |                applyEdit() method
+              |                registerCapability() method
+              |                unregisterCapability() method
+              |                telemetryEvent() method
+              |                publishDiagnostics() method
+              |                showMessage() method
+              |                showMessageRequest() method
+              |                logMessage() method
+              |                workspaceFolders() method
+              |                configuration() method
+              |                semanticHighlighting() method
+              |""".stripMargin
         )
       }
     } yield ()


### PR DESCRIPTION
Another instance of the deprecated `lines` method was recently added to the code base. This method causes metals to be not build on JDK >= 11.

This commit also updates the CI to build with JDKs 8 and 11 using AdpotOpenJDK. The majority of tests are JDK 11 as default, with a single test using JDK8 as a legacy compatibility smoke test. This should help prevent future additions of this method.

Finally, this commit drops cross building with deprecated scala versions, as they are unable to parse class files generated with bytecode for JDKs > 8.

See: ce9c890c27efec49fd8ad78746e2f406bfd89d3b and 4d78f9cf5a2e6c49d8a6e2474a49a8bbb99e216c for more context.