### PR TITLE
Add in timer methods to a new timerProvider.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Timed.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Timed.scala
@@ -1,6 +1,0 @@
-package scala.meta.internal.metals
-
-case class Timed[T](value: T, timer: Timer)
-object Timed {
-  def apply[T](value: T, time: Time): Timed[T] = Timed(value, new Timer(time))
-}

--- a/metals/src/main/scala/scala/meta/internal/metals/TimerProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/TimerProvider.scala
@@ -1,0 +1,46 @@
+package scala.meta.internal.metals
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+/**
+ * Helper class to provider functionality around timers.
+ */
+final class TimerProvider(time: Time)(implicit ec: ExecutionContext) {
+  def timed[T](
+      didWhat: String,
+      reportStatus: Boolean = false
+  )(thunk: => Future[T]): Future[T] = {
+    withTimer(didWhat, reportStatus)(thunk).map { case (_, value) =>
+      value
+    }
+  }
+
+  def timedThunk[T](
+      didWhat: String,
+      onlyIf: Boolean = true,
+      thresholdMillis: Long = 0
+  )(thunk: => T): T = {
+    val elapsed = new Timer(time)
+    val result = thunk
+    if (
+      onlyIf && (thresholdMillis == 0 || elapsed.elapsedMillis > thresholdMillis)
+    ) {
+      scribe.info(s"time: $didWhat in $elapsed")
+    }
+    result
+  }
+
+  def withTimer[T](didWhat: String, reportStatus: Boolean)(
+      thunk: => Future[T]
+  ): Future[(Timer, T)] = {
+    val elapsed = new Timer(time)
+    val result = thunk
+    result.map { value =>
+      if (reportStatus || elapsed.isLogWorthy) {
+        scribe.info(s"time: $didWhat in $elapsed")
+      }
+      (elapsed, value)
+    }
+  }
+}


### PR DESCRIPTION
This doesn't add in any new functionality, but we have  a few timer
related methods floating around in `MetalsLanguageServer`, and I've
started to really notice how much stuff we have stuck in there. I'd like
to slowly start moving some stuff out, and these were easy to move out.
Plus some of other methods that use these I plan on moving out as well,
so it will be helpful to have these in their own class to make that
easier instead of passing them from `MetalsLanguageServer` into
other classes.

I ended up deleting the `Timed` class as well since it wasn't being used
at all.

Also this relates to some overdue work in listed in here https://github.com/scalameta/metals/issues/672