### PR TITLE
Make sure we detect scala App trait when using hover. 

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/HoverProvider.scala
@@ -170,7 +170,7 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
   ): Option[Hover] = {
     if (tpe == null || tpe.isErroneous || tpe == NoType) None
     else if (symbol == null || symbol == NoSymbol || symbol.isErroneous) None
-    else if (symbol.info.finalResultType.isInstanceOf[ClassInfoType]) None
+    else if (tpe.typeSymbol.isAnonymousClass) None
     else if (symbol.hasPackageFlag || symbol.hasModuleFlag) {
       Some(
         new Hover(

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -16,6 +16,13 @@ class HoverTermSuite extends BaseHoverSuite {
   )
 
   check(
+    "app",
+    """|object Main extends <<Ap@@p>>{}
+       |""".stripMargin,
+    "abstract trait App: App".hover
+  )
+
+  check(
     "apply",
     """object a {
       |  <<Li@@st(1)>>.map(x => x.toString)


### PR DESCRIPTION
Previously, when using hover over the Scala App trait no information would be returned. Now, it's properly displayed with all needed docs. This also works with a number of other cases in for example Play projects.

![hover-App](https://user-images.githubusercontent.com/3807253/77911307-e1f4df00-7290-11ea-927b-030827d2006e.gif)

Removing the condition altogether would cause anonymous classes to be shown like, so I just changed it to detect the specific scenario.

![anon-hover](https://user-images.githubusercontent.com/3807253/77911378-0486f800-7291-11ea-980e-b16b41f6a2af.gif)
