### PR TITLE
Improve Pants to Bloop export step.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -14,7 +14,6 @@ import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.Timer
 import scala.meta.internal.metals.Time
 import java.nio.file.NoSuchFileException
-import scala.meta.internal.mtags.MD5
 import scala.util.Properties
 import coursierapi.Dependency
 import scala.concurrent.ExecutionContext
@@ -29,6 +28,7 @@ import scala.meta.internal.ansi.LineListener
 import java.util.concurrent.CancellationException
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import scala.sys.process.Process
+import scala.meta.io.Classpath
 
 object BloopPants {
 
@@ -132,20 +132,13 @@ object BloopPants {
       val cacheDir = Files.createDirectories(
         args.workspace.resolve(".pants.d").resolve("metals")
       )
-      val outputFilename = {
-        val processed =
-          args.targets.map(_.replaceAll("[^a-zA-Z0-9]", "")).mkString
-        if (processed.isEmpty()) {
-          MD5.compute(args.targets.mkString) // necessary for targets like "::/"
-        } else {
-          processed
-        }
-      }
+      val outputFilename = PantsConfiguration.outputFilename(args.targets)
       val outputFile = cacheDir.resolve(s"$outputFilename.json")
       val bloopDir = Files.createDirectories(args.out.resolve(".bloop"))
       args.token.checkCanceled()
 
-      val filemap = Filemap.fromPants(args.workspace, args.targets)
+      val filemap =
+        Filemap.fromPants(args.workspace, args.isCache, args.targets)
       val fileCount = filemap.fileCount()
       if (fileCount > args.maxFileCount) {
         val targetSyntax = args.targets.mkString("'", "' '", "'")
@@ -166,7 +159,8 @@ object BloopPants {
         val text =
           new String(Files.readAllBytes(outputFile), StandardCharsets.UTF_8)
         val json = ujson.read(text)
-        new BloopPants(args, bloopDir, json, filemap).run()
+        val export = PantsExport.fromJson(json)
+        new BloopPants(args, bloopDir, export, filemap).run()
       } else {
         throw new NoSuchFileException(
           outputFile.toString(),
@@ -180,7 +174,7 @@ object BloopPants {
       workspace: AbsolutePath,
       targets: List[String]
   )(implicit ec: ExecutionContext): Unit = {
-    val filemap = Filemap.fromPants(workspace.toNIO, targets)
+    val filemap = Filemap.fromPants(workspace.toNIO, isCache = false, targets)
     val bloopDir = workspace.resolve(".bloop")
     for {
       (target, files) <- filemap.iterator()
@@ -234,24 +228,20 @@ object BloopPants {
 private class BloopPants(
     args: Args,
     bloopDir: Path,
-    json: Value,
+    export: PantsExport,
     filemap: Filemap
 )(implicit ec: ExecutionContext) { self =>
   def token: CancelToken = args.token
   def workspace: Path = args.workspace
   def userTargets: List[String] = args.targets
+  def cycles: Cycles = export.cycles
 
-  private val cycles = Cycles.findConnectedComponents(json)
   private val scalaCompiler = "org.scala-lang:scala-compiler:"
-
   private val transitiveClasspath = mutable.Map.empty[String, List[Path]]
   private val isVisited = mutable.Set.empty[String]
   private val binaryDependencySources = mutable.Set.empty[Path]
 
-  val targets: mutable.LinkedHashMap[String, Value] = json.obj("targets").obj
-  val libraries: mutable.LinkedHashMap[String, Value] =
-    json.obj("libraries").obj
-  val compilerVersion: String = libraries.keysIterator
+  val compilerVersion: String = export.libraries.keysIterator
     .collectFirst {
       case module if module.startsWith(scalaCompiler) =>
         module.stripPrefix(scalaCompiler)
@@ -263,89 +253,81 @@ private class BloopPants(
       Properties.versionNumberString
     }
   val allScalaJars: Seq[Path] = {
-    val scalaJars = libraries.collect {
-      case (module, jar) if isScalaJar(module) =>
-        Paths.get(jar.obj("default").str)
-    }.toSeq
-    val hasScalaCompiler =
-      scalaJars.exists(_.getFileName().toString().contains("scala-compiler"))
-    if (hasScalaCompiler) {
-      scalaJars
-    } else {
-      scalaJars ++
-        coursierapi.Fetch
-          .create()
-          .addDependencies(
-            Dependency.of("org.scala-lang", "scala-compiler", compilerVersion)
-          )
-          .fetch()
-          .asScala
-          .map(_.toPath)
+    val compilerClasspath = export.scalaPlatform.compilerClasspath
+    if (compilerClasspath.nonEmpty) compilerClasspath
+    else {
+      val scalaJars: Seq[Path] = export.libraries
+        .collect {
+          case (module, jar) if isScalaJar(module) => jar.default
+        }
+        .flatten
+        .toSeq
+      val hasScalaCompiler =
+        scalaJars.exists(_.getFileName().toString().contains("scala-compiler"))
+      if (hasScalaCompiler) {
+        scalaJars
+      } else {
+        scalaJars ++
+          coursierapi.Fetch
+            .create()
+            .addDependencies(
+              Dependency.of("org.scala-lang", "scala-compiler", compilerVersion)
+            )
+            .fetch()
+            .asScala
+            .map(_.toPath)
+      }
     }
   }
 
   def run(): Int = {
     token.checkCanceled()
-    // Create Bloop projects that only contain the classpath of direct
-    // dependencies but not transitive dependencies.
-    val shallowClasspathProjects = targets.collect {
-      case (id, target) if isSupportedTargetType(target) =>
-        toBloopProject(id, target)
-    }
-    val byName = shallowClasspathProjects.map(p => p.name -> p).toMap
-
-    // Add full transitive classpath to Bloop projects.
-    val fullClasspathProjects = shallowClasspathProjects.map { p =>
-      val children = cycles.children.getOrElse(p.name, Nil)
-      val extraSources = children.flatMap(child => byName(child).sources)
-      val extraDependencies = children
-        .flatMap(child => byName(child).dependencies)
-        .filter(_ != p.name)
-      val dependencies = (p.dependencies ++ extraDependencies).distinct
-      p.copy(
-        classpath = getTransitiveClasspath(p.name, byName),
-        sources = (p.sources ++ extraSources).distinct,
-        dependencies = dependencies.filterNot(_.isBinaryDependency)
-      )
-    }
-
-    val binaryDependenciesToCompile = mutable.Set.empty[String]
-    for {
-      project <- shallowClasspathProjects
-      if !project.name.isBinaryDependency
-      dependency <- project.dependencies.iterator
-      if dependency.isBinaryDependency
-      dependencyProject <- byName.get(dependency)
-      if dependencyProject.sources.nonEmpty
-    } {
-      binaryDependenciesToCompile += dependency
-    }
-
-    val binaryDependencyResolution =
+    val projects = export.targets.valuesIterator
+      .filter(_.isTargetRoot)
+      .map(toBloopProject)
+      .toList
+    // Only emit library sources in one resolution to avoid duplicated
+    // `*-sources.jar` references.
+    val binaryDependenciesSourcesIterator =
       binaryDependencySources.iterator.map(newSourceModule)
-    var generatedProjects = Set.empty[Path]
-    fullClasspathProjects.foreach { bloop =>
-      if (cycles.parents.contains(bloop.name) ||
-        bloop.name.isBinaryDependency) {
-        // do nothing
+    val generatedProjects = new mutable.LinkedHashSet[Path]
+    val byName = projects.map(p => p.name -> p).toMap
+    projects.foreach { project =>
+      if (export.cycles.parents.contains(project.name)) {
+        ()
       } else {
-        val out = bloopDir.resolve(BloopPants.makeJsonFilename(bloop.name))
+        val children =
+          export.cycles.children.getOrElse(project.name, Nil).map(byName)
         val withBinaryResolution =
-          if (binaryDependencyResolution.hasNext) {
+          if (binaryDependenciesSourcesIterator.hasNext) {
             val extraResolution =
-              bloop.resolution.map(_.modules).getOrElse(Nil)
-            bloop.copy(
+              project.resolution.map(_.modules).getOrElse(Nil)
+            project.copy(
               resolution = Some(
                 C.Resolution(
-                  binaryDependencyResolution.toList ++ extraResolution
+                  binaryDependenciesSourcesIterator.toList ++ extraResolution
                 )
               )
             )
           } else {
-            bloop
+            project
           }
-        val json = C.File(BuildInfo.bloopVersion, withBinaryResolution)
-        _root_.bloop.config.write(json, out)
+        val finalProject =
+          if (children.isEmpty) withBinaryResolution
+          else {
+            val newSources =
+              (withBinaryResolution.sources ++ children.flatMap(_.sources)).distinct
+            val newClasspath =
+              (withBinaryResolution.classpath ++ children.flatMap(_.classpath)).distinct
+            withBinaryResolution.copy(
+              sources = newSources,
+              classpath = newClasspath
+            )
+          }
+        val out =
+          bloopDir.resolve(BloopPants.makeJsonFilename(finalProject.name))
+        val json = C.File(BuildInfo.bloopVersion, finalProject)
+        bloop.config.write(json, out)
         generatedProjects += out
       }
     }
@@ -354,156 +336,72 @@ private class BloopPants(
     generatedProjects.size
   }
 
-  private val unsupportedTargetType = Set(
-    "files", "page", "python_binary", "python_tests", "python_library",
-    "python_requirement_library"
-  )
+  private def toBloopProject(target: PantsTarget): C.Project = {
 
-  implicit class XtensionTargetString(value: String) {
-    def isBinaryDependency: Boolean = {
-      !userTargets.exists(target => value.startsWith(target.stripSuffix("::")))
-    }
-    def baseDirectory: Path =
-      PantsConfiguration.baseDirectory(AbsolutePath(workspace), value).toNIO
-  }
-  implicit class XtensionValue(value: Value) {
-    def pantsTargetType: String = value.obj("pants_target_type").str
-    def targetType: String = value.obj("target_type").str
-    def id: String = value.obj("id").str
-    def isTestTarget: Boolean = targetType == "TEST"
-    def isResourceTarget: Boolean = targetType == "RESOURCE"
-  }
-  private def isSupportedTargetType(target: Value): Boolean =
-    // Instead of whitelisting which target types we support, we hardcode which
-    // known target types we know we don't support. Pants plugins can introduce
-    // new target types that are minor variations of for example `scala_library`
-    // that we may want to support.
-    !unsupportedTargetType.contains(target.pantsTargetType)
+    val baseDirectory: Path = PantsConfiguration
+      .baseDirectory(AbsolutePath(workspace), target.name)
+      .toNIO
 
-  private def toBloopProject(
-      id: String,
-      target: Value
-  ): C.Project = {
+    val sources: List[Path] =
+      if (target.targetType.isResource) Nil
+      else filemap.forTarget(target.name).toList
 
-    val baseDirectories = for {
-      roots <- target.obj.get("roots").toList
-      root <- roots.arr
-      sourceRoot <- root.obj.get("source_root")
-    } yield Paths.get(sourceRoot.str)
+    val transitiveDependencies: List[PantsTarget] = (for {
+      dependency <- target.transitiveDependencies
+      if dependency != target.name
+    } yield export.targets(dependency)).toList
 
-    val baseDirectory = id.baseDirectory
+    val dependencies: List[String] = for {
+      dependency <- transitiveDependencies
+      // Rewrite dependencies on targets that belong to a cyclic component.
+      acyclicDependencyName = cycles.acyclicDependency(dependency.name)
+      if acyclicDependencyName != target.name
+      acyclicDependency = export.targets(acyclicDependencyName)
+      if acyclicDependency.isTargetRoot && !acyclicDependency.targetType.isAnyResource
+    } yield acyclicDependency.name
 
-    val sources =
-      if (target.isResourceTarget) Nil
-      else filemap.forTarget(id).toList
-
-    // Extract target dependencies.
-    val dependsOn = (for {
-      dependency <- target.obj("targets").arr
-      acyclicDependency = cycles.acyclicDependency(dependency.str)
-      if acyclicDependency != id
-      if isSupportedTargetType(targets(acyclicDependency))
-    } yield acyclicDependency).toList
-
-    // Extract class directories of direct target dependencies.
-    val dependencyClassdirectories: List[Path] = (for {
-      dependency <- target.obj("targets").arr
-      classDir <- makeClassdirectory(dependency.str)
-    } yield classDir).toList
-
-    // Extract 3rd party library dependencies, and their associated sources.
-    val libraryDependencies = for {
-      dependency <- target.obj("libraries").arr
-      library <- libraries.get(dependency.str)
+    val libraries: List[PantsLibrary] = for {
+      dependency <- transitiveDependencies
+      libraryName <- dependency.libraries
+      library <- export.libraries.get(libraryName).toList
     } yield library
-    val libraryDependencyConfigs: List[String] =
-      List("test", "default", "shaded", "linux-x86_64", "thrift9")
-    val libraryDependencyClasspaths =
-      getLibraryDependencies(libraryDependencies, libraryDependencyConfigs)
-    val sourcesConfigs = List("sources")
-    val libraryDependencySources =
-      getLibraryDependencies(libraryDependencies, sourcesConfigs)
 
-    // Warn about unfamiliar configurations.
-    val knownConfigs = sourcesConfigs ::: libraryDependencyConfigs
-    val unknownConfigs = libraryDependencies
-      .flatMap(lib => lib.obj.keys.toSet -- knownConfigs)
-      .distinct
-    if (unknownConfigs.nonEmpty) {
-      val kinds = unknownConfigs.mkString(",")
-      println(
-        s"[warning] Unknown configs for target '${id}' with type '${target.targetType}': ${kinds}"
-      )
-    }
+    val classpath = new mutable.LinkedHashSet[Path]()
+    classpath ++= (for {
+      dependency <- transitiveDependencies
+      if dependency.isTargetRoot
+    } yield dependency.classesDir(bloopDir))
+    classpath ++= (for {
+      dependency <- transitiveDependencies
+      if !dependency.isTargetRoot
+      entry <- exportClasspath(dependency)
+    } yield entry)
+    classpath ++= libraries.iterator.flatMap(_.nonSources)
+    classpath ++= allScalaJars
 
-    val out = bloopDir.resolve(BloopPants.makeFilename(id))
-    val classDirectory = out.resolve("classes")
-    val javaHome = Option(System.getProperty("java.home")).map(Paths.get(_))
+    binaryDependencySources ++= libraries.flatMap(_.sources)
 
-    val resources =
-      if (target.isResourceTarget) {
-        // Resources are relativized by the directory where the BUILD file exists.
-        Some(List(baseDirectory))
-      } else {
-        None
-      }
+    val out: Path = bloopDir.resolve(target.directoryName)
+    val classDirectory: Path = target.classesDir(bloopDir)
+    val javaHome: Option[Path] =
+      Option(System.getProperty("java.home")).map(Paths.get(_))
 
-    val test = if (target.pantsTargetType.contains("test")) {
-      val scalatest = C.TestFramework(
-        List(
-          "org.scalatest.tools.Framework",
-          "org.scalatest.tools.ScalaTestFramework"
-        )
-      )
-      // These test frameworks are the default output from running `show
-      // testFrameworks` in sbt (excluding spec2). The output from `./pants
-      // export` doesn't include the configured test frameworks.
-      val defaultTestFrameworks = List(
-        scalatest,
-        C.TestFramework(List("org.scalacheck.ScalaCheckFramework")),
-        C.TestFramework(List("com.novocode.junit.JUnitFramework"))
-      )
-      Some(
-        C.Test(
-          frameworks = defaultTestFrameworks,
-          options = C.TestOptions(
-            excludes = Nil,
-            arguments = List(
-              C.TestArgument(
-                List("-o"),
-                Some(scalatest)
-              )
-            )
-          )
-        )
-      )
-    } else {
-      None
-    }
-
-    val resolution: Option[C.Resolution] =
-      if (id.isBinaryDependency) {
-        binaryDependencySources ++= libraryDependencySources
-        binaryDependencySources ++= enclosingSourceDirectory(baseDirectory)
-        None
-      } else {
-        Some(
-          C.Resolution(
-            libraryDependencySources.iterator.map(newSourceModule).toList
-          )
-        )
-      }
+    val resources: List[Path] = for {
+      dependency <- transitiveDependencies
+      if dependency.targetType.isAnyResource
+      entry <- exportClasspath(dependency)
+    } yield entry
 
     C.Project(
-      name = id,
+      name = target.name,
       directory = baseDirectory,
       workspaceDir = Some(workspace),
       sources,
-      dependencies = dependsOn,
-      classpath = dependencyClassdirectories ++ libraryDependencyClasspaths,
+      dependencies = dependencies,
+      classpath = classpath.toList,
       out = out,
       classesDir = classDirectory,
-      resources = resources,
+      resources = if (resources.isEmpty) None else Some(resources),
       scala = Some(
         C.Scala(
           "org.scala-lang",
@@ -526,18 +424,67 @@ private class BloopPants(
       ),
       java = Some(C.Java(Nil)),
       sbt = None,
-      test = test,
+      test = bloopTestFrameworks,
       platform = Some(C.Platform.Jvm(C.JvmConfig(javaHome, Nil), None)),
-      resolution = resolution
+      resolution = None
     )
   }
 
+  val myExportClasspath: mutable.Map[String, List[Path]] =
+    mutable.Map.empty[String, List[Path]]
+  val exportClasspathDir: AbsolutePath = AbsolutePath(
+    workspace.resolve("dist").resolve("export-classpath")
+  )
+  def exportClasspath(target: PantsTarget): List[Path] = {
+    myExportClasspath.getOrElseUpdate(
+      target.name, {
+        val classpathFile =
+          exportClasspathDir.resolve(target.id + "-classpath.txt")
+        if (classpathFile.isFile) {
+          Classpath(classpathFile.readText.trim()).entries.map(_.toNIO)
+        } else {
+          Nil
+        }
+      }
+    )
+  }
   lazy val dist: mutable.Buffer[Path] = Files
     .list(
       workspace.resolve("dist").resolve("export-classpath")
     )
     .asScala
     .toBuffer
+
+  def bloopTestFrameworks: Option[C.Test] = {
+    val scalatest = C.TestFramework(
+      List(
+        "org.scalatest.tools.Framework",
+        "org.scalatest.tools.ScalaTestFramework"
+      )
+    )
+    // These test frameworks are the default output from running `show
+    // testFrameworks` in sbt (excluding spec2). The output from `./pants
+    // export` doesn't include the configured test frameworks.
+    val defaultTestFrameworks = List(
+      scalatest,
+      C.TestFramework(List("org.scalacheck.ScalaCheckFramework")),
+      C.TestFramework(List("com.novocode.junit.JUnitFramework"))
+    )
+    Some(
+      C.Test(
+        frameworks = defaultTestFrameworks,
+        options = C.TestOptions(
+          excludes = Nil,
+          arguments = List(
+            C.TestArgument(
+              List("-o"),
+              Some(scalatest)
+            )
+          )
+        )
+      )
+    )
+  }
 
   def enclosingSourceDirectory(file: Path): Option[Path] = {
     def loop(p: Path): Option[Path] = {
@@ -552,32 +499,6 @@ private class BloopPants(
     }
     loop(file)
   }
-
-  private def makeClassdirectory(target: String): List[Path] =
-    if (target.isBinaryDependency) {
-      if (targets(target).isResourceTarget) {
-        List(target.baseDirectory)
-      } else {
-        dist.iterator.filter { p =>
-          val filename = p.filename
-          filename.startsWith(targets(target).id) &&
-          filename.endsWith(".jar")
-        }.toList
-      }
-    } else {
-      List(bloopDir.resolve(BloopPants.makeFilename(target)).resolve("classes"))
-    }
-
-  private def getLibraryDependencies(
-      libraryDependencies: Seq[Value],
-      keys: List[String]
-  ): Seq[Path] =
-    for {
-      lib <- libraryDependencies
-      path <- keys.collectFirst {
-        case key if lib.obj.contains(key) => lib.obj(key)
-      }
-    } yield Paths.get(path.str)
 
   private def newSourceModule(source: Path) =
     C.Module(
@@ -635,7 +556,7 @@ private class BloopPants(
       module.startsWith("jline:jline:")
 
   private def cleanStaleBloopFiles(
-      generatedProjects: Set[Path]
+      generatedProjects: collection.Set[Path]
   ): Unit = {
     val ls = Files.list(bloopDir)
     try {

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/Filemap.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/Filemap.scala
@@ -6,6 +6,8 @@ import scala.meta.internal.process.SystemProcess
 import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.ansi.LineListener
 import scala.concurrent.ExecutionContext
+import java.nio.file.Files
+import scala.meta.internal.metals.MetalsEnrichments._
 
 class Filemap(
     map: mutable.Map[String, mutable.ArrayBuffer[Path]] = mutable.Map.empty
@@ -25,7 +27,7 @@ class Filemap(
 }
 
 object Filemap {
-  def fromPants(workspace: Path, targets: List[String])(
+  def fromPants(workspace: Path, isCache: Boolean, targets: List[String])(
       implicit ec: ExecutionContext
   ): Filemap = {
     val filemap = new Filemap()
@@ -37,16 +39,40 @@ object Filemap {
         filemap.addPath(target, path)
       }
     })
-    SystemProcess.run(
-      "pants filemap",
-      workspace.resolve("pants").toString() ::
-        "--print-exception-stacktrace=true" ::
-        "filemap" ::
-        targets,
-      workspace,
-      EmptyCancelToken,
-      lines
-    )
+    val outputfile = workspace
+      .resolve(".pants.d")
+      .resolve("metals")
+      .resolve(PantsConfiguration.outputFilename(targets) + "-filemap.txt")
+    val shouldRun =
+      !isCache || !Files.isRegularFile(outputfile)
+    if (shouldRun) {
+      SystemProcess.run(
+        "pants filemap",
+        workspace.resolve("pants").toString() ::
+          "--print-exception-stacktrace=true" ::
+          s"--filemap-output-file=$outputfile" ::
+          "filemap" ::
+          targets,
+        workspace,
+        EmptyCancelToken,
+        lines
+      )
+    }
+    Filemap.fromCache(workspace, outputfile)
+  }
+
+  private def fromCache(workspace: Path, cache: Path): Filemap = {
+    val filemap = new Filemap
+    if (Files.isRegularFile(cache)) {
+      Files.lines(cache).asScala.foreach { line =>
+        val split = line.split(" ", 2)
+        if (split.length == 2) {
+          val path = workspace.resolve(split(0))
+          val target = split(1)
+          filemap.addPath(target, path)
+        }
+      }
+    }
     filemap
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/Filemap.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/Filemap.scala
@@ -30,15 +30,6 @@ object Filemap {
   def fromPants(workspace: Path, isCache: Boolean, targets: List[String])(
       implicit ec: ExecutionContext
   ): Filemap = {
-    val filemap = new Filemap()
-    val lines = new LineListener(line => {
-      val split = line.split(" ", 2)
-      if (split.length == 2) {
-        val path = workspace.resolve(split(0))
-        val target = split(1)
-        filemap.addPath(target, path)
-      }
-    })
     val outputfile = workspace
       .resolve(".pants.d")
       .resolve("metals")
@@ -55,7 +46,7 @@ object Filemap {
           targets,
         workspace,
         EmptyCancelToken,
-        lines
+        LineListener.info
       )
     }
     Filemap.fromCache(workspace, outputfile)

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsConfiguration.scala
@@ -7,6 +7,7 @@ import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import com.google.gson.JsonElement
 import com.google.gson.JsonArray
 import scala.collection.JavaConverters._
+import scala.meta.internal.mtags.MD5
 
 object PantsConfiguration {
 
@@ -100,5 +101,14 @@ object PantsConfiguration {
       }
     }
     buf.result().map(workspace.resolve)
+  }
+  def outputFilename(targets: List[String]): String = {
+    val processed =
+      targets.map(_.replaceAll("[^a-zA-Z0-9]", "")).mkString
+    if (processed.isEmpty()) {
+      MD5.compute(targets.mkString) // necessary for targets like "::/"
+    } else {
+      processed
+    }
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
@@ -1,0 +1,91 @@
+package scala.meta.internal.pantsbuild
+
+import java.nio.file.Paths
+import scala.collection.mutable
+
+case class PantsExport(
+    targets: Map[String, PantsTarget],
+    libraries: Map[String, PantsLibrary],
+    scalaPlatform: PantsScalaPlatform,
+    cycles: Cycles
+)
+
+object PantsExport {
+  def fromJson(output: ujson.Value): PantsExport = {
+
+    val allTargets = output.obj("targets").obj
+    val transitiveDependencyCache = mutable.Map.empty[String, List[String]]
+    def computeTransitiveDependencies(name: String): List[String] = {
+      transitiveDependencyCache.getOrElseUpdate(
+        name, {
+          val isVisited = new mutable.LinkedHashSet[String]()
+          def visit(n: String): Unit = {
+            if (!isVisited(n)) {
+              isVisited += n
+              val target = allTargets(n).obj
+              for {
+                deps <- target.get("targets").iterator
+                dep <- deps.arr.iterator.map(_.str)
+              } {
+                visit(dep)
+              }
+            }
+          }
+          visit(name)
+          isVisited.toList
+        }
+      )
+    }
+    val targets: Map[String, PantsTarget] = allTargets.iterator.map {
+      case (name, valueObj) =>
+        val value = valueObj.obj
+        val dependencies = value("targets").arr.map(_.str)
+        val transitiveDependencies = value.get("transitive_targets") match {
+          case None => computeTransitiveDependencies(name)
+          case Some(transitiveDepencies) => transitiveDepencies.arr.map(_.str)
+        }
+        val libraries = value("libraries").arr.map(_.str)
+        val isTargetRoot = value("is_target_root").bool &&
+          !name.startsWith(".pants.d/gen")
+        val id = value("id").str
+        name -> PantsTarget(
+          name = name,
+          id = id,
+          dependencies = dependencies,
+          transitiveDependencies = transitiveDependencies,
+          libraries = libraries,
+          isTargetRoot = isTargetRoot,
+          targetType = TargetType(value("target_type").str),
+          pantsTargetType = PantsTargetType(value("pants_target_type").str)
+        )
+    }.toMap
+
+    val allLibraries = output.obj("libraries").obj
+    val libraries: Map[String, PantsLibrary] = allLibraries.iterator.map {
+      case (name, valueObj) =>
+        name -> PantsLibrary(name, valueObj.obj.map {
+          case (key, value) =>
+            key -> Paths.get(value.str)
+        })
+    }.toMap
+
+    val scalaCompilerClasspath = output
+      .obj("scala_platform")
+      .obj("compiler_classpath")
+      .arr
+      .map(path => Paths.get(path.str))
+    val scalaPlatform = PantsScalaPlatform(
+      output.obj("scala_platform").obj("scala_version").str,
+      scalaCompilerClasspath
+    )
+
+    val cycles = Cycles.findConnectedComponents(output)
+
+    PantsExport(
+      targets = targets,
+      libraries = libraries,
+      scalaPlatform = scalaPlatform,
+      cycles = cycles
+    )
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsKeys.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsKeys.scala
@@ -1,0 +1,15 @@
+package scala.meta.internal.pantsbuild
+
+/** Key names from the output of `./pants export` */
+object PantsKeys {
+  val targets = "targets"
+  val transitiveTargets = "transitive_targets"
+  val libraries = "libraries"
+  val isTargetRoot = "is_target_root"
+  val id = "id"
+  val pantsTargetType = "pants_target_type"
+  val targetType = "target_type"
+  val scalaPlatform = "scala_platform"
+  val compilerClasspath = "compiler_classpath"
+  val scalaVersion = "scala_version"
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsLibrary.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsLibrary.scala
@@ -1,0 +1,15 @@
+package scala.meta.internal.pantsbuild
+
+import java.nio.file.Path
+
+case class PantsLibrary(
+    name: String,
+    values: collection.Map[String, Path]
+) {
+  def default: Option[Path] = values.get("default")
+  def sources: Option[Path] = values.get("sources")
+  def nonSources: Iterable[Path] = values.collect {
+    case (key, path) if key != "sources" =>
+      path
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsScalaPlatform.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsScalaPlatform.scala
@@ -1,0 +1,8 @@
+package scala.meta.internal.pantsbuild
+
+import java.nio.file.Path
+
+case class PantsScalaPlatform(
+    scalaBinaryVersion: String,
+    compilerClasspath: Seq[Path]
+)

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTarget.scala
@@ -1,0 +1,18 @@
+package scala.meta.internal.pantsbuild
+
+import java.nio.file.Path
+
+case class PantsTarget(
+    name: String,
+    id: String,
+    dependencies: collection.Seq[String],
+    transitiveDependencies: collection.Seq[String],
+    libraries: collection.Seq[String],
+    isTargetRoot: Boolean,
+    targetType: TargetType,
+    pantsTargetType: PantsTargetType
+) {
+  val directoryName: String = BloopPants.makeReadableFilename(name)
+  def classesDir(bloopDir: Path): Path =
+    bloopDir.resolve(directoryName).resolve("classes")
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTargetType.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTargetType.scala
@@ -1,0 +1,25 @@
+package scala.meta.internal.pantsbuild
+
+case class PantsTargetType(value: String) {
+  def isJarLibrary: Boolean = value == "jar_library"
+  def isJvmBinary: Boolean = value == "jvm_binary"
+  def isJvmApp: Boolean = value == "jvm_app"
+  def isScalaLibrary: Boolean = value == "scala_library"
+  def isTarget: Boolean = value == "target"
+  def isResources: Boolean = value == "resources"
+  def isJavaTests: Boolean = value == "java_tests"
+  def isJavaLibrary: Boolean = value == "java_library"
+  def isJavaThriftLibrary: Boolean = value == "java_thrift_library"
+  def isJavaAntlrLibrary: Boolean = value == "java_antrl_library"
+  def isFiles: Boolean = value == "java_files"
+  def isAlias: Boolean = value == "alias"
+  def isSupported: Boolean =
+    !PantsTargetType.unsupportedTargetType.contains(value)
+}
+
+object PantsTargetType {
+  private val unsupportedTargetType = Set(
+    "files", "page", "python_binary", "python_tests", "python_library",
+    "python_requirement_library"
+  )
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/TargetType.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/TargetType.scala
@@ -1,0 +1,9 @@
+package scala.meta.internal.pantsbuild
+
+case class TargetType(value: String) {
+  def isTest: Boolean = value == "TEST"
+  def isTestResource: Boolean = value == "TEST_RESOURCE"
+  def isResource: Boolean = value == "RESOURCE"
+  def isAnyResource: Boolean = isResource || isTest
+  def isSource: Boolean = value == "SOURCE"
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/TargetType.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/TargetType.scala
@@ -4,6 +4,6 @@ case class TargetType(value: String) {
   def isTest: Boolean = value == "TEST"
   def isTestResource: Boolean = value == "TEST_RESOURCE"
   def isResource: Boolean = value == "RESOURCE"
-  def isAnyResource: Boolean = isResource || isTest
+  def isAnyResource: Boolean = isResource || isTestResource
   def isSource: Boolean = value == "SOURCE"
 }


### PR DESCRIPTION
Previously, the Pants to Bloop export step was implemented with fairly
tricky code that was difficult to reason about. This commit cleans up
the implementation so that it's more correct, easier to maintain and it
also runs faster.