### PR TITLE
Change new-scala-file to enable quick creation of a file.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1499,7 +1499,14 @@ class MetalsLanguageServer(
           case name: JsonPrimitive if name.isString =>
             name.getAsString()
         }
-        newFilesProvider.createNewFileDialog(directoryURI, name).asJavaObject
+        val fileType = args.lift(2).collect {
+          case fileType: JsonPrimitive if fileType.isString =>
+            fileType.getAsString()
+        }
+        newFilesProvider
+          .handleFileCreation(directoryURI, name, fileType)
+          .asJavaObject
+
       case ServerCommands.StartAmmoniteBuildServer() =>
         ammonite.start().asJavaObject
       case ServerCommands.StopAmmoniteBuildServer() =>

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -255,7 +255,10 @@ object ServerCommands {
        |
        |Note: requires 'metals/inputBox' capability from language client.
        |""".stripMargin,
-    "[string], where the string is a directory location for the new file."
+    """|[string[]], where the first is a directory location for the new file.
+       |The second and third positions correspond to the file name and file type to allow for quick
+       |creation of a file if all are present.
+       |""".stripMargin
   )
 
   val NewScalaProject = new Command(

--- a/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
@@ -20,234 +20,234 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
     Some(InitializationOptions.Default.copy(inputBoxProvider = Some(true)))
 
   check("new-worksheet-picked")(
-    Some("a/src/main/scala/"),
-    Right(worksheet),
-    Right("Foo"),
-    "a/src/main/scala/Foo.worksheet.sc",
-    ""
+    directory = Some("a/src/main/scala/"),
+    fileType = Right(worksheet),
+    fileName = Right("Foo"),
+    expectedFilePath = "a/src/main/scala/Foo.worksheet.sc",
+    expectedContent = ""
   )
 
   check("new-worksheet-name-provided")(
-    Some("a/src/main/scala/"),
-    Left(worksheet),
-    Right("Foo"),
-    "a/src/main/scala/Foo.worksheet.sc",
-    ""
+    directory = Some("a/src/main/scala/"),
+    fileType = Left(worksheet),
+    fileName = Right("Foo"),
+    expectedFilePath = "a/src/main/scala/Foo.worksheet.sc",
+    expectedContent = ""
   )
 
   check("new-worksheet-fully-provided")(
-    Some("a/src/main/scala/"),
-    Left(worksheet),
-    Left("Foo"),
-    "a/src/main/scala/Foo.worksheet.sc",
-    ""
+    directory = Some("a/src/main/scala/"),
+    fileType = Left(worksheet),
+    fileName = Left("Foo"),
+    expectedFilePath = "a/src/main/scala/Foo.worksheet.sc",
+    expectedContent = ""
   )
 
   check("new-ammonite-script")(
     directory = Some("a/src/main/scala/"),
     fileType = Right(ammonite),
     fileName = Right("Foo"),
-    "a/src/main/scala/Foo.sc",
-    ""
+    expectedFilePath = "a/src/main/scala/Foo.sc",
+    expectedContent = ""
   )
 
   check("new-ammonite-script-name-provided")(
     directory = Some("a/src/main/scala/"),
     fileType = Right(ammonite),
     fileName = Left("Foo"),
-    "a/src/main/scala/Foo.sc",
-    ""
+    expectedFilePath = "a/src/main/scala/Foo.sc",
+    expectedContent = ""
   )
 
   check("new-ammonite-script-fully-provided")(
     directory = Some("a/src/main/scala/"),
     fileType = Left(ammonite),
     fileName = Left("Foo"),
-    "a/src/main/scala/Foo.sc",
-    ""
+    expectedFilePath = "a/src/main/scala/Foo.sc",
+    expectedContent = ""
   )
 
   check("new-class")(
-    Some("a/src/main/scala/foo/"),
-    Right(clazz),
-    Right("Foo"),
-    "a/src/main/scala/foo/Foo.scala",
-    s"""|package foo
-        |
-        |class Foo {
-        |$indent
-        |}
-        |""".stripMargin
+    directory = Some("a/src/main/scala/foo/"),
+    fileType = Right(clazz),
+    fileName = Right("Foo"),
+    expectedFilePath = "a/src/main/scala/foo/Foo.scala",
+    expectedContent = s"""|package foo
+                          |
+                          |class Foo {
+                          |$indent
+                          |}
+                          |""".stripMargin
   )
 
   check("new-class-name-provided")(
-    Some("a/src/main/scala/foo/"),
-    Right(clazz),
-    Left("Foo"),
-    "a/src/main/scala/foo/Foo.scala",
-    s"""|package foo
-        |
-        |class Foo {
-        |$indent
-        |}
-        |""".stripMargin
+    directory = Some("a/src/main/scala/foo/"),
+    fileType = Right(clazz),
+    fileName = Left("Foo"),
+    expectedFilePath = "a/src/main/scala/foo/Foo.scala",
+    expectedContent = s"""|package foo
+                          |
+                          |class Foo {
+                          |$indent
+                          |}
+                          |""".stripMargin
   )
 
   check("new-class-fully-provided")(
-    Some("a/src/main/scala/foo/"),
-    Left(clazz),
-    Left("Foo"),
-    "a/src/main/scala/foo/Foo.scala",
-    s"""|package foo
-        |
-        |class Foo {
-        |$indent
-        |}
-        |""".stripMargin
+    directory = Some("a/src/main/scala/foo/"),
+    fileType = Left(clazz),
+    fileName = Left("Foo"),
+    expectedFilePath = "a/src/main/scala/foo/Foo.scala",
+    expectedContent = s"""|package foo
+                          |
+                          |class Foo {
+                          |$indent
+                          |}
+                          |""".stripMargin
   )
 
   check("new-case-class")(
-    Some("a/src/main/scala/foo/"),
-    Right(caseClass),
-    Right("Foo"),
-    "a/src/main/scala/foo/Foo.scala",
-    """|package foo
-       |
-       |final case class Foo()
-       |""".stripMargin
+    directory = Some("a/src/main/scala/foo/"),
+    fileType = Right(caseClass),
+    fileName = Right("Foo"),
+    expectedFilePath = "a/src/main/scala/foo/Foo.scala",
+    expectedContent = """|package foo
+                         |
+                         |final case class Foo()
+                         |""".stripMargin
   )
 
   check("new-case-class-name-provided")(
-    Some("a/src/main/scala/foo/"),
-    Right(caseClass),
-    Left("Foo"),
-    "a/src/main/scala/foo/Foo.scala",
-    """|package foo
-       |
-       |final case class Foo()
-       |""".stripMargin
+    directory = Some("a/src/main/scala/foo/"),
+    fileType = Right(caseClass),
+    fileName = Left("Foo"),
+    expectedFilePath = "a/src/main/scala/foo/Foo.scala",
+    expectedContent = """|package foo
+                         |
+                         |final case class Foo()
+                         |""".stripMargin
   )
 
   check("new-case-class-fully-provided")(
-    Some("a/src/main/scala/foo/"),
-    Left(caseClass),
-    Left("Foo"),
-    "a/src/main/scala/foo/Foo.scala",
-    """|package foo
-       |
-       |final case class Foo()
-       |""".stripMargin
+    directory = Some("a/src/main/scala/foo/"),
+    fileType = Left(caseClass),
+    fileName = Left("Foo"),
+    expectedFilePath = "a/src/main/scala/foo/Foo.scala",
+    expectedContent = """|package foo
+                         |
+                         |final case class Foo()
+                         |""".stripMargin
   )
 
   check("new-object-null-dir")(
-    None,
-    Right(objekt),
-    Right("Bar"),
-    "Bar.scala",
-    s"""|object Bar {
-        |$indent
-        |}
-        |""".stripMargin
+    directory = None,
+    fileType = Right(objekt),
+    fileName = Right("Bar"),
+    expectedFilePath = "Bar.scala",
+    expectedContent = s"""|object Bar {
+                          |$indent
+                          |}
+                          |""".stripMargin
   )
 
   check("new-object-null-dir-name-provided")(
-    None,
-    Right(objekt),
-    Left("Bar"),
-    "Bar.scala",
-    s"""|object Bar {
-        |$indent
-        |}
-        |""".stripMargin
+    directory = None,
+    fileType = Right(objekt),
+    fileName = Left("Bar"),
+    expectedFilePath = "Bar.scala",
+    expectedContent = s"""|object Bar {
+                          |$indent
+                          |}
+                          |""".stripMargin
   )
 
   check("new-object-null-dir")(
-    None,
-    Left(objekt),
-    Left("Bar"),
-    "Bar.scala",
-    s"""|object Bar {
-        |$indent
-        |}
-        |""".stripMargin
+    directory = None,
+    fileType = Left(objekt),
+    fileName = Left("Bar"),
+    expectedFilePath = "Bar.scala",
+    expectedContent = s"""|object Bar {
+                          |$indent
+                          |}
+                          |""".stripMargin
   )
 
   check("new-trait-new-dir")(
-    Some("a/src/main/scala/"),
-    Right(trate),
-    Right("bar/Baz"),
-    "a/src/main/scala/bar/Baz.scala",
-    s"""|package bar
-        |
-        |trait Baz {
-        |$indent
-        |}
-        |""".stripMargin
+    directory = Some("a/src/main/scala/"),
+    fileType = Right(trate),
+    fileName = Right("bar/Baz"),
+    expectedFilePath = "a/src/main/scala/bar/Baz.scala",
+    expectedContent = s"""|package bar
+                          |
+                          |trait Baz {
+                          |$indent
+                          |}
+                          |""".stripMargin
   )
 
   check("new-trait-new-dir-name-provided")(
-    Some("a/src/main/scala/"),
-    Right(trate),
-    Left("bar/Baz"),
-    "a/src/main/scala/bar/Baz.scala",
-    s"""|package bar
-        |
-        |trait Baz {
-        |$indent
-        |}
-        |""".stripMargin
+    directory = Some("a/src/main/scala/"),
+    fileType = Right(trate),
+    fileName = Left("bar/Baz"),
+    expectedFilePath = "a/src/main/scala/bar/Baz.scala",
+    expectedContent = s"""|package bar
+                          |
+                          |trait Baz {
+                          |$indent
+                          |}
+                          |""".stripMargin
   )
 
   check("new-trait-new-dir-fully-provided")(
-    Some("a/src/main/scala/"),
-    Right(trate),
-    Right("bar/Baz"),
-    "a/src/main/scala/bar/Baz.scala",
-    s"""|package bar
-        |
-        |trait Baz {
-        |$indent
-        |}
-        |""".stripMargin
+    directory = Some("a/src/main/scala/"),
+    fileType = Right(trate),
+    fileName = Right("bar/Baz"),
+    expectedFilePath = "a/src/main/scala/bar/Baz.scala",
+    expectedContent = s"""|package bar
+                          |
+                          |trait Baz {
+                          |$indent
+                          |}
+                          |""".stripMargin
   )
 
   check("new-package-object")(
-    Some("a/src/main/scala/foo"),
-    Right(packageObject),
-    Right(
+    directory = Some("a/src/main/scala/foo"),
+    fileType = Right(packageObject),
+    fileName = Right(
       ""
     ), // Just given an empty string here because it will never be used for package objects
-    "a/src/main/scala/foo/package.scala",
-    s"""|package object foo {
-        |$indent
-        |}
-        |""".stripMargin
+    expectedFilePath = "a/src/main/scala/foo/package.scala",
+    expectedContent = s"""|package object foo {
+                          |$indent
+                          |}
+                          |""".stripMargin
   )
 
   check("new-package-object-provided")(
-    Some("a/src/main/scala/foo"),
-    Left(packageObject),
-    Right(
+    directory = Some("a/src/main/scala/foo"),
+    fileType = Left(packageObject),
+    fileName = Right(
       ""
     ), // Just given an empty string here because it will never be used for package objects
-    "a/src/main/scala/foo/package.scala",
-    s"""|package object foo {
-        |$indent
-        |}
-        |""".stripMargin
+    expectedFilePath = "a/src/main/scala/foo/package.scala",
+    expectedContent = s"""|package object foo {
+                          |$indent
+                          |}
+                          |""".stripMargin
   )
 
   check("new-class-on-file")(
-    Some("a/src/main/scala/foo/Other.scala"),
-    Right(clazz),
-    Right("Foo"),
-    "a/src/main/scala/foo/Foo.scala",
-    s"""|package foo
-        |
-        |class Foo {
-        |$indent
-        |}
-        |""".stripMargin,
+    directory = Some("a/src/main/scala/foo/Other.scala"),
+    fileType = Right(clazz),
+    fileName = Right("Foo"),
+    expectedFilePath = "a/src/main/scala/foo/Foo.scala",
+    expectedContent = s"""|package foo
+                          |
+                          |class Foo {
+                          |$indent
+                          |}
+                          |""".stripMargin,
     existingFiles = """|/a/src/main/scala/foo/Other.scala
                        |package foo
                        |
@@ -256,16 +256,16 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
   )
 
   check("new-class-on-file-name-provided")(
-    Some("a/src/main/scala/foo/Other.scala"),
-    Right(clazz),
-    Left("Foo"),
-    "a/src/main/scala/foo/Foo.scala",
-    s"""|package foo
-        |
-        |class Foo {
-        |$indent
-        |}
-        |""".stripMargin,
+    directory = Some("a/src/main/scala/foo/Other.scala"),
+    fileType = Right(clazz),
+    fileName = Left("Foo"),
+    expectedFilePath = "a/src/main/scala/foo/Foo.scala",
+    expectedContent = s"""|package foo
+                          |
+                          |class Foo {
+                          |$indent
+                          |}
+                          |""".stripMargin,
     existingFiles = """|/a/src/main/scala/foo/Other.scala
                        |package foo
                        |
@@ -274,16 +274,16 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
   )
 
   check("new-class-on-file-fully-provided")(
-    Some("a/src/main/scala/foo/Other.scala"),
-    Right(clazz),
-    Right("Foo"),
-    "a/src/main/scala/foo/Foo.scala",
-    s"""|package foo
-        |
-        |class Foo {
-        |$indent
-        |}
-        |""".stripMargin,
+    directory = Some("a/src/main/scala/foo/Other.scala"),
+    fileType = Right(clazz),
+    fileName = Right("Foo"),
+    expectedFilePath = "a/src/main/scala/foo/Foo.scala",
+    expectedContent = s"""|package foo
+                          |
+                          |class Foo {
+                          |$indent
+                          |}
+                          |""".stripMargin,
     existingFiles = """|/a/src/main/scala/foo/Other.scala
                        |package foo
                        |
@@ -292,10 +292,10 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
   )
 
   check("existing-file")(
-    Some("a/src/main/scala/foo"),
-    Right(clazz),
-    Right("Other"),
-    "a/src/main/scala/foo/Other.scala",
+    directory = Some("a/src/main/scala/foo"),
+    fileType = Right(clazz),
+    fileName = Right("Other"),
+    expectedFilePath = "a/src/main/scala/foo/Other.scala",
     expectedContent = s"""|package foo
                           |
                           |class Other {

--- a/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFilesLspSuite.scala
@@ -19,26 +19,84 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
   override def initializationOptions: Option[InitializationOptions] =
     Some(InitializationOptions.Default.copy(inputBoxProvider = Some(true)))
 
-  check("new-worksheet")(
+  check("new-worksheet-picked")(
     Some("a/src/main/scala/"),
-    "worksheet",
-    Some("Foo"),
+    Right(worksheet),
+    Right("Foo"),
+    "a/src/main/scala/Foo.worksheet.sc",
+    ""
+  )
+
+  check("new-worksheet-name-provided")(
+    Some("a/src/main/scala/"),
+    Left(worksheet),
+    Right("Foo"),
+    "a/src/main/scala/Foo.worksheet.sc",
+    ""
+  )
+
+  check("new-worksheet-fully-provided")(
+    Some("a/src/main/scala/"),
+    Left(worksheet),
+    Left("Foo"),
     "a/src/main/scala/Foo.worksheet.sc",
     ""
   )
 
   check("new-ammonite-script")(
-    Some("a/src/main/scala/"),
-    "ammonite",
-    Some("Foo"),
+    directory = Some("a/src/main/scala/"),
+    fileType = Right(ammonite),
+    fileName = Right("Foo"),
+    "a/src/main/scala/Foo.sc",
+    ""
+  )
+
+  check("new-ammonite-script-name-provided")(
+    directory = Some("a/src/main/scala/"),
+    fileType = Right(ammonite),
+    fileName = Left("Foo"),
+    "a/src/main/scala/Foo.sc",
+    ""
+  )
+
+  check("new-ammonite-script-fully-provided")(
+    directory = Some("a/src/main/scala/"),
+    fileType = Left(ammonite),
+    fileName = Left("Foo"),
     "a/src/main/scala/Foo.sc",
     ""
   )
 
   check("new-class")(
     Some("a/src/main/scala/foo/"),
-    "class",
-    Some("Foo"),
+    Right(clazz),
+    Right("Foo"),
+    "a/src/main/scala/foo/Foo.scala",
+    s"""|package foo
+        |
+        |class Foo {
+        |$indent
+        |}
+        |""".stripMargin
+  )
+
+  check("new-class-name-provided")(
+    Some("a/src/main/scala/foo/"),
+    Right(clazz),
+    Left("Foo"),
+    "a/src/main/scala/foo/Foo.scala",
+    s"""|package foo
+        |
+        |class Foo {
+        |$indent
+        |}
+        |""".stripMargin
+  )
+
+  check("new-class-fully-provided")(
+    Some("a/src/main/scala/foo/"),
+    Left(clazz),
+    Left("Foo"),
     "a/src/main/scala/foo/Foo.scala",
     s"""|package foo
         |
@@ -50,8 +108,30 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-case-class")(
     Some("a/src/main/scala/foo/"),
-    "case-class",
-    Some("Foo"),
+    Right(caseClass),
+    Right("Foo"),
+    "a/src/main/scala/foo/Foo.scala",
+    """|package foo
+       |
+       |final case class Foo()
+       |""".stripMargin
+  )
+
+  check("new-case-class-name-provided")(
+    Some("a/src/main/scala/foo/"),
+    Right(caseClass),
+    Left("Foo"),
+    "a/src/main/scala/foo/Foo.scala",
+    """|package foo
+       |
+       |final case class Foo()
+       |""".stripMargin
+  )
+
+  check("new-case-class-fully-provided")(
+    Some("a/src/main/scala/foo/"),
+    Left(caseClass),
+    Left("Foo"),
     "a/src/main/scala/foo/Foo.scala",
     """|package foo
        |
@@ -60,9 +140,31 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
   )
 
   check("new-object-null-dir")(
-    directory = None,
-    "object",
-    Some("Bar"),
+    None,
+    Right(objekt),
+    Right("Bar"),
+    "Bar.scala",
+    s"""|object Bar {
+        |$indent
+        |}
+        |""".stripMargin
+  )
+
+  check("new-object-null-dir-name-provided")(
+    None,
+    Right(objekt),
+    Left("Bar"),
+    "Bar.scala",
+    s"""|object Bar {
+        |$indent
+        |}
+        |""".stripMargin
+  )
+
+  check("new-object-null-dir")(
+    None,
+    Left(objekt),
+    Left("Bar"),
     "Bar.scala",
     s"""|object Bar {
         |$indent
@@ -72,8 +174,34 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-trait-new-dir")(
     Some("a/src/main/scala/"),
-    "trait",
-    Some("bar/Baz"),
+    Right(trate),
+    Right("bar/Baz"),
+    "a/src/main/scala/bar/Baz.scala",
+    s"""|package bar
+        |
+        |trait Baz {
+        |$indent
+        |}
+        |""".stripMargin
+  )
+
+  check("new-trait-new-dir-name-provided")(
+    Some("a/src/main/scala/"),
+    Right(trate),
+    Left("bar/Baz"),
+    "a/src/main/scala/bar/Baz.scala",
+    s"""|package bar
+        |
+        |trait Baz {
+        |$indent
+        |}
+        |""".stripMargin
+  )
+
+  check("new-trait-new-dir-fully-provided")(
+    Some("a/src/main/scala/"),
+    Right(trate),
+    Right("bar/Baz"),
     "a/src/main/scala/bar/Baz.scala",
     s"""|package bar
         |
@@ -85,8 +213,23 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-package-object")(
     Some("a/src/main/scala/foo"),
-    "package-object",
-    name = None,
+    Right(packageObject),
+    Right(
+      ""
+    ), // Just given an empty string here because it will never be used for package objects
+    "a/src/main/scala/foo/package.scala",
+    s"""|package object foo {
+        |$indent
+        |}
+        |""".stripMargin
+  )
+
+  check("new-package-object-provided")(
+    Some("a/src/main/scala/foo"),
+    Left(packageObject),
+    Right(
+      ""
+    ), // Just given an empty string here because it will never be used for package objects
     "a/src/main/scala/foo/package.scala",
     s"""|package object foo {
         |$indent
@@ -96,8 +239,44 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-class-on-file")(
     Some("a/src/main/scala/foo/Other.scala"),
-    "class",
-    Some("Foo"),
+    Right(clazz),
+    Right("Foo"),
+    "a/src/main/scala/foo/Foo.scala",
+    s"""|package foo
+        |
+        |class Foo {
+        |$indent
+        |}
+        |""".stripMargin,
+    existingFiles = """|/a/src/main/scala/foo/Other.scala
+                       |package foo
+                       |
+                       |class Other
+                       |""".stripMargin
+  )
+
+  check("new-class-on-file-name-provided")(
+    Some("a/src/main/scala/foo/Other.scala"),
+    Right(clazz),
+    Left("Foo"),
+    "a/src/main/scala/foo/Foo.scala",
+    s"""|package foo
+        |
+        |class Foo {
+        |$indent
+        |}
+        |""".stripMargin,
+    existingFiles = """|/a/src/main/scala/foo/Other.scala
+                       |package foo
+                       |
+                       |class Other
+                       |""".stripMargin
+  )
+
+  check("new-class-on-file-fully-provided")(
+    Some("a/src/main/scala/foo/Other.scala"),
+    Right(clazz),
+    Right("Foo"),
     "a/src/main/scala/foo/Foo.scala",
     s"""|package foo
         |
@@ -114,8 +293,8 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("existing-file")(
     Some("a/src/main/scala/foo"),
-    "class",
-    Some("Other"),
+    Right(clazz),
+    Right("Other"),
     "a/src/main/scala/foo/Other.scala",
     expectedContent = s"""|package foo
                           |
@@ -133,12 +312,22 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
     expectedException = List(classOf[FileAlreadyExistsException])
   )
 
-  private def indent = "  "
+  private lazy val indent = "  "
+  private lazy val worksheet = "worksheet"
+  private lazy val ammonite = "ammonite"
+  private lazy val clazz = "class"
+  private lazy val caseClass = "case-class"
+  private lazy val objekt = "object"
+  private lazy val trate = "trait"
+  private lazy val packageObject = "package-object"
+
+  type Provided = String
+  type Picked = String
 
   private def check(testName: TestOptions)(
       directory: Option[String],
-      pickedKind: String,
-      name: Option[String],
+      fileType: Either[Provided, Picked],
+      fileName: Either[Provided, Picked],
       expectedFilePath: String,
       expectedContent: String,
       existingFiles: String = "",
@@ -157,27 +346,51 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
         workspace.resolve("a/src/main/scala/").toNIO
       )
 
-      client.showMessageRequestHandler = { params =>
-        if (isSelectTheKindOfFile(params)) {
-          params.getActions().asScala.find(_.getTitle() == pickedKind)
-        } else {
-          None
+      val ft: String =
+        fileType match {
+          case Left(providedType) => providedType
+          case Right(pickedType) =>
+            client.showMessageRequestHandler = { params =>
+              if (isSelectTheKindOfFile(params)) {
+                params.getActions().asScala.find(_.getTitle() == pickedType)
+              } else {
+                None
+              }
+            }
+            pickedType
         }
-      }
-      name.foreach { name =>
-        client.inputBoxHandler = { params =>
-          if (isEnterName(params, pickedKind)) {
-            Some(new MetalsInputBoxResult(value = name))
-          } else {
-            None
+
+      fileName match {
+        case Left(_) => ()
+        case Right(value) =>
+          client.inputBoxHandler = { params =>
+            if (isEnterName(params, ft)) {
+              Some(new MetalsInputBoxResult(value = value))
+            } else {
+              None
+            }
           }
-        }
+      }
+
+      val selectFileMessage = fileType match {
+        case Left(_) => ""
+        case Right(_) => NewScalaFile.selectTheKindOfFileMessage
+      }
+
+      val selectNameMessage = fileName match {
+        // If given "" as a name, just ignore it (basically for package objects)
+        case Left(_) | Right("") => ""
+        case Right(_) => "\n" + NewScalaFile.enterNameMessage(ft)
       }
 
       val expectedMessages =
-        NewScalaFile.selectTheKindOfFileMessage + name.fold("")(_ =>
-          "\n" + NewScalaFile.enterNameMessage(pickedKind)
-        )
+        selectFileMessage + selectNameMessage
+
+      val args = List(
+        directoryUri,
+        fileName.fold(identity, _ => null.asInstanceOf[String]),
+        fileType.fold(identity, _ => null.asInstanceOf[String])
+      )
 
       val futureToRecover = for {
         _ <- server.initialize(s"""
@@ -191,7 +404,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
           server
             .executeCommand(
               ServerCommands.NewScalaFile.id,
-              directoryUri
+              args: _*
             )
         _ = {
           assertNoDiff(


### PR DESCRIPTION
This changed the current functionality of the new-scala-file command to allow
for another argument in the third position, which signifies the file type. Previously,
we allowed for the name of the file to be in the args in the second position, but now
we also allow the file type to allow for a client to create a file with a single command.
This mainly will allow for the quick-creation of worksheets which can be bound to an
editor action or command.

This also changes up the NewFilesLspSuite to cover the other arguments. Previously the
functionality of the name being passed in wasn't covered. Now, that functionality and
also providing the fileType is also covered in the tests.

Ideally the args for this command would have been an JSON object allowing for the necessary
keys to be set or not, but since it wasn't that way, I hesitate to change it now since
some clients may be using the array with 2 items (directory and name). Implimenting it
this will will allow for backwards compatability with any clients that may already be
utilizing the command with both directory and name being passed in.


Example with it bound to a `quick-worksheet` command in `coc-metals`:
![2020-09-16 22 04 42](https://user-images.githubusercontent.com/13974112/93498585-46285f80-f912-11ea-934a-e410b42fa80f.gif)

Closes #2073 
