### PR TITLE
Change implicits to Dotty syntax.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -13,6 +13,9 @@ To fix this problem:
 project.excludeFilters = [
   "test-workspace"
   "metals-bench/src/main/resources"
+  "mtags/src/main/scala-0.24/"
+  "mtags/src/main/scala-0.25/"
+  "mtags/src/main/scala-0.26/"
   "mtags/src/main/scala-3/"
   "tests/unit/src/test/resources"
 ]

--- a/mtags/src/main/scala-0.24/scala/meta/internal/metals/ClassFinder.scala
+++ b/mtags/src/main/scala-0.24/scala/meta/internal/metals/ClassFinder.scala
@@ -21,7 +21,7 @@ object ClassFinder {
     var symbol = ""
     var isInnerClass: Boolean = false
     var isToplevel: Boolean = true
-    override def traverse(tree: Tree)(implicit ctx: Context): Unit = {
+    override def traverse(tree: Tree)(using ctx: Context): Unit = {
       if (
         tree.sourcePos.exists && tree.sourcePos.start <= offset && offset <= tree.sourcePos.end
       ) {
@@ -75,7 +75,7 @@ object ClassFinder {
       }
     }
 
-    def find(tree: Tree)(implicit ctx: Context): String = {
+    def find(tree: Tree)(using ctx: Context): String = {
       traverse(tree)
       symbol
     }
@@ -84,7 +84,7 @@ object ClassFinder {
   def findClassForOffset(
       offset: Int,
       fileName: String
-  )(implicit ctx: Context): String = {
+  )(using ctx: Context): String = {
     val tree = ctx.run.units.head.untpdTree
     new SymbolTraverser(offset, fileName).find(tree)
   }

--- a/mtags/src/main/scala-0.24/scala/meta/internal/pc/Symbols.scala
+++ b/mtags/src/main/scala-0.24/scala/meta/internal/pc/Symbols.scala
@@ -5,5 +5,5 @@ import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.core.Annotations.AnnotInfo
 
 object Symbols {
-  def isDeprecated(symbol: Symbol)(implicit ctx: Context) = symbol.isDeprecated
+  def isDeprecated(symbol: Symbol)(using ctx: Context) = symbol.isDeprecated
 }

--- a/mtags/src/main/scala-0.25/scala/meta/internal/metals/ClassFinder.scala
+++ b/mtags/src/main/scala-0.25/scala/meta/internal/metals/ClassFinder.scala
@@ -22,7 +22,7 @@ object ClassFinder {
     var symbol = ""
     var isInnerClass: Boolean = false
     var isToplevel: Boolean = true
-    override def traverse(tree: Tree)(implicit ctx: Context): Unit = {
+    override def traverse(tree: Tree)(using ctx: Context): Unit = {
       if (
         tree.sourcePos.exists && tree.sourcePos.start <= offset && offset <= tree.sourcePos.end
       ) {
@@ -76,7 +76,7 @@ object ClassFinder {
       }
     }
 
-    def find(tree: Tree)(implicit ctx: Context): String = {
+    def find(tree: Tree)(using ctx: Context): String = {
       traverse(tree)
       symbol
     }
@@ -85,7 +85,7 @@ object ClassFinder {
   def findClassForOffset(
       offset: Int,
       fileName: String
-  )(implicit ctx: Context): String = {
+  )(using ctx: Context): String = {
     val tree = ctx.run.units.head.untpdTree
     new SymbolTraverser(offset, fileName).find(tree)
   }

--- a/mtags/src/main/scala-0.25/scala/meta/internal/pc/Symbols.scala
+++ b/mtags/src/main/scala-0.25/scala/meta/internal/pc/Symbols.scala
@@ -5,5 +5,5 @@ import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.core.Annotations.AnnotInfo
 
 object Symbols {
-  def isDeprecated(symbol: Symbol)(implicit ctx: Context) = symbol.isDeprecated
+  def isDeprecated(symbol: Symbol)(using ctx: Context) = symbol.isDeprecated
 }

--- a/mtags/src/main/scala-0.26/scala/meta/internal/metals/ClassFinder.scala
+++ b/mtags/src/main/scala-0.26/scala/meta/internal/metals/ClassFinder.scala
@@ -22,7 +22,7 @@ object ClassFinder {
     var symbol = ""
     var isInnerClass: Boolean = false
     var isToplevel: Boolean = true
-    override def traverse(tree: Tree)(implicit ctx: Context): Unit = {
+    override def traverse(tree: Tree)(using ctx: Context): Unit = {
       if (
         tree.sourcePos.exists && tree.sourcePos.start <= offset && offset <= tree.sourcePos.end
       ) {
@@ -76,7 +76,7 @@ object ClassFinder {
       }
     }
 
-    def find(tree: Tree)(implicit ctx: Context): String = {
+    def find(tree: Tree)(using ctx: Context): String = {
       traverse(tree)
       symbol
     }
@@ -85,7 +85,7 @@ object ClassFinder {
   def findClassForOffset(
       offset: Int,
       fileName: String
-  )(implicit ctx: Context): String = {
+  )(using ctx: Context): String = {
     val tree = ctx.run.units.head.untpdTree
     new SymbolTraverser(offset, fileName).find(tree)
   }

--- a/mtags/src/main/scala-0.26/scala/meta/internal/pc/Symbols.scala
+++ b/mtags/src/main/scala-0.26/scala/meta/internal/pc/Symbols.scala
@@ -5,5 +5,5 @@ import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.transform.SymUtils._
 
 object Symbols {
-  def isDeprecated(symbol: Symbol)(implicit ctx: Context) = symbol.isDeprecated
+  def isDeprecated(symbol: Symbol)(using ctx: Context) = symbol.isDeprecated
 }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
@@ -20,7 +20,7 @@ class Scala3CompilerAccess(
     config: PresentationCompilerConfig,
     sh: Option[ScheduledExecutorService],
     newCompiler: () => Scala3CompilerWrapper
-)(implicit ec: ExecutionContextExecutor)
+)(using ec: ExecutionContextExecutor)
     extends CompilerAccess[StoreReporter, InteractiveDriver](
       config,
       sh,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -90,7 +90,7 @@ case class ScalaPresentationCompiler(
       sh,
       () => new Scala3CompilerWrapper(newDriver)
     )(
-      ec
+      using ec
     )
   }
 
@@ -139,7 +139,7 @@ case class ScalaPresentationCompiler(
       params.token
     ) { access =>
       val driver = access.compiler()
-      implicit def ctx: Context = driver.currentCtx
+      given ctx as Context = driver.currentCtx
       val uri = params.uri
       driver.run(uri, params.text)
       val pos = sourcePosition(driver, params, uri)
@@ -251,7 +251,7 @@ case class ScalaPresentationCompiler(
       val uri = params.uri
       driver.run(uri, params.text)
 
-      implicit def ctx: Context = driver.currentCtx
+      given ctx as Context = driver.currentCtx
       val pos = sourcePosition(driver, params, uri)
       val trees = driver.openedTrees(uri)
       val path = Interactive.pathTo(trees, pos)
@@ -312,7 +312,7 @@ case class ScalaPresentationCompiler(
       val uri = params.uri
       driver.run(uri, params.text)
 
-      implicit def ctx: Context = driver.currentCtx
+      given ctx as Context = driver.currentCtx
 
       val pos = sourcePosition(driver, params, uri)
       val trees = driver.openedTrees(uri)
@@ -412,10 +412,10 @@ case class ScalaPresentationCompiler(
 
   private def completionItem(
       completion: Completion
-  )(implicit ctx: Context): CompletionItem = {
+  )(using ctx: Context): CompletionItem = {
     def completionItemKind(
         sym: Symbol
-    )(implicit ctx: Context): CompletionItemKind = {
+    )(using ctx: Context): CompletionItemKind = {
       if (sym.is(Package) || sym.is(Module))
         CompletionItemKind.Module // No CompletionItemKind.Package (https://github.com/Microsoft/language-server-protocol/issues/155)
       else if (sym.isConstructor)
@@ -456,7 +456,7 @@ case class ScalaPresentationCompiler(
       keywordName: Option[String],
       typeInfo: Option[String],
       comments: List[ParsedComment]
-  )(implicit ctx: Context): MarkupContent = {
+  )(using ctx: Context): MarkupContent = {
     val buf = new StringBuilder
     typeInfo.foreach { info =>
       val keyName = keywordName.getOrElse("")
@@ -531,7 +531,7 @@ case class ScalaPresentationCompiler(
         Paths.get(params.uri()).getFileName.toString.stripSuffix(".scala")
       Optional.of(
         ClassFinder.findClassForOffset(params.offset, filename)(
-          driver.currentCtx
+          using driver.currentCtx
         )
       )
     }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SymbolPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SymbolPrinter.scala
@@ -7,9 +7,8 @@ import dotty.tools.dotc.core.Names._
 import dotty.tools.dotc.core.NameOps._
 import dotty.tools.dotc.core.Types._
 import dotty.tools.dotc.core.Flags
-import scala.language.implicitConversions
 
-class SymbolPrinter(implicit ctx: Context) extends RefinedPrinter(ctx) {
+class SymbolPrinter(using ctx: Context) extends RefinedPrinter(ctx) {
 
   private val defaultWidth = 1000
 


### PR DESCRIPTION
While starting to poke around the Scala3 code I notice we have started to use the Dotty syntax for implicits, but only in some places. I'm sort of in favor of unifying the way we approach it. In Scala3 stuff I think it makes sense to be consistent and just fully switch over to the given/using syntax. What do you think?