### PR TITLE
Copy jars from Pants export-classpath into Bloop directory.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.pantsbuild
 
 import java.nio.file.Paths
 import scala.collection.mutable
+import java.nio.file.Files
 
 case class PantsExport(
     targets: Map[String, PantsTarget],
@@ -63,9 +64,11 @@ object PantsExport {
     val allLibraries = output.obj(PantsKeys.libraries).obj
     val libraries: Map[String, PantsLibrary] = allLibraries.iterator.map {
       case (name, valueObj) =>
-        name -> PantsLibrary(name, valueObj.obj.map {
+        name -> PantsLibrary(name, valueObj.obj.flatMap {
           case (key, value) =>
-            key -> Paths.get(value.str)
+            val path = Paths.get(value.str)
+            if (Files.isRegularFile(path)) Some(key -> path)
+            else None
         })
     }.toMap
 


### PR DESCRIPTION
Previously, the Bloop classpath would point to `z.jar` files under the
`.pants.d/` directory. This caused problems since those `z.jar` files
would later get overwritten by `./pants compile` tasks. Now, we copy
those files over to the `.bloop/` directory so that the Bloop classpath
is stable regardless of what Pants commands the user runs.

This commit also filters out classpath entries to jars that don't exist.