### PR TITLE
Bump default mill version and also add it to BuildInfo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -216,6 +216,7 @@ lazy val V = new {
   val coursier = "2.0.0-RC6-23"
   val coursierInterfaces = "0.0.22"
   val ammonite = "2.1.4-11-307f3d8"
+  val mill = "0.8.0"
 }
 
 val genyVersion = Def.setting {
@@ -439,6 +440,7 @@ lazy val metals = project
       "semanticdbVersion" -> V.semanticdb,
       "scalafmtVersion" -> V.scalafmt,
       "ammoniteVersion" -> V.ammonite,
+      "millVersion" -> V.mill,
       "supportedScalaVersions" -> V.supportedScalaVersions,
       "supportedScala2Versions" -> V.scala2Versions,
       "supportedScala3Versions" -> V.scala3Versions,
@@ -574,9 +576,10 @@ lazy val unit = project
       "io.get-coursier" %% "coursier" % V.coursier, // for jars
       "ch.epfl.scala" %% "bloop-config" % V.bloop,
       "org.scalameta" %% "munit" % V.munit,
-      // Only here to have scala-steward update V.ammonite.
-      // Not actually used in tests.
-      "com.lihaoyi" %% "ammonite-util" % V.ammonite intransitive ()
+      // The dependencies listed below are only listed so Scala Steward
+      // will pick them up and update them. They aren't actually used.
+      "com.lihaoyi" %% "ammonite-util" % V.ammonite intransitive (),
+      "com.lihaoyi" % "mill-contrib-testng" % V.mill intransitive ()
     ),
     buildInfoPackage := "tests",
     resourceGenerators.in(Compile) += InputProperties.resourceGenerator(input),

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -4,6 +4,7 @@ import java.nio.file.Path
 
 import scala.util.Properties
 
+import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.io.AbsolutePath
 
@@ -57,7 +58,7 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
 
   override def recommendedVersion: String = version
 
-  override def version: String = "0.7.3"
+  override def version: String = BuildInfo.millVersion
 
   override def toString(): String = "Mill"
 


### PR DESCRIPTION
I know we talked about this before. It's maybe not the cleanest, but it will allow for Scalasteward to just pick these up in the future.