### PR TITLE
Add option to show implicit conversions as decorations

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -103,18 +103,16 @@ final class SyntheticsDecorationProvider(
 
           val syntheticsAtLine = for {
             synthetic <- textDocument.synthetics
-            range <- synthetic.range.toIterable
-            lspRange <- edit.toRevisedStrict(range).toIterable
-            if lspRange.getEnd.getLine == line
             (fullSnippet, range) <- printSyntheticInfo(
               textDocument,
               synthetic,
               toHoverString(textDocument),
               userConfig(),
               isHover = true,
-              isFullLine = !clientConfig.isInlineDecorationProvider()
-            ).toIterable
+              isInlineProvider = clientConfig.isInlineDecorationProvider()
+            )
             realRange <- edit.toRevisedStrict(range).toIterable
+            if realRange.getEnd.getLine == line
           } yield (realRange, fullSnippet)
 
           if (syntheticsAtLine.size > 0) {
@@ -141,7 +139,7 @@ final class SyntheticsDecorationProvider(
     }
 
   private def isSyntheticsEnabled: Boolean = {
-    userConfig().showImplicitArguments || userConfig().showInferredType
+    userConfig().showImplicitArguments || userConfig().showInferredType || userConfig().showImplicitConversionsAndClasses
   }
 
   private def createHoverAtPoint(
@@ -150,21 +148,22 @@ final class SyntheticsDecorationProvider(
       pcHover: Option[l.Hover],
       position: l.Position
   ): Option[l.Hover] = {
-    syntheticsAtLine
-      .find { case (range, _) =>
-        range.getEnd().getCharacter() == position.getCharacter()
-      }
-      .flatMap { case (_, synthetic) =>
-        addToHover(
-          pcHover,
-          "**Synthetics**:\n"
-            +
-              HoverMarkup(
-                synthetic
-              )
-        )
-      }
+    val interestingSynthetics = syntheticsAtLine.collect {
+      case (range, text)
+          if range.getEnd().getCharacter() == position.getCharacter() =>
+        text
+    }.distinct
 
+    if (interestingSynthetics.nonEmpty)
+      addToHover(
+        pcHover,
+        "**Synthetics**:\n"
+          +
+            HoverMarkup(
+              interestingSynthetics.mkString("\n")
+            )
+      )
+    else None
   }
 
   private def createHoverAtLine(
@@ -305,7 +304,7 @@ final class SyntheticsDecorationProvider(
             toDecorationString(textDocument),
             userConfig(),
             isHover = false
-          ).toIterable
+          )
           lspRange <- edit.toRevisedStrict(range).toIterable
         } yield decorationOptions(lspRange, decoration)
 

--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -106,14 +106,16 @@ final class SyntheticsDecorationProvider(
             range <- synthetic.range.toIterable
             lspRange <- edit.toRevisedStrict(range).toIterable
             if lspRange.getEnd.getLine == line
-            fullSnippet <- printSyntheticInfo(
+            (fullSnippet, range) <- printSyntheticInfo(
               textDocument,
               synthetic,
               toHoverString(textDocument),
               userConfig(),
-              simple = false
+              isHover = true,
+              isFullLine = !clientConfig.isInlineDecorationProvider()
             ).toIterable
-          } yield (lspRange, fullSnippet)
+            realRange <- edit.toRevisedStrict(range).toIterable
+          } yield (realRange, fullSnippet)
 
           if (syntheticsAtLine.size > 0) {
             if (clientConfig.isInlineDecorationProvider()) {
@@ -297,13 +299,12 @@ final class SyntheticsDecorationProvider(
         val edit = buffer.tokenEditDistance(path, textDocument.text)
         val decorations = for {
           synthetic <- textDocument.synthetics
-          range <- synthetic.range.toIterable
-          decoration <- printSyntheticInfo(
+          (decoration, range) <- printSyntheticInfo(
             textDocument,
             synthetic,
             toDecorationString(textDocument),
             userConfig(),
-            simple = true
+            isHover = false
           ).toIterable
           lspRange <- edit.toRevisedStrict(range).toIterable
         } yield decorationOptions(lspRange, decoration)

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -37,7 +37,7 @@ case class UserConfiguration(
     superMethodLensesEnabled: Boolean = false,
     showInferredType: Boolean = false,
     showImplicitArguments: Boolean = false,
-    showImplicitConversions: Boolean = false,
+    showImplicitConversionsAndClasses: Boolean = false,
     remoteLanguageServer: Option[String] = None,
     enableStripMarginOnTypeFormatting: Boolean = true,
     excludedPackages: Option[List[String]] = None
@@ -187,7 +187,7 @@ object UserConfiguration {
         "Should display type annotations for inferred types",
         """|When this option is enabled, each method that can have inferred types has them
            |displayed either as additional decorations if they are supported by the editor or
-           |shown in hover otherwise.
+           |shown in the hover.
            |""".stripMargin
       ),
       UserConfigurationOption(
@@ -197,17 +197,17 @@ object UserConfiguration {
         "Should display implicit parameter at usage sites",
         """|When this option is enabled, each method that has implicit arguments has them 
            |displayed either as additional decorations if they are supported by the editor or 
-           |shown in hover otherwise.
+           |shown in the hover.
            |""".stripMargin
       ),
       UserConfigurationOption(
-        "show-implicit-conversions",
+        "show-implicit-conversions-and-classes",
         "false",
         "false",
         "Should display implicit conversion at usage sites",
-        """|When this option is enabled, each place where implicit method is invoked has it 
+        """|When this option is enabled, each place where an implicit method or class is used has it 
            |displayed either as additional decorations if they are supported by the editor or 
-           |shown in hover otherwise.
+           |shown in the hover.
            |""".stripMargin
       ),
       UserConfigurationOption(
@@ -367,8 +367,8 @@ object UserConfiguration {
       getBooleanKey("show-inferred-type").getOrElse(false)
     val showImplicitArguments =
       getBooleanKey("show-implicit-arguments").getOrElse(false)
-    val showImplicitConversions =
-      getBooleanKey("show-implicit-conversions").getOrElse(false)
+    val showImplicitConversionsAndClasses =
+      getBooleanKey("show-implicit-conversions-and-classes").getOrElse(false)
     val remoteLanguageServer =
       getStringKey("remote-language-server")
     val enableStripMarginOnTypeFormatting =
@@ -394,7 +394,7 @@ object UserConfiguration {
           superMethodLensesEnabled,
           showInferredType,
           showImplicitArguments,
-          showImplicitConversions,
+          showImplicitConversionsAndClasses,
           remoteLanguageServer,
           enableStripMarginOnTypeFormatting,
           excludedPackages

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -37,6 +37,7 @@ case class UserConfiguration(
     superMethodLensesEnabled: Boolean = false,
     showInferredType: Boolean = false,
     showImplicitArguments: Boolean = false,
+    showImplicitConversions: Boolean = false,
     remoteLanguageServer: Option[String] = None,
     enableStripMarginOnTypeFormatting: Boolean = true,
     excludedPackages: Option[List[String]] = None
@@ -200,6 +201,16 @@ object UserConfiguration {
            |""".stripMargin
       ),
       UserConfigurationOption(
+        "show-implicit-conversions",
+        "false",
+        "false",
+        "Should display implicit conversion at usage sites",
+        """|When this option is enabled, each place where implicit method is invoked has it 
+           |displayed either as additional decorations if they are supported by the editor or 
+           |shown in hover otherwise.
+           |""".stripMargin
+      ),
+      UserConfigurationOption(
         "remote-language-server",
         """empty string `""`.""",
         """"https://language-server.company.com/message"""",
@@ -356,6 +367,8 @@ object UserConfiguration {
       getBooleanKey("show-inferred-type").getOrElse(false)
     val showImplicitArguments =
       getBooleanKey("show-implicit-arguments").getOrElse(false)
+    val showImplicitConversions =
+      getBooleanKey("show-implicit-conversions").getOrElse(false)
     val remoteLanguageServer =
       getStringKey("remote-language-server")
     val enableStripMarginOnTypeFormatting =
@@ -381,6 +394,7 @@ object UserConfiguration {
           superMethodLensesEnabled,
           showInferredType,
           showImplicitArguments,
+          showImplicitConversions,
           remoteLanguageServer,
           enableStripMarginOnTypeFormatting,
           excludedPackages

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticHoverLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticHoverLspSuite.scala
@@ -35,6 +35,7 @@ class SyntheticHoverLspSuite extends BaseLspSuite("implicits") {
       _ <- server.didChangeConfiguration(
         """{
           |  "show-implicit-arguments": true,
+          |  "show-implicit-conversions": true,
           |  "show-inferred-type": true
           |}
           |""".stripMargin
@@ -55,7 +56,7 @@ class SyntheticHoverLspSuite extends BaseLspSuite("implicits") {
         "  \"foo\".map(c @@=> c.toUpper)",
         """|**With synthetics added**:
            |```scala
-           |"foo".map[scala.Char, scala.Predef.String](c => c.toUpper)(scala.Predef.StringCanBuildFrom)
+           |scala.Predef.augmentString("foo").map[scala.Char, scala.Predef.String](c => scala.LowPriorityImplicits.charWrapper(c).toUpper)(scala.Predef.StringCanBuildFrom)
            |```
            |""".stripMargin
       )

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticHoverLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticHoverLspSuite.scala
@@ -35,7 +35,7 @@ class SyntheticHoverLspSuite extends BaseLspSuite("implicits") {
       _ <- server.didChangeConfiguration(
         """{
           |  "show-implicit-arguments": true,
-          |  "show-implicit-conversions": true,
+          |  "show-implicit-conversions-and-classes": true,
           |  "show-inferred-type": true
           |}
           |""".stripMargin


### PR DESCRIPTION
It seems a good next step after implicit parameters and inferred type. Should be useful in some cases, but I figured it would be good to have it under a separate option.

TODO:
- ~~add option in VS Code extension~~ https://github.com/scalameta/metals-vscode/pull/447

Actually seems to work pretty nice inside metals itself:

![image](https://user-images.githubusercontent.com/3807253/99196420-8b3f0580-278c-11eb-9dd1-c26cfcc27a17.png)
