### PR TITLE
Upgrade Pants sbt testing interface.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -265,7 +265,7 @@ private class BloopPants(
       // runner in Pants. Most importantly, it automatically registers
       // org.scalatest.junit.JUnitRunner even if there is no `@RunWith`
       // annotation.
-      Dependency.of("com.geirsson", "junit-interface", "0.11.1-scalatest")
+      Dependency.of("com.geirsson", "junit-interface", "0.11.3")
     ).flatMap(fetchDependency)
   val allScalaJars: Seq[Path] = {
     val compilerClasspath = export.scalaPlatform.compilerClasspath
@@ -496,7 +496,7 @@ private class BloopPants(
     Some(
       C.Test(
         frameworks = List(
-          C.TestFramework(List("com.geirsson.junit.JUnitFramework"))
+          C.TestFramework(List("com.geirsson.junit.PantsFramework"))
         ),
         options = C.TestOptions(
           excludes = Nil,


### PR DESCRIPTION
This update includes several improvements like

* ScalaTest suites that have an explicit `@RunWith` annotation no longer
  get noisy "Executed no tests" message.
* Nicer pretty-printing of test results.