### PR TITLE
Add additional warn-unused flags

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,9 +1,12 @@
 rules = [
   OrganizeImports,
   ExplicitResultTypes,
+  RemoveUnused
 ]
 
 ExplicitResultTypes.rewriteStructuralTypesToNamedSubclass = false
+
+RemoveUnused.imports = false
 
 OrganizeImports.groupedImports = Explode
 OrganizeImports.expandRelative = true

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,10 @@ inThisBuild(
       "-Yrangepos",
       // -Xlint is unusable because of
       // https://github.com/scala/bug/issues/10448
-      "-Ywarn-unused:imports"
+      "-Ywarn-unused:imports",
+      "-Ywarn-unused:privates",
+      "-Ywarn-unused:patvars",
+      "-Ywarn-unused:locals"
     ),
     scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.2.1-RC1",
     organization := "org.scalameta",
@@ -241,7 +244,13 @@ val sharedSettings = List(
   ),
   scalacOptions --= crossSetting(
     scalaVersion.value,
-    if3 = List("-Yrangepos", "-Ywarn-unused:imports"),
+    if3 = List(
+      "-Yrangepos",
+      "-Ywarn-unused:imports",
+      "-Ywarn-unused:privates",
+      "-Ywarn-unused:locals",
+      "-Ywarn-unused:patvars"
+    ),
     if211 = List("-Ywarn-unused:imports")
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,16 @@ def crossSetting[A](
 
 val MUnitFramework = new TestFramework("munit.Framework")
 
+// -Xlint is unusable because of
+// https://github.com/scala/bug/issues/10448
+val scala212CompilerOptions = List(
+  "-Ywarn-unused:imports",
+  "-Ywarn-unused:privates",
+  "-Ywarn-unused:locals",
+  "-Ywarn-unused:patvars",
+  "-Ywarn-unused:implicits"
+)
+
 inThisBuild(
   List(
     version ~= { dynVer =>
@@ -38,14 +48,8 @@ inThisBuild(
     crossScalaVersions := List(V.scala212),
     scalacOptions ++= List(
       "-target:jvm-1.8",
-      "-Yrangepos",
-      // -Xlint is unusable because of
-      // https://github.com/scala/bug/issues/10448
-      "-Ywarn-unused:imports",
-      "-Ywarn-unused:privates",
-      "-Ywarn-unused:patvars",
-      "-Ywarn-unused:locals"
-    ),
+      "-Yrangepos"
+    ) ::: scala212CompilerOptions,
     scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.2.1-RC1",
     organization := "org.scalameta",
     licenses := Seq(
@@ -244,14 +248,8 @@ val sharedSettings = List(
   ),
   scalacOptions --= crossSetting(
     scalaVersion.value,
-    if3 = List(
-      "-Yrangepos",
-      "-Ywarn-unused:imports",
-      "-Ywarn-unused:privates",
-      "-Ywarn-unused:locals",
-      "-Ywarn-unused:patvars"
-    ),
-    if211 = List("-Ywarn-unused:imports")
+    if3 = "-Yrangepos" :: scala212CompilerOptions,
+    if211 = scala212CompilerOptions
   )
 )
 

--- a/metals-bench/src/main/scala/bench/MetalsBench.scala
+++ b/metals-bench/src/main/scala/bench/MetalsBench.scala
@@ -109,7 +109,7 @@ class MetalsBench {
   def scalametaParse(): Unit = {
     scalaDependencySources.inputs.foreach { input =>
       import scala.meta._
-      val tree = Trees.defaultDialect(input).parse[Source].get
+      Trees.defaultDialect(input).parse[Source].get
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/ansi/LineListener.scala
+++ b/metals/src/main/scala/scala/meta/internal/ansi/LineListener.scala
@@ -20,7 +20,7 @@ object LineListener {
 class LineListener(onLine: String => Unit) {
 
   private var buffer = new StringBuilder()
-  private var stack = mutable.ListBuffer.empty[Char]
+  private val stack = mutable.ListBuffer.empty[Char]
   private var state = AnsiStateMachine.Start
 
   /**

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
@@ -6,7 +6,6 @@ import java.nio.file.StandardCopyOption
 
 import scala.concurrent.Future
 
-import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.io.AbsolutePath
 
@@ -32,8 +31,6 @@ abstract class BuildTool {
   def minimumVersion: String
 
   def recommendedVersion: String
-
-  def onBuildTargets(workspace: AbsolutePath, targets: BuildTargets): Unit = ()
 
   protected lazy val tempDir: Path = {
     val dir = Files.createTempDirectory("metals")

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -3,8 +3,6 @@ package scala.meta.internal.builds
 import java.nio.file.Files
 import java.util.Properties
 
-import scala.concurrent.ExecutionContext
-
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.UserConfiguration
@@ -26,7 +24,7 @@ final class BuildTools(
     workspace: AbsolutePath,
     bspGlobalDirectories: List[AbsolutePath],
     userConfig: () => UserConfiguration
-)(implicit ec: ExecutionContext) {
+) {
   def isAutoConnectable: Boolean =
     isBloop || isBsp
   def isBloop: Boolean = {
@@ -119,5 +117,5 @@ object BuildTools {
       workspace,
       Nil,
       () => UserConfiguration()
-    )(ExecutionContext.global)
+    )
 }

--- a/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
@@ -167,7 +167,7 @@ object Digest {
       }
       true
     } catch {
-      case NonFatal(e) =>
+      case NonFatal(_) =>
         false
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -40,9 +40,7 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
     // In some environments (such as WSL or cygwin), mill must be run using interactive mode (-i)
     val iOption = if (Properties.isWin) List("-i") else Nil
     val cmd =
-      iOption ::: "--predef" :: predefScriptPath(
-        millVersion
-      ).toString :: "mill.contrib.Bloop/install" :: Nil
+      iOption ::: "--predef" :: predefScriptPath.toString :: "mill.contrib.Bloop/install" :: Nil
 
     userConfig().millScript match {
       case Some(script) =>
@@ -65,11 +63,11 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
 
   def executableName = "mill"
 
-  private def predefScript(millVersion: String) =
+  private def predefScript =
     "import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`".getBytes()
 
-  private def predefScriptPath(millVersion: String): Path = {
-    Files.write(tempDir.resolve(predefScriptName), predefScript(millVersion))
+  private def predefScriptPath: Path = {
+    Files.write(tempDir.resolve(predefScriptName), predefScript)
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/builds/MillDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillDigest.scala
@@ -71,7 +71,7 @@ object MillDigest extends Digestable {
               acc.hadImport = false
             }
           // if we are after => and haven't encountered `,`, `}` or newline
-          case other if acc.skip =>
+          case _ if acc.skip =>
           // recognize $file import
           case ident: Token.Ident if ident.pos.text == "$file" =>
             acc.hadFile = true
@@ -94,7 +94,7 @@ object MillDigest extends Digestable {
       }
       acc.allPaths.toList
     } catch {
-      case NonFatal(e) =>
+      case NonFatal(_) =>
         Nil
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
@@ -19,7 +19,6 @@ import scala.meta.internal.metals.MetalsOpenWindowParams
 import scala.meta.internal.metals.MetalsQuickPickItem
 import scala.meta.internal.metals.MetalsQuickPickParams
 import scala.meta.internal.metals.StatusBar
-import scala.meta.internal.metals.Time
 import scala.meta.internal.process.ExitCodes
 import scala.meta.io.AbsolutePath
 
@@ -27,11 +26,9 @@ import coursierapi._
 import org.eclipse.lsp4j.ExecuteCommandParams
 
 class NewProjectProvider(
-    buildTools: BuildTools,
     client: MetalsLanguageClient,
     statusBar: StatusBar,
     config: ClientConfiguration,
-    time: Time,
     shell: ShellRunner,
     icons: Icons,
     workspace: AbsolutePath

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -157,5 +157,4 @@ object SbtBuildTool {
     SbtBuildTool(version, userConfig)
   }
 
-  private def unknown = "<unknown>"
 }

--- a/metals/src/main/scala/scala/meta/internal/implementation/ClassLocation.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ClassLocation.scala
@@ -41,7 +41,7 @@ private[implementation] case class ClassLocation(
       case clsSig: ClassSignature =>
         val newASF = AsSeenFrom.toRealNames(clsSig, translateKey, asSeenFrom)
         ClassLocation(symbol, file, newASF.toMap)
-      case other => this
+      case _ => this
     }
   }
 }
@@ -98,7 +98,7 @@ object AsSeenFrom {
           case None => None
         }
 
-      case other => None
+      case _ => None
     }.toMap
   }
 

--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -162,7 +162,7 @@ final class ImplementationProvider(
           )
         // symbol is in workspace,
         // we might need to search different places for related symbols
-        case Some(textDocument) =>
+        case Some(_) =>
           Some(
             InheritanceContext.fromDefinitions(
               symbolSearch,
@@ -530,7 +530,7 @@ object ImplementationProvider {
         fromClassSignature(classSig)
       case ts: TypeSignature =>
         fromTypeSignature(ts)
-      case other =>
+      case _ =>
         Seq.empty
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -78,7 +78,7 @@ class BuildServerConnection private (
           cancel()
         }
       } catch {
-        case e: TimeoutException =>
+        case _: TimeoutException =>
           scribe.error(
             s"timeout: build server '${conn.displayName}' during shutdown"
           )
@@ -234,7 +234,7 @@ object BuildServerConnection {
 
     def setupServer(): Future[LauncherConnection] = {
       connect().map {
-        case conn @ SocketConnection(name, output, input, _, _) =>
+        case conn @ SocketConnection(_, output, input, _, _) =>
           val tracePrinter = GlobalTrace.setupTracePrinter("BSP")
           val launcher = new Launcher.Builder[MetalsBuildServer]()
             .traceMessages(tracePrinter)

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -323,7 +323,7 @@ final class BuildTargets() {
       all.map(i => i.id -> i.scalac.classpath.toSeq).toSeq
     try {
       toplevels.foldLeft(Option.empty[InferredBuildTarget]) {
-        case (Some(x), toplevel) => Some(x)
+        case (Some(x), _) => Some(x)
         case (None, toplevel) =>
           val classfile = toplevel.owner.value + toplevel.displayName + ".class"
           val resource = classloader

--- a/metals/src/main/scala/scala/meta/internal/metals/Cancelable.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Cancelable.scala
@@ -24,7 +24,7 @@ object Cancelable {
   }
 
   def cancelAll(iterable: Iterable[Cancelable]): Unit = {
-    var errors = ListBuffer.empty[Throwable]
+    val errors = ListBuffer.empty[Throwable]
     iterable.foreach { cancelable =>
       try cancelable.cancel()
       catch { case ex if NonFatal(ex) => errors += ex }

--- a/metals/src/main/scala/scala/meta/internal/metals/Debug.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Debug.scala
@@ -10,7 +10,6 @@ object Debug {
     e.printStackTrace()
   }
   def printEnclosing()(implicit
-      line: sourcecode.Line,
       enclosing: sourcecode.Enclosing
   ): Unit = {
     val enclosingTrimmed =

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -255,19 +255,4 @@ final class Diagnostics(
     toPublish
   }
 
-  private def logStatistics(
-      path: AbsolutePath,
-      prefix: String,
-      suffix: String
-  ): Unit = {
-    if (statistics.isDiagnostics) {
-      for {
-        target <- buildTargets.inverseSources(path)
-        timer <- compileTimer.get(target)
-      } {
-        scribe.info(s"$prefix: $timer $suffix")
-      }
-    }
-  }
-
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/DocumentHighlightProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DocumentHighlightProvider.scala
@@ -76,7 +76,7 @@ final class DocumentHighlightProvider(
 
     def isInObject(desc: Descriptor) =
       desc match {
-        case Descriptor.Term(value) => true
+        case Descriptor.Term(_) => true
         case _ => false
       }
 
@@ -84,7 +84,7 @@ final class DocumentHighlightProvider(
     Symbol(info.symbol) match {
       case GlobalSymbol(
             GlobalSymbol(owner, descriptor),
-            Descriptor.Method(setter, disambiguator)
+            Descriptor.Method(setter, _)
           ) =>
         generateAlternativeSymbols(
           setter.stripSuffix(setterSuffix),
@@ -112,7 +112,7 @@ final class DocumentHighlightProvider(
       case GlobalSymbol(
             GlobalSymbol(
               GlobalSymbol(owner, descriptor),
-              Descriptor.Method(name, disambiguator)
+              Descriptor.Method(name, _)
             ),
             desc
           ) if copyOrApply(name) =>

--- a/metals/src/main/scala/scala/meta/internal/metals/FutureCancelToken.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FutureCancelToken.scala
@@ -18,7 +18,7 @@ case class FutureCancelToken(f: Future[Boolean])(implicit ec: ExecutionContext)
     extends CancelToken {
   var isCancelled: Boolean = false
   f.onComplete {
-    case Failure(exception) =>
+    case Failure(_) =>
       isCancelled = true
     case Success(cancel) =>
       isCancelled = cancel

--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -7,7 +7,6 @@ import java.util.Collections
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.ExecutionContext
 
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.metals.Messages._
@@ -41,8 +40,7 @@ final class InteractiveSemanticdbs(
     statusBar: StatusBar,
     compilers: () => Compilers,
     clientConfig: ClientConfiguration
-)(implicit ec: ExecutionContext)
-    extends Cancelable
+) extends Cancelable
     with Semanticdbs {
   private val activeDocument = new AtomicReference[Option[String]](None)
   private val textDocumentCache = Collections.synchronizedMap(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -418,7 +418,7 @@ object MetalsEnrichments
       indicesOf(str) match {
         case Nil => Some(-1)
         case List(idx) => Some(idx)
-        case indices => None
+        case _ => None
       }
 
     def toAbsolutePathSafe: Option[AbsolutePath] = Try(toAbsolutePath).toOption

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -329,11 +329,9 @@ class MetalsLanguageServer(
       shellRunner
     )
     newProjectProvider = new NewProjectProvider(
-      buildTools,
       languageClient,
       statusBar,
       clientConfig,
-      time,
       shellRunner,
       initialConfig.icons,
       workspace
@@ -659,7 +657,7 @@ class MetalsLanguageServer(
       val port = 5031
       var url = s"http://$host:$port"
       var render: () => String = () => ""
-      var completeCommand: HttpServerExchange => Unit = e => ()
+      var completeCommand: HttpServerExchange => Unit = (_) => ()
       val server = register(
         MetalsHttpServer(
           host,
@@ -1129,13 +1127,13 @@ class MetalsLanguageServer(
   def onTypeFormatting(
       params: DocumentOnTypeFormattingParams
   ): CompletableFuture[util.List[TextEdit]] =
-    CancelTokens.future { token => compilers.onTypeFormatting(params) }
+    CancelTokens.future { _ => compilers.onTypeFormatting(params) }
 
   @JsonRequest("textDocument/rangeFormatting")
   def rangeFormatting(
       params: DocumentRangeFormattingParams
   ): CompletableFuture[util.List[TextEdit]] =
-    CancelTokens.future { token => compilers.rangeFormatting(params) }
+    CancelTokens.future { _ => compilers.rangeFormatting(params) }
 
   @JsonRequest("textDocument/prepareRename")
   def prepareRename(
@@ -1851,7 +1849,6 @@ class MetalsLanguageServer(
       check()
       buildTools
         .loadSupported()
-        .foreach(_.onBuildTargets(workspace, buildTargets))
     }
     timedThunk(
       "started file watcher",

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1764,7 +1764,7 @@ class MetalsLanguageServer(
     result
   }
 
-  private def withTimer[T](didWhat: String, reportStatus: Boolean = false)(
+  private def withTimer[T](didWhat: String, reportStatus: Boolean)(
       thunk: => Future[T]
   ): Future[(Timer, T)] = {
     val elapsed = new Timer(time)

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -115,7 +115,6 @@ final class ReferenceProvider(
       occ: SymbolOccurrence
   ): Set[String] = {
     val name = occ.symbol.desc.name.value
-    val isCopyOrApply = Set("apply", "copy")
     // Returns true if `info` is the companion object matching the occurrence class symbol.
     def isCompanionObject(info: SymbolInformation): Boolean =
       info.isObject &&

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
@@ -53,7 +53,6 @@ final class StatusBar(
       trackBlockingTask(message)(thunk)
     else {
       val task = client().metalsSlowTask(MetalsSlowTaskParams(message))
-      val future = task.asScala
       try {
         thunk
       } catch {
@@ -71,7 +70,6 @@ final class StatusBar(
       trackFuture(message, thunk)
     else {
       val task = client().metalsSlowTask(MetalsSlowTaskParams(message))
-      val future = task.asScala
       thunk.onComplete {
         case Failure(exception) =>
           slowTaskFailed(message, exception)

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
@@ -74,7 +74,7 @@ final class StatusBar(
         case Failure(exception) =>
           slowTaskFailed(message, exception)
           task.cancel(true)
-        case Success(value) =>
+        case Success(_) =>
           task.cancel(true)
       }
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/Synthetics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Synthetics.scala
@@ -27,7 +27,7 @@ object Synthetics {
       t match {
         case ApplyTree(function, arguments) =>
           isStop(function) || arguments.exists(isStop)
-        case SelectTree(qualifier, id) =>
+        case SelectTree(_, id) =>
           id.exists(isStop)
         case IdTree(symbol) =>
           fn(symbol).isStop

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -208,7 +208,7 @@ object UserConfiguration {
     def getIntKey(key: String): Option[Int] =
       getStringKey(key).flatMap { value =>
         Try(value.toInt) match {
-          case Failure(exception) =>
+          case Failure(_) =>
             errors += s"Not a number: '$value'"
             None
           case Success(value) =>
@@ -223,7 +223,7 @@ object UserConfiguration {
           if (elem.isJsonArray()) {
             val parsed = elem.getAsJsonArray().asScala.flatMap { value =>
               Try(value.getAsJsonPrimitive().getAsString()) match {
-                case Failure(exception) =>
+                case Failure(_) =>
                   errors += s"json error: values in '$key' should have value of type string but obtained $value"
                   None
                 case Success(value) =>

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -4,7 +4,6 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 
 import scala.meta.internal.mtags.GlobalSymbolIndex
@@ -28,7 +27,7 @@ final class WorkspaceSymbolProvider(
     val index: GlobalSymbolIndex,
     fileOnDisk: AbsolutePath => AbsolutePath,
     bucketSize: Int = CompressedPackageIndex.DefaultBucketSize
-)(implicit ec: ExecutionContext) {
+) {
   val inWorkspace: TrieMap[Path, WorkspaceSymbolsIndex] =
     TrieMap.empty[Path, WorkspaceSymbolsIndex]
   var inDependencies: ClasspathSearch =

--- a/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
@@ -472,7 +472,7 @@ object Ammonite {
         ()
       }.onComplete {
         case Success(()) =>
-        case f @ Failure(exception) => finished.tryComplete(f)
+        case f @ Failure(_) => finished.tryComplete(f)
       }
       SocketConnection(
         "Ammonite",

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateNewSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateNewSymbol.scala
@@ -1,8 +1,5 @@
 package scala.meta.internal.metals.codeactions
 
-import java.net.URI
-import java.nio.file.Paths
-
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -28,10 +25,6 @@ class CreateNewSymbol() extends CodeAction {
       codeAction.setTitle(CreateNewSymbol.title(name))
       codeAction.setKind(l.CodeActionKind.QuickFix)
       codeAction.setDiagnostics(List(diagnostic).asJava)
-      val directory = Paths
-        .get(URI.create(params.getTextDocument().getUri()))
-        .getParent()
-        .toString()
       codeAction.setCommand(ServerCommands.NewScalaFile.toLSP(List(null, name)))
       codeAction
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -130,8 +130,7 @@ class DebugProvider(
           Option(params.buildTarget)
         )
     ).flatMap {
-      case (clazz, target) :: others
-          if buildClient.buildHasErrors(target.getId()) =>
+      case (_, target) :: _ if buildClient.buildHasErrors(target.getId()) =>
         Future.failed(WorkspaceErrorsException)
       case (clazz, target) :: others =>
         if (others.nonEmpty) {
@@ -171,8 +170,7 @@ class DebugProvider(
           Option(params.buildTarget)
         )
     }).flatMap {
-      case (clazz, target) :: others
-          if buildClient.buildHasErrors(target.getId()) =>
+      case (_, target) :: _ if buildClient.buildHasErrors(target.getId()) =>
         Future.failed(WorkspaceErrorsException)
       case (clazz, target) :: others =>
         if (others.nonEmpty) {
@@ -199,7 +197,7 @@ class DebugProvider(
   }
 
   private val reportErrors: PartialFunction[Throwable, Unit] = {
-    case t if buildClient.buildHasErrors =>
+    case _ if buildClient.buildHasErrors =>
       statusBar.addMessage(Messages.DebugErrorsPresent)
       languageClient.metalsExecuteClientCommand(
         new ExecuteCommandParams(
@@ -211,12 +209,12 @@ class DebugProvider(
       languageClient.showMessage(
         Messages.DebugClassNotFound.invalidClass(t.getMessage())
       )
-    case t @ ClassNotFoundInBuildTargetException(cls, buildTarget) =>
+    case ClassNotFoundInBuildTargetException(cls, buildTarget) =>
       languageClient.showMessage(
         Messages.DebugClassNotFound
           .invalidTargetClass(cls, buildTarget.getDisplayName())
       )
-    case t @ BuildTargetNotFoundException(target) =>
+    case BuildTargetNotFoundException(target) =>
       languageClient.showMessage(
         Messages.DebugClassNotFound
           .invalidTarget(target)
@@ -257,7 +255,7 @@ class DebugProvider(
           parameters.setData(main.toJsonObject)
         }
         parameters
-      case data =>
+      case _ =>
         parameters
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
+++ b/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
@@ -2,7 +2,6 @@ package scala.meta.internal.process
 
 import java.nio.file.Path
 
-import scala.concurrent.ExecutionContext
 import scala.sys.process._
 
 import scala.meta.internal.metals.Time
@@ -16,7 +15,7 @@ object SystemProcess {
       reproduceArgs: List[String],
       cwd: Path,
       token: CancelToken
-  )(implicit ec: ExecutionContext): Unit = {
+  ): Unit = {
     val exportTimer = new Timer(Time.system)
     scribe.info(args.mkString("process: ", " ", ""))
     val exit = Process(args, cwd = Some(cwd.toFile())).!

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -50,7 +50,7 @@ final class RenameProvider(
     clientConfig: ClientConfiguration
 )(implicit executionContext: ExecutionContext) {
 
-  private var awaitingSave = new ConcurrentLinkedQueue[() => Unit]
+  private val awaitingSave = new ConcurrentLinkedQueue[() => Unit]
 
   private def compilationFinished(
       source: AbsolutePath

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -252,7 +252,7 @@ final class RenameProvider(
         Some(Descriptor.Term(name))
       case Descriptor.Term(name) =>
         Some(Descriptor.Type(name))
-      case other =>
+      case _ =>
         None
     }
 

--- a/metals/src/main/scala/scala/meta/internal/tvp/ClasspathSymbols.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/ClasspathSymbols.scala
@@ -146,7 +146,7 @@ class ClasspathSymbols(isStatisticsEnabled: Boolean = false) {
       root: Path,
       path: Path
   ): Seq[TreeViewSymbolInformation] = {
-    var result = mutable.ListBuffer.empty[TreeViewSymbolInformation]
+    val result = mutable.ListBuffer.empty[TreeViewSymbolInformation]
     def isDone = result.lengthCompare(1) > 0
     Files.walkFileTree(
       path,

--- a/metals/src/main/scala/scala/meta/internal/tvp/ScalacpCopyPaste.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/ScalacpCopyPaste.scala
@@ -458,17 +458,6 @@ class ScalacpCopyPaste(node: ScalaSigNode) {
     private def sig(linkMode: LinkMode): s.Signature =
       s.NoSignature // scalacp deviation
 
-    private val syntheticAnnotationsSymbols = Set(
-      "scala/reflect/macros/internal/macroImpl#"
-    )
-
-    private def syntheticAnnotations(annot: s.Annotation): Boolean = {
-      annot.tpe match {
-        case s.TypeRef(_, sym, _) => syntheticAnnotationsSymbols.contains(sym)
-        case _ => false
-      }
-    }
-
     private def annotations: List[s.Annotation] = {
       Nil // scalacp deviation
     }

--- a/metals/src/main/scala/scala/meta/internal/tvp/ScalacpCopyPaste.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/ScalacpCopyPaste.scala
@@ -253,7 +253,7 @@ class ScalacpCopyPaste(node: ScalaSigNode) {
         case sym: SymbolInfoSymbol =>
           if (sym.isModuleClass) {
             sym.infoType match {
-              case ClassInfoType(_, List(TypeRefType(_, anyRef, _))) =>
+              case ClassInfoType(_, List(TypeRefType(_, _, _))) =>
                 sym.isSynthetic && sym.semanticdbDecls.syms.isEmpty
               case _ =>
                 false

--- a/mtags/src/main/scala-2/scala/meta/internal/docstrings/ScaladocParser.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/docstrings/ScaladocParser.scala
@@ -269,8 +269,8 @@ object ScaladocParser {
       docstring: String
   ): Iterator[(String, String)] = {
     for {
-      section @ (start, end) <- ScaladocUtils.tagIndex(docstring).iterator
-      if ScaladocUtils.startsWithTag(docstring, section, "@define")
+      (start, end) <- ScaladocUtils.tagIndex(docstring).iterator
+      if ScaladocUtils.startsWithTag(docstring, start, "@define")
       List("@define", key, value) <- List(
         docstring
           .substring(start, end)
@@ -550,9 +550,7 @@ object ScaladocParser {
               filterEmpty: Boolean = true
           ): Option[Body] =
             (bodyTags.remove(key): @unchecked) match {
-              case Some(r :: rs) if !(filterEmpty && r.blocks.isEmpty) =>
-                //              if (rs.nonEmpty)
-                //                reporter.warning(pos, s"Only one '@${key.name}' tag is allowed")
+              case Some(r :: _) if !(filterEmpty && r.blocks.isEmpty) =>
                 Some(r)
               case _ => None
             }
@@ -571,21 +569,12 @@ object ScaladocParser {
               bodyTags.keys.toSeq flatMap {
                 case stk: SymbolTagKey if (stk.name == key.name) => Some(stk)
                 case stk: SimpleTagKey if (stk.name == key.name) =>
-                  //                reporter.warning(
-                  //                  pos,
-                  //                  s"Tag '@${stk.name}' must be followed by a symbol name"
-                  //                )
                   None
                 case _ => None
               }
             val pairs: Seq[(String, Body)] =
               for (key <- keys) yield {
                 val bs = (bodyTags remove key).get
-                //              if (bs.length > 1)
-                //                reporter.warning(
-                //                  pos,
-                //                  s"Only one '@${key.name}' tag for symbol ${key.symbol} is allowed"
-                //                )
                 (key.symbol, bs.head)
               }
             Map.empty[String, Body] ++ (if (filterEmpty)
@@ -599,11 +588,7 @@ object ScaladocParser {
             m.map {
               case (name, body) =>
                 val newBody = body match {
-                  case Body(List(Paragraph(Chain(content)))) =>
-                    //                  val link = memberLookup(pos, name, site)
-                    //                  val descr = Text(" ") +: content
-                    //                  val entityLink = EntityLink(Monospace(Text(name)), link)
-                    //                  Body(List(Paragraph(Chain(entityLink +: descr))))
+                  case Body(List(Paragraph(Chain(_)))) =>
                     Body(List())
                   case _ => body
                 }
@@ -893,7 +878,7 @@ object ScaladocParser {
         text.replace(escapeChar + TableCellStart, TableCellStart)
 
       def isEndOfText = char == endOfText
-      
+
       def isStartMarkNewline = check(TableCellStart + endOfLine)
 
       def skipStartMarkNewline() = jump(TableCellStart + endOfLine)
@@ -1221,7 +1206,7 @@ object ScaladocParser {
           (iss.last, current) match {
             case (Text(t1), Text(t2)) if skipEndOfLine =>
               iss.update(iss.length - 1, Text(t1 + endOfLine + t2))
-            case (i1, i2) if skipEndOfLine =>
+            case (_, i2) if skipEndOfLine =>
               iss ++= List(Text(endOfLine.toString), i2)
             case _ => iss += current
           }
@@ -1389,10 +1374,7 @@ object ScaladocParser {
       }
     }
 
-    def reportError(pos: Position, message: String): Unit = {
-      //pprint.log(message)
-      //      reporter.warning(pos, message)
-    }
+    def reportError(pos: Position, message: String): Unit = {}
   }
 
   sealed class CharReader(buffer: String) { reader =>

--- a/mtags/src/main/scala-2/scala/meta/internal/docstrings/ScaladocParser.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/docstrings/ScaladocParser.scala
@@ -893,11 +893,7 @@ object ScaladocParser {
         text.replace(escapeChar + TableCellStart, TableCellStart)
 
       def isEndOfText = char == endOfText
-
-      def isNewline = char == endOfLine
-
-      def skipNewline() = jump(endOfLine)
-
+      
       def isStartMarkNewline = check(TableCellStart + endOfLine)
 
       def skipStartMarkNewline() = jump(TableCellStart + endOfLine)

--- a/mtags/src/main/scala-2/scala/meta/internal/docstrings/ScaladocUtils.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/docstrings/ScaladocUtils.scala
@@ -98,7 +98,7 @@ object ScaladocUtils {
    */
   def tagIndex(
       str: String,
-      p: Int => Boolean = (idx => true)
+      p: Int => Boolean = (_ => true)
   ): List[(Int, Int)] = {
     var indices = findAll(str, 0)(idx => str(idx) == '@' && p(idx))
     indices = mergeUsecaseSections(str, indices)

--- a/mtags/src/main/scala-2/scala/meta/internal/metals/DocumentSymbolProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/metals/DocumentSymbolProvider.scala
@@ -117,7 +117,6 @@ class DocumentSymbolProvider(trees: Trees) {
             if (owner.getChildren().isEmpty()) {
               continue()
             } else {
-              val blockPos = block.stats.head.pos
               addChild("finally", SymbolKind.Struct, block.pos, block.pos, "")
               newOwner()
             }

--- a/mtags/src/main/scala-2/scala/meta/internal/metals/SemanticdbDefinition.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/metals/SemanticdbDefinition.scala
@@ -68,7 +68,7 @@ object SemanticdbDefinition {
         }
         try mtags.indexRoot()
         catch {
-          case NonFatal(e) =>
+          case NonFatal(_) =>
         }
       case _ =>
     }

--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsIndexer.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsIndexer.scala
@@ -37,8 +37,6 @@ trait MtagsIndexer {
   private val names = List.newBuilder[s.SymbolOccurrence]
   private val symbols = List.newBuilder[s.SymbolInformation]
 
-  private val root: String =
-    Symbols.RootPackage
   var currentOwner: String = Symbols.EmptyPackage
   private var myLastCurrentOwner: String = currentOwner
   def lastCurrentOwner: String = myLastCurrentOwner

--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/Semanticdbs.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/Semanticdbs.scala
@@ -57,7 +57,7 @@ object Semanticdbs {
       scalaRelativePath: RelativePath,
       semanticdbPath: AbsolutePath,
       charset: Charset,
-      fingerprints: Md5Fingerprints = Md5Fingerprints.empty
+      fingerprints: Md5Fingerprints
   ): TextDocumentLookup = {
     val reluri = scalaRelativePath.toURI(false).toString
     val sdocs = loadTextDocuments(semanticdbPath)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -48,7 +48,6 @@ final class AutoImportsProvider(
 
     symbols.result.collect {
       case sym if isExactMatch(sym, name) =>
-        val ident = Identifier.backtickWrap(sym.name.dropLocal.decoded)
         val pkg = sym.owner.fullName
         val edits = importPosition match {
           case None =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
@@ -25,7 +25,7 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
       val pos = unit.position(params.offset())
       val tree = typedHoverTreeAt(pos)
       tree match {
-        case i @ Import(qual, selectors) =>
+        case i @ Import(_, _) =>
           for {
             member <- i.selector(pos)
             hover <- toHover(member, pos)
@@ -238,7 +238,7 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
   private def typedHoverTreeAt(pos: Position): Tree = {
     val typedTree = typedTreeAt(pos)
     typedTree match {
-      case Import(qual, se) if qual.pos.includes(pos) =>
+      case Import(qual, _) if qual.pos.includes(pos) =>
         qual.findSubtree(pos)
       case Apply(fun, args)
           if !fun.pos.includes(pos) &&

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -106,11 +106,6 @@ class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
       case pt: PolyType => isImplicitMethodType(pt.resultType)
       case _ => false
     }
-    def selectQual(tree: Tree): Tree =
-      tree match {
-        case Select(qual, _) if qual.pos.includes(pos) => loop(qual)
-        case t => t
-      }
     // TODO: guard with try/catch to deal with ill-typed qualifiers.
     val tree =
       if (shouldTypeQualifier) analyzer.newTyper(context).typedQualifier(tree0)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -78,7 +78,7 @@ class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
           } else {
             tree
           }
-        case Apply(sel @ Select(New(_), termNames.CONSTRUCTOR), args)
+        case Apply(sel @ Select(New(_), termNames.CONSTRUCTOR), _)
             if sel.pos != null &&
               sel.pos.isRange &&
               !sel.pos.includes(pos) =>
@@ -111,7 +111,7 @@ class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
       if (shouldTypeQualifier) analyzer.newTyper(context).typedQualifier(tree0)
       else tree0
     typedTree match {
-      case i @ Import(expr, selectors) =>
+      case i @ Import(expr, _) =>
         if (expr.pos.includes(pos)) {
           expr.findSubtree(pos)
         } else {
@@ -120,7 +120,7 @@ class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
             case Some(sym) => Ident(sym.name).setSymbol(sym)
           }
         }
-      case sel @ Select(qualifier, name) if sel.tpe == ErrorType =>
+      case sel @ Select(_, name) if sel.tpe == ErrorType =>
         val symbols = tree.tpe.member(name)
         typedTree.setSymbol(symbols)
       case defn: DefTree if !defn.namePos.metalsIncludes(pos) =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -97,7 +97,7 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
               case TypeRef(
                     _,
                     definitions.OptionClass,
-                    tpe @ TypeRef(_, tuple, args) :: Nil
+                    tpe @ TypeRef(_, _, args) :: Nil
                   ) =>
                 val ctor = head.tpe.typeSymbol.primaryConstructor
                 val params = ctor.paramLists.headOption.getOrElse(Nil)
@@ -402,7 +402,7 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
       completionFallback
         .orElse {
           tree match {
-            case UnApply(q, a) =>
+            case UnApply(q, _) =>
               Option(compiler.typedTreeAt(q.pos).symbol)
             case TreeApply(q @ Select(New(_), _), _) =>
               Option(compiler.typedTreeAt(q.pos).symbol)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -80,7 +80,7 @@ trait ArgCompletions { this: MetalsGlobal =>
       }
 
       completions match {
-        case CompletionResult.ScopeMembers(positionDelta, results, name) =>
+        case CompletionResult.ScopeMembers(_, results, _) =>
           results
             .collect {
               case mem

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/FilenameCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/FilenameCompletions.scala
@@ -67,7 +67,7 @@ trait FilenameCompletions { this: MetalsGlobal =>
           Nil
         }
       } catch {
-        case NonFatal(e) =>
+        case NonFatal(_) =>
           Nil
       }
     }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -499,7 +499,6 @@ trait OverrideCompletions { this: MetalsGlobal =>
    */
   private def hasBody(text: String, t: Template): Option[Int] = {
     val start = t.pos.start
-    val end = t.pos.end
     val offset = text.indexOf('{', start)
     if (offset > 0 && offset < t.pos.end) Some(offset)
     else None

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -316,7 +316,6 @@ trait OverrideCompletions { this: MetalsGlobal =>
         inferEditPosition(text, t).toLSP,
         t,
         text,
-        true,
         _ => true
       )
     }
@@ -372,7 +371,6 @@ trait OverrideCompletions { this: MetalsGlobal =>
       range: l.Range,
       t: Template,
       text: String,
-      shouldAddOverrideKwd: Boolean,
       isCandidate: Symbol => Boolean
   ): List[l.TextEdit] = {
     val overrideMembers = getMembers(

--- a/mtags/src/main/scala-2/scala/tools/nsc/interactive/MetalsGlobalThread.scala
+++ b/mtags/src/main/scala-2/scala/tools/nsc/interactive/MetalsGlobalThread.scala
@@ -29,13 +29,13 @@ final class MetalsGlobalThread(var compiler: Global, name: String = "")
         try {
           compiler.backgroundCompile()
         } catch {
-          case ex: FreshRunReq =>
+          case _: FreshRunReq =>
             compiler.debugLog("fresh run req caught, starting new pass")
         }
         compiler.log.flush()
       }
     } catch {
-      case ex @ ShutdownReq =>
+      case ShutdownReq =>
         compiler.debugLog("exiting presentation compiler")
         compiler.log.close()
 
@@ -51,7 +51,7 @@ final class MetalsGlobalThread(var compiler: Global, name: String = "")
           case _: ThreadDeath =>
             compiler = null
           // - scalac deviation
-          case ex: FreshRunReq =>
+          case _: FreshRunReq =>
             compiler.debugLog(
               "fresh run req caught outside presentation compiler loop; ignored"
             ) // This shouldn't be reported

--- a/mtags/src/main/scala/scala/meta/internal/metals/Fuzzy.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/Fuzzy.scala
@@ -250,8 +250,7 @@ class Fuzzy {
   }
 
   def bloomFilterSymbolStrings(
-      symbols: Iterable[String],
-      pkg: String = ""
+      symbols: Iterable[String]
   ): StringBloomFilter = {
     val estimatedSize = symbols.foldLeft(0) {
       case (accum, string) =>

--- a/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
@@ -132,7 +132,6 @@ class PackageIndex() {
   private def expandJrtClasspath(): Unit = {
     val fs = FileSystems.getFileSystem(URI.create("jrt:/"))
     val dir = fs.getPath("/packages")
-    val start = System.nanoTime()
     for {
       pkg <- Files.newDirectoryStream(dir).iterator().asScala
       symbol = pkg.toString.stripPrefix("/packages/").replace('.', '/') + "/"

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
@@ -201,7 +201,7 @@ abstract class CompilerAccess[Reporter, Compiler](
 
     // User cancelled task.
     token.onCancel.whenCompleteAsync(
-      (isCancelled, ex) => {
+      (isCancelled, _) => {
         if (isCancelled && !result.isDone()) {
           result.cancel(false)
         }

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -58,7 +58,6 @@ abstract class BasePCSuite extends BaseSuite {
       JdkSources().foreach(jdk => index.addSourceJar(jdk))
     if (requiresScalaLibrarySources)
       indexScalaLibrary(index, scalaVersion)
-    val indexer = new Docstrings(index)
     val search = new TestingSymbolSearch(
       ClasspathSearch.fromClasspath(myclasspath),
       new Docstrings(index),

--- a/tests/input/src/main/scala/example/TryCatch.scala
+++ b/tests/input/src/main/scala/example/TryCatch.scala
@@ -8,5 +8,6 @@ class TryCatch {
     case t: Throwable =>
   } finally {
     val text = ""
+    text + ""
   }
 }

--- a/tests/input/src/main/scala/example/TryCatch.scala
+++ b/tests/input/src/main/scala/example/TryCatch.scala
@@ -6,6 +6,7 @@ class TryCatch {
     x + 2
   } catch {
     case t: Throwable =>
+      t.printStackTrace()
   } finally {
     val text = ""
     text + ""

--- a/tests/input/src/main/scala/example/nested/LocalDeclarations.scala
+++ b/tests/input/src/main/scala/example/nested/LocalDeclarations.scala
@@ -19,7 +19,7 @@ object LocalDeclarations {
     val y = new Foo {}
 
     x.x + y.y
-    
+
     new LocalDeclarations with Foo {
       override def foo(): Unit = bar()
     }

--- a/tests/input/src/main/scala/example/nested/LocalDeclarations.scala
+++ b/tests/input/src/main/scala/example/nested/LocalDeclarations.scala
@@ -4,7 +4,9 @@ trait LocalDeclarations {
   def foo(): Unit
 }
 
-trait Foo {}
+trait Foo {
+  val y = 3
+}
 
 object LocalDeclarations {
   def create(): LocalDeclarations = {
@@ -16,6 +18,8 @@ object LocalDeclarations {
 
     val y = new Foo {}
 
+    x.x + y.y
+    
     new LocalDeclarations with Foo {
       override def foo(): Unit = bar()
     }

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -43,9 +43,6 @@ class BaseSuite extends munit.FunSuite with Assertions {
       munitFlakyTransform
     )
 
-  private def scalaBinary(scalaVersion: String): String =
-    scalaVersion.split("\\.").take(2).mkString(".")
-
   val compatProcess: Map[String, String => String] =
     Map.empty[String, String => String]
 

--- a/tests/mtest/src/main/scala/tests/TestHovers.scala
+++ b/tests/mtest/src/main/scala/tests/TestHovers.scala
@@ -58,9 +58,6 @@ trait TestHovers {
 
   }
 
-  private def toScala(hover: Hover) = {
-    hover.getContents
-  }
   private def codeFence(code: String, language: String): String = {
     val trimmed = code.trim
     if (trimmed.isEmpty) ""

--- a/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
@@ -11,7 +11,7 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
 
   def withCompletion(query: String, project: Char = 'a')(
       fn: CompletionList => Unit
-  )(implicit loc: Location): Future[Unit] = {
+  ): Future[Unit] = {
     val filename = s"$project/src/main/scala/$project/${project.toUpper}.scala"
     val text = server
       .textContentsOnDisk(filename)

--- a/tests/unit/src/main/scala/tests/BaseDigestSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseDigestSuite.scala
@@ -29,7 +29,7 @@ trait BaseDigestSuite extends BaseSuite {
       name: String,
       layout: String,
       altLayout: String,
-      isEqual: Boolean = true
+      isEqual: Boolean
   )(implicit loc: Location): Unit = {
     test(name) {
       val root = FileLayout.fromString(layout)

--- a/tests/unit/src/main/scala/tests/BaseRenameLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseRenameLspSuite.scala
@@ -42,7 +42,7 @@ class BaseRenameLspSuite(name: String) extends BaseLspSuite(name) {
       name: TestOptions,
       input: String,
       newName: String,
-      notRenamed: Boolean = false,
+      notRenamed: Boolean,
       nonOpened: Set[String] = Set.empty,
       breakingChange: String => String = identity[String],
       fileRenames: Map[String, String] = Map.empty,

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -193,7 +193,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
 
   test("cancel") {
     val cancelled = Promise[Unit]()
-    client.slowTaskHandler = { params =>
+    client.slowTaskHandler = { _ =>
       cancelled.trySuccess(())
       Some(MetalsSlowTaskResult(cancel = true))
     }

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -76,11 +76,11 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
     _: ShowMessageRequestParams => None
   }
   var inputBoxHandler: MetalsInputBoxParams => Option[MetalsInputBoxResult] = {
-    params: MetalsInputBoxParams => None
+    _: MetalsInputBoxParams => None
   }
 
   private val refreshCount = new AtomicInteger
-  var refreshModelHandler: Int => Unit = count => ()
+  var refreshModelHandler: Int => Unit = (_) => ()
 
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -284,7 +284,7 @@ final class TestingServer(
       base: Map[String, String]
   )(implicit loc: munit.Location): Future[Unit] = {
     for {
-      referenceLocations <- getReferenceLocations(filename, query, base)
+      referenceLocations <- getReferenceLocations(filename, query)
     } yield {
       Assertions.assertSimpleLocationOrdering(referenceLocations)
       val references =
@@ -1084,8 +1084,7 @@ final class TestingServer(
 
   def getReferenceLocations(
       filename: String,
-      query: String,
-      base: Map[String, String]
+      query: String
   ): Future[List[Location]] = {
     for {
       (_, params) <- offsetParams(filename, query, workspace)
@@ -1281,7 +1280,7 @@ final class TestingServer(
       filename: String,
       linePattern: String,
       isIgnored: String => Boolean = _ => true
-  )(implicit loc: munit.Location): String = {
+  ): String = {
     val path = toPath(filename)
     val line = path.toInput.value.linesIterator.zipWithIndex
       .collectFirst {

--- a/tests/unit/src/main/scala/tests/TestingWorkspaceSymbolProvider.scala
+++ b/tests/unit/src/main/scala/tests/TestingWorkspaceSymbolProvider.scala
@@ -1,7 +1,5 @@
 package tests
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.CompressedPackageIndex
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -13,7 +11,6 @@ import scala.meta.io.AbsolutePath
 object TestingWorkspaceSymbolProvider {
   def apply(
       workspace: AbsolutePath,
-      buildTargets: BuildTargets = new BuildTargets,
       statistics: StatisticsConfig = StatisticsConfig.default,
       index: OnDemandSymbolIndex = OnDemandSymbolIndex(),
       bucketSize: Int = CompressedPackageIndex.DefaultBucketSize

--- a/tests/unit/src/test/resources/definition/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/definition/example/TryCatch.scala
@@ -6,6 +6,7 @@ class TryCatch/*TryCatch.scala*/ {
     x/*TryCatch.semanticdb*/ +/*Int.scala*/ 2
   } catch {
     case t/*TryCatch.semanticdb*/: Throwable/*package.scala*/ =>
+      t/*TryCatch.semanticdb*/.printStackTrace/*Throwable.java*/()
   } finally {
     val text/*TryCatch.semanticdb*/ = ""
     text/*TryCatch.semanticdb*/ +/*String.java fallback to java.lang.String#*/ ""

--- a/tests/unit/src/test/resources/definition/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/definition/example/TryCatch.scala
@@ -8,5 +8,6 @@ class TryCatch/*TryCatch.scala*/ {
     case t/*TryCatch.semanticdb*/: Throwable/*package.scala*/ =>
   } finally {
     val text/*TryCatch.semanticdb*/ = ""
+    text/*TryCatch.semanticdb*/ +/*String.java fallback to java.lang.String#*/ ""
   }
 }

--- a/tests/unit/src/test/resources/definition/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/definition/example/nested/LocalDeclarations.scala
@@ -19,7 +19,7 @@ object LocalDeclarations/*LocalDeclarations.scala*/ {
     val y/*LocalDeclarations.semanticdb*/ = new Foo/*LocalDeclarations.scala*/ {}
 
     x/*LocalDeclarations.semanticdb*/.x/*<no symbol>*/ +/*Int.scala*/ y/*LocalDeclarations.semanticdb*/.y/*LocalDeclarations.scala*/
-    
+
     new LocalDeclarations/*LocalDeclarations.scala*/ with Foo/*LocalDeclarations.scala*/ {
       override def foo/*LocalDeclarations.semanticdb*/(): Unit/*Unit.scala*/ = bar/*LocalDeclarations.semanticdb*/()
     }

--- a/tests/unit/src/test/resources/definition/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/definition/example/nested/LocalDeclarations.scala
@@ -4,7 +4,9 @@ trait LocalDeclarations/*LocalDeclarations.scala*/ {
   def foo/*LocalDeclarations.scala*/(): Unit/*Unit.scala*/
 }
 
-trait Foo/*LocalDeclarations.scala*/ {}
+trait Foo/*LocalDeclarations.scala*/ {
+  val y/*LocalDeclarations.scala*/ = 3
+}
 
 object LocalDeclarations/*LocalDeclarations.scala*/ {
   def create/*LocalDeclarations.scala*/(): LocalDeclarations/*LocalDeclarations.scala*/ = {
@@ -16,6 +18,8 @@ object LocalDeclarations/*LocalDeclarations.scala*/ {
 
     val y/*LocalDeclarations.semanticdb*/ = new Foo/*LocalDeclarations.scala*/ {}
 
+    x/*LocalDeclarations.semanticdb*/.x/*<no symbol>*/ +/*Int.scala*/ y/*LocalDeclarations.semanticdb*/.y/*LocalDeclarations.scala*/
+    
     new LocalDeclarations/*LocalDeclarations.scala*/ with Foo/*LocalDeclarations.scala*/ {
       override def foo/*LocalDeclarations.semanticdb*/(): Unit/*Unit.scala*/ = bar/*LocalDeclarations.semanticdb*/()
     }

--- a/tests/unit/src/test/resources/documentSymbol/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/documentSymbol/example/TryCatch.scala
@@ -1,12 +1,13 @@
-/*example(Package):12*/package example
+/*example(Package):13*/package example
 
-/*example.TryCatch(Class):12*/class TryCatch {
-  /*example.TryCatch#try(Struct):11*/try {
+/*example.TryCatch(Class):13*/class TryCatch {
+  /*example.TryCatch#try(Struct):12*/try {
     /*example.TryCatch#try.x(Constant):5*/val x = 2
     x + 2
   } catch {
     /*example.TryCatch#try.catch(Struct):8*/case t: Throwable =>
-  } finally /*example.TryCatch#try.finally(Struct):11*/{
+  } finally /*example.TryCatch#try.finally(Struct):12*/{
     /*example.TryCatch#try.finally.text(Constant):10*/val text = ""
+    text + ""
   }
 }

--- a/tests/unit/src/test/resources/documentSymbol/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/documentSymbol/example/TryCatch.scala
@@ -1,13 +1,14 @@
-/*example(Package):13*/package example
+/*example(Package):14*/package example
 
-/*example.TryCatch(Class):13*/class TryCatch {
-  /*example.TryCatch#try(Struct):12*/try {
+/*example.TryCatch(Class):14*/class TryCatch {
+  /*example.TryCatch#try(Struct):13*/try {
     /*example.TryCatch#try.x(Constant):5*/val x = 2
     x + 2
   } catch {
-    /*example.TryCatch#try.catch(Struct):8*/case t: Throwable =>
-  } finally /*example.TryCatch#try.finally(Struct):12*/{
-    /*example.TryCatch#try.finally.text(Constant):10*/val text = ""
+    /*example.TryCatch#try.catch(Struct):9*/case t: Throwable =>
+      t.printStackTrace()
+  } finally /*example.TryCatch#try.finally(Struct):13*/{
+    /*example.TryCatch#try.finally.text(Constant):11*/val text = ""
     text + ""
   }
 }

--- a/tests/unit/src/test/resources/documentSymbol/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/documentSymbol/example/nested/LocalDeclarations.scala
@@ -19,7 +19,7 @@
     /*example.nested.LocalDeclarations.create.y(Constant):19*/val y = new Foo {}
 
     x.x + y.y
-    
+
     /*example.nested.LocalDeclarations.create.new LocalDeclarations with Foo(Interface):25*/new LocalDeclarations with Foo {
       /*example.nested.LocalDeclarations.create.`new LocalDeclarations with Foo`#foo(Method):24*/override def foo(): Unit = bar()
     }

--- a/tests/unit/src/test/resources/documentSymbol/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/documentSymbol/example/nested/LocalDeclarations.scala
@@ -1,23 +1,27 @@
-/*example.nested(Package):24*/package example.nested
+/*example.nested(Package):28*/package example.nested
 
 /*example.nested.LocalDeclarations(Interface):5*/trait LocalDeclarations {
   /*example.nested.LocalDeclarations#foo(Method):4*/def foo(): Unit
 }
 
-/*example.nested.Foo(Interface):7*/trait Foo {}
+/*example.nested.Foo(Interface):9*/trait Foo {
+  /*example.nested.Foo#y(Constant):8*/val y = 3
+}
 
-/*example.nested.LocalDeclarations(Module):24*/object LocalDeclarations {
-  /*example.nested.LocalDeclarations.create(Method):23*/def create(): LocalDeclarations = {
-    /*example.nested.LocalDeclarations.create.bar(Method):11*/def bar(): Unit = ()
+/*example.nested.LocalDeclarations(Module):28*/object LocalDeclarations {
+  /*example.nested.LocalDeclarations.create(Method):27*/def create(): LocalDeclarations = {
+    /*example.nested.LocalDeclarations.create.bar(Method):13*/def bar(): Unit = ()
 
-    /*example.nested.LocalDeclarations.create.x(Constant):15*/val x = /*example.nested.LocalDeclarations.create.x.new (anonymous)(Interface):15*/new {
-      /*example.nested.LocalDeclarations.create.x.`new (anonymous)`#x(Constant):14*/val x = 2
+    /*example.nested.LocalDeclarations.create.x(Constant):17*/val x = /*example.nested.LocalDeclarations.create.x.new (anonymous)(Interface):17*/new {
+      /*example.nested.LocalDeclarations.create.x.`new (anonymous)`#x(Constant):16*/val x = 2
     }
 
-    /*example.nested.LocalDeclarations.create.y(Constant):17*/val y = new Foo {}
+    /*example.nested.LocalDeclarations.create.y(Constant):19*/val y = new Foo {}
 
-    /*example.nested.LocalDeclarations.create.new LocalDeclarations with Foo(Interface):21*/new LocalDeclarations with Foo {
-      /*example.nested.LocalDeclarations.create.`new LocalDeclarations with Foo`#foo(Method):20*/override def foo(): Unit = bar()
+    x.x + y.y
+    
+    /*example.nested.LocalDeclarations.create.new LocalDeclarations with Foo(Interface):25*/new LocalDeclarations with Foo {
+      /*example.nested.LocalDeclarations.create.`new LocalDeclarations with Foo`#foo(Method):24*/override def foo(): Unit = bar()
     }
 
   }

--- a/tests/unit/src/test/resources/mtags/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/mtags/example/TryCatch.scala
@@ -8,5 +8,6 @@ class TryCatch/*example.TryCatch#*/ {
     case t: Throwable =>
   } finally {
     val text = ""
+    text + ""
   }
 }

--- a/tests/unit/src/test/resources/mtags/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/mtags/example/TryCatch.scala
@@ -6,6 +6,7 @@ class TryCatch/*example.TryCatch#*/ {
     x + 2
   } catch {
     case t: Throwable =>
+      t.printStackTrace()
   } finally {
     val text = ""
     text + ""

--- a/tests/unit/src/test/resources/mtags/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/mtags/example/nested/LocalDeclarations.scala
@@ -4,7 +4,9 @@ trait LocalDeclarations/*example.nested.LocalDeclarations#*/ {
   def foo/*example.nested.LocalDeclarations#foo().*/(): Unit
 }
 
-trait Foo/*example.nested.Foo#*/ {}
+trait Foo/*example.nested.Foo#*/ {
+  val y/*example.nested.Foo#y.*/ = 3
+}
 
 object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
   def create/*example.nested.LocalDeclarations.create().*/(): LocalDeclarations = {
@@ -16,6 +18,8 @@ object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
 
     val y = new Foo {}
 
+    x.x + y.y
+    
     new LocalDeclarations with Foo {
       override def foo(): Unit = bar()
     }

--- a/tests/unit/src/test/resources/mtags/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/mtags/example/nested/LocalDeclarations.scala
@@ -19,7 +19,7 @@ object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
     val y = new Foo {}
 
     x.x + y.y
-    
+
     new LocalDeclarations with Foo {
       override def foo(): Unit = bar()
     }

--- a/tests/unit/src/test/resources/semanticdb/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/TryCatch.scala
@@ -8,5 +8,6 @@ class TryCatch/*example.TryCatch#*/ {
     case t/*local1*/: Throwable/*scala.package.Throwable#*/ =>
   } finally {
     val text/*local2*/ = ""
+    text/*local2*/ +/*java.lang.String#`+`().*/ ""
   }
 }

--- a/tests/unit/src/test/resources/semanticdb/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/TryCatch.scala
@@ -6,6 +6,7 @@ class TryCatch/*example.TryCatch#*/ {
     x/*local0*/ +/*scala.Int#`+`(+4).*/ 2
   } catch {
     case t/*local1*/: Throwable/*scala.package.Throwable#*/ =>
+      t/*local1*/.printStackTrace/*java.lang.Throwable#printStackTrace().*/()
   } finally {
     val text/*local2*/ = ""
     text/*local2*/ +/*java.lang.String#`+`().*/ ""

--- a/tests/unit/src/test/resources/semanticdb/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/nested/LocalDeclarations.scala
@@ -4,7 +4,9 @@ trait LocalDeclarations/*example.nested.LocalDeclarations#*/ {
   def foo/*example.nested.LocalDeclarations#foo().*/(): Unit/*scala.Unit#*/
 }
 
-trait Foo/*example.nested.Foo#*/ {}
+trait Foo/*example.nested.Foo#*/ {
+  val y/*example.nested.Foo#y.*/ = 3
+}
 
 object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
   def create/*example.nested.LocalDeclarations.create().*/(): LocalDeclarations/*example.nested.LocalDeclarations#*/ = {
@@ -16,6 +18,8 @@ object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
 
     val y/*local4*/ = new /*local5*/Foo/*example.nested.Foo#*/ /*java.lang.Object#`<init>`().*/{}
 
+    x/*local1*/.x +/*scala.Int#`+`(+4).*/ y/*local4*/.y/*example.nested.Foo#y.*/
+    
     new /*local6*/LocalDeclarations/*example.nested.LocalDeclarations#*/ /*java.lang.Object#`<init>`().*/with Foo/*example.nested.Foo#*/ {
       override def foo/*local7*/(): Unit/*scala.Unit#*/ = bar/*local0*/()
     }

--- a/tests/unit/src/test/resources/semanticdb/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/nested/LocalDeclarations.scala
@@ -19,7 +19,7 @@ object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
     val y/*local4*/ = new /*local5*/Foo/*example.nested.Foo#*/ /*java.lang.Object#`<init>`().*/{}
 
     x/*local1*/.x +/*scala.Int#`+`(+4).*/ y/*local4*/.y/*example.nested.Foo#y.*/
-    
+
     new /*local6*/LocalDeclarations/*example.nested.LocalDeclarations#*/ /*java.lang.Object#`<init>`().*/with Foo/*example.nested.Foo#*/ {
       override def foo/*local7*/(): Unit/*scala.Unit#*/ = bar/*local0*/()
     }

--- a/tests/unit/src/test/resources/workspace-symbol/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/workspace-symbol/example/TryCatch.scala
@@ -8,5 +8,6 @@ class TryCatch/*example.TryCatch#*/ {
     case t: Throwable =>
   } finally {
     val text = ""
+    text + ""
   }
 }

--- a/tests/unit/src/test/resources/workspace-symbol/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/workspace-symbol/example/TryCatch.scala
@@ -6,6 +6,7 @@ class TryCatch/*example.TryCatch#*/ {
     x + 2
   } catch {
     case t: Throwable =>
+      t.printStackTrace()
   } finally {
     val text = ""
     text + ""

--- a/tests/unit/src/test/resources/workspace-symbol/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/workspace-symbol/example/nested/LocalDeclarations.scala
@@ -4,7 +4,9 @@ trait LocalDeclarations/*example.nested.LocalDeclarations#*/ {
   def foo(): Unit
 }
 
-trait Foo/*example.nested.Foo#*/ {}
+trait Foo/*example.nested.Foo#*/ {
+  val y = 3
+}
 
 object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
   def create(): LocalDeclarations = {
@@ -16,6 +18,8 @@ object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
 
     val y = new Foo {}
 
+    x.x + y.y
+    
     new LocalDeclarations with Foo {
       override def foo(): Unit = bar()
     }

--- a/tests/unit/src/test/resources/workspace-symbol/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/workspace-symbol/example/nested/LocalDeclarations.scala
@@ -19,7 +19,7 @@ object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
     val y = new Foo {}
 
     x.x + y.y
-    
+
     new LocalDeclarations with Foo {
       override def foo(): Unit = bar()
     }

--- a/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
@@ -79,7 +79,7 @@ class DebugProtocolSuite extends BaseDapSuite("debug-protocol") {
       )
       failed = startDebugging()
       debugger <- failed.recoverWith {
-        case e: ResponseErrorException =>
+        case _: ResponseErrorException =>
           server
             .didSave("a/src/main/scala/a/Main.scala") { text => text + "}" }
             .flatMap(_ => startDebugging())

--- a/tests/unit/src/test/scala/tests/DocumentSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DocumentSymbolLspSuite.scala
@@ -29,7 +29,7 @@ class DocumentSymbolLspSuite extends BaseLspSuite("documentSymbol") {
            |}""".stripMargin
       )
       // fix the code to make it parse
-      _ <- server.didChange("a/src/main/scala/a/Main.scala") { text =>
+      _ <- server.didChange("a/src/main/scala/a/Main.scala") { _ =>
         """|
            |object Outer {
            |  class Inner
@@ -45,7 +45,7 @@ class DocumentSymbolLspSuite extends BaseLspSuite("documentSymbol") {
            |}""".stripMargin
       )
       // make the code unparseable again
-      _ <- server.didChange("a/src/main/scala/a/Main.scala") { text =>
+      _ <- server.didChange("a/src/main/scala/a/Main.scala") { _ =>
         """|} // <- parse error
            |object Outer {
            |  class Inner

--- a/tests/unit/src/test/scala/tests/LineListenerSuite.scala
+++ b/tests/unit/src/test/scala/tests/LineListenerSuite.scala
@@ -13,7 +13,7 @@ class LineListenerSuite extends BaseSuite {
       expected: List[String]
   )(implicit loc: Location): Unit = {
     test(name) {
-      var buf = mutable.ListBuffer.empty[String]
+      val buf = mutable.ListBuffer.empty[String]
       val output = new LineListener(line => buf += line)
       act(output)
       output.flushIfNonEmpty()

--- a/tests/unit/src/test/scala/tests/RangeFormattingWhenSelectingSuite.scala
+++ b/tests/unit/src/test/scala/tests/RangeFormattingWhenSelectingSuite.scala
@@ -14,7 +14,6 @@ class RangeFormattingWhenSelectingSuite
        |                  |third line
        |          |fourth line'''.stripMargin>>
        |}""".stripMargin,
-    None,
     s"""
        |object Main {
        |  val str = '''
@@ -35,7 +34,6 @@ class RangeFormattingWhenSelectingSuite
        |                  |third line
        |          |fourth line'''.stripMargin>>
        |}""".stripMargin,
-    None,
     s"""
        |object Main {
        |  val str = '''
@@ -55,7 +53,6 @@ class RangeFormattingWhenSelectingSuite
        |                  |third line
        |          |fourth line'''.stripMargin>>
        |}""".stripMargin,
-    None,
     s"""
        |object Main {
        |  val str = '''first line
@@ -74,7 +71,6 @@ class RangeFormattingWhenSelectingSuite
        |                  |third line
        |          |fourth line'''.stripMargin>>
        |}""".stripMargin,
-    None,
     s"""
        |object Main {
        |  val str = '''|first line
@@ -93,7 +89,6 @@ class RangeFormattingWhenSelectingSuite
        |                  |third line
        |          |fourth line'''.stripMargin>>
        |}""".stripMargin,
-    None,
     s"""
        |object Main {
        |  val str = '''|first line
@@ -117,7 +112,6 @@ class RangeFormattingWhenSelectingSuite
        |               |first line
        |               |second line'''.stripMargin>>
        |}""".stripMargin,
-    None,
     s"""
        |object Main {
        |  val firstString = '''
@@ -133,7 +127,6 @@ class RangeFormattingWhenSelectingSuite
   def check(
       name: String,
       testCase: String,
-      paste: Option[String],
       expectedCase: String
   )(implicit loc: Location): Unit = {
     val tripleQuote = """\u0022\u0022\u0022"""


### PR DESCRIPTION
Added new flags:
- `-Ywarn-unused:privates`
- `-Ywarn-unused:patvars` - one small issue, but easily fixable
- `-Ywarn-unused:locals`
- `-Ywarn-unused:implicits`

I couldn't add `-Ywarn-unused:explicits` because it didn't work well with inheritance. I enabled it for a while and removed anything that seemed no longer needed.