### PR TITLE
Detect Scala 3 main outer methods to create code lenses

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -115,13 +115,14 @@ class MetalsLanguageServer(
   private val symbolDocs = new Docstrings(definitionIndex)
   var buildServer: Option[BuildServerConnection] =
     Option.empty[BuildServerConnection]
-  private val buildTargetClasses = new BuildTargetClasses(() => buildServer)
   private val savedFiles = new ActiveFiles(time)
   private val openedFiles = new ActiveFiles(time)
   private val messages = new Messages(config.icons)
   private val languageClient = new DelegatingLanguageClient(NoopLanguageClient)
   var userConfig: UserConfiguration = UserConfiguration()
   val buildTargets: BuildTargets = new BuildTargets()
+  private val buildTargetClasses =
+    new BuildTargetClasses(() => buildServer, buildTargets)
   private val remote = new RemoteLanguageServer(
     () => workspace,
     () => userConfig,

--- a/tests/slow/src/test/scala/tests/feature/CrossCodeLensLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CrossCodeLensLspSuite.scala
@@ -1,0 +1,18 @@
+package tests.feature
+
+import tests.BaseCodeLensLspSuite
+import scala.meta.internal.metals.{BuildInfo => V}
+
+class CrossCodeLensLspSuite extends BaseCodeLensLspSuite("cross-code-lens") {
+
+  check("main-method-dotty", scalaVersion = Some(V.scala3))(
+    """|package foo
+       |
+       |<<run>><<debug>>
+       |@main def mainMethod(): Unit = {
+       |  println("Hello world!")
+       |}
+       |""".stripMargin
+  )
+
+}

--- a/tests/unit/src/main/scala/tests/BaseCodeLensLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCodeLensLspSuite.scala
@@ -1,0 +1,74 @@
+package tests
+
+import munit.TestOptions
+import munit.Location
+import scala.concurrent.Future
+
+class BaseCodeLensLspSuite(name: String) extends BaseLspSuite(name) {
+
+  def check(
+      name: TestOptions,
+      library: Option[String] = None,
+      scalaVersion: Option[String] = None
+  )(
+      expected: String
+  )(implicit loc: Location): Unit = {
+    test(name) {
+      cleanWorkspace()
+      val original = expected.replaceAll("<<.*>>[^a-zA-Z0-9@]+", "")
+
+      val actualScalaVersion = scalaVersion.getOrElse(BuildInfo.scalaVersion)
+      val sourceFile = {
+        val file = """package (.*).*""".r
+          .findFirstMatchIn(original)
+          .map(_.group(1))
+          .map(packageName => packageName.replaceAll("\\.", "/"))
+          .map(packageDir => s"$packageDir/Foo.scala")
+          .getOrElse("Foo.scala")
+
+        s"a/src/main/scala/$file"
+      }
+
+      val libraryString = library.map(s => s""" "$s" """).getOrElse("")
+      for {
+        _ <- server.initialize(
+          s"""|/metals.json
+              |{
+              |  "a": { 
+              |    "libraryDependencies" : [ $libraryString ],
+              |    "scalaVersion": "$actualScalaVersion"
+              |  }
+              |}
+              |
+              |/$sourceFile
+              |$original
+              |""".stripMargin
+        )
+        _ <- assertCodeLenses(sourceFile, expected)
+      } yield ()
+    }
+  }
+
+  protected def assertCodeLenses(
+      relativeFile: String,
+      expected: String,
+      maxRetries: Int = 4
+  )(implicit loc: Location): Future[Unit] = {
+    val obtained = server.codeLenses(relativeFile)(maxRetries).recover {
+      case _: NoSuchElementException =>
+        server.textContents(relativeFile)
+    }
+
+    obtained.map(assertNoDiff(_, expected))
+  }
+
+  protected def assertNoCodeLenses(
+      relativeFile: String,
+      maxRetries: Int = 4
+  ): Future[Unit] = {
+    server.codeLenses(relativeFile)(maxRetries).failed.flatMap {
+      case _: NoSuchElementException => Future.unit
+      case e => Future.failed(e)
+    }
+  }
+}


### PR DESCRIPTION
Previously, code lenses were only available on classes, now we also show them for main methods.

I am wondering if this should actually be generated differently in Dotty.

@bishabosha Main methods symbol is now shown as `foo/Foo$package.main().` while this is not something that can actually be run. I propose a bit of a hack here to generate a potential main method symbol. I am not sure if that is the right solution though. How is it being done in Dotty itself? Should we generate a different symbol for semanticDB if it's a main method?