### PR TITLE
Add an override for build tool plugin version and promote LSP settings

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -26,8 +26,7 @@ case class GradleBuildTool(userConfig: () => UserConfiguration)
       ""
     }
   }
-  private val versionToUse =
-    userConfig().bloopPluginVersion.getOrElse(BuildInfo.gradleBloopVersion)
+  private val versionToUse = userConfig().bloopVersion
 
   private val initScript =
     s"""

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -26,6 +26,8 @@ case class GradleBuildTool(userConfig: () => UserConfiguration)
       ""
     }
   }
+  private val versionToUse =
+    userConfig().bloopPluginVersion.getOrElse(BuildInfo.gradleBloopVersion)
 
   private val initScript =
     s"""
@@ -35,7 +37,7 @@ case class GradleBuildTool(userConfig: () => UserConfiguration)
        |    mavenCentral()
        |  }
        |  dependencies {
-       |    classpath 'ch.epfl.scala:gradle-bloop_2.11:${BuildInfo.gradleBloopVersion}'
+       |    classpath 'ch.epfl.scala:gradle-bloop_2.11:$versionToUse'
        |  }
        |}
        |allprojects {

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -20,9 +20,11 @@ case class MavenBuildTool(userConfig: () => UserConfiguration)
 
   def args(workspace: AbsolutePath): List[String] = {
     import scala.meta.internal.metals.BuildInfo
+    val versionToUse =
+      userConfig().bloopPluginVersion.getOrElse(BuildInfo.mavenBloopVersion)
     val command =
       List(
-        s"ch.epfl.scala:maven-bloop_2.10:${BuildInfo.mavenBloopVersion}:bloopInstall",
+        s"ch.epfl.scala:maven-bloop_2.10:$versionToUse:bloopInstall",
         "-DdownloadSources=true"
       )
     userConfig().mavenScript match {

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -19,9 +19,7 @@ case class MavenBuildTool(userConfig: () => UserConfiguration)
   }
 
   def args(workspace: AbsolutePath): List[String] = {
-    import scala.meta.internal.metals.BuildInfo
-    val versionToUse =
-      userConfig().bloopPluginVersion.getOrElse(BuildInfo.mavenBloopVersion)
+    val versionToUse = userConfig().bloopVersion
     val command =
       List(
         s"ch.epfl.scala:maven-bloop_2.10:$versionToUse:bloopInstall",

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -82,19 +82,18 @@ case class SbtBuildTool(
       workspace: AbsolutePath,
       config: MetalsServerConfig
   ): Unit = {
-    if (!userConfig().bloopGenerateSbt) return
-    val versionToUse =
-      userConfig().bloopPluginVersion.getOrElse(BuildInfo.sbtBloopVersion)
+    if (userConfig().bloopSbtAlreadyInstalled) return
+    val versionToUse = userConfig().bloopVersion
     val bytes = SbtBuildTool
       .sbtPlugin(versionToUse)
       .getBytes(StandardCharsets.UTF_8)
     val projectDir = workspace.resolve("project")
     projectDir.toFile.mkdir()
-    val metalsPluginfile = projectDir.resolve("metals.sbt")
-    val pluginFileShouldChange = !metalsPluginfile.isFile ||
-      !metalsPluginfile.readAllBytes.sameElements(bytes)
+    val metalsPluginFile = projectDir.resolve("metals.sbt")
+    val pluginFileShouldChange = !metalsPluginFile.isFile ||
+      !metalsPluginFile.readAllBytes.sameElements(bytes)
     if (pluginFileShouldChange) {
-      Files.write(metalsPluginfile.toNIO, bytes)
+      Files.write(metalsPluginFile.toNIO, bytes)
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -82,9 +82,11 @@ case class SbtBuildTool(
       workspace: AbsolutePath,
       config: MetalsServerConfig
   ): Unit = {
-    if (!config.bloopGenerateSbt) return
+    if (!userConfig().bloopGenerateSbt) return
+    val versionToUse =
+      userConfig().bloopPluginVersion.getOrElse(BuildInfo.sbtBloopVersion)
     val bytes = SbtBuildTool
-      .sbtPlugin(config.bloopSbtVersion)
+      .sbtPlugin(versionToUse)
       .getBytes(StandardCharsets.UTF_8)
     val projectDir = workspace.resolve("project")
     projectDir.toFile.mkdir()

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -160,6 +160,26 @@ class Messages(icons: Icons) {
       params
     }
   }
+  object BloopVersionChange {
+    def reconnect: MessageActionItem =
+      new MessageActionItem("Restart Bloop")
+    def notNow: MessageActionItem =
+      new MessageActionItem("Not now")
+    def params(version: String): ShowMessageRequestParams = {
+      val params = new ShowMessageRequestParams()
+      params.setMessage(
+        s"Bloop version was updated, do you want to kill the running server and start Bloop $version?"
+      )
+      params.setType(MessageType.Warning)
+      params.setActions(
+        List(
+          reconnect,
+          notNow
+        ).asJava
+      )
+      params
+    }
+  }
 
   object IncompatibleBloopVersion {
     def manually: MessageActionItem =
@@ -170,15 +190,20 @@ class Messages(icons: Icons) {
       new MessageActionItem("Don't show again")
     def params(
         bloopVersion: String,
-        minimumBloopVersion: String
+        minimumBloopVersion: String,
+        isChangedInSettings: Boolean
     ): ShowMessageRequestParams = {
 
       val params = new ShowMessageRequestParams()
+      val additional =
+        if (isChangedInSettings)
+          "You will also need to remove or update the `bloopVersion` setting"
+        else ""
       params.setMessage(
         s"""|You have Bloop $bloopVersion installed and Metals requires at least Bloop $minimumBloopVersion.
             |If you installed bloop via a system package manager (brew, aur, scoop), please upgrade manually.
             |If not, select "Turn off old server". A newer server will be started automatically afterwards.
-            |""".stripMargin
+            |""".stripMargin + s"\n$additional"
       )
       params.setType(MessageType.Warning)
       params.setActions(

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -168,7 +168,7 @@ class Messages(icons: Icons) {
     def params(version: String): ShowMessageRequestParams = {
       val params = new ShowMessageRequestParams()
       params.setMessage(
-        s"Bloop version was updated, do you want to kill the running server and start Bloop $version?"
+        s"Bloop version was updated, do you want to restart the running Bloop server?"
       )
       params.setType(MessageType.Warning)
       params.setActions(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -829,6 +829,8 @@ class MetalsLanguageServer(
                 case item if item == Messages.BloopVersionChange.reconnect =>
                   bloopServers.shutdownServer()
                   autoConnectToBuildServer().ignoreValue
+                case _ =>
+                  Future.successful(())
               }
           } else if (userConfig.pantsTargets != old.pantsTargets) {
             slowConnectToBuildServer(forceImport = false).ignoreValue

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -819,7 +819,18 @@ class MetalsLanguageServer(
           if (userConfig.symbolPrefixes != old.symbolPrefixes) {
             compilers.restartAll()
           }
-          if (userConfig.pantsTargets != old.pantsTargets) {
+          if (userConfig.bloopVersion != old.bloopVersion) {
+            languageClient
+              .showMessageRequest(
+                Messages.BloopVersionChange.params(userConfig.bloopVersion)
+              )
+              .asScala
+              .flatMap {
+                case item if item == Messages.BloopVersionChange.reconnect =>
+                  bloopServers.shutdownServer()
+                  autoConnectToBuildServer().ignoreValue
+              }
+          } else if (userConfig.pantsTargets != old.pantsTargets) {
             slowConnectToBuildServer(forceImport = false).ignoreValue
           } else {
             Future.successful(())
@@ -1386,7 +1397,7 @@ class MetalsLanguageServer(
     for {
       _ <- disconnectOldBuildServer()
       maybeBuild <- timed("connected to build server") {
-        if (buildTools.isBloop) bloopServers.newServer()
+        if (buildTools.isBloop) bloopServers.newServer(userConfig)
         else bspServers.newServer()
       }
       result <- maybeBuild match {
@@ -1676,7 +1687,8 @@ class MetalsLanguageServer(
       if (!notification.isDismissed) {
         val messageParams = IncompatibleBloopVersion.params(
           bspServerVersion,
-          BuildInfo.bloopVersion
+          BuildInfo.bloopVersion,
+          BuildInfo.bloopVersion != userConfig.bloopVersion
         )
         languageClient.showMessageRequest(messageParams).asScala.foreach {
           case action if action == IncompatibleBloopVersion.shutdown =>

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -59,12 +59,6 @@ final case class MetalsServerConfig(
       "bloop.embedded.version",
       BuildInfo.bloopVersion
     ),
-    bloopSbtVersion: String = System.getProperty(
-      "bloop.sbt.version",
-      BuildInfo.sbtBloopVersion
-    ),
-    bloopGenerateSbt: Boolean =
-      "false" != System.getProperty("bloop.generate.sbt"),
     icons: Icons = Icons.default,
     statistics: StatisticsConfig = StatisticsConfig.default,
     compilers: PresentationCompilerConfigImpl = CompilersConfig()

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsSymbolSearch.scala
@@ -21,7 +21,7 @@ class MetalsSymbolSearch(
     defn: DefinitionProvider
 ) extends SymbolSearch {
   // A cache for definitionSourceToplevels.
-  // The key is an absolutepath to the dependency source file, and
+  // The key is an absolute path to the dependency source file, and
   // the value is the list of symbols that the file contains.
   private val dependencySourceCache =
     new TrieMap[AbsolutePath, ju.List[String]]()

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -30,8 +30,8 @@ case class UserConfiguration(
       PresentationCompilerConfig.defaultSymbolPrefixes().asScala.toMap,
     worksheetScreenWidth: Int = 120,
     worksheetCancelTimeout: Int = 4,
-    bloopGenerateSbt: Boolean = true,
-    bloopPluginVersion: Option[String] = None,
+    bloopSbtAlreadyInstalled: Boolean = false,
+    bloopVersion: String = BuildInfo.bloopVersion,
     pantsTargets: Option[List[String]] = None
 )
 object UserConfiguration {
@@ -109,18 +109,19 @@ object UserConfiguration {
         |""".stripMargin
     ),
     UserConfigurationOption(
-      "bloop-generate-sbt",
-      """true""",
-      "true",
-      "Generate Bloop plugin file",
-      """Option that can specified to false if the user doesn't want to generate an sbt file adding the Bloop sbt plugin."""
+      "bloop-sbt-already-installed",
+      "false",
+      "false",
+      "Don't generate Bloop plugin file for Sbt",
+      "Option that can specified to true if the user doesn't want to generate an sbt file adding the Bloop sbt plugin."
     ),
     UserConfigurationOption(
-      "bloop-plugin-version",
+      "bloop-version",
       BuildInfo.bloopVersion,
       "1.4.0-RC1",
-      "Version of Bloop build tool plugin",
-      "This version will be used for the Bloop build tool plugin, for any supported build tool, while importing in Metals"
+      "Version of Bloop",
+      """|This version will be used for the Bloop build tool plugin, for any supported build tool, 
+         |while importing in Metals as well as for running the embedded server""".stripMargin
     )
   )
 
@@ -232,8 +233,10 @@ object UserConfiguration {
           }
         }
       )
-    val bloopGenerateSbt = getBooleanKey("bloop-generate-sbt").getOrElse(true)
-    val bloopPluginVersion = getStringKey("bloop-plugin-version")
+    val bloopSbtAlreadyInstalled =
+      getBooleanKey("bloop-sbt-already-installed").getOrElse(true)
+    val bloopVersion =
+      getStringKey("bloop-version").getOrElse(BuildInfo.bloopVersion)
     if (errors.isEmpty) {
       Right(
         UserConfiguration(
@@ -246,8 +249,8 @@ object UserConfiguration {
           symbolPrefixes,
           worksheetScreenWidth,
           worksheetCancelTimeout,
-          bloopGenerateSbt,
-          bloopPluginVersion,
+          bloopSbtAlreadyInstalled,
+          bloopVersion,
           pantsTargets
         )
       )

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -112,7 +112,7 @@ object UserConfiguration {
       "bloop-sbt-already-installed",
       "false",
       "false",
-      "Don't generate Bloop plugin file for Sbt",
+      "Don't generate Bloop plugin file for sbt",
       "Option that can specified to true if the user doesn't want to generate an sbt file adding the Bloop sbt plugin."
     ),
     UserConfigurationOption(

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -113,7 +113,7 @@ object UserConfiguration {
       "false",
       "false",
       "Don't generate Bloop plugin file for sbt",
-      "Option that can specified to true if the user doesn't want to generate an sbt file adding the Bloop sbt plugin."
+      "If true, Metals will not generate a `project/metals.sbt` file under the assumption that sbt-bloop is already manually installed in the sbt build. Build import will fail with a 'not valid command bloopInstall' error in case Bloop is not manually installed in the build when using this option."
     ),
     UserConfigurationOption(
       "bloop-version",


### PR DESCRIPTION
Previously, there was not way to override all of the build plugins Bloop versions. Now we add a unified setting for doing so - one setting should be enough since for each workspace we can only use one build tool. 

Or do we want to have a separate setting for each build tool? That would be for 3 different ones: Sbt, Gradle and Maven.

I also promoted some setting to LSP ones.