### PR TITLE
Remove check for focused document on non-supporting editors

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1816,8 +1816,12 @@ class MetalsLanguageServer(
   ): Future[Unit] = {
     paths
       .find { path =>
-        focusedDocument.contains(path) &&
-        path.isWorksheet
+        if (focusedDocument.isDefined) {
+          focusedDocument.contains(path) &&
+          path.isWorksheet
+        } else {
+          path.isWorksheet
+        }
       }
       .fold(Future.successful(()))(
         worksheetProvider.evaluateAndPublish(_, EmptyCancelToken)


### PR DESCRIPTION
Fixes #1258 

~This may not be the most elegant solution, but it seems to do the trick. This PR introduces a private`clientSupportsDidFocus` var in `MetalsLanguageServer` that defaults to false. This will help clients that don't support `didFocusTextDocument` to be able to move back and forth between scala files and worksheets correctly. In it's current state, this won't work once you leave the worksheet. This fixes that issue.~

~It does feel a bit eh doing it like this, so one alternative would be to just make this a client config value which defaults to false, and then for example in `coc-metals` and `vs code` we can have it set to true. Then, any other client that starts to support this, like the `lsp-mode` emacs folks https://github.com/emacs-lsp/lsp-mode/pull/1353, then they'd also have to pass in the property set to true. I sort of think this might be cleaner, but then it introduces another property we'd have to set. Thoughts?~

EDIT: A way simpler solution. This pr just adds in a check to see if the `focusDocument` is defined. If so, it means that the editor supports `didFocusTextDocument`. If that is true, we do an extra check to ensure that the worksheet is focused before re-publishing. If not, then we always re-publish.