### PR TITLE
Update mdoc to 2.2.3 and power completions with worksheet's classpath

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -172,7 +172,7 @@ lazy val V = new {
   val sbtBloop = bloop
   val gradleBloop = bloop
   val mavenBloop = bloop
-  val mdoc = "2.1.5"
+  val mdoc = "2.2.3"
   val scalafmt = "2.5.3"
   val munit = "0.7.9"
   // List of supported Scala versions in SemanticDB. Needs to be manually updated

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals
 
+import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.Collections
 import java.util.concurrent.ScheduledExecutorService
@@ -74,10 +75,25 @@ class Compilers(
     Collections.synchronizedMap(
       new java.util.HashMap[BuildTargetIdentifier, PresentationCompiler]
     )
+  private val jworksheetsCache: ju.Map[AbsolutePath, PresentationCompiler] =
+    Collections.synchronizedMap(
+      new java.util.HashMap[AbsolutePath, PresentationCompiler]
+    )
+
   private val cache = jcache.asScala
 
+  private val worksheetsCache = jworksheetsCache.asScala
+
   // The "rambo" compiler is used for source files that don't belong to a build target.
-  lazy val ramboCompiler: PresentationCompiler = {
+  lazy val ramboCompiler: PresentationCompiler = createRamboCompiler(
+    PackageIndex.scalaLibrary,
+    "metals-default"
+  )
+
+  def createRamboCompiler(
+      classpath: Seq[Path],
+      name: String
+  ): PresentationCompiler = {
     scribe.info(
       "no build target: using presentation compiler with only scala-library"
     )
@@ -86,8 +102,8 @@ class Compilers(
         .getOrElse(EmptySymbolSearch)
     val compiler =
       configure(new ScalaPresentationCompiler(), ramboSearch).newInstance(
-        s"metals-default-${mtags.BuildInfo.scalaCompilerVersion}",
-        PackageIndex.scalaLibrary.asJava,
+        s"$name-${mtags.BuildInfo.scalaCompilerVersion}",
+        classpath.asJava,
         Nil.asJava
       )
     ramboCancelable = Cancelable(() => compiler.shutdown())
@@ -329,14 +345,60 @@ class Compilers(
       path: AbsolutePath,
       interactiveSemanticdbs: Option[InteractiveSemanticdbs]
   ): Option[PresentationCompiler] = {
-    val target = buildTargets
-      .inverseSources(path)
-      .orElse(interactiveSemanticdbs.flatMap(_.getBuildTarget(path)))
-    target match {
-      case None =>
-        if (path.isScalaFilename) Some(ramboCompiler)
-        else None
-      case Some(value) => loadCompiler(value)
+
+    def fromBuildTarget: Option[PresentationCompiler] = {
+      val target = buildTargets
+        .inverseSources(path)
+        .orElse(interactiveSemanticdbs.flatMap(_.getBuildTarget(path)))
+      target match {
+        case None =>
+          if (path.isScalaFilename) Some(ramboCompiler)
+          else None
+        case Some(value) => loadCompiler(value)
+      }
+    }
+
+    if (path.isWorksheet) loadWorksheetCompiler(path).orElse(fromBuildTarget)
+    else fromBuildTarget
+  }
+
+  def loadWorksheetCompiler(
+      path: AbsolutePath
+  ): Option[PresentationCompiler] = {
+    worksheetsCache.get(path)
+  }
+
+  def restartWorksheetPresentationCompiler(
+      path: AbsolutePath,
+      classpath: List[Path]
+  ): Unit = {
+    val created = for {
+      targetId <- buildTargets.inverseSources(path)
+      info <- buildTargets.scalaTarget(targetId)
+      isSupported = ScalaVersions.isSupportedScalaVersion(info.scalaVersion)
+      _ = {
+        if (!isSupported) {
+          scribe.warn(s"unsupported Scala ${info.scalaVersion}")
+        }
+      }
+      if isSupported
+      scalac <- buildTargets.scalacOptions(targetId)
+    } yield {
+      jworksheetsCache.put(
+        path,
+        statusBar.trackBlockingTask(
+          s"${config.icons.sync}Loading worksheet presentation compiler"
+        ) {
+          newCompiler(scalac, info.scalaInfo, classpath)
+        }
+      )
+    }
+
+    created.getOrElse {
+      jworksheetsCache.put(
+        path,
+        createRamboCompiler(classpath, path.toString())
+      )
     }
   }
 
@@ -440,6 +502,14 @@ class Compilers(
       info: ScalaBuildTarget
   ): PresentationCompiler = {
     val classpath = scalac.classpath.map(_.toNIO).toSeq
+    newCompiler(scalac, info, classpath)
+  }
+
+  def newCompiler(
+      scalac: ScalacOptionsItem,
+      info: ScalaBuildTarget,
+      classpath: Seq[Path]
+  ): PresentationCompiler = {
     // The metals_2.12 artifact depends on mtags_2.12.x where "x" matches
     // `mtags.BuildInfo.scalaCompilerVersion`. In the case when
     // `info.getScalaVersion == mtags.BuildInfo.scalaCompilerVersion` then we

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -370,9 +370,10 @@ class Compilers(
 
   def restartWorksheetPresentationCompiler(
       path: AbsolutePath,
-      classpath: List[Path]
+      classpath: List[Path],
+      sources: List[Path]
   ): Unit = {
-    val created = for {
+    val created: Option[Unit] = for {
       targetId <- buildTargets.inverseSources(path)
       info <- buildTargets.scalaTarget(targetId)
       isSupported = ScalaVersions.isSupportedScalaVersion(info.scalaVersion)
@@ -392,9 +393,9 @@ class Compilers(
           val worksheetSearch = new StandaloneSymbolSearch(
             workspace,
             classpath.map(AbsolutePath(_)),
-            Nil,
+            sources.map(AbsolutePath(_)),
             buffers,
-            fallback = Some(search)
+            workspaceFallback = Some(search)
           )
           newCompiler(scalac, info.scalaInfo, classpath, worksheetSearch)
         }

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -114,6 +114,9 @@ object Embedded {
     val resolutionParams = ResolutionParams
       .create()
 
+    /* note(@tgodzik) we add an exclusion so that the mdoc classlaoder does not try to
+     * load coursierapi.Logger and instead will use the already loaded one
+     */
     resolutionParams.addExclusion("io.get-coursier", "interface")
     val jars = downloadMdoc(scalaVersion, scalaBinaryVersion, resolutionParams)
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -516,7 +516,8 @@ class MetalsLanguageServer(
         statusBar,
         diagnostics,
         embedded,
-        worksheetPublisher
+        worksheetPublisher,
+        compilers
       )
     )
     ammonite = register(

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -16,24 +16,17 @@ import scala.meta.pc.SymbolSearchVisitor
 
 import org.eclipse.lsp4j.Location
 
-class RamboSymbolSearch(
+class StandaloneSymbolSearch(
     workspace: AbsolutePath,
-    buffers: Buffers
+    classpath: Seq[AbsolutePath],
+    sources: Seq[AbsolutePath],
+    buffers: Buffers,
+    fallback: Option[SymbolSearch] = None
 ) extends SymbolSearch {
 
-  private val dependencySourceCache =
+  val dependencySourceCache =
     new TrieMap[AbsolutePath, ju.List[String]]()
-
-  private val scalaVersion = BuildInfo.scala212
-
-  private val jars = Embedded
-    .downloadScalaSources(scalaVersion)
-    .map(path => AbsolutePath(path))
-
-  private val (sources, classpath) =
-    jars.partition(_.toString.endsWith("-sources.jar"))
-
-  private val scalaDependency =
+  private val classpathSearch =
     ClasspathSearch.fromClasspath(classpath.toList.map(_.toNIO))
 
   private val index = OnDemandSymbolIndex()
@@ -51,13 +44,18 @@ class RamboSymbolSearch(
     )
 
   def documentation(symbol: String): ju.Optional[SymbolDocumentation] =
-    docs.documentation(symbol)
+    docs
+      .documentation(symbol)
+      .asScala
+      .orElse(fallback.flatMap(_.documentation(symbol).asScala))
+      .asJava
 
   def definition(x: String): ju.List[Location] = {
     destinationProvider
       .fromSymbol(x)
       .flatMap(_.toResult)
       .map(_.locations)
+      .orElse(fallback.map(_.definition(x)))
       .getOrElse(ju.Collections.emptyList())
   }
 
@@ -71,12 +69,34 @@ class RamboSymbolSearch(
           mtags.toplevels(input).asJava
         )
       }
+      .orElse(fallback.map(_.definitionSourceToplevels(sym)))
       .getOrElse(ju.Collections.emptyList())
 
   def search(
       query: String,
       buildTargetIdentifier: String,
       visitor: SymbolSearchVisitor
-  ): Result =
-    scalaDependency.search(WorkspaceSymbolQuery.exact(query), visitor)
+  ): Result = {
+    val res = classpathSearch.search(WorkspaceSymbolQuery.exact(query), visitor)
+    fallback.map(_.search(query, buildTargetIdentifier, visitor)).getOrElse(res)
+  }
+}
+
+object StandaloneSymbolSearch {
+  def apply(
+      workspace: AbsolutePath,
+      buffers: Buffers
+  ): StandaloneSymbolSearch = {
+
+    val scalaVersion = BuildInfo.scala212
+
+    val jars = Embedded
+      .downloadScalaSources(scalaVersion)
+      .map(path => AbsolutePath(path))
+
+    val (sources, classpath) =
+      jars.partition(_.toString.endsWith("-sources.jar"))
+
+    new StandaloneSymbolSearch(workspace, classpath, sources, buffers)
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetClassLoader.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetClassLoader.scala
@@ -10,7 +10,8 @@ package scala.meta.internal.worksheets
  */
 class MdocClassLoader(parent: ClassLoader) extends ClassLoader(null) {
   override def findClass(name: String): Class[_] = {
-    val isShared = name.startsWith("mdoc.interfaces")
+    val isShared =
+      name.startsWith("mdoc.interfaces") || name.startsWith("coursierapi")
     if (isShared) {
       parent.loadClass(name)
     } else {

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -133,6 +133,12 @@ trait CommonMtagsEnrichments {
       else None
   }
 
+  implicit class XtensionOptionScala[T](opt: Option[T]) {
+    def asJava: ju.Optional[T] =
+      if (opt.isDefined) ju.Optional.of(opt.get)
+      else ju.Optional.empty()
+  }
+
   implicit class XtensionCompletionItemData(item: CompletionItem) {
     def data: Option[CompletionItemData] =
       item.getData match {


### PR DESCRIPTION
Previously, worksheets didn't allow any additional dependencies, only the ones in the workspace. Now, it's possible to bring in additional deps like:

```scala
import $dep.`com.lihaoyi::scalatags:0.9.0`
import scalatags.Text.all._

val htmlFile = html(
  body(
    p("This is a big paragraph of text")
  )
) // TypedTag("html",List(WrappedArray(TypedTag("body",List(WrappedArray(TypedTag("p", List(WrappedArray(StringFrag("This is…

htmlFile.render // "<html><body><p>This is a big paragraph of text</p></body></html>"
```