### PR TITLE
Add java sources to standalone worksheets and run compilation before evaluation if necessary.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -429,6 +429,11 @@ class Compilers(
     }
 
     created.getOrElse {
+      val sourcesWithJdk = JdkSources(userConfig().javaHome) match {
+        case Some(absPath) => absPath.toNIO :: sources
+        case None => sources
+      }
+
       jworksheetsCache.put(
         path,
         createStandaloneCompiler(
@@ -436,7 +441,7 @@ class Compilers(
           StandaloneSymbolSearch(
             workspace,
             buffers,
-            sources,
+            sourcesWithJdk,
             classpath,
             isExcludedPackage
           ),

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -577,7 +577,8 @@ class MetalsLanguageServer(
         diagnostics,
         embedded,
         worksheetPublisher,
-        compilers
+        compilers,
+        compilations
       )
     )
     ammonite = register(

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -90,7 +90,6 @@ class StandaloneSymbolSearch(
 }
 
 object StandaloneSymbolSearch {
-
   def apply(
       workspace: AbsolutePath,
       buffers: Buffers,
@@ -106,7 +105,6 @@ object StandaloneSymbolSearch {
       isExcludedPackage
     )
   }
-
   def apply(
       workspace: AbsolutePath,
       buffers: Buffers,


### PR DESCRIPTION
EDIT: This pr has changed a bit since I first started due to me totally overthinking what the actual issue was. So the aim for this now is to address two separate things.

1. Add java sources to the StandaloneSymbolSearch when we have a standalone worksheet so goto definition works on Java sources as you'd expect.
2. Close #1433 by checking to see if a worksheet belongs to a build target. If so, check to see if that build target has been compiled at all, and if not, compile it first.

~Now that you're able to put imports directly in your worksheet, I've
started to more often put worksheets either at the root of project, or
even in a directory of their own. I've started to keep worksheets and
just stick them in a `/worksheets` directory so I can refer to them
later on or share them. However, when starting to do this I realized
that while the goto definition worked fine in the buffer, if you had
something like this in your worksheet at the root of your project:~

```scala
import java.time.Instant

val x = Instant.no@@w()
```
~And you attempted to goto the definition of `now()`, you'd just get a
definition not found message. This is due to when we restart the
worksheet presentation compiler if there is no build target, we still
create a `StandaloneSymbolSearch`, but don't get it a workspace fallback
search if there is none. This would happen if you have a worksheet at
the root of your project, or in a standalone directory causing the
definition to not be found. The first change this pr does is to always
offer the fallback to the workspace search, which allows for `now()` to
be found in the scenario where you have a worksheet at the root, and it
correctly brings you to `Instant.java`.~

~However, if your worksheet was in its own directory completely apart
from a build, this still wouldn't work, because the
`StandaloneSymbolSearch` would be empty since we never indexed the
workspace. The second change introduces indexing the workspace when you
first evaluate a worksheet, and then then does again anytime is
determines that the workspace sources have changed. We do this at the
same time that we would restart the worksheet presentation compiler with
the new sources. This ensures that even in a standalone directory of
worksheets, that going to a definition can still be found in the
`destinationProvider` and correctly brings you to `Instant.java`. An
added benefit of this is that it also allows the user to use workspace
symbols while using worksheets.~