### PR TITLE
fix missing synthetic references 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -210,7 +210,7 @@ final class ReferenceProvider(
       val visited = scala.collection.mutable.Set.empty[AbsolutePath]
       val results: Iterator[Location] = for {
         (path, bloom) <- index.iterator
-        if bloom.mightContain(occ.symbol)
+        if isSymbol.exists(bloom.mightContain)
         scalaPath <- SemanticdbClasspath
           .toScala(workspace, AbsolutePath(path))
           .iterator

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -150,7 +150,7 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
        |""".stripMargin
   )
 
-  checkInSamePackage( // FIXME: doesn't find the case class declaration
+  checkInSamePackage( // FIXME: doesn't find the case class declaration: https://github.com/scalameta/metals/issues/1553#issuecomment-617884934
     "simple-case-class-starting-elsewhere",
     """|case class Main(name: String) // doesn't find this
        |object F {
@@ -177,7 +177,7 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
        |""".stripMargin
   )
 
-  checkInSamePackage( // FIXME: should, but doesn't find the class declaration
+  checkInSamePackage( // FIXME: should, but doesn't find the class declaration: https://github.com/scalameta/metals/issues/1553#issuecomment-617884934
     "case-class-unapply-starting-elsewhere",
     """|sealed trait Stuff
        |case class Foo(n: Int) extends Stuff // doesn't find this
@@ -197,7 +197,7 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
        |""".stripMargin
   )
 
-  checkInSamePackage( // FIXME: doesn't find the class declaration
+  checkInSamePackage( // FIXME: doesn't find the class declaration: https://github.com/scalameta/metals/issues/1553#issuecomment-617884934
     "explicit-unapply",
     """|sealed trait Stuff
        |class Foo(val n: Int) extends Stuff // doesn't find this; but should it?


### PR DESCRIPTION
Fix for one aspect of #1553:

References to case-classes via synthetics (`apply` , `unapply`) occurring in compilation units that neither define not explicitly import the class - these will now be found as expected. 

This fix results in more semanticdb lookups since we now include all those that might contain any of the alternative in addition to just the main type symbol.

The other aspect that isn't fixed just as yet: when starting the search *from* a synthetic the search results won't include the class definition itself as one of the expected references results (though other matching synthetics are returned). - for now the failing tests that demonstrate this issue are coaxed so they'll pass anyway - I'll work on this next.