### PR TITLE
Allow multiple "Create new symbol" actions on a range

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateNewSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateNewSymbol.scala
@@ -35,7 +35,7 @@ class CreateNewSymbol() extends CodeAction {
 
     val codeActions = params.getContext().getDiagnostics().asScala.collect {
       case d @ ScalacDiagnostic.SymbolNotFound(name)
-          if d.getRange().encloses(params.getRange()) =>
+          if params.getRange().overlapsWith(d.getRange()) =>
         createNewSymbol(d, name)
     }
 

--- a/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
@@ -47,6 +47,29 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
             |""".stripMargin
   )
 
+  checkNewSymbol(
+    "multi",
+    """|package a
+       |
+       |<<case class School(name: Missing, location: Location)>>
+       |""".stripMargin,
+    s"""|${ImportMissingSymbol.title("Location", "scala.collection.script")}
+        |${CreateNewSymbol.title("Missing")}
+        |${CreateNewSymbol.title("Location")}
+        |""".stripMargin,
+    selectedActionIndex = 1,
+    pickedKind = "class",
+    newFile =
+      "a/src/main/scala/a/Missing.scala" ->
+        s"""|package a
+            |
+            |class Missing {
+            |$indent
+            |}
+            |""".stripMargin,
+    expectNoDiagnostics = false
+  )
+
   private def indent = "  "
 
   def checkNewSymbol(

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -62,6 +62,8 @@ class ImportMissingSymbolLspSuite
     s"""|${ImportMissingSymbol.title("Future", "scala.concurrent")}
         |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
         |${ImportMissingSymbol.title("Instant", "java.time")}
+        |${CreateNewSymbol.title("Future")}
+        |${CreateNewSymbol.title("Instant")}
         |""".stripMargin,
     """|package a
        |
@@ -86,6 +88,8 @@ class ImportMissingSymbolLspSuite
        |""".stripMargin,
     s"""|${ImportMissingSymbol.title("Instant", "java.time")}
         |${ImportMissingSymbol.title("ListBuffer", "scala.collection.mutable")}
+        |${CreateNewSymbol.title("Instant")}
+        |${CreateNewSymbol.title("ListBuffer")}
         |""".stripMargin,
     """|package a
        |


### PR DESCRIPTION
Previously we would only add "Create new symbol" actions if the diagnostic range enclosed the code action range.

Now we suggest the action if the ranges overlap, which means we can suggest the action multiple times (one per missing symbol in the range).

This also fixes https://github.com/scalameta/coc-metals/issues/134 /cc @ckipp01 