### PR TITLE
Include jdk in the job name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   unit:
-    name: ${{ matrix.os }} unit tests
+    name: ${{ matrix.os }} jdk-${{ matrix.java }} unit tests
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Previously, we could observe ambiguous names of the unit test jobs:
![gh_ambiguous](https://user-images.githubusercontent.com/3709537/71096077-fca5bb00-21ad-11ea-8158-8a96365fd21c.png)
Now, we include the jdk version in the name of those jobs