### PR TITLE
Fix: don't show super lenses on synthetic methods e.g. toString

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/implementation/SuperMethodProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/SuperMethodProvider.scala
@@ -247,7 +247,8 @@ object SuperMethodProvider {
     "scala/AnyRef#",
     "scala/Serializable#",
     "java/io/Serializable#",
-    "scala/AnyVal#"
+    "scala/AnyVal#",
+    "scala/Any#"
   )
 
   def findClassInfo(

--- a/tests/unit/src/test/scala/tests/SuperMethodLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SuperMethodLspSuite.scala
@@ -48,7 +48,21 @@ class SuperMethodLspSuite extends BaseLspSuite("gotosupermethod") {
     checkSuperMethod(code)
   }
 
-  test("type inheritance") {
+  test("synthetic-methods") {
+    val code =
+      """
+        |package a
+        |case class A() {
+        |  override def <<1->0>>toString: String = "A"
+        |  override def <<2->0>>hashCode: Int = 1
+        |  override def <<3->0>>clone(): Object = ???
+        |}
+        |""".stripMargin
+    checkSuperMethod(code)
+
+  }
+
+  test("type-inheritance") {
     val code =
       """
         |package a
@@ -70,7 +84,7 @@ class SuperMethodLspSuite extends BaseLspSuite("gotosupermethod") {
     checkSuperMethod(code)
   }
 
-  test("anonymousclass") {
+  test("anonymous-class") {
     val code =
       """
         |package a
@@ -105,7 +119,7 @@ class SuperMethodLspSuite extends BaseLspSuite("gotosupermethod") {
     checkSuperMethod(code)
   }
 
-  test("generic types") {
+  test("generic-types") {
     val code =
       """
         |package a
@@ -130,7 +144,7 @@ class SuperMethodLspSuite extends BaseLspSuite("gotosupermethod") {
     checkSuperMethod(code)
   }
 
-  test("matching methods") {
+  test("matching-methods") {
     val code =
       """
         |package a
@@ -166,7 +180,7 @@ class SuperMethodLspSuite extends BaseLspSuite("gotosupermethod") {
     checkSuperMethod(code)
   }
 
-  test("multi files") {
+  test("multi-files") {
     val codeA =
       """
         |package a
@@ -194,7 +208,7 @@ class SuperMethodLspSuite extends BaseLspSuite("gotosupermethod") {
     )
   }
 
-  test("jump to external dependency") {
+  test("jump-to-external-dependency") {
     val code =
       """
         |package a


### PR DESCRIPTION
Forgot to include ` "scala/Any#"` in list of ignored parent classes

@tgodzik thanks for reporting!