### PR TITLE
Remove scalacheck

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -445,10 +445,8 @@ lazy val unit = project
     testSettings,
     libraryDependencies ++= List(
       "io.get-coursier" %% "coursier" % V.coursier, // for jars
-      "org.scalameta" %% "testkit" % V.scalameta,
       "ch.epfl.scala" %% "bloop-config" % V.bloop,
-      "org.scalameta" %% "munit" % V.munit,
-      "org.scalameta" %% "munit-scalacheck" % V.munit
+      "org.scalameta" %% "munit" % V.munit
     ),
     buildInfoPackage := "tests",
     resourceGenerators.in(Compile) += InputProperties.resourceGenerator(input),

--- a/tests/unit/src/test/scala/tests/NewFileTemplateSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileTemplateSuite.scala
@@ -1,11 +1,8 @@
 package tests
 
-import munit.ScalaCheckSuite
 import scala.meta.internal.metals.NewFileTemplate
-import org.scalacheck.Gen
-import org.scalacheck.Prop.forAll
 
-class NewFileTemplateSuite extends BaseSuite with ScalaCheckSuite {
+class NewFileTemplateSuite extends BaseSuite {
 
   test("cursor-marker-errors") {
     intercept[IllegalArgumentException] {
@@ -16,14 +13,14 @@ class NewFileTemplateSuite extends BaseSuite with ScalaCheckSuite {
     }
   }
 
-  property("cursor-marker-position") {
+  test("cursor-marker-position") {
     val template =
       s"""|package a
           |
           |case class Foo()
           |""".stripMargin
-    val cursorOffsetGen = Gen.chooseNum(0, template.length)
-    forAll(cursorOffsetGen) { cursorOffset =>
+    val cursorOffsets = 0.to(template.length)
+    cursorOffsets.foreach { cursorOffset =>
       val templateWithCursor = template.patch(cursorOffset, "@@", 0)
       val newFileTemplate = NewFileTemplate(templateWithCursor)
       assertEquals(newFileTemplate.cursorPosition.start, cursorOffset)


### PR DESCRIPTION
Followup of https://github.com/scalameta/metals/pull/1546#discussion_r399216837

I was a bit too eager to add Scalacheck to test the new MUnit module, but it wasn't really necessary.