### PR TITLE
Add in fix for onTypeFormatting on top level multi-line strings

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -403,7 +403,7 @@ object MetalsEnrichments
         upperBound: Int = value.size
     ): Int = {
       var index = upperBound
-      while (index > lowerBound && value(index) != char) {
+      while (index >= lowerBound && value(index) != char) {
         index -= 1
       }
       index

--- a/metals/src/main/scala/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
@@ -16,9 +16,6 @@ import org.eclipse.lsp4j.DocumentRangeFormattingParams
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.Position
 
-/*in order to use onTypeFormatting in vscode,
-you'll have to set editor.formatOnType = true
-and editor.formatOnPaste = true in settings*/
 final class MultilineStringFormattingProvider(
     semanticdbs: Semanticdbs,
     buffer: Buffers


### PR DESCRIPTION
fixes #1311 

We never hit this previously since we never were using this on the top level. However, now that we do in `.sc` files, we run into this. Just a quick fix to account for the beginning being 0, which it is when it's on the top level.

I also took out the comment since it was specific to VS Code settings, which imo didn't belong there.