### PR TITLE
Fix auto-connect BSP server without explicit choice.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -33,7 +33,8 @@ class BspConnector(
 
   def resolve(): BspResolvedResult = {
     resolveExplicit().getOrElse {
-      if (buildTools.isBloop) ResolvedBloop
+      if (buildTools.loadSupported().nonEmpty || buildTools.isBloop)
+        ResolvedBloop
       else bspServers.resolve()
     }
   }


### PR DESCRIPTION
Before this if a `.bsp/sbt.json` file existed and there was no `.bloop/`
yet then it would attempt to auto-connect to sbt. This behavior changes
this slightly now so that the behavior I just explains _only_ happens
if an explicit choice was made before, or if there is a `.bsp/<build-server>.json`
entry that is a Build Tool that Metals doesn't have Bloop support for.

This will supersede https://github.com/scalameta/metals/pull/2292 and closes #2291 

As always, my brain tried to over-complicate things when there was a simple solution. 😬 