### PR TITLE
Implement organize import using scalafix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -413,8 +413,6 @@ lazy val metals = project
       "org.scalameta" % "mdoc-interfaces" % V.mdoc,
       "org.scalameta" %% "scalafmt-dynamic" % V.scalafmt,
       "ch.epfl.scala" % "scalafix-interfaces" % V.scalafix,
-      "ch.epfl.scala" % "scalafix-cli_2.12.12" % V.scalafix,
-      "ch.epfl.scala" % "scalafix-core_2.12" % V.scalafix,
       // For reading classpaths.
       // for fetching ch.epfl.scala:bloop-frontend and other library dependencies
       "io.get-coursier" % "interface" % V.coursierInterfaces,

--- a/build.sbt
+++ b/build.sbt
@@ -413,6 +413,8 @@ lazy val metals = project
       "org.scalameta" % "mdoc-interfaces" % V.mdoc,
       "org.scalameta" %% "scalafmt-dynamic" % V.scalafmt,
       "ch.epfl.scala" % "scalafix-interfaces" % V.scalafix,
+      "ch.epfl.scala" % "scalafix-cli_2.12.12" % V.scalafix,
+      "ch.epfl.scala" % "scalafix-core_2.12" % V.scalafix,
       // For reading classpaths.
       // for fetching ch.epfl.scala:bloop-frontend and other library dependencies
       "io.get-coursier" % "interface" % V.coursierInterfaces,

--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ inThisBuild(
       "-target:jvm-1.8",
       "-Yrangepos"
     ) ::: scala212CompilerOptions,
