### PR TITLE
Move additional settings to InitializationOptions

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -55,7 +55,8 @@ class ClientConfiguration(
       experimentalCapabilities.quickPickProvider
 
   def isOpenFilesOnRenameProvider(): Boolean =
-    experimentalCapabilities.openFilesOnRenameProvider ||
+    initializationOptions.openFilesOnRenameProvider ||
+      experimentalCapabilities.openFilesOnRenameProvider ||
       initialConfig.openFilesOnRenames
 
   def doctorFormatIsJson(): Boolean =
@@ -76,13 +77,16 @@ class ClientConfiguration(
       initialConfig.compilers.isCompletionItemResolve
 
   def isDebuggingProvider(): Boolean =
-    experimentalCapabilities.debuggingProvider
+    initializationOptions.debuggingProvider ||
+      experimentalCapabilities.debuggingProvider
 
   def isDecorationProvider(): Boolean =
-    experimentalCapabilities.decorationProvider
+    initializationOptions.decorationProvider ||
+      experimentalCapabilities.decorationProvider
 
   def isTreeViewProvider(): Boolean =
-    experimentalCapabilities.treeViewProvider
+    initializationOptions.treeViewProvider ||
+      experimentalCapabilities.treeViewProvider
 
   def isDidFocusProvider(): Boolean =
     initializationOptions.didFocusProvider ||

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -6,28 +6,36 @@ import com.google.gson.JsonNull
 
 final case class InitializationOptions(
     compilerOptions: CompilerInitializationOptions,
+    debuggingProvider: Boolean,
+    decorationProvider: Boolean,
     didFocusProvider: Boolean,
     doctorProvider: String,
     executeClientCommandProvider: Boolean,
     inputBoxProvider: Boolean,
     isExitOnShutdown: Boolean,
     isHttpEnabled: Boolean,
+    openFilesOnRenameProvider: Boolean,
     quickPickProvider: Boolean,
     slowTaskProvider: Boolean,
-    statusBarProvider: String
+    statusBarProvider: String,
+    treeViewProvider: Boolean
 ) {
   def this() =
     this(
       compilerOptions = new CompilerInitializationOptions(),
+      debuggingProvider = false,
+      decorationProvider = false,
       didFocusProvider = false,
       doctorProvider = "html",
       executeClientCommandProvider = false,
       inputBoxProvider = false,
       isExitOnShutdown = false,
       isHttpEnabled = false,
+      openFilesOnRenameProvider = false,
       quickPickProvider = false,
       slowTaskProvider = false,
-      statusBarProvider = "off"
+      statusBarProvider = "off",
+      treeViewProvider = false
     )
   def doctorFormatIsJson: Boolean = doctorProvider == "json"
   def statusBarIsOn: Boolean = statusBarProvider == "on"


### PR DESCRIPTION
Previously debuggingProvider, decorationProvider, openFilesOnRenameProvider,
and treeViewProvider were only able to be set via `ClientExperimentalCapabilities`.
Now these are also able to be set via `InitializationOption`, which for some clients
are much easier to set. This is the case for the built-in LSP support in Nvim