### PR TITLE
Use a custom IDEA launcher under a new flag.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/OpenCommand.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/OpenCommand.scala
@@ -51,7 +51,7 @@ object OpenCommand extends Command[OpenOptions]("open") {
         1
       } else {
         if (open.intellij) {
-          IntelliJ.launch(project)
+          IntelliJ.launch(project, open)
         }
         if (open.vscode) {
           VSCode.launch(project)

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/OpenOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/OpenOptions.scala
@@ -4,10 +4,13 @@ import metaconfig.generic
 import metaconfig.annotation._
 import metaconfig.generic.Settings
 import metaconfig.{ConfDecoder, ConfEncoder}
+import java.nio.file.Path
 
 case class OpenOptions(
     @Description("Open IntelliJ in the given project")
     intellij: Boolean = false,
+    @Description("The IntelliJ application or binary to use for launching")
+    intellijLauncher: Option[String] = None,
     @Description("Open VS Code in the given project")
     vscode: Boolean = false,
     @Hidden()
@@ -21,6 +24,8 @@ case class OpenOptions(
 ) {
   def withProject(project: Project): OpenOptions =
     copy(projects = List(project.name))
+  def withWorkspace(workspace: Path): OpenOptions =
+    copy(common = common.copy(workspace = workspace))
   def isEmpty: Boolean = !intellij && !vscode
 }
 

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/SharedCommand.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/SharedCommand.scala
@@ -68,7 +68,7 @@ object SharedCommand {
             OpenCommand.onEmpty(export.project, export.app)
           } else {
             OpenCommand.run(
-              export.open.withProject(export.project),
+              export.open.withProject(export.project).withWorkspace(workspace),
               export.app
             )
           }


### PR DESCRIPTION
Previously, it was not possible to export a Pants build and launch
IntelliJ with a custom IntelliJ version (for example, 2020.1 EAP).
Now, the `--intellij-launcher APP` flag allows users to pass in a custom
launcher.