### PR TITLE
Fix download URL for Coursier command-line interface

### DIFF
--- a/metals-docs/src/main/scala/docs/BootstrapModifier.scala
+++ b/metals-docs/src/main/scala/docs/BootstrapModifier.scala
@@ -21,7 +21,7 @@ class BootstrapModifier extends StringModifier {
            |
            |```sh
            |# Make sure to use coursier v1.1.0-M9 or newer.
-           |curl -L -o coursier https://git.io/coursier
+           |curl -L -o coursier https://git.io/coursier-cli
            |chmod +x coursier
            |./coursier bootstrap \\
            |  --java-opt -Xss4m \\


### PR DESCRIPTION
`https://git.io/coursier` is 404
new get url is `https://git.io/coursier-cli`
ref https://get-coursier.io/docs/cli-overview.html#linux-macos