### PR TITLE
Add -Ximport-suggestion-timeout 0 to the presentation compiler options 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -340,6 +340,9 @@ lazy val mtags3 = project
     unmanagedSourceDirectories.in(Compile) += baseDirectory
       .in(ThisBuild)
       .value / "mtags" / "src" / "main" / "scala",
+    managedSourceDirectories.in(Compile) += baseDirectory
+      .in(ThisBuild)
+      .value / "mtags" / "target" / ("scala-" + scalaVersion.value) / "src_managed" / "main",
     moduleName := "mtags3",
     scalaVersion := V.scala3,
     target := baseDirectory

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -55,7 +55,7 @@ case class GradleBuildTool(userConfig: () => UserConfiguration)
         new String(gradlePropsFile.readAllBytes, StandardCharsets.UTF_8)
       contents.linesIterator.exists(_.startsWith("bloop.configured=true"))
     } catch {
-      case err: IOException => false
+      case _: IOException => false
     }
   }
 


### PR DESCRIPTION
Import suggestions are not used currently and might cause additional overhead for the presentation compiler.

Suggested by @smarter