### PR TITLE
Update setup-gpg action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
-      - uses: olafurpg/setup-gpg@v2
+      - uses: olafurpg/setup-gpg@v3
       - uses: coursier/cache-action@v5
       - name: Publish
         run: |


### PR DESCRIPTION
setup-gpg seems to have issues as well since the new changes introduced by GitHub, so the release workflow is broken. Updating to v3 seems to have fixed the same issue in MUnit, so let's try here as well