### PR TITLE
Add new LSP extension 'metals/pickInput' to implement the "Create Scala file" command

### DIFF
--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -671,6 +671,7 @@ rather then using server properties. The currently available settings for
       "debuggingProvider": boolean,
       "decorationProvider": boolean,
       "inputBoxProvider": boolean,
+      "pickInputProvider": boolean,
       "didFocusProvider": boolean,
       "slowTaskProvider": boolean,
       "executeClientCommandProvider": boolean,

--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -141,6 +141,16 @@ Possible values:
 
 *Usage of `inputBoxProvider` in `ClientCapabilities.experimental` is preferable.*
 
+### `-Dmetals.pick-input`
+
+Possible values:
+
+- `off` (default): the `metals/pickInput` request is not supported. In this case,
+  Metals fallbacks to `window/showMessageRequest`.
+- `on`: the `metals/pickInput` request is fully supported.
+
+*Usage of `pickInputProvider` in `ClientCapabilities.experimental` is preferable.*
+
 ### `-Dmetals.execute-client-command`
 
 Possible values:
@@ -537,6 +547,73 @@ export interface MetalsInputBoxParams {
 ```ts
 export interface MetalsInputBoxResult {
   value?: string;
+  cancelled?: boolean;
+}
+```
+
+### `metals/pickInput`
+
+The Metals pick input request is sent from the server to the client to let the
+user provide a string value by picking one out of a number of given options. It is similar to `window/showMessageRequest`, but the `metals/pickInput` request has richer parameters, that can be used to filter items to pick, like `description` and `detail`.
+
+_Request_:
+
+- method: `metals/pickInput`
+- params: `MetalsPickInputParams` defined as follows. It partially matches [`QuickPickOptions`](https://code.visualstudio.com/api/references/vscode-api#QuickPickOptions) in the Visual Studio Code API, but it also contains `items` of [`MetalsPickItem`](https://code.visualstudio.com/api/references/vscode-api#QuickPickItem), which, in it's turn, partially matches `QuickPickItem`, but these interfaces do not contain options for picking many items:
+
+```ts
+export interface MetalsPickInputParams {
+  /**
+   * An array of items that can be selected from.
+   */
+  items: MetalsPickItem[];
+  /**
+   * An optional flag to include the description when filtering the picks.
+   */
+  matchOnDescription?: boolean;
+  /**
+   * An optional flag to include the detail when filtering the picks.
+   */
+  matchOnDetail?: boolean;
+  /**
+   * An optional string to show as place holder in the input box to guide the user what to pick on.
+   */
+  placeHolder?: string;
+  /**
+   * Set to `true` to keep the picker open when focus moves to another part of the editor or to another window.
+   */
+  ignoreFocusOut?: boolean;
+}
+
+export interface MetalsPickItem {
+  /**
+   * An id for this items that should be return as a result of the picking.
+   */
+  id: string;
+  /**
+   * A human readable string which is rendered prominent.
+   */
+  label: string;
+  /**
+   * A human readable string which is rendered less prominent.
+   */
+  description?: string;
+  /**
+   * A human readable string which is rendered less prominent.
+   */
+  detail?: string;
+  /**
+   * Always show this item.
+   */
+  alwaysShow?: boolean;
+}
+```
+
+- result: `MetalsPickInputResult` defined as follows:
+
+```ts
+export interface MetalsPickInputResult {
+  itemId?: string;
   cancelled?: boolean;
 }
 ```

--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -541,22 +541,22 @@ export interface MetalsInputBoxResult {
 }
 ```
 
-### `metals/pickInput`
+### `metals/quickPick`
 
-The Metals pick input request is sent from the server to the client to let the
-user provide a string value by picking one out of a number of given options. It is similar to `window/showMessageRequest`, but the `metals/pickInput` request has richer parameters, that can be used to filter items to pick, like `description` and `detail`.
+The Metals quick pick request is sent from the server to the client to let the
+user provide a string value by picking one out of a number of given options. It is similar to `window/showMessageRequest`, but the `metals/quickPick` request has richer parameters, that can be used to filter items to pick, like `description` and `detail`.
 
 _Request_:
 
-- method: `metals/pickInput`
-- params: `MetalsPickInputParams` defined as follows. It partially matches [`QuickPickOptions`](https://code.visualstudio.com/api/references/vscode-api#QuickPickOptions) in the Visual Studio Code API, but it also contains `items` of [`MetalsPickItem`](https://code.visualstudio.com/api/references/vscode-api#QuickPickItem), which, in it's turn, partially matches `QuickPickItem`, but these interfaces do not contain options for picking many items:
+- method: `metals/quickPick`
+- params: `MetalsQuickInputParams` defined as follows. It partially matches [`QuickPickOptions`](https://code.visualstudio.com/api/references/vscode-api#QuickPickOptions) in the Visual Studio Code API, but it also contains `items` of [`MetalsQuickPickItem`](https://code.visualstudio.com/api/references/vscode-api#QuickPickItem), which, in it's turn, partially matches `QuickPickItem`, but these interfaces do not contain options for picking many items:
 
 ```ts
-export interface MetalsPickInputParams {
+export interface MetalsQuickPickParams {
   /**
    * An array of items that can be selected from.
    */
-  items: MetalsPickItem[];
+  items: MetalsQuickPickItem[];
   /**
    * An optional flag to include the description when filtering the picks.
    */
@@ -575,7 +575,7 @@ export interface MetalsPickInputParams {
   ignoreFocusOut?: boolean;
 }
 
-export interface MetalsPickItem {
+export interface MetalsQuickPickItem {
   /**
    * An id for this items that should be return as a result of the picking.
    */
@@ -599,10 +599,10 @@ export interface MetalsPickItem {
 }
 ```
 
-- result: `MetalsPickInputResult` defined as follows:
+- result: `MetalsQuickPickResult` defined as follows:
 
 ```ts
-export interface MetalsPickInputResult {
+export interface MetalsQuickPickResult {
   itemId?: string;
   cancelled?: boolean;
 }
@@ -661,7 +661,7 @@ rather then using server properties. The currently available settings for
       "debuggingProvider": boolean,
       "decorationProvider": boolean,
       "inputBoxProvider": boolean,
-      "pickInputProvider": boolean,
+      "quickPickProvider": boolean,
       "didFocusProvider": boolean,
       "slowTaskProvider": boolean,
       "executeClientCommandProvider": boolean,

--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -141,16 +141,6 @@ Possible values:
 
 *Usage of `inputBoxProvider` in `ClientCapabilities.experimental` is preferable.*
 
-### `-Dmetals.pick-input`
-
-Possible values:
-
-- `off` (default): the `metals/pickInput` request is not supported. In this case,
-  Metals fallbacks to `window/showMessageRequest`.
-- `on`: the `metals/pickInput` request is fully supported.
-
-*Usage of `pickInputProvider` in `ClientCapabilities.experimental` is preferable.*
-
 ### `-Dmetals.execute-client-command`
 
 Possible values:

--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -378,6 +378,8 @@ using the Metals sidebar. This feature is only implemented in VS Code.
 
 **Input box**: Editor client implements the `metals/inputBox` request.
 
+**Pick Input**: Editor client implements the `metals/pickInput` request.
+
 **Window state**: Editor client implements the `metals/windowStateDidChange`
 notification.
 

--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -378,7 +378,7 @@ using the Metals sidebar. This feature is only implemented in VS Code.
 
 **Input box**: Editor client implements the `metals/inputBox` request.
 
-**Pick Input**: Editor client implements the `metals/pickInput` request.
+**Quick pick**: Editor client implements the `metals/quickPick` request.
 
 **Window state**: Editor client implements the `metals/windowStateDidChange`
 notification.

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
@@ -7,7 +7,7 @@ final case class ClientExperimentalCapabilities(
     treeViewProvider: java.lang.Boolean = false,
     decorationProvider: java.lang.Boolean = false,
     inputBoxProvider: java.lang.Boolean = false,
-    pickInputProvider: java.lang.Boolean = false,
+    quickPickProvider: java.lang.Boolean = false,
     didFocusProvider: java.lang.Boolean = false,
     slowTaskProvider: java.lang.Boolean = false,
     executeClientCommandProvider: java.lang.Boolean = false,

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
@@ -7,6 +7,7 @@ final case class ClientExperimentalCapabilities(
     treeViewProvider: java.lang.Boolean = false,
     decorationProvider: java.lang.Boolean = false,
     inputBoxProvider: java.lang.Boolean = false,
+    pickInputProvider: java.lang.Boolean = false,
     didFocusProvider: java.lang.Boolean = false,
     slowTaskProvider: java.lang.Boolean = false,
     executeClientCommandProvider: java.lang.Boolean = false,

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -106,16 +106,16 @@ final class ConfiguredLanguageClient(
     }
   }
 
-  override def metalsPickInput(
-      params: MetalsPickInputParams
-  ): CompletableFuture[MetalsPickInputResult] = {
-    if (clientCapabilities.pickInputProvider) {
-      underlying.metalsPickInput(params)
+  override def metalsQuickPick(
+      params: MetalsQuickPickParams
+  ): CompletableFuture[MetalsQuickPickResult] = {
+    if (clientCapabilities.quickPickProvider) {
+      underlying.metalsQuickPick(params)
     } else {
       showMessageRequest(
         toShowMessageRequestParams(params)
       ).asScala
-        .map(item => MetalsPickInputResult(itemId = item.getTitle()))
+        .map(item => MetalsQuickPickResult(itemId = item.getTitle()))
         .asJava
     }
   }
@@ -129,7 +129,7 @@ final class ConfiguredLanguageClient(
   }
 
   private def toShowMessageRequestParams(
-      params: MetalsPickInputParams
+      params: MetalsQuickPickParams
   ): ShowMessageRequestParams = {
     val result = new ShowMessageRequestParams()
     result.setMessage(params.placeHolder)

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -106,12 +106,33 @@ final class ConfiguredLanguageClient(
     }
   }
 
+  override def metalsPickInput(
+      params: MetalsPickInputParams
+  ): CompletableFuture[MetalsPickInputResult] = {
+    if (config.isPickInputEnabled) {
+      underlying.metalsPickInput(params)
+    } else {
+      showMessageRequest(params).asScala
+        .map(item => MetalsPickInputResult(itemId = item.getTitle()))
+        .asJava
+    }
+  }
+
   override def metalsPublishDecorations(
       params: PublishDecorationsParams
   ): Unit = {
     if (clientCapabilities.decorationProvider) {
       underlying.metalsPublishDecorations(params)
     }
+  }
+
+  private implicit def metalsPickInputParams2ShowMessageRequestInputParams(
+      params: MetalsPickInputParams
+  ): ShowMessageRequestParams = {
+    val result = new ShowMessageRequestParams()
+    result.setMessage(params.placeHolder)
+    result.setActions(params.items.map(item => new MessageActionItem(item.id)))
+    result
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -109,7 +109,7 @@ final class ConfiguredLanguageClient(
   override def metalsPickInput(
       params: MetalsPickInputParams
   ): CompletableFuture[MetalsPickInputResult] = {
-    if (config.isPickInputEnabled || clientCapabilities.pickInputProvider) {
+    if (clientCapabilities.pickInputProvider) {
       underlying.metalsPickInput(params)
     } else {
       showMessageRequest(

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -109,10 +109,12 @@ final class ConfiguredLanguageClient(
   override def metalsPickInput(
       params: MetalsPickInputParams
   ): CompletableFuture[MetalsPickInputResult] = {
-    if (config.isPickInputEnabled) {
+    if (config.isPickInputEnabled || clientCapabilities.pickInputProvider) {
       underlying.metalsPickInput(params)
     } else {
-      showMessageRequest(params).asScala
+      showMessageRequest(
+        toShowMessageRequestParams(params)
+      ).asScala
         .map(item => MetalsPickInputResult(itemId = item.getTitle()))
         .asJava
     }
@@ -126,7 +128,7 @@ final class ConfiguredLanguageClient(
     }
   }
 
-  private implicit def metalsPickInputParams2ShowMessageRequestInputParams(
+  private def toShowMessageRequestParams(
       params: MetalsPickInputParams
   ): ShowMessageRequestParams = {
     val result = new ShowMessageRequestParams()

--- a/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
@@ -92,6 +92,12 @@ class DelegatingLanguageClient(var underlying: MetalsLanguageClient)
     underlying.metalsInputBox(params)
   }
 
+  override def metalsPickInput(
+      params: MetalsPickInputParams
+  ): CompletableFuture[MetalsPickInputResult] = {
+    underlying.metalsPickInput(params)
+  }
+
   override def metalsTreeViewDidChange(
       params: TreeViewDidChangeParams
   ): Unit = {

--- a/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
@@ -92,10 +92,10 @@ class DelegatingLanguageClient(var underlying: MetalsLanguageClient)
     underlying.metalsInputBox(params)
   }
 
-  override def metalsPickInput(
-      params: MetalsPickInputParams
-  ): CompletableFuture[MetalsPickInputResult] = {
-    underlying.metalsPickInput(params)
+  override def metalsQuickPick(
+      params: MetalsQuickPickParams
+  ): CompletableFuture[MetalsQuickPickResult] = {
+    underlying.metalsQuickPick(params)
   }
 
   override def metalsTreeViewDidChange(

--- a/metals/src/main/scala/scala/meta/internal/metals/JsonParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JsonParser.scala
@@ -33,14 +33,4 @@ object JsonParser {
     }
   }
 
-  // NOTE(alekseiAlefirov): one cannot do type parameterized extractor, unfortunately (https://github.com/scala/bug/issues/884)
-  // so instantiating this class is a workaround
-  class Of[A: ClassTag] {
-    object Jsonized {
-      def unapply(json: JsonElement): Option[A] = {
-        json.as[A].toOption
-      }
-    }
-  }
-
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -387,11 +387,5 @@ class Messages(icons: Icons) {
     def selectTheKindOfFileMessage = "Select the kind of file to create"
     def enterNameMessage(kind: String): String =
       s"Enter the name for the new $kind"
-
-    def isSelectTheKindOfFile(params: ShowMessageRequestParams): Boolean =
-      params.getMessage() == selectTheKindOfFileMessage
-
-    def isEnterName(params: MetalsInputBoxParams, kind: String): Boolean =
-      params.prompt == enterNameMessage(kind)
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -385,7 +385,8 @@ class Messages(icons: Icons) {
 
   object NewScalaFile {
     def selectTheKindOfFileMessage = "Select the kind of file to create"
-    def enterNameMessage(kind: String): String = s"Enter name for the new $kind"
+    def enterNameMessage(kind: String): String =
+      s"Enter the name for the new $kind"
 
     def isSelectTheKindOfFile(params: ShowMessageRequestParams): Boolean =
       params.getMessage() == selectTheKindOfFileMessage

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -382,4 +382,15 @@ class Messages(icons: Icons) {
         s"Please upgrade to Scala $recommended."
     }
   }
+
+  object NewScalaFile {
+    def selectTheKindOfFileMessage = "Select the kind of file to create"
+    def enterNameMessage(kind: String): String = s"Enter name for the new $kind"
+
+    def isSelectTheKindOfFile(params: ShowMessageRequestParams): Boolean =
+      params.getMessage() == selectTheKindOfFileMessage
+
+    def isEnterName(params: MetalsInputBoxParams, kind: String): Boolean =
+      params.prompt == enterNameMessage(kind)
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -171,6 +171,10 @@ object MetalsEnrichments
           Future.failed(e)
       }
     }
+
+    def liftOption(
+        implicit ec: ExecutionContext
+    ): Future[Option[A]] = future.map(Some(_))
   }
 
   implicit class XtensionJavaList[A](lst: util.List[A]) {
@@ -615,12 +619,6 @@ object MetalsEnrichments
       state.flatMap(
         _.fold(Future.successful(Option.empty[B]))(f(_).liftOption)
       )
-  }
-
-  implicit class OptionFutureLift[A](state: Future[A]) {
-    def liftOption(
-        implicit ec: ExecutionContext
-    ): Future[Option[A]] = state.map(Some(_))
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
@@ -58,6 +58,17 @@ trait MetalsLanguageClient
       params: MetalsInputBoxParams
   ): CompletableFuture[MetalsInputBoxResult]
 
+  /**
+   * Opens an input box to ask the user to pick one of the suggested options.
+   *
+   * @return the user provided pick. The future can be cancelled, meaning
+   *         the input box should be dismissed in the editor.
+   */
+  @JsonRequest("metals/pickInput")
+  def metalsPickInput(
+      params: MetalsPickInputParams
+  ): CompletableFuture[MetalsPickInputResult]
+
   final def showMessage(messageType: MessageType, message: String): Unit = {
     val params = new MessageParams(messageType, message)
     showMessage(params)
@@ -111,4 +122,34 @@ case class MetalsInputBoxResult(
     // value=null when cancelled=true
     @Nullable value: String = null,
     @Nullable cancelled: java.lang.Boolean = null
+)
+
+case class MetalsPickInputParams(
+    items: java.util.List[MetalsPickItem],
+    // An optional flag to include the description when filtering the picks.
+    @Nullable matchOnDescription: java.lang.Boolean = null,
+    // An optional flag to include the detail when filtering the picks.
+    @Nullable matchOnDetail: java.lang.Boolean = null,
+    // An optional string to show as place holder in the input box to guide the user what to pick on.
+    @Nullable placeHolder: String = null,
+    // Set to `true` to keep the picker open when focus moves to another part of the editor or to another window.
+    @Nullable ignoreFocusOut: java.lang.Boolean = null
+)
+
+case class MetalsPickInputResult(
+    // value=null when cancelled=true
+    @Nullable itemId: String = null,
+    @Nullable cancelled: java.lang.Boolean = null
+)
+
+case class MetalsPickItem(
+    id: String,
+    // A human readable string which is rendered prominent.
+    label: String,
+    // A human readable string which is rendered less prominent.
+    @Nullable description: String = null,
+    // A human readable string which is rendered less prominent.
+    @Nullable detail: String = null,
+    // Always show this item.
+    @Nullable alwaysShow: java.lang.Boolean = null
 )

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
@@ -59,15 +59,15 @@ trait MetalsLanguageClient
   ): CompletableFuture[MetalsInputBoxResult]
 
   /**
-   * Opens an input box to ask the user to pick one of the suggested options.
+   * Opens an menu to ask the user to pick one of the suggested options.
    *
    * @return the user provided pick. The future can be cancelled, meaning
    *         the input box should be dismissed in the editor.
    */
-  @JsonRequest("metals/pickInput")
-  def metalsPickInput(
-      params: MetalsPickInputParams
-  ): CompletableFuture[MetalsPickInputResult]
+  @JsonRequest("metals/quickPick")
+  def metalsQuickPick(
+      params: MetalsQuickPickParams
+  ): CompletableFuture[MetalsQuickPickResult]
 
   final def showMessage(messageType: MessageType, message: String): Unit = {
     val params = new MessageParams(messageType, message)
@@ -124,8 +124,8 @@ case class MetalsInputBoxResult(
     @Nullable cancelled: java.lang.Boolean = null
 )
 
-case class MetalsPickInputParams(
-    items: java.util.List[MetalsPickItem],
+case class MetalsQuickPickParams(
+    items: java.util.List[MetalsQuickPickItem],
     // An optional flag to include the description when filtering the picks.
     @Nullable matchOnDescription: java.lang.Boolean = null,
     // An optional flag to include the detail when filtering the picks.
@@ -136,13 +136,13 @@ case class MetalsPickInputParams(
     @Nullable ignoreFocusOut: java.lang.Boolean = null
 )
 
-case class MetalsPickInputResult(
+case class MetalsQuickPickResult(
     // value=null when cancelled=true
     @Nullable itemId: String = null,
     @Nullable cancelled: java.lang.Boolean = null
 )
 
-case class MetalsPickItem(
+case class MetalsQuickPickItem(
     id: String,
     // A human readable string which is rendered prominent.
     label: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -363,7 +363,7 @@ class MetalsLanguageServer(
       languageClient,
       packageProvider,
       config,
-      focusedDocument
+      () => focusedDocument
     )
     multilineStringFormattingProvider = new MultilineStringFormattingProvider(
       semanticdbs,
@@ -1296,7 +1296,7 @@ class MetalsLanguageServer(
               Some(directory.getAsString()).map(new URI(_))
             )
           case Seq(_: JsonNull) =>
-            newFilesProvider.createNewFileDialog(None)
+            newFilesProvider.createNewFileDialog(directoryUri = None)
           case _ =>
             Future.failed(
               new IllegalArgumentException(s"Invalid arguments: $args.")

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -53,6 +53,7 @@ import scala.meta.internal.rename.RenameProvider
 import ch.epfl.scala.bsp4j.CompileReport
 import java.{util => ju}
 import scala.meta.internal.metals.Messages.IncompatibleBloopVersion
+import com.google.gson.JsonNull
 
 class MetalsLanguageServer(
     ec: ExecutionContextExecutorService,
@@ -178,8 +179,7 @@ class MetalsLanguageServer(
   private var foldingRangeProvider: FoldingRangeProvider = _
   private val packageProvider: PackageProvider =
     new PackageProvider(buildTargets)
-  private val newFilesProvider: NewFilesProvider =
-    new NewFilesProvider(workspace, packageProvider)
+  private var newFilesProvider: NewFilesProvider = _
   private var symbolSearch: MetalsSymbolSearch = _
   private var compilers: Compilers = _
   var tables: Tables = _
@@ -357,6 +357,13 @@ class MetalsLanguageServer(
         case _ =>
           Nil
       }
+    )
+    newFilesProvider = new NewFilesProvider(
+      workspace,
+      languageClient,
+      packageProvider,
+      config,
+      focusedDocument
     )
     multilineStringFormattingProvider = new MultilineStringFormattingProvider(
       semanticdbs,
@@ -1282,27 +1289,18 @@ class MetalsLanguageServer(
             Future.failed(new IllegalArgumentException(msg)).asJavaObject
         }
       case ServerCommands.NewScalaFile() =>
-        val parser = new JsonParser.Of[MetalsNewScalaFileParams]
         val args = params.getArguments.asScala
         (args match {
-          case Seq(parser.Jsonized(newScalaFileParams)) =>
-            import newScalaFileParams._
-            val result =
-              newFilesProvider
-                .createNewFile(Option(directory).map(new URI(_)), name, kind)
-            result.onFailure {
-              case NonFatal(e) =>
-                languageClient
-                  .showMessage(
-                    MessageType.Error,
-                    s"Cannot create file:\n ${e.toString()}"
-                  )
-            }
-            result
+          case Seq(directory: JsonPrimitive) if directory.isString =>
+            newFilesProvider.createNewFileDialog(
+              Some(directory.getAsString()).map(new URI(_))
+            )
+          case Seq(_: JsonNull) =>
+            newFilesProvider.createNewFileDialog(None)
           case _ =>
-            val argExample = ServerCommands.NewScalaFile.arguments
-            val msg = s"Invalid arguments: $args. Expecting: $argExample"
-            Future.failed(new IllegalArgumentException(msg))
+            Future.failed(
+              new IllegalArgumentException(s"Invalid arguments: $args.")
+            )
         }).asJavaObject
 
       case cmd =>

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -44,10 +44,6 @@ final case class MetalsServerConfig(
       "metals.input-box",
       default = false
     ),
-    isPickInputEnabled: Boolean = MetalsServerConfig.binaryOption(
-      "metals.pick-input",
-      default = false
-    ),
     isVerbose: Boolean = MetalsServerConfig.binaryOption(
       "metals.verbose",
       default = false
@@ -81,7 +77,6 @@ final case class MetalsServerConfig(
       s"compilers=$compilers",
       s"http=$isHttpEnabled",
       s"input-box=$isInputBoxEnabled",
-      s"pick-input=$isPickInputEnabled",
       s"icons=$icons",
       s"statistics=$statistics",
       s"doctor-format=$doctorFormat"
@@ -113,7 +108,6 @@ object MetalsServerConfig {
           executeClientCommand = ExecuteClientCommandConfig.on,
           globSyntax = GlobSyntaxConfig.vscode,
           isInputBoxEnabled = true,
-          isPickInputEnabled = true,
           compilers = base.compilers.copy(
             _parameterHintsCommand = Some("editor.action.triggerParameterHints"),
             _completionCommand = Some("editor.action.triggerSuggest"),

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -107,7 +107,6 @@ object MetalsServerConfig {
           openFilesOnRenames = true,
           executeClientCommand = ExecuteClientCommandConfig.on,
           globSyntax = GlobSyntaxConfig.vscode,
-          isInputBoxEnabled = true,
           compilers = base.compilers.copy(
             _parameterHintsCommand = Some("editor.action.triggerParameterHints"),
             _completionCommand = Some("editor.action.triggerSuggest"),

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -44,6 +44,10 @@ final case class MetalsServerConfig(
       "metals.input-box",
       default = false
     ),
+    isPickInputEnabled: Boolean = MetalsServerConfig.binaryOption(
+      "metals.pick-input",
+      default = false
+    ),
     isVerbose: Boolean = MetalsServerConfig.binaryOption(
       "metals.verbose",
       default = false
@@ -77,6 +81,7 @@ final case class MetalsServerConfig(
       s"compilers=$compilers",
       s"http=$isHttpEnabled",
       s"input-box=$isInputBoxEnabled",
+      s"pick-input=$isPickInputEnabled",
       s"icons=$icons",
       s"statistics=$statistics",
       s"doctor-format=$doctorFormat"
@@ -107,6 +112,8 @@ object MetalsServerConfig {
           openFilesOnRenames = true,
           executeClientCommand = ExecuteClientCommandConfig.on,
           globSyntax = GlobSyntaxConfig.vscode,
+          isInputBoxEnabled = true,
+          isPickInputEnabled = true,
           compilers = base.compilers.copy(
             _parameterHintsCommand = Some("editor.action.triggerParameterHints"),
             _completionCommand = Some("editor.action.triggerSuggest"),

--- a/metals/src/main/scala/scala/meta/internal/metals/NewFilesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NewFilesProvider.scala
@@ -23,13 +23,13 @@ class NewFilesProvider(
     implicit ec: ExecutionContext
 ) {
 
-  private val classPick = MetalsPickItem(id = "class", label = "Class")
-  private val objectPick = MetalsPickItem(id = "object", label = "Object")
-  private val traitPick = MetalsPickItem(id = "trait", label = "Trait")
+  private val classPick = MetalsQuickPickItem(id = "class", label = "Class")
+  private val objectPick = MetalsQuickPickItem(id = "object", label = "Object")
+  private val traitPick = MetalsQuickPickItem(id = "trait", label = "Trait")
   private val packageObjectPick =
-    MetalsPickItem(id = "package-object", label = "Package Object")
+    MetalsQuickPickItem(id = "package-object", label = "Package Object")
   private val worksheetPick =
-    MetalsPickItem(id = "worksheet", label = "Worksheet")
+    MetalsQuickPickItem(id = "worksheet", label = "Worksheet")
 
   def createNewFileDialog(directoryUri: Option[URI]): Future[Unit] = {
     val directory = directoryUri
@@ -64,8 +64,8 @@ class NewFilesProvider(
 
   private def askForKind: Future[Option[String]] = {
     client
-      .metalsPickInput(
-        MetalsPickInputParams(
+      .metalsQuickPick(
+        MetalsQuickPickParams(
           List(
             classPick,
             objectPick,

--- a/metals/src/main/scala/scala/meta/internal/metals/NewFilesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NewFilesProvider.scala
@@ -7,51 +7,120 @@ import MetalsEnrichments._
 import java.nio.file.Files
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
+import org.eclipse.lsp4j.MessageType
+import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.Location
+import DialogEnrichments._
+import scala.meta.internal.metals.Messages.NewScalaFile
 
 class NewFilesProvider(
     workspace: AbsolutePath,
-    packageProvider: PackageProvider
+    client: MetalsLanguageClient,
+    packageProvider: PackageProvider,
+    serverConfig: MetalsServerConfig,
+    focusedDocument: => Option[AbsolutePath]
 ) {
 
-  def createNewFile(directory: Option[URI], name: String, kind: String)(
+  private val classPick = MetalsPickItem(id = "class", label = "Class")
+  private val objectPick = MetalsPickItem(id = "object", label = "Object")
+  private val traitPick = MetalsPickItem(id = "trait", label = "Trait")
+  private val packageObjectPick =
+    MetalsPickItem(id = "package-object", label = "Package Object")
+  private val worksheetPick =
+    MetalsPickItem(id = "worksheet", label = "Worksheet")
+
+  def createNewFileDialog(directoryUri: Option[URI])(
       implicit ec: ExecutionContext
-  ): Future[URI] = kind match {
-    case "class" | "object" | "trait" =>
-      createClass(directory, name, kind)
-    case "package-object" =>
-      createPackageObject(directory)
-    case "worksheet" =>
-      createWorksheet(directory, name)
-    case invalid => Future.failed(new IllegalArgumentException(invalid))
+  ): Future[Unit] = {
+    val directory = directoryUri
+      .map(_.toString.toAbsolutePath)
+      .orElse(focusedDocument.map(_.parent))
+
+    val newlyCreatedFile =
+      askForKind
+        .continueWith {
+          case kind @ (classPick.id | objectPick.id | traitPick.id) =>
+            askForName(kind)
+              .endWith(
+                createClass(directory, _, kind)
+              )
+          case worksheetPick.id =>
+            askForName(worksheetPick.id)
+              .endWith(
+                createWorksheet(directory, _)
+              )
+          case packageObjectPick.id =>
+            endWith(
+              createPackageObject(directory)
+            )
+          case invalid =>
+            Future.failed(new IllegalArgumentException(invalid))
+        }
+
+    newlyCreatedFile.map {
+      case Some(path) =>
+        openFile(path)
+      case None => ()
+    }
   }
 
-  def createWorksheet(directory: Option[URI], name: String)(
+  private def askForKind(
       implicit ec: ExecutionContext
-  ): Future[URI] = {
-    val path = directory
-      .fold(workspace)(_.toString.toAbsolutePath)
-      .resolve(name + ".worksheet.sc")
-    createFile(path)
+  ): Future[Option[String]] = {
+    client
+      .metalsPickInput(
+        MetalsPickInputParams(
+          List(
+            classPick,
+            objectPick,
+            traitPick,
+            packageObjectPick,
+            worksheetPick
+          ).asJava,
+          placeHolder = NewScalaFile.selectTheKindOfFileMessage
+        )
+      )
+      .asScala
+      .map {
+        case kind if !kind.cancelled => Some(kind.itemId)
+        case _ => None
+      }
   }
 
-  def createClass(directory: Option[URI], name: String, kind: String)(
+  private def askForName(kind: String)(
       implicit ec: ExecutionContext
-  ): Future[URI] = {
-    val path = directory
-      .fold(workspace)(_.toString.toAbsolutePath)
-      .resolve(name + ".scala")
+  ): Future[Option[String]] = {
+    client
+      .metalsInputBox(
+        MetalsInputBoxParams(prompt = NewScalaFile.enterNameMessage(kind))
+      )
+      .asScala
+      .map {
+        case name if !name.cancelled => Some(name.value)
+        case _ => None
+      }
+  }
+
+  private def createClass(
+      directory: Option[AbsolutePath],
+      name: String,
+      kind: String
+  )(
+      implicit ec: ExecutionContext
+  ): Future[AbsolutePath] = {
+    val path = directory.getOrElse(workspace).resolve(name + ".scala")
     val editText =
       packageProvider.packageStatement(path).getOrElse("") +
         classTemplate(kind, name)
     createFileAndWriteText(path, editText)
   }
 
-  def createPackageObject(
-      directory: Option[URI]
-  )(implicit ec: ExecutionContext): Future[URI] = {
+  private def createPackageObject(
+      directory: Option[AbsolutePath]
+  )(implicit ec: ExecutionContext): Future[AbsolutePath] = {
     directory
       .map { directory =>
-        val path = directory.toString.toAbsolutePath.resolve("package.scala")
+        val path = directory.resolve("package.scala")
         createFileAndWriteText(
           path,
           packageProvider.packageStatement(path).getOrElse("")
@@ -66,25 +135,50 @@ class NewFilesProvider(
       )
   }
 
+  private def createWorksheet(directory: Option[AbsolutePath], name: String)(
+      implicit ec: ExecutionContext
+  ): Future[AbsolutePath] = {
+    val path = directory.getOrElse(workspace).resolve(name + ".worksheet.sc")
+    createFile(path)
+  }
+
   private def createFile(
       path: AbsolutePath
-  )(implicit ec: ExecutionContext): Future[URI] = {
+  )(implicit ec: ExecutionContext): Future[AbsolutePath] = {
     val result = Future {
-      Files.createFile(path.toNIO).toUri()
+      AbsolutePath(
+        Files.createFile(path.toNIO)
+      )
     }
     result.onFailure {
-      case NonFatal(e) => scribe.error("Cannot create file", e)
+      case NonFatal(e) =>
+        scribe.error("Cannot create file", e)
+        client.showMessage(
+          MessageType.Error,
+          s"Cannot create file:\n ${e.toString()}"
+        )
     }
     result
   }
 
   private def createFileAndWriteText(path: AbsolutePath, text: String)(
       implicit ec: ExecutionContext
-  ): Future[URI] = {
-    createFile(path).map { newFileUri =>
+  ): Future[AbsolutePath] = {
+    createFile(path).map { _ =>
       path.writeText(text)
-      newFileUri
+      path
     }
+  }
+
+  private def openFile(path: AbsolutePath): Unit = {
+    client.metalsExecuteClientCommand(
+      new ExecuteCommandParams(
+        ClientCommands.GotoLocation.id,
+        List(
+          new Location(path.toString(), new org.eclipse.lsp4j.Range()): Object
+        ).asJava
+      )
+    )
   }
 
   private def classTemplate(kind: String, name: String): String =
@@ -92,5 +186,29 @@ class NewFilesProvider(
         |  
         |}
         |""".stripMargin
+
+}
+
+object DialogEnrichments {
+
+  implicit class DialogContinuation[A](state: Future[Option[A]]) {
+
+    def continueWith[B](
+        continuation: A => Future[Option[B]]
+    )(implicit ec: ExecutionContext): Future[Option[B]] =
+      state.flatMap(_.fold(Future.successful(Option.empty[B]))(continuation))
+
+    def endWith[B](
+        ending: A => Future[B]
+    )(implicit ec: ExecutionContext): Future[Option[B]] =
+      state.flatMap(
+        _.fold(Future.successful(Option.empty[B]))(ending(_).map(Some(_)))
+      )
+
+  }
+
+  def endWith[A](ending: Future[A])(
+      implicit ec: ExecutionContext
+  ): Future[Option[A]] = ending.map(Some(_))
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
@@ -37,10 +37,10 @@ abstract class NoopLanguageClient extends MetalsLanguageClient {
   ): CompletableFuture[MetalsInputBoxResult] = {
     CompletableFuture.completedFuture(MetalsInputBoxResult(cancelled = true))
   }
-  override def metalsPickInput(
-      params: MetalsPickInputParams
-  ): CompletableFuture[MetalsPickInputResult] = {
-    CompletableFuture.completedFuture(MetalsPickInputResult(cancelled = true))
+  override def metalsQuickPick(
+      params: MetalsQuickPickParams
+  ): CompletableFuture[MetalsQuickPickResult] = {
+    CompletableFuture.completedFuture(MetalsQuickPickResult(cancelled = true))
   }
   override def metalsTreeViewDidChange(
       params: TreeViewDidChangeParams

--- a/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
@@ -37,6 +37,11 @@ abstract class NoopLanguageClient extends MetalsLanguageClient {
   ): CompletableFuture[MetalsInputBoxResult] = {
     CompletableFuture.completedFuture(MetalsInputBoxResult(cancelled = true))
   }
+  override def metalsPickInput(
+      params: MetalsPickInputParams
+  ): CompletableFuture[MetalsPickInputResult] = {
+    CompletableFuture.completedFuture(MetalsPickInputResult(cancelled = true))
+  }
   override def metalsTreeViewDidChange(
       params: TreeViewDidChangeParams
   ): Unit = ()

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -136,6 +136,8 @@ object ServerCommands {
     """|Create and open new file with either scala class, object, trait, package object or worksheet.
        |
        |Arguments: [string], where the string is a directory location for the new file.
+       |
+       |Note: requires 'metals/inputBox' capability from language client.
        |""".stripMargin
   )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -2,7 +2,6 @@ package scala.meta.internal.metals
 
 import scala.util.matching.Regex
 import ch.epfl.scala.{bsp4j => b}
-import javax.annotation.Nullable
 
 /**
  * LSP commands supported by the Metals language server.
@@ -134,17 +133,10 @@ object ServerCommands {
   val NewScalaFile = new Command(
     "new-scala-file",
     "Create new scala file",
-    """Create and open new file with either scala class, object, trait, package object or worksheet.""",
-    s"""|MetalsNewScalaFileParams object
-        |Example:
-        |```json
-        |{
-        |   directory: "file:///home/dev/foo/bar/",
-        |   name: 'Baz',
-        |   kind: 'class'
-        |}
-        |```
-    """.stripMargin
+    """|Create and open new file with either scala class, object, trait, package object or worksheet.
+       |
+       |Arguments: [string], where the string is a directory location for the new file.
+       |""".stripMargin
   )
 
   /**
@@ -220,9 +212,3 @@ object ServerCommands {
     NewScalaFile
   )
 }
-
-case class MetalsNewScalaFileParams(
-    @Nullable directory: String,
-    name: String,
-    kind: String
-)

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -71,6 +71,7 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
     _: ShowMessageRequestParams =>
       None
   }
+  var inputBoxHandler: MetalsInputBoxParams => Option[MetalsInputBoxResult] = _
 
   private var refreshedOnIndex = false
   var refreshModelHandler: () => Unit = () => {}
@@ -273,7 +274,13 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
   override def metalsInputBox(
       params: MetalsInputBoxParams
   ): CompletableFuture[MetalsInputBoxResult] = {
-    CompletableFuture.completedFuture(MetalsInputBoxResult(cancelled = true))
+    CompletableFuture.completedFuture {
+      messageRequests.addLast(params.prompt)
+      inputBoxHandler(params) match {
+        case Some(result) => result
+        case None => MetalsInputBoxResult(cancelled = true)
+      }
+    }
   }
 
   override def metalsTreeViewDidChange(

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -71,7 +71,10 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
     _: ShowMessageRequestParams =>
       None
   }
-  var inputBoxHandler: MetalsInputBoxParams => Option[MetalsInputBoxResult] = _
+  var inputBoxHandler: MetalsInputBoxParams => Option[MetalsInputBoxResult] = {
+    _: MetalsInputBoxParams =>
+      None
+  }
 
   private var refreshedOnIndex = false
   var refreshModelHandler: () => Unit = () => {}

--- a/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
@@ -4,15 +4,16 @@ import java.nio.file.Files
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.RecursivelyDelete
-import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.Messages.NewScalaFile
 import scala.meta.internal.metals.MetalsInputBoxResult
+import scala.meta.internal.metals.ClientExperimentalCapabilities
 import scala.concurrent.Future
 import scala.meta.io.AbsolutePath
 
 class NewFilesLspSuite extends BaseLspSuite("new-files") {
-  override def serverConfig: MetalsServerConfig =
-    super.serverConfig.copy(isInputBoxEnabled = true)
+  override def experimentalCapabilities
+      : Option[ClientExperimentalCapabilities] =
+    Some(ClientExperimentalCapabilities(inputBoxProvider = true))
 
   test("new-worksheet") {
     cleanCompileCache("a")


### PR DESCRIPTION
After new-scala-file command has been added to metals https://github.com/scalameta/metals/pull/1339 , client-side service was discussed https://github.com/scalameta/metals-vscode/pull/183 , and it was decided to move and implemet quick-pick communication to server.