### PR TITLE
New `create` option:--no-root-project option

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -246,7 +246,7 @@ private class BloopPants(
     // NOTE(olafur): generate synthetic projects to improve the file tree view
     // in IntelliJ. Details: https://github.com/olafurpg/intellij-bsp-pants/issues/7
     val syntheticProjects: List[C.Project] = sourceRoots.flatMap { root =>
-      if (isBaseDirectory(root.toNIO)) {
+      if (isBaseDirectory(root.toNIO) || args.export.noRootProject) {
         Nil
       } else {
         val name = root

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ExportOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ExportOptions.scala
@@ -15,6 +15,10 @@ case class ExportOptions(
         "If unspecified, coursier will be downloaded automatically."
     )
     coursierBinary: Option[Path] = None,
+    @Description(
+      "Unconditionally prevent generation of '*-project-root' modules"
+    )
+    noRootProject: Boolean = true,
     @Hidden()
     mergeTargetsInSameDirectory: Boolean = false
 )


### PR DESCRIPTION
In some cases, metals generate synthetic '*-project-root' modules. The
new `--no-root-project' unconditionally prevents from it.