### PR TITLE
Don't import {java.util => ju} when no conflicting symbols are available

### DIFF
--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -33,6 +33,11 @@ public interface PresentationCompilerConfig {
     }
 
     /**
+     * Returns true if user didn't modify symbol prefixes
+     */
+    boolean isDefaultSymbolPrefixes();
+
+    /**
      * What text format to use for rendering `override def` labels for completion items.
      */
     OverrideDefFormat overrideDefFormat();

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -195,9 +195,20 @@ class MetalsGlobal(
       val result = tpe match {
         case TypeRef(pre, sym, args) =>
           val ownerSymbol = pre.termSymbol
+          def hasConflictingMembersInScope =
+            history.lookupSymbol(sym.name).exists {
+              case _: LookupSucceeded => true
+              case _ => false
+            }
+
+          def shouldRenamePrefix =
+            !metalsConfig.isDefaultSymbolPrefixes || hasConflictingMembersInScope
+
           history.config.get(ownerSymbol) match {
             case Some(rename)
-                if history.tryShortenName(ShortName(rename, ownerSymbol)) =>
+                if shouldRenamePrefix && history.tryShortenName(
+                  ShortName(rename, ownerSymbol)
+                ) =>
               TypeRef(
                 new PrettyType(rename.toString),
                 sym,

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -37,6 +37,11 @@ case class PresentationCompilerConfigImpl(
   override def completionCommand: Optional[String] =
     Optional.ofNullable(_completionCommand.orNull)
 
+  override val isDefaultSymbolPrefixes: Boolean =
+    _symbolPrefixes == PresentationCompilerConfig
+      .defaultSymbolPrefixes()
+      .asScala
+
   /**
    * Used to update the compiler config after we recieve the InitializationOptions.
    * If the user sets a value in the InitializationOptions, then the value will be

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -125,13 +125,13 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
         |  def foo(param: ArrayDeque@@)
         |}
         |""".stripMargin,
-    """|ju.ArrayDeque[$0]
+    """|ArrayDeque[$0]
        |""".stripMargin,
     compat = Map(
       "2.13" ->
-        """|ju.ArrayDeque[$0]
-           |mutable.ArrayDeque
-           |mutable.ArrayDequeOps
+        """|ArrayDeque[$0]
+           |ArrayDeque
+           |ArrayDequeOps
            |""".stripMargin
     )
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -231,10 +231,10 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  }
        |}
        |""".stripMargin,
-    """|import java.{util => ju}
+    """|import java.util.ArrayDeque
        |object Main {
        |  def foo(): Unit = null match {
-       |    case x: ju.ArrayDeque =>
+       |    case x: ArrayDeque =>
        |  }
        |}
        |""".stripMargin,
@@ -386,11 +386,11 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  def foo: ArrayBuffer@@[Int] = ???
        |}
        |""".stripMargin,
-    """|import scala.collection.mutable
+    """|import scala.collection.mutable.ArrayBuffer
        |
        |object Main {
        |  @noinline
-       |  def foo: mutable.ArrayBuffer[Int] = ???
+       |  def foo: ArrayBuffer[Int] = ???
        |}
        |""".stripMargin,
     filter = _ == "ArrayBuffer - scala.collection.mutable"
@@ -406,10 +406,10 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |""".stripMargin,
     """|package annotationclass
        |
-       |import scala.collection.mutable
+       |import scala.collection.mutable.ArrayBuffer
        |object Main {
        |  @deprecated("", "")
-       |  class Foo extends mutable.ArrayBuffer[Int]
+       |  class Foo extends ArrayBuffer[Int]
        |}
        |""".stripMargin,
     filter = _ == "ArrayBuffer - scala.collection.mutable"
@@ -425,10 +425,10 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |""".stripMargin,
     """|package annotationtrait
        |
-       |import scala.collection.mutable
+       |import scala.collection.mutable.ArrayBuffer
        |object Main {
        |  @deprecated("", "")
-       |  trait Foo extends mutable.ArrayBuffer[Int]
+       |  trait Foo extends ArrayBuffer[Int]
        |}
        |""".stripMargin,
     filter = _ == "ArrayBuffer - scala.collection.mutable"

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -125,11 +125,11 @@ class ImportMissingSymbolLspSuite
        |
        |import scala.concurrent.Future
        |import java.time.Instant
-       |import scala.collection.mutable
+       |import scala.collection.mutable.ListBuffer
        |
        |object A {
        |  val f = Future.successful(Instant.now)
-       |  val b = mutable.ListBuffer.newBuilder[Int]
+       |  val b = ListBuffer.newBuilder[Int]
        |}
        |""".stripMargin,
     expectNoDiagnostics = false
@@ -156,11 +156,11 @@ class ImportMissingSymbolLspSuite
     """|package a
        |
        |import java.time.Instant
-       |import scala.collection.mutable
+       |import scala.collection.mutable.ListBuffer
        |
        |object A {
        |  val f = Future.successful(Instant.now)
-       |  val b = mutable.ListBuffer.newBuilder[Int]
+       |  val b = ListBuffer.newBuilder[Int]
        |}
        |""".stripMargin,
     expectNoDiagnostics = false
@@ -188,12 +188,12 @@ class ImportMissingSymbolLspSuite
     """|package a
        |
        |import java.time.Instant
-       |import scala.collection.mutable
+       |import scala.collection.mutable.ListBuffer
        |
        |object A {
        |  val f = Future.successful(Instant.now)
-       |  val b = mutable.ListBuffer.newBuilder[Int]
-       |  val t = Future.successful(mutable.ListBuffer.empty)
+       |  val b = ListBuffer.newBuilder[Int]
+       |  val t = Future.successful(ListBuffer.empty)
        |}
        |""".stripMargin,
     expectNoDiagnostics = false


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/1502

We only add the default prefixes if there is a conflicting symbol in scope. However, if the user intentionally modified the prefixes we always use the modified ones. 