### PR TITLE
Add quiet log option

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/PantsBuildTool.scala
@@ -80,7 +80,10 @@ case class PantsBuildTool(
         Future {
           val timer = new Timer(Time.system)
           val response = languageClient.metalsSlowTask(
-            Messages.bloopInstallProgress(executableName)
+            Messages.bloopInstallProgress(
+              executableName,
+              userConfig().quietLogs
+            )
           )
           val token = FutureCancelToken(response.asScala.map(_.cancel))
           try {

--- a/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
@@ -83,7 +83,7 @@ class ShellRunner(
     // VS Code versions the message is hidden after a delay.
     val taskResponse =
       languageClient.metalsSlowTask(
-        new MetalsSlowTaskParams(commandRun)
+        new MetalsSlowTaskParams(commandRun, userConfig().quietLogs)
       )
     handler.response = Some(taskResponse)
     val processFuture = handler.completeProcess.future.map { result =>

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -45,7 +45,7 @@ final class Embedded(
   def mdoc(scalaVersion: String, scalaBinaryVersion: String): Mdoc = {
     val classloader = mdocs.getOrElseUpdate(
       scalaBinaryVersion,
-      statusBar.trackSlowTask("Preparing worksheets") {
+      statusBar.trackSlowTask("Preparing worksheets", quietLogs = true) {
         Embedded.newMdocClassLoader(scalaVersion, scalaBinaryVersion)
       }
     )
@@ -62,9 +62,10 @@ final class Embedded(
   ): PresentationCompiler = {
     val classloader = presentationCompilers.getOrElseUpdate(
       ScalaVersions.dropVendorSuffix(info.getScalaVersion),
-      statusBar.trackSlowTask("Preparing presentation compiler") {
-        Embedded.newPresentationCompilerClassLoader(info, scalac)
-      }
+      statusBar
+        .trackSlowTask("Preparing presentation compiler", quietLogs = true) {
+          Embedded.newPresentationCompilerClassLoader(info, scalac)
+        }
     )
     serviceLoader(
       classOf[PresentationCompiler],

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -271,6 +271,7 @@ final class FormattingProvider(
       downloadingScalafmt = Promise()
       statusBar.trackSlowFuture(
         "Loading Scalafmt",
+        quietLogs = true,
         downloadingScalafmt.future
       )
       System.out

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -27,8 +27,8 @@ object Messages {
       "See the logs for more details. "
   )
 
-  def bloopInstallProgress(buildToolExecName: String) =
-    new MetalsSlowTaskParams(s"$buildToolExecName bloopInstall")
+  def bloopInstallProgress(buildToolExecName: String, quietLogs: Boolean) =
+    new MetalsSlowTaskParams(s"$buildToolExecName bloopInstall", quietLogs)
   def dontShowAgain: MessageActionItem =
     new MessageActionItem("Don't show again")
   def notNow: MessageActionItem =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
@@ -103,7 +103,7 @@ case class MetalsStatusParams(
 
 case class MetalsSlowTaskParams(
     message: String,
-    quietLogs: java.lang.Boolean = null,
+    quietLogs: java.lang.Boolean,
     secondsElapsed: java.lang.Integer = null
 )
 case class MetalsSlowTaskResult(cancel: Boolean)

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
@@ -48,11 +48,12 @@ final class StatusBar(
     }
   }
 
-  def trackSlowTask[T](message: String)(thunk: => T): T = {
+  def trackSlowTask[T](message: String, quietLogs: Boolean)(thunk: => T): T = {
     if (clientConfig.statusBarIsOff)
       trackBlockingTask(message)(thunk)
     else {
-      val task = client().metalsSlowTask(MetalsSlowTaskParams(message))
+      val task =
+        client().metalsSlowTask(MetalsSlowTaskParams(message, quietLogs))
       val future = task.asScala
       try {
         thunk
@@ -66,11 +67,16 @@ final class StatusBar(
     }
   }
 
-  def trackSlowFuture[T](message: String, thunk: Future[T]): Unit = {
+  def trackSlowFuture[T](
+      message: String,
+      quietLogs: Boolean,
+      thunk: Future[T]
+  ): Unit = {
     if (clientConfig.statusBarIsOff)
       trackFuture(message, thunk)
     else {
-      val task = client().metalsSlowTask(MetalsSlowTaskParams(message))
+      val task =
+        client().metalsSlowTask(MetalsSlowTaskParams(message, quietLogs))
       val future = task.asScala
       thunk.onComplete {
         case Failure(exception) =>

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -38,7 +38,8 @@ case class UserConfiguration(
     pantsTargets: Option[List[String]] = None,
     superMethodLensesEnabled: Boolean = false,
     remoteLanguageServer: Option[String] = None,
-    enableStripMarginOnTypeFormatting: Boolean = true
+    enableStripMarginOnTypeFormatting: Boolean = true,
+    quietLogs: Boolean = false
 ) {
 
   def currentBloopVersion: String =
@@ -143,6 +144,15 @@ object UserConfiguration {
         "Should display lenses with links to super methods",
         """|Super method lenses are visible above methods definition that override another methods. Clicking on a lens jumps to super method definition.
            |Disabled lenses are not calculated for opened documents which might speed up document processing.
+           |
+           |""".stripMargin
+      ),
+      UserConfigurationOption(
+        "quiet-logs",
+        "false",
+        "false",
+        "Should not display logs from long running tasks",
+        """|If true, Metals will not automatically show logs for any running slow tasks. User can still check Metals output manually to see them.
            |
            |""".stripMargin
       ),
@@ -289,6 +299,8 @@ object UserConfiguration {
       getStringKey("remote-language-server")
     val enableStripMarginOnTypeFormatting =
       getBooleanKey("enable-strip-margin-on-type-formatting").getOrElse(true)
+    val quietLogs =
+      getBooleanKey("quiet-logs").getOrElse(false)
     if (errors.isEmpty) {
       Right(
         UserConfiguration(
@@ -306,7 +318,8 @@ object UserConfiguration {
           pantsTargets,
           superMethodLensesEnabled,
           remoteLanguageServer,
-          enableStripMarginOnTypeFormatting
+          enableStripMarginOnTypeFormatting,
+          quietLogs
         )
       )
     } else {

--- a/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
@@ -146,7 +146,7 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") {
 
   test("cancel") {
     client.slowTaskHandler = params => {
-      if (params == bloopInstallProgress("sbt")) {
+      if (params == bloopInstallProgress("sbt", quietLogs = false)) {
         Thread.sleep(TimeUnit.SECONDS.toMillis(2))
         Some(MetalsSlowTaskResult(cancel = true))
       } else {

--- a/tests/unit/src/main/scala/tests/BaseImportSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseImportSuite.scala
@@ -19,7 +19,7 @@ abstract class BaseImportSuite(suiteName: String)
     ImportBuildChanges.params(buildTool.toString()).getMessage
 
   def progressMessage: String =
-    bloopInstallProgress(buildTool.executableName).message
+    bloopInstallProgress(buildTool.executableName, false).message
 
   def currentDigest(workspace: AbsolutePath): Option[String]
 


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals-vscode/issues/137

Whenever we run a slow taks, the metals logs might be shown for user and this can become a bit annoying.

This change makes sure that we do not show logs when:
- user explicitly doesn't want them
- there are no logs to show

I've set the logs to quiet in places that I don't really see any benefit to showing them (99% they finish super quickly and for example in VS Code it will hide the whole side panel). Especially that even in case of an error they are hidden afterwards. Alternatively we could use the UserConfiguration option everywhere. Opinions?