-    scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.4.0",
+    scalafixDependencies += "com.github.liancheng" %% "organize-imports" % V.organizeImportRule,
     organization := "org.scalameta",
     licenses := Seq(
       "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
@@ -186,6 +186,7 @@ lazy val V = new {
   val mdoc = "2.2.9"
   val scalafmt = "2.6.4"
   val munit = "0.7.12"
+  val scalafix = "0.9.20"
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.
   def supportedScalaBinaryVersions =
@@ -220,6 +221,7 @@ lazy val V = new {
   val coursierInterfaces = "0.0.25"
   val ammonite = "2.2.0-4-4bd225e"
   val mill = "0.8.0"
+  val organizeImportRule = "0.4.0"
 }
 
 val genyVersion = Def.setting {
@@ -410,6 +412,7 @@ lazy val metals = project
       "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1",
       "org.scalameta" % "mdoc-interfaces" % V.mdoc,
       "org.scalameta" %% "scalafmt-dynamic" % V.scalafmt,
+      "ch.epfl.scala" % "scalafix-interfaces" % V.scalafix,
       // For reading classpaths.
       // for fetching ch.epfl.scala:bloop-frontend and other library dependencies
       "io.get-coursier" % "interface" % V.coursierInterfaces,
@@ -444,6 +447,7 @@ lazy val metals = project
       "semanticdbVersion" -> V.semanticdb,
       "scalafmtVersion" -> V.scalafmt,
       "ammoniteVersion" -> V.ammonite,
+      "organizeImportVersion" -> V.organizeImportRule,
       "millVersion" -> V.mill,
       "supportedScalaVersions" -> V.supportedScalaVersions,
       "supportedScala2Versions" -> V.scala2Versions,

--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -204,6 +204,15 @@ functionality.
     <td align="center">Status bar</td>
     <td align="center">Status bar, Slow task</td>
   </tr>
+  <tr>
+     <td>Organize imports</td>
+     <td align="center">✅</td>
+     <td align="center"></td>
+     <td align="center">✅</td>
+     <td align="center"></td>
+     <td align="center">✅</td>
+     <td align="center"></td>
+  </tr>
 </tbody>
 </table>
 
@@ -525,6 +534,13 @@ scripts.
     <td align="center">✅</td>
     <td align="center"></td>
   </tr>
+  <tr>
+     <td>Organize imports</td>
+     <td align="center"></td>
+     <td align="center"></td>
+     <td align="center"></td>
+     <td align="center"></td>
+  </tr>
 </tbody>
 </table>
 
@@ -535,5 +551,4 @@ errors, but not diagnostics coming from the compiler.
 
 Metals does not support the following features:
 
-- Organize imports
 - Refactoring: move class, extract/inline value, convert to block

--- a/metals/src/main/scala/scala/meta/internal/metals/Buffers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Buffers.scala
@@ -9,7 +9,9 @@ import scala.meta.io.AbsolutePath
 /**
  * Manages in-memory text contents of unsaved files in the editor.
  */
-case class Buffers(map: TrieMap[AbsolutePath, String] = TrieMap.empty) {
+case class Buffers(
+    map: TrieMap[AbsolutePath, String] = TrieMap.empty
+) {
   def open: Iterable[AbsolutePath] = map.keys
   def put(key: AbsolutePath, value: String): Unit = map.put(key, value)
   def get(key: AbsolutePath): Option[String] = map.get(key)

--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -11,13 +11,15 @@ import org.eclipse.{lsp4j => l}
 
 final class CodeActionProvider(
     compilers: Compilers,
-    buffers: Buffers
+    buffers: Buffers,
+    scalafixProvider: ScalafixProvider
 ) {
   private val allActions: List[CodeAction] = List(
     new ImplementAbstractMembers(compilers),
     new ImportMissingSymbol(compilers),
     new CreateNewSymbol(),
-    new StringActions(buffers)
+    new StringActions(buffers),
+    new OrganizeImports(scalafixProvider)
   )
 
   def codeActions(

--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -12,6 +12,7 @@ import org.eclipse.{lsp4j => l}
 final class CodeActionProvider(
     compilers: Compilers,
     buffers: Buffers,
+    buildTargets: BuildTargets,
     scalafixProvider: ScalafixProvider
 ) {
   private val allActions: List[CodeAction] = List(
@@ -19,7 +20,7 @@ final class CodeActionProvider(
     new ImportMissingSymbol(compilers),
     new CreateNewSymbol(),
     new StringActions(buffers),
-    new OrganizeImports(scalafixProvider)
+    new OrganizeImports(scalafixProvider, buildTargets)
   )
 
   def codeActions(

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -258,10 +258,10 @@ object Embedded {
 
   def toClassLoader(
       classpath: Classpath,
-      scalafixClassLoader: ClassLoader
+      classLoader: ClassLoader
   ): URLClassLoader = {
     val urls = classpath.entries.map(_.toNIO.toUri.toURL).toArray
-    new URLClassLoader(urls, scalafixClassLoader)
+    new URLClassLoader(urls, classLoader)
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -80,7 +80,7 @@ final class Embedded(
       scalafixClassLoader: ClassLoader
   ): URLClassLoader = {
     val toolClasspathJars =
-        Embedded.organizeImportRule(scalaBinaryVersion)
+      Embedded.organizeImportRule(scalaBinaryVersion)
     toClassLoader(
       Classpath(toolClasspathJars.map(AbsolutePath(_))),
       scalafixClassLoader

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -9,7 +9,6 @@ import scala.collection.concurrent.TrieMap
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.pc.ScalaPresentationCompiler
 import scala.meta.internal.worksheets.MdocClassLoader
-import scala.meta.io.AbsolutePath
 import scala.meta.io.Classpath
 import scala.meta.pc.PresentationCompiler
 
@@ -75,19 +74,6 @@ final class Embedded(
     )
   }
 
-  def organizeImports(
-      scalaBinaryVersion: String,
-      scalafixClassLoader: ClassLoader
-  ): URLClassLoader = {
-    val toolClasspathJars =
-      Embedded.organizeImportRule(scalaBinaryVersion)
-    toClassLoader(
-      Classpath(toolClasspathJars.map(AbsolutePath(_))),
-      scalafixClassLoader
-    )
-
-  }
-
   private def serviceLoader[T](
       cls: Class[T],
       className: String,
@@ -106,13 +92,6 @@ final class Embedded(
     }
   }
 
-  private def toClassLoader(
-      classpath: Classpath,
-      scalafixClassLoader: ClassLoader
-  ): URLClassLoader = {
-    val urls = classpath.entries.map(_.toNIO.toUri.toURL).toArray
-    new URLClassLoader(urls, scalafixClassLoader)
-  }
 }
 
 object Embedded {
@@ -275,6 +254,14 @@ object Embedded {
     val parent =
       new PresentationCompilerClassLoader(this.getClass.getClassLoader)
     new URLClassLoader(allURLs, parent)
+  }
+
+  def toClassLoader(
+      classpath: Classpath,
+      scalafixClassLoader: ClassLoader
+  ): URLClassLoader = {
+    val urls = classpath.entries.map(_.toNIO.toUri.toURL).toArray
+    new URLClassLoader(urls, scalafixClassLoader)
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.metals
 
-import java.io.File
 import java.net.URLClassLoader
 import java.nio.file.Path
 import java.util.ServiceLoader
@@ -81,11 +80,9 @@ final class Embedded(
       scalafixClassLoader: ClassLoader
   ): URLClassLoader = {
     val toolClasspathJars =
-      statusBar.trackBlockingTask("Downloading organize import rule") {
         Embedded.organizeImportRule(scalaBinaryVersion)
-      }
     toClassLoader(
-      Classpath(toolClasspathJars.map(jar => AbsolutePath(jar))),
+      Classpath(toolClasspathJars.map(AbsolutePath(_))),
       scalafixClassLoader
     )
 
@@ -251,18 +248,13 @@ object Embedded {
       resolution = resolutionParams
     )
 
-  def organizeImportRule(scalaBinaryVersion: String): List[File] = {
+  def organizeImportRule(scalaBinaryVersion: String): List[Path] = {
     val dep = Dependency.of(
       "com.github.liancheng",
       s"organize-imports_$scalaBinaryVersion",
       BuildInfo.organizeImportVersion
     )
-    Fetch
-      .create()
-      .withDependencies(dep)
-      .fetch()
-      .asScala
-      .toList
+    downloadDependency(dep, scalaBinaryVersion)
   }
 
   def newPresentationCompilerClassLoader(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -514,6 +514,7 @@ class MetalsLanguageServer(
     scalafixProvider = ScalafixProvider(
       buildTargets,
       buffers,
+      userConfig.scalafixConfigPath,
       workspace,
       embedded,
       statusBar,
@@ -1173,12 +1174,10 @@ class MetalsLanguageServer(
       params: DocumentFormattingParams
   ): CompletableFuture[util.List[TextEdit]] =
     CancelTokens.future { token =>
-      {
-        formattingProvider.format(
-          params.getTextDocument.getUri.toAbsolutePath,
-          token
-        )
-      }
+      formattingProvider.format(
+        params.getTextDocument.getUri.toAbsolutePath,
+        token
+      )
     }
 
   @JsonRequest("textDocument/onTypeFormatting")

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -511,8 +511,15 @@ class MetalsLanguageServer(
       compilers,
       definitionIndex
     )
-    scalafixProvider =
-      ScalafixProvider(buildTargets, buffers, workspace, embedded, statusBar)
+    scalafixProvider = ScalafixProvider(
+      buildTargets,
+      buffers,
+      workspace,
+      embedded,
+      statusBar,
+      clientConfig.icons(),
+      languageClient
+    )
     codeActionProvider = new CodeActionProvider(
       compilers,
       buffers,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -207,6 +207,7 @@ class MetalsLanguageServer(
   private var debugProvider: DebugProvider = _
   private var symbolSearch: MetalsSymbolSearch = _
   private var compilers: Compilers = _
+  private var scalafixProvider: ScalafixProvider = _
   def loadedPresentationCompilerCount(): Int =
     compilers.loadedPresentationCompilerCount()
   var tables: Tables = _
@@ -510,9 +511,12 @@ class MetalsLanguageServer(
       compilers,
       definitionIndex
     )
+    scalafixProvider =
+      ScalafixProvider(buildTargets, buffers, workspace, embedded, statusBar)
     codeActionProvider = new CodeActionProvider(
       compilers,
-      buffers
+      buffers,
+      scalafixProvider
     )
     doctor = new Doctor(
       workspace,
@@ -637,7 +641,11 @@ class MetalsLanguageServer(
       if (initializeParams.supportsCodeActionLiterals) {
         capabilities.setCodeActionProvider(
           new CodeActionOptions(
-            List(CodeActionKind.QuickFix, CodeActionKind.Refactor).asJava
+            List(
+              CodeActionKind.QuickFix,
+              CodeActionKind.Refactor,
+              CodeActionKind.SourceOrganizeImports
+            ).asJava
           )
         )
       } else {
@@ -1158,10 +1166,12 @@ class MetalsLanguageServer(
       params: DocumentFormattingParams
   ): CompletableFuture[util.List[TextEdit]] =
     CancelTokens.future { token =>
-      formattingProvider.format(
-        params.getTextDocument.getUri.toAbsolutePath,
-        token
-      )
+      {
+        formattingProvider.format(
+          params.getTextDocument.getUri.toAbsolutePath,
+          token
+        )
+      }
     }
 
   @JsonRequest("textDocument/onTypeFormatting")
@@ -1514,6 +1524,7 @@ class MetalsLanguageServer(
         ammonite.stop()
       case ServerCommands.NewScalaProject() =>
         newProjectProvider.createNewProjectFromTemplate().asJavaObject
+
       case cmd =>
         scribe.error(s"Unknown command '$cmd'")
         Future.successful(()).asJavaObject

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -512,7 +512,6 @@ class MetalsLanguageServer(
       definitionIndex
     )
     scalafixProvider = ScalafixProvider(
-      buildTargets,
       buffers,
       userConfig.scalafixConfigPath,
       workspace,
@@ -524,6 +523,7 @@ class MetalsLanguageServer(
     codeActionProvider = new CodeActionProvider(
       compilers,
       buffers,
+      buildTargets,
       scalafixProvider
     )
     doctor = new Doctor(

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -1,0 +1,126 @@
+package scala.meta.internal.metals
+
+import java.nio.file.Path
+import java.util
+import java.util.Collections
+import java.util.Optional
+
+import scala.collection.mutable
+import scala.util.Try
+
+import scala.meta._
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+
+import org.eclipse.{lsp4j => l}
+import scalafix.interfaces.Scalafix
+import scalafix.interfaces.ScalafixArguments
+
+case class ScalafixProvider(
+    buildTargets: BuildTargets,
+    buffers: Buffers,
+    workspace: AbsolutePath,
+    embedded: Embedded,
+    statusBar: StatusBar
+) {
+  import ScalafixProvider._
+  private val scalafixCache = mutable.Map.empty[String, Scalafix]
+
+  def organizeImports(file: AbsolutePath): List[l.TextEdit] = {
+    val input = file.toInputFromBuffers(buffers)
+    val scalafixConfPath = workspace.resolve(scalafixFileName)
+    val scalafixConf: Optional[Path] =
+      if (scalafixConfPath.isFile) Optional.of(scalafixConfPath.toNIO)
+      else Optional.empty()
+    val resOpt = for {
+      (scalaVersion, scalaBinaryVersion, classPath) <-
+        getScalaVersionAndClassPath(file)
+      api <- getOrUpdateScalafixCache(scalaBinaryVersion)
+      scalafixArgs = configureApi(api, scalaVersion, classPath)
+      urlClassLoaderWithExternalRule = embedded.organizeImports(
+        scalaBinaryVersion,
+        api.getClass.getClassLoader
+      )
+    } yield {
+      val scalacOption =
+        if (scalaBinaryVersion == "2.13") "-Wunused:imports"
+        else "-Ywarn-unused-import"
+      scalafixArgs
+        .withToolClasspath(urlClassLoaderWithExternalRule)
+        .withConfig(scalafixConf)
+        .withRules(List(organizeImportRuleName).asJava)
+        .withPaths(List(file.toNIO).asJava)
+        .withSourceroot(workspace.toNIO)
+        .withScalacOptions(Collections.singletonList(scalacOption))
+        .evaluate()
+    }
+
+    val fixedOpt = resOpt
+      .flatMap(result => result.getFileEvaluations.headOption)
+      .flatMap(_.previewPatches().asScala)
+    fixedOpt.map(getTextEditsFrom(_, input)).getOrElse(Nil)
+  }
+
+  private def getTextEditsFrom(
+      fixed: String,
+      input: Input
+  ): List[l.TextEdit] = {
+    val fullDocumentRange = Position.Range(input, 0, input.chars.length).toLSP
+    if (fixed != input.text) {
+      List(new l.TextEdit(fullDocumentRange, fixed))
+    } else {
+      Nil
+    }
+  }
+
+  private def getScalaVersionAndClassPath(
+      file: AbsolutePath
+  ): Option[(ScalaVersion, ScalaBinaryVersion, util.List[Path])] = {
+    for {
+      identifier <- buildTargets.inverseSources(file)
+      scalacOptions <- buildTargets.scalacOptions(identifier)
+      scalaBuildTarget <- buildTargets.scalaInfo(identifier)
+      scalaVersion = scalaBuildTarget.getScalaVersion
+      semanticdbTarget = scalacOptions.targetroot(scalaVersion).toNIO
+      scalaBinaryVersion = scalaBuildTarget.getScalaBinaryVersion
+      classPath = scalacOptions.getClasspath.map(AbsolutePath(_).toNIO)
+      _ = classPath.add(semanticdbTarget)
+    } yield (scalaVersion, scalaBinaryVersion, classPath)
+  }
+
+  private def configureApi(
+      api: Scalafix,
+      scalaVersion: ScalaVersion,
+      classPath: util.List[Path]
+  ): ScalafixArguments = {
+    api
+      .newArguments()
+      .withScalaVersion(scalaVersion)
+      .withClasspath(classPath)
+  }
+
+  private def getOrUpdateScalafixCache(
+      scalaBinaryVersion: ScalaBinaryVersion
+  ): Option[Scalafix] = {
+    scalafixCache
+      .get(scalaBinaryVersion)
+      .orElse(
+        statusBar.trackBlockingTask("downloading scalafix") {
+          Try(Scalafix.fetchAndClassloadInstance(scalaBinaryVersion)).toOption
+            .map { api =>
+              scalafixCache.update(scalaBinaryVersion, api)
+              api
+            }
+        }
+      )
+  }
+}
+
+object ScalafixProvider {
+  type ScalaBinaryVersion = String
+  type ScalaVersion = String
+
+  val organizeImportRuleName = "OrganizeImports"
+  val scalafixFileName = ".scalafix.conf"
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -1,17 +1,15 @@
 package scala.meta.internal.metals
 
-import java.nio.file.Path
+import java.nio.file.{Path, PathMatcher}
 import java.util
 import java.util.Collections
 import java.util.Optional
 
 import scala.collection.mutable
 import scala.util.Try
-
 import scala.meta._
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
-
 import org.eclipse.{lsp4j => l}
 import scalafix.interfaces.Scalafix
 import scalafix.interfaces.ScalafixArguments
@@ -27,47 +25,53 @@ case class ScalafixProvider(
   private val scalafixCache = mutable.Map.empty[String, Scalafix]
 
   def organizeImports(file: AbsolutePath): List[l.TextEdit] = {
-    val input = file.toInputFromBuffers(buffers)
-    val scalafixConfPath = workspace.resolve(scalafixFileName)
-    val scalafixConf: Optional[Path] =
-      if (scalafixConfPath.isFile) Optional.of(scalafixConfPath.toNIO)
-      else Optional.empty()
-    val resOpt = for {
-      (scalaVersion, scalaBinaryVersion, classPath) <-
-        getScalaVersionAndClassPath(file)
-      api <- getOrUpdateScalafixCache(scalaBinaryVersion)
-      scalafixArgs = configureApi(api, scalaVersion, classPath)
-      urlClassLoaderWithExternalRule = embedded.organizeImports(
-        scalaBinaryVersion,
-        api.getClass.getClassLoader
-      )
-    } yield {
-      val scalacOption =
-        if (scalaBinaryVersion == "2.13") "-Wunused:imports"
-        else "-Ywarn-unused-import"
-      scalafixArgs
-        .withToolClasspath(urlClassLoaderWithExternalRule)
-        .withConfig(scalafixConf)
-        .withRules(List(organizeImportRuleName).asJava)
-        .withPaths(List(file.toNIO).asJava)
-        .withSourceroot(workspace.toNIO)
-        .withScalacOptions(Collections.singletonList(scalacOption))
-        .evaluate()
-    }
+    val baseMatcher: PathMatcher = scalafix.internal.v1.Args.baseMatcher
+    if(baseMatcher.matches(file.toNIO)) {
+      val input = file.toInputFromBuffers(buffers)
+      val scalafixConfPath = workspace.resolve(scalafixFileName)
+      val scalafixConf: Optional[Path] =
+        if (scalafixConfPath.isFile) Optional.of(scalafixConfPath.toNIO)
+        else Optional.empty()
+      val scalafixEvaluation = for {
+        (scalaVersion, scalaBinaryVersion, classPath) <-
+          getScalaVersionAndClassPath(file)
+        api <- getOrUpdateScalafixCache(scalaBinaryVersion)
+        scalafixArgs = configureApi(api, scalaVersion, classPath)
+        urlClassLoaderWithExternalRule = embedded.organizeImports(
+          scalaBinaryVersion,
+          api.getClass.getClassLoader
+        )
+      } yield {
+        val scalacOption =
+          if (scalaBinaryVersion == "2.13") "-Wunused:imports"
+          else "-Ywarn-unused-import"
+        scalafixArgs
+          .withToolClasspath(urlClassLoaderWithExternalRule)
+          .withConfig(scalafixConf)
+          .withRules(List(organizeImportRuleName).asJava)
+          .withPaths(List(file.toNIO).asJava)
+          .withSourceroot(workspace.toNIO)
+          .withScalacOptions(Collections.singletonList(scalacOption))
+          .evaluate()
+      }
 
-    val fixedOpt = resOpt
-      .flatMap(result => result.getFileEvaluations.headOption)
-      .flatMap(_.previewPatches().asScala)
-    fixedOpt.map(getTextEditsFrom(_, input)).getOrElse(Nil)
+      val newFileContentOpt = scalafixEvaluation
+        .flatMap(result => result.getFileEvaluations.headOption)
+        .flatMap(_.previewPatches().asScala)
+    newFileContentOpt.map(getTextEditsFrom(_, input)).getOrElse(Nil)
+      } else {
+      scribe.info(s"Could not organize import for files that do not match ${baseMatcher.toString}")
+      Nil
+    }
   }
 
   private def getTextEditsFrom(
-      fixed: String,
+      newFileContent: String,
       input: Input
   ): List[l.TextEdit] = {
     val fullDocumentRange = Position.Range(input, 0, input.chars.length).toLSP
-    if (fixed != input.text) {
-      List(new l.TextEdit(fullDocumentRange, fixed))
+    if (newFileContent != input.text) {
+      List(new l.TextEdit(fullDocumentRange, newFileContent))
     } else {
       Nil
     }
@@ -83,7 +87,7 @@ case class ScalafixProvider(
       scalaVersion = scalaBuildTarget.getScalaVersion
       semanticdbTarget = scalacOptions.targetroot(scalaVersion).toNIO
       scalaBinaryVersion = scalaBuildTarget.getScalaBinaryVersion
-      classPath = scalacOptions.getClasspath.map(AbsolutePath(_).toNIO)
+      classPath = scalacOptions.getClasspath.map(_.toAbsolutePath.toNIO)
       _ = classPath.add(semanticdbTarget)
     } yield (scalaVersion, scalaBinaryVersion, classPath)
   }
@@ -105,7 +109,7 @@ case class ScalafixProvider(
     scalafixCache
       .get(scalaBinaryVersion)
       .orElse(
-        statusBar.trackBlockingTask("downloading scalafix") {
+        statusBar.trackBlockingTask("Downloading scalafix") {
           Try(Scalafix.fetchAndClassloadInstance(scalaBinaryVersion)).toOption
             .map { api =>
               scalafixCache.update(scalaBinaryVersion, api)

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -1,15 +1,18 @@
 package scala.meta.internal.metals
 
-import java.nio.file.{Path, PathMatcher}
+import java.nio.file.Path
 import java.util
 import java.util.Collections
 import java.util.Optional
 
 import scala.collection.mutable
 import scala.util.Try
+
 import scala.meta._
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
+
+import org.eclipse.lsp4j.MessageType
 import org.eclipse.{lsp4j => l}
 import scalafix.interfaces.Scalafix
 import scalafix.interfaces.ScalafixArguments
@@ -19,49 +22,64 @@ case class ScalafixProvider(
     buffers: Buffers,
     workspace: AbsolutePath,
     embedded: Embedded,
-    statusBar: StatusBar
+    statusBar: StatusBar,
+    icons: Icons,
+    languageClient: MetalsLanguageClient
 ) {
   import ScalafixProvider._
   private val scalafixCache = mutable.Map.empty[String, Scalafix]
 
   def organizeImports(file: AbsolutePath): List[l.TextEdit] = {
-    val baseMatcher: PathMatcher = scalafix.internal.v1.Args.baseMatcher
-    if(baseMatcher.matches(file.toNIO)) {
-      val input = file.toInputFromBuffers(buffers)
-      val scalafixConfPath = workspace.resolve(scalafixFileName)
-      val scalafixConf: Optional[Path] =
-        if (scalafixConfPath.isFile) Optional.of(scalafixConfPath.toNIO)
-        else Optional.empty()
-      val scalafixEvaluation = for {
-        (scalaVersion, scalaBinaryVersion, classPath) <-
-          getScalaVersionAndClassPath(file)
-        api <- getOrUpdateScalafixCache(scalaBinaryVersion)
-        scalafixArgs = configureApi(api, scalaVersion, classPath)
-        urlClassLoaderWithExternalRule = embedded.organizeImports(
-          scalaBinaryVersion,
-          api.getClass.getClassLoader
-        )
-      } yield {
-        val scalacOption =
-          if (scalaBinaryVersion == "2.13") "-Wunused:imports"
-          else "-Ywarn-unused-import"
-        scalafixArgs
-          .withToolClasspath(urlClassLoaderWithExternalRule)
-          .withConfig(scalafixConf)
-          .withRules(List(organizeImportRuleName).asJava)
-          .withPaths(List(file.toNIO).asJava)
-          .withSourceroot(workspace.toNIO)
-          .withScalacOptions(Collections.singletonList(scalacOption))
-          .evaluate()
-      }
-
-      val newFileContentOpt = scalafixEvaluation
-        .flatMap(result => result.getFileEvaluations.headOption)
-        .flatMap(_.previewPatches().asScala)
-    newFileContentOpt.map(getTextEditsFrom(_, input)).getOrElse(Nil)
-      } else {
-      scribe.info(s"Could not organize import for files that do not match ${baseMatcher.toString}")
+    val fileInput = file.toInput
+    val unsavedFile = file.toInputFromBuffers(buffers)
+    if (fileInput.text.diff(unsavedFile.text).nonEmpty) {
+      scribe.info(s"Organize imports requires saving the file first")
+      languageClient.showMessage(
+        MessageType.Warning,
+        s"Save ${file.toNIO.getFileName} before organizing imports"
+      )
       Nil
+    } else {
+      val baseMatcher = scalafix.internal.v1.Args.baseMatcher
+      if (baseMatcher.matches(file.toNIO)) {
+        val scalafixConfPath = workspace.resolve(scalafixFileName)
+        val scalafixConf: Optional[Path] =
+          if (scalafixConfPath.isFile) Optional.of(scalafixConfPath.toNIO)
+          else Optional.empty()
+        val scalafixEvaluation = for {
+          (scalaVersion, scalaBinaryVersion, classPath) <-
+            getScalaVersionAndClassPath(file)
+          api <- getOrUpdateScalafixCache(scalaBinaryVersion)
+          scalafixArgs = configureApi(api, scalaVersion, classPath)
+          urlClassLoaderWithExternalRule = embedded.organizeImports(
+            scalaBinaryVersion,
+            api.getClass.getClassLoader
+          )
+        } yield {
+          val scalacOption =
+            if (scalaBinaryVersion == "2.13") "-Wunused:imports"
+            else "-Ywarn-unused-import"
+
+          scalafixArgs
+            .withToolClasspath(urlClassLoaderWithExternalRule)
+            .withConfig(scalafixConf)
+            .withRules(List(organizeImportRuleName).asJava)
+            .withPaths(List(file.toNIO).asJava)
+            .withSourceroot(workspace.toNIO)
+            .withScalacOptions(Collections.singletonList(scalacOption))
+            .evaluate()
+        }
+
+        val newFileContentOpt = scalafixEvaluation
+          .flatMap(result => result.getFileEvaluations.headOption)
+          .flatMap(_.previewPatches().asScala)
+        newFileContentOpt.map(getTextEditsFrom(_, fileInput)).getOrElse(Nil)
+      } else {
+        scribe.info(
+          s"""|Could not organize import for ${file.toNIO.getFileName}. Should end with .scala or .sbt"""
+        )
+        Nil
+      }
     }
   }
 
@@ -79,7 +97,7 @@ case class ScalafixProvider(
 
   private def getScalaVersionAndClassPath(
       file: AbsolutePath
-  ): Option[(ScalaVersion, ScalaBinaryVersion, util.List[Path])] = {
+  ): Option[(ScalaVersion, ScalaBinaryVersion, util.List[Path])] =
     for {
       identifier <- buildTargets.inverseSources(file)
       scalacOptions <- buildTargets.scalacOptions(identifier)
@@ -90,7 +108,6 @@ case class ScalafixProvider(
       classPath = scalacOptions.getClasspath.map(_.toAbsolutePath.toNIO)
       _ = classPath.add(semanticdbTarget)
     } yield (scalaVersion, scalaBinaryVersion, classPath)
-  }
 
   private def configureApi(
       api: Scalafix,

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -26,6 +26,7 @@ case class UserConfiguration(
     mavenScript: Option[String] = None,
     millScript: Option[String] = None,
     scalafmtConfigPath: RelativePath = RelativePath(".scalafmt.conf"),
+    scalafixConfigPath: RelativePath = RelativePath(".scalafix.conf"),
     symbolPrefixes: Map[String, String] =
       PresentationCompilerConfig.defaultSymbolPrefixes().asScala.toMap,
     worksheetScreenWidth: Int = 120,
@@ -292,6 +293,10 @@ object UserConfiguration {
       getStringKey("scalafmt-config-path")
         .map(RelativePath(_))
         .getOrElse(default.scalafmtConfigPath)
+    val scalafixConfigPath =
+      getStringKey("scalafix-config-path")
+        .map(RelativePath(_))
+        .getOrElse(default.scalafixConfigPath)
     val sbtScript =
       getStringKey("sbt-script")
     val gradleScript =
@@ -334,6 +339,7 @@ object UserConfiguration {
           mavenScript,
           millScript,
           scalafmtConfigPath,
+          scalafixConfigPath,
           symbolPrefixes,
           worksheetScreenWidth,
           worksheetCancelTimeout,

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
@@ -1,0 +1,50 @@
+package scala.meta.internal.metals.codeactions
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.internal.metals.CodeAction
+import scala.meta.internal.metals.MetalsEnrichments.XtensionString
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ScalafixProvider
+import scala.meta.pc.CancelToken
+
+import org.eclipse.lsp4j.CodeActionParams
+import org.eclipse.{lsp4j => l}
+
+final class OrganizeImports(scalafixProvider: ScalafixProvider)
+    extends CodeAction {
+  override def kind: String = OrganizeImports.kind
+
+  override def contribute(params: CodeActionParams, token: CancelToken)(implicit
+      ec: ExecutionContext
+  ): Future[Seq[l.CodeAction]] = {
+    if (isSourceOrganizeImportCalled(params)) {
+      val uri = params.getTextDocument.getUri
+      val path = uri.toAbsolutePath
+      val edits = scalafixProvider.organizeImports(path)
+
+      val codeAction = new l.CodeAction()
+      codeAction.setTitle(OrganizeImports.title)
+      codeAction.setKind(l.CodeActionKind.SourceOrganizeImports)
+      codeAction.setEdit(
+        new l.WorkspaceEdit(
+          Map(uri -> edits.asJava).asJava
+        )
+      )
+      Future.successful {
+        Seq(codeAction)
+      }
+    } else Future.successful(Seq())
+  }
+
+  private def isSourceOrganizeImportCalled(params: CodeActionParams): Boolean =
+    Option(params.getContext.getOnly)
+      .map(_.asScala.toList.contains(kind))
+      .isDefined
+
+}
+object OrganizeImports {
+  def title: String = "Organize imports"
+  def kind: String = l.CodeActionKind.SourceOrganizeImports
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
@@ -1,50 +1,107 @@
 package scala.meta.internal.metals.codeactions
 
+import java.nio.file.Path
+import java.util.{List => JList}
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.CodeAction
 import scala.meta.internal.metals.MetalsEnrichments.XtensionString
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ScalaVersions
 import scala.meta.internal.metals.ScalafixProvider
+import scala.meta.io.AbsolutePath
 import scala.meta.pc.CancelToken
 
 import org.eclipse.lsp4j.CodeActionParams
 import org.eclipse.{lsp4j => l}
 
-final class OrganizeImports(scalafixProvider: ScalafixProvider)
-    extends CodeAction {
+final class OrganizeImports(
+    scalafixProvider: ScalafixProvider,
+    buildTargets: BuildTargets
+) extends CodeAction {
+  import OrganizeImports._
+
   override def kind: String = OrganizeImports.kind
 
   override def contribute(params: CodeActionParams, token: CancelToken)(implicit
       ec: ExecutionContext
   ): Future[Seq[l.CodeAction]] = {
-    if (isSourceOrganizeImportCalled(params)) {
-      val uri = params.getTextDocument.getUri
-      val path = uri.toAbsolutePath
-      val edits = scalafixProvider.organizeImports(path)
-
-      val codeAction = new l.CodeAction()
-      codeAction.setTitle(OrganizeImports.title)
-      codeAction.setKind(l.CodeActionKind.SourceOrganizeImports)
-      codeAction.setEdit(
-        new l.WorkspaceEdit(
-          Map(uri -> edits.asJava).asJava
-        )
-      )
-      Future.successful {
-        Seq(codeAction)
+    val uri = params.getTextDocument.getUri
+    val file = uri.toAbsolutePath
+    if (isSourceOrganizeImportCalled(params) && isScalaOrSbt(file)) {
+      scalaVersionAndClasspath(file) match {
+        case Some((scalaVersion, scalaBinaryVersion, classpath))
+            if !ScalaVersions.isScala3Version(scalaVersion) =>
+          organizeImportsEdits(
+            file,
+            scalaVersion,
+            scalaBinaryVersion,
+            classpath
+          )
+        case _ => Future.successful(Seq())
       }
     } else Future.successful(Seq())
+
   }
 
-  private def isSourceOrganizeImportCalled(params: CodeActionParams): Boolean =
+  private def organizeImportsEdits(
+      path: AbsolutePath,
+      scalaVersion: ScalaVersion,
+      scalaBinaryVersion: ScalaBinaryVersion,
+      classpath: JList[Path]
+  ): Future[Seq[l.CodeAction]] = {
+    val edits = scalafixProvider.organizeImports(
+      path,
+      scalaVersion,
+      scalaBinaryVersion,
+      classpath
+    )
+    val codeAction = new l.CodeAction()
+    codeAction.setTitle(OrganizeImports.title)
+    codeAction.setKind(l.CodeActionKind.SourceOrganizeImports)
+    codeAction.setEdit(
+      new l.WorkspaceEdit(
+        Map(path.toURI.toString -> edits.asJava).asJava
+      )
+    )
+    Future.successful {
+      Seq(codeAction)
+    }
+
+  }
+
+  private def isSourceOrganizeImportCalled(
+      params: CodeActionParams
+  ): Boolean =
     Option(params.getContext.getOnly)
       .map(_.asScala.toList.contains(kind))
       .isDefined
+
+  private def isScalaOrSbt(file: AbsolutePath): Boolean =
+    Seq("scala", "sbt").contains(file.extension)
+
+  private def scalaVersionAndClasspath(
+      file: AbsolutePath
+  ): Option[(ScalaVersion, ScalaBinaryVersion, JList[Path])] =
+    for {
+      buildId <- buildTargets.inverseSources(file)
+      scalacOptions <- buildTargets.scalacOptions(buildId)
+      scalaBuildTarget <- buildTargets.scalaInfo(buildId)
+      scalaVersion = scalaBuildTarget.getScalaVersion
+      semanticdbTarget = scalacOptions.targetroot(scalaVersion).toNIO
+      scalaBinaryVersion = scalaBuildTarget.getScalaBinaryVersion
+      classPath = scalacOptions.getClasspath.map(_.toAbsolutePath.toNIO)
+      _ = classPath.add(semanticdbTarget)
+    } yield (scalaVersion, scalaBinaryVersion, classPath)
 
 }
 object OrganizeImports {
   def title: String = "Organize imports"
   def kind: String = l.CodeActionKind.SourceOrganizeImports
+
+  type ScalaBinaryVersion = String
+  type ScalaVersion = String
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -917,10 +917,11 @@ final class TestingServer(
       filename: String,
       query: String,
       expected: String,
+      kind: List[String],
       root: AbsolutePath = workspace
   )(implicit loc: munit.Location): Future[List[l.CodeAction]] =
     for {
-      (codeActions, codeActionString) <- codeAction(filename, query, root)
+      (codeActions, codeActionString) <- codeAction(filename, query, root, kind)
     } yield {
       Assertions.assertNoDiff(codeActionString, expected)
       codeActions
@@ -946,7 +947,8 @@ final class TestingServer(
   def codeAction(
       filename: String,
       query: String,
-      root: AbsolutePath
+      root: AbsolutePath,
+      kind: List[String]
   ): Future[(List[l.CodeAction], String)] =
     for {
       (_, params) <- codeActionParams(
@@ -954,7 +956,8 @@ final class TestingServer(
         query,
         root,
         new CodeActionContext(
-          client.diagnostics.getOrElse(toPath(filename), Nil).asJava
+          client.diagnostics.getOrElse(toPath(filename), Nil).asJava,
+          if (kind.nonEmpty) kind.asJava else null
         )
       )
       codeActions <- server.codeAction(params).asScala

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -74,6 +74,10 @@ class UserConfigurationSuite extends BaseSuite {
       obtained.scalafmtConfigPath ==
         UserConfiguration.default.scalafmtConfigPath
     )
+    assert(
+      obtained.scalafixConfigPath ==
+        UserConfiguration.default.scalafixConfigPath
+    )
   }
 
   checkOK(

--- a/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -16,11 +16,11 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
       expectedCode: String,
       selectedActionIndex: Int = 0,
       expectNoDiagnostics: Boolean = true,
-      fileName: String = "A.scala",
       kind: List[String] = Nil,
       scalafixConf: String = "",
       scalacOptions: List[String] = Nil
   )(implicit loc: Location): Unit = {
+    val fileName: String = "A.scala"
     val scalacOptionsJson =
       s""""scalacOptions": ["${scalacOptions.mkString("\",\"")}"]"""
     val path = s"a/src/main/scala/a/$fileName"

--- a/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -16,13 +16,14 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
       expectedCode: String,
       selectedActionIndex: Int = 0,
       expectNoDiagnostics: Boolean = true,
+      fileName: Option[String] = None,
       kind: List[String] = Nil,
       scalafixConf: String = "",
       scalacOptions: List[String] = Nil
   )(implicit loc: Location): Unit = {
     val scalacOptionsJson =
       s""""scalacOptions": ["${scalacOptions.mkString("\",\"")}"]"""
-    val path = "a/src/main/scala/a/A.scala"
+    val path = s"a/src/main/scala/a/${fileName.getOrElse("A.scala")}"
     test(name) {
       cleanWorkspace()
       for {

--- a/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -33,8 +33,7 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
                                   |/$path
                                   |${input
           .replace("<<", "")
-          .replace(">>", "")}
-                                  |""".stripMargin)
+          .replace(">>", "")}""".stripMargin)
         _ <- server.didOpen(path)
         codeActions <-
           server.assertCodeAction(path, input, expectedActions, kind)

--- a/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -16,14 +16,15 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
       expectedCode: String,
       selectedActionIndex: Int = 0,
       expectNoDiagnostics: Boolean = true,
-      fileName: Option[String] = None,
+      fileName: String = "A.scala",
       kind: List[String] = Nil,
       scalafixConf: String = "",
       scalacOptions: List[String] = Nil
   )(implicit loc: Location): Unit = {
     val scalacOptionsJson =
       s""""scalacOptions": ["${scalacOptions.mkString("\",\"")}"]"""
-    val path = s"a/src/main/scala/a/${fileName.getOrElse("A.scala")}"
+    val path = s"a/src/main/scala/a/$fileName"
+    val fileContent = input.replace("<<", "").replace(">>", "")
     test(name) {
       cleanWorkspace()
       for {
@@ -31,9 +32,7 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
                                   |{"a":{$scalacOptionsJson}}
                                   |$scalafixConf
                                   |/$path
-                                  |${input
-          .replace("<<", "")
-          .replace(">>", "")}""".stripMargin)
+                                  |$fileContent""".stripMargin)
         _ <- server.didOpen(path)
         codeActions <-
           server.assertCodeAction(path, input, expectedActions, kind)

--- a/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
@@ -95,7 +95,8 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
           .replace(">>", "")}
                                   |""".stripMargin)
         _ <- server.didOpen(path)
-        codeActions <- server.assertCodeAction(path, input, expectedActions)
+        codeActions <-
+          server.assertCodeAction(path, input, expectedActions, Nil)
         _ <- {
           if (selectedActionIndex >= codeActions.length) {
             fail(s"selectedActionIndex ($selectedActionIndex) is out of bounds")

--- a/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
@@ -1,0 +1,89 @@
+package tests.codeactions
+
+import scala.meta.internal.metals.codeactions.OrganizeImports
+
+class OrganizeImportsLspSuite
+    extends BaseCodeActionLspSuite("OrganizeImports") {
+  val kind: String = OrganizeImports.kind
+  val scalacOption: List[String] = List("-Ywarn-unused-import")
+  val scalafixConf: String =
+    """|/.scalafix.conf
+       |rules = [
+       |  OrganizeImports,
+       |  ExplicitResultTypes,
+       |  RemoveUnused
+       |]
+       |
+       |ExplicitResultTypes.rewriteStructuralTypesToNamedSubclass = false
+       |
+       |RemoveUnused.imports = false
+       |
+       |OrganizeImports.groupedImports = Explode
+       |OrganizeImports.expandRelative = true
+       |OrganizeImports.removeUnused = true
+       |OrganizeImports.groups = [
+       |  "scala."
+       |  "re:javax?\\."
+       |  "*"
+       |]
+       |
+       |""".stripMargin
+
+  check(
+    "basic organize imports",
+    """
+      |package a
+      |import scala.concurrent.duration._
+      |import scala.concurrent.Future<<>>
+      |import scala.concurrent.ExecutionContext.global
+      |
+      |object A {
+      |  val d = Duration(10, MICROSECONDS)
+      |  val k = Future.successful(1)
+      |}
+      |""".stripMargin,
+    s"${OrganizeImports.title}",
+    """
+      |package a
+      |import scala.concurrent.Future
+      |import scala.concurrent.duration._
+      |
+      |object A {
+      |  val d = Duration(10, MICROSECONDS)
+      |  val k = Future.successful(1)
+      |}
+      |""".stripMargin.replace("'", "\""),
+    kind = List(kind),
+    scalacOptions = scalacOption
+  )
+
+  check(
+    "basic organize imports with existing config",
+    """
+      |package a
+      |import scala.concurrent.duration._
+      |import java.util.Optional<<>>
+      |
+      |object A {
+      |  val d = Duration(10, MICROSECONDS)
+      |  val optional = Optional.empty()
+      |}
+      |""".stripMargin,
+    s"${OrganizeImports.title}",
+    """
+      |package a
+      |import scala.concurrent.duration._
+      |
+      |import java.util.Optional
+      |
+      |object A {
+      |  val d = Duration(10, MICROSECONDS)
+      |  val optional = Optional.empty()
+      |}
+      |""".stripMargin.replace("'", "\""),
+    kind = List(kind),
+    scalafixConf = scalafixConf,
+    scalacOptions = scalacOption
+  )
+
+}

--- a/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
@@ -30,7 +30,7 @@ class OrganizeImportsLspSuite
        |""".stripMargin
 
   check(
-    "basic organize imports",
+    "basic",
     """
       |package a
       |import scala.concurrent.duration._
@@ -52,13 +52,13 @@ class OrganizeImportsLspSuite
       |  val d = Duration(10, MICROSECONDS)
       |  val k = Future.successful(1)
       |}
-      |""".stripMargin.replace("'", "\""),
+      |""".stripMargin,
     kind = List(kind),
     scalacOptions = scalacOption
   )
 
   check(
-    "basic organize imports with existing config",
+    "basic-with-existing-config",
     """
       |package a
       |import scala.concurrent.duration._
@@ -86,8 +86,9 @@ class OrganizeImportsLspSuite
     scalacOptions = scalacOption
   )
 
+  // organize import only works .scala or .sbt files.
   check(
-    "should not work on worksheet or Ammonite files",
+    "doesnt-work-on-worksheets",
     """
       |import scala.concurrent.duration._
       |import java.util.Optional<<>>
@@ -104,9 +105,8 @@ class OrganizeImportsLspSuite
       |object A {
       | println("")
       |}
-      |""".stripMargin.replace("'", "\""),
-    fileName = Some("A.worksheet.sc"),
+      |""".stripMargin,
+    fileName = "A.worksheet.sc",
     kind = List(kind)
   )
-
 }

--- a/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
@@ -86,4 +86,27 @@ class OrganizeImportsLspSuite
     scalacOptions = scalacOption
   )
 
+  check(
+    "should not work on worksheet or Ammonite files",
+    """
+      |import scala.concurrent.duration._
+      |import java.util.Optional<<>>
+      |
+      |object A {
+      | println("")
+      |}
+      |""".stripMargin,
+    s"${OrganizeImports.title}",
+    """
+      |import scala.concurrent.duration._
+      |import java.util.Optional
+      |
+      |object A {
+      | println("")
+      |}
+      |""".stripMargin.replace("'", "\""),
+    fileName = Some("A.worksheet.sc"),
+    kind = List(kind),
+  )
+
 }

--- a/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
@@ -106,7 +106,7 @@ class OrganizeImportsLspSuite
       |}
       |""".stripMargin.replace("'", "\""),
     fileName = Some("A.worksheet.sc"),
-    kind = List(kind),
+    kind = List(kind)
   )
 
 }

--- a/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
@@ -80,33 +80,9 @@ class OrganizeImportsLspSuite
       |  val d = Duration(10, MICROSECONDS)
       |  val optional = Optional.empty()
       |}
-      |""".stripMargin.replace("'", "\""),
+      |""".stripMargin,
     kind = List(kind),
     scalafixConf = scalafixConf,
     scalacOptions = scalacOption
-  )
-
-  // organize import only works .scala or .sbt files.
-  check(
-    "doesnt-work-on-worksheets",
-    """
-      |import scala.concurrent.duration._
-      |import java.util.Optional<<>>
-      |
-      |object A {
-      | println("")
-      |}
-      |""".stripMargin,
-    s"${OrganizeImports.title}",
-    """
-      |import scala.concurrent.duration._
-      |import java.util.Optional
-      |
-      |object A {
-      | println("")
-      |}
-      |""".stripMargin,
-    fileName = "A.worksheet.sc",
-    kind = List(kind)
   )
 }


### PR DESCRIPTION
This PR request the new interfaces of Scalafix. The review is still on-going on scalafix side. 
It's a draft, some values are hard-coded. Only working for scala 2.12 projects.
The default [organize config](https://github.com/liancheng/scalafix-organize-imports) is used for now, which is:
```
OrganizeImports {
  coalesceToWildcardImportThreshold = 2147483647 # Int.MaxValue
  expandRelative = false
  groupExplicitlyImportedImplicitsSeparately = false
  groupedImports = Explode
  groups = ["re:javax?\\.", "scala.", "*"]
  importSelectorsOrder = Ascii
  importsOrder = Ascii
  removeUnused = true
}
```
We can think about taking the config found in .scalafix.conf if it exists, if not we will need to choose some default config for organize import code action. 

This is how it works (a shortcut is already bound to organize import and works)
![hello-1596644426584](https://user-images.githubusercontent.com/7843237/89438724-785a7500-d749-11ea-92a5-739b2b39b29f.gif)
