### PR TITLE
Remove condition for jfr, since it's now reliably available on CI

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
@@ -192,8 +192,6 @@ object PackageIndex {
       }.toList
       entry <- entries
       if entry.isFile
-      // The bootclasspath doesn't reliably contain jfr.jar when running test in CI.
-      if !Testing.isEnabled || !entry.toNIO.endsWith("jfr.jar")
     } yield entry
 
   private def findJar(name: String) = {


### PR DESCRIPTION
So this error was actually introduced by me in the previous PR, since I readded `Testing.isEnabled` flag, which hasn't been used for a while.