### PR TITLE
Fix scala3Dependency for various binary scala3/dotty versions

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -156,11 +156,19 @@ object Embedded {
   private def scala3Dependency(scalaVersion: String): Dependency = {
     val binaryVersion =
       ScalaVersions.scalaBinaryVersionFromFullVersion(scalaVersion)
-    Dependency.of(
-      "org.scala-lang",
-      s"scala3-library_$binaryVersion",
-      scalaVersion
-    )
+    if (binaryVersion.startsWith("3")) {
+      Dependency.of(
+        "org.scala-lang",
+        s"scala3-library_$binaryVersion",
+        scalaVersion
+      )
+    } else {
+      Dependency.of(
+        "ch.epfl.lamp",
+        s"dotty-library_$binaryVersion",
+        scalaVersion
+      )
+    }
   }
 
   private def mtagsDependency(scalaVersion: String): Dependency =


### PR DESCRIPTION
This is a quick fix for #2201. This was causing us to try and pull 0.27 from `org:scala-lang`,  which isn't where it lives. Also as a side now, we should add this as one of the checks we do on release to be sure this works. Better yet, we should test to ensure it's continually working.

Closes #2201 