### PR TITLE
Use DefinitionProvider instead of index in RenameProvider 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -415,7 +415,6 @@ class MetalsLanguageServer(
       referencesProvider,
       implementationProvider,
       definitionProvider,
-      definitionIndex,
       workspace,
       languageClient,
       buffers,
@@ -1059,13 +1058,15 @@ class MetalsLanguageServer(
   def prepareRename(
       params: TextDocumentPositionParams
   ): CompletableFuture[l.Range] =
-    CancelTokens { _ => renameProvider.prepareRename(params).orNull }
+    CancelTokens.future { token =>
+      renameProvider.prepareRename(params, token).map(_.orNull)
+    }
 
   @JsonRequest("textDocument/rename")
   def rename(
       params: RenameParams
   ): CompletableFuture[WorkspaceEdit] =
-    CancelTokens { _ => renameProvider.rename(params) }
+    CancelTokens.future { token => renameProvider.rename(params, token) }
 
   @JsonRequest("textDocument/references")
   def references(

--- a/tests/slow/src/test/scala/tests/feature/RenameCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/RenameCrossLspSuite.scala
@@ -1,0 +1,24 @@
+package tests.feature
+
+import tests.BaseRenameLspSuite
+import scala.meta.internal.metals.{BuildInfo => V}
+
+class RenameCrossLspSuite extends BaseRenameLspSuite("rename-cross") {
+
+  renamed(
+    "dotty-outer",
+    """|/a/src/main/scala/a/Main.scala
+       |
+       |@main def main() = {
+       |  <<hello>>("Mark")
+       |  <<hello>>("Anne")
+       |}
+       |def <<hel@@lo>>(name : String) : Unit = {
+       |  println(s"Hello $name")
+       |}
+       |""".stripMargin,
+    newName = "greeting",
+    scalaVersion = Some(V.scala3)
+  )
+
+}

--- a/tests/unit/src/main/scala/tests/BaseRenameLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseRenameLspSuite.scala
@@ -1,0 +1,125 @@
+package tests
+
+import munit.TestOptions
+import munit.Location
+import scala.concurrent.Future
+
+class BaseRenameLspSuite(name: String) extends BaseLspSuite(name) {
+
+  def same(
+      name: String,
+      input: String
+  )(implicit loc: Location): Unit =
+    check(
+      name,
+      input,
+      "SHOULD_NOT_BE_RENAMED",
+      notRenamed = true
+    )
+
+  def renamed(
+      name: TestOptions,
+      input: String,
+      newName: String,
+      nonOpened: Set[String] = Set.empty,
+      breakingChange: String => String = identity[String],
+      fileRenames: Map[String, String] = Map.empty,
+      scalaVersion: Option[String] = None
+  )(implicit loc: Location): Unit =
+    check(
+      name,
+      input,
+      newName,
+      notRenamed = false,
+      nonOpened = nonOpened,
+      breakingChange,
+      fileRenames,
+      scalaVersion
+    )
+
+  private def check(
+      name: TestOptions,
+      input: String,
+      newName: String,
+      notRenamed: Boolean = false,
+      nonOpened: Set[String] = Set.empty,
+      breakingChange: String => String = identity[String],
+      fileRenames: Map[String, String] = Map.empty,
+      scalaVersion: Option[String] = None
+  )(implicit loc: Location): Unit = {
+    test(name) {
+      cleanWorkspace()
+      val allMarkersRegex = "(<<|>>|@@|##.*##)"
+      val files = FileLayout.mapFromString(input)
+      val expectedFiles = files.map {
+        case (file, code) =>
+          fileRenames.getOrElse(file, file) -> {
+            val expected = if (!notRenamed) {
+              code
+                .replaceAll("\\<\\<\\S*\\>\\>", newName)
+                .replaceAll("(##|@@)", "")
+            } else {
+              code.replaceAll(allMarkersRegex, "")
+            }
+            "\n" + breakingChange(expected)
+          }
+      }
+
+      val (filename, edit) = files
+        .find(_._2.contains("@@"))
+        .getOrElse {
+          throw new IllegalArgumentException(
+            "No `@@` was defined that specifies cursor position"
+          )
+        }
+
+      val openedFiles = files.keySet.diff(nonOpened)
+      val fullInput = input.replaceAll(allMarkersRegex, "")
+      val actualScalaVersion = scalaVersion.getOrElse(BuildInfo.scalaVersion)
+      for {
+        _ <- server.initialize(
+          s"""/metals.json
+             |{
+             |  "a" : {
+             |    "scalaVersion": "$actualScalaVersion",
+             |    "compilerPlugins": [
+             |      "org.scalamacros:::paradise:2.1.1"
+             |    ],
+             |    "libraryDependencies": [
+             |      "org.scalatest::scalatest:3.0.5",
+             |      "io.circe::circe-generic:0.12.0"
+             |    ]
+             |  },
+             |  "b" : {
+             |    "scalaVersion": "$actualScalaVersion",
+             |    "dependsOn": [ "a" ]
+             |  }
+             |}
+             |$fullInput""".stripMargin
+        )
+        _ <- Future.sequence {
+          openedFiles.map { file => server.didOpen(file) }
+        }
+        // possible breaking changes for testing
+        _ <- Future.sequence {
+          openedFiles.map { file =>
+            server.didSave(file) { code => breakingChange(code) }
+          }
+        }
+        // change the code to make sure edit distance is being used
+        _ <- Future.sequence {
+          openedFiles.map { file =>
+            server.didChange(file) { code => "\n" + code }
+          }
+        }
+        _ <- server.assertRename(
+          filename,
+          edit.replaceAll("(<<|>>|##.*##)", ""),
+          expectedFiles,
+          files.keySet,
+          newName
+        )
+      } yield ()
+    }
+  }
+}

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -1,10 +1,6 @@
 package tests
-import scala.concurrent.Future
-import munit.Location
-import munit.TestOptions
-import scala.meta.internal.metals.{BuildInfo => V}
 
-class RenameLspSuite extends BaseLspSuite("rename") {
+class RenameLspSuite extends BaseRenameLspSuite("rename") {
 
   renamed(
     "basic",
@@ -587,22 +583,6 @@ class RenameLspSuite extends BaseLspSuite("rename") {
     newName = "name"
   )
 
-  renamed(
-    "dotty-outer",
-    """|/a/src/main/scala/a/Main.scala
-       |
-       |@main def main() = {
-       |  <<hello>>("Mark")
-       |  <<hello>>("Anne")
-       |}
-       |def <<hel@@lo>>(name : String) : Unit = {
-       |  println(s"Hello $name")
-       |}
-       |""".stripMargin,
-    newName = "greeting",
-    scalaVersion = Some(V.scala3)
-  )
-
   // tests currently not working correctly due to issues in SemanticDB
   // https://github.com/scalameta/metals/issues/1086 - most likely due to scalameta bug
   renamed(
@@ -632,120 +612,4 @@ class RenameLspSuite extends BaseLspSuite("rename") {
     newName = "Animal"
   )
 
-  def renamed(
-      name: TestOptions,
-      input: String,
-      newName: String,
-      nonOpened: Set[String] = Set.empty,
-      breakingChange: String => String = identity[String],
-      fileRenames: Map[String, String] = Map.empty,
-      scalaVersion: Option[String] = None
-  )(implicit loc: Location): Unit =
-    check(
-      name,
-      input,
-      newName,
-      notRenamed = false,
-      nonOpened = nonOpened,
-      breakingChange,
-      fileRenames,
-      scalaVersion
-    )
-
-  def same(
-      name: String,
-      input: String
-  )(implicit loc: Location): Unit =
-    check(
-      name,
-      input,
-      "SHOULD_NOT_BE_RENAMED",
-      notRenamed = true
-    )
-
-  def check(
-      name: TestOptions,
-      input: String,
-      newName: String,
-      notRenamed: Boolean = false,
-      nonOpened: Set[String] = Set.empty,
-      breakingChange: String => String = identity[String],
-      fileRenames: Map[String, String] = Map.empty,
-      scalaVersion: Option[String] = None
-  )(implicit loc: Location): Unit = {
-    test(name) {
-      cleanWorkspace()
-      val allMarkersRegex = "(<<|>>|@@|##.*##)"
-      val files = FileLayout.mapFromString(input)
-      val expectedFiles = files.map {
-        case (file, code) =>
-          fileRenames.getOrElse(file, file) -> {
-            val expected = if (!notRenamed) {
-              code
-                .replaceAll("\\<\\<\\S*\\>\\>", newName)
-                .replaceAll("(##|@@)", "")
-            } else {
-              code.replaceAll(allMarkersRegex, "")
-            }
-            "\n" + breakingChange(expected)
-          }
-      }
-
-      val (filename, edit) = files
-        .find(_._2.contains("@@"))
-        .getOrElse {
-          throw new IllegalArgumentException(
-            "No `@@` was defined that specifies cursor position"
-          )
-        }
-
-      val openedFiles = files.keySet.diff(nonOpened)
-      val fullInput = input.replaceAll(allMarkersRegex, "")
-      val actualScalaVersion = scalaVersion.getOrElse(BuildInfo.scalaVersion)
-      for {
-        _ <- server.initialize(
-          s"""/metals.json
-             |{
-             |  "a" : {
-             |    "scalaVersion": "$actualScalaVersion",
-             |    "compilerPlugins": [
-             |      "org.scalamacros:::paradise:2.1.1"
-             |    ],
-             |    "libraryDependencies": [
-             |      "org.scalatest::scalatest:3.0.5",
-             |      "io.circe::circe-generic:0.12.0"
-             |    ]
-             |  },
-             |  "b" : {
-             |    "scalaVersion": "$actualScalaVersion",
-             |    "dependsOn": [ "a" ]
-             |  }
-             |}
-             |$fullInput""".stripMargin
-        )
-        _ <- Future.sequence {
-          openedFiles.map { file => server.didOpen(file) }
-        }
-        // possible breaking changes for testing
-        _ <- Future.sequence {
-          openedFiles.map { file =>
-            server.didSave(file) { code => breakingChange(code) }
-          }
-        }
-        // change the code to make sure edit distance is being used
-        _ <- Future.sequence {
-          openedFiles.map { file =>
-            server.didChange(file) { code => "\n" + code }
-          }
-        }
-        _ <- server.assertRename(
-          filename,
-          edit.replaceAll("(<<|>>|##.*##)", ""),
-          expectedFiles,
-          files.keySet,
-          newName
-        )
-      } yield ()
-    }
-  }
 }


### PR DESCRIPTION
Previously, we would use GlobalSymbolIndex, which might not always work for Scala 3 in case of non-parsable code. Now, we use the definitionProvider, which will in turn ask the PresentationCompiler if the definition is missing. For Scala 2 it will still work mostly the same.

The test might fail locally due to issue being fixed https://github.com/scalacenter/bloop/pull/1253, which makes the test fail on even tries :sweat_smile: 