### PR TITLE
Fix exhaustive match completion on Java enums

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -1544,7 +1544,8 @@ trait Completions { this: MetalsGlobal =>
         isSnippet: Boolean = true
     ): TextEditMember = {
       sym.info // complete
-      if (sym.isCase || fsym.hasModuleFlag) {
+      val isModuleLike = fsym.hasModuleFlag || fsym.hasJavaEnumFlag
+      if (sym.isCase || isModuleLike) {
         // Syntax for deconstructing the symbol as an infix operator, for example `case head :: tail =>`
         val isInfixEligible =
           context.symbolIsInScope(sym) ||
@@ -1566,7 +1567,7 @@ trait Completions { this: MetalsGlobal =>
         val pattern = infixPattern.getOrElse {
           // Fallback to "apply syntax", example `case ::(head, tail) =>`
           val suffix =
-            if (fsym.hasModuleFlag) ""
+            if (isModuleLike) ""
             else {
               sym.primaryConstructor.paramss match {
                 case Nil => "()"

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -186,6 +186,34 @@ class CompletionMatchSuite extends BaseCompletionSuite {
     )
   )
 
+  checkEdit(
+    "exhaustive-java-enum",
+    """
+      |package example
+      |
+      |import java.nio.file.AccessMode
+      |
+      |object Main {
+      |  (null: AccessMode) match@@
+      |}""".stripMargin,
+    """
+      |package example
+      |
+      |import java.nio.file.AccessMode
+      |import java.nio.file.AccessMode.READ
+      |import java.nio.file.AccessMode.WRITE
+      |import java.nio.file.AccessMode.EXECUTE
+      |
+      |object Main {
+      |  (null: AccessMode) match {
+      |\tcase READ => $0
+      |\tcase WRITE =>
+      |\tcase EXECUTE =>
+      |}
+      |}""".stripMargin,
+    filter = _.contains("exhaustive")
+  )
+
   // https://github.com/scalameta/metals/issues/1253
   checkEdit(
     "exhaustive-fully-qualify".fail,


### PR DESCRIPTION
The exhaustive match completion was handling Java enums as if they were
types, whereas they should be matched as values, just like Scala modules
are. That is, the cases should have the form:

    case MyEnumValue =>

Rather than the current, invalid:

    case _: MyEnumValue =>