### PR TITLE
Several improvements to Pants export step

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -29,7 +29,6 @@ import java.util.concurrent.CancellationException
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import scala.sys.process.Process
 import scala.meta.io.Classpath
-import coursierapi.Repository
 import coursierapi.MavenRepository
 
 object BloopPants {
@@ -346,7 +345,12 @@ private class BloopPants(
 
     val sources: List[Path] =
       if (target.targetType.isResource) Nil
-      else filemap.forTarget(target.name).toList
+      else {
+        target.globs.sourceDirectory(workspace) match {
+          case Some(dir) => List(dir)
+          case _ => filemap.forTarget(target.name).toList
+        }
+      }
 
     val transitiveDependencies: List[PantsTarget] = (for {
       dependency <- target.transitiveDependencies

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
@@ -69,17 +69,9 @@ object PantsExport {
         })
     }.toMap
 
-    val scalaCompilerClasspath = output
-      .obj(PantsKeys.scalaPlatform)
-      .obj(PantsKeys.compilerClasspath)
-      .arr
-      .map(path => Paths.get(path.str))
-    val scalaPlatform = PantsScalaPlatform(
-      output.obj(PantsKeys.scalaPlatform).obj(PantsKeys.scalaVersion).str,
-      scalaCompilerClasspath
-    )
-
     val cycles = Cycles.findConnectedComponents(output)
+
+    val scalaPlatform = PantsScalaPlatform.fromJson(output)
 
     PantsExport(
       targets = targets,
@@ -88,4 +80,5 @@ object PantsExport {
       cycles = cycles
     )
   }
+
 }

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
@@ -56,7 +56,8 @@ object PantsExport {
           isTargetRoot = isTargetRoot,
           targetType = TargetType(value(PantsKeys.targetType).str),
           pantsTargetType =
-            PantsTargetType(value(PantsKeys.pantsTargetType).str)
+            PantsTargetType(value(PantsKeys.pantsTargetType).str),
+          globs = PantsGlobs.fromJson(value)
         )
     }.toMap
 

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsGlobs.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsGlobs.scala
@@ -1,0 +1,60 @@
+package scala.meta.internal.pantsbuild
+
+import java.nio.file.Path
+import ujson.Value
+import ujson.Obj
+import ujson.Arr
+import ujson.Str
+
+case class PantsGlobs(
+    include: List[String],
+    exclude: List[String]
+) {
+
+  /** Returns a source directory if this target uses rglobs("*.scala") */
+  def sourceDirectory(workspace: Path): Option[Path] = include match {
+    case head :: Nil if exclude.isEmpty =>
+      PantsGlobs.rglobsSuffixes.collectFirst {
+        case suffix if head.endsWith(suffix) =>
+          workspace.resolve(head.stripSuffix(suffix))
+      }
+    case _ =>
+      None
+  }
+}
+
+object PantsGlobs {
+  private val rglobsSuffixes = List(
+    "/**/*.java",
+    "/**/*.scala"
+  )
+
+  def fromJson(target: Value): PantsGlobs = {
+    target.obj.get("globs") match {
+      case Some(obj: Obj) =>
+        val include = globsFromObject(obj)
+        val exclude = obj.value.get("exclude") match {
+          case Some(arr: Arr) =>
+            arr.value.iterator.flatMap(globsFromObject).toList
+          case _ =>
+            Nil
+        }
+        PantsGlobs(include, exclude)
+      case _ =>
+        PantsGlobs(Nil, Nil)
+    }
+  }
+
+  private def globsFromObject(value: Value): List[String] = value match {
+    case Obj(obj) =>
+      obj.get("globs") match {
+        case Some(arr: Arr) =>
+          arr.value.iterator.collect {
+            case Str(glob) => glob
+          }.toList
+        case _ =>
+          Nil
+      }
+    case _ => Nil
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsScalaPlatform.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsScalaPlatform.scala
@@ -1,8 +1,42 @@
 package scala.meta.internal.pantsbuild
 
+import scala.collection.JavaConverters._
 import java.nio.file.Path
+import ujson.Value
+import java.nio.file.Paths
+import scala.meta.internal.metals.BuildInfo
+import coursierapi.Dependency
+import coursierapi.Fetch
 
 case class PantsScalaPlatform(
     scalaBinaryVersion: String,
     compilerClasspath: Seq[Path]
 )
+
+object PantsScalaPlatform {
+  def fromJson(output: Value): PantsScalaPlatform = {
+    val (scalaVersion, compilerClasspath) =
+      output.obj.get(PantsKeys.scalaPlatform) match {
+        case Some(scalaPlatform) =>
+          scalaPlatform.obj(PantsKeys.scalaVersion).str ->
+            scalaPlatform
+              .obj(PantsKeys.compilerClasspath)
+              .arr
+              .map(path => Paths.get(path.str))
+        case None =>
+          "2.12" ->
+            fetchScalaCompilerClasspath(BuildInfo.scala212)
+      }
+    PantsScalaPlatform(scalaVersion, compilerClasspath)
+  }
+  private def fetchScalaCompilerClasspath(scalaVersion: String): Seq[Path] =
+    Fetch
+      .create()
+      .withDependencies(
+        Dependency.of("org.scala-lang", "scala-compiler", scalaVersion)
+      )
+      .fetch()
+      .asScala
+      .map(_.toPath())
+      .toList
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTarget.scala
@@ -10,7 +10,8 @@ case class PantsTarget(
     libraries: collection.Seq[String],
     isTargetRoot: Boolean,
     targetType: TargetType,
-    pantsTargetType: PantsTargetType
+    pantsTargetType: PantsTargetType,
+    globs: PantsGlobs
 ) {
   val directoryName: String = BloopPants.makeReadableFilename(name)
   def classesDir(bloopDir: Path): Path =


### PR DESCRIPTION
See individual commits for details. In summary:

* faster `bloop test` for ScalaTest targets
* increased compatibility with older versions of Pants
* improved UX for Pants targets that use recursive `**/*.scala` globs