### PR TITLE
Refactor doctor and make sure issues with sbt are properly reported

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -122,7 +122,13 @@ final class BuildTargets(
       scalaTarget <- target.asScalaBuildTarget
     } yield {
       val autoImports = target.asSbtBuildTarget.map(_.getAutoImports.asScala)
-      ScalaTarget(target, scalaTarget, scalac, autoImports)
+      ScalaTarget(
+        target,
+        scalaTarget,
+        scalac,
+        autoImports,
+        target.getDataKind() == "sbt"
+      )
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -548,7 +548,7 @@ object Messages {
 
   object DeprecatedScalaVersion {
     def message(
-        usingNow: Iterable[String]
+        usingNow: Set[String]
     ): String = {
       val using = "legacy " + usingString(usingNow)
       val recommended = recommendationString(usingNow)
@@ -559,7 +559,7 @@ object Messages {
 
   object UnsupportedScalaVersion {
     def message(
-        usingNow: Iterable[String]
+        usingNow: Set[String]
     ): String = {
       val using = usingString(usingNow)
       val recommended = recommendationString(usingNow)
@@ -577,13 +577,36 @@ object Messages {
 
   object FutureScalaVersion {
     def message(
-        usingNow: Iterable[String]
+        usingNow: Set[String]
     ): String = {
       val using = usingString(usingNow)
       val recommended = recommendationString(usingNow)
       val isAre = if (usingNow.size == 1) "is" else "are"
       s"You are using $using, which $isAre not yet supported in this version of Metals. " +
         s"Please downgrade to $recommended for the moment until the new Metals release."
+    }
+  }
+
+  object DeprecatedSbtVersion {
+    def message: String = {
+      val recommended = "1.3.2"
+      s"You are using an old sbt version, navigation for which might not be supported in the future versions of Metals. " +
+        s"Please upgrade to at least sbt $recommended."
+    }
+  }
+
+  object UnsupportedSbtVersion {
+    def message: String = {
+      val recommended = "1.3.2"
+      s"You are using an old sbt version, navigation for which is not supported in this version of Metals. " +
+        s"Please upgrade to at least sbt $recommended."
+    }
+  }
+
+  object FutureSbtVersion {
+    def message: String = {
+      s"You are using an sbt version not yet supported in this version of Metals." +
+        s"Please downgrade to sbt ${BuildInfo.sbtVersion}"
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -15,7 +15,8 @@ case class ScalaTarget(
     info: BuildTarget,
     scalaInfo: ScalaBuildTarget,
     scalac: ScalacOptionsItem,
-    autoImports: Option[Seq[String]]
+    autoImports: Option[Seq[String]],
+    isSbt: Boolean
 ) {
 
   def isSemanticdbEnabled: Boolean = scalac.isSemanticdbEnabled(scalaVersion)

--- a/metals/src/main/scala/scala/meta/internal/troubleshoot/ProblemResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/troubleshoot/ProblemResolver.scala
@@ -1,0 +1,175 @@
+package scala.meta.internal.troubleshoot
+
+import scala.collection.mutable.ListBuffer
+
+import scala.meta.internal.bsp.BspSession
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ScalaTarget
+import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.semver.SemVer
+import scala.meta.io.AbsolutePath
+
+class ProblemResolver(
+    workspace: AbsolutePath,
+    currentBuildServer: () => Option[BspSession],
+    isClientCommandSupported: Boolean
+) {
+
+  def isUnsupportedBloopVersion(): Boolean = {
+    currentBuildServer() match {
+      case Some(bspSession) =>
+        bspSession.main.name == "Bloop" && !SemVer.isCompatibleVersion(
+          BuildInfo.bloopVersion,
+          bspSession.main.version
+        )
+      case None =>
+        false
+    }
+  }
+
+  def recommendation(scala: ScalaTarget): String = {
+    findProblem(scala)
+      .map(_.message)
+      .getOrElse("")
+  }
+
+  def problemMessage(allTargets: List[ScalaTarget]): Option[String] = {
+
+    val unsupportedVersions = ListBuffer[String]()
+    val deprecatedVersions = ListBuffer[String]()
+    val futureVersions = ListBuffer[String]()
+    var misconfiguredProjects = 0
+    var unsupportedSbt = false
+    var deprecatedSbt = false
+    var futureSbt = false
+
+    for {
+      target <- allTargets
+      issue <- findProblem(target)
+    } yield {
+      issue match {
+        case UnsupportedScalaVersion(version) => unsupportedVersions += version
+        case DeprecatedScalaVersion(version) => deprecatedVersions += version
+        case FutureScalaVersion(version) => futureVersions += version
+        case _: SemanticDBDisabled => misconfiguredProjects += 1
+        case _: MissingSourceRoot => misconfiguredProjects += 1
+        case UnsupportedSbtVersion => unsupportedSbt = true
+        case DeprecatedSbtVersion => deprecatedSbt = true
+        case FutureSbtVersion => futureSbt = true
+      }
+    }
+
+    val unsupportedMessage = if (unsupportedVersions.nonEmpty) {
+      Some(Messages.UnsupportedScalaVersion.message(unsupportedVersions.toSet))
+    } else {
+      None
+    }
+    val deprecatedMessage = if (deprecatedVersions.nonEmpty) {
+      Some(Messages.DeprecatedScalaVersion.message(deprecatedVersions.toSet))
+    } else {
+      None
+    }
+
+    val futureMessage = if (futureVersions.nonEmpty) {
+      Some(Messages.FutureScalaVersion.message(futureVersions.toSet))
+    } else {
+      None
+    }
+
+    val deprecatedSbtMessage =
+      if (deprecatedSbt) Some(Messages.DeprecatedSbtVersion.message) else None
+    val unsupportedSbtMessage =
+      if (deprecatedSbt) Some(Messages.UnsupportedSbtVersion.message) else None
+    val futureSbtMessage =
+      if (deprecatedSbt) Some(Messages.FutureSbtVersion.message) else None
+
+    val semanticdbMessage =
+      if (
+        misconfiguredProjects == allTargets.size && misconfiguredProjects > 0
+      ) {
+        Some(Messages.CheckDoctor.allProjectsMisconfigured)
+      } else if (misconfiguredProjects == 1) {
+        val name = allTargets
+          .find(t => !t.isSemanticdbEnabled)
+          .map(_.displayName)
+          .getOrElse("<none>")
+        Some(Messages.CheckDoctor.singleMisconfiguredProject(name))
+      } else if (misconfiguredProjects > 0) {
+        Some(
+          Messages.CheckDoctor.multipleMisconfiguredProjects(
+            misconfiguredProjects
+          )
+        )
+      } else {
+        None
+      }
+
+    val allMessages = List(
+      deprecatedMessage,
+      unsupportedMessage,
+      futureMessage,
+      deprecatedSbtMessage,
+      unsupportedSbtMessage,
+      futureSbtMessage,
+      semanticdbMessage
+    ).flatten
+
+    def scalaVersionsMessages = List(
+      deprecatedMessage,
+      unsupportedMessage,
+      futureMessage
+    ).flatten
+
+    allMessages match {
+      case single :: Nil => Some(single)
+      case Nil => None
+      case messages if messages == scalaVersionsMessages =>
+        Some(
+          s"Your build definition contains multiple unsupported and deprecated Scala versions."
+        )
+      case _ =>
+        Some(
+          s"Multiple problems detected in your build."
+        )
+    }
+  }
+
+  private def findProblem(
+      scalaTarget: ScalaTarget
+  ): Option[ScalaProblem] = {
+    scalaTarget.scalaVersion match {
+      case version
+          if ScalaVersions.isFutureVersion(version) && scalaTarget.isSbt =>
+        Some(FutureSbtVersion)
+      case version if ScalaVersions.isFutureVersion(version) =>
+        Some(FutureScalaVersion(version))
+      case version
+          if !ScalaVersions.isSupportedScalaVersion(
+            version
+          ) && scalaTarget.isSbt =>
+        Some(UnsupportedSbtVersion)
+      case version if !ScalaVersions.isSupportedScalaVersion(version) =>
+        Some(UnsupportedScalaVersion(version))
+      case version if !scalaTarget.isSemanticdbEnabled =>
+        Some(
+          SemanticDBDisabled(
+            version,
+            currentBuildServer().map(_.main.name).getOrElse("<none>"),
+            isUnsupportedBloopVersion()
+          )
+        )
+      case _ if !scalaTarget.isSourcerootDeclared =>
+        Some(MissingSourceRoot(workspace.sourcerootOption))
+      case version
+          if ScalaVersions.isDeprecatedScalaVersion(
+            version
+          ) && scalaTarget.isSbt =>
+        Some(DeprecatedSbtVersion)
+      case version if ScalaVersions.isDeprecatedScalaVersion(version) =>
+        Some(DeprecatedScalaVersion(version))
+      case _ => None
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/troubleshoot/ScalaProblem.scala
+++ b/metals/src/main/scala/scala/meta/internal/troubleshoot/ScalaProblem.scala
@@ -1,0 +1,83 @@
+package scala.meta.internal.troubleshoot
+
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.ScalaVersions
+
+/**
+ * Class describing different issues that a build target can have that might influence
+ * features available to a user. For example without the semanticdb option
+ * "find references" feature will not work. Those problems will be reported to a user
+ * with an explanation on how to fix it.
+ */
+sealed abstract class ScalaProblem {
+
+  /**
+   * Comprehensive message to be presented to the user.
+   */
+  def message: String
+  protected val hint = "run 'Build import' to enable code navigation."
+}
+
+case class UnsupportedScalaVersion(version: String) extends ScalaProblem {
+  override def message: String = {
+    if (ScalaVersions.isSupportedScalaBinaryVersion(version)) {
+      val recommended = ScalaVersions.recommendedVersion(version)
+      s"Upgrade to Scala $recommended and " + hint
+    } else {
+      val versionToUpgradeTo =
+        if (ScalaVersions.isScala3Version(version)) {
+          s"Scala ${BuildInfo.scala3}"
+        } else {
+          s"Scala ${BuildInfo.scala213} or ${BuildInfo.scala212}"
+        }
+      s"Code navigation is not supported for this compiler version, please change to $versionToUpgradeTo and $hint"
+    }
+  }
+}
+
+case class DeprecatedScalaVersion(version: String) extends ScalaProblem {
+  override def message: String =
+    s"Scala $version might not be supported in upcoming versions of Metals, " +
+      s"please upgrade to Scala ${ScalaVersions.recommendedVersion(version)}."
+}
+
+case class FutureScalaVersion(version: String) extends ScalaProblem {
+  override def message: String = s"Scala $version is not yet supported, " +
+    s"please downgrade to Scala ${ScalaVersions.recommendedVersion(version)}."
+}
+
+case class SemanticDBDisabled(
+    scalaVersion: String,
+    bloopVersion: String,
+    unsupportedBloopVersion: Boolean
+) extends ScalaProblem {
+  override def message: String = {
+    if (unsupportedBloopVersion) {
+      s"""|The installed Bloop server version is $bloopVersion while Metals requires at least Bloop version ${BuildInfo.bloopVersion},
+          |To fix this problem please update your Bloop server.""".stripMargin
+    } else if (ScalaVersions.isSupportedScalaVersion(scalaVersion)) {
+      hint.capitalize
+    } else {
+      "Semanticdb is required for code navigation to work correctly in your project," +
+        " however the semanticdb plugin doesn't seem to be enabled. " +
+        "Please enable the semanticdb plugin for this project in order for code navigation to work correctly"
+    }
+  }
+}
+case class MissingSourceRoot(sourcerootOption: String) extends ScalaProblem {
+  override def message: String =
+    s"Add the compiler option $sourcerootOption to ensure code navigation works."
+}
+
+case object UnsupportedSbtVersion extends ScalaProblem {
+  override def message: String =
+    "Code navigation is not supported for this sbt version, please upgrade to at least 1.3.2 and reimport the build"
+}
+case object DeprecatedSbtVersion extends ScalaProblem {
+  override def message: String =
+    "Code navigation might not be supported in the future for this sbt version, please upgrade to at least 1.3.2 and reimport the build"
+}
+case object FutureSbtVersion extends ScalaProblem {
+  override def message: String =
+    "Code navigation for this sbt version is not yet supported"
+}

--- a/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
@@ -230,7 +230,7 @@ class SbtBloopLspSuite
            |scalaVersion := "${V.scala212}"
            |lazy val a = project.settings(scalaVersion := "2.12.4")
            |lazy val b = project.settings(scalaVersion := "2.12.3")
-           |lazy val c = project.settings(scalaVersion := "2.11.12")
+           |lazy val c = project.settings(scalaVersion := "2.11.11")
            |lazy val d = project.settings(scalaVersion := "2.11.8")
            |lazy val e = project.settings(scalaVersion := "2.10.7")
            |lazy val f = project.settings(scalaVersion := "${V.scala212}")
@@ -243,7 +243,7 @@ class SbtBloopLspSuite
            |object A
            |/c/src/main/scala/a/A.scala
            |package a
-           |object A // 2.11.12
+           |object A // 2.11.11
            |/d/src/main/scala/a/A.scala
            |package a
            |object A // 2.11.8
@@ -263,7 +263,7 @@ class SbtBloopLspSuite
       _ = assertNoDiff(
         client.messageRequests.peekLast(),
         UnsupportedScalaVersion.message(
-          Seq("2.12.4", "2.12.3", "2.11.8", "2.10.7")
+          Set("2.12.4", "2.12.3", "2.11.8", "2.11.11", "2.10.7")
         )
       )
       sourceJars <- server.buildTargetSourceJars("a")

--- a/tests/unit/src/test/scala/tests/MessagesSuite.scala
+++ b/tests/unit/src/test/scala/tests/MessagesSuite.scala
@@ -7,7 +7,7 @@ class MessagesSuite extends BaseSuite {
 
   test("deprecated-single") {
     assertDiffEqual(
-      Messages.DeprecatedScalaVersion.message(Seq("2.11.12")),
+      Messages.DeprecatedScalaVersion.message(Set("2.11.12")),
       "You are using legacy Scala version 2.11.12, which might not be supported in future versions of Metals." +
         s" Please upgrade to Scala version ${V.scala212}."
     )
@@ -15,7 +15,7 @@ class MessagesSuite extends BaseSuite {
 
   test("future-single") {
     assertDiffEqual(
-      Messages.FutureScalaVersion.message(Seq("2.13.50")),
+      Messages.FutureScalaVersion.message(Set("2.13.50")),
       "You are using Scala version 2.13.50, which is not yet supported in this version of Metals." +
         s" Please downgrade to Scala version ${V.scala213} for the moment until the new Metals release."
     )
@@ -23,7 +23,7 @@ class MessagesSuite extends BaseSuite {
 
   test("unspported-single") {
     assertDiffEqual(
-      Messages.UnsupportedScalaVersion.message(Seq("2.12.4")),
+      Messages.UnsupportedScalaVersion.message(Set("2.12.4")),
       "You are using Scala version 2.12.4, which is not supported in this version of Metals." +
         s" Please upgrade to Scala version ${V.scala212}."
     )
@@ -31,7 +31,7 @@ class MessagesSuite extends BaseSuite {
 
   test("unspported-multiple") {
     assertDiffEqual(
-      Messages.UnsupportedScalaVersion.message(Seq("2.12.4", "2.12.8")),
+      Messages.UnsupportedScalaVersion.message(Set("2.12.4", "2.12.8")),
       "You are using Scala versions 2.12.4, 2.12.8, which are not supported in this version of Metals." +
         s" Please upgrade to Scala version ${V.scala212}."
     )
@@ -40,7 +40,7 @@ class MessagesSuite extends BaseSuite {
   test("unspported-multiple2") {
     assertDiffEqual(
       Messages.UnsupportedScalaVersion
-        .message(Seq("2.11.9", "2.12.2", "2.12.1")),
+        .message(Set("2.11.9", "2.12.2", "2.12.1")),
       "You are using Scala versions 2.11.9, 2.12.1, 2.12.2, which are not supported in this version of Metals." +
         s" Please upgrade to Scala version ${V.scala212} or alternatively to legacy Scala ${V.scala211}."
     )

--- a/tests/unit/src/test/scala/tests/WarningsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WarningsLspSuite.scala
@@ -30,6 +30,33 @@ class WarningsLspSuite extends BaseLspSuite("warnings") {
     } yield ()
   }
 
+  test("multiple-problems-scala") {
+    cleanWorkspace()
+    val using = V.deprecatedScalaVersions.filter(_.startsWith("2.12")).head
+    val older = "2.12.4"
+    for {
+      _ <- server.initialize(
+        s"""/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "${using}"
+           |  },
+           |  "b": {
+           |    "scalaVersion" : "$older"
+           |  }
+           |}
+           |/a/src/main/scala/a/Main.scala
+           |package a
+           |object Main
+           |""".stripMargin
+      )
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        "Your build definition contains multiple unsupported and deprecated Scala versions."
+      )
+    } yield ()
+  }
+
   test("deprecated-scala-211") {
     cleanWorkspace()
     val using = V.scala211

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -1,0 +1,170 @@
+package tests.troubleshoot
+
+import java.nio.file.Files
+
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.ScalaTarget
+import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.troubleshoot.DeprecatedSbtVersion
+import scala.meta.internal.troubleshoot.DeprecatedScalaVersion
+import scala.meta.internal.troubleshoot.FutureSbtVersion
+import scala.meta.internal.troubleshoot.FutureScalaVersion
+import scala.meta.internal.troubleshoot.MissingSourceRoot
+import scala.meta.internal.troubleshoot.ProblemResolver
+import scala.meta.internal.troubleshoot.SemanticDBDisabled
+import scala.meta.internal.troubleshoot.UnsupportedSbtVersion
+import scala.meta.internal.troubleshoot.UnsupportedScalaVersion
+import scala.meta.io.AbsolutePath
+
+import ch.epfl.scala.bsp4j.BuildTarget
+import ch.epfl.scala.bsp4j.BuildTargetCapabilities
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import ch.epfl.scala.bsp4j.ScalaBuildTarget
+import ch.epfl.scala.bsp4j.ScalaPlatform
+import ch.epfl.scala.bsp4j.ScalacOptionsItem
+import munit.FunSuite
+import munit.TestOptions
+
+class ProblemResolverSuite extends FunSuite {
+
+  checkRecommendation(
+    "unsupported-scala-version",
+    scalaVersion = "2.12.7",
+    UnsupportedScalaVersion("2.12.7").message
+  )
+
+  checkRecommendation(
+    "deprecated-scala-version",
+    scalaVersion = "2.12.8",
+    DeprecatedScalaVersion("2.12.8").message
+  )
+
+  checkRecommendation(
+    "future-scala-version",
+    scalaVersion = "2.12.50",
+    FutureScalaVersion("2.12.50").message
+  )
+
+  checkRecommendation(
+    "ok-scala-version",
+    scalaVersion = BuildInfo.scala212,
+    ""
+  )
+
+  checkRecommendation(
+    "unsupported-sbt-version",
+    scalaVersion = "2.12.7",
+    UnsupportedSbtVersion.message,
+    isSbt = true
+  )
+
+  checkRecommendation(
+    "deprecated-sbt-version",
+    scalaVersion = "2.12.8",
+    DeprecatedSbtVersion.message,
+    isSbt = true
+  )
+
+  checkRecommendation(
+    "future-sbt-version",
+    scalaVersion = "2.12.51",
+    FutureSbtVersion.message,
+    isSbt = true
+  )
+
+  checkRecommendation(
+    "ok-sbt-version",
+    scalaVersion = BuildInfo.scala212,
+    "",
+    isSbt = true
+  )
+
+  checkRecommendation(
+    "missing-semanticdb",
+    scalaVersion = BuildInfo.scala212,
+    SemanticDBDisabled(
+      BuildInfo.scala212,
+      BuildInfo.bloopVersion,
+      false
+    ).message,
+    scalacOpts = Nil
+  )
+
+  checkRecommendation(
+    "missing-sourceroot",
+    scalaVersion = BuildInfo.scala212,
+    MissingSourceRoot("\"-P:semanticdb:sourceroot:$workspace\"").message,
+    scalacOpts = List("-Xplugin:/semanticdb-scalac_2.12.12-4.4.2.jar")
+  )
+
+  def checkRecommendation(
+      name: TestOptions,
+      scalaVersion: String,
+      expected: String,
+      scalacOpts: List[String] = List(
+        "-Xplugin:/semanticdb-scalac_2.12.12-4.4.2.jar",
+        "-P:semanticdb:sourceroot:/tmp/metals"
+      ),
+      isSbt: Boolean = false
+  ): Unit = {
+    test(name) {
+      val workspace = Files.createTempDirectory("metals")
+      workspace.toFile().deleteOnExit()
+      val problemResolver = new ProblemResolver(
+        AbsolutePath(workspace),
+        () => None,
+        isClientCommandSupported = true
+      )
+
+      val target = scalaTarget(name.name, scalaVersion, scalacOpts, isSbt)
+      val message = problemResolver.recommendation(target)
+
+      assertNoDiff(
+        message,
+        expected.replace("$workspace", workspace.toString())
+      )
+    }
+  }
+
+  def scalaTarget(
+      id: String,
+      scalaVersion: String,
+      scalacOptions: List[String],
+      isSbt: Boolean = false
+  ): ScalaTarget = {
+    val scalaBinaryVersion =
+      ScalaVersions.scalaBinaryVersionFromFullVersion(scalaVersion)
+    val buildId = new BuildTargetIdentifier(id)
+    val buildTarget =
+      new BuildTarget(
+        buildId,
+        /* tags = */ Nil.asJava,
+        /* languageIds = */ Nil.asJava,
+        /* dependencies = */ Nil.asJava,
+        /* capabilities = */ new BuildTargetCapabilities(true, true, true)
+      )
+    val scalaBuildTarget = new ScalaBuildTarget(
+      "org.scala-lang",
+      scalaVersion,
+      scalaBinaryVersion,
+      ScalaPlatform.JVM,
+      /* jars = */ Nil.asJava
+    )
+
+    val scalacOptionsItem = new ScalacOptionsItem(
+      buildId,
+      scalacOptions.asJava,
+      /* classpath = */ Nil.asJava,
+      ""
+    )
+
+    ScalaTarget(
+      buildTarget,
+      scalaBuildTarget,
+      scalacOptionsItem,
+      autoImports = None,
+      isSbt = isSbt
+    )
+  }
+}


### PR DESCRIPTION
The main goal of this refactor is to make sure we have just one category of problems that will be reported both in the message request and the doctor. Previously, both would need to be updated independently and testing for those was scarce. Thanks to having a single category of problems we can now properly unit test them to make sure every message is sensible. It's also easier now to see what each problem is caused by and what message will be displayed to the user.

Also, this should fix https://github.com/scalameta/metals/issues/2167 - sbt issues will now be reported separately, so that the users are not confused.