### PR TITLE
Expire docstrings' cache on save

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1579,6 +1579,7 @@ class MetalsLanguageServer(
           }
       }
       workspaceSymbols.didChange(source, symbols)
+      symbolDocs.didChange(symbols.map(_.symbol))
     } catch {
       case NonFatal(e) =>
         scribe.error(source.toString(), e)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1579,7 +1579,10 @@ class MetalsLanguageServer(
           }
       }
       workspaceSymbols.didChange(source, symbols)
-      symbolDocs.didChange(symbols.map(_.symbol))
+
+      // Since the `symbols` here are toplevel symbols,
+      // we cannot use `symbols` for expiring the cache for all symbols in the source.
+      symbolDocs.expireSymbolDefinition(source)
     } catch {
       case NonFatal(e) =>
         scribe.error(source.toString(), e)

--- a/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
@@ -37,6 +37,10 @@ class Docstrings(index: GlobalSymbolIndex) {
     }
   }
 
+  def didChange(symbols: Seq[String]): Unit = {
+    symbols.foreach(sym => indexSymbol(sym))
+  }
+
   private def cacheSymbol(doc: SymbolDocumentation): Unit = {
     cache(doc.symbol()) = doc
   }

--- a/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
@@ -13,6 +13,10 @@ import scala.meta.pc.SymbolDocumentation
 import scala.util.control.NonFatal
 import scala.meta.internal.mtags.GlobalSymbolIndex
 import scala.meta.internal.semanticdb.SymbolOccurrence
+import scala.meta.internal.mtags.ScalaMtags
+import scala.meta.inputs.Input
+import scala.meta.internal.semanticdb.SymbolInformation
+import scala.meta.io.AbsolutePath
 
 /**
  * Implementation of the `documentation(symbol: String): Option[SymbolDocumentation]` method in `SymbolSearch`.
@@ -38,26 +42,33 @@ class Docstrings(index: GlobalSymbolIndex) {
     }
   }
 
-  def didChange(symbols: Seq[String]): Unit = {
-    symbols.foreach(sym => indexSymbol(sym, Some(expireCacheSymbol)))
+  /**
+   * Expire all symbols showed in the given scala source file.
+   *
+   * Note that what this method does is only expiring the cache, and
+   * it doesn't update the cache in honor of the memory footprint.
+   * Otherwise, if we update the cache for symbols every time we save a file,
+   * metals will cache all symbols in files we've saved, and it consumes a considerable amount of memory.
+   *
+   * @param path the absolute path for the source file to update.
+   */
+  def expireSymbolDefinition(path: AbsolutePath): Unit = {
+    path.toLanguage match {
+      case Language.SCALA =>
+        new Deindexer(path.toInput).indexRoot()
+      case _ =>
+    }
   }
 
   private def cacheSymbol(doc: SymbolDocumentation): Unit = {
     cache(doc.symbol()) = doc
   }
 
