### PR TITLE
Fix duplicated code actions

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeAction.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.metals
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.pc.CancelToken
 
 import org.eclipse.{lsp4j => l}
@@ -20,4 +21,31 @@ trait CodeAction {
       token: CancelToken
   )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]]
 
+  implicit val actionDiagnosticOrdering: Ordering[l.CodeAction] =
+    new Ordering[l.CodeAction] {
+
+      override def compare(
+          x: l.CodeAction,
+          y: l.CodeAction
+      ): Int = {
+
+        (
+          x.getDiagnostics().asScala.headOption,
+          y.getDiagnostics().asScala.headOption
+        ) match {
+          case (Some(diagx), Some(diagy)) =>
+            val startx = diagx.getRange().getStart()
+            val starty = diagy.getRange().getStart()
+            val line = startx.getLine().compare(starty.getLine())
+            if (line == 0) {
+              startx.getCharacter().compare(starty.getCharacter())
+            } else {
+              line
+            }
+          case (Some(_), None) => 1
+          case (None, Some(_)) => -1
+          case _ => 0
+        }
+      }
+    }
 }

--- a/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -3,13 +3,14 @@ package tests.codeactions
 import scala.meta.internal.metals.MetalsEnrichments._
 
 import munit.Location
+import munit.TestOptions
 import tests.BaseLspSuite
 
 abstract class BaseCodeActionLspSuite(suiteName: String)
     extends BaseLspSuite(suiteName) {
 
   def check(
-      name: String,
+      name: TestOptions,
       input: String,
       expectedActions: String,
       expectedCode: String,

--- a/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
@@ -6,6 +6,7 @@ import scala.meta.internal.metals.codeactions.CreateNewSymbol
 import scala.meta.internal.metals.codeactions.ImportMissingSymbol
 
 import munit.Location
+import munit.TestOptions
 import org.eclipse.lsp4j.ShowMessageRequestParams
 
 class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
@@ -74,7 +75,7 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
   private def indent = "  "
 
   def checkNewSymbol(
-      name: String,
+      name: TestOptions,
       input: String,
       expectedActions: String,
       pickedKind: String,
@@ -115,7 +116,10 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
         _ = {
           val (path, content) = newFile
           val absolutePath = workspace.resolve(path)
-          assert(absolutePath.exists)
+          assert(
+            absolutePath.exists,
+            s"File $absolutePath should have been created"
+          )
           assertNoDiff(absolutePath.readText, content)
         }
       } yield ()

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -14,8 +14,8 @@ class ImportMissingSymbolLspSuite
        |  val f = <<Future>>.successful(2)
        |}
        |""".stripMargin,
-    s"""|${ImportMissingSymbol.title("Future", "scala.concurrent")}
-        |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
+    s"""|${ImportMissingSymbol.title("Future", "java.util.concurrent")}
+        |${ImportMissingSymbol.title("Future", "scala.concurrent")}
         |${CreateNewSymbol.title("Future")}
         |""".stripMargin,
     """|package a
@@ -25,7 +25,8 @@ class ImportMissingSymbolLspSuite
        |object A {
        |  val f = Future.successful(2)
        |}
-       |""".stripMargin
+       |""".stripMargin,
+    selectedActionIndex = 1
   )
 
   check(
@@ -36,8 +37,8 @@ class ImportMissingSymbolLspSuite
        |  val f = Fu<<tu>>re.successful(2)
        |}
        |""".stripMargin,
-    s"""|${ImportMissingSymbol.title("Future", "scala.concurrent")}
-        |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
+    s"""|${ImportMissingSymbol.title("Future", "java.util.concurrent")}
+        |${ImportMissingSymbol.title("Future", "scala.concurrent")}
         |${CreateNewSymbol.title("Future")}
         |""".stripMargin,
     """|package a
@@ -46,6 +47,30 @@ class ImportMissingSymbolLspSuite
        |
        |object A {
        |  val f = Future.successful(2)
+       |}
+       |""".stripMargin,
+    selectedActionIndex = 1
+  )
+
+  check(
+    "multiple-tries",
+    """|package a
+       |
+       |object A {
+       |  val f = <<Try{}
+       |  val g = Try{}>>
+       |}
+       |""".stripMargin,
+    s"""|${ImportMissingSymbol.title("Try", "scala.util")}
+        |${CreateNewSymbol.title("Try")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.util.Try
+       |
+       |object A {
+       |  val f = Try{}
+       |  val g = Try{}
        |}
        |""".stripMargin
   )
@@ -59,8 +84,9 @@ class ImportMissingSymbolLspSuite
        |  val b = ListBuffer.newBuilder[Int]
        |}
        |""".stripMargin,
-    s"""|${ImportMissingSymbol.title("Future", "scala.concurrent")}
+    s"""|
         |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
+        |${ImportMissingSymbol.title("Future", "scala.concurrent")}
         |${ImportMissingSymbol.title("Instant", "java.time")}
         |${CreateNewSymbol.title("Future")}
         |${CreateNewSymbol.title("Instant")}
@@ -74,7 +100,8 @@ class ImportMissingSymbolLspSuite
        |  val b = ListBuffer.newBuilder[Int]
        |}
        |""".stripMargin,
-    expectNoDiagnostics = false
+    expectNoDiagnostics = false,
+    selectedActionIndex = 1
   )
 
   check(
@@ -118,8 +145,8 @@ class ImportMissingSymbolLspSuite
        |}
        |""".stripMargin,
     s"""|${ImportMissingSymbol.allSymbolsTitle}
-        |${ImportMissingSymbol.title("Future", "scala.concurrent")}
         |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
+        |${ImportMissingSymbol.title("Future", "scala.concurrent")}
         |${ImportMissingSymbol.title("Instant", "java.time")}
         |${ImportMissingSymbol.title("ListBuffer", "scala.collection.mutable")}
         |${CreateNewSymbol.title("Future")}
@@ -150,17 +177,12 @@ class ImportMissingSymbolLspSuite
        |}
        |""".stripMargin,
     s"""|${ImportMissingSymbol.allSymbolsTitle}
-        |${ImportMissingSymbol.title("Future", "scala.concurrent")}
         |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
+        |${ImportMissingSymbol.title("Future", "scala.concurrent")}
         |${ImportMissingSymbol.title("Instant", "java.time")}
-        |${ImportMissingSymbol.title("ListBuffer", "scala.collection.mutable")}
-        |${ImportMissingSymbol.title("Future", "scala.concurrent")}
-        |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
         |${ImportMissingSymbol.title("ListBuffer", "scala.collection.mutable")}
         |${CreateNewSymbol.title("Future")}
         |${CreateNewSymbol.title("Instant")}
-        |${CreateNewSymbol.title("ListBuffer")}
-        |${CreateNewSymbol.title("Future")}
         |${CreateNewSymbol.title("ListBuffer")}
         |""".stripMargin,
     """|package a


### PR DESCRIPTION
Previously, when diagnostics were showing the same symbol code actions were duplicated. Now we make sure the for each unique symbol we have a single code action.

Fixes https://github.com/scalameta/metals/issues/1900