### PR TITLE
Change the non-fatal jar error to debug rather than log warning

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1773,7 +1773,7 @@ class MetalsLanguageServer(
               case e: InvalidJarException =>
                 scribe.warn(s"invalid jar: ${e.path}")
               case NonFatal(e) =>
-                scribe.warn(s"jar error: $path", e)
+                scribe.debug(s"jar error: $path", e)
             })
             tempIndex.addSourceJar(path)
             if (tempIndex.toplevels.nonEmpty) {


### PR DESCRIPTION
fixes #1304

This will fix the warning that users are getting for example about a missing `/Users` directory or other superfluous warnings coming from non fatal errors when we scan the jar files. 

I went ahead and changed this to debug which was mentioned in the issue. If there is a scenario where you think this isn't ideal, what would that scenario be, and what is an alternative way to do this?