### PR TITLE
Add --vscode flag to Pants export tool.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -171,7 +171,7 @@ final class Doctor(
 
   def deprecatedVersionWarning: Option[String] = {
     val deprecatedVersions = (for {
-      target <- buildTargets.all.toIterator
+      target <- relevantTargets.toIterator
       scala <- target.info.asScalaBuildTarget
       if ScalaVersions.isDeprecatedScalaVersion(scala.getScalaVersion())
     } yield scala.getScalaVersion()).toSet
@@ -188,8 +188,11 @@ final class Doctor(
     }
   }
 
+  def relevantTargets(): List[ScalaTarget] =
+    buildTargets.all.filter(_.info.asScalaBuildTarget.isDefined).toList
+
   private def problemSummary: Option[String] = {
-    val targets = buildTargets.all.toList
+    val targets = relevantTargets()
     val isMissingSemanticdb = targets.filter(!_.isSemanticdbEnabled)
     val count = isMissingSemanticdb.length
     val isAllProjects = count == targets.size
@@ -213,7 +216,7 @@ final class Doctor(
   }
 
   private def buildTargetsJson(): String = {
-    val targets = buildTargets.all.toList
+    val targets = relevantTargets()
     val results = if (targets.isEmpty) {
       DoctorResults(
         doctorTitle,
@@ -242,7 +245,7 @@ final class Doctor(
       .element("p")(
         _.text(doctorHeading)
       )
-    val targets = buildTargets.all.toList
+    val targets = relevantTargets()
     if (targets.isEmpty) {
       html
         .element("p")(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -214,6 +214,9 @@ class MetalsLanguageServer(
   private def updateWorkspaceDirectory(params: InitializeParams): Unit = {
     workspace = AbsolutePath(Paths.get(URI.create(params.getRootUri))).dealias
     MetalsLogger.setupLspLogger(workspace, redirectSystemOut)
+    scribe.info(
+      s"started: Metals version ${BuildInfo.metalsVersion} in workspace '$workspace'"
+    )
     val clientExperimentalCapabilities =
       ClientExperimentalCapabilities.from(params.getCapabilities)
 

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -58,6 +58,8 @@ object BloopPants {
             AbsolutePath(args.workspace),
             args.targets
           )(ExecutionContext.global)
+        } else if (args.isVscode && args.isWorkspaceAndOutputSameDirectory) {
+          VSCode.launch(args)
         } else {
           val workspace = args.workspace
           val targets = args.targets
@@ -79,6 +81,8 @@ object BloopPants {
               }
               if (args.isLaunchIntelliJ) {
                 LaunchIntellij.open(args.out)
+              } else if (args.isVscode) {
+                VSCode.launch(args)
               }
           }
         }
@@ -469,26 +473,7 @@ private class BloopPants(
       out = out,
       classesDir = classDirectory,
       resources = None,
-      scala = Some(
-        C.Scala(
-          "org.scala-lang",
-          "scala-compiler",
-          compilerVersion,
-          List.empty[String],
-          allScalaJars.toList,
-          None,
-          setup = Some(
-            C.CompileSetup(
-              C.Mixed,
-              addLibraryToBootClasspath = true,
-              addCompilerToClasspath = false,
-              addExtraJarsToClasspath = false,
-              manageBootClasspath = true,
-              filterLibraryFromClasspath = true
-            )
-          )
-        )
-      ),
+      scala = bloopScala,
       java = Some(C.Java(Nil)),
       sbt = None,
       test = bloopTestFrameworks,
@@ -555,6 +540,28 @@ private class BloopPants(
       }
     )
   }
+
+  private def bloopScala: Option[C.Scala] =
+    Some(
+      C.Scala(
+        "org.scala-lang",
+        "scala-compiler",
+        compilerVersion,
+        List.empty[String],
+        allScalaJars.toList,
+        None,
+        setup = Some(
+          C.CompileSetup(
+            C.Mixed,
+            addLibraryToBootClasspath = true,
+            addCompilerToClasspath = false,
+            addExtraJarsToClasspath = false,
+            manageBootClasspath = true,
+            filterLibraryFromClasspath = true
+          )
+        )
+      )
+    )
 
   private def bloopTestFrameworks: Option[C.Test] = {
     Some(

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/VSCode.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/VSCode.scala
@@ -1,0 +1,63 @@
+package scala.meta.internal.pantsbuild
+
+import scala.meta.io.AbsolutePath
+import scala.sys.process._
+import ujson.Obj
+import scala.meta.internal.metals.BuildInfo
+import ujson.Str
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.util.control.NonFatal
+
+object VSCode {
+  def launch(args: Args): Unit =
+    try {
+      val settings = AbsolutePath(args.out)
+        .resolve(".vscode")
+        .resolve("settings.json")
+      val oldSettings = readSettings(settings)
+      oldSettings("metals.serverVersion") = BuildInfo.metalsVersion
+      oldSettings("metals.pantsTargets") = args.targets.map(Str(_))
+      settings.writeText(ujson.write(oldSettings, indent = 2))
+      scribe.info(s"updated: $settings")
+      exec("code", "--install-extension", "scalameta.metals")
+      exec("code", "--new-window", args.out.toString())
+      findFileToOpen(args).headOption.foreach { file =>
+        exec("code", "--reuse-window", file.toString())
+      }
+    } catch {
+      case NonFatal(e) =>
+        val isCodeNotFound = Option(e.getMessage())
+          .exists(_.contains("Cannot run program \"code\""))
+        if (isCodeNotFound) {
+          scribe.error(
+            "The command 'code' is not installed on this computer. " +
+              "To fix this problem, install VS Code from https://code.visualstudio.com/download, " +
+              "execute the 'Install \"code\" command in PATH' command and then try running again."
+          )
+        } else {
+          scribe.error("failed to launch VS Code", e)
+        }
+    }
+
+  private def exec(command: String*): Unit = {
+    val exit = command.!
+    require(exit == 0, s"command failed: ${command.mkString(" ")}")
+  }
+
+  private def findFileToOpen(args: Args): List[AbsolutePath] = {
+    for {
+      root <- PantsConfiguration.sourceRoots(
+        AbsolutePath(args.workspace),
+        args.targets
+      )
+      file <- root.listRecursive.filter(_.isScalaOrJava).take(1).headOption
+    } yield file
+  }
+  private def readSettings(settings: AbsolutePath): Obj = {
+    if (settings.isFile) {
+      ujson.read(settings.readText).obj
+    } else {
+      Obj()
+    }
+  }
+}


### PR DESCRIPTION
Previously, it required several manual steps to use Metals with Pants.
Now, users can run the exporter tool with the --vscode flag to have
everything setup automatically, including installation of the Metals VS
Code extension.

While working on this feature, I hit on a bug in the Doctor where it
would report a warning about non-Scala targets. This commit fixes that
bug by removing non-Scala targets from the doctor list.