### PR TITLE
Slightly more compliant initialization of codeActionProvider

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -552,6 +552,15 @@ object MetalsEnrichments
         snippetSupport <- Option(completionItem.getSnippetSupport())
       } yield snippetSupport.booleanValue).getOrElse(false)
 
+    def supportsCodeActionLiterals: Boolean =
+      (for {
+        params <- initializeParams
+        capabilities <- Option(params.getCapabilities)
+        textDocument <- Option(capabilities.getTextDocument)
+        codeAction <- Option(textDocument.getCodeAction)
+        literalSupport <- Option(codeAction.getCodeActionLiteralSupport())
+      } yield literalSupport).isDefined
+
   }
 
   implicit class XtensionPromise[T](promise: Promise[T]) {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -500,7 +500,15 @@ class MetalsLanguageServer(
       capabilities.setWorkspaceSymbolProvider(true)
       capabilities.setDocumentSymbolProvider(true)
       capabilities.setDocumentFormattingProvider(true)
-      capabilities.setCodeActionProvider(true)
+      if (initializeParams.supportsCodeActionLiterals) {
+        capabilities.setCodeActionProvider(true)
+      } else {
+        capabilities.setCodeActionProvider(
+          new CodeActionOptions(
+            List(CodeActionKind.QuickFix, CodeActionKind.Refactor).asJava
+          )
+        )
+      }
       capabilities.setTextDocumentSync(TextDocumentSyncKind.Full)
       capabilities.setExperimental(MetalsExperimental())
       new InitializeResult(capabilities)


### PR DESCRIPTION
I don't think this has any practical impact, but it's technically slightly more compliant with the spec.

All the clients I've checked support code action literals anyway.