### PR TITLE
Remove javax from default excluded packages

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ExcludedPackagesHandler.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ExcludedPackagesHandler.scala
@@ -8,9 +8,9 @@ package scala.meta.internal.metals
  */
 class ExcludedPackagesHandler(pkgsToExclude: Option[List[String]] = None) {
   val defaultExclusions: List[String] = List(
-    "META-INF/", "images/", "toolbarButtonGraphics/", "jdk/", "sun/", "javax/",
-    "oracle/", "java/awt/desktop/", "org/jcp/", "org/omg/", "org/graalvm/",
-    "com/oracle/", "com/sun/", "com/apple/", "apple/"
+    "META-INF/", "images/", "toolbarButtonGraphics/", "jdk/", "sun/", "oracle/",
+    "java/awt/desktop/", "org/jcp/", "org/omg/", "org/graalvm/", "com/oracle/",
+    "com/sun/", "com/apple/", "apple/"
   )
 
   /**

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -116,8 +116,8 @@ object UserConfiguration {
         """`[]`.""",
         """["-Xmx1G"]""",
         "Ammonite JVM Properties",
-        """|Optional list of JVM properties to pass along to the Ammonite server. 
-           |Each property needs to be a separate item.\n\nExample: `-Xmx1G` or `-Xms100M`" 
+        """|Optional list of JVM properties to pass along to the Ammonite server.
+           |Each property needs to be a separate item.\n\nExample: `-Xmx1G` or `-Xms100M`"
            |""".stripMargin
       ),
       UserConfigurationOption(
@@ -139,7 +139,7 @@ object UserConfiguration {
             |Example:
             |
             |```js
-            |["--javax"]
+            |["--sun"]
             |```
             |""".stripMargin
       ),

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -50,7 +50,6 @@ abstract class BasePCSuite extends BaseSuite {
     pkg.startsWith("toolbarButtonGraphics/") ||
     pkg.startsWith("jdk/") ||
     pkg.startsWith("sun/") ||
-    pkg.startsWith("javax/") ||
     pkg.startsWith("oracle/") ||
     pkg.startsWith("java/awt/desktop/") ||
     pkg.startsWith("org/jcp/") ||

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -76,7 +76,7 @@ class CompletionIssueSuite extends BaseCompletionSuite {
       |package all
       |import all.World.Countries.{
       |  Sweden,
-      |  Norway
+      |  USA
       |}
       |
       |object World {
@@ -89,15 +89,15 @@ class CompletionIssueSuite extends BaseCompletionSuite {
       |}
       |import all.World.Countries.France
       |object B {
-      |  val allCountries = Sweden + Norway + France + USA@@
+      |  val allCountries = Sweden + France + USA + Norway@@
       |}""".stripMargin,
     """
       |package all
       |import all.World.Countries.{
       |  Sweden,
-      |  Norway
+      |  USA
       |}
-      |import all.World.Countries.USA
+      |import all.World.Countries.Norway
       |
       |object World {
       |  object Countries{
@@ -109,7 +109,7 @@ class CompletionIssueSuite extends BaseCompletionSuite {
       |}
       |import all.World.Countries.France
       |object B {
-      |  val allCountries = Sweden + Norway + France + USA
+      |  val allCountries = Sweden + France + USA + Norway
       |}""".stripMargin
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -16,8 +16,8 @@ class CompletionSuite extends BaseCompletionSuite {
     """|List scala.collection.immutable
        |List - java.awt
        |List - java.util
-       |ListMap - scala.collection.immutable
-       |ListMap - scala.collection.mutable
+       |JList - javax.swing
+       |ListUI - javax.swing.plaf
        |""".stripMargin,
     compat = Map(
       "2.13" ->
@@ -25,7 +25,7 @@ class CompletionSuite extends BaseCompletionSuite {
            |LazyList scala.collection.immutable
            |List - java.awt
            |List - java.util
-           |ListMap - scala.collection.immutable
+           |JList - javax.swing
            |""".stripMargin
     ),
     topLines = Some(5)
@@ -271,6 +271,7 @@ class CompletionSuite extends BaseCompletionSuite {
        |ProcessBuilderImpl - scala.sys.process
        |CertPathBuilderResult - java.security.cert
        |PKIXBuilderParameters - java.security.cert
+       |PooledConnectionBuilder - javax.sql
        |CertPathBuilderException - java.security.cert
        |PKIXCertPathBuilderResult - java.security.cert
        |""".stripMargin
@@ -365,15 +366,15 @@ class CompletionSuite extends BaseCompletionSuite {
       |""".stripMargin,
     """|Path - java.nio.file
        |Paths - java.nio.file
+       |XPath - javax.xml.xpath
        |Path2D - java.awt.geom
        |CertPath - java.security.cert
+       |TreePath - javax.swing.tree
+       |XPathType - javax.xml.crypto.dsig.spec
        |LayoutPath - java.awt.font
+       |XPathNodes - javax.xml.xpath
        |PathMatcher - java.nio.file
-       |GeneralPath - java.awt.geom
        |XPathResult - org.w3c.dom.xpath
-       |PathIterator - java.awt.geom
-       |XPathEvaluator - org.w3c.dom.xpath
-       |XPathException - org.w3c.dom.xpath
        |""".stripMargin
   )
 
@@ -383,9 +384,11 @@ class CompletionSuite extends BaseCompletionSuite {
       |package a
       |import MetaData@@
       |""".stripMargin,
-    """|DatabaseMetaData - java.sql
+    """|RowSetMetaData - javax.sql
+       |DatabaseMetaData - java.sql
        |ParameterMetaData - java.sql
        |ResultSetMetaData - java.sql
+       |RowSetMetaDataImpl - javax.sql.rowset
        |""".stripMargin
   )
 

--- a/tests/slow/src/test/scala/tests/feature/ClasspathSymbolRegressionSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/ClasspathSymbolRegressionSuite.scala
@@ -94,8 +94,8 @@ class ClasspathSymbolRegressionSuite extends BaseWorkspaceSymbolSuite {
        |java.io.File Class
        |java.nio.file.Files Class
        |java.nio.file.Files#FileTypeDetectors Class
+       |javax.annotation.processing.Filer Interface
        |org.apache.hadoop.mapred.IFile Class
-       |org.apache.jute.compiler.JFile Class
        |org.apache.parquet.Files Class
        |scala.meta.inputs.Input.Stream.SerializationProxy#File Class
        |scala.meta.inputs.Input.Stream.SerializationProxy#File Object
@@ -112,6 +112,7 @@ class ClasspathSymbolRegressionSuite extends BaseWorkspaceSymbolSuite {
        |com.google.common.io.MoreFiles Class
        |com.twitter.io.Files Object
        |java.nio.file.Files Class
+       |javax.swing.plaf.basic.BasicDirectoryModel#FilesLoader Class
        |org.apache.hadoop.mapred.MROutputFiles Class
        |org.apache.hadoop.mapred.YarnOutputFiles Class
        |org.apache.ivy.ant.IvyCacheFileset Class
@@ -121,7 +122,6 @@ class ClasspathSymbolRegressionSuite extends BaseWorkspaceSymbolSuite {
        |org.apache.spark.sql.execution.streaming.FileStreamSource.SeenFilesMap Class
        |org.glassfish.jersey.server.internal.scanning.FilesScanner Class
        |scala.meta.internal.io.ListFiles Class
-       |scala.tools.nsc.interactive.CompilerControl#FilesDeletedItem Class
        |""".stripMargin
   )
 

--- a/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
@@ -98,32 +98,32 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
         "Stream@@",
         getExpected(
           """|BaseStream - java.util.stream
-             |DoubleStream - java.util.stream
              |InputStream - java.io
              |IntStream - java.util.stream
              |LogStream - java.rmi.server
              |LongStream - java.util.stream
-             |OutputStream - java.io
              |PrintStream - java.io
              |Stream - java.util.stream
              |Stream scala.collection.immutable
              |StreamBuilder - scala.collection.immutable.Stream
              |StreamCanBuildFrom - scala.collection.immutable.Stream
+             |StreamFilter - javax.xml.stream
+             |StreamResult - javax.xml.transform.stream
              |StreamView - scala.collection.immutable
              |Streamable - scala.reflect.io
              |""".stripMargin,
           Map(
             "2.13" ->
               """|BaseStream - java.util.stream
-                 |DoubleStream - java.util.stream
                  |InputStream - java.io
                  |IntStream - java.util.stream
                  |LogStream - java.rmi.server
                  |LongStream - java.util.stream
-                 |OutputStream - java.io
                  |PrintStream - java.io
                  |Stream - java.util.stream
                  |Stream scala.collection.immutable
+                 |StreamFilter - javax.xml.stream
+                 |StreamResult - javax.xml.transform.stream
                  |StreamShape - scala.collection.convert.StreamExtensions
                  |Streamable - scala.reflect.io
                  |""".stripMargin

--- a/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
@@ -249,6 +249,7 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
       _ <- assertCompletion(
         "Duration@@",
         """|Duration - java.time
+           |Duration - javax.xml.datatype
            |Duration - scala.concurrent.duration
            |DurationConversions - scala.concurrent.duration
            |DurationDouble - scala.concurrent.duration.package
@@ -274,6 +275,7 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
       _ <- assertCompletion(
         "Duration@@",
         """|Duration - java.time
+           |Duration - javax.xml.datatype
            |""".stripMargin,
         includeDetail = false
       )

--- a/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
@@ -17,9 +17,15 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
        |
        |case class School(name: String, location: <<Location>>)
        |""".stripMargin,
-    s"""|${ImportMissingSymbol.title("Location", "scala.collection.script")}
+    s"""|${ImportMissingSymbol.title(
+      "Location",
+      "javax.tools.DocumentationTool"
+    )}
+        |${ImportMissingSymbol.title("Location", "javax.tools.JavaFileManager")}
+        |${ImportMissingSymbol.title("Location", "javax.xml.stream")}
+        |${ImportMissingSymbol.title("Location", "scala.collection.script")}
         |${CreateNewSymbol.title("Location")}""".stripMargin,
-    selectedActionIndex = 1,
+    selectedActionIndex = 4,
     pickedKind = "case-class",
     newFile =
       "a/src/main/scala/a/Location.scala" ->
@@ -35,9 +41,15 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
        |
        |case class School(name: String, location: <<Location>>)
        |""".stripMargin,
-    s"""|${ImportMissingSymbol.title("Location", "scala.collection.script")}
+    s"""|${ImportMissingSymbol.title(
+      "Location",
+      "javax.tools.DocumentationTool"
+    )}
+        |${ImportMissingSymbol.title("Location", "javax.tools.JavaFileManager")}
+        |${ImportMissingSymbol.title("Location", "javax.xml.stream")}
+        |${ImportMissingSymbol.title("Location", "scala.collection.script")}
         |${CreateNewSymbol.title("Location")}""".stripMargin,
-    selectedActionIndex = 1,
+    selectedActionIndex = 4,
     pickedKind = "trait",
     newFile =
       "a/src/main/scala/a/Location.scala" ->
@@ -55,11 +67,17 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
        |
        |<<case class School(name: Missing, location: Location)>>
        |""".stripMargin,
-    s"""|${ImportMissingSymbol.title("Location", "scala.collection.script")}
+    s"""|${ImportMissingSymbol.title(
+      "Location",
+      "javax.tools.DocumentationTool"
+    )}
+        |${ImportMissingSymbol.title("Location", "javax.tools.JavaFileManager")}
+        |${ImportMissingSymbol.title("Location", "javax.xml.stream")}
+        |${ImportMissingSymbol.title("Location", "scala.collection.script")}
         |${CreateNewSymbol.title("Missing")}
         |${CreateNewSymbol.title("Location")}
         |""".stripMargin,
-    selectedActionIndex = 1,
+    selectedActionIndex = 4,
     pickedKind = "class",
     newFile =
       "a/src/main/scala/a/Missing.scala" ->


### PR DESCRIPTION
Closes #2090

As discussed in the issue, the exclusion of javax isn't probably a great default anymore.
We even use some javax imports ourselves in Metals!

This PR removes `javax` from the default set of excluded packages. Users can opt-in to the exclusion using the recently released setting.