### PR TITLE
Hopefully fix flaky test failure

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
@@ -180,27 +180,23 @@ final class BloopInstall(
       digest: String
   )(implicit ec: ExecutionContext): Future[Confirmation] = {
     tables.digests.setStatus(digest, Status.Requested)
-    if (buildTools.isBloop) {
-      languageClient
-        .showMessageRequest(ImportBuildChanges.params(buildTool.toString))
-        .asScala
-        .map { item =>
-          if (item == dontShowAgain) {
-            notification.dismissForever()
-          }
-          Confirmation.fromBoolean(item == ImportBuildChanges.yes)
+    val (params, yes) =
+      if (buildTools.isBloop) {
+        ImportBuildChanges.params(buildTool.toString) ->
+          ImportBuildChanges.yes
+      } else {
+        ImportBuild.params(buildTool.toString) ->
+          ImportBuild.yes
+      }
+    languageClient
+      .showMessageRequest(params)
+      .asScala
+      .map { item =>
+        if (item == dontShowAgain) {
+          notification.dismissForever()
         }
-    } else {
-      languageClient
-        .showMessageRequest(ImportBuild.params(buildTool.toString()))
-        .asScala
-        .map { item =>
-          if (item == dontShowAgain) {
-            notification.dismissForever()
-          }
-          Confirmation.fromBoolean(item == ImportBuild.yes)
-        }
-    }
+        Confirmation.fromBoolean(item == yes)
+      }
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
@@ -135,10 +135,14 @@ final class BloopInstall(
     }
   }
 
+  // NOTE(olafur) there's a chance that we get two build change notifications in
+  // a very short period due to duplicate `didSave` and file watching
+  // notifications. This method is synchronized to prevent asking the user
+  // twice whether to import the build.
   def runIfApproved(
       buildTool: BuildTool,
       digest: String
-  ): Future[BloopInstallResult] = {
+  ): Future[BloopInstallResult] = synchronized {
     oldInstallResult(digest) match {
       case Some(result) =>
         scribe.info(s"skipping build import with status '${result.name}'")


### PR DESCRIPTION
Fixes #1182 

Previously, a race condition could cause Metals to prompt the user twice to import build changes. The duplicate prompt could cause some test suites like `PantsLspSuite` to become flaky. Now, we synchronize on the method that prompts the user to ensure that we finish writing the digest notification status in the H2 database before sending the next prompt.

I'm not sure if this fixes the flaky test failure, but I struggle to see why the Pants build digest should be any more flaky than the other build tool digests.