### PR TITLE
Bug-fix: onTypeFormatting is adding .stripMargin even if it's present

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/metals/MultilineStringFormattingProvider.scala
@@ -208,7 +208,7 @@ object MultilineStringFormattingProvider {
             endPosition,
             text,
             newlineAdded
-          )) indent(startToken, endToken, index)
+          )) indent(startToken, endToken, endIndex)
         else None
       case _ => None
     }

--- a/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/OnTypeFormattingSuite.scala
@@ -12,6 +12,7 @@ class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
   // Ensures that entering a newline at the beginning of a file doesn't
   // throw an exception
   // https://github.com/scalameta/metals/issues/1469
+
   check(
     "top-of-file",
     s"""|@@
@@ -390,6 +391,19 @@ class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
        |object Main {
        |  val str = '''|
        |               |'''.stripMargin
+       |}""".stripMargin
+  )
+
+  check(
+    "dont-add-stripMargin",
+    s"""
+       |object Main {
+       |  val str = s'''|@@'''.stripMargin
+       |}""".stripMargin,
+    s"""
+       |object Main {
+       |  val str = s'''|
+       |                |'''.stripMargin
        |}""".stripMargin
   )
 


### PR DESCRIPTION
Bug-fix: onTypeFormatting is adding .stripMargin even if it's present

fixes #1804