### PR TITLE
Make sure files are compiled when running scalafix 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -14,7 +14,7 @@ final class CodeActionProvider(
     buffers: Buffers,
     buildTargets: BuildTargets,
     scalafixProvider: ScalafixProvider
-) {
+)(implicit ec: ExecutionContext) {
   private val allActions: List[CodeAction] = List(
     new ImplementAbstractMembers(compilers),
     new ImportMissingSymbol(compilers),

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -47,6 +47,16 @@ final class Compilations(
   def wasPreviouslyCompiled(buildTarget: b.BuildTargetIdentifier): Boolean =
     lastCompile.contains(buildTarget)
 
+  def compilationFinished(
+      source: AbsolutePath
+  ): Future[Unit] = {
+    if (currentlyCompiling.isEmpty) {
+      Future(())
+    } else {
+      cascadeCompileFiles(Seq(source))
+    }
+  }
+
   def compileTarget(
       target: b.BuildTargetIdentifier
   ): Future[b.CompileResult] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -517,8 +517,10 @@ class MetalsLanguageServer(
       workspace,
       embedded,
       statusBar,
+      compilations,
       clientConfig.icons(),
-      languageClient
+      languageClient,
+      buildTargets
     )
     codeActionProvider = new CodeActionProvider(
       compilers,

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -24,6 +24,8 @@ case class ScalaTarget(
 
   def id: BuildTargetIdentifier = info.getId()
 
+  def targetroot: AbsolutePath = scalac.targetroot(scalaVersion)
+
   def baseDirectory: String = info.getBaseDirectory()
 
   def fullClasspath: ju.List[Path] = {


### PR DESCRIPTION
This fixes both:
- reporting errors - fixes https://github.com/scalameta/metals/issues/2102

Unfortunately we currently do not have any more information about the actual error message, it will need to be worked on further in scalafix. This hopefully enough for now, most error will be connected to semanticdb not being produced.


- making sure that compilation is run when using scalafix - fixes https://github.com/scalameta/metals/issues/2100

We are not yet able to organize imports in an unsaved file, but I will follow up with an issue for that.