### PR TITLE
Update recommended mappings with the latest

### DIFF
--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -249,7 +249,7 @@ Update the `metals.sbtScript` setting to use a custom `sbt` script instead of th
 default Metals launcher if you need further customizations like reading environment
 variables.
 
-![Sbt Launcher](https://i.imgur.com/kbxNKzI.png)
+![Sbt Launcher](https://i.imgur.com/meciPTg.png)
 ```
 
 ## Configure Java version
@@ -259,7 +259,7 @@ The `coc-metals` extension uses by default the `JAVA_HOME` environment variable 
 
 If no `JAVA_HOME` is detected you can then Open Settings by following the instructions or do it at a later time by using `:CocConfig` or `:CocConfigLocal` which will open up your configuration where you can manually enter your JAVA_HOME location.
 
-![Enter Java Home](https://i.imgur.com/wVThrMq.png)
+![Enter Java Home](https://i.imgur.com/wK07Vju.png)
 
 ## Using latest Metals SNAPSHOT
 
@@ -305,7 +305,7 @@ nmap <Leader>ws <Plug>(coc-metals-expand-decoration)
 Then, when on the line that you'd like to expand the decoration to get the hover information, execute a
 `<leader>ws` in order to see the expanded text for that line.
 
-![Decorations with worksheets](https://i.imgur.com/X8bVmu8.png)
+![Decorations with worksheets](https://i.imgur.com/Bt6DMtH.png)
 
 ## Run doctor
 

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -89,30 +89,46 @@ Here's a recommended configuration:
 " ~/.vimrc
 " Configuration for coc.nvim
 
-" Smaller updatetime for CursorHold & CursorHoldI
-set updatetime=300
+set hidden
 
-" don't give |ins-completion-menu| messages.
-set shortmess+=c
-
-" always show signcolumns
-set signcolumn=yes
-
-" Some server have issues with backup files, see #649
+" Some servers have issues with backup files
 set nobackup
 set nowritebackup
 
 " Better display for messages
 set cmdheight=2
 
-" Use <c-space> for trigger completion.
+" You will have a bad experience with diagnostic messages with the default 4000.
+set updatetime=300
+
+" Don't give |ins-completion-menu| messages.
+set shortmess+=c
+
+" Always show signcolumns
+set signcolumn=yes
+
+" Use tab for trigger completion with characters ahead and navigate.
+" Use command ':verbose imap <tab>' to make sure tab is not mapped by other plugin.
+inoremap <silent><expr> <TAB>
+      \ pumvisible() ? "\<C-n>" :
+      \ <SID>check_back_space() ? "\<TAB>" :
+      \ coc#refresh()
+inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
+
+" Used in the tab autocompletion for coc
+function! s:check_back_space() abort
+  let col = col('.') - 1
+  return !col || getline('.')[col - 1]  =~# '\s'
+endfunction
+
+" Use <c-space> to trigger completion.
 inoremap <silent><expr> <c-space> coc#refresh()
 
-" Use <cr> for confirm completion, `<C-g>u` means break undo chain at current position.
+" Use <cr> to confirm completion, `<C-g>u` means break undo chain at current position.
 " Coc only does snippet and additional edit on confirm.
 inoremap <expr> <cr> pumvisible() ? "\<C-y>" : "\<C-g>u\<CR>"
 
-" Use `[c` and `]c` for navigate diagnostics
+" Use `[c` and `]c` to navigate diagnostics
 nmap <silent> [c <Plug>(coc-diagnostic-prev)
 nmap <silent> ]c <Plug>(coc-diagnostic-next)
 
@@ -122,17 +138,14 @@ nmap <silent> gy <Plug>(coc-type-definition)
 nmap <silent> gi <Plug>(coc-implementation)
 nmap <silent> gr <Plug>(coc-references)
 
-" Remap for do codeAction of current line
-nmap <leader>ac <Plug>(coc-codeaction)
+" Used to expand decorations in worksheets
+nmap <Leader>ws <Plug>(coc-metals-expand-decoration)
 
-" Remap for do action format
-nnoremap <silent> F :call CocAction('format')<CR>
-
-" Use K for show documentation in preview window
+" Use K to either doHover or show documentation in preview window
 nnoremap <silent> K :call <SID>show_documentation()<CR>
 
 function! s:show_documentation()
-  if &filetype == 'vim'
+  if (index(['vim','help'], &filetype) >= 0)
     execute 'h '.expand('<cword>')
   else
     call CocAction('doHover')
@@ -145,8 +158,42 @@ autocmd CursorHold * silent call CocActionAsync('highlight')
 " Remap for rename current word
 nmap <leader>rn <Plug>(coc-rename)
 
+" Remap for format selected region
+xmap <leader>f  <Plug>(coc-format-selected)
+nmap <leader>f  <Plug>(coc-format-selected)
+
+augroup mygroup
+  autocmd!
+  " Setup formatexpr specified filetype(s).
+  autocmd FileType scala setl formatexpr=CocAction('formatSelected')
+  " Update signature help on jump placeholder
+  autocmd User CocJumpPlaceholder call CocActionAsync('showSignatureHelp')
+augroup end
+
+" Remap for do codeAction of selected region, ex: `<leader>aap` for current paragraph
+xmap <leader>a  <Plug>(coc-codeaction-selected)
+nmap <leader>a  <Plug>(coc-codeaction-selected)
+
+" Remap for do codeAction of current line
+nmap <leader>ac  <Plug>(coc-codeaction)
+" Fix autofix problem of current line
+nmap <leader>qf  <Plug>(coc-fix-current)
+
+" Use `:Format` to format current buffer
+command! -nargs=0 Format :call CocAction('format')
+
+" Use `:Fold` to fold current buffer
+command! -nargs=? Fold :call     CocAction('fold', <f-args>)
+
+" Add status line support, for integration with other plugin, checkout `:h coc-status`
+set statusline^=%{coc#status()}%{get(b:,'coc_current_function','')}
+
 " Show all diagnostics
 nnoremap <silent> <space>a  :<C-u>CocList diagnostics<cr>
+" Manage extensions
+nnoremap <silent> <space>e  :<C-u>CocList extensions<cr>
+" Show commands
+nnoremap <silent> <space>c  :<C-u>CocList commands<cr>
 " Find symbol of current document
 nnoremap <silent> <space>o  :<C-u>CocList outline<cr>
 " Search workspace symbols
@@ -253,7 +300,7 @@ to implement Metal's [Decoration Protocol](https://scalameta.org/metals/docs/edi
 If using Neovim, make sure to have the following line in included in your `.vimrc` along with your `coc.nvim` mappings.
 
 ```vim
-nnoremap <leader>ws :call CocAction('runCommand', 'metals.expand-decoration')<CR>
+nmap <Leader>ws <Plug>(coc-metals-expand-decoration)
 ```
 Then, when on the line that you'd like to expand the decoration to get the hover information, execute a
 `<leader>ws` in order to see the expanded text for that line.
@@ -375,16 +422,12 @@ This step cleans up resources that are used by the server.
 ## Using an alternative LSP Client
 
 While we recommend using the `coc-metals` extension with `coc.nvim`, Metals will work
-with these alternative LSP clients.
+with these alternative LSP clients. Keep in mind that they have varying levels of LSP support.
 
-- [`vim-lsc`](https://github.com/natebosch/vim-lsc/): simple installation and
-  low resource usage but limited functionality (no auto-import, cancellation,
-  formatting, folding).
-- [`LanguageClient-neovim`](https://github.com/autozimu/LanguageClient-neovim/):
-  client written in Rust.
-- [`vim-lsp`](https://github.com/prabirshrestha/vim-lsp): simple installation
-  but limited functionality (no auto-import, cancellation and no prompt for
-  build import).
+- [`vim-lsc`](https://github.com/natebosch/vim-lsc/): simple installation and written in Vimscript.
+- [`LanguageClient-neovim`](https://github.com/autozimu/LanguageClient-neovim/): client written in Rust.
+- [`vim-lsp`](https://github.com/prabirshrestha/vim-lsp): simple installation and written in
+    Vimscript.
 
 ### Generating metals binary
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -134,7 +134,6 @@ object MetalsServerConfig {
           statusBar = StatusBarConfig.showMessage,
           isInputBoxEnabled = true,
           executeClientCommand = ExecuteClientCommandConfig.on,
-          icons = Icons.unicode,
           compilers = base.compilers.copy(
             _parameterHintsCommand = Some("editor.action.triggerParameterHints"),
             _completionCommand = Some("editor.action.triggerSuggest"),

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -112,7 +112,6 @@ object MetalsServerConfig {
         base.copy(
           // window/logMessage output is always visible and non-invasive in vim-lsc
           statusBar = StatusBarConfig.logMessage,
-          // Not strictly needed, but helpful while this integration matures.
           isHttpEnabled = true,
           icons = Icons.unicode,
           compilers = base.compilers.copy(
@@ -135,6 +134,7 @@ object MetalsServerConfig {
           statusBar = StatusBarConfig.showMessage,
           isInputBoxEnabled = true,
           executeClientCommand = ExecuteClientCommandConfig.on,
+          icons = Icons.unicode,
           compilers = base.compilers.copy(
             _parameterHintsCommand = Some("editor.action.triggerParameterHints"),
             _completionCommand = Some("editor.action.triggerSuggest"),


### PR DESCRIPTION
There has been some updates to the recommended mappings both from `coc.nvim` and a change in the way I do expands for worksheets.

While changing this up, I noticed this is a huge chunk of stuff to copy here in the docs. In the readme of `coc-metals` I ended up taking this out and instead just linking to a [recommended mapping file](https://github.com/scalameta/coc-metals/blob/master/coc-mappings.vim). Do you think that would be a good idea here to not clog up the docs so much, or do you think it's a good idea having this all right in the docs on the site?