### PR TITLE
add properties back in

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -101,8 +101,11 @@ object MetalsServerConfig {
     System.getProperty("metals.client", "default") match {
       case "vscode" =>
         base.copy(
+          statusBar = StatusBarConfig.on,
+          slowTask = SlowTaskConfig.on,
           icons = Icons.vscode,
           openFilesOnRenames = true,
+          executeClientCommand = ExecuteClientCommandConfig.on,
           globSyntax = GlobSyntaxConfig.vscode,
           compilers = base.compilers.copy(
             _parameterHintsCommand = Some("editor.action.triggerParameterHints"),
@@ -133,6 +136,9 @@ object MetalsServerConfig {
         )
       case "coc-metals" =>
         base.copy(
+          statusBar = StatusBarConfig.showMessage,
+          isInputBoxEnabled = true,
+          executeClientCommand = ExecuteClientCommandConfig.on,
           compilers = base.compilers.copy(
             _parameterHintsCommand = Some("editor.action.triggerParameterHints"),
             _completionCommand = Some("editor.action.triggerSuggest"),


### PR DESCRIPTION
I went a little crazy with #1414 and since we aren't going to merge in https://github.com/scalameta/metals-vscode/pull/207 or https://github.com/scalameta/coc-metals/pull/74 until we do a release, these will need to stay in here. If not, when a user is using a snapshot of Metals, they won't have the necessary values set since they aren't being passed via experimental yet until those are merged. So, we need these for now.