### PR TITLE
Swap ordering in CancelCompletionSuite test to fix flakiness.

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
@@ -91,12 +91,12 @@ class CancelCompletionSuite extends BaseCompletionSuite {
        |""".stripMargin,
     compat = Map(
       "0.25" ->
-        """|assert(assertion: Boolean @InlineParam): Unit
-           |assertFail(message: => Any): Nothing
-           |""".stripMargin,
-      "0.26" ->
         """|assertFail(message: => Any): Nothing
            |assert(assertion: Boolean @InlineParam): Unit
+           |""".stripMargin,
+      "0.26" ->
+        """|assert(assertion: Boolean @InlineParam): Unit
+           |assertFail(message: => Any): Nothing
            |""".stripMargin
     )
   )


### PR DESCRIPTION
So I believe this may have been an oversight when this was changed in https://github.com/scalameta/metals/commit/35af46a840e42c7d504259701e528f73c6787281#diff-56d26dd129140627b4c1c80ace3f1186, but when testing locally, this continually fails for me and this suite has also been somewhat consistently failing in tests. I'm not sure what's going on with the general flakiness of the suites, but this should at least help with this one as it seems the order needs to be swapped.