### PR TITLE
Update screen-record of Scaladoc auto-completion in v0.8.0 release-note.

### DIFF
--- a/website/blog/2020-01-10-cobalt.md
+++ b/website/blog/2020-01-10-cobalt.md
@@ -266,7 +266,7 @@ now supports auto completing scaladoc for method definition and class definition
 on typing `/**`. More details about it can be found in
 [the pull request](https://github.com/scalameta/metals/pull/1250).
 
-![scaladoc](https://user-images.githubusercontent.com/9353584/72200454-11affa00-348d-11ea-8967-a9f909c1b2a8.gif)
+![scaladoc](https://user-images.githubusercontent.com/9353584/72444047-ae0e2f80-37f2-11ea-97b0-c5afac035340.gif)
 
 ## Better support for Vim via coc-metals
 


### PR DESCRIPTION
This PR updates the screen-record of the Scaladoc auto-completion section in v0.8.0's release note.

The previous screen record came from the [Pull Request](https://github.com/scalameta/metals/pull/1250), but it is a bit different from real behavior: we don't add `* @constructor` line for scaladoc on a class definition. Sorry for the confusion!
(the behavior had updated in https://github.com/scalameta/metals/pull/1250/commits/cf8e6070092ac693251e01568b009a7f1bfce601, but I didn't update the screen-record.) 

### before
![scaladoc](https://user-images.githubusercontent.com/9353584/72200454-11affa00-348d-11ea-8967-a9f909c1b2a8.gif)

### after
![scaladoc](https://user-images.githubusercontent.com/9353584/72444047-ae0e2f80-37f2-11ea-97b0-c5afac035340.gif)