### PR TITLE
Add in Scala Sources to standalone worksheets.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -88,7 +88,9 @@ class Compilers(
   // The "rambo" compiler is used for source files that don't belong to a build target.
   lazy val ramboCompiler: PresentationCompiler = createStandaloneCompiler(
     PackageIndex.scalaLibrary,
-    Try(StandaloneSymbolSearch(workspace, buffers, isExcludedPackage))
+    Try(
+      StandaloneSymbolSearch(workspace, buffers, isExcludedPackage, userConfig)
+    )
       .getOrElse(EmptySymbolSearch),
     "metals-default"
   )
@@ -429,11 +431,6 @@ class Compilers(
     }
 
     created.getOrElse {
-      val sourcesWithJdk = JdkSources(userConfig().javaHome) match {
-        case Some(absPath) => absPath.toNIO :: sources
-        case None => sources
-      }
-
       jworksheetsCache.put(
         path,
         createStandaloneCompiler(
@@ -441,9 +438,10 @@ class Compilers(
           StandaloneSymbolSearch(
             workspace,
             buffers,
-            sourcesWithJdk,
+            sources,
             classpath,
-            isExcludedPackage
+            isExcludedPackage,
+            userConfig
           ),
           path.toString()
         )

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -489,6 +489,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
            |import java.time.Instant
            |
            |val x = Instant.now()
+           |val y = List.fill(2)(2)
            |""".stripMargin
       )
       _ <- server.didOpen("Main.worksheet.sc")
@@ -499,6 +500,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
              |import java.time.Instant/*Instant.java*/
              |
              |val x/*L2*/ = Instant/*Instant.java*/.now/*Instant.java*/()
+             |val y/*L3*/ = List/*List.scala*/.fill/*GenTraversableFactory.scala*/(2)(2)
              |""".stripMargin,
           Map.empty,
           scalaVersion


### PR DESCRIPTION
Like we did to fix #2133, if the user is in a situation where they are
given a standalone compiler for worksheets, we then ensure that they not
only have Java sources available to them, but also Scala sources. We
default to the version of Scala in Metals itself.

I do have a check in there to make sure there is no "scala-library" in
sources, but that _probably_ isn't necessary as (in this scenario) the
only time that would happen would be if they have included it as an
import in their worksheet. However, just to be safe, I added it in.

I also moved the logic for this from the compilers to the
StandaloneSymbolSearch apply methods to ensure that we don't get hit on
this in the future if we use these elsewhere.


Closes #2266