### PR TITLE
Update lsp4j to enable more 3.15 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -170,7 +170,7 @@ lazy val V = new {
     Seq(scala211, "2.12.8", "2.12.9", "2.13.0")
   def nonDeprecatedScalaVersions = Seq(scala213, scala212, "2.12.10")
   def guava = "com.google.guava" % "guava" % "28.2-jre"
-  def lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.8.1"
+  def lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.9.0"
   def dap4j =
     "org.eclipse.lsp4j" % "org.eclipse.lsp4j.debug" % "0.8.1"
   val coursier = "2.0.0-RC5-6"

--- a/docs/editors/decoration-protocol.md
+++ b/docs/editors/decoration-protocol.md
@@ -1,7 +1,7 @@
 ---
 id: decoration-protocol
 sidebar_label: Decoration Protocol
-title: Decoration Protocol v0.1.0
+title: Decoration Protocol v0.2.0
 ---
 
 Metals implements a Language Server Protocol extension called the "Decoration
@@ -35,9 +35,9 @@ export interface DecorationOptions {
   range: Range;
   /**
    * The text to display when the mouse hovers over the decoration.
-   * The MarkedString data structure is defined in the LanguageServerProtocol
+   * The MarkupContent data structure is defined in the LanguageServerProtocol
    */
-  hoverMessage?: MarkedString;
+  hoverMessage?: MarkupContent;
   /** The URI of the text document to place text decorations */
   renderOptions: ThemableDecorationInstanceRenderOption;
 }
@@ -113,3 +113,5 @@ export interface PublishDecorationsParams {
 ## Changelog
 
 - v0.1.0: First release with basic support for worksheets.
+- v0.2.0: `MarkedString` in `DecorationOptions` changed to `MarkupContent` to align
+    with LSP 3.15

--- a/metals/src/main/scala/scala/meta/internal/decorations/DecorationClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/DecorationClient.scala
@@ -2,8 +2,8 @@ package scala.meta.internal.decorations
 
 import javax.annotation.Nullable
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
+import org.eclipse.lsp4j.MarkupContent
 import org.eclipse.lsp4j.Range
-import org.eclipse.lsp4j.MarkedString
 
 trait DecorationClient {
   @JsonNotification("metals/publishDecorations")
@@ -14,7 +14,7 @@ trait DecorationClient {
 
 case class DecorationOptions(
     range: Range,
-    @Nullable hoverMessage: MarkedString = null,
+    @Nullable hoverMessage: MarkupContent = null,
     @Nullable renderOptions: ThemableDecorationInstanceRenderOptions = null
 )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -214,8 +214,7 @@ final class Diagnostics(
         range,
         d.getMessage,
         d.getSeverity,
-        d.getSource,
-        d.getCode
+        d.getSource
       )
     }
     if (result.isEmpty) {

--- a/metals/src/main/scala/scala/meta/internal/worksheets/DecorationWorksheetPublisher.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/DecorationWorksheetPublisher.scala
@@ -6,6 +6,7 @@ import scala.meta.internal.decorations.DecorationOptions
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.decorations.ThemableDecorationInstanceRenderOptions
 import scala.meta.internal.decorations.ThemableDecorationAttachmentRenderOptions
+import scala.meta.internal.pc.HoverMarkup
 import MdocEnrichments._
 import scala.meta.internal.decorations.PublishDecorationsParams
 import scala.meta.io.AbsolutePath
@@ -16,8 +17,6 @@ import org.eclipse.lsp4j.MarkupKind
 
 class DecorationWorksheetPublisher() extends WorksheetPublisher {
 
-  private val scalaMarkdownTics = "```scala"
-  private val endTics = "```"
   private val commentHeader = " // "
 
   override def publish(
@@ -45,7 +44,7 @@ class DecorationWorksheetPublisher() extends WorksheetPublisher {
           s.position().toLsp,
           new MarkupContent(
             MarkupKind.MARKDOWN,
-            List(scalaMarkdownTics, s.details, endTics).mkString("\n")
+            HoverMarkup(s.details)
           ),
           ThemableDecorationInstanceRenderOptions(
             after = ThemableDecorationAttachmentRenderOptions(

--- a/metals/src/main/scala/scala/meta/internal/worksheets/DecorationWorksheetPublisher.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/DecorationWorksheetPublisher.scala
@@ -7,15 +7,18 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.decorations.ThemableDecorationInstanceRenderOptions
 import scala.meta.internal.decorations.ThemableDecorationAttachmentRenderOptions
 import MdocEnrichments._
-import org.eclipse.lsp4j.MarkedString
 import scala.meta.internal.decorations.PublishDecorationsParams
 import scala.meta.io.AbsolutePath
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.Hover
+import org.eclipse.lsp4j.MarkupContent
+import org.eclipse.lsp4j.MarkupKind
 
 class DecorationWorksheetPublisher() extends WorksheetPublisher {
 
-  val commentHeader = " // "
+  private val scalaMarkdownTics = "```scala"
+  private val endTics = "```"
+  private val commentHeader = " // "
 
   override def publish(
       languageClient: MetalsLanguageClient,
@@ -40,7 +43,10 @@ class DecorationWorksheetPublisher() extends WorksheetPublisher {
       .map { s =>
         new DecorationOptions(
           s.position().toLsp,
-          new MarkedString("scala", s.details()),
+          new MarkupContent(
+            MarkupKind.MARKDOWN,
+            List(scalaMarkdownTics, s.details, endTics).mkString("\n")
+          ),
           ThemableDecorationInstanceRenderOptions(
             after = ThemableDecorationAttachmentRenderOptions(
               commentHeader + s.summary(),

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionProvider.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.pc
 import scala.meta.internal.mtags.MtagsEnrichments._
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionItemKind
+import org.eclipse.lsp4j.CompletionItemTag
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.InsertTextFormat
 import scala.meta.internal.jdk.CollectionConverters._
@@ -216,7 +217,7 @@ class CompletionProvider(
         item.setKind(completionItemKind(member))
         item.setSortText(f"${idx}%05d")
         if (member.sym.isDeprecated) {
-          item.setDeprecated(true)
+          item.setTags(List(CompletionItemTag.Deprecated).asJava)
         }
         // NOTE: We intentionally don't set the commit character because there are valid scenarios where
         // the user wants to type a dot '.' character without selecting a completion item.

--- a/mtags/src/main/scala/scala/meta/internal/pc/HoverMarkup.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/HoverMarkup.scala
@@ -38,4 +38,10 @@ object HoverMarkup {
     markdown.toString()
   }
 
+  def apply(body: String): String = {
+    s"""|```scala
+        |$body
+        |```""".stripMargin
+  }
+
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/HoverProvider.scala
@@ -11,9 +11,6 @@ import scala.util.control.NonFatal
 class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
   import compiler._
 
-  private val scalaMarkdownTics = "```scala"
-  private val endTics = "```"
-
   def hover(): Option[Hover] = {
     if (params.isWhitespace) {
       None
@@ -179,10 +176,9 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
         new Hover(
           new MarkupContent(
             MarkupKind.MARKDOWN,
-            s"""|${scalaMarkdownTics}
-                |${symbol.javaClassSymbol.keyString} ${symbol.fullName}
-                |${endTics}
-                """.stripMargin
+            HoverMarkup(
+              s"${symbol.javaClassSymbol.keyString} ${symbol.fullName}"
+            )
           )
         )
       )

--- a/mtags/src/main/scala/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/HoverProvider.scala
@@ -1,16 +1,18 @@
 package scala.meta.internal.pc
 
-import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
 import org.eclipse.lsp4j.Hover
-import org.eclipse.lsp4j.MarkedString
+import org.eclipse.lsp4j.MarkupContent
+import org.eclipse.lsp4j.MarkupKind
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.OffsetParams
 import scala.reflect.internal.{Flags => gf}
-import scala.meta.internal.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
 class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
   import compiler._
+
+  private val scalaMarkdownTics = "```scala"
+  private val endTics = "```"
 
   def hover(): Option[Hover] = {
     if (params.isWhitespace) {
@@ -175,14 +177,13 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
     else if (symbol.hasPackageFlag || symbol.hasModuleFlag) {
       Some(
         new Hover(
-          List(
-            JEither.forRight[String, MarkedString](
-              new MarkedString(
-                "scala",
-                s"${symbol.javaClassSymbol.keyString} ${symbol.fullName}"
-              )
-            )
-          ).asJava
+          new MarkupContent(
+            MarkupKind.MARKDOWN,
+            s"""|${scalaMarkdownTics}
+                |${symbol.javaClassSymbol.keyString} ${symbol.fullName}
+                |${endTics}
+                """.stripMargin
+          )
         )
       )
     } else {

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -117,17 +117,27 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
         client.workspaceDecorationHoverMessage,
         """|import java.nio.file.Files
            |val name = "Susan"
+           |```scala
            |name: String = "Susan"
+           |```
            |val greeting = s"Hello $name"
+           |```scala
            |greeting: String = "Hello Susan"
+           |```
            |println(greeting + "\nHow are you?")
+           |```scala
            |// Hello Susan
            |// How are you?
+           |```
            |1.to(10).toVector
+           |```scala
            |res1: Vector[Int] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+           |```
            |val List(a, b) = List(42, 10)
+           |```scala
            |a: Int = 42
            |b: Int = 10
+           |```
            |""".stripMargin
       )
     } yield ()


### PR DESCRIPTION
Since there was a couple issues that mentioned things that LSP 3.15 supports (such as progress), I figured it'd be a good idea to update to the latest 0.9.0 if lsp4j which implements most of 3.15. I also went through and removed/updated a few of the deprecated things.

In short this pr:

- updates the lsp4j library
- removes and replaces some deprecation with the lsp4j update