### PR TITLE
Configure dependabot to update github-actions

### DIFF
--- a/.dependabot.yml
+++ b/.dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Essentially followed the instructions here: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot

I figured this may be useful for keeping the workflows up-to-date