### PR TITLE
New directories namespace `io.github.soc` -> `dev.dirs`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -424,7 +424,7 @@ lazy val metals = project
       // for producing SemanticDB from Java source files
       "com.thoughtworks.qdox" % "qdox" % "2.0.0",
       // for finding paths of global log/cache directories
-      "io.github.soc" % "directories" % "12",
+      "dev.dirs" % "directories" % "21",
       // ==================
       // Scala dependencies
       // ==================

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -25,7 +25,7 @@ import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BspConnectionDetails
 import com.google.gson.Gson
-import io.github.soc.directories.ProjectDirectories
+import dev.dirs.ProjectDirectories
 
 /**
  * Implements BSP server discovery, named "BSP Connection Protocol" in the spec.

--- a/metals/src/main/scala/scala/meta/internal/metals/GlobalTrace.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/GlobalTrace.scala
@@ -9,7 +9,7 @@ import scala.util.control.NonFatal
 import scala.meta.internal.io.PathIO
 import scala.meta.io.AbsolutePath
 
-import io.github.soc.directories.ProjectDirectories
+import dev.dirs.ProjectDirectories
 
 /**
  * Manages JSON-RPC tracing of incoming/outgoing messages via BSP and LSP.


### PR DESCRIPTION
So it looks like this changed namespaces from their personal one to a `dev.dirs` namespace. I just randomly came across this as I was poking around at some of the related code. So this just updates from `io.github.soc` -> `dev.dirs` and bumps the version to the latest.