### PR TITLE
Always launch IntelliJ in the project's root directory

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
@@ -35,15 +35,7 @@ object IntelliJ {
             List("idea")
         }
     }
-    val hasIdeaDirectory = project.bspRoot.resolve(".idea").isDirectory
-    val openDirectory =
-      // NOTE(olafur): it seems necessary to use the parent directory when there
-      // is an existing .idea/ directory. This behavior was discovered by trial
-      // and error. If we don't use the parent directory when there is an
-      // existing idea/ directory then IntelliJ opens the project as a normal
-      // directory without BSP (even if there is a .bsp/ directory).
-      if (hasIdeaDirectory) project.parentRoot
-      else project.bspRoot
+    val openDirectory = project.bspRoot
     val exit = Process(
       command ++ List(openDirectory.toString),
       cwd = Some(openDirectory.toFile)


### PR DESCRIPTION
Commit da56189c introduced a hack, that was applicable for IntelliJ
2019.3. It required to open the root's parent directory instead of the
root directory, except the first time, when the project was imported.

In IntelliJ it's safe to always open the root directory. What is more,
opening the parent directory couses that, the project is not
identified as BSP-based.