### PR TITLE
Make sure that the workspace contains no errors when running 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClassesFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClassesFinder.scala
@@ -89,7 +89,7 @@ class BuildTargetClassesFinder(
 
 }
 
-class BuildTargetNotFoundException(buildTargetName: String)
+case class BuildTargetNotFoundException(buildTargetName: String)
     extends Exception(s"Build target not found: $buildTargetName")
 
 case class ClassNotFoundInBuildTargetException(

--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -52,6 +52,14 @@ final class ForwardingMetalsBuildClient(
   val updatedTreeViews: ju.Set[BuildTargetIdentifier] =
     ConcurrentHashSet.empty[BuildTargetIdentifier]
 
+  def buildHasErrors(buildTargetId: BuildTargetIdentifier): Boolean = {
+    buildTargets
+      .buildTargetTransitiveDependencies(buildTargetId)
+      .exists(hasReportedError.contains(_))
+  }
+
+  override def buildHasErrors: Boolean = !hasReportedError.isEmpty()
+
   def reset(): Unit = {
     cancel()
     updatedTreeViews.clear()

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -319,6 +319,38 @@ class Messages(icons: Icons) {
     }
   }
 
+  val DebugErrorsPresent: MetalsStatusParams = new MetalsStatusParams(
+    "$(error) Errors in workspace",
+    tooltip = "Cannot run or debug due to existing errors in the workspace. " +
+      "Please fix the errors and retry.",
+    command = ClientCommands.FocusDiagnostics.id,
+    show = true
+  )
+
+  object DebugClassNotFound {
+
+    def invalidTargetClass(cls: String, target: String): MessageParams = {
+      new MessageParams(
+        MessageType.Error,
+        s"Class '$cls' not found in build target '$target'."
+      )
+    }
+
+    def invalidTarget(target: String): MessageParams = {
+      new MessageParams(
+        MessageType.Error,
+        s"Target '$target' not found."
+      )
+    }
+
+    def invalidClass(cls: String): MessageParams = {
+      new MessageParams(
+        MessageType.Error,
+        s"Class '$cls' not found."
+      )
+    }
+  }
+
   object MissingScalafmtConf {
     def tryAgain(isAgain: Boolean): String =
       if (isAgain) ", try formatting again"

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsBuildClient.scala
@@ -32,4 +32,7 @@ trait MetalsBuildClient {
 
   def ongoingCompilations(): TreeViewCompilations
 
+  def buildHasErrors(buildTargetId: b.BuildTargetIdentifier): Boolean
+
+  def buildHasErrors: Boolean
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -370,7 +370,10 @@ class MetalsLanguageServer(
       buildTargets,
       buildTargetClasses,
       compilations,
-      languageClient
+      languageClient,
+      buildClient,
+      messages,
+      statusBar
     )
     referencesProvider = new ReferenceProvider(
       workspace,


### PR DESCRIPTION
Previously, run/debug would hang if run in a broken workspace. Now, we display all issue about why we weren't able and make sure that we only allow run on a clean workspace.

Fixes https://github.com/scalameta/metals/issues/1641

When running in a workspace with errors:

![debug-error1](https://user-images.githubusercontent.com/3807253/80094273-43456080-8566-11ea-9f9e-9e8d8de55f37.gif)

When running non existing class:

![debug-class-not-found](https://user-images.githubusercontent.com/3807253/80094335-59532100-8566-11ea-8ca7-d0e1bef7b880.gif)

When running non exiting target:

![debug-target-not-found](https://user-images.githubusercontent.com/3807253/80094366-68d26a00-8566-11ea-9891-f7486fdc7eee.gif)

When running class not in a target, but the target was defined:

![debug-class-in-target](https://user-images.githubusercontent.com/3807253/80094400-7ab40d00-8566-11ea-9a13-606cf81ed002.gif)
