### PR TITLE
Update Deprecated Usage Of `setDeprecated` from `lsp4j`

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -451,7 +451,7 @@ case class ScalaPresentationCompiler(
     }
 
     if (completion.symbols.forall(_.isDeprecated)) {
-      item.setTags((Option(item.getTags).fold(Set.empty[CompletionItemTag])(_.asScala.toSet) ++ Set(CompletionItemTag.Deprecated)).toList.asJava)
+      item.setTags(List(CompletionItemTag.Deprecated).asJava)
     }
 
     completion.symbols.headOption

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -451,7 +451,7 @@ case class ScalaPresentationCompiler(
     }
 
     if (completion.symbols.forall(_.isDeprecated)) {
-      item.setTags((item.getTags.asScala.toSet ++ Set(CompletionItemTag.Deprecated)).toList.asJava)
+      item.setTags((Option(item.getTags).fold(Set.empty[CompletionItemTag])(_.asScala.toSet) ++ Set(CompletionItemTag.Deprecated)).toList.asJava)
     }
 
     completion.symbols.headOption

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -83,8 +83,6 @@ case class ScalaPresentationCompiler(
     workspace: Option[Path] = None
 ) extends PresentationCompiler {
 
-  import ScalaPresentationCompiler._
-
   def this() = this(Nil, Nil)
 
   import InteractiveDriver._
@@ -448,13 +446,10 @@ case class ScalaPresentationCompiler(
       doc <- ParsedComment.docOf(sym)
     } yield doc
 
-    if (documentation.nonEmpty) {
-      item.setDocumentation(hoverContent(None, None, documentation))
+    if (completion.symbols.forall(_.isDeprecated)) {
+      item.setTags((item.getTags.asScala.toSet ++ Set(CompletionItemTag.Deprecated)).toList.asJava)
     }
 
-    if (completion.symbols.forall(_.isDeprecated)) {
-      setCompletionItemDeprecated(item)
-    }
     completion.symbols.headOption
       .foreach(s => item.setKind(completionItemKind(s)))
     item
@@ -545,13 +540,4 @@ case class ScalaPresentationCompiler(
       )
     }
   }
-}
-
-object ScalaPresentationCompiler {
-  private[this] val deprecatedTagList: List[CompletionItemTag] =
-    List(CompletionItemTag.Deprecated)
-
-  /** Add the `Deprecated` tag to the completion item. */
-  private def setCompletionItemDeprecated(value: CompletionItem): Unit =
-    value.setTags(deprecatedTagList.asJava)
 }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -20,6 +20,7 @@ import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionItemKind
+import org.eclipse.lsp4j.CompletionItemTag
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.Range
@@ -81,6 +82,8 @@ case class ScalaPresentationCompiler(
     config: PresentationCompilerConfig = PresentationCompilerConfigImpl(),
     workspace: Option[Path] = None
 ) extends PresentationCompiler {
+
+  import ScalaPresentationCompiler._
 
   def this() = this(Nil, Nil)
 
@@ -449,7 +452,9 @@ case class ScalaPresentationCompiler(
       item.setDocumentation(hoverContent(None, None, documentation))
     }
 
-    item.setDeprecated(completion.symbols.forall(_.isDeprecated))
+    if (completion.symbols.forall(_.isDeprecated)) {
+      setCompletionItemDeprecated(item)
+    }
     completion.symbols.headOption
       .foreach(s => item.setKind(completionItemKind(s)))
     item
@@ -540,4 +545,13 @@ case class ScalaPresentationCompiler(
       )
     }
   }
+}
+
+object ScalaPresentationCompiler {
+  private[this] val deprecatedTagList: List[CompletionItemTag] =
+    List(CompletionItemTag.Deprecated)
+
+  /** Add the `Deprecated` tag to the completion item. */
+  private def setCompletionItemDeprecated(value: CompletionItem): Unit =
+    value.setTags(deprecatedTagList.asJava)
 }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -446,6 +446,10 @@ case class ScalaPresentationCompiler(
       doc <- ParsedComment.docOf(sym)
     } yield doc
 
+    if (documentation.nonEmpty) {
+      item.setDocumentation(hoverContent(None, None, documentation))
+    }
+
     if (completion.symbols.forall(_.isDeprecated)) {
       item.setTags((item.getTags.asScala.toSet ++ Set(CompletionItemTag.Deprecated)).toList.asJava)
     }


### PR DESCRIPTION
In a very amusing situation, `setDeprecated` from `org.eclipse.lsp4j.CompletionItem` is now itself deprecated.

This commit updates the usage to the new form, using `setTags` to add a `deprecated` tag on the `CompletionItem`.