### PR TITLE
Upgrade to the latest junit-interface.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -299,7 +299,7 @@ private class BloopPants(
       // runner in Pants. Most importantly, it automatically registers
       // org.scalatest.junit.JUnitRunner even if there is no `@RunWith`
       // annotation.
-      Dependency.of("com.geirsson", "junit-interface", "0.11.9")
+      Dependency.of("com.geirsson", "junit-interface", "0.11.10")
     ).flatMap(fetchDependency)
   val allScalaJars: Seq[Path] = {
     val compilerClasspath = export.scalaPlatform.compilerClasspath


### PR DESCRIPTION
This release includes a critical fix for an issue that makes the Bloop
server unresponsive https://github.com/scalacenter/bloop/issues/1155