### PR TITLE
Track and show progress to user about connecting to sbt

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -395,7 +395,8 @@ class MetalsLanguageServer(
       buildTools,
       languageClient,
       tables,
-      () => userConfig
+      () => userConfig,
+      statusBar
     )
     semanticdbs = AggregateSemanticdbs(
       List(


### PR DESCRIPTION
Depending on the size of the project, when the decision to use sbt server is made, it may take a bit of time to start sbt before the bsp connection can be made. This shows the process in the status bar so the user has an idea of what's going one instead of not having a clue what's happening for that time.