### PR TITLE
Fix worksheet gif for cobalt release notes to show proper extension

### DIFF
--- a/website/blog/2020-01-10-cobalt.md
+++ b/website/blog/2020-01-10-cobalt.md
@@ -160,7 +160,8 @@ available in all supported editors.
 
 Worksheets are a way to evaluate code in real time to test and prototype any new
 features in a simple way. To create a worksheet all that is needed is to create
-a file with the extension `worksheet.sc` and Metals will take care of the rest.
+a file with the extension `.worksheet.sc` within the source directory of your 
+workspace (like `/src/main/scala`) and Metals will take care of the rest.
 
 There are two ways worksheets are implemented for different editors. One is with
 an additional extension to LSP called `Decoration extension` and it's used by

--- a/website/blog/2020-01-10-cobalt.md
+++ b/website/blog/2020-01-10-cobalt.md
@@ -168,7 +168,7 @@ Visual Studio Code and coc-metals.
 
 Visual Studio Code:
 
-![worksheet](https://user-images.githubusercontent.com/1408093/68093266-b0b3e680-fe8b-11e9-92dd-0165f169966f.gif)
+![worksheet](https://i.imgur.com/8c1NkIx.gif)
 
 The other way worksheets are implemented for all other editors that don't
 support the `Decoration extension` is using workspace/applyEdits and comments


### PR DESCRIPTION
Previously, the gif was showing a wrong extension.