### PR TITLE
Merge pull request #1363 from olafurpg/pants-resources

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/TargetType.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/TargetType.scala
@@ -4,6 +4,6 @@ case class TargetType(value: String) {
   def isTest: Boolean = value == "TEST"
   def isTestResource: Boolean = value == "TEST_RESOURCE"
   def isResource: Boolean = value == "RESOURCE"
-  def isAnyResource: Boolean = isResource || isTestResource
+  def isAnyResource: Boolean = isResource || isTestResource || isSource
   def isSource: Boolean = value == "SOURCE"
 }


### PR DESCRIPTION
Previously, we only included resources on the classpath from Pants
targets with type "RESOURCE" or "TEST_RESOURCE". However, Pants also
includes "SOURCE" types on the classpath so this change fixes that.