### PR TITLE
Don't ask .scalafmt.conf creation again

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DismissedNotifications.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DismissedNotifications.scala
@@ -13,6 +13,8 @@ final class DismissedNotifications(conn: () => Connection, time: Time) {
   val DoctorWarning = new Notification(4)
   val IncompatibleBloop = new Notification(5)
   val ReconnectBsp = new Notification(6)
+  val CreateScalafmtFile = new Notification(7)
+  val ChangeScalafmtVersion = new Notification(8)
 
   class Notification(val id: Int)(implicit name: sourcecode.Name) {
     override def toString: String = s"Notification(${name.value}, $id)"

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -310,7 +310,8 @@ object Messages {
       params.setActions(
         List(
           changeVersion,
-          notNow
+          notNow,
+          dontShowAgain
         ).asJava
       )
       params
@@ -371,7 +372,8 @@ object Messages {
       params.setActions(
         List(
           createFile,
-          notNow
+          notNow,
+          dontShowAgain
         ).asJava
       )
       params

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -355,7 +355,8 @@ class MetalsLanguageServer(
           folders.asScala.map(_.getUri.toAbsolutePath).toList
         case _ =>
           Nil
-      }
+      },
+      tables
     )
     newFilesProvider = new NewFilesProvider(
       workspace,


### PR DESCRIPTION
When "Format on Compile" or "Format on Save" is enabled in the editor-wide settings, Metals asks `.scalafmt.conf` creation every time. It would be nice if the dialog has a volatile "Don't ask again" option for `.scalafmt.conf` creation.