### PR TITLE
Fix incompatibility between currently used Bloop and sbt versions < 1.3.0

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -69,7 +69,8 @@ class BspConnector(
           SbtBuildTool.writeSingleSbtMetalsPlugin(
             workspace.resolve("project"),
             userConfig,
-            isBloop = false
+            isBloop = false,
+            details.getVersion()
           )
           val connectionF = bspServers.newServer(workspace, details)
           statusBar


### PR DESCRIPTION
On 1.2.8 we are currently getting:
`[error] java.lang.NoSuchMethodError: sbt.Keys$.reresolveSbtArtifacts()Lsbt/SettingKey;`

I think it's fine to stop supporting 1.2.x in Bloop, since users can always use the older version and not much changes in the integration plugin. But inside Metals this might be problematic, because we force the Bloop version on users.

I am also not 100% how we could fix it in Bloop especially that we compile for 1.3.0 in reality.