### PR TITLE
Update Sublime doc regarding organize imports

### DIFF
--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -209,7 +209,7 @@ functionality.
      <td align="center">✅</td>
      <td align="center"></td>
      <td align="center">✅</td>
-     <td align="center"></td>
+     <td align="center">✅</td>
      <td align="center">✅</td>
      <td align="center"></td>
   </tr>

--- a/docs/editors/sublime.md
+++ b/docs/editors/sublime.md
@@ -86,6 +86,17 @@ This paragraph contains a few tips & trick that can improve your daily productiv
 
 ### Optional LSP client tweaks
 
+If you want Metals to automatically organize the imports on file save set the following setting in the "Preferences > Preferences: LSP Settings":
+
+```json
+{
+  // ...
+  "lsp_code_actions_on_save": {
+    "source.organizeImports": true
+  }
+}
+```
+
 If you prefer to only enable Metals completions
 (without mixing them with the default ones from Sublime) set the following setting
 in the "Preferences > Preferences: LSP Settings":


### PR DESCRIPTION
Currently it seems that [LSP](https://github.com/sublimelsp/LSP/) supports `source.organizeImports` only as code action on save.