### PR TITLE
Don't create Bloop projects for Pants targets of type "files".

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
@@ -45,15 +45,14 @@ object PantsExport {
             case Some(transitiveDepencies) => transitiveDepencies.arr.map(_.str)
           }
         val libraries = value(PantsKeys.libraries).arr.map(_.str)
-        val isTargetRoot = value(PantsKeys.isTargetRoot).bool &&
-          !name.startsWith(".pants.d/gen")
+        val isPantsTargetRoot = value(PantsKeys.isTargetRoot).bool
         name -> PantsTarget(
           name = name,
           id = value(PantsKeys.id).str,
           dependencies = dependencies,
           transitiveDependencies = transitiveDependencies,
           libraries = libraries,
-          isTargetRoot = isTargetRoot,
+          isPantsTargetRoot = isPantsTargetRoot,
           targetType = TargetType(value(PantsKeys.targetType).str),
           pantsTargetType =
             PantsTargetType(value(PantsKeys.pantsTargetType).str),

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTarget.scala
@@ -10,11 +10,16 @@ case class PantsTarget(
     dependencies: collection.Seq[String],
     transitiveDependencies: collection.Seq[String],
     libraries: collection.Seq[String],
-    isTargetRoot: Boolean,
+    isPantsTargetRoot: Boolean,
     targetType: TargetType,
     pantsTargetType: PantsTargetType,
     globs: PantsGlobs
 ) {
+
+  def isTargetRoot: Boolean =
+    isPantsTargetRoot &&
+      !name.startsWith(".pants.d") &&
+      !pantsTargetType.isFiles
   val directoryName: String = BloopPants.makeReadableFilename(name)
   def baseDirectory(workspace: Path): Path =
     PantsConfiguration

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTargetType.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTargetType.scala
@@ -11,7 +11,8 @@ case class PantsTargetType(value: String) {
   def isJavaLibrary: Boolean = value == "java_library"
   def isJavaThriftLibrary: Boolean = value == "java_thrift_library"
   def isJavaAntlrLibrary: Boolean = value == "java_antrl_library"
-  def isFiles: Boolean = value == "java_files"
+  def isJavaFiles: Boolean = value == "java_files"
+  def isFiles: Boolean = value == "files"
   def isAlias: Boolean = value == "alias"
   def isSupported: Boolean =
     !PantsTargetType.unsupportedTargetType.contains(value)


### PR DESCRIPTION
Previously, we created Bloop projects for "files" targets with an empty
classpath and `*.java` and `*.scala` files resulting in false compile
errors. Now, we ignore those targets since they're not compiled by Pants
anyways.