### PR TITLE
Add in the scala steward conf file

### DIFF
--- a/.scalasteward.conf
+++ b/.scalasteward.conf
@@ -1,0 +1,1 @@
+pullRequests.frequency = "0 0 1,15 * ?"


### PR DESCRIPTION
This pr adds in a conf file for scalasteward. I recently added metals back in [here](https://github.com/scala-steward-org/repos/pull/253). I figured setting the frequency to weekly? to start out with was a good middle ground? What do you guys think? Also, is there any dependencies we want ignored by steward? You can see the configuration options [here](https://github.com/fthomas/scala-steward/blob/master/docs/repo-specific-configuration.md).