### PR TITLE
Use workspace level Gradle wrapper if present

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -78,7 +78,7 @@ case class GradleBuildTool(userConfig: () => UserConfiguration)
         script :: cmd
       case None =>
         val workspaceGradle = workspaceGradleLauncher(workspace)
-        if (workspaceGradle.toFile.exists())
+        if (workspaceGradle.isFile)
           workspaceGradle.toString() :: cmd
         else
           embeddedGradleLauncher.toString() :: cmd


### PR DESCRIPTION
For build import: choose workspace Gradle wrapper if present over downloading version 5.3.1
Update minimum Gradle version to 4.3 as that is the minimum Bloop now supports