### PR TITLE
Allow for exhaustive pattern matching in case of sealed upper bound types

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -150,7 +150,7 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
       text: String
   ) extends CompletionPosition {
     override def contribute: List[Member] = {
-      val tpe = prefix.widen
+      val tpe = prefix.widen.bounds.hi
       val members = ListBuffer.empty[TextEditMember]
       val importPos = autoImportPosition(pos, text)
       val context = doLocateImportContext(pos, importPos)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -149,7 +149,7 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
       pos: Position,
       text: String
   ) extends CompletionPosition {
-    private def getSubclassesResult(tpe: Type): List[Symbol] = {
+    private def subclassesForType(tpe: Type): List[Symbol] = {
       val subclasses = ListBuffer.empty[Symbol]
       if (tpe.typeSymbol.isRefinementClass) {
         val RefinedType(parents, _) = tpe
@@ -166,7 +166,7 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
       val members = ListBuffer.empty[TextEditMember]
       val importPos = autoImportPosition(pos, text)
       val context = doLocateImportContext(pos, importPos)
-      val subclassesResult = getSubclassesResult(tpe)
+      val subclassesResult = subclassesForType(tpe)
 
       // sort subclasses by declaration order
       // see: https://github.com/scalameta/metals-feature-requests/issues/49

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -149,15 +149,24 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
       pos: Position,
       text: String
   ) extends CompletionPosition {
+    private def getSubclassesResult(tpe: Type): List[Symbol] = {
+      val subclasses = ListBuffer.empty[Symbol]
+      if (tpe.typeSymbol.isRefinementClass) {
+        val RefinedType(parents, _) = tpe
+        parents.foreach(t =>
+          t.typeSymbol.foreachKnownDirectSubClass { sym => subclasses += sym }
+        )
+      } else {
+        tpe.typeSymbol.foreachKnownDirectSubClass { sym => subclasses += sym }
+      }
+      subclasses.result()
+    }
     override def contribute: List[Member] = {
       val tpe = prefix.widen.bounds.hi
       val members = ListBuffer.empty[TextEditMember]
       val importPos = autoImportPosition(pos, text)
       val context = doLocateImportContext(pos, importPos)
-      val subclasses = ListBuffer.empty[Symbol]
-
-      tpe.typeSymbol.foreachKnownDirectSubClass { sym => subclasses += sym }
-      val subclassesResult = subclasses.result()
+      val subclassesResult = getSubclassesResult(tpe)
 
       // sort subclasses by declaration order
       // see: https://github.com/scalameta/metals-feature-requests/issues/49

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -248,6 +248,36 @@ class CompletionMatchSuite extends BaseCompletionSuite {
     """
       |package example
       |
+      |sealed trait Test
+      |case object Foo extends Test
+      |case object Bar extends Test
+      |
+      |object Main {
+      |  def testExhaustive[T <: Test](test: T): Boolean =
+      |    test m@@
+      |}""".stripMargin,
+    """
+      |package example
+      |
+      |sealed trait Test
+      |case object Foo extends Test
+      |case object Bar extends Test
+      |
+      |object Main {
+      |  def testExhaustive[T <: Test](test: T): Boolean =
+      |    test match {
+      |\tcase Foo => $0
+      |\tcase Bar =>
+      |}
+      |}""".stripMargin,
+    filter = _.contains("exhaustive")
+  )
+
+  checkEdit(
+    "exhaustive-upper-type-bounds with refinement",
+    """
+      |package example
+      |
       |sealed trait TestA
       |case object Foo extends TestA
       |case object Bar extends TestA

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -243,32 +243,39 @@ class CompletionMatchSuite extends BaseCompletionSuite {
     filter = _.contains("exhaustive")
   )
 
-  // https://github.com/scalameta/metals/issues/1066
   checkEdit(
     "exhaustive-upper-type-bounds",
     """
       |package example
       |
-      |sealed trait Test
-      |case object Foo extends Test
-      |case object Bar extends Test
+      |sealed trait TestA
+      |case object Foo extends TestA
+      |case object Bar extends TestA
+      |sealed trait TestB
+      |case object Baz extends TestB
+      |case object Goo extends TestB
       |
       |object Main {
-      |  def testExhaustive[T <: Test](test: T): Boolean =
+      |  def testExhaustive[T <: TestA with TestB](test: T): Boolean =
       |    test m@@
       |}""".stripMargin,
     """
       |package example
       |
-      |sealed trait Test
-      |case object Foo extends Test
-      |case object Bar extends Test
+      |sealed trait TestA
+      |case object Foo extends TestA
+      |case object Bar extends TestA
+      |sealed trait TestB
+      |case object Baz extends TestB
+      |case object Goo extends TestB
       |
       |object Main {
-      |  def testExhaustive[T <: Test](test: T): Boolean =
+      |  def testExhaustive[T <: TestA with TestB](test: T): Boolean =
       |    test match {
       |\tcase Foo => $0
       |\tcase Bar =>
+      |\tcase Baz =>
+      |\tcase Goo =>
       |}
       |}""".stripMargin,
     filter = _.contains("exhaustive")

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -242,4 +242,35 @@ class CompletionMatchSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     filter = _.contains("exhaustive")
   )
+
+  // https://github.com/scalameta/metals/issues/1066
+  checkEdit(
+    "exhaustive-upper-type-bounds",
+    """
+      |package example
+      |
+      |sealed trait Test
+      |case object Foo extends Test
+      |case object Bar extends Test
+      |
+      |object Main {
+      |  def testExhaustive[T <: Test](test: T): Boolean =
+      |    test m@@
+      |}""".stripMargin,
+    """
+      |package example
+      |
+      |sealed trait Test
+      |case object Foo extends Test
+      |case object Bar extends Test
+      |
+      |object Main {
+      |  def testExhaustive[T <: Test](test: T): Boolean =
+      |    test match {
+      |\tcase Foo => $0
+      |\tcase Bar =>
+      |}
+      |}""".stripMargin,
+      filter = _.contains("exhaustive")
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -271,6 +271,6 @@ class CompletionMatchSuite extends BaseCompletionSuite {
       |\tcase Bar =>
       |}
       |}""".stripMargin,
-      filter = _.contains("exhaustive")
+    filter = _.contains("exhaustive")
   )
 }


### PR DESCRIPTION
Allow for exhaustive pattern matching in case of sealed upper bound types

Changes:
* added a test to check exhaustive match with upper type bounds
* update match case completion
* handle refinement type

fixes #1066 