### PR TITLE
Keep modifiers when implementing abstract members

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -209,7 +209,11 @@ trait OverrideCompletions { this: MetalsGlobal =>
         // https://github.com/scalameta/metals/issues/565#issuecomment-472761240
         else ""
 
-      val _modifs = sym.flagString.replace("package ", "")
+      val _modifs = sym.flagString
+        .replace("package ", "")
+        .replace("object ", "")
+        .replace("trait ", "")
+        .replace("class ", "")
       val modifs =
         if (_modifs.isEmpty) ""
         else _modifs + " "

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -209,9 +209,10 @@ trait OverrideCompletions { this: MetalsGlobal =>
         // https://github.com/scalameta/metals/issues/565#issuecomment-472761240
         else ""
 
-      val lzy: String =
-        if (sym.isLazy) "lazy "
-        else ""
+      val _modifs = sym.flagString.replace("package ", "")
+      val modifs =
+        if (_modifs.isEmpty) ""
+        else _modifs + " "
 
       val keyword: String =
         if (isVarSetter(sym)) "var "
@@ -232,7 +233,7 @@ trait OverrideCompletions { this: MetalsGlobal =>
 
       val name: String = Identifier(sym.name)
 
-      val filterText: String = s"${overrideKeyword}${lzy}${keyword}${name}"
+      val filterText: String = s"${overrideKeyword}${modifs}${keyword}${name}"
 
       // if we had no val or def then filter will be empty
       def toMember = new OverrideDefMember(

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -213,11 +213,11 @@ trait OverrideCompletions { this: MetalsGlobal =>
         if (sym.isLazy) "lazy "
         else ""
 
-      val _modifs = sym.flagString
-        .replace("package ", "")
-        .replace("object ", "")
-        .replace("trait ", "")
-        .replace("class ", "")
+      val _modifs =
+        sym.flagString.replace(
+          sym.privateWithin.toString(),
+          sym.privateWithin.name.toString()
+        )
 
       val modifs =
         if (_modifs.isEmpty) ""

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -209,11 +209,16 @@ trait OverrideCompletions { this: MetalsGlobal =>
         // https://github.com/scalameta/metals/issues/565#issuecomment-472761240
         else ""
 
+      val lzy: String =
+        if (sym.isLazy) "lazy "
+        else ""
+
       val _modifs = sym.flagString
         .replace("package ", "")
         .replace("object ", "")
         .replace("trait ", "")
         .replace("class ", "")
+
       val modifs =
         if (_modifs.isEmpty) ""
         else _modifs + " "
@@ -237,7 +242,9 @@ trait OverrideCompletions { this: MetalsGlobal =>
 
       val name: String = Identifier(sym.name)
 
-      val filterText: String = s"${overrideKeyword}${modifs}${keyword}${name}"
+      val filterText: String = s"${overrideKeyword}${lzy}${keyword}${name}"
+      val insertText: String =
+        s"${overrideKeyword}${modifs}${keyword}${name}$signature"
 
       // if we had no val or def then filter will be empty
       def toMember = new OverrideDefMember(
@@ -261,9 +268,9 @@ trait OverrideCompletions { this: MetalsGlobal =>
       private def edit = new l.TextEdit(
         range,
         if (clientSupportsSnippets && shouldMoveCursor) {
-          s"$filterText$signature = $${0:???}"
+          s"$insertText = $${0:???}"
         } else {
-          s"$filterText$signature = ???"
+          s"$insertText = ???"
         }
       )
     }

--- a/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
@@ -636,6 +636,50 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
+    "access-modifiers",
+    """|package a
+       |
+       |trait Base {
+       |  // private is not available for abstract members
+       |  protected[a] def f(): Unit
+       |  protected def d(): Unit
+       |  protected[a] val s: Unit
+       |  implicit val a: String
+       |  lazy val l: Boolean
+       |}
+       |object Test {
+       |   class <<Concrete>> extends Base
+       |}
+       |""".stripMargin,
+    """|package a
+       |
+       |trait Base {
+       |  // private is not available for abstract members
+       |  protected[a] def f(): Unit
+       |  protected def d(): Unit
+       |  protected[a] val s: Unit
+       |  implicit val a: String
+       |  lazy val l: Boolean
+       |}
+       |object Test {
+       |   class Concrete extends Base {
+       |
+       |     override protected[a] def f(): Unit = ???
+       |
+       |     override protected def d(): Unit = ???
+       |
+       |     override protected[a] val s: Unit = ???
+       |
+       |     override implicit val a: String = ???
+       |
+       |     override lazy val l: Boolean = ???
+       |
+       |   }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
     "complete-braces-indent",
     """|package a
        |

--- a/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
@@ -645,7 +645,7 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
        |  protected def d(): Unit
        |  protected[a] val s: Unit
        |  implicit val a: String
-       |  lazy val l: Boolean
+       |  // lazy values might not be abstract
        |}
        |object Test {
        |   class <<Concrete>> extends Base
@@ -659,7 +659,7 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
        |  protected def d(): Unit
        |  protected[a] val s: Unit
        |  implicit val a: String
-       |  lazy val l: Boolean
+       |  // lazy values might not be abstract
        |}
        |object Test {
        |   class Concrete extends Base {
@@ -671,8 +671,6 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
        |     override protected[a] val s: Unit = ???
        |
        |     override implicit val a: String = ???
-       |
-       |     override lazy val l: Boolean = ???
        |
        |   }
        |}


### PR DESCRIPTION
Fixes #1759

Not sure if this is a bug or intended behaviour but `flagString` generates modifiers like `protected[package x.y.z]` and they need to be stripped manually.