### PR TITLE
Show date in logs

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
@@ -98,7 +98,7 @@ object MetalsLogger {
   def newFileWriter(logfile: AbsolutePath): FileWriter =
     FileWriter().path(_ => logfile.toNIO).autoFlush
 
-  def defaultFormat: Formatter = formatter"$levelPaddedRight $message"
+  def defaultFormat: Formatter = formatter"$date $levelPaddedRight $message"
 
   def silent: LoggerSupport = new LoggerSupport {
     override def log[M](record: LogRecord[M]): Unit = ()


### PR DESCRIPTION
I think it can be useful to show date in metals logs
```
2020.04.16 11:31:34 INFO  Connected to Build server v1.4.0-RC1-162-888454e1
2020.04.16 11:31:34 INFO  time: indexed workspace in 0.54s
2020.04.16 11:31:51 INFO  shutting down Metals
```