### PR TITLE
Try to fix Debug Adapter Suites

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
@@ -25,6 +25,9 @@ object DebugProtocol {
   import scala.meta.internal.metals.JsonParser._
   val FirstMessageId = 1
 
+  val serverName = "dap-server"
+  val clientName = "dap-client"
+
   def copy(original: Source): Source = {
     val source = new Source
     source.setAdapterData(original.getAdapterData)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
@@ -138,12 +138,12 @@ private[debug] object DebugProxy {
     for {
       server <- connectToServer()
         .map(new SocketEndpoint(_))
-        .map(endpoint => withLogger(endpoint, "dap-server"))
+        .map(endpoint => withLogger(endpoint, DebugProtocol.serverName))
         .map(new MessageIdAdapter(_))
         .map(new ServerAdapter(_))
       client <- awaitClient()
         .map(new SocketEndpoint(_))
-        .map(endpoint => withLogger(endpoint, "dap-client"))
+        .map(endpoint => withLogger(endpoint, DebugProtocol.clientName))
         .map(new MessageIdAdapter(_))
     } yield new DebugProxy(name, sourcePathProvider, client, server)
   }

--- a/tests/unit/src/main/scala/tests/BaseDapSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseDapSuite.scala
@@ -8,8 +8,48 @@ import scala.concurrent.Future
 import scala.meta.internal.metals.debug.DebugWorkspaceLayout
 import scala.meta.internal.metals.debug.Stoppage
 import scala.meta.internal.metals.debug.TestDebugger
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.GlobalTrace
+import scala.meta.internal.metals.debug.DebugProtocol
+import scala.util.Failure
+import scala.util.Success
 
 abstract class BaseDapSuite(suiteName: String) extends BaseLspSuite(suiteName) {
+
+  private val dapClient =
+    GlobalTrace.protocolTracePath(DebugProtocol.clientName)
+  private val dapServer =
+    GlobalTrace.protocolTracePath(DebugProtocol.serverName)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    dapClient.touch()
+    dapServer.touch()
+  }
+
+  protected def logDapTraces() = {
+    scribe.warn("The DAP test failed, printing the traces")
+    scribe.warn(dapClient.toString() + ":")
+    scribe.info(dapClient.readText)
+    scribe.warn(dapServer.toString() + ":")
+    scribe.info(dapServer.readText)
+  }
+
+  override def munitTestTransforms: List[TestTransform] =
+    super.munitTestTransforms :+
+      new TestTransform("Print DAP traces", { test =>
+        test.withBody(() =>
+          test
+            .body()
+            .andThen {
+              case Failure(exception) =>
+                logDapTraces()
+                exception
+              case Success(value) => value
+            }(munitExecutionContext)
+        )
+      })
+
   def debugMain(
       buildTarget: String,
       main: String,

--- a/tests/unit/src/main/scala/tests/BaseDapSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseDapSuite.scala
@@ -13,6 +13,7 @@ import scala.meta.internal.metals.GlobalTrace
 import scala.meta.internal.metals.debug.DebugProtocol
 import scala.util.Failure
 import scala.util.Success
+import munit.GenericBeforeEach
 
 abstract class BaseDapSuite(suiteName: String) extends BaseLspSuite(suiteName) {
 
@@ -21,13 +22,13 @@ abstract class BaseDapSuite(suiteName: String) extends BaseLspSuite(suiteName) {
   private val dapServer =
     GlobalTrace.protocolTracePath(DebugProtocol.serverName)
 
-  override def beforeAll(): Unit = {
-    super.beforeAll()
+  override def beforeEach(context: GenericBeforeEach[Future[Any]]): Unit = {
+    super.beforeEach(context)
     dapClient.touch()
     dapServer.touch()
   }
 
-  protected def logDapTraces() = {
+  protected def logDapTraces(): Unit = {
     scribe.warn("The DAP test failed, printing the traces")
     scribe.warn(dapClient.toString() + ":")
     scribe.info(dapClient.readText)

--- a/tests/unit/src/test/scala/tests/debug/BreakpointDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/BreakpointDapSuite.scala
@@ -7,6 +7,8 @@ import scala.meta.internal.metals.debug.Stoppage
 import munit.Location
 import munit.TestOptions
 
+// note(@tgodzik) all test have `System.exit(0)` added to avoid occasional issue due to:
+// https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment
 class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
 
   // disabled, because finding enclosing class for the breakpoint line is not working
@@ -20,6 +22,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |
                 |  def main(args: Array[String]): Unit = {
                 |>>  println()
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -33,6 +36,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |  // this line must remain empty
                 |  def main(args: Array[String]): Unit = {
                 |>>  println()
+                |    System.exit(0)
                 |  }
                 |  class Succeeding
                 |}
@@ -52,6 +56,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |object Main {
                 |  def main(args: Array[String]): Unit = {
                 |    Bar.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -70,6 +75,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |object Main {
                 |  def main(args: Array[String]): Unit = {
                 |    Bar()
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -90,6 +96,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |    this match {
                 |      case Bar() =>
                 |    }
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -109,6 +116,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |  def main(args: Array[String]): Unit = {
                 |    val bar = new Bar {}
                 |    bar.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -128,6 +136,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |  def main(args: Array[String]): Unit = {
                 |    val bar = new Bar
                 |    bar.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -147,6 +156,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |      }
                 |    }
                 |    bar.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -166,6 +176,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |  def main(args: Array[String]): Unit = {
                 |    val bar = new Bar
                 |    bar.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -188,6 +199,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |      case bar(1) => println()
                 |      case _ =>
                 |    }
+                |    System.exit(0)
                 |  }
                 |}
 
@@ -209,6 +221,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |object Main {
                 |  def main(args: Array[String]): Unit = {
                 |    Bar.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -229,6 +242,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |object Main {
                 |  def main(args: Array[String]): Unit = {
                 |    Bar()
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -243,6 +257,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |    for {
                 |>>    x <- List()
                 |    } println(x)
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -259,6 +274,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |  } {
                 |>>    println(x)
                 |    }
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -275,6 +291,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |    } yield {
                 |>>    println(x)
                 |    }
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -296,6 +313,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |  def main(args: Array[String]): Unit = {
                 |    val foo = new Foo {}
                 |    foo.Bar.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -317,6 +335,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |  def main(args: Array[String]): Unit = {
                 |    val bar = new Bar
                 |    bar.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -338,6 +357,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |  def main(args: Array[String]): Unit = {
                 |    val bar = new Bar {}
                 |    bar.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin
@@ -356,6 +376,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |object Main {
                 |    def main(args: Array[String]): Unit = {
                 |      call()
+                |      System.exit(0)
                 |    }
                 |}
                 |""".stripMargin
@@ -369,6 +390,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |    List(1).foreach{ e =>
                 |>>    println(e)
                 |    }
+                |    System.exit(0);
                 |  }
                 |}
                 |""".stripMargin
@@ -380,6 +402,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |object Main {
                 |  def main(args: Array[String]): Unit = {
                 |    Foo.A.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |
@@ -402,6 +425,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |object Main {
                 |  def main(args: Array[String]): Unit = {
                 |    Foo.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |
@@ -422,6 +446,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |object Main {
                 |  def main(args: Array[String]): Unit = {
                 |    Foo.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |
@@ -446,6 +471,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |object Main {
                 |  def main(args: Array[String]): Unit = {
                 |    Foo.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |
@@ -474,6 +500,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |object Main {
                 |  def main(args: Array[String]): Unit = {
                 |    Foo.call()
+                |    System.exit(0)
                 |  }
                 |}
                 |
@@ -513,6 +540,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |object Main {
                 |    def main(args: Array[String]): Unit = {
                 |      a.Foo.call()
+                |      System.exit(0)
                 |    }
                 |}
                 |""".stripMargin
@@ -533,6 +561,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |object Main {
                 |    def main(args: Array[String]): Unit = {
                 |      not.matching.Foo.call()
+                |      System.exit(0)
                 |    }
                 |}
                 |""".stripMargin
@@ -545,6 +574,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
                 |object Main {
                 |    def main(args: Array[String]): Unit = {
                 |      foo.Target.call()
+                |      System.exit(0)
                 |    }
                 |}
                 |
@@ -577,6 +607,7 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
          |>>  println(1)
          |>>  println(2)
          |>>  println(3)
+         |    System.exit(0)
          |  }
          |}
          |""".stripMargin

--- a/tests/unit/src/test/scala/tests/debug/StackFrameDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/StackFrameDapSuite.scala
@@ -8,6 +8,8 @@ import scala.meta.internal.metals.debug.Variable
 import scala.meta.internal.metals.debug.Variables
 import munit.Location
 
+// note(@tgodzik) all test have `System.exit(0)` added to avoid occasional issue due to:
+// https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment
 class StackFrameDapSuite extends BaseDapSuite("debug-stack-frame") {
   assertStackFrame("foreach")(
     source = """|a/src/main/scala/Main.scala
@@ -16,6 +18,7 @@ class StackFrameDapSuite extends BaseDapSuite("debug-stack-frame") {
                 |    List(1, 2).foreach { value =>
                 |>>      println(value)
                 |    }
+                |    System.exit(0)
                 |  }
                 |}""".stripMargin,
     expectedFrames = List(
@@ -29,6 +32,7 @@ class StackFrameDapSuite extends BaseDapSuite("debug-stack-frame") {
                 |object Main {
                 |  def main(args: Array[String]): Unit = {
                 |>>  println()
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin,
@@ -44,6 +48,7 @@ class StackFrameDapSuite extends BaseDapSuite("debug-stack-frame") {
                 |object Main {
                 |  def main(args: Array[String]): Unit = {
                 |    foo()
+                |    System.exit(0)
                 |  }
                 |
                 |  def foo(): Unit = {
@@ -84,6 +89,7 @@ class StackFrameDapSuite extends BaseDapSuite("debug-stack-frame") {
                 |      x <- List(1)
                 |>>    z = x + 2
                 |    } println(z)
+                |    System.exit(0)
                 |  }
                 |}
                 |""".stripMargin,
@@ -104,6 +110,7 @@ class StackFrameDapSuite extends BaseDapSuite("debug-stack-frame") {
                 |  def main(args: Array[String]): Unit = {
                 |    val foo = new Foo
                 |>>  println()
+                |    System.exit(0)
                 |  }
                 |}
                 |
@@ -128,6 +135,7 @@ class StackFrameDapSuite extends BaseDapSuite("debug-stack-frame") {
                 |  def main(args: Array[String]): Unit = {
                 |    val list = List(1, 2)
                 |>>  println()
+                |    System.exit(0)
                 |  }
                 |}
                 |

--- a/tests/unit/src/test/scala/tests/debug/StepDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/StepDapSuite.scala
@@ -6,7 +6,10 @@ import scala.meta.internal.metals.debug.DebugWorkspaceLayout
 import scala.meta.internal.metals.debug.StepNavigator
 import munit.Location
 
+// note(@tgodzik) all test have `System.exit(0)` added to avoid occasional issue due to:
+// https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment
 class StepDapSuite extends BaseDapSuite("debug-step") {
+
   assertSteps("step-out")(
     sources = """|/a/src/main/scala/Main.scala
                  |package a
@@ -18,6 +21,7 @@ class StepDapSuite extends BaseDapSuite("debug-step") {
                  |
                  |  def main(args: Array[String]): Unit = {
                  |    foo()
+                 |    System.exit(0)
                  |  }
                  |}
                  |""".stripMargin,
@@ -25,7 +29,7 @@ class StepDapSuite extends BaseDapSuite("debug-step") {
     instrument = steps =>
       steps
         .at("a/src/main/scala/Main.scala", line = 5)(StepOut)
-        .at("a/src/main/scala/Main.scala", line = 9)(Continue)
+        .at("a/src/main/scala/Main.scala", line = 10)(Continue)
   )
 
   assertSteps("step-over")(
@@ -36,6 +40,7 @@ class StepDapSuite extends BaseDapSuite("debug-step") {
                  |  def main(args: Array[String]): Unit = {
                  |>>  println(1)
                  |    println(2)
+                 |    System.exit(0)
                  |  }
                  |}
                  |""".stripMargin,
@@ -53,6 +58,7 @@ class StepDapSuite extends BaseDapSuite("debug-step") {
                  |object ScalaMain {
                  |  def main(args: Array[String]): Unit = {
                  |>>  JavaClass.foo(7)
+                 |    System.exit(0)
                  |  }
                  |}
                  |
@@ -69,7 +75,7 @@ class StepDapSuite extends BaseDapSuite("debug-step") {
       steps
         .at("a/src/main/scala/a/ScalaMain.scala", line = 5)(StepIn)
         .at("a/src/main/java/a/JavaClass.java", line = 5)(StepOut)
-        .at("a/src/main/scala/a/ScalaMain.scala", line = 5)(Continue)
+        .at("a/src/main/scala/a/ScalaMain.scala", line = 6)(Continue)
   )
 
   assertSteps("step-into-scala-lib")(
@@ -79,6 +85,7 @@ class StepDapSuite extends BaseDapSuite("debug-step") {
                  |object Main {
                  |  def main(args: Array[String]): Unit = {
                  |>>  println("foo")
+                 |    System.exit(0)
                  |  }
                  |}
                  |""".stripMargin,
@@ -96,6 +103,7 @@ class StepDapSuite extends BaseDapSuite("debug-step") {
                  |object Main {
                  |  def main(args: Array[String]): Unit = {
                  |>>  System.out.println("foo")
+                 |    System.exit(0)
                  |  }
                  |}
                  |""".stripMargin,
@@ -119,6 +127,7 @@ class StepDapSuite extends BaseDapSuite("debug-step") {
                  |  def main(args: Array[String]): Unit = {
                  |    val foo = new Foo
                  |>>  foo.call()
+                 |    System.exit(0)
                  |  }
                  |}
                  |
@@ -132,7 +141,7 @@ class StepDapSuite extends BaseDapSuite("debug-step") {
     instrument = steps =>
       steps
         .at("a/src/main/scala/a/Main.scala", line = 6)(Continue)
-        .at("a/src/main/scala/a/Main.scala", line = 12)(Continue)
+        .at("a/src/main/scala/a/Main.scala", line = 13)(Continue)
   )
 
   def assertSteps(name: String)(


### PR DESCRIPTION
Trying to fix the issues with the DAP Suites:
- we now print the DAP traces on failures
- added System.exit(0) to all main methods to avoid [this issue](https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment), which caused rare but consistent failures

