### PR TITLE
Add support for Scala 2.12.11

### DIFF
--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -10,6 +10,7 @@ coursier fetch \
   org.scalameta:mtags_2.13.1:$version \
   org.scalameta:mtags_2.13.0:$version \
   org.scalameta:mtags_2.12.10:$version \
+  org.scalameta:mtags_2.12.11:$version \
   org.scalameta:mtags_2.12.9:$version \
   org.scalameta:mtags_2.12.8:$version \
   org.scalameta:mtags_2.11.12:$version $suffix

--- a/build.sbt
+++ b/build.sbt
@@ -143,9 +143,9 @@ commands += Command.command("save-expect") { s =>
 lazy val V = new {
   val scala210 = "2.10.7"
   val scala211 = "2.11.12"
-  val scala212 = "2.12.10"
+  val scala212 = "2.12.11"
   val scala213 = "2.13.1"
-  val scalameta = "4.3.4"
+  val scalameta = "4.3.6"
   val semanticdb = scalameta
   val bsp = "2.0.0-M4+10-61e61e87"
   val bloop = "1.4.0-RC1-90-70cfd9e2"
@@ -166,8 +166,9 @@ lazy val V = new {
       .distinct
   def supportedScalaVersions =
     nonDeprecatedScalaVersions ++ deprecatedScalaVersions
-  def deprecatedScalaVersions = Seq("2.12.8", "2.12.9", scala211)
-  def nonDeprecatedScalaVersions = Seq("2.13.0", scala213, scala212)
+  def deprecatedScalaVersions =
+    Seq(scala211, "2.12.8", "2.12.9", "2.12.10", "2.13.0")
+  def nonDeprecatedScalaVersions = Seq(scala213, scala212)
   def guava = "com.google.guava" % "guava" % "28.2-jre"
   def lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.8.1"
   def dap4j =

--- a/mtags/src/main/scala/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/completions/Completions.scala
@@ -235,7 +235,7 @@ trait Completions { this: MetalsGlobal =>
             } else {
               val short = shortType(info, history)
               if (short == NoType) ""
-              else sym.infoString(short).replaceAllLiterally(" <: <?>", "")
+              else sym.infoString(short).trim.replaceAllLiterally(" <: <?>", "")
             }
         }
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.6.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.11")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.12")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.2")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.1.1")
 addSbtPlugin("org.scalameta" % "sbt-munit" % "0.5.2")

--- a/sbt
+++ b/sbt
@@ -10,7 +10,7 @@ declare -r sbt_release_version="1.2.8"
 declare -r sbt_unreleased_version="1.2.8"
 
 declare -r latest_213="2.13.1"
-declare -r latest_212="2.12.10"
+declare -r latest_212="2.12.11"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"
 declare -r latest_29="2.9.3"

