### PR TITLE
Fix missing classes from _empty_ package in treeView.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/tvp/ClasspathSymbols.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/ClasspathSymbols.scala
@@ -97,7 +97,9 @@ class ClasspathSymbols(isStatisticsEnabled: Boolean = false) {
     val buf = Array.newBuilder[TreeViewSymbolInformation]
     def list(root: AbsolutePath): Unit = {
       val dir =
-        if (symbol == Scala.Symbols.RootPackage) root
+        if (
+          symbol == Scala.Symbols.RootPackage || symbol == Scala.Symbols.EmptyPackage
+        ) root
         else root.resolve(Symbol(symbol).enclosingPackage.value)
 
       dir.list.foreach {

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -60,6 +60,10 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
                                |  "a": {},
                                |  "b": {}
                                |}
+                               |/a/src/main/scala/a/Zero.scala
+                               |class Zero {
+                               | val a = 1
+                               |}
                                |/a/src/main/scala/a/First.scala
                                |package a
                                |class First {
@@ -99,7 +103,19 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
       _ <- server.didOpen("b/src/main/scala/b/Third.scala")
       _ = server.assertTreeViewChildren(
         s"projects:${server.buildTarget("a")}",
-        "a/ +"
+        """|_empty_/ -
+           |a/ -
+           |""".stripMargin
+      )
+      _ = server.assertTreeViewChildren(
+        s"projects:${server.buildTarget("a")}!/_empty_/",
+        """|Zero class +
+           |""".stripMargin
+      )
+      _ = server.assertTreeViewChildren(
+        s"projects:${server.buildTarget("a")}!/_empty_/Zero#",
+        """|a val
+           |""".stripMargin
       )
       _ = server.assertTreeViewChildren(
         s"projects:${server.buildTarget("a")}!/a/",


### PR DESCRIPTION
Previously if we were looking for members underneath `_empty_` we ended up
looking for them in `<uri>/_empty_` rather than just looking for them in the
root where they are stored. This adds in another check where when we look to
see if a symbol is in the root package, we also check to see if it's an empty
package, and if so, then just return the root value to look for it.

Closes #1648 