### PR TITLE
Rename user configuration options for decoration provider

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
@@ -122,7 +122,7 @@ object SemanticdbTreePrinter {
        *  hello()<<(str)>>
        */
       case tree @ s.ApplyTree(_: s.OriginalTree, _)
-          if userConfig.implicitArgumentAnnotationsEnabled =>
+          if userConfig.showImplicitArguments =>
         printTree(tree)
 
       /**
@@ -130,7 +130,7 @@ object SemanticdbTreePrinter {
        *  hello<<[String]>>("")
        */
       case tree @ s.TypeApplyTree(_: s.OriginalTree, _)
-          if userConfig.typeAnnotationsEnabled =>
+          if userConfig.showInferredType =>
         printTree(tree)
       case _ => None
     }

--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -139,7 +139,7 @@ final class SyntheticsDecorationProvider(
     }
 
   private def isSyntheticsEnabled: Boolean = {
-    userConfig().implicitArgumentAnnotationsEnabled || userConfig().typeAnnotationsEnabled
+    userConfig().showImplicitArguments || userConfig().showInferredType
   }
 
   private def createHoverAtPoint(

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -35,8 +35,8 @@ case class UserConfiguration(
     bloopVersion: Option[String] = None,
     ammoniteJvmProperties: Option[List[String]] = None,
     superMethodLensesEnabled: Boolean = false,
-    typeAnnotationsEnabled: Boolean = false,
-    implicitArgumentAnnotationsEnabled: Boolean = false,
+    showInferredType: Boolean = false,
+    showImplicitArguments: Boolean = false,
     remoteLanguageServer: Option[String] = None,
     enableStripMarginOnTypeFormatting: Boolean = true,
     excludedPackages: Option[List[String]] = None
@@ -180,17 +180,17 @@ object UserConfiguration {
            |""".stripMargin
       ),
       UserConfigurationOption(
-        "type-annotations-enabled",
+        "show-inferred-type",
         "false",
         "false",
-        "Should display type annotations for infered types",
+        "Should display type annotations for inferred types",
         """|When this option is enabled, each method that can have inferred types has them
            |displayed either as additional decorations if they are supported by the editor or
            |shown in hover otherwise.
            |""".stripMargin
       ),
       UserConfigurationOption(
-        "implicit-argument-annotations-enabled",
+        "show-implicit-arguments",
         "false",
         "false",
         "Should display implicit parameter at usage sites",
@@ -352,10 +352,10 @@ object UserConfiguration {
       getStringKey("bloop-version")
     val superMethodLensesEnabled =
       getBooleanKey("super-method-lenses-enabled").getOrElse(false)
-    val typeAnnotationsEnabled =
-      getBooleanKey("type-annotations-enabled").getOrElse(false)
-    val implicitArgumentAnnotationsEnabled =
-      getBooleanKey("implicit-argument-annotations-enabled").getOrElse(false)
+    val showInferredType =
+      getBooleanKey("show-inferred-type").getOrElse(false)
+    val showImplicitArguments =
+      getBooleanKey("show-implicit-arguments").getOrElse(false)
     val remoteLanguageServer =
       getStringKey("remote-language-server")
     val enableStripMarginOnTypeFormatting =
@@ -379,8 +379,8 @@ object UserConfiguration {
           bloopVersion,
           ammoniteProperties,
           superMethodLensesEnabled,
-          typeAnnotationsEnabled,
-          implicitArgumentAnnotationsEnabled,
+          showInferredType,
+          showImplicitArguments,
           remoteLanguageServer,
           enableStripMarginOnTypeFormatting,
           excludedPackages

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -49,8 +49,8 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
       )
       _ <- server.didChangeConfiguration(
         """{
-          |  "implicit-argument-annotations-enabled": true,
-          |  "type-annotations-enabled": true
+          |  "show-implicit-arguments": true,
+          |  "show-inferred-type": true
           |}
           |""".stripMargin
       )
@@ -159,8 +159,8 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
       )
       _ <- server.didChangeConfiguration(
         """{
-          |  "implicit-argument-annotations-enabled": true,
-          |  "type-annotations-enabled": false
+          |  "show-implicit-arguments": true,
+          |  "show-inferred-type": false
           |}
           |""".stripMargin
       )
@@ -181,8 +181,8 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
       )
       _ <- server.didChangeConfiguration(
         """{
-          |  "implicit-argument-annotations-enabled": false,
-          |  "type-annotations-enabled": true
+          |  "show-implicit-arguments": false,
+          |  "show-inferred-type": true
           |}
           |""".stripMargin
       )

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticHoverLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticHoverLspSuite.scala
@@ -34,8 +34,8 @@ class SyntheticHoverLspSuite extends BaseLspSuite("implicits") {
       )
       _ <- server.didChangeConfiguration(
         """{
-          |  "implicit-argument-annotations-enabled": true,
-          |  "type-annotations-enabled": true
+          |  "show-implicit-arguments": true,
+          |  "show-inferred-type": true
           |}
           |""".stripMargin
       )


### PR DESCRIPTION
While writing the release notes it dawned on me that the previous names might not be too clear, especially the `annotation` part.

It's not yet release so changing the names should not be a problem, what do you think?

