### PR TITLE
Return all rename file changes up to a threshold

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -379,7 +379,8 @@ class MetalsLanguageServer(
       workspace,
       languageClient,
       buffers,
-      compilations
+      compilations,
+      config
     )
     semanticDBIndexer =
       new SemanticdbIndexer(referencesProvider, implementationProvider)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -3,8 +3,6 @@ package scala.meta.internal.metals
 import scala.meta.internal.metals.Configs._
 import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
-import scala.util.Success
-import scala.util.Try
 
 /**
  * Configuration parameters for the Metals language server.
@@ -57,14 +55,8 @@ final case class MetalsServerConfig(
       "metals.warnings",
       default = true
     ),
-    openFilesOnRenames: Boolean = MetalsServerConfig.binaryOption(
-      "metals.open-files-on-rename",
-      default = false
-    ),
-    renameFileThreshold: Int = MetalsServerConfig.intOption(
-      "metals.rename-file-threshold",
-      default = 300
-    ),
+    openFilesOnRenames: Boolean = false,
+    renameFileThreshold: Int = 300,
     bloopEmbeddedVersion: String = System.getProperty(
       "bloop.embedded.version",
       BuildInfo.bloopVersion
@@ -97,25 +89,11 @@ object MetalsServerConfig {
       case Some("false" | "off") => false
       case Some(other) =>
         scribe.warn(
-          s"Invalid property, required 'true|on' or 'false|off', but got '$other'. Using the default value '$default'"
+          s"Invalid value for property '$key', required 'true|on' or 'false|off', but got '$other'. Using the default value '$default'"
         )
         default
       case None => default
     }
-  def intOption(key: String, default: Int): Int = {
-    sys.props.get(key) match {
-      case Some(property) =>
-        Try(property.toInt) match {
-          case Success(value) => value
-          case _ =>
-            scribe.warn(
-              s"Invalid property, required Int, but got '$property'. Using the default value '$default'"
-            )
-            default
-        }
-      case None => default
-    }
-  }
 
   def base: MetalsServerConfig = MetalsServerConfig()
   def default: MetalsServerConfig = {

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -1,4 +1,5 @@
 package scala.meta.internal.rename
+
 import scala.meta.internal.metals.ReferenceProvider
 import org.eclipse.lsp4j.RenameParams
 import org.eclipse.lsp4j.WorkspaceEdit
@@ -23,8 +24,6 @@ import org.eclipse.lsp4j.MessageType
 import org.eclipse.lsp4j.{Range => LSPRange}
 import org.eclipse.lsp4j.jsonrpc.messages.{Either => LSPEither}
 import scala.meta.internal.metals.Buffers
-import java.net.URI
-import java.nio.file.Paths
 import scala.meta.internal.metals.TextEdits
 import scala.meta.internal.metals.Compilations
 import org.eclipse.lsp4j.TextDocumentEdit
@@ -35,6 +34,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import scala.meta.internal.async.ConcurrentQueue
 import scala.meta.internal.semanticdb.Synthetic
 import scala.meta.internal.semanticdb.SelectTree
+import scala.meta.internal.metals.MetalsServerConfig
 
 final class RenameProvider(
     referenceProvider: ReferenceProvider,
@@ -45,7 +45,8 @@ final class RenameProvider(
     workspace: AbsolutePath,
     client: MetalsLanguageClient,
     buffers: Buffers,
-    compilations: Compilations
+    compilations: Compilations,
+    metalsConfig: MetalsServerConfig
 ) {
 
   private var awaitingSave = new ConcurrentLinkedQueue[() => Unit]
@@ -135,14 +136,21 @@ final class RenameProvider(
         val textEdits = for (loc <- locs) yield {
           textEdit(isOccurence, loc, params.getNewName())
         }
-        Seq(uri -> textEdits.toList)
+        Seq(uri.toAbsolutePath -> textEdits.toList)
       }
       val fileChanges = allChanges.flatten.toMap
-      val (openedEdits, closedEdits) = fileChanges.partition {
-        case (file, edits) =>
-          val path = AbsolutePath(Paths.get(new URI(file)))
-          buffers.contains(path)
-      }
+      val (openedEdits, closedEdits) =
+        if (!metalsConfig.openFilesOnRenames || fileChanges.keySet.size >= metalsConfig.renameFileThreshold) {
+          if (metalsConfig.openFilesOnRenames) {
+            client.showMessage(fileThreshold(fileChanges.keySet.size))
+          }
+          fileChanges.partition {
+            case (path, edits) =>
+              buffers.contains(path)
+          }
+        } else {
+          (fileChanges, Map.empty[AbsolutePath, List[TextEdit]])
+        }
 
       awaitingSave.add(() => changeClosedFiles(closedEdits))
 
@@ -158,12 +166,12 @@ final class RenameProvider(
   }
 
   private def documentEdits(
-      openedEdits: Map[String, List[TextEdit]]
+      openedEdits: Map[AbsolutePath, List[TextEdit]]
   ): List[LSPEither[TextDocumentEdit, ResourceOperation]] = {
     openedEdits.map {
       case (file, edits) =>
         val textId = new VersionedTextDocumentIdentifier()
-        textId.setUri(file)
+        textId.setUri(file.toURI.toString())
         val ed = new TextDocumentEdit(textId, edits.asJava)
         LSPEither.forLeft[TextDocumentEdit, ResourceOperation](ed)
     }.toList
@@ -171,7 +179,7 @@ final class RenameProvider(
 
   private def fileRenames(
       isOccurence: (String => Boolean) => Boolean,
-      fileChanges: Set[String],
+      fileChanges: Set[AbsolutePath],
       newName: String
   ): Option[LSPEither[TextDocumentEdit, ResourceOperation]] = {
     fileChanges
@@ -179,14 +187,15 @@ final class RenameProvider(
         isOccurence { str =>
           str.owner.isPackage &&
           (str.desc.isType || str.desc.isTerm) &&
-          file.endsWith(s"/${str.desc.name.value}.scala")
+          file.toString.endsWith(s"/${str.desc.name.value}.scala")
         }
       }
       .map { file =>
+        val uri = file.toURI.toString
         val newFile =
-          file.replaceAll("/[^/]+\\.scala$", s"/$newName.scala")
+          uri.replaceAll("/[^/]+\\.scala$", s"/$newName.scala")
         LSPEither.forRight[TextDocumentEdit, ResourceOperation](
-          new RenameFile(file, newFile)
+          new RenameFile(uri, newFile)
         )
       }
   }
@@ -223,13 +232,14 @@ final class RenameProvider(
     )
   }
 
-  private def changeClosedFiles(fileEdits: Map[String, List[TextEdit]]) = {
+  private def changeClosedFiles(
+      fileEdits: Map[AbsolutePath, List[TextEdit]]
+  ) = {
     fileEdits.toArray.par.foreach {
       case (file, changes) =>
-        val path = AbsolutePath(Paths.get(new URI(file)))
-        val text = path.readText
+        val text = file.readText
         val newText = TextEdits.applyEdits(text, changes)
-        path.writeText(newText)
+        file.writeText(newText)
     }
   }
 
@@ -355,6 +365,16 @@ final class RenameProvider(
       new TextDocumentIdentifier(location.getUri()),
       location.getRange().getStart()
     )
+  }
+
+  private def fileThreshold(
+      files: Int
+  ): MessageParams = {
+    val message =
+      s"""|Renamed symbol is present in over $files files.
+          |It will be renamed outside the editor in the background, 
+          |otherwise the editor might become unresponsive.""".stripMargin
+    new MessageParams(MessageType.Warning, message)
   }
 
   private def javaSymbol(

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -190,7 +190,7 @@ final class RenameProvider(
         isOccurence { str =>
           str.owner.isPackage &&
           (str.desc.isType || str.desc.isTerm) &&
-          file.toString.endsWith(s"/${str.desc.name.value}.scala")
+          file.toURI.toString.endsWith(s"/${str.desc.name.value}.scala")
         }
       }
       .map { file =>


### PR DESCRIPTION
Previously, we would only send edits for open files when renaming. This causes an issue if the user wants to see a preview of all files.

Now, this changed to return up to threshold number of files for VS Code, so that preview can work correctly. The behavior is unchanged for other editors, since it might be problematic to save all files there.

![preview](https://user-images.githubusercontent.com/3807253/74045493-27053f00-49cd-11ea-9f53-af3b330d98cd.gif)

Tested on ZIO and Akka, where there were over 200 files changed. It seems VS code is much more optimized now.

ZIO example:

![preview2](https://user-images.githubusercontent.com/3807253/74045503-2b315c80-49cd-11ea-9e47-9909191f914c.gif)
