### PR TITLE
Revert "Update interface to 0.0.24 (#1918)"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -207,7 +207,7 @@ lazy val V = new {
   def dap4j =
     "org.eclipse.lsp4j" % "org.eclipse.lsp4j.debug" % "0.9.0"
   val coursier = "2.0.0-RC6-23"
-  val coursierInterfaces = "0.0.24"
+  val coursierInterfaces = "0.0.22"
   val ammonite = "2.1.4-11-307f3d8"
 }
 


### PR DESCRIPTION
This reverts commit 36513652eb73cfc64e10858cc61320a4c048f6a9.

Fixes https://github.com/scalameta/metals/issues/1925