### PR TITLE
Calculate semanticdb for standalone files

### DIFF
--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -492,7 +492,7 @@ scripts.
     <td align="center"></td>
     <td align="center"></td>
     <td align="center">✅</td>
-    <td align="center"></td>
+    <td align="center">✅</td>
   </tr>
   <tr>
     <td>Run/Debug</td>
@@ -506,14 +506,14 @@ scripts.
     <td align="center"></td>
     <td align="center"></td>
     <td align="center">✅</td>
-    <td align="center"></td>
+    <td align="center">✅</td>
   </tr>
   <tr>
     <td>Rename symbol</td>
     <td align="center"></td>
     <td align="center"></td>
     <td align="center">✅</td>
-    <td align="center"></td>
+    <td align="center">✅</td>
   </tr>
   <tr>
     <td>Code actions</td>
@@ -534,7 +534,7 @@ scripts.
     <td align="center"></td>
     <td align="center"></td>
     <td align="center">✅</td>
-    <td align="center"></td>
+    <td align="center">✅</td>
   </tr>
   <tr>
     <td>Formatting</td>
@@ -555,7 +555,7 @@ scripts.
     <td align="center"></td>
     <td align="center"></td>
     <td align="center">✅</td>
-    <td align="center"></td>
+    <td align="center">✅</td>
   </tr>
   <tr>
      <td>Organize imports</td>
@@ -569,7 +569,7 @@ scripts.
     <td align="center"></td>
     <td align="center"></td>
     <td align="center">✅</td>
-    <td align="center"></td>
+    <td align="center">✅</td>
   </tr>
 </tbody>
 </table>

--- a/metals/src/main/resources/db/migration/V1__Create_tables.sql
+++ b/metals/src/main/resources/db/migration/V1__Create_tables.sql
@@ -6,6 +6,14 @@ create table dependency_source(
   build_target_uri varchar not null
 );
 
