### PR TITLE
Make sure to not duplicate semanticdbOptions when using sbt BSP.

### DIFF
--- a/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
+++ b/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
@@ -55,16 +55,17 @@ object MetalsPlugin extends AutoPlugin {
       if (in) classDirectory.value
       else semanticdbTargetRoot.value
     },
-    semanticdbOptions ++= {
+    semanticdbOptions := {
+      val old = semanticdbOptions.value
       val targetRoot = semanticdbTargetRoot.value
       val versionOfScala = scalaVersion.value
       if (
         ScalaInstance.isDotty(versionOfScala) || !supportedScala2Versions
           .contains(versionOfScala)
       )
-        Nil
+        old
       else
-        List(
+        (Seq(
           s"-P:semanticdb:sourceroot:${baseDirectory.in(ThisBuild).value}",
           s"-P:semanticdb:targetroot:$targetRoot",
           "-Yrangepos",
@@ -72,7 +73,7 @@ object MetalsPlugin extends AutoPlugin {
           s"-P:semanticdb:synthetics:on",
           // Don't fail compilation in case of Scalameta crash during SemanticDB generation.
           s"-P:semanticdb:failures:warning"
-        )
+        ) ++ old).distinct
     }
   )
 }


### PR DESCRIPTION
closes #2245

Thanks for your thorough issue @asflierl. What you mentioned as your _temporary_ fix is actually the way to go I think. Since if we don't duplicate those values in the semanticdbOptions, then when it's removed in `Test`, we no longer have the issue as you pointed out.