### PR TITLE
Allow running main classes from dependencies

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -8,6 +8,7 @@ import scala.util.Success
 import scala.util.Try
 
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier

--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -12,6 +12,7 @@ import scala.util.Success
 
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ammonite.Ammonite
+import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.tvp._
 import scala.meta.internal.worksheets.WorksheetProvider
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -40,6 +40,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ammonite.Ammonite
 import scala.meta.internal.metals.codelenses.RunTestCodeLens
 import scala.meta.internal.metals.codelenses.SuperMethodCodeLens
+import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.metals.debug.DebugParametersJsonParsers
 import scala.meta.internal.metals.debug.DebugProvider
 import scala.meta.internal.mtags._
@@ -490,7 +491,8 @@ class MetalsLanguageServer(
       languageClient,
       buildClient,
       statusBar,
-      compilers
+      compilers,
+      definitionIndex
     )
     codeActionProvider = new CodeActionProvider(
       compilers,

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -4,7 +4,6 @@ import java.util.Collections.singletonList
 
 import scala.meta.internal.implementation.TextDocumentWithPath
 import scala.meta.internal.metals.Buffers
-import scala.meta.internal.metals.BuildTargetClasses
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.ClientCommands.StartDebugSession
 import scala.meta.internal.metals.ClientCommands.StartRunSession
@@ -13,6 +12,7 @@ import scala.meta.internal.metals.Command
 import scala.meta.internal.metals.JsonParser._
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.TokenEditDistance
+import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.semanticdb.TextDocument
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -1,11 +1,14 @@
-package scala.meta.internal.metals
+package scala.meta.internal.metals.debug
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-import scala.meta.internal.metals.BuildTargetClasses.Classes
+import scala.meta.internal.metals.BatchedFunction
+import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.metals.debug.BuildTargetClasses.Classes
 import scala.meta.internal.semanticdb.Scala.Descriptor
 import scala.meta.internal.semanticdb.Scala.Symbols
 
@@ -92,7 +95,7 @@ final class BuildTargetClasses(
       target = item.getTarget
       aClass <- item.getClasses.asScala
       descriptors = descriptorsForMainClasses(target)
-      symbol <- createSymbols(
+      symbol <- symbolFromClassName(
         aClass.getClassName,
         descriptors
       )
@@ -109,7 +112,8 @@ final class BuildTargetClasses(
       item <- result.getItems.asScala
       target = item.getTarget
       className <- item.getClasses.asScala
-      symbol <- createSymbols(className, List(Descriptor.Term, Descriptor.Type))
+      symbol <-
+        symbolFromClassName(className, List(Descriptor.Term, Descriptor.Type))
     } {
       classes(target).testClasses.put(symbol, className)
     }
@@ -128,7 +132,7 @@ final class BuildTargetClasses(
     }
   }
 
-  private def createSymbols(
+  def symbolFromClassName(
       className: String,
       descriptors: List[String => Descriptor]
   ): List[String] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
@@ -1,21 +1,30 @@
-package scala.meta.internal.metals
+package scala.meta.internal.metals.debug
 
+import scala.collection.JavaConverters._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
+import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.mtags.OnDemandSymbolIndex
+import scala.meta.internal.mtags.Symbol
+import scala.meta.internal.semanticdb.Scala.Descriptor
+import scala.meta.io.AbsolutePath
+
+import ch.epfl.scala.bsp4j.BuildTarget
 import ch.epfl.scala.{bsp4j => b}
 
 class BuildTargetClassesFinder(
     buildTargets: BuildTargets,
-    buildTargetClasses: BuildTargetClasses
+    buildTargetClasses: BuildTargetClasses,
+    index: OnDemandSymbolIndex
 ) {
 
   //In case of success returns non-empty list
   def findMainClassAndItsBuildTarget(
       className: String,
       buildTarget: Option[String]
-  ): Try[List[(b.ScalaMainClass, b.BuildTarget)]] =
+  ): Try[List[(b.ScalaMainClass, b.BuildTarget)]] = {
     findClassAndBuildTarget(
       className,
       buildTarget,
@@ -25,7 +34,21 @@ class BuildTargetClassesFinder(
         .mainClasses
         .values,
       { clazz: b.ScalaMainClass => clazz.getClassName }
-    )
+    ).recoverWith {
+      case ex =>
+        val found = ex match {
+          // We check whether there is a main in dependencies that is not reported via BSP
+          case ClassNotFoundInBuildTargetException(className, target) =>
+            revertToDependencies(className, Some(target))
+          case _: ClassNotFoundException =>
+            revertToDependencies(className, buildTarget = None)
+        }
+        found match {
+          case Nil => Failure(ex)
+          case deps => Success(deps)
+        }
+    }
+  }
 
   //In case of success returns non-empty list
   def findTestClassAndItsBuildTarget(
@@ -39,6 +62,30 @@ class BuildTargetClassesFinder(
       buildTargetClasses.classesOf(_).testClasses.values,
       { clazz: String => clazz }
     )
+
+  private def revertToDependencies(
+      className: String,
+      buildTarget: Option[BuildTarget]
+  ): List[(b.ScalaMainClass, BuildTarget)] = {
+
+    def findTarget(path: AbsolutePath) =
+      for {
+        targetId <- buildTargets.inferBuildTarget(path)
+        target <- buildTargets.info(targetId)
+      } yield target
+
+    for {
+      symbol <- buildTargetClasses.symbolFromClassName(
+        className,
+        List(Descriptor.Term, Descriptor.Type)
+      )
+      cls <- index.definition(Symbol(symbol))
+      target <- buildTarget.orElse(findTarget(cls.path))
+    } yield (
+      new b.ScalaMainClass(className, Nil.asJava, Nil.asJava),
+      target
+    )
+  }
 
   private def findClassAndBuildTarget[A](
       className: String,
@@ -58,8 +105,7 @@ class BuildTargetClassesFinder(
           }
           .reverse
       if (classes.nonEmpty) Success(classes)
-      else
-        Failure(new ClassNotFoundException(className))
+      else Failure(new ClassNotFoundException(className))
     } { targetName =>
       buildTargets
         .findByDisplayName(targetName)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -15,11 +15,7 @@ import scala.util.Failure
 import scala.util.Try
 
 import scala.meta.internal.metals.BuildServerConnection
-import scala.meta.internal.metals.BuildTargetClasses
-import scala.meta.internal.metals.BuildTargetClassesFinder
-import scala.meta.internal.metals.BuildTargetNotFoundException
 import scala.meta.internal.metals.BuildTargets
-import scala.meta.internal.metals.ClassNotFoundInBuildTargetException
 import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.Compilations
 import scala.meta.internal.metals.Compilers
@@ -34,6 +30,7 @@ import scala.meta.internal.metals.MetalsBuildClient
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.internal.metals.StatusBar
+import scala.meta.internal.mtags.OnDemandSymbolIndex
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import ch.epfl.scala.{bsp4j => b}
@@ -52,12 +49,14 @@ class DebugProvider(
     languageClient: MetalsLanguageClient,
     buildClient: MetalsBuildClient,
     statusBar: StatusBar,
-    compilers: Compilers
+    compilers: Compilers,
+    index: OnDemandSymbolIndex
 ) {
 
   lazy val buildTargetClassesFinder = new BuildTargetClassesFinder(
     buildTargets,
-    buildTargetClasses
+    buildTargetClasses,
+    index
   )
 
   def start(


### PR DESCRIPTION
Previously, we would only allow running main classes defined inside workspace source, which information was supplied by Bloop. Now, we also try to find the class inside dependencies to allow running things like Play framework server:

![play-run](https://user-images.githubusercontent.com/3807253/90043064-d77d3400-dccb-11ea-8f73-ecdf0fd71b5b.gif)

Fixes https://github.com/scalameta/metals/issues/1667