### PR TITLE
Add in better message for user if trying to fetch invalid Ammonite.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -278,6 +278,14 @@ object Messages {
     }
   }
 
+  def errorFromThrowable(
+      throwable: Throwable
+  ): MessageParams =
+    new MessageParams(
+      MessageType.Error,
+      throwable.getMessage()
+    )
+
   object IncompatibleBloopVersion {
     def manually: MessageActionItem =
       new MessageActionItem("I'll update manually")


### PR DESCRIPTION
I came across this today in an Ammonite script. I wanted to try
something out with 2.13 and I without really thinking put the following
at the top of my Ammonite script.

```scala
// scala 2.13.4
```

And it just showed me:
```
Error importing /Users/ckipp/Documents/scala-workspace/worksheets/tester.sc. See
 the logs for more details.
```

When in reality, we have a much better message to show the user, since
we know the reason it failed is that the version of Ammonite we are
using isn't available for that Scala Version. So this change better
captures that exception, and actually shows it to the user. So now in
this same situation you'd instead see:

```
Error fetching Ammonite 2.3.8 for scala 2.13.4
```

Part of this is also because I'm seeing a pattern in the survey results
so far of people having something go wrong, and not fully understanding
what the issue is. So hopefully small changes like this will help with
that, and moving forward I'd like to do a better job at showing info the
users that we have and know is either more helpful or actionable then a
generic error message.