### PR TITLE
add openFilesOnRenameProvider to experimental

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
@@ -11,6 +11,7 @@ final case class ClientExperimentalCapabilities(
     didFocusProvider: java.lang.Boolean = false,
     slowTaskProvider: java.lang.Boolean = false,
     executeClientCommandProvider: java.lang.Boolean = false,
+    openFilesOnRenameProvider: java.lang.Boolean = false,
     doctorProvider: String = "html",
     statusBarProvider: String = "off"
 ) {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -393,7 +393,8 @@ class MetalsLanguageServer(
       languageClient,
       buffers,
       compilations,
-      config
+      config,
+      clientExperimentalCapabilities
     )
     semanticDBIndexer = new SemanticdbIndexer(
       referencesProvider,


### PR DESCRIPTION
This setting was merged in right around when I was doing #1414, so I didn't include it. However, this can also go into `ClientExperimentalCapabilities`. It's also very VS Code specific, so we may be able to just fully remove it from the ServerConfig options.

To summarize, this pr moves the `metalsconfig.openFilesOnRenames` to an experimental provider. I'll also add this into the vscode extension.