### PR TITLE
Support `extra_jvm_options` from Pants

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -418,6 +418,11 @@ private class BloopPants(
     val tags =
       if (target.targetType.isTest) List(Tag.Test) else List(Tag.Library)
 
+    // Pants' `extra_jvm_options` should apply only to test execution,
+    // so we ignore them for non-test targets.
+    val extraJvmOptions =
+      if (target.targetType.isTest) target.extraJvmOptions else Nil
+
     C.Project(
       name = target.dependencyName,
       directory = baseDirectory,
@@ -440,7 +445,7 @@ private class BloopPants(
             javaHome,
             List(
               s"-Duser.dir=$workspace"
-            )
+            ) ++ extraJvmOptions
           ),
           None
         )

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsExport.scala
@@ -108,7 +108,8 @@ object PantsExport {
           globs = PantsGlobs.fromJson(value),
           roots = PantsRoots.fromJson(value),
           scalacOptions = asStringList(value, PantsKeys.scalacArgs),
-          javacOptions = asStringList(value, PantsKeys.javacArgs)
+          javacOptions = asStringList(value, PantsKeys.javacArgs),
+          extraJvmOptions = asStringList(value, PantsKeys.extraJvmOptions)
         )
     }.toMap
 

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsKeys.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsKeys.scala
@@ -23,4 +23,5 @@ object PantsKeys {
   val strict = "strict"
   val scalacArgs = "scalac_args"
   val javacArgs = "javac_args"
+  val extraJvmOptions = "extra_jvm_options"
 }

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsTarget.scala
@@ -18,7 +18,8 @@ case class PantsTarget(
     globs: PantsGlobs,
     roots: PantsRoots,
     scalacOptions: List[String],
-    javacOptions: List[String]
+    javacOptions: List[String],
+    extraJvmOptions: List[String]
 ) {
   def isGeneratedTarget: Boolean = name.startsWith(".pants.d")
   private val prefixedId = id.stripPrefix(".")


### PR DESCRIPTION
Previously, we did not export custom JVM options that are defined in Pants to Bloop. Now, those JVM options are forwarded to Bloop so that bloop test respect original Pants configuration like memory settings or GC flags.