### PR TITLE
Account for possible null value in ScalaTarget's baseDirectory

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -26,7 +26,10 @@ case class ScalaTarget(
 
   def targetroot: AbsolutePath = scalac.targetroot(scalaVersion)
 
-  def baseDirectory: String = info.getBaseDirectory()
+  def baseDirectory: String = {
+    val baseDir = info.getBaseDirectory()
+    if (baseDir != null) baseDir else ""
+  }
 
   def fullClasspath: ju.List[Path] = {
     scalac.getClasspath().map(_.toAbsolutePath.toNIO)


### PR DESCRIPTION
I discovered this while playing around with the Mill BSP support since some of the build targets don't always have the `baseDirectory` set as it can be absent [according to the spec](https://build-server-protocol.github.io/docs/specification.html#build-target). This was throwing a null pointer exception when we then tried to order by the base dir in the Doctor. In the case of `null` I just set it to an empty `""` which only affects the ordering of the target in the Doctor or tree view.