### PR TITLE
Fix wrong definition position for worksheets

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -363,7 +363,7 @@ object WorksheetProvider {
       pos => {
         new Position(pos.getLine() - 1, pos.getCharacter() - ident.size)
       },
-      filterOutLocations = { loc => loc.getUri().isWorksheet }
+      filterOutLocations = { loc => !loc.getUri().isWorksheet }
     )
     Some((modifiedInput, adjustLspData))
   }

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -465,8 +465,8 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
           Map(
             V.scala3 ->
               """|/a/src/main/scala/Main.worksheet.sc
-                 |val message/*L1*/ = "Hello World!"
-                 |println/*<no symbol>*/(message/*L1*/)
+                 |val message/*L0*/ = "Hello World!"
+                 |println/*<no symbol>*/(message/*L0*/)
                  |""".stripMargin
           ),
           scalaVersion


### PR DESCRIPTION
I haven't noticed that the test position were actually bad. They should point to 0 line after adjustments.