### PR TITLE
Allow to remove all breakpoints when debugging

### DIFF
--- a/tests/unit/src/main/scala/tests/BaseDapSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseDapSuite.scala
@@ -85,6 +85,20 @@ abstract class BaseDapSuite(suiteName: String) extends BaseLspSuite(suiteName) {
     }
   }
 
+  def removeBreakpoints(
+      debugger: TestDebugger,
+      workspace: DebugWorkspaceLayout
+  ): Future[List[SetBreakpointsResponse]] = {
+    Future.sequence {
+      workspace.files
+        .filter(_.breakpoints.nonEmpty)
+        .map { file =>
+          val path = server.toPath(file.relativePath)
+          debugger.setBreakpoints(path, Nil)
+        }
+    }
+  }
+
   def scalaVersion = BuildInfo.scalaVersion
 
   def assertBreakpoints(


### PR DESCRIPTION
Previously, if all breakpoints were removed for a class this event would not be registered by the debug server. Now, we make sure to send an additional empty request for each removed class/object.

How does it work:
- Breakpoint request is sent per file for example `Main.scala`.
- We partition the request based on where a breakpoint is located, for example `dap-fqcn:Main` for class Main and `dap-fqcn:Main$` for object Main.
- Breakpoints are sent to Bloop and set internally by microsoft debug server per path.
- When updated breakpoints are sent, we do not know which ones were removed and we cannot just use the file path, since that is not used by the server itself. This is why I added an internal list of uris that were specified previously and send an additional empty request for any that were not set previously.

Fixes https://github.com/scalameta/metals/issues/1760