### PR TITLE
Add properties for bloop zipkin tracing to fastpass

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/BloopZipkinTraceProperties.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/BloopZipkinTraceProperties.scala
@@ -1,0 +1,18 @@
+package scala.meta.internal.pantsbuild.commands
+
+import scala.meta.internal.pantsbuild.commands.BloopGlobalSettings.Property
+
+object BloopZipkinTraceProperties {
+
+  val localServiceName: Property = Property(
+    "metals.bloop.trace.localServiceName"
+  )
+
+  val traceStartAnnotation: Property = Property(
+    "metals.bloop.trace.traceStartAnnotation"
+  )
+
+  val traceEndAnnotation: Property = Property(
+    "metals.bloop.trace.traceEndAnnotation"
+  )
+}

--- a/metals/src/main/scala/scala/meta/internal/zipkin/Property.scala
+++ b/metals/src/main/scala/scala/meta/internal/zipkin/Property.scala
@@ -1,0 +1,32 @@
+package scala.meta.internal.zipkin
+
+case class Property(metalsProperty: String) {
+
+  val bloopProperty: String = metalsProperty.stripPrefix("metals.")
+
+  def value: Option[String] = Option(System.getProperty(metalsProperty))
+
+  def updateOptions(options: List[String]): List[String] = {
+    value match {
+      case Some(newValue) =>
+        val oldValue = readValue(options)
+        if (!oldValue.contains(newValue)) {
+          val otherOptions =
+            options.filterNot(_.startsWith(s"-D$bloopProperty="))
+          val newOption = s"-D$bloopProperty=$newValue"
+          newOption :: otherOptions
+        } else {
+          options
+        }
+      case None =>
+        options
+    }
+  }
+
+  def readValue(options: List[String]): Option[String] = {
+    val regex = s"-D$bloopProperty=(.*)".r
+    options.collectFirst {
+      case regex(value) => value.stripPrefix(s"-D$bloopProperty=")
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/zipkin/Property.scala
+++ b/metals/src/main/scala/scala/meta/internal/zipkin/Property.scala
@@ -1,10 +1,12 @@
 package scala.meta.internal.zipkin
+import java.util.Properties
 
 case class Property(metalsProperty: String) {
 
   val bloopProperty: String = metalsProperty.stripPrefix("metals.")
 
-  def value: Option[String] = Option(System.getProperty(metalsProperty))
+  def value: Option[String] =
+    Property.definitions.map(_.getProperty(metalsProperty))
 
   def updateOptions(options: List[String]): List[String] = {
     value match {
@@ -27,6 +29,18 @@ case class Property(metalsProperty: String) {
     val regex = s"-D$bloopProperty=(.*)".r
     options.collectFirst {
       case regex(value) => value.stripPrefix(s"-D$bloopProperty=")
+    }
+  }
+}
+object Property {
+
+  val definitions: Option[Properties] = {
+    Option(
+      getClass.getResourceAsStream("/fastpass.properties")
+    ).map { in =>
+      val prop = new Properties
+      prop.load(in)
+      prop
     }
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/zipkin/ZipkinProperties.scala
+++ b/metals/src/main/scala/scala/meta/internal/zipkin/ZipkinProperties.scala
@@ -1,8 +1,8 @@
-package scala.meta.internal.pantsbuild.commands
+package scala.meta.internal.zipkin
 
-import scala.meta.internal.pantsbuild.commands.BloopGlobalSettings.Property
+object ZipkinProperties {
 
-object BloopZipkinTraceProperties {
+  val zipkinServerUrl: Property = Property("metals.zipkin.server.url")
 
   val localServiceName: Property = Property(
     "metals.bloop.trace.localServiceName"
@@ -14,5 +14,12 @@ object BloopZipkinTraceProperties {
 
   val traceEndAnnotation: Property = Property(
     "metals.bloop.trace.traceEndAnnotation"
+  )
+
+  val All: List[Property] = List(
+    zipkinServerUrl,
+    localServiceName,
+    traceStartAnnotation,
+    traceEndAnnotation
   )
 }

--- a/metals/src/main/scala/scala/meta/internal/zipkin/ZipkinUrls.scala
+++ b/metals/src/main/scala/scala/meta/internal/zipkin/ZipkinUrls.scala
@@ -1,7 +1,0 @@
-package scala.meta.internal.zipkin
-import scala.meta.internal.pantsbuild.commands.BloopGlobalSettings.Property
-
-object ZipkinUrls {
-
-  val zipkinServerUrl: Property = Property("metals.zipkin.server.url")
-}

--- a/metals/src/main/scala/scala/meta/internal/zipkin/ZipkinUrls.scala
+++ b/metals/src/main/scala/scala/meta/internal/zipkin/ZipkinUrls.scala
@@ -1,7 +1,7 @@
 package scala.meta.internal.zipkin
+import scala.meta.internal.pantsbuild.commands.BloopGlobalSettings.Property
 
 object ZipkinUrls {
-  def url: Option[String] = {
-    Option(System.getProperty("metals.zipkin.server.url"))
-  }
+
+  val zipkinServerUrl: Property = Property("metals.zipkin.server.url")
 }


### PR DESCRIPTION
This change adds the properties introduced in https://github.com/scalacenter/bloop/pull/1231 to fastpass.