### PR TITLE
Skip coursier download in fastpass create with --coursier-binary option

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
@@ -49,10 +49,12 @@ object IntelliJ {
   }
 
   /** The .bsp/bloop.json file is necessary for IntelliJ to automatically impor the project */
-  def writeBsp(project: Project): Unit = {
+  def writeBsp(project: Project, coursierBinary: Option[Path] = None): Unit = {
     val bspJson = project.root.bspJson.toNIO
     Files.createDirectories(bspJson.getParent)
-    val coursier = downloadCoursier(bspJson.resolveSibling("coursier"))
+    val coursier = coursierBinary.getOrElse(
+      downloadCoursier(bspJson.resolveSibling("coursier"))
+    )
     val targetsJson = new JsonArray()
     project.targets.foreach { target =>
       targetsJson.add(target)

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ExportOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ExportOptions.scala
@@ -3,12 +3,18 @@ package scala.meta.internal.pantsbuild.commands
 import metaconfig.generic
 import metaconfig.annotation._
 import metaconfig.ConfCodec
+import java.nio.file.Path
 
 case class ExportOptions(
     @Description(
       "Don't download *-sources.jar for 3rd party dependencies."
     )
     noSources: Boolean = false,
+    @Description(
+      "The path to the coursier binary." +
+        "If unspecified, coursier will be downloaded automatically."
+    )
+    coursierBinary: Option[Path] = None,
     @Hidden()
     mergeTargetsInSameDirectory: Boolean = false
 )

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/SharedCommand.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/SharedCommand.scala
@@ -47,7 +47,7 @@ object SharedCommand {
           }
           1
         case Success(count) =>
-          IntelliJ.writeBsp(export.project)
+          IntelliJ.writeBsp(export.project, export.export.coursierBinary)
           val targets = LogMessages.pluralName("Pants target", count)
           export.app.info(
             s"exported ${targets} to project '${export.project.name}' in $timer"


### PR DESCRIPTION
Users will now be able to optionally specify a path to their `coursier` binary to skip downloading it.