### PR TITLE
Revert adding buildChanged flag to RefreshModel command

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -206,7 +206,7 @@ final class Compilations(
           // See https://github.com/scalacenter/bloop/issues/1067
           classes.rebuildIndex(targets).foreach { _ =>
             if (targets.exists(isCurrentlyFocused)) {
-              languageClient.refreshModel(buildChanged = false)
+              languageClient.refreshModel()
             }
           }
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
@@ -43,12 +43,9 @@ trait MetalsLanguageClient
   @JsonNotification("metals/executeClientCommand")
   def metalsExecuteClientCommand(params: ExecuteCommandParams): Unit
 
-  final def refreshModel(buildChanged: Boolean): Unit = {
+  final def refreshModel(): Unit = {
     val command = ClientCommands.RefreshModel.id
-    val params = new ExecuteCommandParams(
-      command,
-      List(buildChanged.asInstanceOf[Object]).asJava
-    )
+    val params = new ExecuteCommandParams(command, Nil.asJava)
     metalsExecuteClientCommand(params)
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1900,7 +1900,7 @@ class MetalsLanguageServer(
     val targets = buildTargets.all.map(_.id).toSeq
     buildTargetClasses
       .rebuildIndex(targets)
-      .foreach(_ => languageClient.refreshModel(buildChanged = true))
+      .foreach(_ => languageClient.refreshModel())
   }
 
   private def checkRunningBloopVersion(bspServerVersion: String) = {

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -138,10 +138,11 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
                            |```""".stripMargin
       hoverRes <- assertHoverAtPos("main.sc", 10, 5)
       _ = assertNoDiff(hoverRes, expectedHoverRes)
+
       refreshedPromise = {
         val promise = Promise[Unit]()
-        server.client.refreshBuildHandler = { () =>
-          if (!promise.isCompleted)
+        server.client.refreshModelHandler = { refreshCount =>
+          if (refreshCount > 0 && !promise.isCompleted)
             promise.success(())
         }
         promise

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -81,7 +81,6 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
 
   private val refreshCount = new AtomicInteger
   var refreshModelHandler: Int => Unit = count => ()
-  var refreshBuildHandler: () => Unit = () => ()
 
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams
@@ -89,13 +88,7 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
     clientCommands.addLast(params)
     params.getCommand match {
       case ClientCommands.RefreshModel.id =>
-        val buildChanged =
-          params.getArguments().asScala.head.asInstanceOf[Boolean]
-        val count = refreshCount.getAndIncrement()
-        refreshModelHandler(count)
-        if (buildChanged) {
-          refreshBuildHandler()
-        }
+        refreshModelHandler(refreshCount.getAndIncrement())
       case _ =>
     }
   }


### PR DESCRIPTION
In https://github.com/scalameta/metals/commit/a821715e949ca87e48cc5b41fe70815789eae405 

There was added a flag 'buildChanged' for a command `RefreshModel` sent from metals to clients.
It was done according to description to get rid of flakiness of ammonite tests but it will be also visible by all clients.

Even though adding a parameter is not a problem, problem is it is undocumented and not mentioned anywhere.

Because it is only used in ammonite test which is marked as 'flaky' I think it makes sense to revert this for now and look at it later after release.

Unless you feel it makes sense to keep it then let's add documentation for it and put that in Release Notes.

Fixes: #1863