### PR TITLE
Bugfix - formatting for multilines adds pipe in the wrong place

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
@@ -142,7 +142,12 @@ object MultilineStringFormattingProvider {
       tokens.zipWithIndex
         .exists(
           shouldFormatMultiString(sourceText, tokens, startPos, endPos) orElse
-            shouldFormatInterpolationString(sourceText, tokens, startPos) orElse {
+            shouldFormatInterpolationString(
+              sourceText,
+              tokens,
+              startPos,
+              endPos
+            ) orElse {
             case _ => false
           }
         )
@@ -164,17 +169,18 @@ object MultilineStringFormattingProvider {
   private def shouldFormatInterpolationString(
       sourceText: String,
       tokens: Tokens,
-      start: StartPosition
+      start: StartPosition,
+      endPosition: EndPosition
   ): PartialFunction[(Token, Int), Boolean] = {
     case (token: Interpolation.Start, index: Int)
-        if token.start < start.start => {
+        if token.pos.start <= start.start => {
       var endIndex = index + 1
       while (!tokens(endIndex)
           .isInstanceOf[Interpolation.End]) endIndex += 1
       isMultilineString(sourceText, token) && hasStripMarginSuffix(
         endIndex,
         tokens
-      )
+      ) && tokens(endIndex).pos.end > endPosition.end
     }
   }
 

--- a/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
@@ -291,6 +291,23 @@ class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
   )
 
   check(
+    "after-interpolation-string",
+    s"""
+       |object Main {
+       |  val str = s'''
+       |               |word'''.stripMargin@@
+       |}
+       |""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = s'''
+       |               |word'''.stripMargin
+       |$indent
+       |}
+       |""".stripMargin
+  )
+
+  check(
     "real-pipe",
     s"""
        |object Main {
@@ -307,6 +324,7 @@ class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
        |}
        |""".stripMargin
   )
+
   check(
     "string-two-lines",
     s"""

--- a/tests/unit/src/test/scala/tests/RangeFormattingWhenPastingSuite.scala
+++ b/tests/unit/src/test/scala/tests/RangeFormattingWhenPastingSuite.scala
@@ -3,6 +3,7 @@ package tests
 import munit.Location
 
 class RangeFormattingWhenPastingSuite extends BaseLspSuite("rangeFormatting") {
+  private val indent = "  "
 
   check(
     "lines",
@@ -301,6 +302,29 @@ class RangeFormattingWhenPastingSuite extends BaseLspSuite("rangeFormatting") {
        |}""".stripMargin
   )
 
+  check(
+    "pasting-after-interpolation",
+    s"""
+       |object Main {
+       |  val str = s'''
+       |               |ok'''.stripMargin
+       |  @@
+       |}""".stripMargin,
+    s"""
+       |  val other = '''
+       |              |  some text
+       |              |'''.stripMargin""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = s'''
+       |               |ok'''.stripMargin
+       |$indent
+       |  val other = '''
+       |              |  some text
+       |              |'''.stripMargin
+       |}""".stripMargin
+  )
+
   def check(
       name: String,
       testCase: String,
@@ -327,7 +351,7 @@ class RangeFormattingWhenPastingSuite extends BaseLspSuite("rangeFormatting") {
           "a/src/main/scala/a/Main.scala",
           testCode, // bez @@
           expected,
-          paste,
+          unmangle(paste),
           workspace
         )
       } yield ()


### PR DESCRIPTION
Missing condition on when to stop formatting a string
fixes  #1712