### PR TITLE
Status bar config "on" by default for sublime

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -171,7 +171,7 @@ object MetalsServerConfig {
       case "sublime" =>
         base.copy(
           isHttpEnabled = true,
-          statusBar = StatusBarConfig.showMessage,
+          statusBar = StatusBarConfig.on,
           icons = Icons.unicode,
           isExitOnShutdown = true,
           compilers = base.compilers.copy(


### PR DESCRIPTION
It seems like since: https://github.com/scalameta/metals/pull/1903  `-Dmetals.status-bar=on` is overridden by `-Dmetals.client=sublime` which forces `statusBar = StatusBarConfig.showMessage`.

This a short term fix until https://github.com/scalameta/metals-sublime is migrated into setting all intialization options without client name.