### PR TITLE
Use proper range for references with backticks

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -67,7 +67,7 @@ final class ReferenceProvider(
 
   def references(
       params: ReferenceParams,
-      checkMatchesText: Boolean = false,
+      canSkipExactMatchCheck: Boolean = true,
       includeSynthetics: Synthetic => Boolean = _ => true
   ): ReferencesResult = {
     val source = params.getTextDocument.getUri.toAbsolutePath
@@ -86,7 +86,7 @@ final class ReferenceProvider(
               occurrence,
               alternatives,
               params.getContext.isIncludeDeclaration,
-              checkMatchesText,
+              canSkipExactMatchCheck,
               includeSynthetics
             )
             ReferencesResult(occurrence.symbol, locations)
@@ -181,7 +181,7 @@ final class ReferenceProvider(
       occ: SymbolOccurrence,
       alternatives: Set[String],
       isIncludeDeclaration: Boolean,
-      checkMatchesText: Boolean,
+      canSkipExactMatchCheck: Boolean,
       includeSynthetics: Synthetic => Boolean
   ): Seq[Location] = {
     val isSymbol = alternatives + occ.symbol
@@ -192,7 +192,7 @@ final class ReferenceProvider(
         distance,
         params.getTextDocument.getUri,
         isIncludeDeclaration,
-        checkMatchesText,
+        canSkipExactMatchCheck,
         includeSynthetics
       )
     } else {
@@ -219,7 +219,7 @@ final class ReferenceProvider(
             semanticdbDistance,
             uri,
             isIncludeDeclaration,
-            checkMatchesText,
+            canSkipExactMatchCheck,
             includeSynthetics
           )
         } catch {
@@ -239,7 +239,7 @@ final class ReferenceProvider(
       distance: TokenEditDistance,
       uri: String,
       isIncludeDeclaration: Boolean,
-      checkMatchesText: Boolean,
+      canSkipExactMatchCheck: Boolean,
       includeSynthetics: Synthetic => Boolean
   ): Seq[Location] = {
     val buf = Seq.newBuilder[Location]
@@ -266,7 +266,6 @@ final class ReferenceProvider(
        * for some issues with macro annotations, so with renames we
        * must be sure that a proper name is replaced.
        */
-      val canSkipExactMatchCheck = !checkMatchesText
       if (canSkipExactMatchCheck) {
         add(range)
       } else {

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -80,6 +80,12 @@ final class RenameProvider(
       val symbolOccurence =
         definitionProvider.symbolOccurence(source, textParams)
 
+      val suggestedName = params.getNewName()
+      val newName =
+        if (suggestedName.charAt(0) == '`')
+          suggestedName.substring(1, suggestedName.length() - 1)
+        else suggestedName
+
       def includeSynthetic(syn: Synthetic) = {
         syn.tree match {
           case SelectTree(_, id) =>
@@ -90,7 +96,7 @@ final class RenameProvider(
 
       val allReferences = for {
         (occurence, semanticDb) <- symbolOccurence.toIterable
-        if canRenameSymbol(occurence.symbol, Option(params.getNewName()))
+        if canRenameSymbol(occurence.symbol, Option(newName))
         parentSymbols = implementationProvider
           .topMethodParents(occurence.symbol, semanticDb)
         txtParams <- {
@@ -133,7 +139,7 @@ final class RenameProvider(
         (uri, locs) <- allReferences.toList.distinct.groupBy(_.getUri())
       } yield {
         val textEdits = for (loc <- locs) yield {
-          textEdit(isOccurence, loc, params.getNewName())
+          textEdit(isOccurence, loc, newName)
         }
         Seq(uri -> textEdits.toList)
       }
@@ -148,7 +154,7 @@ final class RenameProvider(
 
       val edits = documentEdits(openedEdits)
       val renames =
-        fileRenames(isOccurence, fileChanges.keySet, params.getNewName())
+        fileRenames(isOccurence, fileChanges.keySet, newName)
       new WorkspaceEdit((edits ++ renames).asJava)
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -103,7 +103,7 @@ final class RenameProvider(
             // we can't get definition by name for local symbols
             toReferenceParams(txtParams, includeDeclaration = isLocal),
             // local symbol will not contain a proper name
-            checkMatchesText = !isLocal,
+            checkMatchesText = true,
             includeSynthetics = includeSynthetic
           )
           .locations

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -108,8 +108,7 @@ final class RenameProvider(
           .references(
             // we can't get definition by name for local symbols
             toReferenceParams(txtParams, includeDeclaration = isLocal),
-            // local symbol will not contain a proper name
-            checkMatchesText = true,
+            canSkipExactMatchCheck = false,
             includeSynthetics = includeSynthetic
           )
           .locations

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -525,6 +525,23 @@ class RenameLspSuite extends BaseLspSuite("rename") {
     newName = "other"
   )
 
+  // If renaming in VS Code, backticks are taken as part of the name
+  renamed(
+    "backtick4",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main{
+       |  def local = {
+       |    val greeting = "Hello"
+       |    "" match {
+       |      case `gre@@eting` =>
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "`greeting`"
+  )
+
   // tests currently not working correctly due to issues in SemanticDB
   // issue https://github.com/scalameta/scalameta/issues/1169
   // possibly issue https://github.com/scalameta/scalameta/issues/1845
@@ -606,7 +623,7 @@ class RenameLspSuite extends BaseLspSuite("rename") {
             val expected = if (!notRenamed) {
               code
                 .replaceAll("\\<\\<\\S*\\>\\>", newName)
-                .replaceAll("##", "")
+                .replaceAll("(##|@@)", "")
             } else {
               code.replaceAll(allMarkersRegex, "")
             }

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -469,6 +469,62 @@ class RenameLspSuite extends BaseLspSuite("rename") {
     newName = "anotherName"
   )
 
+  renamed(
+    "nested-symbol",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Foo {
+       |  object <<Ma@@in>>
+       |}
+       |""".stripMargin,
+    newName = "Child",
+    fileRenames = Map.empty
+  )
+
+  renamed(
+    "backtick",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main{
+       |  val <<greet@@ing>> = "Hello"
+       |  "" match {
+       |    case `<<greeting>>` =>
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "other"
+  )
+
+  renamed(
+    "backtick2",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main{
+       |  val <<greeting>> = "Hello"
+       |  "" match {
+       |    case `<<gre@@eting>>` =>
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "other"
+  )
+
+  renamed(
+    "backtick3",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main{
+       |  def local = {
+       |    val <<greet@@ing>> = "Hello"
+       |    "" match {
+       |      case `<<greeting>>` =>
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "other"
+  )
+
   // tests currently not working correctly due to issues in SemanticDB
   // issue https://github.com/scalameta/scalameta/issues/1169
   // possibly issue https://github.com/scalameta/scalameta/issues/1845
@@ -500,18 +556,6 @@ class RenameLspSuite extends BaseLspSuite("rename") {
        |}
        |""".stripMargin,
     newName = "Animal"
-  )
-
-  renamed(
-    "nested-symbol",
-    """|/a/src/main/scala/a/Main.scala
-       |package a
-       |object Foo {
-       |  object <<Ma@@in>>
-       |}
-       |""".stripMargin,
-    newName = "Child",
-    fileRenames = Map.empty
   )
 
   def renamed(


### PR DESCRIPTION
Previously rename would not work with backticks. Now, the reference provider returns proper ranges not including the backticks, we an exact match is needed for renames.

Fixes https://github.com/scalameta/metals/issues/1421
