### PR TITLE
Add in ... to signifigy truncation in worksheets

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/worksheets/DecorationWorksheetPublisher.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/DecorationWorksheetPublisher.scala
@@ -48,7 +48,7 @@ class DecorationWorksheetPublisher() extends WorksheetPublisher {
           ),
           ThemableDecorationInstanceRenderOptions(
             after = ThemableDecorationAttachmentRenderOptions(
-              commentHeader + s.summary(),
+              commentHeader + truncatify(s),
               color = "green",
               fontStyle = "italic"
             )

--- a/metals/src/main/scala/scala/meta/internal/worksheets/MdocEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/MdocEnrichments.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.worksheets
 
 import org.eclipse.{lsp4j => l}
+import mdoc.interfaces.EvaluatedWorksheetStatement
 import mdoc.{interfaces => i}
 
 object MdocEnrichments {
@@ -47,6 +48,17 @@ object MdocEnrichments {
         "mdoc"
       )
     }
+  }
+
+  /**
+   * Determines whether or not an evaluated worksheet statement summary is
+   * complete or not. If it is complete, it just returns the summary, otherwise
+   * it will chop off the last 3 chars and replace them with … to signify
+   * continuation
+   */
+  def truncatify(statement: EvaluatedWorksheetStatement): String = {
+    if (statement.isSummaryComplete()) statement.summary()
+    else statement.summary() + "…"
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorkspaceEditWorksheetPublisher.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorkspaceEditWorksheetPublisher.scala
@@ -17,6 +17,7 @@ import scala.meta.inputs.Input
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.TokenEditDistance
 import scala.meta.internal.pc.HoverMarkup
+import scala.meta.internal.worksheets.MdocEnrichments.truncatify
 import WorkspaceEditWorksheetPublisher._
 
 class WorkspaceEditWorksheetPublisher(buffers: Buffers)
@@ -110,11 +111,9 @@ class WorkspaceEditWorksheetPublisher(buffers: Buffers)
   }
 
   private def renderMessage(statement: EvaluatedWorksheetStatement): String = {
-    import statement._
     val out = new StringBuilder()
     out.append("  /*>  ")
-    out.append(summary())
-    out.append(if (!isSummaryComplete()) "..." else "")
+    out.append(truncatify(statement))
     out.append("  */")
     out.result()
   }

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -77,7 +77,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
            |import java.nio.file.Files
            |val name = "Susan" // "Susan"
            |val greeting = s"Hello $name" // "Hello Susan"
-           |println(greeting + "\nHow are you?") // Hello Susan
+           |println(greeting + "\nHow are you?") // Hello Susan…
            |1.to(10).toVector // Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
            |val List(a, b) = List(42, 10) // a=42, b=10
            |""".stripMargin
@@ -108,7 +108,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
            |import java.nio.file.Files
            |val name = "Susan" // "Susan"
            |val greeting = s"Hello $name" // "Hello Susan"
-           |println(greeting + "\nHow are you?") // Hello Susan
+           |println(greeting + "\nHow are you?") // Hello Susan…
            |1.to(10).toVector // Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
            |val List(a, b) = List(42, 10) // a=42, b=10
            |""".stripMargin


### PR DESCRIPTION
This pr adds in a way to signify in worksheets that a lint is truncated or continued. For example instead of just ending, you'll now see that the line will end in a `...`. It's not added to the end to lengthen the line, but if what we are showing is not complete, we drop the last 3 chars and replace them.

Closes #1575 