### PR TITLE
Fix issues in files with Scala 2.13 specific syntax

### DIFF
--- a/metals-bench/src/main/scala/bench/MetalsBench.scala
+++ b/metals-bench/src/main/scala/bench/MetalsBench.scala
@@ -21,6 +21,7 @@ import scala.reflect.io.VirtualFile
 import tests.InputProperties
 import tests.Library
 import scala.tools.nsc.interactive.Global
+import scala.meta.internal.metals.Trees
 
 @State(Scope.Benchmark)
 class MetalsBench {
@@ -106,7 +107,7 @@ class MetalsBench {
   def scalametaParse(): Unit = {
     scalaDependencySources.inputs.foreach { input =>
       import scala.meta._
-      val tree = input.parse[Source].get
+      val tree = Trees.defaultDialect(input).parse[Source].get
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
@@ -10,6 +10,7 @@ import scala.meta.internal.mtags.MD5
 import scala.meta.io.AbsolutePath
 import scala.util.control.NonFatal
 import scala.xml.Node
+import scala.meta.internal.metals.Trees
 
 case class Digest(
     md5: String,
@@ -153,7 +154,7 @@ object Digest {
   ): Boolean = {
     try {
       val input = file.toInput
-      val tokens = input.tokenize.get
+      val tokens = Trees.defaultDialect(input).tokenize.get
       tokens.foreach {
         case token if token.isWhiteSpaceOrComment => // Do nothing
         case token =>

--- a/metals/src/main/scala/scala/meta/internal/builds/MillDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillDigest.scala
@@ -6,6 +6,7 @@ import scala.meta.io.AbsolutePath
 import scala.collection.mutable
 import java.security.MessageDigest
 import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.internal.metals.Trees
 
 object MillDigest extends Digestable {
   override protected def digestWorkspace(
@@ -39,7 +40,7 @@ object MillDigest extends Digestable {
   ): List[AbsolutePath] = {
     try {
       val input = file.toInput
-      val tokens = input.tokenize.get.tokens
+      val tokens = Trees.defaultDialect(input).tokenize.get.tokens
       val acc = ImportLinesAcc()
       tokens.foreach { token =>
         token match {

--- a/mtags/src/main/scala-2/scala/meta/internal/docstrings/MarkdownGenerator.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/docstrings/MarkdownGenerator.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.docstrings
 
 import scala.meta._
 import scala.collection.Seq
+import scala.meta.internal.metals.Trees
 
 /**
  * Generates markdown from the docstring
@@ -16,7 +17,7 @@ object MarkdownGenerator {
    * @return a sequence of markdown strings - one per docstring comment in the code
    */
   def toMarkdown(code: String): Seq[String] =
-    code.tokenize.get.collect {
+    Trees.defaultDialect(code).tokenize.get.collect {
       case c: Token.Comment if c.syntax.startsWith("/**") =>
         fromDocstring(c.syntax, Map.empty)
     }

--- a/mtags/src/main/scala-2/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
@@ -195,7 +195,8 @@ object MultilineStringFormattingProvider {
       val virtualFile = Input.VirtualFile(source.toString(), sourceText)
       val startPos = range.getStart.toMeta(virtualFile)
       val endPos = range.getEnd.toMeta(virtualFile)
-      fn(startPos, endPos, sourceText, virtualFile.tokenize.toOption)
+      val tokens = Trees.defaultDialect(virtualFile).tokenize.toOption
+      fn(startPos, endPos, sourceText, tokens)
     } else Nil
   }
 

--- a/mtags/src/main/scala-2/scala/meta/internal/metals/TokenEditDistance.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/metals/TokenEditDistance.scala
@@ -5,7 +5,9 @@ import difflib.myers.Equalizer
 import org.eclipse.{lsp4j => l}
 import scala.annotation.tailrec
 import scala.meta.Token
-import scala.meta._
+import scala.meta.Input
+import scala.meta.Position
+import scala.meta.Tokens
 import scala.meta.internal.mtags.MtagsEnrichments._
 import java.util.logging.Logger
 
@@ -280,10 +282,10 @@ object TokenEditDistance {
       unchanged
     } else {
       val result = for {
-        revised <- revisedInput.tokenize.toOption
+        revised <- Trees.defaultDialect(revisedInput).tokenize.toOption
         original <- {
           if (originalInput == revisedInput) Some(revised)
-          else originalInput.tokenize.toOption
+          else Trees.defaultDialect(originalInput).tokenize.toOption
         }
       } yield {
         if (doNothingWhenUnchanged && revised == original) unchanged

--- a/mtags/src/main/scala-2/scala/meta/internal/metals/Trees.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/metals/Trees.scala
@@ -73,3 +73,9 @@ final class Trees {
     }
   }
 }
+
+object Trees {
+
+  implicit val defaultDialect: Dialect = scala.meta.dialects.Scala213
+
+}

--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -17,9 +17,11 @@ import scala.meta.io.AbsolutePath
 import scala.{meta => m}
 import java.net.URI
 import scala.meta.XtensionTokenizeInputLike
+import scala.meta.internal.metals.Trees
 
 object MtagsEnrichments extends MtagsEnrichments
 trait MtagsEnrichments extends CommonMtagsEnrichments {
+  import Trees.defaultDialect
 
   implicit class XtensionInputOffset(input: Input) {
     def toLanguage: Language = input match {

--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/ScalaMtags.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/ScalaMtags.scala
@@ -1,12 +1,27 @@
 package scala.meta.internal.mtags
 
-import scala.meta._
+import scala.meta.Parsed
+import scala.meta.Source
+import scala.meta.Tree
+import scala.meta.Term
+import scala.meta.Type
+import scala.meta.Template
+import scala.meta.Member
+import scala.meta.Name
+import scala.meta.Ctor
+import scala.meta.Defn
+import scala.meta.Pkg
+import scala.meta.Decl
+import scala.meta.Mod
+import scala.meta.quasiquotes._
 import scala.meta.inputs.Input
 import scala.meta.internal.semanticdb.Language
 import scala.meta.internal.semanticdb.SymbolInformation.Kind
 import scala.meta.internal.semanticdb.SymbolInformation.Property
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.transversers.SimpleTraverser
+import scala.meta.Pat
+import scala.meta.internal.metals.Trees
 
 object ScalaMtags {
   def index(input: Input.VirtualFile): MtagsIndexer = {
@@ -16,7 +31,9 @@ object ScalaMtags {
 class ScalaMtags(val input: Input.VirtualFile)
     extends SimpleTraverser
     with MtagsIndexer {
-  private val root: Parsed[Source] = input.parse[Source]
+
+  private val root: Parsed[Source] = Trees.defaultDialect(input).parse[Source]
+
   def source: Source = root.get
   override def language: Language = Language.SCALA
   override def indexRoot(): Unit = {

--- a/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
@@ -19,6 +19,36 @@ class DefinitionCrossLspSuite
     }
   }
 
+  test("underscore") {
+    cleanDatabase()
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "${BuildInfo.scala213}"
+           |  }
+           |}
+           |/a/src/main/scala/a/Main.scala
+           |object Main {
+           |  println("hello!")
+           |  val tests = new Test
+           |  tests.dummy()
+           |}
+           |/a/src/main/scala/a/Test.scala
+           |class Test{
+           |  val x = 100_000
+           |  def dummy() = x
+           |}
+           |""".stripMargin
+      )
+      _ = server.didOpen("a/src/main/scala/a/Main.scala")
+      _ = server.didOpen("a/src/main/scala/a/Test.scala")
+      _ = server.assertReferenceDefinitionBijection()
+    } yield ()
+  }
+
   def basicDefinitionTest(scalaVersion: String): Future[Unit] = {
     cleanDatabase()
     for {

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -94,6 +94,7 @@ import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.ClientExperimentalCapabilities
 import scala.meta.internal.metals.DebugUnresolvedMainClassParams
 import com.google.gson.JsonElement
+import scala.meta.internal.metals.Trees
 
 /**
  * Wrapper around `MetalsLanguageServer` with helpers methods for testing purposes.
@@ -333,7 +334,7 @@ final class TestingServer(
       source <- workspaceSources()
       input = source.toInputFromBuffers(buffers)
       identifier = source.toTextDocumentIdentifier
-      token <- input.tokenize.get
+      token <- Trees.defaultDialect(input).tokenize.get
       if token.isIdentifier
       params = token.toPositionParams(identifier)
       definition = server.definitionResult(params).asJava.get()
@@ -1150,7 +1151,7 @@ final class TestingServer(
     val identifier = path.toTextDocumentIdentifier
     val occurrences = ListBuffer.empty[s.SymbolOccurrence]
     var last = List[String]()
-    input.tokenize.get.foreach { token =>
+    Trees.defaultDialect(input).tokenize.get.foreach { token =>
       val params = token.toPositionParams(identifier)
       val definition = server
         .definitionOrReferences(params, definitionOnly = true)

--- a/tests/unit/src/test/scala/tests/DefinitionSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionSuite.scala
@@ -8,6 +8,7 @@ import scala.meta.internal.{semanticdb => s}
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.mtags.Symbol
+import scala.meta.internal.metals.Trees
 
 /**
  * Assert that every identifier has a definition and every non-identifier has no definition.
@@ -43,7 +44,7 @@ class DefinitionSuite extends DirectoryExpectSuite("definition") {
       ExpectTestCase(
         file, { () =>
           val input = file.input
-          val tokens = input.tokenize.get
+          val tokens = Trees.defaultDialect(input).tokenize.get
           val sb = new StringBuilder
           tokens.foreach(token => {
             sb.append(token.syntax)


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/1664

Previously, we would use 2.12 parser and tokenizer by default. Now we define the default dialect as 2.13 in one place and make sure it's used everywhere.