### PR TITLE
Account for possible null value on PopupChoiceReset message request

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/PopupChoiceReset.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/PopupChoiceReset.scala
@@ -51,7 +51,9 @@ class PopupChoiceReset(
       .showMessageRequest(choicesParams())
       .asScala
       .flatMap { item =>
-        if (item.getTitle() == PopupChoiceReset.BuildTool) {
+        if (item == null) {
+          Future.successful(())
+        } else if (item.getTitle() == PopupChoiceReset.BuildTool) {
           reset(PopupChoiceReset.BuildTool)
         } else if (item.getTitle() == PopupChoiceReset.BuildImport) {
           reset(PopupChoiceReset.BuildImport)
@@ -63,6 +65,6 @@ class PopupChoiceReset(
 }
 
 object PopupChoiceReset {
-  final val BuildTool = "build tool selection"
-  final val BuildImport = "build import"
+  final val BuildTool = "Build tool selection"
+  final val BuildImport = "Build import"
 }


### PR DESCRIPTION
I randomly noticed this tonight when using the interactive reset choice functionality. According to [the spec](https://microsoft.github.io/language-server-protocol/specification.html#window_showMessageRequest), the showMessage request can return a `MessageActionItem` or `null`. We weren't accounting for the `null` and I was seeing null pointer exceptions being thrown when I cancelled the request. This just adds in a check.