### PR TITLE
teach metals to accept configuration of range formatting

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -18,7 +18,8 @@ final case class InitializationOptions(
     quickPickProvider: Boolean,
     slowTaskProvider: Boolean,
     statusBarProvider: String,
-    treeViewProvider: Boolean
+    treeViewProvider: Boolean,
+    provideRangeFormatting: Boolean
 ) {
   def this() =
     this(
@@ -35,7 +36,8 @@ final case class InitializationOptions(
       quickPickProvider = false,
       slowTaskProvider = false,
       statusBarProvider = "off",
-      treeViewProvider = false
+      treeViewProvider = false,
+      provideRangeFormatting = false
     )
   def doctorFormatIsJson: Boolean = doctorProvider == "json"
   def statusBarIsOn: Boolean = statusBarProvider == "on"

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -18,8 +18,7 @@ final case class InitializationOptions(
     quickPickProvider: Boolean,
     slowTaskProvider: Boolean,
     statusBarProvider: String,
-    treeViewProvider: Boolean,
-    provideRangeFormatting: Boolean
+    treeViewProvider: Boolean
 ) {
   def this() =
     this(
@@ -36,8 +35,7 @@ final case class InitializationOptions(
       quickPickProvider = false,
       slowTaskProvider = false,
       statusBarProvider = "off",
-      treeViewProvider = false,
-      provideRangeFormatting = false
+      treeViewProvider = false
     )
   def doctorFormatIsJson: Boolean = doctorProvider == "json"
   def statusBarIsOn: Boolean = statusBarProvider == "on"

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -541,7 +541,9 @@ class MetalsLanguageServer(
       capabilities.setDocumentOnTypeFormattingProvider(
         new DocumentOnTypeFormattingOptions("\n")
       )
-      capabilities.setDocumentRangeFormattingProvider(true)
+      capabilities.setDocumentRangeFormattingProvider(
+        clientConfig.initializationOptions.provideRangeFormatting
+      )
       capabilities.setSignatureHelpProvider(
         new SignatureHelpOptions(List("(", "[").asJava)
       )

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -542,7 +542,7 @@ class MetalsLanguageServer(
         new DocumentOnTypeFormattingOptions("\n")
       )
       capabilities.setDocumentRangeFormattingProvider(
-        clientConfig.initializationOptions.provideRangeFormatting
+        initialConfig.allowMultilineStringFormatting
       )
       capabilities.setSignatureHelpProvider(
         new SignatureHelpOptions(List("(", "[").asJava)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -72,7 +72,11 @@ final case class MetalsServerConfig(
     ),
     icons: Icons = Icons.default,
     statistics: StatisticsConfig = StatisticsConfig.default,
-    compilers: PresentationCompilerConfigImpl = CompilersConfig()
+    compilers: PresentationCompilerConfigImpl = CompilersConfig(),
+    allowMultilineStringFormatting: Boolean = MetalsServerConfig.binaryOption(
+      "metals.allow-multiline-string-formatting",
+      default = true
+    )
 ) {
   override def toString: String =
     List[String](


### PR DESCRIPTION
This PR provides an escape hatch to Emacs users who find the beahvior documented in
formatting can opt-in to this behavior.

My main concern is that this change appears not backwards compatible. I am not familiar
with Metals JSON deserialization system. Ideally the `InitializationOptions` would
default to `true` for `provideRangeFormater` if it is not present in the JSON payload
from the `initialize` request.

I will make a corresponding change to https://github.com/emacs-lsp/lsp-mode to support
this new configuration option.

Thank you for your time.

I tried to test this locally, but after running `sbt +publishLocal`, I can't build a Scala-metals binary as described under the vim section of the contributing docs (there is no Emacs section):
```
~/projects/metals/coursier bootstrap \                                
  --java-opt -Dmetals.client=emacs \
  org.scalameta:mtags_2.11.12:0.9.1-SNAPSHOT \
  -r bintray:scalacenter/releases \
  -o /usr/local/bin/metals-emacs-snapshot -f -M scala.meta.metals.Main
```

The Main class appears to be missing. Could you please advise as to how to get a working binary?