### PR TITLE
Add release notes for 0.9.7

### DIFF
--- a/website/blog/2020-11-26-lithium.md
+++ b/website/blog/2020-11-26-lithium.md
@@ -6,7 +6,7 @@ authorImageURL: https://github.com/tgodzik.png
 ---
 
 We're happy to announce the release of Metals v0.9.7, which introduces the
-support for newest Scala 3 milestone `3.0.0-M2`.
+support for the newest Scala 3 milestone, `3.0.0-M2`.
 
 <table>
 <tbody>

--- a/website/blog/2020-11-26-lithium.md
+++ b/website/blog/2020-11-26-lithium.md
@@ -1,0 +1,97 @@
+---
+author: Tomasz Godzik
+title: Metals v0.9.7 - Lithium
+authorURL: https://twitter.com/TomekGodzik
+authorImageURL: https://github.com/tgodzik.png
+---
+
+We're happy to announce the release of Metals v0.9.7, which introduces the
+support for newest Scala 3 milestone `3.0.0-M2`.
+
+<table>
+<tbody>
+  <tr>
+    <td>Commits since last release</td>
+    <td align="center">17</td>
+  </tr>
+  <tr>
+    <td>Merged PRs</td>
+    <td align="center">7</td>
+  </tr>
+    <tr>
+    <td>Contributors</td>
+    <td align="center">5</td>
+  </tr>
+  <tr>
+    <td>Closed issues</td>
+    <td align="center">3</td>
+  </tr>
+  <tr>
+    <td>New features</td>
+    <td align="center">0</td>
+  </tr>
+</tbody>
+</table>
+
+For full details: https://github.com/scalameta/metals/milestone/30?closed=1
+
+Metals is a language server for Scala that works with VS Code, Vim, Emacs,
+Sublime Text, Atom and Eclipse. Metals is developed at the
+[Scala Center](https://scala.epfl.ch/) and [VirtusLab](https://virtuslab.com)
+with the help from [Lunatech](https://lunatech.com) along with contributors from
+the community.
+
+## TL;DR
+
+Check out [https://scalameta.org/metals/](https://scalameta.org/metals/), and
+give Metals a try!
+
+- Scala 3.0.0-M2 support
+
+## Miscellaneous
+
+- Don't add semanticDB plugin for Scala 2.10 when using sbt BSP.
+- Autocomplete empty scaladoc if nothing is defined afterwards.
+
+## Contributors
+
+Big thanks to everybody who contributed to this release or reported an issue!
+
+```
+$ git shortlog -sn --no-merges v0.9.6..v0.9.7
+Tomasz Godzik
+Chris Kipp
+Bjorn Regnell
+Ethan Atkins
+Rikito Taniguchi
+```
+
+## Merged PRs
+
+## [v0.9.7](https://github.com/scalameta/metals/tree/v0.9.7) (2020-11-26)
+
+[Full Changelog](https://github.com/scalameta/metals/compare/v0.9.6...v0.9.7)
+
+**Merged pull requests:**
+
+- Add support for Scala 3 3.0.0-M2
+  [\#2260](https://github.com/scalameta/metals/pull/2260)
+  ([tgodzik](https://github.com/tgodzik))
+- Don't add semanticDB plugin for Scala 2.10 when using sbt BSP
+  [\#2258](https://github.com/scalameta/metals/pull/2258)
+  ([ckipp01](https://github.com/ckipp01))
+- Bump swoval to latest version
+  [\#2259](https://github.com/scalameta/metals/pull/2259)
+  ([eatkins](https://github.com/eatkins))
+- Fix documentation about buildTarget
+  [\#2257](https://github.com/scalameta/metals/pull/2257)
+  ([tgodzik](https://github.com/tgodzik))
+- Autocomplete empty scaladoc if nothing is defined afterwards
+  [\#2252](https://github.com/scalameta/metals/pull/2252)
+  ([tanishiking](https://github.com/tanishiking))
+- New directories namespace `io.github.soc` -> `dev.dirs`
+  [\#2251](https://github.com/scalameta/metals/pull/2251)
+  ([ckipp01](https://github.com/ckipp01))
+- Add release notes for 0.9.6
+  [\#2249](https://github.com/scalameta/metals/pull/2249)
+  ([tgodzik](https://github.com/tgodzik))


### PR DESCRIPTION
Just a quick release for people to be able to sensibly work with 3.0.0-M2 without the need for a snapshot. If we don't release straightaway then people start asking questions :sweat_smile: 