### PR TITLE
Add support to query remote language server as fallback.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -296,6 +296,8 @@ lazy val metals = project
       "com.lihaoyi" %% "ujson" % "0.9.9",
       "ch.epfl.scala" %% "bloop-config" % V.bloop,
       "ch.epfl.scala" %% "bloop-frontend" % V.bloop,
+      // For remote language server
+      "com.lihaoyi" %% "requests" % "0.5.1",
       // for producing SemanticDB from Scala source files
       "org.scalameta" %% "scalameta" % V.scalameta,
       "org.scalameta" % "semanticdb-scalac-core" % V.scalameta cross CrossVersion.full

--- a/docs/contributors/remote-language-server.md
+++ b/docs/contributors/remote-language-server.md
@@ -1,0 +1,146 @@
+---
+id: remote-language-server
+title: Remote Language Servers
+---
+
+Metals has experimental support to offload certain requests to a remote language
+server. This feature can be used to navigate large codebases when its not
+possible to index all the code on a local computer.
+
+## Difference from local language servers
+
+There are some important differences between local and remote language servers:
+
+- Instead of JSON-RPC, a remote language server responds to HTTP POST requests
+  with an `application/json` header and a JSON-formatted body.
+- Instead of using absolute `file://` URIs, a remote language server uses
+  relative `source://` URIs. For example, the absolute URI
+  `file://path/to/workspace/src/main/scala/Address.scala` becomes the relative
+  URI `source://src/main/scala/Address.scala` when communicating with a remote
+  language server.
+
+## Methods
+
+Each remote language server method expects a JSON-formatted body of type
+`JsonRpcRequest<T>`.
+
+```ts
+interface JsonRpcRequest<T> {
+  /** The JSON-RPC method name, for example textDocument/definition */
+  method: string;
+
+  /** The parameter for the JSON-RPC method, for example `TextDocumentPositionParams` */
+  params: T;
+
+  /** The ID of this request, can be any integer number. */
+  id: number;
+}
+```
+
+### `textDocument/definition`
+
+The `textDocument/definition` request is sent from the client to the server to
+get the list of definitions for a given position.
+
+_Request_:
+
+- method: `textDocument/definition`
+- params: `JsonRpcRequest<TextDocumentPositionParams>`, where
+  `TextDocumentPositionParams` is defined in LSP.
+
+_Response_:
+
+- result: `Location[]`, as defined in LSP.
+
+_Example request_:
+
+```sh
+curl --location --request POST 'http://remote-language-server.com' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+  "method": "textDocument/definition",
+  "params": {
+    "textDocument": {
+      "uri": "source://src/main/scala/Address.scala"
+    },
+    "position": {
+      "line": 5,
+      "character": 10
+    }
+  },
+  "id": 10
+}'
+```
+
+_Example response_:
+
+```json
+[
+  {
+    "uri": "source://src/main/scala/User.scala",
+    "range": {
+      "start": { "line": 61, "character": 15 },
+      "end": { "line": 61, "character": 31 }
+    }
+  }
+]
+```
+
+### `textDocument/references`
+
+The `textDocument/references` request is sent from the client to the server to
+get the list of all references to a symbol at a given position.
+
+_Request_:
+
+- method: `textDocument/references`
+- params: `JsonRpcRequest<ReferenceParams>`, where `ReferenceParams` is defined
+  in LSP.
+
+_Response_:
+
+- result: `Location[]`, as defined in LSP.
+
+_Example request_:
+
+```sh
+curl --location --request POST 'http://remote-language-server.com' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+  "method": "textDocument/references",
+  "params": {
+    "textDocument": {
+      "uri": "source://src/main/scala/Address.scala"
+    },
+    "position": {
+      "line": 5,
+      "character": 10
+    },
+    "context": {
+      "includeDeclaration": true
+    }
+  },
+  "id": 10
+}'
+```
+
+_Example response_:
+
+```json
+[
+  {
+    "uri": "source://src/main/scala/User.scala",
+    "range": {
+      "start": { "line": 61, "character": 15 },
+      "end": { "line": 61, "character": 31 }
+    }
+  },
+  {
+    "uri": "source://src/main/scala/Country.scala",
+    "range": {
+      "start": { "line": 62, "character": 16 },
+      "end": { "line": 62, "character": 32 }
+    }
+  }
+]
+```

--- a/docs/contributors/remote-language-server.md
+++ b/docs/contributors/remote-language-server.md
@@ -12,7 +12,12 @@ possible to index all the code on a local computer.
 There are some important differences between local and remote language servers:
 
 - Instead of JSON-RPC, a remote language server responds to HTTP POST requests
