### PR TITLE
Include ScalaBuildTarget in ScalaTarget 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -76,13 +76,15 @@ final class BuildTargets() {
     for {
       (id, target) <- buildTargetInfo.iterator
       scalac <- scalacTargetInfo.get(id)
-    } yield ScalaTarget(target, scalac)
+      scalaTarget <- target.asScalaBuildTarget
+    } yield ScalaTarget(target, scalaTarget, scalac)
 
   def scalaTarget(id: BuildTargetIdentifier): Option[ScalaTarget] =
     for {
       info <- buildTargetInfo.get(id)
       scalac <- scalacTargetInfo.get(id)
-    } yield ScalaTarget(info, scalac)
+      scalaTarget <- info.asScalaBuildTarget
+    } yield ScalaTarget(info, scalaTarget, scalac)
 
   def allWorkspaceJars: Iterator[AbsolutePath] = {
     val isVisited = new ju.HashSet[AbsolutePath]()
@@ -296,7 +298,7 @@ final class BuildTargets() {
       null
     )
     lazy val classpaths =
-      all.map(i => i.info.getId -> i.scalac.classpath.toSeq).toSeq
+      all.map(i => i.id -> i.scalac.classpath.toSeq).toSeq
     try {
       toplevels.foldLeft(Option.empty[InferredBuildTarget]) {
         case (Some(x), toplevel) => Some(x)

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -219,12 +219,11 @@ class Compilers(
       target: BuildTargetIdentifier
   ): Option[PresentationCompiler] = {
     for {
-      info <- buildTargets.info(target)
-      scala <- info.asScalaBuildTarget
-      isSupported = ScalaVersions.isSupportedScalaVersion(scala.getScalaVersion)
+      info <- buildTargets.scalaTarget(target)
+      isSupported = ScalaVersions.isSupportedScalaVersion(info.scalaVersion)
       _ = {
         if (!isSupported) {
-          scribe.warn(s"unsupported Scala ${scala.getScalaVersion}")
+          scribe.warn(s"unsupported Scala ${info.scalaVersion}")
         }
       }
       if isSupported
@@ -235,7 +234,7 @@ class Compilers(
           statusBar.trackBlockingTask(
             s"${statusBar.icons.sync}Loading presentation compiler"
           ) {
-            newCompiler(scalac, scala)
+            newCompiler(scalac, info.scalaInfo)
           }
         }
       )

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -69,6 +69,7 @@ object MetalsEnrichments
       decodeJson(buildTarget.getData, classOf[b.ScalaBuildTarget])
     }
   }
+
   implicit class XtensionTaskStart(task: b.TaskStartParams) {
     def asCompileTask: Option[b.CompileTask] = {
       decodeJson(task.getData, classOf[b.CompileTask])

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1677,7 +1677,7 @@ class MetalsLanguageServer(
         .foreach(focusedDocumentBuildTarget.set)
     }
 
-    val targets = buildTargets.all.map(_.info.getId).toSeq
+    val targets = buildTargets.all.map(_.id).toSeq
     buildTargetClasses
       .rebuildIndex(targets)
       .foreach(_ => languageClient.refreshModel())

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -37,5 +37,5 @@ case class ScalaTarget(
 
   def displayName: String = info.getDisplayName()
 
-  def scalaBinaryVersion: String = scalaInfo.getScalaVersion()
+  def scalaBinaryVersion: String = scalaInfo.getScalaBinaryVersion()
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -6,15 +6,24 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
 import java.{util => ju}
 import java.nio.file.Path
+import ch.epfl.scala.bsp4j.ScalaBuildTarget
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 
-case class ScalaTarget(info: BuildTarget, scalac: ScalacOptionsItem) {
+case class ScalaTarget(
+    info: BuildTarget,
+    scalaInfo: ScalaBuildTarget,
+    scalac: ScalacOptionsItem
+) {
   def isSemanticdbEnabled: Boolean = scalac.isSemanticdbEnabled
 
-  def isScalaTarget: Boolean = info.getLanguageIds().contains("scala")
+  def id: BuildTargetIdentifier = info.getId()
+
+  def baseDirectory: String = info.getBaseDirectory()
 
   def fullClasspath: ju.List[Path] = {
     scalac.getClasspath().map(_.toAbsolutePath.toNIO)
   }
+
   def jarClasspath: List[AbsolutePath] = {
     scalac
       .getClasspath()
@@ -24,4 +33,9 @@ case class ScalaTarget(info: BuildTarget, scalac: ScalacOptionsItem) {
       .map(_.toAbsolutePath)
   }
 
+  def scalaVersion: String = scalaInfo.getScalaVersion()
+
+  def displayName: String = info.getDisplayName()
+
+  def scalaBinaryVersion: String = scalaInfo.getScalaVersion()
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
@@ -32,37 +32,36 @@ final class Warnings(
     }
     val isReported: Option[Unit] = for {
       buildTarget <- buildTargets.inverseSources(path)
-      info <- buildTargets.info(buildTarget)
-      scala <- info.asScalaBuildTarget
+      info <- buildTargets.scalaTarget(buildTarget)
       scalacOptions <- buildTargets.scalacOptions(buildTarget)
     } yield {
       if (!scalacOptions.isSemanticdbEnabled) {
-        if (isSupportedScalaVersion(scala.getScalaVersion)) {
+        if (isSupportedScalaVersion(info.scalaVersion)) {
           logger.error(
-            s"$doesntWorkBecause the SemanticDB compiler plugin is not enabled for the build target ${info.getDisplayName}."
+            s"$doesntWorkBecause the SemanticDB compiler plugin is not enabled for the build target ${info.displayName}."
           )
           buildMisconfiguration()
         } else {
           logger.error(
-            s"$doesntWorkBecause the Scala version ${scala.getScalaVersion} is not supported. " +
+            s"$doesntWorkBecause the Scala version ${info.scalaVersion} is not supported. " +
               s"To fix this problem, change the Scala version to ${isLatestScalaVersion.mkString(" or ")}."
           )
           statusBar.addMessage(
-            s"${icons.alert}Unsupported Scala ${scala.getScalaVersion}"
+            s"${icons.alert}Unsupported Scala ${info.scalaVersion}"
           )
         }
       } else {
         if (!scalacOptions.isSourcerootDeclared) {
           val option = workspace.sourcerootOption
           logger.error(
-            s"$doesntWorkBecause the build target ${info.getDisplayName} is missing the compiler option $option. " +
+            s"$doesntWorkBecause the build target ${info.displayName} is missing the compiler option $option. " +
               s"To fix this problems, update the build settings to include this compiler option."
           )
           buildMisconfiguration()
         } else if (isCompiling(buildTarget)) {
           val tryAgain = "Wait until compilation is finished and try again"
           logger.error(
-            s"$doesntWorkBecause the build target ${info.getDisplayName} is being compiled. $tryAgain."
+            s"$doesntWorkBecause the build target ${info.displayName} is being compiled. $tryAgain."
           )
           statusBar.addMessage(icons.info + tryAgain)
         } else {

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -52,13 +52,13 @@ class MetalsTreeViewProvider(
     Build,
     "projects",
     "Projects",
-    _.info.getId(),
+    _.id,
     _.getUri(),
     uri => new BuildTargetIdentifier(uri),
-    _.info.getDisplayName(),
-    _.info.getBaseDirectory, { () =>
+    _.displayName,
+    _.baseDirectory, { () =>
       buildTargets.all.filter(target =>
-        buildTargets.buildTargetSources(target.info.getId()).nonEmpty
+        buildTargets.buildTargetSources(target.id).nonEmpty
       )
     }, { (id, symbol) =>
       doCompile(id)

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -254,8 +254,7 @@ class WorksheetProvider(
     mdocs.get(target).orElse {
       for {
         info <- buildTargets.scalaTarget(target)
-        scala <- info.info.asScalaBuildTarget
-        scalaVersion = scala.getScalaVersion
+        scalaVersion = info.scalaVersion
         isSupported = ScalaVersions.isSupportedScalaVersion(scalaVersion)
         _ = {
           if (!isSupported) {
@@ -270,7 +269,7 @@ class WorksheetProvider(
           .filterNot(_.contains("semanticdb"))
           .asJava
         val mdoc = embedded
-          .mdoc(scala.getScalaVersion(), scala.getScalaBinaryVersion())
+          .mdoc(info.scalaVersion, info.scalaBinaryVersion)
           .withClasspath(info.fullClasspath.asScala.distinct.asJava)
           .withScalacOptions(scalacOptions)
         mdocs(target) = mdoc

--- a/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
+++ b/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
@@ -22,6 +22,9 @@ import scala.meta.internal.metals.WorkspaceSymbolProvider
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.Classpath
 import scala.{meta => m}
+import ch.epfl.scala.bsp4j.ScalaBuildTarget
+import ch.epfl.scala.bsp4j.ScalaPlatform
+import com.google.gson.Gson
 
 /**
  *  Equivalent to scala.meta.internal.metals.MetalsEnrichments
@@ -70,6 +73,16 @@ object MetalsTestEnrichments {
         Nil.asJava,
         new BuildTargetCapabilities(true, true, true)
       )
+      val scalaTarget = new ScalaBuildTarget(
+        "org.scala-lang",
+        BuildInfo.scalaVersion,
+        BuildInfo.scalaVersion.split('.').take(2).mkString("."),
+        ScalaPlatform.JVM,
+        Nil.asJava
+      )
+      val gson = new Gson
+      val data = gson.toJsonTree(scalaTarget)
+      buildTarget.setData(data)
       val result = new WorkspaceBuildTargetsResult(List(buildTarget).asJava)
       wsp.buildTargets.addWorkspaceBuildTargets(result)
       val item = new ScalacOptionsItem(

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1020,11 +1020,11 @@ final class TestingServer(
 
   def buildTarget(displayName: String): String = {
     server.buildTargets.all
-      .find(_.info.getDisplayName() == displayName)
-      .map(_.info.getId().getUri())
+      .find(_.displayName == displayName)
+      .map(_.id.getUri())
       .getOrElse {
         val alternatives =
-          server.buildTargets.all.map(_.info.getDisplayName()).mkString(" ")
+          server.buildTargets.all.map(_.displayName).mkString(" ")
         throw new NoSuchElementException(
           s"$displayName (alternatives: ${alternatives}"
         )


### PR DESCRIPTION
Previously, we had to check if `ScalaTarget` is a Scala target, which was a bit confusing. Now, we include the target inside the ScalaTarget class and avoid running `asScalaBuildTarget` unneccessarily.

Overall, I think this makes sense and it annoyed me a bit when dealing with it. :sweat_smile: 