### PR TITLE
Automatically add -J to jvm properties and make sure run JVM targets fists

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClassesFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClassesFinder.scala
@@ -49,9 +49,13 @@ class BuildTargetClassesFinder(
   ): Try[List[(A, b.BuildTarget)]] =
     buildTarget.fold {
       val classes =
-        findClassesByName(className).collect {
-          case (clazz, BuildTargetIdOf(buildTarget)) => (clazz, buildTarget)
-        }
+        findClassesByName(className)
+          .collect {
+            case (clazz, BuildTargetIdOf(buildTarget)) => (clazz, buildTarget)
+          }
+          .sortBy {
+            case (_, target) => buildTargets.buildTargetsOrder(target.getId())
+          }
       if (classes.nonEmpty) Success(classes)
       else
         Failure(new ClassNotFoundException(className))


### PR DESCRIPTION
This PR addresses 2 small issues:
- Add automatically `-J` for Bloop so that users don't have to remember about it - fixes https://github.com/scalameta/metals/issues/1765
- Make sure that we use a more relevant build target if none was specified, which was an issue in scalameta. When running tests we would pick up js tests first, which are not supported on the same level as jvm ones.