### PR TITLE
Project root again

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -268,9 +268,25 @@ private class BloopPants(
     )
     val isBaseDirectory =
       projects.iterator.filter(_.sources.nonEmpty).map(_.directory).toSet
+    // NOTE(olafur): generate synthetic projects to improve the file tree view
+    // in IntelliJ. Details: https://github.com/olafurpg/intellij-bsp-pants/issues/7
+    val syntheticProjects: List[C.Project] = sourceRoots.flatMap { root =>
+      if (isBaseDirectory(root.toNIO) || args.export.noRootProject) {
+        Nil
+      } else {
+        val name = root
+          .toRelative(AbsolutePath(workspace))
+          .toURI(isDirectory = false)
+          .toString()
+        // NOTE(olafur): cannot be `name + "-root"` since that conflicts with the
+        // IntelliJ-generated root project.
+        List(toEmptyBloopProject(name + "-project-root", root.toNIO))
+      }
+    }
     val generatedProjects = new mutable.LinkedHashSet[Path]
-    val byName = projects.map(p => p.name -> p).toMap
-    projects.foreach { project =>
+    val allProjects = syntheticProjects ::: projects
+    val byName = allProjects.map(p => p.name -> p).toMap
+    allProjects.foreach { project =>
       // NOTE(olafur): we probably want to generate projects with empty
       // sources/classpath and single dependency on the parent.
       if (!export.cycles.parents.contains(project.name)) {

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -271,7 +271,7 @@ private class BloopPants(
     // NOTE(olafur): generate synthetic projects to improve the file tree view
     // in IntelliJ. Details: https://github.com/olafurpg/intellij-bsp-pants/issues/7
     val syntheticProjects: List[C.Project] = sourceRoots.flatMap { root =>
-      if (isBaseDirectory(root.toNIO) || args.export.noRootProject) {
+      if (isBaseDirectory(root.toNIO)) {
         Nil
       } else {
         val name = root

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ExportOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ExportOptions.scala
@@ -15,10 +15,6 @@ case class ExportOptions(
         "If unspecified, coursier will be downloaded automatically."
     )
     coursierBinary: Option[Path] = None,
-    @Description(
-      "Unconditionally prevent generation of '*-project-root' modules"
-    )
-    noRootProject: Boolean = true,
     @Hidden()
     mergeTargetsInSameDirectory: Boolean = false
 )

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ExportOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ExportOptions.scala
@@ -15,6 +15,10 @@ case class ExportOptions(
         "If unspecified, coursier will be downloaded automatically."
     )
     coursierBinary: Option[Path] = None,
+    @Description(
+      "Unconditionally prevent generation of '*-project-root' modules"
+    )
+    noRootProject: Boolean = true,
     @Hidden()
     mergeTargetsInSameDirectory: Boolean = false
 )


### PR DESCRIPTION
I deleted the `-project-root` generation code as I thought because it could be detected by IntelliJ Scala Plugin as a parent target for a test during test run. Now, after the target detection in the plugin was improved, it seems to be safe to generate these modules.