### PR TITLE
Add release notes for 0.9.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ Steps to reproduce the behavior:
 
 - Operating system: macOS/Windows/Linux
 - Editor: Visual Studio Code/Atom/Vim/Sublime/Emacs
-- Metals version: v0.9.4
+- Metals version: v0.9.5
 
 **Additional context**
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -18,7 +18,7 @@ labels: "question"
 
 - Operating system: macOS/Windows/Linux
 - Editor: Visual Studio Code/Atom/Vim/Sublime/Emacs
-- Metals version: v0.9.4
+- Metals version: v0.9.5
 
 **Additional context**
 

--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -6,10 +6,9 @@ argumentsRest=${@:2}
 suffix=${argumentsRest:-}
 
 coursier fetch \
-  org.scalameta:mtags_0.25.0:$version \
-  org.scalameta:mtags_0.26.0-RC1:$version \
   org.scalameta:mtags_0.26.0:$version \
   org.scalameta:mtags_0.27.0-RC1:$version \
+  org.scalameta:mtags_3.0.0-M1:$version \
   org.scalameta:metals_2.12:$version \
   org.scalameta:mtags_2.13.0:$version \
   org.scalameta:mtags_2.13.1:$version \

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scala.collection.mutable
 import scala.sys.process._
 import Tests._
 
-def localSnapshotVersion = "0.9.5-SNAPSHOT"
+def localSnapshotVersion = "0.9.6-SNAPSHOT"
 def isCI = System.getenv("CI") != null
 
 def isScala211(v: Option[(Long, Long)]): Boolean = v.contains((2, 11))

