### PR TITLE
Improve code lens generation time

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -93,7 +93,7 @@ final class ImplementationProvider(
       textDocument: TextDocument
   ): String => Option[SymbolInformation] = {
     lazy val global =
-      new GlobalClassTable(buildTargets).globalSymbolTableFor(anyWorkspacePath)
+      globalTable.globalSymbolTableFor(anyWorkspacePath)
     val textSymbolsMap = textDocument.symbols.map(s => s.symbol -> s).toMap
     val memoized: mutable.Map[String, SymbolInformation] = mutable.Map.empty
     symbol => {
@@ -112,7 +112,7 @@ final class ImplementationProvider(
       textDocument: TextDocument
   ): String => Option[SymbolInformation] = {
     lazy val global =
-      new GlobalClassTable(buildTargets).globalSymbolTableFor(anyWorkspacePath)
+      globalTable.globalSymbolTableFor(anyWorkspacePath)
     symbol => {
       textDocument.symbols
         .find(_.symbol == symbol)

--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -97,7 +97,8 @@ final class ImplementationProvider(
     val textSymbolsMap = textDocument.symbols.map(s => s.symbol -> s).toMap
     val memoized: mutable.Map[String, SymbolInformation] = mutable.Map.empty
     symbol => {
-      val result = memoized.get(symbol)
+      val result = memoized
+        .get(symbol)
         .orElse(textSymbolsMap.get(symbol))
         .orElse(findSymbolInformation(symbol))
         .orElse(global.flatMap(_.safeInfo(symbol)))
@@ -113,7 +114,8 @@ final class ImplementationProvider(
     lazy val global =
       new GlobalClassTable(buildTargets).globalSymbolTableFor(anyWorkspacePath)
     symbol => {
-      textDocument.symbols.find(_.symbol == symbol)
+      textDocument.symbols
+        .find(_.symbol == symbol)
         .orElse(findSymbolInformation(symbol))
         .orElse(global.flatMap(_.safeInfo(symbol)))
     }

--- a/metals/src/main/scala/scala/meta/internal/implementation/SuperMethodProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/SuperMethodProvider.scala
@@ -197,7 +197,7 @@ object SuperMethodProvider {
         documentWithPath.textDocument,
         findSymbol
       )
-    val methodName = msi.symbol.desc.name.value
+    val methodName = msi.displayName
     val result = for {
       classSymbolInformation <- classSymbolInformationOption.toIterable
       bottomClassSig = classSymbolInformation.signature

--- a/metals/src/main/scala/scala/meta/internal/implementation/SuperMethodProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/SuperMethodProvider.scala
@@ -197,6 +197,7 @@ object SuperMethodProvider {
         documentWithPath.textDocument,
         findSymbol
       )
+    val methodName = msi.symbol.desc.name.value
     val result = for {
       classSymbolInformation <- classSymbolInformationOption.toIterable
       bottomClassSig = classSymbolInformation.signature
@@ -210,6 +211,7 @@ object SuperMethodProvider {
         case cs: ClassSignature => cs
       }
       methodSymbolLink <- classSig.getDeclarations.symlinks
+      if msi.isLocal || methodSymbolLink.contains(methodName)
       mSymbolInformation <- findSymbol(methodSymbolLink).toIterable
       methodSignature <- Option(mSymbolInformation.signature).collect {
         case m: MethodSignature => m

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1189,8 +1189,8 @@ class MetalsLanguageServer(
   ): CompletableFuture[util.List[CodeLens]] =
     CancelTokens { _ =>
       timedThunk("code lens generation", thresholdMillis = 1.second.toMillis) {
-      val path = params.getTextDocument.getUri.toAbsolutePath
-      codeLensProvider.findLenses(path).toList.asJava
+        val path = params.getTextDocument.getUri.toAbsolutePath
+        codeLensProvider.findLenses(path).toList.asJava
       }
     }
 
@@ -1643,7 +1643,11 @@ class MetalsLanguageServer(
     }
   }
 
-  def timedThunk[T](didWhat: String, onlyIf: Boolean = true, thresholdMillis: Long = 0)(thunk: => T): T = {
+  def timedThunk[T](
+      didWhat: String,
+      onlyIf: Boolean = true,
+      thresholdMillis: Long = 0
+  )(thunk: => T): T = {
     val elapsed = new Timer(time)
     val result = thunk
     if (onlyIf && (thresholdMillis == 0 || elapsed.elapsedMillis > thresholdMillis)) {

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
@@ -33,7 +33,8 @@ final class SuperMethodCodeLens(
     val path = textDocumentWithPath.filePath
 
     val search = implementationProvider.defaultSymbolSearchMemoize(
-      path, textDocument
+      path,
+      textDocument
     )
     val distance = buffers.tokenEditDistance(path, textDocument.text)
 

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
@@ -32,8 +32,8 @@ final class SuperMethodCodeLens(
     val textDocument = textDocumentWithPath.textDocument
     val path = textDocumentWithPath.filePath
 
-    val search = implementationProvider.defaultSymbolSearch(
-      textDocumentWithPath
+    val search = implementationProvider.defaultSymbolSearchMemoize(
+      path, textDocument
     )
     val distance = buffers.tokenEditDistance(path, textDocument.text)
 


### PR DESCRIPTION
Currently when we search for a symbol definition we firstly check if it exists in current document.
We do that by going one by one and comparing. It is okay for single pass, but checking multiple symbols is very inefficient. This converts list of symbols to a map [symbol -> symbolinformation].

When we found parent class for given method we fetched each method of parent class and checked if it is super method. We compared method 'f' to X#aaa(), X#bbb(), X#f(), but it is easy to see don't need to fetch methods and compare types if names don't match.

Added a map to memoize SymbolInformation for single request. I will verify how much it actually helps but wanted to get your opinion what you think.

Added logging if lenses generation takes longer than 1s.