### PR TITLE
Add in top level-completions for empty file.

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -309,7 +309,7 @@ class CompletionProvider(
     }
     completions.foreach(visit)
     completion.contribute.foreach(visit)
-    buf ++= keywords(pos, editRange, latestParentTrees)
+    buf ++= keywords(pos, editRange, latestParentTrees, completion)
     val searchResults =
       if (kind == CompletionListKind.Scope) {
         workspaceSymbolListMembers(query, pos, visit)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
@@ -12,7 +12,10 @@ trait Keywords { this: MetalsGlobal =>
       latestEnclosing: List[Tree]
   ): List[Member] = {
     getIdentifierName(latestEnclosing, pos) match {
-      case None => Nil
+      case None =>
+        Keyword.all.collect {
+          case kw if kw.isPackage => mkTextEditMember(kw, editRange)
+        }
       case Some(name) =>
         val isExpression = this.isExpression(latestEnclosing)
         val isBlock = this.isBlock(latestEnclosing)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
@@ -9,12 +9,23 @@ trait Keywords { this: MetalsGlobal =>
   def keywords(
       pos: Position,
       editRange: l.Range,
-      latestEnclosing: List[Tree]
+      latestEnclosing: List[Tree],
+      completion: CompletionPosition
   ): List[Member] = {
     getIdentifierName(latestEnclosing, pos) match {
       case None =>
-        Keyword.all.collect {
-          case kw if kw.isPackage => mkTextEditMember(kw, editRange)
+        completion match {
+          // This whole block is meant to catch top level completions, however
+          // it's also valid to have a scaladoc comment at the top level, so we
+          // explicitly check that we don't have a scaladocCompletion before we
+          // grab the top level completions since it's safe to assume if someone
+          // has already typed /* then they are going for the scaladoc, not the
+          // other stuff.
+          case _: ScaladocCompletion => List.empty
+          case _ =>
+            Keyword.all.collect {
+              case kw if kw.isPackage => mkTextEditMember(kw, editRange)
+            }
         }
       case Some(name) =>
         val isExpression = this.isExpression(latestEnclosing)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -739,7 +739,7 @@ trait Completions { this: MetalsGlobal =>
   def inferIdentStart(pos: Position, text: String): Int = {
     def fallback: Int = {
       var i = pos.point - 1
-      while (i > 0 && Chars.isIdentifierPart(text.charAt(i))) {
+      while (i >= 0 && Chars.isIdentifierPart(text.charAt(i))) {
         i -= 1
       }
       i + 1

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -372,4 +372,22 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |""".stripMargin
   )
 
+  check(
+    "topLevel".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "@@",
+    """|abstract class
+       |case class
+       |class
+       |final
+       |import
+       |object
+       |package
+       |private
+       |protected
+       |sealed abstract class
+       |sealed class
+       |sealed trait
+       |trait
+       |""".stripMargin
+  )
 }


### PR DESCRIPTION
This adds some some somewhat sensible top-level completions when you attempt to
trigger a completion in an empty file. For example `p@@` will produce:

- package
- private
- protected
- import

All which would be valid compared to the behavior previously where nothing was
recommended.

Closes #1663