### PR TITLE
Add in spacing in vscode icons only.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
@@ -69,7 +69,7 @@ class NewProjectProvider(
               case matching if matching.groupCount == 2 =>
                 MetalsQuickPickItem(
                   id = matching.group(1),
-                  label = s"${icons.github} " + matching.group(1),
+                  label = s"${icons.github}" + matching.group(1),
                   description = matching.group(2)
                 )
             }
@@ -98,7 +98,7 @@ class NewProjectProvider(
         case Some((template, inputPath, Some(projectName))) =>
           createNewProject(
             inputPath,
-            template.label.replace(s"${icons.github} ", ""),
+            template.label.replace(s"${icons.github}", ""),
             projectName
           )
         // It's fine to just return if the user resigned
@@ -379,7 +379,7 @@ object NewProjectProvider {
         description = "Akka HTTP application using Kubernetes"
       )
     ).map { item =>
-      item.copy(label = s"${icons.github} " + item.label)
+      item.copy(label = s"${icons.github}" + item.label)
     } ++ Seq(custom, more)
 
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/Icons.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Icons.scala
@@ -65,7 +65,7 @@ object Icons {
     override def check: String = "$(check) "
     override def findsuper: String = "$(arrow-up)"
     override def folder: String = "$(folder)"
-    override def github: String = "$(github)"
+    override def github: String = "$(github) "
   }
   case object atom extends Icons {
     private def span(id: String) = s"<span class='icon icon-$id'></span> "


### PR DESCRIPTION
Since VS Code is the only one using an actual icon for spacing it's
better to put the spacing there since we are doing a replace on the
icon and times producing labels that have one empty space and other
times two empty spaces causing odd spacing in other clients. This
change will allow for more consistent spacing in those clients while
keeping the same spacing in VS Code.

For example what this looks like in coc-metals without the change :(

<img width="507" alt="Screenshot 2020-06-15 at 16 25 11" src="https://user-images.githubusercontent.com/13974112/84669715-77fde480-af25-11ea-9f60-66ed08b091bf.png">

And after the change :)

<img width="507" alt="Screenshot 2020-06-15 at 16 29 07" src="https://user-images.githubusercontent.com/13974112/84669745-821fe300-af25-11ea-9a97-0c22e60c213c.png">

