### PR TITLE
fix indentation for multiline string when using format selection

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -405,11 +405,12 @@ object MetalsEnrichments
         lowerBound: Int,
         upperBound: Int
     ): Int = {
+      val safeLowerBound = Math.max(0, lowerBound)
       var index = upperBound
-      while (index >= lowerBound && value(index) != char) {
+      while (index >= safeLowerBound && value(index) != char) {
         index -= 1
       }
-      if (index < lowerBound) -1 else index
+      if (index < safeLowerBound) -1 else index
     }
 
     def toAbsolutePathSafe: Option[AbsolutePath] = Try(toAbsolutePath).toOption

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -402,14 +402,14 @@ object MetalsEnrichments
 
     def lastIndexBetween(
         char: Char,
-        lowerBound: Int = 0,
-        upperBound: Int = value.size
+        lowerBound: Int,
+        upperBound: Int
     ): Int = {
       var index = upperBound
       while (index >= lowerBound && value(index) != char) {
         index -= 1
       }
-      index
+      if (index < lowerBound) -1 else index
     }
 
     def toAbsolutePathSafe: Option[AbsolutePath] = Try(toAbsolutePath).toOption

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -582,10 +582,27 @@ final class TestingServer(
       query: String,
       expected: String,
       paste: String,
-      root: AbsolutePath = workspace
+      root: AbsolutePath
   )(implicit loc: munit.Location): Future[Unit] = {
     for {
       (_, params) <- rangeFormattingParams(filename, query, paste, root)
+      multiline <- server.rangeFormatting(params).asScala
+      format = TextEdits.applyEdits(
+        textContents(filename),
+        multiline.asScala.toList
+      )
+    } yield {
+      Assertions.assertNoDiff(format, expected)
+    }
+  }
+  def rangeFormatting(
+      filename: String,
+      query: String,
+      expected: String,
+      root: AbsolutePath = workspace
+  )(implicit loc: munit.Location): Future[Unit] = {
+    for {
+      (_, params) <- rangeFormattingParams(filename, query, root)
       multiline <- server.rangeFormatting(params).asScala
       format = TextEdits.applyEdits(
         textContents(filename),
@@ -776,6 +793,20 @@ final class TestingServer(
         val range = new l.Range(start, end)
         val params = new DocumentRangeFormattingParams()
         params.setRange(range)
+        params.setTextDocument(textId)
+        (text, params)
+    }
+  }
+
+  private def rangeFormattingParams(
+      filename: String,
+      original: String,
+      root: AbsolutePath
+  ): Future[(String, DocumentRangeFormattingParams)] = {
+    rangeFromString(filename, original, root) {
+      case (text, textId, rangeSelection) =>
+        val params = new DocumentRangeFormattingParams()
+        params.setRange(rangeSelection)
         params.setTextDocument(textId)
         (text, params)
     }

--- a/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
@@ -9,15 +9,13 @@ class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
   // https://github.com/scalameta/metals/issues/1469
   check(
     "top-of-file",
-    s"""
-       |@@
-       |object Main {}
-       |""".stripMargin,
-    s"""
-       |
-       |
-       |object Main {}
-       |""".stripMargin
+    s"""|@@
+        |object Main {}
+        |""".stripMargin,
+    s"""|
+        |
+        |object Main {}
+        |""".stripMargin
   )
 
   check(

--- a/tests/unit/src/test/scala/tests/RangeFormattingWhenPastingSuite.scala
+++ b/tests/unit/src/test/scala/tests/RangeFormattingWhenPastingSuite.scala
@@ -2,7 +2,7 @@ package tests
 
 import munit.Location
 
-class RangeFormattingSuite extends BaseLspSuite("rangeFormatting") {
+class RangeFormattingWhenPastingSuite extends BaseLspSuite("rangeFormatting") {
 
   check(
     "lines",
@@ -257,6 +257,28 @@ class RangeFormattingSuite extends BaseLspSuite("rangeFormatting") {
        |  '''.stripMargin
        |}""".stripMargin
   )
+  check(
+    "with-wrong-indentation",
+    s"""
+       |object Main {
+       |  val str = '''
+       |  |
+       |      |@@
+       |  '''.stripMargin
+       |}""".stripMargin,
+    s"""| |first line
+        |
+        | |second line""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = '''
+       |  |
+       |      |first line
+       |      |
+       |      |second line
+       |  '''.stripMargin
+       |}""".stripMargin
+  )
 
   check(
     "with-pipes-skip-line",
@@ -305,7 +327,8 @@ class RangeFormattingSuite extends BaseLspSuite("rangeFormatting") {
           "a/src/main/scala/a/Main.scala",
           testCode, // bez @@
           expected,
-          paste
+          paste,
+          workspace
         )
       } yield ()
     }

--- a/tests/unit/src/test/scala/tests/RangeFormattingWhenSelectingSuite.scala
+++ b/tests/unit/src/test/scala/tests/RangeFormattingWhenSelectingSuite.scala
@@ -1,0 +1,166 @@
+package tests
+
+import munit.Location
+
+class RangeFormattingWhenSelectingSuite
+    extends BaseLspSuite("rangeFormatting") {
+  check(
+    "start-misindent-line",
+    s"""
+       |object Main {
+       |  val str = '''
+       |              |first line
+       |           <<        |second line
+       |                  |third line
+       |          |fourth line'''.stripMargin>>
+       |}""".stripMargin,
+    None,
+    s"""
+       |object Main {
+       |  val str = '''
+       |              |first line
+       |                   |second line
+       |                   |third line
+       |                   |fourth line'''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
+    "starting-well-indent-line",
+    s"""
+       |object Main {
+       |  val str = '''
+       |              |first line<<
+       |                   |second line
+       |                  |third line
+       |          |fourth line'''.stripMargin>>
+       |}""".stripMargin,
+    None,
+    s"""
+       |object Main {
+       |  val str = '''
+       |              |first line
+       |              |second line
+       |              |third line
+       |              |fourth line'''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
+    "starting-fist-line",
+    s"""
+       |object Main {
+       |  val str = '''first line<<
+       |                   |second line
+       |                  |third line
+       |          |fourth line'''.stripMargin>>
+       |}""".stripMargin,
+    None,
+    s"""
+       |object Main {
+       |  val str = '''first line
+       |              |second line
+       |              |third line
+       |              |fourth line'''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
+    "first-line-with-pipe",
+    s"""
+       |object Main {
+       |  val str = '''|first line<<
+       |                   |second line
+       |                  |third line
+       |          |fourth line'''.stripMargin>>
+       |}""".stripMargin,
+    None,
+    s"""
+       |object Main {
+       |  val str = '''|first line
+       |               |second line
+       |               |third line
+       |               |fourth line'''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
+    "entire-string",
+    s"""
+       |object Main {
+       |  <<val str = '''|first line
+       |                   |second line
+       |                  |third line
+       |          |fourth line'''.stripMargin>>
+       |}""".stripMargin,
+    None,
+    s"""
+       |object Main {
+       |  val str = '''|first line
+       |               |second line
+       |               |third line
+       |               |fourth line'''.stripMargin
+       |}""".stripMargin
+  )
+
+  // This test shows that currently we don't handle
+  // if current selection contains more than one and only one multi-line string
+  check(
+    "two-string",
+    s"""
+       |object Main {
+       |<<  val firstString = '''
+       |                        |first line
+       |                            |second line'''.stripMargin
+       |
+       |  val str2 = '''
+       |               |first line
+       |               |second line'''.stripMargin>>
+       |}""".stripMargin,
+    None,
+    s"""
+       |object Main {
+       |  val firstString = '''
+       |                        |first line
+       |                            |second line'''.stripMargin
+       |
+       |  val str2 = '''
+       |               |first line
+       |               |second line'''.stripMargin
+       |}""".stripMargin
+  )
+
+  def check(
+      name: String,
+      testCase: String,
+      paste: Option[String],
+      expectedCase: String
+  )(implicit loc: Location): Unit = {
+    val tripleQuote = """\u0022\u0022\u0022"""
+
+    def unmangle(string: String): String =
+      string.replaceAll("'''", tripleQuote)
+
+    val testCode = unmangle(testCase)
+    val base =
+      testCode.replaceAllLiterally("<<", "").replaceAllLiterally(">>", "")
+    val expected = unmangle(expectedCase)
+    test(name) {
+      for {
+        _ <- server.initialize(
+          s"""/metals.json
+             |{"a":{}}
+             |/a/src/main/scala/a/Main.scala
+      """.stripMargin + base
+        )
+        _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+
+        _ <- server.rangeFormatting(
+          "a/src/main/scala/a/Main.scala",
+          testCode, // with << >>
+          expected
+        )
+      } yield ()
+    }
+  }
+}


### PR DESCRIPTION
The goal is to list the tests we would like to see working.

In the gif below, I listed all cases that work/don't work
![hello-world-template-1586167831750](https://user-images.githubusercontent.com/7843237/78548107-7b2b7480-7800-11ea-8ed1-db7a25bbcdbb.gif)

closes #1509 