### PR TITLE
Do not accept synthetic symbol with matching qualifier

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Synthetics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Synthetics.scala
@@ -27,7 +27,7 @@ object Synthetics {
       case ApplyTree(function, arguments) =>
         isStop(function) || arguments.exists(isStop)
       case SelectTree(qualifier, id) =>
-        id.exists(isStop) || isStop(qualifier)
+        id.exists(isStop)
       case IdTree(symbol) =>
         fn(symbol).isStop
       case TypeApplyTree(function, _) =>

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -186,4 +186,36 @@ object ReferenceLspSuite extends BaseLspSuite("reference") {
       _ = server.assertReferenceDefinitionBijection()
     } yield ()
   }
+
+  testAsync("implicit") {
+    for {
+      _ <- server.initialize(
+        """
+          |/metals.json
+          |{
+          |  "a": {}
+          |}
+          |/a/src/main/scala/a/A.scala
+          |package a
+          |trait Document
+          |
+          |class DD extends Document
+          |
+          |trait Hello[T <: Document]{
+          |
+          |  implicit class Better[T <: Document](doc : T){
+          |    def other() = {}
+          |  }
+          |}
+          |
+          |class Hey extends Hello[DD]{
+          |  Some(new DD).map(_.other())
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ = assertNoDiagnostics()
+      _ = server.assertReferenceDefinitionBijection()
+    } yield ()
+  }
 }


### PR DESCRIPTION
This would cause `_` below be showed as referenced
```scala
trait Document
class DD extends Document
trait Hello[T <: Document] {
  implicit class Better[T <: Document](doc: T) {
    def other() = {}
  }
}

class He@@y extends Hello[DD] {
  Some(new DD()).map(<<_>>.other())
}
```
reported to me offline - more coworkers using Metals! Yay!

As far as I checked this should not cause any regressions.