### PR TITLE
Properly set the arguments field in sever commands documentation

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -162,12 +162,10 @@ object ServerCommands {
        |
        |Note: document in json argument must be absolute path.
        |""".stripMargin,
-    """|```json
-       |{
+    """|{
        |  document: "file:///home/dev/foo/Bar.scala",
        |  position: {line: 5, character: 12}
        |}
-       |```
        |""".stripMargin
   )
 
@@ -182,12 +180,10 @@ object ServerCommands {
        |
        |Note: document in json argument must be absolute path.
        |""".stripMargin,
-    """|```json
-       |{
+    """|{
        |  document: "file:///home/dev/foo/Bar.scala",
        |  position: {line: 5, character: 12}
        |}
-       |```
        |""".stripMargin
   )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -162,10 +162,16 @@ object ServerCommands {
        |
        |Note: document in json argument must be absolute path.
        |""".stripMargin,
-    """|{
+    """|
+       |Object with `document` and `position`
+       |
+       |Example:
+       |```json
+       |{
        |  document: "file:///home/dev/foo/Bar.scala",
        |  position: {line: 5, character: 12}
        |}
+       |```
        |""".stripMargin
   )
 
@@ -180,10 +186,15 @@ object ServerCommands {
        |
        |Note: document in json argument must be absolute path.
        |""".stripMargin,
-    """|{
+    """|Object with `document` and `position`
+       |
+       |Example:
+       |```json
+       |{
        |  document: "file:///home/dev/foo/Bar.scala",
        |  position: {line: 5, character: 12}
        |}
+       |```
        |""".stripMargin
   )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -147,8 +147,8 @@ object ServerCommands {
     "Goto location",
     """|Move the cursor to the definition of the argument symbol.
        |
-       |Arguments: [string], where the string is a SemanticDB symbol.
-       |""".stripMargin
+       |""".stripMargin,
+    "[string], where the string is a SemanticDB symbol."
   )
 
   val GotoSuperMethod = new Command(
@@ -161,9 +161,8 @@ object ServerCommands {
        |If symbol under cursor is invalid or does not override anything then command is ignored.
        |
        |Note: document in json argument must be absolute path.
-       |
-       |Arguments:
-       |```json
+       |""".stripMargin,
+    """|```json
        |{
        |  document: "file:///home/dev/foo/Bar.scala",
        |  position: {line: 5, character: 12}
@@ -182,9 +181,8 @@ object ServerCommands {
        |QuickPick will show up only if more than one result is found.
        |
        |Note: document in json argument must be absolute path.
-       |
-       |Arguments:
-       |```json
+       |""".stripMargin,
+    """|```json
        |{
        |  document: "file:///home/dev/foo/Bar.scala",
        |  position: {line: 5, character: 12}
@@ -198,10 +196,9 @@ object ServerCommands {
     "Create new scala file",
     """|Create and open new file with either scala class, object, trait, package object or worksheet.
        |
-       |Arguments: [string], where the string is a directory location for the new file.
-       |
        |Note: requires 'metals/inputBox' capability from language client.
-       |""".stripMargin
+       |""".stripMargin,
+    "[string], where the string is a directory location for the new file."
   )
 
   /**


### PR DESCRIPTION
For several commands the `arguments` field was left with its default value `null`
while the description mentioned arguments to be sent as seen bellow:

![image](https://user-images.githubusercontent.com/1632384/79068393-d65cdb80-7cc6-11ea-955d-68b5ca6d3297.png)
