### PR TITLE
Fix issue #1236, make worksheets handle unpositioned diagnostics.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/worksheets/MdocEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/MdocEnrichments.scala
@@ -6,6 +6,11 @@ import mdoc.{interfaces => i}
 object MdocEnrichments {
 
   implicit class XtensionRangePosition(p: i.RangePosition) {
+    def isNone: Boolean =
+      p.startLine() < 0 &&
+        p.startColumn() < 0 &&
+        p.endColumn() < 0 &&
+        p.endLine() < 0
     def toLsp: l.Range = {
       new l.Range(
         new l.Position(

--- a/metals/src/main/scala/scala/meta/internal/worksheets/MdocEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/MdocEnrichments.scala
@@ -12,16 +12,24 @@ object MdocEnrichments {
         p.endColumn() < 0 &&
         p.endLine() < 0
     def toLsp: l.Range = {
-      new l.Range(
-        new l.Position(
-          p.startLine(),
-          p.startColumn()
-        ),
-        new l.Position(
-          p.endLine(),
-          p.endColumn()
+      if (isNone) {
+        // Don't construct invalid positions with negative values
+        new l.Range(
+          new l.Position(0, 0),
+          new l.Position(0, 0)
         )
-      )
+      } else {
+        new l.Range(
+          new l.Position(
+            p.startLine(),
+            p.startColumn()
+          ),
+          new l.Position(
+            p.endLine(),
+            p.endColumn()
+          )
+        )
+      }
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -228,7 +228,6 @@ class WorksheetProvider(
       .diagnostics()
       .iterator()
       .asScala
-      .filterNot(_.position().isNone)
       .map(_.toLsp)
       .toSeq
     diagnostics.onPublishDiagnostics(

--- a/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -299,17 +299,30 @@ trait MtagsEnrichments {
     }
   }
 
+  implicit class XtensionLspPosition(pos: l.Position) {
+    def isNone: Boolean =
+      pos.getLine() < 0 &&
+        pos.getCharacter() < 0
+  }
+
   implicit class XtensionLspRange(range: l.Range) {
     def isOffset: Boolean =
       range.getStart == range.getEnd
+    def isNone: Boolean =
+      range.getStart().isNone &&
+        range.getEnd().isNone
     def toMeta(input: m.Input): m.Position =
-      m.Position.Range(
-        input,
-        range.getStart.getLine,
-        range.getStart.getCharacter,
-        range.getEnd.getLine,
-        range.getEnd.getCharacter
-      )
+      if (range.isNone) {
+        m.Position.None
+      } else {
+        m.Position.Range(
+          input,
+          range.getStart.getLine,
+          range.getStart.getCharacter,
+          range.getEnd.getLine,
+          range.getEnd.getCharacter
+        )
+      }
     def encloses(position: l.Position): Boolean = {
       range.getStart.getLine <= position.getLine &&
       range.getStart.getLine >= position.getLine &&

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -341,7 +341,13 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
            |""".stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/Main.worksheet.sc")
-      _ = assertNoDiagnostics()
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|a/src/main/scala/Main.worksheet.sc:1:1: warning: there was one feature warning; re-run with -feature for details
+           |trait Foo[F[_]]
+           |^
+           |""".stripMargin
+      )
     } yield ()
   }
 

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -337,14 +337,18 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
            |/metals.json
            |{"a": {"scalaVersion": "$scalaVersion"}}
            |/a/src/main/scala/Main.worksheet.sc
-           |trait Foo[F[_]]
+           |type Structural = {
+           |  def foo(): Int
+           |}
+           |class Foo { def foo(): Int = 42 }
+           |new Foo().asInstanceOf[Structural].foo()
            |""".stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/Main.worksheet.sc")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|a/src/main/scala/Main.worksheet.sc:1:1: warning: there was one feature warning; re-run with -feature for details
-           |trait Foo[F[_]]
+           |type Structural = {
            |^
            |""".stripMargin
       )

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -330,4 +330,19 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
       } yield ()
     }
 
+  testAsync("no-position") {
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{"a": {"scalaVersion": "$scalaVersion"}}
+           |/a/src/main/scala/Main.worksheet.sc
+           |trait Foo[F[_]]
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.worksheet.sc")
+      _ = assertNoDiagnostics()
+    } yield ()
+  }
+
 }


### PR DESCRIPTION
Previously, worksheets did not gracefully handle diagnostics that had no
positions resulting in hanging "Evaluating worksheet" notification
windows. Now, we filter out such diagnostics so that the worksheet
finishes evaluation. We also ensure that unexpected exceptions no longer
cause hanging "Evaluating worksheet" notification windows.