### PR TITLE
Update ammonite to fix issues with file watching

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -208,7 +208,7 @@ lazy val V = new {
     "org.eclipse.lsp4j" % "org.eclipse.lsp4j.debug" % "0.9.0"
   val coursier = "2.0.0-RC6-19"
   val coursierInterfaces = "0.0.22"
-  val ammonite = "2.1.4"
+  val ammonite = "2.1.4-6-2179b35"
 }
 
 val genyVersion = Def.setting {

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -144,7 +144,6 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
         }
         promise
       }
-      _ <- server.didSave("main.sc")(identity)
       _ <- server.didSave("main.sc") { _ =>
         s""" // scala $scalaVersion
            |import $$ivy.`com.github.alexarchambault::case-app:2.0.0-M16`
@@ -153,7 +152,7 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
       }
       // wait for Ammonite build targets to be reloaded
       _ <- refreshedPromise.future
-      _ <- server.didSave("main.sc")(identity)
+      _ <- server.didSave("main.sc") { text => text + "\nval a = 1" }
       // Hover on class defined in dependency loaded after the re-index.
       // Fails if interactive compilers were not properly discarded prior
       // to re-indexing.


### PR DESCRIPTION
Previously, ammonite would remove all directories inside the target, which would cause the file watching to break. Now it only removes relevant files. This might also help with the ammonite suite flakiness.