### PR TITLE
Add support for breakpoints in toplevel methods in Dotty

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -68,11 +68,12 @@ class DebugProvider(
       val proxyServer = new ServerSocket(0)
       val host = InetAddresses.toUriString(proxyServer.getInetAddress)
       val port = proxyServer.getLocalPort
+      proxyServer.setSoTimeout(10 * 1000)
       val uri = URI.create(s"tcp://$host:$port")
       val connectedToServer = Promise[Unit]()
 
       val awaitClient =
-        () => Future(proxyServer.accept()).withTimeout(10, TimeUnit.SECONDS)
+        () => Future(proxyServer.accept())
 
       val jvmOptionsTranslatedParams = translateJvmParams(parameters)
       // long timeout, since server might take a while to compile the project

--- a/mtags/src/main/scala-3/scala/scala/meta/internal/metals/ClassFinder.scala
+++ b/mtags/src/main/scala-3/scala/scala/meta/internal/metals/ClassFinder.scala
@@ -4,7 +4,9 @@ import org.eclipse.lsp4j.Position
 import dotty.tools.dotc.ast.untpd.Tree
 import dotty.tools.dotc.ast.untpd.PackageDef
 import dotty.tools.dotc.ast.untpd.TypeDef
+import dotty.tools.dotc.ast.untpd.DefDef
 import dotty.tools.dotc.ast.untpd.ModuleDef
+import dotty.tools.dotc.ast.untpd.Template
 import dotty.tools.dotc.ast.untpd.UntypedTreeTraverser
 import dotty.tools.dotc.ast.untpd
 import dotty.tools.dotc.util.SourcePosition
@@ -14,9 +16,11 @@ import dotty.tools.dotc.core.Flags
 
 object ClassFinder {
 
-  class SymbolTraverser(offset: Int) extends UntypedTreeTraverser {
+  class SymbolTraverser(offset: Int, fileName: String)
+      extends UntypedTreeTraverser {
     var symbol = ""
     var isInnerClass: Boolean = false
+    var isOuter: Boolean = true
     override def traverse(tree: Tree)(implicit ctx: Context): Unit = {
       if (tree.sourcePos.exists && tree.sourcePos.start <= offset && offset <= tree.sourcePos.end) {
         val delimeter =
@@ -29,25 +33,43 @@ object ClassFinder {
           case pkg: PackageDef if !pkg.symbol.isEmptyPackage =>
             val name = pkg._1.show
             symbol = symbol + name
+            super.traverseChildren(tree)
+
+          case _: PackageDef =>
+            super.traverseChildren(tree)
 
           case obj: ModuleDef if obj.mods.is(Flags.Package) =>
             val prefix = if (symbol.isEmpty()) "" else "."
             val name = obj.name.show
             symbol = symbol + prefix + name + ".package" + "$"
             isInnerClass = true
+            isOuter = false
+            super.traverseChildren(tree)
 
           case obj: ModuleDef =>
             val name = obj.name.show
             symbol = symbol + delimeter + name + "$"
             isInnerClass = true
+            isOuter = false
+            super.traverseChildren(tree)
 
           case cls: TypeDef =>
             val name = cls.name.show
             symbol = symbol + delimeter + name
             isInnerClass = true
+            isOuter = false
+            super.traverseChildren(tree)
+
+          case method: DefDef if isOuter =>
+            symbol = symbol + delimeter + fileName + "$package"
+            isInnerClass = true
+            isOuter = false
+
+          case _: Template =>
+            super.traverseChildren(tree)
+
           case _ =>
         }
-        super.traverseChildren(tree)
       }
     }
 
@@ -58,9 +80,10 @@ object ClassFinder {
   }
 
   def findClassForOffset(
-      offset: Int
+      offset: Int,
+      fileName: String
   )(implicit ctx: Context): String = {
     val tree = ctx.run.units.head.untpdTree
-    new SymbolTraverser(offset).find(tree)
+    new SymbolTraverser(offset, fileName).find(tree)
   }
 }

--- a/mtags/src/main/scala-3/scala/scala/meta/internal/metals/ClassFinder.scala
+++ b/mtags/src/main/scala-3/scala/scala/meta/internal/metals/ClassFinder.scala
@@ -20,7 +20,7 @@ object ClassFinder {
       extends UntypedTreeTraverser {
     var symbol = ""
     var isInnerClass: Boolean = false
-    var isOuter: Boolean = true
+    var isToplevel: Boolean = true
     override def traverse(tree: Tree)(implicit ctx: Context): Unit = {
       if (tree.sourcePos.exists && tree.sourcePos.start <= offset && offset <= tree.sourcePos.end) {
         val delimeter =
@@ -43,27 +43,27 @@ object ClassFinder {
             val name = obj.name.show
             symbol = symbol + prefix + name + ".package" + "$"
             isInnerClass = true
-            isOuter = false
+            isToplevel = false
             super.traverseChildren(tree)
 
           case obj: ModuleDef =>
             val name = obj.name.show
             symbol = symbol + delimeter + name + "$"
             isInnerClass = true
-            isOuter = false
+            isToplevel = false
             super.traverseChildren(tree)
 
           case cls: TypeDef =>
             val name = cls.name.show
             symbol = symbol + delimeter + name
             isInnerClass = true
-            isOuter = false
+            isToplevel = false
             super.traverseChildren(tree)
 
-          case method: DefDef if isOuter =>
+          case method: DefDef if isToplevel =>
             symbol = symbol + delimeter + fileName + "$package"
             isInnerClass = true
-            isOuter = false
+            isToplevel = false
 
           case _: Template =>
             super.traverseChildren(tree)

--- a/mtags/src/main/scala-3/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -510,8 +510,12 @@ case class ScalaPresentationCompiler(
     ) { access =>
       val driver = access.compiler()
       driver.run(params.uri, params.text)
+      val filename =
+        Paths.get(params.uri()).getFileName.toString.stripSuffix(".scala")
       Optional.of(
-        ClassFinder.findClassForOffset(params.offset)(driver.currentCtx)
+        ClassFinder.findClassForOffset(params.offset, filename)(
+          driver.currentCtx
+        )
       )
     }
   }

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -147,6 +147,17 @@ abstract class BasePCSuite extends BaseSuite {
         if (isIgnoredScalaVersion(scalaVersion))
           test.withTags(test.tags + munit.Ignore)
         else test
+      }),
+      new TestTransform("Run for Scala version", { test =>
+        test.tags
+          .collectFirst {
+            case RunForScalaVersion(versions) =>
+              if (versions(scalaVersion))
+                test
+              else test.withTags(test.tags + munit.Ignore)
+          }
+          .getOrElse(test)
+
       })
     )
 
@@ -190,6 +201,18 @@ abstract class BasePCSuite extends BaseSuite {
 
     def apply(version: String): IgnoreScalaVersion = {
       IgnoreScalaVersion(Set(version))
+    }
+  }
+
+  case class RunForScalaVersion(versions: Set[String])
+      extends Tag("RunScalaVersion")
+
+  object RunForScalaVersion {
+    def apply(versions: Seq[String]): RunForScalaVersion =
+      RunForScalaVersion(versions.toSet)
+
+    def apply(version: String): RunForScalaVersion = {
+      RunForScalaVersion(Set(version))
     }
   }
 }

--- a/tests/cross/src/test/scala/tests/pc/ClassBreakpointSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/ClassBreakpointSuite.scala
@@ -10,6 +10,7 @@ import scala.meta.internal.metals.EmptyCancelToken
 
 import munit.TestOptions
 import tests.BasePCSuite
+import tests.BuildInfoVersions
 
 class ClassBreakpointSuite extends BasePCSuite {
 
@@ -111,6 +112,16 @@ class ClassBreakpointSuite extends BasePCSuite {
        |}
        |""".stripMargin,
     "a.b.c.package$"
+  )
+
+  check(
+    "method-dotty".tag(RunForScalaVersion(BuildInfoVersions.scala3Versions)),
+    """|package a.b
+       |def method() = {
+       |>>  println(0)
+       |}
+       |""".stripMargin,
+    "a.b.Main$package"
   )
 
   def check(

--- a/tests/slow/src/test/scala/tests/feature/CrossDebugSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CrossDebugSuite.scala
@@ -1,0 +1,73 @@
+package tests.feature
+
+import scala.meta.internal.metals.{BuildInfo => V}
+
+import tests.BaseDapSuite
+
+class CrossDebugSuite extends BaseDapSuite("cross-debug") {
+
+  override def scalaVersion: String = V.scala3
+
+  assertBreakpoints(
+    "outer",
+    main = Some("a.helloWorld")
+  )(
+    source = """|/a/src/main/scala/a/Main.scala
+                |package a
+                |
+                |@main 
+                |def helloWorld(): Unit = {
+                |>>println("Hello world")
+                |  System.exit(0)
+                |}
+                |
+                |""".stripMargin
+  )
+
+  assertBreakpoints(
+    "unapply",
+    main = Some("a.helloWorld")
+  )(
+    source =
+      """|/a/src/main/scala/a/Main.scala
+         |package a
+         |
+         |@main 
+         |def helloWorld(): Unit = {
+         |  object Even {
+         |>>  def unapply(s: String): Boolean = s.size % 2 == 0
+         |  }
+         |
+         |  "even" match {
+         |    case s @ Even() => println(s"$s has an even number of characters")
+         |    case s          => println(s"$s has an odd number of characters")
+         |  }
+         |  System.exit(0)
+         |}
+         |
+         |""".stripMargin
+  )
+
+  assertBreakpoints(
+    "outer-object",
+    main = Some("a.helloWorld")
+  )(
+    source = """|/a/src/main/scala/a/Main.scala
+                |package a
+                |
+                |@main 
+                |def helloWorld(): Unit = {
+                |  object Hello{
+                |    def run() = {
+                |>>    println("Hello world")
+                |    }
+                |  }
+                |  Hello.run()
+                |  System.exit(0)
+                |}
+                |
+                |
+                |""".stripMargin
+  )
+
+}

--- a/tests/slow/src/test/scala/tests/feature/CrossDebugSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CrossDebugSuite.scala
@@ -28,28 +28,27 @@ class CrossDebugSuite extends BaseDapSuite("cross-debug") {
     "unapply",
     main = Some("a.helloWorld")
   )(
-    source =
-      """|/a/src/main/scala/a/Main.scala
-         |package a
-         |
-         |@main 
-         |def helloWorld(): Unit = {
-         |  object Even {
-         |>>  def unapply(s: String): Boolean = s.size % 2 == 0
-         |  }
-         |
-         |  "even" match {
-         |    case s @ Even() => println(s"$s has an even number of characters")
-         |    case s          => println(s"$s has an odd number of characters")
-         |  }
-         |  System.exit(0)
-         |}
-         |
-         |""".stripMargin
+    source = """|/a/src/main/scala/a/Main.scala
+                |package a
+                |
+                |@main 
+                |def helloWorld(): Unit = {
+                |  object Even {
+                |>>  def unapply(s: String): Boolean = s.size % 2 == 0
+                |  }
+                |
+                |  "even" match {
+                |    case Even() => 
+                |    case _      => 
+                |  }
+                |  System.exit(0)
+                |}
+                |
+                |""".stripMargin
   )
 
   assertBreakpoints(
-    "outer-object",
+    "object-in-toplevel-method",
     main = Some("a.helloWorld")
   )(
     source = """|/a/src/main/scala/a/Main.scala

--- a/tests/unit/src/main/scala/tests/BaseDapSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseDapSuite.scala
@@ -9,13 +9,17 @@ import scala.util.Success
 import scala.meta.internal.metals.GlobalTrace
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.debug.DebugProtocol
+import scala.meta.internal.metals.debug.DebugStep._
 import scala.meta.internal.metals.debug.DebugWorkspaceLayout
+import scala.meta.internal.metals.debug.StepNavigator
 import scala.meta.internal.metals.debug.Stoppage
 import scala.meta.internal.metals.debug.TestDebugger
 
 import ch.epfl.scala.bsp4j.DebugSessionParamsDataKind
 import ch.epfl.scala.bsp4j.ScalaMainClass
 import munit.GenericBeforeEach
+import munit.Location
+import munit.TestOptions
 import org.eclipse.lsp4j.debug.SetBreakpointsResponse
 
 abstract class BaseDapSuite(suiteName: String) extends BaseLspSuite(suiteName) {
@@ -32,9 +36,11 @@ abstract class BaseDapSuite(suiteName: String) extends BaseLspSuite(suiteName) {
   }
 
   protected def logDapTraces(): Unit = {
-    scribe.warn("The DAP test failed, printing the traces")
-    scribe.warn(dapClient.toString() + ":\n" + dapClient.readText)
-    scribe.warn(dapServer.toString() + ":\n" + dapServer.readText)
+    if (isCI) {
+      scribe.warn("The DAP test failed, printing the traces")
+      scribe.warn(dapClient.toString() + ":\n" + dapClient.readText)
+      scribe.warn(dapServer.toString() + ":\n" + dapServer.readText)
+    }
   }
 
   override def munitTestTransforms: List[TestTransform] =
@@ -75,4 +81,48 @@ abstract class BaseDapSuite(suiteName: String) extends BaseLspSuite(suiteName) {
         }
     }
   }
+
+  def scalaVersion = BuildInfo.scalaVersion
+
+  def assertBreakpoints(
+      name: TestOptions,
+      main: Option[String] = None
+  )(
+      source: String
+  )(implicit loc: Location): Unit = {
+    test(name) {
+
+      cleanWorkspace()
+      val workspaceLayout = DebugWorkspaceLayout(source)
+      val layout =
+        s"""|/metals.json
+            |{ 
+            |  "a": {"scalaVersion": "$scalaVersion"},  "b": {"scalaVersion": "$scalaVersion"} 
+            |}
+            |$workspaceLayout
+            |""".stripMargin
+
+      val expectedBreakpoints = workspaceLayout.files.flatMap { file =>
+        file.breakpoints.map(b => Breakpoint(file.relativePath, b.startLine))
+      }
+
+      val navigator = expectedBreakpoints.foldLeft(StepNavigator(workspace)) {
+        (navigator, breakpoint) =>
+          navigator.at(breakpoint.relativePath, breakpoint.line + 1)(Continue)
+      }
+
+      for {
+        _ <- server.initialize(layout)
+        _ = assertNoDiagnostics()
+        debugger <- debugMain("a", main.getOrElse("a.Main"), navigator)
+        _ <- debugger.initialize
+        _ <- debugger.launch
+        _ <- setBreakpoints(debugger, workspaceLayout)
+        _ <- debugger.configurationDone
+        _ <- debugger.shutdown
+      } yield ()
+    }
+  }
+
+  private final case class Breakpoint(relativePath: String, line: Int)
 }


### PR DESCRIPTION
Addresses one of the points in https://github.com/scalameta/metals/issues/1705

Previously, we did't stop at breakpoints inside toplevel methods when debugging. Now, we use a proper name for a class name generated from an outer method