### PR TITLE
Fix issue when warning about Bloop version change 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -11,7 +11,7 @@ case class GradleBuildTool(userConfig: () => UserConfiguration)
 
   private val initScriptName = "init-script.gradle"
 
-  private def additionalRepos = {
+  private def additionalRepos: String = {
     val isSnapshotVersion = BuildInfo.gradleBloopVersion.contains("+")
     if (isSnapshotVersion)
       """|maven{
@@ -21,9 +21,8 @@ case class GradleBuildTool(userConfig: () => UserConfiguration)
       ""
     }
   }
-  private val versionToUse = userConfig().bloopVersion
 
-  private val initScript =
+  private def initScript(versionToUse: String) =
     s"""
        |initscript {
        |  repositories{
@@ -40,7 +39,8 @@ case class GradleBuildTool(userConfig: () => UserConfiguration)
     """.stripMargin.getBytes()
 
   private lazy val initScriptPath: Path = {
-    Files.write(tempDir.resolve(initScriptName), initScript)
+    val bloopVersion = userConfig().currentBloopVersion
+    Files.write(tempDir.resolve(initScriptName), initScript(bloopVersion))
   }
 
   private lazy val gradleWrapper = {

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -19,15 +19,14 @@ case class MavenBuildTool(userConfig: () => UserConfiguration)
   }
 
   def args(workspace: AbsolutePath): List[String] = {
-    val versionToUse = userConfig().bloopVersion
-    val command =
+    def command(versionToUse: String) =
       List(
         s"ch.epfl.scala:maven-bloop_2.10:$versionToUse:bloopInstall",
         "-DdownloadSources=true"
       )
     userConfig().mavenScript match {
       case Some(script) =>
-        script :: command
+        script :: command(userConfig().currentBloopVersion)
       case None =>
         writeProperties()
         val javaArgs = List[String](
@@ -44,7 +43,7 @@ case class MavenBuildTool(userConfig: () => UserConfiguration)
         List(
           javaArgs,
           jarArgs,
-          command
+          command(userConfig().currentBloopVersion)
         ).flatten
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -83,7 +83,7 @@ case class SbtBuildTool(
       config: MetalsServerConfig
   ): Unit = {
     if (userConfig().bloopSbtAlreadyInstalled) return
-    val versionToUse = userConfig().bloopVersion
+    val versionToUse = userConfig().currentBloopVersion
     val bytes = SbtBuildTool
       .sbtPlugin(versionToUse)
       .getBytes(StandardCharsets.UTF_8)

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -56,7 +56,7 @@ final class BloopServers(
   def newServer(
       userConfiguration: UserConfiguration
   ): Future[Option[BuildServerConnection]] = {
-    val bloopVersion = userConfiguration.bloopVersion
+    val bloopVersion = userConfiguration.currentBloopVersion
     BuildServerConnection
       .fromSockets(
         workspace,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -841,7 +841,9 @@ class MetalsLanguageServer(
           if (userConfig.bloopVersion != old.bloopVersion) {
             languageClient
               .showMessageRequest(
-                Messages.BloopVersionChange.params(userConfig.bloopVersion)
+                Messages.BloopVersionChange.params(
+                  userConfig.currentBloopVersion
+                )
               )
               .asScala
               .flatMap {
@@ -1732,7 +1734,7 @@ class MetalsLanguageServer(
         val messageParams = IncompatibleBloopVersion.params(
           bspServerVersion,
           BuildInfo.bloopVersion,
-          BuildInfo.bloopVersion != userConfig.bloopVersion
+          isChangedInSettings = userConfig.bloopVersion != None
         )
         languageClient.showMessageRequest(messageParams).asScala.foreach {
           case action if action == IncompatibleBloopVersion.shutdown =>

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -31,9 +31,15 @@ case class UserConfiguration(
     worksheetScreenWidth: Int = 120,
     worksheetCancelTimeout: Int = 4,
     bloopSbtAlreadyInstalled: Boolean = false,
-    bloopVersion: String = BuildInfo.bloopVersion,
+    bloopVersion: Option[String] = None,
     pantsTargets: Option[List[String]] = None
-)
+) {
+
+  def currentBloopVersion: String =
+    bloopVersion.getOrElse(BuildInfo.bloopVersion)
+
+}
+
 object UserConfiguration {
 
   def default: UserConfiguration = UserConfiguration()
@@ -235,8 +241,7 @@ object UserConfiguration {
       )
     val bloopSbtAlreadyInstalled =
       getBooleanKey("bloop-sbt-already-installed").getOrElse(false)
-    val bloopVersion =
-      getStringKey("bloop-version").getOrElse(BuildInfo.bloopVersion)
+    val bloopVersion = getStringKey("bloop-version")
     if (errors.isEmpty) {
       Right(
         UserConfiguration(


### PR DESCRIPTION
Previously. the warning about Bloop version change would pop up always when starting the workspace when the user had a non default setting. Now, the default is changed to None, which stops the consistent warning.