### PR TITLE
Add in math max when looking for lastIndex

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
@@ -78,10 +78,13 @@ final class MultilineStringFormattingProvider(
       newlineAdded: Boolean
   ): Boolean = {
     val newLineBeforePos =
-      text.lastIndexBetween('\n', upperBound = pos.start - 1)
+      text.lastIndexBetween('\n', upperBound = Math.max(pos.start - 1, 0))
     val pipeSearchStop =
       if (newlineAdded)
-        text.lastIndexBetween('\n', upperBound = newLineBeforePos - 1)
+        text.lastIndexBetween(
+          '\n',
+          upperBound = Math.max(newLineBeforePos - 1, 0)
+        )
       else newLineBeforePos
     val lastPipe = text.lastIndexBetween('|', pipeSearchStop, pos.start - 1)
     lastPipe > pipeSearchStop

--- a/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
@@ -4,6 +4,22 @@ import munit.Location
 
 class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
 
+  // Ensures that entering a newline at the beginning of a file doesn't
+  // throw an exception
+  // https://github.com/scalameta/metals/issues/1469
+  check(
+    "top-of-file",
+    s"""
+       |@@
+       |object Main {}
+       |""".stripMargin,
+    s"""
+       |
+       |
+       |object Main {}
+       |""".stripMargin
+  )
+
   check(
     "correct-string",
     s"""


### PR DESCRIPTION
This prs adds in logic that will protect from getting indexOutOfBounds exceptions when the user is at the beginning of a file and inserts a new line.

Closes #1469 