### PR TITLE
Reworked Bloop connection and Tree View

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -72,6 +72,8 @@ final class BuildTargets() {
   def scalacOptions: Iterable[ScalacOptionsItem] =
     scalacTargetInfo.values
 
+  def allBuildTargetIds: Seq[BuildTargetIdentifier] =
+    all.toSeq.map(_.info.getId())
   def all: Iterator[ScalaTarget] =
     for {
       (id, target) <- buildTargetInfo.iterator

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -78,7 +78,7 @@ final class DefinitionProvider(
       if (result.isEmpty) {
         compilers().definition(params, token)
       } else {
-        if (result.isEmpty && fromSemanticdb.isEmpty) {
+        if (fromSemanticdb.isEmpty) {
           warnings.noSemanticdb(path)
         }
         Future.successful(result)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -66,6 +66,10 @@ final case class MetalsServerConfig(
       "bloop.embedded.version",
       BuildInfo.bloopVersion
     ),
+    askToReconnect: Boolean = MetalsServerConfig.binaryOption(
+      "metals.ask-to-reconnect",
+      default = false
+    ),
     icons: Icons = Icons.default,
     statistics: StatisticsConfig = StatisticsConfig.default,
     compilers: PresentationCompilerConfigImpl = CompilersConfig()
@@ -81,6 +85,7 @@ final case class MetalsServerConfig(
       s"compilers=$compilers",
       s"http=$isHttpEnabled",
       s"input-box=$isInputBoxEnabled",
+      s"ask-to-reconnect=$askToReconnect",
       s"icons=$icons",
       s"statistics=$statistics",
       s"doctor-format=$doctorFormat"

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -37,7 +37,7 @@ object ServerCommands {
 
   val RestartBuildServer = new Command(
     "build-restart",
-    "Restart the build server",
+    "Restart build server",
     """Unconditionally stop the current running Bloop server and start a new one using Bloop launcher"""
   )
 
@@ -73,6 +73,16 @@ object ServerCommands {
        |Run the cascade compile task to additionally compile the inverse dependencies of the current build target.
        |For example, if you change the API in main sources and run cascade compile then it will also compile the
        |test sources that depend on main.
+       |""".stripMargin
+  )
+
+  val CleanCompile = new Command(
+    "compile-clean",
+    "Clean compile workspace",
+    """|Recompile all build targets in this workspace.
+       |
+       |By default, Metals compiles the files incrementally. In case of any compile artifacts corruption 
+       |this command might be run to make sure everything is recompiled correctly.
        |""".stripMargin
   )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -245,7 +245,7 @@ class DebugProvider(
           result <- Future.fromTry(f())
         } yield result
       case _: ClassNotFoundException =>
-        val allTargets = buildTargets.all.toSeq.map(_.info.getId())
+        val allTargets = buildTargets.allBuildTargetIds
         for {
           _ <- compilations.compileTargets(allTargets)
           _ <- buildTargetClasses.rebuildIndex(allTargets)

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -36,7 +36,7 @@ class MetalsTreeViewProvider(
   )
   val libraries = new ClasspathTreeView[AbsolutePath, AbsolutePath](
     definitionIndex,
-    Build,
+    Project,
     "libraries",
     "Libraries",
     identity,
@@ -47,9 +47,10 @@ class MetalsTreeViewProvider(
     () => buildTargets.allWorkspaceJars,
     (path, symbol) => classpath.symbols(path, symbol)
   )
+
   val projects = new ClasspathTreeView[ScalaTarget, BuildTargetIdentifier](
     definitionIndex,
-    Build,
+    Project,
     "projects",
     "Projects",
     _.id,
@@ -75,18 +76,9 @@ class MetalsTreeViewProvider(
     languageClient.metalsTreeViewDidChange(
       TreeViewDidChangeParams(
         Array(
-          TreeViewNode(
-            Build,
-            null,
-            null,
-            null
-          ),
-          TreeViewNode(
-            Compile,
-            null,
-            null,
-            null
-          )
+          TreeViewNode.empty(Project),
+          TreeViewNode.empty(Build),
+          TreeViewNode.empty(Compile)
         )
       )
     )
@@ -100,7 +92,7 @@ class MetalsTreeViewProvider(
     val toUpdate = pendingProjectUpdates.asScala.iterator
       .filter { id =>
         !isCollapsed.getOrElse(id, true) &&
-        isVisible(Build)
+        isVisible(Project)
       }
       .flatMap(buildTargets.scalaTarget)
       .toArray
@@ -152,7 +144,7 @@ class MetalsTreeViewProvider(
             1,
             TimeUnit.SECONDS
           )
-        case Build =>
+        case Project =>
           flushPendingProjectUpdates()
         case _ =>
       }
@@ -166,7 +158,7 @@ class MetalsTreeViewProvider(
   ): TreeViewParentResult = {
     TreeViewParentResult(
       params.viewId match {
-        case Build =>
+        case Project =>
           val uri = params.nodeUri
           if (libraries.matches(uri)) {
             libraries.parent(uri).orNull
@@ -211,12 +203,10 @@ class MetalsTreeViewProvider(
           echoCommand(ServerCommands.BloopGithub, "github"),
           echoCommand(ServerCommands.ScalametaTwitter, "twitter")
         )
-      case Build =>
+      case Project =>
         Option(params.nodeUri) match {
           case None =>
             Array(
-              TreeViewNode.fromCommand(ServerCommands.ImportBuild),
-              TreeViewNode.fromCommand(ServerCommands.ConnectBuildServer),
               projects.root,
               libraries.root
             )
@@ -229,14 +219,27 @@ class MetalsTreeViewProvider(
               Array.empty
             }
         }
-      case Compile =>
+      case Build =>
         Option(params.nodeUri) match {
           case None =>
             Array(
-              TreeViewNode.fromCommand(ServerCommands.CascadeCompile),
-              TreeViewNode.fromCommand(ServerCommands.CancelCompile),
-              ongoingCompilationNode
+              TreeViewNode.fromCommand(ServerCommands.ImportBuild, "sync"),
+              TreeViewNode
+                .fromCommand(ServerCommands.ConnectBuildServer, "connect"),
+              TreeViewNode
+                .fromCommand(ServerCommands.CascadeCompile, "cascade"),
+              TreeViewNode.fromCommand(ServerCommands.CancelCompile, "cancel"),
+              TreeViewNode.fromCommand(ServerCommands.CleanCompile, "clean"),
+              TreeViewNode
+                .fromCommand(ServerCommands.RestartBuildServer, "debug-stop")
             )
+          case _ =>
+            Array()
+        }
+      case Compile =>
+        Option(params.nodeUri) match {
+          case None =>
+            ongoingCompilations
           case Some(uri) =>
             if (uri == ongoingCompilationNode.nodeUri) {
               ongoingCompilations
@@ -279,9 +282,9 @@ class MetalsTreeViewProvider(
       result.map { uriChain =>
         uriChain.foreach { uri =>
           // Cache results
-          children(TreeViewChildrenParams(Build, uri))
+          children(TreeViewChildrenParams(Project, uri))
         }
-        TreeViewNodeRevealResult(Build, uriChain.toArray)
+        TreeViewNodeRevealResult(Project, uriChain.toArray)
       }
     }
   }
@@ -299,18 +302,16 @@ class MetalsTreeViewProvider(
     } yield TreeViewNode(
       Compile,
       id.getUri,
-      s"${info.getDisplayName()} - ${compilation.timer.toStringSeconds} (${compilation.progressPercentage}%)"
+      s"${info.getDisplayName()} - ${compilation.timer.toStringSeconds} (${compilation.progressPercentage}%)",
+      icon = "compile"
     )
   }
 
   private def ongoingCompilationNode: TreeViewNode = {
-    val size = compilations().size
-    val counter = if (size > 0) s" ($size)" else ""
     TreeViewNode(
       Compile,
-      "metals://ongoing-compilations",
-      s"Ongoing compilations$counter",
-      collapseState = MetalsTreeItemCollapseState.collapsed
+      null,
+      Compile
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/tvp/TreeViewNode.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/TreeViewNode.scala
@@ -24,20 +24,24 @@ case class TreeViewNode(
 }
 
 object TreeViewNode {
-  def fromCommand(command: Command): TreeViewNode =
+  def fromCommand(
+      command: Command,
+      icon: String = TreeViewNode.command
+  ): TreeViewNode =
     TreeViewNode(
       viewId = "commands",
       nodeUri = s"metals://command/${command.id}",
       label = command.title,
       command = MetalsCommand(
         command.title,
-        command.id,
+        "metals." + command.id,
         command.description
       ),
       tooltip = command.description,
-      icon = TreeViewNode.command
+      icon = icon
     )
-  def command: String = "command"
+  def command: String = "debug-start"
+  def empty(viewId: String): TreeViewNode = TreeViewNode(viewId, null, viewId)
   def sortAlphabetically(
       result: Array[TreeViewNode],
       custom: (TreeViewNode, TreeViewNode) => Int = (_, _) => 0

--- a/metals/src/main/scala/scala/meta/internal/tvp/TreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/TreeViewProvider.scala
@@ -5,9 +5,10 @@ import scala.meta.io.AbsolutePath
 import org.eclipse.{lsp4j => l}
 
 trait TreeViewProvider {
+  val Project = TreeViewProvider.Project
   val Build = TreeViewProvider.Build
-  val Compile = TreeViewProvider.Compile
   val Help = TreeViewProvider.Help
+  val Compile = TreeViewProvider.Compile
   def init(): Unit = ()
   def reset(): Unit = ()
   def children(
@@ -32,6 +33,7 @@ trait TreeViewProvider {
 }
 
 object TreeViewProvider {
+  val Project = "metalsPackages"
   val Build = "metalsBuild"
   val Compile = "metalsCompile"
   val Help = "metalsHelp"

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1273,7 +1273,7 @@ final class TestingServer(
       uri: String,
       expected: String
   )(implicit loc: munit.Location): Unit = {
-    val viewId: String = TreeViewProvider.Build
+    val viewId: String = TreeViewProvider.Project
     val result =
       server.treeView.children(TreeViewChildrenParams(viewId, uri)).nodes
     val obtained = result

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -80,7 +80,8 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
                                |""".stripMargin)
       _ = assertNoDiff(
         client.workspaceTreeViewChanges,
-        s"""|${TreeViewProvider.Build} <root>
+        s"""|${TreeViewProvider.Project} <root>
+            |${TreeViewProvider.Build} <root>
             |${TreeViewProvider.Compile} <root>
             |""".stripMargin
       )
@@ -196,8 +197,6 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
             }
           ),
           s"""|root
-              |  Import build command
-              |  Connect to build server command
               |  Projects (0)
               |  Libraries (${expectedLibrariesCount})
               |  Libraries (${expectedLibrariesCount})
@@ -251,8 +250,6 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
             }
           ),
           s"""|root
-              |  Import build command
-              |  Connect to build server command
               |  Projects (0)
               |  Libraries (${expectedLibrariesCount})
               |  Libraries (${expectedLibrariesCount})


### PR DESCRIPTION
Previously, we would only reconnect if the user asked for it and often this would not show up quickly.
Now, we make the reconnection work better by:
- reconnecting as soon as the build server is disconnected (fixes https://github.com/scalameta/metals/issues/1354)
- making reconnection automatic unless the user specifically asks for it not to be via system property `metals.ask-to-reconnect=true`
- moving compilation outside the initial build server connection - longer running compilations would then produce invalid exceptions and break the next connection
- reindexing and compiling the workspace on reconnection (this is needed since workspaces would not have all the classpath updated)

Also in this PR:
-  a new clean-compile command was introduced, which together with the restart bloop command was added to tree view
- tree view now has 4 parts - one for help, one for project view, one for commands and one for running compilations

The reworked tree view would look like this:

![image](https://user-images.githubusercontent.com/3807253/80972250-30f8db80-8e1e-11ea-847b-b74ebc0ba0c3.png)


I am also thinking of:
- adding icons to compiling projects, I've seen it break in some cases
- partly reindexing the workspace - not sure if that is sensible since Bloop has a different directory for each client and when reconnecting we are effectively a different client