### PR TITLE
Http client delegates `metalsInputBox` to the underlying client

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
@@ -52,12 +52,6 @@ final class MetalsHttpClient(
 )(implicit ec: ExecutionContext)
     extends DelegatingLanguageClient(initial) {
 
-  override def metalsInputBox(
-      params: MetalsInputBoxParams
-  ): CompletableFuture[MetalsInputBoxResult] = {
-    CompletableFuture.completedFuture(MetalsInputBoxResult(cancelled = true))
-  }
-
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams
   ): Unit = {


### PR DESCRIPTION
To fix https://github.com/scalameta/metals/issues/1605 .
Sublime client has `isHttpEnabled` configuration `on` by default, and this prevents the language server from sending `metalsInputBox` request, even if `metals.input-box` is set to `on`.
Changed the Http client (layer) to delegate the method to it's underlying client (which, by the way, in practice happens to be a `ConfiguredLanguageClient`, that does the configuration check).