### PR TITLE
Compare release candidates and milestones in addition to major.minor.patch

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -60,7 +60,7 @@ object ScalaVersions {
     latestBinaryVersionFor(scalaVersion)
       .map(latest =>
         latest != scalaVersion && SemVer
-          .isCompatibleVersion(latest, scalaVersion)
+          .isLaterVersion(latest, scalaVersion)
       )
       .getOrElse {
         val versions =
@@ -68,7 +68,7 @@ object ScalaVersions {
             isLatestScalaVersion.filter(isScala3Version)
           else
             isLatestScalaVersion.filter(!isScala3Version(_))
-        versions.forall(ver => SemVer.isCompatibleVersion(ver, scalaVersion))
+        versions.forall(ver => SemVer.isLaterVersion(ver, scalaVersion))
       }
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/semver/SemVer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/semver/SemVer.scala
@@ -1,15 +1,45 @@
 package scala.meta.internal.semver
 
+import scala.util.Try
+
 object SemVer {
 
-  case class Version(major: Int, minor: Int, patch: Int) {
+  case class Version(
+      major: Int,
+      minor: Int,
+      patch: Int,
+      releaseCandidate: Option[Int],
+      milestone: Option[Int]
+  ) {
     def >(that: Version): Boolean = {
       this.major > that.major ||
       (this.major == that.major && this.minor > that.minor) ||
-      (this.major == that.major && this.minor == that.minor && this.patch > that.patch)
+      (this.major == that.major && this.minor == that.minor && this.patch > that.patch) ||
+      // 3.0.0-RC1 > 3.0.0-M1
+      this.releaseCandidate.isDefined && that.milestone.isDefined ||
+      // 3.0.0 > 3.0.0-M2 and 3.0.0 > 3.0.0-RC1
+      (this.milestone.isEmpty && this.releaseCandidate.isEmpty && (that.milestone.isDefined || that.releaseCandidate.isDefined)) ||
+      // 3.0.0-RC2 > 3.0.0-RC1
+      comparePreRelease(that, (v: Version) => v.releaseCandidate) ||
+      // 3.0.0-M2 > 3.0.0-M1
+      comparePreRelease(that, (v: Version) => v.milestone)
+
     }
 
     def >=(that: Version): Boolean = this > that || this == that
+
+    private def comparePreRelease(
+        that: Version,
+        preRelease: Version => Option[Int]
+    ): Boolean = {
+      val thisPrerelease = preRelease(this)
+      val thatPrerelease = preRelease(that)
+      this.major == that.major && this.minor == that.minor && this.patch == that.patch &&
+      thisPrerelease.isDefined && thatPrerelease.isDefined && thisPrerelease
+        .zip(thatPrerelease)
+        .exists { case (a, b) => a > b }
+    }
+
   }
 
   object Version {
@@ -17,11 +47,27 @@ object SemVer {
       val Array(major, minor, patch) =
         version.replaceAll("(-|\\+).+$", "").split('.').map(_.toInt)
 
-      Version(major, minor, patch)
+      val prereleaseString = version.stripPrefix(s"$major.$minor.$patch")
+
+      def fromSuffix(name: String) = {
+        if (prereleaseString.startsWith(name))
+          Try(
+            prereleaseString.stripPrefix(name).replaceAll("\\-.*", "").toInt
+          ).toOption
+        else None
+      }
+      val releaseCandidate = fromSuffix("-RC")
+      val milestone = fromSuffix("-M")
+
+      Version(major, minor, patch, releaseCandidate, milestone)
     }
   }
 
   def isCompatibleVersion(minimumVersion: String, version: String): Boolean = {
     Version.fromString(version) >= Version.fromString(minimumVersion)
+  }
+
+  def isLaterVersion(earlierVersion: String, laterVersion: String): Boolean = {
+    Version.fromString(laterVersion) > Version.fromString(earlierVersion)
   }
 }

--- a/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
@@ -143,4 +143,137 @@ class ScalaVersionsSuite extends BaseSuite {
         V.scala3
     )
   }
+
+  test("compare-3.0.0-M1<=3.0.0-M2") {
+    assert(
+      SemVer.isCompatibleVersion("3.0.0-M1", "3.0.0-M2")
+    )
+  }
+
+  test("compare-3.0.0-M2>=3.0.0-M1") {
+    assert(
+      !SemVer.isCompatibleVersion("3.0.0-M2", "3.0.0-M1")
+    )
+  }
+
+  test("compare-3.0.0-RC1<=3.0.0-RC2") {
+    assert(
+      SemVer.isCompatibleVersion("3.0.0-RC1", "3.0.0-RC2")
+    )
+  }
+
+  test("compare-3.0.0-RC2>=3.0.0-RC1") {
+    assert(
+      !SemVer.isCompatibleVersion("3.0.0-RC2", "3.0.0-RC1")
+    )
+  }
+
+  test("compare-3.0.0-RC1<=3.0.0") {
+    assert(
+      SemVer.isCompatibleVersion("3.0.0-RC1", "3.0.0")
+    )
+  }
+
+  test("compare-3.0.0>=3.0.0-RC1") {
+    assert(
+      !SemVer.isCompatibleVersion("3.0.0", "3.0.0-RC1")
+    )
+  }
+
+  test("compare-3.0.0-M1<=3.0.0") {
+    assert(
+      SemVer.isCompatibleVersion("3.0.0-M1", "3.0.0")
+    )
+  }
+
+  test("compare-3.0.0>=3.0.0-M1") {
+    assert(
+      !SemVer.isCompatibleVersion("3.0.0", "3.0.0-M1")
+    )
+  }
+
+  test("compare-3.0.0-RC1<3.0.0") {
+    assert(
+      SemVer.isLaterVersion("3.0.0-RC1", "3.0.0")
+    )
+  }
+
+  test("compare-3.0.0>3.0.0-RC1") {
+    assert(
+      !SemVer.isLaterVersion("3.0.0", "3.0.0-RC1")
+    )
+  }
+
+  test("compare-3.0.0-M1<3.0.0") {
+    assert(
+      SemVer.isLaterVersion("3.0.0-M1", "3.0.0")
+    )
+  }
+
+  test("compare-3.0.0>3.0.0-M1") {
+    assert(
+      !SemVer.isLaterVersion("3.0.0", "3.0.0-M1")
+    )
+  }
+
+  test("compare-3.0.0-M1<3.0.0-RC1") {
+    assert(
+      SemVer.isLaterVersion("3.0.0-M1", "3.0.0-RC1")
+    )
+  }
+
+  test("compare-3.0.0-RC1>3.0.0-M1") {
+    assert(
+      !SemVer.isLaterVersion("3.0.0-RC1", "3.0.0-M1")
+    )
+  }
+
+  test("compare-RC1<=RC1-SNAPSHOT") {
+    assert(
+      SemVer.isCompatibleVersion(
+        "3.0.0-RC1-bin-20201125-1c3538a-NIGHTLY",
+        "3.0.0-RC2-bin-20201125-1c3538a-NIGHTLY"
+      )
+    )
+  }
+
+  test("compare-RC2>=RC1-SNAPSHOT") {
+    assert(
+      !SemVer.isCompatibleVersion(
+        "3.0.0-RC2-bin-20201125-1c3538a-NIGHTLY",
+        "3.0.0-RC1-bin-20201125-1c3538a-NIGHTLY"
+      )
+    )
+  }
+
+  test("compare-RC1<RC2-SNAPSHOT") {
+    assert(
+      SemVer.isLaterVersion(
+        "3.0.0-RC1-bin-20201125-1c3538a-NIGHTLY",
+        "3.0.0-RC2-bin-20201125-1c3538a-NIGHTLY"
+      )
+    )
+  }
+
+  test("compare-RC2>RC1-SNAPSHOT") {
+    assert(
+      !SemVer.isLaterVersion(
+        "3.0.0-RC2-bin-20201125-1c3538a-NIGHTLY",
+        "3.0.0-RC1-bin-20201125-1c3538a-NIGHTLY"
+      )
+    )
+  }
+
+  test("not-future-3-M1") {
+    assert(
+      !ScalaVersions.isFutureVersion("3.0.0-M1")
+    )
+  }
+
+  test("not-future-3-M2") {
+    assert(
+      !ScalaVersions.isFutureVersion("3.0.0-M2")
+    )
+  }
+
 }

--- a/tests/unit/src/test/scala/tests/WarningsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WarningsLspSuite.scala
@@ -99,10 +99,9 @@ class WarningsLspSuite extends BaseLspSuite("warnings") {
     } yield ()
   }
 
-  // We no longer run 0.2 version in tests
-  test("unsupported-scala-3".ignore) {
+  test("no-warnings-scala-3") {
     cleanWorkspace()
-    val using = "0.21.0"
+    val using = "3.0.0-M1"
     for {
       _ <- server.initialize(
         s"""/metals.json
@@ -116,10 +115,7 @@ class WarningsLspSuite extends BaseLspSuite("warnings") {
            |object Main
            |""".stripMargin
       )
-      _ = assertNoDiff(
-        client.workspaceMessageRequests,
-        Messages.UnsupportedScalaVersion.message(Set(using))
-      )
+      _ = assertEmpty(client.workspaceMessageRequests)
     } yield ()
   }
 }


### PR DESCRIPTION
This showed up as a warning when using 3.0.0-M1:

![image](https://user-images.githubusercontent.com/3807253/100384699-0b812880-3021-11eb-95e8-9cc4289c7258.png)
