### PR TITLE
Fix Bloop sending a restart message when custom version of Bloop is used

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -165,7 +165,7 @@ class Messages(icons: Icons) {
       new MessageActionItem("Restart Bloop")
     def notNow: MessageActionItem =
       new MessageActionItem("Not now")
-    def params(version: String): ShowMessageRequestParams = {
+    def params(): ShowMessageRequestParams = {
       val params = new ShowMessageRequestParams()
       params.setMessage(
         s"Bloop version was updated, do you want to restart the running Bloop server?"

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -841,7 +841,11 @@ class MetalsLanguageServer(
           val expectedBloopVersion = userConfig.currentBloopVersion
           val correctVersionRunning =
             buildServer.map(_.version).contains(expectedBloopVersion)
-          if (buildServer.nonEmpty && !correctVersionRunning) {
+          val allVersionsDefined = buildServer.nonEmpty && userConfig.bloopVersion.nonEmpty
+          val changedToNoVersion = old.bloopVersion.isDefined && userConfig.bloopVersion.isEmpty
+          val versionChanged = allVersionsDefined && !correctVersionRunning
+          val versionRevertedToDefault = changedToNoVersion && !correctVersionRunning
+          if (versionRevertedToDefault || versionChanged) {
             languageClient
               .showMessageRequest(
                 Messages.BloopVersionChange.params()

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -838,12 +838,13 @@ class MetalsLanguageServer(
           if (userConfig.symbolPrefixes != old.symbolPrefixes) {
             compilers.restartAll()
           }
-          if (userConfig.bloopVersion != old.bloopVersion) {
+          val expectedBloopVersion = userConfig.currentBloopVersion
+          val correctVersionRunning =
+            buildServer.map(_.version).contains(expectedBloopVersion)
+          if (buildServer.nonEmpty && !correctVersionRunning) {
             languageClient
               .showMessageRequest(
-                Messages.BloopVersionChange.params(
-                  userConfig.currentBloopVersion
-                )
+                Messages.BloopVersionChange.params()
               )
               .asScala
               .flatMap {

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -241,6 +241,8 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
           ImportBuildChanges.yes
         } else if (isSameMessage(ImportBuild.params)) {
           ImportBuild.yes
+        } else if (BloopVersionChange.params() == params) {
+          BloopVersionChange.notNow
         } else if (CheckDoctor.isDoctor(params)) {
           CheckDoctor.moreInformation
         } else if (SelectBspServer.isSelectBspServer(params)) {


### PR DESCRIPTION
Previously, we were being asked to restart Bloop each time we opened a new window and the Bloop default version was changed. This is due to the fact that those settings are only being sent later on and not part of the default settings. Now, we only ask to restart if we know that the running version is different than the one specified. There might be a race condition, where those settings are sent after the connection to Bloop is established, but there is really no way around it.

I was sure I fixed it previously, but this was not the case.

There are be 3 scenarios when we ask to restart Bloop:
- bloop version is too old - that's a separate case after establishing a connection
- if the version doesn't correspond to the one set in the settings - nothing happens if no setting for Bloop was defined
- if the version was defined previously and changed to None, which means we should reverse to default