### PR TITLE
Avoid long filename for Pants output file.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsConfiguration.scala
@@ -107,6 +107,9 @@ object PantsConfiguration {
       targets.map(_.replaceAll("[^a-zA-Z0-9]", "")).mkString
     if (processed.isEmpty()) {
       MD5.compute(targets.mkString) // necessary for targets like "::/"
+    } else if (processed.length() > 15) {
+      // Avoid too long filename.
+      s"${processed.take(15)}-${MD5.compute(targets.mkString)}"
     } else {
       processed
     }


### PR DESCRIPTION
Previously, when exporting a large number of Pants targets, the export
step would fail with an "File name too long" error. Now, we guarantee
the name is always short so the error doesn't happen.