### PR TITLE
Fix continuous compilation when opening tree view in sbt BSP

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspSession.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspSession.scala
@@ -30,6 +30,8 @@ case class BspSession(
 
   def mainConnection: BuildServerConnection = main
 
+  def mainConnectionIsBloop: Boolean = main.name == "Bloop"
+
   def version: String = main.version
 
   def workspaceReload(): Future[List[Object]] =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -652,7 +652,8 @@ class MetalsLanguageServer(
         definitionIndex,
         clientConfig.initialConfig.statistics,
         id => compilations.compileTarget(id),
-        sh
+        sh,
+        () => bspSession.map(_.mainConnectionIsBloop).getOrElse(false)
       )
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -26,7 +26,8 @@ class MetalsTreeViewProvider(
     definitionIndex: GlobalSymbolIndex,
     statistics: StatisticsConfig,
     doCompile: BuildTargetIdentifier => Unit,
-    sh: ScheduledExecutorService
+    sh: ScheduledExecutorService,
+    isBloop: () => Boolean
 ) extends TreeViewProvider {
   private val ticks =
     TrieMap.empty[String, ScheduledFuture[_]]
@@ -67,7 +68,7 @@ class MetalsTreeViewProvider(
       )
     },
     { (id, symbol) =>
-      doCompile(id)
+      if (isBloop()) doCompile(id)
       buildTargets.scalacOptions(id) match {
         case None =>
           Nil.iterator


### PR DESCRIPTION
So I've put more time into this than I care to admit. I'll be honest
that this isn't the fix that I really want, but sort of the fix that may
just makes the most sense at the moment.

This is an interesting one. So for a bit of background I'm assuming that
the `doCompile` was first added in the situation where a user opens up
their `build.sbt` while using Bloop, and then tries to open the tree
view. Without this compile request here, the tree view projects will be
empty. However, with it, it will trigger the necessary compilation and
populate the tree. However, subsequent compile requests or notifications
of compiles seem to cause no problems with Bloop. _Even_ though a
compile request _probably_ isn't needed here every time. However, with
sbt BSP, since loading the build up includes compilation, this isn't
needed. Just commenting it out when using sbt BSP works fine. It took me
a while to figure this out, but this is due to Bloop returning no-op
compilations and us marking the compilation as such. If we remove that
check from compilations and never mark any of Bloop's compilations as
no-op's then we get the same issue when using Bloop and there is a
continuous compile request cycle.

A quick fix for this is to just add in a check to see if the user is
using Bloop, and if so leave the `doCompile` to account for the cases it
is needed, but then if the user isn't using Bloop, then skip it.
Everything seems to work fine without it when not using Bloop.

Again, I think there may still be some logic in there that isn't right,
for example the `pendingProjectUpdates` in `MetalsTreeViewProvider`
never gets anything taken out of it, so it's always has an entry. That
may in part be the issue, but until someone takes the time and does a
deep dive into the TVP stuff to see what's going on, this fixes the
issue.