### PR TITLE
Delete all created folders created for the FileWatcher

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
@@ -67,11 +67,13 @@ final class FileWatcher(
         } else {
           path
         }
-        pathToCreate.createDirectories()
+        val createdPaths = pathToCreate.createDirectories()
         // this is a workaround for MacOS, it will continue watching
         // directories even if they are removed, however it doesn't
         // work on some other systems like Linux
-        if (isSource) createdSourceDirectories.add(pathToCreate)
+        if (isSource) {
+          createdPaths.foreach(createdSourceDirectories.add)
+        }
       }
       if (buildTargets.isInsideSourceRoot(path)) {
         () // Do nothing, already covered by a source root
@@ -95,7 +97,7 @@ final class FileWatcher(
       }
     }
     startWatching(new ju.ArrayList(sourceDirectoriesToWatch))
-    createdSourceDirectories.asScala.foreach { dir =>
+    createdSourceDirectories.asScala.sortBy(_.toNIO).reverse.foreach { dir =>
       if (dir.isEmptyDirectory) {
         dir.delete()
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
@@ -67,7 +67,7 @@ final class FileWatcher(
         } else {
           path
         }
-        val createdPaths = pathToCreate.createDirectories()
+        val createdPaths = pathToCreate.createAndGetDirectories()
         // this is a workaround for MacOS, it will continue watching
         // directories even if they are removed, however it doesn't
         // work on some other systems like Linux
@@ -97,6 +97,7 @@ final class FileWatcher(
       }
     }
     startWatching(new ju.ArrayList(sourceDirectoriesToWatch))
+    // reverse sorting here is necessary to delete parent paths at the end
     createdSourceDirectories.asScala.sortBy(_.toNIO).reverse.foreach { dir =>
       if (dir.isEmptyDirectory) {
         dir.delete()

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -308,7 +308,10 @@ object MetalsEnrichments
       }
     }
 
-    def createDirectories(): Seq[AbsolutePath] = {
+    def createDirectories(): AbsolutePath =
+      AbsolutePath(Files.createDirectories(path.dealias.toNIO))
+
+    def createAndGetDirectories(): Seq[AbsolutePath] = {
       def createDirectoriesRec(
           absolutePath: AbsolutePath,
           toCreate: Seq[AbsolutePath]

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -308,8 +308,17 @@ object MetalsEnrichments
       }
     }
 
-    def createDirectories(): AbsolutePath = {
-      AbsolutePath(Files.createDirectories(path.dealias.toNIO))
+    def createDirectories(): Seq[AbsolutePath] = {
+      def createDirectoriesRec(
+          absolutePath: AbsolutePath,
+          toCreate: Seq[AbsolutePath]
+      ): Seq[AbsolutePath] = {
+        if (absolutePath.exists)
+          toCreate.map(path => AbsolutePath(Files.createDirectory(path.toNIO)))
+        else
+          createDirectoriesRec(absolutePath.parent, absolutePath +: toCreate)
+      }
+      createDirectoriesRec(path, Nil)
     }
 
     def delete(): Unit = {

--- a/tests/unit/src/test/scala/tests/MetalsEnrichmentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/MetalsEnrichmentsSuite.scala
@@ -1,0 +1,23 @@
+package tests
+
+import java.nio.file.Files
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.{AbsolutePath, RelativePath}
+
+class MetalsEnrichmentsSuite extends BaseSuite {
+
+  test("create-directories") {
+    val tmpDir = Files.createTempDirectory("metals-enrichment")
+    val absoluteTmpPath = AbsolutePath(tmpDir)
+    val nothingToCreate: Seq[AbsolutePath] =
+      absoluteTmpPath.createAndGetDirectories()
+    assertEquals(nothingToCreate, Nil, "workspace is already created")
+
+    val created = absoluteTmpPath.resolve("a/b/c").createAndGetDirectories()
+    val relativeCreated =
+      created.map(_.toRelative(absoluteTmpPath)).sortBy(_.toNIO)
+    val expected = Seq("a", "a/b", "a/b/c").map(RelativePath.apply)
+    assertEquals(relativeCreated, expected)
+  }
+}


### PR DESCRIPTION
The issue was that we create directories recursively, but we delete only the child one.

fixes #1609
