### PR TITLE
Show implicit arguments and type annotations for Scala files 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
@@ -1,0 +1,138 @@
+package scala.meta.internal.decorations
+
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metap.PrinterSymtab
+import scala.meta.internal.semanticdb.Print
+import scala.meta.internal.{semanticdb => s}
+import scala.meta.metap.Format
+
+object SemanticdbTreePrinter {
+
+  def printSyntheticInfo(
+      textDocument: s.TextDocument,
+      synthetic: s.Synthetic,
+      printSymbol: String => String,
+      userConfig: UserConfiguration,
+      simple: Boolean
+  ): Option[String] = {
+
+    lazy val symtab = PrinterSymtab.fromTextDocument(textDocument)
+
+    def printTree(t: s.Tree): Option[String] =
+      t match {
+        case s.Tree.Empty => None
+        case s.OriginalTree(_) => None
+        case s.TypeApplyTree(function, typeArguments) =>
+          Some(printTree(function).getOrElse("") + printTypeArgs(typeArguments))
+        case s.ApplyTree(function, arguments) =>
+          Some(printTree(function).getOrElse("") + printArgs(arguments))
+        case s.LiteralTree(constant) =>
+          Some(printConstant(constant))
+        case s.SelectTree(_, id) =>
+          id.flatMap(printTree)
+        case s.FunctionTree(parameters, body) =>
+          printTree(body).map(printed => printArgs(parameters) + "=>" + printed)
+        case s.IdTree(symbol) =>
+          Some(printSymbol(symbol))
+        case s.MacroExpansionTree(beforeExpansion, _) =>
+          printTree(beforeExpansion)
+      }
+
+    def printPrefix(t: s.Type): String = {
+      printType(t) match {
+        case "" => ""
+        case s => s"$s."
+      }
+    }
+    def printTypeArgs(typeArgs: Seq[s.Type]): String =
+      typeArgs match {
+        case Nil => ""
+        case _ => typeArgs.map(printType).mkString("[", ", ", "]")
+      }
+
+    def printArgs(args: Seq[s.Tree]): String =
+      args match {
+        case Nil => ""
+        case _ => args.flatMap(printTree).mkString("(", ", ", ")")
+      }
+
+    def printType(t: s.Type): String =
+      t match {
+        case s.Type.Empty => ""
+        case s.RepeatedType(tpe) =>
+          s"${printType(tpe)}*"
+        case s.SingleType(prefix, symbol) =>
+          s"${printPrefix(prefix)}${printSymbol(symbol)}"
+        case s.TypeRef(prefix, symbol, typeArguments) =>
+          s"${printPrefix(prefix)}${printSymbol(symbol)}${printTypeArgs(typeArguments)}"
+        case s.WithType(types) =>
+          types.map(printType).mkString(" with ")
+        case s.ConstantType(constant) =>
+          printConstant(constant)
+        case s.ByNameType(tpe) =>
+          s"=> ${printType(tpe)}"
+        case s.ThisType(symbol) =>
+          s"this.${printSymbol(symbol)}"
+        case s.IntersectionType(types) =>
+          types.map(printType).mkString(" & ")
+        case s.UnionType(types) =>
+          types.map(printType).mkString(" | ")
+        case s.SuperType(prefix, symbol) =>
+          s"super.${printPrefix(prefix)}${printSymbol(symbol)}"
+        case s.AnnotatedType(annots, tp) =>
+          val mapped = annots
+            .map(x => s"@${printType(x.tpe)}")
+            .reduceLeft((x, y) => s"$x $y")
+          s"$mapped ${printType(tp)}"
+        // this should not need to be printed but just in case we revert to semanticdb printer
+        case s.UniversalType(_, tpe) =>
+          if (simple)
+            s"[ ... ] => ${printType(tpe)}"
+          else Print.tpe(Format.Detailed, t, symtab)
+        case s.ExistentialType(tpe, _) =>
+          if (simple)
+            s"${printType(tpe)} forSome { ... }"
+          else Print.tpe(Format.Detailed, t, symtab)
+        case s.StructuralType(tpe, _) =>
+          if (simple)
+            s" ${printType(tpe)} { ... }"
+          else Print.tpe(Format.Detailed, t, symtab)
+      }
+
+    def printConstant(c: s.Constant): String =
+      c match {
+        case s.FloatConstant(value) => value.toString
+        case s.LongConstant(value) => value.toString
+        case s.DoubleConstant(value) => value.toString
+        case s.NullConstant() => "null"
+        case s.IntConstant(value) => value.toString
+        case s.CharConstant(value) => value.toString
+        case s.ByteConstant(value) => value.toString
+        case s.UnitConstant() => "()"
+        case s.ShortConstant(value) => value.toString
+        case s.Constant.Empty => ""
+        case s.BooleanConstant(value) => value.toString
+        case s.StringConstant(value) => value
+      }
+
+    synthetic.tree match {
+      /**
+       *  implicit val str = ""
+       *  def hello()(implicit a : String)
+       *  hello()<<(str)>>
+       */
+      case tree @ s.ApplyTree(_: s.OriginalTree, _)
+          if userConfig.implicitArgumentAnnotationsEnabled =>
+        printTree(tree)
+
+      /**
+       *  def hello[T](T object) = object
+       *  hello<<[String]>>("")
+       */
+      case tree @ s.TypeApplyTree(_: s.OriginalTree, _)
+          if userConfig.typeAnnotationsEnabled =>
+        printTree(tree)
+      case _ => None
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -1,0 +1,324 @@
+package scala.meta.internal.decorations
+
+import java.nio.charset.Charset
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.Try
+
+import scala.meta.internal.metals.Buffers
+import scala.meta.internal.metals.ClientConfiguration
+import scala.meta.internal.metals.Diagnostics
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.mtags.Md5Fingerprints
+import scala.meta.internal.mtags.SemanticdbClasspath
+import scala.meta.internal.mtags.Semanticdbs
+import scala.meta.internal.pc.HoverMarkup
+import scala.meta.internal.semanticdb.Scala._
+import scala.meta.internal.semanticdb.TextDocument
+import scala.meta.internal.semanticdb.TextDocuments
+import scala.meta.io.AbsolutePath
+
+import org.eclipse.lsp4j.TextDocumentPositionParams
+import org.eclipse.{lsp4j => l}
+
+final class SyntheticsDecorationProvider(
+    workspace: AbsolutePath,
+    semanticdbs: Semanticdbs,
+    buffer: Buffers,
+    client: DecorationClient,
+    fingerprints: Md5Fingerprints,
+    charset: Charset,
+    diagnostics: Diagnostics,
+    focusedDocument: () => Option[AbsolutePath],
+    clientConfig: ClientConfiguration,
+    userConfig: () => UserConfiguration
+)(implicit ec: ExecutionContext) {
+
+  import SemanticdbTreePrinter.printSyntheticInfo
+
+  private object Document {
+    /* We update it with each compilation in order not read the same file on
+     * each change. When typing documents stay the same most of the time.
+     */
+    private val document = new AtomicReference[TextDocument]
+
+    def currentDocument: Option[TextDocument] = Option(document.get())
+
+    def set(doc: TextDocument): Unit = document.set(doc)
+  }
+
+  def publishSynthetics(path: AbsolutePath): Future[Unit] = {
+
+    // If focused document is not supported we can't be sure what is currently open
+    def isFocusedDocument =
+      focusedDocument().contains(path) || !clientConfig.isDidFocusProvider()
+
+    /**
+     * Worksheets currently do not use semanticdb, which is why this will not work.
+     * If at any time worksheets will support it, we need to make sure that the
+     * evaluation will not be replaced with implicit decorations.
+     */
+    if (!path.isWorksheet && isFocusedDocument) {
+      val textDocument = currentDocument(path)
+      textDocument match {
+        case Some(doc) =>
+          publishSyntheticDecorations(path, doc)
+        case _ =>
+          Future.successful(())
+      }
+
+    } else
+      Future.successful(())
+  }
+
+  def onChange(textDocument: TextDocuments, path: Path): Unit = {
+    for {
+      focused <- focusedDocument()
+      filePath = AbsolutePath(path)
+      sourcePath <- SemanticdbClasspath.toScala(workspace, filePath)
+      if sourcePath == focused || !clientConfig.isDidFocusProvider()
+      textDoc <- textDocument.documents.headOption
+      source <- fingerprints.loadLastValid(sourcePath, textDoc.md5, charset)
+    } {
+      val docWithText = textDoc.withText(source)
+      Document.set(docWithText)
+      publishSyntheticDecorations(sourcePath, docWithText)
+    }
+  }
+
+  def addSyntheticsHover(
+      params: TextDocumentPositionParams,
+      pcHover: Option[l.Hover]
+  ): Option[l.Hover] =
+    if (isSyntheticsEnabled) {
+      val path = params.getTextDocument().getUri().toAbsolutePath
+      val line = params.getPosition().getLine()
+      val newHover = currentDocument(path) match {
+        case Some(textDocument) =>
+          val edit = buffer.tokenEditDistance(path, textDocument.text)
+
+          val syntheticsAtLine = for {
+            synthetic <- textDocument.synthetics
+            range <- synthetic.range.toIterable
+            lspRange <- edit.toRevisedStrict(range).toIterable
+            if lspRange.getEnd.getLine == line
+            fullSnippet <- printSyntheticInfo(
+              textDocument,
+              synthetic,
+              toHoverString(textDocument),
+              userConfig(),
+              simple = false
+            ).toIterable
+          } yield (lspRange, fullSnippet)
+
+          if (syntheticsAtLine.size > 0) {
+            if (clientConfig.isInlineDecorationProvider()) {
+              createHoverAtPoint(
+                path,
+                syntheticsAtLine,
+                pcHover,
+                params.getPosition()
+              )
+            } else {
+              createHoverAtLine(path, syntheticsAtLine, pcHover).orElse(
+                pcHover
+              )
+            }
+          } else {
+            None
+          }
+        case None => None
+      }
+      newHover.orElse(pcHover)
+    } else {
+      pcHover
+    }
+
+  private def isSyntheticsEnabled: Boolean = {
+    userConfig().implicitArgumentAnnotationsEnabled || userConfig().typeAnnotationsEnabled
+  }
+
+  private def createHoverAtPoint(
+      path: AbsolutePath,
+      syntheticsAtLine: Seq[(l.Range, String)],
+      pcHover: Option[l.Hover],
+      position: l.Position
+  ): Option[l.Hover] = {
+    syntheticsAtLine
+      .find {
+        case (range, _) =>
+          range.getEnd().getCharacter() == position.getCharacter()
+      }
+      .flatMap {
+        case (_, synthetic) =>
+          addToHover(
+            pcHover,
+            "**Synthetics**:\n"
+              +
+                HoverMarkup(
+                  synthetic
+                )
+          )
+      }
+
+  }
+
+  private def createHoverAtLine(
+      path: AbsolutePath,
+      syntheticsAtLine: Seq[(l.Range, String)],
+      pcHover: Option[l.Hover]
+  ): Option[l.Hover] =
+    Try {
+      val line = syntheticsAtLine.head._1.getEnd().getLine()
+      for {
+        currentText <- buffer.get(path)
+        lineText <- currentText.linesIterator.drop(line).headOption
+        created <- createLine(syntheticsAtLine, pcHover, lineText)
+      } yield created
+    }.toOption.flatten
+
+  private def createLine(
+      syntheticsAtLine: Seq[(l.Range, String)],
+      pcHover: Option[l.Hover],
+      lineText: String
+  ) = {
+    val withEnd = syntheticsAtLine
+      .map {
+        case (range, str) => (range.getEnd().getCharacter(), str)
+      }
+      .sortBy(_._1) :+ (lineText.size, "")
+    val lineWithDecorations = withEnd
+      .foldLeft(("", 0)) {
+        case ((current, index), (char, text)) =>
+          val toAdd = lineText.substring(index, char) + text
+          (current + toAdd, char)
+      }
+      ._1
+
+    addToHover(
+      pcHover,
+      "**With synthetics added**:\n"
+        + HoverMarkup(
+          lineWithDecorations.trim()
+        )
+    )
+  }
+
+  private def addToHover(
+      pcHover: Option[l.Hover],
+      text: String
+  ): Option[l.Hover] = {
+    // Left is not handled currently, but we do not use it in Metals
+    if (pcHover.exists(_.getContents().isLeft())) {
+      None
+    } else {
+      val previousContent = pcHover
+        .filter(_.getContents().isRight())
+        .map(_.getContents().getRight.getValue + "\n")
+        .getOrElse("")
+      Some(
+        new l.Hover(
+          new l.MarkupContent(
+            l.MarkupKind.MARKDOWN,
+            previousContent + text
+          )
+        )
+      )
+    }
+  }
+
+  private def currentDocument(path: AbsolutePath): Option[TextDocument] = {
+    Document.currentDocument match {
+      case Some(doc) if workspace.resolve(doc.uri) == path => Some(doc)
+      case _ =>
+        val textDocument = semanticdbs
+          .textDocument(path)
+          .documentIncludingStale
+        textDocument.foreach(Document.set)
+        textDocument
+    }
+  }
+
+  private def toSymbolName(symbol: String, textDoc: TextDocument): String = {
+    if (symbol.isLocal)
+      textDoc.symbols
+        .find(_.symbol == symbol)
+        .map(_.displayName)
+        .getOrElse(symbol)
+    else symbol
+  }
+
+  private def toHoverString(textDoc: TextDocument)(symbol: String): String = {
+    toSymbolName(symbol, textDoc)
+      .replace("/", ".")
+      .stripSuffix(".")
+      .stripSuffix("#")
+      .stripPrefix("_empty_.")
+      .replace("#", ".")
+      .replace("()", "")
+  }
+
+  private def toDecorationString(
+      textDoc: TextDocument
+  )(symbol: String): String = {
+    if (symbol.isLocal)
+      textDoc.symbols
+        .find(_.symbol == symbol)
+        .map(_.displayName)
+        .getOrElse(symbol)
+    else symbol.desc.name.value
+  }
+
+  private def decorationOptions(
+      lspRange: l.Range,
+      decorationText: String
+  ) = {
+    // We don't add hover due to https://github.com/microsoft/vscode/issues/105302
+    new DecorationOptions(
+      lspRange,
+      renderOptions = ThemableDecorationInstanceRenderOptions(
+        after = ThemableDecorationAttachmentRenderOptions(
+          decorationText,
+          color = "grey",
+          fontStyle = "italic",
+          opacity = 0.7
+        )
+      )
+    )
+  }
+
+  private def publishSyntheticDecorations(
+      path: AbsolutePath,
+      textDocument: TextDocument
+  ): Future[Unit] =
+    Future {
+      if (clientConfig.isInlineDecorationProvider()) {
+        val edit = buffer.tokenEditDistance(path, textDocument.text)
+        val decorations = for {
+          synthetic <- textDocument.synthetics
+          range <- synthetic.range.toIterable
+          decoration <- printSyntheticInfo(
+            textDocument,
+            synthetic,
+            toDecorationString(textDocument),
+            userConfig(),
+            simple = true
+          ).toIterable
+          lspRange <- edit.toRevisedStrict(range).toIterable
+        } yield decorationOptions(lspRange, decoration)
+
+        val params =
+          new PublishDecorationsParams(
+            path.toURI.toString(),
+            decorations.toArray
+          )
+
+        client.metalsPublishDecorations(params)
+      }
+    }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -125,6 +125,9 @@ class ClientConfiguration(
       false
     )
 
+  def isInlineDecorationProvider(): Boolean =
+    initializationOptions.inlineDecorationProvider.getOrElse(false)
+
   def isTreeViewProvider(): Boolean =
     extract(
       initializationOptions.treeViewProvider,

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -18,6 +18,9 @@ import org.eclipse.{lsp4j => l}
  * @param compilerOptions configuration for the `PresentationCompilerConfig`.
  * @param debuggingProvider if the client supports debugging.
  * @param decorationProvider if the client implements the Metals Decoration Protocol.
+ * @param inlineDecorationProvider if the client implements the Metals Decoration Protocol
+ *                                 and supports decorations to be show inside text and not
+ *                                 only at the end of a line.
  * @param didFocusProvider if the client implements the `metals/didFocusTextDocument` command.
  * @param doctorProvider format that the client would like the Doctor to be returned in.
  * @param executeClientCommandProvider if the client implements `metals/executeClientCommand`.
@@ -39,6 +42,7 @@ final case class InitializationOptions(
     compilerOptions: CompilerInitializationOptions,
     debuggingProvider: Option[Boolean],
     decorationProvider: Option[Boolean],
+    inlineDecorationProvider: Option[Boolean],
     didFocusProvider: Option[Boolean],
     doctorProvider: Option[String],
     executeClientCommandProvider: Option[Boolean],
@@ -85,6 +89,7 @@ object InitializationOptions {
     None,
     None,
     None,
+    None,
     None
   )
 
@@ -112,6 +117,8 @@ object InitializationOptions {
       compilerOptions = extractCompilerOptions(jsonObj),
       debuggingProvider = jsonObj.getBooleanOption("debuggingProvider"),
       decorationProvider = jsonObj.getBooleanOption("decorationProvider"),
+      inlineDecorationProvider =
+        jsonObj.getBooleanOption("inlineDecorationProvider"),
       didFocusProvider = jsonObj.getBooleanOption("didFocusProvider"),
       doctorProvider = jsonObj.getStringOption("doctorProvider"),
       executeClientCommandProvider =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -31,6 +31,7 @@ import scala.meta.internal.builds.BuildTool
 import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.builds.NewProjectProvider
 import scala.meta.internal.builds.ShellRunner
+import scala.meta.internal.decorations.SyntheticsDecorationProvider
 import scala.meta.internal.implementation.ImplementationProvider
 import scala.meta.internal.implementation.Supermethods
 import scala.meta.internal.io.FileIO
@@ -198,6 +199,7 @@ class MetalsLanguageServer(
   private var renameProvider: RenameProvider = _
   private var documentHighlightProvider: DocumentHighlightProvider = _
   private var formattingProvider: FormattingProvider = _
+  private var syntheticsDecorator: SyntheticsDecorationProvider = _
   private var initializeParams: Option[InitializeParams] = None
   private var referencesProvider: ReferenceProvider = _
   private var workspaceSymbols: WorkspaceSymbolProvider = _
@@ -460,9 +462,22 @@ class MetalsLanguageServer(
       compilations,
       clientConfig
     )
+    syntheticsDecorator = new SyntheticsDecorationProvider(
+      workspace,
+      semanticdbs,
+      buffers,
+      languageClient,
+      fingerprints,
+      charset,
+      diagnostics,
+      () => focusedDocument,
+      clientConfig,
+      () => userConfig
+    )
     semanticDBIndexer = new SemanticdbIndexer(
       referencesProvider,
       implementationProvider,
+      syntheticsDecorator,
       buildTargets
     )
     documentHighlightProvider = new DocumentHighlightProvider(
@@ -817,6 +832,7 @@ class MetalsLanguageServer(
     val path = params.getTextDocument.getUri.toAbsolutePath
     focusedDocument = Some(path)
     openedFiles.add(path)
+    syntheticsDecorator.publishSynthetics(path)
 
     // Update md5 fingerprint from file contents on disk
     fingerprints.add(path, FileIO.slurp(path, charset))
@@ -867,6 +883,7 @@ class MetalsLanguageServer(
     } else if (openedFiles.isRecentlyActive(path)) {
       CompletableFuture.completedFuture(DidFocusResult.RecentlyActive)
     } else {
+      syntheticsDecorator.publishSynthetics(path)
       buildTargets.inverseSources(path) match {
         case Some(target) =>
           val isAffectedByCurrentCompilation =
@@ -916,7 +933,12 @@ class MetalsLanguageServer(
         val path = params.getTextDocument.getUri.toAbsolutePath
         buffers.put(path, change.getText)
         diagnostics.didChange(path)
-        parseTrees(path).asJava
+        Future
+          .sequence(
+            List(parseTrees(path), syntheticsDecorator.publishSynthetics(path))
+          )
+          .ignoreValue
+          .asJava
     }
 
   @JsonNotification("textDocument/didClose")
@@ -1135,6 +1157,9 @@ class MetalsLanguageServer(
     CancelTokens.future { token =>
       compilers
         .hover(params, token, interactiveSemanticdbs)
+        .map { hover =>
+          syntheticsDecorator.addSyntheticsHover(params, hover)
+        }
         .map(
           _.orElse {
             val path = params.getTextDocument.getUri.toAbsolutePath

--- a/metals/src/main/scala/scala/meta/internal/metals/MutableMd5Fingerprints.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MutableMd5Fingerprints.scala
@@ -1,8 +1,10 @@
 package scala.meta.internal.metals
 
+import java.nio.charset.Charset
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 
+import scala.meta.internal.io.FileIO
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.mtags.MD5
 import scala.meta.internal.mtags.Md5Fingerprints
@@ -32,6 +34,21 @@ final class MutableMd5Fingerprints extends Md5Fingerprints {
       prints.clear()
       prints.add(fingerprint)
       fingerprint.text
+
+    }
+  }
+
+  override def loadLastValid(
+      path: AbsolutePath,
+      soughtMd5: String,
+      charset: Charset
+  ): Option[String] = {
+    val text = FileIO.slurp(path, charset)
+    val md5 = MD5.compute(text)
+    if (soughtMd5 != md5) {
+      lookupText(path, soughtMd5)
+    } else {
+      Some(text)
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
@@ -5,6 +5,7 @@ import java.nio.file.Path
 
 import scala.util.control.NonFatal
 
+import scala.meta.internal.decorations.SyntheticsDecorationProvider
 import scala.meta.internal.implementation.ImplementationProvider
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.semanticdb.TextDocuments
@@ -14,6 +15,7 @@ import ch.epfl.scala.bsp4j.ScalacOptionsResult
 class SemanticdbIndexer(
     referenceProvider: ReferenceProvider,
     implementationProvider: ImplementationProvider,
+    implicitDecorator: SyntheticsDecorationProvider,
     buildTargets: BuildTargets
 ) {
 
@@ -82,6 +84,7 @@ class SemanticdbIndexer(
           val doc = TextDocuments.parseFrom(Files.readAllBytes(file))
           referenceProvider.onChange(doc, file)
           implementationProvider.onChange(doc, file)
+          implicitDecorator.onChange(doc, file)
         } catch {
           case NonFatal(e) =>
             scribe.warn(s"unexpected error processing the file $file", e)

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -35,6 +35,8 @@ case class UserConfiguration(
     bloopVersion: Option[String] = None,
     ammoniteJvmProperties: Option[List[String]] = None,
     superMethodLensesEnabled: Boolean = false,
+    typeAnnotationsEnabled: Boolean = false,
+    implicitArgumentAnnotationsEnabled: Boolean = false,
     remoteLanguageServer: Option[String] = None,
     enableStripMarginOnTypeFormatting: Boolean = true,
     excludedPackages: Option[List[String]] = None
@@ -167,6 +169,26 @@ object UserConfiguration {
         """|Super method lenses are visible above methods definition that override another methods. Clicking on a lens jumps to super method definition.
            |Disabled lenses are not calculated for opened documents which might speed up document processing.
            |
+           |""".stripMargin
+      ),
+      UserConfigurationOption(
+        "type-annotations-enabled",
+        "false",
+        "false",
+        "Should display type annotations for infered types",
+        """|When this option is enabled, each method that can have inferred types has them
+           |displayed either as additional decorations if they are supported by the editor or
+           |shown in hover otherwise.
+           |""".stripMargin
+      ),
+      UserConfigurationOption(
+        "implicit-argument-annotations-enabled",
+        "false",
+        "false",
+        "Should display implicit parameter at usage sites",
+        """|When this option is enabled, each method that has implicit arguments has them 
+           |displayed either as additional decorations if they are supported by the editor or 
+           |shown in hover otherwise.
            |""".stripMargin
       ),
       UserConfigurationOption(
@@ -324,6 +346,10 @@ object UserConfiguration {
       getStringKey("bloop-version")
     val superMethodLensesEnabled =
       getBooleanKey("super-method-lenses-enabled").getOrElse(false)
+    val typeAnnotationsEnabled =
+      getBooleanKey("type-annotations-enabled").getOrElse(false)
+    val implicitArgumentAnnotationsEnabled =
+      getBooleanKey("implicit-argument-annotations-enabled").getOrElse(false)
     val remoteLanguageServer =
       getStringKey("remote-language-server")
     val enableStripMarginOnTypeFormatting =
@@ -347,6 +373,8 @@ object UserConfiguration {
           bloopVersion,
           ammoniteProperties,
           superMethodLensesEnabled,
+          typeAnnotationsEnabled,
+          implicitArgumentAnnotationsEnabled,
           remoteLanguageServer,
           enableStripMarginOnTypeFormatting,
           excludedPackages

--- a/mtags/src/main/scala-2/scala/meta/internal/metals/TokenEditDistance.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/metals/TokenEditDistance.scala
@@ -9,6 +9,7 @@ import scala.meta.Position
 import scala.meta.Token
 import scala.meta.Tokens
 import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.internal.{semanticdb => s}
 
 import difflib._
 import difflib.myers.Equalizer
@@ -142,6 +143,25 @@ final class TokenEditDistance private (
 
   def toRevised(pos: l.Position): Either[EmptyResult, Position] = {
     toRevised(pos.getLine, pos.getCharacter)
+  }
+
+  def toRevisedStrict(range: s.Range): Option[l.Range] = {
+    if (isUnchanged) Some(range.toLSP)
+    else {
+      (
+        toRevised(range.startLine, range.startCharacter),
+        toRevised(range.endLine, range.endCharacter)
+      ) match {
+        case (Right(start), Right(end)) =>
+          Some(
+            new l.Range(
+              new l.Position(start.startLine, start.startColumn),
+              new l.Position(end.startLine, end.startColumn)
+            )
+          )
+        case _ => None
+      }
+    }
   }
 
   def toRevised(

--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/Md5Fingerprints.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/Md5Fingerprints.scala
@@ -1,4 +1,6 @@
 package scala.meta.internal.mtags
+import java.nio.charset.Charset
+
 import scala.meta.io.AbsolutePath
 
 /**
@@ -6,6 +8,12 @@ import scala.meta.io.AbsolutePath
  */
 trait Md5Fingerprints {
   def lookupText(path: AbsolutePath, md5: String): Option[String]
+
+  def loadLastValid(
+      path: AbsolutePath,
+      soughtMd5: String,
+      charset: Charset
+  ): Option[String]
 }
 
 object Md5Fingerprints {
@@ -13,5 +21,11 @@ object Md5Fingerprints {
     new Md5Fingerprints {
       override def lookupText(path: AbsolutePath, md5: String): Option[String] =
         None
+
+      override def loadLastValid(
+          path: AbsolutePath,
+          soughtMd5: String,
+          charset: Charset
+      ): Option[String] = None
     }
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -900,6 +900,17 @@ final class TestingServer(
     }
   }
 
+  def assertHoverAtLine(
+      filename: String,
+      query: String,
+      expected: String,
+      root: AbsolutePath = workspace
+  )(implicit loc: munit.Location): Future[Unit] = {
+    val text = root.resolve(filename).readText
+    val fullQuery = text.replace(query.replace("@@", "") + "\n", query + "\n")
+    assertHover(filename, fullQuery, expected, root)
+  }
+
   def assertHover(
       filename: String,
       query: String,

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -1,0 +1,205 @@
+package tests.decorations
+
+import scala.meta.internal.metals.InitializationOptions
+
+import tests.BaseLspSuite
+
+class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
+
+  override def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(
+        inlineDecorationProvider = Some(true),
+        decorationProvider = Some(true)
+      )
+    )
+
+  test("basic") {
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {}
+           |}
+           |
+           |/a/src/main/scala/Main.scala
+           |import scala.concurrent.Future
+           |case class Location(city: String)
+           |object Main{
+           |  def hello()(implicit name: String, from: Location) = {
+           |    println(s"Hello $$name from $${from.city}")
+           |  }
+           |  implicit val andy : String = "Andy"
+           |
+           |  def greeting() = {
+           |    implicit val boston = Location("Boston")
+           |    hello()
+           |    hello();    hello()
+           |  }
+           |  
+           |  "foo".map(c => c.toUpper)
+           |  "foo".map(c => c.toInt)
+           |  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+           |  Future{
+           |    println("")
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didChangeConfiguration(
+        """{
+          |  "implicit-argument-annotations-enabled": true,
+          |  "type-annotations-enabled": true
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      _ <- server.didSave("a/src/main/scala/Main.scala")(identity)
+      _ = assertNoDiagnostics()
+      _ = assertNoDiff(
+        client.workspaceDecorations,
+        """|import scala.concurrent.Future
+           |case class Location(city: String)
+           |object Main{
+           |  def hello()(implicit name: String, from: Location) = {
+           |    println(s"Hello $name from ${from.city}")
+           |  }
+           |  implicit val andy : String = "Andy"
+           |
+           |  def greeting() = {
+           |    implicit val boston = Location("Boston")
+           |    hello()(andy, boston)
+           |    hello()(andy, boston);    hello()(andy, boston)
+           |  }
+           |  
+           |  "foo".map[Char, String](c => c.toUpper)(StringCanBuildFrom)
+           |  "foo".map[Int, IndexedSeq[Int]](c => c.toInt)(fallbackStringCanBuildFrom[Int])
+           |  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+           |  Future{
+           |    println("")
+           |  }(ec)
+           |}
+           |""".stripMargin
+      )
+      // Implicit parameters
+      _ <- server.assertHoverAtLine(
+        "a/src/main/scala/Main.scala",
+        "    hello()@@",
+        """|**Synthetics**:
+           |```scala
+           |(Main.andy, boston)
+           |```
+           |""".stripMargin
+      )
+      // Inferred type parameters
+      _ <- server.assertHoverAtLine(
+        "a/src/main/scala/Main.scala",
+        "  \"foo\".map@@(c => c.toUpper)",
+        """|**Expression type**:
+           |```scala
+           |String
+           |```
+           |**Symbol signature**:
+           |```scala
+           |def map[B, That](f: Char => B)(implicit bf: CanBuildFrom[String,B,That]): That
+           |```
+           |**Synthetics**:
+           |```scala
+           |[scala.Char, scala.Predef.String]
+           |```
+           |""".stripMargin
+      )
+      // Normal hover without synthetics
+      _ <- server.assertHoverAtLine(
+        "a/src/main/scala/Main.scala",
+        "  \"foo\".m@@ap(c => c.toUpper)",
+        """|**Expression type**:
+           |```scala
+           |String
+           |```
+           |**Symbol signature**:
+           |```scala
+           |def map[B, That](f: Char => B)(implicit bf: CanBuildFrom[String,B,That]): That
+           |```
+           |""".stripMargin
+      )
+      // Implicit parameter from Predef
+      _ <- server.assertHoverAtLine(
+        "a/src/main/scala/Main.scala",
+        "  \"foo\".map(c => c.toInt)@@",
+        """|**Synthetics**:
+           |```scala
+           |(scala.LowPriorityImplicits.fallbackStringCanBuildFrom[scala.Int])
+           |```
+           |""".stripMargin
+      )
+    } yield ()
+  }
+
+  test("single-option") {
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {}
+           |}
+           |
+           |/a/src/main/scala/Main.scala
+           |object Main{
+           |  def hello()(implicit name: String) = {
+           |    println(s"Hello $$name!")
+           |  }
+           |  implicit val andy : String = "Andy"
+           |  hello()
+           |  "foo".map(c => c.toUpper)
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didChangeConfiguration(
+        """{
+          |  "implicit-argument-annotations-enabled": true,
+          |  "type-annotations-enabled": false
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      _ <- server.didSave("a/src/main/scala/Main.scala")(identity)
+      _ = assertNoDiagnostics()
+      _ = assertNoDiff(
+        client.workspaceDecorations,
+        """|object Main{
+           |  def hello()(implicit name: String) = {
+           |    println(s"Hello $name!")
+           |  }
+           |  implicit val andy : String = "Andy"
+           |  hello()(andy)
+           |  "foo".map(c => c.toUpper)(StringCanBuildFrom)
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didChangeConfiguration(
+        """{
+          |  "implicit-argument-annotations-enabled": false,
+          |  "type-annotations-enabled": true
+          |}
+          |""".stripMargin
+      )
+      _ = client.decorations.clear()
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      _ = assertNoDiff(
+        client.workspaceDecorations,
+        """|object Main{
+           |  def hello()(implicit name: String) = {
+           |    println(s"Hello $name!")
+           |  }
+           |  implicit val andy : String = "Andy"
+           |  hello()
+           |  "foo".map[Char, String](c => c.toUpper)
+           |}
+           |""".stripMargin
+      )
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticHoverLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticHoverLspSuite.scala
@@ -1,0 +1,64 @@
+package tests.decorations
+
+import tests.BaseLspSuite
+
+class SyntheticHoverLspSuite extends BaseLspSuite("implicits") {
+
+  test("hovers") {
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {}
+           |}
+           |
+           |/a/src/main/scala/com/example/Main.scala
+           |package com.example
+           |import scala.concurrent.Future
+           |case class Location(city: String)
+           |object Main{
+           |  def hello()(implicit name: String, from: Location) = {
+           |    println(s"Hello $$name from $${from.city}")
+           |  }
+           |  implicit val andy : String = "Andy"
+           |
+           |  def greeting() = {
+           |    implicit val boston = Location("Boston")
+           |    hello()
+           |  }
+           |  
+           |  "foo".map(c => c.toUpper)
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didChangeConfiguration(
+        """{
+          |  "implicit-argument-annotations-enabled": true,
+          |  "type-annotations-enabled": true
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/com/example/Main.scala")
+      _ <- server.didSave("a/src/main/scala/com/example/Main.scala")(identity)
+      _ <- server.assertHoverAtLine(
+        "a/src/main/scala/com/example/Main.scala",
+        "    hello()@@",
+        """|**With synthetics added**:
+           |```scala
+           |hello()(com.example.Main.andy, boston)
+           |```
+           |""".stripMargin
+      )
+      _ <- server.assertHoverAtLine(
+        "a/src/main/scala/com/example/Main.scala",
+        "  \"foo\".map(c @@=> c.toUpper)",
+        """|**With synthetics added**:
+           |```scala
+           |"foo".map[scala.Char, scala.Predef.String](c => c.toUpper)(scala.Predef.StringCanBuildFrom)
+           |```
+           |""".stripMargin
+      )
+    } yield ()
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/scalameta/metals/issues/2009

![metals-sample-1601562464506](https://user-images.githubusercontent.com/3807253/94822976-966beb00-0403-11eb-8fd7-546d5a864722.gif)

Some issues that I found when working on this:
- hovers on decorations inside text will pop up only before that decoration - https://github.com/microsoft/vscode/issues/105302
- not sure how to do go to definition for the implicits - I was thinking of maybe adding code lenses above or adding an option in definitionProvider to also search for synthetics if the cursor matches the end of sythetic occurence. I decided that we can work on it later

This also requires a PR for VS Code: https://github.com/scalameta/metals-vscode/pull/413