### PR TITLE
Add in ability to export worksheet evaluations.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -28,6 +28,11 @@ object Messages {
       s"Scala ${unsupportedVersion} is not supported in worksheets. Falling back to ${fallback} without your classpath.\n" +
         s"Consider using ${recommended} instead to fix this."
     )
+
+    val unableToExport = new MessageParams(
+      MessageType.Warning,
+      "Unable to export worksheet. Please fix any diagnostics, save, and try again."
+    )
   }
 
   val NoBspSupport = new MessageParams(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1620,8 +1620,7 @@ class MetalsLanguageServer(
         val args = params.getArguments.asScala
         val worksheet = args.lift(0).collect {
           case ws: JsonPrimitive if ws.isString =>
-            val a = new URI(ws.getAsString())
-            AbsolutePath.fromAbsoluteUri(a)
+            ws.getAsString().toAbsolutePath
         }
 
         val output = worksheet.flatMap(worksheetProvider.copyWorksheetOutput(_))

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -293,6 +293,17 @@ object ServerCommands {
        |""".stripMargin
   )
 
+  val CopyWorksheetOutput = new Command(
+    "copy-worksheet-output",
+    "Copy Worksheet Output",
+    """|Copy the contents of a worksheet to your local buffer.
+       |
+       |Note: This command returns the contents of the worksheet, and the LSP client
+       |is in charge of taking that content and putting it into your local buffer.
+       |""".stripMargin,
+    "[uri], the uri of the worksheet that you'd like to copy the contents of."
+  )
+
   /**
    * Open the browser at the given url.
    */

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -145,7 +145,7 @@ class WorksheetProvider(
    * Check to see for a given path if there is an evaluated worksheet that
    * matches thie exact input.
    *
-   * @param path to the input used to search previous  evaluations.
+   * @param path to the input used to search previous evaluations.
    * @return possible evaluated output.
    */
   def copyWorksheetOutput(path: AbsolutePath): Option[String] = {

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -594,6 +594,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
   }
 
   test("export") {
+    assume(!isWindows, "This test is flaky on Windows")
     for {
       _ <- server.initialize(
         s"""

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -15,7 +15,6 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
 
   override def userConfig: UserConfiguration =
     super.userConfig.copy(worksheetScreenWidth = 40, worksheetCancelTimeout = 1)
-
   override def munitIgnore: Boolean = !isValidScalaVersionForEnv(scalaVersion)
 
   // sourcecode is not yet published for Scala 3
@@ -594,4 +593,116 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
     } yield ()
   }
 
+  test("export") {
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{"a": {"scalaVersion": "${scalaVersion}"}}
+           |/a/src/main/scala/foo/Main.worksheet.sc
+           |case class Hi(a: Int, b: Int, c: Int)
+           |val hi1 =
+           |  Hi(1, 2, 3)
+           |val hi2 = Hi(4, 5, 6)
+           |
+           |val hellos = List(hi1, hi2)
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
+      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
+      export = server.exportEvaluation(
+        "a/src/main/scala/foo/Main.worksheet.sc"
+      )
+      _ = assertEquals(
+        export,
+        Some(
+          getExpected(
+            """|
+               |case class Hi(a: Int, b: Int, c: Int)
+               |val hi1 =
+               |  Hi(1, 2, 3)
+               |// hi1: Hi = Hi(1, 2, 3)
+               |val hi2 = Hi(4, 5, 6)
+               |// hi2: Hi = Hi(4, 5, 6)
+               |
+               |val hellos = List(hi1, hi2)
+               |// hellos: List[Hi] = List(Hi(1, 2, 3), Hi(4, 5, 6))""".stripMargin,
+            Map(
+              V.scala213 -> """|
+                               |case class Hi(a: Int, b: Int, c: Int)
+                               |val hi1 =
+                               |  Hi(1, 2, 3)
+                               |// hi1: Hi = Hi(a = 1, b = 2, c = 3)
+                               |val hi2 = Hi(4, 5, 6)
+                               |// hi2: Hi = Hi(a = 4, b = 5, c = 6)
+                               |
+                               |val hellos = List(hi1, hi2)
+                               |// hellos: List[Hi] = List(Hi(a = 1, b = 2, c = 3), Hi(a = 4, b = 5, c = 6))""".stripMargin,
+              V.scala3 -> """|
+                             |case class Hi(a: Int, b: Int, c: Int)
+                             |val hi1 =
+                             |  Hi(1, 2, 3)
+                             |// hi1: Hi = Hi(1,2,3)
+                             |val hi2 = Hi(4, 5, 6)
+                             |// hi2: Hi = Hi(4,5,6)
+                             |
+                             |val hellos = List(hi1, hi2)
+                             |// hellos: List[Hi] = List(Hi(1,2,3), Hi(4,5,6))""".stripMargin
+            ),
+            scalaVersion
+          )
+        )
+      )
+      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(
+        _.replace(
+          "Hi(1, 2, 3)",
+          "Hi(7, 8, 9)"
+        )
+      )
+      export = server.exportEvaluation(
+        "a/src/main/scala/foo/Main.worksheet.sc"
+      )
+      _ = assertEquals(
+        export,
+        Some(
+          getExpected(
+            """|
+               |case class Hi(a: Int, b: Int, c: Int)
+               |val hi1 =
+               |  Hi(7, 8, 9)
+               |// hi1: Hi = Hi(7, 8, 9)
+               |val hi2 = Hi(4, 5, 6)
+               |// hi2: Hi = Hi(4, 5, 6)
+               |
+               |val hellos = List(hi1, hi2)
+               |// hellos: List[Hi] = List(Hi(7, 8, 9), Hi(4, 5, 6))""".stripMargin,
+            Map(
+              V.scala213 -> """|
+                               |case class Hi(a: Int, b: Int, c: Int)
+                               |val hi1 =
+                               |  Hi(7, 8, 9)
+                               |// hi1: Hi = Hi(a = 7, b = 8, c = 9)
+                               |val hi2 = Hi(4, 5, 6)
+                               |// hi2: Hi = Hi(a = 4, b = 5, c = 6)
+                               |
+                               |val hellos = List(hi1, hi2)
+                               |// hellos: List[Hi] = List(Hi(a = 7, b = 8, c = 9), Hi(a = 4, b = 5, c = 6))""".stripMargin,
+              V.scala3 -> """|
+                             |case class Hi(a: Int, b: Int, c: Int)
+                             |val hi1 =
+                             |  Hi(7, 8, 9)
+                             |// hi1: Hi = Hi(7,8,9)
+                             |val hi2 = Hi(4, 5, 6)
+                             |// hi2: Hi = Hi(4,5,6)
+                             |
+                             |val hellos = List(hi1, hi2)
+                             |// hellos: List[Hi] = List(Hi(7,8,9), Hi(4,5,6))""".stripMargin
+            ),
+            scalaVersion
+          )
+        )
+      )
+    } yield ()
+
+  }
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -558,6 +558,11 @@ final class TestingServer(
     server.stacktraceAnalyzer.stacktraceLenses(stacktrace.split('\n').toList)
   }
 
