### PR TITLE
Compute 'Import missing symbol' code actions for all diagnostics in range

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -507,13 +507,13 @@ class MetalsLanguageServer(
       capabilities.setDocumentSymbolProvider(true)
       capabilities.setDocumentFormattingProvider(true)
       if (initializeParams.supportsCodeActionLiterals) {
-        capabilities.setCodeActionProvider(true)
-      } else {
         capabilities.setCodeActionProvider(
           new CodeActionOptions(
             List(CodeActionKind.QuickFix, CodeActionKind.Refactor).asJava
           )
         )
+      } else {
+        capabilities.setCodeActionProvider(true)
       }
       capabilities.setTextDocumentSync(TextDocumentSyncKind.Full)
       capabilities.setExperimental(MetalsExperimental())

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
@@ -46,7 +46,8 @@ class ImportMissingSymbol(compilers: Compilers) extends CodeAction {
     Future
       .sequence(params.getContext().getDiagnostics().asScala.collect {
         case d @ ScalacDiagnostic.SymbolNotFound(name)
-            if d.getRange().encloses(params.getRange().getEnd()) =>
+            if d.getRange().encloses(params.getRange().getEnd()) ||
+              params.getRange().encloses(d.getRange().getStart()) =>
           importMissingSymbol(d, name)
       })
       .map(_.flatten)

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
@@ -46,8 +46,7 @@ class ImportMissingSymbol(compilers: Compilers) extends CodeAction {
     Future
       .sequence(params.getContext().getDiagnostics().asScala.collect {
         case d @ ScalacDiagnostic.SymbolNotFound(name)
-            if d.getRange().encloses(params.getRange().getEnd()) ||
-              params.getRange().encloses(d.getRange().getStart()) =>
+            if params.getRange().overlapsWith(d.getRange()) =>
           importMissingSymbol(d, name)
       })
       .map(_.flatten)

--- a/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -318,9 +318,11 @@ trait MtagsEnrichments {
   implicit class XtensionLspRange(range: l.Range) {
     def isOffset: Boolean =
       range.getStart == range.getEnd
+
     def isNone: Boolean =
       range.getStart().isNone &&
         range.getEnd().isNone
+
     def toMeta(input: m.Input): m.Position =
       if (range.isNone) {
         m.Position.None
@@ -333,6 +335,7 @@ trait MtagsEnrichments {
           range.getEnd.getCharacter
         )
       }
+
     def encloses(position: l.Position): Boolean = {
       val startsBeforeOrAt =
         range.getStart.getLine < position.getLine ||
@@ -344,8 +347,24 @@ trait MtagsEnrichments {
             range.getEnd.getCharacter >= position.getCharacter)
       startsBeforeOrAt && endsAtOrAfter
     }
+
     def encloses(other: l.Range): Boolean =
       encloses(other.getStart) && encloses(other.getEnd)
+
+    def overlapsWith(other: l.Range): Boolean = {
+      val startsBeforeOtherEnds =
+        range.getStart.getLine < other.getEnd.getLine ||
+          (range.getStart.getLine == other.getEnd.getLine &&
+            range.getStart.getCharacter <= other.getEnd.getCharacter)
+
+      val endsAfterOtherStarts =
+        range.getEnd.getLine > other.getStart.getLine ||
+          (range.getEnd.getLine == other.getStart.getLine &&
+            range.getEnd.getCharacter >= other.getStart.getCharacter)
+
+      startsBeforeOtherEnds && endsAfterOtherStarts
+    }
+
     def copy(
         startLine: Int = range.getStart().getLine(),
         startCharacter: Int = range.getStart().getCharacter(),

--- a/tests/unit/src/test/scala/tests/DocumentSymbolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DocumentSymbolSuite.scala
@@ -4,7 +4,7 @@ import scala.meta.internal.metals.DocumentSymbolProvider
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.{semanticdb => s}
-import tests.MetalsTestEnrichments._
+import MetalsTestEnrichments._
 
 /**
  * Checks the positions of document symbols inside a document

--- a/tests/unit/src/test/scala/tests/FoldingRangeSuite.scala
+++ b/tests/unit/src/test/scala/tests/FoldingRangeSuite.scala
@@ -4,7 +4,7 @@ import java.nio.file.Paths
 import java.util
 import java.util.UUID
 import org.eclipse.{lsp4j => l}
-import tests.BuildInfo.testResourceDirectory
+import BuildInfo.testResourceDirectory
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.FoldingRangeProvider
 import scala.meta.io.AbsolutePath

--- a/tests/unit/src/test/scala/tests/MtagsEnrichmentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/MtagsEnrichmentsSuite.scala
@@ -35,6 +35,24 @@ object MtagsEnrichmentsSuite extends BaseSuite {
     )
   }
 
+  test("LspRange-overlaps") {
+    def r(start: l.Position, end: l.Position) = new l.Range(start, end)
+    def p(line: Int, character: Int) = new l.Position(line, character)
+    assert(
+      // same line
+      r(p(2, 10), p(2, 20)).overlapsWith(r(p(2, 8), p(2, 12))),
+      r(p(2, 10), p(2, 20)).overlapsWith(r(p(2, 18), p(2, 22))),
+      r(p(2, 10), p(2, 20)).overlapsWith(r(p(2, 6), p(2, 9))) == false,
+      r(p(2, 10), p(2, 20)).overlapsWith(r(p(2, 21), p(2, 30))) == false,
+      // multi line
+      r(p(2, 10), p(5, 10)).overlapsWith(r(p(1, 10), p(4, 10))),
+      r(p(2, 10), p(5, 10)).overlapsWith(r(p(3, 10), p(6, 10))),
+      r(p(2, 10), p(5, 10)).overlapsWith(r(p(2, 8), p(4, 10))),
+      r(p(2, 10), p(5, 10)).overlapsWith(r(p(1, 10), p(2, 9))) == false,
+      r(p(2, 10), p(5, 10)).overlapsWith(r(p(5, 11), p(6, 10))) == false
+    )
+  }
+
   test("SemanticdbRange-single-line") {
     def r(start: (Int, Int), end: (Int, Int)) =
       s.Range(start._1, start._2, end._1, end._2)

--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -6,7 +6,7 @@ import org.eclipse.lsp4j.WorkspaceSymbolParams
 import scala.concurrent.Future
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.Messages
-import tests.MetalsTestEnrichments._
+import MetalsTestEnrichments._
 
 object WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
 

--- a/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -11,7 +11,8 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
       input: String,
       expectedActions: String,
       expectedCode: String,
-      selectedActionIndex: Int = 0
+      selectedActionIndex: Int = 0,
+      expectNoDiagnostics: Boolean = false
   ): Unit = {
     val path = "a/src/main/scala/a/A.scala"
     testAsync(name) {
@@ -20,7 +21,9 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
         _ <- server.initialize(s"""/metals.json
                                   |{"a":{}}
                                   |/$path
-                                  |${input.replaceAllLiterally("@@", "")}
+                                  |${input
+                                    .replaceAllLiterally("<<", "")
+                                    .replaceAllLiterally(">>", "")}
                                   |""".stripMargin)
         _ <- server.didOpen(path)
         codeActions <- server.assertCodeAction(path, input, expectedActions)
@@ -32,7 +35,7 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
           server.toPath(path).readText
         }
         _ = assertNoDiff(server.bufferContents(path), expectedCode)
-        _ = assertNoDiagnostics()
+        _ = if (expectNoDiagnostics) assertNoDiagnostics() else ()
       } yield ()
     }
   }

--- a/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -12,7 +12,7 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
       expectedActions: String,
       expectedCode: String,
       selectedActionIndex: Int = 0,
-      expectNoDiagnostics: Boolean = false
+      expectNoDiagnostics: Boolean = true
   ): Unit = {
     val path = "a/src/main/scala/a/A.scala"
     testAsync(name) {

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -6,11 +6,11 @@ object ImportMissingSymbolLspSuite
     extends BaseCodeActionLspSuite("importMissingSymbol") {
 
   check(
-    "auto-import",
+    "basic",
     """|package a
        |
        |object A {
-       |  val f = Fut@@ure.successful(2)
+       |  val f = <<Future>>.successful(2)
        |}
        |""".stripMargin,
     s"""|${ImportMissingSymbol.title("Future", "scala.concurrent")}
@@ -22,6 +22,30 @@ object ImportMissingSymbolLspSuite
        |
        |object A {
        |  val f = Future.successful(2)
+       |}
+       |""".stripMargin,
+    expectNoDiagnostics = true
+  )
+
+  check(
+    "multi",
+    """|package a
+       |
+       |object A {
+       |  val f = <<Future.successful(Instant.now)>>
+       |  val b = ListBuffer.newBuilder[Int]
+       |}
+       |""".stripMargin,
+    s"""|${ImportMissingSymbol.title("Future", "scala.concurrent")}
+        |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
+        |${ImportMissingSymbol.title("Instant", "java.time")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.concurrent.Future
+       |
+       |object A {
+       |  val f = Future.successful(Instant.now)
        |}
        |""".stripMargin
   )

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -23,8 +23,7 @@ object ImportMissingSymbolLspSuite
        |object A {
        |  val f = Future.successful(2)
        |}
-       |""".stripMargin,
-    expectNoDiagnostics = true
+       |""".stripMargin
   )
 
   check(
@@ -45,8 +44,7 @@ object ImportMissingSymbolLspSuite
        |object A {
        |  val f = Future.successful(2)
        |}
-       |""".stripMargin,
-    expectNoDiagnostics = true
+       |""".stripMargin
   )
 
   check(
@@ -70,7 +68,8 @@ object ImportMissingSymbolLspSuite
        |  val f = Future.successful(Instant.now)
        |  val b = ListBuffer.newBuilder[Int]
        |}
-       |""".stripMargin
+       |""".stripMargin,
+    expectNoDiagnostics = false
   )
 
   check(
@@ -93,7 +92,8 @@ object ImportMissingSymbolLspSuite
        |  val f = Future.successful(Instant.now)
        |  val b = ListBuffer.newBuilder[Int]
        |}
-       |""".stripMargin
+       |""".stripMargin,
+    expectNoDiagnostics = false
   )
 
 }

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -28,7 +28,29 @@ object ImportMissingSymbolLspSuite
   )
 
   check(
-    "multi",
+    "enclosed-range",
+    """|package a
+       |
+       |object A {
+       |  val f = Fu<<tu>>re.successful(2)
+       |}
+       |""".stripMargin,
+    s"""|${ImportMissingSymbol.title("Future", "scala.concurrent")}
+        |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.concurrent.Future
+       |
+       |object A {
+       |  val f = Future.successful(2)
+       |}
+       |""".stripMargin,
+    expectNoDiagnostics = true
+  )
+
+  check(
+    "multi-same-line",
     """|package a
        |
        |object A {
@@ -46,6 +68,30 @@ object ImportMissingSymbolLspSuite
        |
        |object A {
        |  val f = Future.successful(Instant.now)
+       |  val b = ListBuffer.newBuilder[Int]
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "multi-across-lines",
+    """|package a
+       |
+       |object A {
+       |  val f = Future.successful(<<Instant.now)
+       |  val b = ListBuffer.newBuilder[Int]>>
+       |}
+       |""".stripMargin,
+    s"""|${ImportMissingSymbol.title("Instant", "java.time")}
+        |${ImportMissingSymbol.title("ListBuffer", "scala.collection.mutable")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import java.time.Instant
+       |
+       |object A {
+       |  val f = Future.successful(Instant.now)
+       |  val b = ListBuffer.newBuilder[Int]
        |}
        |""".stripMargin
   )


### PR DESCRIPTION
Fixes #1283 

Previously we computed the 'Import missing symbol' code action for a single diagnostic under the cursor. Now we compute all diagnostics whose range overlap with the code action range sent by the client. This allows computing auto-imports for all diagnostics in a range at once.

This is especially relevant for clients like Vim, which - by default - sends a code action request for the entire line.

Here's how it looks like in VS Code:

![2020-01-11 17 07 56](https://user-images.githubusercontent.com/691940/72207037-fd6ffb00-3494-11ea-8898-c557e2c46732.gif)
