### PR TITLE
Make sure a file exists when searching for definition

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -251,6 +251,7 @@ class DestinationProvider(
   def fromSymbol(symbol: String): Option[DefinitionDestination] = {
     for {
       symbolDefinition <- index.definition(Symbol(symbol))
+      if symbolDefinition.path.exists
       destinationDoc = bestTextDocument(symbolDefinition)
       defnPathInput = symbolDefinition.path.toInputFromBuffers(buffers)
       defnOriginalInput = Input.VirtualFile(


### PR DESCRIPTION
Partly fixes #1814

I couldn't reproduce any other issues.