### PR TITLE
Remove logging from ClasspathLoader 

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
@@ -44,7 +44,7 @@ final class OnDemandSymbolIndex(
     toIndexSource: AbsolutePath => Option[AbsolutePath] = _ => None
 ) extends GlobalSymbolIndex {
   val mtags = new Mtags
-  private val sourceJars = new ClasspathLoader(onError)
+  private val sourceJars = new ClasspathLoader()
   var indexedSources = 0L
   def close(): Unit = sourceJars.close()
   private val onErrorOption = onError.andThen(_ => None)

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ClasspathLoader.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ClasspathLoader.scala
@@ -5,8 +5,6 @@ import java.net.URLClassLoader
 import java.util
 
 import scala.collection.Seq
-import scala.util.Failure
-import scala.util.Success
 import scala.util.Try
 
 import scala.meta.internal.jdk.CollectionConverters._
@@ -67,9 +65,7 @@ object ClasspathLoader {
  * Scala data structures like `AbsolutePath` and `Option[T]` instead of
  * `java.net.URL` and nulls.
  */
-final class ClasspathLoader(
-    onError: PartialFunction[Throwable, Unit] = PartialFunction.empty
-) {
+final class ClasspathLoader() {
   val loader = new OpenClassLoader
   def close(): Unit = loader.close()
   override def toString: String = loader.getURLs.toList.toString()
@@ -87,12 +83,7 @@ final class ClasspathLoader(
   }
 
   def loadClass(symbol: String): Option[Class[_]] = {
-    Try(loader.loadClass(symbol)) match {
-      case Failure(exception) =>
-        onError.lift(exception)
-        None
-      case Success(value) => Some(value)
-    }
+    Try(loader.loadClass(symbol)).toOption
   }
 
   /** Load a resource from the classpath. */


### PR DESCRIPTION
Previously, we would if a class was not found and in most cases this is not an issue, since it's only needed for checking Java 9 + modules. Now, we only return an Option.

Previously I thought this would be under the debug flag, but this might have changed recently and these logs will not be too useful or even confuse the user.