### PR TITLE
Export Pants 3rdparty sources

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
@@ -87,7 +87,8 @@ case class PantsBuildTool(
             val project = Project.create(
               name = "metals",
               SharedOptions(workspace = workspace.toNIO),
-              targets
+              targets,
+              sources = true
             )
             val args = Export(
               project,

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/BloopPants.scala
@@ -153,6 +153,7 @@ object BloopPants {
       "--concurrent",
       s"--no-quiet",
       s"--${noSources}export-dep-as-jar-sources",
+      s"--${noSources}export-dep-as-jar-libraries-sources",
       s"--export-dep-as-jar-output-file=$outputFile",
       s"export-dep-as-jar",
       "--respect-strict-deps"

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/Export.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/Export.scala
@@ -20,7 +20,7 @@ case class Export(
     isRegenerate: Boolean = false,
     token: CancelToken = EmptyCancelToken
 ) {
-  def isSources: Boolean = !export.noSources
+  def isSources: Boolean = !export.disableSources
   def isMergeTargetsInSameDirectory: Boolean =
     export.mergeTargetsInSameDirectory
   def root = project.root

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/CreateCommand.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/CreateCommand.scala
@@ -48,7 +48,12 @@ object CreateCommand extends Command[CreateOptions]("create") {
         )
         1
       case None =>
-        val project = Project.create(name, create.common, create.targets)
+        val project = Project.create(
+          name,
+          create.common,
+          create.targets,
+          create.export.disableSources
+        )
         SharedCommand.interpretExport(
           Export(project, create.open, app).copy(export = create.export)
         )

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ExportOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ExportOptions.scala
@@ -7,9 +7,14 @@ import java.nio.file.Path
 
 case class ExportOptions(
     @Description(
-      "Don't download *-sources.jar for 3rd party dependencies."
+      "Disable downloading of -sources.jar for 3rd party dependencies."
     )
-    noSources: Boolean = false,
+    disableSources: Boolean = false,
+    @Description(
+      "Enable downloading of sources for 3rdparty dependencies. This flag has no impact unless " +
+        "downloading of sources has been disabled for this project via the --disable-sources flag."
+    )
+    enableSources: Boolean = false,
     @Description(
       "The path to the coursier binary." +
         "If unspecified, coursier will be downloaded automatically."

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ProjectRoot.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/ProjectRoot.scala
@@ -6,5 +6,7 @@ case class ProjectRoot(
     bspRoot: AbsolutePath
 ) {
   val bspJson: AbsolutePath = bspRoot.resolve(".bsp").resolve("bloop.json")
+  val pantsLibrariesJson: AbsolutePath =
+    bspRoot.resolve(".pants").resolve("libraries.json")
   val bloopRoot: AbsolutePath = bspRoot.resolve(".bloop")
 }

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/RefreshCommand.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/RefreshCommand.scala
@@ -29,7 +29,13 @@ object RefreshCommand extends Command[RefreshOptions]("refresh") {
         case Some(project) =>
           SharedCommand.interpretExport(
             Export(project, refresh.open, app).copy(
-              export = refresh.export,
+              export = refresh.export.copy(
+                // Preserve --no-sources flag from `fastpass create` command
+                // during `fastpass refresh`.
+                disableSources =
+                  (!project.sources || refresh.export.disableSources) &&
+                    !refresh.export.enableSources
+              ),
               isCache = refresh.update
             )
           )

--- a/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/SharedCommand.scala
+++ b/metals/src/main/scala/scala/meta/internal/pantsbuild/commands/SharedCommand.scala
@@ -58,7 +58,11 @@ object SharedCommand {
           }
           1
         case Success(exportResult) =>
-          IntelliJ.writeBsp(export.project, export.export.coursierBinary)
+          IntelliJ.writeBsp(
+            export.project,
+            export.export.coursierBinary,
+            exportResult
+          )
           exportResult.foreach { result =>
             val targets =
               LogMessages.pluralName("Pants target", result.exportedTargets)


### PR DESCRIPTION
Previously, we didn't export library dependency sources with Pants since
it wasn't possible with the Pants v1.25 `export-dep-as-jar`. Now, we can
use `--export-dep-as-jar-libraries-sources` that got added in Pants
v1.26.