### PR TITLE
Implement textDocument/documentSymbol for Scala 3

### DIFF
--- a/mtags/src/main/scala-3/scala/scala/meta/internal/metals/DocumentSymbolProvider.scala
+++ b/mtags/src/main/scala-3/scala/scala/meta/internal/metals/DocumentSymbolProvider.scala
@@ -1,0 +1,176 @@
+package scala.meta.internal.metals
+
+import java.util
+import org.eclipse.lsp4j.DocumentSymbol
+import org.eclipse.lsp4j.SymbolKind
+import org.eclipse.{lsp4j => l}
+import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.internal.jdk.CollectionConverters._
+import java.net.URI
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.util.SourceFile
+import dotty.tools.dotc.util.SourcePosition
+import dotty.tools.dotc.parsing.Parsers.Parser
+import dotty.tools.dotc.ast.untpd._
+import dotty.tools.dotc.printing.Showable
+import dotty.tools.dotc.core.{Flags => f}
+import java.{util => ju}
+
+/**
+ *  Retrieves all the symbols defined in a document
+ */
+class DocumentSymbolProvider() {
+
+  def documentSymbols()(implicit ctx: Context): util.List[DocumentSymbol] = {
+    val tree = ctx.run.units.head.untpdTree
+    new SymbolTraverser().symbols(tree)
+  }
+
+  class SymbolTraverser extends UntypedTreeTraverser {
+    var owner: DocumentSymbol = new DocumentSymbol(
+      "root",
+      SymbolKind.Namespace,
+      new l.Range(new l.Position(0, 0), new l.Position(0, 0)),
+      new l.Range(new l.Position(0, 0), new l.Position(0, 0)),
+      "",
+      new ju.ArrayList[DocumentSymbol]()
+    )
+    def symbols(
+        tree: Tree
+    )(implicit ctx: Context): ju.List[DocumentSymbol] = {
+      traverse(tree)
+      owner.getChildren
+    }
+
+    def addChild(
+        name: String,
+        kind: SymbolKind,
+        range: SourcePosition,
+        selection: SourcePosition,
+        detail: String
+    ): Unit = {
+      owner.getChildren.add(
+        new DocumentSymbol(
+          name,
+          kind,
+          range.toLSP,
+          selection.toLSP,
+          detail,
+          new ju.ArrayList[DocumentSymbol]()
+        )
+      )
+    }
+    override def traverse(tree: Tree)(implicit ctx: Context): Unit = {
+
+      def continue(withNewOwner: Boolean = false): Unit = {
+        val oldRoot = owner
+        val children = owner.getChildren.asScala
+        val hasChildren = children.nonEmpty
+        if (withNewOwner && hasChildren) owner = children.last
+        super.traverseChildren(tree)
+        owner = oldRoot
+      }
+
+      def newOwner(): Unit = {
+        continue(withNewOwner = true)
+      }
+
+      def show(s: Showable): String =
+        s match {
+          case t: Tree if t.isEmpty => ""
+          case _ => s.show
+        }
+
+      tree match {
+        case t: PackageDef =>
+          addChild(t.pid.show, SymbolKind.Package, t.sourcePos, t.sourcePos, "")
+          newOwner()
+        case n @ New(t: Template) =>
+          // val (name, selection) = (t.constr, t.parents) match {
+          //   case (t, Nil => ("(anonymous)", t.sourcePos)
+          //   case inits =>
+          //     (inits.map(_.tpe.syntax).mkString(" with "), inits.head.pos)
+          // }
+          // if (t.templ.stats.nonEmpty) {
+          //   addChild(s"new $name", SymbolKind.Interface, t.pos, selection, "")
+          //   newOwner()
+          // } else continue()
+          continue() // TODO(gabro)
+        case t: Template =>
+          continue()
+        case t: Block =>
+          if (owner.getName() == "try") {
+            if (owner.getChildren().isEmpty()) {
+              continue()
+            } else {
+              val blockPos = t.stats.head.sourcePos
+              addChild(
+                "finally",
+                SymbolKind.Struct,
+                t.sourcePos,
+                t.sourcePos,
+                ""
+              )
+              newOwner()
+            }
+          } else {
+            continue()
+          }
+        case t: CaseDef =>
+          if (owner.getName() == "try" && owner
+              .getChildren()
+              .asScala
+              .forall(_.getName() != "catch"))
+            addChild("catch", SymbolKind.Struct, t.sourcePos, t.sourcePos, "")
+        case t: Try =>
+          if (t.cases.nonEmpty) {
+            addChild("try", SymbolKind.Struct, t.sourcePos, t.sourcePos, "")
+            newOwner()
+          } else {
+            continue()
+          }
+        case t: TypeDef =>
+          val isClass = t.isClassDef
+          val isTrait = t.mods.flags.is(f.Trait)
+          val isEnum = t.mods.isEnumClass
+          val isEnumCase = t.mods.isEnumCase
+          val kind =
+            if (isClass) SymbolKind.Class
+            else if (isTrait) SymbolKind.Interface
+            else if (isEnum) SymbolKind.Enum
+            else if (isEnumCase) SymbolKind.EnumMember
+            else SymbolKind.TypeParameter
+          addChild(t.name.show, kind, t.sourcePos, t.sourcePos, "")
+          newOwner()
+        case t: ModuleDef =>
+          addChild(t.name.show, SymbolKind.Module, t.sourcePos, t.sourcePos, "")
+          newOwner()
+        case t: DefDef
+            if !t.isEmpty && !t.name.eq(
+              dotty.tools.dotc.core.StdNames.nme.CONSTRUCTOR
+            ) =>
+          addChild(
+            show(t.name),
+            SymbolKind.Method,
+            t.sourcePos,
+            t.sourcePos,
+            show(t.tpt)
+          )
+          newOwner()
+        case t: ValDef if !t.isEmpty =>
+          val isVar = t.mods.hasMod(classOf[Mod.Var])
+          val symbolKind =
+            if (isVar) SymbolKind.Variable else SymbolKind.Constant
+          addChild(
+            show(t.name),
+            symbolKind,
+            t.sourcePos,
+            t.sourcePos,
+            show(t.tpt)
+          )
+          newOwner()
+        case _ =>
+      }
+    }
+  }
+}

--- a/mtags/src/main/scala-3/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -1,3 +1,16 @@
 package scala.meta.internal.mtags
 
-object MtagsEnrichments extends CommonMtagsEnrichments
+import org.eclipse.{lsp4j => l}
+import dotty.tools.dotc.util.SourcePosition
+
+object MtagsEnrichments extends CommonMtagsEnrichments {
+
+  def (pos: SourcePosition).toLSP: l.Range = {
+    new l.Range(
+        new l.Position(pos.startLine, pos.startColumn),
+        new l.Position(pos.endLine, pos.endColumn)
+    )
+  }
+
+}
+


### PR DESCRIPTION
Closes #1636 

This PR implements the `DocumentSymbolProvider` for Scala 3.

A few things to notice:
- we're using the dotty presentation compiler to parse the source. I've tried using the `Parser` directly but I couldn't make positions work for some reason

- that said, using the PC grants us parsing error recovery, so we get an outline even if the buffer parses only partially

- I still think it will make sense to switch back to the Scalameta parser once it's available for Scala 3, since it's way easier to work with in term of syntactic trees

- I haven't tried using the typed trees for this, which may be more convenient (working with symbols instead of trees)

This is still WIP, since it misses a few edge cases and tests.


![2020-04-17 17 48 49](https://user-images.githubusercontent.com/691940/79589011-047e5900-80d5-11ea-93a3-b80bb502fb3a.gif)
