### PR TITLE
Use scala.sys.Process for BloopPants command-line.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -24,7 +24,6 @@ import scala.util.control.NonFatal
 import scala.meta.internal.pc.InterruptException
 import scala.meta.internal.metals.MetalsLogger
 import scala.meta.io.AbsolutePath
-import scala.meta.internal.ansi.LineListener
 import java.util.concurrent.CancellationException
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import scala.sys.process.Process
@@ -235,8 +234,7 @@ object BloopPants {
       command,
       command,
       args.workspace,
-      args.token,
-      LineListener.info
+      args.token
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/Filemap.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/Filemap.scala
@@ -4,7 +4,6 @@ import java.nio.file.Path
 import scala.collection.mutable
 import scala.meta.internal.process.SystemProcess
 import scala.meta.internal.metals.EmptyCancelToken
-import scala.meta.internal.ansi.LineListener
 import scala.concurrent.ExecutionContext
 import java.nio.file.Files
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -48,8 +47,7 @@ object Filemap {
           targets,
         reproduceCommand,
         workspace,
-        EmptyCancelToken,
-        LineListener.info
+        EmptyCancelToken
       )
       catch {
         case NonFatal(e) =>

--- a/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
+++ b/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
@@ -4,11 +4,8 @@ import java.nio.file.Path
 import scala.meta.internal.metals.Timer
 import scala.meta.internal.metals.Time
 import scala.concurrent.ExecutionContext
-import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.pc.CancelToken
-import com.zaxxer.nuprocess.NuProcessBuilder
-import com.zaxxer.nuprocess.NuProcess
-import scala.meta.internal.ansi.LineListener
+import scala.sys.process._
 
 object SystemProcess {
   def run(
@@ -16,23 +13,11 @@ object SystemProcess {
       args: List[String],
       reproduceArgs: List[String],
       cwd: Path,
-      token: CancelToken,
-      stdout: LineListener
+      token: CancelToken
   )(implicit ec: ExecutionContext): Unit = {
     val exportTimer = new Timer(Time.system)
-    var process = Option.empty[NuProcess]
-    val handler = new ProcessHandler(stdout, LineListener.info)
-    val pb = new NuProcessBuilder(handler, args.asJava)
-    pb.setCwd(cwd)
     scribe.info(args.mkString("process: ", " ", ""))
-    val runningProcess = pb.start()
-    token.onCancel().asScala.foreach { cancel =>
-      if (cancel) {
-        ProcessHandler.destroyProcess(runningProcess)
-      }
-    }
-    val exit = handler.completeProcess.future.asJava.get()
-    token.checkCanceled()
+    val exit = Process(args, cwd = Some(cwd.toFile())).!
     if (exit != 0) {
       val message =
         s"command failed with exit code $exit: ${reproduceArgs.mkString(" ")}"


### PR DESCRIPTION
Previously, it was not possible to build a native-image for the
command-line interface. With this commit, it's possible to build a
standalone binary with native-image.