### PR TITLE
Ensure the edit positions are correct for autoImports with Ammonite.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -268,7 +268,13 @@ class Compilers(
       token: CancelToken
   ): Future[ju.List[AutoImportsResult]] = {
     withPC(params, None) { (pc, pos) =>
-      pc.autoImports(name, CompilerOffsetParams.fromPos(pos, token)).asScala
+      pc.autoImports(name, CompilerOffsetParams.fromPos(pos, token))
+        .asScala
+        .map { list =>
+          if (params.getTextDocument.getUri.isAmmoniteScript)
+            list.map(Ammonite.adjustImportResult(_, pos.input.text))
+          list
+        }
     }.getOrElse(Future.successful(new ju.ArrayList))
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
@@ -22,6 +22,7 @@ import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals._
 import scala.meta.io.AbsolutePath
+import scala.meta.pc.AutoImportsResult
 
 import ammrunner.AmmoniteFetcher
 import ammrunner.AmmoniteFetcherException
@@ -406,6 +407,16 @@ object Ammonite {
         textEdit.setRange(adjustRange(textEdit.getRange, adjustPos))
       for (l <- Option(item.getAdditionalTextEdits); textEdit <- l.asScala)
         textEdit.setRange(adjustRange(textEdit.getRange, adjustPos))
+    }
+  }
+
+  def adjustImportResult(
+      autoImportResult: AutoImportsResult,
+      scalaCode: String
+  ): Unit = {
+    val adjustPos = adjustPosition(scalaCode)
+    for (textEdit <- autoImportResult.edits.asScala) {
+      textEdit.setRange(adjustRange(textEdit.getRange, adjustPos))
     }
   }
 


### PR DESCRIPTION
Previously the edit for autoImports when triggered from a code action would contain
reference to the position the presentation compiler had for the generated Scala
file that the Ammonite script created. Like other functionality that we have that
interacts with the Presentation compiler while dealing with Ammonite we ensure that
the edits have positions that are adjusted to ensure they land in the correct place
in the script, not the generated Scala file.

Fixes #1870 

Behavior explained in the issue:

![2020-06-30 15 33 16](https://user-images.githubusercontent.com/13974112/86132372-1625a900-bae7-11ea-94b5-3504055d01b1.gif)


Behavior after the change:

![2020-06-30 15 31 54](https://user-images.githubusercontent.com/13974112/86132424-276eb580-bae7-11ea-87d9-bfe958a38ae3.gif)
