### PR TITLE
Change scalafix and scalafmt conf to absolute path 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -218,10 +218,7 @@ final class FormattingProvider(
 
   private def scalafmtConf: AbsolutePath = {
     val configpath = userConfig().scalafmtConfigPath
-    (workspace :: workspaceFolders).iterator
-      .map(_.resolve(configpath))
-      .collectFirst { case path if path.isFile => path }
-      .getOrElse(workspace.resolve(configpath))
+    configpath.getOrElse(workspace.resolve(".scalafmt.conf"))
   }
 
   private val activeReporter: ScalafmtReporter = new ScalafmtReporter {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -529,7 +529,7 @@ class MetalsLanguageServer(
     )
     scalafixProvider = ScalafixProvider(
       buffers,
-      userConfig.scalafixConfigPath,
+      () => userConfig,
       workspace,
       embedded,
       statusBar,

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -21,7 +21,7 @@ import scalafix.interfaces.Scalafix
 
 case class ScalafixProvider(
     buffers: Buffers,
-    scalafixConfigPath: RelativePath,
+    userConfig: () => UserConfiguration,
     workspace: AbsolutePath,
     embedded: Embedded,
     statusBar: StatusBar,
@@ -50,7 +50,8 @@ case class ScalafixProvider(
       Future.successful(Nil)
     } else {
       compilations.compilationFinished(file).flatMap { _ =>
-        val scalafixConfPath = workspace.resolve(scalafixConfigPath)
+        val scalafixConfPath = userConfig().scalafixConfigPath
+          .getOrElse(workspace.resolve(".scalafix.conf"))
         val scalafixConf =
           if (scalafixConfPath.isFile) Some(scalafixConfPath.toNIO)
           else None

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -7,9 +7,9 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-import scala.meta.RelativePath
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.mtags.Symbol
+import scala.meta.io.AbsolutePath
 import scala.meta.pc.PresentationCompilerConfig
 
 import com.google.gson.JsonElement
@@ -25,8 +25,8 @@ case class UserConfiguration(
     gradleScript: Option[String] = None,
     mavenScript: Option[String] = None,
     millScript: Option[String] = None,
-    scalafmtConfigPath: RelativePath = RelativePath(".scalafmt.conf"),
-    scalafixConfigPath: RelativePath = RelativePath(".scalafix.conf"),
+    scalafmtConfigPath: Option[AbsolutePath] = None,
+    scalafixConfigPath: Option[AbsolutePath] = None,
     symbolPrefixes: Map[String, String] =
       PresentationCompilerConfig.defaultSymbolPrefixes().asScala.toMap,
     worksheetScreenWidth: Int = 120,
@@ -106,12 +106,20 @@ object UserConfiguration {
       ),
       UserConfigurationOption(
         "scalafmt-config-path",
-        default.scalafmtConfigPath.toString,
+        """empty string `""`.""",
         """"project/.scalafmt.conf"""",
         "Scalafmt config path",
         """Optional custom path to the .scalafmt.conf file.
-          |Should be relative to the workspace root directory and use forward slashes / for file
-          |separators (even on Windows).
+          |Should be an absolute path and use forward slashes `/` for file separators (even on Windows).
+          |""".stripMargin
+      ),
+      UserConfigurationOption(
+        "scalafix-config-path",
+        """empty string `""`.""",
+        """"project/.scalafix.conf"""",
+        "Scalafix config path",
+        """Optional custom path to the .scalafix.conf file.
+          |Should be an absolute path and use forward slashes `/` for file separators (even on Windows).
           |""".stripMargin
       ),
       UserConfigurationOption(
@@ -313,12 +321,10 @@ object UserConfiguration {
       getStringKey("java-home")
     val scalafmtConfigPath =
       getStringKey("scalafmt-config-path")
-        .map(RelativePath(_))
-        .getOrElse(default.scalafmtConfigPath)
+        .map(AbsolutePath(_))
     val scalafixConfigPath =
       getStringKey("scalafix-config-path")
-        .map(RelativePath(_))
-        .getOrElse(default.scalafixConfigPath)
+        .map(AbsolutePath(_))
     val sbtScript =
       getStringKey("sbt-script")
     val gradleScript =

--- a/tests/unit/src/test/scala/tests/FormattingLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/FormattingLspSuite.scala
@@ -76,7 +76,9 @@ class FormattingLspSuite extends BaseLspSuite("formatting") {
         val config = new JsonObject
         config.add(
           "scalafmt-config-path",
-          new JsonPrimitive("project/.scalafmt.conf")
+          new JsonPrimitive(
+            workspace.resolve("./project/.scalafmt.conf").toString()
+          )
         )
         server.didChangeConfiguration(config.toString)
       }
@@ -324,30 +326,4 @@ class FormattingLspSuite extends BaseLspSuite("formatting") {
       }
     } yield ()
   }
-
-  test("workspace-folder") {
-    for {
-      _ <- server.initialize(
-        s"""|/a/.scalafmt.conf
-            |version=${V.scalafmtVersion}
-            |maxColumn=10
-            |/Main.scala
-            |object   Main { val x = 2 }
-            |""".stripMargin,
-        expectError = true,
-        workspaceFolders = List("a")
-      )
-      _ <- server.didOpen("Main.scala")
-      _ <- server.formatting("Main.scala")
-      _ = assertNoDiff(
-        server.bufferContents("Main.scala"),
-        """object Main {
-          |  val x =
-          |    2
-          |}
-          |""".stripMargin
-      )
-    } yield ()
-  }
-
 }


### PR DESCRIPTION
This changes `metals.scalafixConfigPath` and `metals.scalafmtConfigPath` to use absolute path instead of a relative one. I found the previous behaviour to be problematic because:
- to set global config user would need to set each workspace to a different relative path and it's much more often that people have one global config than that they have a different naming scheme in each workspace they work in
- for scalafmt we would search the defined relative path in each workspace folder, while we currently do not support multiple workspace folders, so it might be quite random which config we choose.

It's important to note it's still possible to specify the path as for example `project/.scalafix.conf`, which will work the same way as previously. @olafurpg not sure why it was a relative path in the beginning, but I feel like it's no longer needed this way. Let me know if this approach might cause some issues.

I also fixed the issue with scalafix config not being updated