### PR TITLE
Always run mill in interactive mode and strip the '--mill-version'

### DIFF
--- a/metals/src/main/resources/millw.bat
+++ b/metals/src/main/resources/millw.bat
@@ -21,6 +21,7 @@ if [%~1%]==[--mill-version] (
     rem shift command doesn't work within parentheses
     if not [%~2%]==[] (
         set MILL_VERSION=%~2%
+        set "STRIP_VERSION_PARAMS=true"
     ) else (
         echo You specified --mill-version without a version.
         echo Please provide a version that matches one provided on
@@ -80,4 +81,15 @@ if not exist "%MILL%" (
 set MILL_DOWNLOAD_PATH=
 set MILL_VERSION=
 
-"%MILL%" %*
+set MILL_PARAMS=%*
+
+if defined STRIP_VERSION_PARAMS (
+    for /f "tokens=1-2*" %%a in ("%*") do (
+        rem strip %%a - It's the "--mill-version" option.
+        rem strip %%b - it's the version number that comes after the option.
+        rem keep  %%c - It's the remaining options.
+        set MILL_PARAMS=%%c
+    )
+)
+
+"%MILL%" %MILL_PARAMS%

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -34,12 +34,11 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
     } else {
       version
     }
-    val cmd = List(
-      "-i", // In some environments (such as WSL or cygwin), mill must be run using interactive mode (-i)
-      "--predef",
-      predefScriptPath(millVersion).toString,
-      "mill.contrib.Bloop/install"
-    )
+
+    // In some environments (such as WSL or cygwin), mill must be run using interactive mode (-i)
+    val iOption = if (Properties.isWin) List("-i") else Nil
+    val cmd = iOption ::: "--predef" :: predefScriptPath(millVersion).toString :: "mill.contrib.Bloop/install" :: Nil
+
     userConfig().millScript match {
       case Some(script) =>
         script :: cmd

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -37,7 +37,8 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
 
     // In some environments (such as WSL or cygwin), mill must be run using interactive mode (-i)
     val iOption = if (Properties.isWin) List("-i") else Nil
-    val cmd = iOption ::: "--predef" :: predefScriptPath(millVersion).toString :: "mill.contrib.Bloop/install" :: Nil
+    val cmd =
+      iOption ::: "--predef" :: predefScriptPath(millVersion).toString :: "mill.contrib.Bloop/install" :: Nil
 
     userConfig().millScript match {
       case Some(script) =>

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -35,6 +35,7 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
       version
     }
     val cmd = List(
+      "-i", // In some environments (such as WSL or cygwin), mill must be run using interactive mode (-i)
       "--predef",
       predefScriptPath(millVersion).toString,
       "mill.contrib.Bloop/install"


### PR DESCRIPTION
This pull request fixes two problems:

1) Issue 1: In some Windows environments (e.g. WSL or cygwin) running mill results in an error: Failed to connect to server. The workaround as indicated on http://www.lihaoyi.com/mill/index.html is to run mill in interactive mode using `-i` option. As explained by @lefou on the referenced issue, it is safe to always run with this option.

2) Issue 2: The millw.bat takes an option "--mill-version" in order to download the specified version of mill. millw afterwards executes mill by passing all the same options including the "--mill-version". This option, however, is not known by mill, so it must be stripped before passing the remaining options.

Fixes #1710 
