### PR TITLE
Use onTypeFormatting to create multiline string

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -412,7 +412,9 @@ class Compilers(
             _symbolPrefixes = userConfig().symbolPrefixes,
             isCompletionSnippetsEnabled =
               initializeParams.supportsCompletionSnippets,
-            isFoldOnlyLines = initializeParams.foldOnlyLines
+            isFoldOnlyLines = initializeParams.foldOnlyLines,
+            isStripMarginEnabledOnTypeFormatting =
+              userConfig().enableStripMarginOnTypeFormatting
           )
       )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -413,7 +413,7 @@ class Compilers(
             isCompletionSnippetsEnabled =
               initializeParams.supportsCompletionSnippets,
             isFoldOnlyLines = initializeParams.foldOnlyLines,
-            isStripMarginEnabledOnTypeFormatting =
+            isStripMarginOnTypeFormattingEnabled =
               userConfig().enableStripMarginOnTypeFormatting
           )
       )

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -575,7 +575,7 @@ class MetalsLanguageServer(
       capabilities.setRenameProvider(renameOptions)
       capabilities.setDocumentHighlightProvider(true)
       capabilities.setDocumentOnTypeFormattingProvider(
-        new DocumentOnTypeFormattingOptions("\n")
+        new DocumentOnTypeFormattingOptions("\n", List("\"").asJava)
       )
       capabilities.setDocumentRangeFormattingProvider(
         initialConfig.allowMultilineStringFormatting

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -37,7 +37,8 @@ case class UserConfiguration(
     bloopVersion: Option[String] = None,
     pantsTargets: Option[List[String]] = None,
     superMethodLensesEnabled: Boolean = false,
-    remoteLanguageServer: Option[String] = None
+    remoteLanguageServer: Option[String] = None,
+    enableStripMarginOnTypeFormatting: Boolean = true
 ) {
 
   def currentBloopVersion: String =
@@ -273,6 +274,8 @@ object UserConfiguration {
       getBooleanKey("super-method-lenses-enabled").getOrElse(false)
     val remoteLanguageServer =
       getStringKey("remote-language-server")
+    val enableStripMarginOnTypeFormatting =
+      getBooleanKey("enable-strip-margin-on-type-formatting").getOrElse(true)
     if (errors.isEmpty) {
       Right(
         UserConfiguration(
@@ -289,7 +292,8 @@ object UserConfiguration {
           bloopVersion,
           pantsTargets,
           superMethodLensesEnabled,
-          remoteLanguageServer
+          remoteLanguageServer,
+          enableStripMarginOnTypeFormatting
         )
       )
     } else {

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -50,6 +50,11 @@ public interface PresentationCompilerConfig {
     boolean isCompletionItemDetailEnabled();
 
     /**
+     * Returns false if the <code>UserConfiguration.enableStripMarginOnTypeFormatting</code> is configured to false.
+     */
+    boolean isStripMarginEnabledOnTypeFormatting();
+
+    /**
      * Returns true if the <code>CompletionItem.documentation</code> field should be populated.
      */
     boolean isCompletionItemDocumentationEnabled();

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -52,7 +52,7 @@ public interface PresentationCompilerConfig {
     /**
      * Returns false if the <code>UserConfiguration.enableStripMarginOnTypeFormatting</code> is configured to false.
      */
-    boolean isStripMarginEnabledOnTypeFormatting();
+    boolean isStripMarginOnTypeFormattingEnabled();
 
     /**
      * Returns true if the <code>CompletionItem.documentation</code> field should be populated.

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -80,6 +80,7 @@ case class ScalaPresentationCompiler(
       config: PresentationCompilerConfig
   ): PresentationCompiler =
     copy(config = config)
+
   def this() = this(buildTargetIdentifier = "")
 
   val compilerAccess =
@@ -151,7 +152,10 @@ case class ScalaPresentationCompiler(
       source: String
   ): CompletableFuture[ju.List[TextEdit]] =
     CompletableFuture.supplyAsync(
-      () => MultilineStringFormattingProvider.format(params, source).asJava,
+      () =>
+        MultilineStringFormattingProvider
+          .format(params, source, config.isStripMarginEnabledOnTypeFormatting)
+          .asJava,
       ec
     )
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -154,7 +154,7 @@ case class ScalaPresentationCompiler(
     CompletableFuture.supplyAsync(
       () =>
         MultilineStringFormattingProvider
-          .format(params, source, config.isStripMarginEnabledOnTypeFormatting)
+          .format(params, source, config.isStripMarginOnTypeFormattingEnabled)
           .asJava,
       ec
     )

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -23,7 +23,7 @@ case class PresentationCompilerConfigImpl(
     isSignatureHelpDocumentationEnabled: Boolean = true,
     isCompletionSnippetsEnabled: Boolean = true,
     isCompletionItemResolve: Boolean = true,
-    isStripMarginEnabledOnTypeFormatting: Boolean = true,
+    isStripMarginOnTypeFormattingEnabled: Boolean = true,
     timeoutDelay: Long = 20,
     timeoutUnit: TimeUnit = TimeUnit.SECONDS
 ) extends PresentationCompilerConfig {

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -23,6 +23,7 @@ case class PresentationCompilerConfigImpl(
     isSignatureHelpDocumentationEnabled: Boolean = true,
     isCompletionSnippetsEnabled: Boolean = true,
     isCompletionItemResolve: Boolean = true,
+    isStripMarginEnabledOnTypeFormatting: Boolean = true,
     timeoutDelay: Long = 20,
     timeoutUnit: TimeUnit = TimeUnit.SECONDS
 ) extends PresentationCompilerConfig {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.2")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.15")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.16")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.0")
 addSbtPlugin("org.scalameta" % "sbt-munit" % "0.7.7")

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -813,17 +813,17 @@ final class TestingServer(
       original: String,
       root: AbsolutePath,
       autoIndent: String,
-      replaceWith: String
+      triggerChar: String
   ): Future[(String, DocumentOnTypeFormattingParams)] = {
     positionFromString(
       filename,
       original,
       root,
       replaceWith =
-        if (replaceWith == "\n") replaceWith + autoIndent else replaceWith
+        if (triggerChar == "\n") triggerChar + autoIndent else triggerChar
     ) {
       case (text, textId, start) =>
-        if (replaceWith == "\n") {
+        if (triggerChar == "\n") {
           start.setLine(start.getLine() + 1) // + newline
           start.setCharacter(autoIndent.size)
         }
@@ -831,7 +831,7 @@ final class TestingServer(
           textId,
           new FormattingOptions,
           start,
-          replaceWith
+          triggerChar
         )
         (text, params)
     }

--- a/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
@@ -353,15 +353,54 @@ class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
        |}""".stripMargin
   )
 
+  check(
+    "4-quotes",
+    s"""
+       |object Main {
+       |  val str = '''@@
+       |}""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = ''''''
+       |}""".stripMargin,
+    replaceWith = "\""
+  )
+  check(
+    "4-quotes-interpolation",
+    s"""
+       |object Main {
+       |  val str = s'''@@
+       |}""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = s''''''
+       |}""".stripMargin,
+    replaceWith = "\""
+  )
+
+  check(
+    "add-stripMargin",
+    s"""
+       |object Main {
+       |  val str = '''|@@'''
+       |}""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = '''|
+       |               |'''.stripMargin
+       |}""".stripMargin
+  )
+
   def check(
       name: String,
       testCase: String,
       expectedCase: String,
-      autoIndent: String = "  "
+      autoIndent: String = indent,
+      replaceWith: String = "\n"
   )(implicit loc: Location): Unit = {
-    val tripleQuote = """\u0022\u0022\u0022"""
+    val quote = """\u0022"""
     def unmangle(string: String): String =
-      string.replaceAll("'''", tripleQuote)
+      string.replaceAll("'", quote)
 
     val testCode = unmangle(testCase)
     val base = testCode.replaceAll("(@@)", "")
@@ -379,7 +418,8 @@ class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
           "a/src/main/scala/a/Main.scala",
           testCode,
           expected,
-          autoIndent
+          autoIndent,
+          replaceWith
         )
       } yield ()
     }

--- a/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
@@ -402,7 +402,7 @@ class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
     s"""
        |object Main {
        |  val str = '''|
-       |  '''
+       |               |'''
        |}""".stripMargin,
     stripMarginEnabled = false
   )
@@ -418,7 +418,7 @@ class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
        |object Main {
        |  val str = '''|
        |               |
-       |  '''
+       |               |'''
        |}""".stripMargin
   )
 

--- a/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
@@ -1,8 +1,8 @@
 package tests
 
-import munit.Location
-
 import scala.concurrent.Future
+
+import munit.Location
 
 class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
   private val indent = "  "

--- a/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
@@ -448,7 +448,7 @@ class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
         _ <- if (!stripMarginEnabled)
           server.didChangeConfiguration(
             """{
-              |  "enable-strip-margin-on-type-formatting": flase
+              |  "enable-strip-margin-on-type-formatting": false
               |}
               |""".stripMargin
           )

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -214,4 +214,13 @@ class UserConfigurationSuite extends BaseSuite {
     """Unexpected 'pants-targets' configuration. Expected a string or a list of strings. Obtained: 42"""
   )
 
+  checkOK(
+    "strip-margin false",
+    """
+      |{
+      | "enable-strip-margin-on-type-formatting": false
+      |}
+    """.stripMargin
+  ) { ok => assert(ok.enableStripMarginOnTypeFormatting == false) }
+
 }


### PR DESCRIPTION
By default, strip margin is added, but it's configurable with 
`   "metals.enable-strip-margin-on-type-formatting" : true `


![2020-05-15 13 00 05](https://user-images.githubusercontent.com/7843237/82043599-2951f600-96ac-11ea-808e-22ae6fa0e3be.gif)
