### PR TITLE
Add separate "debug" code lens

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -53,6 +53,28 @@ object ClientCommands {
        |""".stripMargin
   )
 
+  val StartRunSession = new Command(
+    "metals-run-session-start",
+    "Start run session",
+    s"""|Starts a run session. The address of a new Debug Adapter can be obtained 
+        | by using the ${ServerCommands.StartDebugAdapter.id} metals server command
+        | with the same arguments as provided to this command.
+    """.stripMargin,
+    s"""|DebugSessionParameters object. It should be forwarded
+        |to the ${ServerCommands.StartDebugAdapter.id} command as is.
+        |
+        |Example:
+        |```json
+        |{
+        |  "targets": ["mybuild://workspace/foo/?id=foo"],
+        |   dataKind: "${b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS}",
+        |   data: {
+        |      className: "com.foo.App"
+        |   }
+        |}```
+    """.stripMargin
+  )
+
   val StartDebugSession = new Command(
     "metals-debug-session-start",
     "Start debug session",

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1220,16 +1220,18 @@ class MetalsLanguageServer(
         val args = params.getArguments.asScala
         args match {
           case Seq(param: JsonElement) =>
-            val session = Future
-              .fromTry(param.as[b.DebugSessionParams])
-              .flatMap(
-                DebugServer
-                  .start(_, definitionProvider, buildTargets, buildServer)
+            val session = for {
+              params <- Future.fromTry(param.as[b.DebugSessionParams])
+              server <- DebugServer.start(
+                params,
+                definitionProvider,
+                buildTargets,
+                buildServer
               )
-              .map { server =>
-                cancelables.add(server)
-                DebugSession(server.sessionName, server.uri.toString)
-              }
+            } yield {
+              cancelables.add(server)
+              DebugSession(server.sessionName, server.uri.toString)
+            }
 
             session.asJavaObject
           case _ =>

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
@@ -1,9 +1,9 @@
 package scala.meta.internal.metals.debug
 
 import com.google.gson.JsonElement
-import org.eclipse.lsp4j.{debug => dap}
 import org.eclipse.lsp4j.debug.DisconnectArguments
 import org.eclipse.lsp4j.debug.InitializeRequestArguments
+import org.eclipse.lsp4j.debug.LaunchRequestArguments
 import org.eclipse.lsp4j.debug.SetBreakpointsArguments
 import org.eclipse.lsp4j.debug.SetBreakpointsResponse
 import org.eclipse.lsp4j.debug.Source
@@ -15,6 +15,8 @@ import org.eclipse.lsp4j.jsonrpc.messages.RequestMessage
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
+import org.eclipse.lsp4j.{debug => dap}
+import scala.meta.internal.metals.debug.DebugProxy.DebugMode
 import scala.reflect.ClassTag
 import scala.util.Failure
 import scala.util.Try
@@ -80,6 +82,17 @@ object DebugProtocol {
     ): Option[InitializeRequestArguments] = {
       if (request.getMethod != "initialize") None
       else parse[InitializeRequestArguments](request.getParams).toOption
+    }
+  }
+
+  object LaunchRequest {
+    def unapply(request: DebugRequestMessage): Option[DebugMode] = {
+      if (request.getMethod != "launch") None
+      else
+        parse[LaunchRequestArguments](request.getParams).toOption.map {
+          case args if args.getNoDebug => DebugMode.Disabled
+          case _ => DebugMode.Enabled
+        }
     }
   }
 

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Debugger.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Debugger.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.metals.debug
 
-import java.util.Collections
 import java.util.concurrent.TimeUnit
 import org.eclipse.lsp4j.debug.Capabilities
 import org.eclipse.lsp4j.debug.ConfigurationDoneArguments
@@ -40,8 +39,11 @@ final class Debugger(server: RemoteServer)(implicit ec: ExecutionContext) {
     server.initialize(arguments).asScala
   }
 
-  def launch: Future[Unit] = {
-    server.launch(Collections.emptyMap()).asScala.ignoreValue
+  def launch(debug: java.lang.Boolean): Future[Unit] = {
+    val arguments = Map[String, AnyRef](
+      "noDebug" -> java.lang.Boolean.valueOf(!debug)
+    )
+    server.launch(arguments.asJava).asScala.ignoreValue
   }
 
   def configurationDone: Future[Unit] = {

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Stoppage.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Stoppage.scala
@@ -20,8 +20,17 @@ object Stoppage {
 
   object Handler {
     case object Continue extends Handler {
-      override def apply(stoppage: Stoppage): Future[DebugStep] =
+      override def apply(stoppage: Stoppage): Future[DebugStep] = {
         Future.successful(DebugStep.Continue)
+      }
+      override def shutdown: Future[Unit] = Future.unit
+    }
+
+    case object Fail extends Handler {
+      override def apply(stoppage: Stoppage): Future[DebugStep] = {
+        val error = s"Unexpected stoppage: $stoppage"
+        Future.failed(new IllegalStateException(error))
+      }
       override def shutdown: Future[Unit] = Future.unit
     }
   }

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/TestDebugger.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/TestDebugger.scala
@@ -36,7 +36,11 @@ final class TestDebugger(
   }
 
   def launch: Future[Unit] = {
-    ifNotFailed(debugger.launch)
+    ifNotFailed(debugger.launch(debug = true))
+  }
+
+  def launch(debug: Boolean): Future[Unit] = {
+    ifNotFailed(debugger.launch(debug))
   }
 
   def configurationDone: Future[Unit] = {

--- a/tests/unit/src/main/scala/tests/CodeLensesTextEdits.scala
+++ b/tests/unit/src/main/scala/tests/CodeLensesTextEdits.scala
@@ -3,18 +3,21 @@ package tests
 import org.eclipse.{lsp4j => l}
 
 object CodeLensesTextEdits {
-  def apply(ranges: Seq[l.CodeLens]): List[l.TextEdit] = {
-    ranges.map(convert).toList
+  def apply(lenses: Seq[l.CodeLens]): Iterable[l.TextEdit] = {
+    for {
+      (line, lenses) <- lenses.groupBy(_.getRange.getStart.getLine)
+      textEdit = convert(line, lenses)
+    } yield textEdit
   }
 
-  private def convert(lens: l.CodeLens): l.TextEdit = {
-    val range = lens.getRange
-    val pos = new l.Position(range.getStart.getLine, 0)
-    new l.TextEdit(new l.Range(pos, pos), print(lens))
+  private def convert(line: Int, lenses: Seq[l.CodeLens]): l.TextEdit = {
+    val pos = new l.Position(line, 0)
+    val edit = lenses.map(print).mkString
+    new l.TextEdit(new l.Range(pos, pos), edit + System.lineSeparator())
   }
 
   private def print(lens: l.CodeLens): String = {
     val command = lens.getCommand
-    s"<<${command.getTitle}>>\n"
+    s"<<${command.getTitle}>>"
   }
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -536,7 +536,7 @@ final class TestingServer(
       _ <- server.compilations.compileFiles(List(path))
       lenses <- codeLenses.future
       textEdits = CodeLensesTextEdits(lenses)
-    } yield TextEdits.applyEdits(textContents(filename), textEdits)
+    } yield TextEdits.applyEdits(textContents(filename), textEdits.toList)
   }
 
   def formatCompletion(

--- a/tests/unit/src/test/scala/tests/CodeLensesLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeLensesLspSuite.scala
@@ -3,7 +3,7 @@ import scala.concurrent.Future
 
 object CodeLensesLspSuite extends BaseLspSuite("codeLenses") {
   check("empty-package")(
-    """|<<run>>
+    """|<<run>><<debug>>
        |object Main {
        |  def main(args: Array[String]): Unit = {}
        |}
@@ -19,7 +19,7 @@ object CodeLensesLspSuite extends BaseLspSuite("codeLenses") {
 
   check("main")(
     """|package foo
-       |<<run>>
+       |<<run>><<debug>>
        |object Main {
        |  def main(args: Array[String]): Unit = {}
        |}
@@ -28,7 +28,7 @@ object CodeLensesLspSuite extends BaseLspSuite("codeLenses") {
 
   check("non-ascii")(
     """|package foo.bar
-       |<<run>>
+       |<<run>><<debug>>
        |object :: {
        |  def main(args: Array[String]): Unit = {}
        |}
@@ -37,7 +37,7 @@ object CodeLensesLspSuite extends BaseLspSuite("codeLenses") {
 
   check("test-suite-class", library = "org.scalatest::scalatest:3.0.5")(
     """|package foo.bar
-       |<<test>>
+       |<<test>><<debug test>>
        |class Foo extends org.scalatest.FunSuite {
        |  test("foo") {}
        |}
@@ -46,7 +46,7 @@ object CodeLensesLspSuite extends BaseLspSuite("codeLenses") {
 
   check("test-suite-object", library = "com.lihaoyi::utest:0.7.2")(
     """|package foo.bar
-       |<<test>>
+       |<<test>><<debug test>>
        |object Foo extends utest.TestSuite {
        |  val tests = utest.Tests {}
        |}
@@ -79,7 +79,7 @@ object CodeLensesLspSuite extends BaseLspSuite("codeLenses") {
       _ <- assertCodeLenses(
         "a/src/main/scala/Foo.scala",
         """|package foo.bar
-           |<<run>>
+           |<<run>><<debug>>
            |object Foo {
            |  def main(args: Array[String]): Unit = {}
            |}
@@ -88,7 +88,7 @@ object CodeLensesLspSuite extends BaseLspSuite("codeLenses") {
       _ <- assertCodeLenses(
         "a/src/main/scala/Bar.scala",
         """|package foo.bar
-           |<<run>>
+           |<<run>><<debug>>
            |object Bar {
            |  def main(args: Array[String]): Unit = {}
            |}
@@ -137,7 +137,7 @@ object CodeLensesLspSuite extends BaseLspSuite("codeLenses") {
       )
       _ <- assertCodeLenses(
         "a/src/main/scala/Main.scala",
-        """<<run>>
+        """<<run>><<debug>>
           |object Main {
           |  def main(args: Array[String]): Unit = {}
           |}
@@ -165,7 +165,7 @@ object CodeLensesLspSuite extends BaseLspSuite("codeLenses") {
       )
       _ <- assertCodeLenses(
         "a/src/main/scala/Main.scala",
-        """<<run>>
+        """<<run>><<debug>>
           |object Main {
           |  def main(args: Array[String]): Unit = ???
           |}
@@ -176,7 +176,7 @@ object CodeLensesLspSuite extends BaseLspSuite("codeLenses") {
       )
       _ <- assertCodeLenses(
         "a/src/main/scala/Main.scala",
-        """<<run>>
+        """<<run>><<debug>>
           |object Main {
           |  def main(args: Array[String]): Unit = ???
           |

--- a/tests/unit/src/test/scala/tests/debug/BreakpointDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/BreakpointDapSuite.scala
@@ -3,6 +3,7 @@ import tests.BaseDapSuite
 import scala.meta.internal.metals.debug.DebugStep._
 import scala.meta.internal.metals.debug.DebugWorkspaceLayout
 import scala.meta.internal.metals.debug.StepNavigator
+import scala.meta.internal.metals.debug.Stoppage
 
 object BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
 
@@ -427,6 +428,38 @@ object BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |}
                 |""".stripMargin
   )
+
+  testAsync("no-debug") {
+    val workspaceLayout = DebugWorkspaceLayout(
+      """|/a/src/main/scala/a/Main.scala
+         |package a
+         |object Main {
+         |  def main(args: Array[String]): Unit = {
+         |>>  println(1)
+         |>>  println(2)
+         |>>  println(3)
+         |  }
+         |}
+         |""".stripMargin
+    )
+
+    for {
+      _ <- server.initialize(
+        s"""|/metals.json
+            |{ "a": {} }
+            |
+            |$workspaceLayout
+            |""".stripMargin
+      )
+      debugger <- debugMain("a", "a.Main", Stoppage.Handler.Fail)
+      _ <- debugger.initialize
+      _ <- debugger.launch(debug = false)
+      _ <- setBreakpoints(debugger, workspaceLayout)
+      _ <- debugger.configurationDone
+      _ <- debugger.shutdown
+      output <- debugger.allOutput
+    } yield assertNoDiff(output, "1\n2\n3\n")
+  }
 
   def assertBreakpoints(name: String, disabled: Boolean = false)(
       source: String

--- a/tests/unit/src/test/scala/tests/debug/StepDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/StepDapSuite.scala
@@ -163,9 +163,4 @@ object StepDapSuite extends BaseDapSuite("debug-step") {
       } yield ()
     }
   }
-
-  private def javaLibRoot: String = {
-    if (isJava8) ".metals/readonly"
-    else ".metals/readonly/java.base"
-  }
 }


### PR DESCRIPTION
Closes #1188 
Previously, there was no way to run program and ignore the breakpoints.
Now, we introduce a separate command `StartRunSession` which ignores the breakpoint requests altogether.
Both commands (`StartRunSession` and `StartDebugSession`) are shown to the user as separate code lenses.

TODO: rebase after #1010 gets merged