### PR TITLE
Change go to parent lenses to true by default

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -132,7 +132,7 @@ object UserConfiguration {
     ),
     UserConfigurationOption(
       "super-method-lenses-enabled",
-      "false",
+      "true",
       "false",
       "Should display lenses with links to super methods",
       """|Super method lenses are visible above methods definition that override another methods. Clicking on a lens jumps to super method definition.
@@ -255,7 +255,7 @@ object UserConfiguration {
     val bloopVersion =
       getStringKey("bloop-version")
     val superMethodLensesEnabled =
-      getBooleanKey("super-method-lenses-enabled").getOrElse(false)
+      getBooleanKey("super-method-lenses-enabled").getOrElse(true)
     if (errors.isEmpty) {
       Right(
         UserConfiguration(


### PR DESCRIPTION
I just realised that I was totally mistaken before and the code lenses will work without the VS Code release.

@kpbochenek To confirm.