### PR TITLE
Handle initialization options

### DIFF
--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -78,7 +78,7 @@ example, in vim-lsc the `window/logMessage` notification is always displayed in
 the UI so `-Dmetals.status-bar=log-message` can be configured to direct
 higher-priority messages to the logs. However, whenever possible, if the client
 supports the ability to add in `experimental` items to the `ClientCapabilities`
-interface and/or to `InitializationOptions`, this is preferable.
+interface or to `InitializationOptions`, this is preferable.
 
 ### `-Dmetals.verbose`
 

--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -284,6 +284,9 @@ Possible values:
 - `off`: the client does not add any indentation when receiving a multi-line
   textEdit
 
+*Usage of `doctorProvider` in `InitializationOptions.compilerOptions.snippetAutoIndent` is preferable.*
+
+
 ### `-Dmetals.doctor-format`
 
 Format that you'd like Doctor to return information in.

--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -677,11 +677,11 @@ The currently available settings for `InitializationOptions` are listed below.
       "isExitOnShutdown" : boolean,
       "isHttpEnabled": boolean,
       "compilerOptions":{
-        "isCompletionItemDetailEnabled": boolean
-        "isCompletionItemDocumentationEnabled": boolean
-        "isHoverDocumentationEnabled": boolean
-        "snippetAutoIndent": boolean
-        "isSignatureHelpDocumentationEnabled": boolean
+        "isCompletionItemDetailEnabled": boolean,
+        "isCompletionItemDocumentationEnabled": boolean,
+        "isHoverDocumentationEnabled": boolean,
+        "snippetAutoIndent": boolean,
+        "isSignatureHelpDocumentationEnabled": boolean,
         "isCompletionItemResolve": boolean
       }
     }

--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -78,7 +78,7 @@ example, in vim-lsc the `window/logMessage` notification is always displayed in
 the UI so `-Dmetals.status-bar=log-message` can be configured to direct
 higher-priority messages to the logs. However, whenever possible, if the client
 supports the ability to add in `experimental` items to the `ClientCapabilities`
-interface, this is preferable.
+interface and/or to `InitializationOptions`, this is preferable.
 
 ### `-Dmetals.verbose`
 
@@ -119,7 +119,7 @@ Possible values:
   `window/showMessage` notifications. Used by coc.nvim and sublime at the
   moment.
 
-*Usage of `statusBarProvider` in `ClientCapabilities.experimental` is
+*Usage of `statusBarProvider` in `InitializationOptions` is
 preferable.*
 
 ### `-Dmetals.slow-task`
@@ -131,6 +131,9 @@ Possible values:
 - `status-bar`: the `metals/slowTask` request is not supported, but send updates
   about slow tasks via `metals/status`.
 
+*Usage of `slowTaskProvider` in `InitializationOptions` is
+preferable.*
+
 ### `-Dmetals.input-box`
 
 Possible values:
@@ -139,7 +142,7 @@ Possible values:
   Metals tries to fallback to `window/showMessageRequest` when possible.
 - `on`: the `metals/inputBox` request is fully supported.
 
-*Usage of `inputBoxProvider` in `ClientCapabilities.experimental` is preferable.*
+*Usage of `inputBoxProvider` in `InitializationOptions` is preferable.*
 
 ### `-Dmetals.execute-client-command`
 
