### PR TITLE
Add new page on website with overiew of test suites in the code…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -476,9 +476,10 @@ lazy val docs = project
     skip.in(publish) := true,
     moduleName := "metals-docs",
     mdoc := run.in(Compile).evaluated,
+    munitRepository := Some("scalameta/metals"),
     libraryDependencies ++= List(
       "org.jsoup" % "jsoup" % "1.12.1"
     )
   )
   .dependsOn(metals)
-  .enablePlugins(DocusaurusPlugin)
+  .enablePlugins(DocusaurusPlugin, MUnitReportPlugin)

--- a/docs/contributors/tests.md
+++ b/docs/contributors/tests.md
@@ -1,0 +1,10 @@
+---
+id: tests
+title: Tests overview
+---
+
+The following table is an overview of the test suites in the Metals codebase.
+
+```scala mdoc:munit
+
+```

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -36,6 +36,9 @@
       "contributors/releasing": {
         "title": "Making a release"
       },
+      "contributors/tests": {
+        "title": "Tests overview"
+      },
       "contributors/updating-website": {
         "title": "Contributing to the website"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -26,7 +26,8 @@
       "contributors/project-goals",
       "contributors/getting-started",
       "contributors/updating-website",
-      "contributors/releasing"
+      "contributors/releasing",
+      "contributors/tests"
     ]
   }
 }


### PR DESCRIPTION
Examples:

**The new sidebar**
<img width="242" alt="Screenshot 2020-01-28 at 10 14 18" src="https://user-images.githubusercontent.com/1408093/73254939-3f987c80-41b7-11ea-9d3a-dc4ad34ada3a.png">

**Tests sorted by duration**
<img width="903" alt="Screenshot 2020-01-28 at 10 10 24" src="https://user-images.githubusercontent.com/1408093/73254942-40311300-41b7-11ea-9e6b-41c27e6b7212.png">

**Tests sorted by flakyness** (the flakyness score in the `R` column is calculated incorrectly, I'll need to fix that)
<img width="831" alt="Screenshot 2020-01-28 at 10 11 47" src="https://user-images.githubusercontent.com/1408093/73254940-3f987c80-41b7-11ea-877f-b283a14a1f59.png">
