### PR TITLE
Make sure we also are able to run/debug in java-only build targets

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClasses.scala
@@ -91,13 +91,8 @@ final class BuildTargetClasses(
     for {
       item <- result.getItems.asScala
       target = item.getTarget
-      buildTarget <- buildTargets.scalaTarget(target)
       aClass <- item.getClasses.asScala
-      descriptors = {
-        if (ScalaVersions.isScala3Version(buildTarget.scalaVersion))
-          List(Descriptor.Term, Descriptor.Type)
-        else List(Descriptor.Term)
-      }
+      descriptors = descriptorsForMainClasses(target)
       symbol <- createSymbols(
         aClass.getClassName,
         descriptors
@@ -118,6 +113,19 @@ final class BuildTargetClasses(
       symbol <- createSymbols(className, List(Descriptor.Term, Descriptor.Type))
     } {
       classes(target).testClasses.put(symbol, className)
+    }
+  }
+
+  private def descriptorsForMainClasses(
+      buildTarget: b.BuildTargetIdentifier
+  ): List[String => Descriptor] = {
+    buildTargets.scalaTarget(buildTarget) match {
+      case Some(scalaBuildTarget) =>
+        if (ScalaVersions.isScala3Version(scalaBuildTarget.scalaVersion))
+          List(Descriptor.Term, Descriptor.Type)
+        else List(Descriptor.Term)
+      case None =>
+        List(Descriptor.Type)
     }
   }
 

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -458,10 +458,10 @@ final class TestingServer(
   // https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment
   private def assertSystemExit(parameter: AnyRef) = {
     def check() = {
-      val workspaceScalaFiles =
-        workspace.listRecursive.filter(_.isScala).toList
+      val workspaceFiles =
+        workspace.listRecursive.filter(_.isScalaOrJava).toList
       val usesSystemExit =
-        workspaceScalaFiles.exists(_.text.contains("System.exit(0)"))
+        workspaceFiles.exists(_.text.contains("System.exit(0)"))
       if (!usesSystemExit)
         throw new RuntimeException(
           "All debug test for main classes should have `System.exit(0)`"
@@ -1246,9 +1246,9 @@ final class TestingServer(
   }
 
   def buildTarget(displayName: String): String = {
-    server.buildTargets.all
-      .find(_.displayName == displayName)
-      .map(_.id.getUri())
+    server.buildTargets
+      .findByDisplayName(displayName)
+      .map(_.getId().getUri())
       .getOrElse {
         val alternatives =
           server.buildTargets.all.map(_.displayName).mkString(" ")

--- a/tests/unit/src/test/scala/tests/debug/BreakpointDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/BreakpointDapSuite.scala
@@ -416,13 +416,14 @@ class BreakpointDapSuite extends BaseDapSuite("debug-breakpoint") {
   )
 
   assertBreakpoints("java-static-method")(
-    source = """|/a/src/main/scala/a/Main.scala
-                |package a
-                |object Main {
-                |  def main(args: Array[String]): Unit = {
-                |    Foo.call()
-                |    System.exit(0)
-                |  }
+    source = """|/a/src/main/scala/a/Main.java
+                |package a;
+                |
+                |public class Main {
+                |    public static void main(String[] args) {
+                |        Foo.call();
+                |        System.exit(0);
+                |    }
                 |}
                 |
                 |/a/src/main/java/a/Foo.java


### PR DESCRIPTION
Previously, Metals would filter out main classes from non-scala targets. Now, we also allow to run in the java only build target.

Fixes https://github.com/scalameta/metals/issues/1815

Together with scalameta/metals-vscode#300 it will allow users to just click run for Scala configuration even if Metals was not activated in the workspace.