### PR TITLE
Avoid re-compilation when restarting Bloop in Pants workspace

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTarget.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.pantsbuild
 
 import java.nio.file.Path
+import java.nio.file.Files
 
 case class PantsTarget(
     name: String,
@@ -15,5 +16,5 @@ case class PantsTarget(
 ) {
   val directoryName: String = BloopPants.makeReadableFilename(name)
   def classesDir(bloopDir: Path): Path =
-    bloopDir.resolve(directoryName).resolve("classes")
+    Files.createDirectories(bloopDir.resolve(directoryName).resolve("classes"))
 }


### PR DESCRIPTION
Previously, Bloop would trigger a re-compilation after restarting the
server. Now, the newly started Bloop server re-uses the cached
compilation.

Related PR https://github.com/scalacenter/bloop/pull/1129