### PR TITLE
Create a new file next to an existing one if user selected a file 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/NewFilesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NewFilesProvider.scala
@@ -36,7 +36,13 @@ class NewFilesProvider(
       name: Option[String]
   ): Future[Unit] = {
     val directory = directoryUri
-      .map(_.toString.toAbsolutePath)
+      .map { uri =>
+        val path = uri.toString.toAbsolutePath
+        if (path.isFile)
+          path.parent
+        else
+          path
+      }
       .orElse(focusedDocument().map(_.parent))
 
     val newlyCreatedFile =

--- a/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
@@ -82,6 +82,24 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
         |""".stripMargin
   )
 
+  check("new-class-on-file")(
+    Some("a/src/main/scala/foo/Other.scala"),
+    "class",
+    Some("Foo"),
+    "a/src/main/scala/foo/Foo.scala",
+    s"""|package foo
+        |
+        |class Foo {
+        |$indent
+        |}
+        |""".stripMargin,
+    existingFiles = """|/a/src/main/scala/foo/Other.scala
+                       |package foo
+                       |
+                       |class Other
+                       |""".stripMargin
+  )
+
   private def indent = "  "
 
   private def check(testName: String)(
@@ -89,7 +107,8 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
       pickedKind: String,
       name: Option[String],
       expectedFilePath: String,
-      expectedContent: String
+      expectedContent: String,
+      existingFiles: String = ""
   ): Unit = test(testName) {
     val directoryUri = directory.fold(null.asInstanceOf[String])(
       workspace.resolve(_).toURI.toString()
@@ -131,6 +150,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
                                 |{
                                 |  "a": { }
                                 |}
+                                |$existingFiles
                                 |""".stripMargin)
       _ <- server.executeCommand(
         ServerCommands.NewScalaFile.id,


### PR DESCRIPTION
This will allow us to have the `New Scala File` option also when right clicking on a file.

![new-file](https://user-images.githubusercontent.com/3807253/78816593-3c4d1880-79d2-11ea-80a0-8096b3c2a61b.gif)
