### PR TITLE
Add .scalafmt.conf symbolic link when exporting Pants build.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -231,6 +231,26 @@ object BloopPants {
       Files.deleteIfExists(workspaceBloop)
       Files.createSymbolicLink(workspaceBloop, outBloop)
     }
+
+    val inScalafmt = {
+      val link = args.workspace.resolve(".scalafmt.conf")
+      // Configuration file may be symbolic link.
+      val relpath =
+        if (Files.isSymbolicLink(link)) Files.readSymbolicLink(link)
+        else link
+      // Symbolic link may be relative to workspace directory.
+      if (relpath.isAbsolute()) relpath
+      else args.workspace.resolve(relpath)
+    }
+    val outScalafmt = args.out.resolve(".scalafmt.conf")
+    if (!args.out.startsWith(args.workspace) &&
+      Files.exists(inScalafmt) && {
+        !Files.exists(outScalafmt) ||
+        Files.isSymbolicLink(outScalafmt)
+      }) {
+      Files.deleteIfExists(outScalafmt)
+      Files.createSymbolicLink(outScalafmt, inScalafmt)
+    }
   }
 
   private def runPantsExport(


### PR DESCRIPTION
Previously, when exporting the Pants build to a separate directory the
`.scalafmt.conf` file in the original build did not get detected in the
exported build. Now, we insert a symbolic link to the config in the
original Pants build.