### PR TITLE
Handle fatal exceptions when evaluating worksheets.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,7 +155,7 @@ lazy val V = new {
   val sbtBloop = bloop
   val gradleBloop = bloop
   val mavenBloop = bloop
-  val mdoc = "2.1.1"
+  val mdoc = "2.1.3"
   val scalafmt = "2.4.1"
   val munit = "0.4.3"
   // List of supported Scala versions in SemanticDB. Needs to be manually updated

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -99,7 +99,7 @@ object Embedded {
         Repository.central(),
         Repository.ivy2Local(),
         MavenRepository.of(
-          "https://oss.sonatype.org/content/repositories/releases/"
+          "https://oss.sonatype.org/content/repositories/public/"
         ),
         MavenRepository.of(
           "https://oss.sonatype.org/content/repositories/snapshots/"


### PR DESCRIPTION
Fixes #1456. Previously, fatal exceptions were not caught while
evaluating worksheet making them stay stuck in "evaluating". Now,
fatal exceptions are caught in mdoc and are reported inline
in worksheets like normal non-fatal exceptions.