### PR TITLE
Add missing docs and move versions to a more prominent location.

### DIFF
--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -235,7 +235,7 @@ Default value: `false`
 ##### `didFocusProvider`
 
 Boolean value to signify that the client supports the
-[`metals/didFocusTextDocument`](#metalsdid-focus-text-document) extension.
+[`metals/didFocusTextDocument`](#metalsdidfocustextdocument) extension.
 
 Default value: `false`
 
@@ -328,7 +328,7 @@ Default: `false`
 ##### `quickPickProvider`
 
 Boolean value to signify whether or not the client implements the
-[`metals/quickPick`](#metalsquick-pick) extensions.
+[`metals/quickPick`](#metalsquickpick) extensions.
 
 Default value: `false`
 

--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -4,6 +4,18 @@ title: Text Editors
 sidebar_label: Overview
 ---
 
+## Latest Metals server versions
+
+To find out how to set the version in your editor please check out the editor
+specific sections.
+
+```scala mdoc:releases
+
+```
+
+
+## Editor support
+
 Metals works with the following text editors with varying degree of
 functionality.
 
@@ -187,8 +199,8 @@ functionality.
     <td>Metals Extensions</td>
     <td align="center">✅</td>
     <td align="center">Status bar</td>
-    <td align="center">Status bar</td>
-    <td align="center">Status bar</td>
+    <td align="center">Status bar, Quick pick</td>
+    <td align="center">Status bar, Input box</td>
     <td align="center">Status bar</td>
     <td align="center">Status bar, Slow task</td>
   </tr>
@@ -372,7 +384,8 @@ using the Metals sidebar. This feature is only implemented in VS Code.
 **Tree view**: Editor client implements the
 [Tree View Protocol](tree-view-protocol.md).
 
-**Did focus**: Editor client implements the `metals/didFocusTextDocument` notification.
+**Did focus**: Editor client implements the `metals/didFocusTextDocument`
+notification.
 
 **Slow task**: Editor client implements the `metals/slowTask` request.
 

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -323,7 +323,7 @@ Then, when on the line that you'd like to expand the decoration to get the hover
 
 coc-metals has a built-in implementation of the [Tree View
 Protocol](https://scalameta.org/metals/docs/editors/tree-view-protocol.html).
-If you have the [recommended mappings](coc-mappings.vim) copied, you'll notice
+If you have the [recommended mappings](vim.md#recommended-cocnvim-mappings) copied, you'll notice
 that in the bottom you'll have some TVP related settings. You can start by
 opening the TVP panel by using the default `<space> t`. Once open, you'll see
 there are three parts to the panel. The first being the `MetalsCompile` window
@@ -409,6 +409,10 @@ If you'd like to get autocompletion help for the configuration values you can
 install [coc-json](https://github.com/neoclide/coc-json).
 
 ```scala mdoc:user-config:lsp-config-coc
+```
+
+```scala mdoc:new-project:vim
+
 ```
 
 ## Enable on type formatting for multiline string formatting

--- a/docs/editors/vscode.md
+++ b/docs/editors/vscode.md
@@ -23,10 +23,14 @@ Install the Metals extension from the
 > if they are installed. The
 > [Dotty Language Server](https://marketplace.visualstudio.com/items?itemName=lampepfl.dotty)
 > does **not** need to be disabled because the Metals and Dotty extensions don't
-> conflict with each other.
+> conflict with each other. However, if you want to work on Scala 3 code in a
+> workspace that was previously opened with `Dotty Language Server` you need to
+> first remove `.dotty-ide-artifact` before opening the workspace with Metals.
 
-Next, open a directory containing a `build.sbt` file. The extension activates
-when a `*.scala` or `*.sbt` file is opened.
+Next, open a directory containing your Scala code. The extension activates when
+the main directory contains `build.sbt` or `build.sc` file, a Scala file is
+opened, which insludes `*.sbt`, `*.scala` and `*.sc` file, or a standard Scala
+directory structure `src/main/scala` is detected.
 
 ```scala mdoc:editor:vscode
 Update the "Sbt Script" setting to use a custom `sbt` script instead of the
@@ -120,29 +124,36 @@ without opening the sidebar.
 As you type, the symbol outline is also visible at the top of the file.
 ![Document Symbols Outline](https://i.imgur.com/L217n4q.png)
 
-## Enable on type formatting for multiline string formatting
+```scala mdoc:parent-lenses:vscode
 
-![pipes](https://i.imgur.com/iXGYOf0.gif)
+```
+
+```scala mdoc:new-project:vscode
+
+```
+
+## On type formatting for multiline string formatting
+
+![on-type](https://imgur.com/a0O2vCs.gif)
 
 To properly support adding `|` in multiline strings we are using the
-`onTypeFormatting` method. To enable the functionality you need to enable
-`onTypeFormatting` inside Visual Studio Code.
+`onTypeFormatting` method. The functionality is enabled by default, but you can
+disable/enable `onTypeFormatting` inside Visual Studio Code settings by checking
+`Editor: Format On Type`:
 
-This needs to be done in settings by checking `Editor: Format On Type`:
+![on-type-setting](https://i.imgur.com/s6nT9rC.png)
 
-![on-type](https://i.imgur.com/4eVvSP5.gif)
-
-## Enable formatting on paste for multiline strings
+## Formatting on paste for multiline strings
 
 Whenever text is paste into a multiline string with `|` it will be properly
 formatted by Metals:
 
-![format-on-paste](https://i.imgur.com/yJLAIxQ.gif)
+![format-on-paste](https://i.imgur.com/fF0XWYC.gif)
 
-To enable this feature you need to enable formatting on paste in Visual Studio
-Code by checking `Editor: Format On Paste`:
+This feature is enabled by default. If you need to disable/enable formatting on
+paste in Visual Studio Code you can check the `Editor: Format On Paste` setting:
 
-![format-on-paste](https://i.imgur.com/OaBxwer.png)
+![format-on-paste-setting](https://i.imgur.com/rMrk27F.png)
 
 ## Coming from IntelliJ
 

--- a/metals-docs/src/main/resources/META-INF/services/mdoc.StringModifier
+++ b/metals-docs/src/main/resources/META-INF/services/mdoc.StringModifier
@@ -10,3 +10,5 @@ docs.BootstrapModifier
 docs.RequirementsModifier
 docs.VersionedDocsModifier
 docs.AutomaticInstallationModifier
+docs.ParentLensesModifier
+docs.NewProjectModifier

--- a/metals-docs/src/main/scala/docs/NewProjectModifier.scala
+++ b/metals-docs/src/main/scala/docs/NewProjectModifier.scala
@@ -1,0 +1,51 @@
+package docs
+
+import scala.meta.inputs.Input
+
+import mdoc.Reporter
+import mdoc.StringModifier
+
+class NewProjectModifier extends StringModifier {
+
+  override val name: String = "new-project"
+
+  override def process(
+      info: String,
+      code: Input,
+      reporter: Reporter
+  ): String = {
+    val isVscode = info == "vscode"
+    val newScalaProject =
+      if (isVscode) "Metals: New Scala project"
+      else "new-scala-project"
+    val chooseWindow =
+      if (isVscode)
+        "\n5. Choose whether to open a new window for the created project or use the existing one."
+      else ""
+
+    val fromButtons =
+      if (isVscode)
+        "\nThe same command will be invoked when clicking the \"New Scala Project\" button in the Metals view."
+      else ""
+    s"""|## Create new project from template
+        |
+        |It is possible using Metals to easily setup a new project using the exiting [giter8](https://github.com/foundweekends/giter8/wiki/giter8-templates) templates. 
+        |This is an equivalent to the `sbt new` command, which uses the same mechanism.
+        |There is a great number of templates already available and it should be easy to find something for yourself.
+        |To start the setup you can use the $newScalaProject command, which works as following:
+        |1. Choose the template and then:
+        |    1. Use the proposed templates.
+        |    2. Choose "Discover more" and then choose from the list downloaded from the Giter8 wiki page.
+        |    3. Input a custom Github repository following the `organization/repo` schema.
+        |3. Navigate to the parent directory that you want to create your new project in.
+        |4. Choose the name or accept the default one.
+        |$chooseWindow
+        |$fromButtons
+        |
+        |If you feel like a template should be included in the default displayed ones do not hesitate to create a 
+        |[PR](https://github.com/scalameta/metals/blob/cda5b8c2029e5f201fb8d0636e0365d796407bd9/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala#L308)
+        |or file an issue.
+        |""".stripMargin
+  }
+
+}

--- a/metals-docs/src/main/scala/docs/ParentLensesModifier.scala
+++ b/metals-docs/src/main/scala/docs/ParentLensesModifier.scala
@@ -1,0 +1,46 @@
+package docs
+
+import scala.meta.inputs.Input
+
+import mdoc.Reporter
+import mdoc.StringModifier
+
+class ParentLensesModifier extends StringModifier {
+  override val name: String = "parent-lenses"
+
+  override def process(
+      info: String,
+      code: Input,
+      reporter: Reporter
+  ): String = {
+
+    val isVSCode = info == "vscode"
+    val gotoToSuper =
+      if (isVSCode) "Metals: Go to super method" else "goto-super-method"
+    val superMethodHierarchy =
+      if (isVSCode) "Metals: Reveal super method hierachy"
+      else "super-method-hierarchy"
+    val additionalInfo =
+      if (info == "vscode") "\nYou can also bind those commands to a shortcut."
+      else ""
+
+    s"""|## Go to parent code lenses
+        |
+        |Metals has the ability to display code lenses that, when invoked, 
+        |will go to the parent class that contains the definition of the method or symbol.
+        |Unfortunately, it might cause some lag in larger code bases, 
+        |which is why it is not enabled currently by default.
+        |
+        |To enable the feature you need to modify the setting `metals.superMethodLensesEnabled` to `true`.
+        |
+        |Even without using the code lenses it's still possible to navigate the method hierarchy 
+        |using two commands:
+        |
+        | - `$gotoToSuper` - immediately goes to the parent of the method the cursor is pointing to
+        |
+        | - `$superMethodHierarchy` - displays the full method hierachy and enables to move to any parent, 
+        |it is best used with the Metals Quick Pick extension.
+        |$additionalInfo
+        |""".stripMargin
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -238,6 +238,9 @@ object ServerCommands {
     "New Scala Project",
     """|Create a new Scala project using one of the available g8 templates. 
        |This includes simple projects as well as samples for most of the popular Scala frameworks.
+       |The command reuses the Metals quick pick extension to work and can function with `window/showMessageRequest`, 
+       |however the experience will not be optimal in that case. Some editors might also offer to open the newly created
+       |project via `openNewWindowProvider`, but it is not necessary for the main functionality to work. 
        |""".stripMargin
   )
 


### PR DESCRIPTION
This PR adds the following:
- new Scala project documentation for vim and VS Code
- parent code lenses documentation for vim and VS Code
- fixes a number of smaller issues
- moves versions to a more prominent location