### PR TITLE
Fix behavir when the format dialog is closed without choosing action

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -157,11 +157,11 @@ final class FormattingProvider(
               tables.dismissedNotifications.ChangeScalafmtVersion
                 .dismiss(24, TimeUnit.HOURS)
               None
-            } else {
+            } else if (item == Messages.dontShowAgain) {
               tables.dismissedNotifications.ChangeScalafmtVersion
                 .dismissForever()
               None
-            }
+            } else None
           }
       }
     } else Future.successful(None)
@@ -183,11 +183,11 @@ final class FormattingProvider(
           tables.dismissedNotifications.CreateScalafmtFile
             .dismiss(24, TimeUnit.HOURS)
           false
-        } else {
+        } else if (item == Messages.dontShowAgain) {
           tables.dismissedNotifications.CreateScalafmtFile
             .dismissForever()
           false
-        }
+        } else false
       }
     } else Future.successful(false)
   }


### PR DESCRIPTION
My previous pull request https://github.com/scalameta/metals/pull/1607 contains a trivial issue that dismisses forever when we close the format dialog without choosing any action. It should do nothing in this case.
