### PR TITLE
Allow only to dismiss build server reconnection for 5 minutes

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -125,10 +125,7 @@ case class BuildServerConnection(
         case response if response == Messages.DisconnectedServer.reconnect =>
           reconnect()
         case response if response == Messages.DisconnectedServer.notNow =>
-          connection
-        case response
-            if response == Messages.DisconnectedServer.dismissForever =>
-          notification.dismissForever()
+          notification.dismiss(5, TimeUnit.MINUTES)
           connection
       }
     } else {

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -143,8 +143,6 @@ class Messages(icons: Icons) {
       new MessageActionItem("Reconnect to build server")
     def notNow: MessageActionItem =
       new MessageActionItem("Not now")
-    def dismissForever: MessageActionItem =
-      new MessageActionItem("Don't show again")
     def params(): ShowMessageRequestParams = {
 
       val params = new ShowMessageRequestParams()
@@ -156,8 +154,7 @@ class Messages(icons: Icons) {
       params.setActions(
         List(
           reconnect,
-          notNow,
-          dismissForever
+          notNow
         ).asJava
       )
       params


### PR DESCRIPTION
Previously, user could dismiss the notification about reconnecting to the build server forever. Now it's possible only for 5 minutes.

@olafurpg is this alright?