### PR TITLE
Fix version of sbt-metals for pre 0.8.0 instructions

### DIFF
--- a/docs/build-tools/sbt.md
+++ b/docs/build-tools/sbt.md
@@ -69,7 +69,7 @@ First, install the Bloop and Metals plugins globally
 //   ~/.sbt/0.13/plugins/plugins.sbt
 //   ~/.sbt/1.0/plugins/plugins.sbt
 resolvers += Resolver.sonatypeRepo("snapshots")
-addSbtPlugin("org.scalameta" % "sbt-metals" % "@VERSION@")
+addSbtPlugin("org.scalameta" % "sbt-metals" % "0.7.6")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "@BLOOP_VERSION@")
 ```
 


### PR DESCRIPTION
Minor, but it currently shows the snapshot version which does not exist, since we stopped publishing `sbt-metals`.

![image](https://user-images.githubusercontent.com/691940/72599738-9332dc80-3912-11ea-8847-645f84b0ea57.png)
