### PR TITLE
Fix multi-line range formatting when on first line

### DIFF
--- a/tests/unit/src/test/scala/tests/RangeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/RangeFormattingSuite.scala
@@ -62,6 +62,23 @@ object RangeFormattingSuite extends BaseLspSuite("rangeFormatting") {
   )
 
   check(
+    "paste-on-fist-line",
+    s"""
+       |object Main {
+       |  val str = '''| hi @@
+       |               |
+       |               '''.stripMargin
+       |}""".stripMargin,
+    s"""|first line""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = '''| hi first line
+       |               |
+       |               '''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
     "without-stripmargin",
     s"""
        |object Main {


### PR DESCRIPTION
Closes #1244 

When I originally worked on this (my first Metals ticket 🎉 ), I totally forgot about the case where you paste on the first line of the multi-line string. This adds in a check for that and also a test for it.