### PR TITLE
fix logic for detected if bloop-sbt is already installed

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -234,7 +234,7 @@ object UserConfiguration {
         }
       )
     val bloopSbtAlreadyInstalled =
-      getBooleanKey("bloop-sbt-already-installed").getOrElse(true)
+      getBooleanKey("bloop-sbt-already-installed").getOrElse(false)
     val bloopVersion =
       getStringKey("bloop-version").getOrElse(BuildInfo.bloopVersion)
     if (errors.isEmpty) {


### PR DESCRIPTION
Fixes #1341 

`getBooleanKey("bloop-sbt-already-installed").getOrElse(true)` would always be setting this value to true unless the user specifically said they didn't have it installed via the setting. The fix will change this to get the setting or default to `false` which will correctly allow Metals to create the `metals.sbt` file that is needed for bloop.