--- a/test-workspace/build.sbt
+++ b/test-workspace/build.sbt
@@ -1,5 +1,5 @@
 inThisBuild(
   Vector(
-    scalaVersion := "2.12.10"
+    scalaVersion := "2.12.11"
   )
 )

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -124,7 +124,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
   }
 
   def check(
-      name: String,
+      name: TestOptions,
       original: String,
       expected: String,
       includeDocs: Boolean = false,
@@ -144,7 +144,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       val out = new StringBuilder()
       val withPkg =
         if (original.contains("package") || !enablePackageWrap) original
-        else s"package ${scala.meta.Term.Name(name)}\n$original"
+        else s"package ${scala.meta.Term.Name(name.name)}\n$original"
       val baseItems = getItems(withPkg, filename)
       val items = topLines match {
         case Some(top) => baseItems.take(top)

--- a/tests/slow/src/test/resources/test-pom.xml
+++ b/tests/slow/src/test/resources/test-pom.xml
@@ -18,7 +18,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <scala.version>2.12.10</scala.version>
+    <scala.version>2.12.11</scala.version>
   </properties>
   <dependencies>
     <!--DEPENDENCY-->

--- a/tests/slow/src/test/scala/tests/SymlinkedProjectSuite.scala
+++ b/tests/slow/src/test/scala/tests/SymlinkedProjectSuite.scala
@@ -2,24 +2,25 @@ package tests
 import java.nio.file.Files
 import java.util.UUID
 import scala.meta.io.AbsolutePath
+import scala.meta.internal.metals.{BuildInfo => V}
 
 class SymlinkedProjectSuite extends BaseLspSuite("symlinked-project") {
   test("definitions-from-other-file") {
     for {
       _ <- server.initialize(
-        """|/project/build.properties
-           |sbt.version=1.2.6
-           |
-           |/build.sbt
-           |scalaVersion := "2.12.10"
-           |
-           |/src/main/scala/Foo.scala
-           |class Foo
-           |
-           |/src/main/scala/Bar.scala
-           |object Bar{
-           |  val foo = new Foo
-           |}
+        s"""|/project/build.properties
+            |sbt.version=1.2.6
+            |
+            |/build.sbt
+            |scalaVersion := "${V.scala212}"
+            |
+            |/src/main/scala/Foo.scala
+            |class Foo
+            |
+            |/src/main/scala/Bar.scala
+            |object Bar{
+            |  val foo = new Foo
+            |}
         """.stripMargin
       )
       _ <- server.didOpen("src/main/scala/Bar.scala")

--- a/tests/slow/src/test/scala/tests/gradle/GradleLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/gradle/GradleLspSuite.scala
@@ -22,17 +22,17 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
     cleanWorkspace()
     for {
       _ <- server.initialize(
-        """|/build.gradle
-           |plugins {
-           |    id 'scala'
-           |}
-           |repositories {
-           |    mavenCentral()
-           |}
-           |dependencies {
-           |    implementation 'org.scala-lang:scala-library:2.12.10'
-           |}
-           |""".stripMargin
+        s"""|/build.gradle
+            |plugins {
+            |    id 'scala'
+            |}
+            |repositories {
+            |    mavenCentral()
+            |}
+            |dependencies {
+            |    implementation 'org.scala-lang:scala-library:${V.scala212}'
+            |}
+            |""".stripMargin
       )
       _ = assertNoDiff(
         client.workspaceMessageRequests,
@@ -70,17 +70,17 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
     cleanWorkspace()
     for {
       _ <- server.initialize(
-        """|/build.gradle
-           |plugins {
-           |    id 'scala'
-           |}
-           |repositories {
-           |    mavenCentral()
-           |}
-           |dependencies {
-           |    implementation 'org.scala-lang:scala-reflect:2.12.10'
-           |}
-           |""".stripMargin
+        s"""|/build.gradle
+            |plugins {
+            |    id 'scala'
+            |}
+            |repositories {
+            |    mavenCentral()
+            |}
+            |dependencies {
+            |    implementation 'org.scala-lang:scala-reflect:${V.scala212}'
+            |}
+            |""".stripMargin
       )
       _ = assertNoDiff(
         client.workspaceMessageRequests,
@@ -99,17 +99,17 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
     cleanWorkspace()
     for {
       _ <- server.initialize(
-        """|/build.gradle
-           |plugins {
-           |    id 'scala'
-           |}
-           |repositories {
-           |    mavenCentral()
-           |}
-           |dependencies {
-           |    implementation 'org.scala-lang:scala-library:2.12.10'
-           |}
-           |""".stripMargin
+        s"""|/build.gradle
+            |plugins {
+            |    id 'scala'
+            |}
+            |repositories {
+            |    mavenCentral()
+            |}
+            |dependencies {
+            |    implementation 'org.scala-lang:scala-library:${V.scala212}'
+            |}
+            |""".stripMargin
       )
       _ = assertNoDiff(
         client.workspaceMessageRequests,
@@ -134,22 +134,22 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
     cleanWorkspace()
     for {
       _ <- server.initialize(
-        """|/build.gradle
-           |plugins {
-           |    id 'scala'
-           |}
-           |repositories {
-           |    mavenCentral()
-           |}
-           |dependencies {
-           |    implementation 'org.scala-lang:scala-library:2.12.10'
-           |}
-           |/src/main/scala/reload/Main.scala
-           |package reload
-           |object Main extends App {
-           |  println("sourcecode.Line(42)")
-           |}
-           |""".stripMargin
+        s"""|/build.gradle
+            |plugins {
+            |    id 'scala'
+            |}
+            |repositories {
+            |    mavenCentral()
+            |}
+            |dependencies {
+            |    implementation 'org.scala-lang:scala-library:${V.scala212}'
+            |}
+            |/src/main/scala/reload/Main.scala
+            |package reload
+            |object Main extends App {
+            |  println("sourcecode.Line(42)")
+            |}
+            |""".stripMargin
       )
       _ <- server.didOpen("src/main/scala/reload/Main.scala")
       _ = assertNoDiff(client.workspaceDiagnostics, "")
@@ -192,16 +192,16 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
       _ = assertStatus(!_.isInstalled)
       _ = client.messageRequests.clear()
       _ <- server.didSave("build.gradle") { _ =>
-        """|plugins {
-           |    id 'scala'
-           |}
-           |repositories {
-           |    mavenCentral()
-           |}
-           |dependencies {
-           |    implementation 'org.scala-lang:scala-library:2.12.10'
-           |}
-           |""".stripMargin
+        s"""|plugins {
+            |    id 'scala'
+            |}
+            |repositories {
+            |    mavenCentral()
+            |}
+            |dependencies {
+            |    implementation 'org.scala-lang:scala-library:${V.scala212}'
+            |}
+            |""".stripMargin
       }
       _ = assertNoDiff(
         client.workspaceMessageRequests,
@@ -305,30 +305,30 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
     cleanWorkspace()
     for {
       _ <- server.initialize(
-        """
-          |/build.gradle
-          |plugins {
-          |    id 'scala'
-          |}
-          |repositories {
-          |    mavenCentral()
-          |}
-          |dependencies {
-          |    implementation 'org.scala-lang:scala-library:2.12.10'
-          |}
-          |tasks.withType(ScalaCompile) {
-          |    scalaCompileOptions.additionalParameters = [
-          |         '-Xfatal-warnings',
-          |         '-Ywarn-unused'
-          |    ]
-          |}
-          |/src/main/scala/warning/Warning.scala
-          |import scala.concurrent.Future // unused
-          |object Warning
-          |object A{
-          |  object B
-          |}
-          |""".stripMargin
+        s"""
+           |/build.gradle
+           |plugins {
+           |    id 'scala'
+           |}
+           |repositories {
+           |    mavenCentral()
+           |}
+           |dependencies {
+           |    implementation 'org.scala-lang:scala-library:${V.scala212}'
+           |}
+           |tasks.withType(ScalaCompile) {
+           |    scalaCompileOptions.additionalParameters = [
+           |         '-Xfatal-warnings',
+           |         '-Ywarn-unused'
+           |    ]
+           |}
+           |/src/main/scala/warning/Warning.scala
+           |import scala.concurrent.Future // unused
+           |object Warning
+           |object A{
+           |  object B
+           |}
+           |""".stripMargin
       )
       _ = assertStatus(_.isInstalled)
       _ <- server.didOpen("src/main/scala/warning/Warning.scala")

--- a/tests/slow/src/test/scala/tests/mill/MillLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/mill/MillLspSuite.scala
@@ -5,6 +5,7 @@ import scala.meta.internal.builds.MillDigest
 import scala.meta.internal.metals.Messages._
 import scala.meta.internal.builds.MillBuildTool
 import tests.BaseImportSuite
+import scala.meta.internal.metals.{BuildInfo => V}
 
 class MillLspSuite extends BaseImportSuite("mill-import") {
 
@@ -18,12 +19,12 @@ class MillLspSuite extends BaseImportSuite("mill-import") {
     cleanWorkspace()
     for {
       _ <- server.initialize(
-        """
-          |/build.sc
-          |import mill._, scalalib._
-          |object foo extends ScalaModule {
-          |  def scalaVersion = "2.12.10"
-          |}
+        s"""
+           |/build.sc
+           |import mill._, scalalib._
+           |object foo extends ScalaModule {
+           |  def scalaVersion = "${V.scala212}"
+           |}
         """.stripMargin
       )
       _ = assertNoDiff(
@@ -43,11 +44,11 @@ class MillLspSuite extends BaseImportSuite("mill-import") {
       _ = assertNoDiff(client.workspaceMessageRequests, "")
       _ <- server.didChange("build.sc") { text =>
         text +
-          """|
-             |object bar extends ScalaModule {
-             |  def scalaVersion = "2.12.10"
-             |}
-             |""".stripMargin
+          s"""|
+              |object bar extends ScalaModule {
+              |  def scalaVersion = "${V.scala212}"
+              |}
+              |""".stripMargin
       }
       _ = assertNoDiff(client.workspaceMessageRequests, "")
       _ <- server.didSave("build.sc")(identity)
@@ -67,19 +68,19 @@ class MillLspSuite extends BaseImportSuite("mill-import") {
     cleanWorkspace()
     for {
       _ <- server.initialize(
-        """
-          |/build.sc
-          |import mill._, scalalib._
-          |object foo extends ScalaModule {
-          |  def scalaVersion = "2.12.10"
-          |  /*DEPS*/
-          |}
-          |/foo/src/reload/Main.scala
-          |package reload
-          |object Main extends App {
-          |  println("sourcecode.Line(42)")
-          |}
-          |""".stripMargin
+        s"""
+           |/build.sc
+           |import mill._, scalalib._
+           |object foo extends ScalaModule {
+           |  def scalaVersion = "${V.scala212}"
+           |  /*DEPS*/
+           |}
+           |/foo/src/reload/Main.scala
+           |package reload
+           |object Main extends App {
+           |  println("sourcecode.Line(42)")
+           |}
+           |""".stripMargin
       )
       _ <- server.didOpen("foo/src/reload/Main.scala")
       _ = assertNoDiff(client.workspaceDiagnostics, "")
@@ -121,11 +122,11 @@ class MillLspSuite extends BaseImportSuite("mill-import") {
       _ = assertStatus(!_.isInstalled)
       _ = client.messageRequests.clear()
       _ <- server.didSave("build.sc") { _ =>
-        """
-          |import mill._, scalalib._
-          |object foo extends ScalaModule {
-          |  def scalaVersion = "2.12.10"
-          |}
+        s"""
+           |import mill._, scalalib._
+           |object foo extends ScalaModule {
+           |  def scalaVersion = "${V.scala212}"
+           |}
         """.stripMargin,
       }
       _ = assertNoDiff(
@@ -143,20 +144,20 @@ class MillLspSuite extends BaseImportSuite("mill-import") {
     cleanWorkspace()
     for {
       _ <- server.initialize(
-        """
-          |/build.sc
-          |import mill._, scalalib._
-          |object foo extends ScalaModule {
-          |  def scalaVersion = "2.12.10"
-          |  def scalacOptions = Seq("-Xfatal-warnings", "-Ywarn-unused")
-          |}
-          |/foo/src/Warning.scala
-          |import scala.concurrent.Future // unused
-          |object Warning
-          |object A{
-          |  object B
-          |}
-          |""".stripMargin
+        s"""
+           |/build.sc
+           |import mill._, scalalib._
+           |object foo extends ScalaModule {
+           |  def scalaVersion = "${V.scala212}"
+           |  def scalacOptions = Seq("-Xfatal-warnings", "-Ywarn-unused")
+           |}
+           |/foo/src/Warning.scala
+           |import scala.concurrent.Future // unused
+           |object Warning
+           |object A{
+           |  object B
+           |}
+           |""".stripMargin
       )
       _ = assertStatus(_.isInstalled)
       _ <- server.didOpen("foo/src/Warning.scala")

--- a/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
@@ -30,7 +30,7 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
         s"""|/project/build.properties
             |sbt.version=$sbtVersion
             |/build.sbt
-            |scalaVersion := "2.12.10"
+            |scalaVersion := "${V.scala212}"
             |""".stripMargin
       )
       _ = assertNoDiff(
@@ -72,7 +72,7 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
         s"""|/project/build.properties
             |sbt.version=$sbtVersion
             |/build.sbt
-            |scalaVersion := "2.12.10"
+            |scalaVersion := "${V.scala212}"
             |""".stripMargin
       )
       _ = assertNoDiff(
@@ -101,7 +101,7 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
         s"""|/project/build.properties
             |sbt.version=$sbtVersion
             |/build.sbt
-            |scalaVersion := "2.12.10"
+            |scalaVersion := "${V.scala212}"
             |/src/main/scala/reload/Main.scala
             |package reload
             |object Main extends App {
@@ -142,7 +142,7 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
            |sbt.version=$sbtVersion
            |/build.sbt
            |version := "1.0"
-           |scalaVersion := "2.12.10"
+           |scalaVersion := "${V.scala212}"
            |""".stripMargin,
         expectError = true
       )
@@ -181,7 +181,9 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
       )
       _ = assertStatus(!_.isInstalled)
       _ = client.messageRequests.clear()
-      _ <- server.didSave("build.sbt") { _ => """scalaVersion := "2.12.10" """ }
+      _ <- server.didSave("build.sbt") { _ =>
+        s"""scalaVersion := "${V.scala212}" """
+      }
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
@@ -201,7 +203,7 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
            |/project/build.properties
            |sbt.version=$sbtVersion
            |/build.sbt
-           |scalaVersion := "2.12.10"
+           |scalaVersion := "${V.scala212}"
            |lazy val a = project.settings(scalaVersion := "2.12.4")
            |lazy val b = project.settings(scalaVersion := "2.12.3")
            |lazy val c = project.settings(scalaVersion := "2.11.12")
@@ -254,7 +256,9 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
         client.showMessages.clear()
         client.clientCommands.clear()
       }
-      _ <- server.didSave("build.sbt")(_ => """scalaVersion := "2.12.10" """)
+      _ <- server.didSave("build.sbt")(_ =>
+        s"""scalaVersion := "${V.scala212}" """
+      )
       _ = {
         val expected = ClientCommands.ReloadDoctor.id :: Nil
         val actual = client.workspaceClientCommands
@@ -275,7 +279,7 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
            |/project/build.properties
            |sbt.version=$sbtVersion
            |/build.sbt
-           |scalaVersion := "2.12.10"
+           |scalaVersion := "${V.scala212}"
            |libraryDependencies +=
            |  // dependency won't resolve without the `bintray:scalacenter/releases` resolver
            |  // that is defined in the `custom-repositories` file.
@@ -301,7 +305,7 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
            |/project/build.properties
            |sbt.version=$sbtVersion
            |/build.sbt
-           |scalaVersion := "2.12.10"
+           |scalaVersion := "${V.scala212}"
            |/.jvmopts
            |-Xms1536M
            |-Xmx1536M
@@ -321,7 +325,7 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
            |/project/build.properties
            |sbt.version=$sbtVersion
            |/build.sbt
-           |scalaVersion := "2.12.10"
+           |scalaVersion := "${V.scala212}"
            |scalacOptions ++= List(
            |  "-Xfatal-warnings",
            |  "-Ywarn-unused"
@@ -363,7 +367,7 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
            |/project/build.properties
            |sbt.version=$sbtVersion
            |/build.sbt
-           |scalaVersion := "2.12.10"
+           |scalaVersion := "${V.scala212}"
            |""".stripMargin,
         expectError = true,
         preInitialized = () => {

--- a/tests/unit/src/main/scala/tests/QuickBuild.scala
+++ b/tests/unit/src/main/scala/tests/QuickBuild.scala
@@ -39,7 +39,7 @@ import scala.util.matching.Regex
  * A build is declared in metals.json and looks like this: {{{
  *   {
  *     "id": {
- *       "scalaVersion": "2.12.10",
+ *       "scalaVersion": "2.12.11",
  *       "libraryDependencies": [
  *         "org.scalatest::scalatest:3.0.5",
  *       ],

--- a/tests/unit/src/test/scala/tests/SyntaxErrorLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SyntaxErrorLspSuite.scala
@@ -102,9 +102,6 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
         """|a/src/main/scala/Main.scala:1:8: error: identifier expected but 'object' found.
            |object object A
            |       ^^^^^^
-           |a/src/main/scala/Main.scala:2:1: error: <error> is already defined as object <error>
-           |object object B
-           |^^^^^^^^^^^^^^^
            |a/src/main/scala/Main.scala:2:8: error: identifier expected but 'object' found.
            |object object B
            |       ^^^^^^
@@ -116,9 +113,6 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
         """|a/src/main/scala/Main.scala:2:8: error: identifier expected but 'object' found.
            |object object A
            |       ^^^^^^
-           |a/src/main/scala/Main.scala:3:1: error: <error> is already defined as object <error>
-           |object object B
-           |^^^^^^^^^^^^^^^
            |a/src/main/scala/Main.scala:3:8: error: identifier expected but 'object' found.
            |object object B
            |       ^^^^^^

--- a/tests/unit/src/test/scala/tests/digest/MillDigestSuite.scala
+++ b/tests/unit/src/test/scala/tests/digest/MillDigestSuite.scala
@@ -4,6 +4,8 @@ package digest
 import scala.meta.io.AbsolutePath
 import scala.meta.internal.builds.MillDigest
 
+import scala.meta.internal.metals.{BuildInfo => V}
+
 class MillDigestSuite extends BaseDigestSuite {
 
   override def digestCurrent(
@@ -12,89 +14,89 @@ class MillDigestSuite extends BaseDigestSuite {
 
   checkSame(
     "solo-build.sc",
-    """
-      |/build.sc
-      |import mill._, scalalib._
-      |object foo extends ScalaModule {
-      |  def scalaVersion = "2.12.10"
-      |}
+    s"""
+       |/build.sc
+       |import mill._, scalalib._
+       |object foo extends ScalaModule {
+       |  def scalaVersion = "${V.scala212}"
+       |}
     """.stripMargin,
-    """
-      |/build.sc
-      |import mill._, scalalib._
-      |object foo extends ScalaModule {
-      |  def scalaVersion = "2.12.10"
-      |}
+    s"""
+       |/build.sc
+       |import mill._, scalalib._
+       |object foo extends ScalaModule {
+       |  def scalaVersion = "${V.scala212}"
+       |}
     """.stripMargin
   )
 
   checkSame(
     "multiline-comment",
-    """
-      |/build.sc
-      |import mill._, scalalib._
-      |object foo extends ScalaModule {
-      |  def scalaVersion = "2.12.10"
-      |}
+    s"""
+       |/build.sc
+       |import mill._, scalalib._
+       |object foo extends ScalaModule {
+       |  def scalaVersion = "${V.scala212}"
+       |}
     """.stripMargin,
-    """
-      |/build.sc
-      |import mill._, scalalib._
-      | /* This is a multi
-      | line comment */
-      |object foo extends ScalaModule {
-      |  def scalaVersion = "2.12.10"
-      |}
+    s"""
+       |/build.sc
+       |import mill._, scalalib._
+       | /* This is a multi
+       | line comment */
+       |object foo extends ScalaModule {
+       |  def scalaVersion = "${V.scala212}"
+       |}
     """.stripMargin
   )
 
   checkSame(
     "comment",
-    """
-      |/build.sc
-      |import mill._, scalalib._
-      |object foo extends ScalaModule {
-      |  def scalaVersion = "2.12.10"
-      |}
+    s"""
+       |/build.sc
+       |import mill._, scalalib._
+       |object foo extends ScalaModule {
+       |  def scalaVersion = "${V.scala212}"
+       |}
     """.stripMargin,
-    """
-      |/build.sc
-      |import mill._, scalalib._
-      | // this is a comment
-      |object foo extends ScalaModule {
-      |  def scalaVersion = "2.12.10"
-      |}
+    s"""
+       |/build.sc
+       |import mill._, scalalib._
+       | // this is a comment
+       |object foo extends ScalaModule {
+       |  def scalaVersion = "${V.scala212}"
+       |}
     """.stripMargin
   )
 
   checkSame(
     "whitespace",
-    """
-      |/build.sc
-      |import mill._, scalalib._
-      |object foo extends ScalaModule {
-      |  def scalaVersion = "2.12.10"
-      |}
+    s"""
+       |/build.sc
+       |import mill._, scalalib._
+       |object foo extends ScalaModule {
+       |  def scalaVersion = "${V.scala212}"
+       |}
     """.stripMargin,
-    """
-      |/build.sc
-      |import mill._, scalalib._
-      |
-      |object foo extends ScalaModule {
-      |
-      | def scalaVersion =    "2.12.10"
-      |}
+    s"""
+       |/build.sc
+       |import mill._, scalalib._
+       |
+       |object foo extends ScalaModule {
+       |
+       | def scalaVersion =    "${V.scala212}"
+       |}
     """.stripMargin
   )
 
   checkDiff(
     "significant-tokens",
-    """
-      |/build.sc
-      |import mill._, scalalib._
-      |object foo extends ScalaModule {
-      |  def scalaVersion = "2.12.10"
-      |}
+    s"""
+       |/build.sc
+       |import mill._, scalalib._
+       |object foo extends ScalaModule {
+       |  def scalaVersion = "${V.scala212}"
+       |}
     """.stripMargin,
     """
       |/build.sc
@@ -109,7 +111,7 @@ class MillDigestSuite extends BaseDigestSuite {
     s"""
        |import mill._, scalalib._
        |object $name extends ScalaModule {
-       | def scalaVersion = "2.12.10"
+       | def scalaVersion = "${V.scala212}"
        |}
       """.stripMargin
 


### PR DESCRIPTION
This PR adds support for Scala 2.12.11, ~~however we need to wait with the stable release until https://github.com/scalameta/scalameta/pull/2004 is merged.~~

~~Semanticdb is causing Bloop to behave rather flakily, but that is under 4.3.4 version too.~~

Updated to 4.3.6, which should have everything fixed.