### PR TITLE
Remove gson runtime reflection with manual reads for configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ website/i18n/*
 !website/i18n/en.json
 
 project/metals.sbt
+coursier

--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -707,7 +707,7 @@ to be set via `InitializationOptions`, which is preferable.
       "openFilesOnRenameProvider": boolean,
       "quickPickProvider": boolean,
       "slowTaskProvider": boolean,
-      "statusBarProvider": boolean,
+      "statusBarProvider": "on" | "off" | "show-message" | "log-message",
       "treeViewProvider": boolean
       "openNewWindowProvider": boolean
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -15,6 +15,10 @@ class ClientConfiguration(
     var initializationOptions: InitializationOptions
 ) {
 
+  def extract(a: Option[Boolean], b: Option[Boolean], c: Boolean): Boolean = {
+    a.orElse(b).getOrElse(c)
+  }
+
   def statusBarIsOn(): Boolean =
     initializationOptions.statusBarIsOn ||
       experimentalCapabilities.statusBarIsOn ||
@@ -36,28 +40,39 @@ class ClientConfiguration(
       initialConfig.statusBar.isOff
 
   def slowTaskIsOn(): Boolean =
-    initializationOptions.slowTaskProvider ||
-      experimentalCapabilities.slowTaskProvider ||
+    extract(
+      initializationOptions.slowTaskProvider,
+      experimentalCapabilities.slowTaskProvider,
       initialConfig.slowTask.isOn
+    )
 
   def isExecuteClientCommandProvider(): Boolean =
-    initializationOptions.executeClientCommandProvider ||
-      experimentalCapabilities.executeClientCommandProvider ||
+    extract(
+      initializationOptions.executeClientCommandProvider,
+      experimentalCapabilities.executeClientCommandProvider,
       initialConfig.executeClientCommand.isOn
+    )
 
   def isInputBoxEnabled(): Boolean =
-    initializationOptions.inputBoxProvider ||
-      experimentalCapabilities.inputBoxProvider ||
+    extract(
+      initializationOptions.inputBoxProvider,
+      experimentalCapabilities.inputBoxProvider,
       initialConfig.isInputBoxEnabled
+    )
 
   def isQuickPickProvider(): Boolean =
-    initializationOptions.quickPickProvider ||
-      experimentalCapabilities.quickPickProvider
+    extract(
+      initializationOptions.quickPickProvider,
+      experimentalCapabilities.quickPickProvider,
+      false
+    )
 
   def isOpenFilesOnRenameProvider(): Boolean =
-    initializationOptions.openFilesOnRenameProvider ||
-      experimentalCapabilities.openFilesOnRenameProvider ||
+    extract(
+      initializationOptions.openFilesOnRenameProvider,
+      experimentalCapabilities.openFilesOnRenameProvider,
       initialConfig.openFilesOnRenames
+    )
 
   def doctorFormatIsJson(): Boolean =
     initializationOptions.doctorFormatIsJson ||
@@ -65,35 +80,48 @@ class ClientConfiguration(
       initialConfig.doctorFormat.isJson
 
   def isHttpEnabled(): Boolean =
-    initializationOptions.isHttpEnabled ||
-      initialConfig.isHttpEnabled
+    initializationOptions.isHttpEnabled.getOrElse(initialConfig.isHttpEnabled)
 
   def isExitOnShutdown(): Boolean =
-    initializationOptions.isExitOnShutdown ||
+    initializationOptions.isExitOnShutdown.getOrElse(
       initialConfig.isExitOnShutdown
+    )
 
   def isCompletionItemResolve(): Boolean =
-    initializationOptions.compilerOptions.isCompletionItemResolve &&
+    initializationOptions.compilerOptions.isCompletionItemResolve.getOrElse(
       initialConfig.compilers.isCompletionItemResolve
+    )
 
   def isDebuggingProvider(): Boolean =
-    initializationOptions.debuggingProvider ||
-      experimentalCapabilities.debuggingProvider
+    extract(
+      initializationOptions.debuggingProvider,
+      experimentalCapabilities.debuggingProvider,
+      false
+    )
 
   def isDecorationProvider(): Boolean =
-    initializationOptions.decorationProvider ||
-      experimentalCapabilities.decorationProvider
+    extract(
+      initializationOptions.decorationProvider,
+      experimentalCapabilities.decorationProvider,
+      false
+    )
 
   def isTreeViewProvider(): Boolean =
-    initializationOptions.treeViewProvider ||
-      experimentalCapabilities.treeViewProvider
+    extract(
+      initializationOptions.treeViewProvider,
+      experimentalCapabilities.treeViewProvider,
+      false
+    )
 
   def isDidFocusProvider(): Boolean =
-    initializationOptions.didFocusProvider ||
-      experimentalCapabilities.didFocusProvider
+    extract(
+      initializationOptions.didFocusProvider,
+      experimentalCapabilities.didFocusProvider,
+      false
+    )
 
   def isOpenNewWindowProvider(): Boolean =
-    initializationOptions.openNewWindowProvider
+    initializationOptions.openNewWindowProvider.getOrElse(false)
 }
 
 object ClientConfiguration {

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -35,8 +35,8 @@ class ClientConfiguration(
       initialConfig.statusBar.isLogMessage
 
   def statusBarIsOff(): Boolean =
-    initializationOptions.statusBarIsOff &&
-      experimentalCapabilities.statusBarIsOff &&
+    initializationOptions.statusBarIsOff ||
+      experimentalCapabilities.statusBarIsOff ||
       initialConfig.statusBar.isOff
 
   def slowTaskIsOn(): Boolean =

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -15,29 +15,16 @@ class ClientConfiguration(
     var initializationOptions: InitializationOptions
 ) {
 
-  def extract(a: Option[Boolean], b: Option[Boolean], c: Boolean): Boolean = {
-    a.orElse(b).getOrElse(c)
+  def extract[T](primary: Option[T], secondary: Option[T], default: T): T = {
+    primary.orElse(secondary).getOrElse(default)
   }
 
-  def statusBarIsOn(): Boolean =
-    initializationOptions.statusBarIsOn ||
-      experimentalCapabilities.statusBarIsOn ||
-      initialConfig.statusBar.isOn
-
-  def statusBarIsShow(): Boolean =
-    initializationOptions.statusBarIsShowMessage ||
-      experimentalCapabilities.statusBarIsShowMessage ||
-      initialConfig.statusBar.isShowMessage
-
-  def statusBarIsLog(): Boolean =
-    initializationOptions.statusBarIsLogMessage ||
-      experimentalCapabilities.statusBarIsLogMessage ||
-      initialConfig.statusBar.isLogMessage
-
-  def statusBarIsOff(): Boolean =
-    initializationOptions.statusBarIsOff ||
-      experimentalCapabilities.statusBarIsOff ||
-      initialConfig.statusBar.isOff
+  def statusBarState(): StatusBarState.StatusBarState =
+    extract(
+      initializationOptions.statusBarState,
+      experimentalCapabilities.statusBarState,
+      StatusBarState.Off
+    )
 
   def slowTaskIsOn(): Boolean =
     extract(

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
@@ -24,12 +24,8 @@ final case class ClientExperimentalCapabilities(
     treeViewProvider: Option[Boolean]
 ) {
   def doctorFormatIsJson: Boolean = doctorProvider.exists(_ == "json")
-  def statusBarIsOn: Boolean = statusBarProvider.exists(_ == "on")
-  def statusBarIsOff: Boolean = statusBarProvider.exists(_ == "off")
-  def statusBarIsShowMessage: Boolean =
-    statusBarProvider.exists(_ == "show-message")
-  def statusBarIsLogMessage: Boolean =
-    statusBarProvider.exists(_ == "log-message")
+  def statusBarState: Option[StatusBarState.StatusBarState] =
+    statusBarProvider.flatMap(StatusBarState.fromString)
 }
 
 object ClientExperimentalCapabilities {

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
@@ -1,58 +1,99 @@
 package scala.meta.internal.metals
-import com.google.gson.JsonElement
-import com.google.gson.JsonNull
+import com.google.gson.JsonObject
 import org.eclipse.{lsp4j => l}
 
+/**
+ * While all these values can be set here, they are here only for
+ * compatablity with clients that were setting them this way. From
+ * a client perspective it's preferable and recommended to use
+ * InitializationOptions instead. From a development perspective
+ * don't add something here unless it's truly a more "experimental"
+ * type feature.
+ */
 final case class ClientExperimentalCapabilities(
-    debuggingProvider: Boolean,
-    decorationProvider: Boolean,
-    didFocusProvider: Boolean,
-    doctorProvider: String,
-    executeClientCommandProvider: Boolean,
-    inputBoxProvider: Boolean,
-    openFilesOnRenameProvider: Boolean,
-    quickPickProvider: Boolean,
-    slowTaskProvider: Boolean,
-    statusBarProvider: String,
-    treeViewProvider: Boolean
+    debuggingProvider: Option[Boolean],
+    decorationProvider: Option[Boolean],
+    didFocusProvider: Option[Boolean],
+    doctorProvider: Option[String],
+    executeClientCommandProvider: Option[Boolean],
+    inputBoxProvider: Option[Boolean],
+    openFilesOnRenameProvider: Option[Boolean],
+    quickPickProvider: Option[Boolean],
+    slowTaskProvider: Option[Boolean],
+    statusBarProvider: Option[String],
+    treeViewProvider: Option[Boolean]
 ) {
-  def this() =
-    this(
-      debuggingProvider = false,
-      decorationProvider = false,
-      didFocusProvider = false,
-      doctorProvider = "html",
-      executeClientCommandProvider = false,
-      inputBoxProvider = false,
-      openFilesOnRenameProvider = false,
-      quickPickProvider = false,
-      slowTaskProvider = false,
-      statusBarProvider = "off",
-      treeViewProvider = false
-    )
-  def doctorFormatIsJson: Boolean = doctorProvider == "json"
-  def statusBarIsOn: Boolean = statusBarProvider == "on"
-  def statusBarIsOff: Boolean = statusBarProvider == "off"
-  def statusBarIsShowMessage: Boolean = statusBarProvider == "show-message"
-  def statusBarIsLogMessage: Boolean = statusBarProvider == "log-message"
+  def doctorFormatIsJson: Boolean = doctorProvider.exists(_ == "json")
+  def statusBarIsOn: Boolean = statusBarProvider.exists(_ == "on")
+  def statusBarIsOff: Boolean = statusBarProvider.exists(_ == "off")
+  def statusBarIsShowMessage: Boolean =
+    statusBarProvider.exists(_ == "show-message")
+  def statusBarIsLogMessage: Boolean =
+    statusBarProvider.exists(_ == "log-message")
 }
 
 object ClientExperimentalCapabilities {
-  val Default = new ClientExperimentalCapabilities()
+  import scala.meta.internal.metals.JsonParser._
+  val Default: ClientExperimentalCapabilities = ClientExperimentalCapabilities(
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None
+  )
 
   def from(
       capabilities: l.ClientCapabilities
   ): ClientExperimentalCapabilities = {
-    import scala.meta.internal.metals.JsonParser._
     capabilities.getExperimental match {
-      // NOTE: (ckipp01) For some reason when some editors (emacs) leave out the
-      // `InitializationOptions` key, it is parsed as a `JsonNull` while others
-      // that leave it out it's parsed as a normal `null`. Why? I have no idea.
-      case _: JsonNull => Default
-      case json: JsonElement =>
-        json.as[ClientExperimentalCapabilities].getOrElse(Default)
+      case json: JsonObject =>
+        // Note (ckipp01) We used to do this with reflection going from the JsonElement straight to
+        // InitializationOptions, but there was a lot of issues with it such as setting
+        // nulls for unset values, needing a default constructor, and not being able to
+        // work as expected with Options. This is a bit more verbose, but it gives us full
+        // control over how the InitializationOptions are created.
+        extractToClientExperimentalCapabilities(json)
       case _ =>
         Default
     }
+  }
+
+  def extractToClientExperimentalCapabilities(
+      json: JsonObject
+  ): ClientExperimentalCapabilities = {
+    val jsonObj = json.toJsonObject
+    val debuggingProvider = jsonObj.getBooleanOption("debuggingProvider")
+    val decorationProvider =
+      jsonObj.getBooleanOption("decorationProvider")
+    val didFocusProvider = jsonObj.getBooleanOption("didFocusProvider")
+    val doctorProvider = jsonObj.getStringOption("doctorProvider")
+    val executeClientCommandProvider =
+      jsonObj.getBooleanOption("executeClientCommandProvider")
+    val inputBoxProvider = jsonObj.getBooleanOption("inputBoxProvider")
+    val openFilesOnRenameProvider =
+      jsonObj.getBooleanOption("openFilesOnRenameProvider")
+    val quickPickProvider = jsonObj.getBooleanOption("quickPickProvider")
+    val slowTaskProvider = jsonObj.getBooleanOption("slowTaskProvider")
+    val statusBarProvider = jsonObj.getStringOption("statusBarProvider")
+    val treeViewProvider = jsonObj.getBooleanOption("treeViewProvider")
+    ClientExperimentalCapabilities(
+      debuggingProvider,
+      decorationProvider,
+      didFocusProvider,
+      doctorProvider,
+      executeClientCommandProvider,
+      inputBoxProvider,
+      openFilesOnRenameProvider,
+      quickPickProvider,
+      slowTaskProvider,
+      statusBarProvider,
+      treeViewProvider
+    )
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
@@ -68,32 +68,20 @@ object ClientExperimentalCapabilities {
       json: JsonObject
   ): ClientExperimentalCapabilities = {
     val jsonObj = json.toJsonObject
-    val debuggingProvider = jsonObj.getBooleanOption("debuggingProvider")
-    val decorationProvider =
-      jsonObj.getBooleanOption("decorationProvider")
-    val didFocusProvider = jsonObj.getBooleanOption("didFocusProvider")
-    val doctorProvider = jsonObj.getStringOption("doctorProvider")
-    val executeClientCommandProvider =
-      jsonObj.getBooleanOption("executeClientCommandProvider")
-    val inputBoxProvider = jsonObj.getBooleanOption("inputBoxProvider")
-    val openFilesOnRenameProvider =
-      jsonObj.getBooleanOption("openFilesOnRenameProvider")
-    val quickPickProvider = jsonObj.getBooleanOption("quickPickProvider")
-    val slowTaskProvider = jsonObj.getBooleanOption("slowTaskProvider")
-    val statusBarProvider = jsonObj.getStringOption("statusBarProvider")
-    val treeViewProvider = jsonObj.getBooleanOption("treeViewProvider")
     ClientExperimentalCapabilities(
-      debuggingProvider,
-      decorationProvider,
-      didFocusProvider,
-      doctorProvider,
-      executeClientCommandProvider,
-      inputBoxProvider,
-      openFilesOnRenameProvider,
-      quickPickProvider,
-      slowTaskProvider,
-      statusBarProvider,
-      treeViewProvider
+      debuggingProvider = jsonObj.getBooleanOption("debuggingProvider"),
+      decorationProvider = jsonObj.getBooleanOption("decorationProvider"),
+      didFocusProvider = jsonObj.getBooleanOption("didFocusProvider"),
+      doctorProvider = jsonObj.getStringOption("doctorProvider"),
+      executeClientCommandProvider =
+        jsonObj.getBooleanOption("executeClientCommandProvider"),
+      inputBoxProvider = jsonObj.getBooleanOption("inputBoxProvider"),
+      openFilesOnRenameProvider =
+        jsonObj.getBooleanOption("openFilesOnRenameProvider"),
+      quickPickProvider = jsonObj.getBooleanOption("quickPickProvider"),
+      slowTaskProvider = jsonObj.getBooleanOption("slowTaskProvider"),
+      statusBarProvider = jsonObj.getStringOption("statusBarProvider"),
+      treeViewProvider = jsonObj.getBooleanOption("treeViewProvider")
     )
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -32,12 +32,12 @@ final class ConfiguredLanguageClient(
   }
 
   override def metalsStatus(params: MetalsStatusParams): Unit = {
-    if (clientConfig.statusBarIsOn) {
+    if (clientConfig.statusBarState == StatusBarState.On) {
       underlying.metalsStatus(params)
     } else if (params.text.nonEmpty && !pendingShowMessage.get()) {
-      if (clientConfig.statusBarIsShow) {
+      if (clientConfig.statusBarState == StatusBarState.ShowMessage) {
         underlying.showMessage(new MessageParams(MessageType.Log, params.text))
-      } else if (clientConfig.statusBarIsLog) {
+      } else if (clientConfig.statusBarState == StatusBarState.LogMessage) {
         underlying.logMessage(new MessageParams(MessageType.Log, params.text))
       } else {
         ()
@@ -70,7 +70,9 @@ final class ConfiguredLanguageClient(
   }
 
   override def logMessage(message: MessageParams): Unit = {
-    if (clientConfig.statusBarIsLog && message.getType == MessageType.Log) {
+    if (
+      clientConfig.statusBarState == StatusBarState.LogMessage && message.getType == MessageType.Log
+    ) {
       // window/logMessage is reserved for the status bar so we don't publish
       // scribe.{info,warn,error} logs here. Users should look at .metals/metals.log instead.
       ()

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -1,69 +1,145 @@
 package scala.meta.internal.metals
+
 import scala.meta.internal.pc.CompilerInitializationOptions
 
-import com.google.gson.JsonElement
-import com.google.gson.JsonNull
+import com.google.gson.JsonObject
 import org.eclipse.{lsp4j => l}
 
+/**
+ * Whever possible, this is the preferred way to configure Metals from the client.
+ * Eventually this will be accumulated in the ClientConfiguration along with
+ * ClientExperimentalCapabilities and the InitialConfig. If the values aren't directly
+ * passed in here, we default everything to None to signify that the client didn't
+ * directly set the value. The defaults will then be handled by the ClientConfiguration
+ * so we don't need to worry about them here.
+ */
 final case class InitializationOptions(
     compilerOptions: CompilerInitializationOptions,
-    debuggingProvider: Boolean,
-    decorationProvider: Boolean,
-    didFocusProvider: Boolean,
-    doctorProvider: String,
-    executeClientCommandProvider: Boolean,
-    inputBoxProvider: Boolean,
-    isExitOnShutdown: Boolean,
-    isHttpEnabled: Boolean,
-    openFilesOnRenameProvider: Boolean,
-    quickPickProvider: Boolean,
-    slowTaskProvider: Boolean,
-    statusBarProvider: String,
-    treeViewProvider: Boolean,
-    openNewWindowProvider: Boolean
+    debuggingProvider: Option[Boolean],
+    decorationProvider: Option[Boolean],
+    didFocusProvider: Option[Boolean],
+    doctorProvider: Option[String],
+    executeClientCommandProvider: Option[Boolean],
+    inputBoxProvider: Option[Boolean],
+    isExitOnShutdown: Option[Boolean],
+    isHttpEnabled: Option[Boolean],
+    openFilesOnRenameProvider: Option[Boolean],
+    quickPickProvider: Option[Boolean],
+    slowTaskProvider: Option[Boolean],
+    statusBarProvider: Option[String],
+    treeViewProvider: Option[Boolean],
+    openNewWindowProvider: Option[Boolean]
 ) {
-  def this() =
-    this(
-      compilerOptions = new CompilerInitializationOptions(),
-      debuggingProvider = false,
-      decorationProvider = false,
-      didFocusProvider = false,
-      doctorProvider = "html",
-      executeClientCommandProvider = false,
-      inputBoxProvider = false,
-      isExitOnShutdown = false,
-      isHttpEnabled = false,
-      openFilesOnRenameProvider = false,
-      quickPickProvider = false,
-      slowTaskProvider = false,
-      statusBarProvider = "off",
-      treeViewProvider = false,
-      openNewWindowProvider = false
-    )
-  def doctorFormatIsJson: Boolean = doctorProvider == "json"
-  def statusBarIsOn: Boolean = statusBarProvider == "on"
-  def statusBarIsOff: Boolean = statusBarProvider == "off"
-  def statusBarIsShowMessage: Boolean = statusBarProvider == "show-message"
-  def statusBarIsLogMessage: Boolean = statusBarProvider == "log-message"
+  def doctorFormatIsJson: Boolean = doctorProvider.exists(_ == "json")
+  def statusBarIsOn: Boolean = statusBarProvider.exists(_ == "on")
+  def statusBarIsOff: Boolean = statusBarProvider.exists(_ == "off")
+  def statusBarIsShowMessage: Boolean =
+    statusBarProvider.exists(_ == "show-message")
+  def statusBarIsLogMessage: Boolean =
+    statusBarProvider.exists(_ == "log-message")
 }
 
 object InitializationOptions {
-  val Default = new InitializationOptions()
+  import scala.meta.internal.metals.JsonParser._
+
+  val Default: InitializationOptions = InitializationOptions(
+    CompilerInitializationOptions.default,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None
+  )
 
   def from(
       initializeParams: l.InitializeParams
   ): InitializationOptions = {
-    import scala.meta.internal.metals.JsonParser._
     initializeParams.getInitializationOptions() match {
-      // NOTE: (ckipp01) For some reason when some editors (emacs) leave out the
-      // `InitializationOptions` key, it is parsed as a `JsonNull` while others
-      // that leave it out it's parsed as a normal `null`. Why? I have no idea.
-      case _: JsonNull =>
-        Default
-      case json: JsonElement =>
-        json.as[InitializationOptions].getOrElse(Default)
+      case json: JsonObject =>
+        // Note (ckipp01) We used to do this with reflection going from the JsonElement straight to
+        // InitializationOptions, but there was a lot of issues with it such as setting
+        // nulls for unset values, needing a default constructor, and not being able to
+        // work as expected with Options. This is a bit more verbose, but it gives us full
+        // control over how the InitializationOptions are created.
+        extractToInitializationOptions(json)
       case _ =>
         Default
     }
   }
+
+  def extractToInitializationOptions(
+      json: JsonObject
+  ): InitializationOptions = {
+    val jsonObj = json.toJsonObject
+    val compilerOptions = extractCompilerOptions(jsonObj)
+    val debuggingProvider = jsonObj.getBooleanOption("debuggingProvider")
+    val decorationProvider =
+      jsonObj.getBooleanOption("decorationProvider")
+    val didFocusProvider = jsonObj.getBooleanOption("didFocusProvider")
+    val doctorProvider = jsonObj.getStringOption("doctorProvider")
+    val executeClientCommandProvider =
+      jsonObj.getBooleanOption("executeClientCommandProvider")
+    val inputBoxProvider = jsonObj.getBooleanOption("inputBoxProvider")
+    val isExitOnShutdown = jsonObj.getBooleanOption("isExitOnShutdown")
+    val isHttpEnabled = jsonObj.getBooleanOption("isHttpEnabled")
+    val openFilesOnRenameProvider =
+      jsonObj.getBooleanOption("openFilesOnRenameProvider")
+    val quickPickProvider = jsonObj.getBooleanOption("quickPickProvider")
+    val slowTaskProvider = jsonObj.getBooleanOption("slowTaskProvider")
+    val statusBarProvider = jsonObj.getStringOption("statusBarProvider")
+    val treeViewProvider = jsonObj.getBooleanOption("treeViewProvider")
+    val openNewWindowProvider =
+      jsonObj.getBooleanOption("openNewWindowProvider")
+    InitializationOptions(
+      compilerOptions,
+      debuggingProvider,
+      decorationProvider,
+      didFocusProvider,
+      doctorProvider,
+      executeClientCommandProvider,
+      inputBoxProvider,
+      isExitOnShutdown,
+      isHttpEnabled,
+      openFilesOnRenameProvider,
+      quickPickProvider,
+      slowTaskProvider,
+      statusBarProvider,
+      treeViewProvider,
+      openNewWindowProvider
+    )
+  }
+
+  def extractCompilerOptions(
+      json: JsonObject
+  ): CompilerInitializationOptions = {
+    val compilerObj = json.getObjectOption("compilerOptions")
+    CompilerInitializationOptions(
+      isCompletionItemDetailEnabled = compilerObj.flatMap(
+        _.getBooleanOption("isCompletionItemDetailEnabled")
+      ),
+      isCompletionItemDocumentationEnabled = compilerObj.flatMap(
+        _.getBooleanOption("isCompletionItemDocumentationEnabled")
+      ),
+      isHoverDocumentationEnabled = compilerObj.flatMap(
+        _.getBooleanOption("isHoverDocumentationEnabled")
+      ),
+      snippetAutoIndent =
+        compilerObj.flatMap(_.getBooleanOption("snippetAutoIndent")),
+      isSignatureHelpDocumentationEnabled = compilerObj.flatMap(
+        _.getBooleanOption("isSignatureHelpDocumentationEnabled")
+      ),
+      isCompletionItemResolve =
+        compilerObj.flatMap(_.getBooleanOption("isCompletionItemResolve"))
+    )
+  }
+
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -31,12 +31,8 @@ final case class InitializationOptions(
     openNewWindowProvider: Option[Boolean]
 ) {
   def doctorFormatIsJson: Boolean = doctorProvider.exists(_ == "json")
-  def statusBarIsOn: Boolean = statusBarProvider.exists(_ == "on")
-  def statusBarIsOff: Boolean = statusBarProvider.exists(_ == "off")
-  def statusBarIsShowMessage: Boolean =
-    statusBarProvider.exists(_ == "show-message")
-  def statusBarIsLogMessage: Boolean =
-    statusBarProvider.exists(_ == "log-message")
+  def statusBarState: Option[StatusBarState.StatusBarState] =
+    statusBarProvider.flatMap(StatusBarState.fromString)
 }
 
 object InitializationOptions {

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -80,41 +80,24 @@ object InitializationOptions {
       json: JsonObject
   ): InitializationOptions = {
     val jsonObj = json.toJsonObject
-    val compilerOptions = extractCompilerOptions(jsonObj)
-    val debuggingProvider = jsonObj.getBooleanOption("debuggingProvider")
-    val decorationProvider =
-      jsonObj.getBooleanOption("decorationProvider")
-    val didFocusProvider = jsonObj.getBooleanOption("didFocusProvider")
-    val doctorProvider = jsonObj.getStringOption("doctorProvider")
-    val executeClientCommandProvider =
-      jsonObj.getBooleanOption("executeClientCommandProvider")
-    val inputBoxProvider = jsonObj.getBooleanOption("inputBoxProvider")
-    val isExitOnShutdown = jsonObj.getBooleanOption("isExitOnShutdown")
-    val isHttpEnabled = jsonObj.getBooleanOption("isHttpEnabled")
-    val openFilesOnRenameProvider =
-      jsonObj.getBooleanOption("openFilesOnRenameProvider")
-    val quickPickProvider = jsonObj.getBooleanOption("quickPickProvider")
-    val slowTaskProvider = jsonObj.getBooleanOption("slowTaskProvider")
-    val statusBarProvider = jsonObj.getStringOption("statusBarProvider")
-    val treeViewProvider = jsonObj.getBooleanOption("treeViewProvider")
-    val openNewWindowProvider =
-      jsonObj.getBooleanOption("openNewWindowProvider")
     InitializationOptions(
-      compilerOptions,
-      debuggingProvider,
-      decorationProvider,
-      didFocusProvider,
-      doctorProvider,
-      executeClientCommandProvider,
-      inputBoxProvider,
-      isExitOnShutdown,
-      isHttpEnabled,
-      openFilesOnRenameProvider,
-      quickPickProvider,
-      slowTaskProvider,
-      statusBarProvider,
-      treeViewProvider,
-      openNewWindowProvider
+      compilerOptions = extractCompilerOptions(jsonObj),
+      debuggingProvider = jsonObj.getBooleanOption("debuggingProvider"),
+      decorationProvider = jsonObj.getBooleanOption("decorationProvider"),
+      didFocusProvider = jsonObj.getBooleanOption("didFocusProvider"),
+      doctorProvider = jsonObj.getStringOption("doctorProvider"),
+      executeClientCommandProvider =
+        jsonObj.getBooleanOption("executeClientCommandProvider"),
+      inputBoxProvider = jsonObj.getBooleanOption("inputBoxProvider"),
+      isExitOnShutdown = jsonObj.getBooleanOption("isExitOnShutdown"),
+      isHttpEnabled = jsonObj.getBooleanOption("isHttpEnabled"),
+      openFilesOnRenameProvider =
+        jsonObj.getBooleanOption("openFilesOnRenameProvider"),
+      quickPickProvider = jsonObj.getBooleanOption("quickPickProvider"),
+      slowTaskProvider = jsonObj.getBooleanOption("slowTaskProvider"),
+      statusBarProvider = jsonObj.getStringOption("statusBarProvider"),
+      treeViewProvider = jsonObj.getBooleanOption("treeViewProvider"),
+      openNewWindowProvider = jsonObj.getBooleanOption("openNewWindowProvider")
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/JsonParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JsonParser.scala
@@ -34,6 +34,20 @@ object JsonParser {
     }
   }
 
+  implicit class XtensionSerializedAsOption(json: JsonObject) {
+    def getStringOption(key: String): Option[String] = {
+      Try(json.get(key).getAsString()).toOption
+    }
+
+    def getBooleanOption(key: String): Option[Boolean] = {
+      Try(json.get(key).getAsBoolean()).toOption
+    }
+
+    def getObjectOption(key: String): Option[JsonObject] = {
+      Try(json.get(key).toJsonObject).toOption
+    }
+  }
+
   // NOTE(alekseiAlefirov): one cannot do type parameterized extractor, unfortunately (https://github.com/scala/bug/issues/884)
   // so instantiating this class is a workaround
   class Of[A: ClassTag] {

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
@@ -49,7 +49,7 @@ final class StatusBar(
   }
 
   def trackSlowTask[T](message: String)(thunk: => T): T = {
-    if (clientConfig.statusBarIsOff)
+    if (clientConfig.statusBarState == StatusBarState.Off)
       trackBlockingTask(message)(thunk)
     else {
       val task = client().metalsSlowTask(MetalsSlowTaskParams(message))
@@ -67,7 +67,7 @@ final class StatusBar(
   }
 
   def trackSlowFuture[T](message: String, thunk: Future[T]): Unit = {
-    if (clientConfig.statusBarIsOff)
+    if (clientConfig.statusBarState == StatusBarState.Off)
       trackFuture(message, thunk)
     else {
       val task = client().metalsSlowTask(MetalsSlowTaskParams(message))

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBarState.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBarState.scala
@@ -10,7 +10,7 @@ object StatusBarState {
   def fromString(value: String): Option[StatusBarState] =
     value match {
       case "on" => Some(On)
-      case "Off" => Some(Off)
+      case "off" => Some(Off)
       case "show-message" => Some(ShowMessage)
       case "log-message" => Some(LogMessage)
       case _ => None

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBarState.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBarState.scala
@@ -1,0 +1,19 @@
+package scala.meta.internal.metals
+
+object StatusBarState {
+  sealed trait StatusBarState
+  case object On extends StatusBarState
+  case object Off extends StatusBarState
+  case object ShowMessage extends StatusBarState
+  case object LogMessage extends StatusBarState
+
+  def fromString(value: String): Option[StatusBarState] =
+    value match {
+      case "on" => Some(On)
+      case "Off" => Some(Off)
+      case "show-message" => Some(ShowMessage)
+      case "log-message" => Some(LogMessage)
+      case _ => None
+    }
+
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerInitializationOptions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerInitializationOptions.scala
@@ -1,20 +1,22 @@
 package scala.meta.internal.pc
 
+/**
+ * Represents the Compiler InitializationOptions that the client
+ * sends in during the `initialize` process. If the the client doesn't
+ * doesn't explicity send in anything, we default everything to None to
+ * signify the client didn't set this. This will then default to what is
+ * currently set (more than likely the defaults) in the PresentationCompilerConfigImpl.
+ */
 case class CompilerInitializationOptions(
-    isCompletionItemDetailEnabled: Boolean,
-    isCompletionItemDocumentationEnabled: Boolean,
-    isHoverDocumentationEnabled: Boolean,
-    snippetAutoIndent: Boolean,
-    isSignatureHelpDocumentationEnabled: Boolean,
-    isCompletionItemResolve: Boolean
-) {
-  def this() =
-    this(
-      isCompletionItemDetailEnabled = true,
-      isCompletionItemDocumentationEnabled = true,
-      isHoverDocumentationEnabled = true,
-      snippetAutoIndent = true,
-      isSignatureHelpDocumentationEnabled = true,
-      isCompletionItemResolve = true
-    )
+    isCompletionItemDetailEnabled: Option[Boolean],
+    isCompletionItemDocumentationEnabled: Option[Boolean],
+    isHoverDocumentationEnabled: Option[Boolean],
+    snippetAutoIndent: Option[Boolean],
+    isSignatureHelpDocumentationEnabled: Option[Boolean],
+    isCompletionItemResolve: Option[Boolean]
+)
+
+object CompilerInitializationOptions {
+  def default: CompilerInitializationOptions =
+    CompilerInitializationOptions(None, None, None, None, None, None)
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -34,20 +34,33 @@ case class PresentationCompilerConfigImpl(
   override def completionCommand: Optional[String] =
     Optional.ofNullable(_completionCommand.orNull)
 
+  /**
+   * Used to update the compiler config after we recieve the InitializationOptions.
+   * If the user sets a value in the InitializationOptions, then the value will be
+   * captures and set here. If not, we just resort back tot he default that already
+   * exists.
+   */
   def update(
       options: CompilerInitializationOptions
   ): PresentationCompilerConfigImpl =
     copy(
-      isCompletionItemDetailEnabled =
-        isCompletionItemDetailEnabled || options.isCompletionItemDetailEnabled,
+      isCompletionItemDetailEnabled = options.isCompletionItemDetailEnabled
+        .fold(this.isCompletionItemDetailEnabled)(identity),
       isCompletionItemDocumentationEnabled =
-        isCompletionItemDocumentationEnabled || options.isCompletionItemDocumentationEnabled,
-      isHoverDocumentationEnabled =
-        isHoverDocumentationEnabled || options.isHoverDocumentationEnabled,
-      snippetAutoIndent = snippetAutoIndent || options.snippetAutoIndent,
+        options.isCompletionItemDocumentationEnabled.fold(
+          this.isCompletionItemDocumentationEnabled
+        )(identity),
+      isHoverDocumentationEnabled = options.isHoverDocumentationEnabled.fold(
+        this.isHoverDocumentationEnabled
+      )(identity),
+      snippetAutoIndent =
+        options.snippetAutoIndent.fold(this.snippetAutoIndent)(identity),
       isSignatureHelpDocumentationEnabled =
-        isSignatureHelpDocumentationEnabled || options.isSignatureHelpDocumentationEnabled,
-      isCompletionItemResolve =
-        isCompletionItemResolve || options.isCompletionItemResolve
+        options.isSignatureHelpDocumentationEnabled.fold(
+          this.isSignatureHelpDocumentationEnabled
+        )(identity),
+      isCompletionItemResolve = options.isCompletionItemResolve.fold(
+        this.isCompletionItemResolve
+      )(identity)
     )
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -37,7 +37,7 @@ case class PresentationCompilerConfigImpl(
   /**
    * Used to update the compiler config after we recieve the InitializationOptions.
    * If the user sets a value in the InitializationOptions, then the value will be
-   * captures and set here. If not, we just resort back tot he default that already
+   * captures and set here. If not, we just resort back to the default that already
    * exists.
    */
   def update(
@@ -45,22 +45,21 @@ case class PresentationCompilerConfigImpl(
   ): PresentationCompilerConfigImpl =
     copy(
       isCompletionItemDetailEnabled = options.isCompletionItemDetailEnabled
-        .fold(this.isCompletionItemDetailEnabled)(identity),
+        .getOrElse(this.isCompletionItemDetailEnabled),
       isCompletionItemDocumentationEnabled =
-        options.isCompletionItemDocumentationEnabled.fold(
+        options.isCompletionItemDocumentationEnabled.getOrElse(
           this.isCompletionItemDocumentationEnabled
-        )(identity),
-      isHoverDocumentationEnabled = options.isHoverDocumentationEnabled.fold(
-        this.isHoverDocumentationEnabled
-      )(identity),
+        ),
+      isHoverDocumentationEnabled = options.isHoverDocumentationEnabled
+        .getOrElse(this.isHoverDocumentationEnabled),
       snippetAutoIndent =
-        options.snippetAutoIndent.fold(this.snippetAutoIndent)(identity),
+        options.snippetAutoIndent.getOrElse(this.snippetAutoIndent),
       isSignatureHelpDocumentationEnabled =
-        options.isSignatureHelpDocumentationEnabled.fold(
+        options.isSignatureHelpDocumentationEnabled.getOrElse(
           this.isSignatureHelpDocumentationEnabled
-        )(identity),
-      isCompletionItemResolve = options.isCompletionItemResolve.fold(
+        ),
+      isCompletionItemResolve = options.isCompletionItemResolve.getOrElse(
         this.isCompletionItemResolve
-      )(identity)
+      )
     )
 }

--- a/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
@@ -3,11 +3,19 @@ package tests.feature
 import scala.concurrent.Future
 
 import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.InitializationOptions
 
 import tests.BaseCompletionLspSuite
 
 class DefinitionCrossLspSuite
     extends BaseCompletionLspSuite("definition-cross") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(statusBarProvider =
+        Some("show-message")
+      )
+    )
 
   if (super.isValidScalaVersionForEnv(BuildInfo.scala211)) {
     test("2.11") {

--- a/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
@@ -12,8 +12,8 @@ class DefinitionCrossLspSuite
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
-      InitializationOptions.Default.copy(statusBarProvider =
-        Some("show-message")
+      InitializationOptions.Default.copy(
+        statusBarProvider = Some("show-message")
       )
     )
 

--- a/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
@@ -77,7 +77,7 @@ class DefinitionCrossLspSuite
       _ <- server.didOpen("scala/Predef.scala")
       _ = assertNoDiff(
         client.workspaceMessageRequests,
-        ""
+        "Preparing presentation compiler"
       )
       _ = assertNoDiff(client.workspaceDiagnostics, "")
     } yield ()

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -10,7 +10,7 @@ import scala.meta.internal.metals.{BuildInfo => V}
 abstract class BaseWorksheetLspSuite(scalaVersion: String)
     extends BaseLspSuite("worksheet") {
   override def initializationOptions: Option[InitializationOptions] =
-    Some(InitializationOptions.Default.copy(decorationProvider = true))
+    Some(InitializationOptions.Default.copy(decorationProvider = Some(true)))
 
   override def userConfig: UserConfiguration =
     super.userConfig.copy(worksheetScreenWidth = 40, worksheetCancelTimeout = 1)

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -416,11 +416,12 @@ final class TestingServer(
         .toMap
         .asJava
 
+    params.setInitializationOptions(existingInitOptions.toJson)
     params.setCapabilities(
       new ClientCapabilities(
         workspaceCapabilities,
         textDocumentCapabilities,
-        existingInitOptions.toJson
+        Map.empty.asJava.toJson
       )
     )
     params.setWorkspaceFolders(

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -393,9 +393,9 @@ final class TestingServer(
     textDocumentCapabilities.setFoldingRange(new FoldingRangeCapabilities)
     val initOptions = initializationOptions.getOrElse(
       InitializationOptions.Default.copy(
-        debuggingProvider = true,
-        treeViewProvider = true,
-        slowTaskProvider = true
+        debuggingProvider = Some(true),
+        treeViewProvider = Some(true),
+        slowTaskProvider = Some(true)
       )
     )
     params.setCapabilities(

--- a/tests/unit/src/test/scala/tests/FormattingLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/FormattingLspSuite.scala
@@ -1,6 +1,7 @@
 package tests
 
 import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.Messages.MissingScalafmtConf
 import scala.meta.internal.metals.Messages.MissingScalafmtVersion
@@ -10,6 +11,11 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 
 class FormattingLspSuite extends BaseLspSuite("formatting") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(slowTaskProvider = Some(false))
+    )
 
   test("basic") {
     for {

--- a/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
@@ -17,7 +17,7 @@ import org.eclipse.lsp4j.ShowMessageRequestParams
 class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   override def initializationOptions: Option[InitializationOptions] =
-    Some(InitializationOptions.Default.copy(inputBoxProvider = true))
+    Some(InitializationOptions.Default.copy(inputBoxProvider = Some(true)))
 
   check("new-worksheet")(
     Some("a/src/main/scala/"),

--- a/tests/unit/src/test/scala/tests/NewProjectLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewProjectLspSuite.scala
@@ -24,7 +24,7 @@ class NewProjectLspSuite extends BaseLspSuite("new-project") {
   override def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default
-        .copy(inputBoxProvider = true, openNewWindowProvider = true)
+        .copy(inputBoxProvider = Some(true), openNewWindowProvider = Some(true))
     )
 
   def scalatestTemplate(name: String = "scalatest-example"): String =

--- a/tests/unit/src/test/scala/tests/NewProjectLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewProjectLspSuite.scala
@@ -180,7 +180,7 @@ class NewProjectLspSuite extends BaseLspSuite("new-project") {
         if (isSelectProject(params)) {
           onSelectProject(findAction)
         } else if (isOpenWindow(params)) {
-          findAction("yes")
+          findAction("Yes")
         } else {
           onDirectorySelect(params, findAction)
         }


### PR DESCRIPTION
While this is a bit more verbose than what we had, it allows this to be
much more explicit and represent what we actually want to do. When this
was first done (https://github.com/scalameta/metals/pull/1674) I had a
bunch of issues with `null` being set for values that didn't exist, not
easily being able to use `Option` in the structure, and also needing
default constructors in order for it to work correct. I didn't love it,
and have wanted to revisit this for a while. I also figured this was a
good idea to take care of as a precursor to
https://github.com/scalameta/metals/issues/1895

By doing it the way we previously did it caused us to have to check
configuration like this:

 1. Is `InitializationOptions` set to a non-default value?
 2. Is `ClientExperimentalCapabilities` set to a non-default value?
 3. If so, take their value or use the default set in the initial
    config.

Instead, all we really wanted to know was really:

  1. Did `InitializationOptions` set anything?
  2. Did `ClientExperimentalCapabilities` set anything?
  3. If neither, _then_ take the default

Again, this is a bit more verbose but I think ultimately more clearer
and closer to what we actually want.