### PR TITLE
Use bloop.export-jar-classifiers property

### DIFF
--- a/docs/build-tools/sbt.md
+++ b/docs/build-tools/sbt.md
@@ -49,10 +49,10 @@ addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "@BLOOP_VERSION@")
 Next, run:
 
 ```
-sbt "set bloopExportJarClassifiers := Some(Set(\"source\"))" bloopInstall
+sbt -Dbloop.export-jar-classifiers=sources bloopInstall
 ```
 
-to generate the Bloop JSON configuration files. You can also set the 
+to generate the Bloop JSON configuration files. You can also set the
 `bloopExportJarClassifiers` setting inside your main build.sbt file, but using
 the above command will do it automatically for you in the current sbt session.
 

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -25,7 +25,7 @@ case class SbtBuildTool(
 
   override def args(workspace: AbsolutePath): List[String] = {
     val sbtArgs = List[String](
-      "set bloopExportJarClassifiers in Global := Some(Set(\"sources\"))",
+      "-Dbloop.export-jar-classifiers=sources",
       "bloopInstall"
     )
     val allArgs = userConfig().sbtScript match {


### PR DESCRIPTION
This is my first contribution attempt, let me know if this corresponds to the issue (#1142).

At the moment, the only test I've carried on is using my local version:
- with VSCode (`publishLocal`)
- compiling a `build.sbt` file with `javacOptions.in(Global) ++= Seq("-Dbloop.export-jar-classifiers=\"sources\"")`

