### PR TITLE
Allow for reset in html doctor

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -215,7 +215,7 @@ object SbtBuildTool {
    */
   private def metalsPluginDetails(version: String) =
     (
-      "This file enables semsantic information to be produced by sbt.",
+      "This file enables semantic information to be produced by sbt.",
       s""""org.scalameta" % "sbt-metals" % "$version""""
     )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -589,10 +589,13 @@ class MetalsLanguageServer(
       clientConfig
     )
     popupChoiceReset = new PopupChoiceReset(
+      workspace,
       tables,
       languageClient,
       doctor,
-      () => slowConnectToBuildServer(forceImport = true).map(_ => ())
+      () => slowConnectToBuildServer(forceImport = true),
+      bspConnector,
+      () => quickConnectToBuildServer()
     )
 
     val worksheetPublisher =


### PR DESCRIPTION
This pr adds in an `(Reset)` option in the html view of the doctor to reset your build server choice. The button is only shown if you've _explicitly_ chosen a build server. So for a user that just connects and uses the default, they will see that they are using Bloop as their build server, but won't be able to reset it, because there is no choice made.

So after making a choice if they do a `bsp-switch`, they the flow would look like this if they wanted to use Doctor to switch back and forth.

![2020-10-31 13 51 43](https://user-images.githubusercontent.com/13974112/97779837-20cd7900-1b81-11eb-9ae6-af916713f334.gif)

Closes #2171 