### PR TITLE
Further polish to --vscode flag

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -80,7 +80,7 @@ object BloopPants {
                 scribe.info(s"output: ${args.out}")
               }
               if (args.isLaunchIntelliJ) {
-                LaunchIntellij.open(args.out)
+                IntelliJ.launch(args.out)
               } else if (args.isVscode) {
                 VSCode.launch(args)
               }

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
@@ -8,8 +8,8 @@ import java.nio.charset.StandardCharsets
 import scala.meta.internal.metals.{BuildInfo => V}
 import java.net.URL
 
-object LaunchIntellij {
-  def open(directory: Path): Unit = {
+object IntelliJ {
+  def launch(directory: Path): Unit = {
     val applications = Paths.get("/Applications")
     val candidates = List(
       applications.resolve("Twitter IntelliJ IDEA CE.app"),


### PR DESCRIPTION
* Use absolute path to `code` binary so that it works even if it's not
  on $PATH
* Rename `LaunchIntellij` into `IntelliJ` for consistency with `VSCode`