### PR TITLE
Add support for rambo worksheets without build target

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -41,11 +41,11 @@ final class Embedded(
     mdocs.clear()
   }
 
-  def mdoc(info: ScalaBuildTarget): Mdoc = {
+  def mdoc(scalaVersion: String, scalaBinaryVersion: String): Mdoc = {
     val classloader = mdocs.getOrElseUpdate(
-      info.getScalaBinaryVersion(),
+      scalaBinaryVersion,
       statusBar.trackSlowTask("Preparing worksheets") {
-        Embedded.newMdocClassLoader(info)
+        Embedded.newMdocClassLoader(scalaVersion, scalaBinaryVersion)
       }
     )
     serviceLoader(
@@ -106,14 +106,17 @@ object Embedded {
         )
       )
 
-  def newMdocClassLoader(info: ScalaBuildTarget): URLClassLoader = {
+  def newMdocClassLoader(
+      scalaVersion: String,
+      scalaBinaryVersion: String
+  ): URLClassLoader = {
     val mdoc = Dependency.of(
       "org.scalameta",
-      s"mdoc_${info.getScalaBinaryVersion()}",
+      s"mdoc_${scalaBinaryVersion}",
       BuildInfo.mdocVersion
     )
-    val settings = fetchSettings(mdoc, info.getScalaVersion())
-    val jars = fetchSettings(mdoc, info.getScalaVersion()).fetch()
+    val settings = fetchSettings(mdoc, scalaVersion)
+    val jars = fetchSettings(mdoc, scalaVersion).fetch()
     val parent =
       new MdocClassLoader(this.getClass.getClassLoader)
     val urls = jars.iterator.asScala.map(_.toURI().toURL()).toArray

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -64,6 +64,12 @@ class WorksheetProvider(
     Executors.newSingleThreadScheduledExecutor()
   private val cancelables = new MutableCancelable()
   private val mdocs = new TrieMap[BuildTargetIdentifier, Mdoc]()
+  private val currentScalaVersion =
+    scala.meta.internal.mtags.BuildInfo.scalaCompilerVersion
+  private val currentBinaryVersion =
+    currentScalaVersion.split('.').take(2).mkString(".")
+  private lazy val ramboMdoc =
+    embedded.mdoc(currentScalaVersion, currentBinaryVersion)
 
   def onBuildTargetDidCompile(target: BuildTargetIdentifier): Unit = {
     clearBuildTarget(target)
@@ -139,7 +145,7 @@ class WorksheetProvider(
       // infinite loops.
       val thread = new Thread(s"Evaluating Worksheet ${path.filename}") {
         override def run(): Unit = {
-          try result.complete(evaluateWorksheet(path, token))
+          try result.complete(Some(evaluateWorksheet(path, token)))
           catch {
             case e @ (NonFatal(_) | InterruptException()) =>
               result.completeExceptionally(e)
@@ -218,12 +224,10 @@ class WorksheetProvider(
   private def evaluateWorksheet(
       path: AbsolutePath,
       token: CancelToken
-  ): Option[EvaluatedWorksheet] = {
-    for {
-      mdoc <- getMdoc(path)
-      input = path.toInputFromBuffers(buffers)
-    } yield mdoc.evaluateWorksheet(input.path, input.value)
-  }.map { worksheet =>
+  ): EvaluatedWorksheet = {
+    val mdoc = getMdoc(path)
+    val input = path.toInputFromBuffers(buffers)
+    val worksheet = mdoc.evaluateWorksheet(input.path, input.value)
     val toPublish = worksheet
       .diagnostics()
       .iterator()
@@ -238,12 +242,14 @@ class WorksheetProvider(
     worksheet
   }
 
-  private def getMdoc(path: AbsolutePath): Option[Mdoc] = {
-    for {
+  private def getMdoc(path: AbsolutePath): Mdoc = {
+    val mdoc = for {
       target <- buildTargets.inverseSources(path)
       mdoc <- getMdoc(target)
     } yield mdoc
+    mdoc.getOrElse(ramboMdoc)
   }
+
   private def getMdoc(target: BuildTargetIdentifier): Option[Mdoc] = {
     mdocs.get(target).orElse {
       for {
@@ -264,7 +270,7 @@ class WorksheetProvider(
           .filterNot(_.contains("semanticdb"))
           .asJava
         val mdoc = embedded
-          .mdoc(scala)
+          .mdoc(scala.getScalaVersion(), scala.getScalaBinaryVersion())
           .withClasspath(info.fullClasspath.asScala.distinct.asJava)
           .withScalacOptions(scalacOptions)
         mdocs(target) = mdoc


### PR DESCRIPTION
Previously, when worksheet was created outside a build target it was not evaluated. Now, it's evaluated with the default Scala version, but without any classpath.