-  with an `application/json` header and a JSON-formatted body.
+  with an `application/json` header and a JSON-formatted body. The reason HTTP
+  is chosen over JSON-RPC is because it makes the remote language server
+  accesible from more clients, for example via `curl`. A caveat with using HTTP
+  instead of JSON-RPC is that it's not possible for the remote language server
+  to push notification down to the client. In the future, we could consider
+  using JSON-RPC via websockets instead.
 - Instead of using absolute `file://` URIs, a remote language server uses
   relative `source://` URIs. For example, the absolute URI
   `file://path/to/workspace/src/main/scala/Address.scala` becomes the relative

--- a/docs/contributors/remote-language-server.md
+++ b/docs/contributors/remote-language-server.md
@@ -4,7 +4,7 @@ title: Remote Language Servers
 ---
 
 Metals has experimental support to offload certain requests to a remote language
-server. This feature can be used to navigate large codebases when its not
+server. This feature can be used to navigate large codebases when it's not
 possible to index all the code on a local computer.
 
 ## Difference from local language servers
@@ -149,3 +149,21 @@ _Example response_:
   }
 ]
 ```
+
+## Open questions
+
+The protocol for remote language servers is new and likely to have breaking
+changes in upcoming releases. The protocol in this document should be considered
+as a proof-of-concept that demonstrates the feasibility of this approach. There
+remain a few open questions in order to extend remote language servers to
+support richer functionality:
+
+- how do we ensure that results from the remote server are synchronized with the
+  file changes to the local disk?
+- how do we combine local and remote `workspace/symbol` results?
+- how should `textDocument/definition` return results to library dependency
+  sources that are not present on local disk?
+
+Given these open questions and the experimental status of remote language
+servers, this functionality may be removed from Metals in future releases
+without notice.

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -19,6 +19,7 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
 import scala.meta.internal.semanticdb.SymbolOccurrence
 import org.eclipse.lsp4j.Position
+import scala.meta.internal.remotels.RemoteLanguageServer
 
 /**
  * Implements goto definition that works even in code that doesn't parse.
@@ -44,7 +45,8 @@ final class DefinitionProvider(
     icons: Icons,
     statusBar: StatusBar,
     warnings: Warnings,
-    compilers: () => Compilers
+    compilers: () => Compilers,
+    remote: RemoteLanguageServer
 )(implicit ec: ExecutionContext) {
 
   val destinationProvider = new DestinationProvider(
@@ -61,17 +63,28 @@ final class DefinitionProvider(
       token: CancelToken
   ): Future[DefinitionResult] = {
     val fromSemanticdb =
-      semanticdbs.textDocument(path).documentIncludingStale match {
-        case Some(doc) =>
-          definitionFromSnapshot(path, params, doc)
-        case _ =>
-          warnings.noSemanticdb(path)
-          DefinitionResult.empty
+      semanticdbs.textDocument(path).documentIncludingStale
+    val fromSnapshot = fromSemanticdb match {
+      case Some(doc) =>
+        definitionFromSnapshot(path, params, doc)
+      case _ =>
+        DefinitionResult.empty
+    }
+    val fromCompiler =
+      if (fromSnapshot.locations.isEmpty()) {
+        if (remote.isEnabledForPath(path)) {
+          Future(remote.definition(params).getOrElse(fromSnapshot))
+        } else {
+          compilers().definition(params, token)
+        }
+      } else {
+        Future.successful(fromSnapshot)
       }
-    if (fromSemanticdb.locations.isEmpty()) {
-      compilers().definition(params, token)
-    } else {
-      Future.successful(fromSemanticdb)
+    fromCompiler.map { result =>
+      if (result.locations.isEmpty() && fromSemanticdb.isEmpty) {
+        warnings.noSemanticdb(path)
+      }
+      result
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -70,21 +70,21 @@ final class DefinitionProvider(
       case _ =>
         DefinitionResult.empty
     }
-    val fromCompiler =
-      if (fromSnapshot.locations.isEmpty()) {
-        if (remote.isEnabledForPath(path)) {
-          remote.definition(params).map(_.getOrElse(fromSnapshot))
-        } else {
-          compilers().definition(params, token)
-        }
+    val fromIndex =
+      if (fromSnapshot.isEmpty && remote.isEnabledForPath(path)) {
+        remote.definition(params).map(_.getOrElse(fromSnapshot))
       } else {
         Future.successful(fromSnapshot)
       }
-    fromCompiler.map { result =>
-      if (result.locations.isEmpty() && fromSemanticdb.isEmpty) {
-        warnings.noSemanticdb(path)
+    fromIndex.flatMap { result =>
+      if (result.isEmpty) {
+        compilers().definition(params, token)
+      } else {
+        if (result.isEmpty && fromSemanticdb.isEmpty) {
+          warnings.noSemanticdb(path)
+        }
+        Future.successful(result)
       }
-      result
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -73,7 +73,7 @@ final class DefinitionProvider(
     val fromCompiler =
       if (fromSnapshot.locations.isEmpty()) {
         if (remote.isEnabledForPath(path)) {
-          Future(remote.definition(params).getOrElse(fromSnapshot))
+          remote.definition(params).map(_.getOrElse(fromSnapshot))
         } else {
           compilers().definition(params, token)
         }

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionResult.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionResult.scala
@@ -12,7 +12,9 @@ case class DefinitionResult(
     symbol: String,
     definition: Option[AbsolutePath],
     semanticdb: Option[TextDocument]
-)
+) {
+  def isEmpty: Boolean = locations.isEmpty()
+}
 
 object DefinitionResult {
   def empty(symbol: String): DefinitionResult =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -125,6 +125,7 @@ class MetalsLanguageServer(
   private val remote = new RemoteLanguageServer(
     () => workspace,
     () => userConfig,
+    config,
     buffers,
     buildTargets
   )

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -56,6 +56,7 @@ import scala.meta.internal.metals.Messages.IncompatibleBloopVersion
 import scala.meta.internal.implementation.Supermethods
 import scala.meta.internal.metals.codelenses.RunTestCodeLens
 import scala.meta.internal.metals.codelenses.SuperMethodCodeLens
+import scala.meta.internal.remotels.RemoteLanguageServer
 
 class MetalsLanguageServer(
     ec: ExecutionContextExecutorService,
@@ -121,6 +122,12 @@ class MetalsLanguageServer(
   private val languageClient = new DelegatingLanguageClient(NoopLanguageClient)
   var userConfig: UserConfiguration = UserConfiguration()
   val buildTargets: BuildTargets = new BuildTargets()
+  private val remote = new RemoteLanguageServer(
+    () => workspace,
+    () => userConfig,
+    buffers,
+    buildTargets
+  )
   val compilations: Compilations = new Compilations(
     buildTargets,
     buildTargetClasses,
@@ -334,7 +341,8 @@ class MetalsLanguageServer(
       config.icons,
       statusBar,
       warnings,
-      () => compilers
+      () => compilers,
+      remote
     )
     formattingProvider = new FormattingProvider(
       workspace,
@@ -367,7 +375,8 @@ class MetalsLanguageServer(
       workspace,
       semanticdbs,
       buffers,
-      definitionProvider
+      definitionProvider,
+      remote
     )
     implementationProvider = new ImplementationProvider(
       semanticdbs,
@@ -413,7 +422,8 @@ class MetalsLanguageServer(
       buffers,
       compilations,
       config,
-      clientExperimentalCapabilities
+      clientExperimentalCapabilities,
+      remote
     )
     semanticDBIndexer = new SemanticdbIndexer(
       referencesProvider,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -422,8 +422,7 @@ class MetalsLanguageServer(
       buffers,
       compilations,
       config,
-      clientExperimentalCapabilities,
-      remote
+      clientExperimentalCapabilities
     )
     semanticDBIndexer = new SemanticdbIndexer(
       referencesProvider,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -56,6 +56,10 @@ final case class MetalsServerConfig(
       "metals.warnings",
       default = true
     ),
+    remoteTimeout: String = System.getProperty(
+      "metals.timeout",
+      "1 minute"
+    ),
     openFilesOnRenames: Boolean = false,
     renameFileThreshold: Int = 300,
     bloopEmbeddedVersion: String = System.getProperty(

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -21,12 +21,14 @@ import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.AbsolutePath
 import scala.util.control.NonFatal
 import scala.meta.internal.semanticdb.Synthetic
+import scala.meta.internal.remotels.RemoteLanguageServer
 
 final class ReferenceProvider(
     workspace: AbsolutePath,
     semanticdbs: Semanticdbs,
     buffers: Buffers,
-    definition: DefinitionProvider
+    definition: DefinitionProvider,
+    remote: RemoteLanguageServer
 ) {
   var referencedPackages: BloomFilter[CharSequence] = BloomFilters.create(10000)
   val index: TrieMap[Path, BloomFilter[CharSequence]] =
@@ -94,7 +96,7 @@ final class ReferenceProvider(
             ReferencesResult.empty
         }
       case None =>
-        ReferencesResult.empty
+        remote.references(params).getOrElse(ReferencesResult.empty)
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -22,9 +22,6 @@ import scala.meta.io.AbsolutePath
 import scala.util.control.NonFatal
 import scala.meta.internal.semanticdb.Synthetic
 import scala.meta.internal.remotels.RemoteLanguageServer
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
-import java.util.concurrent.TimeUnit
 
 final class ReferenceProvider(
     workspace: AbsolutePath,
@@ -104,9 +101,7 @@ final class ReferenceProvider(
         // its dependencies (including rename provider) asynchronous. The remote
         // language server returns `Future.successful(None)` when it's disabled
         // so this isn't even blocking for normal usage of Metals.
-        Await
-          .result(remote.references(params), Duration(1, TimeUnit.MINUTES))
-          .getOrElse(ReferencesResult.empty)
+        remote.referencesBlocking(params).getOrElse(ReferencesResult.empty)
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -33,7 +33,8 @@ case class UserConfiguration(
     bloopSbtAlreadyInstalled: Boolean = false,
     bloopVersion: Option[String] = None,
     pantsTargets: Option[List[String]] = None,
-    superMethodLensesEnabled: Boolean = true
+    superMethodLensesEnabled: Boolean = true,
+    remoteLanguageServer: Option[String] = None
 ) {
 
   def currentBloopVersion: String =
@@ -139,6 +140,17 @@ object UserConfiguration {
          |Disabled lenses are not calculated for opened documents which might speed up document processing.
          |
          |""".stripMargin
+    ),
+    UserConfigurationOption(
+      "remote-language-server",
+      """empty string `""`.""",
+      "https://language-server.company.com/message",
+      "Remote language server",
+      """A URL pointing to an endpoint that implements a remote language server.
+        |
+        |See https://scalameta.org/metals/docs/contributors/remote-language-server.html for
+        |documentation on remote language servers.
+        |""".stripMargin
     )
   )
 
@@ -256,6 +268,8 @@ object UserConfiguration {
       getStringKey("bloop-version")
     val superMethodLensesEnabled =
       getBooleanKey("super-method-lenses-enabled").getOrElse(true)
+    val remoteLanguageServer =
+      getStringKey("remote-language-server")
     if (errors.isEmpty) {
       Right(
         UserConfiguration(
@@ -271,7 +285,8 @@ object UserConfiguration {
           bloopSbtAlreadyInstalled,
           bloopVersion,
           pantsTargets,
-          superMethodLensesEnabled
+          superMethodLensesEnabled,
+          remoteLanguageServer
         )
       )
     } else {

--- a/metals/src/main/scala/scala/meta/internal/remotels/RemoteLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/remotels/RemoteLanguageServer.scala
@@ -25,9 +25,9 @@ class RemoteLanguageServer(
     buffers: Buffers,
     buildTargets: BuildTargets
 )(implicit ec: ExecutionContext) {
-  def isEnabled: Boolean = config().remoteLanguageServer.isDefined
   def isEnabledForPath(path: AbsolutePath): Boolean =
-    isEnabled && buildTargets.inverseSources(path).isEmpty
+    config().remoteLanguageServer.isDefined &&
+      buildTargets.inverseSources(path).isEmpty
 
   def references(
       params: l.ReferenceParams

--- a/metals/src/main/scala/scala/meta/internal/remotels/RemoteLocationResult.scala
+++ b/metals/src/main/scala/scala/meta/internal/remotels/RemoteLocationResult.scala
@@ -1,0 +1,6 @@
+package scala.meta.internal.remotels
+
+import java.{util => ju}
+import org.eclipse.{lsp4j => l}
+
+class RemoteLocationResult(val result: ju.List[l.Location])

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -164,7 +164,7 @@ final class TestingServer(
       }
       .mkString("\n")
   }
-  def workspaceSources: Seq[AbsolutePath] = {
+  def workspaceSources(): Seq[AbsolutePath] = {
     for {
       sourceItem <- server.buildTargets.sourceItems.toSeq
       if sourceItem.exists
@@ -304,7 +304,7 @@ final class TestingServer(
     def newRef(symbol: String, loc: Location): SymbolReference =
       SymbolReference(symbol, loc, loc.getRange.toMeta(readInput(loc.getUri)))
     for {
-      source <- workspaceSources
+      source <- workspaceSources()
       input = source.toInputFromBuffers(buffers)
       identifier = source.toTextDocumentIdentifier
       token <- input.tokenize.get

--- a/tests/unit/src/test/scala/tests/remotels/RemoteLanguageServerLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/remotels/RemoteLanguageServerLspSuite.scala
@@ -1,0 +1,39 @@
+package tests.remotels
+
+import scala.meta.internal.metals.UserConfiguration
+
+class RemoteLanguageServerLspSuite extends tests.BaseLspSuite("remotels") {
+
+  private val remote = TestingRemoteLanguageServer()
+
+  override def beforeAll(): Unit = remote.start()
+  override def afterAll(): Unit = remote.stop()
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(remoteLanguageServer = Some(remote.address))
+
+  test("basic") {
+    for {
+      _ <- server.initialize(
+        """|/metals.json
+           |{
+           |  "a": { }
+           |}
+           |/Foo.scala
+           |object Foo {
+           |  val x = 42
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("Foo.scala")
+      _ = assertNoDiff(
+        server.workspaceDefinitions,
+        """|/Foo.scala
+           |object Foo/*L0*/ {
+           |  val x/*L1*/ = 42
+           |}
+           |""".stripMargin
+      )
+    } yield ()
+  }
+
+}

--- a/tests/unit/src/test/scala/tests/remotels/TestingRemoteLanguageServer.scala
+++ b/tests/unit/src/test/scala/tests/remotels/TestingRemoteLanguageServer.scala
@@ -1,0 +1,67 @@
+package tests.remotels
+
+import io.undertow.Undertow
+import scala.meta.internal.metals.MetalsHttpServer
+import io.undertow.Handlers.path
+import scala.meta.internal.io.InputStreamIO
+import java.nio.charset.StandardCharsets
+import scala.meta.internal.metals.JsonParser._
+import scala.util.control.NonFatal
+import scala.meta.internal.remotels.RemoteLocationResult
+import org.eclipse.{lsp4j => l}
+import org.eclipse.lsp4j.TextDocumentPositionParams
+import java.{util => ju}
+
+class TestingRemoteLanguageServer(server: Undertow) {
+  def address: String = {
+    MetalsHttpServer.address(server) + "/message"
+  }
+  def start(): Unit = {
+    server.start()
+  }
+  def stop(): Unit = {
+    server.stop()
+  }
+}
+object TestingRemoteLanguageServer {
+  def apply(): TestingRemoteLanguageServer = {
+    val host = "localhost"
+    val port = MetalsHttpServer.freePort(host, 9876)
+    val server = Undertow
+      .builder()
+      .addHttpListener(port, host)
+      .setHandler(
+        path().addExactPath(
+          "/message",
+          MetalsHttpServer.textHandler(
+            "application/json",
+            e => {
+              try {
+                val request = new String(
+                  InputStreamIO.readBytes(e.getInputStream()),
+                  StandardCharsets.UTF_8
+                ).parseJson.toJsonObject
+                val params =
+                  request.get("params").as[TextDocumentPositionParams].get
+                val response = new RemoteLocationResult(
+                  ju.Collections.singletonList(
+                    new l.Location(
+                      params.getTextDocument().getUri(),
+                      new l.Range(params.getPosition(), params.getPosition())
+                    )
+                  )
+                )
+                response.toJson.toString()
+              } catch {
+                case NonFatal(e) =>
+                  scribe.error(e)
+                  ""
+              }
+            }
+          )
+        )
+      )
+      .build()
+    new TestingRemoteLanguageServer(server)
+  }
+}

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -24,6 +24,7 @@
       "editors/tree-view-protocol",
       "editors/decoration-protocol",
       "editors/debug-adapter-protocol",
+      "contributors/remote-language-server",
       "contributors/project-goals",
       "contributors/getting-started",
       "contributors/updating-website",


### PR DESCRIPTION
Previously, Metals only supported responding to definition/requests from a local index that was built by Metals. For some large codebases it's not practical to index all the code locally making it difficult to use Metals.

Now, Metals supports querying a remote language server as a fallback when the local index is not able to respond to definition/references requests. This feature is especially helpful in a large monorepo where there exists a lot of code but the user is only actively working on a small part of the codebase. With a remote language server, users can query the remote language server for source files that the user is not editing without building a local index.

Big thanks to @ShaneDelmore who has implemented a remote language server that is backed by a SQL index of SemanticDBs. Our early experiments show that this approach is scalable to large codebases and response times are ~200-300ms for most "goto definition" requests on a good internet connection. One "find references" requests that returned ~30k results took 9 seconds to respond with my 4G tethered internet connection from the countryside in Iceland.

This remote language server is currently tied to our internal Pants/CI infrastructure so there isn't much code that's worth sharing publicly at this point. We hope this initial PR sparks enough interest for people to start experimenting with implementing remote language servers that integrate with other build tools such as sbt/Gradle/Maven.