### PR TITLE
Update to latest munit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,7 +155,7 @@ lazy val V = new {
   val mavenBloop = bloop
   val mdoc = "2.1.3"
   val scalafmt = "2.4.2"
-  val munit = "0.4.3"
+  val munit = "0.7.1"
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.
   def supportedScalaBinaryVersions =

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -70,13 +70,15 @@ abstract class BasePCSuite extends BaseSuite {
     JdkSources().foreach(jdk => index.addSourceJar(jdk))
   }
 
-  override def munitNewTest(test: Test): Test = {
-    val testName =
-      if (isCI && BuildInfo.scalaCompilerVersion != BuildInfoVersions.scala212)
-        s"${BuildInfo.scalaCompilerVersion}-${test.name}"
-      else test.name
-    test.withName(testName)
-  }
+  override def munitTestTransforms: List[TestTransform] =
+    super.munitTestTransforms :+
+      new TestTransform("Add Compiler Version", { test =>
+        val testName =
+          if (isCI && BuildInfo.scalaCompilerVersion != BuildInfoVersions.scala212)
+            s"${BuildInfo.scalaCompilerVersion}-${test.name}"
+          else test.name
+        test.withName(testName)
+      })
 
   def indexScalaLibrary(): Unit = {
     val sources = Fetch()

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -1,9 +1,9 @@
 package tests
+
 import java.nio.file.Files
 import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutorService
-import scala.concurrent.Future
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.ClientExperimentalCapabilities
@@ -121,21 +121,6 @@ abstract class BaseLspSuite(suiteName: String) extends BaseSuite {
         case NonFatal(_) =>
           scribe.warn(s"Unable to delete workspace $workspace")
       }
-    }
-  }
-
-  def flakyTest(name: String, maxRetries: Int = 3)(
-      run: => Future[Unit]
-  ): Unit = {
-    test(name) {
-      def loop(n: Int): Future[Unit] = {
-        run.recoverWith {
-          case NonFatal(_) if n > 0 =>
-            scribe.info(s"test retry: $name")
-            loop(n - 1)
-        }
-      }
-      loop(maxRetries)
     }
   }
 }

--- a/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
@@ -12,7 +12,7 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
     basicTest(V.scala212)
   }
 
-  flakyTest("workspace") {
+  test("workspace".flaky) {
     cleanWorkspace()
     for {
       _ <- server.initialize(
@@ -206,7 +206,7 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
     } yield ()
   }
 
-  flakyTest("rambo") {
+  test("rambo".flaky) {
     cleanWorkspace()
     for {
       _ <- server.initialize(


### PR DESCRIPTION
The pr updates to the latest munit. It follows the new pattern of using `TestTransforms` that this commit demonstrates and outlines https://github.com/scalameta/munit/commit/f2d277df78d159ef644727416fdf8281e1e1e4f2.

Closes #1527 