### PR TITLE
Generate bloop.settings.json with project refresh command

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -148,7 +148,7 @@ lazy val V = new {
   val scalameta = "4.3.6"
   val semanticdb = scalameta
   val bsp = "2.0.0-M4+10-61e61e87"
-  val bloop = "1.4.0-RC1-90-70cfd9e2"
+  val bloop = "1.4.0-RC1-105-118a551b"
   val bloopNightly = bloop
   val sbtBloop = bloop
   val gradleBloop = bloop
@@ -295,6 +295,7 @@ lazy val metals = project
       // For exporting Pants builds.
       "com.lihaoyi" %% "ujson" % "0.9.9",
       "ch.epfl.scala" %% "bloop-config" % V.bloop,
+      "ch.epfl.scala" %% "bloop-frontend" % V.bloop,
       // for producing SemanticDB from Scala source files
       "org.scalameta" %% "scalameta" % V.scalameta,
       "org.scalameta" % "semanticdb-scalac-core" % V.scalameta cross CrossVersion.full

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
@@ -92,6 +92,8 @@ object IntelliJ {
       coursier.toString,
       "launch",
       s"org.scalameta:metals_2.12:${V.metalsVersion}",
+      "-r",
+      "sonatype:snapshots",
       "--main",
       classOf[BloopPants].getName,
       "--",
@@ -100,12 +102,13 @@ object IntelliJ {
       project.common.workspace.toString,
       project.name
     )
-    val settings = WorkspaceSettings(None, None, Some(refreshCommand))
-    WorkspaceSettings.writeToFile(
-      AbsolutePath(project.common.bloopDirectory),
-      settings,
-      NoopLogger
-    )
+    val configDir = AbsolutePath(project.common.bloopDirectory)
+    val currentSettings = WorkspaceSettings
+      .readFromFile(configDir, NoopLogger)
+      .getOrElse(WorkspaceSettings(None, None, None))
+    val settings =
+      currentSettings.copy(refreshProjectsCommand = Some(refreshCommand))
+    WorkspaceSettings.writeToFile(configDir, settings, NoopLogger)
   }
 
   private def downloadCoursier(destination: Path): Path = {

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
@@ -103,6 +103,7 @@ object IntelliJ {
       project.name
     )
     val configDir = AbsolutePath(project.common.bloopDirectory)
+    if (!configDir.exists) configDir.createDirectories
     val currentSettings = WorkspaceSettings
       .readFromFile(configDir, NoopLogger)
       .getOrElse(WorkspaceSettings(None, None, None))


### PR DESCRIPTION
This PR is regarding https://github.com/scalacenter/bloop/issues/1182 i.e. bloop can run custom refresh project command before requesting build targets which is implemented in https://github.com/scalacenter/bloop/pull/1195 this PR adds logic to generate the config file with refresh command that will invoke fastpass.