### PR TITLE
Add ability to specify zipkin url for fastpass

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -325,6 +325,7 @@ lazy val metals = project
         "-H:+ReportUnsupportedElementsAtRuntime",
         "--initialize-at-build-time",
         "--initialize-at-run-time=scala.meta.internal.pantsbuild,metaconfig",
+        "--initialize-at-build-time=scala.meta.internal.pantsbuild.ZipkinUrls",
         "--no-server",
         "--enable-http",
         "--enable-https",

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ZipkinUrls.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ZipkinUrls.scala
@@ -1,0 +1,44 @@
+package scala.meta.internal.pantsbuild.commands
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
+import scala.meta.io.AbsolutePath
+
+object ZipkinUrls {
+
+  def url: Option[String] =
+    Option(System.getProperty("metals.zipkin.server.url"))
+
+  def updateZipkinServerUrl(): Boolean = {
+    ZipkinUrls.url match {
+      case Some(newUrl) =>
+        import scala.meta.internal.metals.MetalsEnrichments._
+        val homedir = AbsolutePath(System.getProperty("user.home"))
+        val jvmopts = homedir.resolve(".bloop").resolve(".jvmopts")
+        val oldOptions =
+          if (jvmopts.isFile) jvmopts.readText.linesIterator.toList
+          else Nil
+        val zipkin = "-Dzipkin.server.url=(.*)".r
+        val oldUrl = oldOptions.collectFirst { case zipkin(url) => url }
+        if (oldUrl.contains(newUrl)) {
+          false
+        } else {
+          val otherOptions =
+            oldOptions.filterNot(_.startsWith("-Dzipkin.server.url")).toList
+          val zipkinOption = s"-Dzipkin.server.url=$newUrl"
+          val allOptions = zipkinOption :: otherOptions
+          scribe.info(s"zipkin: new server URL '$newUrl'")
+          Files.write(
+            jvmopts.toNIO,
+            allOptions.mkString("\n").getBytes(StandardCharsets.UTF_8),
+            StandardOpenOption.TRUNCATE_EXISTING,
+            StandardOpenOption.CREATE
+          )
+          true
+        }
+      case None =>
+        false
+    }
+  }
+}


### PR DESCRIPTION
We currently can only submit traces to Bloop's default of `http://127.0.0.1:9411/api/v2/spans`, unless we manually write to `~/.bloop/.jvmopts`. This change will allow `BloopPants` to write to `~/.bloop/.jvmopts` automatically. Binary versions of `fastpass` can be built with the correct server url statically embedded.