### PR TITLE
Add "case class" option in NewFilesProvider

### DIFF
--- a/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
@@ -36,6 +36,17 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
        |""".stripMargin
   )
 
+  check("new-case-class")(
+    Some("a/src/main/scala/foo/"),
+    "case-class",
+    Some("Foo"),
+    "a/src/main/scala/foo/Foo.scala",
+    """|package foo
+       |
+       |final case class Foo()
+       |""".stripMargin
+  )
+
   check("new-object-null-dir")(
     directory = None,
     "object",


### PR DESCRIPTION
Closes #1524 

Previously we would offer the choice to create:

- class
- object
- trait
- package object
- worksheet

now we also include "case class" right after "class"