### PR TITLE
Analyze stacktrace

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -42,6 +42,11 @@ class ClientConfiguration(
       initialConfig.renameFileThreshold
     )
 
+  def isCommandInHtmlSupported(): Boolean =
+    extract(initializationOptions.isCommandInHtmlSupported,
+      experimentalCapabilities.isCommandInHtmlSupported,
+      initialConfig.isCommandInHtmlSupported)
+
   def icons(): Icons =
     initializationOptions.icons
       .map(Icons.fromString)

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -43,9 +43,11 @@ class ClientConfiguration(
     )
 
   def isCommandInHtmlSupported(): Boolean =
-    extract(initializationOptions.isCommandInHtmlSupported,
+    extract(
+      initializationOptions.isCommandInHtmlSupported,
       experimentalCapabilities.isCommandInHtmlSupported,
-      initialConfig.isCommandInHtmlSupported)
+      initialConfig.isCommandInHtmlSupported
+    )
 
   def icons(): Icons =
     initializationOptions.icons

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
@@ -79,7 +79,8 @@ object ClientExperimentalCapabilities {
       executeClientCommandProvider =
         jsonObj.getBooleanOption("executeClientCommandProvider"),
       inputBoxProvider = jsonObj.getBooleanOption("inputBoxProvider"),
-      isCommandInHtmlSupported = jsonObj.getBooleanOption("isCommandInHtmlSupported"),
+      isCommandInHtmlSupported =
+        jsonObj.getBooleanOption("isCommandInHtmlSupported"),
       openFilesOnRenameProvider =
         jsonObj.getBooleanOption("openFilesOnRenameProvider"),
       quickPickProvider = jsonObj.getBooleanOption("quickPickProvider"),

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
@@ -20,6 +20,7 @@ final case class ClientExperimentalCapabilities(
     doctorProvider: Option[String],
     executeClientCommandProvider: Option[Boolean],
     inputBoxProvider: Option[Boolean],
+    isCommandInHtmlSupported: Option[Boolean],
     openFilesOnRenameProvider: Option[Boolean],
     quickPickProvider: Option[Boolean],
     slowTaskProvider: Option[Boolean],
@@ -36,6 +37,7 @@ final case class ClientExperimentalCapabilities(
 object ClientExperimentalCapabilities {
   import scala.meta.internal.metals.JsonParser._
   val Default: ClientExperimentalCapabilities = ClientExperimentalCapabilities(
+    None,
     None,
     None,
     None,
@@ -77,6 +79,7 @@ object ClientExperimentalCapabilities {
       executeClientCommandProvider =
         jsonObj.getBooleanOption("executeClientCommandProvider"),
       inputBoxProvider = jsonObj.getBooleanOption("inputBoxProvider"),
+      isCommandInHtmlSupported = jsonObj.getBooleanOption("isCommandInHtmlSupported"),
       openFilesOnRenameProvider =
         jsonObj.getBooleanOption("openFilesOnRenameProvider"),
       quickPickProvider = jsonObj.getBooleanOption("quickPickProvider"),

--- a/metals/src/main/scala/scala/meta/internal/metals/CodeLensProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeLensProvider.scala
@@ -14,7 +14,7 @@ final class CodeLensProvider(
 ) {
   // code lenses will be refreshed after compilation or when workspace gets indexed
   def findLenses(path: AbsolutePath): Seq[l.CodeLens] = {
-    if (stacktraceAnalyzer.matches(path)) {
+    if (stacktraceAnalyzer.isStackTraceFile(path)) {
       stacktraceAnalyzer.stacktraceLenses(path)
     } else {
       semanticdbs

--- a/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
@@ -14,4 +14,8 @@ object Directories {
     RelativePath(".metals").resolve("pc.log")
   def workspaceSymbol: RelativePath =
     RelativePath(".metals").resolve("workspace-symbol.md")
+  def stacktrace: RelativePath =
+    RelativePath(".metals").resolve(stacktraceFilename)
+
+  val stacktraceFilename = "stacktrace.scala"
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -121,7 +121,8 @@ object InitializationOptions {
       inputBoxProvider = jsonObj.getBooleanOption("inputBoxProvider"),
       isExitOnShutdown = jsonObj.getBooleanOption("isExitOnShutdown"),
       isHttpEnabled = jsonObj.getBooleanOption("isHttpEnabled"),
-      isCommandInHtmlSupported = jsonObj.getBooleanOption("isCommandInHtmlSupported"),
+      isCommandInHtmlSupported =
+        jsonObj.getBooleanOption("isCommandInHtmlSupported"),
       openFilesOnRenameProvider =
         jsonObj.getBooleanOption("openFilesOnRenameProvider"),
       quickPickProvider = jsonObj.getBooleanOption("quickPickProvider"),

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -47,6 +47,7 @@ final case class InitializationOptions(
     inputBoxProvider: Option[Boolean],
     isExitOnShutdown: Option[Boolean],
     isHttpEnabled: Option[Boolean],
+    isCommandInHtmlSupported: Option[Boolean],
     openFilesOnRenameProvider: Option[Boolean],
     quickPickProvider: Option[Boolean],
     renameFileThreshold: Option[Int],
@@ -67,6 +68,7 @@ object InitializationOptions {
 
   val Default: InitializationOptions = InitializationOptions(
     CompilerInitializationOptions.default,
+    None,
     None,
     None,
     None,
@@ -119,6 +121,7 @@ object InitializationOptions {
       inputBoxProvider = jsonObj.getBooleanOption("inputBoxProvider"),
       isExitOnShutdown = jsonObj.getBooleanOption("isExitOnShutdown"),
       isHttpEnabled = jsonObj.getBooleanOption("isHttpEnabled"),
+      isCommandInHtmlSupported = jsonObj.getBooleanOption("isCommandInHtmlSupported"),
       openFilesOnRenameProvider =
         jsonObj.getBooleanOption("openFilesOnRenameProvider"),
       quickPickProvider = jsonObj.getBooleanOption("quickPickProvider"),

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -40,7 +40,6 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ammonite.Ammonite
 import scala.meta.internal.metals.codelenses.RunTestCodeLens
 import scala.meta.internal.metals.codelenses.SuperMethodCodeLens
-import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.metals.config.DoctorFormat
 import scala.meta.internal.metals.debug.DebugParametersJsonParsers
 import scala.meta.internal.metals.debug.DebugProvider

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -58,6 +58,10 @@ final case class MetalsServerConfig(
       "metals.http",
       default = false
     ),
+    isCommandInHtmlSupported: Boolean = MetalsServerConfig.binaryOption(
+      "metals.commands-in-html",
+      default = false
+    ),
     isInputBoxEnabled: Boolean = MetalsServerConfig.binaryOption(
       "metals.input-box",
       default = false
@@ -129,6 +133,7 @@ object MetalsServerConfig {
         base.copy(
           icons = Icons.vscode,
           globSyntax = GlobSyntaxConfig.vscode,
+          isCommandInHtmlSupported = true,
           compilers = base.compilers.copy(
             _parameterHintsCommand =
               Some("editor.action.triggerParameterHints"),

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -157,8 +157,14 @@ object ServerCommands {
   val AnalyzeStacktrace = new Command(
     "analyze-stacktrace",
     "Analyze stacktrace",
-    """|<TODO>
+    """|Converts provided stacktrace in the parameter to a format that contains links
+       |to locations of places where the exception was raised.
        |
+       |If the configuration parameter of the client (support-commands-in-html) is true
+       |then client is requested to display html with links
+       |already pointing to proper locations in user codebase.
+       |Otherwise client will display simple scala file
+       |but with code lenses that on action move user to proper location in codebase.
        |""".stripMargin,
     "[string], where the string is a stacktrace."
   )

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -157,18 +157,7 @@ object ServerCommands {
   val AnalyzeStacktrace = new Command(
     "analyze-stacktrace",
     "Analyze stacktrace",
-<<<<<<< HEAD
-    """|Converts provided stacktrace in parameter to a format that contains links to locations
-       |of places where exception was raised.
-       |
-       |Depending on a configuration parameter of a client(support-commands-in-html)
-       |if parametes is true then client is requested to display html with links
-       |already pointing to proper locations in user codebase.
-       |if parameter is false then client is requested to display simple scala file
-       |but with code lenses that on action move user to proper location in codebase.
-=======
     """|<TODO>
->>>>>>> Analyze stacktrace
        |
        |""".stripMargin,
     "[string], where the string is a stacktrace."

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -164,12 +164,12 @@ object ServerCommands {
        |then client is requested to display html with links
        |already pointing to proper locations in user codebase.
        |Otherwise client will display simple scala file
-       |but with code lenses that on action move user to proper location in codebase.
+       |but with code lenses that direct user to proper location in codebase.
        |""".stripMargin,
     "[string], where the string is a stacktrace."
   )
 
-  val GotoLocationForSymbol = new Command(
+  val GotoSymbol = new Command(
     "goto",
     "Goto location for symbol",
     """|Move the cursor to the definition of the argument symbol.
@@ -178,7 +178,7 @@ object ServerCommands {
     "[string], where the string is a SemanticDB symbol."
   )
 
-  val GotoLocationForPosition = new Command(
+  val GotoPosition = new Command(
     "goto-position",
     "Goto location for position",
     """|Move the cursor to the location provided in arguments.
@@ -353,8 +353,8 @@ object ServerCommands {
       CleanCompile,
       BspSwitch,
       StartDebugAdapter,
-      GotoLocationForSymbol,
-      GotoLocationForPosition,
+      GotoSymbol,
+      GotoPosition,
       NewScalaFile,
       NewScalaProject,
       GotoSuperMethod,

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -157,6 +157,7 @@ object ServerCommands {
   val AnalyzeStacktrace = new Command(
     "analyze-stacktrace",
     "Analyze stacktrace",
+<<<<<<< HEAD
     """|Converts provided stacktrace in parameter to a format that contains links to locations
        |of places where exception was raised.
        |
@@ -165,6 +166,9 @@ object ServerCommands {
        |already pointing to proper locations in user codebase.
        |if parameter is false then client is requested to display simple scala file
        |but with code lenses that on action move user to proper location in codebase.
+=======
+    """|<TODO>
+>>>>>>> Analyze stacktrace
        |
        |""".stripMargin,
     "[string], where the string is a stacktrace."

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -154,13 +154,32 @@ object ServerCommands {
        |""".stripMargin
   )
 
-  val GotoLocation = new Command(
+  val AnalyzeStacktrace = new Command(
+    "analyze-stacktrace",
+    "Analyze stacktrace",
+    """|<TODO>
+       |
+       |""".stripMargin,
+    "[string], where the string is a stacktrace."
+  )
+
+  val GotoLocationForSymbol = new Command(
     "goto",
-    "Goto location",
+    "Goto location for symbol",
     """|Move the cursor to the definition of the argument symbol.
        |
        |""".stripMargin,
     "[string], where the string is a SemanticDB symbol."
+  )
+
+  val GotoLocationForPosition = new Command(
+    "goto-position",
+    "Goto location for position",
+    """|Move the cursor to the location provided in arguments.
+       |It simply forwards request to client.
+       |
+       |""".stripMargin,
+    "[location], where the location is a lsp location object."
   )
 
   val GotoSuperMethod = new Command(
@@ -328,10 +347,12 @@ object ServerCommands {
       CleanCompile,
       BspSwitch,
       StartDebugAdapter,
-      GotoLocation,
+      GotoLocationForSymbol,
+      GotoLocationForPosition,
       NewScalaFile,
       NewScalaProject,
       GotoSuperMethod,
+      AnalyzeStacktrace,
       SuperMethodHierarchy,
       ResetChoicePopup,
       StartAmmoniteBuildServer,

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -157,7 +157,14 @@ object ServerCommands {
   val AnalyzeStacktrace = new Command(
     "analyze-stacktrace",
     "Analyze stacktrace",
-    """|<TODO>
+    """|Converts provided stacktrace in parameter to a format that contains links to locations
+       |of places where exception was raised.
+       |
+       |Depending on a configuration parameter of a client(support-commands-in-html)
+       |if parametes is true then client is requested to display html with links
+       |already pointing to proper locations in user codebase.
+       |if parameter is false then client is requested to display simple scala file
+       |but with code lenses that on action move user to proper location in codebase.
        |
        |""".stripMargin,
     "[string], where the string is a stacktrace."

--- a/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
@@ -1,20 +1,24 @@
 package scala.meta.internal.metals
 
+import java.io.FileWriter
+import java.net.URLEncoder
+import java.util.Collections.singletonList
+
+import scala.io.Source
+import scala.util.Try
+
 import scala.meta.internal.metals.MetalsEnrichments._
-import org.eclipse.{lsp4j => l}
+import scala.meta.io.AbsolutePath
+
 import com.google.gson.JsonPrimitive
 import org.eclipse.lsp4j.Location
-import scala.meta.io.AbsolutePath
-import java.io.FileWriter
-import scala.io.Source
-
-import java.util.Collections.singletonList
-import scala.util.Try
+import org.eclipse.{lsp4j => l}
 
 class StacktraceAnalyzer(
     workspace: AbsolutePath,
     definitionProvider: DefinitionProvider,
-    gotoicon: String
+    gotoicon: String,
+    commandsInHtmlSupported: Boolean
 ) {
 
   def analyzeCommand(
@@ -63,32 +67,26 @@ class StacktraceAnalyzer(
       path: AbsolutePath,
       position: l.Position
   ): java.util.List[Location] = {
-    val lineOpt = readStacktraceFileLine(path, position.getLine())
+    val lineOpt = readStacktraceFileLine(path, position.getLine)
     lineOpt match {
       case Some(line) =>
-        val symbol = getSymbolFromLine(line)
-        val lineNumber = tryGetLineNumberFromStacktrace(line)
-        val result = definitionProvider.fromSymbol(convert(symbol))
-        result.forEach { r =>
-          lineNumber.foreach { ln =>
-            adjustPosition(ln, r.getRange().getStart())
-            adjustPosition(ln, r.getRange().getEnd())
-          }
-        }
-        result
+        getSymbolLocationFromLine(line).toList.asJava
       case None =>
         java.util.Collections.emptyList()
     }
   }
 
   private def adjustPosition(lineNumber: Int, pos: l.Position): Unit = {
-    pos.setLine(lineNumber - 1)
+    pos.setLine(lineNumber)
     pos.setCharacter(0)
   }
 
   private def tryGetLineNumberFromStacktrace(line: String): Try[Int] = {
     Try(
-      Integer.valueOf(line.substring(line.indexOf(":") + 1, line.indexOf(")")))
+      // number is 1-based, but editors are 0-based
+      Integer.valueOf(
+        line.substring(line.indexOf(":") + 1, line.indexOf(")"))
+      ) - 1
     )
   }
 
@@ -100,22 +98,11 @@ class StacktraceAnalyzer(
     scope.mkString("/") ++ "." ++ method ++ "()."
   }
 
-  private def getSymbolFromLine(line: String): String = {
-    line.substring(line.indexOf("at ") + 3, line.indexOf("("))
-  }
-
   def stacktraceLenses(content: List[String]): Seq[l.CodeLens] = {
     (for {
       (line, row) <- content.zipWithIndex
       if line.trim.startsWith("at ")
-      symbol = getSymbolFromLine(line)
-      location <-
-        definitionProvider.fromSymbol(convert(symbol)).asScala.headOption
-      lineNumber = tryGetLineNumberFromStacktrace(line)
-      _ = lineNumber.foreach { ln =>
-        adjustPosition(ln, location.getRange().getStart())
-        adjustPosition(ln, location.getRange().getEnd())
-      }
+      location <- getSymbolLocationFromLine(line)
       range = new l.Range(new l.Position(row, 0), new l.Position(row, 0))
     } yield makeGotoLocationCodeLens(location, range)).toSeq
   }
@@ -138,26 +125,92 @@ class StacktraceAnalyzer(
   private def analyzeStackTrace(
       stacktrace: String
   ): Option[l.ExecuteCommandParams] = {
-    val path = workspace.resolve(Directories.stacktrace)
-    val pathStr = path.toFile.toString
+    if (commandsInHtmlSupported) {
+      Some(makeHtmlCommandParams(stacktrace))
+    } else {
+      val path = workspace.resolve(Directories.stacktrace)
+      val pathStr = path.toFile.toString
 
-    path.toFile.createNewFile()
-    val fw = new FileWriter(pathStr)
-    try {
-      fw.write(stacktrace)
-    } finally {
-      fw.close()
+      path.toFile.createNewFile()
+      val fw = new FileWriter(pathStr)
+      try {
+        fw.write(stacktrace)
+      } finally {
+        fw.close()
+      }
+      val pos = new l.Position(0, 0)
+      val range = new l.Range(pos, pos)
+      val location = new l.Location(pathStr, range)
+      Some(makeGotoCommandParams(location))
     }
-    val pos = new l.Position(0, 0)
-    val range = new l.Range(pos, pos)
-    Some(makeCommandParams(new Location(pathStr, range)))
   }
 
-  private def makeCommandParams(location: Location): l.ExecuteCommandParams = {
+  private def makeGotoCommandParams(
+      location: Location
+  ): l.ExecuteCommandParams = {
     new l.ExecuteCommandParams(
       ClientCommands.GotoLocation.id,
       List[Object](location, java.lang.Boolean.TRUE).asJava
     )
+  }
+
+  private def getSymbolLocationFromLine(line: String): Option[l.Location] = {
+    val symbol = getSymbolFromLine(line)
+    definitionProvider.fromSymbol(convert(symbol)).asScala.headOption.map {
+      location =>
+        val lineNumberOpt = tryGetLineNumberFromStacktrace(line)
+        lineNumberOpt.foreach { lineNumber =>
+          adjustPosition(lineNumber, location.getRange().getStart())
+          adjustPosition(lineNumber, location.getRange().getEnd())
+        }
+        location
+    }
+  }
+
+  private def getSymbolFromLine(line: String): String = {
+    line.substring(line.indexOf("at ") + 3, line.indexOf("("))
+  }
+
+  private def makeHtmlCommandParams(
+      stacktrace: String
+  ): l.ExecuteCommandParams = {
+    def htmlStack(builder: HtmlBuilder): Unit = {
+      for (line <- stacktrace.split('\n')) {
+        if (line.contains("at ")) {
+          getSymbolLocationFromLine(line) match {
+            case Some(location) =>
+              builder
+                .text("at ")
+                .link(
+                  gotoLocationUsingUri(
+                    location.getUri,
+                    location.getRange.getStart.getLine
+                  ),
+                  line.substring(line.indexOf("at ") + 3)
+                )
+            case None =>
+              builder.raw(line)
+          }
+        } else {
+          builder.raw(line)
+        }
+        builder.raw("<br>")
+      }
+    }
+
+    val output = new HtmlBuilder()
+      .element("h3")(_.text(s"Stacktrace"))
+      .call(htmlStack)
+      .render
+    new l.ExecuteCommandParams(
+      "metals-show-stacktrace",
+      List[Object](output).asJava
+    )
+  }
+
+  private def gotoLocationUsingUri(uri: String, line: Int): String = {
+    val param = s"""["${uri}",${line},true]"""
+    s"command:metals.goto-path-uri?${URLEncoder.encode(param)}"
   }
 
   private def parseJsonParams(

--- a/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
@@ -1,0 +1,174 @@
+package scala.meta.internal.metals
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import org.eclipse.{lsp4j => l}
+import com.google.gson.JsonPrimitive
+import org.eclipse.lsp4j.Location
+import scala.meta.io.AbsolutePath
+import java.io.FileWriter
+import scala.io.Source
+
+import java.util.Collections.singletonList
+import scala.util.Try
+
+class StacktraceAnalyzer(
+    workspace: AbsolutePath,
+    definitionProvider: DefinitionProvider,
+    gotoicon: String
+) {
+
+  def analyzeCommand(
+      commandParams: l.ExecuteCommandParams
+  ): Option[l.ExecuteCommandParams] = {
+    parseJsonParams(commandParams)
+      .flatMap(analyzeStackTrace)
+  }
+
+  def matches(path: AbsolutePath): Boolean =
+    path == workspace.resolve(Directories.stacktrace)
+
+  def highlight(
+      path: AbsolutePath,
+      lineNumber: Int
+  ): java.util.List[l.DocumentHighlight] = {
+    val lineOpt = readStacktraceFileLine(path, lineNumber)
+    lineOpt match {
+      case Some(line) =>
+        val from = new l.Position(lineNumber, line.indexOf("at ") + 3)
+        val to = new l.Position(lineNumber, line.indexOf("("))
+        val range = new l.Range(from, to)
+        singletonList(
+          new l.DocumentHighlight(range, l.DocumentHighlightKind.Read)
+        )
+      case None =>
+        java.util.Collections.emptyList()
+    }
+  }
+
+  def stacktraceLenses(path: AbsolutePath): Seq[l.CodeLens] = {
+    stacktraceLenses(readStacktraceFile(path))
+  }
+
+  private def readStacktraceFileLine(
+      path: AbsolutePath,
+      lineNumber: Int
+  ): Option[String] =
+    readStacktraceFile(path).drop(lineNumber).headOption
+
+  private def readStacktraceFile(path: AbsolutePath): List[String] = {
+    Source.fromFile(path.toString).getLines().toList
+  }
+
+  def definition(
+      path: AbsolutePath,
+      position: l.Position
+  ): java.util.List[Location] = {
+    val lineOpt = readStacktraceFileLine(path, position.getLine())
+    lineOpt match {
+      case Some(line) =>
+        val symbol = getSymbolFromLine(line)
+        val lineNumber = tryGetLineNumberFromStacktrace(line)
+        val result = definitionProvider.fromSymbol(convert(symbol))
+        result.forEach { r =>
+          lineNumber.foreach { ln =>
+            adjustPosition(ln, r.getRange().getStart())
+            adjustPosition(ln, r.getRange().getEnd())
+          }
+        }
+        result
+      case None =>
+        java.util.Collections.emptyList()
+    }
+  }
+
+  private def adjustPosition(lineNumber: Int, pos: l.Position): Unit = {
+    pos.setLine(lineNumber - 1)
+    pos.setCharacter(0)
+  }
+
+  private def tryGetLineNumberFromStacktrace(line: String): Try[Int] = {
+    Try(
+      Integer.valueOf(line.substring(line.indexOf(":") + 1, line.indexOf(")")))
+    )
+  }
+
+  private def convert(symbol: String): String = {
+    val components =
+      symbol.split('.').map(_.replace("$", "").replace("<init>", "init")).toList
+    val scope = components.dropRight(1)
+    val method = components.last
+    scope.mkString("/") ++ "." ++ method ++ "()."
+  }
+
+  private def getSymbolFromLine(line: String): String = {
+    line.substring(line.indexOf("at ") + 3, line.indexOf("("))
+  }
+
+  def stacktraceLenses(content: List[String]): Seq[l.CodeLens] = {
+    (for {
+      (line, row) <- content.zipWithIndex
+      if line.trim.startsWith("at ")
+      symbol = getSymbolFromLine(line)
+      location <-
+        definitionProvider.fromSymbol(convert(symbol)).asScala.headOption
+      lineNumber = tryGetLineNumberFromStacktrace(line)
+      _ = lineNumber.foreach { ln =>
+        adjustPosition(ln, location.getRange().getStart())
+        adjustPosition(ln, location.getRange().getEnd())
+      }
+      range = new l.Range(new l.Position(row, 0), new l.Position(row, 0))
+    } yield makeGotoLocationCodeLens(location, range)).toSeq
+  }
+
+  private def makeGotoLocationCodeLens(
+      location: l.Location,
+      range: l.Range
+  ): l.CodeLens = {
+    new l.CodeLens(
+      range,
+      new l.Command(
+        s"$gotoicon open",
+        ServerCommands.GotoLocationForPosition.id,
+        List[Object](location: Object, java.lang.Boolean.TRUE).asJava
+      ),
+      null
+    )
+  }
+
+  private def analyzeStackTrace(
+      stacktrace: String
+  ): Option[l.ExecuteCommandParams] = {
+    val path = workspace.resolve(Directories.stacktrace)
+    val pathStr = path.toFile.toString
+
+    path.toFile.createNewFile()
+    val fw = new FileWriter(pathStr)
+    try {
+      fw.write(stacktrace)
+    } finally {
+      fw.close()
+    }
+    val pos = new l.Position(0, 0)
+    val range = new l.Range(pos, pos)
+    Some(makeCommandParams(new Location(pathStr, range)))
+  }
+
+  private def makeCommandParams(location: Location): l.ExecuteCommandParams = {
+    new l.ExecuteCommandParams(
+      ClientCommands.GotoLocation.id,
+      List[Object](location, java.lang.Boolean.TRUE).asJava
+    )
+  }
+
+  private def parseJsonParams(
+      commandParams: l.ExecuteCommandParams
+  ): Option[String] = {
+    for {
+      args <- Option(commandParams.getArguments)
+      argObject <- args.asScala.headOption
+      arg = argObject.asInstanceOf[JsonPrimitive]
+      if arg.isString()
+      stacktrace = arg.getAsString()
+    } yield stacktrace
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
@@ -13,12 +13,21 @@ import scala.meta.io.AbsolutePath
 import com.google.gson.JsonPrimitive
 import org.eclipse.lsp4j.Location
 import org.eclipse.{lsp4j => l}
+import scala.meta.internal.metals.MetalsEnrichments._
+import org.eclipse.{lsp4j => l}
+import com.google.gson.JsonPrimitive
+import org.eclipse.lsp4j.Location
+import scala.meta.io.AbsolutePath
+import java.io.FileWriter
+import scala.io.Source
+
+import java.util.Collections.singletonList
+import scala.util.Try
 
 class StacktraceAnalyzer(
     workspace: AbsolutePath,
     definitionProvider: DefinitionProvider,
-    gotoicon: String,
-    commandsInHtmlSupported: Boolean
+    gotoicon: String
 ) {
 
   def analyzeCommand(
@@ -67,26 +76,32 @@ class StacktraceAnalyzer(
       path: AbsolutePath,
       position: l.Position
   ): java.util.List[Location] = {
-    val lineOpt = readStacktraceFileLine(path, position.getLine)
+    val lineOpt = readStacktraceFileLine(path, position.getLine())
     lineOpt match {
       case Some(line) =>
-        getSymbolLocationFromLine(line).toList.asJava
+        val symbol = getSymbolFromLine(line)
+        val lineNumber = tryGetLineNumberFromStacktrace(line)
+        val result = definitionProvider.fromSymbol(convert(symbol))
+        result.forEach { r =>
+          lineNumber.foreach { ln =>
+            adjustPosition(ln, r.getRange().getStart())
+            adjustPosition(ln, r.getRange().getEnd())
+          }
+        }
+        result
       case None =>
         java.util.Collections.emptyList()
     }
   }
 
   private def adjustPosition(lineNumber: Int, pos: l.Position): Unit = {
-    pos.setLine(lineNumber)
+    pos.setLine(lineNumber - 1)
     pos.setCharacter(0)
   }
 
   private def tryGetLineNumberFromStacktrace(line: String): Try[Int] = {
     Try(
-      // number is 1-based, but editors are 0-based
-      Integer.valueOf(
-        line.substring(line.indexOf(":") + 1, line.indexOf(")"))
-      ) - 1
+      Integer.valueOf(line.substring(line.indexOf(":") + 1, line.indexOf(")")))
     )
   }
 
@@ -98,11 +113,22 @@ class StacktraceAnalyzer(
     scope.mkString("/") ++ "." ++ method ++ "()."
   }
 
+  private def getSymbolFromLine(line: String): String = {
+    line.substring(line.indexOf("at ") + 3, line.indexOf("("))
+  }
+
   def stacktraceLenses(content: List[String]): Seq[l.CodeLens] = {
     (for {
       (line, row) <- content.zipWithIndex
       if line.trim.startsWith("at ")
-      location <- getSymbolLocationFromLine(line)
+      symbol = getSymbolFromLine(line)
+      location <-
+        definitionProvider.fromSymbol(convert(symbol)).asScala.headOption
+      lineNumber = tryGetLineNumberFromStacktrace(line)
+      _ = lineNumber.foreach { ln =>
+        adjustPosition(ln, location.getRange().getStart())
+        adjustPosition(ln, location.getRange().getEnd())
+      }
       range = new l.Range(new l.Position(row, 0), new l.Position(row, 0))
     } yield makeGotoLocationCodeLens(location, range)).toSeq
   }
@@ -125,92 +151,26 @@ class StacktraceAnalyzer(
   private def analyzeStackTrace(
       stacktrace: String
   ): Option[l.ExecuteCommandParams] = {
-    if (commandsInHtmlSupported) {
-      Some(makeHtmlCommandParams(stacktrace))
-    } else {
-      val path = workspace.resolve(Directories.stacktrace)
-      val pathStr = path.toFile.toString
+    val path = workspace.resolve(Directories.stacktrace)
+    val pathStr = path.toFile.toString
 
-      path.toFile.createNewFile()
-      val fw = new FileWriter(pathStr)
-      try {
-        fw.write(stacktrace)
-      } finally {
-        fw.close()
-      }
-      val pos = new l.Position(0, 0)
-      val range = new l.Range(pos, pos)
-      val location = new l.Location(pathStr, range)
-      Some(makeGotoCommandParams(location))
+    path.toFile.createNewFile()
+    val fw = new FileWriter(pathStr)
+    try {
+      fw.write(stacktrace)
+    } finally {
+      fw.close()
     }
+    val pos = new l.Position(0, 0)
+    val range = new l.Range(pos, pos)
+    Some(makeCommandParams(new Location(pathStr, range)))
   }
 
-  private def makeGotoCommandParams(
-      location: Location
-  ): l.ExecuteCommandParams = {
+  private def makeCommandParams(location: Location): l.ExecuteCommandParams = {
     new l.ExecuteCommandParams(
       ClientCommands.GotoLocation.id,
       List[Object](location, java.lang.Boolean.TRUE).asJava
     )
-  }
-
-  private def getSymbolLocationFromLine(line: String): Option[l.Location] = {
-    val symbol = getSymbolFromLine(line)
-    definitionProvider.fromSymbol(convert(symbol)).asScala.headOption.map {
-      location =>
-        val lineNumberOpt = tryGetLineNumberFromStacktrace(line)
-        lineNumberOpt.foreach { lineNumber =>
-          adjustPosition(lineNumber, location.getRange().getStart())
-          adjustPosition(lineNumber, location.getRange().getEnd())
-        }
-        location
-    }
-  }
-
-  private def getSymbolFromLine(line: String): String = {
-    line.substring(line.indexOf("at ") + 3, line.indexOf("("))
-  }
-
-  private def makeHtmlCommandParams(
-      stacktrace: String
-  ): l.ExecuteCommandParams = {
-    def htmlStack(builder: HtmlBuilder): Unit = {
-      for (line <- stacktrace.split('\n')) {
-        if (line.contains("at ")) {
-          getSymbolLocationFromLine(line) match {
-            case Some(location) =>
-              builder
-                .text("at ")
-                .link(
-                  gotoLocationUsingUri(
-                    location.getUri,
-                    location.getRange.getStart.getLine
-                  ),
-                  line.substring(line.indexOf("at ") + 3)
-                )
-            case None =>
-              builder.raw(line)
-          }
-        } else {
-          builder.raw(line)
-        }
-        builder.raw("<br>")
-      }
-    }
-
-    val output = new HtmlBuilder()
-      .element("h3")(_.text(s"Stacktrace"))
-      .call(htmlStack)
-      .render
-    new l.ExecuteCommandParams(
-      "metals-show-stacktrace",
-      List[Object](output).asJava
-    )
-  }
-
-  private def gotoLocationUsingUri(uri: String, line: Int): String = {
-    val param = s"""["${uri}",${line},true]"""
-    s"command:metals.goto-path-uri?${URLEncoder.encode(param)}"
   }
 
   private def parseJsonParams(

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -50,7 +50,7 @@ class StandaloneSymbolSearch(
       .orElse(workspaceFallback.flatMap(_.documentation(symbol).asScala))
       .asJava
 
-  def definition(x: String): ju.List[Location] = {
+  override def definition(x: String): ju.List[Location] = {
     destinationProvider
       .fromSymbol(x)
       .flatMap(_.toResult)

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
@@ -87,7 +87,7 @@ final class SuperMethodCodeLens(
   ): l.Command = {
     new l.Command(
       s"${clientConfig.icons.findsuper} ${name}",
-      ServerCommands.GotoLocation.id,
+      ServerCommands.GotoLocationForSymbol.id,
       singletonList(symbol)
     )
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
@@ -87,7 +87,7 @@ final class SuperMethodCodeLens(
   ): l.Command = {
     new l.Command(
       s"${clientConfig.icons.findsuper} ${name}",
-      ServerCommands.GotoLocationForSymbol.id,
+      ServerCommands.GotoSymbol.id,
       singletonList(symbol)
     )
   }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -555,6 +555,10 @@ final class TestingServer(
       .asScala
   }
 
+  def analyzeStacktrace(stacktrace: String): Seq[l.CodeLens] = {
+    server.stacktraceAnalyzer.stacktraceLenses(stacktrace.split('\n').toList)
+  }
+
   def didOpen(filename: String): Future[Unit] = {
     Debug.printEnclosing()
     val abspath = toPath(filename)

--- a/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
@@ -1,7 +1,8 @@
 package tests
 
-import org.eclipse.{lsp4j => l}
 import scala.collection.mutable
+
+import org.eclipse.{lsp4j => l}
 
 class AnalyzeStacktraceLspSuite extends BaseLspSuite("analyzestacktrace") {
 

--- a/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
@@ -1,0 +1,93 @@
+package tests
+
+import org.eclipse.{lsp4j => l}
+import scala.collection.mutable
+
+class AnalyzeStacktraceLspSuite extends BaseLspSuite("analyzestacktrace") {
+
+  test("simple") {
+    val code =
+      """|package a.b
+         |
+         |object Main {
+         |<<5>>  def main(args: Array[String]): Unit = {
+         |<<4>>    new ClassError().raise
+         |  }
+         |}
+         |
+         |
+         |class ClassError {
+         |  def raise: ClassConstrError = {
+         |<<3>>    ObjectError.raise
+         |  }
+         |}
+         |
+         |object ObjectError {
+         |  def raise: ClassConstrError = {
+         |<<2>>    new ClassConstrError()
+         |  }
+         |}
+         |
+         |class ClassConstrError {
+         |  val a = 3
+         |<<1>>  throw new Exception("error")
+         |  val b = 4
+         |}
+         |
+         |""".stripMargin
+
+    // code above is executed in REPL and resulted stacktrace is printed here:
+    val stacktrace = """|Exception in thread "main" java.lang.Exception: error
+                        |	at a.b.ClassConstrError.<init>(Main.scala:24)
+                        |	at a.b.ObjectError$.raise(Main.scala:18)
+                        |	at a.b.ClassError.raise(Main.scala:12)
+                        |	at a.b.Main$.main(Main.scala:5)
+                        |	at a.b.Main.main(Main.scala)
+                        |""".stripMargin
+
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{"a":{}}
+           |/a/src/main/scala/a/Main.scala
+           |${prepare(code)}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      lenses = server.analyzeStacktrace(stacktrace)
+      output =
+        lenses
+          .map(cl =>
+            cl.getRange.getStart.getLine -> cl
+              .getCommand()
+              .getArguments()
+              .get(0)
+              .asInstanceOf[l.Location]
+              .getRange
+              .getStart
+              .getLine
+          )
+          .toMap
+      _ = assertEquals(output, getExpected(code))
+    } yield ()
+  }
+
+  private def getExpected(code: String): Map[Int, Int] = {
+    val result: mutable.Buffer[(Int, Int)] = mutable.Buffer()
+    for ((line, idx) <- code.split('\n').zipWithIndex) {
+      if (line.contains("<<") && line.contains(">>")) {
+        val marker = Integer.valueOf(
+          line.substring(line.indexOf("<<") + 2, line.indexOf(">>"))
+        )
+        result += ((marker, idx))
+      }
+    }
+    result.toList.toMap
+  }
+
+  private def prepare(code: String): String = {
+    code.replaceAll("<<.*>>", "")
+  }
+}

--- a/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
@@ -11,7 +11,7 @@ class AnalyzeStacktraceLspSuite extends BaseLspSuite("analyzestacktrace") {
       """|package a.b
          |
          |object Main {
-         |<<5>>  def main(args: Array[String]): Unit = {
+         |  def main(args: Array[String]): Unit = {
          |<<4>>    new ClassError().raise
          |  }
          |}

--- a/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
@@ -1,8 +1,7 @@
 package tests
 
-import scala.collection.mutable
-
 import org.eclipse.{lsp4j => l}
+import scala.collection.mutable
 
 class AnalyzeStacktraceLspSuite extends BaseLspSuite("analyzestacktrace") {
 

--- a/tests/unit/src/test/scala/tests/StacktraceParseSuite.scala
+++ b/tests/unit/src/test/scala/tests/StacktraceParseSuite.scala
@@ -1,0 +1,62 @@
+package tests
+
+import scala.meta.internal.metals.StacktraceAnalyzer
+
+class StacktraceParseSuite extends BaseSuite {
+
+  test("convert-stacktrace-line-to-symbol") {
+
+    // --- CLASS ---
+    testConversion("p1.p2.Class.method", "p1/p2/Class#")
+    testConversion(
+      "p1.p2.OutsideClass$InsideClass.method",
+      List("p1/p2/OutsideClass#", "p1/p2/OutsideClass#InsideClass#")
+    )
+
+    // --- TRAIT ---
+    // For trait both lines are present with the same line
+    testConversion("p1.p2.Trait.method$", "p1/p2/Trait#")
+    testConversion("p1.p2.Trait.method", "p1/p2/Trait#")
+    // <package> -> <package> -> <trait> -> <trait> -> <method>
+    testConversion(
+      "p1.p2.OutsideTrait$InsideTrait.method$",
+      List("p1/p2/OutsideTrait#", "p1/p2/OutsideTrait#InsideTrait#")
+    )
+    testConversion(
+      "p1.p2.OutsideTrait$InsideTrait.method",
+      List("p1/p2/OutsideTrait#", "p1/p2/OutsideTrait#InsideTrait#")
+    )
+
+    // --- OBJECT ---
+    testConversion("p1.p2.Object$.method", "p1/p2/Object.")
+    testConversion(
+      "p1.p2.ObjectParent$ObjectException$.method",
+      List("p1/p2/ObjectParent.", "p1/p2/ObjectParent.ObjectException.")
+    )
+
+    // exception in template body
+    testConversion("p1.p2.ConstructorClass.<init>", "p1/p2/ConstructorClass#")
+    testConversion(
+      "p1.p2.ConstructorObject$.<init>",
+      "p1/p2/ConstructorObject."
+    )
+
+    // exception inside anonymous block
+    testConversion("p1.p2.Object$.$anonfun$method$1", "p1/p2/Object.")
+    testConversion("p1.p2.Class.$anonfun$method$1", "p1/p2/Class#")
+
+    // specialized method
+    testConversion("p1.p2.Object$.foreach$mVc$sp", "p1/p2/Object.")
+    testConversion("p1.p2.Class.foreach$mVc$sp", "p1/p2/Class#")
+  }
+
+  def testConversion(line: String, expected: String): Unit = {
+    val obtained = StacktraceAnalyzer.convert(line)
+    assert(clue(obtained).contains(clue(expected)))
+  }
+
+  def testConversion(line: String, expectedOneOf: List[String]): Unit = {
+    val obtained = StacktraceAnalyzer.convert(line)
+    assert(clue(expectedOneOf).diff(clue(obtained)).nonEmpty)
+  }
+}

--- a/tests/unit/src/test/scala/tests/StacktraceParseSuite.scala
+++ b/tests/unit/src/test/scala/tests/StacktraceParseSuite.scala
@@ -4,59 +4,54 @@ import scala.meta.internal.metals.StacktraceAnalyzer
 
 class StacktraceParseSuite extends BaseSuite {
 
-  test("convert-stacktrace-line-to-symbol") {
+  // --- CLASS ---
+  testConversion("p1.p2.Class.method", "p1/p2/Class#")
+  testConversion(
+    "p1.p2.OutsideClass$InsideClass.method",
+    "p1/p2/OutsideClass#"
+  )
 
-    // --- CLASS ---
-    testConversion("p1.p2.Class.method", "p1/p2/Class#")
-    testConversion(
-      "p1.p2.OutsideClass$InsideClass.method",
-      List("p1/p2/OutsideClass#", "p1/p2/OutsideClass#InsideClass#")
-    )
+  // --- TRAIT ---
+  // For trait both lines are present with the same line
+  testConversion("p1.p2.Trait.method$", "p1/p2/Trait#")
+  testConversion("p1.p2.Trait.method", "p1/p2/Trait#")
+  // <package> -> <package> -> <trait> -> <trait> -> <method>
+  testConversion(
+    "p1.p2.OutsideTrait$InsideTrait.method$",
+    "p1/p2/OutsideTrait#"
+  )
+  testConversion(
+    "p1.p2.OutsideTrait$InsideTrait.method",
+    "p1/p2/OutsideTrait#"
+  )
 
-    // --- TRAIT ---
-    // For trait both lines are present with the same line
-    testConversion("p1.p2.Trait.method$", "p1/p2/Trait#")
-    testConversion("p1.p2.Trait.method", "p1/p2/Trait#")
-    // <package> -> <package> -> <trait> -> <trait> -> <method>
-    testConversion(
-      "p1.p2.OutsideTrait$InsideTrait.method$",
-      List("p1/p2/OutsideTrait#", "p1/p2/OutsideTrait#InsideTrait#")
-    )
-    testConversion(
-      "p1.p2.OutsideTrait$InsideTrait.method",
-      List("p1/p2/OutsideTrait#", "p1/p2/OutsideTrait#InsideTrait#")
-    )
+  // --- OBJECT ---
+  testConversion("p1.p2.Object$.method", "p1/p2/Object.")
+  testConversion(
+    "p1.p2.ObjectParent$ObjectException$.method",
+    "p1/p2/ObjectParent."
+  )
 
-    // --- OBJECT ---
-    testConversion("p1.p2.Object$.method", "p1/p2/Object.")
-    testConversion(
-      "p1.p2.ObjectParent$ObjectException$.method",
-      List("p1/p2/ObjectParent.", "p1/p2/ObjectParent.ObjectException.")
-    )
+  // exception in template body
+  testConversion("p1.p2.ConstructorClass.<init>", "p1/p2/ConstructorClass#")
+  testConversion(
+    "p1.p2.ConstructorObject$.<init>",
+    "p1/p2/ConstructorObject."
+  )
 
-    // exception in template body
-    testConversion("p1.p2.ConstructorClass.<init>", "p1/p2/ConstructorClass#")
-    testConversion(
-      "p1.p2.ConstructorObject$.<init>",
-      "p1/p2/ConstructorObject."
-    )
+  // exception inside anonymous block
+  testConversion("p1.p2.Object$.$anonfun$method$1", "p1/p2/Object.")
+  testConversion("p1.p2.Class.$anonfun$method$1", "p1/p2/Class#")
 
-    // exception inside anonymous block
-    testConversion("p1.p2.Object$.$anonfun$method$1", "p1/p2/Object.")
-    testConversion("p1.p2.Class.$anonfun$method$1", "p1/p2/Class#")
-
-    // specialized method
-    testConversion("p1.p2.Object$.foreach$mVc$sp", "p1/p2/Object.")
-    testConversion("p1.p2.Class.foreach$mVc$sp", "p1/p2/Class#")
-  }
+  // specialized method
+  testConversion("p1.p2.Object$.foreach$mVc$sp", "p1/p2/Object.")
+  testConversion("p1.p2.Class.foreach$mVc$sp", "p1/p2/Class#")
 
   def testConversion(line: String, expected: String): Unit = {
-    val obtained = StacktraceAnalyzer.convert(line)
-    assert(clue(obtained).contains(clue(expected)))
+    test(line) {
+      val obtained = StacktraceAnalyzer.toToplevelSymbol(line)
+      assert(clue(obtained).contains(clue(expected)))
+    }
   }
 
-  def testConversion(line: String, expectedOneOf: List[String]): Unit = {
-    val obtained = StacktraceAnalyzer.convert(line)
-    assert(clue(expectedOneOf).diff(clue(obtained)).nonEmpty)
-  }
 }


### PR DESCRIPTION
Stacktrace analyzer PoC

![stacktrace-analyze](https://user-images.githubusercontent.com/10478402/89100942-e0345700-d3fb-11ea-9fd5-888d18033cab.gif)

It creates `.metals/stacktrace.scala` file with stacktrace (provided in command, in vscode PR taken from clipboard like in Intellij)
Because stacktrace lines are in format: `scope.class.method(filename:line)` I try to convert `scope.class.method` into symbol and look for definition of it. If found I use path where definition is located and set line from stacktrace.
For very simple stacktraces it works okay, there might be issues with annonymous classes etc. (to be tested further).

If you are on a given line you can do action 'go to definition' that will move cursor to place where stacktrace line points to.
For every located symbol also there are added code lenses. 

For `goto-location` I added optional parameter `otherWindow` which says to client that it would be perfect if you moved cursor to given location but in another window/frame/tab. (you can see this in action in gif, clicking "jump" opens position on other window)

Right now please don't comment 'use different name for this variable' etc. but let me know what do you think about this concept generally?
If it looks good to you I will polish code and change status 'Draft' -> PR.

Complementary vscode PR:  https://github.com/scalameta/metals-vscode/pull/371

Not much changes on VSCode side so I don't expect problems on vim/emacs side but feedback for those editors would be good too