### PR TITLE
Set the working directory to the workspace in Pants export.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -450,7 +450,17 @@ private class BloopPants(
       java = Some(C.Java(Nil)),
       sbt = None,
       test = bloopTestFrameworks,
-      platform = Some(C.Platform.Jvm(C.JvmConfig(javaHome, Nil), None)),
+      platform = Some(
+        C.Platform.Jvm(
+          C.JvmConfig(
+            javaHome,
+            List(
+              s"-Duser.dir=$workspace"
+            )
+          ),
+          None
+        )
+      ),
       resolution = None
     )
   }


### PR DESCRIPTION
Previously, the working directory would default to the base directory of
the Pants target (directory containing BUILD file). Now, the working
directory will be the root of the Pants build, reproducing the Pants
behavior for run/test.