### PR TITLE
Use actual mill version in predef

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -50,18 +50,18 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
   override def digest(workspace: AbsolutePath): Option[String] =
     MillDigest.current(workspace)
 
-  override def minimumVersion: String = "0.4.0"
+  override def minimumVersion: String = "0.6.0"
 
   override def recommendedVersion: String = version
 
-  override def version: String = "0.5.2"
+  override def version: String = "0.6.0"
 
   override def toString(): String = "Mill"
 
   def executableName = "mill"
 
   private def predefScript(millVersion: String) =
-    s"import $$ivy.`com.lihaoyi::mill-contrib-bloop:$millVersion`".getBytes()
+    "import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`".getBytes()
 
   private def predefScriptPath(millVersion: String): Path = {
     Files.write(tempDir.resolve(predefScriptName), predefScript(millVersion))


### PR DESCRIPTION
As of recent versions of mill, the `$ivy` importers support
substituting `$MILL_VERSION` with the current version of mill.

The changes presented here modify the predef import to use the literal
`$MILL_VERSION` instead of a the value read from mill's version
file. While both these values are usually equivalent, they can differ
when using a local mill wrapper script (e.g. when developing and
testing mill locally).

In essence, the changes ensure that the correct bloop plugin will
always be used.