@@ -151,8 +154,7 @@ Possible values:
 - `on`: the `metals/executeClientCommand` notification is supported and all
   [Metals client commands](#metals-client-commands) are handled.
 
-*Usage of `executeClientCommandProvider` in `ClientCapabilities.experimental` is
-preferable.*
+*Usage of `executeClientCommandProvider` in `InitializationOptions` is preferable.*
 
 ### `-Dmetals.http`
 
@@ -162,6 +164,8 @@ Possible values:
 - `on`: start a server with the [Metals HTTP client] to interact with the server
   through a basic web UI. This option is needed for editor clients that don't
   support necessary requests such as `window/showMessageRequest`.
+
+*Usage of `isHttpEnabled` in `InitializationOptions` is preferable.*
 
 ### `-Dmetals.icons`
 
@@ -188,6 +192,8 @@ Possible values:
   It's not possible for Sublime Text packages to register a callback when the
   editor is quit. See [LSP#410](https://github.com/tomv564/LSP/issues/410) for
   more details.
+
+  *Usage of `isExitOnShutdown` in `InitializationOptions` is preferable.*
 
 ### `-Dmetals.bloop-protocol`
 
@@ -288,7 +294,7 @@ Possible values:
   the browser or web view
 - `json`: json representation of the information returned by Doctor
 
-*Usage of `doctorProvider` in `ClientCapabilities.experimental` is preferable.*
+*Usage of `doctorProvider` in `InitializationOptions` is preferable.*
 
 ### `-Dbloop.embedded.version`
 
@@ -643,30 +649,48 @@ specification.
 - `didChangeWatchedFiles` client capability is used to determine whether to
   register file watchers.
 
-#### `experimental`
+#### `InitializationOptions` and `experimental`
 
-During the `initialize` we also have the ability to pass in `experimental`
-capabilities. In Metals we have a few different "providers". Some are also LSP
+During the `initialize` we also have the ability to pass in `InitializationOptions` and `experimental` capabilities. 
+In Metals we have a few different "providers". Some are also LSP
 extensions, such as `metals/inputBox` which you read about above, and others
-used to be server properties that have been migrated to `clientCapabilities`.
+used to be server properties that have been migrated to `clientCapabilities` and `InitializationOptions`.
 Whenever possible, instead of introducing a new server property, try to
 introduce it here. The main reason for this is that it allows clients to
 initialize and define their "support" for certain things solely through LSP
-rather then using server properties. The currently available settings for
-`experimental` are listed below.
+rather then using server properties. 
+
+The currently available settings for `InitializationOptions` are listed below.
+
+```js
+    "InitializationOptions": {
+      "statusBarProvider": "on" | "off" | "show-message" | "log-message",
+      "didFocusProvider": boolean,
+      "slowTaskProvider": boolean,
+      "inputBoxProvider": boolean,
+      "quickPickProvider": boolean,
+      "executeClientCommandProvider": boolean,
+      "doctorProvider": "json" | "html",
+      "isExitOnShutdown" : boolean,
+      "isHttpEnabled": boolean,
+      "compilerOptions":{
+        "isCompletionItemDetailEnabled": boolean
+        "isCompletionItemDocumentationEnabled": boolean
+        "isHoverDocumentationEnabled": boolean
+        "snippetAutoIndent": boolean
+        "isSignatureHelpDocumentationEnabled": boolean
+        "isCompletionItemResolve": boolean
+      }
+    }
+```
+
+The currently available settings for `experimental` are listed below.
 
 ```js
     "experimental": {
       "treeViewProvider": boolean,
       "debuggingProvider": boolean,
-      "decorationProvider": boolean,
-      "inputBoxProvider": boolean,
-      "quickPickProvider": boolean,
-      "didFocusProvider": boolean,
-      "slowTaskProvider": boolean,
-      "executeClientCommandProvider": boolean,
-      "doctorProvider": "json" | "html",
-      "statusBarProvider": "on" | "off" | "show-message" | "log-message"
+      "decorationProvider": boolean
     }
 ```
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -353,10 +353,6 @@ class Compilers(
       pc: PresentationCompiler,
       search: SymbolSearch
   ): PresentationCompiler = {
-    val initializationOptions = initializeParams
-      .map(InitializationOptions.from(_))
-      .getOrElse(InitializationOptions.Default)
-
     pc.withSearch(search)
       .withExecutorService(ec)
       .withScheduledExecutorService(sh)

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -352,7 +352,14 @@ class Compilers(
   private def configure(
       pc: PresentationCompiler,
       search: SymbolSearch
-  ): PresentationCompiler =
+  ): PresentationCompiler = {
+    val initializationOptions = initializeParams
+      .map(InitializationOptions.from(_))
+      .getOrElse(InitializationOptions.Default)
+
+    val isCompletionItemDetailEnabled =
+      config.compilers.isCompletionItemDetailEnabled || initializationOptions.isCompletionItemDetailEnabled
+
     pc.withSearch(search)
       .withExecutorService(ec)
       .withScheduledExecutorService(sh)
@@ -361,9 +368,11 @@ class Compilers(
           _symbolPrefixes = userConfig().symbolPrefixes,
           isCompletionSnippetsEnabled =
             initializeParams.supportsCompletionSnippets,
-          isFoldOnlyLines = initializeParams.foldOnlyLines
+          isFoldOnlyLines = initializeParams.foldOnlyLines,
+          isCompletionItemDetailEnabled = isCompletionItemDetailEnabled
         )
       )
+  }
 
   def newCompiler(
       scalac: ScalacOptionsItem,

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -352,7 +352,7 @@ class Compilers(
   private def configure(
       pc: PresentationCompiler,
       search: SymbolSearch
-  ): PresentationCompiler = {
+  ): PresentationCompiler =
     pc.withSearch(search)
       .withExecutorService(ec)
       .withScheduledExecutorService(sh)
@@ -370,7 +370,6 @@ class Compilers(
             isFoldOnlyLines = initializeParams.foldOnlyLines
           )
       )
-  }
 
   def newCompiler(
       scalac: ScalacOptionsItem,

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -358,8 +358,8 @@ class Compilers(
       .withScheduledExecutorService(sh)
       .withConfiguration(
         initializeParams
-          .map(p => {
-            val options = InitializationOptions.from(p).compilerOptions
+          .map(params => {
+            val options = InitializationOptions.from(params).compilerOptions
             config.compilers.update(options)
           })
           .getOrElse(config.compilers)

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -357,20 +357,22 @@ class Compilers(
       .map(InitializationOptions.from(_))
       .getOrElse(InitializationOptions.Default)
 
-    val isCompletionItemDetailEnabled =
-      config.compilers.isCompletionItemDetailEnabled || initializationOptions.isCompletionItemDetailEnabled
-
     pc.withSearch(search)
       .withExecutorService(ec)
       .withScheduledExecutorService(sh)
       .withConfiguration(
-        config.compilers.copy(
-          _symbolPrefixes = userConfig().symbolPrefixes,
-          isCompletionSnippetsEnabled =
-            initializeParams.supportsCompletionSnippets,
-          isFoldOnlyLines = initializeParams.foldOnlyLines,
-          isCompletionItemDetailEnabled = isCompletionItemDetailEnabled
-        )
+        initializeParams
+          .map(p => {
+            val options = InitializationOptions.from(p).compilerOptions
+            config.compilers.update(options)
+          })
+          .getOrElse(config.compilers)
+          .copy(
+            _symbolPrefixes = userConfig().symbolPrefixes,
+            isCompletionSnippetsEnabled =
+              initializeParams.supportsCompletionSnippets,
+            isFoldOnlyLines = initializeParams.foldOnlyLines
+          )
       )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -25,9 +25,14 @@ final class ConfiguredLanguageClient(
     extends DelegatingLanguageClient(initial) {
 
   private var clientCapabilities = ClientExperimentalCapabilities.Default
+  private var initializationOptions = InitializationOptions.Default
 
   override def configure(capabilities: ClientExperimentalCapabilities): Unit = {
     clientCapabilities = capabilities
+  }
+
+  override def configure(options: InitializationOptions): Unit = {
+    initializationOptions = options
   }
 
   override def shutdown(): Unit = {
@@ -35,12 +40,12 @@ final class ConfiguredLanguageClient(
   }
 
   override def metalsStatus(params: MetalsStatusParams): Unit = {
-    if (config.statusBar.isOn || clientCapabilities.statusBarIsOn) {
+    if (config.statusBar.isOn || clientCapabilities.statusBarIsOn || initializationOptions.statusBarIsOn) {
       underlying.metalsStatus(params)
     } else if (params.text.nonEmpty && !pendingShowMessage.get()) {
-      if (config.statusBar.isShowMessage || clientCapabilities.statusBarIsShowMessage) {
+      if (config.statusBar.isShowMessage || clientCapabilities.statusBarIsShowMessage || initializationOptions.statusBarIsShowMessage) {
         underlying.showMessage(new MessageParams(MessageType.Log, params.text))
-      } else if (config.statusBar.isLogMessage || clientCapabilities.statusBarIsLogMessage) {
+      } else if (config.statusBar.isLogMessage || clientCapabilities.statusBarIsLogMessage || initializationOptions.statusBarIsLogMessage) {
         underlying.logMessage(new MessageParams(MessageType.Log, params.text))
       } else {
         ()
@@ -52,7 +57,7 @@ final class ConfiguredLanguageClient(
   override def metalsSlowTask(
       params: MetalsSlowTaskParams
   ): CompletableFuture[MetalsSlowTaskResult] = {
-    if (config.slowTask.isOn || clientCapabilities.slowTaskProvider) {
+    if (config.slowTask.isOn || clientCapabilities.slowTaskProvider || initializationOptions.slowTask) {
       underlying.metalsSlowTask(params)
     } else {
       new CompletableFuture[MetalsSlowTaskResult]()
@@ -73,7 +78,9 @@ final class ConfiguredLanguageClient(
   }
 
   override def logMessage(message: MessageParams): Unit = {
-    if ((config.statusBar.isLogMessage || clientCapabilities.statusBarIsLogMessage) && message.getType == MessageType.Log) {
+    val statusBarIsLogMessage =
+      config.statusBar.isLogMessage || clientCapabilities.statusBarIsLogMessage || initializationOptions.statusBarIsLogMessage
+    if (statusBarIsLogMessage && message.getType == MessageType.Log) {
       // window/logMessage is reserved for the status bar so we don't publish
       // scribe.{info,warn,error} logs here. Users should look at .metals/metals.log instead.
       ()
@@ -85,7 +92,7 @@ final class ConfiguredLanguageClient(
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams
   ): Unit = {
-    if (config.executeClientCommand.isOn || clientCapabilities.executeClientCommandProvider) {
+    if (config.executeClientCommand.isOn || clientCapabilities.executeClientCommandProvider || initializationOptions.executeClientCommand) {
       params.getCommand match {
         case ClientCommands.RefreshModel()
             if !clientCapabilities.debuggingProvider =>
@@ -99,7 +106,7 @@ final class ConfiguredLanguageClient(
   override def metalsInputBox(
       params: MetalsInputBoxParams
   ): CompletableFuture[MetalsInputBoxResult] = {
-    if (config.isInputBoxEnabled || clientCapabilities.inputBoxProvider) {
+    if (config.isInputBoxEnabled || clientCapabilities.inputBoxProvider || initializationOptions.inputBox) {
       underlying.metalsInputBox(params)
     } else {
       CompletableFuture.completedFuture(MetalsInputBoxResult(cancelled = true))
@@ -109,7 +116,7 @@ final class ConfiguredLanguageClient(
   override def metalsQuickPick(
       params: MetalsQuickPickParams
   ): CompletableFuture[MetalsQuickPickResult] = {
-    if (clientCapabilities.quickPickProvider) {
+    if (clientCapabilities.quickPickProvider || initializationOptions.quickPick) {
       underlying.metalsQuickPick(params)
     } else {
       showMessageRequest(

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -57,7 +57,7 @@ final class ConfiguredLanguageClient(
   override def metalsSlowTask(
       params: MetalsSlowTaskParams
   ): CompletableFuture[MetalsSlowTaskResult] = {
-    if (config.slowTask.isOn || clientCapabilities.slowTaskProvider || initializationOptions.slowTask) {
+    if (config.slowTask.isOn || clientCapabilities.slowTaskProvider || initializationOptions.slowTaskProvider) {
       underlying.metalsSlowTask(params)
     } else {
       new CompletableFuture[MetalsSlowTaskResult]()
@@ -92,7 +92,7 @@ final class ConfiguredLanguageClient(
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams
   ): Unit = {
-    if (config.executeClientCommand.isOn || clientCapabilities.executeClientCommandProvider || initializationOptions.executeClientCommand) {
+    if (config.executeClientCommand.isOn || clientCapabilities.executeClientCommandProvider || initializationOptions.executeClientCommandProvider) {
       params.getCommand match {
         case ClientCommands.RefreshModel()
             if !clientCapabilities.debuggingProvider =>
@@ -106,7 +106,7 @@ final class ConfiguredLanguageClient(
   override def metalsInputBox(
       params: MetalsInputBoxParams
   ): CompletableFuture[MetalsInputBoxResult] = {
-    if (config.isInputBoxEnabled || clientCapabilities.inputBoxProvider || initializationOptions.inputBox) {
+    if (config.isInputBoxEnabled || clientCapabilities.inputBoxProvider || initializationOptions.inputBoxProvider) {
       underlying.metalsInputBox(params)
     } else {
       CompletableFuture.completedFuture(MetalsInputBoxResult(cancelled = true))
@@ -116,7 +116,7 @@ final class ConfiguredLanguageClient(
   override def metalsQuickPick(
       params: MetalsQuickPickParams
   ): CompletableFuture[MetalsQuickPickResult] = {
-    if (clientCapabilities.quickPickProvider || initializationOptions.quickPick) {
+    if (clientCapabilities.quickPickProvider || initializationOptions.quickPickProvider) {
       underlying.metalsQuickPick(params)
     } else {
       showMessageRequest(

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -40,7 +40,11 @@ final class ConfiguredLanguageClient(
   }
 
   override def metalsStatus(params: MetalsStatusParams): Unit = {
-    if (config.statusBar.isOn || clientCapabilities.statusBarIsOn || initializationOptions.statusBarIsOn) {
+    val statusBarIsOn = config.statusBar.isOn ||
+      clientCapabilities.statusBarIsOn ||
+      initializationOptions.statusBarIsOn
+
+    if (statusBarIsOn) {
       underlying.metalsStatus(params)
     } else if (params.text.nonEmpty && !pendingShowMessage.get()) {
       if (config.statusBar.isShowMessage || clientCapabilities.statusBarIsShowMessage || initializationOptions.statusBarIsShowMessage) {
@@ -57,7 +61,11 @@ final class ConfiguredLanguageClient(
   override def metalsSlowTask(
       params: MetalsSlowTaskParams
   ): CompletableFuture[MetalsSlowTaskResult] = {
-    if (config.slowTask.isOn || clientCapabilities.slowTaskProvider || initializationOptions.slowTaskProvider) {
+    val slowTaskIsOn = config.slowTask.isOn ||
+      clientCapabilities.slowTaskProvider ||
+      initializationOptions.slowTaskProvider
+
+    if (slowTaskIsOn) {
       underlying.metalsSlowTask(params)
     } else {
       new CompletableFuture[MetalsSlowTaskResult]()
@@ -78,8 +86,10 @@ final class ConfiguredLanguageClient(
   }
 
   override def logMessage(message: MessageParams): Unit = {
-    val statusBarIsLogMessage =
-      config.statusBar.isLogMessage || clientCapabilities.statusBarIsLogMessage || initializationOptions.statusBarIsLogMessage
+    val statusBarIsLogMessage = config.statusBar.isLogMessage ||
+      clientCapabilities.statusBarIsLogMessage ||
+      initializationOptions.statusBarIsLogMessage
+
     if (statusBarIsLogMessage && message.getType == MessageType.Log) {
       // window/logMessage is reserved for the status bar so we don't publish
       // scribe.{info,warn,error} logs here. Users should look at .metals/metals.log instead.
@@ -92,7 +102,11 @@ final class ConfiguredLanguageClient(
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams
   ): Unit = {
-    if (config.executeClientCommand.isOn || clientCapabilities.executeClientCommandProvider || initializationOptions.executeClientCommandProvider) {
+    val executeClientCommandProvider = config.executeClientCommand.isOn ||
+      clientCapabilities.executeClientCommandProvider ||
+      initializationOptions.executeClientCommandProvider
+
+    if (executeClientCommandProvider) {
       params.getCommand match {
         case ClientCommands.RefreshModel()
             if !clientCapabilities.debuggingProvider =>
@@ -106,7 +120,11 @@ final class ConfiguredLanguageClient(
   override def metalsInputBox(
       params: MetalsInputBoxParams
   ): CompletableFuture[MetalsInputBoxResult] = {
-    if (config.isInputBoxEnabled || clientCapabilities.inputBoxProvider || initializationOptions.inputBoxProvider) {
+    val isInputBoxEnabled = config.isInputBoxEnabled ||
+      clientCapabilities.inputBoxProvider ||
+      initializationOptions.inputBoxProvider
+
+    if (isInputBoxEnabled) {
       underlying.metalsInputBox(params)
     } else {
       CompletableFuture.completedFuture(MetalsInputBoxResult(cancelled = true))

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -44,12 +44,20 @@ final class ConfiguredLanguageClient(
       clientCapabilities.statusBarIsOn ||
       initializationOptions.statusBarIsOn
 
+    val statusBarIsShow = config.statusBar.isShowMessage ||
+      clientCapabilities.statusBarIsShowMessage ||
+      initializationOptions.statusBarIsShowMessage
+
+    val statusBarIsLog = config.statusBar.isLogMessage ||
+      clientCapabilities.statusBarIsLogMessage ||
+      initializationOptions.statusBarIsLogMessage
+
     if (statusBarIsOn) {
       underlying.metalsStatus(params)
     } else if (params.text.nonEmpty && !pendingShowMessage.get()) {
-      if (config.statusBar.isShowMessage || clientCapabilities.statusBarIsShowMessage || initializationOptions.statusBarIsShowMessage) {
+      if (statusBarIsShow) {
         underlying.showMessage(new MessageParams(MessageType.Log, params.text))
-      } else if (config.statusBar.isLogMessage || clientCapabilities.statusBarIsLogMessage || initializationOptions.statusBarIsLogMessage) {
+      } else if (statusBarIsLog) {
         underlying.logMessage(new MessageParams(MessageType.Log, params.text))
       } else {
         ()

--- a/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
@@ -46,6 +46,14 @@ class DelegatingLanguageClient(var underlying: MetalsLanguageClient)
     }
   }
 
+  def configure(initializationOptions: InitializationOptions): Unit = {
+    underlying match {
+      case client: ConfiguredLanguageClient =>
+        client.configure(initializationOptions)
+      case _ =>
+    }
+  }
+
   override def metalsStatus(params: MetalsStatusParams): Unit = {
     underlying.metalsStatus(params)
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -34,7 +34,7 @@ final class Doctor(
   private val doctorFormatIsJson =
     config.doctorFormat.isJson || clientExperimentalCapabilities.doctorFormatIsJson || initializationOptions.doctorFormatIsJson
   private val executeClientCommandProvider =
-    config.executeClientCommand.isOn || clientExperimentalCapabilities.executeClientCommandProvider || initializationOptions.executeClientCommand
+    config.executeClientCommand.isOn || clientExperimentalCapabilities.executeClientCommandProvider || initializationOptions.executeClientCommandProvider
 
   def isUnsupportedBloopVersion(serverVersion: String): Boolean = {
     bspServerName.contains("Bloop") && !SemVer.isCompatibleVersion(

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -10,7 +10,6 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ScalaVersions._
 import scala.meta.io.AbsolutePath
 import scala.meta.internal.semver.SemVer
-import ch.epfl.scala.bsp.endpoints.Build.initialize
 
 /**
  * Helps the user figure out what is mis-configured in the build through the "Run doctor" command.

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -31,10 +31,6 @@ final class Doctor(
   private val hasProblems = new AtomicBoolean(false)
   private var bspServerName: Option[String] = None
   private var bspServerVersion: Option[String] = None
-  private val doctorFormatIsJson =
-    config.doctorFormat.isJson || clientExperimentalCapabilities.doctorFormatIsJson || initializationOptions.doctorFormatIsJson
-  private val executeClientCommandProvider =
-    config.executeClientCommand.isOn || clientExperimentalCapabilities.executeClientCommandProvider || initializationOptions.executeClientCommandProvider
 
   def isUnsupportedBloopVersion(serverVersion: String): Boolean = {
     bspServerName.contains("Bloop") && !SemVer.isCompatibleVersion(
@@ -76,7 +72,13 @@ final class Doctor(
       clientCommand: Command,
       onServer: MetalsHttpServer => Unit
   ): Unit = {
+    val executeClientCommandProvider = config.executeClientCommand.isOn ||
+      clientExperimentalCapabilities.executeClientCommandProvider ||
+      initializationOptions.executeClientCommandProvider
+
     if (executeClientCommandProvider) {
+      val doctorFormatIsJson =
+        config.doctorFormat.isJson || clientExperimentalCapabilities.doctorFormatIsJson || initializationOptions.doctorFormatIsJson
       val output =
         if (doctorFormatIsJson)
           buildTargetsJson()
@@ -133,6 +135,10 @@ final class Doctor(
     def isMaven: Boolean = workspace.resolve("pom.xml").isFile
     def hint() =
       if (isMaven) {
+        val doctorFormatIsJson = config.doctorFormat.isJson ||
+          clientExperimentalCapabilities.doctorFormatIsJson ||
+          initializationOptions.doctorFormatIsJson
+
         val website =
           if (doctorFormatIsJson)
             "Metals Website - https://scalameta.org/metals/docs/build-tools/maven.html"

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -33,6 +33,7 @@ final class FormattingProvider(
     userConfig: () => UserConfiguration,
     client: MetalsLanguageClient,
     clientExperimentalCapabilities: ClientExperimentalCapabilities,
+    initializationOptions: InitializationOptions,
     statusBar: StatusBar,
     icons: Icons,
     workspaceFolders: List[AbsolutePath]
@@ -139,7 +140,9 @@ final class FormattingProvider(
   }
 
   private def askScalafmtVersion(): Future[Option[String]] = {
-    if (clientExperimentalCapabilities.inputBoxProvider || serverConfig.isInputBoxEnabled) {
+    val isInputBoxEnabled =
+      serverConfig.isInputBoxEnabled || clientExperimentalCapabilities.inputBoxProvider || initializationOptions.inputBox
+    if (isInputBoxEnabled) {
       client
         .metalsInputBox(MissingScalafmtVersion.inputBox())
         .asScala

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -141,7 +141,7 @@ final class FormattingProvider(
 
   private def askScalafmtVersion(): Future[Option[String]] = {
     val isInputBoxEnabled =
-      serverConfig.isInputBoxEnabled || clientExperimentalCapabilities.inputBoxProvider || initializationOptions.inputBox
+      serverConfig.isInputBoxEnabled || clientExperimentalCapabilities.inputBoxProvider || initializationOptions.inputBoxProvider
     if (isInputBoxEnabled) {
       client
         .metalsInputBox(MissingScalafmtVersion.inputBox())

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -10,13 +10,13 @@ final case class InitializationOptions(
     inputBoxProvider: java.lang.Boolean = false,
     quickPickProvider: java.lang.Boolean = false,
     executeClientCommandProvider: java.lang.Boolean = false,
-    doctorFormatProvider: String = "html",
+    doctorProvider: String = "html",
     isExitOnShutdown: java.lang.Boolean = false,
     isHttpEnabled: java.lang.Boolean = false,
     compilerOptions: CompilerInitializationOptions =
       CompilerInitializationOptions()
 ) {
-  def doctorFormatIsJson: Boolean = doctorFormatProvider == "json"
+  def doctorFormatIsJson: Boolean = doctorProvider == "json"
   def statusBarIsOn: Boolean = statusBarProvider == "on"
   def statusBarIsOff: Boolean = statusBarProvider == "off"
   def statusBarIsShowMessage: Boolean = statusBarProvider == "show-message"

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -12,6 +12,7 @@ final case class InitializationOptions(
     executeClientCommandProvider: java.lang.Boolean = false,
     doctorFormatProvider: String = "html",
     isExitOnShutdown: java.lang.Boolean = false,
+    isHttpEnabled: java.lang.Boolean = false,
     compilerOptions: CompilerInitializationOptions =
       CompilerInitializationOptions()
 ) {

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -1,0 +1,37 @@
+package scala.meta.internal.metals
+import com.google.gson.JsonElement
+import org.eclipse.{lsp4j => l}
+
+final case class InitializationOptions(
+    statusBar: String = "off",
+    didFocus: java.lang.Boolean = false,
+    slowTask: java.lang.Boolean = false,
+    inputBox: java.lang.Boolean = false,
+    quickPick: java.lang.Boolean = false,
+    executeClientCommand: java.lang.Boolean = false,
+    doctorFormat: String = "html",
+    isCompletionItemDetailEnabled: java.lang.Boolean = false,
+    isExitOnShutdown: java.lang.Boolean = false
+) {
+  def doctorFormatIsJson: Boolean = doctorFormat == "json"
+  def statusBarIsOn: Boolean = statusBar == "on"
+  def statusBarIsOff: Boolean = statusBar == "off"
+  def statusBarIsShowMessage: Boolean = statusBar == "show-message"
+  def statusBarIsLogMessage: Boolean = statusBar == "log-message"
+}
+
+object InitializationOptions {
+  val Default = new InitializationOptions()
+
+  def from(
+      initializeParams: l.InitializeParams
+  ): InitializationOptions = {
+    import scala.meta.internal.metals.JsonParser._
+    initializeParams.getInitializationOptions() match {
+      case json: JsonElement =>
+        json.as[InitializationOptions].getOrElse(Default)
+      case _ =>
+        Default
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -1,23 +1,25 @@
 package scala.meta.internal.metals
 import com.google.gson.JsonElement
 import org.eclipse.{lsp4j => l}
+import scala.meta.internal.pc.CompilerInitializationOptions
 
 final case class InitializationOptions(
-    statusBar: String = "off",
-    didFocus: java.lang.Boolean = false,
-    slowTask: java.lang.Boolean = false,
-    inputBox: java.lang.Boolean = false,
-    quickPick: java.lang.Boolean = false,
-    executeClientCommand: java.lang.Boolean = false,
-    doctorFormat: String = "html",
-    isCompletionItemDetailEnabled: java.lang.Boolean = false,
-    isExitOnShutdown: java.lang.Boolean = false
+    statusBarProvider: String = "off",
+    didFocusProvider: java.lang.Boolean = false,
+    slowTaskProvider: java.lang.Boolean = false,
+    inputBoxProvider: java.lang.Boolean = false,
+    quickPickProvider: java.lang.Boolean = false,
+    executeClientCommandProvider: java.lang.Boolean = false,
+    doctorFormatProvider: String = "html",
+    isExitOnShutdown: java.lang.Boolean = false,
+    compilerOptions: CompilerInitializationOptions =
+      CompilerInitializationOptions()
 ) {
-  def doctorFormatIsJson: Boolean = doctorFormat == "json"
-  def statusBarIsOn: Boolean = statusBar == "on"
-  def statusBarIsOff: Boolean = statusBar == "off"
-  def statusBarIsShowMessage: Boolean = statusBar == "show-message"
-  def statusBarIsLogMessage: Boolean = statusBar == "log-message"
+  def doctorFormatIsJson: Boolean = doctorFormatProvider == "json"
+  def statusBarIsOn: Boolean = statusBarProvider == "on"
+  def statusBarIsOff: Boolean = statusBarProvider == "off"
+  def statusBarIsShowMessage: Boolean = statusBarProvider == "show-message"
+  def statusBarIsLogMessage: Boolean = statusBarProvider == "log-message"
 }
 
 object InitializationOptions {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -598,7 +598,7 @@ class MetalsLanguageServer(
   }
 
   private def startHttpServer(): Unit = {
-    if (config.isHttpEnabled) {
+    if (config.isHttpEnabled || initializationOptions.isHttpEnabled) {
       val host = "localhost"
       val port = 5031
       var url = s"http://$host:$port"

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
@@ -34,9 +34,12 @@ final class StatusBar(
     progressTicks: ProgressTicks = ProgressTicks.braille,
     val icons: Icons,
     statusBar: StatusBarConfig,
-    clientCapabilities: ClientExperimentalCapabilities
+    clientCapabilities: ClientExperimentalCapabilities,
+    initializationOptions: InitializationOptions
 )(implicit ec: ExecutionContext)
     extends Cancelable {
+  private val statusBarIsOff =
+    statusBar.isOff && clientCapabilities.statusBarIsOff && initializationOptions.statusBarIsOff
 
   def trackBlockingTask[T](message: String)(thunk: => T): T = {
     val promise = Promise[Unit]()
@@ -49,7 +52,7 @@ final class StatusBar(
   }
 
   def trackSlowTask[T](message: String)(thunk: => T): T = {
-    if (statusBar.isOff && clientCapabilities.statusBarIsOff)
+    if (statusBarIsOff)
       trackBlockingTask(message)(thunk)
     else {
       val task = client().metalsSlowTask(MetalsSlowTaskParams(message))
@@ -67,7 +70,7 @@ final class StatusBar(
   }
 
   def trackSlowFuture[T](message: String, thunk: Future[T]): Unit = {
-    if (statusBar.isOff && clientCapabilities.statusBarIsOff)
+    if (statusBarIsOff)
       trackFuture(message, thunk)
     else {
       val task = client().metalsSlowTask(MetalsSlowTaskParams(message))

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
@@ -49,7 +49,11 @@ final class StatusBar(
   }
 
   def trackSlowTask[T](message: String)(thunk: => T): T = {
-    if (statusBar.isOff && clientCapabilities.statusBarIsOff && initializationOptions.statusBarIsOff)
+    val statusBarIsOff = statusBar.isOff &&
+      clientCapabilities.statusBarIsOff &&
+      initializationOptions.statusBarIsOff
+
+    if (statusBarIsOff)
       trackBlockingTask(message)(thunk)
     else {
       val task = client().metalsSlowTask(MetalsSlowTaskParams(message))
@@ -67,7 +71,11 @@ final class StatusBar(
   }
 
   def trackSlowFuture[T](message: String, thunk: Future[T]): Unit = {
-    if (statusBar.isOff && clientCapabilities.statusBarIsOff && initializationOptions.statusBarIsOff)
+    val statusBarIsOff = statusBar.isOff &&
+      clientCapabilities.statusBarIsOff &&
+      initializationOptions.statusBarIsOff
+
+    if (statusBarIsOff)
       trackFuture(message, thunk)
     else {
       val task = client().metalsSlowTask(MetalsSlowTaskParams(message))

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
@@ -38,9 +38,6 @@ final class StatusBar(
     initializationOptions: InitializationOptions
 )(implicit ec: ExecutionContext)
     extends Cancelable {
-  private val statusBarIsOff =
-    statusBar.isOff && clientCapabilities.statusBarIsOff && initializationOptions.statusBarIsOff
-
   def trackBlockingTask[T](message: String)(thunk: => T): T = {
     val promise = Promise[Unit]()
     trackFuture(message, promise.future)
@@ -52,7 +49,7 @@ final class StatusBar(
   }
 
   def trackSlowTask[T](message: String)(thunk: => T): T = {
-    if (statusBarIsOff)
+    if (statusBar.isOff && clientCapabilities.statusBarIsOff && initializationOptions.statusBarIsOff)
       trackBlockingTask(message)(thunk)
     else {
       val task = client().metalsSlowTask(MetalsSlowTaskParams(message))
@@ -70,7 +67,7 @@ final class StatusBar(
   }
 
   def trackSlowFuture[T](message: String, thunk: Future[T]): Unit = {
-    if (statusBarIsOff)
+    if (statusBar.isOff && clientCapabilities.statusBarIsOff && initializationOptions.statusBarIsOff)
       trackFuture(message, thunk)
     else {
       val task = client().metalsSlowTask(MetalsSlowTaskParams(message))

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerInitializationOptions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerInitializationOptions.scala
@@ -5,5 +5,6 @@ case class CompilerInitializationOptions(
     isCompletionItemDocumentationEnabled: java.lang.Boolean = true,
     isHoverDocumentationEnabled: Boolean = true,
     snippetAutoIndent: Boolean = true,
-    isSignatureHelpDocumentationEnabled: Boolean = true
+    isSignatureHelpDocumentationEnabled: Boolean = true,
+    isCompletionItemResolve: Boolean = true
 )

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerInitializationOptions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerInitializationOptions.scala
@@ -1,0 +1,9 @@
+package scala.meta.internal.pc
+
+case class CompilerInitializationOptions(
+    isCompletionItemDetailEnabled: java.lang.Boolean = true,
+    isCompletionItemDocumentationEnabled: java.lang.Boolean = true,
+    isHoverDocumentationEnabled: Boolean = true,
+    snippetAutoIndent: Boolean = true,
+    isSignatureHelpDocumentationEnabled: Boolean = true
+)

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -44,6 +44,8 @@ case class PresentationCompilerConfigImpl(
         isHoverDocumentationEnabled || options.isHoverDocumentationEnabled,
       snippetAutoIndent = snippetAutoIndent || options.snippetAutoIndent,
       isSignatureHelpDocumentationEnabled =
-        isSignatureHelpDocumentationEnabled || options.isSignatureHelpDocumentationEnabled
+        isSignatureHelpDocumentationEnabled || options.isSignatureHelpDocumentationEnabled,
+      isCompletionItemResolve =
+        isCompletionItemResolve || options.isCompletionItemResolve
     )
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -31,4 +31,19 @@ case class PresentationCompilerConfigImpl(
     Optional.ofNullable(_parameterHintsCommand.orNull)
   override def completionCommand: Optional[String] =
     Optional.ofNullable(_completionCommand.orNull)
+
+  def update(
+      options: CompilerInitializationOptions
+  ): PresentationCompilerConfigImpl =
+    copy(
+      isCompletionItemDetailEnabled =
+        isCompletionItemDetailEnabled || options.isCompletionItemDetailEnabled,
+      isCompletionItemDocumentationEnabled =
+        isCompletionItemDocumentationEnabled || options.isCompletionItemDocumentationEnabled,
+      isHoverDocumentationEnabled =
+        isHoverDocumentationEnabled || options.isHoverDocumentationEnabled,
+      snippetAutoIndent = snippetAutoIndent || options.snippetAutoIndent,
+      isSignatureHelpDocumentationEnabled =
+        isSignatureHelpDocumentationEnabled || options.isSignatureHelpDocumentationEnabled
+    )
 }

--- a/tests/unit/src/test/scala/tests/StatusBarSuite.scala
+++ b/tests/unit/src/test/scala/tests/StatusBarSuite.scala
@@ -7,7 +7,10 @@ import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.ProgressTicks
 import scala.meta.internal.metals.StatusBar
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.meta.internal.metals.ClientExperimentalCapabilities
+import scala.meta.internal.metals.{
+  ClientExperimentalCapabilities,
+  InitializationOptions
+}
 
 class StatusBarSuite extends BaseSuite {
   val time = new FakeTime
@@ -19,7 +22,8 @@ class StatusBarSuite extends BaseSuite {
     ProgressTicks.dots,
     Icons.default,
     StatusBarConfig.default,
-    ClientExperimentalCapabilities.Default
+    ClientExperimentalCapabilities.Default,
+    InitializationOptions.Default
   )
   override def beforeEach(context: BeforeEach): Unit = {
     client.statusParams.clear()


### PR DESCRIPTION
fixes https://github.com/scalameta/metals/issues/1614

Migrated from `clientExperimentalCapabilities`
- [x] statusBar
- [x] didFocus
- [x] slowTask
- [x] InputBox
- [x] quickPick
- [x] execute-client-command
- [x] doctorFormat


Migrated from server properties 
- [x] exit-on-shutdown
- [x] completion-item.detail
- [x] completion-item.documentation
- [x] isHoverDocumentationEnabled
- [x] hover.documentation
- [x] signature-help.documentation
- [x] completion-item.resolve
- [x] http

The following have been left out because they are none boolean settings so we have to decide on a priority if setting is set both ways: 
- icons
- glob-syntax
- completionCommand
- signature-help.command
- overrideDefFormat

- [x] Update doc to make initialization options the recommended way for this flags