### PR TITLE
Refactor NewFileProvider

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -43,6 +43,7 @@ import scala.meta.internal.metals.codelenses.SuperMethodCodeLens
 import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.metals.debug.DebugParametersJsonParsers
 import scala.meta.internal.metals.debug.DebugProvider
+import scala.meta.internal.metals.newScalaFile.NewFileProvider
 import scala.meta.internal.mtags._
 import scala.meta.internal.remotels.RemoteLanguageServer
 import scala.meta.internal.rename.RenameProvider
@@ -202,7 +203,7 @@ class MetalsLanguageServer(
   private var workspaceSymbols: WorkspaceSymbolProvider = _
   private val packageProvider: PackageProvider =
     new PackageProvider(buildTargets)
-  private var newFilesProvider: NewFilesProvider = _
+  private var newFileProvider: NewFileProvider = _
   private var debugProvider: DebugProvider = _
   private var symbolSearch: MetalsSymbolSearch = _
   private var compilers: Compilers = _
@@ -392,7 +393,7 @@ class MetalsLanguageServer(
       },
       tables
     )
-    newFilesProvider = new NewFilesProvider(
+    newFileProvider = new NewFileProvider(
       workspace,
       languageClient,
       packageProvider,
@@ -1503,7 +1504,7 @@ class MetalsLanguageServer(
           case fileType: JsonPrimitive if fileType.isString =>
             fileType.getAsString()
         }
-        newFilesProvider
+        newFileProvider
           .handleFileCreation(directoryURI, name, fileType)
           .asJavaObject
 

--- a/metals/src/main/scala/scala/meta/internal/metals/PackageProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/PackageProvider.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.metals
 import java.nio.file.Path
 
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.newScalaFile.NewFileTemplate
 import scala.meta.io.AbsolutePath
 
 import org.eclipse.lsp4j.Position

--- a/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileTemplate.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileTemplate.scala
@@ -1,4 +1,4 @@
-package scala.meta.internal.metals
+package scala.meta.internal.metals.newScalaFile
 
 import scala.{meta => m}
 

--- a/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileTypes.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileTypes.scala
@@ -1,0 +1,62 @@
+package scala.meta.internal.metals.newScalaFile
+
+import scala.meta.internal.metals.MetalsQuickPickItem
+
+object NewFileTypes {
+  sealed trait NewFileType {
+    val id: String
+    val label: String
+    def toQuickPickItem: MetalsQuickPickItem = MetalsQuickPickItem(id, label)
+  }
+
+  case object Class extends NewFileType {
+    override val id: String = "class"
+    override val label: String = "Class"
+  }
+
+  case object CaseClass extends NewFileType {
+    override val id: String = "case-class"
+    override val label: String = "Case Class"
+  }
+
+  case object Object extends NewFileType {
+    override val id: String = "object"
+    override val label: String = "Object"
+  }
+
+  case object Trait extends NewFileType {
+    override val id: String = "trait"
+    override val label: String = "Trait"
+  }
+
+  case object PackageObject extends NewFileType {
+    override val id: String = "package-object"
+    override val label: String = "Package Object"
+  }
+
+  case object Worksheet extends NewFileType {
+    override val id: String = "worksheet"
+    override val label: String = "Worksheet"
+  }
+
+  case object AmmoniteScript extends NewFileType {
+    override val id: String = "ammonite"
+    override val label: String = "Ammonite Script"
+  }
+
+  def getFromString(id: String): Option[NewFileType] =
+    id match {
+      case Class.id => Some(Class)
+      case CaseClass.id => Some(CaseClass)
+      case Object.id => Some(Object)
+      case Trait.id => Some(Trait)
+      case PackageObject.id => Some(PackageObject)
+      case Worksheet.id => Some(Worksheet)
+      case AmmoniteScript.id => Some(AmmoniteScript)
+      case invalid =>
+        scribe.error(
+          s"Invalid filetype given to new-scala-file command: $invalid"
+        )
+        None
+    }
+}

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -7,7 +7,7 @@ object TestGroups {
       "tests.DebugProtocolSuite", "tests.BillLspSuite",
       "tests.CodeLensLspSuite", "tests.codeactions.ImportMissingSymbolLspSuite",
       "tests.debug.StepDapSuite", "tests.debug.StackFrameDapSuite",
-      "tests.FormattingLspSuite", "tests.NewFilesLspSuite",
+      "tests.FormattingLspSuite", "tests.NewFileLspSuite",
       "tests.CascadeLspSuite", "tests.DiagnosticsLspSuite",
       "tests.worksheets.WorksheetNoDecorationsLspSuite",
       "tests.CompletionLspSuite", "tests.TreeViewLspSuite",

--- a/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
@@ -10,18 +10,19 @@ import scala.meta.internal.metals.MetalsInputBoxParams
 import scala.meta.internal.metals.MetalsInputBoxResult
 import scala.meta.internal.metals.RecursivelyDelete
 import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.metals.newScalaFile.NewFileTypes._
 
 import munit.TestOptions
 import org.eclipse.lsp4j.ShowMessageRequestParams
 
-class NewFilesLspSuite extends BaseLspSuite("new-files") {
+class NewFileLspSuite extends BaseLspSuite("new-file") {
 
   override def initializationOptions: Option[InitializationOptions] =
     Some(InitializationOptions.Default.copy(inputBoxProvider = Some(true)))
 
   check("new-worksheet-picked")(
     directory = Some("a/src/main/scala/"),
-    fileType = Right(worksheet),
+    fileType = Right(Worksheet),
     fileName = Right("Foo"),
     expectedFilePath = "a/src/main/scala/Foo.worksheet.sc",
     expectedContent = ""
@@ -29,7 +30,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-worksheet-name-provided")(
     directory = Some("a/src/main/scala/"),
-    fileType = Left(worksheet),
+    fileType = Left(Worksheet),
     fileName = Right("Foo"),
     expectedFilePath = "a/src/main/scala/Foo.worksheet.sc",
     expectedContent = ""
@@ -37,7 +38,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-worksheet-fully-provided")(
     directory = Some("a/src/main/scala/"),
-    fileType = Left(worksheet),
+    fileType = Left(Worksheet),
     fileName = Left("Foo"),
     expectedFilePath = "a/src/main/scala/Foo.worksheet.sc",
     expectedContent = ""
@@ -45,7 +46,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-ammonite-script")(
     directory = Some("a/src/main/scala/"),
-    fileType = Right(ammonite),
+    fileType = Right(AmmoniteScript),
     fileName = Right("Foo"),
     expectedFilePath = "a/src/main/scala/Foo.sc",
     expectedContent = ""
@@ -53,7 +54,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-ammonite-script-name-provided")(
     directory = Some("a/src/main/scala/"),
-    fileType = Right(ammonite),
+    fileType = Right(AmmoniteScript),
     fileName = Left("Foo"),
     expectedFilePath = "a/src/main/scala/Foo.sc",
     expectedContent = ""
@@ -61,7 +62,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-ammonite-script-fully-provided")(
     directory = Some("a/src/main/scala/"),
-    fileType = Left(ammonite),
+    fileType = Left(AmmoniteScript),
     fileName = Left("Foo"),
     expectedFilePath = "a/src/main/scala/Foo.sc",
     expectedContent = ""
@@ -69,7 +70,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-class")(
     directory = Some("a/src/main/scala/foo/"),
-    fileType = Right(clazz),
+    fileType = Right(Class),
     fileName = Right("Foo"),
     expectedFilePath = "a/src/main/scala/foo/Foo.scala",
     expectedContent = s"""|package foo
@@ -82,7 +83,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-class-name-provided")(
     directory = Some("a/src/main/scala/foo/"),
-    fileType = Right(clazz),
+    fileType = Right(Class),
     fileName = Left("Foo"),
     expectedFilePath = "a/src/main/scala/foo/Foo.scala",
     expectedContent = s"""|package foo
@@ -95,7 +96,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-class-fully-provided")(
     directory = Some("a/src/main/scala/foo/"),
-    fileType = Left(clazz),
+    fileType = Left(Class),
     fileName = Left("Foo"),
     expectedFilePath = "a/src/main/scala/foo/Foo.scala",
     expectedContent = s"""|package foo
@@ -108,7 +109,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-case-class")(
     directory = Some("a/src/main/scala/foo/"),
-    fileType = Right(caseClass),
+    fileType = Right(CaseClass),
     fileName = Right("Foo"),
     expectedFilePath = "a/src/main/scala/foo/Foo.scala",
     expectedContent = """|package foo
@@ -119,7 +120,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-case-class-name-provided")(
     directory = Some("a/src/main/scala/foo/"),
-    fileType = Right(caseClass),
+    fileType = Right(CaseClass),
     fileName = Left("Foo"),
     expectedFilePath = "a/src/main/scala/foo/Foo.scala",
     expectedContent = """|package foo
@@ -130,7 +131,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-case-class-fully-provided")(
     directory = Some("a/src/main/scala/foo/"),
-    fileType = Left(caseClass),
+    fileType = Left(CaseClass),
     fileName = Left("Foo"),
     expectedFilePath = "a/src/main/scala/foo/Foo.scala",
     expectedContent = """|package foo
@@ -141,7 +142,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-object-null-dir")(
     directory = None,
-    fileType = Right(objekt),
+    fileType = Right(Object),
     fileName = Right("Bar"),
     expectedFilePath = "Bar.scala",
     expectedContent = s"""|object Bar {
@@ -152,7 +153,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-object-null-dir-name-provided")(
     directory = None,
-    fileType = Right(objekt),
+    fileType = Right(Object),
     fileName = Left("Bar"),
     expectedFilePath = "Bar.scala",
     expectedContent = s"""|object Bar {
@@ -163,7 +164,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-object-null-dir")(
     directory = None,
-    fileType = Left(objekt),
+    fileType = Left(Object),
     fileName = Left("Bar"),
     expectedFilePath = "Bar.scala",
     expectedContent = s"""|object Bar {
@@ -174,7 +175,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-trait-new-dir")(
     directory = Some("a/src/main/scala/"),
-    fileType = Right(trate),
+    fileType = Right(Trait),
     fileName = Right("bar/Baz"),
     expectedFilePath = "a/src/main/scala/bar/Baz.scala",
     expectedContent = s"""|package bar
@@ -187,7 +188,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-trait-new-dir-name-provided")(
     directory = Some("a/src/main/scala/"),
-    fileType = Right(trate),
+    fileType = Right(Trait),
     fileName = Left("bar/Baz"),
     expectedFilePath = "a/src/main/scala/bar/Baz.scala",
     expectedContent = s"""|package bar
@@ -200,7 +201,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-trait-new-dir-fully-provided")(
     directory = Some("a/src/main/scala/"),
-    fileType = Right(trate),
+    fileType = Right(Trait),
     fileName = Right("bar/Baz"),
     expectedFilePath = "a/src/main/scala/bar/Baz.scala",
     expectedContent = s"""|package bar
@@ -213,7 +214,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-package-object")(
     directory = Some("a/src/main/scala/foo"),
-    fileType = Right(packageObject),
+    fileType = Right(PackageObject),
     fileName = Right(
       ""
     ), // Just given an empty string here because it will never be used for package objects
@@ -226,7 +227,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-package-object-provided")(
     directory = Some("a/src/main/scala/foo"),
-    fileType = Left(packageObject),
+    fileType = Left(PackageObject),
     fileName = Right(
       ""
     ), // Just given an empty string here because it will never be used for package objects
@@ -239,7 +240,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-class-on-file")(
     directory = Some("a/src/main/scala/foo/Other.scala"),
-    fileType = Right(clazz),
+    fileType = Right(Class),
     fileName = Right("Foo"),
     expectedFilePath = "a/src/main/scala/foo/Foo.scala",
     expectedContent = s"""|package foo
@@ -257,7 +258,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-class-on-file-name-provided")(
     directory = Some("a/src/main/scala/foo/Other.scala"),
-    fileType = Right(clazz),
+    fileType = Right(Class),
     fileName = Left("Foo"),
     expectedFilePath = "a/src/main/scala/foo/Foo.scala",
     expectedContent = s"""|package foo
@@ -275,7 +276,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("new-class-on-file-fully-provided")(
     directory = Some("a/src/main/scala/foo/Other.scala"),
-    fileType = Right(clazz),
+    fileType = Right(Class),
     fileName = Right("Foo"),
     expectedFilePath = "a/src/main/scala/foo/Foo.scala",
     expectedContent = s"""|package foo
@@ -293,7 +294,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
   check("existing-file")(
     directory = Some("a/src/main/scala/foo"),
-    fileType = Right(clazz),
+    fileType = Right(Class),
     fileName = Right("Other"),
     expectedFilePath = "a/src/main/scala/foo/Other.scala",
     expectedContent = s"""|package foo
@@ -313,20 +314,15 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
   )
 
   private lazy val indent = "  "
-  private lazy val worksheet = "worksheet"
-  private lazy val ammonite = "ammonite"
-  private lazy val clazz = "class"
-  private lazy val caseClass = "case-class"
-  private lazy val objekt = "object"
-  private lazy val trate = "trait"
-  private lazy val packageObject = "package-object"
 
+  type ProvidedFileType = NewFileType
+  type PickedFileType = NewFileType
   type Provided = String
   type Picked = String
 
   private def check(testName: TestOptions)(
       directory: Option[String],
-      fileType: Either[Provided, Picked],
+      fileType: Either[ProvidedFileType, PickedFileType],
       fileName: Either[Provided, Picked],
       expectedFilePath: String,
       expectedContent: String,
@@ -348,16 +344,16 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
 
       val ft: String =
         fileType match {
-          case Left(providedType) => providedType
+          case Left(providedType) => providedType.label
           case Right(pickedType) =>
             client.showMessageRequestHandler = { params =>
               if (isSelectTheKindOfFile(params)) {
-                params.getActions().asScala.find(_.getTitle() == pickedType)
+                params.getActions().asScala.find(_.getTitle() == pickedType.id)
               } else {
                 None
               }
             }
-            pickedType
+            pickedType.label
         }
 
       fileName match {
@@ -389,7 +385,7 @@ class NewFilesLspSuite extends BaseLspSuite("new-files") {
       val args = List(
         directoryUri,
         fileName.fold(identity, _ => null.asInstanceOf[String]),
-        fileType.fold(identity, _ => null.asInstanceOf[String])
+        fileType.fold(ft => ft.id, _ => null.asInstanceOf[String])
       )
 
       val futureToRecover = for {

--- a/tests/unit/src/test/scala/tests/NewFileTemplateSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileTemplateSuite.scala
@@ -1,6 +1,6 @@
 package tests
 
-import scala.meta.internal.metals.NewFileTemplate
+import scala.meta.internal.metals.newScalaFile.NewFileTemplate
 
 class NewFileTemplateSuite extends BaseSuite {
 


### PR DESCRIPTION
Today I sat down to write an Ammonite script and when I used the
new-scala-file command I saw the following message:

```
Enter the name for the new ammonite
```

This bugged me a bit since I wanted it to say "for the new Ammonite
Script". The same thing happens when you try to create a case-class. The
message that you see is:

```
Enter the name for the new case-class
```

I think it's nicer to show "Case Class" here. This along with a couple
other small things I noticed when I did
https://github.com/scalameta/metals/pull/2075 like just matching against
strings to get the fileType and not really having any sort of ADT for
the new filetypes. So I made some opinionated choices and refactored
some stuff related to the new-scala-file command into its own package.
This _I hope_ makes it a bit easier to work with and also has the added
benefit of showing the label in the message instead of the id like we
were before.