### PR TITLE
Fix auto imports and go to sources for worksheets outside sources

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals
 
+import java.nio.file.Path
 import java.{util => ju}
 
 import scala.collection.concurrent.TrieMap
@@ -85,11 +86,25 @@ class StandaloneSymbolSearch(
 }
 
 object StandaloneSymbolSearch {
+
+  def apply(
+      workspace: AbsolutePath,
+      buffers: Buffers,
+      sources: Seq[Path],
+      classpath: Seq[Path]
+  ): StandaloneSymbolSearch = {
+    new StandaloneSymbolSearch(
+      workspace,
+      classpath.map(path => AbsolutePath(path)),
+      sources.map(path => AbsolutePath(path)),
+      buffers
+    )
+  }
+
   def apply(
       workspace: AbsolutePath,
       buffers: Buffers
   ): StandaloneSymbolSearch = {
-
     val scalaVersion = BuildInfo.scala212
 
     val jars = Embedded

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -63,54 +63,6 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
     } yield ()
   }
 
-  if (scalaVersion == V.scala212) {
-    test("completion-imports") {
-      for {
-        _ <- server.initialize(
-          s"""
-             |/metals.json
-             |{
-             |  "a": {}
-             |}
-             |/a/src/main/scala/foo/Main.worksheet.sc
-             |import $$dep.`com.lihaoyi::scalatags:0.9.0`
-             |import scalatags.Text.all._
-             |
-             |val htmlFile = html(
-             |  body(
-             |    p("This is a big paragraph of text")
-             |  )
-             |)
-             |
-             |htmlFile.render
-             |""".stripMargin
-        )
-        _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
-        _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
-        identity <- server.completion(
-          "a/src/main/scala/foo/Main.worksheet.sc",
-          "htmlFile.render@@"
-        )
-        _ = assertNoDiff(identity, "render: String")
-        _ = assertNoDiagnostics()
-        _ = assertNoDiff(
-          client.workspaceDecorations,
-          """|import $dep.`com.lihaoyi::scalatags:0.9.0`
-             |import scalatags.Text.all._
-             |
-             |val htmlFile = html(
-             |  body(
-             |    p("This is a big paragraph of text")
-             |  )
-             |) // : scalatags.Text.TypedTag[String] = TypedTag("html",List(WrappedArray(TypedTag("body",List(WrappedArray(TypedTag("p",Li…
-             |
-             |htmlFile.render // : String = "<html><body><p>This is a big paragraph of text</p></body></html>"
-             |""".stripMargin
-        )
-      } yield ()
-    }
-  }
-
   test("outside-target") {
     for {
       _ <- server.initialize(

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
@@ -2,4 +2,72 @@ package tests.worksheets
 
 import scala.meta.internal.metals.{BuildInfo => V}
 
-class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala212)
+import munit.TestOptions
+
+class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala212) {
+
+  checkWorksheetDeps(
+    "imports-inside",
+    "a/src/main/scala/foo/Main.worksheet.sc"
+  )
+
+  checkWorksheetDeps("imports-outside", "Main.worksheet.sc")
+
+  def checkWorksheetDeps(opts: TestOptions, path: String): Unit = {
+    test(opts) {
+      for {
+        _ <- server.initialize(
+          s"""
+             |/metals.json
+             |{
+             |  "a": {}
+             |}
+             |/$path
+             |import $$dep.`com.lihaoyi::scalatags:0.9.0`
+             |import scalatags.Text.all._
+             |val htmlFile = html(
+             |  body(
+             |    p("This is a big paragraph of text")
+             |  )
+             |)
+             |htmlFile.render
+             |""".stripMargin
+        )
+        _ <- server.didOpen(path)
+        _ <- server.didSave(path)(identity)
+        identity <- server.completion(
+          path,
+          "htmlFile.render@@"
+        )
+        _ = assertNoDiff(
+          server.workspaceDefinitions,
+          s"""|/$path
+              |import $$dep/*<no symbol>*/.`com.lihaoyi::scalatags:0.9.0`/*<no symbol>*/
+              |import scalatags.Text/*Text.scala*/.all/*Text.scala*/._
+              |val htmlFile/*L2*/ = html/*Text.scala*/(
+              |  body/*Text.scala*/(
+              |    p/*Text.scala*/("This is a big paragraph of text")
+              |  )
+              |)
+              |htmlFile/*L2*/.render/*Text.scala*/
+              |""".stripMargin
+        )
+        _ <- server.didOpen("scalatags/Text.scala")
+        _ = assertNoDiff(identity, "render: String")
+        _ = assertNoDiagnostics()
+        _ = assertNoDiff(
+          client.workspaceDecorations,
+          """|import $dep.`com.lihaoyi::scalatags:0.9.0`
+             |import scalatags.Text.all._
+             |val htmlFile = html(
+             |  body(
+             |    p("This is a big paragraph of text")
+             |  )
+             |) // : scalatags.Text.TypedTag[String] = TypedTag("html",List(WrappedArray(TypedTag("body",List(WrappedArray(TypedTag("p",Li…
+             |htmlFile.render // : String = "<html><body><p>This is a big paragraph of text</p></body></html>"
+             |""".stripMargin
+        )
+      } yield ()
+    }
+  }
+}


### PR DESCRIPTION
The sources and classpath was not forwarded to the symbol search for worksheets outside build targets.

Fixes https://github.com/scalameta/metals/issues/2029