### PR TITLE
Add in a preparePr alias.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import scala.collection.mutable
+import scala.sys.process._
 
 def localSnapshotVersion = "0.9.1-SNAPSHOT"
 def isCI = System.getenv("CI") != null
@@ -150,8 +151,17 @@ onLoad.in(Global) ~= { old =>
 cancelable.in(Global) := true
 crossScalaVersions := Nil
 
+lazy val execScalafmt = taskKey[Unit]("Execute scalafmt executable in /bin")
+execScalafmt := {
+  "bin/scalafmt" !
+}
+
 addCommandAlias("scalafixAll", "all compile:scalafix test:scalafix")
 addCommandAlias("scalafixCheck", "; scalafix --check ; test:scalafix --check")
+addCommandAlias(
+  "preparePr",
+  "scalafixAll ; execScalafmt"
+)
 
 commands += Command.command("save-expect") { s =>
   "unit/test:runMain tests.SaveExpect" ::


### PR DESCRIPTION
The idea behind this is to simplify the process for a contributor
to prepare their code for a pull-request. Currently a person has to
both execute the bin/scalafmt and also run scalafix via sbt. This
simplifies this to one step so a contributor can just run
`sbt preparePr` to run scalfix and then scalafmt.

The idea for this comes from #672 
> add a prePR command to run scalafmt+scalafix before a PR, currently you need to run the steps separately (scalafixAll in sbt shell and ./bin/scalafmt --diff from the terminal)

An alternative approach would be to just add the scalafmt-sbt plugin and use that, but I wasn't sure if there was opposition to that since we are using the `bin/scalafmt` route.
I also looked into added scalafix-cli in bin, but afaik including the `OrganzeImports` dependency rule that way is not easy.
Thoughts?