### PR TITLE
Try to fix breakpoint DAP suites

### DIFF
--- a/tests/unit/src/test/scala/tests/debug/StackFrameDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/StackFrameDapSuite.scala
@@ -7,6 +7,7 @@ import scala.meta.internal.metals.debug.StackFrameCollector
 import scala.meta.internal.metals.debug.Variable
 import scala.meta.internal.metals.debug.Variables
 import munit.Location
+import munit.TestOptions
 
 // note(@tgodzik) all test have `System.exit(0)` added to avoid occasional issue due to:
 // https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment
@@ -155,7 +156,7 @@ class StackFrameDapSuite extends BaseDapSuite("debug-stack-frame") {
   )
 
   def assertStackFrame(
-      name: String,
+      name: TestOptions,
       disabled: Boolean = false
   )(source: String, expectedFrames: List[Variables])(
       implicit loc: Location


### PR DESCRIPTION
It seems that the reason for some of the DAP issues with breakpoints is that the source is not set when sending back results of the breakpoint request to the client. I have no idea how it's possible, but to be on the save side I added an additional print statement and I copy the original source.

The failure in question with the logs is here:
[step-dap-suite.txt](https://github.com/scalameta/metals/files/4635973/step-dap-suite.txt)
