### PR TITLE
Add missing config in Eglot

### DIFF
--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -140,6 +140,8 @@ To configure Eglot with Metals:
 ;; Add melpa-stable to your packages repositories
 (add-to-list 'package-archives '("melpa-stable" . "https://stable.melpa.org/packages/") t)
 
+(package-initialize)
+
 ;; Install use-package if not already installed
 (unless (package-installed-p 'use-package)
   (package-refresh-contents)


### PR DESCRIPTION
While trying to configure LSP client Eglot I had an error when opening emacs, then I found the reason why:

https://github.com/melpa/melpa/issues/6091#issuecomment-477348940