### PR TITLE
Use g8 templates to provide "New Scala Project"

### DIFF
--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -688,6 +688,7 @@ The currently available settings for `InitializationOptions` are listed below.
       "slowTaskProvider": boolean,
       "statusBarProvider": "on" | "off" | "show-message" | "log-message",
       "treeViewProvider": boolean
+      "openNewWindowProvider": boolean
     }
 ```
 
@@ -708,6 +709,7 @@ to be set via `InitializationOptions`, which is preferable.
       "slowTaskProvider": boolean,
       "statusBarProvider": boolean,
       "treeViewProvider": boolean
+      "openNewWindowProvider": boolean
     }
 ```
 

--- a/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
@@ -5,29 +5,18 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-import scala.meta.internal.builds.BuildTool
-import scala.meta.internal.builds.BuildTools
-import scala.meta.internal.builds.Digest
 import scala.meta.internal.builds.Digest.Status
-import scala.meta.internal.metals.Messages._
-import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.internal.process.ExitCodes
-import scala.meta.internal.process.ProcessHandler
-import scala.meta.io.AbsolutePath
-
-import com.zaxxer.nuprocess.NuProcessBuilder
-import org.eclipse.lsp4j.MessageActionItem
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.meta.internal.builds.Digest.Status
-import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.io.AbsolutePath
-import scala.meta.internal.process.ExitCodes
-import scala.meta.internal.metals.MetalsLanguageClient
-import scala.meta.internal.metals.Tables
-import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.Confirmation
+import scala.meta.internal.metals.Messages._
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MetalsLanguageClient
+import scala.meta.internal.metals.Tables
+import scala.meta.internal.process.ExitCodes
+import scala.meta.io.AbsolutePath
+
+import org.eclipse.lsp4j.MessageActionItem
 
 /**
  * Runs `sbt/gradle/mill/mvn bloopInstall` processes.

--- a/metals/src/main/scala/scala/meta/internal/builds/BloopInstallResult.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopInstallResult.scala
@@ -1,4 +1,4 @@
-package scala.meta.internal.metals
+package scala.meta.internal.builds
 
 import scala.meta.internal.builds.Digest.Status
 

--- a/metals/src/main/scala/scala/meta/internal/builds/BloopPluginBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopPluginBuildTool.scala
@@ -1,7 +1,6 @@
 package scala.meta.internal.builds
 import scala.concurrent.Future
 
-import scala.meta.internal.metals.BloopInstallResult
 import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.io.AbsolutePath
 

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
@@ -6,7 +6,6 @@ import java.nio.file.StandardCopyOption
 
 import scala.concurrent.Future
 
-import scala.meta.internal.metals.BloopInstallResult
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.io.AbsolutePath

--- a/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
@@ -1,0 +1,306 @@
+package scala.meta.internal.builds
+
+import scala.meta.io.AbsolutePath
+import scala.meta.internal.metals.MetalsLanguageClient
+import scala.meta.internal.metals.MetalsQuickPickItem
+import scala.concurrent.Future
+import scala.meta.internal.metals.MetalsQuickPickParams
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.concurrent.ExecutionContext
+import scala.meta.internal.metals.MetalsInputBoxParams
+import org.eclipse.lsp4j.ExecuteCommandParams
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.ClientCommands
+import java.net.URI
+import scala.util.Try
+import scala.meta.internal.metals.StatusBar
+import coursierapi._
+import scala.meta.internal.metals.Time
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.MetalsOpenWindowParams
+import scala.meta.internal.metals.JsonParser._
+
+class NewProjectProvider(
+    buildTools: BuildTools,
+    client: MetalsLanguageClient,
+    statusBar: StatusBar,
+    userConfig: () => UserConfiguration,
+    time: Time,
+    messages: Messages,
+    shell: ShellRunner
+)(implicit context: ExecutionContext) {
+
+  // TODO ask if not build tool
+
+  private val templatesUrl =
+    "https://github.com/foundweekends/giter8/wiki/giter8-templates.md"
+  private val gitterDependency = Dependency
+    .of("org.foundweekends.giter8", "giter8_2.12", "0.12.0")
+  // equal to cmd's: g8 playframework/play-scala-seed.g8 --name=../<<name>>
+  private val gitterMain = "giter8.Giter8"
+
+  lazy val allTemplatesFromWeb: Seq[MetalsQuickPickItem] = {
+    statusBar.trackBlockingTask("Fetching template information from Github") {
+      // Matches:
+      // - [jimschubert/finatra.g8](https://github.com/jimschubert/finatra.g8)
+      //(A simple Finatra 2.5 template with sbt-revolver and sbt-native-packager)
+      val pattern = """\[(.+)\]\s*\(.+\)\s*\((.+)\)""".r
+      val all = for {
+        result <- Try(requests.get(templatesUrl)).toOption.toIterable
+        if result.statusCode == 200
+      } yield {
+        pattern.findAllIn(result.text).matchData.toList.collect {
+          case matching if matching.groupCount == 2 =>
+            val id = nameFromPath(matching.group(1))
+            MetalsQuickPickItem(
+              id = id,
+              label = matching.group(1),
+              description = matching.group(2)
+            )
+        }
+      }
+      NewProjectProvider.back +: all.flatten.toSeq
+    }
+  }
+
+  def checkNew(): Future[Unit] = {
+    val base = AbsolutePath(System.getProperty("user.home"))
+    askForTemplate(NewProjectProvider.defaultTemplates)
+      .flatMapOption { template =>
+        constructPath(base).mapOptionInside { path => (template, path) }
+      }
+      .flatMapOption {
+        case (template, path) =>
+          askForName(template.id, messages.NewScalaProject.enterName).map {
+            name => Some((template, path, name))
+          }
+      }
+      .flatMap {
+        case Some((template, inputPath, Some(projectName))) =>
+          createNewProject(inputPath, template.label, projectName)
+        // It's fine to just return if the user resigned
+        case _ => Future.successful(())
+      }
+  }
+
+  private def createNewProject(
+      inputPath: AbsolutePath,
+      template: String,
+      projectName: String
+  ) = {
+    val projectPath = inputPath.resolve(projectName)
+    val parent = projectPath.parent
+    projectPath.createDirectories()
+    val command = List(
+      template,
+      s"--name=${projectPath.filename}"
+    )
+    shell
+      .runJava(
+        gitterDependency,
+        gitterMain,
+        parent,
+        command
+      )
+      .flatMap {
+        case result if result == 0 =>
+          askForWindow(projectPath.toURI)
+        case _ =>
+          Future.successful {
+            client.showMessage(
+              messages.NewScalaProject
+                .creationFailed(template, parent.toString())
+            )
+          }
+      }
+  }
+
+  // TODO use proper class instead of separate params
+  private def askForWindow(uri: URI): Future[Unit] = {
+
+    def openWindow(newWindow: Boolean) = {
+      val params = MetalsOpenWindowParams(
+        uri.toString(),
+        new java.lang.Boolean(newWindow)
+      )
+      val command = new ExecuteCommandParams(
+        ClientCommands.OpenWindow.id,
+        List[Object](
+          params.toJsonObject
+        ).asJava
+      )
+      client.metalsExecuteClientCommand(command)
+    }
+    client
+      .showMessageRequest(messages.NewScalaProject.askForNewWindowParams())
+      .asScala
+      .map {
+        case msg if msg == messages.NewScalaProject.yes =>
+          openWindow(newWindow = true)
+        case msg if msg == messages.NewScalaProject.no =>
+          openWindow(newWindow = false)
+      }
+  }
+
+  private def askForTemplate(
+      templates: Seq[MetalsQuickPickItem]
+  ): Future[Option[MetalsQuickPickItem]] = {
+    client
+      .metalsQuickPick(
+        MetalsQuickPickParams(
+          templates.asJava,
+          placeHolder = messages.NewScalaProject.selectTheTemplate
+        )
+      )
+      .asScala
+      .flatMap {
+        case kind if kind.itemId == NewProjectProvider.more.id =>
+          askForTemplate(allTemplatesFromWeb)
+        case kind if kind.itemId == NewProjectProvider.back.id =>
+          askForTemplate(NewProjectProvider.defaultTemplates)
+        case kind if kind.itemId == NewProjectProvider.custom.id =>
+          askForName("", messages.NewScalaProject.enterG8Template)
+            .mapOptionInside { g8Path =>
+              MetalsQuickPickItem(
+                nameFromPath(g8Path),
+                g8Path,
+                NewProjectProvider.custom.description
+              )
+            }
+        case kind if !kind.cancelled =>
+          Future.successful(
+            templates
+              .find(_.id == kind.itemId)
+          )
+        case _ => Future.successful(None)
+      }
+  }
+
+  private def askForName(
+      default: String,
+      pompt: String
+  ): Future[Option[String]] = {
+    client
+      .metalsInputBox(
+        MetalsInputBoxParams(
+          prompt = pompt,
+          value = default
+        )
+      )
+      .asScala
+      .flatMap {
+        case name if !name.cancelled && name.value.nonEmpty =>
+          Future.successful(Some(name.value))
+        case name if name.cancelled => Future.successful(None)
+        // reask if empty
+        case _ => askForName(default, pompt)
+      }
+  }
+
+  private def constructPath(
+      from: AbsolutePath
+  ): Future[Option[AbsolutePath]] = {
+    val paths = from.list.toList
+      .map(_.filename)
+      .map(path => MetalsQuickPickItem(id = path, label = path))
+    val currentDir = MetalsQuickPickItem(id = ".", label = ".")
+    val parentDir = MetalsQuickPickItem(id = "..", label = "..")
+    val includeUp = if (from.hasParent) List(parentDir) else Nil
+    client
+      .metalsQuickPick(
+        MetalsQuickPickParams(
+          (currentDir :: includeUp ::: paths).asJava,
+          placeHolder = from.toString()
+        )
+      )
+      .asScala
+      .flatMap {
+        case path if path.cancelled => Future.successful(None)
+        case path if path.itemId == currentDir.id =>
+          Future.successful(Some(from))
+        case path if path.itemId == parentDir.id =>
+          constructPath(from.parent)
+        case path =>
+          constructPath(from.resolve(path.itemId))
+      }
+  }
+
+  // scala/hello-world.g8 -> hello-world
+  private def nameFromPath(g8Path: String) = {
+    g8Path.replaceAll(".*/", "").replace(".g8", "")
+  }
+}
+
+object NewProjectProvider {
+
+  val custom = MetalsQuickPickItem(
+    id = "custom",
+    label = "Custom",
+    description = "Enter template manually"
+  )
+
+  val more = MetalsQuickPickItem(
+    id = "more",
+    label = "Discover more...",
+    description = "From github.com/foundweekends/giter8/wiki/giter8-templates"
+  )
+
+  val back = MetalsQuickPickItem(
+    id = "back",
+    label = "Back",
+    description = "Back to curated Metals templates"
+  )
+
+  // TODO - templates for maven/gradle/mill
+  val defaultTemplates = Seq(
+    MetalsQuickPickItem(
+      id = "hello-world",
+      label = "scala/hello-world.g8",
+      description = "A template to demonstrate a minimal Scala application"
+    ),
+    MetalsQuickPickItem(
+      id = "hello-world",
+      label = "scala/scalatest-example.g8",
+      description = "A template for trying out ScalaTest"
+    ),
+    MetalsQuickPickItem(
+      id = "akka-scala-seed",
+      label = "akka/akka-scala-seed.g8",
+      description = "A minimal seed template for an Akka with Scala build"
+    ),
+    MetalsQuickPickItem(
+      id = "zio-project-seed",
+      label = "zio/zio-project-seed.g8",
+      description = "A template for ZIO"
+    ),
+    MetalsQuickPickItem(
+      id = "play-scala-seed",
+      label = "playframework/play-scala-seed.g8",
+      description = "Play Scala Seed Template"
+    ),
+    MetalsQuickPickItem(
+      id = "lagom-scala",
+      label = "lagom/lagom-scala.g8",
+      description = "A Lagom Scala seed template for sbt"
+    ),
+    MetalsQuickPickItem(
+      id = "scala-native",
+      label = "scala-native/scala-native.g8",
+      description = "Scala Native"
+    ),
+    // Uncomment once Scala 3 support is merged
+    // MetalsQuickPickItem(
+    //   id = "dotty",
+    //   label = "lampepfl/dotty.g8",
+    //   description = "A template for trying out Dotty"
+    // ),
+    MetalsQuickPickItem(
+      id = "http4s",
+      label = "http4s/http4s.g8",
+      description = "http4s services"
+    ),
+    custom,
+    more
+  )
+
+}

