### PR TITLE
Enable BuildInfo for mtags3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -340,9 +340,6 @@ lazy val mtags3 = project
     unmanagedSourceDirectories.in(Compile) += baseDirectory
       .in(ThisBuild)
       .value / "mtags" / "src" / "main" / "scala",
-    managedSourceDirectories.in(Compile) += baseDirectory
-      .in(ThisBuild)
-      .value / "mtags" / "target" / ("scala-" + scalaVersion.value) / "src_managed" / "main",
     moduleName := "mtags3",
     scalaVersion := V.scala3,
     target := baseDirectory
@@ -352,6 +349,7 @@ lazy val mtags3 = project
   )
   .dependsOn(interfaces)
   .disablePlugins(ScalafixPlugin)
+  .enablePlugins(BuildInfoPlugin)
 
 lazy val mtags = project
   .settings(


### PR DESCRIPTION
I didn't realize this before I cleaned and then tried to compile again and then kept hitting on this:
```
[error] -- [E006] Not Found Error: /Users/ckipp/Documents/scala-workspace/scalameta-org/metals/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala:100:47
[error] 100 |      if (SemVer.isCompatibleVersion("0.25.0", BuildInfo.scalaCompilerVersion))
[error]     |                                               ^^^^^^^^^
[error]     |                                               Not found: BuildInfo
[error] one error found
```
We didn't have the `BuildInfo` plugin enabled for `mtag3` which is causing this to fail for someone if they do a fresh check and try to build or if you clean everything locally and try to build again since we are accessing `BuildInfo` here in `mtags3`.