### PR TITLE
Fix rename for hierarchy with generics

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/implementation/ClassLocation.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ClassLocation.scala
@@ -30,7 +30,7 @@ private[implementation] case class ClassLocation(
     this.copy(asSeenFrom = newASF)
   }
 
-  // Translate postion based names to real names in the class
+  // Translate position based names to real names in the class
   def toRealNames(
       classInfo: SymbolInformation,
       translateKey: Boolean
@@ -100,7 +100,16 @@ object AsSeenFrom {
     }.toMap
   }
 
-  // Translate postion based names to real names in the class
+  // Translate position based names to real names in the class
+  def toRealNames(
+      parentClassSig: ClassSignature,
+      childClassSig: ClassSignature,
+      asSeenFrom: Option[Map[String, String]]
+  ): Map[String, String] = {
+    val mappedKeys = toRealNames(parentClassSig, true, asSeenFrom)
+    toRealNames(childClassSig, false, Some(mappedKeys))
+  }
+
   def toRealNames(
       classSig: ClassSignature,
       translateKey: Boolean,

--- a/metals/src/main/scala/scala/meta/internal/implementation/MethodImplementation.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/MethodImplementation.scala
@@ -29,8 +29,8 @@ object MethodImplementation {
   import ImplementationProvider._
 
   def findParentSymbol(
-      childSymbol: SymbolInformation,
-      childClassSig: ClassSignature,
+      bottomSymbolInformation: SymbolInformation,
+      bottomClassSig: ClassSignature,
       parentClassSig: ClassSignature,
       asSeenFromMap: Map[String, String],
       findSymbol: String => Option[SymbolInformation]
@@ -41,7 +41,7 @@ object MethodImplementation {
       methodSymbolInfo <- findSymbol(methodSymbol)
       asSeenFrom = AsSeenFrom.toRealNames(
         parentClassSig,
-        translateKey = true,
+        bottomClassSig,
         Some(asSeenFromMap)
       )
       context = Context(
@@ -49,7 +49,11 @@ object MethodImplementation {
         findSymbol,
         asSeenFrom
       )
-      if isOverridenMethod(methodSymbolInfo, childSymbol, findParent = true)(
+      if isOverridenMethod(
+        methodSymbolInfo,
+        bottomSymbolInformation,
+        findParent = true
+      )(
         context
       )
     } yield methodSymbol

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -1,6 +1,7 @@
 package tests
 import scala.concurrent.Future
 import munit.Location
+import munit.TestOptions
 
 class RenameLspSuite extends BaseLspSuite("rename") {
 
@@ -32,6 +33,20 @@ class RenameLspSuite extends BaseLspSuite("rename") {
        |}
        |""".stripMargin,
     newName = "Login"
+  )
+
+  renamed(
+    "generics",
+    """/a/src/main/scala/a/Main.scala
+      |package a
+      |trait S1[X] { def <<torename>>(p: X): String = "" }
+      |trait T1[Z] extends S1[Z] { override def <<torename>>(p: Z): String = super.<<torename>>(p) }
+      |trait T2[X] extends T1[X] { override def <<torename>>(p: X): String = super.<<torename>>(p) }
+      |trait T3[I, J] extends T2[I] { override def <<torename>>(p: I): String = super.<<torename>>(p) }
+      |trait T4[I, J] extends T3[J, I] { override def <<torename>>(p: J): String = super.<<torename>>(p) }
+      |trait T5[U] extends T4[U, U] { override def <<tore@@name>>(p: U): String = super.<<torename>>(p) }
+      |""".stripMargin,
+    newName = "newname"
   )
 
   renamed(
@@ -576,7 +591,7 @@ class RenameLspSuite extends BaseLspSuite("rename") {
   )
 
   def renamed(
-      name: String,
+      name: TestOptions,
       input: String,
       newName: String,
       nonOpened: Set[String] = Set.empty,
@@ -605,7 +620,7 @@ class RenameLspSuite extends BaseLspSuite("rename") {
     )
 
   def check(
-      name: String,
+      name: TestOptions,
       input: String,
       newName: String,
       notRenamed: Boolean = false,


### PR DESCRIPTION
Currently rename doesn't find proper top level class when generics are involved in inheritance hierarchy.

Added test describes problematic scenario. 

`AsSeenFrom` values were not translated during searching for a top level class and in resolving this map wrong `ClassSignature` was provided.

After changing those 2 issues test passes and rename works properly in VSCode.

![rename_bug](https://user-images.githubusercontent.com/10478402/76083588-47b1bc00-5fae-11ea-86ab-3c94acd6497f.gif)
