### PR TITLE
Add sbt and bloop directory as bsp directory

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -157,8 +157,10 @@ final class BspServers(
 
 object BspServers {
   def globalInstallDirectories: List[AbsolutePath] = {
-    val dirs = ProjectDirectories.fromPath("bsp")
-    List(dirs.dataLocalDir, dirs.dataDir).distinct
+    val bspDirs = ProjectDirectories.fromPath("bsp")
+    val bloopDirs = ProjectDirectories.fromPath("bloop")
+    val sbtDirs = ProjectDirectories.fromPath("sbt")
+    List(bspDirs.dataLocalDir, bspDirs.dataDir, bloopDirs.dataLocalDir, bloopDirs.dataDir, sbtDirs.dataLocalDir, sbtDirs.dataDir).distinct
       .map(path => Try(AbsolutePath(path)).toOption)
       .flatten
   }


### PR DESCRIPTION
As of the moment, even if you do have sbt in your path, the config generator will still go to the tmp directory of the metals folder that has the sbt-launcher.

This commit allows us to detect the sbt-launcher that maybe BSP capable