### PR TITLE
Ensure scalacOptions for Test are correct for sbt BSP.

### DIFF
--- a/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
+++ b/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
@@ -1,13 +1,14 @@
 package metals
 
-import sbt._
-import sbt.Keys._
-import Project.inConfig
-import sbt.internal.inc.ScalaInstance
 import scala.meta.internal.sbtmetals.BuildInfo
 
+import sbt._
+import sbt.Keys._
+import sbt.internal.inc.ScalaInstance
+import sbt.plugins.JvmPlugin
+
 object MetalsPlugin extends AutoPlugin {
-  override def requires = plugins.JvmPlugin
+  override def requires = JvmPlugin
   override def trigger = allRequirements
 
   val semanticdbVersion = BuildInfo.semanticdbVersion
@@ -49,7 +50,7 @@ object MetalsPlugin extends AutoPlugin {
       val targetRoot = semanticdbTargetRoot.value
       val versionOfScala = scalaVersion.value
       if (ScalaInstance.isDotty(versionOfScala))
-        List("-semanticdb-target", targetRoot.toString)
+        List.empty
       else
         List(
           s"-P:semanticdb:sourceroot:${baseDirectory.in(ThisBuild).value}",


### PR DESCRIPTION
So in the same project, this is the diff I got from before these changes and after, which match the desired outcome of #2189 

```diff
sbt:dotty-test> show Test / scalacOptions
[info] * -bootclasspath
[info] * /Users/ckipp/.sdkman/candidates/java/8.0.242-librca/jre/lib/resources.jar:/Users/ckipp/.sdkman/candidates/java/8.0.242-librca/jre/lib/rt.jar:/Users/ckipp/.sdkman/candidates/java/8.0.242-librca/jre/lib/sunrsasign.jar:/Users/ckipp/.sdkman/candidates/java/8.0.242-librca/jre/lib/jsse.jar:/Users/ckipp/.sdkman/candidates/java/8.0.242-librca/jre/lib/jce.jar:/Users/ckipp/.sdkman/candidates/java/8.0.242-librca/jre/lib/charsets.jar:/Users/ckipp/.sdkman/candidates/java/8.0.242-librca/jre/lib/jfr.jar:/Users/ckipp/.sdkman/candidates/java/8.0.242-librca/jre/classes
[info] * -Ysemanticdb
[info] * -semanticdb-target
- [info] * /Users/ckipp/Documents/scala-workspace/dotty-test/target/scala-0.27/meta
[info] * /Users/ckipp/Documents/scala-workspace/dotty-test/target/scala-0.27/test-meta
```

Fixes #2189