### PR TITLE
Bump memory for test forks to 2GB

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -588,7 +588,7 @@ lazy val unit = project
     testSettings,
     Test / testOptions := Seq(Tests.Filter(name => isInTestShard(name))),
     sharedSettings,
-    Test / javaOptions += "-Xmx1G",
+    Test / javaOptions += "-Xmx2G",
     libraryDependencies ++= List(
       "io.get-coursier" %% "coursier" % V.coursier, // for jars
       "ch.epfl.scala" %% "bloop-config" % V.bloop,

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1319,6 +1319,7 @@ final class TestingServer(
     val parents = (reveal.uriChain :+ null).map { uri =>
       server.treeView.children(TreeViewChildrenParams(reveal.viewId, uri))
     }
+
     val label = parents.iterator
       .flatMap { r =>
         r.nodes.iterator.map { n =>
@@ -1327,19 +1328,20 @@ final class TestingServer(
             case Some(value) => s" $value"
           }
           val label = n.label + icon
-          n.nodeUri -> label
+          n.nodeUri.toLowerCase -> label
         }
       }
       .toMap
       .updated("root", "root")
+
     val tree = parents
       .zip(reveal.uriChain :+ "root")
       .foldLeft(PrettyPrintTree.empty) {
         case (child, (parent, uri)) =>
           PrettyPrintTree(
-            label(uri),
+            label(uri.toLowerCase),
             parent.nodes
-              .map(n => PrettyPrintTree(label(n.nodeUri)))
+              .map(n => PrettyPrintTree(label(n.nodeUri.toLowerCase)))
               .filterNot(t => isIgnored(t.value))
               .toList :+ child
           )


### PR DESCRIPTION
It seems 1GB for a fork was not enough on MacOS. And since we do not have multiple forks running it should be fine.
Current xmx for each process:
- bloop 2GB
- sbt 1GB
- test fork 2GB

With max 7GB it leaves 2GB spare for class space, which should be enough.