### PR TITLE
Turn off go to parent code lenses by default

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -33,7 +33,7 @@ case class UserConfiguration(
     bloopSbtAlreadyInstalled: Boolean = false,
     bloopVersion: Option[String] = None,
     pantsTargets: Option[List[String]] = None,
-    superMethodLensesEnabled: Boolean = true,
+    superMethodLensesEnabled: Boolean = false,
     remoteLanguageServer: Option[String] = None
 ) {
 
@@ -133,7 +133,7 @@ object UserConfiguration {
     ),
     UserConfigurationOption(
       "super-method-lenses-enabled",
-      "true",
+      "false",
       "false",
       "Should display lenses with links to super methods",
       """|Super method lenses are visible above methods definition that override another methods. Clicking on a lens jumps to super method definition.
@@ -267,7 +267,7 @@ object UserConfiguration {
     val bloopVersion =
       getStringKey("bloop-version")
     val superMethodLensesEnabled =
-      getBooleanKey("super-method-lenses-enabled").getOrElse(true)
+      getBooleanKey("super-method-lenses-enabled").getOrElse(false)
     val remoteLanguageServer =
       getStringKey("remote-language-server")
     if (errors.isEmpty) {

--- a/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
@@ -1,6 +1,12 @@
 package tests
 
+import scala.meta.internal.metals.UserConfiguration
+
 class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(superMethodLensesEnabled = true)
+
   check("empty-package")(
     """|<<run>><<debug>>
        |object Main {


### PR DESCRIPTION
Turning them off until we can get the situation under control.