### PR TITLE
Remove deprecations

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/implementation/Supermethods.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/Supermethods.scala
@@ -50,7 +50,7 @@ class Supermethods(
       params <- parseJsonParams(commandParams)
       methodsHierarchy <- getSuperMethodHierarchySymbols(params)
       if methodsHierarchy.nonEmpty
-    } yield execute(methodsHierarchy)).getOrElse(Future.successful())
+    } yield execute(methodsHierarchy)).getOrElse(Future.successful(()))
   }
 
   def getGoToSuperMethodLocation(

--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -16,7 +16,6 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.mtags.TextDocumentLookup
 import scala.meta.internal.semanticdb.TextDocument
-import scala.meta.internal.tokenizers.PlatformTokenizerCache
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.AbsolutePath
 
@@ -145,7 +144,6 @@ final class InteractiveSemanticdbs(
         .semanticdbTextDocument(uri, text)
         .get(config.compilers.timeoutDelay, config.compilers.timeoutUnit)
       val textDocument = TextDocument.parseFrom(bytes)
-      PlatformTokenizerCache.megaCache.clear() // :facepalm:
       textDocument
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1922,10 +1922,11 @@ class MetalsLanguageServer(
       } yield occ) match {
         case Some(occ) =>
           if (occ.role.isDefinition && !definitionOnly) {
-            val referenceContext = new ReferenceContext(false)
-            val refParams = new ReferenceParams(referenceContext)
-            refParams.setTextDocument(positionParams.getTextDocument())
-            refParams.setPosition(positionParams.getPosition())
+            val refParams = new ReferenceParams(
+              positionParams.getTextDocument(),
+              positionParams.getPosition(),
+              new ReferenceContext(false)
+            )
             val result = referencesResult(refParams)
             if (result.locations.isEmpty) {
               // Fallback again to the original behavior that returns

--- a/metals/src/main/scala/scala/meta/internal/metals/NewFilesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NewFilesProvider.scala
@@ -168,13 +168,14 @@ class NewFilesProvider(
       path.touch()
       path
     }
-    result.onFailure {
-      case NonFatal(e) =>
+    result.failed.foreach {
+      case NonFatal(e) => {
         scribe.error("Cannot create file", e)
         client.showMessage(
           MessageType.Error,
           s"Cannot create file:\n ${e.toString()}"
         )
+      }
     }
     result
   }

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/Graph.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/Graph.scala
@@ -11,7 +11,7 @@ case class Graph(
 )
 object Graph {
   def fromSeq(graph: Seq[Seq[Int]]): Graph = {
-    Graph(Value.Str(""), _.toInt, _.toString, graph.map(_.toArray).toArray)
+    Graph(ujson.Str(""), _.toInt, _.toString, graph.map(_.toArray).toArray)
   }
   def fromProjects(projects: Seq[C.Project]): Graph = {
     val edges = new Array[Array[Int]](projects.length)
@@ -21,7 +21,7 @@ object Graph {
       case (project, i) =>
         edges(i) = project.dependencies.iterator.map(index).toArray
     }
-    Graph(Value.Str(""), index.apply _, rindex.apply _, edges)
+    Graph(ujson.Str(""), index.apply _, rindex.apply _, edges)
   }
   def fromTargets(targets: IndexedSeq[PantsTarget]): Graph = {
     val edges = new Array[Array[Int]](targets.length)
@@ -31,7 +31,7 @@ object Graph {
       case (project, i) =>
         edges(i) = project.dependencies.iterator.map(index).toArray
     }
-    Graph(Value.Str(""), index.apply _, rindex.apply _, edges)
+    Graph(ujson.Str(""), index.apply _, rindex.apply _, edges)
   }
   def fromExport(export: Value): Graph = {
     val targets = export.obj("targets").obj

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorkspaceEditWorksheetPublisher.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorkspaceEditWorksheetPublisher.scala
@@ -3,18 +3,20 @@ package scala.meta.internal.worksheets
 import scala.meta.internal.metals.MetalsLanguageClient
 import mdoc.interfaces.EvaluatedWorksheet
 import scala.meta.io.AbsolutePath
-import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams
+import org.eclipse.lsp4j.Hover
+import org.eclipse.lsp4j.MarkupContent
+import org.eclipse.lsp4j.MarkupKind
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.TextEdit
-import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
-import org.eclipse.lsp4j.MarkedString
+import org.eclipse.lsp4j.WorkspaceEdit
 import scala.meta.internal.metals.MetalsEnrichments._
 import mdoc.interfaces.EvaluatedWorksheetStatement
 import scala.meta.inputs.Input
-import org.eclipse.lsp4j.{Position, Range}
 import scala.meta.internal.metals.Buffers
-import org.eclipse.lsp4j.Hover
 import scala.meta.internal.metals.TokenEditDistance
+import scala.meta.internal.pc.HoverMarkup
 import WorkspaceEditWorksheetPublisher._
 
 class WorkspaceEditWorksheetPublisher(buffers: Buffers)
@@ -44,11 +46,10 @@ class WorkspaceEditWorksheetPublisher(buffers: Buffers)
         .toPosition(position)
       message <- getHoverMessage(snapshotPosition, messages.hovers)
     } yield new Hover(
-      List(
-        JEither.forRight[String, MarkedString](
-          new MarkedString("scala", message)
-        )
-      ).asJava
+      new MarkupContent(
+        MarkupKind.MARKDOWN,
+        HoverMarkup(message)
+      )
     )
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaMtags.scala
@@ -5,7 +5,6 @@ import scala.meta.inputs.Input
 import scala.meta.internal.semanticdb.Language
 import scala.meta.internal.semanticdb.SymbolInformation.Kind
 import scala.meta.internal.semanticdb.SymbolInformation.Property
-import scala.meta.internal.tokenizers.PlatformTokenizerCache
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.transversers.SimpleTraverser
 
@@ -25,8 +24,6 @@ class ScalaMtags(val input: Input.VirtualFile)
       case Parsed.Success(tree) => apply(tree)
       case _ => // do nothing in case of parse error
     }
-    // :facepalm: https://github.com/scalameta/scalameta/issues/1068
-    PlatformTokenizerCache.megaCache.clear()
   }
   def currentTree: Tree = myCurrentTree
   private var myCurrentTree: Tree = q"a"


### PR DESCRIPTION
A bit more house-keeping.

This pr removes a couple of the other deprecations from the lsp4j update recently. I also just went ahead and updated the other stuff that I noticed when adding the `-deprecation` flag. However, the two that I didn't update seem to be a bit more involved, so I left them as is.

The remaining deprecated warnings are:

1. The usage of `Thread.stop()` if various places
2. The usage of `PlatformTokenizerCache.megaCache.clear()`