### PR TITLE
Bump version of organizeImportRule to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -234,7 +234,7 @@ lazy val V = new {
   val coursier = "2.0.7"
   val ammonite = "2.2.0-26-61ee0965"
   val mill = "0.9.3"
-  val organizeImportRule = "0.4.2"
+  val organizeImportRule = "0.4.4"
 }
 
 val genyVersion = Def.setting {


### PR DESCRIPTION
Without this being the latest users may be using certain new
settings that have been added which will cause a warning that
the rule can't be found, but it's just because the setting
doesn't yet exist with this version.

I found this when I found #2306, but this doesn't fix the the
underlying issue.