### PR TITLE
Don't generate timestamp in `.bsp/bloop.json` file.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
@@ -71,7 +71,6 @@ object IntelliJ {
     "--",
     "${V.bloopVersion}"
   ],
-  "timestamp": "${System.currentTimeMillis()}",
   "pantsTargets": ${targetsJson.toString},
   "X-detectExternalProjectFiles": false
 }


### PR DESCRIPTION
This field is no longer used.