### PR TITLE
Discard 'code' from BSP diagnostics

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -482,8 +482,9 @@ object MetalsEnrichments
         diag.getRange.toLSP,
         fansi.Str(diag.getMessage).plainText,
         diag.getSeverity.toLSP,
-        if (diag.getSource == null) "scalac" else diag.getSource,
-        diag.getCode
+        if (diag.getSource == null) "scalac" else diag.getSource
+        // We omit diag.getCode since Bloop's BSP implementation uses 'code' with different semantics
+        // than LSP. See https://github.com/scalacenter/bloop/issues/1134 for details
       )
   }
 


### PR DESCRIPTION
Fixes #1220 

This is a temporary fix that discards the `code` property from BSP diagnostics. If we decide to change the `code` property semantics in BSP, then we can revert this fix. See the discussion here https://github.com/scalacenter/bloop/pull/1135