### PR TITLE
Do not generate synthetic modules

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -243,25 +243,9 @@ private class BloopPants(
     )
     val isBaseDirectory =
       projects.iterator.filter(_.sources.nonEmpty).map(_.directory).toSet
-    // NOTE(olafur): generate synthetic projects to improve the file tree view
-    // in IntelliJ. Details: https://github.com/olafurpg/intellij-bsp-pants/issues/7
-    val syntheticProjects: List[C.Project] = sourceRoots.flatMap { root =>
-      if (isBaseDirectory(root.toNIO) || args.export.noRootProject) {
-        Nil
-      } else {
-        val name = root
-          .toRelative(AbsolutePath(workspace))
-          .toURI(isDirectory = false)
-          .toString()
-        // NOTE(olafur): cannot be `name + "-root"` since that conflicts with the
-        // IntelliJ-generated root project.
-        List(toEmptyBloopProject(name + "-project-root", root.toNIO))
-      }
-    }
     val generatedProjects = new mutable.LinkedHashSet[Path]
-    val allProjects = syntheticProjects ::: projects
-    val byName = allProjects.map(p => p.name -> p).toMap
-    allProjects.foreach { project =>
+    val byName = projects.map(p => p.name -> p).toMap
+    projects.foreach { project =>
       // NOTE(olafur): we probably want to generate projects with empty
       // sources/classpath and single dependency on the parent.
       if (!export.cycles.parents.contains(project.name)) {

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ExportOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ExportOptions.scala
@@ -15,10 +15,6 @@ case class ExportOptions(
         "If unspecified, coursier will be downloaded automatically."
     )
     coursierBinary: Option[Path] = None,
-    @Description(
-      "Unconditionally prevent generation of '*-project-root' modules"
-    )
-    noRootProject: Boolean = true,
     @Hidden()
     mergeTargetsInSameDirectory: Boolean = false
 )


### PR DESCRIPTION
Don't generate synthetic '*-project-root' modules. Their only purpose
was to help improve the "Project Files" view in IntelliJ.

According to https://github.com/scalameta/metals/pull/1490#pullrequestreview-374238184