### PR TITLE
Sbt support - multiply bsp connections

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,6 +169,7 @@ commands += Command.command("save-expect") { s =>
 lazy val V = new {
   val scala210 = "2.10.7"
   val scala211 = "2.11.12"
+  val `scala2.12.10` = "2.12.10"
   val scala212 = "2.12.12"
   val scala213 = "2.13.3"
   val scalameta = "4.3.20"
@@ -491,12 +492,14 @@ lazy val testSettings: Seq[Def.Setting[_]] = List(
 
 def crossPublishLocal(scalaV: String) =
   Def.task[Unit] {
+    val versionValue = version.in(ThisBuild).value
     // Runs `publishLocal` for mtags with `scalaVersion := $scalaV`
     val newState = Project
       .extract(state.value)
       .appendWithSession(
         List(
           scalaVersion.in(mtags) := scalaV,
+          version.in(ThisBuild) := versionValue,
           useSuperShell.in(ThisBuild) := false
         ),
         state.value
@@ -524,7 +527,7 @@ def publishBinaryMtags =
     .in(interfaces)
     .dependsOn(
       publishAllMtags(
-        List(V.scala211, V.scala212, V.scala213, V.scala3)
+        List(V.scala211, V.`scala2.12.10`, V.scala212, V.scala213, V.scala3)
       )
     )
 

--- a/build.sbt
+++ b/build.sbt
@@ -169,7 +169,7 @@ commands += Command.command("save-expect") { s =>
 lazy val V = new {
   val scala210 = "2.10.7"
   val scala211 = "2.11.12"
-  val `scala2.12.10` = "2.12.10"
+  val sbtScala = "2.12.10"
   val scala212 = "2.12.12"
   val scala213 = "2.13.3"
   val scalameta = "4.3.20"
@@ -527,7 +527,7 @@ def publishBinaryMtags =
     .in(interfaces)
     .dependsOn(
       publishAllMtags(
-        List(V.scala211, V.`scala2.12.10`, V.scala212, V.scala213, V.scala3)
+        List(V.scala211, V.sbtScala, V.scala212, V.scala213, V.scala3)
       )
     )
 

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -3,6 +3,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.Properties
 
+import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals._
 import scala.meta.io.AbsolutePath
 
@@ -85,12 +86,47 @@ case class SbtBuildTool(
   private def writeSbtMetalsPlugin(
       workspace: AbsolutePath
   ): Unit = {
+
+    def containsScalaOrSbtFiles(dir: AbsolutePath): Boolean =
+      dir.list.exists { f =>
+        val name = f.filename
+        f.isFile && (f.isScala || f.isSbt) && name != "metals.sbt"
+      }
+
+    def sbtMetaDirs(
+        dir: AbsolutePath,
+        acc: List[AbsolutePath]
+    ): List[AbsolutePath] = {
+      if (dir.exists && containsScalaOrSbtFiles(dir)) {
+        val nextMeta = dir.resolve("project")
+        sbtMetaDirs(nextMeta, nextMeta :: acc)
+      } else {
+        acc
+      }
+    }
+
+    // by default create the following directory structure
+    //  workspace/
+    //     project/
+    //       metals.sbt
+    //       project/
+    //          metals.sbt
+    // and check if there are more inner meta projects
+    val mainMeta = workspace.resolve("project")
+    val metaMeta = mainMeta.resolve("project")
+    val dirs = sbtMetaDirs(metaMeta, List(mainMeta, metaMeta))
+
+    dirs.foreach(writeSbtMetalsPlugin0)
+  }
+
+  private def writeSbtMetalsPlugin0(
+      projectDir: AbsolutePath
+  ): Unit = {
     if (userConfig().bloopSbtAlreadyInstalled) return
     val versionToUse = userConfig().currentBloopVersion
     val bytes = SbtBuildTool
       .sbtPlugin(versionToUse)
       .getBytes(StandardCharsets.UTF_8)
-    val projectDir = workspace.resolve("project")
     projectDir.toFile.mkdir()
     val metalsPluginFile = projectDir.resolve("metals.sbt")
     val pluginFileShouldChange = !metalsPluginFile.isFile ||

--- a/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
@@ -1,0 +1,58 @@
+package scala.meta.internal.metals
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.pc.AutoImportsResult
+
+import org.eclipse.lsp4j.CompletionList
+import org.eclipse.lsp4j.Hover
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.{Range => LspRange}
+
+trait AdjustLspData {
+
+  def adjustPos(pos: Position): Position
+
+  def adjustRange(range: LspRange): LspRange =
+    new LspRange(
+      adjustPos(range.getStart),
+      adjustPos(range.getEnd)
+    )
+
+  def adjustHoverResp(hover: Hover): Hover =
+    if (hover.getRange == null)
+      hover
+    else {
+      val newRange = adjustRange(hover.getRange)
+      val newHover = new Hover
+      newHover.setContents(hover.getContents)
+      newHover.setRange(newRange)
+      newHover
+    }
+
+  def adjustCompletionListInPlace(list: CompletionList): Unit = {
+    for (item <- list.getItems.asScala) {
+      for (textEdit <- Option(item.getTextEdit))
+        textEdit.setRange(adjustRange(textEdit.getRange))
+      for (l <- Option(item.getAdditionalTextEdits); textEdit <- l.asScala)
+        textEdit.setRange(adjustRange(textEdit.getRange))
+    }
+  }
+
+  def adjustImportResult(
+      autoImportResult: AutoImportsResult
+  ): Unit = {
+    for (textEdit <- autoImportResult.edits.asScala) {
+      textEdit.setRange(adjustRange(textEdit.getRange))
+    }
+  }
+}
+
+object AdjustLspData {
+
+  def create(f: Position => Position): AdjustLspData =
+    new AdjustLspData {
+      override def adjustPos(pos: Position): Position = f(pos)
+    }
+
+  val default: AdjustLspData = AdjustLspData.create(identity)
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -56,6 +56,7 @@ final class BloopServers(
   }
 
   def newServer(
+      workspace: AbsolutePath,
       userConfiguration: UserConfiguration
   ): Future[Option[BuildServerConnection]] = {
     val bloopVersion = userConfiguration.currentBloopVersion

--- a/metals/src/main/scala/scala/meta/internal/metals/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BspConnector.scala
@@ -1,0 +1,62 @@
+package scala.meta.internal.metals
+
+import java.nio.file.Files
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.internal.builds.BuildTools
+import scala.meta.io.AbsolutePath
+
+class BspConnector(
+    bloopServers: BloopServers,
+    bspServers: BspServers
+) {
+
+  def connect(
+      workspace: AbsolutePath,
+      userConfiguration: UserConfiguration,
+      buildTools: BuildTools
+  )(implicit ec: ExecutionContext): Future[Option[BspSession]] = {
+
+    def connect(
+        workspace: AbsolutePath
+    ): Future[Option[BuildServerConnection]] = {
+      if (buildTools.isBloop)
+        bloopServers.newServer(workspace, userConfiguration)
+      else
+        bspServers.newServer(workspace)
+    }
+
+    val metaDirectories =
+      if (buildTools.isSbt) sbtMetaWorkspaces(workspace) else List.empty
+
+    connect(workspace).flatMap { mainOpt =>
+      mainOpt match {
+        case None => Future.successful(None)
+        case Some(main) =>
+          val metaConns = metaDirectories.map(connect(_))
+          Future
+            .sequence(metaConns)
+            .map(meta => Some(BspSession(main, meta.flatten)))
+      }
+    }
+
+  }
+
+  private def sbtMetaWorkspaces(root: AbsolutePath): List[AbsolutePath] = {
+    def recursive(
+        p: AbsolutePath,
+        acc: List[AbsolutePath]
+    ): List[AbsolutePath] = {
+      val projectDir = p.resolve("project")
+      val bloopDir = projectDir.resolve(".bloop")
+      if (Files.exists(bloopDir.toNIO))
+        recursive(projectDir, projectDir :: acc)
+      else
+        acc
+    }
+    recursive(root, List.empty)
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/BspSession.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BspSession.scala
@@ -1,0 +1,38 @@
+package scala.meta.internal.metals
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+case class BspSession(
+    main: BuildServerConnection,
+    meta: List[BuildServerConnection]
+)(implicit ec: ExecutionContext)
+    extends Cancelable {
+
+  val connections: List[BuildServerConnection] = main :: meta
+
+  def importBuilds(): Future[List[BspSession.BspBuild]] = {
+    def importSingle(conn: BuildServerConnection): Future[BspSession.BspBuild] =
+      MetalsLanguageServer.importedBuild(conn).map(BspSession.BspBuild(conn, _))
+
+    Future.sequence(connections.map(importSingle))
+  }
+
+  def cancel(): Unit = connections.foreach(_.cancel())
+
+  def shutdown(): Future[Unit] =
+    Future.sequence(connections.map(_.shutdown())).map(_ => ())
+
+  def mainConnection: BuildServerConnection = main
+
+  def version: String = main.version
+}
+
+object BspSession {
+
+  case class BspBuild(
+      connection: BuildServerConnection,
+      build: ImportedBuild
+  )
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -36,7 +36,8 @@ class BuildServerConnection private (
     initialConnection: BuildServerConnection.LauncherConnection,
     languageClient: LanguageClient,
     reconnectNotification: DismissedNotifications#Notification,
-    config: MetalsServerConfig
+    config: MetalsServerConfig,
+    workspace: AbsolutePath
 )(implicit ec: ExecutionContextExecutorService)
     extends Cancelable {
 
@@ -58,6 +59,8 @@ class BuildServerConnection private (
 
   // the name is set before when establishing conenction
   def name: String = initialConnection.socketConnection.serverName
+
+  def workspaceDirectory: AbsolutePath = workspace
 
   def onReconnection(
       index: BuildServerConnection => Future[Unit]
@@ -265,7 +268,8 @@ object BuildServerConnection {
         connection,
         languageClient,
         reconnectNotification,
-        config
+        config,
+        workspace
       )
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetClasses.scala
@@ -15,7 +15,6 @@ import ch.epfl.scala.{bsp4j => b}
  * In-memory index of main class symbols grouped by their enclosing build target
  */
 final class BuildTargetClasses(
-    buildServer: b.BuildTargetIdentifier => Option[BuildServerConnection],
     buildTargets: BuildTargets
 )(implicit val ec: ExecutionContext) {
   private val index = TrieMap.empty[b.BuildTargetIdentifier, Classes]
@@ -56,7 +55,7 @@ final class BuildTargetClasses(
       targets: Seq[b.BuildTargetIdentifier]
   ): Future[Unit] = {
     Future
-      .traverse(targets.groupBy(buildServer)) {
+      .traverse(targets.groupBy(buildTargets.buildServerOf)) {
         case (None, _) =>
           Future.successful(())
         case (Some(connection), targets0) =>

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -264,9 +264,7 @@ final class BuildTargets(
   def workspaceDirectory(
       buildTarget: BuildTargetIdentifier
   ): Option[AbsolutePath] =
-    targetToConnection
-      .get(buildTarget)
-      .map(_.workspaceDirectory)
+    buildServerOf(buildTarget).map(_.workspaceDirectory)
 
   /**
    * Returns the first build target containing this source file.

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -15,6 +15,7 @@ import scala.util.control.NonFatal
 
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ammonite.Ammonite
 import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.Symbol
 import scala.meta.io.AbsolutePath
@@ -29,7 +30,9 @@ import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult
 /**
  * In-memory cache for looking up build server metadata.
  */
-final class BuildTargets() {
+final class BuildTargets(
+    ammoniteBuildServer: BuildTargetIdentifier => Option[BuildServerConnection]
+) {
   private var workspace = PathIO.workingDirectory
   def setWorkspaceDirectory(newWorkspace: AbsolutePath): Unit = {
     workspace = newWorkspace
@@ -53,6 +56,9 @@ final class BuildTargets() {
     new ConcurrentLinkedQueue[AbsolutePath => Seq[BuildTargetIdentifier]]()
   // if workspace contains symlinks, original source items are kept here and source items dealiased
   private val originalSourceItems = ConcurrentHashSet.empty[AbsolutePath]
+
+  private val targetToConnection =
+    new mutable.HashMap[BuildTargetIdentifier, BuildServerConnection]
 
   val buildTargetsOrder: BuildTargetIdentifier => Int = {
     (t: BuildTargetIdentifier) =>
@@ -102,17 +108,25 @@ final class BuildTargets() {
     all.toSeq.map(_.info.getId())
   def all: Iterator[ScalaTarget] =
     for {
-      (id, target) <- buildTargetInfo.iterator
-      scalac <- scalacTargetInfo.get(id)
-      scalaTarget <- target.asScalaBuildTarget
-    } yield ScalaTarget(target, scalaTarget, scalac)
+      (_, target) <- buildTargetInfo.iterator
+      scalaTarget <- toScalaTarget(target)
+    } yield scalaTarget
 
   def scalaTarget(id: BuildTargetIdentifier): Option[ScalaTarget] =
     for {
-      info <- buildTargetInfo.get(id)
-      scalac <- scalacTargetInfo.get(id)
-      scalaTarget <- info.asScalaBuildTarget
-    } yield ScalaTarget(info, scalaTarget, scalac)
+      target <- buildTargetInfo.get(id)
+      scalaTarget <- toScalaTarget(target)
+    } yield scalaTarget
+
+  private def toScalaTarget(target: BuildTarget): Option[ScalaTarget] = {
+    for {
+      scalac <- scalacTargetInfo.get(target.getId)
+      scalaTarget <- target.asScalaBuildTarget
+    } yield {
+      val autoImports = target.asSbtBuildTarget.map(_.getAutoImports.asScala)
+      ScalaTarget(target, scalaTarget, scalac, autoImports)
+    }
+  }
 
   def allWorkspaceJars: Iterator[AbsolutePath] = {
     val isVisited = new ju.HashSet[AbsolutePath]()
@@ -225,6 +239,34 @@ final class BuildTargets() {
       buildTarget: BuildTargetIdentifier
   ): Option[ScalacOptionsItem] =
     scalacTargetInfo.get(buildTarget)
+
+  /**
+   * Returns meta build target for `*.sbt`  files.
+   * It selects build target by directory of its connection
+   *   because `*.sbt` aren't included in `sourceFiles` set
+   */
+  def sbtBuildScalaTarget(file: AbsolutePath): Option[ScalaTarget] = {
+    val targetMetaBuildDir = file.parent.resolve("project")
+    buildTargetInfo.values
+      .find { target =>
+        val isMetaBuild = target.getDataKind == "sbt"
+        if (isMetaBuild) {
+          workspaceDirectory(target.getId)
+            .map(_ == targetMetaBuildDir)
+            .getOrElse(false)
+        } else {
+          false
+        }
+      }
+      .flatMap(toScalaTarget)
+  }
+
+  def workspaceDirectory(
+      buildTarget: BuildTargetIdentifier
+  ): Option[AbsolutePath] =
+    targetToConnection
+      .get(buildTarget)
+      .map(_.workspaceDirectory)
 
   /**
    * Returns the first build target containing this source file.
@@ -413,9 +455,35 @@ final class BuildTargets() {
     !isSourceRoot.contains(path) &&
     isSourceRoot.asScala.exists { root => path.toNIO.startsWith(root.toNIO) }
   }
+
+  def resetConnections(
+      idToConn: List[(BuildTargetIdentifier, BuildServerConnection)]
+  ): Unit = {
+    targetToConnection.clear()
+    idToConn.foreach { case (id, conn) => targetToConnection.put(id, conn) }
+  }
+
+  def buildServerOf(
+      id: BuildTargetIdentifier
+  ): Option[BuildServerConnection] = {
+    ammoniteBuildServer(id).orElse(targetToConnection.get(id))
+  }
 }
 
 object BuildTargets {
+
+  def withAmmonite(ammonite: () => Ammonite): BuildTargets = {
+    val ammoniteBuildServerF =
+      (id: BuildTargetIdentifier) =>
+        if (Ammonite.isAmmBuildTarget(id)) ammonite().buildServer
+        else None
+
+    new BuildTargets(ammoniteBuildServerF)
+  }
+
+  def withoutAmmonite: BuildTargets =
+    new BuildTargets(_ => None)
+
   def isInverseDependency(
       query: BuildTargetIdentifier,
       roots: List[BuildTargetIdentifier],

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -17,7 +17,6 @@ final class Compilations(
     buildTargets: BuildTargets,
     classes: BuildTargetClasses,
     workspace: () => AbsolutePath,
-    buildServer: BuildTargetIdentifier => Option[BuildServerConnection],
     languageClient: MetalsLanguageClient,
     isCurrentlyFocused: b.BuildTargetIdentifier => Boolean,
     compileWorksheets: Seq[AbsolutePath] => Future[Unit]
@@ -125,7 +124,7 @@ final class Compilations(
     }
 
     val groupedTargetIds = buildTargets.allBuildTargetIds
-      .groupBy(buildServer(_))
+      .groupBy(buildTargets.buildServerOf(_))
     Future
       .traverse(groupedTargetIds) {
         case (connectionOpt, targetIds) =>
@@ -158,7 +157,9 @@ final class Compilations(
   ): CancelableFuture[Map[BuildTargetIdentifier, b.CompileResult]] = {
 
     val targetsByBuildServer = targets
-      .flatMap(target => buildServer(target).map(_ -> target).toSeq)
+      .flatMap(target =>
+        buildTargets.buildServerOf(target).map(_ -> target).toSeq
+      )
       .groupBy {
         case (buildServer, _) =>
           buildServer

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -26,7 +26,6 @@ import scala.meta.pc.SymbolSearch
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import ch.epfl.scala.bsp4j.CompileReport
-import ch.epfl.scala.bsp4j.ScalaBuildTarget
 import ch.epfl.scala.bsp4j.ScalacOptionsItem
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionList
@@ -100,11 +99,12 @@ class Compilers(
       Try(StandaloneSymbolSearch(workspace, buffers))
         .getOrElse(EmptySymbolSearch)
     val compiler =
-      configure(new ScalaPresentationCompiler(), standaloneSearch).newInstance(
-        s"$name-${mtags.BuildInfo.scalaCompilerVersion}",
-        classpath.asJava,
-        Nil.asJava
-      )
+      configure(new ScalaPresentationCompiler(), standaloneSearch)
+        .newInstance(
+          s"$name-${mtags.BuildInfo.scalaCompilerVersion}",
+          classpath.asJava,
+          Nil.asJava
+        )
     ramboCancelable = Cancelable(() => compiler.shutdown())
     compiler
   }
@@ -251,12 +251,11 @@ class Compilers(
       params: CompletionParams,
       token: CancelToken
   ): Future[CompletionList] =
-    withPC(params, None) { (pc, pos) =>
+    withPCAndAdjustLsp(params, None) { (pc, pos, adjust) =>
       pc.complete(CompilerOffsetParams.fromPos(pos, token))
         .asScala
         .map { list =>
-          if (params.getTextDocument.getUri.isAmmoniteScript)
-            Ammonite.adjustCompletionListInPlace(list, pos.input.text)
+          adjust.adjustCompletionListInPlace(list)
           list
         }
     }.getOrElse(Future.successful(new CompletionList()))
@@ -266,12 +265,11 @@ class Compilers(
       name: String,
       token: CancelToken
   ): Future[ju.List[AutoImportsResult]] = {
-    withPC(params, None) { (pc, pos) =>
+    withPCAndAdjustLsp(params, None) { (pc, pos, adjust) =>
       pc.autoImports(name, CompilerOffsetParams.fromPos(pos, token))
         .asScala
         .map { list =>
-          if (params.getTextDocument.getUri.isAmmoniteScript)
-            list.map(Ammonite.adjustImportResult(_, pos.input.text))
+          list.map(adjust.adjustImportResult)
           list
         }
     }.getOrElse(Future.successful(new ju.ArrayList))
@@ -292,15 +290,11 @@ class Compilers(
       token: CancelToken,
       interactiveSemanticdbs: InteractiveSemanticdbs
   ): Future[Option[Hover]] =
-    withPC(params, Some(interactiveSemanticdbs)) { (pc, pos) =>
-      pc.hover(CompilerOffsetParams.fromPos(pos, token))
-        .asScala
-        .map(_.asScala.map { hover =>
-          if (params.getTextDocument.getUri.isAmmoniteScript)
-            Ammonite.adjustHoverResp(hover, pos.input.text)
-          else
-            hover
-        })
+    withPCAndAdjustLsp(params, Some(interactiveSemanticdbs)) {
+      (pc, pos, adjust) =>
+        pc.hover(CompilerOffsetParams.fromPos(pos, token))
+          .asScala
+          .map(_.asScala.map { hover => adjust.adjustHoverResp(hover) })
     }.getOrElse {
       Future.successful(Option.empty)
     }
@@ -364,6 +358,8 @@ class Compilers(
     }
 
     if (path.isWorksheet) loadWorksheetCompiler(path).orElse(fromBuildTarget)
+    else if (path.isSbt)
+      buildTargets.sbtBuildScalaTarget(path).flatMap(loadCompilerForTarget)
     else fromBuildTarget
   }
 
@@ -380,11 +376,12 @@ class Compilers(
   ): Unit = {
     val created: Option[Unit] = for {
       targetId <- buildTargets.inverseSources(path)
-      info <- buildTargets.scalaTarget(targetId)
-      isSupported = ScalaVersions.isSupportedScalaVersion(info.scalaVersion)
+      scalaTarget <- buildTargets.scalaTarget(targetId)
+      isSupported =
+        ScalaVersions.isSupportedScalaVersion(scalaTarget.scalaVersion)
       _ = {
         if (!isSupported) {
-          scribe.warn(s"unsupported Scala ${info.scalaVersion}")
+          scribe.warn(s"unsupported Scala ${scalaTarget.scalaVersion}")
         }
       }
       if isSupported
@@ -402,7 +399,7 @@ class Compilers(
             buffers,
             workspaceFallback = Some(search)
           )
-          newCompiler(scalac, info.scalaInfo, classpath, worksheetSearch)
+          newCompiler(scalac, scalaTarget, classpath, worksheetSearch)
         }
       )
     }
@@ -417,28 +414,29 @@ class Compilers(
 
   def loadCompiler(
       target: BuildTargetIdentifier
+  ): Option[PresentationCompiler] =
+    buildTargets.scalaTarget(target).flatMap(loadCompilerForTarget)
+
+  def loadCompilerForTarget(
+      scalaTarget: ScalaTarget
   ): Option[PresentationCompiler] = {
-    for {
-      info <- buildTargets.scalaTarget(target)
-      isSupported = ScalaVersions.isSupportedScalaVersion(info.scalaVersion)
-      _ = {
-        if (!isSupported) {
-          scribe.warn(s"unsupported Scala ${info.scalaVersion}")
-        }
-      }
-      if isSupported
-      scalac <- buildTargets.scalacOptions(target)
-    } yield {
-      jcache.computeIfAbsent(
-        target,
+    val isSupported =
+      ScalaVersions.isSupportedScalaVersion(scalaTarget.scalaVersion)
+    if (!isSupported) {
+      scribe.warn(s"unsupported Scala ${scalaTarget.scalaVersion}")
+      None
+    } else {
+      val out = jcache.computeIfAbsent(
+        scalaTarget.info.getId,
         { _ =>
           statusBar.trackBlockingTask(
             s"${config.icons.sync}Loading presentation compiler"
           ) {
-            newCompiler(scalac, info.scalaInfo, search)
+            newCompiler(scalaTarget.scalac, scalaTarget, search)
           }
         }
       )
+      Some(out)
     }
   }
 
@@ -462,27 +460,80 @@ class Compilers(
     else
       None
 
+  private def sbtInputPosAdjustmentOpt(
+      path: AbsolutePath,
+      position: LspPosition
+  ): Option[(Input.VirtualFile, LspPosition, AdjustLspData)] = {
+
+    buildTargets
+      .sbtBuildScalaTarget(path)
+      .flatMap(_.autoImports)
+      .map { imports =>
+        val appendStr = imports.mkString("", "\n", "\n")
+        val appendLineSize = imports.size
+
+        val originInput = path.toInputFromBuffers(buffers)
+
+        val modifiedInput =
+          originInput.copy(value = appendStr + originInput.value)
+        val pos = new LspPosition(
+          appendLineSize + position.getLine(),
+          position.getCharacter()
+        )
+        val adjustLspData = AdjustLspData.create(pos => {
+          new LspPosition(pos.getLine() - appendLineSize, pos.getCharacter())
+        })
+        (modifiedInput, pos, adjustLspData)
+      }
+  }
+
   private def withPC[T](
       params: TextDocumentPositionParams,
       interactiveSemanticdbs: Option[InteractiveSemanticdbs]
   )(fn: (PresentationCompiler, Position) => T): Option[T] = {
+    withPCAndAdjustLsp(params, interactiveSemanticdbs)((compiler, pos, _) =>
+      fn(compiler, pos)
+    )
+  }
+
+  private def withPCAndAdjustLsp[T](
+      params: TextDocumentPositionParams,
+      interactiveSemanticdbs: Option[InteractiveSemanticdbs]
+  )(fn: (PresentationCompiler, Position, AdjustLspData) => T): Option[T] = {
     val path = params.getTextDocument.getUri.toAbsolutePath
     loadCompiler(path, interactiveSemanticdbs).map { compiler =>
-      def defaultInputPos = {
-        val input = path
-          .toInputFromBuffers(buffers)
-          .copy(path = params.getTextDocument.getUri())
-        val pos = params.getPosition
-        (input, pos)
-      }
-
-      val (input, paramsPos) =
-        ammoniteInputPosOpt(path, params.getPosition, interactiveSemanticdbs)
-          .getOrElse(defaultInputPos)
-      val pos = paramsPos.toMeta(input)
-
-      fn(compiler, pos)
+      val (input, pos, adjust) =
+        sourceAdjustments(params, interactiveSemanticdbs)
+      val metaPos = pos.toMeta(input)
+      fn(compiler, metaPos, adjust)
     }
+  }
+
+  private def sourceAdjustments(
+      params: TextDocumentPositionParams,
+      interactiveSemanticdbs: Option[InteractiveSemanticdbs]
+  ): (Input.VirtualFile, LspPosition, AdjustLspData) = {
+
+    val path = params.getTextDocument.getUri.toAbsolutePath
+    val position = params.getPosition
+
+    def default = {
+      val input = path.toInputFromBuffers(buffers)
+      (input, position, AdjustLspData.default)
+    }
+
+    val forScripts =
+      if (path.isAmmoniteScript) {
+        ammoniteInputPosOpt(path, position, interactiveSemanticdbs)
+          .map {
+            case (input, pos) =>
+              (input, pos, Ammonite.adjustLspData(input.text))
+          }
+      } else if (path.isSbt) {
+        sbtInputPosAdjustmentOpt(path, position)
+      } else None
+
+    forScripts.getOrElse(default)
   }
 
   private def configure(
@@ -512,16 +563,16 @@ class Compilers(
 
   def newCompiler(
       scalac: ScalacOptionsItem,
-      info: ScalaBuildTarget,
+      target: ScalaTarget,
       search: SymbolSearch
   ): PresentationCompiler = {
     val classpath = scalac.classpath.map(_.toNIO).toSeq
-    newCompiler(scalac, info, classpath, search)
+    newCompiler(scalac, target, classpath, search)
   }
 
   def newCompiler(
       scalac: ScalacOptionsItem,
-      info: ScalaBuildTarget,
+      target: ScalaTarget,
       classpath: Seq[Path],
       search: SymbolSearch
   ): PresentationCompiler = {
@@ -530,10 +581,14 @@ class Compilers(
     // `info.getScalaVersion == mtags.BuildInfo.scalaCompilerVersion` then we
     // skip fetching the mtags module from Maven.
     val pc: PresentationCompiler =
-      if (ScalaVersions.isCurrentScalaCompilerVersion(info.getScalaVersion())) {
+      if (
+        ScalaVersions.isCurrentScalaCompilerVersion(
+          target.scalaInfo.getScalaVersion()
+        )
+      ) {
         new ScalaPresentationCompiler()
       } else {
-        embedded.presentationCompiler(info, scalac)
+        embedded.presentationCompiler(target.scalaInfo, scalac)
       }
     val options = plugins.filterSupportedOptions(scalac.getOptions.asScala)
     configure(pc, search).newInstance(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -66,8 +66,24 @@ object MetalsEnrichments
     with MtagsEnrichments {
 
   implicit class XtensionBuildTarget(buildTarget: b.BuildTarget) {
+
+    def isSbtBuild: Boolean =
+      buildTarget.getDataKind == "sbt"
+
     def asScalaBuildTarget: Option[b.ScalaBuildTarget] = {
-      decodeJson(buildTarget.getData, classOf[b.ScalaBuildTarget])
+      if (isSbtBuild) {
+        decodeJson(buildTarget.getData, classOf[b.SbtBuildTarget])
+          .map(_.getScalaBuildTarget)
+      } else {
+        decodeJson(buildTarget.getData, classOf[b.ScalaBuildTarget])
+      }
+    }
+
+    def asSbtBuildTarget: Option[b.SbtBuildTarget] = {
+      buildTarget.getDataKind match {
+        case "sbt" => decodeJson(buildTarget.getData, classOf[b.SbtBuildTarget])
+        case _ => None
+      }
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1665,6 +1665,7 @@ class MetalsLanguageServer(
       case Some(value) =>
         bspSession = None
         diagnostics.reset()
+        buildTargets.resetConnections(List.empty)
         value.shutdown()
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -88,8 +88,8 @@ class MetalsLanguageServer(
   val isCancelled = new AtomicBoolean(false)
   override def cancel(): Unit = {
     if (isCancelled.compareAndSet(false, true)) {
-      val buildShutdown = buildServer match {
-        case Some(build) => build.shutdown()
+      val buildShutdown = bspSession match {
+        case Some(session) => session.shutdown()
         case None => Future.successful(())
       }
       try cancelables.cancel()
@@ -123,20 +123,16 @@ class MetalsLanguageServer(
     new AtomicReference[b.BuildTargetIdentifier]()
   private val definitionIndex = newSymbolIndex()
   private val symbolDocs = new Docstrings(definitionIndex)
-  var buildServer: Option[BuildServerConnection] =
-    Option.empty[BuildServerConnection]
-  private def buildServerOf(
-      target: b.BuildTargetIdentifier
-  ): Option[BuildServerConnection] =
-    if (Ammonite.isAmmBuildTarget(target)) ammonite.buildServer
-    else buildServer
+  var bspSession: Option[BspSession] =
+    Option.empty[BspSession]
   private val savedFiles = new ActiveFiles(time)
   private val openedFiles = new ActiveFiles(time)
   private val languageClient = new DelegatingLanguageClient(NoopLanguageClient)
   var userConfig: UserConfiguration = UserConfiguration()
-  val buildTargets: BuildTargets = new BuildTargets()
+  var ammonite: Ammonite = _
+  val buildTargets: BuildTargets = BuildTargets.withAmmonite(() => ammonite)
   private val buildTargetClasses =
-    new BuildTargetClasses(buildServerOf, buildTargets)
+    new BuildTargetClasses(buildTargets)
   private val remote = new RemoteLanguageServer(
     () => workspace,
     () => userConfig,
@@ -148,7 +144,6 @@ class MetalsLanguageServer(
     buildTargets,
     buildTargetClasses,
     () => workspace,
-    buildServerOf,
     languageClient,
     buildTarget => focusedDocumentBuildTarget.get() == buildTarget,
     worksheets => onWorksheetChanged(worksheets)
@@ -189,6 +184,7 @@ class MetalsLanguageServer(
   private var buildClient: ForwardingMetalsBuildClient = _
   private var bloopServers: BloopServers = _
   private var bspServers: BspServers = _
+  private var bspConnector: BspConnector = _
   private var codeLensProvider: CodeLensProvider = _
   private var supermethods: Supermethods = _
   private var codeActionProvider: CodeActionProvider = _
@@ -216,7 +212,6 @@ class MetalsLanguageServer(
   var httpServer: Option[MetalsHttpServer] = None
   var treeView: TreeViewProvider = NoopTreeViewProvider
   var worksheetProvider: WorksheetProvider = _
-  var ammonite: Ammonite = _
   var popupChoiceReset: PopupChoiceReset = _
 
   private val clientConfig: ClientConfiguration =
@@ -357,6 +352,10 @@ class MetalsLanguageServer(
       bspGlobalDirectories,
       clientConfig.initialConfig
     )
+    bspConnector = new BspConnector(
+      bloopServers,
+      bspServers
+    )
     semanticdbs = AggregateSemanticdbs(
       List(
         fileSystemSemanticdbs,
@@ -484,7 +483,7 @@ class MetalsLanguageServer(
     )
     debugProvider = new DebugProvider(
       definitionProvider,
-      buildServer,
+      () => bspSession.map(_.mainConnection),
       buildTargets,
       buildTargetClasses,
       compilations,
@@ -946,9 +945,9 @@ class MetalsLanguageServer(
           }
           val expectedBloopVersion = userConfig.currentBloopVersion
           val correctVersionRunning =
-            buildServer.map(_.version).contains(expectedBloopVersion)
+            bspSession.map(_.version).contains(expectedBloopVersion)
           val allVersionsDefined =
-            buildServer.nonEmpty && userConfig.bloopVersion.nonEmpty
+            bspSession.nonEmpty && userConfig.bloopVersion.nonEmpty
           val changedToNoVersion =
             old.bloopVersion.isDefined && userConfig.bloopVersion.isEmpty
           val versionChanged = allVersionsDefined && !correctVersionRunning
@@ -1623,15 +1622,15 @@ class MetalsLanguageServer(
     {
       for {
         _ <- disconnectOldBuildServer()
-        maybeBuild <- timed("connected to build server") {
-          if (buildTools.isBloop) bloopServers.newServer(userConfig)
-          else bspServers.newServer()
+        maybeSession <- timed("connected to build server") {
+          bspConnector.connect(workspace, userConfig, buildTools)
         }
-        result <- maybeBuild match {
-          case Some(build) =>
-            val result = connectToNewBuildServer(build)
-            build.onReconnection { reconnected =>
-              connectToNewBuildServer(reconnected)
+        result <- maybeSession match {
+          case Some(session) =>
+            val result = connectToNewBuildServer(session)
+            session.mainConnection.onReconnection { newMainConn =>
+              val updSession = session.copy(main = newMainConn)
+              connectToNewBuildServer(updSession)
                 .flatMap(compileAllOpenFiles)
                 .ignoreValue
             }
@@ -1658,35 +1657,44 @@ class MetalsLanguageServer(
   }
 
   private def disconnectOldBuildServer(): Future[Unit] = {
-    if (buildServer.isDefined) {
+    if (bspSession.isDefined) {
       scribe.info("disconnected: build server")
     }
-    buildServer match {
+    bspSession match {
       case None => Future.successful(())
       case Some(value) =>
-        buildServer = None
+        bspSession = None
         diagnostics.reset()
         value.shutdown()
     }
   }
 
   private def connectToNewBuildServer(
-      build: BuildServerConnection
+      session: BspSession
   ): Future[BuildChange] = {
-    scribe.info(s"Connected to Build server v${build.version}")
-    cancelables.add(build)
+    scribe.info(s"Connected to Build server v${session.version}")
+    cancelables.add(session)
     compilers.cancel()
-    buildServer = Some(build)
-    val importedBuild0 = timed("imported build") {
-      MetalsLanguageServer.importedBuild(build)
+    bspSession = Some(session)
+    val importedBuilds0 = timed("imported build") {
+      session.importBuilds()
     }
     for {
-      i <- statusBar.trackFuture("Importing build", importedBuild0)
+      i <- statusBar.trackFuture("Importing build", importedBuilds0)
       _ = {
-        lastImportedBuild = i
+        val idToConnection = i.flatMap { bspBuild =>
+          val targets =
+            bspBuild.build.workspaceBuildTargets.getTargets().asScala
+          targets.map(t => (t.getId(), bspBuild.connection))
+        }
+        buildTargets.resetConnections(idToConnection)
+        lastImportedBuilds = i.map(_.build)
       }
-      _ <- profiledIndexWorkspace(() => doctor.check(build.name, build.version))
-      _ = checkRunningBloopVersion(build.version)
+      _ <- profiledIndexWorkspace(() => {
+        val main = session.mainConnection
+        doctor.check(main.name, main.version)
+      })
+      _ = checkRunningBloopVersion(session.version)
     } yield {
       BuildChange.Reconnected
     }
@@ -1851,10 +1859,10 @@ class MetalsLanguageServer(
     scribe.info(s"memory: $footprint")
   }
 
-  private var lastImportedBuild = ImportedBuild.empty
+  private var lastImportedBuilds = List.empty[ImportedBuild]
 
   private def indexWorkspace(check: () => Unit): Unit = {
-    val i = lastImportedBuild ++ ammonite.lastImportedBuild
+    val i = (ammonite.lastImportedBuild :: lastImportedBuilds).reduce(_ ++ _)
     timedThunk(
       "updated build targets",
       clientConfig.initialConfig.statistics.isIndex

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -14,7 +14,8 @@ import ch.epfl.scala.bsp4j.ScalacOptionsItem
 case class ScalaTarget(
     info: BuildTarget,
     scalaInfo: ScalaBuildTarget,
-    scalac: ScalacOptionsItem
+    scalac: ScalacOptionsItem,
+    autoImports: Option[Seq[String]]
 ) {
 
   def isSemanticdbEnabled: Boolean = scalac.isSemanticdbEnabled(scalaVersion)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -45,7 +45,7 @@ import org.eclipse.lsp4j.MessageType
 
 class DebugProvider(
     definitionProvider: DefinitionProvider,
-    buildServer: => Option[BuildServerConnection],
+    buildServer: () => Option[BuildServerConnection],
     buildTargets: BuildTargets,
     buildTargetClasses: BuildTargetClasses,
     compilations: Compilations,
@@ -77,7 +77,7 @@ class DebugProvider(
       val jvmOptionsTranslatedParams = translateJvmParams(parameters)
       // long timeout, since server might take a while to compile the project
       val connectToServer = () => {
-        buildServer
+        buildServer()
           .map(_.startDebugSession(jvmOptionsTranslatedParams))
           .getOrElse(BuildServerUnavailableError)
           .withTimeout(60, TimeUnit.SECONDS)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -405,7 +405,7 @@ class MetalsGlobal(
     }
     val unit = newCompilationUnit(codeWithCursor, filename)
     val source =
-      if (filename.isScalaScript)
+      if (filename.isScalaScript || filename.isSbt)
         ScriptSourceFile(unit.source.file, unit.source.content)
       else unit.source
     val richUnit = new RichCompilationUnit(source)

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -251,11 +251,14 @@ trait CommonMtagsEnrichments {
   }
 
   implicit class XtensionStringDoc(doc: String) {
+    def isScala: Boolean =
+      doc.endsWith(".scala")
+    def isSbt: Boolean =
+      doc.endsWith(".sbt")
     def isScalaScript: Boolean =
       doc.endsWith(".sc")
     def isScalaFilename: Boolean =
-      doc.endsWith(".scala") ||
-        doc.endsWith(".sc")
+      doc.isScala || isScalaScript || isSbt
     def isAmmoniteGeneratedFile: Boolean =
       doc.endsWith(".sc.scala")
     def isAmmoniteScript: Boolean =
@@ -358,6 +361,9 @@ trait CommonMtagsEnrichments {
         case Language.SCALA | Language.JAVA => true
         case _ => false
       }
+    }
+    def isSbt: Boolean = {
+      filename.endsWith(".sbt")
     }
     def isScalaScript: Boolean = {
       filename.endsWith(".sc")

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -54,7 +54,7 @@ abstract class BaseLspSuite(suiteName: String) extends BaseSuite {
   def assertConnectedToBuildServer(
       expectedName: String
   )(implicit loc: Location): Unit = {
-    val obtained = server.server.buildServer.get.name
+    val obtained = server.server.bspSession.get.mainConnection.name
     assertNoDiff(obtained, expectedName)
   }
 

--- a/tests/unit/src/main/scala/tests/QuickBuild.scala
+++ b/tests/unit/src/main/scala/tests/QuickBuild.scala
@@ -66,7 +66,9 @@ case class QuickBuild(
     compilerPlugins: Array[String],
     scalacOptions: Array[String],
     dependsOn: Array[String],
-    additionalSources: Array[String]
+    additionalSources: Array[String],
+    sbtVersion: String,
+    sbtAutoImports: Array[String]
 ) {
   def withId(id: String): QuickBuild =
     QuickBuild(
@@ -77,7 +79,9 @@ case class QuickBuild(
       orEmpty(compilerPlugins),
       orEmpty(scalacOptions),
       orEmpty(dependsOn),
-      orEmpty(additionalSources)
+      orEmpty(additionalSources),
+      sbtVersion,
+      orEmpty(sbtAutoImports)
     )
   private def orEmpty(array: Array[String]): Array[String] =
     if (array == null) new Array(0) else array
@@ -198,6 +202,10 @@ case class QuickBuild(
         s"dotty-compiler_$binaryVersion"
       else s"scala-compiler"
 
+    val sbt = Option(sbtVersion).map { version =>
+      C.Sbt(version, sbtAutoImports.toList)
+    }
+
     C.Project(
       id,
       baseDirectory,
@@ -237,7 +245,7 @@ case class QuickBuild(
         )
       ),
       java = Some(C.Java(Nil)),
-      sbt = None,
+      sbt = sbt,
       test = testFrameworks,
       platform =
         Some(C.Platform.Jvm(C.JvmConfig(javaHome, Nil), None, None, None)),

--- a/tests/unit/src/main/scala/tests/ScriptsAssertions.scala
+++ b/tests/unit/src/main/scala/tests/ScriptsAssertions.scala
@@ -1,0 +1,100 @@
+package tests
+
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
+
+import scala.concurrent.Future
+
+import scala.meta.internal.metals.MetalsEnrichments._
+
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextDocumentPositionParams
+
+trait ScriptsAssertions { self: BaseLspSuite =>
+
+  def assertDefinitionAtLocation(
+      file: String,
+      definitionAt: String,
+      expectedLocation: String,
+      expectedLine: java.lang.Integer = null
+  ): Future[Unit] = {
+
+    val pos = {
+      val content =
+        new String(server.toPath(file).readAllBytes, StandardCharsets.UTF_8)
+      val value = definitionAt.replaceAllLiterally("@@", "")
+      val idx = content.onlyIndexOf(value).getOrElse {
+        throw new Exception(
+          s"Found multiple occurrences of '$value' in '$content'"
+        )
+      }
+      val pipeCount = definitionAt.split("@@", -1).length - 1
+      assert(pipeCount <= 1, s"Found several '|' characters in '$definitionAt'")
+      val pipeIdx = Some(definitionAt.indexOf("@@"))
+        .filter(_ >= 0)
+        .getOrElse(0)
+      content.indexToLspPosition(idx + pipeIdx)
+    }
+
+    server.server
+      .definition(
+        new TextDocumentPositionParams(
+          new TextDocumentIdentifier(server.toPath(file).toNIO.toUri.toString),
+          pos
+        )
+      )
+      .asScala
+      .map { locations =>
+        val locations0 = locations.asScala
+        assert(
+          locations0.length == 1,
+          s"Expected a single location ($expectedLocation, ${Option(expectedLine)}), got ${locations0.length} ($locations0)"
+        )
+        val locationUri = new URI(locations0.head.getUri)
+        assert(
+          locationUri.getScheme == "file",
+          s"Expected file location, got URI $locationUri"
+        )
+        val locationPath = workspace.toNIO.relativize(Paths.get(locationUri))
+        val alternativeExpectedLocation =
+          if (isWindows) Some(expectedLocation.replace('/', '\\'))
+          else None
+        assert(
+          locationPath.toString == expectedLocation || alternativeExpectedLocation
+            .exists(_ == locationPath.toString),
+          s"Expected location $expectedLocation${alternativeExpectedLocation
+            .fold("")(loc => s"(or $loc)")}, got $locationPath"
+        )
+        for (expectedLine0 <- Option(expectedLine)) {
+          val line = locations0.head.getRange.getStart.getLine
+          assert(
+            line == expectedLine0,
+            s"Expected line $expectedLine0, got $line"
+          )
+        }
+        ()
+      }
+  }
+
+  def assertHoverAtPos(
+      path: String,
+      line: Int,
+      char: Int
+  ): Future[String] =
+    server.server
+      .hover(
+        new TextDocumentPositionParams(
+          new TextDocumentIdentifier(
+            server.toPath(path).toNIO.toUri.toASCIIString
+          ),
+          new Position(line, char)
+        )
+      )
+      .asScala
+      .map { res =>
+        val code = server.textContents(path)
+        TestHovers.renderAsString(code, Option(res), includeRange = true)
+      }
+}

--- a/tests/unit/src/main/scala/tests/TestingDiagnostics.scala
+++ b/tests/unit/src/main/scala/tests/TestingDiagnostics.scala
@@ -11,7 +11,7 @@ import scala.meta.io.AbsolutePath
 object TestingDiagnostics {
   def apply(
       workspace: AbsolutePath = PathIO.workingDirectory,
-      buildTargets: BuildTargets = new BuildTargets(),
+      buildTargets: BuildTargets = BuildTargets.withoutAmmonite,
       buffers: Buffers = Buffers()
   ): Diagnostics = {
     new Diagnostics(

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -182,17 +182,18 @@ final class TestingServer(
   }
 
   def buildTargetSourceJars(buildTarget: String): Future[Seq[String]] = {
-    server.buildServer match {
-      case Some(build) =>
+    server.bspSession match {
+      case Some(session) =>
+        val main = session.mainConnection
         for {
-          workspaceBuildTargets <- build.workspaceBuildTargets()
+          workspaceBuildTargets <- main.workspaceBuildTargets()
           ids =
             workspaceBuildTargets.getTargets
               .map(_.getId)
               .asScala
               .filter(_.getUri().contains(s"?id=$buildTarget"))
           dependencySources <-
-            build
+            main
               .buildTargetDependencySources(
                 new b.DependencySourcesParams(ids.asJava)
               )
@@ -442,7 +443,7 @@ final class TestingServer(
   }
 
   def assertBuildServerConnection(): Unit = {
-    require(server.buildServer.isDefined, "Build server did not initialize")
+    require(server.bspSession.isDefined, "Build server did not initialize")
   }
 
   def toPath(filename: String): AbsolutePath =

--- a/tests/unit/src/main/scala/tests/TestingWorkspaceSymbolProvider.scala
+++ b/tests/unit/src/main/scala/tests/TestingWorkspaceSymbolProvider.scala
@@ -18,7 +18,7 @@ object TestingWorkspaceSymbolProvider {
     new WorkspaceSymbolProvider(
       workspace = workspace,
       statistics = statistics,
-      buildTargets = new BuildTargets,
+      buildTargets = BuildTargets.withoutAmmonite,
       index = index,
       _.toFileOnDisk(workspace),
       bucketSize = bucketSize

--- a/tests/unit/src/test/scala/tests/BuildServerConnectionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BuildServerConnectionLspSuite.scala
@@ -23,7 +23,7 @@ class BuildServerConnectionLspSuite
       )
       _ <- server.didOpen("a/src/main/scala/a/A.scala")
       _ = assertNoDiagnostics()
-      _ = server.server.buildServer.get.cancel()
+      _ = server.server.bspSession.get.cancel()
       _ = assertNoDiagnostics()
       _ <- server.executeCommand(ServerCommands.ConnectBuildServer.id)
       _ <- server.didSave("a/src/main/scala/a/A.scala")(


### PR DESCRIPTION
This PR fixes https://github.com/scalameta/metals/issues/1838 by establishing additional BSP connection for each Sbt meta project.

It adds the following for Sbt:
- completions
- go to definition
- hover

Doesn't yet add:
- diagnostics
- references
- rename

