### PR TITLE
Improve Scala 3 hover

### DIFF
--- a/metals-bench/src/main/scala/bench/SourceCompletion.scala
+++ b/metals-bench/src/main/scala/bench/SourceCompletion.scala
@@ -44,7 +44,7 @@ object SourceCompletion {
     fromPath(path, readResource(path), query)
   }
   def fromPath(path: String, text: String, query: String): SourceCompletion = {
-    val queryIndex = text.indexOf(query.replaceAllLiterally("@@", ""))
+    val queryIndex = text.indexOf(query.replace("@@", ""))
     if (queryIndex < 0) throw new IllegalArgumentException(query)
     val offset = query.indexOf("@@")
     if (offset < 0) throw new IllegalArgumentException(query)

--- a/metals/src/main/scala/scala/meta/internal/metals/NewFileTemplate.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NewFileTemplate.scala
@@ -9,7 +9,7 @@ import scala.meta.internal.mtags.MtagsEnrichments._
 final case class NewFileTemplate private (template: String) {
   import NewFileTemplate._
 
-  lazy val fileContent: String = template.replaceAllLiterally(cursorMarker, "")
+  lazy val fileContent: String = template.replace(cursorMarker, "")
 
   lazy val cursorPosition: m.Position = {
     val input = m.Input.String(template)

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsGlobs.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/PantsGlobs.scala
@@ -24,7 +24,7 @@ case class PantsGlobs(
         // NOTE(olafur) Pants globs interpret "**/*.scala" as "zero or more
         // directories" while Bloop uses `java.nio.file.PathMatcher`, which
         // interprets it as "one or more directories".
-        .replaceAllLiterally("**/*", "**")
+        .replace("**/*", "**")
       s"glob:$pattern"
     }
     val includeGlobs = include.map(relativizeGlob)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionItemResolver.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionItemResolver.scala
@@ -66,7 +66,7 @@ class CompletionItemResolver(
     out.toString
   }
 
-  // NOTE(olafur): it's hacky to use `String.replaceAllLiterally("x$1", paramName)`, ideally we would use the
+  // NOTE(olafur): it's hacky to use `String.replace("x$1", paramName)`, ideally we would use the
   // signature printer to pretty-print the signature from scratch with parameter names. However, that approach
   // is tricky because it would require us to JSON serialize/deserialize Scala compiler types. The reason
   // we don't print Java parameter names in `textDocument/completions` is because that requires parsing the
@@ -83,7 +83,7 @@ class CompletionItemResolver(
       .zipWithIndex
       .foldLeft(detail) {
         case (accum, (param, i)) =>
-          accum.replaceAllLiterally(
+          accum.replace(
             s"x$$${i + 1}",
             param.displayName()
           )

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -235,7 +235,7 @@ trait Completions { this: MetalsGlobal =>
             } else {
               val short = shortType(info, history)
               if (short == NoType) ""
-              else sym.infoString(short).trim.replaceAllLiterally(" <: <?>", "")
+              else sym.infoString(short).trim.replace(" <: <?>", "")
             }
         }
     }

--- a/mtags/src/main/scala-3/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -254,20 +254,29 @@ case class ScalaPresentationCompiler(
           case Nil =>
             ju.Optional.empty()
           case symbols =>
+            val printer = SymbolPrinter()
             val docComments = symbols.flatMap(ParsedComment.docOf)
-
             val keywordName = symbols.headOption.map { symbol =>
-              SymbolPrinter().fullDefinition(
+              printer.fullDefinition(
                 symbol,
                 tpw
               )
             }
+            val typeString = symbols.headOption.map { symbol =>
+              tpw match {
+                // https://github.com/lampepfl/dotty/issues/8891
+                case _: ImportType =>
+                  printer.typeString(symbol.typeRef)
+                case _ =>
+                  printer.typeString(tpw)
+              }
+            }
             val content = hoverContent(
               keywordName,
-              Some(tpw.show),
+              typeString,
               docComments
             )
-            ju.Optional.of(new Hover(content, null))
+            ju.Optional.of(new Hover(content))
         }
       }
     }

--- a/mtags/src/main/scala-3/scala/scala/meta/internal/pc/SymbolPrinter.scala
+++ b/mtags/src/main/scala-3/scala/scala/meta/internal/pc/SymbolPrinter.scala
@@ -1,16 +1,27 @@
 package scala.meta.internal.pc
 
-import dotty.tools.dotc.printing.PlainPrinter
+import dotty.tools.dotc.printing.RefinedPrinter
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Symbols._
 import dotty.tools.dotc.core.Names._
+import dotty.tools.dotc.core.NameOps._
 import dotty.tools.dotc.core.Types._
 import dotty.tools.dotc.core.Flags
 import scala.language.implicitConversions
 
-class SymbolPrinter(implicit ctx: Context) extends PlainPrinter(ctx) {
+class SymbolPrinter(implicit ctx: Context) extends RefinedPrinter(ctx) {
 
-  def fullDefinition(sym: Symbol, tpe: Type) = {
+  private val defaultWidth = 1000
+
+  override def nameString(name: Name): String = {
+    name.stripModuleClassSuffix.toString()
+  }
+
+  def typeString(tpw: Type): String = {
+    toText(tpw).mkString(defaultWidth, false)
+  }
+
+  def fullDefinition(sym: Symbol, tpe: Type): String = {
 
     def isNullary = tpe match {
       case tpe: (MethodType | PolyType) =>
@@ -20,7 +31,7 @@ class SymbolPrinter(implicit ctx: Context) extends PlainPrinter(ctx) {
     }
 
     val isImplicit = sym.is(Flags.Implicit)
-    val name = sym.name
+    val name = nameString(sym)
     val implicitKeyword = if (isImplicit) "implicit " else ""
     keyString(sym) match {
       case key @ ("var" | "val") =>

--- a/tests/cross/src/main/scala/tests/BaseCodeActionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCodeActionSuite.scala
@@ -20,7 +20,7 @@ abstract class BaseCodeActionSuite extends BasePCSuite {
       case t :: Nil => t.group(1)
       case _ => fail("Multiple <<targets>> found")
     }
-    val code2 = code.replaceAllLiterally("<<", "").replaceAllLiterally(">>", "")
+    val code2 = code.replace("<<", "").replace(">>", "")
     val offset = code.indexOf("<<") + target.length()
     val file = tmp.resolve(filename)
     Files.write(file.toNIO, code2.getBytes(StandardCharsets.UTF_8))

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -72,12 +72,12 @@ abstract class BaseCompletionSuite extends BasePCSuite {
   )(implicit loc: Location): Unit = {
     val compatTemplate = compat.map {
       case (key, value) =>
-        key -> template.replaceAllLiterally("___", value)
+        key -> template.replace("___", value)
     }
     checkEdit(
       name = name,
-      original = template.replaceAllLiterally("___", original),
-      expected = template.replaceAllLiterally("___", expected),
+      original = template.replace("___", original),
+      expected = template.replace("___", expected),
       filterText = filterText,
       assertSingleItem = assertSingleItem,
       filter = filter,
@@ -231,8 +231,8 @@ abstract class BaseCompletionSuite extends BasePCSuite {
 
   override val compatProcess: Map[String, String => String] = Map(
     "2.13" -> { s =>
-      s.replaceAllLiterally("equals(obj: Any)", "equals(obj: Object)")
-        .replaceAllLiterally(
+      s.replace("equals(obj: Any)", "equals(obj: Object)")
+        .replace(
           "singletonList[T](o: T)",
           "singletonList[T <: Object](o: T)"
         )

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -148,7 +148,7 @@ abstract class BasePCSuite extends BaseSuite {
     )
 
   def params(code: String, filename: String = "test.scala"): (String, Int) = {
-    val code2 = code.replaceAllLiterally("@@", "")
+    val code2 = code.replace("@@", "")
     val offset = code.indexOf("@@")
     if (offset < 0) {
       fail("missing @@")

--- a/tests/cross/src/main/scala/tests/BaseSignatureHelpSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseSignatureHelpSuite.scala
@@ -65,7 +65,7 @@ abstract class BaseSignatureHelpSuite extends BasePCSuite {
                 val pdoc = doc(param.getDocumentation)
                   .stripPrefix("```scala\n")
                   .stripSuffix("\n```")
-                  .replaceAllLiterally("\n```\n", " ")
+                  .replace("\n```\n", " ")
                 if (includeDocs && pdoc.nonEmpty) {
                   out
                     .append("  @param ")
@@ -90,8 +90,8 @@ abstract class BaseSignatureHelpSuite extends BasePCSuite {
 
   override val compatProcess: Map[String, String => String] = Map(
     "2.13" -> { s =>
-      s.replaceAllLiterally("valueOf(obj: Any)", "valueOf(obj: Object)")
-        .replaceAllLiterally("Map[A, B]: Map", "Map[K, V]: Map")
+      s.replace("valueOf(obj: Any)", "valueOf(obj: Object)")
+        .replace("Map[A, B]: Map", "Map[K, V]: Map")
     }
   )
 }

--- a/tests/cross/src/main/scala/tests/pc/BaseHoverSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BaseHoverSuite.scala
@@ -26,8 +26,8 @@ abstract class BaseHoverSuite
       val filename = "Hover.scala"
       val pkg = scala.meta.Term.Name(name).syntax
       val noRange = original
-        .replaceAllLiterally("<<", "")
-        .replaceAllLiterally(">>", "")
+        .replace("<<", "")
+        .replace(">>", "")
       val packagePrefix =
         if (automaticPackage) s"package $pkg\n"
         else ""
@@ -47,11 +47,11 @@ abstract class BaseHoverSuite
         h <- hover.asScala
         range <- Option(h.getRange)
       } {
-        val base = codeOriginal.replaceAllLiterally("@@", "")
+        val base = codeOriginal.replace("@@", "")
         val withRange = replaceInRange(base, range)
         assertNoDiff(
           withRange,
-          packagePrefix + original.replaceAllLiterally("@@", ""),
+          packagePrefix + original.replace("@@", ""),
           "Invalid range"
         )
       }
@@ -60,7 +60,7 @@ abstract class BaseHoverSuite
 
   override val compatProcess: Map[String, String => String] = Map(
     "2.13" -> { s =>
-      s.replaceAllLiterally(
+      s.replace(
         "def map[B, That](f: Int => B)(implicit bf: CanBuildFrom[List[Int],B,That]): That",
         "def map[B](f: Int => B): List[B]"
       )

--- a/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
@@ -18,8 +18,8 @@ abstract class BasePcDefinitionSuite extends BasePCSuite {
   )(implicit loc: Location): Unit = {
     test(name) {
       val noRange = original
-        .replaceAllLiterally("<<", "")
-        .replaceAllLiterally(">>", "")
+        .replace("<<", "")
+        .replace(">>", "")
       val filename = "A.scala"
       val uri = s"file:///$filename"
       val (code, offset) = params(noRange, filename)
@@ -58,7 +58,7 @@ abstract class BasePcDefinitionSuite extends BasePCSuite {
         }
       }
       val obtained = TextEdits.applyEdits(code, edits)
-      val expected = original.replaceAllLiterally("@@", "")
+      val expected = original.replace("@@", "")
       assertNoDiff(
         obtained,
         getExpected(expected, compat, scalaVersion)

--- a/tests/cross/src/main/scala/tests/pc/CrossTestEnrichments.scala
+++ b/tests/cross/src/main/scala/tests/pc/CrossTestEnrichments.scala
@@ -2,6 +2,6 @@ package tests.pc
 
 object CrossTestEnrichments {
   implicit class XtensionStringCross(s: String) {
-    def triplequoted: String = s.replaceAllLiterally("'''", "\"\"\"")
+    def triplequoted: String = s.replace("'''", "\"\"\"")
   }
 }

--- a/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
@@ -153,7 +153,7 @@ class HoverDefnSuite extends BaseHoverSuite {
       |""".stripMargin,
     "",
     compat = Map(
-      "0." -> "object MyObject$: object.MyObject$".hover
+      "0." -> "object MyObject: object.MyObject".hover
     )
   )
 

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -56,7 +56,7 @@ class HoverTermSuite extends BaseHoverSuite {
     """|def apply(name: String): Person
        |""".stripMargin.hover,
     compat = Map(
-      "0." -> "class Person: case-apply.Person$".hover
+      "0." -> "case class Person: case-apply.Person".hover
     )
   )
 
@@ -152,7 +152,7 @@ class HoverTermSuite extends BaseHoverSuite {
     compat = Map(
       "0.23" -> "def unapply: Int".hover,
       // https://github.com/lampepfl/dotty/issues/8835
-      "0.24" -> "object num$: interpolator-unapply.a.Xtension#num$".hover
+      "0.24" -> "object num: interpolator-unapply.a.Xtension#num".hover
     )
   )
 
@@ -340,7 +340,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |```
        |""".stripMargin,
     compat = Map(
-      "0." -> "object FileVisitResult$: java.nio.file.FileVisitResult$".hover
+      "0." -> "object FileVisitResult: java.nio.file.FileVisitResult".hover
     )
   )
 
@@ -363,7 +363,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin,
     automaticPackage = false,
     compat = Map(
-      "0." -> "object Foo$: app.Outer.Foo$".hover
+      "0." -> "object Foo: app.Outer.Foo".hover
     )
   )
 
@@ -417,7 +417,7 @@ class HoverTermSuite extends BaseHoverSuite {
     """|class java.nio.file.Files
        |""".stripMargin.hover,
     compat = Map(
-      "0." -> "object Files$: ImportType(Select(Select(Ident(java),nio),file))".hover
+      "0." -> "object Files: java.nio.file.Files".hover
     )
   )
 
@@ -429,7 +429,7 @@ class HoverTermSuite extends BaseHoverSuite {
     """|class java.nio.file.Paths
        |""".stripMargin.hover,
     compat = Map(
-      "0." -> "object Paths$: ImportType(Select(Select(Ident(java),nio),file))".hover
+      "0." -> "object Paths: java.nio.file.Paths".hover
     )
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -20,9 +20,9 @@ class CompletionCaseSuite extends BaseCompletionSuite {
   override val compatProcess: Map[String, String => String] = Map(
     "2.11" -> { (s: String) =>
       // The standard library renamed fields of Some/Left/Right for 2.12.0.
-      s.replaceAllLiterally("Some(value)", "Some(x)")
-        .replaceAllLiterally("Left(value)", "Left(a)")
-        .replaceAllLiterally("Right(value)", "Right(b)")
+      s.replace("Some(value)", "Some(x)")
+        .replace("Left(value)", "Left(a)")
+        .replace("Right(value)", "Right(b)")
     }
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -192,7 +192,7 @@ class CompletionIssueSuite extends BaseCompletionSuite {
 
   override val compatProcess: Map[String, String => String] = Map(
     "2.13" -> { s =>
-      s.replaceAllLiterally(
+      s.replace(
         "::[B >: Int](x: B): List[B]",
         "::[B >: Int](elem: B): List[B]"
       )

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -647,7 +647,7 @@ class CompletionSuite extends BaseCompletionSuite {
     // NOTE(olafur) The compiler produces non-deterministic results for this
     // test case, sometime it uses Double and sometimes it uses Float depending
     // other whether its a clean compiler or reused one.
-    postProcessObtained = _.replaceAllLiterally("Float", "Double"),
+    postProcessObtained = _.replace("Float", "Double"),
     stableOrder = false,
     compat = Map(
       "2.13" ->

--- a/tests/cross/src/test/scala/tests/pc/PrettyPrintSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PrettyPrintSuite.scala
@@ -15,7 +15,7 @@ class PrettyPrintSuite extends BaseCompletionSuite {
       expected: String,
       compat: Map[String, String] = Map.empty
   )(implicit loc: Location): Unit = {
-    val signature = original.replaceAllLiterally("@@", "")
+    val signature = original.replace("@@", "")
     val completion = original.replaceFirst("@@.*", "@@")
     val suffix = " = ${0:???}"
     val compatWithSuffix = compat.map {

--- a/tests/slow/src/test/scala/tests/feature/SyntaxErrorLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/SyntaxErrorLspSuite.scala
@@ -137,13 +137,13 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
       )
       _ <- server.didOpen("a/src/main/scala/Main.scala")
       _ <- server.didChange("a/src/main/scala/Main.scala")(
-        _.replaceAllLiterally("val b", "val\n  val b")
+        _.replace("val b", "val\n  val b")
       )
       _ <- server.didChange("a/src/main/scala/Main.scala")(
-        _.replaceAllLiterally("val\n", "val \n")
+        _.replace("val\n", "val \n")
       )
       _ <- server.didChange("a/src/main/scala/Main.scala")(
-        _.replaceAllLiterally("val \n", "")
+        _.replace("val \n", "")
       )
       _ = assertNoDiff(
         client.workspaceDiagnostics,
@@ -200,7 +200,7 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
       }
       _ = assertNoDiff(client.workspaceDiagnostics, typeMismatch)
       _ <- server.didChange("a/src/main/scala/A.scala")(
-        _.replaceAllLiterally("\"\"", "\"")
+        _.replace("\"\"", "\"")
       )
       // assert that a tokenization error results in a single diagnostic, hides type errors.
       _ = assertNoDiff(
@@ -211,7 +211,7 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
            |""".stripMargin
       )
       _ <- server.didChange("a/src/main/scala/A.scala")(
-        _.replaceAllLiterally("\"", "\"\"\n  // close")
+        _.replace("\"", "\"\"\n  // close")
       )
       // assert that once the tokenization error is fixed, the type error reappears.
       _ = assertNoDiff(client.workspaceDiagnostics, typeMismatch)
@@ -225,7 +225,7 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
        |}
        |""".stripMargin,
     Assert(
-      _.replaceAllLiterally("\"1\".substring(0)", ""),
+      _.replace("\"1\".substring(0)", ""),
       """|a/src/main/scala/A.scala:2:19: error: type mismatch;
          | found   : String
          | required: Int
@@ -234,7 +234,7 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
          |""".stripMargin
     ),
     Assert(
-      _.replaceAllLiterally(".lengthCompare()", "."),
+      _.replace(".lengthCompare()", "."),
       """|a/src/main/scala/A.scala:2:5: error: type mismatch;
          | found   : String
          | required: Int
@@ -254,7 +254,7 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
        |}
        |""".stripMargin,
     Assert(
-      _.replaceAllLiterally("object A", "object B"),
+      _.replace("object A", "object B"),
       """|a/src/main/scala/A.scala:2:3: error: not enough arguments for method lengthCompare: (len: Int)Int.
          |Unspecified value parameter len.
          |  "".lengthCompare()
@@ -270,7 +270,7 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
        |}
        |""".stripMargin,
     Assert(
-      _.replaceAllLiterally("\"\"", "\"a\" // comment"),
+      _.replace("\"\"", "\"a\" // comment"),
       """|a/src/main/scala/A.scala:2:29: error: type mismatch;
          | found   : String("")
          | required: Int
@@ -287,7 +287,7 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
        |}
        |""".stripMargin,
     Assert(
-      _.replaceAllLiterally("\"b\"", "\"c\""),
+      _.replace("\"b\"", "\"c\""),
       """|a/src/main/scala/A.scala:2:16: error: type mismatch;
          | found   : String("ab")
          | required: Int
@@ -304,7 +304,7 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
        |}
        |""".stripMargin,
     Assert(
-      _.replaceAllLiterally("t = \"a\" + \"b\"", ""),
+      _.replace("t = \"a\" + \"b\"", ""),
       """|a/src/main/scala/A.scala:2:11: error: type mismatch;
          | found   : String("ab")
          | required: Int

--- a/tests/slow/src/test/scala/tests/pants/PantsLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/pants/PantsLspSuite.scala
@@ -154,7 +154,7 @@ class PantsLspSuite extends BaseImportSuite("pants") {
       _ = assertNoDiagnostics() // "core" was compiled during import
       _ <- server.didOpen("core/Lib.scala")
       _ <- server.didSave("core/Lib.scala")(
-        _.replaceAllLiterally("greeting", "greeting: Int")
+        _.replace("greeting", "greeting: Int")
       )
       _ = assertNoDiagnostics() // no errors because "core" is not exported.
     } yield ()

--- a/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
@@ -13,7 +13,7 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
     val filename = s"$project/src/main/scala/$project/${project.toUpper}.scala"
     val text = server
       .textContentsOnDisk(filename)
-      .replaceAllLiterally("// @@", query.replaceAllLiterally("@@", ""))
+      .replace("// @@", query.replace("@@", ""))
     for {
       _ <- server.didChange(filename)(_ => text)
       completion <- server.completionList(filename, query)
@@ -46,7 +46,7 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
     val filename = s"$project/src/main/scala/$project/${project.toUpper}.scala"
     val text = server
       .textContentsOnDisk(filename)
-      .replaceAllLiterally("// @@", query.replaceAllLiterally("@@", ""))
+      .replace("// @@", query.replace("@@", ""))
     for {
       _ <- server.didChange(filename)(_ => text)
       completion <- server.completionList(filename, query)

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -163,10 +163,10 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
       _ <- cancelled.future
       _ = client.slowTaskHandler = (_ => None)
       _ <- server.didSave("a/src/main/scala/Main.worksheet.sc")(
-        _.replaceAllLiterally("Stream", "// Stream")
+        _.replace("Stream", "// Stream")
       )
       _ <- server.didSave("a/src/main/scala/Main.worksheet.sc")(
-        _.replaceAllLiterally("42", "43")
+        _.replace("42", "43")
       )
       _ = assertNoDiff(
         client.workspaceDecorations,
@@ -292,7 +292,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
           |""".stripMargin
       )
       _ <- server.didSave("a/src/main/scala/a/Util.scala")(
-        _.replaceAllLiterally("n + 1", "n + 2")
+        _.replace("n + 1", "n + 2")
       )
       _ <- server.didSave("a/src/main/scala/a/Main.worksheet.sc")(identity)
       _ = assertNoDiff(
@@ -324,7 +324,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
            |""".stripMargin
       )
       _ <- server.didChange("a/src/main/scala/a/Main.worksheet.sc")(
-        _.replaceAllLiterally("val x", "def y = \nval x")
+        _.replace("val x", "def y = \nval x")
       )
       _ = assertNoDiff(
         client.workspaceDiagnostics,

--- a/tests/unit/src/main/scala/tests/FileLayout.scala
+++ b/tests/unit/src/main/scala/tests/FileLayout.scala
@@ -10,7 +10,7 @@ object FileLayout {
 
   def mapFromString(layout: String): Map[String, String] = {
     if (!layout.trim.isEmpty) {
-      val lines = layout.replaceAllLiterally("\r\n", "\n")
+      val lines = layout.replace("\r\n", "\n")
       lines
         .split("(?=\n/)")
         .map { row =>

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -538,7 +538,7 @@ final class TestingServer(
     val input = path.toInputFromBuffers(buffers)
     val offset = query.indexOf("@@")
     if (offset < 0) sys.error("missing @@")
-    val start = input.text.indexOf(query.replaceAllLiterally("@@", ""))
+    val start = input.text.indexOf(query.replace("@@", ""))
     if (start < 0)
       sys.error(s"missing query '$query' from text:\n${input.text}")
     val point = start + offset
@@ -694,7 +694,7 @@ final class TestingServer(
   ): Future[T] = {
     val offset = original.indexOf("@@")
     if (offset < 0) sys.error(s"missing @@\n$original")
-    val text = original.replaceAllLiterally("@@", replaceWith)
+    val text = original.replace("@@", replaceWith)
     val input = m.Input.String(text)
     val path = root.resolve(filename)
     path.touch()
@@ -726,8 +726,8 @@ final class TestingServer(
       sys.error(s"invalid range, >> must come after <<\n$original")
     val text =
       original
-        .replaceAllLiterally("<<", replaceWith)
-        .replaceAllLiterally(">>", replaceWith)
+        .replace("<<", replaceWith)
+        .replace(">>", replaceWith)
     val input = m.Input.String(text)
     val path = root.resolve(filename)
     path.touch()

--- a/tests/unit/src/test/scala/tests/BuildServerConnectionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BuildServerConnectionLspSuite.scala
@@ -27,7 +27,7 @@ class BuildServerConnectionLspSuite
       _ = assertNoDiagnostics()
       _ <- server.executeCommand(ServerCommands.ConnectBuildServer.id)
       _ <- server.didSave("a/src/main/scala/a/A.scala")(
-        _.replaceAllLiterally("val n = 42", "val n: String = 42")
+        _.replace("val n = 42", "val n: String = 42")
       )
       _ = assertNoDiff(
         client.workspaceDiagnostics,

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -202,7 +202,7 @@ class DefinitionLspSuite extends BaseLspSuite("definition") {
         """.stripMargin
       )
       _ <- server.didSave("a/src/main/scala/a/Main.scala")(
-        _.replaceAllLiterally("max(1, 2)", "max")
+        _.replace("max(1, 2)", "max")
       )
       _ = assertNoDiff(
         server.workspaceDefinitions,
@@ -279,7 +279,7 @@ class DefinitionLspSuite extends BaseLspSuite("definition") {
       _ <- server.didOpen("a/src/main/scala/a/Main.scala")
       _ = assertNoDiff(client.workspaceDiagnostics, "")
       _ <- server.didChange("a/src/main/scala/a/Main.scala")(
-        _.replaceAllLiterally("// ", "")
+        _.replace("// ", "")
       )
       _ = assertNoDiff(
         server.workspaceDefinitions,

--- a/tests/unit/src/test/scala/tests/DiagnosticsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DiagnosticsLspSuite.scala
@@ -108,7 +108,7 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
       )
       _ <- server.didOpen("a/src/main/scala/Main.scala")
       _ <- server.didSave("a/src/main/scala/Main.scala")(
-        _.replaceAllLiterally("val a = 2", "val a = 1\n  val a = 2")
+        _.replace("val a = 2", "val a = 1\n  val a = 2")
       )
       _ = assertNoDiff(
         client.workspaceDiagnostics,
@@ -122,7 +122,7 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
            |""".stripMargin
       )
       _ <- server.didSave("a/src/main/scala/Main.scala")(
-        _.replaceAllLiterally("val a = 1\n  ", "")
+        _.replace("val a = 1\n  ", "")
       )
       // FIXME: https://github.com/scalacenter/bloop/issues/785
       _ = assertNoDiff(client.workspaceDiagnostics, "")
@@ -255,7 +255,7 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
       _ <- server.executeCommand(ServerCommands.DisconnectBuildServer.id)
       _ = assertNoDiagnostics()
       _ <- server.didSave("a/src/main/scala/a/B.scala")(
-        _.replaceAllLiterally("String", "Int")
+        _.replace("String", "Int")
       )
       _ <- server.didClose("a/src/main/scala/a/B.scala")
       _ <- server.didOpen("a/src/main/scala/a/A.scala")

--- a/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
@@ -48,7 +48,7 @@ class DidFocusLspSuite extends BaseLspSuite("did-focus") {
       didCompile <- server.didFocus("b/src/main/scala/b/B.scala")
       _ = assert(didCompile == AlreadyCompiled)
       _ <- server.didSave("a/src/main/scala/a/A.scala")(
-        _.replaceAllLiterally("val x = 1", "val x = \"string\"")
+        _.replace("val x = 1", "val x = \"string\"")
       )
       _ = fakeTime.elapseSeconds(10)
       _ = assertNoDiagnostics()
@@ -105,21 +105,21 @@ class DidFocusLspSuite extends BaseLspSuite("did-focus") {
       }
       _ = fakeTime.elapseSeconds(10)
       _ <- server.didSave("a/src/main/scala/a/A.scala")(
-        _.replaceAllLiterally("1", "\"\"")
+        _.replace("1", "\"\"")
       )
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         xMismatch
       )
       _ <- server.didSave("b/src/main/scala/b/B.scala")(
-        _.replaceAllLiterally("2", "\"\"")
+        _.replace("2", "\"\"")
       )
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         xMismatch
       )
       didSaveA = server.didSave("a/src/main/scala/a/A.scala")(
-        _.replaceAllLiterally("Int", "String")
+        _.replace("Int", "String")
       )
       // Focus before compilation of A.scala is complete.
       didCompile <- server.didFocus("b/src/main/scala/b/B.scala")

--- a/tests/unit/src/test/scala/tests/RangeFormattingWhenSelectingSuite.scala
+++ b/tests/unit/src/test/scala/tests/RangeFormattingWhenSelectingSuite.scala
@@ -143,7 +143,7 @@ class RangeFormattingWhenSelectingSuite
 
     val testCode = unmangle(testCase)
     val base =
-      testCode.replaceAllLiterally("<<", "").replaceAllLiterally(">>", "")
+      testCode.replace("<<", "").replace(">>", "")
     val expected = unmangle(expectedCase)
     test(name) {
       for {

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -135,10 +135,10 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
       // Assert that goto definition and reference are still bijective after buffer changes
       // in both the definition source and reference sources.
       _ <- server.didChange("a/src/main/scala/a/A.scala")(
-        _.replaceAllLiterally("a: Int", "\n")
+        _.replace("a: Int", "\n")
       )
       _ <- server.didChange("b/src/main/scala/b/B.scala")(
-        _.replaceAllLiterally("val b", "\n  val number")
+        _.replace("val b", "\n  val number")
       )
       _ <- server.executeCommand(ServerCommands.ConnectBuildServer.id)
       _ = server.assertReferenceDefinitionDiff(

--- a/tests/unit/src/test/scala/tests/WindowStateDidChangeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WindowStateDidChangeLspSuite.scala
@@ -21,7 +21,7 @@ class WindowStateDidChangeLspSuite
       _ = server.windowStateDidChange(focused = false)
       _ = assert(server.server.pauseables.isPaused.get())
       didChange = server.didChange("a/src/main/scala/a/A.scala")(
-        _.replaceAllLiterally("= 42", "=")
+        _.replace("= 42", "=")
       )
       _ = Thread.sleep(10) // give the parser a moment to complete.
       // Assert didChange is still running because parsing is paused.

--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -45,7 +45,7 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
         "a.b.PazQux"
       )
       _ <- server.didSave("a/src/main/scala/a/B.scala")(
-        _.replaceAllLiterally("class B", "  class HaddockBax")
+        _.replace("class B", "  class HaddockBax")
       )
       _ = assertNoDiff(
         server.workspaceSymbol("Had"),

--- a/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -23,8 +23,8 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
                                   |{"a":{}}
                                   |/$path
                                   |${input
-                                    .replaceAllLiterally("<<", "")
-                                    .replaceAllLiterally(">>", "")}
+                                    .replace("<<", "")
+                                    .replace(">>", "")}
                                   |""".stripMargin)
         _ <- server.didOpen(path)
         codeActions <- server.assertCodeAction(path, input, expectedActions)

--- a/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
@@ -89,8 +89,8 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
                                   |{"a":{}}
                                   |/$path
                                   |${input
-                                    .replaceAllLiterally("<<", "")
-                                    .replaceAllLiterally(">>", "")}
+                                    .replace("<<", "")
+                                    .replace(">>", "")}
                                   |""".stripMargin)
         _ <- server.didOpen(path)
         codeActions <- server.assertCodeAction(path, input, expectedActions)

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetNoDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetNoDecorationsLspSuite.scala
@@ -95,8 +95,8 @@ class WorksheetNoDecorationsLspSuite
       "@@".r
         .findAllMatchIn(query)
         .map { m =>
-          val before = query.substring(0, m.start).replaceAllLiterally("@@", "")
-          val after = query.substring(m.end).replaceAllLiterally("@@", "")
+          val before = query.substring(0, m.start).replace("@@", "")
+          val after = query.substring(m.end).replace("@@", "")
           before + "@@" + after
         }
         .toList


### PR DESCRIPTION
Couple of smaller things touched here:
- fix Dotty warnings `replaceAllLiterally` is exactly the same as java's String.replace, 
- make object show properly on Hover `ObjectName` instead of `ObjectName$`
- fix hover on multiple imports like `import java.nio.file{ Files => File, P@@aths}`