### PR TITLE
Send notification 'metals/executeClientCommand' on command metals.goto

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
@@ -60,7 +60,9 @@ final class MetalsHttpClient(
 
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams
-  ): Unit = {}
+  ): Unit = {
+    underlying.metalsExecuteClientCommand(params)
+  }
 
   // =============
   // metals/status


### PR DESCRIPTION
This is change which I described in my gitter comment:
https://gitter.im/scalameta/metals?at=5e15799ba1e15049012067bf

> I forked coc.nvim and added TreeViewProtocol support for metals. But there is one thing which requires small change in metals. When user clicks on node with class/trait/object, this class should be opened in editor. Coc.nvim sends "workspace/executeCommand" with command "metals.goto". Metals sends empty response and usually sends notification "metals/executeClientCommand" with "metals-goto-location". But option isHttpEnabled of MetalsServerConfig is activated for coc.nvim and as result MetalsHttpClient does nothing for executeClientCommand.