### PR TITLE
Add Bloop zipkin trace debug and verbose settings

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/zipkin/ZipkinProperties.scala
+++ b/metals/src/main/scala/scala/meta/internal/zipkin/ZipkinProperties.scala
@@ -4,6 +4,10 @@ object ZipkinProperties {
 
   val zipkinServerUrl: Property = Property("metals.zipkin.server.url")
 
+  val debug: Property = Property("metals.bloop.trace.debug")
+
+  val verbose: Property = Property("metals.bloop.trace.verbose")
+
   val localServiceName: Property = Property(
     "metals.bloop.trace.localServiceName"
   )
@@ -18,6 +22,8 @@ object ZipkinProperties {
 
   val All: List[Property] = List(
     zipkinServerUrl,
+    debug,
+    verbose,
     localServiceName,
     traceStartAnnotation,
     traceEndAnnotation


### PR DESCRIPTION
This change allows fastpass to configure additional Bloop Zipkin properties, specifically with trace verbosity and setting the `debug` sampling flag. 