### PR TITLE
Fix `filterText` value for completion item in string interpolation

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
@@ -48,13 +48,12 @@ trait InterpolatorCompletions { this: MetalsGlobal =>
         .append('}')
         .toString
     }
-    val filter: String =
-      text.substring(ident.pos.start - 1, cursor.point - query.length)
+
     override def contribute: List[Member] = {
       metalsTypeMembers(ident.pos).collect {
         case m if CompletionFuzzy.matches(query, m.sym.name) =>
           val edit = new l.TextEdit(pos, newText(m.sym))
-          val filterText = filter + m.sym.name.decoded
+          val filterText = m.sym.getterName.decoded
           new TextEditMember(filterText, edit, m.sym)
       }
     }
@@ -127,15 +126,12 @@ trait InterpolatorCompletions { this: MetalsGlobal =>
       out.toString
     }
 
-    val filter: String =
-      text.substring(lit.pos.start, pos.point - interpolator.name.length)
-
     override def contribute: List[Member] = {
       metalsScopeMembers(pos).collect {
         case s: ScopeMember
             if CompletionFuzzy.matches(interpolator.name, s.sym.name) =>
           val edit = new l.TextEdit(nameRange, newText(s.sym))
-          val filterText = filter + s.sym.name.decoded
+          val filterText = s.sym.getterName.decoded
           new TextEditMember(
             filterText,
             edit,

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -21,7 +21,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |  def message = s"Hello $myName$0, you are welcome"
        |}
        |""".stripMargin,
-    filterText = "\"Hello $myName"
+    filterText = "myName"
   )
 
   checkEdit(
@@ -36,7 +36,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |  def message = s"$myName$0"
        |}
        |""".stripMargin,
-    filterText = "\"$myName"
+    filterText = "myName"
   )
 
   checkEdit(
@@ -51,7 +51,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |  def message = s"${myName$0}me"
        |}
        |""".stripMargin,
-    filterText = "\"$myName"
+    filterText = "myName"
   )
 
   checkEdit(
@@ -66,7 +66,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |  def message = s'''${myName$0}me'''
        |}
        |""".stripMargin.triplequoted,
-    filterText = "'''$myName".triplequoted
+    filterText = "myName"
   )
 
   checkEdit(
@@ -85,7 +85,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |    |'''.stripMargin
        |}
        |""".stripMargin.triplequoted,
-    filterText = "'''\n    |$myName".triplequoted
+    filterText = "myName".triplequoted
   )
 
   checkEdit(
@@ -100,7 +100,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |  s"$myName$0 $$"
        |}
        |""".stripMargin.triplequoted,
-    filterText = "\"$myName"
+    filterText = "myName"
   )
 
   checkEdit(
@@ -423,7 +423,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |""".stripMargin.triplequoted,
     """|member: String
        |""".stripMargin,
-    filterText = "$Main.member"
+    filterText = "member"
   )
 
   checkEditLine(
@@ -512,7 +512,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |  s"Hello ${`type`$0}"
        |}
        |""".stripMargin,
-    filterText = "\"Hello $type"
+    filterText = "type"
   )
 
   checkEdit(
@@ -527,6 +527,6 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |  s"Hello ${`hello world`$0}"
        |}
        |""".stripMargin,
-    filterText = "\"Hello $hello world"
+    filterText = "hello world"
   )
 }


### PR DESCRIPTION
Fixes #1703.

It seems, that this problem happened because of the `filterText` value in completion item that started with `$` or `${`.
For example:
```scala
// input
val fooBar = "test"
"${fooBa@@"

// returned completion item
CompletionList [
  isIncomplete = false
  items = SeqWrapper (
    CompletionItem [
      label = "fooBar"
      kind = Value
      tags = null
      detail = ": String"
      documentation = null
      deprecated = null
      preselect = true
      sortText = "00000"
      filterText = ""${fooBar " // should be "fooBar"
     ... 
```
