### PR TITLE
Add support for loading env variables from a .env file.

### DIFF
--- a/docs/editors/debug-adapter-protocol.md
+++ b/docs/editors/debug-adapter-protocol.md
@@ -59,8 +59,9 @@ identically named classes in different modules. A uri will be returned that can
 be used by the DAP client.
 
 `envFile` is an optional parameter, which allows you to specify a path to a
-`.env` file with additional environment variables. It supports single line as
-well as multi-line quoted values (without value substitution). Any variables
+`.env` file with additional environment variables. The path can be either
+absolute or relative to your project workspace. The parser supports single line
+as well as multi-line quoted values (without value substitution). Any variables
 defined in the `env` object take precedence over those from the `.env` file.
 
 ### Wiring it all together

--- a/docs/editors/debug-adapter-protocol.md
+++ b/docs/editors/debug-adapter-protocol.md
@@ -40,7 +40,8 @@ Apart from using code lenses, users can start a debug session by executing the
   "buildTarget": "foo",
   "args": ["bar"],
   "jvmOptions": ["-Dpropert=123"],
-  "env": { "RETRY": "TRUE" }
+  "env": { "RETRY": "TRUE" },
+  "envFile": ".env"
 }
 ```
 
@@ -56,6 +57,10 @@ Apart from using code lenses, users can start a debug session by executing the
 `buildTarget` is an optional parameter, which might be useful if there are
 identically named classes in different modules. A uri will be returned that can
 be used by the DAP client.
+
+`envFile` is an optional parameter, which allows you to specify a path to a
+`.env` file with additional environment variables. It supports single line as
+well as multi-line quoted values (without value substitution).
 
 ### Wiring it all together
 

--- a/docs/editors/debug-adapter-protocol.md
+++ b/docs/editors/debug-adapter-protocol.md
@@ -63,6 +63,30 @@ be used by the DAP client.
 absolute or relative to your project workspace. The parser supports single line
 as well as multi-line quoted values (without value substitution). Any variables
 defined in the `env` object take precedence over those from the `.env` file.
+Here's an example of a supported .env file:
+
+```bash
+# single line values
+key1=value 1
+key2='value 2'   # ignored inline comment
+key3="value 3"
+
+# multi-line values
+key4='line 1
+line 2'
+key5="line 1
+line 2"
+
+# export statements
+export key6=value 6
+
+# comma delimiter
+key7:value 6
+
+# keys cannot contain dots or dashes
+a.b.key8=value 8   # will be ignored
+a-b-key9=value 9   # will be ignored
+```
 
 ### Wiring it all together
 

--- a/docs/editors/debug-adapter-protocol.md
+++ b/docs/editors/debug-adapter-protocol.md
@@ -60,7 +60,8 @@ be used by the DAP client.
 
 `envFile` is an optional parameter, which allows you to specify a path to a
 `.env` file with additional environment variables. It supports single line as
-well as multi-line quoted values (without value substitution).
+well as multi-line quoted values (without value substitution). Any variables
+defined in the `env` object take precedence over those from the `.env` file.
 
 ### Wiring it all together
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -500,6 +500,7 @@ class MetalsLanguageServer(
       )
     )
     debugProvider = new DebugProvider(
+      workspace,
       definitionProvider,
       () => bspSession.map(_.mainConnection),
       buildTargets,

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -375,7 +375,8 @@ case class DebugUnresolvedMainClassParams(
     @Nullable buildTarget: String = null,
     @Nullable args: java.util.List[String] = null,
     @Nullable jvmOptions: java.util.List[String] = null,
-    @Nullable env: java.util.Map[String, String] = null
+    @Nullable env: java.util.Map[String, String] = null,
+    @Nullable envFile: String = null
 )
 
 case class DebugUnresolvedTestClassParams(

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -129,7 +129,8 @@ object ServerCommands {
         |   buildTarget: "foo",
         |   args: ["bar"],
         |   jvmOptions: ["-Dfile.encoding=UTF-16"],
-        |   env: {"NUM" : "123"}
+        |   env: {"NUM" : "123"},
+        |   envFile: ".env"
         |}
         |```
         |

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -162,14 +162,12 @@ class DebugProvider(
               .map(_.map { case (key, value) => s"$key=$value" }.toList)
           } else Future.successful(List.empty)
 
