### PR TITLE
Add in a few missing docs on the extensions and commands.

### DIFF
--- a/docs/editors/new-editor.md
+++ b/docs/editors/new-editor.md
@@ -693,6 +693,8 @@ interface MetalsSlowTaskParams {
    * In VS Code, the Metals "Output channel" is not toggled when this flag is true.
    */
   quietLogs?: boolean;
+  /** Time that has elapsed since the begging of the task. */
+  secondsElapsed?: number;
 }
 ```
 
@@ -707,7 +709,7 @@ interface MetalsSlowTaskResult {
    * If false, the user dismissed the dialogue but want to
    * continue running the task.
    */
-  message: string;
+  cancel: boolean;
 }
 ```
 
@@ -924,6 +926,22 @@ _Notification_:
 interface WindowStateDidChangeParams( {
   /** If true, the editor application window is focused. False, otherwise. */
   focused: boolean;
+}
+```
+
+### `metals/openWindow`
+
+The  `metals/openWindow` params are used with the New Scala Project
+functionality. After the new project has been created, if the editor has the
+ability to open the project in a new window then these params are used with the
+the `metals-open-folder` command.
+
+```ts
+interface MetalsOpenWindowParams {
+  /** Location of the newly created project. */
+  uri: string;
+  /** Whether or not to open the project in a new window. */
+  openNewWindow: boolean;
 }
 ```
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -146,6 +146,7 @@ object ClientCommands {
       ToggleLogs,
       FocusDiagnostics,
       GotoLocation,
-      EchoCommand
+      EchoCommand,
+      RefreshModel
     )
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -306,14 +306,14 @@ object ServerCommands {
 
   val StartAmmoniteBuildServer = new Command(
     "ammonite-start",
-    "Start an Ammonite build server",
-    "Something"
+    "Start Ammonite build server",
+    "Start Ammonite build server"
   )
 
   val StopAmmoniteBuildServer = new Command(
     "ammonite-stop",
     "Stop Ammonite build server",
-    "Something"
+    "Stop Ammonite build server"
   )
 
   def all: List[Command] =


### PR DESCRIPTION
While working on https://github.com/scalameta/metals-languageclient/pull/163 I noticed a few things in the docs that were missing. This addresses those missing pieces.