### PR TITLE
Fix bug around resetting presentation compilers.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -347,9 +347,19 @@ final class BuildTargets() {
   ): Boolean = {
     BuildTargets.isInverseDependency(query, roots, inverseDependencies.get)
   }
-  def inverseDependencies(
+  def inverseDependencyLeaves(
       target: BuildTargetIdentifier
   ): collection.Set[BuildTargetIdentifier] = {
+    computeInverseDependencies(target).leaves
+  }
+  def allInverseDependencies(
+      target: BuildTargetIdentifier
+  ): collection.Set[BuildTargetIdentifier] = {
+    computeInverseDependencies(target).visited
+  }
+  private def computeInverseDependencies(
+      target: BuildTargetIdentifier
+  ): BuildTargets.InverseDependencies = {
     BuildTargets.inverseDependencies(List(target), inverseDependencies.get)
   }
 
@@ -421,9 +431,9 @@ object BuildTargets {
   def inverseDependencies(
       root: List[BuildTargetIdentifier],
       inverseDeps: BuildTargetIdentifier => Option[Seq[BuildTargetIdentifier]]
-  ): collection.Set[BuildTargetIdentifier] = {
+  ): InverseDependencies = {
     val isVisited = mutable.Set.empty[BuildTargetIdentifier]
-    val result = mutable.Set.empty[BuildTargetIdentifier]
+    val leaves = mutable.Set.empty[BuildTargetIdentifier]
     def loop(toVisit: List[BuildTargetIdentifier]): Unit = toVisit match {
       case Nil => ()
       case head :: tail =>
@@ -436,13 +446,18 @@ object BuildTargets {
               // Only add leaves of the tree to the result to minimize the number
               // of targets that we compile. If `B` depends on `A`, it's faster
               // in Bloop to compile only `B` than `A+B`.
-              result += head
+              leaves += head
           }
           loop(tail)
         }
     }
     loop(root)
-    result
+    InverseDependencies(isVisited, leaves)
   }
+
+  case class InverseDependencies(
+      visited: collection.Set[BuildTargetIdentifier],
+      leaves: collection.Set[BuildTargetIdentifier]
+  )
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -54,7 +54,7 @@ final class Compilations(
 
   def cascadeCompileFiles(paths: Seq[AbsolutePath]): Future[b.CompileResult] = {
     val targets =
-      expand(paths).flatMap(buildTargets.inverseDependencies).distinct
+      expand(paths).flatMap(buildTargets.inverseDependencyLeaves).distinct
     for {
       result <- cascadeBatch(targets)
       _ <- compileWorksheets(paths)

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -79,6 +79,8 @@ class Compilers(
   }
   var ramboCancelable = Cancelable.empty
 
+  def loadedPresentationCompilerCount(): Int = cache.values.count(_.isLoaded())
+
   override def cancel(): Unit = {
     Cancelable.cancelEach(cache.values)(_.shutdown())
     cache.clear()
@@ -120,7 +122,7 @@ class Compilers(
       // Restart PC for all build targets that depend on this target since the classfiles
       // may have changed.
       for {
-        target <- buildTargets.inverseDependencies(report.getTarget)
+        target <- buildTargets.allInverseDependencies(report.getTarget)
         compiler <- cache.get(target)
       } {
         compiler.restart()

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -194,6 +194,8 @@ class MetalsLanguageServer(
   private var debugProvider: DebugProvider = _
   private var symbolSearch: MetalsSymbolSearch = _
   private var compilers: Compilers = _
+  def loadedPresentationCompilerCount(): Int =
+    compilers.loadedPresentationCompilerCount()
   var tables: Tables = _
   var statusBar: StatusBar = _
   private var embedded: Embedded = _

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -149,4 +149,16 @@ public abstract class PresentationCompiler {
     // Internal methods - not intended for public use
     // ==============================================
     public abstract List<String> diagnosticsForDebuggingPurposes();
+
+    /**
+     * Returns false if the presentation compiler has not been used since the last reset.
+     * 
+     * NOTE(olafur) This method was added for testing purposes. It's critical
+     * that we correctly reset the presentation compiler when build compilation
+     * complete to prevent the presentatin compiler from returning stale
+     * results. It's difficult to reliably test that a compiler is not
+     * returning stale results so we test instead against the implementation
+     * detail that the compiler is `null` when it has been reset.
+     */
+    public abstract boolean isLoaded();
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
@@ -42,6 +42,8 @@ class CompilerAccess(
     if (isEmpty) new StoreReporter()
     else _compiler.reporter.asInstanceOf[StoreReporter]
 
+  def isLoaded(): Boolean = _compiler != null
+
   def shutdown(): Unit = {
     shutdownCurrentCompiler()
     jobs.shutdown()

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -67,6 +67,8 @@ case class ScalaPresentationCompiler(
     access.shutdownCurrentCompiler()
   }
 
+  def isLoaded(): Boolean = access.isLoaded()
+
   override def newInstance(
       buildTargetIdentifier: String,
       classpath: util.List[Path],

--- a/tests/unit/src/test/scala/tests/CompilersLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompilersLspSuite.scala
@@ -1,0 +1,52 @@
+package tests
+
+import scala.concurrent.Future
+
+class CompilersLspSuite extends BaseCompletionLspSuite("compilers") {
+  test("reset-pc") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        """/metals.json
+          |{
+          |  "a": {},
+          |  "b": { "dependsOn": ["a"] }
+          |}
+          |/a/src/main/scala/a/A.scala
+          |package a
+          |object A {
+          |  // @@
+          |  def completeThisUniqueName() = 42
+          |}
+          |/b/src/main/scala/b/B.scala
+          |package b
+          |object B {
+          |  // @@
+          |  def completeThisUniqueName() = 42
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ <- server.didOpen("b/src/main/scala/b/B.scala")
+      _ = assertNoDiagnostics()
+      _ <- Future.sequence(
+        List('a', 'b').map(project =>
+          assertCompletion(
+            "completeThisUniqueNa@@",
+            "completeThisUniqueName(): Int",
+            project = project
+          )
+        )
+      )
+      _ = assertEquals(2, server.server.loadedPresentationCompilerCount())
+      _ <- server.didSave("b/src/main/scala/b/B.scala")(_ =>
+        "package b; object B"
+      )
+      _ <- server.didSave("a/src/main/scala/a/A.scala")(_ =>
+        "package a; object A"
+      )
+      _ = assertNoDiagnostics()
+      _ = assertEquals(0, server.server.loadedPresentationCompilerCount())
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/InverseDependenciesSuite.scala
+++ b/tests/unit/src/test/scala/tests/InverseDependenciesSuite.scala
@@ -32,7 +32,7 @@ class InverseDependenciesSuite extends BaseSuite {
         }
       )
       assertNoDiff(
-        obtained.toSeq.map(_.getUri).sorted.mkString("\n"),
+        obtained.leaves.toSeq.map(_.getUri).sorted.mkString("\n"),
         expected
       )
     }


### PR DESCRIPTION
Previously, Metals didn't correctly reset all presentation compiler
after a successful compilation. Users could observe this bug when
completions don't return symbols from other files that have been
recently changed.

Now, Metals resets all presentation compilers that may be affected by a
successful compile notification making it less likely that
completions/hover/signatureHelp return stale results.

This root cause of this bug was discovered in #1523 by Tomasz. The
problem was that Metals only collected the leaf build targets that
depend on the compiled target. Now, we reset all inverse dependencies
regardless if they're leaf targets or not.