### PR TITLE
Changes for decorationProvider if `isHttpEnabled` is true.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -72,7 +72,7 @@ final class Doctor(
       clientCommand: Command,
       onServer: MetalsHttpServer => Unit
   ): Unit = {
-    if (clientConfig.isExecuteClientCommandProvider) {
+    if (clientConfig.isExecuteClientCommandProvider && !clientConfig.isHttpEnabled) {
       val output =
         if (clientConfig.doctorFormatIsJson)
           buildTargetsJson()
@@ -88,7 +88,7 @@ final class Doctor(
           onServer(server)
         case None =>
           scribe.warn(
-            "Unable to run doctor. To fix this problem enable -Dmetals.http=true"
+            "Unable to run doctor. Make sure `isHttpEnabled` is set to `true`."
           )
       }
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
@@ -51,7 +51,7 @@ final class MetalsHttpClient(
     icons: Icons,
     time: Time,
     sh: ScheduledExecutorService,
-    config: MetalsServerConfig
+    clientConfig: ClientConfiguration
 )(implicit ec: ExecutionContext)
     extends DelegatingLanguageClient(initial) {
 
@@ -184,7 +184,11 @@ final class MetalsHttpClient(
 
   override def metalsPublishDecorations(
       params: PublishDecorationsParams
-  ): Unit = ()
+  ): Unit = {
+    if (clientConfig.isDecorationProvider) {
+      underlying.metalsPublishDecorations(params)
+    }
+  }
 
   // =======
   // Helpers

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -672,7 +672,7 @@ class MetalsLanguageServer(
         clientConfig.initialConfig.icons,
         time,
         sh,
-        clientConfig.initialConfig
+        clientConfig
       )
       render = () => newClient.renderHtml
       completeCommand = e => newClient.completeCommand(e)


### PR DESCRIPTION
This has multiple changes to account for the case where a client may
have `isDecorationProvider` and also `isHttpEnabled` both set to true.

- Checks to make sure that `isHttpEnabled` wins before sending doctor
- Makes sure the publishDecorations is forwarded
