### PR TITLE
Add helper to pre-download Metals dependencies.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -160,6 +160,12 @@ lazy val V = new {
   val munit = "0.4.3"
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.
+  def supportedScalaBinaryVersions =
+    supportedScalaVersions.iterator
+      .map(CrossVersion.partialVersion)
+      .collect { case Some((a, b)) => s"$a.$b" }
+      .toList
+      .distinct
   def supportedScalaVersions =
     nonDeprecatedScalaVersions ++ deprecatedScalaVersions
   def deprecatedScalaVersions = Seq("2.12.8", "2.12.9", scala211)
@@ -309,6 +315,7 @@ lazy val metals = project
       "semanticdbVersion" -> V.semanticdb,
       "scalafmtVersion" -> V.scalafmt,
       "supportedScalaVersions" -> V.supportedScalaVersions,
+      "supportedScalaBinaryVersions" -> V.supportedScalaBinaryVersions,
       "deprecatedScalaVersions" -> V.deprecatedScalaVersions,
       "scala211" -> V.scala211,
       "scala212" -> V.scala212,

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -109,16 +109,9 @@ object Embedded {
       scalaVersion: String,
       scalaBinaryVersion: String
   ): URLClassLoader = {
-    val mdoc = Dependency.of(
-      "org.scalameta",
-      s"mdoc_${scalaBinaryVersion}",
-      BuildInfo.mdocVersion
-    )
-    val settings = fetchSettings(mdoc, scalaVersion)
-    val jars = fetchSettings(mdoc, scalaVersion).fetch()
-    val parent =
-      new MdocClassLoader(this.getClass.getClassLoader)
-    val urls = jars.iterator.asScala.map(_.toURI().toURL()).toArray
+    val jars = downloadMdoc(scalaVersion, scalaBinaryVersion)
+    val parent = new MdocClassLoader(this.getClass.getClassLoader)
+    val urls = jars.iterator.map(_.toUri().toURL()).toArray
     new URLClassLoader(urls, parent)
   }
 
@@ -150,6 +143,15 @@ object Embedded {
     BuildInfo.metalsVersion
   )
 
+  private def mdocDependency(
+      scalaVersion: String,
+      scalaBinaryVersion: String
+  ): Dependency = Dependency.of(
+    "org.scalameta",
+    s"mdoc_${scalaBinaryVersion}",
+    BuildInfo.mdocVersion
+  )
+
   private def semanticdbScalacDependency(scalaVersion: String): Dependency =
     Dependency.of(
       "org.scalameta",
@@ -171,6 +173,14 @@ object Embedded {
     downloadDependency(semanticdbScalacDependency(scalaVersion), scalaVersion)
   def downloadMtags(scalaVersion: String): List[Path] =
     downloadDependency(mtagsDependency(scalaVersion), scalaVersion)
+  def downloadMdoc(
+      scalaVersion: String,
+      scalaBinaryVersion: String
+  ): List[Path] =
+    downloadDependency(
+      mdocDependency(scalaVersion, scalaBinaryVersion),
+      scalaVersion
+    )
 
   def newPresentationCompilerClassLoader(
       info: ScalaBuildTarget,

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -52,10 +52,7 @@ final class FormattingProvider(
     )
   }
 
-  private var scalafmt = Scalafmt
-    .create(this.getClass.getClassLoader)
-    .withReporter(EmptyScalafmtReporter)
-    .withDefaultVersion(BuildInfo.scalafmtVersion)
+  private var scalafmt = FormattingProvider.newScalafmt()
   private val reporterPromise =
     new AtomicReference[Option[Promise[Boolean]]](None)
   private val cancelToken = new AtomicReference[Option[CancelChecker]](None)
@@ -263,4 +260,12 @@ final class FormattingProvider(
       new PrintWriter(downloadOutputStream())
     }
   }
+}
+
+object FormattingProvider {
+  def newScalafmt(): Scalafmt =
+    Scalafmt
+      .create(this.getClass.getClassLoader)
+      .withReporter(EmptyScalafmtReporter)
+      .withDefaultVersion(BuildInfo.scalafmtVersion)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -17,7 +17,7 @@ object ScalaVersions {
   def isDeprecatedScalaVersion(version: String): Boolean =
     _isDeprecatedScalaVersion(dropVendorSuffix(version))
   def isSupportedScalaBinaryVersion(scalaVersion: String): Boolean =
-    Set("2.13", "2.12", "2.11").exists { binaryVersion =>
+    BuildInfo.supportedScalaBinaryVersions.exists { binaryVersion =>
       scalaVersion.startsWith(binaryVersion)
     }
 
@@ -28,4 +28,7 @@ object ScalaVersions {
 
   def isCurrentScalaCompilerVersion(version: String): Boolean =
     ScalaVersions.dropVendorSuffix(version) == mtags.BuildInfo.scalaCompilerVersion
+
+  def scalaBinaryVersionFromFullVersion(scalaVersion: String): String =
+    scalaVersion.split('.').take(2).mkString(".")
 }

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -66,7 +66,7 @@ class WorksheetProvider(
   private val currentScalaVersion =
     scala.meta.internal.mtags.BuildInfo.scalaCompilerVersion
   private val currentBinaryVersion =
-    currentScalaVersion.split('.').take(2).mkString(".")
+    ScalaVersions.scalaBinaryVersionFromFullVersion(currentScalaVersion)
   private lazy val ramboMdoc =
     embedded.mdoc(currentScalaVersion, currentBinaryVersion)
 

--- a/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
+++ b/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
@@ -1,0 +1,75 @@
+package scala.meta.metals
+
+import scala.meta.internal.metals.Embedded
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.metals.FormattingProvider
+import java.nio.file.Files
+import bloop.launcher.Launcher
+import scala.meta.internal.metals.MetalsLogger
+
+object DownloadDependencies {
+
+  /**
+   * A main class that populates the Coursier download cache with Metals dependencies.
+   *
+   * The `org.scalameta:metals` artifact on Maven Central doesn't directly
+   * depend on all of its dependencies. Some dependencies like Scalafmt are
+   * dynamic depending on the Scalafmt version that users have configured in
+   * their workspace. This main method does a best-effort to try and
+   * pre-download as much as possible.
+   *
+   * @param args ignored.
+   */
+  def main(args: Array[String]): Unit = {
+    MetalsLogger.updateDefaultFormat()
+    downloadMdoc()
+    downloadScalafmt()
+    downloadMtags()
+    downloadSemanticDB()
+    // NOTE(olafur): important, Bloop comes last because it does System.exit()
+    downloadBloop()
+  }
+
+  def downloadMdoc(): Unit = {
+    scribe.info("Downloading mdoc")
+    BuildInfo.supportedScalaVersions.foreach { scalaVersion =>
+      Embedded
+        .newMdocClassLoader(
+          scalaVersion,
+          ScalaVersions.scalaBinaryVersionFromFullVersion(scalaVersion)
+        )
+        .close()
+    }
+  }
+
+  def downloadScalafmt(): Unit = {
+    scribe.info("Downloading scalafmt")
+    val scalafmt = FormattingProvider.newScalafmt()
+    val tmp = Files.createTempFile("scalafmt", "Foo.scala")
+    val config = Files.createTempFile("scalafmt", ".scalafmt.conf")
+    scalafmt.format(config, tmp, "object Foo { }")
+    Files.deleteIfExists(tmp)
+    Files.deleteIfExists(config)
+  }
+
+  def downloadMtags(): Unit = {
+    scribe.info("Downloading mtags")
+    BuildInfo.supportedScalaVersions.foreach { scalaVersion =>
+      Embedded.downloadMtags(scalaVersion)
+    }
+  }
+
+  def downloadSemanticDB(): Unit = {
+    scribe.info("Downloading semanticdb-scalac")
+    BuildInfo.supportedScalaVersions.foreach { scalaVersion =>
+      Embedded.downloadSemanticdbScalac(scalaVersion)
+    }
+  }
+
+  def downloadBloop(): Unit = {
+    scribe.info("Downloading bloop")
+    // NOTE(olafur): this starts a daemon process for the Bloop server.
+    Launcher.main(Array("--skip-bsp-connection", BuildInfo.bloopVersion))
+  }
+}

--- a/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
+++ b/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
@@ -34,12 +34,10 @@ object DownloadDependencies {
   def downloadMdoc(): Unit = {
     scribe.info("Downloading mdoc")
     BuildInfo.supportedScalaVersions.foreach { scalaVersion =>
-      Embedded
-        .newMdocClassLoader(
-          scalaVersion,
-          ScalaVersions.scalaBinaryVersionFromFullVersion(scalaVersion)
-        )
-        .close()
+      Embedded.downloadMdoc(
+        scalaVersion,
+        ScalaVersions.scalaBinaryVersionFromFullVersion(scalaVersion)
+      )
     }
   }
 


### PR DESCRIPTION
Previously, there was no convenient way to build a Docker image with all
of Metals dependencies pre-cached. This commit adds a new
`DownloadDependencies` main entrypoint that downloads artifacts that
Metals is likely to depend on.

You can launch this tool with the following script (requires Java 8 installation or newer), which should work on Linux and macOS.

```sh
METALS_VERSION=0.8.2 # Not released yet
curl -Lo coursier https://git.io/coursier-cli
chmod +x coursier
./coursier launch org.scalameta:metals_2.12:$METALS_VERSION --main scala.meta.metals.DownloadDependencies
```

We can't guarantee Metals will always work offline after running this
method. For example, the following cases are not handled:

* user opens Metals in a Gradle/Maven/Mill/sbt build.
* user has configured an older Scalafmt version.

A separate tool is needed to populate those caches (at least for now)

Context: https://github.com/eclipse/che-plugin-registry/pull/356