### PR TITLE
Specify cursor position when creating new files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -445,7 +445,8 @@ lazy val unit = project
       "io.get-coursier" %% "coursier" % V.coursier, // for jars
       "org.scalameta" %% "testkit" % V.scalameta,
       "ch.epfl.scala" %% "bloop-config" % V.bloop,
-      "org.scalameta" %% "munit" % V.munit
+      "org.scalameta" %% "munit" % V.munit,
+      "org.scalameta" %% "munit-scalacheck" % V.munit
     ),
     buildInfoPackage := "tests",
     resourceGenerators.in(Compile) += InputProperties.resourceGenerator(input),

--- a/metals/src/main/scala/scala/meta/internal/metals/NewFileTemplate.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NewFileTemplate.scala
@@ -1,0 +1,41 @@
+package scala.meta.internal.metals
+
+import scala.{meta => m}
+import scala.meta.internal.mtags.MtagsEnrichments._
+
+/**
+ * File template which allows specifying the cursor position using @@
+ */
+final case class NewFileTemplate private (template: String) {
+  import NewFileTemplate._
+
+  lazy val fileContent: String = template.replaceAllLiterally(cursorMarker, "")
+
+  lazy val cursorPosition: m.Position = {
+    val input = m.Input.String(template)
+    val offset = template.indexOf(cursorMarker)
+    input.toOffsetPosition(offset)
+  }
+
+  def map(f: String => String): NewFileTemplate =
+    NewFileTemplate(f(template))
+
+}
+
+object NewFileTemplate {
+  private val cursorMarker = "@@"
+
+  /**
+   * @param template the file template string. Must contain exactly one cursor marker (@@)
+   */
+  def apply(template: String): NewFileTemplate = {
+    val cursorMarkersCount = cursorMarker.r.findAllMatchIn(template).length
+    require(
+      cursorMarkersCount == 1,
+      s"File templates must contain exactly one cursor marker '$cursorMarker'. Found $cursorMarkersCount"
+    )
+    new NewFileTemplate(template)
+  }
+
+  def empty = new NewFileTemplate(cursorMarker)
+}

--- a/tests/unit/src/test/scala/tests/NewFileTemplateSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileTemplateSuite.scala
@@ -7,7 +7,7 @@ import org.scalacheck.Prop.forAll
 
 class NewFileTemplateSuite extends BaseSuite with ScalaCheckSuite {
 
-  test("it requires exactly one cursor marker") {
+  test("cursor-marker-errors") {
     intercept[IllegalArgumentException] {
       NewFileTemplate("no cursor markers")
     }
@@ -16,7 +16,7 @@ class NewFileTemplateSuite extends BaseSuite with ScalaCheckSuite {
     }
   }
 
-  property("cursor marker position is computed correctly") {
+  property("cursor-marker-position") {
     val template =
       s"""|package a
           |

--- a/tests/unit/src/test/scala/tests/NewFileTemplateSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileTemplateSuite.scala
@@ -1,0 +1,33 @@
+package tests
+
+import munit.ScalaCheckSuite
+import scala.meta.internal.metals.NewFileTemplate
+import org.scalacheck.Gen
+import org.scalacheck.Prop.forAll
+
+class NewFileTemplateSuite extends BaseSuite with ScalaCheckSuite {
+
+  test("it requires exactly one cursor marker") {
+    intercept[IllegalArgumentException] {
+      NewFileTemplate("no cursor markers")
+    }
+    intercept[IllegalArgumentException] {
+      NewFileTemplate("many cursor @@ markers @@")
+    }
+  }
+
+  property("cursor marker position is computed correctly") {
+    val template =
+      s"""|package a
+          |
+          |case class Foo()
+          |""".stripMargin
+    val cursorOffsetGen = Gen.chooseNum(0, template.length)
+    forAll(cursorOffsetGen) { cursorOffset =>
+      val templateWithCursor = template.patch(cursorOffset, "@@", 0)
+      val newFileTemplate = NewFileTemplate(templateWithCursor)
+      assertEquals(newFileTemplate.cursorPosition.start, cursorOffset)
+    }
+  }
+
+}


### PR DESCRIPTION
Closes #1529 

Previously we would set the cursor position at the beginning of the file when creating a new file. Now we place the cursor in a more convenient position, depending on the type of file.

Demo:
![2020-03-23 17 49 31](https://user-images.githubusercontent.com/691940/77632315-1cd3db80-6f4e-11ea-9283-a2b522cedf1d.gif)
