### PR TITLE
Strip out `[E]` or `[error]` from stacktrace in analyzer.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
@@ -59,11 +59,20 @@ class StacktraceAnalyzer(
   def stacktraceLenses(content: List[String]): Seq[l.CodeLens] = {
     (for {
       (line, row) <- content.zipWithIndex
-      if line.trim.startsWith("at ")
-      location <- fileLocationFromLine(line)
+      cleanedLine = stripErrorSignifier(line)
+      if cleanedLine.startsWith("at ")
+      location <- fileLocationFromLine(cleanedLine)
       range = new l.Range(new l.Position(row, 0), new l.Position(row, 0))
     } yield makeGotoLocationCodeLens(location, range)).toSeq
   }
+
+  /**
+   * Strip out the `[E]` when the line is coming from bloop-cli.
+   * Or
+   * Strip out the `[error]` when the line is coming from sbt
+   */
+  private def stripErrorSignifier(line: String) =
+    line.replaceFirst("""(\[E\]|\[error\])""", "").trim
 
   private def makeGotoLocationCodeLens(
       location: l.Location,

--- a/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
@@ -6,74 +6,120 @@ import org.eclipse.{lsp4j => l}
 
 class AnalyzeStacktraceLspSuite extends BaseLspSuite("analyzestacktrace") {
 
-  test("simple") {
-    val code =
-      """|package a.b
-         |
-         |object Main {
-         |  def main(args: Array[String]): Unit = {
-         |<<4>>    new ClassError().raise
-         |  }
-         |}
-         |
-         |
-         |class ClassError {
-         |  def raise: ClassConstrError = {
-         |<<3>>    ObjectError.raise
-         |  }
-         |}
-         |
-         |object ObjectError {
-         |  def raise: ClassConstrError = {
-         |<<2>>    new ClassConstrError()
-         |  }
-         |}
-         |
-         |class ClassConstrError {
-         |  val a = 3
-         |<<1>>  throw new Exception("error")
-         |  val b = 4
-         |}
-         |
-         |""".stripMargin
+  check(
+    "simple",
+    code,
+    """|Exception in thread "main" java.lang.Exception: error
+       |	at a.b.ClassConstrError.<init>(Main.scala:24)
+       |	at a.b.ObjectError$.raise(Main.scala:18)
+       |	at a.b.ClassError.raise(Main.scala:12)
+       |	at a.b.Main$.main(Main.scala:5)
+       |	at a.b.Main.main(Main.scala)
+       |""".stripMargin
+  )
 
-    // code above is executed in REPL and resulted stacktrace is printed here:
-    val stacktrace = """|Exception in thread "main" java.lang.Exception: error
-                        |	at a.b.ClassConstrError.<init>(Main.scala:24)
-                        |	at a.b.ObjectError$.raise(Main.scala:18)
-                        |	at a.b.ClassError.raise(Main.scala:12)
-                        |	at a.b.Main$.main(Main.scala:5)
-                        |	at a.b.Main.main(Main.scala)
-                        |""".stripMargin
+  check(
+    "bloop-cli",
+    code,
+    """|[E] Exception in thread "main" java.lang.Exception: error
+       |[E] 	at a.b.ClassConstrError.<init>(Main.scala:24)
+       |[E] 	at a.b.ObjectError$.raise(Main.scala:18)
+       |[E] 	at a.b.ClassError.raise(Main.scala:12)
+       |[E] 	at a.b.Main$.main(Main.scala:5)
+       |[E] 	at a.b.Main.main(Main.scala)
+       |""".stripMargin
+  )
 
-    cleanWorkspace()
-    for {
-      _ <- server.initialize(
-        s"""
-           |/metals.json
-           |{"a":{}}
-           |/a/src/main/scala/a/Main.scala
-           |${prepare(code)}
-           |""".stripMargin
-      )
-      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
-      lenses = server.analyzeStacktrace(stacktrace)
-      output =
-        lenses
-          .map(cl =>
-            cl.getRange.getStart.getLine -> cl
-              .getCommand()
-              .getArguments()
-              .get(0)
-              .asInstanceOf[l.Location]
-              .getRange
-              .getStart
-              .getLine
-          )
-          .toMap
-      _ = assertEquals(output, getExpected(code))
-    } yield ()
+  /**
+   * This stack trace in the check here is the part of the trace that matches
+   * the output of the rest above. However, notable I remove the following:
+   *
+   * [error]         at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+   * [error]         at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+   * [error]         at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+   * [error]         at java.lang.reflect.Method.invoke(Method.java:498)
+   *
+   * I remove it mainly because it works exactly the same as the rest of the lens
+   * functionality, but instead I want to just ensure that the `[error]` here is being
+   * striped out correctly.
+   */
+  check(
+    "sbt",
+    code,
+    """|[error] java.lang.Exception: error
+       |[error]         at a.b.ClassConstrError.<init>(Main.scala:24)
+       |[error]         at a.b.ObjectError$.raise(Main.scala:18)
+       |[error]         at a.b.ClassError.raise(Main.scala:12)
+       |[error]         at a.b.Main$.main(Main.scala:5)
+       |[error]         at a.b.Main.main(Main.scala)
+       |""".stripMargin
+  )
+
+  def check(
+      name: String,
+      code: String,
+      stacktrace: String
+  ): Unit = {
+    test(name) {
+      cleanWorkspace()
+      for {
+        _ <- server.initialize(
+          s"""
+             |/metals.json
+             |{"a":{}}
+             |/a/src/main/scala/a/Main.scala
+             |${prepare(code)}
+             |""".stripMargin
+        )
+        _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+        lenses = server.analyzeStacktrace(stacktrace)
+        output =
+          lenses
+            .map(cl =>
+              cl.getRange.getStart.getLine -> cl
+                .getCommand()
+                .getArguments()
+                .get(0)
+                .asInstanceOf[l.Location]
+                .getRange
+                .getStart
+                .getLine
+            )
+            .toMap
+        _ = assertEquals(output, getExpected(code))
+      } yield ()
+    }
   }
+
+  private lazy val code: String =
+    """|package a.b
+       |
+       |object Main {
+       |  def main(args: Array[String]): Unit = {
+       |<<4>>    new ClassError().raise
+       |  }
+       |}
+       |
+       |
+       |class ClassError {
+       |  def raise: ClassConstrError = {
+       |<<3>>    ObjectError.raise
+       |  }
+       |}
+       |
+       |object ObjectError {
+       |  def raise: ClassConstrError = {
+       |<<2>>    new ClassConstrError()
+       |  }
+       |}
+       |
+       |class ClassConstrError {
+       |  val a = 3
+       |<<1>>  throw new Exception("error")
+       |  val b = 4
+       |}
+       |
+       |""".stripMargin
 
   private def getExpected(code: String): Map[Int, Int] = {
     val result: mutable.Buffer[(Int, Int)] = mutable.Buffer()


### PR DESCRIPTION
So in some clients (VS Code), the stacktrace will be printed without any
prefaces, which allows for the stacktrace to be correctly parsed and the lenses
created for them when utilyzing the stacktrace-anlyzer functionality. However,
for some clients that don't have a nice built-in way to run the application
in the client, they may be resorting to run via their build tool or with the
bloop-cli. This change ensures that a person can copy the stacktrace from
sbt or from bloop cli and still utilize the functionality.

Note that nothing special for Mill was needed since Mill also doesn't preface
the stacktrace output with any `[E]` or anything.

![2020-09-19 12 39 59](https://user-images.githubusercontent.com/13974112/93665264-6ae91800-fa75-11ea-9ba6-ec6c928da780.gif)
