### PR TITLE
Remove optimisation to reuse semanticdb jar from the classpath

### DIFF
--- a/tests/slow/src/test/scala/tests/feature/FoldingCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/FoldingCrossLspSuite.scala
@@ -1,0 +1,43 @@
+package tests.feature
+
+import tests.BaseLspSuite
+import scala.meta.internal.metals.{BuildInfo => V}
+
+class FoldingCrossLspSuite extends BaseLspSuite("foldingRange-cross") {
+
+  test("base-213") {
+    for {
+      _ <- server.initialize(
+        s"""|
+            |/metals.json
+            |{
+            |  "a": { "scalaVersion" : "${V.scala213}" }
+            |}
+            |/a/src/main/scala/a/Main.scala
+            |object Main {
+            |  def foo = {
+            |    ???
+            |    ???
+            |    ???
+            |  }
+            |
+            |  val justAPadding = ???
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      _ <- server.assertFolded(
+        "a/src/main/scala/a/Main.scala",
+        """object Main >>region>>{
+          |  def foo = >>region>>{
+          |    ???
+          |    ???
+          |    ???
+          |  }<<region<<
+          |
+          |  val justAPadding = ???
+          |}<<region<<""".stripMargin
+      )
+    } yield ()
+  }
+}

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -558,6 +558,14 @@ final class TestingServer(
     } yield TextEdits.applyEdits(textContents(filename), textEdits)
   }
 
+  def assertFolded(filename: String, expected: String)(
+      implicit loc: munit.Location
+  ): Future[Unit] =
+    for {
+      folded <- foldingRange(filename)
+      _ = Assertions.assertNoDiff(folded, expected)
+    } yield ()
+
   def onTypeFormatting(
       filename: String,
       query: String,

--- a/tests/unit/src/test/scala/tests/FoldingRangeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/FoldingRangeLspSuite.scala
@@ -1,8 +1,5 @@
 package tests
 
-import scala.concurrent.Future
-import munit.Location
-
 class FoldingRangeLspSuite extends BaseLspSuite("foldingRange") {
   test("parse-error") {
     for {
@@ -25,7 +22,7 @@ class FoldingRangeLspSuite extends BaseLspSuite("foldingRange") {
            |""".stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/a/Main.scala")
-      _ <- assertFolded(
+      _ <- server.assertFolded(
         "a/src/main/scala/a/Main.scala",
         """object Main >>region>>{
           |  def foo = >>region>>{
@@ -40,7 +37,7 @@ class FoldingRangeLspSuite extends BaseLspSuite("foldingRange") {
       _ <- server.didChange("a/src/main/scala/a/Main.scala") { text =>
         "__" + "\n\n" + text
       }
-      _ <- assertFolded(
+      _ <- server.assertFolded(
         "a/src/main/scala/a/Main.scala",
         """__
           |
@@ -56,12 +53,4 @@ class FoldingRangeLspSuite extends BaseLspSuite("foldingRange") {
       )
     } yield ()
   }
-
-  private def assertFolded(filename: String, expected: String)(
-      implicit loc: Location
-  ): Future[Unit] =
-    for {
-      folded <- server.foldingRange(filename)
-      _ = assertNoDiff(folded, expected)
-    } yield ()
 }


### PR DESCRIPTION
Previously, we would only download mtags module and reuse the semanticDB jars on the classpath, but that can cause other libraries not be fetched and cause unpredictable or easy to miss runtime issues.

Now, we fetch all the transitive dependencies of mtags.

Fixes https://github.com/scalameta/metals/issues/1647