### PR TITLE
Fix recommendations for Scala versions and add better messages.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -182,7 +182,7 @@ final class Doctor(
 
     def message(
         filter: String => Boolean,
-        apply: (Iterable[String], Iterable[String]) => String
+        apply: Iterable[String] => String
     ): Option[String] = {
       val versions = (for {
         target <- allTargets.toIterator
@@ -190,13 +190,7 @@ final class Doctor(
       } yield target.scalaVersion).toSet
 
       if (versions.nonEmpty) {
-        val recommendedVersions = versions.map(recommendedVersion)
-        Some(
-          apply(
-            versions,
-            recommendedVersions
-          )
-        )
+        Some(apply(versions))
       } else {
         None
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -371,66 +371,66 @@ class Messages(icons: Icons) {
     def selectTheKindOfFileMessage = "Select the kind of file to create"
     def enterNameMessage(kind: String): String =
       s"Enter the name for the new $kind"
+
+  }
+
+  private def usingString(usingNow: Iterable[String]): String = {
+    if (usingNow.size == 1)
+      s"Scala version ${usingNow.head}"
+    else
+      usingNow.toSeq
+        .sortWith(SemVer.isCompatibleVersion)
+        .mkString("Scala versions ", ", ", "")
+  }
+
+  private def recommendationString(usingNow: Iterable[String]): String = {
+    val shouldBeUsing = usingNow.map(ScalaVersions.recommendedVersion).toSet
+
+    if (shouldBeUsing.size == 1) s"Scala version ${shouldBeUsing.head}"
+    else
+      shouldBeUsing.toSeq
+        .sortWith(SemVer.isCompatibleVersion)
+        .mkString("Scala versions ", ", ", "")
   }
 
   object DeprecatedScalaVersion {
     def message(
-        usingNow: Iterable[String],
-        shouldBeUsing: Iterable[String]
+        usingNow: Iterable[String]
     ): String = {
-      val using =
-        if (usingNow.size == 1)
-          s"a legacy Scala version ${usingNow.head}"
-        else usingNow.mkString("legacy Scala versions ", ", ", "")
-      val recommended =
-        if (shouldBeUsing.size == 1) shouldBeUsing.head
-        else shouldBeUsing.mkString(" and ")
+      val using = "legacy " + usingString(usingNow)
+      val recommended = recommendationString(usingNow)
       s"You are using $using, which might not be supported in future versions of Metals. " +
-        s"Please upgrade to Scala $recommended."
+        s"Please upgrade to $recommended."
     }
   }
 
   object UnsupportedScalaVersion {
     def message(
-        usingNow: Iterable[String],
-        shouldBeUsing: Iterable[String]
+        usingNow: Iterable[String]
     ): String = {
-      val using =
-        if (usingNow.size == 1)
-          s"a Scala version ${usingNow.head}"
-        else
-          usingNow.toSeq
-            .sortWith(SemVer.isCompatibleVersion)
-            .mkString("Scala versions ", ", ", "")
-      val recommended =
-        shouldBeUsing.toSeq
-          .sortWith(SemVer.isCompatibleVersion)
-          .mkString(" or ")
+      val using = usingString(usingNow)
+      val recommended = recommendationString(usingNow)
+      val uses211 = usingNow.exists(
+        ScalaVersions.scalaBinaryVersionFromFullVersion(_) == "2.11"
+      )
+      val deprecatedAleternative =
+        if (uses211) s" or alternatively to legacy Scala ${BuildInfo.scala211}"
+        else ""
       val isAre = if (usingNow.size == 1) "is" else "are"
       s"You are using $using, which $isAre not supported in this version of Metals. " +
-        s"Please upgrade to Scala $recommended."
+        s"Please upgrade to $recommended$deprecatedAleternative."
     }
   }
 
   object FutureScalaVersion {
     def message(
-        usingNow: Iterable[String],
-        shouldBeUsing: Iterable[String]
+        usingNow: Iterable[String]
     ): String = {
-      val using =
-        if (usingNow.size == 1)
-          s"a Scala version ${usingNow.head}"
-        else
-          usingNow.toSeq
-            .sortWith(SemVer.isCompatibleVersion)
-            .mkString("Scala versions ", ", ", "")
-      val recommended =
-        shouldBeUsing.toSeq
-          .sortWith(SemVer.isCompatibleVersion)
-          .mkString(" or ")
+      val using = usingString(usingNow)
+      val recommended = recommendationString(usingNow)
       val isAre = if (usingNow.size == 1) "is" else "are"
       s"You are using $using, which $isAre not yet supported in this version of Metals. " +
-        s"Please downgrade to Scala $recommended for the moment until the new Metals release."
+        s"Please downgrade to $recommended for the moment until the new Metals release."
     }
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -383,6 +383,22 @@ class Messages(icons: Icons) {
     }
   }
 
+  object UnsupportedScalaVersion {
+    def message(
+        usingNow: Iterable[String],
+        shouldBeUsing: Iterable[String]
+    ): String = {
+      val using =
+        if (usingNow.size == 1)
+          s"a Scala version ${usingNow.head}"
+        else usingNow.toSeq.sorted.mkString("Scala versions ", ", ", "")
+      val recommended = shouldBeUsing.mkString(" and ")
+      val isAre = if (usingNow.size == 1) "is" else "are"
+      s"You are using $using, which $isAre not supported in this version of Metals. " +
+        s"Please upgrade to Scala $recommended."
+    }
+  }
+
   object NewScalaFile {
     def selectTheKindOfFileMessage = "Select the kind of file to create"
     def enterNameMessage(kind: String): String =

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -9,6 +9,7 @@ import scala.meta.internal.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.meta.internal.builds.BuildTool
 import scala.meta.io.AbsolutePath
+import scala.meta.internal.semver.SemVer
 
 /**
  * Constants for requests/dialogues via LSP window/showMessage and window/showMessageRequest.
@@ -391,8 +392,14 @@ class Messages(icons: Icons) {
       val using =
         if (usingNow.size == 1)
           s"a Scala version ${usingNow.head}"
-        else usingNow.toSeq.sorted.mkString("Scala versions ", ", ", "")
-      val recommended = shouldBeUsing.mkString(" and ")
+        else
+          usingNow.toSeq
+            .sortWith(SemVer.isCompatibleVersion)
+            .mkString("Scala versions ", ", ", "")
+      val recommended =
+        shouldBeUsing.toSeq
+          .sortWith(SemVer.isCompatibleVersion)
+          .mkString(" or ")
       val isAre = if (usingNow.size == 1) "is" else "are"
       s"You are using $using, which $isAre not supported in this version of Metals. " +
         s"Please upgrade to Scala $recommended."

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -367,6 +367,12 @@ class Messages(icons: Icons) {
          |""".stripMargin
   }
 
+  object NewScalaFile {
+    def selectTheKindOfFileMessage = "Select the kind of file to create"
+    def enterNameMessage(kind: String): String =
+      s"Enter the name for the new $kind"
+  }
+
   object DeprecatedScalaVersion {
     def message(
         usingNow: Iterable[String],
@@ -406,9 +412,25 @@ class Messages(icons: Icons) {
     }
   }
 
-  object NewScalaFile {
-    def selectTheKindOfFileMessage = "Select the kind of file to create"
-    def enterNameMessage(kind: String): String =
-      s"Enter the name for the new $kind"
+  object FutureScalaVersion {
+    def message(
+        usingNow: Iterable[String],
+        shouldBeUsing: Iterable[String]
+    ): String = {
+      val using =
+        if (usingNow.size == 1)
+          s"a Scala version ${usingNow.head}"
+        else
+          usingNow.toSeq
+            .sortWith(SemVer.isCompatibleVersion)
+            .mkString("Scala versions ", ", ", "")
+      val recommended =
+        shouldBeUsing.toSeq
+          .sortWith(SemVer.isCompatibleVersion)
+          .mkString(" or ")
+      val isAre = if (usingNow.size == 1) "is" else "are"
+      s"You are using $using, which $isAre not yet supported in this version of Metals. " +
+        s"Please downgrade to Scala $recommended for the moment until the new Metals release."
+    }
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -16,6 +16,8 @@ case class ScalaTarget(
 ) {
   def isSemanticdbEnabled: Boolean = scalac.isSemanticdbEnabled
 
+  def isSourcerootDeclared: Boolean = scalac.isSourcerootDeclared
+
   def id: BuildTargetIdentifier = info.getId()
 
   def baseDirectory: String = info.getBaseDirectory()

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -22,9 +22,18 @@ object ScalaVersions {
     }
 
   val isLatestScalaVersion: Set[String] =
-    Set(BuildInfo.scala213, BuildInfo.scala212, BuildInfo.scala211)
+    Set(BuildInfo.scala212, BuildInfo.scala213)
 
-  def recommendedVersion(scalaVersion: String): String = BuildInfo.scala212
+  def recommendedVersion(scalaVersion: String): String = {
+    val binaryVersion = scalaBinaryVersionFromFullVersion(scalaVersion)
+    isLatestScalaVersion
+      .find(latest =>
+        binaryVersion == scalaBinaryVersionFromFullVersion(latest)
+      )
+      .getOrElse {
+        BuildInfo.scala212
+      }
+  }
 
   def isCurrentScalaCompilerVersion(version: String): Boolean =
     ScalaVersions.dropVendorSuffix(version) == mtags.BuildInfo.scalaCompilerVersion

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -31,7 +31,7 @@ object ScalaVersions {
         binaryVersion == scalaBinaryVersionFromFullVersion(latest)
       )
       .getOrElse {
-        BuildInfo.scala212
+        BuildInfo.scala213
       }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -35,7 +35,7 @@ object ScalaVersions {
 
   def recommendedVersion(scalaVersion: String): String = {
     latestBinaryVersionFor(scalaVersion).getOrElse {
-      BuildInfo.scala213
+      BuildInfo.scala212
     }
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/semver/SemVer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/semver/SemVer.scala
@@ -6,8 +6,9 @@ object SemVer {
 
     def splitVersion(v: String) =
       v.replaceAll("(-|\\+).+$", "").split('.')
-
-    (splitVersion(minimumVersion), splitVersion(version)) match {
+    val minVersionSplit = splitVersion(minimumVersion).map(_.toInt)
+    val versionSplit = splitVersion(version).map(_.toInt)
+    (minVersionSplit, versionSplit) match {
       case (Array(minMajor, minMinor, minPatch), Array(major, minor, patch)) =>
         (major > minMajor) ||
           (major == minMajor && minor > minMinor) ||

--- a/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
@@ -240,7 +240,7 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
         client.messageRequests.peekLast(),
         UnsupportedScalaVersion.message(
           Seq("2.12.4", "2.12.3", "2.11.8", "2.10.7"),
-          Seq(V.scala212)
+          Seq(V.scala212, V.scala213)
         )
       )
       sourceJars <- server.buildTargetSourceJars("a")

--- a/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
@@ -239,8 +239,7 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
       _ = assertNoDiff(
         client.messageRequests.peekLast(),
         UnsupportedScalaVersion.message(
-          Seq("2.12.4", "2.12.3", "2.11.8", "2.10.7"),
-          Seq(V.scala212, V.scala213)
+          Seq("2.12.4", "2.12.3", "2.11.8", "2.10.7")
         )
       )
       sourceJars <- server.buildTargetSourceJars("a")

--- a/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
@@ -238,7 +238,10 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
       _ = assertStatus(_.isInstalled)
       _ = assertNoDiff(
         client.messageRequests.peekLast(),
-        CheckDoctor.multipleMisconfiguredProjects(8)
+        UnsupportedScalaVersion.message(
+          Seq("2.12.4", "2.12.3", "2.11.8", "2.10.7"),
+          Seq(V.scala212)
+        )
       )
       sourceJars <- server.buildTargetSourceJars("a")
       _ = assert(sourceJars.nonEmpty) // source jars should not be empty

--- a/tests/unit/src/test/scala/tests/BillLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BillLspSuite.scala
@@ -7,6 +7,7 @@ import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.RecursivelyDelete
 
 class BillLspSuite extends BaseLspSuite("bill") {
 
@@ -43,6 +44,7 @@ class BillLspSuite extends BaseLspSuite("bill") {
   }
 
   test("diagnostics") {
+    cleanWorkspace()
     Bill.installWorkspace(workspace.toNIO)
     testRoundtripCompilation()
   }
@@ -86,6 +88,8 @@ class BillLspSuite extends BaseLspSuite("bill") {
   }
 
   test("global") {
+    RecursivelyDelete(globalBsp)
+    cleanWorkspace()
     Bill.installGlobal(globalBsp.toNIO)
     testRoundtripCompilation()
   }
@@ -109,14 +113,14 @@ class BillLspSuite extends BaseLspSuite("bill") {
   }
 
   test("conflict") {
-    cleanDatabase()
+    cleanWorkspace()
     Bill.installWorkspace(workspace.toNIO, "Bill")
     Bill.installWorkspace(workspace.toNIO, "Bob")
     testSelectServerDialogue()
   }
 
   test("mix") {
-    cleanDatabase()
+    cleanWorkspace()
     Bill.installWorkspace(workspace.toNIO, "Bill")
     Bill.installGlobal(globalBsp.toNIO, "Bob")
     testSelectServerDialogue()

--- a/tests/unit/src/test/scala/tests/MessagesSuite.scala
+++ b/tests/unit/src/test/scala/tests/MessagesSuite.scala
@@ -1,0 +1,47 @@
+package tests
+
+import scala.meta.internal.metals.Messages
+
+class MessagesSuite extends BaseSuite {
+
+  test("deprecated-single") {
+    assertDiffEqual(
+      Messages.DeprecatedScalaVersion.message(Seq("2.11.12")),
+      "You are using legacy Scala version 2.11.12, which might not be supported in future versions of Metals." +
+        " Please upgrade to Scala version 2.12.11."
+    )
+  }
+
+  test("future-single") {
+    assertDiffEqual(
+      Messages.FutureScalaVersion.message(Seq("2.13.50")),
+      "You are using Scala version 2.13.50, which is not yet supported in this version of Metals." +
+        " Please downgrade to Scala version 2.13.1 for the moment until the new Metals release."
+    )
+  }
+
+  test("unspported-single") {
+    assertDiffEqual(
+      Messages.UnsupportedScalaVersion.message(Seq("2.12.4")),
+      "You are using Scala version 2.12.4, which is not supported in this version of Metals." +
+        " Please upgrade to Scala version 2.12.11."
+    )
+  }
+
+  test("unspported-multiple") {
+    assertDiffEqual(
+      Messages.UnsupportedScalaVersion.message(Seq("2.12.4", "2.12.8")),
+      "You are using Scala versions 2.12.4, 2.12.8, which are not supported in this version of Metals." +
+        " Please upgrade to Scala version 2.12.11."
+    )
+  }
+
+  test("unspported-multiple2") {
+    assertDiffEqual(
+      Messages.UnsupportedScalaVersion
+        .message(Seq("2.11.9", "2.12.2", "2.12.1")),
+      "You are using Scala versions 2.11.9, 2.12.1, 2.12.2, which are not supported in this version of Metals." +
+        " Please upgrade to Scala version 2.12.11 or alternatively to legacy Scala 2.11.12."
+    )
+  }
+}

--- a/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
@@ -2,17 +2,18 @@ package tests
 
 import scala.meta.internal.metals.ScalaVersions
 import scala.meta.internal.metals.{BuildInfo => V}
+import scala.meta.internal.semver.SemVer
 
 class ScalaVersionsSuite extends BaseSuite {
 
-  test("Idempotent minor release") {
+  test("idempotent-minor-release") {
     assert(
       ScalaVersions.dropVendorSuffix("2.12.4") ==
         "2.12.4"
     )
   }
 
-  test("Retain pre-release version") {
+  test("retain-pre-release-version") {
     assert(
       ScalaVersions.dropVendorSuffix("2.13.0-RC1") ==
         "2.13.0-RC1"
@@ -23,7 +24,7 @@ class ScalaVersionsSuite extends BaseSuite {
     )
   }
 
-  test("Drop Typelevel vendor suffix") {
+  test("drop-typelevel-vendor-suffix") {
     assert(
       ScalaVersions.dropVendorSuffix("2.12.4-bin-typelevel-4") ==
         "2.12.4"
@@ -55,6 +56,42 @@ class ScalaVersionsSuite extends BaseSuite {
     assert(
       ScalaVersions.recommendedVersion("2.13.0") ==
         V.scala213
+    )
+  }
+
+  test("2.12.11-comapatible-with-2.12.5") {
+    assert(
+      SemVer.isCompatibleVersion("2.12.5", "2.12.11")
+    )
+  }
+
+  test("2.12.5-not-compatible-with-2.12.11") {
+    assert(
+      !SemVer.isCompatibleVersion("2.12.11", "2.12.5")
+    )
+  }
+
+  test("2.12.7-compatible-with-2.12.5") {
+    assert(
+      SemVer.isCompatibleVersion("2.12.5", "2.12.7")
+    )
+  }
+
+  test("2.12.5-not-compatible-with-2.12.7") {
+    assert(
+      !SemVer.isCompatibleVersion("2.12.7", "2.12.5")
+    )
+  }
+
+  test("2.12.11-compatible-with-2.11.12") {
+    assert(
+      SemVer.isCompatibleVersion("2.11.12", "2.12.11")
+    )
+  }
+
+  test("2.11.12-not-compatible-with-2.12.11") {
+    assert(
+      !SemVer.isCompatibleVersion("2.12.11", "2.11.12")
     )
   }
 }

--- a/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
@@ -59,6 +59,42 @@ class ScalaVersionsSuite extends BaseSuite {
     )
   }
 
+  test("future-213") {
+    assert(
+      ScalaVersions.isFutureVersion("2.13.31")
+    )
+  }
+
+  test("not-future-213") {
+    assert(
+      !ScalaVersions.isFutureVersion("2.13.1")
+    )
+  }
+
+  test("future-212") {
+    assert(
+      ScalaVersions.isFutureVersion("2.12.31")
+    )
+  }
+
+  test("not-future-212") {
+    assert(
+      !ScalaVersions.isFutureVersion("2.12.10")
+    )
+  }
+
+  test("not-future-211") {
+    assert(
+      !ScalaVersions.isFutureVersion("2.11.10")
+    )
+  }
+
+  test("future-214") {
+    assert(
+      ScalaVersions.isFutureVersion("2.15.10")
+    )
+  }
+
   test("2.12.11-comapatible-with-2.12.5") {
     assert(
       SemVer.isCompatibleVersion("2.12.5", "2.12.11")

--- a/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
@@ -48,7 +48,7 @@ class ScalaVersionsSuite extends BaseSuite {
   test("recommended-211") {
     assert(
       ScalaVersions.recommendedVersion("2.11.4") ==
-        V.scala213
+        V.scala212
     )
   }
 

--- a/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
@@ -48,7 +48,7 @@ class ScalaVersionsSuite extends BaseSuite {
   test("recommended-211") {
     assert(
       ScalaVersions.recommendedVersion("2.11.4") ==
-        V.scala212
+        V.scala213
     )
   }
 

--- a/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
@@ -1,8 +1,10 @@
 package tests
 
 import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.metals.{BuildInfo => V}
 
 class ScalaVersionsSuite extends BaseSuite {
+
   test("Idempotent minor release") {
     assert(
       ScalaVersions.dropVendorSuffix("2.12.4") ==
@@ -25,6 +27,34 @@ class ScalaVersionsSuite extends BaseSuite {
     assert(
       ScalaVersions.dropVendorSuffix("2.12.4-bin-typelevel-4") ==
         "2.12.4"
+    )
+  }
+
+  test("recommended-future") {
+    assert(
+      ScalaVersions.recommendedVersion(V.scala212 + "1") ==
+        V.scala212
+    )
+  }
+
+  test("recommended-212") {
+    assert(
+      ScalaVersions.recommendedVersion("2.12.4") ==
+        V.scala212
+    )
+  }
+
+  test("recommended-211") {
+    assert(
+      ScalaVersions.recommendedVersion("2.11.4") ==
+        V.scala212
+    )
+  }
+
+  test("recommended-213") {
+    assert(
+      ScalaVersions.recommendedVersion("2.13.0") ==
+        V.scala213
     )
   }
 }

--- a/tests/unit/src/test/scala/tests/WarningsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WarningsLspSuite.scala
@@ -1,16 +1,95 @@
 package tests
 
 import scala.meta.internal.metals.{BuildInfo => V}
-import scala.meta.internal.metals.ScalaVersions
 import scala.meta.internal.metals.Messages
 
 class WarningsLspSuite extends BaseLspSuite("warnings") {
-  // NOTE(olafur) Ignored because at the time of this writing we have no deprecated
-  // Scala versions.
-  test("deprecated-scala".ignore) {
+
+  test("deprecated-scala-212") {
     cleanWorkspace()
-    val using = V.deprecatedScalaVersions.head
-    val recommended = ScalaVersions.recommendedVersion(using)
+    val using = V.deprecatedScalaVersions.filter(_.startsWith("2.12")).head
+    val recommended = V.scala212
+    for {
+      _ <- server.initialize(
+        s"""/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "${using}"
+           |  }
+           |}
+           |/a/src/main/scala/a/Main.scala
+           |package a
+           |object Main
+           |""".stripMargin
+      )
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        Messages.DeprecatedScalaVersion.message(
+          Set(using),
+          Set(recommended)
+        )
+      )
+    } yield ()
+  }
+
+  test("deprecated-scala-211") {
+    cleanWorkspace()
+    val using = V.scala211
+    val recommended = V.scala212
+    for {
+      _ <- server.initialize(
+        s"""/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "${using}"
+           |  }
+           |}
+           |/a/src/main/scala/a/Main.scala
+           |package a
+           |object Main
+           |""".stripMargin
+      )
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        Messages.DeprecatedScalaVersion.message(
+          Set(using),
+          Set(recommended)
+        )
+      )
+    } yield ()
+  }
+
+  test("unsupported-scala-212") {
+    cleanWorkspace()
+    val using = "2.12.4"
+    val recommended = V.scala212
+    for {
+      _ <- server.initialize(
+        s"""/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "${using}"
+           |  }
+           |}
+           |/a/src/main/scala/a/Main.scala
+           |package a
+           |object Main
+           |""".stripMargin
+      )
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        Messages.UnsupportedScalaVersion.message(
+          Set(using),
+          Set(recommended)
+        )
+      )
+    } yield ()
+  }
+
+  test("deprecated-scala-213") {
+    cleanWorkspace()
+    val using = V.deprecatedScalaVersions.filter(_.startsWith("2.13")).head
+    val recommended = V.scala213
     for {
       _ <- server.initialize(
         s"""/metals.json

--- a/tests/unit/src/test/scala/tests/WarningsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WarningsLspSuite.scala
@@ -35,7 +35,7 @@ class WarningsLspSuite extends BaseLspSuite("warnings") {
   test("deprecated-scala-211") {
     cleanWorkspace()
     val using = V.scala211
-    val recommended = V.scala212
+    val recommended = V.scala213
     for {
       _ <- server.initialize(
         s"""/metals.json

--- a/tests/unit/src/test/scala/tests/WarningsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WarningsLspSuite.scala
@@ -8,7 +8,6 @@ class WarningsLspSuite extends BaseLspSuite("warnings") {
   test("deprecated-scala-212") {
     cleanWorkspace()
     val using = V.deprecatedScalaVersions.filter(_.startsWith("2.12")).head
-    val recommended = V.scala212
     for {
       _ <- server.initialize(
         s"""/metals.json
@@ -25,8 +24,7 @@ class WarningsLspSuite extends BaseLspSuite("warnings") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         Messages.DeprecatedScalaVersion.message(
-          Set(using),
-          Set(recommended)
+          Set(using)
         )
       )
     } yield ()
@@ -35,7 +33,6 @@ class WarningsLspSuite extends BaseLspSuite("warnings") {
   test("deprecated-scala-211") {
     cleanWorkspace()
     val using = V.scala211
-    val recommended = V.scala213
     for {
       _ <- server.initialize(
         s"""/metals.json
@@ -51,10 +48,7 @@ class WarningsLspSuite extends BaseLspSuite("warnings") {
       )
       _ = assertNoDiff(
         client.workspaceMessageRequests,
-        Messages.DeprecatedScalaVersion.message(
-          Set(using),
-          Set(recommended)
-        )
+        Messages.DeprecatedScalaVersion.message(Set(using))
       )
     } yield ()
   }
@@ -62,7 +56,6 @@ class WarningsLspSuite extends BaseLspSuite("warnings") {
   test("unsupported-scala-212") {
     cleanWorkspace()
     val using = "2.12.4"
-    val recommended = V.scala212
     for {
       _ <- server.initialize(
         s"""/metals.json
@@ -78,10 +71,7 @@ class WarningsLspSuite extends BaseLspSuite("warnings") {
       )
       _ = assertNoDiff(
         client.workspaceMessageRequests,
-        Messages.UnsupportedScalaVersion.message(
-          Set(using),
-          Set(recommended)
-        )
+        Messages.UnsupportedScalaVersion.message(Set(using))
       )
     } yield ()
   }
@@ -89,7 +79,6 @@ class WarningsLspSuite extends BaseLspSuite("warnings") {
   test("deprecated-scala-213") {
     cleanWorkspace()
     val using = V.deprecatedScalaVersions.filter(_.startsWith("2.13")).head
-    val recommended = V.scala213
     for {
       _ <- server.initialize(
         s"""/metals.json
@@ -105,10 +94,7 @@ class WarningsLspSuite extends BaseLspSuite("warnings") {
       )
       _ = assertNoDiff(
         client.workspaceMessageRequests,
-        Messages.DeprecatedScalaVersion.message(
-          Set(using),
-          Set(recommended)
-        )
+        Messages.DeprecatedScalaVersion.message(Set(using))
       )
     } yield ()
   }


### PR DESCRIPTION
Previously, we would recommened Scala 2.12.11 even if the user is already using 2.13. Also, when using an unsupported Scala version we would just say that project is misconfigured, which is the same in case of a missing semanticDB. 

Now, we recommend the last version for each binary except 2.11. And we also display if any Scala version is unsupported in the warning.

Closes https://github.com/scalameta/metals/issues/1548

![image](https://user-images.githubusercontent.com/3807253/77742488-d0a09e00-7016-11ea-9e09-597e1118f896.png)
