### PR TITLE
Rename file only if renamed symbol is directly enclosed by a package (closes #1380)

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -176,10 +176,11 @@ final class RenameProvider(
   ): Option[LSPEither[TextDocumentEdit, ResourceOperation]] = {
     fileChanges
       .find { file =>
-        isOccurence(str => {
+        isOccurence { str =>
+          str.owner.isPackage &&
           (str.desc.isType || str.desc.isTerm) &&
-            file.endsWith(s"/${str.desc.name.value}.scala")
-        })
+          file.endsWith(s"/${str.desc.name.value}.scala")
+        }
       }
       .map { file =>
         val newFile =

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -502,6 +502,17 @@ class RenameLspSuite extends BaseLspSuite("rename") {
     newName = "Animal"
   )
 
+  renamed(
+    "nested-symbol",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Foo {
+       |  object <<Ma@@in>>
+       |}
+       |""".stripMargin,
+    newName = "Child"
+  )
+
   def renamed(
       name: String,
       input: String,

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -510,7 +510,8 @@ class RenameLspSuite extends BaseLspSuite("rename") {
        |  object <<Ma@@in>>
        |}
        |""".stripMargin,
-    newName = "Child"
+    newName = "Child",
+    fileRenames = Map.empty
   )
 
   def renamed(


### PR DESCRIPTION
Previously, if a symbol was renamed that wasn't a top-level definition in the file but had a matching name, the file could be renamed. Now, the file will only be renamed if the symbol is only enclosed by a package.