### PR TITLE
Bump setup-scala and cache-action actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,10 @@ jobs:
             CACHE_PATH: ~\AppData\Local\Coursier\Cache\v1
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: "adopt@1.${{ matrix.java }}"
-      - uses: coursier/cache-action@v4
+      - uses: coursier/cache-action@v5
       - name: Run unit tests
         run: |
           bin/test.sh unit/test
@@ -108,10 +108,10 @@ jobs:
             os: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: "adopt@1.11"
-      - uses: coursier/cache-action@v4
+      - uses: coursier/cache-action@v5
       - name: ${{ matrix.command }}
         run: ${{ matrix.command }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
       - uses: olafurpg/setup-gpg@v2
-      - uses: coursier/cache-action@v4
+      - uses: coursier/cache-action@v5
       - name: Publish
         run: |
           sbt ci-release


### PR DESCRIPTION
We are getting a bunch of warnings in CI
```
The `add-path` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

I was hoping this might get rid of some of them, but I'm assuming the changes may need to actually happen in the actions themselves. I'll take a peak, but either way, good to upgrade.