### PR TITLE
Add fetch related stuff in one call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,7 @@ jobs:
       - uses: olafurpg/setup-scala@v7
       - uses: olafurpg/setup-gpg@v2
       - uses: coursier/cache-action@v3
-      - run: git fetch --unshallow
-      - run: git fetch --tags
+      - run: git fetch --tags --unshallow -f
       - name: Publish
         run: |
           sbt ci-release


### PR DESCRIPTION
I'm not really sure what's going on, but in the last release, we are for some reason getting the following on the `git fetch --tags` call:

```
 * [new tag]           v0.4.0     -> v0.4.0
```
This is possibly the cause for the odd snapshot we currently have: `0.4.4+112-6154859a-SNAPSHOT`, which is a bit annoying since if you use it, it will warn you that you are using an out of date version every time you open Metals.

It actually seems that all the tags are pulled during the `git fetch --unshallow` call above if you look in the logs, https://github.com/scalameta/metals/runs/1139811242#step:6:47, but I figured this could also just all be done in the same `fetch` call. I don't know really why, but _maybe_ this could help? Thoughts?