### PR TITLE
Use built-in fetch depth and bump coursier cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: olafurpg/setup-scala@v7
         with:
           java-version: "adopt@1.${{ matrix.java }}"
-      - uses: coursier/cache-action@v3
+      - uses: coursier/cache-action@v4
       - name: Run unit tests
         run: |
           bin/test.sh unit/test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: olafurpg/setup-scala@v7
       - uses: olafurpg/setup-gpg@v2
-      - uses: coursier/cache-action@v3
-      - run: git fetch --unshallow
-      - run: git fetch --tags
+      - uses: coursier/cache-action@v4
       - name: Publish
         run: |
           sbt ci-release


### PR DESCRIPTION
Thanks for point this out in https://github.com/scalameta/metals/pull/2084 @kpbochenek. This utilizes the built-in way to make sure you get all the history for branches and tags without having to issue any of your own git commands. https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches

This also bumps the coursier cache action version.