### PR TITLE
Record visited Scala files to make sure they are not duplicated

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -196,12 +196,15 @@ final class ReferenceProvider(
         includeSynthetics
       )
     } else {
+      val visited = scala.collection.mutable.Set.empty[AbsolutePath]
       val results: Iterator[Location] = for {
         (path, bloom) <- index.iterator
         if bloom.mightContain(occ.symbol)
         scalaPath <- SemanticdbClasspath
           .toScala(workspace, AbsolutePath(path))
           .iterator
+        if !visited(scalaPath)
+        _ = visited.add(scalaPath)
         if scalaPath.exists
         semanticdb <- semanticdbs
           .textDocument(scalaPath)


### PR DESCRIPTION
Previously, if we had two targets for one file, like for example JS and JVM, we would get duplicated results due to 2 different semanticDB files being created. Now we check if a given file was already processed.

Prematurely closed https://github.com/scalameta/metals/pull/1450
There is actually another simple way to fix it.