### PR TITLE
Add support for dotty 0.27.0-RC1 and update mdoc

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -16,6 +16,7 @@ project.excludeFilters = [
   "mtags/src/main/scala-0.24/"
   "mtags/src/main/scala-0.25/"
   "mtags/src/main/scala-0.26/"
+  "mtags/src/main/scala-0.27/"
   "mtags/src/main/scala-3/"
   "tests/unit/src/test/resources"
 ]

--- a/build.sbt
+++ b/build.sbt
@@ -178,13 +178,14 @@ lazy val V = new {
   val bsp = "2.0.0-M4+10-61e61e87"
   val bloop = "1.4.3-27-dfdc9971"
   val scala3 = "0.26.0"
+  val scala3Candidate = "0.27.0-RC1"
   val bloopNightly = bloop
   val sbtBloop = bloop
   val gradleBloop = bloop
   val mavenBloop = bloop
-  val mdoc = "2.2.5"
+  val mdoc = "2.2.7"
   val scalafmt = "2.6.4"
-  val munit = "0.7.10"
+  val munit = "0.7.12"
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.
   def supportedScalaBinaryVersions =
@@ -201,8 +202,8 @@ lazy val V = new {
   def scala2Versions = nonDeprecatedScala2Versions ++ deprecatedScala2Versions
 
   // Scala 3
-  def nonDeprecatedScala3Versions = Seq(scala3, "0.25.0")
-  def deprecatedScala3Versions = Seq("0.25.0-RC2", "0.26.0-RC1")
+  def nonDeprecatedScala3Versions = Seq(scala3, scala3Candidate)
+  def deprecatedScala3Versions = Seq("0.25.0", "0.26.0-RC1")
   def scala3Versions = nonDeprecatedScala3Versions ++ deprecatedScala3Versions
 
   def supportedScalaVersions = scala2Versions ++ scala3Versions

--- a/mtags/src/main/scala-0.27/scala/meta/internal/pc/Symbols.scala
+++ b/mtags/src/main/scala-0.27/scala/meta/internal/pc/Symbols.scala
@@ -1,0 +1,9 @@
+package scala.meta.internal.pc
+
+import dotty.tools.dotc.core.Symbols._
+import dotty.tools.dotc.core.Contexts._
+import dotty.tools.dotc.transform.SymUtils._
+
+object Symbols {
+  def isDeprecated(symbol: Symbol)(using ctx: Context) = symbol.isDeprecated
+}

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -129,7 +129,6 @@ case class ScalaPresentationCompiler(
           Completion.completions(pos)(using ctx.fresh.setCompilationUnit(unit))._2
         case None => Nil
       }
-
       new CompletionList(
         /*isIncomplete = */ false,
         items.map(completionItem).asJava

--- a/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
@@ -13,6 +13,7 @@ import scala.meta.internal.pc.InterruptException
 import scala.meta.pc.CancelToken
 
 import munit.Location
+import munit.TestOptions
 import tests.BaseCompletionSuite
 
 class CancelCompletionSuite extends BaseCompletionSuite {
@@ -34,7 +35,7 @@ class CancelCompletionSuite extends BaseCompletionSuite {
   }
 
   def checkCancelled(
-      name: String,
+      name: TestOptions,
       query: String,
       expected: String,
       compat: Map[String, String]
@@ -81,7 +82,7 @@ class CancelCompletionSuite extends BaseCompletionSuite {
   }
 
   checkCancelled(
-    "basic",
+    "basic".tag(IgnoreScalaVersion("0.27.0-RC1")),
     """
       |object A {
       |  val x = asser@@

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetNegSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetNegSuite.scala
@@ -35,7 +35,7 @@ class CompletionSnippetNegSuite extends BaseCompletionSuite {
   )
 
   checkSnippet(
-    "scope",
+    "scope".tag(IgnoreScalaVersion("0.27.0-RC1")),
     """
       |object Main {
       |  printl@@
@@ -46,7 +46,7 @@ class CompletionSnippetNegSuite extends BaseCompletionSuite {
        |println
        |""".stripMargin,
     compat = Map(
-      "0." -> "println"
+      "0.26" -> "println"
     )
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -46,7 +46,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "extension",
+    "extension".tag(IgnoreScalaVersion("0.27.0-RC1")),
     """
       |object A {
       |  "".stripSu@@
@@ -460,7 +460,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "commit1",
+    "commit1".tag(IgnoreScalaVersion("0.27.0-RC1")),
     """
       |package a
       |
@@ -788,7 +788,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "pat",
+    "pat".tag(IgnoreScalaVersion("0.27.0-RC1")),
     s"""|object Main {
         |  Option(1) match {
         |    case Som@@
@@ -802,7 +802,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "pat1",
+    "pat1".tag(IgnoreScalaVersion("0.27.0-RC1")),
     s"""|object Main {
         |  Option(1) match {
         |    case List(Som@@)
@@ -816,7 +816,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "adt",
+    "adt".tag(IgnoreScalaVersion("0.27.0-RC1")),
     s"""|object Main {
         |  Option(1) match {
         |    case No@@
@@ -835,7 +835,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "adt1",
+    "adt1".tag(IgnoreScalaVersion("0.27.0-RC1")),
     s"""|object Main {
         |  Option(1) match {
         |    case S@@
@@ -861,7 +861,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "adt2",
+    "adt2".tag(IgnoreScalaVersion("0.27.0-RC1")),
     s"""|object Main {
         |  Option(1) match {
         |    case _: S@@
@@ -887,7 +887,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "adt3",
+    "adt3".tag(IgnoreScalaVersion("0.27.0-RC1")),
     s"""|import Matches._
         |object Matches {
         |  val Number = "".r
@@ -915,7 +915,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "adt4",
+    "adt4".tag(IgnoreScalaVersion("0.27.0-RC1")),
     s"""|object Main {
         |  val Number = "".r
         |  "" match {
@@ -937,7 +937,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "adt5",
+    "adt5".tag(IgnoreScalaVersion("0.27.0-RC1")),
     s"""|object Main {
         |  val Number = "".r
         |  "" match {
@@ -996,7 +996,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "sort",
+    "sort".tag(IgnoreScalaVersion("0.27.0-RC1")),
     s"""|object Main {
         |  def printnnn = ""
         |  def printmmm = ""

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -64,6 +64,10 @@ class BaseSuite extends munit.FunSuite with Assertions {
 
     postProcess(result)
   }
+  protected def toJsonArray(list: List[String]): String = {
+    if (list.isEmpty) "[]"
+    else s"[${list.mkString("\"", """", """", "\"")}]"
+  }
 }
 
 object BaseSuite {

--- a/tests/slow/src/test/scala/tests/feature/WorksheetCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/WorksheetCrossLspSuite.scala
@@ -3,7 +3,7 @@ package tests.feature
 import scala.meta.internal.metals.{BuildInfo => V}
 
 class Worksheet211LspSuite extends tests.BaseWorksheetLspSuite(V.scala211)
-class Worksheet026LspSuite extends tests.BaseWorksheetLspSuite(V.scala3)
+class Worksheet3LspSuite extends tests.BaseWorksheetLspSuite(V.scala3)
 class Worksheet213LspSuite extends tests.BaseWorksheetLspSuite(V.scala213) {
 
   test("literals") {

--- a/tests/unit/src/main/scala/tests/BaseRangesSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseRangesSuite.scala
@@ -6,6 +6,9 @@ import munit.Location
 
 abstract class BaseRangesSuite(name: String) extends BaseLspSuite(name) {
 
+  protected def libraryDependencies: List[String] = Nil
+  protected def compilerPlugins: List[String] = Nil
+
   def assertCheck(
       filename: String,
       edit: String,
@@ -38,6 +41,7 @@ abstract class BaseRangesSuite(name: String) extends BaseLspSuite(name) {
     }
 
     val actualScalaVersion = scalaVersion.getOrElse(BuildInfo.scalaVersion)
+
     test(name) {
       cleanWorkspace()
       for {
@@ -46,13 +50,8 @@ abstract class BaseRangesSuite(name: String) extends BaseLspSuite(name) {
              |{"a":
              |  {
              |    "scalaVersion" : "$actualScalaVersion",
-             |    "compilerPlugins": [
-             |      "org.scalamacros:::paradise:2.1.1"
-             |    ],
-             |    "libraryDependencies": [
-             |      "org.scalatest::scalatest:3.0.5",
-             |      "io.circe::circe-generic:0.12.0"
-             |    ]
+             |    "compilerPlugins": ${toJsonArray(compilerPlugins)},
+             |    "libraryDependencies": ${toJsonArray(libraryDependencies)}
              |  }
              |}
              |${input

--- a/tests/unit/src/main/scala/tests/BaseRenameLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseRenameLspSuite.scala
@@ -7,6 +7,9 @@ import munit.TestOptions
 
 class BaseRenameLspSuite(name: String) extends BaseLspSuite(name) {
 
+  protected def libraryDependencies: List[String] = Nil
+  protected def compilerPlugins: List[String] = Nil
+
   def same(
       name: String,
       input: String
@@ -83,13 +86,8 @@ class BaseRenameLspSuite(name: String) extends BaseLspSuite(name) {
              |{
              |  "a" : {
              |    "scalaVersion": "$actualScalaVersion",
-             |    "compilerPlugins": [
-             |      "org.scalamacros:::paradise:2.1.1"
-             |    ],
-             |    "libraryDependencies": [
-             |      "org.scalatest::scalatest:3.0.5",
-             |      "io.circe::circe-generic:0.12.0"
-             |    ]
+             |    "compilerPlugins": ${toJsonArray(compilerPlugins)},
+             |    "libraryDependencies": ${toJsonArray(libraryDependencies)}
              |  },
              |  "b" : {
              |    "scalaVersion": "$actualScalaVersion",

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -26,7 +26,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
            |{
            |  "a": {
            |    "scalaVersion": "$scalaVersion",
-           |    "libraryDependencies": ["com.lihaoyi::sourcecode:0.1.8"]
+           |    "libraryDependencies": ["com.lihaoyi::sourcecode:0.2.1"]
            |  }
            |}
            |/a/src/main/scala/foo/Main.worksheet.sc
@@ -56,9 +56,18 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
       _ = assertNoDiagnostics()
       _ = assertNoDiff(
         client.workspaceDecorations,
-        """|identity(42) // : Int = 42
-           |val name = sourcecode.Name.generate.value // : String = "name"
-           |""".stripMargin
+        getExpected(
+          """|identity(42) // : Int = 42
+             |val name = sourcecode.Name.generate.value // : String = "name"
+             |""".stripMargin,
+          Map(
+            V.scala3 ->
+              """|identity(42) // : Int = 42
+                 |val name = sourcecode.Name.generate.value // : String = name
+                 |""".stripMargin
+          ),
+          scalaVersion
+        )
       )
     } yield ()
   }
@@ -112,40 +121,83 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
       _ = assertNoDiagnostics()
       _ = assertNoDiff(
         client.workspaceDecorations,
-        """|import java.nio.file.Files
-           |val name = "Susan" // : String = "Susan"
-           |val greeting = s"Hello $name" // : String = "Hello Susan"
-           |println(greeting + "\nHow are you?") // Hello Susan…
-           |1.to(10).toVector // : Vector[Int] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-           |val List(a, b) = List(42, 10) // a: Int = 42, b: Int = 10
-           |""".stripMargin
+        getExpected(
+          """|import java.nio.file.Files
+             |val name = "Susan" // : String = "Susan"
+             |val greeting = s"Hello $name" // : String = "Hello Susan"
+             |println(greeting + "\nHow are you?") // Hello Susan…
+             |1.to(10).toVector // : Vector[Int] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+             |val List(a, b) = List(42, 10) // a: Int = 42, b: Int = 10
+             |""".stripMargin,
+          Map(
+            V.scala3 ->
+              """|import java.nio.file.Files
+                 |val name = "Susan" // : String = Susan
+                 |val greeting = s"Hello $name" // : String = Hello Susan
+                 |println(greeting + "\nHow are you?") // Hello Susan…
+                 |1.to(10).toVector // : Vector[Int] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+                 |val List(a, b) = List(42, 10) // a: Int = 42, b: Int = 10
+                 |""".stripMargin
+          ),
+          scalaVersion
+        )
       )
       _ = assertNoDiff(
         client.workspaceDecorationHoverMessage,
-        """|import java.nio.file.Files
-           |val name = "Susan"
-           |```scala
-           |name: String = "Susan"
-           |```
-           |val greeting = s"Hello $name"
-           |```scala
-           |greeting: String = "Hello Susan"
-           |```
-           |println(greeting + "\nHow are you?")
-           |```scala
-           |// Hello Susan
-           |// How are you?
-           |```
-           |1.to(10).toVector
-           |```scala
-           |res1: Vector[Int] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-           |```
-           |val List(a, b) = List(42, 10)
-           |```scala
-           |a: Int = 42
-           |b: Int = 10
-           |```
-           |""".stripMargin
+        getExpected(
+          """|import java.nio.file.Files
+             |val name = "Susan"
+             |```scala
+             |name: String = "Susan"
+             |```
+             |val greeting = s"Hello $name"
+             |```scala
+             |greeting: String = "Hello Susan"
+             |```
+             |println(greeting + "\nHow are you?")
+             |```scala
+             |// Hello Susan
+             |// How are you?
+             |```
+             |1.to(10).toVector
+             |```scala
+             |res1: Vector[Int] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+             |```
+             |val List(a, b) = List(42, 10)
+             |```scala
+             |a: Int = 42
+             |b: Int = 10
+             |```
+             |""".stripMargin,
+          Map(
+            V.scala3 ->
+              """|import java.nio.file.Files
+                 |val name = "Susan"
+                 |```scala
+                 |name: String = Susan
+                 |```
+                 |val greeting = s"Hello $name"
+                 |```scala
+                 |greeting: String = Hello Susan
+                 |```
+                 |println(greeting + "\nHow are you?")
+                 |```scala
+                 |// Hello Susan
+                 |// How are you?
+                 |```
+                 |1.to(10).toVector
+                 |```scala
+                 |res1: Vector[Int] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+                 |```
+                 |val List(a, b) = List(42, 10)
+                 |```scala
+                 |a: Int = 42
+                 |b: Int = 10
+                 |```
+                 |""".stripMargin
+          ),
+          scalaVersion
+        )
       )
     } yield ()
   }

--- a/tests/unit/src/main/scala/tests/QuickBuild.scala
+++ b/tests/unit/src/main/scala/tests/QuickBuild.scala
@@ -106,7 +106,7 @@ case class QuickBuild(
       s"src/main/scala-$binaryVersion",
       s"src/main/scala-$binaryVersion"
     ).map(relpath => baseDirectory.resolve(relpath))
-    val allDependencies =
+    val scalaDependencies =
       if (ScalaVersions.isScala3Version(scalaVersion)) {
         Array(
           s"org.scala-lang:scala-library:2.13.1",
@@ -117,7 +117,9 @@ case class QuickBuild(
           s"org.scala-lang:scala-library:$scalaVersion",
           s"org.scala-lang:scala-reflect:$scalaVersion"
         )
-      } ++ libraryDependencies
+      }
+
+    val allDependencies = scalaDependencies ++ libraryDependencies
     val allJars = classDirectory :: QuickBuild.fetch(
       allDependencies,
       scalaVersion,

--- a/tests/unit/src/test/scala/tests/ImplementationLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ImplementationLspSuite.scala
@@ -532,6 +532,12 @@ class ImplementationLspSuite extends BaseRangesSuite("implementation") {
        |""".stripMargin
   )
 
+  override protected def libraryDependencies: List[String] =
+    List("org.scalatest::scalatest:3.0.5", "io.circe::circe-generic:0.12.0")
+
+  override protected def compilerPlugins: List[String] =
+    List("org.scalamacros:::paradise:2.1.1")
+
   override def assertCheck(
       filename: String,
       edit: String,

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -623,4 +623,9 @@ class RenameLspSuite extends BaseRenameLspSuite("rename") {
     newName = "Animal"
   )
 
+  override protected def libraryDependencies: List[String] =
+    List("org.scalatest::scalatest:3.0.5", "io.circe::circe-generic:0.12.0")
+
+  override protected def compilerPlugins: List[String] =
+    List("org.scalamacros:::paradise:2.1.1")
 }


### PR DESCRIPTION
The updated mdoc now uses `toString` and inbuilt mechanism for reporting types, which solves the issue with pprint dependency.

Fixes https://github.com/scalameta/metals/issues/2024