### PR TITLE
Support java files inside java modules for go to definition

### DIFF
--- a/tests/unit/src/test/scala/tests/JdkSourcesSuite.scala
+++ b/tests/unit/src/test/scala/tests/JdkSourcesSuite.scala
@@ -1,9 +1,26 @@
 package tests
 
 import scala.meta.internal.metals.JdkSources
+import scala.meta.internal.mtags.OnDemandSymbolIndex
+import scala.meta.internal.mtags.Symbol
 
 class JdkSourcesSuite extends BaseSuite {
   test("src.zip") {
     JdkSources.getOrThrow()
+  }
+
+  test("index-src.zip") {
+    val jdk = JdkSources.getOrThrow()
+    val symbolIndex = OnDemandSymbolIndex()
+
+    symbolIndex.addSourceJar(jdk)
+
+    val pathsDef = symbolIndex.definition(Symbol("java/nio/file/Paths#"))
+    assert(pathsDef.isDefined, "Cannot find java/nio/file/Paths#")
+
+    val swingBoxDef =
+      symbolIndex.definition(Symbol("javax/swing/Box."))
+    assert(swingBoxDef.isDefined, "Cannot find javax/swing/Box.")
+
   }
 }


### PR DESCRIPTION
Previously, we would not find any java files from dependencies in java modules. Now, we make sure we java symbols are added as non-trivial for java modules.

Fixes https://github.com/scalameta/metals/issues/1514