### PR TITLE
Sort references before returning them

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -185,6 +185,7 @@ final class ReferenceProvider(
       includeSynthetics: Synthetic => Boolean
   ): Seq[Location] = {
     val isSymbol = alternatives + occ.symbol
+    pprint.log(alternatives)
     if (occ.symbol.isLocal) {
       referenceLocations(
         snapshot,

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -286,7 +286,11 @@ final class ReferenceProvider(
       range <- synthetic.range.toList
     } add(range)
 
-    buf.result()
+    buf.result().sortWith(sortByLocationPosition)
+  }
+
+  private def sortByLocationPosition(l1: Location, l2: Location): Boolean = {
+    l1.getRange.getStart.getLine < l2.getRange.getStart.getLine
   }
 
   private def findRealRange(

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -185,7 +185,6 @@ final class ReferenceProvider(
       includeSynthetics: Synthetic => Boolean
   ): Seq[Location] = {
     val isSymbol = alternatives + occ.symbol
-    pprint.log(alternatives)
     if (occ.symbol.isLocal) {
       referenceLocations(
         snapshot,

--- a/tests/mtest/src/main/scala/tests/Assertions.scala
+++ b/tests/mtest/src/main/scala/tests/Assertions.scala
@@ -1,5 +1,6 @@
 package tests
 
+import org.eclipse.lsp4j
 import munit.Location
 import scala.meta.io.AbsolutePath
 
@@ -57,6 +58,15 @@ trait Assertions extends munit.Assertions {
     }
   }
 
+  def assertSimpleLocationOrdering(locations: List[lsp4j.Location]): Unit = {
+    val grouped = locations.groupBy(_.getUri)
+    grouped.foreach {
+      case (_, group) => {
+        val lineStarts = group.map(_.getRange.getStart.getLine)
+        assert(lineStarts == lineStarts.sorted)
+      }
+    }
+  }
 }
 
 object Assertions extends Assertions

--- a/tests/unit/src/main/scala/tests/BaseRangesSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseRangesSuite.scala
@@ -1,0 +1,63 @@
+package tests
+
+import munit.Location
+import scala.concurrent.Future
+
+abstract class BaseRangesSuite(name: String) extends BaseLspSuite(name) {
+
+  def assertCheck(
+      filename: String,
+      edit: String,
+      expected: Map[String, String],
+      base: Map[String, String]
+  ): Future[Unit]
+
+  def check(name: String, input: String)(implicit loc: Location): Unit = {
+    val files = FileLayout.mapFromString(input)
+    val (filename, edit) = files
+      .find(_._2.contains("@@"))
+      .map {
+        case (fileName, code) =>
+          (fileName, code.replaceAll("(<<|>>)", ""))
+      }
+      .getOrElse {
+        throw new IllegalArgumentException(
+          "No `@@` was defined that specifies cursor position"
+        )
+      }
+    val expected = files.map {
+      case (fileName, code) =>
+        fileName -> code.replaceAll("@@", "")
+    }
+    val base = files.map {
+      case (fileName, code) =>
+        fileName -> code.replaceAll("(<<|>>|@@)", "")
+    }
+
+    test(name) {
+      cleanWorkspace()
+      for {
+        _ <- server.initialize(
+          s"""/metals.json
+             |{"a":
+             |  {
+             |    "compilerPlugins": [
+             |      "org.scalamacros:::paradise:2.1.1"
+             |    ],
+             |    "libraryDependencies": [
+             |      "org.scalatest::scalatest:3.0.5",
+             |      "io.circe::circe-generic:0.12.0"
+             |    ]
+             |  }
+             |}
+             |${input
+               .replaceAll("(<<|>>|@@)", "")}""".stripMargin
+        )
+        _ <- Future.sequence(
+          files.map(file => server.didOpen(s"${file._1}"))
+        )
+        _ <- assertCheck(filename, edit, expected, base)
+      } yield ()
+    }
+  }
+}

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -213,9 +213,13 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
     "companion",
     """|/a/src/main/scala/a/Main.scala
        |package a
-       |class <<Ma@@in>>{}
-       |object <<Main>>{
-       |  new <<Main>>
+       |case class <<Ma@@in>>(name : String){
+       |  val appl = <<Main>>.apply("")
+       |}
+       |/a/src/main/scala/a/Other.scala
+       |package a
+       |object Other{
+       | val appl = <<Main>>.apply("")
        |}
        |""".stripMargin
   )

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -210,17 +210,15 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
   }
 
   check(
-    "companion",
+    "ordering",
     """|/a/src/main/scala/a/Main.scala
        |package a
-       |case class <<Ma@@in>>(name : String){
-       |  val appl = <<Main>>.apply("")
-       |}
+       |trait <<A@@A>>
        |/a/src/main/scala/a/Other.scala
        |package a
-       |object Other{
-       | val appl = <<Main>>.apply("")
-       |}
+       |trait BB extends <<AA>>
+       |trait CC extends <<AA>>
+       |trait DD extends <<AA>>
        |""".stripMargin
   )
 

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -1,8 +1,10 @@
 package tests
 
 import scala.meta.internal.metals.ServerCommands
+import scala.concurrent.Future
 
-class ReferenceLspSuite extends BaseLspSuite("reference") {
+class ReferenceLspSuite extends BaseRangesSuite("reference") {
+
   test("case-class") {
     cleanWorkspace()
     for {
@@ -205,5 +207,25 @@ class ReferenceLspSuite extends BaseLspSuite("reference") {
       _ = assertNoDiagnostics()
       _ = server.assertReferenceDefinitionBijection()
     } yield ()
+  }
+
+  check(
+    "companion",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |class <<Ma@@in>>{}
+       |object <<Main>>{
+       |  new <<Main>>
+       |}
+       |""".stripMargin
+  )
+
+  override def assertCheck(
+      filename: String,
+      edit: String,
+      expected: Map[String, String],
+      base: Map[String, String]
+  ): Future[Unit] = {
+    server.assertReferences(filename, edit, expected, base)
   }
 }


### PR DESCRIPTION
This is a naive approach to close #1520 which sorts the references before they are returned. @tgodzik you mentioned changing to a sorted collection, but I wasn't sure how to do a sorted builder, or if that was what you actually meant. I didn't want to get rid of the builder as I assumed that it was used for performance. So this approach just sorts the collection right as it's about to be returned.