### PR TITLE
Support scaladoc auto completion on type `/**`

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -494,7 +494,7 @@ class MetalsLanguageServer(
       capabilities.setCompletionProvider(
         new CompletionOptions(
           config.compilers.isCompletionItemResolve,
-          List(".").asJava
+          List(".", "*").asJava
         )
       )
       capabilities.setWorkspaceSymbolProvider(true)

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -27,9 +27,8 @@ class CompletionProvider(
         // Insert potentially missing `}` to avoid "unclosed literal" error in String interpolator..
         CURSOR + "}"
       case '*'
-          if params
-            .text()
-            .charAt(i - 1) == '*' && params.text().charAt(i - 2) == '/' =>
+          if params.text().charAt(i - 1) == '*' &&
+            params.text().charAt(i - 2) == '/' =>
         // Insert potentially missing `*/` to avoid comment out all codes after the "/**".
         CURSOR + "*/"
       case _ =>

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -26,6 +26,12 @@ class CompletionProvider(
       case '{' if params.text().charAt(i - 1) == '$' =>
         // Insert potentially missing `}` to avoid "unclosed literal" error in String interpolator..
         CURSOR + "}"
+      case '*'
+          if params
+            .text()
+            .charAt(i - 1) == '*' && params.text().charAt(i - 2) == '/' =>
+        // Insert potentially missing `*/` to avoid comment out all codes after the "/**".
+        CURSOR + "*/"
       case _ =>
         // Default _CURSOR_ instrumentation.
         CURSOR

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -20,7 +20,7 @@ import scala.collection.immutable.Nil
 /**
  * Utility methods for completions.
  */
-trait Completions extends ScaladocCompletion { this: MetalsGlobal =>
+trait Completions { this: MetalsGlobal =>
 
   val clientSupportsSnippets: Boolean =
     metalsConfig.isCompletionSnippetsEnabled()

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -16,12 +16,11 @@ import scala.meta.internal.tokenizers.Chars
 import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
 import scala.util.control.NonFatal
 import scala.collection.immutable.Nil
-import scala.reflect.internal.ModifierFlags
 
 /**
  * Utility methods for completions.
  */
-trait Completions { this: MetalsGlobal =>
+trait Completions extends ScaladocCompletion { this: MetalsGlobal =>
 
   val clientSupportsSnippets: Boolean =
     metalsConfig.isCompletionSnippetsEnabled()
@@ -337,7 +336,7 @@ trait Completions { this: MetalsGlobal =>
   // variable but it avoids repeating traversals from the compiler
   // implementation of `completionsAt(pos)`.
   var lastVisistedParentTrees: List[Tree] = Nil
-  sealed abstract class CompletionPosition {
+  abstract class CompletionPosition {
     def isType: Boolean = false
     def isNew: Boolean = false
 
@@ -431,9 +430,7 @@ trait Completions { this: MetalsGlobal =>
           new AssociatedMemberDefFinder(pos).findAssociatedDef(unit.body)
         }
         associatedDef
-          .map(definition =>
-            CompletionPosition.Scaladoc(editRange, definition, pos, text)
-          )
+          .map(definition => Scaladoc(editRange, definition, pos, text))
           .getOrElse(CompletionPosition.None)
       case (ident: Ident) :: (a: Apply) :: _ =>
         fromIdentApply(ident, a)
@@ -676,50 +673,6 @@ trait Completions { this: MetalsGlobal =>
         inferCompletionPosition(pos, text, tail, completions, editRange)
       case _ =>
         CompletionPosition.None
-    }
-  }
-
-  /**
-   * Find a method definition right after the given position.
-   *
-   * @param pos The position of scaladoc in the original source.
-   *            This class will find the associated member def based on this pos.
-   */
-  class AssociatedMemberDefFinder(pos: Position) extends Traverser {
-    private var associatedDef: Option[MemberDef] = None
-
-    /**
-     * Collect all the member definitions whose position is
-     * below the given `pos`. And then return the closest member definiton.
-     */
-    def findAssociatedDef(root: Tree): Option[MemberDef] = {
-      associatedDef = None
-      traverse(root)
-      associatedDef
-    }
-    override def traverse(t: Tree): Unit = {
-      t match {
-        case typedef: TypeDef => process(typedef)
-        case clsdef: ClassDef => process(clsdef)
-        case defdef: DefDef => process(defdef)
-        case moduledef: ModuleDef => process(moduledef)
-        case pkgdef: PackageDef => process(pkgdef)
-        case valdef: ValDef => process(valdef)
-        case _ if treePos(t).includes(pos) => super.traverse(t)
-        case _ =>
-      }
-    }
-    private def process(t: MemberDef): Unit = {
-      // if the node's location is below the current associate def,
-      // we don't have to visit the node because it can't be an associated def.
-      if (associatedDef
-          .map(cur =>
-            t.pos.isDefined && cur.pos.isDefined && t.pos.point <= cur.pos.point
-          )
-          .getOrElse(true)) {
-        if (t.pos.isDefined && t.pos.start >= pos.start) associatedDef = Some(t)
-        if (treePos(t).includes(pos)) super.traverse(t)
-      }
     }
   }
 
@@ -1686,158 +1639,6 @@ trait Completions { this: MetalsGlobal =>
         }
       }
     }
-
-    /**
-     * A scaladoc completion showing the parameters of the given associated definition.
-     *
-     * @param editRange the range in the original source file.
-     * @param associatedDef the memberDef associated with the scaladoc to complete.
-     *                      This class will construct scaladoc based on the params of this definition.
-     * @param pos the position of the completion request.
-     * @param text the text of the original source code.
-     */
-    case class Scaladoc(
-        editRange: l.Range,
-        associatedDef: MemberDef,
-        pos: Position,
-        text: String
-    ) extends CompletionPosition {
-      // The indent for gutter asterisks aligned in column three.
-      // |/**
-      // |  *
-      private val scaladocIndent = "  "
-
-      override def contribute: List[Member] = {
-        val necessaryIndent = inferIndent(pos, text)
-        val indent = s"${necessaryIndent}${scaladocIndent}"
-
-        val params: List[ValDef] = getParams(associatedDef)
-        val cursor =
-          if (clientSupportsSnippets) " $0" else ""
-
-        val scaladocParamLines: String = params
-          .map { param =>
-            s"${indent}* @param ${param.name}"
-          }
-          .mkString("\n")
-
-        // Add `* @return` only if the associatedDef is method definition.
-        val returnLine =
-          if (associatedDef.isInstanceOf[DefDef]) s"${indent}* @return" else ""
-
-        // Construct the following new text.
-        // """
-        //
-        //   * $0 <- move cursor here. Add an empty line below here, only if there's @param or @return line.
-        //   *
-        //   * @param param1
-        //   * @param param2
-        //   * @return
-        //   */
-        // """
-        val maybeEmptyLine =
-          if (scaladocParamLines.isEmpty && returnLine.isEmpty) ""
-          else s"${indent}*"
-        val newText: String =
-          s"""|${indent}*${cursor}
-              |${maybeEmptyLine}
-              |${scaladocParamLines}
-              |${returnLine}
-              |${indent}*/""".stripMargin
-            .split("\n")
-            .filter(!_.isEmpty) // remove empty lines: scaladocParamLines and returnLine can be empty
-            .mkString("\n", "\n", "")
-
-        List(
-          new TextEditMember(
-            "Scaladoc Comment",
-            new l.TextEdit(
-              editRange,
-              newText
-            ),
-            completionsSymbol(associatedDef.name.toString()),
-            label = Some("/** */"),
-            detail = Some("Scaladoc Comment")
-          )
-        )
-      }
-
-      // Infers the indentation at the completion position by counting the number of leading
-      // spaces in the line.
-      // For example:
-      // |"""
-      // |object A {
-      // |  /**<COMPLETE> // inferred indent is 4 spaces
-      // |  def foo(x: Int) = ???
-      // |}
-      // |"""
-      private def inferIndent(pos: Position, text: String): String = {
-        if (metalsConfig.snippetAutoIndent()) {
-          ""
-        } else {
-          try {
-            val line =
-              text.split(System.lineSeparator())(pos.line - 1)
-            line.takeWhile(ch => ch != '/')
-          } catch { case NonFatal(_) => "" }
-        }
-      }
-
-      /**
-       * Returns the parameters of the given memberDef
-       *
-       * @param memberDef The memberDef to construct scaladoc.
-       */
-      private def getParams(memberDef: MemberDef): List[ValDef] = {
-        memberDef match {
-          case defdef: DefDef =>
-            defdef.vparamss.flatten
-          case clazz: ClassDef =>
-            // If the associated def is a class definition,
-            // retrieve the constructor from the class, and caluculate the lines
-            // from the constructor definition instead.
-            new ConstructorFinder(clazz).getConstructor match {
-              case Some(defdef) => getParams(defdef)
-              case scala.None => Nil
-            }
-          case _ => Nil
-        }
-      }
-
-      class ConstructorFinder(clazz: ClassDef) extends Traverser {
-        private var found: Option[DefDef] = scala.None
-        def getConstructor: Option[DefDef] = {
-          // Don't try to find the constructor for trait/abstract definition
-          // because they don't have a constructor
-          if (!clazz.mods.hasFlag(
-              ModifierFlags.ABSTRACT |
-                ModifierFlags.TRAIT |
-                ModifierFlags.INTERFACE
-            )) {
-            found = scala.None
-            clazz.impl.body.foreach(traverse)
-            found
-          } else {
-            scala.None
-          }
-        }
-        override def traverse(tree: Tree): Unit = {
-          if (found
-              .map(cur =>
-                tree.pos.isDefined && cur.pos.isDefined && tree.pos.point <= cur.pos.point
-              )
-              .getOrElse(true)) {
-            tree match {
-              case constructor: DefDef
-                  if constructor.name == termNames.CONSTRUCTOR =>
-                found = Some(constructor)
-              case _ =>
-                super.traverse(tree)
-            }
-          }
-        }
-      }
-    }
   }
 
   class PatternMatch(pos: Position) {
@@ -2071,14 +1872,5 @@ trait Completions { this: MetalsGlobal =>
           }
       }
     }
-  }
-
-  def isScaladocCompletion(pos: Position, text: String): Boolean = {
-    try {
-      val line =
-        text.split(System.lineSeparator())(pos.line - 1)
-      // check if the line starts with `/**`
-      line.matches("^\\s*\\/\\*\\*\\s*$")
-    } catch { case NonFatal(_) => false }
   }
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
@@ -30,6 +30,7 @@ class MetalsGlobal(
     val metalsConfig: PresentationCompilerConfig
 ) extends Global(settings, reporter)
     with Completions
+    with ScaladocCompletions
     with Signatures
     with Compat
     with GlobalProxy

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScaladocCompletion.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScaladocCompletion.scala
@@ -1,0 +1,215 @@
+package scala.meta.internal.pc
+
+import org.eclipse.{lsp4j => l}
+
+import scala.util.control.NonFatal
+import scala.reflect.internal.ModifierFlags
+import scala.collection.immutable.Nil
+
+trait ScaladocCompletion { this: MetalsGlobal =>
+
+  /**
+   * A scaladoc completion showing the parameters of the given associated definition.
+   *
+   * @param editRange the range in the original source file.
+   * @param associatedDef the memberDef associated with the scaladoc to complete.
+   *                      This class will construct scaladoc based on the params of this definition.
+   * @param pos the position of the completion request.
+   * @param text the text of the original source code.
+   */
+  case class Scaladoc(
+      editRange: l.Range,
+      associatedDef: MemberDef,
+      pos: Position,
+      text: String
+  ) extends CompletionPosition {
+    // The indent for gutter asterisks aligned in column three.
+    // |/**
+    // |  *
+    private val scaladocIndent = "  "
+
+    override def contribute: List[Member] = {
+      val necessaryIndent = inferIndent(pos, text)
+      val indent = s"${necessaryIndent}${scaladocIndent}"
+
+      val params: List[ValDef] = getParams(associatedDef)
+      val cursor =
+        if (clientSupportsSnippets) " $0" else ""
+
+      val scaladocParamLines: String = params
+        .map { param =>
+          s"${indent}* @param ${param.name}"
+        }
+        .mkString("\n")
+
+      // Add `* @return` only if the associatedDef is method definition.
+      val returnLine =
+        if (associatedDef.isInstanceOf[DefDef]) s"${indent}* @return" else ""
+
+      // Construct the following new text.
+      // """
+      //
+      //   * $0 <- move cursor here. Add an empty line below here, only if there's @param or @return line.
+      //   *
+      //   * @param param1
+      //   * @param param2
+      //   * @return
+      //   */
+      // """
+      val maybeEmptyLine =
+        if (scaladocParamLines.isEmpty && returnLine.isEmpty) ""
+        else s"${indent}*"
+      val newText: String =
+        s"""|${indent}*${cursor}
+            |${maybeEmptyLine}
+            |${scaladocParamLines}
+            |${returnLine}
+            |${indent}*/""".stripMargin
+          .split("\n")
+          .filter(!_.isEmpty) // remove empty lines: scaladocParamLines and returnLine can be empty
+          .mkString("\n", "\n", "")
+
+      List(
+        new TextEditMember(
+          "Scaladoc Comment",
+          new l.TextEdit(
+            editRange,
+            newText
+          ),
+          completionsSymbol(associatedDef.name.toString()),
+          label = Some("/** */"),
+          detail = Some("Scaladoc Comment")
+        )
+      )
+    }
+
+    // Infers the indentation at the completion position by counting the number of leading
+    // spaces in the line.
+    // For example:
+    // |"""
+    // |object A {
+    // |  /**<COMPLETE> // inferred indent is 4 spaces
+    // |  def foo(x: Int) = ???
+    // |}
+    // |"""
+    private def inferIndent(pos: Position, text: String): String = {
+      if (metalsConfig.snippetAutoIndent()) {
+        ""
+      } else {
+        try {
+          val line =
+            text.split(System.lineSeparator())(pos.line - 1)
+          line.takeWhile(ch => ch != '/')
+        } catch { case NonFatal(_) => "" }
+      }
+    }
+
+    /**
+     * Returns the parameters of the given memberDef
+     *
+     * @param memberDef The memberDef to construct scaladoc.
+     */
+    private def getParams(memberDef: MemberDef): List[ValDef] = {
+      memberDef match {
+        case defdef: DefDef =>
+          defdef.vparamss.flatten
+        case clazz: ClassDef =>
+          // If the associated def is a class definition,
+          // retrieve the constructor from the class, and caluculate the lines
+          // from the constructor definition instead.
+          new ConstructorFinder(clazz).getConstructor match {
+            case Some(defdef) => getParams(defdef)
+            case scala.None => Nil
+          }
+        case _ => Nil
+      }
+    }
+
+    class ConstructorFinder(clazz: ClassDef) extends Traverser {
+      private var found: Option[DefDef] = scala.None
+      def getConstructor: Option[DefDef] = {
+        // Don't try to find the constructor for trait/abstract definition
+        // because they don't have a constructor
+        if (!clazz.mods.hasFlag(
+            ModifierFlags.ABSTRACT |
+              ModifierFlags.TRAIT |
+              ModifierFlags.INTERFACE
+          )) {
+          found = scala.None
+          clazz.impl.body.foreach(traverse)
+          found
+        } else {
+          scala.None
+        }
+      }
+      override def traverse(tree: Tree): Unit = {
+        if (found
+            .map(cur =>
+              tree.pos.isDefined && cur.pos.isDefined && tree.pos.point <= cur.pos.point
+            )
+            .getOrElse(true)) {
+          tree match {
+            case constructor: DefDef
+                if constructor.name == termNames.CONSTRUCTOR =>
+              found = Some(constructor)
+            case _ =>
+              super.traverse(tree)
+          }
+        }
+      }
+    }
+  }
+
+  protected def isScaladocCompletion(pos: Position, text: String): Boolean = {
+    try {
+      val line =
+        text.split(System.lineSeparator())(pos.line - 1)
+      // check if the line starts with `/**`
+      line.matches("^\\s*\\/\\*\\*\\s*$")
+    } catch { case NonFatal(_) => false }
+  }
+
+  /**
+   * Find a method definition right after the given position.
+   *
+   * @param pos The position of scaladoc in the original source.
+   *            This class will find the associated member def based on this pos.
+   */
+  protected class AssociatedMemberDefFinder(pos: Position) extends Traverser {
+    private var associatedDef: Option[MemberDef] = None
+
+    /**
+     * Collect all the member definitions whose position is
+     * below the given `pos`. And then return the closest member definiton.
+     */
+    def findAssociatedDef(root: Tree): Option[MemberDef] = {
+      associatedDef = None
+      traverse(root)
+      associatedDef
+    }
+    override def traverse(t: Tree): Unit = {
+      t match {
+        case typedef: TypeDef => process(typedef)
+        case clsdef: ClassDef => process(clsdef)
+        case defdef: DefDef => process(defdef)
+        case moduledef: ModuleDef => process(moduledef)
+        case pkgdef: PackageDef => process(pkgdef)
+        case valdef: ValDef => process(valdef)
+        case _ if treePos(t).includes(pos) => super.traverse(t)
+        case _ =>
+      }
+    }
+    private def process(t: MemberDef): Unit = {
+      // if the node's location is below the current associate def,
+      // we don't have to visit the node because it can't be an associated def.
+      if (associatedDef
+          .map(cur =>
+            t.pos.isDefined && cur.pos.isDefined && t.pos.point <= cur.pos.point
+          )
+          .getOrElse(true)) {
+        if (t.pos.isDefined && t.pos.start >= pos.start) associatedDef = Some(t)
+        if (treePos(t).includes(pos)) super.traverse(t)
+      }
+    }
+  }
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScaladocCompletion.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScaladocCompletion.scala
@@ -117,18 +117,25 @@ trait ScaladocCompletion { this: MetalsGlobal =>
       memberDef match {
         case defdef: DefDef =>
           defdef.symbol.paramss.flatten
-            .filter(!_.isSynthetic)
+            .filterNot(_.isSynthetic)
             .map(_.name.toString())
         case clazz: ClassDef =>
           // If the associated def is a class definition,
           // retrieve the constructor from the class, and caluculate the lines
           // from the constructor definition instead.
           clazz.symbol.primaryConstructor.paramss.flatten
-            .filter(sym =>
-              // FIXME: All synthetic params should be filtered out by checking SYNTHETIC flag.
-              // evidence params for classs constructor look like they don't have SYNTHETIC flag.
-              !sym.isSynthetic &&
-                !sym.name.startsWith(nme.EVIDENCE_PARAM_PREFIX)
+            .filterNot(sym =>
+              // NOTE: We check the symbol name not starts with `EVIDENCE_PARAM_PREFIX`
+              // to avoid line that `* @param evidence$1` in case the class constructor requires type class instance, like:
+              // `case class Test[T: Ordering](t: T) = {}`
+              // Those parameters are added by TreeBuilder here
+              // https://github.com/scala/scala/blob/ba9701059216c629410f4f23a2175d20ad62484b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala#L135
+              //
+              // Though the `SYNTHETIC` modifiers on DefDef survive during type checking,
+              // the modifiers on class constructor attached in TreeBuilder seem not to remain
+              // after type-checking. That's why check if the param name starts with `EVIDENCE_PARAM_PREFIX` for a class constructor.
+              sym.isSynthetic ||
+                sym.name.startsWith(nme.EVIDENCE_PARAM_PREFIX)
             )
             .map(_.name.toString())
         case _ => Nil

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScaladocCompletion.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScaladocCompletion.scala
@@ -47,7 +47,10 @@ trait ScaladocCompletion { this: MetalsGlobal =>
       val builder = new StringBuilder()
 
       val hasConstructor = associatedDef.symbol.primaryConstructor.isDefined && !associatedDef.symbol.isAbstractClass
-      val shouldHaveReturnLine = associatedDef.isInstanceOf[DefDef]
+      val hasReturnValue =
+        associatedDef.symbol.isMethod &&
+          !(associatedDef.symbol.asMethod.returnType.finalResultType
+            =:= typeOf[Unit])
 
       // newline after `/**`
       builder.append("\n")
@@ -58,7 +61,7 @@ trait ScaladocCompletion { this: MetalsGlobal =>
       else builder.append("\n")
 
       // add empty line if there's parameter or "@return" or "@constructor" line.
-      if (params.nonEmpty || shouldHaveReturnLine || hasConstructor)
+      if (params.nonEmpty || hasReturnValue || hasConstructor)
         builder.append(s"${indent}*\n")
 
       // * @constructor
@@ -70,7 +73,7 @@ trait ScaladocCompletion { this: MetalsGlobal =>
 
       // * @return
       // */
-      if (shouldHaveReturnLine) builder.append(s"${indent}* @return\n")
+      if (hasReturnValue) builder.append(s"${indent}* @return\n")
       builder.append(s"${indent}*/")
 
       List(

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScaladocCompletion.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScaladocCompletion.scala
@@ -116,14 +116,21 @@ trait ScaladocCompletion { this: MetalsGlobal =>
     private def getParams(memberDef: MemberDef): List[String] = {
       memberDef match {
         case defdef: DefDef =>
-          defdef.vparamss.flatten.map(param => param.name.toString())
+          defdef.symbol.paramss.flatten
+            .filter(!_.isSynthetic)
+            .map(_.name.toString())
         case clazz: ClassDef =>
           // If the associated def is a class definition,
           // retrieve the constructor from the class, and caluculate the lines
           // from the constructor definition instead.
-          clazz.symbol.primaryConstructor.paramss.flatten.map(sym =>
-            sym.name.toString()
-          )
+          clazz.symbol.primaryConstructor.paramss.flatten
+            .filter(sym =>
+              // FIXME: All synthetic params should be filtered out by checking SYNTHETIC flag.
+              // evidence params for classs constructor look like they don't have SYNTHETIC flag.
+              !sym.isSynthetic &&
+                !sym.name.startsWith(nme.EVIDENCE_PARAM_PREFIX)
+            )
+            .map(_.name.toString())
         case _ => Nil
       }
     }

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScaladocCompletion.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScaladocCompletion.scala
@@ -103,7 +103,7 @@ trait ScaladocCompletion { this: MetalsGlobal =>
       if (metalsConfig.snippetAutoIndent()) {
         ""
       } else {
-        // 3 is the length of "/**$" <- $ is a cursor
+        // 4 is the length of "/**$" <- $ is a cursor
         " " * (pos.column - 4)
       }
     }

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScaladocCompletion.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScaladocCompletion.scala
@@ -45,6 +45,8 @@ trait ScaladocCompletion { this: MetalsGlobal =>
       //   */
       // """
       val builder = new StringBuilder()
+
+      val hasConstructor = associatedDef.symbol.primaryConstructor.isDefined && !associatedDef.symbol.isAbstractClass
       val shouldHaveReturnLine = associatedDef.isInstanceOf[DefDef]
 
       // newline after `/**`
@@ -55,9 +57,12 @@ trait ScaladocCompletion { this: MetalsGlobal =>
       if (clientSupportsSnippets) builder.append(" $0\n")
       else builder.append("\n")
 
-      // add empty line if there's parameter or "@return" line.
-      if (params.nonEmpty || shouldHaveReturnLine)
+      // add empty line if there's parameter or "@return" or "@constructor" line.
+      if (params.nonEmpty || shouldHaveReturnLine || hasConstructor)
         builder.append(s"${indent}*\n")
+
+      // * @constructor
+      if (hasConstructor) builder.append(s"${indent}* @constructor\n")
 
       // * @param p1
       // * @param p2

--- a/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
@@ -44,16 +44,16 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
        |""".stripMargin,
     """|object A {
        |  /**
-       |  *
-       |  * @param param1 $0
-       |  * @param param2
-       |  * @return
-       |  */
+       |    * $0
+       |    *
+       |    * @param param1
+       |    * @param param2
+       |    * @return
+       |    */
        |  def test1(param1: Int, param2: Int): Int = ???
        |  def test2(param1: Int, param2: Int, param3: Int): Int = ???
        |}
-       |""".stripMargin,
-    filter = _.contains("/** */")
+       |""".stripMargin
   )
 
   checkEdit(
@@ -66,15 +66,15 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
        |""".stripMargin,
     """|object A {
        |  /**
-       |  *
-       |  * @param param1 $0
-       |  * @param param2
-       |  */
+       |    * $0
+       |    *
+       |    * @param param1
+       |    * @param param2
+       |    */
        |  class Test1(param1: Int, param2: Int) {}
        |  class Test2(param1: Int, param2: Int, param3: Int) {}
        |}
-       |""".stripMargin,
-    filter = _.contains("/** */")
+       |""".stripMargin
   )
 
   checkEdit(
@@ -86,29 +86,11 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
        |""".stripMargin,
     """|object A {
        |  /**
-       |  *
-       |  */
+       |    * $0
+       |    */
        |  val x = 1
        |}
-       |""".stripMargin,
-    filter = _.contains("/** */")
-  )
-
-  checkEdit(
-    "scaladoc-valdef-edit",
-    """|object A {
-       |  /**@@
-       |  val x = 1
-       |}
-       |""".stripMargin,
-    """|object A {
-       |  /**
-       |  *
-       |  */
-       |  val x = 1
-       |}
-       |""".stripMargin,
-    filter = _.contains("/** */")
+       |""".stripMargin
   )
 
   checkEdit(
@@ -120,33 +102,13 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|/**
-       |  *
+       |  * $0
        |  */
        |object A {
        |  // do not calculate scaladoc based on the method
        |  def test(x: Int): Int = ???
        |}
-       |""".stripMargin,
-    filter = _.contains("/** */")
-  )
-
-  checkEdit(
-    "scaladoc-objectdef-edit",
-    """|/**@@
-       |object A {
-       |  // do not calculate scaladoc based on the method
-       |  def test(x: Int): Int = ???
-       |}
-       |""".stripMargin,
-    """|/**
-       |  *
-       |  */
-       |object A {
-       |  // do not calculate scaladoc based on the method
-       |  def test(x: Int): Int = ???
-       |}
-       |""".stripMargin,
-    filter = _.contains("/** */")
+       |""".stripMargin
   )
 
   checkEdit(
@@ -161,15 +123,15 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
     """|object A {
        |  def test(x: Int): Int = {
        |    /**
-       |  *
-       |  * @param y $0
-       |  * @return
-       |  */
+       |      * $0
+       |      *
+       |      * @param y
+       |      * @return
+       |      */
        |    def nest(y: Int) = ???
        |  }
        |}
-       |""".stripMargin,
-    filter = _.contains("/** */")
+       |""".stripMargin
   )
 
   checkEdit(
@@ -182,13 +144,13 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
        |""".stripMargin,
     """|object A {
        |  /**
-       |  *
-       |  * @return $0
-       |  */
+       |    * $0
+       |    *
+       |    * @return
+       |    */
        |  def test1: Int = ???
        |  def test2(param1: Int, param2: Int, param3: Int): Int = ???
        |}
-       |""".stripMargin,
-    filter = _.contains("/** */")
+       |""".stripMargin
   )
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
@@ -68,7 +68,6 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
        |  /**
        |    * $0
        |    *
-       |    * @constructor
        |    * @param param1
        |    * @param param2
        |    */
@@ -148,7 +147,6 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
        |  /**
        |    * $0
        |    *
-       |    * @constructor
        |    * @param x
        |    */
        |  case class B(x: Int) {
@@ -275,11 +273,30 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
        |  /**
        |    * $0
        |    *
-       |    * @constructor
        |    * @param x
        |    * @param y
        |    */
        |  case class Test[T: Ordering](x: T, y: T) {}
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "classdef-curried",
+    """|object A {
+       |  /**@@
+       |  case class Test(a: Int, b: String)(c: Long)
+       |}
+       |""".stripMargin,
+    """|object A {
+       |  /**
+       |    * $0
+       |    *
+       |    * @param a
+       |    * @param b
+       |    * @param c
+       |    */
+       |  case class Test(a: Int, b: String)(c: Long)
        |}
        |""".stripMargin
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
@@ -68,6 +68,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
        |  /**
        |    * $0
        |    *
+       |    * @constructor
        |    * @param param1
        |    * @param param2
        |    */
@@ -147,6 +148,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
        |  /**
        |    * $0
        |    *
+       |    * @constructor
        |    * @param x
        |    */
        |  case class B(x: Int) {

--- a/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
@@ -4,7 +4,7 @@ import tests.BaseCompletionSuite
 
 object CompletionScaladocSuite extends BaseCompletionSuite {
   check(
-    "scaladoc-methoddef",
+    "methoddef-label",
     """
       |object A {
       |  /**@@
@@ -15,7 +15,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   check(
-    "scaladoc-classdef",
+    "classdef-label",
     """
       |object A {
       |  /**@@
@@ -26,7 +26,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   check(
-    "scaladoc-no-completion",
+    "no-completion",
     """
       |object A {
       |  /**@@
@@ -35,7 +35,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "scaladoc-methoddef-edit",
+    "methoddef",
     """|object A {
        |  /**@@
        |  def test1(param1: Int, param2: Int): Int = ???
@@ -57,7 +57,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "scaladoc-classdef-edit",
+    "classdef",
     """|object A {
        |  /**@@
        |  class Test1(param1: Int, param2: Int) {}
@@ -79,7 +79,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "scaladoc-valdef-edit",
+    "valdef",
     """|object A {
        |  /**@@
        |  val x = 1
@@ -95,7 +95,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "scaladoc-objectdef-edit",
+    "objectdef",
     """|/**@@
        |object A {
        |  // do not calculate scaladoc based on the method
@@ -113,7 +113,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "scaladoc-defdef-nested-edit",
+    "defdef-nested",
     """|object A {
        |  def test(x: Int): Int = {
        |    /**@@
@@ -136,7 +136,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "scaladoc-classdef-nested-edit",
+    "classdef-nested",
     """|object A {
        |  /**@@
        |  case class B(x: Int) {
@@ -159,7 +159,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "scaladoc-trait-classdef-nested-edit",
+    "trait-classdef-nested",
     """|object A {
        |  /**@@
        |  trait B {
@@ -181,7 +181,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "scaladoc-defdef-no-param-cursor",
+    "defdef-no-param-cursor",
     """|object A {
        |  /**@@
        |  def test1: Int = ???
@@ -201,7 +201,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "scaladoc-defdef-returns-unit",
+    "defdef-returns-unit",
     """|// Don't add @return line for a method whose return type is Unit.
        |object A {
        |  /**@@
@@ -222,7 +222,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "scaladoc-defdef-returns-inferred-unit",
+    "defdef-returns-inferred-unit",
     """|// Don't add @return line for a method whose return type is Unit.
        |object A {
        |  /**@@
@@ -243,7 +243,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "scaladoc-defdef-type-typeclass",
+    "defdef-evidence",
     """|// do not add compiler generated param like `evidence$1`
        |object A {
        |  /**@@
@@ -265,7 +265,7 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "scaladoc-classdef-type-typeclass",
+    "classdef-evidence",
     """|object A {
        |  /**@@
        |  case class Test[T: Ordering](x: T, y: T) {}

--- a/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
@@ -1,0 +1,194 @@
+package tests.pc
+
+import tests.BaseCompletionSuite
+
+object CompletionScaladocSuite extends BaseCompletionSuite {
+  check(
+    "scaladoc-methoddef",
+    """
+      |object A {
+      |  /**@@
+      |  def test(x: Int, y: Int): Int = ???
+      |}""".stripMargin,
+    """|/** */Scaladoc Comment
+       |""".stripMargin
+  )
+
+  check(
+    "scaladoc-classdef",
+    """
+      |object A {
+      |  /**@@
+      |  case class(x: Int) {}
+      |}""".stripMargin,
+    """|/** */Scaladoc Comment
+       |""".stripMargin
+  )
+
+  check(
+    "scaladoc-no-completion",
+    """
+      |object A {
+      |  /**@@
+      |}""".stripMargin,
+    ""
+  )
+
+  checkEdit(
+    "scaladoc-methoddef-edit",
+    """|object A {
+       |  /**@@
+       |  def test1(param1: Int, param2: Int): Int = ???
+       |  def test2(param1: Int, param2: Int, param3: Int): Int = ???
+       |}
+       |""".stripMargin,
+    """|object A {
+       |  /**
+       |  *
+       |  * @param param1 $0
+       |  * @param param2
+       |  * @return
+       |  */
+       |  def test1(param1: Int, param2: Int): Int = ???
+       |  def test2(param1: Int, param2: Int, param3: Int): Int = ???
+       |}
+       |""".stripMargin,
+    filter = _.contains("/** */")
+  )
+
+  checkEdit(
+    "scaladoc-classdef-edit",
+    """|object A {
+       |  /**@@
+       |  class Test1(param1: Int, param2: Int) {}
+       |  class Test2(param1: Int, param2: Int, param3: Int) {}
+       |}
+       |""".stripMargin,
+    """|object A {
+       |  /**
+       |  *
+       |  * @param param1 $0
+       |  * @param param2
+       |  */
+       |  class Test1(param1: Int, param2: Int) {}
+       |  class Test2(param1: Int, param2: Int, param3: Int) {}
+       |}
+       |""".stripMargin,
+    filter = _.contains("/** */")
+  )
+
+  checkEdit(
+    "scaladoc-valdef-edit",
+    """|object A {
+       |  /**@@
+       |  val x = 1
+       |}
+       |""".stripMargin,
+    """|object A {
+       |  /**
+       |  *
+       |  */
+       |  val x = 1
+       |}
+       |""".stripMargin,
+    filter = _.contains("/** */")
+  )
+
+  checkEdit(
+    "scaladoc-valdef-edit",
+    """|object A {
+       |  /**@@
+       |  val x = 1
+       |}
+       |""".stripMargin,
+    """|object A {
+       |  /**
+       |  *
+       |  */
+       |  val x = 1
+       |}
+       |""".stripMargin,
+    filter = _.contains("/** */")
+  )
+
+  checkEdit(
+    "scaladoc-objectdef-edit",
+    """|/**@@
+       |object A {
+       |  // do not calculate scaladoc based on the method
+       |  def test(x: Int): Int = ???
+       |}
+       |""".stripMargin,
+    """|/**
+       |  *
+       |  */
+       |object A {
+       |  // do not calculate scaladoc based on the method
+       |  def test(x: Int): Int = ???
+       |}
+       |""".stripMargin,
+    filter = _.contains("/** */")
+  )
+
+  checkEdit(
+    "scaladoc-objectdef-edit",
+    """|/**@@
+       |object A {
+       |  // do not calculate scaladoc based on the method
+       |  def test(x: Int): Int = ???
+       |}
+       |""".stripMargin,
+    """|/**
+       |  *
+       |  */
+       |object A {
+       |  // do not calculate scaladoc based on the method
+       |  def test(x: Int): Int = ???
+       |}
+       |""".stripMargin,
+    filter = _.contains("/** */")
+  )
+
+  checkEdit(
+    "scaladoc-defdef-nested-edit",
+    """|object A {
+       |  def test(x: Int): Int = {
+       |    /**@@
+       |    def nest(y: Int) = ???
+       |  }
+       |}
+       |""".stripMargin,
+    """|object A {
+       |  def test(x: Int): Int = {
+       |    /**
+       |  *
+       |  * @param y $0
+       |  * @return
+       |  */
+       |    def nest(y: Int) = ???
+       |  }
+       |}
+       |""".stripMargin,
+    filter = _.contains("/** */")
+  )
+
+  checkEdit(
+    "scaladoc-defdef-no-param-cursor",
+    """|object A {
+       |  /**@@
+       |  def test1: Int = ???
+       |  def test2(param1: Int, param2: Int, param3: Int): Int = ???
+       |}
+       |""".stripMargin,
+    """|object A {
+       |  /**
+       |  *
+       |  * @return $0
+       |  */
+       |  def test1: Int = ???
+       |  def test2(param1: Int, param2: Int, param3: Int): Int = ???
+       |}
+       |""".stripMargin,
+    filter = _.contains("/** */")
+  )
+}

--- a/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
@@ -199,4 +199,66 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin
   )
+
+  checkEdit(
+    "scaladoc-defdef-returns-unit",
+    """|// Don't add @return line for a method whose return type is Unit.
+       |object A {
+       |  /**@@
+       |  def test(param1: Int, param2: Int): Unit = ???
+       |}
+       |""".stripMargin,
+    """|// Don't add @return line for a method whose return type is Unit.
+       |object A {
+       |  /**
+       |    * $0
+       |    *
+       |    * @param param1
+       |    * @param param2
+       |    */
+       |  def test(param1: Int, param2: Int): Unit = ???
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "scaladoc-defdef-returns-inferred-unit",
+    """|// Don't add @return line for a method whose return type is Unit.
+       |object A {
+       |  /**@@
+       |  def test(param1: Int, param2: Int) = {}
+       |}
+       |""".stripMargin,
+    """|// Don't add @return line for a method whose return type is Unit.
+       |object A {
+       |  /**
+       |    * $0
+       |    *
+       |    * @param param1
+       |    * @param param2
+       |    */
+       |  def test(param1: Int, param2: Int) = {}
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "scaladoc-defdef-type-poly",
+    """|object A {
+       |  /**@@
+       |  def test[T: Ordering](x: T, y: T): T = if(x < y) x else y
+       |}
+       |""".stripMargin,
+    """|object A {
+       |  /**
+       |    * $0
+       |    *
+       |    * @param x
+       |    * @param y
+       |    * @return
+       |    */
+       |  def test[T: Ordering](x: T, y: T): T = if(x < y) x else y
+       |}
+       |""".stripMargin
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
@@ -243,13 +243,15 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "scaladoc-defdef-type-poly",
-    """|object A {
+    "scaladoc-defdef-type-typeclass",
+    """|// do not add compiler generated param like `evidence$1`
+       |object A {
        |  /**@@
        |  def test[T: Ordering](x: T, y: T): T = if(x < y) x else y
        |}
        |""".stripMargin,
-    """|object A {
+    """|// do not add compiler generated param like `evidence$1`
+       |object A {
        |  /**
        |    * $0
        |    *
@@ -258,6 +260,26 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
        |    * @return
        |    */
        |  def test[T: Ordering](x: T, y: T): T = if(x < y) x else y
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "scaladoc-classdef-type-typeclass",
+    """|object A {
+       |  /**@@
+       |  case class Test[T: Ordering](x: T, y: T) {}
+       |}
+       |""".stripMargin,
+    """|object A {
+       |  /**
+       |    * $0
+       |    *
+       |    * @constructor
+       |    * @param x
+       |    * @param y
+       |    */
+       |  case class Test[T: Ordering](x: T, y: T) {}
        |}
        |""".stripMargin
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
@@ -135,6 +135,50 @@ object CompletionScaladocSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
+    "scaladoc-classdef-nested-edit",
+    """|object A {
+       |  /**@@
+       |  case class B(x: Int) {
+       |    case class C(y: Int) {}
+       |  }
+       |}
+       |""".stripMargin,
+    """|object A {
+       |  /**
+       |    * $0
+       |    *
+       |    * @param x
+       |    */
+       |  case class B(x: Int) {
+       |    case class C(y: Int) {}
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "scaladoc-trait-classdef-nested-edit",
+    """|object A {
+       |  /**@@
+       |  trait B {
+       |    // do not complete scaladef for class C
+       |    case class C(y: Int) {}
+       |  }
+       |}
+       |""".stripMargin,
+    """|object A {
+       |  /**
+       |    * $0
+       |    */
+       |  trait B {
+       |    // do not complete scaladef for class C
+       |    case class C(y: Int) {}
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
     "scaladoc-defdef-no-param-cursor",
     """|object A {
        |  /**@@


### PR DESCRIPTION
Closes #1252

This PR enables the metals server to auto-complete scaladoc for **method definition** and **class definition** on type `/**`

![vscode-scaladoc](https://user-images.githubusercontent.com/9353584/72200454-11affa00-348d-11ea-8967-a9f909c1b2a8.gif)


### Implement Overview
- Enable to fire `textDocument/completion` on type `*` by setting `triggerCharacters` on `initialize`.
- If the line only have a `/**`, try to complete scaladoc
  - Close the comment by inserting `*/` behind the cursor before adding the source to the compilation unit, so that metals can traverse whole AST in the source.
  - Find an associated member definition by traverse the AST for the source, and ~collect all `MemberDef` that is defined below the `/**`.~, and get the closest `MemberDef` that is defined below the `/**` as an associated definition.
  - Generate scaladoc based on the definition.

### Questions
#### CursorPosition
<details>
<summary>Outdated :)</summary>

~Currently, after the completionEdit, the cursor will move to behind the first parameter like,

```scala
/**@@
def test(x: Int, y: Int): Int = ???
```

to

```scala
/**
  *
  * @param x | <- move the cursor to here like tsserver
  * @param y
  * @return
  */
def test(x: Int, y: Int): Int = ???
```

Is it ok to move the cursor here? 

```scala
/**
  * | <- maybe we should move cursor here instead? like intellij-scala-plugin
  *
  * @param x
  * @param y
  * @return
  */
def test(x: Int, y: Int): Int = ???
```

</details>

```scala
/**
  * | <- move cursor here instead? like intellij-scala-plugin, is it ok?
  *
  * @param x
  * @param y
  * @return
  */
def test(x: Int, y: Int): Int = ???
```

#### Scaladoc or Javadoc? 
Now, this PR add scaladoc with Javadoc style with gutter asterisks aligned in column three like:

```scala
/**
  * | <- move cursor here
  *
  * @param x
  * @return
  */
def method(x: Int): Int = ???
```

https://docs.scala-lang.org/style/scaladoc.html

But, IMO it's common to write scaladoc with Javadoc style, with gutter asterisks aligned in column two:

```scala
/**
 * | <- move cursor here
 *
 * @param x
 * @return
 */
def method(x: Int): Int = ???
```

Should we complete the doc that format instead?

---

- I haven't checked the behavior on Windows yet, and I'm going to confirm the behavior later (after setting up the windows working environment) and check it with other language server client than VSCode

