### PR TITLE
Display used BuildServer in Doctor

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BspConnector.scala
@@ -8,10 +8,24 @@ import scala.concurrent.Future
 import scala.meta.internal.builds.BuildTools
 import scala.meta.io.AbsolutePath
 
+import ch.epfl.scala.bsp4j.BspConnectionDetails
+
+sealed trait BspResolveResult
+case object ResolveNone extends BspResolveResult
+case object ResolveBloop extends BspResolveResult
+case class ResolveBspOne(details: BspConnectionDetails) extends BspResolveResult
+case class ResolveMultiple(md5: String, details: List[BspConnectionDetails])
+    extends BspResolveResult
+
 class BspConnector(
     bloopServers: BloopServers,
     bspServers: BspServers
 ) {
+
+  def resolve(buildTools: BuildTools): BspResolveResult = {
+    if (buildTools.isBloop) ResolveBloop
+    else bspServers.resolve()
+  }
 
   def connect(
       workspace: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -518,6 +518,8 @@ class MetalsLanguageServer(
       workspace,
       buildTargets,
       languageClient,
+      () => bspSession.map(_.mainConnection.name),
+      () => bspConnector.resolve(buildTools),
       () => httpServer,
       tables,
       clientConfig


### PR DESCRIPTION
No logic was changed in this PR (hopefully :D )

Added displaying BuildServer that is currently used and one that will be used after restart of metals.
To make it reliable I extracted resolving it to single method.