### PR TITLE
Make sure to persist users choice of build tool

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopInstall.scala
@@ -221,9 +221,13 @@ final class BloopInstall(
       .showMessageRequest(ChooseBuildTool.params(buildTools))
       .asScala
       .map { choice =>
-        buildTools.find(buildTool =>
+        val foundBuildTool = buildTools.find(buildTool =>
           new MessageActionItem(buildTool.executableName) == choice
         )
+        foundBuildTool.foreach(buildTool =>
+          tables.buildTool.chooseBuildTool(buildTool.executableName)
+        )
+        foundBuildTool
       }
   }
 }


### PR DESCRIPTION
I'm a bit embarrassed to admit this, but somehow when I rebased #1758 after the amm branch got merged in, the persisting of the users choice of what build tool the want was removed.... This caused workspaces with both an builds.sbt and build.sc file to ask the user to choose every time they opened the workspace. This pr fixes that by _actually_ persisting the change.