### PR TITLE
Silence noisy FlywayDB logs

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
@@ -62,8 +62,7 @@ object MetalsLogger {
     override def id = "MetalsFilter"
     override def priority: Priority = Priority.Normal
     override def apply[M](record: LogRecord[M]): Option[LogRecord[M]] = {
-      // FIXME: filter on `org.flywaydb` instead of `scribe.sl4j` https://github.com/outr/scribe/issues/100
-      if (record.className.startsWith("scribe.slf4j") && record.level < scribe.Level.Warn.value) {
+      if (record.className.startsWith("org.flywaydb") && record.level < scribe.Level.Warn.value) {
         None
       } else {
         Some(record)


### PR DESCRIPTION
This removes noisy logs like this
```
INFO  Creating Schema History table "PUBLIC"."flyway_schema_history" ...
INFO  Current version of schema "PUBLIC": << Empty Schema >>
INFO  Migrating schema "PUBLIC" to version 1 - Create tables
INFO  Migrating schema "PUBLIC" to version 2 - Server discovery
INFO  Migrating schema "PUBLIC" to version 3 - Jar symbols
INFO  Successfully applied 3 migrations to schema "PUBLIC" (execution time 00:00.053s)
```