### PR TITLE
Recognize .srcjar extension as jar files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -306,7 +306,7 @@ object MetalsEnrichments
 
     def isJar: Boolean = {
       val filename = path.toNIO.getFileName.toString
-      filename.endsWith(".jar")
+      filename.endsWith(".jar") || filename.endsWith(".srcjar")
     }
 
     /**


### PR DESCRIPTION
- Bazel uses .srcjar extension to recognize files that need to be
unpacked and compiled.
- For this convention, `rules_scala`'s emits protobuf source jars
with .srcjar extension.
- As is, providing the path to a .srcjar file in the resolution field
of a Bloop configuration file does not work in Metals because it isn't
recognized as a jar file.