### PR TITLE
remove -1 from determining if a new line is before pos

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
@@ -78,7 +78,7 @@ final class MultilineStringFormattingProvider(
       newlineAdded: Boolean
   ): Boolean = {
     val newLineBeforePos =
-      text.lastIndexBetween('\n', upperBound = pos.start - 1)
+      text.lastIndexBetween('\n', upperBound = pos.start)
     val pipeSearchStop =
       if (newlineAdded)
         text.lastIndexBetween('\n', upperBound = newLineBeforePos - 1)


### PR DESCRIPTION
This pr removes logic that was creating an exception from being thrown when a new line was being added as the first thing in a file.

Closes #1469 