### PR TITLE
Dynamically read fastpass zipkin properties from fastpass/fastpass.properties

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/BloopGlobalSettings.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/BloopGlobalSettings.scala
@@ -5,11 +5,12 @@ import scala.util.control.NonFatal
 import ujson.Obj
 import java.nio.file.Paths
 import java.nio.file.Path
+import scala.meta.internal.zipkin.Property
 import scala.meta.internal.zipkin.ZipkinProperties
 import ujson.Str
 
 object BloopGlobalSettings {
-  def update(newHome: Option[Path]): Boolean = {
+  def update(workspace: AbsolutePath, newHome: Option[Path]): Boolean = {
     import scala.meta.internal.metals.MetalsEnrichments._
     val homedir = AbsolutePath(System.getProperty("user.home"))
     val file = homedir.resolve(".bloop").resolve("bloop.json")
@@ -25,8 +26,9 @@ object BloopGlobalSettings {
         .map(_.arr.map(_.str).toList)
         .getOrElse(Nil)
 
+      val properties = Property.fromFile(workspace)
       val newOptions: List[String] = ZipkinProperties.All.foldLeft(oldOptions) {
-        (options, prop) => prop.updateOptions(options)
+        (options, prop) => prop.updateOptions(properties)(options)
       }
       val isHomeChanged = newHome.isDefined && newHome != oldHome
       val isOptionsChanged = newOptions != oldOptions

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/SharedCommand.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/SharedCommand.scala
@@ -74,7 +74,7 @@ object SharedCommand {
           )
           symlinkProjectViewRoots(export.project)
           if (export.export.canBloopExit) {
-            restartBloopIfNewSettings()
+            restartBloopIfNewSettings(AbsolutePath(workspace))
           }
           if (export.open.isEmpty) {
             OpenCommand.onEmpty(export.project, export.app)
@@ -89,9 +89,9 @@ object SharedCommand {
     }
   }
 
-  def restartBloopIfNewSettings(): Unit = {
+  def restartBloopIfNewSettings(workspace: AbsolutePath): Unit = {
     val isUpdatedBloopSettings =
-      BloopGlobalSettings.update(JdkSources.defaultJavaHomePath)
+      BloopGlobalSettings.update(workspace, JdkSources.defaultJavaHomePath)
     if (isUpdatedBloopSettings) {
       restartBloopServer()
     } else {


### PR DESCRIPTION
Previously, properties could only be read statically, as that was necessary for linking the properties statically during native-image build. 
This change will allow users to set a `fastpass/fastpass.properties` file in the root of their workspace to pass along zipkin properties for Bloop. It's meant to solve the problem posed by running `fastpass` via `coursier` as in: https://github.com/pantsbuild/intellij-pants-plugin/pull/516