### PR TITLE
Set BuildTool version via BuildInfo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ website/i18n/*
 !website/i18n/en.json
 
 project/metals.sbt
+
+# Created if you run ./bin/test.sh locally
+coursier

--- a/build.sbt
+++ b/build.sbt
@@ -207,6 +207,9 @@ lazy val V = new {
   val coursier = "2.0.0-RC6-21"
   val coursierInterfaces = "0.0.22"
   val ammonite = "2.1.4-6-2179b35"
+  val mill = "0.7.3"
+  val gradle = "6.1.0"
+  val maven = "3.6.3"
 }
 
 val genyVersion = Def.setting {
@@ -423,8 +426,11 @@ lazy val metals = project
       "bloopVersion" -> V.bloop,
       "bloopNightlyVersion" -> V.bloop,
       "sbtBloopVersion" -> V.sbtBloop,
+      "gradleVersion" -> V.gradle,
       "gradleBloopVersion" -> V.gradleBloop,
+      "mavenVersion" -> V.maven,
       "mavenBloopVersion" -> V.mavenBloop,
+      "millVersion" -> V.mill,
       "scalametaVersion" -> V.scalameta,
       "semanticdbVersion" -> V.semanticdb,
       "scalafmtVersion" -> V.scalafmt,

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -87,10 +87,10 @@ case class GradleBuildTool(userConfig: () => UserConfiguration)
     }
   }
 
-  // @tgodzik This this is the wrapper version we specify it as such,
+  // @tgodzik This is the wrapper version we specify it as such,
   // since it's hard to determine which version will be used as gradle
   // doesn't save it in any settings
-  override def version: String = "5.3.1"
+  override def version: String = BuildInfo.gradleVersion
 
   override def minimumVersion: String = "4.3.0"
 

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.builds
 
+import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.JavaBinary
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.UserConfiguration
@@ -56,7 +57,7 @@ case class MavenBuildTool(userConfig: () => UserConfiguration)
 
   override def recommendedVersion: String = version
 
-  override def version: String = "3.6.1"
+  override def version: String = BuildInfo.mavenVersion
 
   override def toString(): String = "Maven"
 

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -4,6 +4,7 @@ import java.nio.file.Path
 
 import scala.util.Properties
 
+import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.io.AbsolutePath
 
@@ -59,7 +60,7 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
 
   override def recommendedVersion: String = version
 
-  override def version: String = "0.7.3"
+  override def version: String = BuildInfo.millVersion
 
   override def toString(): String = "Mill"
 


### PR DESCRIPTION
Previously we set the recommended version for the various BuildTools
by having the version hardcoded in the BuildTool file. This moves
the version for Maven, Mill, and Gradle into the build.sbt file and
uses BuildInfo to access those versions like we currently do with
the SBT build tool. This will also allow us to get some help from our
friend ScalaSteward.