### PR TITLE
Remove Pants targets of type 'target'

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTargetType.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTargetType.scala
@@ -28,6 +28,6 @@ object PantsTargetType {
   private val unsupportedTargetType = Set(
     "files", "page", "python_binary", "python_tests", "python_library",
     "python3_binary", "python23_library", "python_requirement_library",
-    "ruby_thrift_library", "python_thrift_library"
+    "ruby_thrift_library", "python_thrift_library", "target"
   )
 }


### PR DESCRIPTION
These targets have no source code and are not supposed to be compiled by
Bloop. These targets have conflicting base directories with other
targets causing highlighting bugs in IntelliJ.