### PR TITLE
add in checkmark for debug on emacs

### DIFF
--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -98,7 +98,7 @@ functionality.
     <td align="center"></td>
     <td align="center"></td>
     <td align="center"></td>
-    <td align="center"></td>
+    <td align="center">✅</td>
     <td align="center"></td>
   </tr>
   <tr>


### PR DESCRIPTION
As a follow-up to the comment in the feature request about debug support with `dap-mode`, https://github.com/scalameta/metals-feature-requests/issues/84#issuecomment-589452103, I've gone ahead and updated the overview table to reflect that you can now run/debug in emacs.