### PR TITLE
Improve logic to merge Pants targets.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/Args.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/Args.scala
@@ -22,6 +22,7 @@ case class Args(
     isVscode: Boolean = false,
     isLaunchIntelliJ: Boolean = false,
     isSources: Boolean = true,
+    isMergeTargetsInSameDirectory: Boolean = true,
     maxFileCount: Int = 5000,
     projectName: Option[String] = None,
     workspace: Path = PathIO.workingDirectory.toNIO,
@@ -64,6 +65,10 @@ case class Args(
        |    The name of the IntelliJ project to generate when using the  --intellij flag.
        |    Ignored when --intellij is not used. Defaults to the name of the directory
        |    containing the Pants build.
+       |  --merge-targets-in-same-directory
+       |    If enabled, automatically merge targets that are defined in the same directory.
+       |    Disabled by default. This option may help improve the experience in IntelliJ,
+       |    since IntelliJ only supports one module per base directory.
        |  --no-sources
        |    Do not download library sources of 3rd party dependencies.
        |
@@ -117,6 +122,13 @@ object Args {
         )
       case "--regenerate" :: tail =>
         parse(tail, base.copy(isRegenerate = true))
+      case "--merge-targets-in-same-directory" :: tail =>
+        parse(
+          tail,
+          base.copy(
+            isMergeTargetsInSameDirectory = true
+          )
+        )
       case "--intellij" :: tail =>
         parse(tail, base.copy(isIntelliJ = true, isLaunchIntelliJ = true))
       case "--vscode" :: tail =>

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/Graph.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/Graph.scala
@@ -23,6 +23,16 @@ object Graph {
     }
     Graph(Value.Str(""), index.apply _, rindex.apply _, edges)
   }
+  def fromTargets(targets: IndexedSeq[PantsTarget]): Graph = {
+    val edges = new Array[Array[Int]](targets.length)
+    val index = targets.map(_.name).zipWithIndex.toMap
+    val rindex = index.map(_.swap).toMap
+    targets.zipWithIndex.foreach {
+      case (project, i) =>
+        edges(i) = project.dependencies.iterator.map(index).toArray
+    }
+    Graph(Value.Str(""), index.apply _, rindex.apply _, edges)
+  }
   def fromExport(export: Value): Graph = {
     val targets = export.obj("targets").obj
     val index = targets.keysIterator.zipWithIndex.toMap

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsConfiguration.scala
@@ -33,9 +33,15 @@ object PantsConfiguration {
     new BuildTargetIdentifier(uri.toString())
   }
 
+  def baseDirectoryString(target: String): String = {
+    val colon = target.lastIndexOf(':')
+    if (colon < 0) target
+    else target.substring(0, colon)
+  }
+
   /** Returns the nearest enclosing directory of a Pants target */
   def baseDirectory(workspace: AbsolutePath, target: String): AbsolutePath = {
-    workspace.resolve(target.substring(0, target.lastIndexOf(':')))
+    workspace.resolve(baseDirectoryString(target))
   }
 
   def pantsTargetsFromGson(
@@ -107,9 +113,9 @@ object PantsConfiguration {
       targets.map(_.replaceAll("[^a-zA-Z0-9]", "")).mkString
     if (processed.isEmpty()) {
       MD5.compute(targets.mkString) // necessary for targets like "::/"
-    } else if (processed.length() > 15) {
+    } else if (processed.length() > 30) {
       // Avoid too long filename.
-      s"${processed.take(15)}-${MD5.compute(targets.mkString)}"
+      s"${processed.take(15)}...${processed.takeRight(15)}-${MD5.compute(targets.mkString)}"
     } else {
       processed
     }

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTargetType.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTargetType.scala
@@ -8,6 +8,7 @@ case class PantsTargetType(value: String) {
   def isTarget: Boolean = value == "target"
   def isResources: Boolean = value == "resources"
   def isJavaTests: Boolean = value == "java_tests"
+  def isJUnitTests: Boolean = value == "junit_tests"
   def isJavaLibrary: Boolean = value == "java_library"
   def isJavaThriftLibrary: Boolean = value == "java_thrift_library"
   def isJavaAntlrLibrary: Boolean = value == "java_antrl_library"
@@ -15,6 +16,8 @@ case class PantsTargetType(value: String) {
   def isFiles: Boolean = value == "files"
   def isAlias: Boolean = value == "alias"
   def isNodeModule: Boolean = value == "node_module"
+
+  def isScalaOrJavaLibrary: Boolean = isScalaLibrary || isJavaLibrary
   def isSupported: Boolean =
     !PantsTargetType.unsupportedTargetType.contains(value)
 }


### PR DESCRIPTION
There are cases where we automatically merge multiple Pants targets into
a single Bloop project. For example, this is needed for Pants targets
that use the `java_sources` option since those dependencies translate
into cyclic dependencies in the output of `./pants export`.

Previously, the logic for merging targets did not always work correctly.
This commit fixes several issues in the logic so that we can merge
almost any two targets more reliably.

Merging targets is not always be safe, for example when two targets
have dependencies with conflicting binary APIs. However, merging targets
can be helpful to either improve compilation performance (reduced number
of targets) or improve the IDE experience (IntelliJ doesn't support multiple
targets in the same directory)