### PR TITLE
Send stackTraces as paths rather than URIs

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
@@ -97,7 +97,7 @@ private[debug] final class DebugProxy(
         case frame =>
           sourcePathProvider.findPathFor(frame.getSource) match {
             case Some(path) =>
-              frame.getSource.setPath(path.toURI.toString)
+              frame.getSource.setPath(adapters.adaptPathForClient(path))
             case None =>
               // don't send invalid source if we couldn't adapt it
               frame.setSource(null)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/SetBreakpointsRequestHandler.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/SetBreakpointsRequestHandler.scala
@@ -21,7 +21,8 @@ private[debug] final class SetBreakpointsRequestHandler(
   def apply(
       request: SetBreakpointsArguments
   ): Future[SetBreakpointsResponse] = {
-    val path = adapters.adaptPath(request.getSource.getPath).toAbsolutePath
+    val path =
+      adapters.adaptPathForServer(request.getSource.getPath).toAbsolutePath
 
     val topLevels = Mtags.allToplevels(path.toInput)
     val occurrences = path.toLanguage match {


### PR DESCRIPTION
I'm trying to launch debugger from vim. I use this plugin
https://github.com/puremourning/vimspector

It starts and does first initialization query:
```
{
  "type": "request",
  "seq": 1,
  "command": "initialize",
  "arguments": {
    ....
    "pathFormat": "path",
    ....
  }
}
```
But even if it sets `pathFormat` to "path", metals returns path as URI in stackTraces (I get this log from dap-client.trace.json):
```
{
  "type": "response",
  "command": "stackTrace",
  "body": {
    "stackFrames": [
      {
        "id": 1,
        "source": {
          "name": "Test.scala",
          "path": "file:///home/dbykov/reps/test/src/main/scala/test/Test.scala",
          "sourceReference": 0
        },
      },
      ....
   ]
}
```

This breaks vimspector. I check dap-client.trace.json from python debugger and it returns these paths in path format.

So I made small change to send path depending on `pathFormat`. It fixes vimspector. I also did quick test in VScode and it still works.

What do you think?