### PR TITLE
Expose fastpass metadata in .bsp/bloop.json

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/IntelliJ.scala
@@ -75,6 +75,8 @@ object IntelliJ {
     "${V.bloopVersion}"
   ],
   "pantsTargets": ${targetsJson.toString},
+  "fastpassVersion": "${V.metalsVersion}",
+  "fastpassProjectName": "${project.name}",
   "X-detectExternalProjectFiles": false
 }
 """


### PR DESCRIPTION
This will be consumed by pants plugin to handle automatic fastpass updates.