-  private def expireCacheSymbol(occ: SymbolOccurrence): Unit = {
-    cache.remove(occ.symbol)
-  }
-
-  private def indexSymbol(
-      symbol: String,
-      occFn: Option[SymbolOccurrence => Unit] = None
-  ): Unit = {
+  private def indexSymbol(symbol: String): Unit = {
     index.definition(Symbol(symbol)) match {
       case Some(defn) =>
         try {
-          indexSymbolDefinition(defn, occFn)
+          indexSymbolDefinition(defn)
         } catch {
           case NonFatal(e) =>
             logger.log(Level.SEVERE, defn.path.toURI.toString, e)
@@ -66,18 +77,27 @@ class Docstrings(index: GlobalSymbolIndex) {
     }
   }
 
-  private def indexSymbolDefinition(
-      defn: SymbolDefinition,
-      occFn: Option[SymbolOccurrence => Unit]
-  ): Unit = {
+  private def indexSymbolDefinition(defn: SymbolDefinition): Unit = {
     defn.path.toLanguage match {
       case Language.JAVA =>
         JavadocIndexer
           .foreach(defn.path.toInput)(cacheSymbol)
       case Language.SCALA =>
         ScaladocIndexer
-          .foreach(defn.path.toInput)(cacheSymbol, occFn)
+          .foreach(defn.path.toInput)(cacheSymbol)
       case _ =>
+    }
+  }
+
+  private class Deindexer(
+      input: Input.VirtualFile
+  ) extends ScalaMtags(input) {
+    override def visitOccurrence(
+        occ: SymbolOccurrence,
+        sinfo: SymbolInformation,
+        owner: String
+    ): Unit = {
+      cache.remove(occ.symbol)
     }
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/metals/ScaladocIndexer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/ScaladocIndexer.scala
@@ -17,8 +17,7 @@ import scala.meta.pc.SymbolDocumentation
  */
 class ScaladocIndexer(
     input: Input.VirtualFile,
-    fn: SymbolDocumentation => Unit,
-    occFn: Option[SymbolOccurrence => Unit]
+    fn: SymbolDocumentation => Unit
 ) extends ScalaMtags(input) {
   val defines: mutable.Map[String, String] = mutable.Map.empty[String, String]
   override def visitOccurrence(
@@ -26,106 +25,101 @@ class ScaladocIndexer(
       sinfo: SymbolInformation,
       owner: String
   ): Unit = {
-    occFn match {
-      case Some(occFn) =>
-        occFn(occ)
-      case None =>
-        val docstring = currentTree.origin match {
-          case Origin.None => ""
-          case parsed: Origin.Parsed =>
-            val leadingDocstring =
-              ScaladocIndexer.findLeadingDocstring(
-                source.tokens,
-                parsed.pos.start - 1
-              )
-            leadingDocstring match {
-              case Some(value) => value
-              case None => ""
-            }
-        }
-        // Register `@define` macros to use for expanding in later docstrings.
-        defines ++= ScaladocParser.extractDefines(docstring)
-        val comment = ScaladocParser.parseComment(docstring, defines)
-        val markdown = MarkdownGenerator.toMarkdown(comment)
-        def param(name: String, default: String): SymbolDocumentation = {
-          val paramDoc = comment.valueParams
-            .get(name)
-            .orElse(comment.typeParams.get(name))
-            .map(MarkdownGenerator.toMarkdown)
-            .getOrElse("")
-          MetalsSymbolDocumentation(
-            Symbols.Global(owner, Descriptor.Parameter(name)),
-            name,
-            paramDoc,
-            default
+    val docstring = currentTree.origin match {
+      case Origin.None => ""
+      case parsed: Origin.Parsed =>
+        val leadingDocstring =
+          ScaladocIndexer.findLeadingDocstring(
+            source.tokens,
+            parsed.pos.start - 1
           )
+        leadingDocstring match {
+          case Some(value) => value
+          case None => ""
         }
-        def mparam(member: Member): SymbolDocumentation = {
-          val default = member match {
-            case Term.Param(_, _, _, Some(term)) => term.syntax
-            case _ =>
-              ""
-          }
-          param(member.name.value, default)
-        }
-        val info = currentTree match {
-          case _: Defn.Trait | _: Pkg.Object | _: Defn.Val | _: Defn.Var |
-              _: Decl.Val | _: Decl.Var | _: Defn.Type | _: Decl.Type =>
-            Some(
-              MetalsSymbolDocumentation(
-                occ.symbol,
-                sinfo.displayName,
-                markdown
-              )
-            )
-          case t: Defn.Def =>
-            Some(
-              MetalsSymbolDocumentation(
-                occ.symbol,
-                t.name.value,
-                markdown,
-                "",
-                t.tparams.map(mparam).asJava,
-                t.paramss.flatten.map(mparam).asJava
-              )
-            )
-          case t: Decl.Def =>
-            Some(
-              MetalsSymbolDocumentation(
-                occ.symbol,
-                t.name.value,
-                markdown,
-                "",
-                t.tparams.map(mparam).asJava,
-                t.paramss.flatten.map(mparam).asJava
-              )
-            )
-          case t: Defn.Class =>
-            Some(
-              MetalsSymbolDocumentation(
-                occ.symbol,
-                t.name.value,
-                markdown,
-                "",
-                // Type parameters are intentionally excluded because constructors
-                // cannot have type parameters.
-                Nil.asJava,
-                t.ctor.paramss.flatten.map(mparam).asJava
-              )
-            )
-          case t: Member =>
-            Some(
-              MetalsSymbolDocumentation(
-                occ.symbol,
-                t.name.value,
-                markdown
-              )
-            )
-          case _ =>
-            None
-        }
-        info.foreach(fn)
     }
+    // Register `@define` macros to use for expanding in later docstrings.
+    defines ++= ScaladocParser.extractDefines(docstring)
+    val comment = ScaladocParser.parseComment(docstring, defines)
+    val markdown = MarkdownGenerator.toMarkdown(comment)
+    def param(name: String, default: String): SymbolDocumentation = {
+      val paramDoc = comment.valueParams
+        .get(name)
+        .orElse(comment.typeParams.get(name))
+        .map(MarkdownGenerator.toMarkdown)
+        .getOrElse("")
+      MetalsSymbolDocumentation(
+        Symbols.Global(owner, Descriptor.Parameter(name)),
+        name,
+        paramDoc,
+        default
+      )
+    }
+    def mparam(member: Member): SymbolDocumentation = {
+      val default = member match {
+        case Term.Param(_, _, _, Some(term)) => term.syntax
+        case _ =>
+          ""
+      }
+      param(member.name.value, default)
+    }
+    val info = currentTree match {
+      case _: Defn.Trait | _: Pkg.Object | _: Defn.Val | _: Defn.Var |
+          _: Decl.Val | _: Decl.Var | _: Defn.Type | _: Decl.Type =>
+        Some(
+          MetalsSymbolDocumentation(
+            occ.symbol,
+            sinfo.displayName,
+            markdown
+          )
+        )
+      case t: Defn.Def =>
+        Some(
+          MetalsSymbolDocumentation(
+            occ.symbol,
+            t.name.value,
+            markdown,
+            "",
+            t.tparams.map(mparam).asJava,
+            t.paramss.flatten.map(mparam).asJava
+          )
+        )
+      case t: Decl.Def =>
+        Some(
+          MetalsSymbolDocumentation(
+            occ.symbol,
+            t.name.value,
+            markdown,
+            "",
+            t.tparams.map(mparam).asJava,
+            t.paramss.flatten.map(mparam).asJava
+          )
+        )
+      case t: Defn.Class =>
+        Some(
+          MetalsSymbolDocumentation(
+            occ.symbol,
+            t.name.value,
+            markdown,
+            "",
+            // Type parameters are intentionally excluded because constructors
+            // cannot have type parameters.
+            Nil.asJava,
+            t.ctor.paramss.flatten.map(mparam).asJava
+          )
+        )
+      case t: Member =>
+        Some(
+          MetalsSymbolDocumentation(
+            occ.symbol,
+            t.name.value,
+            markdown
+          )
+        )
+      case _ =>
+        None
+    }
+    info.foreach(fn)
   }
 }
 
@@ -135,17 +129,11 @@ object ScaladocIndexer {
    * Extracts Scaladoc from Scala source code.
    *
    * @param fn callback function for calculated SymbolDocumentation
-   * @param occFn (optional) callback function for SymbolOccurrence
-   *              if this function is given, ScaladocIndexer DO NOT
-   *              calculate Scaladoc for symbols.
    */
   def foreach(
       input: Input.VirtualFile
-  )(
-      fn: SymbolDocumentation => Unit,
-      occFn: Option[SymbolOccurrence => Unit]
-  ): Unit = {
-    new ScaladocIndexer(input, fn, occFn).indexRoot()
+  )(fn: SymbolDocumentation => Unit): Unit = {
+    new ScaladocIndexer(input, fn).indexRoot()
   }
 
   /**

--- a/mtags/src/main/scala/scala/meta/internal/metals/ScaladocIndexer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/ScaladocIndexer.scala
@@ -17,7 +17,8 @@ import scala.meta.pc.SymbolDocumentation
  */
 class ScaladocIndexer(
     input: Input.VirtualFile,
-    fn: SymbolDocumentation => Unit
+    fn: SymbolDocumentation => Unit,
+    occFn: Option[SymbolOccurrence => Unit]
 ) extends ScalaMtags(input) {
   val defines: mutable.Map[String, String] = mutable.Map.empty[String, String]
   override def visitOccurrence(
@@ -25,110 +26,126 @@ class ScaladocIndexer(
       sinfo: SymbolInformation,
       owner: String
   ): Unit = {
-    val docstring = currentTree.origin match {
-      case Origin.None => ""
-      case parsed: Origin.Parsed =>
-        val leadingDocstring =
-          ScaladocIndexer.findLeadingDocstring(
-            source.tokens,
-            parsed.pos.start - 1
-          )
-        leadingDocstring match {
-          case Some(value) => value
-          case None => ""
+    occFn match {
+      case Some(occFn) =>
+        occFn(occ)
+      case None =>
+        val docstring = currentTree.origin match {
+          case Origin.None => ""
+          case parsed: Origin.Parsed =>
+            val leadingDocstring =
+              ScaladocIndexer.findLeadingDocstring(
+                source.tokens,
+                parsed.pos.start - 1
+              )
+            leadingDocstring match {
+              case Some(value) => value
+              case None => ""
+            }
         }
+        // Register `@define` macros to use for expanding in later docstrings.
+        defines ++= ScaladocParser.extractDefines(docstring)
+        val comment = ScaladocParser.parseComment(docstring, defines)
+        val markdown = MarkdownGenerator.toMarkdown(comment)
+        def param(name: String, default: String): SymbolDocumentation = {
+          val paramDoc = comment.valueParams
+            .get(name)
+            .orElse(comment.typeParams.get(name))
+            .map(MarkdownGenerator.toMarkdown)
+            .getOrElse("")
+          MetalsSymbolDocumentation(
+            Symbols.Global(owner, Descriptor.Parameter(name)),
+            name,
+            paramDoc,
+            default
+          )
+        }
+        def mparam(member: Member): SymbolDocumentation = {
+          val default = member match {
+            case Term.Param(_, _, _, Some(term)) => term.syntax
+            case _ =>
+              ""
+          }
+          param(member.name.value, default)
+        }
+        val info = currentTree match {
+          case _: Defn.Trait | _: Pkg.Object | _: Defn.Val | _: Defn.Var |
+              _: Decl.Val | _: Decl.Var | _: Defn.Type | _: Decl.Type =>
+            Some(
+              MetalsSymbolDocumentation(
+                occ.symbol,
+                sinfo.displayName,
+                markdown
+              )
+            )
+          case t: Defn.Def =>
+            Some(
+              MetalsSymbolDocumentation(
+                occ.symbol,
+                t.name.value,
+                markdown,
+                "",
+                t.tparams.map(mparam).asJava,
+                t.paramss.flatten.map(mparam).asJava
+              )
+            )
+          case t: Decl.Def =>
+            Some(
+              MetalsSymbolDocumentation(
+                occ.symbol,
+                t.name.value,
+                markdown,
+                "",
+                t.tparams.map(mparam).asJava,
+                t.paramss.flatten.map(mparam).asJava
+              )
+            )
+          case t: Defn.Class =>
+            Some(
+              MetalsSymbolDocumentation(
+                occ.symbol,
+                t.name.value,
+                markdown,
+                "",
+                // Type parameters are intentionally excluded because constructors
+                // cannot have type parameters.
+                Nil.asJava,
+                t.ctor.paramss.flatten.map(mparam).asJava
+              )
+            )
+          case t: Member =>
+            Some(
+              MetalsSymbolDocumentation(
+                occ.symbol,
+                t.name.value,
+                markdown
+              )
+            )
+          case _ =>
+            None
+        }
+        info.foreach(fn)
     }
-    // Register `@define` macros to use for expanding in later docstrings.
-    defines ++= ScaladocParser.extractDefines(docstring)
-    val comment = ScaladocParser.parseComment(docstring, defines)
-    val markdown = MarkdownGenerator.toMarkdown(comment)
-    def param(name: String, default: String): SymbolDocumentation = {
-      val paramDoc = comment.valueParams
-        .get(name)
-        .orElse(comment.typeParams.get(name))
-        .map(MarkdownGenerator.toMarkdown)
-        .getOrElse("")
-      MetalsSymbolDocumentation(
-        Symbols.Global(owner, Descriptor.Parameter(name)),
-        name,
-        paramDoc,
-        default
-      )
-    }
-    def mparam(member: Member): SymbolDocumentation = {
-      val default = member match {
-        case Term.Param(_, _, _, Some(term)) => term.syntax
-        case _ =>
-          ""
-      }
-      param(member.name.value, default)
-    }
-    val info = currentTree match {
-      case _: Defn.Trait | _: Pkg.Object | _: Defn.Val | _: Defn.Var |
-          _: Decl.Val | _: Decl.Var | _: Defn.Type | _: Decl.Type =>
-        Some(
-          MetalsSymbolDocumentation(
-            occ.symbol,
-            sinfo.displayName,
-            markdown
-          )
-        )
-      case t: Defn.Def =>
-        Some(
-          MetalsSymbolDocumentation(
-            occ.symbol,
-            t.name.value,
-            markdown,
-            "",
-            t.tparams.map(mparam).asJava,
-            t.paramss.flatten.map(mparam).asJava
-          )
-        )
-      case t: Decl.Def =>
-        Some(
-          MetalsSymbolDocumentation(
-            occ.symbol,
-            t.name.value,
-            markdown,
-            "",
-            t.tparams.map(mparam).asJava,
-            t.paramss.flatten.map(mparam).asJava
-          )
-        )
-      case t: Defn.Class =>
-        Some(
-          MetalsSymbolDocumentation(
-            occ.symbol,
-            t.name.value,
-            markdown,
-            "",
-            // Type parameters are intentionally excluded because constructors
-            // cannot have type parameters.
-            Nil.asJava,
-            t.ctor.paramss.flatten.map(mparam).asJava
-          )
-        )
-      case t: Member =>
-        Some(
-          MetalsSymbolDocumentation(
-            occ.symbol,
-            t.name.value,
-            markdown
-          )
-        )
-      case _ =>
-        None
-    }
-    info.foreach(fn)
   }
 }
 
 object ScaladocIndexer {
 
+  /**
+   * Extracts Scaladoc from Scala source code.
+   *
+   * @param fn callback function for calculated SymbolDocumentation
+   * @param occFn (optional) callback function for SymbolOccurrence
+   *              if this function is given, ScaladocIndexer DO NOT
+   *              calculate Scaladoc for symbols.
+   */
   def foreach(
       input: Input.VirtualFile
-  )(fn: SymbolDocumentation => Unit): Unit = {
-    new ScaladocIndexer(input, fn).indexRoot()
+  )(
+      fn: SymbolDocumentation => Unit,
+      occFn: Option[SymbolOccurrence => Unit]
+  ): Unit = {
+    new ScaladocIndexer(input, fn, occFn).indexRoot()
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/1471

### Problem
Since the cache in `scala.meta.internal.metals.Docstrings` never expired, once the docstring for the symbol has cached, it won't update until the metals server restart.
That's why even if we update Javadoc comments, the change won't reflect the docstrings showed on hover as https://github.com/scalameta/metals/issues/1471.

### How this PR fixed the problem
- Implemented `Docstrings#didChange(symbols: Seq[String]): Unit` that expires the cache for the docstrings of given (scalameta) symbols.
- Call `Docstrings#didChange` method on save (from `indexSourceFile`).

![docstrings](https://user-images.githubusercontent.com/9353584/75621846-14051980-5bdd-11ea-949d-d3c54f7295fa.gif)