### PR TITLE
Add source and line to debug output in case of stack traces

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -564,7 +564,8 @@ class MetalsLanguageServer(
       buildClient,
       statusBar,
       compilers,
-      definitionIndex
+      definitionIndex,
+      stacktraceAnalyzer
     )
     scalafixProvider = ScalafixProvider(
       buffers,

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -32,6 +32,7 @@ import scala.meta.internal.metals.Messages.UnresolvedDebugSessionParams
 import scala.meta.internal.metals.MetalsBuildClient
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsLanguageClient
+import scala.meta.internal.metals.StacktraceAnalyzer
 import scala.meta.internal.metals.StatusBar
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.io.AbsolutePath
@@ -55,7 +56,8 @@ class DebugProvider(
     buildClient: MetalsBuildClient,
     statusBar: StatusBar,
     compilers: Compilers,
-    index: OnDemandSymbolIndex
+    index: OnDemandSymbolIndex,
+    stacktraceAnalyzer: StacktraceAnalyzer
 ) {
 
   lazy val buildTargetClassesFinder = new BuildTargetClassesFinder(
@@ -112,7 +114,8 @@ class DebugProvider(
             sourcePathProvider,
             awaitClient,
             connectToServer,
-            compilers
+            compilers,
+            stacktraceAnalyzer
           )
       }
       val server = new DebugServer(sessionName, uri, proxyFactory)


### PR DESCRIPTION
Just found out this is actually pretty simple to do and should work in all clients.

![metals-sample-1605631480731](https://user-images.githubusercontent.com/3807253/99419796-c95b3700-28fc-11eb-8323-bcfcbd5b1aae.gif)
