### PR TITLE
Undeprecate 2.12.10.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -167,8 +167,8 @@ lazy val V = new {
   def supportedScalaVersions =
     nonDeprecatedScalaVersions ++ deprecatedScalaVersions
   def deprecatedScalaVersions =
-    Seq(scala211, "2.12.8", "2.12.9", "2.12.10", "2.13.0")
-  def nonDeprecatedScalaVersions = Seq(scala213, scala212)
+    Seq(scala211, "2.12.8", "2.12.9", "2.13.0")
+  def nonDeprecatedScalaVersions = Seq(scala213, scala212, "2.12.10")
   def guava = "com.google.guava" % "guava" % "28.2-jre"
   def lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.8.1"
   def dap4j =


### PR DESCRIPTION
Currently, users get the following warning

> You are using a legacy Scala version 2.12.10, which might not be
> supported in future versions of Metals. Please upgrade to Scala 2.12.11.

Scala 2.12.11 just came out, we should wait at least a few months before
calling it "legacy".