--- a/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
@@ -4,6 +4,8 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import scala.meta.internal.metals.BloopInstallResult
+import scala.meta.internal.metals.Timer
+import scala.meta.internal.metals.Time
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.FutureCancelToken
 import scala.meta.internal.metals.Messages

--- a/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
@@ -3,9 +3,6 @@ package scala.meta.internal.builds
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-import scala.meta.internal.metals.BloopInstallResult
-import scala.meta.internal.metals.Timer
-import scala.meta.internal.metals.Time
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.FutureCancelToken
 import scala.meta.internal.metals.Messages

--- a/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.builds
 
 import scala.concurrent.Future
+import scala.util.Properties
 
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.JavaBinary
@@ -40,12 +41,13 @@ class ShellRunner(
       arguments: List[String]
   ): Future[Int] = {
 
+    val classpathSeparator = if (Properties.isWin) ";" else ":"
     val classpath = Fetch
       .create()
       .withDependencies(dependency)
       .fetch()
       .asScala
-      .mkString(":")
+      .mkString(classpathSeparator)
 
     val cmd = List(
       JavaBinary(userConfig().javaHome),

--- a/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
@@ -1,0 +1,108 @@
+package scala.meta.internal.builds
+
+import scala.concurrent.Future
+import scala.meta.internal.metals.Timer
+import scala.meta.internal.process.ProcessHandler
+import com.zaxxer.nuprocess.NuProcessBuilder
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+import scala.meta.internal.metals.MetalsLanguageClient
+import scala.meta.internal.process.ExitCodes
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.Time
+import scala.meta.internal.metals.StatusBar
+import scala.meta.internal.metals.MetalsSlowTaskParams
+import scala.meta.internal.metals.JavaBinary
+import scala.meta.internal.metals.Cancelable
+import scala.meta.internal.metals.MutableCancelable
+import coursierapi._
+
+class ShellRunner(
+    languageClient: MetalsLanguageClient,
+    userConfig: () => UserConfiguration,
+    time: Time,
+    statusBar: StatusBar
+)(
+    implicit executionContext: scala.concurrent.ExecutionContext
+) extends Cancelable {
+
+  private val cancelables = new MutableCancelable()
+  override def cancel(): Unit = {
+    cancelables.cancel()
+  }
+
+  def runJava(
+      dependency: Dependency,
+      main: String,
+      dir: AbsolutePath,
+      arguments: List[String]
+  ): Future[Int] = {
+
+    val classpath = Fetch
+      .create()
+      .withDependencies(dependency)
+      .fetch()
+      .asScala
+      .mkString(":")
+
+    val cmd = List(
+      JavaBinary(userConfig().javaHome),
+      "-classpath",
+      classpath,
+      main
+    ) ::: arguments
+    run(main, cmd, dir, redirectErrorOutput = false)
+  }
+
+  def run(
+      running: String,
+      args: List[String],
+      directory: AbsolutePath,
+      redirectErrorOutput: Boolean,
+      additionalEnv: Map[String, String] = Map.empty
+  ): Future[Int] = {
+    val elapsed = new Timer(time)
+    val handler = ProcessHandler(
+      joinErrorWithInfo = redirectErrorOutput
+    )
+    val pb = new NuProcessBuilder(handler, args.asJava)
+    pb.setCwd(directory.toNIO)
+    userConfig().javaHome.foreach(pb.environment().put("JAVA_HOME", _))
+    additionalEnv.foreach {
+      case (key, value) =>
+        pb.environment().put(key, value)
+    }
+    val runningProcess = pb.start()
+    // NOTE(olafur): older versions of VS Code don't respect cancellation of
+    // window/showMessageRequest, meaning the "cancel build import" button
+    // stays forever in view even after successful build import. In newer
+    // VS Code versions the message is hidden after a delay.
+    val taskResponse =
+      languageClient.metalsSlowTask(
+        new MetalsSlowTaskParams(running)
+      )
+    handler.response = Some(taskResponse)
+    val processFuture = handler.completeProcess.future.map { result =>
+      taskResponse.cancel(false)
+      scribe.info(
+        s"time: ran '$running' in $elapsed"
+      )
+      result
+    }
+    statusBar.trackFuture(
+      s"Running $running bloopInstall",
+      processFuture
+    )
+    taskResponse.asScala.foreach { item =>
+      if (item.cancel) {
+        scribe.info("user cancelled build import")
+        handler.completeProcess.trySuccess(ExitCodes.Cancel)
+        ProcessHandler.destroyProcess(runningProcess)
+      }
+    }
+    cancelables
+      .add(() => ProcessHandler.destroyProcess(runningProcess))
+      .add(() => taskResponse.cancel(false))
+    processFuture
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -123,7 +123,23 @@ object ClientCommands {
        |""".stripMargin
   )
 
+  val OpenWindow = new Command(
+    "metals-open-window",
+    "Open new window",
+    """Open a new window with the specified directory.""".stripMargin,
+    """|An object with `uri` and `newWindow` fields.
+       |Example: 
+       |```json
+       |{
+       |  "uri": "file://path/to/Definition.scala",
+       |  "newWindow": true
+       |}
+       |```
+       |""".stripMargin
+  )
+
   def all: List[Command] = List(
+    OpenWindow,
     RunDoctor,
     ReloadDoctor,
     ToggleLogs,

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -123,9 +123,9 @@ object ClientCommands {
        |""".stripMargin
   )
 
-  val OpenWindow = new Command(
-    "metals-open-window",
-    "Open new window",
+  val OpenFolder = new Command(
+    "metals-open-folder",
+    "Open a specified folder either in the same or new window",
     """Open a new window with the specified directory.""".stripMargin,
     """|An object with `uri` and `newWindow` fields.
        |Example: 
@@ -139,7 +139,7 @@ object ClientCommands {
   )
 
   def all: List[Command] = List(
-    OpenWindow,
+    OpenFolder,
     RunDoctor,
     ReloadDoctor,
     ToggleLogs,

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -131,7 +131,7 @@ object ClientCommands {
        |Example: 
        |```json
        |{
-       |  "uri": "file://path/to/Definition.scala",
+       |  "uri": "file://path/to/directory",
        |  "newWindow": true
        |}
        |```

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -92,6 +92,8 @@ class ClientConfiguration(
     initializationOptions.didFocusProvider ||
       experimentalCapabilities.didFocusProvider
 
+  def isOpenNewWindowProvider(): Boolean =
+    initializationOptions.openNewWindowProvider
 }
 
 object ClientConfiguration {

--- a/metals/src/main/scala/scala/meta/internal/metals/Icons.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Icons.scala
@@ -7,13 +7,17 @@ abstract class Icons {
   def info: String
   def check: String
   def findsuper: String
+  def folder: String
+  def github: String
   final def all: List[String] = List(
     rocket,
     sync,
     alert,
     info,
     check,
-    findsuper
+    findsuper,
+    folder,
+    github
   )
 }
 object Icons {
@@ -38,6 +42,8 @@ object Icons {
     override def info: String = "ℹ️ "
     override def check: String = "✅ "
     override def findsuper: String = "⏫ "
+    override def folder: String = "📁 "
+    override def github: String = ""
   }
   case object none extends Icons {
     override def rocket: String = ""
@@ -46,6 +52,8 @@ object Icons {
     override def info: String = ""
     override def check: String = ""
     override def findsuper: String = ""
+    override def folder: String = ""
+    override def github: String = ""
   }
   // icons for vscode can be found here("Icons in Labels"):
   // https://code.visualstudio.com/api/references/icons-in-labels
@@ -56,6 +64,8 @@ object Icons {
     override def info: String = "$(info) "
     override def check: String = "$(check) "
     override def findsuper: String = "$(arrow-up)"
+    override def folder: String = "$(folder)"
+    override def github: String = "$(github)"
   }
   case object atom extends Icons {
     private def span(id: String) = s"<span class='icon icon-$id'></span> "
@@ -65,5 +75,7 @@ object Icons {
     override def info: String = span("info")
     override def check: String = span("check")
     override def findsuper: String = span("up-arrow")
+    override def folder: String = span("file-directory")
+    override def github: String = span("github")
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -19,7 +19,8 @@ final case class InitializationOptions(
     quickPickProvider: Boolean,
     slowTaskProvider: Boolean,
     statusBarProvider: String,
-    treeViewProvider: Boolean
+    treeViewProvider: Boolean,
+    openNewWindowProvider: Boolean
 ) {
   def this() =
     this(
@@ -36,7 +37,8 @@ final case class InitializationOptions(
       quickPickProvider = false,
       slowTaskProvider = false,
       statusBarProvider = "off",
-      treeViewProvider = false
+      treeViewProvider = false,
+      openNewWindowProvider = false
     )
   def doctorFormatIsJson: Boolean = doctorProvider == "json"
   def statusBarIsOn: Boolean = statusBarProvider == "on"

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -521,7 +521,7 @@ object Messages {
     def enterName: String =
       "Enter a name or a relative path for the new project"
     def enterG8Template: String =
-      "Enter the gitter template, for example `scala/hello-world.g8`," +
+      "Enter the giter template, for example `scala/hello-world.g8`," +
         " which corresponds to a github path `github.com/scala/hello-world.g8`"
     def creationFailed(what: String, where: String) = new MessageParams(
       MessageType.Error,

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -515,4 +515,34 @@ object Messages {
       s"Error importing $script. See the logs for more details."
     )
   }
+
+  object NewScalaProject {
+    def selectTheTemplate: String = "Select the template to use"
+    def enterName: String =
+      "Enter a name or a relative path for the new project"
+    def enterG8Template: String =
+      "Enter the gitter template for example `scala/hello-world.g8`," +
+        " which corresponds to a github path `github.com/scala/hello-world.g8`"
+    def creationFailed(what: String, where: String) = new MessageParams(
+      MessageType.Error,
+      s"Could not create $what in $where"
+    )
+
+    def yes = new MessageActionItem("Yes")
+    def no = new MessageActionItem("No")
+    def newWindowMessage =
+      "Do you want to open the new project in an another window?"
+    def askForNewWindowParams(): ShowMessageRequestParams = {
+      val params = new ShowMessageRequestParams()
+      params.setMessage(newWindowMessage)
+      params.setType(MessageType.Info)
+      params.setActions(
+        List(
+          yes,
+          no
+        ).asJava
+      )
+      params
+    }
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -527,11 +527,19 @@ object Messages {
       MessageType.Error,
       s"Could not create $what in $where"
     )
-
+    def templateDownloadFailed(why: String) = new MessageParams(
+      MessageType.Error,
+      s"Failed to download templates from the web.\n" + why
+    )
     def yes = new MessageActionItem("Yes")
     def no = new MessageActionItem("No")
     def newWindowMessage =
-      "Do you want to open the new project in the current window?"
+      "Do you want to open the new project in a new window?"
+    def newProjectCreated(path: AbsolutePath) = new MessageParams(
+      MessageType.Info,
+      s"New project has been in created in $path"
+    )
+
     def askForNewWindowParams(): ShowMessageRequestParams = {
       val params = new ShowMessageRequestParams()
       params.setMessage(newWindowMessage)
@@ -549,12 +557,12 @@ object Messages {
 
   object NoBuildTool {
 
-    def newProject =
+    def newProject: String =
       "No build tool detected in the current folder." +
         " Do you want to create a new project?"
 
-    def inCurrent = new MessageActionItem("In current folder")
-    def newWindow = new MessageActionItem("In new folder")
+    def inCurrent = new MessageActionItem("In the current directory")
+    def newWindow = new MessageActionItem("In a new directory")
     def dismiss = new MessageActionItem("Not now")
 
     def noBuildToolAskForTemplate(): ShowMessageRequestParams = {

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -521,7 +521,7 @@ object Messages {
     def enterName: String =
       "Enter a name or a relative path for the new project"
     def enterG8Template: String =
-      "Enter the gitter template for example `scala/hello-world.g8`," +
+      "Enter the gitter template, for example `scala/hello-world.g8`," +
         " which corresponds to a github path `github.com/scala/hello-world.g8`"
     def creationFailed(what: String, where: String) = new MessageParams(
       MessageType.Error,
@@ -531,7 +531,7 @@ object Messages {
     def yes = new MessageActionItem("Yes")
     def no = new MessageActionItem("No")
     def newWindowMessage =
-      "Do you want to open the new project in an another window?"
+      "Do you want to open the new project in the current window?"
     def askForNewWindowParams(): ShowMessageRequestParams = {
       val params = new ShowMessageRequestParams()
       params.setMessage(newWindowMessage)
@@ -544,5 +544,32 @@ object Messages {
       )
       params
     }
+
+  }
+
+  object NoBuildTool {
+
+    def newProject =
+      "No build tool detected in the current folder." +
+        " Do you want to create a new project?"
+
+    def inCurrent = new MessageActionItem("In current folder")
+    def newWindow = new MessageActionItem("In new folder")
+    def dismiss = new MessageActionItem("Not now")
+
+    def noBuildToolAskForTemplate(): ShowMessageRequestParams = {
+      val params = new ShowMessageRequestParams()
+      params.setMessage(newProject)
+      params.setType(MessageType.Info)
+      params.setActions(
+        List(
+          inCurrent,
+          newWindow,
+          dismiss
+        ).asJava
+      )
+      params
+    }
+
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -660,6 +660,13 @@ object MetalsEnrichments
       state.flatMap(
         _.fold(Future.successful(Option.empty[B]))(f(_).liftOption)
       )
+
+    def mapOptionInside[B](
+        f: A => B
+    )(implicit ec: ExecutionContext): Future[Option[B]] =
+      state.map(
+        _.map(f)
+      )
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
@@ -147,6 +147,11 @@ case class MetalsQuickPickResult(
     @Nullable cancelled: java.lang.Boolean = null
 )
 
+case class MetalsOpenWindowParams(
+    uri: String,
+    openNewWindow: java.lang.Boolean
+)
+
 case class MetalsQuickPickItem(
     id: String,
     // A human readable string which is rendered prominent.

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -333,7 +333,6 @@ class MetalsLanguageServer(
       languageClient,
       buildTools,
       tables,
-      messages,
       shellRunner
     )
     newProjectProvider = new NewProjectProvider(
@@ -342,8 +341,8 @@ class MetalsLanguageServer(
       statusBar,
       () => userConfig,
       time,
-      messages,
-      shellRunner
+      shellRunner,
+      initialConfig.icons
     )
     bloopServers = new BloopServers(
       workspace,
@@ -1413,7 +1412,7 @@ class MetalsLanguageServer(
       case ServerCommands.StopAmmoniteBuildServer() =>
         ammonite.stop()
       case ServerCommands.NewScalaProject() =>
-        newProjectProvider.checkNew().asJavaObject
+        newProjectProvider.checkNew(existingDirectory = None).asJavaObject
       case cmd =>
         scribe.error(s"Unknown command '$cmd'")
         Future.successful(()).asJavaObject

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -26,8 +26,11 @@ import scala.concurrent.duration._
 import scala.util.Success
 import scala.util.control.NonFatal
 
+import scala.meta.internal.builds.BloopInstall
 import scala.meta.internal.builds.BuildTool
 import scala.meta.internal.builds.BuildTools
+import scala.meta.internal.builds.NewProjectProvider
+import scala.meta.internal.builds.ShellRunner
 import scala.meta.internal.implementation.ImplementationProvider
 import scala.meta.internal.implementation.Supermethods
 import scala.meta.internal.io.FileIO
@@ -64,17 +67,6 @@ import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
 import org.eclipse.{lsp4j => l}
-
-import java.{util => ju}
-import scala.meta.internal.metals.Messages.IncompatibleBloopVersion
-import scala.meta.internal.implementation.Supermethods
-import scala.meta.internal.metals.codelenses.RunTestCodeLens
-import scala.meta.internal.metals.codelenses.SuperMethodCodeLens
-import scala.meta.internal.remotels.RemoteLanguageServer
-import scala.concurrent.duration._
-import scala.meta.internal.builds.NewProjectProvider
-import scala.meta.internal.builds.ShellRunner
-import scala.meta.internal.builds.BloopInstall
 
 class MetalsLanguageServer(
     ec: ExecutionContextExecutorService,
@@ -339,10 +331,11 @@ class MetalsLanguageServer(
       buildTools,
       languageClient,
       statusBar,
-      () => userConfig,
+      clientConfig,
       time,
       shellRunner,
-      initialConfig.icons
+      initialConfig.icons,
+      workspace
     )
     bloopServers = new BloopServers(
       workspace,
@@ -1412,7 +1405,7 @@ class MetalsLanguageServer(
       case ServerCommands.StopAmmoniteBuildServer() =>
         ammonite.stop()
       case ServerCommands.NewScalaProject() =>
-        newProjectProvider.checkNew(existingDirectory = None).asJavaObject
+        newProjectProvider.createNewProjectFromTemplate().asJavaObject
       case cmd =>
         scribe.error(s"Unknown command '$cmd'")
         Future.successful(()).asJavaObject

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -220,6 +220,12 @@ object ServerCommands {
     "[string], where the string is a directory location for the new file."
   )
 
+  val NewScalaProject = new Command(
+    "new-scala-project",
+    "New Scala Project",
+    """Create a new Scala project, works with sbt"""
+  )
+
   /**
    * Open the browser at the given url.
    */
@@ -304,6 +310,7 @@ object ServerCommands {
     StartDebugAdapter,
     GotoLocation,
     NewScalaFile,
+    NewScalaProject,
     GotoSuperMethod,
     SuperMethodHierarchy,
     StartAmmoniteBuildServer,

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -223,7 +223,9 @@ object ServerCommands {
   val NewScalaProject = new Command(
     "new-scala-project",
     "New Scala Project",
-    """Create a new Scala project, works with sbt"""
+    """|Create a new Scala project using one of the available g8 templates. 
+       |This includes simple projects as well as samples for most of the popular Scala frameworks.
+       |""".stripMargin
   )
 
   /**

--- a/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
@@ -93,8 +93,8 @@ final class Warnings(
     if (tools.isEmpty) {
       scribe.warn(
         s"no build tool detected in workspace '$workspace'. " +
-          s"The most common cause for this problem is that the editor was opened in the wrong working directory, " +
-          s"for example if you use sbt then the workspace directory should contain build.sbt. "
+          "The most common cause for this problem is that the editor was opened in the wrong working directory, " +
+          "for example if you use sbt then the workspace directory should contain build.sbt. "
       )
     } else {
       val what =

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -208,7 +208,7 @@ class MetalsTreeViewProvider(
         )
       case Project =>
         Option(params.nodeUri) match {
-          case None =>
+          case None if buildTargets.all.nonEmpty =>
             Array(
               projects.root,
               libraries.root
@@ -221,12 +221,15 @@ class MetalsTreeViewProvider(
             } else {
               Array.empty
             }
+          case _ => Array.empty
         }
       case Build =>
         Option(params.nodeUri) match {
           case None =>
             Array(
               TreeViewNode.fromCommand(ServerCommands.ImportBuild, "sync"),
+              TreeViewNode
+                .fromCommand(ServerCommands.NewScalaProject, "empty-window"),
               TreeViewNode
                 .fromCommand(ServerCommands.ConnectBuildServer, "connect"),
               TreeViewNode

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -284,6 +284,13 @@ trait CommonMtagsEnrichments {
       AbsolutePath(path.toNIO.getParent)
     }
 
+    def parentOpt: Option[AbsolutePath] = {
+      if (hasParent)
+        Some(AbsolutePath(path.toNIO.getParent))
+      else
+        None
+    }
+
     def hasParent: Boolean = {
       path.toNIO.getParent != null
     }
@@ -291,6 +298,9 @@ trait CommonMtagsEnrichments {
     def exists: Boolean = {
       Files.exists(path.toNIO)
     }
+
+    def root: Option[AbsolutePath] =
+      Option(path.toNIO.getRoot()).map(AbsolutePath(_))
 
     def list: Generator[AbsolutePath] = {
       if (path.isDirectory) Files.list(path.toNIO).asScala.map(AbsolutePath(_))

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -284,6 +284,10 @@ trait CommonMtagsEnrichments {
       AbsolutePath(path.toNIO.getParent)
     }
 
+    def hasParent: Boolean = {
+      path.toNIO.getParent != null
+    }
+
     def exists: Boolean = {
       Files.exists(path.toNIO)
     }

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -9,9 +9,9 @@ import scala.util.control.NonFatal
 
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.Buffers
-import scala.meta.internal.metals.ClientExperimentalCapabilities
 import scala.meta.internal.metals.ExecuteClientCommandConfig
 import scala.meta.internal.metals.Icons
+import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.MetalsLogger
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.RecursivelyDelete
@@ -41,8 +41,7 @@ abstract class BaseLspSuite(suiteName: String) extends BaseSuite {
   var client: TestingClient = _
   var workspace: AbsolutePath = _
 
-  protected def experimentalCapabilities
-      : Option[ClientExperimentalCapabilities] = None
+  protected def initializationOptions: Option[InitializationOptions] = None
 
   override def afterAll(): Unit = {
     if (server != null) {
@@ -76,7 +75,7 @@ abstract class BaseLspSuite(suiteName: String) extends BaseSuite {
       bspGlobalDirectories,
       sh,
       time,
-      experimentalCapabilities
+      initializationOptions
     )(ex)
     server.server.userConfig = this.userConfig
   }

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -2,15 +2,15 @@ package tests
 
 import scala.concurrent.Promise
 
-import scala.meta.internal.metals.ClientExperimentalCapabilities
+import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.MetalsSlowTaskResult
 import scala.meta.internal.metals.UserConfiguration
 
 abstract class BaseWorksheetLspSuite(scalaVersion: String)
     extends BaseLspSuite("worksheet") {
-  override def experimentalCapabilities
-      : Option[ClientExperimentalCapabilities] =
-    Some(ClientExperimentalCapabilities.Default.copy(decorationProvider = true))
+  override def initializationOptions: Option[InitializationOptions] =
+    Some(InitializationOptions.Default.copy(decorationProvider = true))
+
   override def userConfig: UserConfiguration =
     super.userConfig.copy(worksheetScreenWidth = 40, worksheetCancelTimeout = 1)
 

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -76,7 +76,7 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
     _: ShowMessageRequestParams => None
   }
   var inputBoxHandler: MetalsInputBoxParams => Option[MetalsInputBoxResult] = {
-    _: MetalsInputBoxParams => None
+    params: MetalsInputBoxParams => None
   }
 
   private val refreshCount = new AtomicInteger

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -30,12 +30,12 @@ import scala.meta.internal.io.FileIO
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.ClientCommands
-import scala.meta.internal.metals.ClientExperimentalCapabilities
 import scala.meta.internal.metals.Debug
 import scala.meta.internal.metals.DebugSession
 import scala.meta.internal.metals.DebugUnresolvedMainClassParams
 import scala.meta.internal.metals.DidFocusResult
 import scala.meta.internal.metals.Directories
+import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsLanguageServer
 import scala.meta.internal.metals.MetalsServerConfig
@@ -119,7 +119,7 @@ final class TestingServer(
     bspGlobalDirectories: List[AbsolutePath],
     sh: ScheduledExecutorService,
     time: Time,
-    experimentalCapabilities: Option[ClientExperimentalCapabilities]
+    initializationOptions: Option[InitializationOptions]
 )(implicit ex: ExecutionContextExecutorService) {
   import scala.meta.internal.metals.JsonParser._
   val server = new MetalsLanguageServer(
@@ -388,8 +388,8 @@ final class TestingServer(
     val workspaceCapabilities = new WorkspaceClientCapabilities()
     val textDocumentCapabilities = new TextDocumentClientCapabilities
     textDocumentCapabilities.setFoldingRange(new FoldingRangeCapabilities)
-    val experimental = experimentalCapabilities.getOrElse(
-      ClientExperimentalCapabilities.Default.copy(
+    val initOptions = initializationOptions.getOrElse(
+      InitializationOptions.Default.copy(
         debuggingProvider = true,
         treeViewProvider = true,
         slowTaskProvider = true
@@ -399,7 +399,7 @@ final class TestingServer(
       new ClientCapabilities(
         workspaceCapabilities,
         textDocumentCapabilities,
-        experimental.toJson
+        initOptions.toJson
       )
     )
     params.setWorkspaceFolders(

--- a/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
@@ -3,7 +3,7 @@ package tests
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
 
-import scala.meta.internal.metals.ClientExperimentalCapabilities
+import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.Messages.NewScalaFile
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsInputBoxParams
@@ -15,9 +15,10 @@ import munit.TestOptions
 import org.eclipse.lsp4j.ShowMessageRequestParams
 
 class NewFilesLspSuite extends BaseLspSuite("new-files") {
-  override def experimentalCapabilities
-      : Option[ClientExperimentalCapabilities] =
-    Some(ClientExperimentalCapabilities.Default.copy(inputBoxProvider = true))
+
+  override def initializationOptions: Option[InitializationOptions] =
+    Some(InitializationOptions.Default.copy(inputBoxProvider = true))
+
   check("new-worksheet")(
     Some("a/src/main/scala/"),
     "worksheet",

--- a/tests/unit/src/test/scala/tests/NewProjectLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewProjectLspSuite.scala
@@ -1,0 +1,211 @@
+package tests
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import scala.util.Try
+
+import scala.meta.internal.builds.NewProjectProvider
+import scala.meta.internal.metals.InitializationOptions
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MetalsInputBoxParams
+import scala.meta.internal.metals.MetalsInputBoxResult
+import scala.meta.internal.metals.ServerCommands
+import scala.meta.io.AbsolutePath
+
+import munit.TestOptions
+import org.apache.commons.io.FileUtils
+import org.eclipse.lsp4j.MessageActionItem
+import org.eclipse.lsp4j.ShowMessageRequestParams
+
+class NewProjectLspSuite extends BaseLspSuite("new-project") {
+
+  override def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default
+        .copy(inputBoxProvider = true, openNewWindowProvider = true)
+    )
+
+  def scalatestTemplate(name: String = "scalatest-example"): String =
+    s"""|/$name/build.sbt
+        |lazy val root = (project in file(".")).
+        |  settings(
+        |    inThisBuild(List(
+        |      organization := "com.example",
+        |      scalaVersion := "2.13.1"
+        |    )),
+        |    name := "scalatest-example"
+        |  )
+        |
+        |libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0" % Test
+        |
+        |
+        |/$name/project/build.properties
+        |sbt.version=1.3.10
+        |
+        |
+        |/$name/src/main/scala/CubeCalculator.scala
+        |object CubeCalculator extends App {
+        |  def cube(x: Int) = {
+        |    x * x * x
+        |  }
+        |}
+        |
+        |/$name/src/test/scala/CubeCalculatorTest.scala
+        |class CubeCalculatorTest extends org.scalatest.FunSuite {
+        |  test("CubeCalculator.cube") {
+        |    assert(CubeCalculator.cube(3) === 27)
+        |  }
+        |}
+        |
+        |""".stripMargin
+
+  check("basic-template")(
+    pickedProject = Some("scala/scalatest-example.g8"),
+    name = None,
+    expectedContent = scalatestTemplate()
+  )
+
+  check("custom-name")(
+    pickedProject = Some("scala/scalatest-example.g8"),
+    name = Some("my-custom-name"),
+    expectedContent = scalatestTemplate("my-custom-name")
+  )
+
+  check("custom-template")(
+    pickedProject = None,
+    name = Some("my-custom-name"),
+    customTemplate = Some("scala/scalatest-example.g8"),
+    expectedContent = scalatestTemplate("my-custom-name")
+  )
+
+  check("website-template")(
+    pickedProject = None,
+    name = None,
+    templateFromg8Site = Some("scala/scalatest-example.g8"),
+    expectedContent = scalatestTemplate()
+  )
+
+  private def check(testName: TestOptions)(
+      pickedProject: Option[String],
+      name: Option[String],
+      expectedContent: String,
+      customTemplate: Option[String] = None,
+      templateFromg8Site: Option[String] = None
+  ): Unit = test(testName) {
+
+    val tmpDirectory = AbsolutePath(Files.createTempDirectory("metals"))
+
+    def isSelectProject(params: ShowMessageRequestParams): Boolean =
+      params.getMessage() == Messages.NewScalaProject.selectTheTemplate
+
+    def isEnterTemplate(params: MetalsInputBoxParams): Boolean =
+      params.prompt == Messages.NewScalaProject.enterG8Template
+
+    def isOpenWindow(params: ShowMessageRequestParams): Boolean =
+      params.getMessage() == Messages.NewScalaProject
+        .askForNewWindowParams()
+        .getMessage()
+
+    def isChooseName(params: MetalsInputBoxParams): Boolean =
+      params.prompt == Messages.NewScalaProject.enterName
+
+    def onSelectProject(findAction: String => Option[MessageActionItem]) = {
+      if (customTemplate.isDefined) {
+        findAction(NewProjectProvider.custom.id)
+      } else if (templateFromg8Site.isDefined) {
+        findAction(NewProjectProvider.more.id)
+          .orElse(findAction(templateFromg8Site.get))
+      } else {
+        findAction(pickedProject.getOrElse(""))
+      }
+    }
+
+    def onDirectorySelect(
+        params: ShowMessageRequestParams,
+        findAction: String => Option[MessageActionItem]
+    ) = {
+      val file =
+        Try(Paths.get(params.getMessage())).map(AbsolutePath.apply).toOption
+      file.flatMap { path =>
+        if (path == tmpDirectory) {
+          val res = findAction("ok")
+          res
+        } else {
+          val next =
+            tmpDirectory.toRelative(path).toNIO.iterator().next().filename
+          findAction(next)
+        }
+      }
+    }
+
+    client.showMessageRequestHandler = { params =>
+      val findAction = { (name: String) =>
+        params.getActions().asScala.find(_.getTitle() == name)
+      }
+      if (isSelectProject(params)) {
+        onSelectProject(findAction)
+      } else if (isOpenWindow(params)) {
+        findAction("yes")
+      } else {
+        onDirectorySelect(params, findAction)
+      }
+    }
+
+    client.inputBoxHandler = { params =>
+      if (isChooseName(params)) {
+        Some(
+          new MetalsInputBoxResult(value = name.getOrElse(params.value))
+        )
+      } else if (isEnterTemplate(params)) {
+        Some(
+          new MetalsInputBoxResult(value = customTemplate.get)
+        )
+      } else {
+        None
+      }
+    }
+
+    def ignoreVersions(text: String) =
+      text.replaceAll("\\d+\\.\\d+\\.\\d+", "1.0.0")
+
+    def directoryOutput(dir: AbsolutePath) = {
+      dir.listRecursive.toList
+        .sortBy(_.toString())
+        .collect {
+          case file if (file.isFile) =>
+            s"""|/${file.toRelative(tmpDirectory)}
+                |${file.readText}
+                |""".stripMargin
+        }
+        .mkString("\n")
+    }
+
+    val testFuture = for {
+      _ <- server.initialize(s"""
+                                |/metals.json
+                                |{
+                                |  "a": { }
+                                |}
+                                |""".stripMargin)
+      _ <- server
+        .executeCommand(
+          ServerCommands.NewScalaProject.id
+        )
+      output = directoryOutput(tmpDirectory)
+    } yield assertDiffEqual(
+      ignoreVersions(output),
+      ignoreVersions(expectedContent),
+      // note(@tgodzik) The template is pretty stable for last couple of years except for versions.
+      "This test is based on https://github.com/scala/scalatest-example.g8, it might have changed."
+    )
+
+    testFuture.onComplete {
+      case _ =>
+        FileUtils.deleteDirectory(tmpDirectory.toNIO.toFile())
+    }
+    testFuture
+  }
+
+}

--- a/tests/unit/src/test/scala/tests/UnsupportedDebuggingLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/UnsupportedDebuggingLspSuite.scala
@@ -7,16 +7,18 @@ import scala.util.Failure
 import scala.util.Success
 
 import scala.meta.internal.metals.ClientCommands
-import scala.meta.internal.metals.ClientExperimentalCapabilities
+import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.MetalsEnrichments._
 
 class UnsupportedDebuggingLspSuite
     extends BaseLspSuite("unsupported-debugging") {
-  override val experimentalCapabilities: Some[ClientExperimentalCapabilities] =
+
+  override val initializationOptions: Some[InitializationOptions] =
     Some(
       // NOTE: Default is fine here since they default to off
-      ClientExperimentalCapabilities.Default
+      InitializationOptions.Default
     )
+
   test("no-code-lenses") {
     for {
       _ <- server.initialize(


### PR DESCRIPTION
In this PR we introduce the way to quickly create a new project based on the existing g8 templates.
User can choose from curated Metals templates, write a custom template or use the existing list in the documentation  https://github.com/foundweekends/giter8/wiki/giter8-templates.md

We can also pick the name for the new project, directory where it should be located and at the end we can open a new window or stay in the current and open the new project there.

![advanced-new-project](https://user-images.githubusercontent.com/3807253/81842954-2d1b3680-954d-11ea-934a-96fe53cafeb9.gif)

This command will also work with an empty workspace, clicking on the the "New Scala Project" will activate Metals and run the command.

![newcommers](https://user-images.githubusercontent.com/3807253/81842831-fe04c500-954c-11ea-997a-c21e8e064de0.gif)

PR to VS Code: https://github.com/scalameta/metals-vscode/pull/300 
This should also work without it.