### PR TITLE
Add `--version` command line option

### DIFF
--- a/metals/src/main/scala/scala/meta/metals/Main.scala
+++ b/metals/src/main/scala/scala/meta/metals/Main.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 
+import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.GlobalTrace
 import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.internal.metals.MetalsLanguageServer
@@ -15,6 +16,19 @@ import org.eclipse.lsp4j.jsonrpc.Launcher
 
 object Main {
   def main(args: Array[String]): Unit = {
+    if (args.exists(Set("-v", "--version", "-version"))) {
+      val supportedScalaVersions =
+        BuildInfo.supportedScalaVersions.sorted.mkString(", ")
+
+      println(
+        s"""|metals ${BuildInfo.metalsVersion}
+            |
+            |# Note:
+            |#   supported Scala versions: $supportedScalaVersions""".stripMargin
+      )
+
+      sys.exit(0)
+    }
     val systemIn = System.in
     val systemOut = System.out
     val tracePrinter = GlobalTrace.setup("LSP")


### PR DESCRIPTION
I am using metals for emacs on a few systems. And more often than not, I am not sure which version is currently installed, or whether I should run `coursier bootstrap ...` to generate a new script.

This PR adds a `--version` command line option, which can also be called as `-v` or `-version` showing the current version of metals and additionally the supported Scala versions.