### PR TITLE
Add VersionedDocsModifier

### DIFF
--- a/metals-docs/src/main/resources/META-INF/services/mdoc.StringModifier
+++ b/metals-docs/src/main/resources/META-INF/services/mdoc.StringModifier
@@ -8,3 +8,4 @@ docs.TextEditorModifier
 docs.CommandsModifiers
 docs.BootstrapModifier
 docs.RequirementsModifier
+docs.VersionedDocsModifier

--- a/metals-docs/src/main/scala/docs/VersionedDocsModifier.scala
+++ b/metals-docs/src/main/scala/docs/VersionedDocsModifier.scala
@@ -1,0 +1,25 @@
+package docs
+
+import mdoc.Reporter
+import mdoc.StringModifier
+import scala.meta.inputs.Input
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.semver.SemVer.Version
+
+class VersionedDocsModifier extends StringModifier {
+  val name = "since"
+
+  override def process(
+      version: String,
+      code: Input,
+      reporter: Reporter
+  ): String = {
+    val unreleased =
+      Version.fromString(version) >= Version.fromString(BuildInfo.metalsVersion)
+
+    if (unreleased) {
+      s"> 🚧 This documentation section describes a feature that is currently unreleased. The expected release version is $version\n"
+    } else ""
+
+  }
+}

--- a/metals-docs/src/main/scala/docs/VersionedDocsModifier.scala
+++ b/metals-docs/src/main/scala/docs/VersionedDocsModifier.scala
@@ -19,7 +19,9 @@ class VersionedDocsModifier extends StringModifier {
 
     if (unreleased) {
       s"> 🚧 This documentation section describes a feature that is currently unreleased. The expected release version is $version\n"
-    } else ""
+    } else {
+      ""
+    }
 
   }
 }

--- a/mtags/src/main/scala/scala/meta/internal/semver/SemVer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/semver/SemVer.scala
@@ -2,18 +2,26 @@ package scala.meta.internal.semver
 
 object SemVer {
 
-  def isCompatibleVersion(minimumVersion: String, version: String): Boolean = {
-
-    def splitVersion(v: String) =
-      v.replaceAll("(-|\\+).+$", "").split('.')
-    val minVersionSplit = splitVersion(minimumVersion).map(_.toInt)
-    val versionSplit = splitVersion(version).map(_.toInt)
-    (minVersionSplit, versionSplit) match {
-      case (Array(minMajor, minMinor, minPatch), Array(major, minor, patch)) =>
-        (major > minMajor) ||
-          (major == minMajor && minor > minMinor) ||
-          (major == minMajor && minor == minMinor && patch >= minPatch)
-      case _ => false
+  case class Version(major: Int, minor: Int, patch: Int) {
+    def >(that: Version): Boolean = {
+      this.major > that.major ||
+      (this.major == that.major && this.minor > that.minor) ||
+      (this.major == that.major && this.minor == that.minor && this.patch > that.patch)
     }
+
+    def >=(that: Version): Boolean = this > that || this == that
+  }
+
+  object Version {
+    def fromString(version: String): Version = {
+      val Array(major, minor, patch) =
+        version.replaceAll("(-|\\+).+$", "").split('.').map(_.toInt)
+
+      Version(major, minor, patch)
+    }
+  }
+
+  def isCompatibleVersion(minimumVersion: String, version: String): Boolean = {
+    Version.fromString(version) >= Version.fromString(minimumVersion)
   }
 }

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -39,6 +39,9 @@
       "contributors/releasing": {
         "title": "Making a release"
       },
+      "contributors/remote-language-server": {
+        "title": "Remote Language Servers"
+      },
       "contributors/tests": {
         "title": "Tests overview"
       },
@@ -53,7 +56,7 @@
         "sidebar_label": "Debug Adapter Protocol"
       },
       "editors/decoration-protocol": {
-        "title": "Decoration Protocol v0.1.0",
+        "title": "Decoration Protocol v0.2.0",
         "sidebar_label": "Decoration Protocol"
       },
       "editors/eclipse": {


### PR DESCRIPTION
This PR adds a custom mdoc modifier that inserts a warning about unreleased features in the documentation.

The idea is that we can freely merge documentation for unreleased features, and the warning will be displayed until we release a stable version.

## Demo

Assuming the latest stable is 0.8.3, the demo shows how the warning is displayed when using `mdoc:since:0.8.4` but it's not displayed when using `mdoc:since:0.8.2`

![2020-04-04 12 53 04](https://user-images.githubusercontent.com/691940/78425544-b77d9a00-7673-11ea-972f-1c5111477613.gif)
