### PR TITLE
Don't search for runTest code lenses in Ammonite scripts and worksheets.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -35,15 +35,20 @@ final class RunTestCodeLens(
   ): Seq[l.CodeLens] = {
     val textDocument = textDocumentWithPath.textDocument
     val path = textDocumentWithPath.filePath
-    val distance = buffers.tokenEditDistance(path, textDocument.text)
+    if (path.isAmmoniteScript || path.isWorksheet) {
+      Seq.empty
+    } else {
+      val distance = buffers.tokenEditDistance(path, textDocument.text)
 
-    buildTargets
-      .inverseSources(path)
-      .map { buildTarget =>
-        val classes = buildTargetClasses.classesOf(buildTarget)
-        codeLenses(textDocument, buildTarget, classes, distance)
-      }
-      .getOrElse(Seq.empty)
+      buildTargets
+        .inverseSources(path)
+        .map { buildTarget =>
+          val classes = buildTargetClasses.classesOf(buildTarget)
+          codeLenses(textDocument, buildTarget, classes, distance)
+        }
+        .getOrElse(Seq.empty)
+
+    }
   }
 
   private def codeLenses(

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -97,7 +97,8 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
     } yield ()
   }
 
-  test("hover") {
+  // https://github.com/scalameta/metals/issues/1801
+  test("hover".flaky) {
     for {
       _ <- server.initialize(
         s"""


### PR DESCRIPTION
Up to this point we search for all types of code lenses even in Ammonite scripts
where there won't be any run or test code lenses that appear. This will save us a
bit as we won't look through all the symbols in the textDocument for the main method.
It's probably not a huge deal, but no need to do it.