### PR TITLE
Don't add semanticDB plugin for Scala 2.10 when using sbt BSP

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -488,7 +488,8 @@ lazy val `sbt-metals` = project
     sbtPlugin := true,
     buildInfoPackage := "scala.meta.internal.sbtmetals",
     buildInfoKeys := Seq[BuildInfoKey](
-      "semanticdbVersion" -> V.semanticdb
+      "semanticdbVersion" -> V.semanticdb,
+      "supportedScala2Versions" -> V.scala2Versions
     )
   )
   .enablePlugins(BuildInfoPlugin)


### PR DESCRIPTION
This addresses the problem outlined in #2250 where the semanticdb compiler plugin was being added to a 2.10 projects as well as semanticdb related settings in both `scalacOptions` and `semanticdbOptions`. Now this just adds in a check to ensure we don't do any of that for projects on 2.10.x.

Closes #2250