### PR TITLE
Add auto-install of vscode liveshare extension to fastpass

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -123,12 +123,21 @@ object ClientCommands {
        |""".stripMargin
   )
 
+  val Liveshare = new Command(
+    "metals-liveshare",
+    "Liveshare!!",
+    "Something something liveshare",
+    """|No Idea Sorry
+       |""".stripMargin
+  )
+
   def all: List[Command] = List(
     RunDoctor,
     ReloadDoctor,
     ToggleLogs,
     FocusDiagnostics,
     GotoLocation,
-    EchoCommand
+    EchoCommand,
+    Liveshare
   )
 }

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/VSCode.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/VSCode.scala
@@ -23,6 +23,7 @@ object VSCode {
       scribe.info(s"updated: $settings")
       val code = codeCommand()
       exec(code, "--install-extension", "scalameta.metals")
+      exec(code, "--install-extension", "ms-vsliveshare.vsliveshare-pack")
       exec(code, "--new-window", project.common.workspace.toString())
       findFileToOpen(project).headOption.foreach { file =>
         exec(code, "--reuse-window", file.toString())

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/LiveshareCommand.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/LiveshareCommand.scala
@@ -1,0 +1,31 @@
+package scala.meta.internal.pantsbuild.commands
+
+package scala.meta.internal.pantsbuild.commands
+
+import metaconfig.cli.Command
+import metaconfig.cli.CliApp
+import org.typelevel.paiges.Doc
+import metaconfig.cli.Messages
+
+object LiveshareCommand extends Command[LiveshareCommand]("liveshare") {
+  override def description: Doc =
+    Doc.paragraph("Open a Liveshare session for the given project")
+  override def options: Doc = Messages.options(LiveshareOptions())
+
+  override def complete(
+      context: TabCompletionContext
+  ): List[TabCompletionItem] =
+    SharedCommand.complete(context)
+
+  def run(info: InfoOptions, app: CliApp): Int = {
+    SharedCommand.withOneProject(
+      "open a liveshare session for",
+      info.projects,
+      info.common,
+      app
+    ) { project =>
+      project.targets.foreach { target => println(target) }
+      0
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/LiveshareOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/LiveshareOptions.scala
@@ -1,0 +1,21 @@
+package scala.meta.internal.pantsbuild.commands
+
+import metaconfig.generic
+import metaconfig.annotation._
+import metaconfig.generic.Settings
+import metaconfig.{ConfDecoder, ConfEncoder}
+
+case class LiveshareOptions(
+    @Inline common: SharedOptions = SharedOptions()
+)
+object LiveshareOptions {
+  val default: LiveshareOptions = LiveshareOptions()
+  implicit lazy val surface: generic.Surface[LiveshareOptions] =
+    generic.deriveSurface[LiveshareOptions]
+  implicit lazy val encoder: ConfEncoder[LiveshareOptions] =
+    generic.deriveEncoder[LiveshareOptions]
+  implicit lazy val decoder: ConfDecoder[LiveshareOptions] =
+    generic.deriveDecoder[LiveshareOptions](default)
+  implicit lazy val settings: Settings[LiveshareOptions] =
+    Settings[LiveshareOptions]
+}


### PR DESCRIPTION
This change will allow users of `fastpass` to automatically get Microsoft's `Live Share Extension Pack` installed for VSCode, which offers a novel way to pair program remotely on code using the hosting person's environment.