### PR TITLE
Change config options to match coc

### DIFF
--- a/metals-docs/src/main/scala/docs/UserConfigurationModifier.scala
+++ b/metals-docs/src/main/scala/docs/UserConfigurationModifier.scala
@@ -62,7 +62,7 @@ class UserConfigurationModifier extends StringModifier {
                |**Example**:
                |```json
                |{
-               |  "metals.${option.key}": "${option.example}"
+               |  "metals.${option.camelCaseKey}": "${option.example}"
                |}
                |```
                |""".stripMargin

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfigurationOption.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfigurationOption.scala
@@ -15,4 +15,9 @@ case class UserConfigurationOption(
   def headerID: String = {
     title.toLowerCase().replace(' ', '-')
   }
+  def camelCaseKey: String =
+    key.split('-').toList match {
+      case head :: tail => head ++ tail.flatMap(_.capitalize)
+      case _ => key
+    }
 }


### PR DESCRIPTION
This pr changes the way the available config options for metals is displayed in the vim editor page. They are displayed with dashes by default, but when a user is setting them using `coc-metals` they are displayed in camel-case when in `:CocConfig`. This was on oversight when I re-did the docs. This corrects that (only on the vim editor page).