### PR TITLE
Enable verbose sbt loggers in CI.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,8 @@ def crossSetting[A](
     case _ => otherwise
   }
 
+val MUnitFramework = new TestFramework("munit.Framework")
+
 inThisBuild(
   List(
     version ~= { dynVer =>
@@ -339,7 +341,15 @@ lazy val testSettings: Seq[Def.Setting[_]] = List(
   Test / parallelExecution := false,
   skip.in(publish) := true,
   fork := true,
-  testFrameworks := List(new TestFramework("munit.Framework"))
+  testFrameworks := List(MUnitFramework),
+  testOptions.in(Test) ++= {
+    if (isCI) {
+      // Enable verbose logging using sbt loggers in CI.
+      List(Tests.Argument(MUnitFramework, "+l", "--verbose"))
+    } else {
+      Nil
+    }
+  }
 )
 
 lazy val mtest = project


### PR DESCRIPTION
Previously, we used the default MUnit test arguments when testing in CI.
In some cases, the CI logs haven't included recently what test suite
is failing so this change is an attempt to try and fix that by enabling
verbose loggers and telling MUnit to use the sbt loggers instead of
`System.out.println()`.