### PR TITLE
Fix issues with semanticdb on windows

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/Semanticdbs.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/Semanticdbs.scala
@@ -61,7 +61,7 @@ object Semanticdbs {
   ): TextDocumentLookup = {
     val reluri = scalaRelativePath.toURI(false).toString
     val sdocs = loadTextDocuments(semanticdbPath)
-    sdocs.documents.find(_.uri == reluri) match {
+    sdocs.documents.find(_.uri.replace("\\", "/") == reluri) match {
       case None => TextDocumentLookup.NoMatchingUri(scalaPath, sdocs)
       case Some(sdoc) =>
         val text = FileIO.slurp(scalaPath, charset)

--- a/tests/slow/src/test/scala/tests/feature/CrossReferenceSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CrossReferenceSuite.scala
@@ -1,0 +1,36 @@
+package tests.feature
+
+import scala.concurrent.Future
+
+import scala.meta.internal.metals.{BuildInfo => V}
+
+import tests.BaseRangesSuite
+
+class CrossReferenceSuite extends BaseRangesSuite("cross-reference-suite") {
+
+  check(
+    "references-dotty",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |
+       |object Main{
+       |  def <<hel@@lo>>() = println("Hello world")
+       |  <<hello>>()
+       |  <<hello>>()
+       |  <<hello>>()
+       |}
+       |
+       |""".stripMargin,
+    scalaVersion = Some(V.scala3)
+  )
+
+  override def assertCheck(
+      filename: String,
+      edit: String,
+      expected: Map[String, String],
+      base: Map[String, String]
+  ): Future[Unit] = {
+    server.assertReferences(filename, edit, expected, base)
+  }
+
+}

--- a/tests/unit/src/main/scala/tests/BaseRangesSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseRangesSuite.scala
@@ -13,7 +13,9 @@ abstract class BaseRangesSuite(name: String) extends BaseLspSuite(name) {
       base: Map[String, String]
   ): Future[Unit]
 
-  def check(name: String, input: String)(implicit loc: Location): Unit = {
+  def check(name: String, input: String, scalaVersion: Option[String] = None)(
+      implicit loc: Location
+  ): Unit = {
     val files = FileLayout.mapFromString(input)
     val (filename, edit) = files
       .find(_._2.contains("@@"))
@@ -35,6 +37,7 @@ abstract class BaseRangesSuite(name: String) extends BaseLspSuite(name) {
         fileName -> code.replaceAll("(<<|>>|@@)", "")
     }
 
+    val actualScalaVersion = scalaVersion.getOrElse(BuildInfo.scalaVersion)
     test(name) {
       cleanWorkspace()
       for {
@@ -42,6 +45,7 @@ abstract class BaseRangesSuite(name: String) extends BaseLspSuite(name) {
           s"""/metals.json
              |{"a":
              |  {
+             |    "scalaVersion" : "$actualScalaVersion",
              |    "compilerPlugins": [
              |      "org.scalamacros:::paradise:2.1.1"
              |    ],


### PR DESCRIPTION
Previously, we would not find semanticdb file if the relative path was done with `\\`. Now, we make sure that the slash is used all the time.