### PR TITLE
Forward compiler options in Pants export.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -430,8 +430,8 @@ private class BloopPants(
       out = out,
       classesDir = classesDir,
       resources = resources,
-      scala = bloopScala,
-      java = Some(C.Java(Nil)),
+      scala = bloopScala(target.scalacOptions),
+      java = Some(C.Java(target.javacOptions)),
       sbt = None,
       test = bloopTestFrameworks,
       platform = Some(
@@ -529,13 +529,13 @@ private class BloopPants(
     }
   }
 
-  def bloopScala: Option[C.Scala] =
+  def bloopScala(scalacOptions: List[String]): Option[C.Scala] =
     Some(
       C.Scala(
         "org.scala-lang",
         "scala-compiler",
         compilerVersion,
-        List.empty[String],
+        scalacOptions,
         allScalaJars,
         None,
         setup = Some(

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
@@ -106,7 +106,9 @@ object PantsExport {
           targetType = targetType,
           pantsTargetType = pantsTargetType,
           globs = PantsGlobs.fromJson(value),
-          roots = PantsRoots.fromJson(value)
+          roots = PantsRoots.fromJson(value),
+          scalacOptions = asStringList(value, PantsKeys.scalacArgs),
+          javacOptions = asStringList(value, PantsKeys.javacArgs)
         )
     }.toMap
 
@@ -135,5 +137,11 @@ object PantsExport {
       jvmDistribution = jvmDistribution
     )
   }
+
+  private def asStringList(obj: Obj, key: String): List[String] =
+    obj.value.get(key) match {
+      case None => Nil
+      case Some(value) => value.arr.map(_.str).toList
+    }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsKeys.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsKeys.scala
@@ -21,4 +21,6 @@ object PantsKeys {
   val defaultPlatform = "default_platform"
   val java8 = "java8"
   val strict = "strict"
+  val scalacArgs = "scalac_args"
+  val javacArgs = "javac_args"
 }

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTarget.scala
@@ -16,7 +16,9 @@ case class PantsTarget(
     targetType: TargetType,
     pantsTargetType: PantsTargetType,
     globs: PantsGlobs,
-    roots: PantsRoots
+    roots: PantsRoots,
+    scalacOptions: List[String],
+    javacOptions: List[String]
 ) {
   def isGeneratedTarget: Boolean = name.startsWith(".pants.d")
   private val prefixedId = id.stripPrefix(".")


### PR DESCRIPTION
Previously, the exported Bloop projects had an empty Scalac options
list. Now, we forward compiler options like warning about unused
imports.