### PR TITLE
Bump scalafmt version up to 2.6.3.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "2.6.1"
+version = "2.6.3"
 project.git = true
 align.preset = none
 align.stripMargin = true

--- a/build.sbt
+++ b/build.sbt
@@ -183,7 +183,7 @@ lazy val V = new {
   val gradleBloop = bloop
   val mavenBloop = bloop
   val mdoc = "2.2.3"
-  val scalafmt = "2.6.1"
+  val scalafmt = "2.6.3"
   val munit = "0.7.9"
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -292,8 +292,7 @@ trait OverrideCompletions { this: MetalsGlobal =>
       (List.empty[l.TextEdit], Set.empty[l.TextEdit])
     ) { (editsAndImports, overrideDefMember) =>
       val edits = overrideDefMember.edit :: editsAndImports._1
-      val imports = overrideDefMember.autoImports.toSet ++ editsAndImports
-        ._2
+      val imports = overrideDefMember.autoImports.toSet ++ editsAndImports._2
       (edits, imports)
     }
   }


### PR DESCRIPTION
Since we're probably releasing today I figured it'd be a good idea to bump the version of scalafmt that the server recommends for people if they don't have it set in their conf file. I also bumped it for the codebase, which only caused one small change.