### PR TITLE
Make sure we don't compile twice for open files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1018,7 +1018,10 @@ class MetalsLanguageServer(
         Future {
           diagnostics.didDelete(path)
         }.asJava
-      } else if (isScalaOrJava && !savedFiles.isRecentlyActive(path)) {
+      } else if (
+        isScalaOrJava && !savedFiles.isRecentlyActive(path) && !buffers
+          .contains(path)
+      ) {
         event.eventType() match {
           case EventType.CREATE =>
             buildTargets.onCreate(path)


### PR DESCRIPTION
Previously, compilation would be run twice for each file saved in the editor. Now, it's only run once. 

If the file is open in the editor it should be the one responsible for the content, not the file watcher. 

Fixes https://github.com/scalameta/metals/issues/1836