### PR TITLE
Fix issues when go to implementation resolves local symbols

### DIFF
--- a/tests/unit/src/test/scala/tests/ImplementationLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ImplementationLspSuite.scala
@@ -51,6 +51,26 @@ object ImplementationLspSuite extends BaseLspSuite("implementation") {
   )
 
   check(
+    "file-locals",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |trait Ap@@p
+       |object outer{
+       |  abstract class <<State>> extends App
+       |  val app = new <<>>State{}
+       |}
+       |/a/src/main/scala/a/Other.scala
+       |package a
+       |object Other{
+       |  def main(){
+       |    trait Inner
+       |    object InnerImpl extends Inner
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  check(
     "basic-value",
     """|/a/src/main/scala/a/Main.scala
        |package a


### PR DESCRIPTION
Previously, we would get implementation for if a parent local symbol name matched any other local symbol name. Now, we check if those are in the same file.