### PR TITLE
Ignore pants ivy sources without a default scope

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -263,10 +263,13 @@ private class BloopPants(
       Properties.versionNumberString
     }
   val allScalaJars: Seq[Path] = {
-    val scalaJars = libraries.collect {
-      case (module, jar) if isScalaJar(module) =>
-        Paths.get(jar.obj("default").str)
-    }.toSeq
+    val scalaJars = libraries
+      .collect {
+        case (module, jar) if isScalaJar(module) =>
+          jar.obj.get("default")
+      }
+      .flatMap(_.map(source => Paths.get(source.str)))
+      .toSeq
     val hasScalaCompiler =
       scalaJars.exists(_.getFileName().toString().contains("scala-compiler"))
     if (hasScalaCompiler) {
@@ -629,7 +632,6 @@ private class BloopPants(
   private def isScalaJar(module: String): Boolean =
     module.startsWith(scalaCompiler) ||
       module.startsWith("org.scala-lang:scala-reflect:") ||
-      module.startsWith("org.scala-lang:scala-library:") ||
       module.startsWith("org.scala-lang:scala-library:") ||
       module.startsWith("org.fursesource:jansi:") ||
       module.startsWith("jline:jline:")


### PR DESCRIPTION
In my build dependencies, I have:

```json
{
    "libraries": {
            "io.netty:netty-transport-native-epoll:4.1.38.Final": {
            "linux-x86_64": "/home/lbordowitz/.ivy2/pants/io.netty/netty-transport-native-epoll/jars/netty-transport-native-epoll-4.1.38.Final-linux-x86_64.jar"
        },
    },
}
```

There's no `default` key provided, and metals fails every time I try to import it. This fix causes the import to ignore those entries that don't have a "default-scoped" target.