### PR TITLE
Show warning about unsupported Scala version in worksheets

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -18,6 +18,18 @@ import org.eclipse.lsp4j.ShowMessageRequestParams
  */
 object Messages {
 
+  object Worksheets {
+    def unsupportedScalaVersion(
+        unsupportedVersion: String,
+        fallback: String,
+        recommended: String
+    ) = new MessageParams(
+      MessageType.Warning,
+      s"Scala ${unsupportedVersion} is not supported in worksheets. Falling back to ${fallback} without your classpath.\n" +
+        s"Consider using ${recommended} instead to fix this."
+    )
+  }
+
   val NoBspSupport = new MessageParams(
     MessageType.Warning,
     "Workspace doesn't support BSP, please see logs."


### PR DESCRIPTION
This is a quick follow-up to my comment in #2190 about showing the message to the user when they are using a worksheet but their Scala version isn't supported. So now instead of just logging it, we both log it and show it to the user.

Another question that I _think_ I remember being discussed somewhere, but I find it a bit unexpected that if I'm using 0.27-RC1 we show the message about what version they _should_ be using, but then instead of defaulting to that version, we default to 2.12.12. I'm assuming because we already have everything we need for it, but would it be possible to instead of defaulting to 2.12.12, we detect that the user wants a Scala 3 version and default to the recommended Scala 3 instead? Basically make the rambo compiler closer to what they want.