### PR TITLE
Add in , as a trigger for SignatureHelp.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -606,7 +606,7 @@ class MetalsLanguageServer(
         initialConfig.allowMultilineStringFormatting
       )
       capabilities.setSignatureHelpProvider(
-        new SignatureHelpOptions(List("(", "[").asJava)
+        new SignatureHelpOptions(List("(", "[", ",").asJava)
       )
       capabilities.setCompletionProvider(
         new CompletionOptions(


### PR DESCRIPTION
This will allow users to enter a parameter or two, step out, and then back
in and still get signature help. Currently, if you leave the parameters
and step back in, you will no longer get signature help. Also some clients
won't update and send another request to the server while you are in the
parameter group and hit ,. Now with this being explicit they will.

Just some examples. In VS Code before:
![2020-07-23 15 47 20](https://user-images.githubusercontent.com/13974112/88294483-92816580-ccfc-11ea-840b-d0faf96988f7.gif)

In VS Code after:
![2020-07-23 15 48 02](https://user-images.githubusercontent.com/13974112/88294512-a036eb00-ccfc-11ea-9dfc-5235f3dff841.gif)

In coc-metals before:
![2020-07-23 15 51 58](https://user-images.githubusercontent.com/13974112/88294536-adec7080-ccfc-11ea-9e2b-1d44cf93f1b8.gif)

In coc-metals after:
![2020-07-23 15 51 12](https://user-images.githubusercontent.com/13974112/88294578-b9d83280-ccfc-11ea-9651-14deea9ceac5.gif)

Closes https://github.com/scalameta/coc-metals/issues/264
