### PR TITLE
Fix unit test failure on Oracle JDK 8

### DIFF
--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -32,10 +32,14 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
       "scala-library", "scala-reflect", "sourcecode_2.12"
     )
 
-    if (scala.util.Properties.isJavaAtLeast(9.toString)) {
-      otherLibraries
-    } else {
-      otherLibraries ++ jdk8Libraries
+    (
+      scala.util.Properties.isJavaAtLeast(9.toString),
+      scala.util.Properties.javaVmVendor
+    ) match {
+      case (true, _) => otherLibraries
+      case (false, "Oracle Corporation") =>
+        otherLibraries ++ jdk8Libraries + "jfr"
+      case _ => otherLibraries ++ jdk8Libraries
     }
   }
 


### PR DESCRIPTION
Fixes #1885 

Adapt `TreeViewLspSuite` to handle the presence of `jfr.jar` bundled along Oracle JDK 8 libraries