### PR TITLE
Simplify TestHovers and remove warning

### DIFF
--- a/tests/mtest/src/main/scala/tests/TestHovers.scala
+++ b/tests/mtest/src/main/scala/tests/TestHovers.scala
@@ -1,7 +1,6 @@
 package tests
 
 import scala.meta.inputs.Input
-import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.pc.HoverMarkup
 
@@ -28,21 +27,7 @@ trait TestHovers {
   ): String = {
     hover match {
       case Some(value) =>
-        val types = value.getContents.asScala match {
-          case Right(value) =>
-            value.getValue
-          case Left(values) =>
-            values.asScala
-              .map { e =>
-                e.asScala match {
-                  case Left(value) =>
-                    value
-                  case Right(marked) =>
-                    codeFence(marked.getValue, marked.getLanguage)
-                }
-              }
-              .mkString("\n")
-        }
+        val types = value.getContents.getRight.getValue()
         val range = Option(value.getRange) match {
           case Some(value) if includeRange =>
             codeFence(


### PR DESCRIPTION
While tinkering, I've noticed a deprecation warning due to a usage of `MarkedString`.

In `TestHovers` we still handled the case in which we returned a `MarkedString` or a `String` in `Hover` (now deprecated in lsp4j), but in the implementation we actually just use `MarkupContent` so that code branch is effectively unused.

I think it's safe to remove it, let's see whether the CI thinks otherwise