### PR TITLE
Add jvm parameters configuration for Ammonite

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -411,7 +411,7 @@ lazy val metals = project
       "org.scalameta" %% "scalameta" % V.scalameta,
       "org.scalameta" % "semanticdb-scalac-core" % V.scalameta cross CrossVersion.full,
       // For starting Ammonite
-      "io.github.alexarchambault.ammonite" %% "ammonite-runner" % "0.2.5"
+      "io.github.alexarchambault.ammonite" %% "ammonite-runner" % "0.2.6"
     ),
     buildInfoPackage := "scala.meta.internal.metals",
     buildInfoKeys := Seq[BuildInfoKey](

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -195,6 +195,27 @@ object Messages {
     }
   }
 
+  object AmmoniteJvmParametersChange {
+    def restart: MessageActionItem =
+      new MessageActionItem("Restart Ammonite")
+    def notNow: MessageActionItem =
+      new MessageActionItem("Not now")
+    def params(): ShowMessageRequestParams = {
+      val params = new ShowMessageRequestParams()
+      params.setMessage(
+        s"Ammonite JVM parameters have been updated, do you want to restart the ammonite BSP server? (the changes will only be picked up after the restart)"
+      )
+      params.setType(MessageType.Info)
+      params.setActions(
+        List(
+          restart,
+          notNow
+        ).asJava
+      )
+      params
+    }
+  }
+
   object IncompatibleBloopVersion {
     def manually: MessageActionItem =
       new MessageActionItem("I'll update manually")

--- a/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
@@ -246,13 +246,20 @@ final class Ammonite(
       case (command, script) =>
         val extraScripts = buffers.open.toVector
           .filter(path => path.isAmmoniteScript && path != script)
+        val jvmOpts = userConfig().ammoniteJvmProperties.getOrElse(Nil)
+        val commandWithJVMOpts =
+          command.addJvmArgs(jvmOpts: _*)
         val futureConn = BuildServerConnection.fromSockets(
           workspace(),
           buildClient,
           languageClient,
           () =>
             Ammonite
-              .socketConn(command, script +: extraScripts, workspace()),
+              .socketConn(
+                commandWithJVMOpts,
+                script +: extraScripts,
+                workspace()
+              ),
           tables().dismissedNotifications.ReconnectAmmonite,
           config
         )


### PR DESCRIPTION
We run a separate ammonite bsp server per workspace. Previously, there was no way to limit the memory used by it. Now, users can specify configuration options that limit the memory or make other changes to the JVM used by ammonite. Alternatively, .jvmopts will also be picked up as is the case with Metals server itself.

VS Code PR: https://github.com/scalameta/metals-vscode/pull/337