### PR TITLE
Pick the most valued build target instead of least for running or debugging

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClassesFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClassesFinder.scala
@@ -56,6 +56,7 @@ class BuildTargetClassesFinder(
           .sortBy {
             case (_, target) => buildTargets.buildTargetsOrder(target.getId())
           }
+          .reverse
       if (classes.nonEmpty) Success(classes)
       else
         Failure(new ClassNotFoundException(className))


### PR DESCRIPTION
I missed that when testing it in https://github.com/scalameta/metals/pull/1781 - sortBy will give us the lowest numbers first. 

Did some manual tests, which should be enough here, since unit testing this might prove very difficult.