### PR TITLE
Refactor: split Completions.scala into smaller files

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -345,11 +345,11 @@ class CompletionProvider(
         CompletionResult.NoResults,
         getLastVisitedParentTrees(pos)
       ) match {
-        case CompletionPosition.None =>
+        case NoneCompletion =>
           logger.warning(e.getMessage)
           (
             InterestingMembers(Nil, SymbolSearch.Result.COMPLETE),
-            CompletionPosition.None,
+            NoneCompletion,
             editRange,
             noQuery
           )

--- a/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Completions.scala
@@ -1,16 +1,11 @@
 package scala.meta.internal.pc
 
-import java.lang.StringBuilder
-import java.net.URI
-import java.nio.file.Paths
 import java.util.logging.Level
 
 import org.eclipse.{lsp4j => l}
 
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 import scala.meta.internal.jdk.CollectionConverters._
-import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.tokenizers.Chars
 import scala.util.control.NonFatal
@@ -411,14 +406,14 @@ trait Completions { this: MetalsGlobal =>
         ident: Ident,
         apply: Apply
     ): CompletionPosition = {
-      if (CompletionPosition.hasLeadingBrace(ident, text)) {
+      if (hasLeadingBrace(ident, text)) {
         if (isCasePrefix(ident.name)) {
-          CompletionPosition.CaseKeyword(EmptyTree, editRange, pos, text, apply)
+          CaseKeyword(EmptyTree, editRange, pos, text, apply)
         } else {
           CompletionPosition.None
         }
       } else {
-        CompletionPosition.Arg(ident, apply, pos, text, completions)
+        Arg(ident, apply, pos, text, completions)
       }
     }
 
@@ -435,13 +430,13 @@ trait Completions { this: MetalsGlobal =>
       case (ident: Ident) :: (_: Select) :: (_: Assign) :: (a: Apply) :: _ =>
         fromIdentApply(ident, a)
       case Ident(_) :: PatternMatch(c, m) =>
-        CompletionPosition.CasePattern(isTyped = false, c, m)
+        CasePattern(isTyped = false, c, m)
       case Ident(_) :: Typed(_, _) :: PatternMatch(c, m) =>
-        CompletionPosition.CasePattern(isTyped = true, c, m)
+        CasePattern(isTyped = true, c, m)
       case (lit @ Literal(Constant(_: String))) :: head :: _ =>
         isPossibleInterpolatorSplice(pos, text) match {
           case Some(i) =>
-            CompletionPosition.InterpolatorScope(lit, pos, i, text)
+            InterpolatorScope(lit, pos, i, text)
           case _ =>
             isPossibleInterpolatorMember(lit, head, text, pos)
               .getOrElse(CompletionPosition.None)
@@ -469,15 +464,15 @@ trait Completions { this: MetalsGlobal =>
           _ => true
         )
       case (m @ Match(_, Nil)) :: parent :: _ =>
-        CompletionPosition.CaseKeyword(m.selector, editRange, pos, text, parent)
+        CaseKeyword(m.selector, editRange, pos, text, parent)
       case Ident(name) :: (_: CaseDef) :: (m: Match) :: parent :: _
           if isCasePrefix(name) =>
-        CompletionPosition.CaseKeyword(m.selector, editRange, pos, text, parent)
+        CaseKeyword(m.selector, editRange, pos, text, parent)
       case (ident @ Ident(name)) :: Block(_, expr) :: (_: CaseDef) :: (m: Match) :: parent :: _
           if ident == expr && isCasePrefix(name) =>
-        CompletionPosition.CaseKeyword(m.selector, editRange, pos, text, parent)
+        CaseKeyword(m.selector, editRange, pos, text, parent)
       case (c: DefTree) :: (p: PackageDef) :: _ if c.namePos.includes(pos) =>
-        CompletionPosition.Filename(c, p, pos, editRange)
+        Filename(c, p, pos, editRange)
       case (ident: Ident) :: (t: Template) :: _ =>
         Override(
           ident.name,
@@ -498,124 +493,7 @@ trait Completions { this: MetalsGlobal =>
     }
   }
 
-  def isCasePrefix(name: Name): Boolean = {
-    val prefix = name.decoded.stripSuffix(CURSOR)
-    Set("c", "ca", "cas", "case").contains(prefix)
-  }
-
-  def interpolatorMemberArg(parent: Tree, lit: Literal): Option[Ident] =
-    parent match {
-      case Apply(
-          Select(
-            Apply(Ident(TermName("StringContext")), _ :: parts),
-            _
-          ),
-          args
-          ) =>
-        parts.zip(args).collectFirst {
-          case (`lit`, i: Ident) => i
-        }
-      case _ =>
-        None
-    }
-
-  def interpolatorMemberSelect(lit: Literal): Option[String] = lit match {
-    case Literal(Constant(s: String)) =>
-      if (s.startsWith(s".$CURSOR")) Some("")
-      else if (s.startsWith(".") &&
-        s.length > 2 &&
-        s.charAt(1).isUnicodeIdentifierStart) {
-        val cursor = s.indexOf(CURSOR)
-        if (cursor < 0) None
-        else {
-          val isValidIdentifier =
-            2.until(cursor).forall(i => s.charAt(i).isUnicodeIdentifierPart)
-          if (isValidIdentifier) {
-            Some(s.substring(1, cursor))
-          } else {
-            None
-          }
-        }
-      } else {
-        None
-      }
-    case _ =>
-      None
-  }
-
-  def isPossibleInterpolatorMember(
-      lit: Literal,
-      parent: Tree,
-      text: String,
-      cursor: Position
-  ): Option[CompletionPosition.InterpolatorType] = {
-    for {
-      query <- interpolatorMemberSelect(lit)
-      if text.charAt(lit.pos.point - 1) != '}'
-      arg <- interpolatorMemberArg(parent, lit)
-    } yield {
-      CompletionPosition.InterpolatorType(
-        query,
-        arg,
-        lit,
-        cursor,
-        text
-      )
-    }
-  }
-
-  case class InterpolationSplice(
-      dollar: Int,
-      name: String,
-      needsBraces: Boolean
-  )
-  def isPossibleInterpolatorSplice(
-      pos: Position,
-      text: String
-  ): Option[InterpolationSplice] = {
-    val offset = pos.point
-    val chars = pos.source.content
-    var i = offset
-    while (i > 0 && (chars(i) match { case '$' | '\n' => false; case _ => true })) {
-      i -= 1
-    }
-    val isCandidate = i > 0 &&
-      chars(i) == '$' && {
-      val start = chars(i + 1) match {
-        case '{' => i + 2
-        case _ => i + 1
-      }
-      start == offset || {
-        chars(start).isUnicodeIdentifierStart &&
-        (start + 1).until(offset).forall(j => chars(j).isUnicodeIdentifierPart)
-      }
-    }
-    if (isCandidate) {
-      val name = chars(i + 1) match {
-        case '{' => text.substring(i + 2, offset)
-        case _ => text.substring(i + 1, offset)
-      }
-      Some(
-        InterpolationSplice(
-          i,
-          name,
-          needsBraces = text.charAt(i + 1) == '{' ||
-            (text.charAt(offset) match {
-              case '"' => false // end of string literal
-              case ch => ch.isUnicodeIdentifierPart
-            })
-        )
-      )
-    } else {
-      None
-    }
-  }
-
-  def isMatchPrefix(name: Name): Boolean =
-    name.endsWith(CURSOR) &&
-      "match".startsWith(name.toString().stripSuffix(CURSOR))
-
-  def inferCompletionPosition(
+  private def inferCompletionPosition(
       pos: Position,
       text: String,
       enclosing: List[Tree],
@@ -632,7 +510,7 @@ trait Completions { this: MetalsGlobal =>
             case t: CompletionResult.TypeMembers =>
               t.results.collectFirst {
                 case result if result.prefix.isDefined =>
-                  CompletionPosition.MatchKeyword(
+                  MatchKeyword(
                     result.prefix,
                     editRange,
                     pos,
@@ -672,6 +550,7 @@ trait Completions { this: MetalsGlobal =>
       case _ =>
         CompletionPosition.None
     }
+
   }
 
   object CompletionPosition {
@@ -690,708 +569,8 @@ trait Completions { this: MetalsGlobal =>
       override def isNew: Boolean = true
     }
 
-    /**
-     * A completion to select type members inside string interpolators.
-     *
-     * Example: {{{
-     *   // before
-     *   s"Hello $name.len@@!"
-     *   // after
-     *   s"Hello ${name.length()$0}"
-     * }}}
-     *
-     * @param query the member query, "len" in the  example above.
-     * @param ident the identifier from where we select a member from, "name" above.
-     * @param literalPart the string literal part of the interpolator trailing
-     *                    the identifier including cursor instrumentation, "len_CURSOR_!"
-     *                    in the example above.
-     * @param cursor the cursor position where the completion is triggered, `@@` in the example above.
-     * @param text the text of the original source file without `_CURSOR_` instrumentation.
-     */
-    case class InterpolatorType(
-        query: String,
-        ident: Ident,
-        literalPart: Literal,
-        cursor: Position,
-        text: String
-    ) extends CompletionPosition {
-      val pos: l.Range = ident.pos.withEnd(cursor.point).toLSP
-      def newText(sym: Symbol): String = {
-        new StringBuilder()
-          .append('{')
-          .append(text, ident.pos.start, ident.pos.end)
-          .append('.')
-          .append(Identifier.backtickWrap(sym.getterName.decoded))
-          .append(sym.snippetCursor)
-          .append('}')
-          .toString
-      }
-      val filter: String =
-        text.substring(ident.pos.start - 1, cursor.point - query.length)
-      override def contribute: List[Member] = {
-        metalsTypeMembers(ident.pos).collect {
-          case m if CompletionFuzzy.matches(query, m.sym.name) =>
-            val edit = new l.TextEdit(pos, newText(m.sym))
-            val filterText = filter + m.sym.name.decoded
-            new TextEditMember(filterText, edit, m.sym)
-        }
-      }
-    }
-
-    /**
-     * A completion to convert a string literal into a string literal, example `"Hello $na@@"`.
-     *
-     * When converting a string literal into an interpolator we need to ensure a few cases:
-     *
-     * - escape existing `$` characters into `$$`, which are printed as `\$\$` in order to
-     *   escape the TextMate snippet syntax.
-     * - wrap completed name in curly braces `s"Hello ${name}_` when the trailing character
-     *   can be treated as an identifier part.
-     * - insert the  leading `s` interpolator.
-     * - place the cursor at the end of the completed name using TextMate `$0` snippet syntax.
-     *
-     * @param lit The string literal, includes an instrumented `_CURSOR_` that we need to handle.
-     * @param pos The offset position of the cursor, right below `@@_CURSOR_`.
-     * @param interpolator Metadata about this interpolation, the location of the leading dollar
-     *                     character and whether the completed name needs to be wrapped in
-     *                     curly braces.
-     * @param text The text of the original source code without the instrumented `_CURSOR_`.
-     */
-    case class InterpolatorScope(
-        lit: Literal,
-        pos: Position,
-        interpolator: InterpolationSplice,
-        text: String
-    ) extends CompletionPosition {
-
-      val offset: Int =
-        if (lit.pos.focusEnd.line == pos.line) CURSOR.length else 0
-      val nameStart: Position =
-        pos.withStart(pos.start - interpolator.name.size)
-      val nameRange = nameStart.toLSP
-      val hasClosingBrace: Boolean = text.charAt(pos.point) == '}'
-      val hasOpeningBrace: Boolean = text.charAt(
-        pos.start - interpolator.name.size - 1
-      ) == '{'
-
-      def additionalEdits(): List[l.TextEdit] = {
-        val interpolatorEdit =
-          if (text.charAt(lit.pos.start - 1) != 's')
-            List(new l.TextEdit(lit.pos.withEnd(lit.pos.start).toLSP, "s"))
-          else Nil
-        val dollarEdits = for {
-          i <- lit.pos.start to (lit.pos.end - CURSOR.length())
-          if text.charAt(i) == '$' && i != interpolator.dollar
-        } yield new l.TextEdit(pos.source.position(i).withEnd(i).toLSP, "$")
-        interpolatorEdit ++ dollarEdits
-      }
-
-      def newText(sym: Symbol): String = {
-        val out = new StringBuilder()
-        val symbolName = sym.getterName.decoded
-        val identifier = Identifier.backtickWrap(symbolName)
-        val symbolNeedsBraces =
-          interpolator.needsBraces ||
-            identifier.startsWith("`") ||
-            sym.isNonNullaryMethod
-        if (symbolNeedsBraces && !hasOpeningBrace) {
-          out.append('{')
-        }
-        out.append(identifier)
-        out.append(sym.snippetCursor)
-        if (symbolNeedsBraces && !hasClosingBrace) {
-          out.append('}')
-        }
-        out.toString
-      }
-
-      val filter: String =
-        text.substring(lit.pos.start, pos.point - interpolator.name.length)
-
-      override def contribute: List[Member] = {
-        metalsScopeMembers(pos).collect {
-          case s: ScopeMember
-              if CompletionFuzzy.matches(interpolator.name, s.sym.name) =>
-            val edit = new l.TextEdit(nameRange, newText(s.sym))
-            val filterText = filter + s.sym.name.decoded
-            new TextEditMember(
-              filterText,
-              edit,
-              s.sym,
-              additionalTextEdits = additionalEdits()
-            )
-        }
-      }
-    }
-
-    /**
-     * Completion for the name of a toplevel class, trait or object matching the filename.
-     *
-     * Example: {{{
-     *   // src/main/scala/app/UserDatabaseService.scala
-     *   class User@@ // completes "UserDatabaseService"
-     * }}}
-     *
-     * @param toplevel the toplevel class, trait or object definition.
-     * @param pkg the enclosing package definition.
-     * @param pos the completion position.
-     * @param editRange the range to replace in the completion.
-     */
-    case class Filename(
-        toplevel: DefTree,
-        pkg: PackageDef,
-        pos: Position,
-        editRange: l.Range
-    ) extends CompletionPosition {
-      val query: String = toplevel.name.toString().stripSuffix(CURSOR)
-      override def contribute: List[Member] = {
-        try {
-          val name = Paths
-            .get(URI.create(pos.source.file.name))
-            .getFileName()
-            .toString()
-            .stripSuffix(".scala")
-          val isTermName = toplevel.name.isTermName
-          val siblings = pkg.stats.count {
-            case d: DefTree =>
-              d.name.toString() == name &&
-                d.name.isTermName == isTermName
-            case _ => false
-          }
-          if (!name.isEmpty &&
-            CompletionFuzzy.matches(query, name) &&
-            siblings == 0) {
-            List(
-              new TextEditMember(
-                name,
-                new l.TextEdit(editRange, name),
-                toplevel.symbol
-                  .newErrorSymbol(TermName(name))
-                  .setInfo(NoType),
-                label = Some(s"${toplevel.symbol.keyString} ${name}")
-              )
-            )
-          } else {
-            Nil
-          }
-        } catch {
-          case NonFatal(e) =>
-            Nil
-        }
-      }
-    }
-
     case object None extends CompletionPosition
 
-    /** Returns true if the identifier comes after an opening brace character '{' */
-    def hasLeadingBrace(ident: Ident, text: String): Boolean = {
-      val openDelim: Int = {
-        var start = ident.pos.start - 1
-        while (start > 0 && text.charAt(start).isWhitespace) {
-          start -= 1
-        }
-        start
-      }
-      text.length > openDelim &&
-      openDelim >= 0 &&
-      text.charAt(openDelim) == '{'
-    }
-
-    case class Arg(
-        ident: Ident,
-        apply: Apply,
-        pos: Position,
-        text: String,
-        completions: CompletionResult
-    ) extends CompletionPosition {
-      val editRange: l.Range =
-        pos.withStart(ident.pos.start).withEnd(pos.start).toLSP
-      val method: Tree = typedTreeAt(apply.fun.pos)
-      val methodSym = method.symbol
-      lazy val baseParams: List[Symbol] =
-        if (method.tpe == null) Nil
-        else {
-          method.tpe.paramss.headOption
-            .getOrElse(methodSym.paramss.flatten)
-        }
-      lazy val isNamed: Set[Name] = apply.args.iterator
-        .filterNot(_ == ident)
-        .zip(baseParams.iterator)
-        .map {
-          case (AssignOrNamedArg(Ident(name), _), _) =>
-            name
-          case (_, param) =>
-            param.name
-        }
-        .toSet
-      val prefix: String = ident.name.toString.stripSuffix(CURSOR)
-      lazy val allParams: List[Symbol] = {
-        baseParams.iterator.filterNot { param =>
-          isNamed(param.name) ||
-          param.name.containsChar('$') // exclude synthetic parameters
-        }.toList
-      }
-      lazy val params: List[Symbol] =
-        allParams.filter(param => param.name.startsWith(prefix))
-      lazy val isParamName: Set[String] = params.iterator
-        .map(_.name)
-        .filterNot(isNamed)
-        .map(_.toString().trim())
-        .toSet
-
-      override def isCandidate(member: Member): Boolean = true
-
-      def isName(m: Member): Boolean =
-        isParamName(m.sym.nameString.trim())
-
-      override def compare(o1: Member, o2: Member): Int = {
-        val byName = -java.lang.Boolean.compare(isName(o1), isName(o2))
-        if (byName != 0) byName
-        else {
-          java.lang.Boolean.compare(
-            o1.isInstanceOf[NamedArgMember],
-            o2.isInstanceOf[NamedArgMember]
-          )
-        }
-      }
-
-      override def isPrioritized(member: Member): Boolean = {
-        member.isInstanceOf[NamedArgMember] ||
-        isParamName(member.sym.name.toString().trim())
-      }
-
-      private def matchingTypesInScope(
-          paramType: Type
-      ): List[String] = {
-
-        def notNothingOrNull(mem: ScopeMember): Boolean = {
-          !(mem.sym.tpe =:= definitions.NothingTpe || mem.sym.tpe =:= definitions.NullTpe)
-        }
-
-        completions match {
-          case CompletionResult.ScopeMembers(positionDelta, results, name) =>
-            results
-              .collect {
-                case mem
-                    if mem.sym.tpe <:< paramType && notNothingOrNull(mem) && mem.sym.isTerm =>
-                  mem.sym.name.toString().trim()
-              }
-              // None and Nil are always in scope
-              .filter(name => name != "Nil" && name != "None")
-          case _ =>
-            Nil
-        }
-      }
-
-      private def findDefaultValue(param: Symbol): String = {
-        val matchingType = matchingTypesInScope(param.tpe)
-        if (matchingType.size == 1) {
-          s":${matchingType.head}"
-        } else if (matchingType.size > 1) {
-          s"|???,${matchingType.mkString(",")}|"
-        } else {
-          ":???"
-        }
-      }
-
-      private def fillAllFields(): List[TextEditMember] = {
-        val suffix = "autofill"
-        val shouldShow =
-          allParams.exists(param => param.name.startsWith(prefix))
-        val isExplicitlyCalled = suffix.startsWith(prefix)
-        val hasParamsToFill = allParams.count(!_.hasDefault) > 1
-        if ((shouldShow || isExplicitlyCalled) && hasParamsToFill && clientSupportsSnippets) {
-          val editText = allParams.zipWithIndex
-            .collect {
-              case (param, index) if !param.hasDefault =>
-                s"${param.name} = $${${index + 1}${findDefaultValue(param)}}"
-            }
-            .mkString(", ")
-          val edit = new l.TextEdit(editRange, editText)
-          List(
-            new TextEditMember(
-              filterText = s"$prefix-$suffix",
-              edit = edit,
-              methodSym,
-              label = Some("Autofill with default values")
-            )
-          )
-        } else {
-          List.empty
-        }
-      }
-
-      private def findPossibleDefaults(): List[TextEditMember] = {
-        params.flatMap { param =>
-          val allMemebers = matchingTypesInScope(param.tpe)
-          allMemebers.map { memberName =>
-            val editText = param.name + " = " + memberName
-            val edit = new l.TextEdit(editRange, editText)
-            new TextEditMember(
-              filterText = param.name.toString(),
-              edit = edit,
-              completionsSymbol(s"$param=$memberName"),
-              label = Some(editText),
-              detail = Some(" : " + param.tpe)
-            )
-          }
-        }
-      }
-
-      override def contribute: List[Member] = {
-        params.map(param => new NamedArgMember(param)) ::: findPossibleDefaults() ::: fillAllFields()
-      }
-    }
-
-    /**
-     * A `match` keyword completion to generate an exhaustive pattern match for sealed types.
-     *
-     * @param prefix the type of the qualifier being matched.
-     */
-    case class MatchKeyword(
-        prefix: Type,
-        editRange: l.Range,
-        pos: Position,
-        text: String
-    ) extends CompletionPosition {
-      override def contribute: List[Member] = {
-        val tpe = prefix.widen
-        val members = ListBuffer.empty[TextEditMember]
-        val importPos = autoImportPosition(pos, text)
-        val context = doLocateImportContext(pos, importPos)
-        val subclasses = ListBuffer.empty[Symbol]
-
-        tpe.typeSymbol.foreachKnownDirectSubClass { sym =>
-          subclasses += sym
-        }
-        val subclassesResult = subclasses.result()
-
-        // sort subclasses by declaration order
-        // see: https://github.com/scalameta/metals-feature-requests/issues/49
-        val sortedSubclasses =
-          if (subclassesResult.forall(_.pos.isDefined)) {
-            // if all the symbols of subclasses' position is defined
-            // we can sort those symbols by declaration order
-            // based on their position information quite cheaply
-            subclassesResult.sortBy(subclass =>
-              (subclass.pos.line, subclass.pos.column)
-            )
-          } else {
-            // Read all the symbols in the source that contains
-            // the definition of the symbol in declaration order
-            val defnSymbols = search
-              .definitionSourceToplevels(semanticdbSymbol(tpe.typeSymbol))
-              .asScala
-            if (defnSymbols.length > 0) {
-              val symbolIdx = defnSymbols.zipWithIndex.toMap
-              subclassesResult
-                .sortBy(sym => {
-                  symbolIdx.getOrElse(semanticdbSymbol(sym), -1)
-                })
-            } else {
-              subclassesResult
-            }
-          }
-
-        sortedSubclasses.foreach { sym =>
-          val (shortName, edits) =
-            importPos match {
-              case Some(value) =>
-                ShortenedNames.synthesize(sym, pos, context, value)
-              case scala.None =>
-                (sym.fullNameSyntax, Nil)
-            }
-          members += toCaseMember(
-            shortName,
-            sym,
-            sym.dealiasedSingleType,
-            context,
-            editRange,
-            edits,
-            isSnippet = false
-          )
-        }
-        val basicMatch = new TextEditMember(
-          "match",
-          new l.TextEdit(
-            editRange,
-            if (clientSupportsSnippets) {
-              "match {\n\tcase$0\n}"
-            } else {
-              "match"
-            }
-          ),
-          completionsSymbol("match"),
-          label = Some("match"),
-          command = metalsConfig.completionCommand().asScala
-        )
-        val result: List[Member] = members.toList match {
-          case Nil => List(basicMatch)
-          case head :: tail =>
-            val newText = new l.TextEdit(
-              editRange,
-              tail
-                .map(_.edit.getNewText())
-                .mkString(
-                  if (clientSupportsSnippets) {
-                    s"match {\n\t${head.edit.getNewText} $$0\n\t"
-                  } else {
-                    s"match {\n\t${head.edit.getNewText}\n\t"
-                  },
-                  "\n\t",
-                  "\n}"
-                )
-            )
-            val detail =
-              s" ${metalsToLongString(tpe, new ShortenedNames())} (${members.length} cases)"
-            val exhaustiveMatch = new TextEditMember(
-              "match (exhaustive)",
-              newText,
-              tpe.typeSymbol,
-              label = Some("match (exhaustive)"),
-              detail = Some(detail),
-              additionalTextEdits =
-                members.toList.flatMap(_.additionalTextEdits)
-            )
-            List(exhaustiveMatch, basicMatch)
-        }
-        result
-      }
-    }
-
-    /**
-     * A `case` completion showing the valid subtypes of the type being deconstructed.
-     *
-     * @param selector the match expression being deconstructed or `EmptyTree` when
-     *                 not in a match expression (for example `List(1).foreach { case@@ }`.
-     * @param editRange the range in the original source file enclosing the `case` keyword being completed.
-     *                  Used as the position of the main text edit of the completion.
-     * @param pos the position of the completion in the instrumented source file with `_CURSOR_` instrumentation.
-     * @param text the text of the original source file without `_CURSOR_`.
-     * @param parent the parent tree node of the pattern match, for example `Apply(_, _)` when in
-     *               `List(1).foreach { cas@@ }`, used as fallback to compute the type of the selector when
-     *               it's `EmptyTree`.
-     */
-    case class CaseKeyword(
-        selector: Tree,
-        editRange: l.Range,
-        pos: Position,
-        text: String,
-        parent: Tree
-    ) extends CompletionPosition {
-      val context: Context = doLocateContext(pos)
-      val parents: Parents = selector match {
-        case EmptyTree =>
-          val typedParent = typedTreeAt(parent.pos)
-          typedParent match {
-            case Apply(_, Function(params, _) :: Nil) =>
-              new Parents(params.map(_.symbol.info))
-            case _ =>
-              val seenFrom = typedParent match {
-                case TreeApply(fun, _)
-                    if fun.tpe != null && !fun.tpe.isErroneous =>
-                  fun.tpe
-                case _ =>
-                  metalsSeenFromType(typedParent, typedParent.symbol)
-              }
-              seenFrom.paramss match {
-                case (head :: Nil) :: _
-                    if definitions.isFunctionType(head.info) ||
-                      definitions.isPartialFunctionType(head.info) =>
-                  val argTypes =
-                    if (definitions.isPartialFunctionType(head.info)) {
-                      head.info.typeArgs.init
-                    } else {
-                      metalsFunctionArgTypes(head.info)
-                    }
-                  new Parents(argTypes)
-                case _ =>
-                  new Parents(NoType)
-              }
-          }
-        case sel => new Parents(sel.pos)
-      }
-      override def isPrioritized(member: Member): Boolean =
-        member.isInstanceOf[TextEditMember]
-      override def contribute: List[Member] = {
-        val result = ListBuffer.empty[Member]
-        val isVisited = mutable.Set.empty[Symbol]
-        def visit(
-            sym: Symbol,
-            name: String,
-            autoImports: List[l.TextEdit]
-        ): Unit = {
-          val fsym = sym.dealiasedSingleType
-          val isValid = !isVisited(sym) &&
-            !isVisited(fsym) &&
-            !parents.isParent(fsym) &&
-            (fsym.isCase ||
-              fsym.hasModuleFlag ||
-              fsym.isInstanceOf[TypeSymbol]) &&
-            parents.isSubClass(fsym, includeReverse = false)
-          def recordVisit(s: Symbol): Unit = {
-            if (s != NoSymbol && !isVisited(s)) {
-              isVisited += s
-              recordVisit(s.moduleClass)
-              recordVisit(s.module)
-              recordVisit(s.dealiased)
-            }
-          }
-          if (isValid) {
-            recordVisit(sym)
-            recordVisit(fsym)
-            result += toCaseMember(
-              name,
-              sym,
-              fsym,
-              context,
-              editRange,
-              autoImports
-            )
-          }
-        }
-
-        // Step 1: walk through scope members.
-        metalsScopeMembers(pos).iterator
-          .foreach(m => visit(m.sym.dealiased, Identifier(m.sym.name), Nil))
-
-        // Step 2: walk through known direct subclasses of sealed types.
-        val autoImport = autoImportPosition(pos, text)
-        parents.selector.typeSymbol.foreachKnownDirectSubClass { sym =>
-          autoImport match {
-            case Some(value) =>
-              val (shortName, edits) =
-                ShortenedNames.synthesize(sym, pos, context, value)
-              visit(sym, shortName, edits)
-            case scala.None =>
-              visit(sym, sym.fullNameSyntax, Nil)
-          }
-        }
-
-        // Step 3: special handle case when selector is a tuple or `FunctionN`.
-        if (definitions.isTupleType(parents.selector)) {
-          result += new TextEditMember(
-            "case () =>",
-            new l.TextEdit(
-              editRange,
-              if (clientSupportsSnippets) "case ($0) =>" else "case () =>"
-            ),
-            parents.selector.typeSymbol,
-            label = Some(s"case ${parents.selector} =>"),
-            command = metalsConfig.parameterHintsCommand().asScala
-          )
-        }
-
-        result.toList
-      }
-    }
-
-    def toCaseMember(
-        name: String,
-        sym: Symbol,
-        fsym: Symbol,
-        context: Context,
-        editRange: l.Range,
-        autoImports: List[l.TextEdit],
-        isSnippet: Boolean = true
-    ): TextEditMember = {
-      sym.info // complete
-      val isModuleLike = fsym.hasModuleFlag || fsym.hasJavaEnumFlag
-      if (sym.isCase || isModuleLike) {
-        // Syntax for deconstructing the symbol as an infix operator, for example `case head :: tail =>`
-        val isInfixEligible =
-          context.symbolIsInScope(sym) ||
-            autoImports.nonEmpty
-        val infixPattern: Option[String] =
-          if (isInfixEligible &&
-            sym.isCase &&
-            !Character.isUnicodeIdentifierStart(sym.decodedName.head)) {
-            sym.primaryConstructor.paramss match {
-              case (a :: b :: Nil) :: _ =>
-                Some(
-                  s"${a.decodedName} ${sym.decodedName} ${b.decodedName}"
-                )
-              case _ => scala.None
-            }
-          } else {
-            scala.None
-          }
-        val pattern = infixPattern.getOrElse {
-          // Fallback to "apply syntax", example `case ::(head, tail) =>`
-          val suffix =
-            if (isModuleLike) ""
-            else {
-              sym.primaryConstructor.paramss match {
-                case Nil => "()"
-                case head :: _ =>
-                  head
-                    .map(param => Identifier(param.name))
-                    .mkString("(", ", ", ")")
-              }
-            }
-          name + suffix
-        }
-        val label = s"case $pattern =>"
-        new TextEditMember(
-          filterText = label,
-          edit = new l.TextEdit(
-            editRange,
-            label + (if (isSnippet && clientSupportsSnippets) " $0" else "")
-          ),
-          sym = sym,
-          label = Some(label),
-          additionalTextEdits = autoImports
-        )
-      } else {
-        // Symbol is not a case class with unapply deconstructor so we use typed pattern, example `_: User`
-        val suffix = sym.typeParams match {
-          case Nil => ""
-          case tparams => tparams.map(_ => "_").mkString("[", ", ", "]")
-        }
-        new TextEditMember(
-          s"case _: $name",
-          new l.TextEdit(
-            editRange,
-            if (isSnippet && clientSupportsSnippets)
-              s"case $${0:_}: $name$suffix => "
-            else s"case _: $name$suffix =>"
-          ),
-          sym,
-          Some(s"case _: $name$suffix =>"),
-          additionalTextEdits = autoImports
-        )
-      }
-
-    }
-
-    case class CasePattern(
-        isTyped: Boolean,
-        c: CaseDef,
-        m: Match
-    ) extends CompletionPosition {
-      override def contribute: List[Member] = Nil
-      override def isCandidate(member: Member): Boolean = {
-        // Can't complete regular def methods in pattern matching.
-        !member.sym.isMethod || !member.sym.isVal
-      }
-      val parents = new Parents(m.selector.pos)
-      override def isPrioritized(head: Member): Boolean = {
-        parents.isSubClass(head.sym, includeReverse = false) || {
-          def alternatives(unapply: Symbol): Boolean =
-            unapply.alternatives.exists { unapply =>
-              unapply.info
-              unapply.paramLists match {
-                case (param :: Nil) :: Nil =>
-                  parents.isSubClass(param, includeReverse = true)
-                case _ =>
-                  false
-              }
-            }
-          alternatives(head.sym.tpe.member(termNames.unapply)) ||
-          alternatives(head.sym.tpe.member(termNames.unapplySeq))
-        }
-      }
-    }
   }
 
   class PatternMatch(pos: Position) {
@@ -1548,32 +727,6 @@ trait Completions { this: MetalsGlobal =>
       }
     }
     result
-  }
-
-  class Parents(val selector: Type) {
-    def this(pos: Position) = this(typedTreeAt(pos).tpe)
-    def this(tpes: List[Type]) = this(
-      tpes match {
-        case Nil => NoType
-        case head :: Nil => head
-        case _ => definitions.tupleType(tpes)
-      }
-    )
-    val isParent: Set[Symbol] =
-      Set(selector.typeSymbol, selector.typeSymbol.companion)
-        .filterNot(_ == NoSymbol)
-    val isBottom: Set[Symbol] = Set[Symbol](
-      definitions.NullClass,
-      definitions.NothingClass
-    )
-    def isSubClass(sym: Symbol, includeReverse: Boolean): Boolean = {
-      val typeSymbol = sym.tpe.typeSymbol
-      !isBottom(typeSymbol) &&
-      isParent.exists { parent =>
-        typeSymbol.isSubClass(parent) ||
-        (includeReverse && parent.isSubClass(typeSymbol))
-      }
-    }
   }
 
   /**

--- a/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
@@ -29,7 +29,7 @@ class MetalsGlobal(
     val buildTargetIdentifier: String,
     val metalsConfig: PresentationCompilerConfig
 ) extends Global(settings, reporter)
-    with Completions
+    with completions.Completions
     with completions.ArgCompletions
     with completions.FilenameCompletions
     with completions.InterpolatorCompletions

--- a/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
@@ -34,7 +34,10 @@ class MetalsGlobal(
     with completions.FilenameCompletions
     with completions.InterpolatorCompletions
     with completions.MatchCaseCompletions
+    with completions.NewCompletions
+    with completions.NoneCompletions
     with completions.ScaladocCompletions
+    with completions.TypeCompletions
     with completions.OverrideCompletions
     with Signatures
     with Compat

--- a/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MetalsGlobal.scala
@@ -30,8 +30,12 @@ class MetalsGlobal(
     val metalsConfig: PresentationCompilerConfig
 ) extends Global(settings, reporter)
     with Completions
-    with ScaladocCompletions
-    with OverrideCompletions
+    with completions.ArgCompletions
+    with completions.FilenameCompletions
+    with completions.InterpolatorCompletions
+    with completions.MatchCaseCompletions
+    with completions.ScaladocCompletions
+    with completions.OverrideCompletions
     with Signatures
     with Compat
     with GlobalProxy

--- a/mtags/src/main/scala/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -372,7 +372,7 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
             memberOrdering(
               qual.name.toString(),
               new ShortenedNames(),
-              CompletionPosition.None
+              NoneCompletion
             )
           )
           .map(_.sym.javaClassSymbol)

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -1,0 +1,155 @@
+package scala.meta.internal.pc.completions
+
+import org.eclipse.{lsp4j => l}
+
+import scala.collection.immutable.Nil
+import scala.meta.internal.pc.MetalsGlobal
+
+trait ArgCompletions { this: MetalsGlobal =>
+
+  case class Arg(
+      ident: Ident,
+      apply: Apply,
+      pos: Position,
+      text: String,
+      completions: CompletionResult
+  ) extends CompletionPosition {
+    val editRange: l.Range =
+      pos.withStart(ident.pos.start).withEnd(pos.start).toLSP
+    val method: Tree = typedTreeAt(apply.fun.pos)
+    val methodSym = method.symbol
+    lazy val baseParams: List[Symbol] =
+      if (method.tpe == null) Nil
+      else {
+        method.tpe.paramss.headOption
+          .getOrElse(methodSym.paramss.flatten)
+      }
+    lazy val isNamed: Set[Name] = apply.args.iterator
+      .filterNot(_ == ident)
+      .zip(baseParams.iterator)
+      .map {
+        case (AssignOrNamedArg(Ident(name), _), _) =>
+          name
+        case (_, param) =>
+          param.name
+      }
+      .toSet
+    val prefix: String = ident.name.toString.stripSuffix(CURSOR)
+    lazy val allParams: List[Symbol] = {
+      baseParams.iterator.filterNot { param =>
+        isNamed(param.name) ||
+        param.name.containsChar('$') // exclude synthetic parameters
+      }.toList
+    }
+    lazy val params: List[Symbol] =
+      allParams.filter(param => param.name.startsWith(prefix))
+    lazy val isParamName: Set[String] = params.iterator
+      .map(_.name)
+      .filterNot(isNamed)
+      .map(_.toString().trim())
+      .toSet
+
+    override def isCandidate(member: Member): Boolean = true
+
+    def isName(m: Member): Boolean =
+      isParamName(m.sym.nameString.trim())
+
+    override def compare(o1: Member, o2: Member): Int = {
+      val byName = -java.lang.Boolean.compare(isName(o1), isName(o2))
+      if (byName != 0) byName
+      else {
+        java.lang.Boolean.compare(
+          o1.isInstanceOf[NamedArgMember],
+          o2.isInstanceOf[NamedArgMember]
+        )
+      }
+    }
+
+    override def isPrioritized(member: Member): Boolean = {
+      member.isInstanceOf[NamedArgMember] ||
+      isParamName(member.sym.name.toString().trim())
+    }
+
+    private def matchingTypesInScope(
+        paramType: Type
+    ): List[String] = {
+
+      def notNothingOrNull(mem: ScopeMember): Boolean = {
+        !(mem.sym.tpe =:= definitions.NothingTpe || mem.sym.tpe =:= definitions.NullTpe)
+      }
+
+      completions match {
+        case CompletionResult.ScopeMembers(positionDelta, results, name) =>
+          results
+            .collect {
+              case mem
+                  if mem.sym.tpe <:< paramType && notNothingOrNull(mem) && mem.sym.isTerm =>
+                mem.sym.name.toString().trim()
+            }
+            // None and Nil are always in scope
+            .filter(name => name != "Nil" && name != "None")
+        case _ =>
+          Nil
+      }
+    }
+
+    private def findDefaultValue(param: Symbol): String = {
+      val matchingType = matchingTypesInScope(param.tpe)
+      if (matchingType.size == 1) {
+        s":${matchingType.head}"
+      } else if (matchingType.size > 1) {
+        s"|???,${matchingType.mkString(",")}|"
+      } else {
+        ":???"
+      }
+    }
+
+    private def fillAllFields(): List[TextEditMember] = {
+      val suffix = "autofill"
+      val shouldShow =
+        allParams.exists(param => param.name.startsWith(prefix))
+      val isExplicitlyCalled = suffix.startsWith(prefix)
+      val hasParamsToFill = allParams.count(!_.hasDefault) > 1
+      if ((shouldShow || isExplicitlyCalled) && hasParamsToFill && clientSupportsSnippets) {
+        val editText = allParams.zipWithIndex
+          .collect {
+            case (param, index) if !param.hasDefault =>
+              s"${param.name} = $${${index + 1}${findDefaultValue(param)}}"
+          }
+          .mkString(", ")
+        val edit = new l.TextEdit(editRange, editText)
+        List(
+          new TextEditMember(
+            filterText = s"$prefix-$suffix",
+            edit = edit,
+            methodSym,
+            label = Some("Autofill with default values")
+          )
+        )
+      } else {
+        List.empty
+      }
+    }
+
+    private def findPossibleDefaults(): List[TextEditMember] = {
+      params.flatMap { param =>
+        val allMemebers = matchingTypesInScope(param.tpe)
+        allMemebers.map { memberName =>
+          val editText = param.name + " = " + memberName
+          val edit = new l.TextEdit(editRange, editText)
+          new TextEditMember(
+            filterText = param.name.toString(),
+            edit = edit,
+            completionsSymbol(s"$param=$memberName"),
+            label = Some(editText),
+            detail = Some(" : " + param.tpe)
+          )
+        }
+      }
+    }
+
+    override def contribute: List[Member] = {
+      params.map(param => new NamedArgMember(param)) ::: findPossibleDefaults() ::: fillAllFields()
+    }
+  }
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -7,7 +7,7 @@ import scala.meta.internal.pc.MetalsGlobal
 
 trait ArgCompletions { this: MetalsGlobal =>
 
-  case class Arg(
+  case class ArgCompletion(
       ident: Ident,
       apply: Apply,
       pos: Position,

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/Completions.scala
@@ -396,7 +396,7 @@ trait Completions { this: MetalsGlobal =>
     catch {
       case NonFatal(e) =>
         logger.log(Level.SEVERE, e.getMessage(), e)
-        CompletionPosition.None
+        NoneCompletion
     }
   }
   def completionPositionUnsafe(
@@ -415,7 +415,7 @@ trait Completions { this: MetalsGlobal =>
         if (isCasePrefix(ident.name)) {
           CaseKeyword(EmptyTree, editRange, pos, text, apply)
         } else {
-          CompletionPosition.None
+          NoneCompletion
         }
       } else {
         Arg(ident, apply, pos, text, completions)
@@ -429,7 +429,7 @@ trait Completions { this: MetalsGlobal =>
         }
         associatedDef
           .map(definition => Scaladoc(editRange, definition, pos, text))
-          .getOrElse(CompletionPosition.None)
+          .getOrElse(NoneCompletion)
       case (ident: Ident) :: (a: Apply) :: _ =>
         fromIdentApply(ident, a)
       case (ident: Ident) :: (_: Select) :: (_: Assign) :: (a: Apply) :: _ =>
@@ -444,7 +444,7 @@ trait Completions { this: MetalsGlobal =>
             InterpolatorScope(lit, pos, i, text)
           case _ =>
             isPossibleInterpolatorMember(lit, head, text, pos)
-              .getOrElse(CompletionPosition.None)
+              .getOrElse(NoneCompletion)
         }
       case (_: Ident) ::
             Select(Ident(TermName("scala")), TypeName("Unit")) ::
@@ -535,46 +535,26 @@ trait Completions { this: MetalsGlobal =>
         tail match {
           case (v: ValOrDefDef) :: _ =>
             if (v.tpt.pos.includes(pos)) {
-              CompletionPosition.Type
+              TypeCompletion
             } else {
-              CompletionPosition.None
+              NoneCompletion
             }
           case _ =>
             inferCompletionPosition(pos, text, tail, completions, editRange)
         }
       case AppliedTypeTree(_, args) :: _ =>
         if (args.exists(_.pos.includes(pos))) {
-          CompletionPosition.Type
+          TypeCompletion
         } else {
-          CompletionPosition.None
+          NoneCompletion
         }
       case New(_) :: _ =>
-        CompletionPosition.New
+        NewCompletion
       case head :: tail if !head.pos.includes(pos) =>
         inferCompletionPosition(pos, text, tail, completions, editRange)
       case _ =>
-        CompletionPosition.None
+        NoneCompletion
     }
-
-  }
-
-  object CompletionPosition {
-
-    /**
-     * A completion inside a type position, example `val x: Map[Int, Strin@@]`
-     */
-    case object Type extends CompletionPosition {
-      override def isType: Boolean = true
-    }
-
-    /**
-     * A completion inside a new expression, example `new Array@@`
-     */
-    case object New extends CompletionPosition {
-      override def isNew: Boolean = true
-    }
-
-    case object None extends CompletionPosition
 
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/Completions.scala
@@ -1,4 +1,4 @@
-package scala.meta.internal.pc
+package scala.meta.internal.pc.completions
 
 import java.util.logging.Level
 
@@ -10,6 +10,11 @@ import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.tokenizers.Chars
 import scala.util.control.NonFatal
 import scala.collection.immutable.Nil
+import scala.meta.internal.pc.{
+  IdentifierComparator,
+  MetalsGlobal,
+  MemberOrdering
+}
 
 /**
  * Utility methods for completions.

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/FilenameCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/FilenameCompletions.scala
@@ -1,0 +1,70 @@
+package scala.meta.internal.pc.completions
+
+import org.eclipse.{lsp4j => l}
+import java.nio.file.Paths
+import java.net.URI
+
+import scala.collection.immutable.Nil
+import scala.meta.internal.pc.{CompletionFuzzy, MetalsGlobal}
+import scala.util.control.NonFatal
+
+trait FilenameCompletions { this: MetalsGlobal =>
+
+  /**
+   * Completion for the name of a toplevel class, trait or object matching the filename.
+   *
+   * Example: {{{
+   *   // src/main/scala/app/UserDatabaseService.scala
+   *   class User@@ // completes "UserDatabaseService"
+   * }}}
+   *
+   * @param toplevel the toplevel class, trait or object definition.
+   * @param pkg the enclosing package definition.
+   * @param pos the completion position.
+   * @param editRange the range to replace in the completion.
+   */
+  case class Filename(
+      toplevel: DefTree,
+      pkg: PackageDef,
+      pos: Position,
+      editRange: l.Range
+  ) extends CompletionPosition {
+    val query: String = toplevel.name.toString().stripSuffix(CURSOR)
+    override def contribute: List[Member] = {
+      try {
+        val name = Paths
+          .get(URI.create(pos.source.file.name))
+          .getFileName()
+          .toString()
+          .stripSuffix(".scala")
+        val isTermName = toplevel.name.isTermName
+        val siblings = pkg.stats.count {
+          case d: DefTree =>
+            d.name.toString() == name &&
+              d.name.isTermName == isTermName
+          case _ => false
+        }
+        if (!name.isEmpty &&
+          CompletionFuzzy.matches(query, name) &&
+          siblings == 0) {
+          List(
+            new TextEditMember(
+              name,
+              new l.TextEdit(editRange, name),
+              toplevel.symbol
+                .newErrorSymbol(TermName(name))
+                .setInfo(NoType),
+              label = Some(s"${toplevel.symbol.keyString} ${name}")
+            )
+          )
+        } else {
+          Nil
+        }
+      } catch {
+        case NonFatal(e) =>
+          Nil
+      }
+    }
+  }
+
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/FilenameCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/FilenameCompletions.scala
@@ -23,7 +23,7 @@ trait FilenameCompletions { this: MetalsGlobal =>
    * @param pos the completion position.
    * @param editRange the range to replace in the completion.
    */
-  case class Filename(
+  case class FilenameCompletion(
       toplevel: DefTree,
       pkg: PackageDef,
       pos: Position,

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
@@ -26,7 +26,7 @@ trait InterpolatorCompletions { this: MetalsGlobal =>
    * @param cursor the cursor position where the completion is triggered, `@@` in the example above.
    * @param text the text of the original source file without `_CURSOR_` instrumentation.
    */
-  case class InterpolatorType(
+  case class InterpolatorTypeCompletion(
       query: String,
       ident: Ident,
       literalPart: Literal,
@@ -75,7 +75,7 @@ trait InterpolatorCompletions { this: MetalsGlobal =>
    *                     curly braces.
    * @param text The text of the original source code without the instrumented `_CURSOR_`.
    */
-  case class InterpolatorScope(
+  case class InterpolatorScopeCompletion(
       lit: Literal,
       pos: Position,
       interpolator: InterpolationSplice,
@@ -147,13 +147,13 @@ trait InterpolatorCompletions { this: MetalsGlobal =>
       parent: Tree,
       text: String,
       cursor: Position
-  ): Option[InterpolatorType] = {
+  ): Option[InterpolatorTypeCompletion] = {
     for {
       query <- interpolatorMemberSelect(lit)
       if text.charAt(lit.pos.point - 1) != '}'
       arg <- interpolatorMemberArg(parent, lit)
     } yield {
-      InterpolatorType(
+      InterpolatorTypeCompletion(
         query,
         arg,
         lit,

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
@@ -1,0 +1,255 @@
+package scala.meta.internal.pc.completions
+
+import java.lang.StringBuilder
+import org.eclipse.{lsp4j => l}
+
+import scala.collection.immutable.Nil
+import scala.meta.internal.pc.{CompletionFuzzy, MetalsGlobal, Identifier}
+
+trait InterpolatorCompletions { this: MetalsGlobal =>
+
+  /**
+   * A completion to select type members inside string interpolators.
+   *
+   * Example: {{{
+   *   // before
+   *   s"Hello $name.len@@!"
+   *   // after
+   *   s"Hello ${name.length()$0}"
+   * }}}
+   *
+   * @param query the member query, "len" in the  example above.
+   * @param ident the identifier from where we select a member from, "name" above.
+   * @param literalPart the string literal part of the interpolator trailing
+   *                    the identifier including cursor instrumentation, "len_CURSOR_!"
+   *                    in the example above.
+   * @param cursor the cursor position where the completion is triggered, `@@` in the example above.
+   * @param text the text of the original source file without `_CURSOR_` instrumentation.
+   */
+  case class InterpolatorType(
+      query: String,
+      ident: Ident,
+      literalPart: Literal,
+      cursor: Position,
+      text: String
+  ) extends CompletionPosition {
+    val pos: l.Range = ident.pos.withEnd(cursor.point).toLSP
+    def newText(sym: Symbol): String = {
+      new StringBuilder()
+        .append('{')
+        .append(text, ident.pos.start, ident.pos.end)
+        .append('.')
+        .append(Identifier.backtickWrap(sym.getterName.decoded))
+        .append(sym.snippetCursor)
+        .append('}')
+        .toString
+    }
+    val filter: String =
+      text.substring(ident.pos.start - 1, cursor.point - query.length)
+    override def contribute: List[Member] = {
+      metalsTypeMembers(ident.pos).collect {
+        case m if CompletionFuzzy.matches(query, m.sym.name) =>
+          val edit = new l.TextEdit(pos, newText(m.sym))
+          val filterText = filter + m.sym.name.decoded
+          new TextEditMember(filterText, edit, m.sym)
+      }
+    }
+  }
+
+  /**
+   * A completion to convert a string literal into a string literal, example `"Hello $na@@"`.
+   *
+   * When converting a string literal into an interpolator we need to ensure a few cases:
+   *
+   * - escape existing `$` characters into `$$`, which are printed as `\$\$` in order to
+   *   escape the TextMate snippet syntax.
+   * - wrap completed name in curly braces `s"Hello ${name}_` when the trailing character
+   *   can be treated as an identifier part.
+   * - insert the  leading `s` interpolator.
+   * - place the cursor at the end of the completed name using TextMate `$0` snippet syntax.
+   *
+   * @param lit The string literal, includes an instrumented `_CURSOR_` that we need to handle.
+   * @param pos The offset position of the cursor, right below `@@_CURSOR_`.
+   * @param interpolator Metadata about this interpolation, the location of the leading dollar
+   *                     character and whether the completed name needs to be wrapped in
+   *                     curly braces.
+   * @param text The text of the original source code without the instrumented `_CURSOR_`.
+   */
+  case class InterpolatorScope(
+      lit: Literal,
+      pos: Position,
+      interpolator: InterpolationSplice,
+      text: String
+  ) extends CompletionPosition {
+
+    val offset: Int =
+      if (lit.pos.focusEnd.line == pos.line) CURSOR.length else 0
+    val nameStart: Position =
+      pos.withStart(pos.start - interpolator.name.size)
+    val nameRange = nameStart.toLSP
+    val hasClosingBrace: Boolean = text.charAt(pos.point) == '}'
+    val hasOpeningBrace: Boolean = text.charAt(
+      pos.start - interpolator.name.size - 1
+    ) == '{'
+
+    def additionalEdits(): List[l.TextEdit] = {
+      val interpolatorEdit =
+        if (text.charAt(lit.pos.start - 1) != 's')
+          List(new l.TextEdit(lit.pos.withEnd(lit.pos.start).toLSP, "s"))
+        else Nil
+      val dollarEdits = for {
+        i <- lit.pos.start to (lit.pos.end - CURSOR.length())
+        if text.charAt(i) == '$' && i != interpolator.dollar
+      } yield new l.TextEdit(pos.source.position(i).withEnd(i).toLSP, "$")
+      interpolatorEdit ++ dollarEdits
+    }
+
+    def newText(sym: Symbol): String = {
+      val out = new StringBuilder()
+      val symbolName = sym.getterName.decoded
+      val identifier = Identifier.backtickWrap(symbolName)
+      val symbolNeedsBraces =
+        interpolator.needsBraces ||
+          identifier.startsWith("`") ||
+          sym.isNonNullaryMethod
+      if (symbolNeedsBraces && !hasOpeningBrace) {
+        out.append('{')
+      }
+      out.append(identifier)
+      out.append(sym.snippetCursor)
+      if (symbolNeedsBraces && !hasClosingBrace) {
+        out.append('}')
+      }
+      out.toString
+    }
+
+    val filter: String =
+      text.substring(lit.pos.start, pos.point - interpolator.name.length)
+
+    override def contribute: List[Member] = {
+      metalsScopeMembers(pos).collect {
+        case s: ScopeMember
+            if CompletionFuzzy.matches(interpolator.name, s.sym.name) =>
+          val edit = new l.TextEdit(nameRange, newText(s.sym))
+          val filterText = filter + s.sym.name.decoded
+          new TextEditMember(
+            filterText,
+            edit,
+            s.sym,
+            additionalTextEdits = additionalEdits()
+          )
+      }
+    }
+  }
+
+  def isPossibleInterpolatorMember(
+      lit: Literal,
+      parent: Tree,
+      text: String,
+      cursor: Position
+  ): Option[InterpolatorType] = {
+    for {
+      query <- interpolatorMemberSelect(lit)
+      if text.charAt(lit.pos.point - 1) != '}'
+      arg <- interpolatorMemberArg(parent, lit)
+    } yield {
+      InterpolatorType(
+        query,
+        arg,
+        lit,
+        cursor,
+        text
+      )
+    }
+  }
+
+  case class InterpolationSplice(
+      dollar: Int,
+      name: String,
+      needsBraces: Boolean
+  )
+
+  def isPossibleInterpolatorSplice(
+      pos: Position,
+      text: String
+  ): Option[InterpolationSplice] = {
+    val offset = pos.point
+    val chars = pos.source.content
+    var i = offset
+    while (i > 0 && (chars(i) match { case '$' | '\n' => false; case _ => true })) {
+      i -= 1
+    }
+    val isCandidate = i > 0 &&
+      chars(i) == '$' && {
+      val start = chars(i + 1) match {
+        case '{' => i + 2
+        case _ => i + 1
+      }
+      start == offset || {
+        chars(start).isUnicodeIdentifierStart &&
+        (start + 1).until(offset).forall(j => chars(j).isUnicodeIdentifierPart)
+      }
+    }
+    if (isCandidate) {
+      val name = chars(i + 1) match {
+        case '{' => text.substring(i + 2, offset)
+        case _ => text.substring(i + 1, offset)
+      }
+      Some(
+        InterpolationSplice(
+          i,
+          name,
+          needsBraces = text.charAt(i + 1) == '{' ||
+            (text.charAt(offset) match {
+              case '"' => false // end of string literal
+              case ch => ch.isUnicodeIdentifierPart
+            })
+        )
+      )
+    } else {
+      None
+    }
+  }
+
+  private def interpolatorMemberArg(parent: Tree, lit: Literal): Option[Ident] =
+    parent match {
+      case Apply(
+          Select(
+            Apply(Ident(TermName("StringContext")), _ :: parts),
+            _
+          ),
+          args
+          ) =>
+        parts.zip(args).collectFirst {
+          case (`lit`, i: Ident) => i
+        }
+      case _ =>
+        None
+    }
+
+  private def interpolatorMemberSelect(lit: Literal): Option[String] =
+    lit match {
+      case Literal(Constant(s: String)) =>
+        if (s.startsWith(s".$CURSOR")) Some("")
+        else if (s.startsWith(".") &&
+          s.length > 2 &&
+          s.charAt(1).isUnicodeIdentifierStart) {
+          val cursor = s.indexOf(CURSOR)
+          if (cursor < 0) None
+          else {
+            val isValidIdentifier =
+              2.until(cursor).forall(i => s.charAt(i).isUnicodeIdentifierPart)
+            if (isValidIdentifier) {
+              Some(s.substring(1, cursor))
+            } else {
+              None
+            }
+          }
+        } else {
+          None
+        }
+      case _ =>
+        None
+    }
+
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -24,7 +24,7 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
    *               `List(1).foreach { cas@@ }`, used as fallback to compute the type of the selector when
    *               it's `EmptyTree`.
    */
-  case class CaseKeyword(
+  case class CaseKeywordCompletion(
       selector: Tree,
       editRange: l.Range,
       pos: Position,
@@ -143,7 +143,7 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
    *
    * @param prefix the type of the qualifier being matched.
    */
-  case class MatchKeyword(
+  case class MatchKeywordCompletion(
       prefix: Type,
       editRange: l.Range,
       pos: Position,
@@ -253,7 +253,7 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
     }
   }
 
-  case class CasePattern(
+  case class CasePatternCompletion(
       isTyped: Boolean,
       c: CaseDef,
       m: Match

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -1,0 +1,411 @@
+package scala.meta.internal.pc.completions
+
+import org.eclipse.{lsp4j => l}
+
+import scala.collection.immutable.Nil
+import scala.meta.internal.pc.{Identifier, MetalsGlobal}
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.internal.jdk.CollectionConverters._
+
+trait MatchCaseCompletions { this: MetalsGlobal =>
+
+  /**
+   * A `case` completion showing the valid subtypes of the type being deconstructed.
+   *
+   * @param selector the match expression being deconstructed or `EmptyTree` when
+   *                 not in a match expression (for example `List(1).foreach { case@@ }`.
+   * @param editRange the range in the original source file enclosing the `case` keyword being completed.
+   *                  Used as the position of the main text edit of the completion.
+   * @param pos the position of the completion in the instrumented source file with `_CURSOR_` instrumentation.
+   * @param text the text of the original source file without `_CURSOR_`.
+   * @param parent the parent tree node of the pattern match, for example `Apply(_, _)` when in
+   *               `List(1).foreach { cas@@ }`, used as fallback to compute the type of the selector when
+   *               it's `EmptyTree`.
+   */
+  case class CaseKeyword(
+      selector: Tree,
+      editRange: l.Range,
+      pos: Position,
+      text: String,
+      parent: Tree
+  ) extends CompletionPosition {
+    val context: Context = doLocateContext(pos)
+    val parents: Parents = selector match {
+      case EmptyTree =>
+        val typedParent = typedTreeAt(parent.pos)
+        typedParent match {
+          case Apply(_, Function(params, _) :: Nil) =>
+            new Parents(params.map(_.symbol.info))
+          case _ =>
+            val seenFrom = typedParent match {
+              case TreeApply(fun, _)
+                  if fun.tpe != null && !fun.tpe.isErroneous =>
+                fun.tpe
+              case _ =>
+                metalsSeenFromType(typedParent, typedParent.symbol)
+            }
+            seenFrom.paramss match {
+              case (head :: Nil) :: _
+                  if definitions.isFunctionType(head.info) ||
+                    definitions.isPartialFunctionType(head.info) =>
+                val argTypes =
+                  if (definitions.isPartialFunctionType(head.info)) {
+                    head.info.typeArgs.init
+                  } else {
+                    metalsFunctionArgTypes(head.info)
+                  }
+                new Parents(argTypes)
+              case _ =>
+                new Parents(NoType)
+            }
+        }
+      case sel => new Parents(sel.pos)
+    }
+    override def isPrioritized(member: Member): Boolean =
+      member.isInstanceOf[TextEditMember]
+    override def contribute: List[Member] = {
+      val result = ListBuffer.empty[Member]
+      val isVisited = mutable.Set.empty[Symbol]
+      def visit(
+          sym: Symbol,
+          name: String,
+          autoImports: List[l.TextEdit]
+      ): Unit = {
+        val fsym = sym.dealiasedSingleType
+        val isValid = !isVisited(sym) &&
+          !isVisited(fsym) &&
+          !parents.isParent(fsym) &&
+          (fsym.isCase ||
+            fsym.hasModuleFlag ||
+            fsym.isInstanceOf[TypeSymbol]) &&
+          parents.isSubClass(fsym, includeReverse = false)
+        def recordVisit(s: Symbol): Unit = {
+          if (s != NoSymbol && !isVisited(s)) {
+            isVisited += s
+            recordVisit(s.moduleClass)
+            recordVisit(s.module)
+            recordVisit(s.dealiased)
+          }
+        }
+        if (isValid) {
+          recordVisit(sym)
+          recordVisit(fsym)
+          result += toCaseMember(
+            name,
+            sym,
+            fsym,
+            context,
+            editRange,
+            autoImports
+          )
+        }
+      }
+
+      // Step 1: walk through scope members.
+      metalsScopeMembers(pos).iterator
+        .foreach(m => visit(m.sym.dealiased, Identifier(m.sym.name), Nil))
+
+      // Step 2: walk through known direct subclasses of sealed types.
+      val autoImport = autoImportPosition(pos, text)
+      parents.selector.typeSymbol.foreachKnownDirectSubClass { sym =>
+        autoImport match {
+          case Some(value) =>
+            val (shortName, edits) =
+              ShortenedNames.synthesize(sym, pos, context, value)
+            visit(sym, shortName, edits)
+          case scala.None =>
+            visit(sym, sym.fullNameSyntax, Nil)
+        }
+      }
+
+      // Step 3: special handle case when selector is a tuple or `FunctionN`.
+      if (definitions.isTupleType(parents.selector)) {
+        result += new TextEditMember(
+          "case () =>",
+          new l.TextEdit(
+            editRange,
+            if (clientSupportsSnippets) "case ($0) =>" else "case () =>"
+          ),
+          parents.selector.typeSymbol,
+          label = Some(s"case ${parents.selector} =>"),
+          command = metalsConfig.parameterHintsCommand().asScala
+        )
+      }
+
+      result.toList
+    }
+  }
+
+  /**
+   * A `match` keyword completion to generate an exhaustive pattern match for sealed types.
+   *
+   * @param prefix the type of the qualifier being matched.
+   */
+  case class MatchKeyword(
+      prefix: Type,
+      editRange: l.Range,
+      pos: Position,
+      text: String
+  ) extends CompletionPosition {
+    override def contribute: List[Member] = {
+      val tpe = prefix.widen
+      val members = ListBuffer.empty[TextEditMember]
+      val importPos = autoImportPosition(pos, text)
+      val context = doLocateImportContext(pos, importPos)
+      val subclasses = ListBuffer.empty[Symbol]
+
+      tpe.typeSymbol.foreachKnownDirectSubClass { sym =>
+        subclasses += sym
+      }
+      val subclassesResult = subclasses.result()
+
+      // sort subclasses by declaration order
+      // see: https://github.com/scalameta/metals-feature-requests/issues/49
+      val sortedSubclasses =
+        if (subclassesResult.forall(_.pos.isDefined)) {
+          // if all the symbols of subclasses' position is defined
+          // we can sort those symbols by declaration order
+          // based on their position information quite cheaply
+          subclassesResult.sortBy(subclass =>
+            (subclass.pos.line, subclass.pos.column)
+          )
+        } else {
+          // Read all the symbols in the source that contains
+          // the definition of the symbol in declaration order
+          val defnSymbols = search
+            .definitionSourceToplevels(semanticdbSymbol(tpe.typeSymbol))
+            .asScala
+          if (defnSymbols.length > 0) {
+            val symbolIdx = defnSymbols.zipWithIndex.toMap
+            subclassesResult
+              .sortBy(sym => {
+                symbolIdx.getOrElse(semanticdbSymbol(sym), -1)
+              })
+          } else {
+            subclassesResult
+          }
+        }
+
+      sortedSubclasses.foreach { sym =>
+        val (shortName, edits) =
+          importPos match {
+            case Some(value) =>
+              ShortenedNames.synthesize(sym, pos, context, value)
+            case scala.None =>
+              (sym.fullNameSyntax, Nil)
+          }
+        members += toCaseMember(
+          shortName,
+          sym,
+          sym.dealiasedSingleType,
+          context,
+          editRange,
+          edits,
+          isSnippet = false
+        )
+      }
+      val basicMatch = new TextEditMember(
+        "match",
+        new l.TextEdit(
+          editRange,
+          if (clientSupportsSnippets) {
+            "match {\n\tcase$0\n}"
+          } else {
+            "match"
+          }
+        ),
+        completionsSymbol("match"),
+        label = Some("match"),
+        command = metalsConfig.completionCommand().asScala
+      )
+      val result: List[Member] = members.toList match {
+        case Nil => List(basicMatch)
+        case head :: tail =>
+          val newText = new l.TextEdit(
+            editRange,
+            tail
+              .map(_.edit.getNewText())
+              .mkString(
+                if (clientSupportsSnippets) {
+                  s"match {\n\t${head.edit.getNewText} $$0\n\t"
+                } else {
+                  s"match {\n\t${head.edit.getNewText}\n\t"
+                },
+                "\n\t",
+                "\n}"
+              )
+          )
+          val detail =
+            s" ${metalsToLongString(tpe, new ShortenedNames())} (${members.length} cases)"
+          val exhaustiveMatch = new TextEditMember(
+            "match (exhaustive)",
+            newText,
+            tpe.typeSymbol,
+            label = Some("match (exhaustive)"),
+            detail = Some(detail),
+            additionalTextEdits = members.toList.flatMap(_.additionalTextEdits)
+          )
+          List(exhaustiveMatch, basicMatch)
+      }
+      result
+    }
+  }
+
+  case class CasePattern(
+      isTyped: Boolean,
+      c: CaseDef,
+      m: Match
+  ) extends CompletionPosition {
+    override def contribute: List[Member] = Nil
+    override def isCandidate(member: Member): Boolean = {
+      // Can't complete regular def methods in pattern matching.
+      !member.sym.isMethod || !member.sym.isVal
+    }
+    val parents = new Parents(m.selector.pos)
+    override def isPrioritized(head: Member): Boolean = {
+      parents.isSubClass(head.sym, includeReverse = false) || {
+        def alternatives(unapply: Symbol): Boolean =
+          unapply.alternatives.exists { unapply =>
+            unapply.info
+            unapply.paramLists match {
+              case (param :: Nil) :: Nil =>
+                parents.isSubClass(param, includeReverse = true)
+              case _ =>
+                false
+            }
+          }
+        alternatives(head.sym.tpe.member(termNames.unapply)) ||
+        alternatives(head.sym.tpe.member(termNames.unapplySeq))
+      }
+    }
+  }
+
+  def isMatchPrefix(name: Name): Boolean =
+    name.endsWith(CURSOR) &&
+      "match".startsWith(name.toString().stripSuffix(CURSOR))
+
+  /** Returns true if the identifier comes after an opening brace character '{' */
+  def hasLeadingBrace(ident: Ident, text: String): Boolean = {
+    val openDelim: Int = {
+      var start = ident.pos.start - 1
+      while (start > 0 && text.charAt(start).isWhitespace) {
+        start -= 1
+      }
+      start
+    }
+    text.length > openDelim &&
+    openDelim >= 0 &&
+    text.charAt(openDelim) == '{'
+  }
+
+  def isCasePrefix(name: Name): Boolean = {
+    val prefix = name.decoded.stripSuffix(CURSOR)
+    Set("c", "ca", "cas", "case").contains(prefix)
+  }
+
+  private def toCaseMember(
+      name: String,
+      sym: Symbol,
+      fsym: Symbol,
+      context: Context,
+      editRange: l.Range,
+      autoImports: List[l.TextEdit],
+      isSnippet: Boolean = true
+  ): TextEditMember = {
+    sym.info // complete
+    val isModuleLike = fsym.hasModuleFlag || fsym.hasJavaEnumFlag
+    if (sym.isCase || isModuleLike) {
+      // Syntax for deconstructing the symbol as an infix operator, for example `case head :: tail =>`
+      val isInfixEligible =
+        context.symbolIsInScope(sym) ||
+          autoImports.nonEmpty
+      val infixPattern: Option[String] =
+        if (isInfixEligible &&
+          sym.isCase &&
+          !Character.isUnicodeIdentifierStart(sym.decodedName.head)) {
+          sym.primaryConstructor.paramss match {
+            case (a :: b :: Nil) :: _ =>
+              Some(
+                s"${a.decodedName} ${sym.decodedName} ${b.decodedName}"
+              )
+            case _ => scala.None
+          }
+        } else {
+          scala.None
+        }
+      val pattern = infixPattern.getOrElse {
+        // Fallback to "apply syntax", example `case ::(head, tail) =>`
+        val suffix =
+          if (isModuleLike) ""
+          else {
+            sym.primaryConstructor.paramss match {
+              case Nil => "()"
+              case head :: _ =>
+                head
+                  .map(param => Identifier(param.name))
+                  .mkString("(", ", ", ")")
+            }
+          }
+        name + suffix
+      }
+      val label = s"case $pattern =>"
+      new TextEditMember(
+        filterText = label,
+        edit = new l.TextEdit(
+          editRange,
+          label + (if (isSnippet && clientSupportsSnippets) " $0" else "")
+        ),
+        sym = sym,
+        label = Some(label),
+        additionalTextEdits = autoImports
+      )
+    } else {
+      // Symbol is not a case class with unapply deconstructor so we use typed pattern, example `_: User`
+      val suffix = sym.typeParams match {
+        case Nil => ""
+        case tparams => tparams.map(_ => "_").mkString("[", ", ", "]")
+      }
+      new TextEditMember(
+        s"case _: $name",
+        new l.TextEdit(
+          editRange,
+          if (isSnippet && clientSupportsSnippets)
+            s"case $${0:_}: $name$suffix => "
+          else s"case _: $name$suffix =>"
+        ),
+        sym,
+        Some(s"case _: $name$suffix =>"),
+        additionalTextEdits = autoImports
+      )
+    }
+  }
+
+  class Parents(val selector: Type) {
+    def this(pos: Position) = this(typedTreeAt(pos).tpe)
+    def this(tpes: List[Type]) = this(
+      tpes match {
+        case Nil => NoType
+        case head :: Nil => head
+        case _ => definitions.tupleType(tpes)
+      }
+    )
+    val isParent: Set[Symbol] =
+      Set(selector.typeSymbol, selector.typeSymbol.companion)
+        .filterNot(_ == NoSymbol)
+    val isBottom: Set[Symbol] = Set[Symbol](
+      definitions.NullClass,
+      definitions.NothingClass
+    )
+    def isSubClass(sym: Symbol, includeReverse: Boolean): Boolean = {
+      val typeSymbol = sym.tpe.typeSymbol
+      !isBottom(typeSymbol) &&
+      isParent.exists { parent =>
+        typeSymbol.isSubClass(parent) ||
+        (includeReverse && parent.isSubClass(typeSymbol))
+      }
+    }
+  }
+
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/NewCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/NewCompletions.scala
@@ -1,0 +1,14 @@
+package scala.meta.internal.pc.completions
+
+import scala.meta.internal.pc.MetalsGlobal
+
+trait NewCompletions { this: MetalsGlobal =>
+
+  /**
+   * A completion inside a new expression, example `new Array@@`
+   */
+  case object NewCompletion extends CompletionPosition {
+    override def isNew: Boolean = true
+  }
+
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/NoneCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/NoneCompletions.scala
@@ -1,0 +1,9 @@
+package scala.meta.internal.pc.completions
+
+import scala.meta.internal.pc.MetalsGlobal
+
+trait NoneCompletions { this: MetalsGlobal =>
+
+  case object NoneCompletion extends CompletionPosition
+
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -31,7 +31,7 @@ trait OverrideCompletions { this: MetalsGlobal =>
    * @param start the position start of the completion.
    * @param isCandidate the determination of whether the symbol will be a possible completion item.
    */
-  case class Override(
+  case class OverrideCompletion(
       name: Name,
       t: Template,
       pos: Position,

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -1,4 +1,4 @@
-package scala.meta.internal.pc
+package scala.meta.internal.pc.completions
 
 import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
 
@@ -6,6 +6,7 @@ import org.eclipse.{lsp4j => l}
 
 import scala.collection.mutable
 import scala.collection.immutable.Nil
+import scala.meta.internal.pc.{CompletionFuzzy, MetalsGlobal, Identifier}
 
 trait OverrideCompletions { this: MetalsGlobal =>
 

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/ScaladocCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/ScaladocCompletions.scala
@@ -1,10 +1,11 @@
-package scala.meta.internal.pc
+package scala.meta.internal.pc.completions
 
 import java.lang.StringBuilder
 
 import org.eclipse.{lsp4j => l}
 
 import scala.collection.immutable.Nil
+import scala.meta.internal.pc.MetalsGlobal
 
 trait ScaladocCompletions { this: MetalsGlobal =>
 

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/ScaladocCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/ScaladocCompletions.scala
@@ -18,7 +18,7 @@ trait ScaladocCompletions { this: MetalsGlobal =>
    * @param pos the position of the completion request.
    * @param text the text of the original source code.
    */
-  case class Scaladoc(
+  case class ScaladocCompletion(
       editRange: l.Range,
       associatedDef: MemberDef,
       pos: Position,

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/TypeCompletions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/TypeCompletions.scala
@@ -1,0 +1,14 @@
+package scala.meta.internal.pc.completions
+
+import scala.meta.internal.pc.MetalsGlobal
+
+trait TypeCompletions { this: MetalsGlobal =>
+
+  /**
+   * A completion inside a type position, example `val x: Map[Int, Strin@@]`
+   */
+  case object TypeCompletion extends CompletionPosition {
+    override def isType: Boolean = true
+  }
+
+}


### PR DESCRIPTION
> split Completions.scala into smaller files, it's at ~1.6k lines now with a lot of unrelated functionality grouped in one place

https://github.com/scalameta/metals/issues/672

---

This PR split `Completions.scala` into smaller files and reduced the size of `Completions.scala` from 1.6K lines to around 800 lines.

- move each concrete class of `CompletePosition` (e.g. `MatchKeyword`, `InterpolatorType`) into another files.
  - We already split some of them into smaller files
    - ScaladocCompletions.scala https://github.com/scalameta/metals/pull/1250#discussion_r363080599
    - OverrideCompletions.scala https://github.com/scalameta/metals/pull/1379
- move those files into `mtags/src/main/scala/scala/meta/internal/pc/completions/*.scala`

---

BTW, I used `ImportMissingSymbol` feature of Metals a lot for this PR, it's amazing :tada: