### PR TITLE
Only check relevant text for default indent

### DIFF
--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -475,7 +475,7 @@ final class TestingServer(
       root: AbsolutePath = workspace
   )(implicit loc: munit.Location): Future[Unit] = {
     for {
-      (text, params) <- rangeFormattingParams(filename, query, paste, root)
+      (_, params) <- rangeFormattingParams(filename, query, paste, root)
       multiline <- server.rangeFormatting(params).asScala
       format = TextEdits.applyEdits(
         textContents(filename),

--- a/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
@@ -38,6 +38,40 @@ class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
   )
 
   check(
+    "multiple-multi1",
+    s"""
+       |object Main {
+       |  val str = '''|@@'''.stripMargin
+       |  val other = '''|
+       |                 |'''.stripMargin
+       |}""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = '''|
+       |               |'''.stripMargin
+       |  val other = '''|
+       |                 |'''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
+    "multiple-multi2",
+    s"""
+       |object Main {
+       |  val str = '''|
+       |               |'''.stripMargin
+       |  val other = '''|@@'''.stripMargin
+       |}""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = '''|
+       |               |'''.stripMargin
+       |  val other = '''|
+       |                 |'''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
     "interpolated-string",
     s"""
        |object Main {

--- a/tests/unit/src/test/scala/tests/RangeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/RangeFormattingSuite.scala
@@ -64,6 +64,106 @@ class RangeFormattingSuite extends BaseLspSuite("rangeFormatting") {
   )
 
   check(
+    "multiple-multi-single1",
+    s"""
+       |object Main {
+       |  val str = '''
+       |              |@@
+       |              |'''.stripMargin
+       |  val other = '''
+       |                |
+       |                |'''.stripMargin
+       |}""".stripMargin,
+    s"""|  some text""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = '''
+       |              |  some text
+       |              |'''.stripMargin
+       |  val other = '''
+       |                |
+       |                |'''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
+    "multiple-multi-single2",
+    s"""
+       |object Main {
+       |  val str = '''
+       |              |
+       |              |'''.stripMargin
+       |  val other = '''
+       |                |@@
+       |                |'''.stripMargin
+       |}""".stripMargin,
+    s"""|  some text""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = '''
+       |              |
+       |              |'''.stripMargin
+       |  val other = '''
+       |                |  some text
+       |                |'''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
+    "multiple-multi-double1",
+    s"""
+       |object Main {
+       |  val str = '''
+       |              |@@
+       |              |'''.stripMargin
+       |  val other = '''
+       |                |
+       |                |'''.stripMargin
+       |}""".stripMargin,
+    s"""|some text
+        |  some other text
+        |""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = '''
+       |              |some text
+       |              |  some other text
+       |              |
+       |              |'''.stripMargin
+       |  val other = '''
+       |                |
+       |                |'''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
+    "multiple-multi-double2",
+    s"""
+       |object Main {
+       |  val str = '''
+       |              |
+       |              |'''.stripMargin
+       |  val other = '''
+       |                |@@
+       |                |'''.stripMargin
+       |}""".stripMargin,
+    s"""|  some text
+        |some other text
+        |""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = '''
+       |              |
+       |              |'''.stripMargin
+       |  val other = '''
+       |                |  some text
+       |                |some other text
+       |                |
+       |                |'''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
     "paste-on-first-line-with-pipe",
     s"""
        |object Main {


### PR DESCRIPTION
This pr changes the way we check for the default indent when doing onTypeFormatting. Instead of checking all the text on the page, we just check a substring of the text from the previous line. Then we grab the first index of the pipe to ensure we are actually getting the pipe from the multiline rather than a pipe that might be in the string. This also works in worksheets when on the first line, since the position of the onTypeFormatting will start on the second line, so there should be no worry there to get a indexOutOfBounds exception. I also added a couple tests to test when we have multiple multiline strings in a file.

Closes #1477 