### PR TITLE
Add Bloop jvmopts in tests to limit memory used by it

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -4,6 +4,11 @@ function bloop_version {
   grep "val bloop" build.sbt | sed -n 's/.*"\(.*\)".*/\1/p'
 }
 
+mkdir -p ~/.bloop
+touch ~/.bloop/.jvmopts
+echo "-Xss16m" >> ~/.bloop/.jvmopts 
+echo "-Xmx1G"  >> ~/.bloop/.jvmopts 
+
 curl -Lo coursier https://git.io/coursier-cli && chmod +x coursier
 ./coursier launch ch.epfl.scala:bloopgun-core_2.12:$(bloop_version) -- about
 


### PR DESCRIPTION
This should help address the `Out of memory` issues we've been seeing.