--- a/website/blog/2020-11-10-lithium.md
+++ b/website/blog/2020-11-10-lithium.md
@@ -1,0 +1,538 @@
+---
+author: Tomasz Godzik
+title: Metals v0.9.5 - Lithium
+authorURL: https://twitter.com/TomekGodzik
+authorImageURL: https://github.com/tgodzik.png
+---
+
+We're happy to announce the release of Metals v0.9.5, which brings about some of
+the long awaited features such as implicit decorations and the organize imports
+code action. We also greatly simplified connecting to the sbt BSP server and
+added support for Scala 3's first milestone `3.0.0-M1`.
+
+<table>
+<tbody>
+  <tr>
+    <td>Commits since last release</td>
+    <td align="center">185</td>
+  </tr>
+  <tr>
+    <td>Merged PRs</td>
+    <td align="center">70</td>
+  </tr>
+    <tr>
+    <td>Contributors</td>
+    <td align="center">9</td>
+  </tr>
+  <tr>
+    <td>Closed issues</td>
+    <td align="center">33</td>
+  </tr>
+  <tr>
+    <td>New features</td>
+    <td align="center">5</td>
+  </tr>
+</tbody>
+</table>
+
+For full details: https://github.com/scalameta/metals/milestone/28?closed=1
+
+Metals is a language server for Scala that works with VS Code, Vim, Emacs,
+Sublime Text, Atom and Eclipse. Metals is developed at the
+[Scala Center](https://scala.epfl.ch/) and [VirtusLab](https://virtuslab.com)
+with the help from [Lunatech](https://lunatech.com) along with contributors from
+the community.
+
+## TL;DR
+
+Check out [https://scalameta.org/metals/](https://scalameta.org/metals/), and
+give Metals a try!
+
+- Organize imports code action.
+- Show implicit parameters and inferred type decorations.
+- Improved sbt BSP support.
+- Support for Scala 3.0.0-M1.
+- Remote debugging.
+- Environment variables in run/debug.
+
+## Organize imports code action
+
+One of the most requested features in the Metals repository, current list can be
+found [here](https://github.com/scalameta/metals/issues/707), was the ability to
+automatically organize imports. We are happy to announce, that thanks to
+[mlachkar's](https://github.com/mlachkar) amazing contributions to both
+[Scalafix](https://github.com/scalacenter/scalafix) and Metals, this new feature
+is now available via an `Organize imports` code action.
+
+![imports](https://i.imgur.com/8YBdjjC.gif)
+
+Depending on the editor this code action can be invoked differently, please
+consult your specific editor's documentation. For example in Visual Studio Code
+'organize imports' can be invoked from command console, shortcut, or from the
+dropdown menu when right clicking inside a file.
+
+The organize imports code action is enabled using
+[Scalafix](https://github.com/scalacenter/scalafix) and specifically the awesome
+organize imports rule created by [liancheng](https://github.com/liancheng).
+
+The rule can be used to automatically sort imports in a file by the Ascii order,
+which is the default setting, or use the user specific configuration defined
+using scalafix configuration file. This file can be either `.scalafix.conf` in
+the current workspace or an absolute file specified in the
+`metals.scalafixConfigPath` user setting. It's important to note that the new
+code action is consistent with how sbt's scalafix plugin will behave.
+
+An example scalafix configuration for the organize imports rule can look like
+this:
+
+```scala
+OrganizeImports {
+  groups = ["javax?\\.", "scala.", "*"]
+  removeUnused = true
+}
+```
+
+This will sort imports into 3 groups defined with regexes and remove any unused
+ones. Specifically, it will turn:
+
+```scala
+import scala.collection.mutable.{Buffer, ArrayBuffer}
+import java.time.Clock
+import java.lang.{Long => JLong, Double => JDouble}
+
+object RemoveUnused {
+  val buffer: ArrayBuffer[Int] = ArrayBuffer.empty[Int]
+  val long: JLong = JLong.parseLong("0")
+}
+```
+
+into
+
+```scala
+import java.lang.{Long => JLong}
+
+import scala.collection.mutable.ArrayBuffer
+
+object RemoveUnused {
+  val buffer: ArrayBuffer[Int] = ArrayBuffer.empty[Int]
+  val long: JLong = JLong.parseLong("0")
+}
+```
+
+Please do NOT use the Scalafix built-in RemoveUnused.imports together with
+OrganizeImports to remove unused imports, since it might result in a broken
+code.
+
+More information can be found in the
+[liancheng/scalafix-organize-imports](https://github.com/liancheng/scalafix-organize-imports)
+repository.
+
+## Show implicits and type decorations
+
+Another highly anticipated feature was the ability to show additional
+information about the code, which is not provided explicitly. In this new
+release, users can use two new options when looking through their code:
+
+- `metals.showImplicitArguments` will enable users to see implicit parameters
+  within their code:
+
+![params](https://i.imgur.com/vAvM7YV.png)
+
+- `metals.showInferredType` will enable users to see inferred type for any
+  generic methods they are using:
+
+![types](https://i.imgur.com/K3QrUd2.png)
+
+Both new options are disabled by default, since they add a great number of
+information, which might not be necessary for all users. Full name with package
+for each of the additional types or values will be available on hover.
+
+Unfortunately, due to current limitations, additional decorations are only
+possible in Visual Studio Code. In other editors the additional information is
+available via hover and new `With synthetics added` section, which shows how the
+whole current line would look with the additional decorations.
+
+Example of how this alternative approach looks in Vim:
+
+![vim-sample](https://user-images.githubusercontent.com/13974112/94804295-e094a280-03ea-11eb-8282-2a783446e7c8.png)
+
+## Improved sbt BSP support
+
+In recent months, [eed3si9n](https://github.com/eed3si9n) and
+[adpi2](https://github.com/adpi2) worked, under the auspices of Scala Center, on
+making sbt capable of acting as a
+[Build Server Protocol](https://build-server-protocol.github.io/) server. This
+enables Metals and other editors such as Intellij IDEA to directly communicate
+with sbt in order to compile the user's code.
+
+Some more work was required in order to make the new features work smoothly with
+Metals and currently, thanks to [ckipp01](https://github.com/ckipp01), users can
+easily try out the new sbt BSP support. It's important to note that using Bloop
+instead of sbt is still the recommended approach as we believe it provides the
+best user experience and features like running or debugging are still not yet
+implemented for sbt. More details and explanations can be found in the
+[blogpost](/metals/blog/2020/11/06/sbt-BSP-support).
+
+## Remote debugging
+
+Thanks to the great work of [pvid](https://github.com/pvid), Metals now supports
+remote debugging, which means that it can attach to a running process with the
+proper JVM options specified. There is no longer a need to run the application
+or test from within the editor.
+
+In case of a simple java process those options will take a form of for example:
+
+`-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005`
+
+Some of the more important options here are:
+
+- `suspend=y` will make the process wait for Metals to connect to it if
+  specified to `y`. `n` will cause the process to run normally.
+- `address=5005` specifies which port to use and it can be any free port.
+
+For a detailed explanation of the different options please refer to the proper
+documentation
+[here](https://docs.oracle.com/javase/8/docs/technotes/guides/jpda/conninv.html)
+
+When using sbt, remote debugging can be achieved by specifying additional
+settings:
+
+```scala
+  javaOptions in run := List("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"),
+  fork in run := true
+```
+
+This will cause running `sbt run` to wait for Metals to connect to it, which
+might be especially useful when reading user input, which is currently
+impossible to do for example from within VS Code. Similarly, these options can
+be specified in any of the supported build tools.
+
+To later connect to the running process, you need to use the additional Attach
+request type with the `buildTarget`, `hostname` and `port` fields specified. In
+case of Visual Studio Code this will take a form of:
+
+```json
+{
+  "type": "scala",
+  "request": "attach",
+  "name": "Attach",
+  "buildTarget": "root",
+  "hostName": "localhost",
+  "port": 5005
+}
+```
+
+## Environment variables in run/debug
+
+Metals now supports specifying additional environment options when running or
+debugging applications. This can be done twofold:
+
+- By specifying the new `env` field:
+
+```json
+{
+  "type": "scala",
+  "name": "Debug Main",
+  "request": "launch",
+  "mainClass": "Main",
+  "args": ["hello", "world"],
+  "env": { "VARIABLE1": " 123" }
+}
+```
+
+- By using the `envFile` field:
+
+```json
+{
+  "type": "scala",
+  "name": "Debug Main",
+  "request": "launch",
+  "mainClass": "Main",
+  "args": ["hello", "world"],
+  "envFile": "local.env"
+}
+```
+
+Where the `local.env` file can take a form of:
+
+```
+# single line values
+key1=value 1
+key2='value 2'   # ignored inline comment
+key3="value 3"
+
+# multi-line values
+key4='line 1
+line 2'
+key5="line 1
+line 2"
+
+# export statements
+export key6=value 6
+
+# comma delimiter
+key7:value 6
+
+# keys cannot contain dots or dashes
+a.b.key8=value 8   # will be ignored
+a-b-key9=value 9   # will be ignored
+```
+
+The format is adapted from
+[mefellows/sbt-dotenv](https://github.com/mefellows/sbt-dotenv) and
+[bkeepers/dotenv](https://github.com/bkeepers/dotenv). Example
+json configurations above are defined for Visual Studio Code, the `type` and
+`name` fields can be omitted when using in other clients.
+
+This new feature has been contributed by [mwz](https://github.com/mwz). Thanks
+for the great work!
+
+## Miscellaneous
+
+- Removed `javax` from default excluded packages - it can be added back in the
+  configuration.
+- Fixed top level completions in empty files.
+- Fixed issues with run/debug when using VPN.
+- Fixed go to java sources in standalone worksheets.
+- Fixed issues with worksheets if the workspace was not first compiled.
+- Fixed sbt completions coming from `project/*.scala` files.
+- Only use `import {java.util => ju}` when there are conflicting symbols in the
+  file.
+- Muted InvalidProtocolException in the logs - this exception might happen.
+  normally and does not break anything.
+- Changed scalafix and scalafmt location in user configuration to absolute path.
+- Only report parsing errors after Scala version is confirmed for a file.
+- Added automatic retry in case of build server connection failure.
+
+## Contributors
+
+Big thanks to everybody who contributed to this release or reported an issue!
+
+```
+$ git shortlog -sn --no-merges v0.9.4..v0.9.5
+Chris Kipp
+Scala Steward
+Tomasz Godzik
+Michael Wizner
+Meriam Lachkar
+Gabriele Petronella
+Krzysiek Bochenek
+Pavol Vidlicka
+Vadim Chelyshov
+```
+
+## Merged PRs
+
+## [v0.9.5](https://github.com/scalameta/metals/tree/v0.9.5) (2020-11-10)
+
+[Full Changelog](https://github.com/scalameta/metals/compare/v0.9.4...v0.9.5)
+
+**Merged pull requests:**
+
+- Rename user configuration options for decoration provider
+  [\#2196](https://github.com/scalameta/metals/pull/2196)
+  ([tgodzik](https://github.com/tgodzik))
+- Show warning about unsupported Scala version in worksheets
+  [\#2194](https://github.com/scalameta/metals/pull/2194)
+  ([ckipp01](https://github.com/ckipp01))
+- Add support for Scala3 3.0.0-M1
+  [\#2190](https://github.com/scalameta/metals/pull/2190)
+  ([tgodzik](https://github.com/tgodzik))
+- Update scalafix [\#2192](https://github.com/scalameta/metals/pull/2192)
+  ([tgodzik](https://github.com/tgodzik))
+- Add retry in case of timeout in build/initialize
+  [\#2184](https://github.com/scalameta/metals/pull/2184)
+  ([tgodzik](https://github.com/tgodzik))
+- Ensure scalacOptions for Test are correct for sbt BSP.
+  [\#2191](https://github.com/scalameta/metals/pull/2191)
+  ([ckipp01](https://github.com/ckipp01))
+- Support remote debugging
+  [\#2125](https://github.com/scalameta/metals/pull/2125)
+  ([pvid](https://github.com/pvid))
+- Add in timer methods to a new timerProvider.
+  [\#2186](https://github.com/scalameta/metals/pull/2186)
+  ([ckipp01](https://github.com/ckipp01))
+- Remove condition for jfr, since it's now reliably available on CI
+  [\#2185](https://github.com/scalameta/metals/pull/2185)
+  ([tgodzik](https://github.com/tgodzik))
+- Make sure build server is connected or not available before parsing
+  [\#2169](https://github.com/scalameta/metals/pull/2169)
+  ([tgodzik](https://github.com/tgodzik))
+- Preload scalafix to optimize first organize imports run
+  [\#2168](https://github.com/scalameta/metals/pull/2168)
+  ([tgodzik](https://github.com/tgodzik))
+- Allow for reset in html doctor
+  [\#2172](https://github.com/scalameta/metals/pull/2172)
+  ([ckipp01](https://github.com/ckipp01))
+- Track and show progress to user about connecting to sbt
+  [\#2182](https://github.com/scalameta/metals/pull/2182)
+  ([ckipp01](https://github.com/ckipp01))
+- Remove old bloop script now that we just use coursier
+  [\#2181](https://github.com/scalameta/metals/pull/2181)
+  ([ckipp01](https://github.com/ckipp01))
+- Update interface to 1.0.1
+  [\#2178](https://github.com/scalameta/metals/pull/2178)
+  ([scala-steward](https://github.com/scala-steward))
+- Update mdoc-interfaces, sbt-mdoc to 2.2.10
+  [\#2180](https://github.com/scalameta/metals/pull/2180)
+  ([scala-steward](https://github.com/scala-steward))
+- Update flyway-core to 7.0.4
+  [\#2179](https://github.com/scalameta/metals/pull/2179)
+  ([scala-steward](https://github.com/scala-steward))
+- Update coursier to 2.0.5
+  [\#2177](https://github.com/scalameta/metals/pull/2177)
+  ([scala-steward](https://github.com/scala-steward))
+- Update scribe, scribe-slf4j to 2.8.6
+  [\#2176](https://github.com/scalameta/metals/pull/2176)
+  ([scala-steward](https://github.com/scala-steward))
+- Update guava to 30.0-jre
+  [\#2175](https://github.com/scalameta/metals/pull/2175)
+  ([scala-steward](https://github.com/scala-steward))
+- Update bloop-config, bloop-launcher to 1.4.4-23-dbacf644
+  [\#2174](https://github.com/scalameta/metals/pull/2174)
+  ([scala-steward](https://github.com/scala-steward))
+- Update sbt-dotty to 0.4.5
+  [\#2173](https://github.com/scalameta/metals/pull/2173)
+  ([scala-steward](https://github.com/scala-steward))
+- Fix resolver for sbt-metals snapshot
+  [\#2170](https://github.com/scalameta/metals/pull/2170)
+  ([ckipp01](https://github.com/ckipp01))
+- Enable smoother sbt bsp integration.
+  [\#2154](https://github.com/scalameta/metals/pull/2154)
+  ([ckipp01](https://github.com/ckipp01))
+- Change scalafix and scalafmt conf to absolute path
+  [\#2165](https://github.com/scalameta/metals/pull/2165)
+  ([tgodzik](https://github.com/tgodzik))
+- Fix race condition while using textDocument/foldingRange
+  [\#2166](https://github.com/scalameta/metals/pull/2166)
+  ([tgodzik](https://github.com/tgodzik))
+- Account for possible null value in ScalaTarget's baseDirectory
+  [\#2164](https://github.com/scalameta/metals/pull/2164)
+  ([ckipp01](https://github.com/ckipp01))
+- Update mill scripts [\#2162](https://github.com/scalameta/metals/pull/2162)
+  ([tgodzik](https://github.com/tgodzik))
+- Mute InvalidProtocolException which might happen normally
+  [\#2159](https://github.com/scalameta/metals/pull/2159)
+  ([tgodzik](https://github.com/tgodzik))
+- Update sbt to 1.4.1 [\#2161](https://github.com/scalameta/metals/pull/2161)
+  ([tgodzik](https://github.com/tgodzik))
+- Make sure that default version is picked up for Scalafmt provider
+  [\#2158](https://github.com/scalameta/metals/pull/2158)
+  ([tgodzik](https://github.com/tgodzik))
+- Don't import {java.util => ju} when no conflicting symbols are available
+  [\#2155](https://github.com/scalameta/metals/pull/2155)
+  ([tgodzik](https://github.com/tgodzik))
+- Fixed sbt completions coming from project/\*.scala
+  [\#2129](https://github.com/scalameta/metals/pull/2129)
+  ([dos65](https://github.com/dos65))
+- Add java sources to standalone worksheets and run compilation before
+  evaluation if necessary.
+  [\#2133](https://github.com/scalameta/metals/pull/2133)
+  ([ckipp01](https://github.com/ckipp01))
+- Bump setup-scala and cache-action actions
+  [\#2149](https://github.com/scalameta/metals/pull/2149)
+  ([ckipp01](https://github.com/ckipp01))
+- Add JFR for non oracle JDK releases
+  [\#2137](https://github.com/scalameta/metals/pull/2137)
+  ([tgodzik](https://github.com/tgodzik))
+- Bump scalafmt up to 2.7.4
+  [\#2148](https://github.com/scalameta/metals/pull/2148)
+  ([ckipp01](https://github.com/ckipp01))
+- Update scalameta, semanticdb-scalac, ... to 4.3.24
+  [\#2147](https://github.com/scalameta/metals/pull/2147)
+  ([scala-steward](https://github.com/scala-steward))
+- Update munit, sbt-munit to 0.7.14
+  [\#2146](https://github.com/scalameta/metals/pull/2146)
+  ([scala-steward](https://github.com/scala-steward))
+- Update jol-core to 0.14
+  [\#2144](https://github.com/scalameta/metals/pull/2144)
+  ([scala-steward](https://github.com/scala-steward))
+- Update flyway-core to 7.0.3
+  [\#2143](https://github.com/scalameta/metals/pull/2143)
+  ([scala-steward](https://github.com/scala-steward))
+- Update undertow-core to 2.2.2.Final
+  [\#2142](https://github.com/scalameta/metals/pull/2142)
+  ([scala-steward](https://github.com/scala-steward))
+- Update coursier to 2.0.3
+  [\#2141](https://github.com/scalameta/metals/pull/2141)
+  ([scala-steward](https://github.com/scala-steward))
+- Update scribe, scribe-slf4j to 2.8.3
+  [\#2140](https://github.com/scalameta/metals/pull/2140)
+  ([scala-steward](https://github.com/scala-steward))
+- Update ujson to 1.2.2 [\#2139](https://github.com/scalameta/metals/pull/2139)
+  ([scala-steward](https://github.com/scala-steward))
+- Update jackson-databind to 2.11.3
+  [\#2138](https://github.com/scalameta/metals/pull/2138)
+  ([scala-steward](https://github.com/scala-steward))
+- Use 127.0.0.1 address always for DebugProvider
+  [\#2135](https://github.com/scalameta/metals/pull/2135)
+  ([tgodzik](https://github.com/tgodzik))
+- Add support for loading env variables from a .env file.
+  [\#2123](https://github.com/scalameta/metals/pull/2123)
+  ([mwz](https://github.com/mwz))
+- Do not show hover if the type is error
+  [\#2126](https://github.com/scalameta/metals/pull/2126)
+  ([tgodzik](https://github.com/tgodzik))
+- Make sure files are compiled when running scalafix
+  [\#2119](https://github.com/scalameta/metals/pull/2119)
+  ([tgodzik](https://github.com/tgodzik))
+- Show implicit arguments and type annotations for Scala files
+  [\#2103](https://github.com/scalameta/metals/pull/2103)
+  ([tgodzik](https://github.com/tgodzik))
+- Account for possible null value on PopupChoiceReset message request
+  [\#2121](https://github.com/scalameta/metals/pull/2121)
+  ([ckipp01](https://github.com/ckipp01))
+- Support environment variables when running or debugging
+  [\#2118](https://github.com/scalameta/metals/pull/2118)
+  ([tgodzik](https://github.com/tgodzik))
+- Add in top level-completions for empty file.
+  [\#2088](https://github.com/scalameta/metals/pull/2088)
+  ([ckipp01](https://github.com/ckipp01))
+- Update scalafix-interfaces to 0.9.21
+  [\#2114](https://github.com/scalameta/metals/pull/2114)
+  ([scala-steward](https://github.com/scala-steward))
+- Update sbt-mdoc to 2.2.9
+  [\#2113](https://github.com/scalameta/metals/pull/2113)
+  ([scala-steward](https://github.com/scala-steward))
+- Update flyway-core to 6.5.7
+  [\#2112](https://github.com/scalameta/metals/pull/2112)
+  ([scala-steward](https://github.com/scala-steward))
+- Update undertow-core to 2.2.0.Final
+  [\#2111](https://github.com/scalameta/metals/pull/2111)
+  ([scala-steward](https://github.com/scala-steward))
+- Update directory-watcher to 0.10.1
+  [\#2110](https://github.com/scalameta/metals/pull/2110)
+  ([scala-steward](https://github.com/scala-steward))
+- Update scribe, scribe-slf4j to 2.7.13
+  [\#2109](https://github.com/scalameta/metals/pull/2109)
+  ([scala-steward](https://github.com/scala-steward))
+- Update sbt-scalafix, scalafix-interfaces to 0.9.21
+  [\#2108](https://github.com/scalameta/metals/pull/2108)
+  ([scala-steward](https://github.com/scala-steward))
+- Update bloop-config, bloop-launcher to 1.4.4-15-56a96a99
+  [\#2107](https://github.com/scalameta/metals/pull/2107)
+  ([scala-steward](https://github.com/scala-steward))
+- Update organize-import rule to add Scala 2.11 support
+  [\#2101](https://github.com/scalameta/metals/pull/2101)
+  ([gabro](https://github.com/gabro))
+- Simplify TestHovers and remove warning
+  [\#2098](https://github.com/scalameta/metals/pull/2098)
+  ([gabro](https://github.com/gabro))
+- Display used BuildServer in Doctor
+  [\#2097](https://github.com/scalameta/metals/pull/2097)
+  ([kpbochenek](https://github.com/kpbochenek))
+- Implement organize import using scalafix
+  [\#1971](https://github.com/scalameta/metals/pull/1971)
+  ([mlachkar](https://github.com/mlachkar))
+- Remove javax from default excluded packages
+  [\#2091](https://github.com/scalameta/metals/pull/2091)
+  ([gabro](https://github.com/gabro))
+- Add documentation for new parameter in GotoLocation
+  [\#2095](https://github.com/scalameta/metals/pull/2095)
+  ([kpbochenek](https://github.com/kpbochenek))
+- Fix Metals version in the blog post
+  [\#2089](https://github.com/scalameta/metals/pull/2089)
+  ([tgodzik](https://github.com/tgodzik))
+- Add release notes for v0.9.4
+  [\#2081](https://github.com/scalameta/metals/pull/2081)
+  ([tgodzik](https://github.com/tgodzik))


### PR DESCRIPTION
It took me longer than expected, but it's here! :sweat_smile: 

After the release notes are approved I will release Metals together with the extension, merge @ckipp01's blog, update the link in the release notes and then merge the release notes. At least, this is the plan.

TODOS:
- [x] get release notes reviewed
- [x] release Metals v0.9.5
- [x] release Metals VS Code extension
- [x] merge blog
- [x] update link and make sure PR list is up to date
- [ ] merge release notes
- [ ] create release in Metals repo and announce