+  def exportEvaluation(filename: String): Option[String] = {
+    val path = toPath(filename)
+    server.worksheetProvider.copyWorksheetOutput(path)
+  }
+
   def didOpen(filename: String): Future[Unit] = {
     Debug.printEnclosing()
     val abspath = toPath(filename)


### PR DESCRIPTION
~Atm this is just here to show how https://github.com/scalameta/mdoc/pull/427 is meant to be used from the Metals side. I still need to add in some tests here, but I wanted to at least have this up to help with the mdoc review.~

~So when everything is fine and there are no error diagnostics the user will be able to just copy the output of a worksheet with a command like so:~

![2020-12-05 13 33 50](https://user-images.githubusercontent.com/13974112/101243158-8f60a200-36fe-11eb-8b71-586b31dd1d0e.gif)

If there is a diagnostic error, then you won't be able to export

![2020-12-05 13 36 08](https://user-images.githubusercontent.com/13974112/101243207-df3f6900-36fe-11eb-9e6b-05193f2a28dd.gif)

You can see what is needed for a client to implement this [here in coc-metals](https://github.com/scalameta/coc-metals/pull/360/files)

## New Approach
EDIT: The gifs are now out of date as the output are no longer on the same line, but all of them are under. Also, the full implementation of this is now done in Metals, no longer in mdoc.
