### PR TITLE
Default to Bloop is no choice was made about Build Server.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -31,12 +31,7 @@ class BspConnector(
     statusBar: StatusBar
 )(implicit ec: ExecutionContext) {
 
-  def resolve(): BspResolvedResult = {
-    resolveExplicit().getOrElse {
-      if (buildTools.isBloop) ResolvedBloop
-      else bspServers.resolve()
-    }
-  }
+  def resolve(): BspResolvedResult = resolveExplicit().getOrElse(ResolvedBloop)
 
   private def resolveExplicit(): Option[BspResolvedResult] = {
     tables.buildServers.selectedServer().flatMap { sel =>

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -71,16 +71,6 @@ class BspConnector(
             .map(Some(_))
         case ResolvedBspOne(details) =>
           bspServers.newServer(workspace, details).map(Some(_))
-        case ResolvedMultiple(_, availableServers) =>
-          val query =
-            Messages.SelectBspServer.request(availableServers, None)
-          for {
-            Some(item) <- client
-              .showMessageRequest(query.params)
-              .asScala
-              .map(item => query.details.get(item.getTitle))
-            conn <- bspServers.newServer(workspace, item)
-          } yield Some(conn)
       }
     }
 

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspResolvedResult.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspResolvedResult.scala
@@ -12,5 +12,3 @@ case object ResolvedNone extends BspResolvedResult
 case object ResolvedBloop extends BspResolvedResult
 case class ResolvedBspOne(details: BspConnectionDetails)
     extends BspResolvedResult
-case class ResolvedMultiple(md5: String, details: List[BspConnectionDetails])
-    extends BspResolvedResult

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -10,7 +10,6 @@ import scala.concurrent.ExecutionContext
 import scala.meta.internal.bsp.BspResolvedResult
 import scala.meta.internal.bsp.ResolvedBloop
 import scala.meta.internal.bsp.ResolvedBspOne
-import scala.meta.internal.bsp.ResolvedMultiple
 import scala.meta.internal.bsp.ResolvedNone
 import scala.meta.internal.metals.Messages.CheckDoctor
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -316,11 +315,6 @@ final class Doctor(
           case ResolvedBspOne(details) =>
             (
               s"Build server currently being used is ${details.getName()}.",
-              false
-            )
-          case ResolvedMultiple(_, _) =>
-            (
-              "Multiple build servers found for your workspace. Attempt to connect to choose your desired server.",
               false
             )
         }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -319,6 +319,7 @@ object Messages {
         params: ShowMessageRequestParams,
         details: Map[String, BspConnectionDetails]
     )
+    // TODO This is currently only being used in tests. This can probably be removed
     def message: String =
       "Multiple build servers detected, which one do you want to use?"
     def isSelectBspServer(params: ShowMessageRequestParams): Boolean =

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -9,6 +9,7 @@ import scala.util.control.NonFatal
 
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.Buffers
+import scala.meta.internal.metals.ClientConfiguration
 import scala.meta.internal.metals.ExecuteClientCommandConfig
 import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.InitializationOptions
@@ -16,6 +17,7 @@ import scala.meta.internal.metals.MetalsLogger
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.RecursivelyDelete
 import scala.meta.internal.metals.SlowTaskConfig
+import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.Time
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.io.AbsolutePath
@@ -125,5 +127,16 @@ abstract class BaseLspSuite(suiteName: String) extends BaseSuite {
           scribe.warn(s"Unable to delete workspace $workspace")
       }
     }
+  }
+  def createTablesAndConnect(): Unit = {
+    server.server.tables = new Tables(
+      workspace,
+      time,
+      ClientConfiguration.Default()
+    )
+    server.server.tables.connect()
+  }
+  def chooseBuildServer(buildServerName: String): Unit = {
+    server.server.tables.buildServers.chooseServer(buildServerName)
   }
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -134,6 +134,7 @@ final class TestingServer(
     // relying on the macOS/Windows file watchers causes flaky test failures.
     isReliableFileWatcher = Properties.isLinux
   )
+
   server.connectToLanguageClient(client)
   private val readonlySources = TrieMap.empty[String, AbsolutePath]
   def statusBarHistory: String = {

--- a/tests/unit/src/test/scala/tests/BillLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BillLspSuite.scala
@@ -47,12 +47,16 @@ class BillLspSuite extends BaseLspSuite("bill") {
 
   test("diagnostics") {
     cleanWorkspace()
+    createTablesAndConnect()
+    chooseBuildServer("Bill")
     Bill.installWorkspace(workspace.toNIO)
     testRoundtripCompilation()
   }
 
   test("reconnect-manual") {
     cleanWorkspace()
+    createTablesAndConnect()
+    chooseBuildServer("Bill")
     Bill.installWorkspace(workspace.toNIO)
     for {
       _ <- server.initialize(
@@ -89,6 +93,8 @@ class BillLspSuite extends BaseLspSuite("bill") {
 
   test("reconnect") {
     cleanWorkspace()
+    createTablesAndConnect()
+    chooseBuildServer("Bill")
     Bill.installWorkspace(workspace.toNIO)
     for {
       _ <- server.initialize(
@@ -182,6 +188,8 @@ class BillLspSuite extends BaseLspSuite("bill") {
   test("global") {
     RecursivelyDelete(globalBsp)
     cleanWorkspace()
+    createTablesAndConnect()
+    chooseBuildServer("Bill")
     Bill.installGlobal(globalBsp.toNIO)
     testRoundtripCompilation()
   }
@@ -202,20 +210,5 @@ class BillLspSuite extends BaseLspSuite("bill") {
         ).mkString("\n")
       )
     } yield ()
-  }
-
-  test("conflict") {
-    cleanWorkspace()
-    Bill.installWorkspace(workspace.toNIO, "Bill")
-    Bill.installWorkspace(workspace.toNIO, "Bob")
-    testSelectServerDialogue()
-  }
-
-  test("mix") {
-    cleanWorkspace()
-    RecursivelyDelete(globalBsp)
-    Bill.installWorkspace(workspace.toNIO, "Bill")
-    Bill.installGlobal(globalBsp.toNIO, "Bob")
-    testSelectServerDialogue()
   }
 }


### PR DESCRIPTION
Previously if there was no explicit choice made about the Build Server a
user wanted, then we would default to Bloop _if a `.bloop/`_ existed.
However, I didn't take into account if there was no `.bloop/` available,
but a `.bsp/<build-server>.json` available. Now, no matter what we
default to Bloop if there was no explicit choice made.

Closes #2291

Note, there really isn't tests for the `BspConnector`, and I realize that it can actually be tested in isolation. This fixes the issue right away, but I don't add in tests for the BspConnector. We can either merge this is now for a quick fix and I can add in a suite to start testing the `BspConnector` or we can leave this open for a bit until I add them.