+-- The relationship between library dependency sources under .metals/readonly/**
+-- and worksheets they belong to. Required to know what classpath to use
+-- for compiling dependency sources.
+create table worksheet_dependency_source(
+  text_document_uri varchar primary key,
+  worksheet_uri varchar not null
+);
+
 -- The relationship between what library dependency sources under .metals/readonly/**
 -- map to which build targets.
 create table sbt_digest(

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -333,10 +333,23 @@ class Compilers(
         .asScala
         .map { c =>
           adjust.adjustLocations(c.locations())
+          val definitionPaths = c
+            .locations()
+            .map { loc =>
+              loc.getUri().toAbsolutePath
+            }
+            .asScala
+            .toSet
+
+          val definitionPath = if (definitionPaths.size == 1) {
+            Some(definitionPaths.head)
+          } else {
+            None
+          }
           DefinitionResult(
             c.locations(),
             c.symbol(),
-            None,
+            definitionPath,
             None
           )
         }

--- a/metals/src/main/scala/scala/meta/internal/metals/Debug.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Debug.scala
@@ -9,11 +9,11 @@ object Debug {
     e.setStackTrace(e.getStackTrace.slice(2, 30))
     e.printStackTrace()
   }
-  def printEnclosing()(implicit
+  def printEnclosing(additionalInfo: String = "")(implicit
       enclosing: sourcecode.Enclosing
   ): Unit = {
     val enclosingTrimmed =
       enclosing.value.split(' ').filter(_ != "$anonfun").mkString(" ")
-    scribe.info(enclosingTrimmed)
+    scribe.info(enclosingTrimmed + " " + additionalInfo)
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
@@ -23,6 +23,8 @@ final class Tables(
     new Digests(() => connection, time)
   val dependencySources =
     new DependencySources(() => connection)
+  val worksheetSources =
+    new WorksheetDependencySources(() => connection)
   val dismissedNotifications =
     new DismissedNotifications(() => connection, time)
   val buildServers =

--- a/metals/src/main/scala/scala/meta/internal/metals/WorksheetDependencySources.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorksheetDependencySources.scala
@@ -1,0 +1,30 @@
+package scala.meta.internal.metals
+
+import java.sql.Connection
+
+import scala.meta.internal.metals.JdbcEnrichments._
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+
+final class WorksheetDependencySources(conn: () => Connection) {
+  def setWorksheet(
+      dependencySource: AbsolutePath,
+      worksheetSource: AbsolutePath
+  ): Int = {
+    conn().update(
+      "merge into worksheet_dependency_source key(text_document_uri) values (?, ?);"
+    ) { stmt =>
+      stmt.setString(1, dependencySource.toURI.toString)
+      stmt.setString(2, worksheetSource.toURI.toString())
+    }
+  }
+  def getWorksheet(
+      dependencySource: AbsolutePath
+  ): Option[AbsolutePath] = {
+    conn().query(
+      "select worksheet_uri from worksheet_dependency_source where text_document_uri = ?;"
+    ) { stmt => stmt.setString(1, dependencySource.toURI.toString) } { rs =>
+      rs.getString(1).toAbsolutePath
+    }
+  }.headOption
+}

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -522,7 +522,7 @@ final class TestingServer(
   }
 
   def didSave(filename: String)(fn: String => String): Future[Unit] = {
-    Debug.printEnclosing()
+    Debug.printEnclosing(filename)
     val abspath = toPath(filename)
     val oldText = abspath.toInputFromBuffers(buffers).text
     val newText = fn(oldText)
@@ -540,7 +540,7 @@ final class TestingServer(
   }
 
   def didChange(filename: String)(fn: String => String): Future[Unit] = {
-    Debug.printEnclosing()
+    Debug.printEnclosing(filename)
     val abspath = toPath(filename)
     val oldText = abspath.toInputFromBuffers(buffers).text
     val newText = fn(oldText)
@@ -564,7 +564,7 @@ final class TestingServer(
   }
 
   def didOpen(filename: String): Future[Unit] = {
-    Debug.printEnclosing()
+    Debug.printEnclosing(filename)
     val abspath = toPath(filename)
     val uri = abspath.toURI.toString
     val extension = PathIO.extension(abspath.toNIO)
@@ -579,7 +579,7 @@ final class TestingServer(
   }
 
   def didClose(filename: String): Future[Unit] = {
-    Debug.printEnclosing()
+    Debug.printEnclosing(filename)
     val abspath = toPath(filename)
     val uri = abspath.toURI.toString
     Future.successful {

--- a/tests/unit/src/test/scala/tests/WorksheetDependencySourcesSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorksheetDependencySourcesSuite.scala
@@ -1,0 +1,28 @@
+package tests
+
+import scala.meta.internal.metals.WorksheetDependencySources
+
+class WorksheetDependencySourcesSuite extends BaseTablesSuite {
+  def dependencySources: WorksheetDependencySources = tables.worksheetSources
+  test("basic") {
+    val textDocument = workspace.resolve("a.scala")
+    val worksheet1 = workspace.resolve("w1.worksheet.sc")
+    val worksheet2 = workspace.resolve("w2.worksheet.sc")
+    assertDiffEqual(
+      dependencySources.setWorksheet(textDocument, worksheet1),
+      1
+    )
+    assertDiffEqual(
+      dependencySources.getWorksheet(textDocument).get,
+      worksheet1
+    )
+    assertDiffEqual(
+      dependencySources.setWorksheet(textDocument, worksheet2),
+      1
+    )
+    assertDiffEqual(
+      dependencySources.getWorksheet(textDocument).get,
+      worksheet2
+    )
+  }
+}


### PR DESCRIPTION
This solves all issues connected to semanticdb in standalone files. It's now possible to find references, rename etc in standalone files. This was also helpful for testing out and fixing an issue with URIs being wongly produced for semanticdb files produced in the compiler.

Fixes https://github.com/scalameta/metals/issues/2340