### PR TITLE
Clear fingerprints when semanticdb hash matches

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MutableMd5Fingerprints.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MutableMd5Fingerprints.scala
@@ -28,11 +28,12 @@ final class MutableMd5Fingerprints extends Md5Fingerprints {
       prints <- Option(fingerprints.get(path))
       fingerprint <- prints.asScala.find(_.md5 == md5)
     } yield {
-      // remove non-active md5 fingerprints.
-//      prints.clear()
+      // clear older fingerprints that no longer correspond to the semanticDB hash
+      prints.clear()
       prints.add(fingerprint)
       fingerprint.text
     }
   }
+
   override def toString: String = s"Md5FingerprintProvider($fingerprints)"
 }


### PR DESCRIPTION
Not sure why this part of code was commented out, but it resulted in fingerprints never getting cleared, which means we had copies of all revisions in memory.