### PR TITLE
During rename matching methods ignore return type

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/implementation/MethodImplementation.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/MethodImplementation.scala
@@ -213,13 +213,11 @@ object MethodImplementation {
             sig2.typeParameters
           )
         )
-        val returnTypesEqual =
-          typesAreEqual(sig1.returnType, sig2.returnType)(newContext)
         lazy val enrichedSig1 =
           addParameterSignatures(sig1, context.findSymbol)
         lazy val enrichedSig2 =
           addParameterSignatures(sig2, context.findSymbol)
-        returnTypesEqual && paramsAreEqual(
+        paramsAreEqual(
           enrichedSig1.parameterLists,
           enrichedSig2.parameterLists
         )(newContext)

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -27,7 +27,7 @@ class RenameLspSuite extends BaseLspSuite("rename") {
        |package a
        |case class <<User>>(name : String)
        |object Main{
-       |  val user = <<U@@ser>>.apply("James")
+       |  val user = <<User>>.apply("James")
        |  val user2 = <<U@@ser>>(name = "Roger")
        |  user.copy(name = "")
        |}
@@ -45,6 +45,19 @@ class RenameLspSuite extends BaseLspSuite("rename") {
       |trait T3[I, J] extends T2[I] { override def <<torename>>(p: I): String = super.<<torename>>(p) }
       |trait T4[I, J] extends T3[J, I] { override def <<torename>>(p: J): String = super.<<torename>>(p) }
       |trait T5[U] extends T4[U, U] { override def <<tore@@name>>(p: U): String = super.<<torename>>(p) }
+      |""".stripMargin,
+    newName = "newname"
+  )
+
+  renamed(
+    "match-ret-type",
+    """/a/src/main/scala/a/Main.scala
+      |package a
+      |trait P
+      |trait PP extends P
+      |trait A { def <<torename>>(a: String): P = ??? }
+      |trait B extends A { override def <<tore@@name>>(a: String): PP = ??? }
+      |
       |""".stripMargin,
     newName = "newname"
   )
@@ -580,7 +593,7 @@ class RenameLspSuite extends BaseLspSuite("rename") {
     "type-params",
     """|/a/src/main/scala/a/Main.scala
        |package a
-       |trait <<A@@BC>>
+       |trait <<ABC>>
        |class CBD[T <: <<AB@@C>>]
        |object Main{
        |  val a = classOf[ABC]
@@ -654,8 +667,7 @@ class RenameLspSuite extends BaseLspSuite("rename") {
           )
         }
 
-      val openedFiles = files.keySet
-        .filterNot(file => nonOpened.contains(file))
+      val openedFiles = files.keySet.diff(nonOpened)
       val fullInput = input.replaceAll(allMarkersRegex, "")
       for {
         _ <- server.initialize(
@@ -689,7 +701,7 @@ class RenameLspSuite extends BaseLspSuite("rename") {
             }
           }
         }
-        // chnage the code to make sure edit distance is being used
+        // change the code to make sure edit distance is being used
         _ <- Future.sequence {
           openedFiles.map { file =>
             server.didChange(file) { code =>
@@ -701,7 +713,7 @@ class RenameLspSuite extends BaseLspSuite("rename") {
           filename,
           edit.replaceAll("(<<|>>|##.*##)", ""),
           expectedFiles,
-          files.toMap.keySet,
+          files.keySet,
           newName
         )
       } yield ()


### PR DESCRIPTION
Fixes  #1474

Currently we check in rename that both methods must have strictly same return type.

In overridden method is is possible to return subtype of a type returned in parent. We could check if a return type of overridden method is subtype of returned parent type.

But it is not needed as return type is not used in scala for method comparison which means there is no possibility to define 2 methods being only different by return type. 

Scala will not compile such situation therefere it is okay to omit checking return type in rename because either methods will match or file will not compile.

![rename_bug2](https://user-images.githubusercontent.com/10478402/76090111-48048400-5fbb-11ea-9352-16b1d09f3a5a.gif)