### PR TITLE
Don't filter out named parameters for methods defined later in a class

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -275,7 +275,9 @@ class CompletionProvider(
           (isIgnored(head.sym) || isIgnored(head.sym.companion))
       def isNotLocalForwardReference: Boolean =
         !head.sym.isLocalToBlock ||
-          !head.sym.pos.isAfter(pos)
+          !head.sym.pos.isAfter(pos) ||
+          head.sym.isParameter
+
       def isFileAmmoniteCompletion() =
         isAmmoniteScript && {
           head match {

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -203,6 +203,19 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   check(
+    "arg14",
+    s"""|object Main {
+        |  val isLargeBanana = true
+        |  processFile(isResourceFil@@)
+        |  def processFile(isResourceFile: Boolean): Unit = ()
+        |}
+        |""".stripMargin,
+    """|isResourceFile = : Boolean
+       |isResourceFile = isLargeBanana : Boolean
+       |""".stripMargin
+  )
+
+  check(
     "priority",
     s"""|object Main {
         |  def foo(argument : Int) : Int = argument


### PR DESCRIPTION
Previously, we would treat named parameters for methods defined later in the code as local forward references. Now, we make sure that named parameters are not filtered out in that case.

Fixes https://github.com/scalameta/metals/issues/1845

