### PR TITLE
Add in explicit `TextDocumentSyncOptions`.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -614,7 +614,13 @@ class MetalsLanguageServer(
       } else {
         capabilities.setCodeActionProvider(true)
       }
-      capabilities.setTextDocumentSync(TextDocumentSyncKind.Full)
+
+      val textDocumentSyncOptions = new TextDocumentSyncOptions
+      textDocumentSyncOptions.setChange(TextDocumentSyncKind.Full)
+      textDocumentSyncOptions.setSave(new SaveOptions(true))
+      textDocumentSyncOptions.setOpenClose(true)
+
+      capabilities.setTextDocumentSync(textDocumentSyncOptions)
 
       val serverInfo = new ServerInfo("Metals", BuildInfo.metalsVersion)
       new InitializeResult(capabilities, serverInfo)


### PR DESCRIPTION
This pr changes the way Metals sets the `TextDocumentSync` in `ServerCapabilities`. We used to just send a 1 for this to signify a "full" synchronization. However, there are also other fields in the `TextDocumentSyncOptions` which state that if they aren't present, then they should be set to false. There seems to be some inconsistency with how clients handle this. One of those options is `save` and there really isn't anything explicitly saying that the `textDocument/didSave` events should be fired. So some clients (nvim for example), don't send them unless it is explicitly stated in the `TextDocumentSyncOptions`. This change creates a `TextDocumentSyncOptions` object  with the `change` still set to `TextDocumentSyncKind.Full`, but it also explicitly tells clients that we want `save` events and also `open/close` events. Again, most send them anyways, but this will capture the cases where they don't.

The two fields that we aren't setting are `willSaveWaitUntil` and `willSave`, which I don't believe Metals uses at all.

General `TextDocumentSync` info can be found [here in the spec](https://microsoft.github.io/language-server-protocol/specification#textDocument_synchronization).
You can see an example of where not having this will bite the user [here in the nvim lsp client](https://github.com/neovim/neovim/blob/b751d16cadfc3d2c7e7958432956859b3e2482fa/runtime/lua/vim/lsp/protocol.lua#L880-L892) since it defaults the `text_document_save` to false if it just receives a number.