### PR TITLE
fix auto import position when package object inside package

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -187,6 +187,19 @@ trait MtagsEnrichments extends CommonMtagsEnrichments {
     }
   }
 
+  implicit class XtensionList[T](list: List[T]) {
+    def collectLast[R](fun: PartialFunction[T, R]): Option[R] = {
+      def loop(current: List[T]): Option[R] = {
+        current match {
+          case Nil => None
+          case head :: tl =>
+            loop(tl).orElse(fun.lift(head))
+        }
+      }
+      loop(list)
+    }
+  }
+
   implicit class XtensionTreeTokenStream(tree: m.Tree) {
     def leadingTokens: Iterator[m.Token] = tree.origin match {
       case Origin.Parsed(input, _, pos) =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImports.scala
@@ -47,7 +47,7 @@ trait AutoImports { this: MetalsGlobal =>
     findLastVisitedParentTree(pos) match {
       case Some(_: Import) => None
       case _ =>
-        val enclosingPackage = lastVisitedParentTrees.collectFirst {
+        val enclosingPackage = lastVisitedParentTrees.reverse.collectFirst {
           case pkg: PackageDef => pkg
         }
         enclosingPackage match {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImports.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.pc
 
 import scala.reflect.internal.FatalError
+import scala.meta.internal.mtags.MtagsEnrichments._
 
 trait AutoImports { this: MetalsGlobal =>
 
@@ -47,7 +48,7 @@ trait AutoImports { this: MetalsGlobal =>
     findLastVisitedParentTree(pos) match {
       case Some(_: Import) => None
       case _ =>
-        val enclosingPackage = lastVisitedParentTrees.reverse.collectFirst {
+        val enclosingPackage = lastVisitedParentTrees.collectLast {
           case pkg: PackageDef => pkg
         }
         enclosingPackage match {

--- a/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
@@ -107,6 +107,24 @@ class AutoImportsSuite extends BaseCodeActionSuite {
        |""".stripMargin
   )
 
+  checkEdit(
+    "import-inside-package-object",
+    """|package a
+       |
+       |package object b {
+       |  val l = s"${<<ListBuffer>>(2)}"
+       |}
+       |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.mutable
+       |
+       |package object b {
+       |  val l = s"${mutable.ListBuffer(2)}"
+       |}
+       |""".stripMargin
+  )
+
   def check(
       name: String,
       original: String,

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -177,4 +177,32 @@ class ImportMissingSymbolLspSuite
     expectNoDiagnostics = false
   )
 
+  check(
+    "multi-package-object",
+    """|package a
+       |
+       |package object b {
+       | object A {
+       |    val f = Future.successful(<<Instant.now)>>
+       |    val b = ListBuffer.newBuilder[Int]
+       | }
+       |}
+       |""".stripMargin,
+    s"""|${ImportMissingSymbol.title("Instant", "java.time")}
+        |${CreateNewSymbol.title("Instant")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import java.time.Instant
+       |
+       |package object b {
+       | object A {
+       |    val f = Future.successful(Instant.now)
+       |    val b = ListBuffer.newBuilder[Int]
+       | }
+       |}
+       |""".stripMargin,
+    expectNoDiagnostics = false
+  )
+
 }


### PR DESCRIPTION
fixes https://github.com/scalameta/metals/issues/1669
The tree is read from ground to top and get the first package he sees which is a package object in our case. Reversing the tree should do the trick. 
I'm not totally sure, sounds too easy :)