-        envFromFile.flatMap { envFromFile =>
+        envFromFile.map { envFromFile =>
           clazz.setEnvironmentVariables((envFromFile ::: env).asJava)
-          Future.successful(
-            new b.DebugSessionParams(
-              singletonList(target.getId()),
-              b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS,
-              clazz.toJson
-            )
+          new b.DebugSessionParams(
+            singletonList(target.getId()),
+            b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS,
+            clazz.toJson
           )
         }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -31,6 +31,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.internal.metals.StatusBar
 import scala.meta.internal.mtags.OnDemandSymbolIndex
+import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import ch.epfl.scala.{bsp4j => b}
@@ -41,6 +42,7 @@ import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.MessageType
 
 class DebugProvider(
+    workspace: AbsolutePath,
     definitionProvider: DefinitionProvider,
     buildServer: () => Option[BuildServerConnection],
     buildTargets: BuildTargets,
@@ -143,7 +145,8 @@ class DebugProvider(
         clazz.setJvmOptions(
           Option(params.jvmOptions).getOrElse(List().asJava)
         )
-        val env =
+
+        val env: List[String] =
           if (params.env != null)
             params.env.asScala.map {
               case (key, value) => s"$key=$value"
@@ -151,14 +154,25 @@ class DebugProvider(
           else
             Nil
 
-        clazz.setEnvironmentVariables(env.asJava)
-        Future.successful(
-          new b.DebugSessionParams(
-            singletonList(target.getId()),
-            b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS,
-            clazz.toJson
+        val envFromFile: Future[List[String]] =
+          if (params.envFile != null) {
+            val path = AbsolutePath(params.envFile)(workspace)
+            DotEnvFileParser
+              .parse(path)
+              .map(_.map { case (key, value) => s"$key=$value" }.toList)
+          } else Future.successful(List.empty)
+
+        envFromFile.flatMap { envFromFile =>
+          clazz.setEnvironmentVariables((envFromFile ::: env).asJava)
+          Future.successful(
+            new b.DebugSessionParams(
+              singletonList(target.getId()),
+              b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS,
+              clazz.toJson
+            )
           )
-        )
+        }
+
       //should not really happen due to
       //`findMainClassAndItsBuildTarget` succeeding with non-empty list
       case Nil => Future.failed(new ju.NoSuchElementException(params.mainClass))

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
@@ -1,0 +1,71 @@
+package scala.meta.internal.metals.debug
+
+import java.nio.charset.Charset
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.matching.Regex
+import scala.util.matching.Regex.Groups
+
+import scala.meta.internal.io.FileIO
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+
+object DotEnvFileParser {
+  // DotEnv file regex adopted from the following projects:
+  //  - https://github.com/mefellows/sbt-dotenv
+  //  - https://github.com/bkeepers/dotenv
+  val LineRegex: Regex =
+    """(?xms)
+    ^                         # start of line
+    \s*                       # leading whitespace
+    (?:export\s+)?            # optional export
+    ([a-zA-Z_]+[a-zA-Z0-9_]*) # key
+    (?:\s*=\s*|\s*\:\s*)      # separator (= or :)
+    (                         # value capture group
+      '(?:\\'|[^'])*'         # single quoted value or
+      |
+      "(?:\\"|[^"])*"         # double quoted value or
+      |
+      [^\r\n]*                # unquoted value    
+    )
+    \s*                       # trailing whitespace
+    (?:\#.*)?                 # optional comment
+    $                         # end of line
+  """.r
+
+  def parse(
+      path: AbsolutePath
+  )(implicit ec: ExecutionContext): Future[Map[String, String]] =
+    if (path.exists && path.isFile && path.toFile.canRead)
+      Future(parse(FileIO.slurp(path, Charset.defaultCharset)))
+    else
+      Future.failed(
+        new IllegalArgumentException(
+          s"Unable to open the specified .env file $path. " +
+            "Please make sure the file exists and is readable."
+        )
+      )
+
+  def parse(content: String): Map[String, String] = {
+    LineRegex
+      .findAllMatchIn(content)
+      .map(_ match { case Groups(k, v) => (k -> unquote(v)) })
+      .toMap
+  }
+
+  private def unquote(value: String): String = {
+    value.trim match {
+      case s if startsEndsWith(s, "'") => trim(s).trim
+      case s if startsEndsWith(s, "\"") => trim(s).trim
+      case s => s
+    }
+  }
+
+  private def startsEndsWith(s: String, prefixSuffix: String): Boolean =
+    s.startsWith(prefixSuffix) && s.endsWith(prefixSuffix)
+
+  private def trim(s: String): String =
+    if (s.length > 1) s.substring(1, s.length - 1)
+    else s
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
@@ -12,7 +12,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
 
 object DotEnvFileParser {
-  // DotEnv file regex adopted from the following projects:
+  // DotEnv file regex adapted from the following projects:
   //  - https://github.com/mefellows/sbt-dotenv
   //  - https://github.com/bkeepers/dotenv
   val LineRegex: Regex =

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
@@ -50,7 +50,7 @@ object DotEnvFileParser {
   def parse(content: String): Map[String, String] = {
     LineRegex
       .findAllMatchIn(content)
-      .map(_ match { case Groups(k, v) => (k -> unquote(v)) })
+      .map(_ match { case Groups(k, v) => (k -> unescape(unquote(v))) })
       .toMap
   }
 
@@ -68,4 +68,7 @@ object DotEnvFileParser {
   private def trim(s: String): String =
     if (s.length > 1) s.substring(1, s.length - 1)
     else s
+
+  private def unescape(s: String): String =
+    s.replaceAll("""\\([^$])""", "$1")
 }

--- a/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
@@ -212,7 +212,7 @@ class DebugProtocolSuite extends BaseDapSuite("debug-protocol") {
           "a",
           singletonList("Arkansas"),
           singletonList("-Dname=Megan"),
-          Map("GREETING" -> "Welcome").asJava,
+          Map("GREETING" -> "Welcome", "MIDDLE_NAME" -> "Olivia").asJava,
           envFile.getFileName.toString
         ).toJson
       )
@@ -221,7 +221,7 @@ class DebugProtocolSuite extends BaseDapSuite("debug-protocol") {
       _ <- debugger.configurationDone
       _ <- debugger.shutdown
       output <- debugger.allOutput
-    } yield assertNoDiff(output, "Welcome Megan Emily Morris from Arkansas")
+    } yield assertNoDiff(output, "Welcome Megan Olivia Morris from Arkansas")
   }
 
   test("run-unrelated-error") {

--- a/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
@@ -1,7 +1,11 @@
 package tests
 
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.Collections.emptyList
 import java.util.Collections.singletonList
+
+import scala.util.Random
 
 import scala.meta.internal.metals.DebugUnresolvedMainClassParams
 import scala.meta.internal.metals.DebugUnresolvedTestClassParams
@@ -173,6 +177,14 @@ class DebugProtocolSuite extends BaseDapSuite("debug-protocol") {
   test("run-unresolved-params") {
     cleanCompileCache("a")
     cleanWorkspace()
+    val envFile: Path =
+      Files.write(
+        workspace
+          .resolve(Random.alphanumeric.take(10).mkString.toLowerCase + ".env")
+          .toNIO,
+        "MIDDLE_NAME=Emily\nLAST_NAME=Morris".getBytes()
+      )
+
     for {
       _ <- server.initialize(
         s"""/metals.json
@@ -185,8 +197,10 @@ class DebugProtocolSuite extends BaseDapSuite("debug-protocol") {
            |  def main(args: Array[String]) = {
            |    val name = sys.props.getOrElse("name", "")
            |    val location = args(0)
-           |    val greeting = sys.env("HELLO") 
-           |    print(s"$$greeting $$name from $$location")
+           |    val greeting = sys.env("GREETING")
+           |    val middleName = sys.env("MIDDLE_NAME")
+           |    val lastName = sys.env("LAST_NAME")
+           |    print(s"$$greeting $$name $$middleName $$lastName from $$location")
            |    System.exit(0)
            |  }
            |}
@@ -198,7 +212,8 @@ class DebugProtocolSuite extends BaseDapSuite("debug-protocol") {
           "a",
           singletonList("Arkansas"),
           singletonList("-Dname=Megan"),
-          Map("HELLO" -> "Welcome").asJava
+          Map("GREETING" -> "Welcome").asJava,
+          envFile.getFileName.toString
         ).toJson
       )
       _ <- debugger.initialize
@@ -206,7 +221,7 @@ class DebugProtocolSuite extends BaseDapSuite("debug-protocol") {
       _ <- debugger.configurationDone
       _ <- debugger.shutdown
       output <- debugger.allOutput
-    } yield assertNoDiff(output, "Welcome Megan from Arkansas")
+    } yield assertNoDiff(output, "Welcome Megan Emily Morris from Arkansas")
   }
 
   test("run-unrelated-error") {

--- a/tests/unit/src/test/scala/tests/debug/DotEnvFileParserSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/DotEnvFileParserSuite.scala
@@ -5,90 +5,151 @@ import scala.meta.internal.metals.debug.DotEnvFileParser._
 import tests.BaseSuite
 
 class DotEnvFileParserSuite extends BaseSuite {
+  val keyValue = Map("KEY" -> "value")
+
   test("parse empty values") {
     assertDiffEqual(parse("KEY="), Map("KEY" -> ""))
   }
 
   test("parse values separated by :") {
-    assertDiffEqual(parse("KEY:value"), Map("KEY" -> "value"))
+    assertDiffEqual(parse("KEY:value"), keyValue)
   }
 
   test("parse values separated by : with spaces around separator") {
-    val expected = Map("KEY" -> "value")
-    assertDiffEqual(parse("KEY:  value"), expected)
-    assertDiffEqual(parse("KEY  :value"), expected)
-    assertDiffEqual(parse("KEY  :  value"), expected)
+    assertDiffEqual(parse("KEY:  value"), keyValue)
+    assertDiffEqual(parse("KEY  :value"), keyValue)
+    assertDiffEqual(parse("KEY  :  value"), keyValue)
   }
 
   test("parse unquoted values") {
-    assertDiffEqual(parse("KEY=value"), Map("KEY" -> "value"))
+    assertDiffEqual(parse("KEY=value"), keyValue)
   }
 
   test("strip unquoted values") {
-    assertDiffEqual(parse("KEY=value  "), Map("KEY" -> "value"))
+    assertDiffEqual(parse("KEY=value  "), keyValue)
   }
 
   test("parse unquoted values with spaces around separator") {
-    val expected = Map("KEY" -> "value")
-    assertDiffEqual(parse("KEY  =value"), expected)
-    assertDiffEqual(parse("KEY=  value"), expected)
-    assertDiffEqual(parse("KEY  =  value"), expected)
+    assertDiffEqual(parse("KEY  =value"), keyValue)
+    assertDiffEqual(parse("KEY=  value"), keyValue)
+    assertDiffEqual(parse("KEY  =  value"), keyValue)
   }
 
   test("parse unquoted values with leading and trailing spaces") {
-    val expected = Map("KEY" -> "value")
-    assertDiffEqual(parse("  KEY=value"), expected)
-    assertDiffEqual(parse("KEY=value  "), expected)
-    assertDiffEqual(parse("  KEY=value  "), expected)
+    assertDiffEqual(parse("  KEY=value"), keyValue)
+    assertDiffEqual(parse("KEY=value  "), keyValue)
+    assertDiffEqual(parse("  KEY=value  "), keyValue)
   }
 
   test("parse single quoted values") {
-    assertDiffEqual(parse("KEY='value'"), Map("KEY" -> "value"))
+    assertDiffEqual(parse("KEY='value'"), keyValue)
   }
 
   test("strip single quoted values") {
-    val expected = Map("KEY" -> "value")
-    assertDiffEqual(parse("KEY='  value'"), expected)
-    assertDiffEqual(parse("KEY='value  '"), expected)
-    assertDiffEqual(parse("KEY=' value  '"), expected)
+    assertDiffEqual(parse("KEY='  value'"), keyValue)
+    assertDiffEqual(parse("KEY='value  '"), keyValue)
+    assertDiffEqual(parse("KEY=' value  '"), keyValue)
   }
 
   test("parse double quoted values") {
-    assertDiffEqual(parse("""KEY="value""""), Map("KEY" -> "value"))
+    assertDiffEqual(parse("""KEY="value""""), keyValue)
   }
 
   test("strip double quoted values") {
-    val expected = Map("KEY" -> "value")
-    assertDiffEqual(parse("""KEY="  value""""), expected)
-    assertDiffEqual(parse("""KEY="value  """"), expected)
-    assertDiffEqual(parse("""KEY="  value  """"), expected)
+    assertDiffEqual(parse("""KEY="  value""""), keyValue)
+    assertDiffEqual(parse("""KEY="value  """"), keyValue)
+    assertDiffEqual(parse("""KEY="  value  """"), keyValue)
   }
 
-  test("parse escaped double quotes") { ??? }
+  test("parse escaped double quotes") {
+    assertDiffEqual(parse("""KEY="\"quoted\"""""), Map("KEY" -> "\"quoted\""))
+  }
 
-  test("parse export keyword") { ??? }
+  test("parse export keyword") {
+    assertDiffEqual(parse("export KEY=value"), keyValue)
+  }
 
-  test("ignore lines with no assignment") { ??? }
+  test("ignore lines with no assignment") {
+    assertDiffEqual(parse("KEY"), Map.empty)
+  }
 
-  test("ignore lines with comments") { ??? }
+  test("ignore lines with comments") {
+    assertDiffEqual(parse("#KEY=value"), Map.empty)
+  }
 
-  test("ignore empty lines") { ??? }
+  test("ignore empty lines") {
+    assertDiffEqual(parse(" \nKEY=value"), keyValue)
+  }
 
-  test("ignore inline comments") { ??? }
+  test("allow # and spaces in unquoted values") {
+    assertDiffEqual(
+      parse("KEY=v a l u e # not a comment"),
+      Map("KEY" -> "v a l u e # not a comment")
+    )
+  }
 
-  test("allow # in quoted values") { ??? }
+  test("ignore inline comments after single quoted values") {
+    assertDiffEqual(parse("KEY='value' # comment"), keyValue)
+  }
 
-  test("parse multi-line single quoted values") { ??? }
+  test("ignore inline comments after double quoted values") {
+    assertDiffEqual(parse("""KEY="value" # comment"""), keyValue)
+  }
 
-  test("parse multi-line double quoted values") { ??? }
+  test("allow # in quoted values") {
+    assertDiffEqual(parse("""export KEY="v#l#e""""), Map("KEY" -> "v#l#e"))
+  }
 
-  test("parse multiple values") { ??? }
+  test("parse multi-line single quoted values") {
+    val content = """KEY='line1
+                    |line2'""".stripMargin
+    assertDiffEqual(parse(content), Map("KEY" -> "line1\nline2"))
+  }
 
-  test("parse multiple values with mixed quoting") { ??? }
+  test("parse multi-line double quoted values") {
+    val content = """KEY="line1
+                    |line2"""".stripMargin
+    assertDiffEqual(parse(content), Map("KEY" -> "line1\nline2"))
+  }
 
-  test("parse multiple values with mixed quoting") { ??? }
+  test("parse multiple values") {
+    val content = """KEY=value
+                    |KEY2=value2""".stripMargin
+    assertDiffEqual(parse(content), Map("KEY" -> "value", "KEY2" -> "value2"))
+  }
 
-  test("exclude variables with . in the name") { ??? }
+  test("parse multiple values with mixed quoting") {
+    val content = """KEY=value
+                    |KEY2='value2'
+                    |KEY3="value3"""".stripMargin
+    assertDiffEqual(
+      parse(content),
+      Map("KEY" -> "value", "KEY2" -> "value2", "KEY3" -> "value3")
+    )
+  }
 
-  test("exclude variables with - in the name") { ??? }
+  test("parse multiple multi-line values with mixed quoting") {
+    val content = """KEY=value
+                    |ignored
+                    |KEY2='value2 line1
+                    |value2 line2'
+                    |KEY3="value3 line1
+                    |value3 line2"""".stripMargin
+    assertDiffEqual(
+      parse(content),
+      Map(
+        "KEY" -> "value",
+        "KEY2" -> "value2 line1\nvalue2 line2",
+        "KEY3" -> "value3 line1\nvalue3 line2"
+      )
+    )
+  }
+
+  test("exclude variables with . in the name") {
+    assertDiffEqual(parse("K.E.Y=value"), Map.empty)
+  }
+
+  test("exclude variables with - in the name") {
+    assertDiffEqual(parse("K-E-Y=value"), Map.empty)
+  }
 }

--- a/tests/unit/src/test/scala/tests/debug/DotEnvFileParserSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/DotEnvFileParserSuite.scala
@@ -5,7 +5,7 @@ import scala.meta.internal.metals.debug.DotEnvFileParser._
 import tests.BaseSuite
 
 class DotEnvFileParserSuite extends BaseSuite {
-  val keyValue = Map("KEY" -> "value")
+  val keyValue: Map[String, String] = Map("KEY" -> "value")
 
   test("parse empty values") {
     assertDiffEqual(parse("KEY="), Map("KEY" -> ""))

--- a/tests/unit/src/test/scala/tests/debug/DotEnvFileParserSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/DotEnvFileParserSuite.scala
@@ -103,13 +103,19 @@ class DotEnvFileParserSuite extends BaseSuite {
   test("parse multi-line single quoted values") {
     val content = """KEY='line1
                     |line2'""".stripMargin
-    assertDiffEqual(parse(content), Map("KEY" -> "line1\nline2"))
+    assertDiffEqual(
+      parse(content),
+      Map("KEY" -> s"line1${System.lineSeparator}line2")
+    )
   }
 
   test("parse multi-line double quoted values") {
     val content = """KEY="line1
                     |line2"""".stripMargin
-    assertDiffEqual(parse(content), Map("KEY" -> "line1\nline2"))
+    assertDiffEqual(
+      parse(content),
+      Map("KEY" -> s"line1${System.lineSeparator}line2")
+    )
   }
 
   test("parse multiple values") {
@@ -139,8 +145,8 @@ class DotEnvFileParserSuite extends BaseSuite {
       parse(content),
       Map(
         "KEY" -> "value",
-        "KEY2" -> "value2 line1\nvalue2 line2",
-        "KEY3" -> "value3 line1\nvalue3 line2"
+        "KEY2" -> s"value2 line1${System.lineSeparator}value2 line2",
+        "KEY3" -> s"value3 line1${System.lineSeparator}value3 line2"
       )
     )
   }
@@ -151,5 +157,12 @@ class DotEnvFileParserSuite extends BaseSuite {
 
   test("exclude variables with - in the name") {
     assertDiffEqual(parse("K-E-Y=value"), Map.empty)
+  }
+
+  test("retain the original line separators") {
+    assertDiffEqual(
+      parse("KEY=\"line1\r\nline2\""),
+      Map("KEY" -> "line1\r\nline2")
+    )
   }
 }

--- a/tests/unit/src/test/scala/tests/debug/DotEnvFileParserSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/DotEnvFileParserSuite.scala
@@ -1,0 +1,94 @@
+package tests.debug
+
+import scala.meta.internal.metals.debug.DotEnvFileParser._
+
+import tests.BaseSuite
+
+class DotEnvFileParserSuite extends BaseSuite {
+  test("parse empty values") {
+    assertDiffEqual(parse("KEY="), Map("KEY" -> ""))
+  }
+
+  test("parse values separated by :") {
+    assertDiffEqual(parse("KEY:value"), Map("KEY" -> "value"))
+  }
+
+  test("parse values separated by : with spaces around separator") {
+    val expected = Map("KEY" -> "value")
+    assertDiffEqual(parse("KEY:  value"), expected)
+    assertDiffEqual(parse("KEY  :value"), expected)
+    assertDiffEqual(parse("KEY  :  value"), expected)
+  }
+
+  test("parse unquoted values") {
+    assertDiffEqual(parse("KEY=value"), Map("KEY" -> "value"))
+  }
+
+  test("strip unquoted values") {
+    assertDiffEqual(parse("KEY=value  "), Map("KEY" -> "value"))
+  }
+
+  test("parse unquoted values with spaces around separator") {
+    val expected = Map("KEY" -> "value")
+    assertDiffEqual(parse("KEY  =value"), expected)
+    assertDiffEqual(parse("KEY=  value"), expected)
+    assertDiffEqual(parse("KEY  =  value"), expected)
+  }
+
+  test("parse unquoted values with leading and trailing spaces") {
+    val expected = Map("KEY" -> "value")
+    assertDiffEqual(parse("  KEY=value"), expected)
+    assertDiffEqual(parse("KEY=value  "), expected)
+    assertDiffEqual(parse("  KEY=value  "), expected)
+  }
+
+  test("parse single quoted values") {
+    assertDiffEqual(parse("KEY='value'"), Map("KEY" -> "value"))
+  }
+
+  test("strip single quoted values") {
+    val expected = Map("KEY" -> "value")
+    assertDiffEqual(parse("KEY='  value'"), expected)
+    assertDiffEqual(parse("KEY='value  '"), expected)
+    assertDiffEqual(parse("KEY=' value  '"), expected)
+  }
+
+  test("parse double quoted values") {
+    assertDiffEqual(parse("""KEY="value""""), Map("KEY" -> "value"))
+  }
+
+  test("strip double quoted values") {
+    val expected = Map("KEY" -> "value")
+    assertDiffEqual(parse("""KEY="  value""""), expected)
+    assertDiffEqual(parse("""KEY="value  """"), expected)
+    assertDiffEqual(parse("""KEY="  value  """"), expected)
+  }
+
+  test("parse escaped double quotes") { ??? }
+
+  test("parse export keyword") { ??? }
+
+  test("ignore lines with no assignment") { ??? }
+
+  test("ignore lines with comments") { ??? }
+
+  test("ignore empty lines") { ??? }
+
+  test("ignore inline comments") { ??? }
+
+  test("allow # in quoted values") { ??? }
+
+  test("parse multi-line single quoted values") { ??? }
+
+  test("parse multi-line double quoted values") { ??? }
+
+  test("parse multiple values") { ??? }
+
+  test("parse multiple values with mixed quoting") { ??? }
+
+  test("parse multiple values with mixed quoting") { ??? }
+
+  test("exclude variables with . in the name") { ??? }
+
+  test("exclude variables with - in the name") { ??? }
+}


### PR DESCRIPTION
This PR adds support for loading environment variables from .env files.

This is still a WIP, but I wanted to make sure this approach is ok before I spend more time on implementing more tests and cleaning up the code.

I added a new `envFile` parameter to `DebugUnresolvedMainClassParams` which allows you to specify either a relative (to your project workspace) or an absolute path to an `.env` file in the `launch.json` config, e.g.:
```diff
 "version": "0.2.0",
  "configurations": [
    {
      "type": "scala",
      "name": "Debug ",
      "request": "launch",
      "mainClass": "Main",
+     "envFile": ".env"
    }
  ]
}
```

If the path is present, the file is parsed and the env variables are prepended to the env variables defined in the `env` object introduced in #2118 with the intention of making `env` override any variables from the `.env` file.

I've adapted the .env file parser regex from both [mefellows/sbt-dotenv](https://github.com/mefellows/sbt-dotenv) and [bkeepers/dotenv](https://github.com/bkeepers/dotenv).
It supports single/double-quoted and unquoted values as well as multiline values, both `=` and `:` separators as well as export statements, but it doesn't support value substitution (something that could potentially be added later if anyone needs it.)

Please let me know if you're happy with this approach and if there's anything major to address so far.