### PR TITLE
Handle workspaces with multiple build files.

### DIFF
--- a/metals/src/main/resources/db/migration/V1__Create_tables.sql
+++ b/metals/src/main/resources/db/migration/V1__Create_tables.sql
@@ -22,3 +22,7 @@ create table dismissed_notification(
   when_expires timestamp
 );
 
+-- The choice of build tool when multiple build tool files are found in a workspace
+create table chosen_build_tool(
+  build_tool varchar primary key
+);

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -81,16 +81,21 @@ final class BuildTools(
     if (isBazel) buf += "Bazel"
     buf.result()
   }
+
   def isEmpty: Boolean = {
     all.isEmpty
   }
-  def loadSupported(): Option[BuildTool] = {
-    if (isSbt) Some(SbtBuildTool(workspace, userConfig))
-    else if (isGradle) Some(GradleBuildTool(userConfig))
-    else if (isMaven) Some(MavenBuildTool(userConfig))
-    else if (isMill) Some(MillBuildTool(userConfig))
-    else if (isPants) Some(PantsBuildTool(userConfig))
-    else None
+
+  def loadSupported(): List[BuildTool] = {
+    val buf = List.newBuilder[BuildTool]
+
+    if (isSbt) buf += SbtBuildTool(workspace, userConfig)
+    if (isGradle) buf += GradleBuildTool(userConfig)
+    if (isMaven) buf += MavenBuildTool(userConfig)
+    if (isMill) buf += MillBuildTool(userConfig)
+    if (isPants) buf += PantsBuildTool(userConfig)
+
+    buf.result()
   }
 
   override def toString: String = {
@@ -98,6 +103,7 @@ final class BuildTools(
     if (names.isEmpty) "<no build tool>"
     else names
   }
+
   def isBuildRelated(workspace: AbsolutePath, path: AbsolutePath): Boolean = {
     if (isSbt) SbtBuildTool.isSbtRelatedPath(workspace, path)
     else if (isGradle) GradleBuildTool.isGradleRelatedPath(workspace, path)

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
@@ -15,7 +15,6 @@ import scala.meta.internal.process.ProcessHandler
 import scala.meta.internal.process.ExitCodes
 import scala.meta.internal.metals.Messages._
 import org.eclipse.lsp4j.MessageActionItem
-import scala.meta.internal.semver.SemVer
 
 /**
  * Runs `sbt/gradle/mill/mvn bloopInstall` processes.
@@ -219,31 +218,9 @@ final class BloopInstall(
       .showMessageRequest(ChooseBuildTool.params(buildTools))
       .asScala
       .map { choice =>
-        val selectedBuildTool =
-          buildTools.find(buildTool =>
-            new MessageActionItem(buildTool.executableName) == choice
-          )
-        selectedBuildTool match {
-          case Some(buildTool) => {
-            val isCompatibleVersion = SemVer.isCompatibleVersion(
-              buildTool.minimumVersion,
-              buildTool.version
-            )
-            if (isCompatibleVersion) {
-              tables.buildTool.chooseBuildTool(choice.getTitle)
-              Some(buildTool)
-            } else {
-              scribe.warn(
-                s"Unsupported $buildTool version ${buildTool.version}"
-              )
-              languageClient.showMessage(
-                Messages.IncompatibleBuildToolVersion.params(buildTool)
-              )
-              None
-            }
-          }
-          case None => None
-        }
+        buildTools.find(buildTool =>
+          new MessageActionItem(buildTool.executableName) == choice
+        )
       }
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ChosenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ChosenBuildTool.scala
@@ -1,0 +1,19 @@
+package scala.meta.internal.metals
+
+import java.sql.Connection
+import JdbcEnrichments._
+
+class ChosenBuildTool(conn: () => Connection) {
+  def selectedBuildTool(): Option[String] = {
+    conn()
+      .query(
+        "select * from chosen_build_tool LIMIT 1;"
+      )(_ => ()) { _.getString("build_tool") }
+      .headOption
+  }
+  def chooseBuildTool(buildTool: String): Int = {
+    conn().update {
+      "insert into chosen_build_tool values (?);"
+    } { stmt => stmt.setString(1, buildTool) }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -248,10 +248,16 @@ final class Doctor(
 
   private def buildTargetsJson(): String = {
     val targets = allTargets()
+    val heading = tables.buildTool.selectedBuildTool() match {
+      case Some(value) =>
+        doctorHeading + s"\n\nYour ${value} build definition has been imported."
+      case None => doctorHeading
+    }
+
     val results = if (targets.isEmpty) {
       DoctorResults(
         doctorTitle,
-        doctorHeading,
+        heading,
         Some(
           List(
             DoctorMessage(
@@ -266,7 +272,7 @@ final class Doctor(
     } else {
       val targetResults =
         targets.sortBy(_.baseDirectory).map(extractTargetInfo)
-      DoctorResults(doctorTitle, doctorHeading, None, Some(targetResults)).toJson
+      DoctorResults(doctorTitle, heading, None, Some(targetResults)).toJson
     }
     ujson.write(results)
   }
@@ -276,6 +282,15 @@ final class Doctor(
       .element("p")(
         _.text(doctorHeading)
       )
+
+    tables.buildTool.selectedBuildTool() match {
+      case Some(value) =>
+        html.element("p")(
+          _.text(s"Your ${value} build definition has been imported.")
+        )
+      case None => ()
+    }
+
     val targets = allTargets()
     if (targets.isEmpty) {
       html

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -69,6 +69,20 @@ object Messages {
 
   }
 
+  object ChooseBuildTool {
+    def params(builtTools: List[BuildTool]): ShowMessageRequestParams = {
+      val messageActionItems =
+        builtTools.map(bt => new MessageActionItem(bt.executableName))
+      val params = new ShowMessageRequestParams()
+      params.setMessage(
+        "Multiple build definitions found. Which would you like to use?"
+      )
+      params.setType(MessageType.Info)
+      params.setActions(messageActionItems.asJava)
+      params
+    }
+  }
+
   val PartialNavigation = new MetalsStatusParams(
     "$(info) Partial navigation",
     tooltip =

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -66,7 +66,6 @@ object Messages {
       )
       params
     }
-
   }
 
   object ChooseBuildTool {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1467,7 +1467,7 @@ class MetalsLanguageServer(
           Future(None)
         }
       }
-      case buildTools @ head :: tail =>
+      case buildTools =>
         bloopInstall.checkForChosenBuildTool(buildTools)
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
@@ -24,6 +24,8 @@ final class Tables(
     new DismissedNotifications(() => connection, time)
   val buildServers =
     new ChosenBuildServers(() => connection, time)
+  val buildTool =
+    new ChosenBuildTool(() => connection)
 
   def connect(): Unit = {
     this._connection =

--- a/tests/slow/src/test/scala/tests/MultipleBuildFilesLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/MultipleBuildFilesLspSuite.scala
@@ -9,10 +9,11 @@ import scala.meta.internal.builds.MillBuildTool
 class MultipleBuildFilesLspSuite
     extends BaseImportSuite("multiple-build-files") {
 
-  // SBT will be the main tool for this test, but Mill will be added
+  // SBT will be the main tool for this test, which is what will be
+  // chosen when the user is prompted in the test
   val buildTool: SbtBuildTool = SbtBuildTool(None, () => userConfig)
 
-  val alternativeBuildTool = MillBuildTool(() => userConfig)
+  val alternativeBuildTool: MillBuildTool = MillBuildTool(() => userConfig)
 
   def chooseBuildToolMessage: String =
     ChooseBuildTool.params(List(buildTool, alternativeBuildTool)).getMessage

--- a/tests/slow/src/test/scala/tests/MultipleBuildFilesLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/MultipleBuildFilesLspSuite.scala
@@ -1,0 +1,66 @@
+package tests
+
+import scala.meta.internal.metals.{BuildInfo => V}
+import scala.meta.internal.builds.SbtBuildTool
+import scala.meta.io.AbsolutePath
+import scala.meta.internal.metals.Messages.ChooseBuildTool
+import scala.meta.internal.builds.MillBuildTool
+
+class MultipleBuildFilesLspSuite
+    extends BaseImportSuite("multiple-build-files") {
+
+  // SBT will be the main tool for this test, but Mill will be added
+  val buildTool: SbtBuildTool = SbtBuildTool(None, () => userConfig)
+
+  val alternativeBuildTool = MillBuildTool(() => userConfig)
+
+  def chooseBuildToolMessage: String =
+    ChooseBuildTool.params(List(buildTool, alternativeBuildTool)).getMessage
+
+  override def currentDigest(
+      workspace: AbsolutePath
+  ): Option[String] = None
+
+  test("basic") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        s"""|/build.sbt
+            |scalaVersion := "${V.scala212}"
+            |/build.sc
+            |import mill._, scalalib._
+            |object foo extends ScalaModule {
+            |  def scalaVersion = "${V.scala212}"
+            |}
+            |""".stripMargin
+      )
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          // Project has no .bloop directory so user is asked to "import via bloop"
+          chooseBuildToolMessage,
+          importBuildMessage,
+          progressMessage
+        ).mkString("\n")
+      )
+      _ = client.messageRequests.clear() // restart
+      _ = assertNoDiff(client.workspaceMessageRequests, "")
+      _ <- server.didChange("build.sbt") { text =>
+        text + "\nversion := \"1.0.0\"\n"
+      }
+      _ = assertNoDiff(client.workspaceMessageRequests, "")
+      _ <- server.didSave("build.sbt")(identity)
+    } yield {
+      assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          // Ensure that after a choice was made, the user doesn't get re-prompted
+          // to choose their build tool again
+          importBuildChangesMessage,
+          progressMessage
+        ).mkString("\n")
+      )
+    }
+  }
+
+}

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -257,7 +257,8 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
         } else if (SelectBspServer.isSelectBspServer(params)) {
           params.getActions.asScala.find(_.getTitle == "Bob").get
         } else if (isSameMessageFromList(ChooseBuildTool.params)) {
-          params.getActions.asScala.toList.headOption
+          params.getActions.asScala.toList
+            .find(_.getTitle == "sbt")
             .getOrElse(new MessageActionItem("fail"))
         } else if (MissingScalafmtConf.isCreateScalafmtConf(params)) {
           null

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -43,6 +43,7 @@ import org.eclipse.lsp4j.CodeAction
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.Command
 import scala.concurrent.Future
+import scala.meta.internal.builds.BuildTool
 
 /**
  * Fake LSP client that responds to notifications/requests initiated by the server.
@@ -227,6 +228,21 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
         .map(tool => createParams(tool.toString()))
         .contains(params)
     }
+    // NOTE: (ckipp01) Just for easiness of testing, we are going to just look
+    // for sbt and mill builds together, which are most common. The logic however
+    // is identical for all build tools.
+    def isSameMessageFromList(
+        createParams: List[BuildTool] => ShowMessageRequestParams
+    ): Boolean = {
+      val buildTools = BuildTools
+        .default()
+        .allAvailable
+        .filter(bt => bt.executableName == "sbt" || bt.executableName == "mill")
+
+      val targetParams = createParams(buildTools)
+      params == targetParams
+    }
+
     CompletableFuture.completedFuture {
       messageRequests.addLast(params.getMessage)
       showMessageRequestHandler(params).getOrElse {
@@ -240,6 +256,9 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
           CheckDoctor.moreInformation
         } else if (SelectBspServer.isSelectBspServer(params)) {
           params.getActions.asScala.find(_.getTitle == "Bob").get
+        } else if (isSameMessageFromList(ChooseBuildTool.params)) {
+          params.getActions.asScala.toList.headOption
+            .getOrElse(new MessageActionItem("fail"))
         } else if (MissingScalafmtConf.isCreateScalafmtConf(params)) {
           null
         } else {

--- a/tests/unit/src/test/scala/tests/ChosenBuildToolSuite.scala
+++ b/tests/unit/src/test/scala/tests/ChosenBuildToolSuite.scala
@@ -1,0 +1,15 @@
+package tests
+
+import scala.meta.internal.metals.ChosenBuildTool
+
+class ChosenBuildToolSuite extends BaseTablesSuite {
+  def buildTool: ChosenBuildTool = tables.buildTool
+  test("basic") {
+    assert(buildTool.selectedBuildTool().isEmpty)
+    assertDiffEqual(buildTool.chooseBuildTool("sbt"), 1)
+    assertDiffEqual(
+      buildTool.selectedBuildTool().get,
+      "sbt"
+    )
+  }
+}

--- a/tests/unit/src/test/scala/tests/DetectionSuite.scala
+++ b/tests/unit/src/test/scala/tests/DetectionSuite.scala
@@ -206,4 +206,29 @@ class DetectionSuite extends BaseSuite {
        |</project>
        |""".stripMargin
   )
+
+  /**------------ Multiple Build Files ------------**/
+  def checkMulti(name: String, layout: String, isTrue: Boolean = true)(
+      implicit loc: Location
+  ): Unit = {
+    test(s"sbt-$name") {
+      check(
+        layout,
+        p => {
+          val bt = BuildTools.default(p)
+          bt.isSbt && bt.isMill
+        },
+        isTrue
+      )
+    }
+  }
+
+  checkMulti(
+    "sbt-and-mill",
+    """|/build.sbt
+       |lazy val a = project
+       |/build.sc
+       |import mill._
+       |""".stripMargin
+  )
 }


### PR DESCRIPTION
  Previously this always defaulted to the first found, many times leading
  to an SBT build if a workspace had both a `build.sbt` and a `build.sc`
  file. Now both are grabbed and the user is prompted to choose whether
  the space if for build tool A or build tool B. This choice is remembered
  and they are not asked about this again.

### Demo

![2020-05-17 14 26 07](https://user-images.githubusercontent.com/13974112/82146192-d6fb0b80-984a-11ea-8655-69c6b4b7c3ef.gif)

### Chosen Approach

I went back and forth on how the flow should go for this. I really wanted that when it was detected that multiple build definitions were found that it'd prompt like the following:

```
New workspace found. Would you like to import:?
1. Import sbt build
2. Import mill build
3. Not now
4. Don't show again
```

However, after doing that it was quite messy since you have to carry a list of `BuildTool` round to multiple methods, which all would have to handle if there was one more many. I found it way simpler and less of a change to simply prompt the user right away when multiple were found to get their intention for the workspace. Then all of the rest of the logic can remained unchanged. I'm still open to the alternative way that I outlined I guess, but I really think it will messier and more code without much benefit.

All that to say, I wanted to throw this up here to make sure this approach was ok before I started to write tests for this.

Closes #1757 