### PR TITLE
Show  imports in worksheet dependency example.

### DIFF
--- a/website/blog/2020-07-01-lithium.md
+++ b/website/blog/2020-07-01-lithium.md
@@ -119,7 +119,7 @@ pprint.log(Properties.releaseVersion)
 ```
 
 The Scala version is independent from any build tool used in the workspace and
-without specifying the exact version it will used the default Ammonite Scala
+without specifying the exact version it will use the default Ammonite Scala
 version.
 
 To learn more about Ammonite please visit the documentation website at
@@ -139,13 +139,13 @@ and diagnostics working right from the start.
 You can add them using the following syntax:
 
 ```
-$dep.`organisation::artifact:version`
+$ivy.`organisation::artifact:version`
 ```
 
 For example:
 
 ```
-$dep.`com.lihaoyi::scalatags:0.9.0`
+$ivy.`com.lihaoyi::scalatags:0.9.0`
 ```
 
 `::` is the same as `%%` in sbt, which will append the current Scala binary
@@ -180,7 +180,7 @@ The command is also available as a button in the welcome view of the Visual
 Studio Code Metals extension, which means it will be visible in case there are
 no imported projects in the current workspace.
 
-The first curated templates were choosen by the team, however we are happy to
+The first curated templates were chosen by the team, however we are happy to
 include more so that it's easier for people to discover new amazing libraries or
 frameworks.
 
@@ -244,7 +244,7 @@ This great new feature was contributed by [ckipp01](https://github.com/ckipp01)!
   underscore numeric literals (`val num = 100_000`).
 - Always run Mill in interactive mode.
 - Improvements to hover in Scala 3 files.
-- make sure auto imports are correct for Ammonite scripts
+- Make sure auto imports are correct for Ammonite scripts
 
 ## Contributors
 


### PR DESCRIPTION
Mainly this just switches the `$dep` syntax to `$ivy` to not confuse people.

It also just corrects a few typos.