### PR TITLE
Add lsp-metals as required dependency in Emacs docs

### DIFF
--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -67,6 +67,9 @@ To use Metals in Emacs, place this snippet in your Emacs configuration (for exam
          (lsp-mode . lsp-lens-mode)
   :config (setq lsp-prefer-flymake nil))
 
+;; Add metals backend for lsp-mode
+(use-package lsp-metals)
+
 ;; Enable nice rendering of documentation on hover
 (use-package lsp-ui)
 


### PR DESCRIPTION
I had an issue using the metals backend this morning, and I solved by requiring the metals backend for lsp-mode. I think it would be useful to have it in the docs.