### PR TITLE
Remove `-XX:+CMSClassUnloadingEnabled` From `.jvmopts`

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -3,5 +3,4 @@
 -Xmx2G
 -XX:ReservedCodeCacheSize=1024m
 -XX:+TieredCompilation
--XX:+CMSClassUnloadingEnabled
 -Dfile.encoding=UTF-8


### PR DESCRIPTION
The CMS GC was deprecated in JRE 9 and it was removed in JRE 14. If one happens to attempt to launch SBT on the current JRE (15), it will fail due to this flag.

Further, if the running JRE supports the CMS GC and chooses to use it, `-XX:+CMSClassUnloadingEnabled` is enabled by default, so we shouldn't need to explicitly enable it in most cases anyway.

> -XX:+CMSClassUnloadingEnabled
>  Enables class unloading when using the concurrent mark-sweep (CMS) garbage collector. This option is enabled by default. To disable class unloading for the CMS garbage collector, specify -XX:-CMSClassUnloadingEnabled.

I realize that JREs 14/15 are not officially supported, but it is nice to be able to launch `sbt` without having to switch JREs even in this case.