### PR TITLE
Do not include scala boot library

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -136,6 +136,8 @@ object Embedded {
       .withResolutionParams(resolutionParams)
       .withMainArtifacts()
   }
+  private def scalaDependency(scalaVersion: String): Dependency =
+    Dependency.of("org.scala-lang", "scala-library", scalaVersion)
 
   private def mtagsDependency(scalaVersion: String): Dependency = Dependency.of(
     "org.scalameta",
@@ -161,13 +163,22 @@ object Embedded {
 
   private def downloadDependency(
       dep: Dependency,
-      scalaVersion: String
+      scalaVersion: String,
+      classfiers: Seq[String] = Seq.empty
   ): List[Path] =
     fetchSettings(dep, scalaVersion)
+      .addClassifiers(classfiers: _*)
       .fetch()
       .asScala
       .toList
       .map(_.toPath())
+
+  def downloadScalaSources(scalaVersion: String): List[Path] =
+    downloadDependency(
+      scalaDependency(scalaVersion),
+      scalaVersion,
+      classfiers = Seq("sources")
+    )
 
   def downloadSemanticdbScalac(scalaVersion: String): List[Path] =
     downloadDependency(semanticdbScalacDependency(scalaVersion), scalaVersion)

--- a/metals/src/main/scala/scala/meta/internal/metals/RamboSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/RamboSymbolSearch.scala
@@ -1,0 +1,80 @@
+package scala.meta.internal.metals
+
+import scala.meta.pc.SymbolSearch
+import scala.meta.pc.SymbolDocumentation
+import java.{util => ju}
+import org.eclipse.lsp4j.Location
+import scala.meta.pc.SymbolSearchVisitor
+import scala.meta.pc.SymbolSearch.Result
+
+import scala.meta.internal.mtags.OnDemandSymbolIndex
+import scala.meta.io.AbsolutePath
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.mtags.Symbol
+import scala.meta.internal.mtags.Mtags
+import scala.collection.concurrent.TrieMap
+
+class RamboSymbolSearch(
+    workspace: AbsolutePath,
+    buffers: Buffers
+) extends SymbolSearch {
+
+  private val dependencySourceCache =
+    new TrieMap[AbsolutePath, ju.List[String]]()
+
+  private val scalaVersion = BuildInfo.scala212
+
+  private val jars = Embedded
+    .downloadScalaSources(scalaVersion)
+    .map(path => AbsolutePath(path))
+
+  private val (sources, classpath) =
+    jars.partition(_.toString.endsWith("-sources.jar"))
+
+  private val scalaDependency =
+    ClasspathSearch.fromClasspath(classpath.toList.map(_.toNIO))
+
+  private val index = OnDemandSymbolIndex()
+  sources.foreach(index.addSourceJar)
+
+  private val docs = new Docstrings(index)
+  private val mtags = new Mtags()
+  private val destinationProvider =
+    new DestinationProvider(
+      index,
+      buffers,
+      mtags,
+      workspace,
+      semanticdbsFallback = None
+    )
+
+  def documentation(symbol: String): ju.Optional[SymbolDocumentation] =
+    docs.documentation(symbol)
+
+  def definition(x: String): ju.List[Location] = {
+    destinationProvider
+      .fromSymbol(x)
+      .flatMap(_.toResult)
+      .map(_.locations)
+      .getOrElse(ju.Collections.emptyList())
+  }
+
+  def definitionSourceToplevels(sym: String): ju.List[String] =
+    index
+      .definition(Symbol(sym))
+      .map { symDef =>
+        val input = symDef.path.toInput
+        dependencySourceCache.getOrElseUpdate(
+          symDef.path,
+          mtags.toplevels(input).asJava
+        )
+      }
+      .getOrElse(ju.Collections.emptyList())
+
+  def search(
+      query: String,
+      buildTargetIdentifier: String,
+      visitor: SymbolSearchVisitor
+  ): Result =
+    scalaDependency.search(WorkspaceSymbolQuery.exact(query), visitor)
+}

--- a/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
+++ b/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
@@ -27,8 +27,16 @@ object DownloadDependencies {
     downloadScalafmt()
     downloadMtags()
     downloadSemanticDB()
+    downloadScala()
     // NOTE(olafur): important, Bloop comes last because it does System.exit()
     downloadBloop()
+  }
+
+  def downloadScala(): Unit = {
+    scribe.info("Downloading scala library and sources")
+    BuildInfo.supportedScalaVersions.foreach { scalaVersion =>
+      Embedded.downloadScalaSources(scalaVersion)
+    }
   }
 
   def downloadMdoc(): Unit = {

--- a/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
@@ -123,9 +123,6 @@ class PackageIndex() {
     } else {
       PackageIndex.bootClasspath.foreach(visit)
     }
-    PackageIndex.scalaLibrary.foreach { scalaLibrary =>
-      visit(AbsolutePath(scalaLibrary))
-    }
   }
 
   private def expandJrtClasspath(): Unit = {

--- a/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
@@ -17,6 +17,36 @@ class CompletionCrossLspSuite
       basicTest(V.scala213)
     }
   }
+
+  test("serializable-2.13") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        """/metals.json
+          |{
+          |  "a": { "scalaVersion": "2.13.1" }
+          |}
+          |/a/src/main/scala/a/A.scala
+          |package a
+          |trait Serializable
+          |object Main // @@
+          |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ = assertNoDiagnostics()
+      _ <- assertCompletion(
+        "extends Serializable@@",
+        """|Serializable a
+           |Serializable - java.io
+           |DefaultSerializable - scala.collection.generic
+           |SerializablePermission - java.io
+           |NotSerializableException - java.io
+           |
+           |""".stripMargin
+      )
+    } yield ()
+  }
+
   // NOTE(olafur): I'm unable to reproduce failures for this test when running
   // locally but this test still fails when running in CI, see
   // https://github.com/scalameta/metals/pull/1277#issuecomment-578406803

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -295,4 +295,35 @@ class DefinitionLspSuite extends BaseLspSuite("definition") {
     } yield ()
   }
 
+  test("rambo") {
+    cleanDatabase()
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "${scala.meta.internal.metals.BuildInfo.scala212}"
+           |  }
+           |}
+           |/Main.scala
+           |object Main {
+           |  println("hello!")
+           |  val arr = Seq("").toArray()
+           |}
+           |""".stripMargin
+      )
+      _ = client.messageRequests.clear()
+      _ <- server.didOpen("Main.scala")
+      _ = server.workspaceDefinitions // trigger definition
+      _ <- server.didOpen("scala/Predef.scala")
+      _ <- server.didOpen("scala/collection/TraversableOnce.scala")
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        ""
+      )
+      _ = assertNoDiff(client.workspaceDiagnostics, "")
+    } yield ()
+  }
+
 }

--- a/tests/unit/src/test/scala/tests/HoverLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/HoverLspSuite.scala
@@ -22,6 +22,27 @@ class HoverLspSuite extends BaseLspSuite("hover") with TestHovers {
     } yield ()
   }
 
+  test("basic-rambo") {
+    for {
+      _ <- server.initialize(
+        """|/a/src/main/scala/a/Main.scala
+           |object Main extends App {
+           |  // @@
+           |}
+           |""".stripMargin,
+        expectError = true
+      )
+      _ <- server.assertHover(
+        "a/src/main/scala/a/Main.scala",
+        """
+          |object Main {
+          |  Option(1).he@@ad
+          |}""".stripMargin,
+        """override def head: Int""".hover
+      )
+    } yield ()
+  }
+
   test("docstrings") {
     for {
       _ <- server.initialize(


### PR DESCRIPTION
Previously. the 2.12.10 library was indexed in a target even if the target used only 2.13.1 Scala version. Now, only the right libraries are included.