### PR TITLE
Fix scaladoc for methods in Completions

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -366,10 +366,13 @@ trait Completions { this: MetalsGlobal =>
     final def isPrioritizedCached(m: Member): Boolean =
       cache.getOrElseUpdate(m.sym, isPrioritized(m))
 
+    /**
+     * Returns true if this member should be sorted at the top of completion items.
+     */
     def isPrioritized(m: Member): Boolean = true
 
     /**
-     * Returns true if this member should be sorted at the top of completion items.
+     * Returns candidate completion items.
      */
     def contribute: List[Member] = Nil
 


### PR DESCRIPTION
This PR is just a minor fix on scaladoc :)
The scaladoc for the `contribute` method looks like for `isPrioritize` method.