### PR TITLE
Update organize-import rule to add Scala 2.11 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -221,7 +221,7 @@ lazy val V = new {
   val coursierInterfaces = "0.0.25"
   val ammonite = "2.2.0-4-4bd225e"
   val mill = "0.8.0"
-  val organizeImportRule = "0.4.0"
+  val organizeImportRule = "0.4.2"
 }
 
 val genyVersion = Def.setting {


### PR DESCRIPTION
Partially addresses #2099 by adding 2.11 support for organize imports (the error reporting part is still missing)