### PR TITLE
Change require to warning for the presentation compiler

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -179,7 +179,9 @@ case class ScalaPresentationCompiler(
     val (isSuccess, unprocessed) =
       settings.processArguments(options, processAll = true)
     require(isSuccess, unprocessed)
-    require(unprocessed.isEmpty, unprocessed)
+    if (unprocessed.nonEmpty) {
+      logger.warning(s"Unknown compiler options: ${unprocessed.mkString(", ")}")
+    }
     new MetalsGlobal(
       settings,
       new StoreReporter,


### PR DESCRIPTION
That require was causing some issue when `utf-8` was used and it actually doesn't cause the presentation compiler to break.

Fixes https://github.com/scalameta/metals/issues/1303