### PR TITLE
Improve IntelliJ application detection when launching Pants bui…

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
@@ -12,7 +12,9 @@ object IntelliJ {
   def launch(directory: Path): Unit = {
     val applications = Paths.get("/Applications")
     val candidates = List(
+      applications.resolve("Twitter IntelliJ IDEA.app"),
       applications.resolve("Twitter IntelliJ IDEA CE.app"),
+      applications.resolve("IntelliJ IDEA.app"),
       applications.resolve("IntelliJ IDEA CE.app")
     )
     writeBsp(directory)


### PR DESCRIPTION
Previously, the `--intellij` flag did not detect an IntelliJ Ultimate
installation, only Community Edition. Now it supports both, trying first
to launch the Ultimate edition.