### PR TITLE
Update Sublime settings regarding window/showMessage

### DIFF
--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -168,7 +168,7 @@ Possible values:
 
 - `off` (default): don't start a server with the Metals HTTP client.
 - `on`: start a server with the [Metals HTTP client] to interact with the server
-  through a basic web UI.
+  through a basic web UI. This option is needed for editor clients that don't support necessary requests such as `window/showMessageRequest`.
 
 ### `-Dmetals.icons`
 

--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -114,7 +114,7 @@ Possible values:
 - `log-message`: translate `metals/status` notifications to `window/logMessage`
   notifications. Used by vim-lsc at the moment.
 - `show-message`: translate `metals/status` notifications to
-  `window/showMessage` notifications. Used by coc.nvim at the moment.
+  `window/showMessage` notifications. Used by coc.nvim and sublime at the moment.
 
 ### `-Dmetals.slow-task`
 
@@ -168,9 +168,7 @@ Possible values:
 
 - `off` (default): don't start a server with the Metals HTTP client.
 - `on`: start a server with the [Metals HTTP client] to interact with the server
-  through a basic web UI. This option is needed for editor clients like Sublime
-  Text that don't support necessary requests such as
-  `window/showMessageRequest`.
+  through a basic web UI.
 
 ### `-Dmetals.icons`
 

--- a/docs/editors/sublime.md
+++ b/docs/editors/sublime.md
@@ -201,11 +201,6 @@ Open "Preferences > Key Binding" and add:
 
 ![Import after Enter key was hit](https://i.imgur.com/RDYx9mB.gif)
 
-## Known issues
-
-- The Sublime Text client uses an alert window for `window/showMessage` that
-  prevents you from editing code so Metals uses `window/logMessage` instead.
-
 ```scala mdoc:generic
 
 ```

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
@@ -33,7 +33,7 @@ import scala.meta.internal.decorations.PublishDecorationsParams
  * - Become permanent/primary interface for ordinary users. The end goal is to
  *   enable users to interact with Metals from their editor, not via a browser.
  *
- * The most popular LSP clients in editors like Vim and Sublime currently have
+ * The most popular LSP clients in editors like Vim currently have
  * limited support so that endpoints like `window/showMessageRequest` are ignored,
  * with no workaround for users to interact with the Metals language server.
  * This http client allows users in those editors to trigger server commands

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -144,7 +144,7 @@ object MetalsServerConfig {
       case "sublime" =>
         base.copy(
           isHttpEnabled = true,
-          showMessage = ShowMessageConfig.showMessage,
+          showMessage = StatusBarConfig.showMessage,
           showMessageRequest = ShowMessageRequestConfig.on,
           icons = Icons.unicode,
           isExitOnShutdown = true,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -144,7 +144,8 @@ object MetalsServerConfig {
       case "sublime" =>
         base.copy(
           isHttpEnabled = true,
-          showMessage = StatusBarConfig.showMessage,
+          showMessage = ShowMessageConfig.on,
+          statusBar = StatusBarConfig.showMessage,
           showMessageRequest = ShowMessageRequestConfig.on,
           icons = Icons.unicode,
           isExitOnShutdown = true,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -19,7 +19,7 @@ import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
  * @param isNoInitialized set true if the editor client doesn't call the `initialized`
  *                        notification for some reason, see https://github.com/natebosch/vim-lsc/issues/113
  * @param isHttpEnabled whether to start the Metals HTTP client interface. This is needed
- *                      for clients with limited support for UI dialogues like Sublime Text
+ *                      for clients with limited support for UI dialogues
  *                      that don't implement window/showMessageRequest yet.
  * @param icons what icon set to use for messages.
  */
@@ -144,9 +144,7 @@ object MetalsServerConfig {
       case "sublime" =>
         base.copy(
           isHttpEnabled = true,
-          // Sublime text opens an invasive alert dialogue for window/showMessage
-          // and window/showMessageRequest.
-          showMessage = ShowMessageConfig.logMessage,
+          showMessage = ShowMessageConfig.showMessage,
           showMessageRequest = ShowMessageRequestConfig.on,
           icons = Icons.unicode,
           isExitOnShutdown = true,


### PR DESCRIPTION
Previously LSP displayed a dialog box for `window/showMessage`, latest version (0.9.3 via PR https://github.com/tomv564/LSP/pull/811) displays that in the status bar.

Additionally: 
- make `metals/status` go as `window/showMessage`
- removed some outdated comments.