### PR TITLE
Improve rendering of Pants command errors.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -156,7 +156,7 @@ object BloopPants {
       s"--export-dep-as-jar-output-file=$outputFile",
       s"export-dep-as-jar"
     ) ++ args.targets
-    val shortName = "pants export-classpath export"
+    val shortName = "pants export-dep-as-jar"
     val bloopSymlink = args.workspace.resolve(".bloop")
     val bloopSymlinkTarget =
       if (Files.isSymbolicLink(bloopSymlink)) {

--- a/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
+++ b/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.process
 import java.nio.file.Path
 import scala.meta.internal.metals.Timer
 import scala.meta.internal.metals.Time
+import scala.meta.internal.pantsbuild.MessageOnlyException
 import scala.concurrent.ExecutionContext
 import scala.meta.pc.CancelToken
 import scala.sys.process._
@@ -19,10 +20,9 @@ object SystemProcess {
     scribe.info(args.mkString("process: ", " ", ""))
     val exit = Process(args, cwd = Some(cwd.toFile())).!
     if (exit != 0) {
-      val message =
-        s"command failed with exit code $exit: ${reproduceArgs.mkString(" ")}"
-      scribe.error(message)
-      sys.error(message)
+      val message = s"$shortName command failed with exit code $exit, " +
+        s"to reproduce run the command below:\n\t${reproduceArgs.mkString(" ")}"
+      throw MessageOnlyException(message)
     } else {
       scribe.info(s"time: ran '$shortName' in $exportTimer")
     }


### PR DESCRIPTION
Previously, fastpass printed a large non-helpful stacktrace when the
Pants export-dep-as-jar command failed (which happens frequently). Now,
fastpass prints a more readable message without a stacktrace
making it easier to find the Pants error message.