### PR TITLE
Add support for Sbt's Scala files

### DIFF
--- a/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtLspSuite.scala
@@ -517,6 +517,34 @@ class SbtLspSuite extends BaseImportSuite("sbt-import") with ScriptsAssertions {
 
   }
 
+  test("scala-file-hover") {
+    cleanWorkspace()
+    for {
+      _ <- server.initialize(
+        s"""|/build.sbt
+            |scalaVersion := "$scalaVersion"
+            |/project/Deps.scala
+            |import sbt._
+            |import Keys._
+            |object Deps {
+            |  val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
+            |}
+         """.stripMargin
+      )
+      hoverRes <- assertHoverAtPos("project/Deps.scala", 3, 9)
+      expectedHoverRes =
+        """|```scala
+           |val scalatest: ModuleID
+           |```
+           |```range
+           |val scalatest = "org.scalatest" %% "scalatest" % "3.0.5"
+           |```
+           |""".stripMargin
+      _ = assertNoDiff(hoverRes, expectedHoverRes)
+    } yield ()
+
+  }
+
   test("sbt-file-autocomplete") {
     cleanWorkspace()
     for {


### PR DESCRIPTION
Previously, Sbt support would only work for `*.sbt` files, now it also works for `project/*.scala` ones.