### PR TITLE
Add additional newline to fix problems with markdown

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -221,7 +221,7 @@ final class SyntheticsDecorationProvider(
         new l.Hover(
           new l.MarkupContent(
             l.MarkupKind.MARKDOWN,
-            previousContent + text
+            previousContent + "\n" + text
           )
         )
       )

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -226,7 +226,7 @@ class Compilers(
       ds.asScala.headOption match {
         case None =>
           diagnostics.onNoSyntaxError(path)
-        case Some(diagnostic) =>
+        case Some(diagnostic) if !path.isInReadonlyDirectory(workspace) =>
           diagnostics.onSyntaxError(path, adjust.adjustDiagnostic(diagnostic))
       }
     }

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -104,6 +104,7 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
            |```scala
            |def map[B, That](f: Char => B)(implicit bf: CanBuildFrom[String,B,That]): That
            |```
+           |
            |**Synthetics**:
            |```scala
            |[scala.Char, scala.Predef.String]


### PR DESCRIPTION
It seems if any previous content ends with a list, `*` gets treated as an another item.

![metals-1605202520026](https://user-images.githubusercontent.com/3807253/98978068-ae15b380-2519-11eb-806b-95076db28b07.gif)
