### PR TITLE
Autocomplete empty scaladoc if nothing is defined afterwards

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -436,9 +436,9 @@ trait Completions { this: MetalsGlobal =>
         }
         associatedDef
           .map(definition =>
-            ScaladocCompletion(editRange, definition, pos, text)
+            ScaladocCompletion(editRange, Some(definition), pos, text)
           )
-          .getOrElse(NoneCompletion)
+          .getOrElse(ScaladocCompletion(editRange, None, pos, text))
       case (ident: Ident) :: (a: Apply) :: _ =>
         fromIdentApply(ident, a)
       case (ident: Ident) :: (_: Select) :: (_: Assign) :: (a: Apply) :: _ =>

--- a/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
@@ -29,13 +29,15 @@ class CompletionScaladocSuite extends BaseCompletionSuite {
        |""".stripMargin
   )
 
+  // see: https://github.com/scalameta/metals/issues/1941
   check(
-    "no-completion",
+    "no-associated-def-label",
     """
       |object A {
       |  /**@@
       |}""".stripMargin,
-    ""
+    """|/** */Scaladoc Comment
+       |""".stripMargin
   )
 
   checkEdit(
@@ -301,6 +303,19 @@ class CompletionScaladocSuite extends BaseCompletionSuite {
        |    * @param c
        |    */
        |  case class Test(a: Int, b: String)(c: Long)
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "no-associated-def",
+    """|object A {
+       |  /**@@
+       |}""".stripMargin,
+    """|object A {
+       |  /**
+       |    * $0
+       |    */
        |}
        |""".stripMargin
   )


### PR DESCRIPTION
This enables us to autocomplete empty scaladoc even if nothing is defined after the `/**`, like:

![scaladoc](https://user-images.githubusercontent.com/9353584/99936214-f64c9580-2da5-11eb-9b2d-1a9c47458028.gif)

fix https://github.com/scalameta/metals/issues/1941
