### PR TITLE
Make sure we don't download invalid dependencies for Scala 3 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -431,6 +431,7 @@ lazy val metals = project
       "scalafmtVersion" -> V.scalafmt,
       "supportedScalaVersions" -> V.supportedScalaVersions,
       "supportedScala2Versions" -> V.scala2Versions,
+      "supportedScala3Versions" -> V.scala3Versions,
       "supportedScalaBinaryVersions" -> V.supportedScalaBinaryVersions,
       "deprecatedScalaVersions" -> V.deprecatedScalaVersions,
       "nonDeprecatedScalaVersions" -> V.nonDeprecatedScalaVersions,

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -141,6 +141,12 @@ object Embedded {
   private def scalaDependency(scalaVersion: String): Dependency =
     Dependency.of("org.scala-lang", "scala-library", scalaVersion)
 
+  private def dottyDependency(scalaVersion: String): Dependency = {
+    val binaryVersion =
+      ScalaVersions.scalaBinaryVersionFromFullVersion(scalaVersion)
+    Dependency.of("ch.epfl.lamp", s"dotty-library_$binaryVersion", scalaVersion)
+  }
+
   private def mtagsDependency(scalaVersion: String): Dependency = Dependency.of(
     "org.scalameta",
     s"mtags_$scalaVersion",
@@ -178,6 +184,13 @@ object Embedded {
   def downloadScalaSources(scalaVersion: String): List[Path] =
     downloadDependency(
       scalaDependency(scalaVersion),
+      scalaVersion,
+      classfiers = Seq("sources")
+    )
+
+  def downloadDottySources(scalaVersion: String): List[Path] =
+    downloadDependency(
+      dottyDependency(scalaVersion),
       scalaVersion,
       classfiers = Seq("sources")
     )

--- a/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
+++ b/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
@@ -34,14 +34,18 @@ object DownloadDependencies {
 
   def downloadScala(): Unit = {
     scribe.info("Downloading scala library and sources")
-    BuildInfo.supportedScalaVersions.foreach { scalaVersion =>
+    BuildInfo.supportedScala2Versions.foreach { scalaVersion =>
       Embedded.downloadScalaSources(scalaVersion)
+    }
+
+    BuildInfo.supportedScala3Versions.foreach { scalaVersion =>
+      Embedded.downloadDottySources(scalaVersion)
     }
   }
 
   def downloadMdoc(): Unit = {
     scribe.info("Downloading mdoc")
-    BuildInfo.supportedScalaVersions.foreach { scalaVersion =>
+    BuildInfo.supportedScala2Versions.foreach { scalaVersion =>
       Embedded.downloadMdoc(
         scalaVersion,
         ScalaVersions.scalaBinaryVersionFromFullVersion(scalaVersion)
@@ -68,7 +72,7 @@ object DownloadDependencies {
 
   def downloadSemanticDB(): Unit = {
     scribe.info("Downloading semanticdb-scalac")
-    BuildInfo.supportedScalaVersions.foreach { scalaVersion =>
+    BuildInfo.supportedScala2Versions.foreach { scalaVersion =>
       Embedded.downloadSemanticdbScalac(scalaVersion)
     }
   }


### PR DESCRIPTION
Previously, we would try to download mtags for Scala 0.24 etc. which does not exist. Now we make sure that we only download proper dependencies.