### PR TITLE
Ensure semanticdb is enabled with sbt BSP and Scala 3.

### DIFF
--- a/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
+++ b/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
@@ -50,6 +50,11 @@ object MetalsPlugin extends AutoPlugin {
            else None)).distinct
       }
     },
+    semanticdbEnabled := {
+      val old = semanticdbEnabled.value
+      if (ScalaInstance.isDotty(scalaVersion.value)) true
+      else old
+    },
     semanticdbTargetRoot := {
       val in = semanticdbIncludeInJar.value
       if (in) classDirectory.value


### PR DESCRIPTION
This addresses the first part of #2285, but there is still more work
to be done to get the sourceroot issue figured out.