### PR TITLE
Bare minimum arg completion for scala3

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Completions.scala
@@ -1,0 +1,104 @@
+package scala.meta.internal.pc
+
+import dotty.tools.dotc.ast.tpd.{Ident, Apply, Tree, NamedArg, Template, Block, Literal, Select}
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.util.SourcePosition
+import dotty.tools.dotc.core.Constants.Constant
+import dotty.tools.dotc.interactive.Completion
+import dotty.tools.dotc.core.Symbols.Symbol
+import dotty.tools.dotc.core.Names.Name
+
+trait Completions {
+  def completionPosition(
+    pos: SourcePosition,
+    path: List[Tree],
+  )(using ctx: Context): List[Completion] = {
+    path match {
+      case (ident: Ident) :: (app: Apply) :: _ => // fun(arg@@)
+        ArgCompletion(Some(ident), app, pos).contribute
+      case (app: Apply) :: _ => // fun(@@)
+        ArgCompletion(None, app, pos).contribute
+      case _ =>
+        Nil
+    }
+  }
+}
+
+case class ArgCompletion(
+  ident: Option[Ident],
+  apply: Apply,
+  pos: SourcePosition,
+)(using ctx: Context) {
+  val method = apply.fun
+  val methodSym = method.symbol
+
+  // paramSymss contains both type params and value params
+  val vparamss = methodSym.paramSymss.filter(
+    params => params.forall(p => p.isTerm)
+  )
+  val argss = collectArgss(apply)
+
+  // get params and args we are interested in
+  // e.g.
+  // in the following case, the interesting args and params are 
+  // - params: [apple, banana]
+  // - args: [apple, b]
+  // ```
+  // def curry(x; Int)(apple: String, banana: String) = ???
+  // curry(1)(apple = "test", b@@)
+  // ```
+  val (baseParams, baseArgs) = vparamss.zip(argss).lastOption.getOrElse((Nil, Nil))
+
+  val args = ident
+    .map(i => baseArgs.filterNot(_ == i)).getOrElse(baseArgs)
+    .filterNot(isUselessLiteral)
+
+  val isNamed: Set[Name] = args.iterator
+    .zip(baseParams.iterator)
+    // filter out synthesized default args
+    .filterNot {
+      case (Ident(name), _) => name.toString.contains("$")
+      case (Select(Ident(_), name), _) => name.toString.contains("$") // apply method of case class
+      case _ => false
+    }
+    .map {
+      case (NamedArg(name, _), _) => name
+      case (_, param) => param.name
+    }.toSet
+
+  val allParams: List[Symbol] = {
+    baseParams.filterNot(param =>
+      isNamed(param.name) ||
+      param.name.toString.contains("$") // filter out synthesized param, like evidence
+    )
+  }
+
+  val prefix = ident.map(_.name.toString).getOrElse("")
+  val params: List[Symbol] = allParams.filter(param => param.name.startsWith(prefix))
+
+  def contribute: List[Completion] = {
+    val printer = SymbolPrinter()
+    params.map(p => {
+      Completion(
+        s"${p.name.toString} = ",
+        printer.typeString(p.info),
+        List(p)
+      )
+    })
+  }
+
+  private def isUselessLiteral(arg: Tree): Boolean = {
+    arg match {
+      case Literal(Constant(())) => true // unitLiteral
+      case Literal(Constant(null)) => true // nullLiteral
+      case _ => false
+    }
+  }
+
+  private def collectArgss(a: Apply): List[List[Tree]] = {
+    a.fun match {
+      case app: Apply => collectArgss(app) :+ a.args
+      case _ => List(a.args)
+    }
+  }
+}

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -81,7 +81,7 @@ case class ScalaPresentationCompiler(
     sh: Option[ScheduledExecutorService] = None,
     config: PresentationCompilerConfig = PresentationCompilerConfigImpl(),
     workspace: Option[Path] = None
-) extends PresentationCompiler {
+) extends PresentationCompiler with Completions {
 
   def this() = this(Nil, Nil)
 
@@ -124,7 +124,10 @@ case class ScalaPresentationCompiler(
       val pos = sourcePosition(driver, params, uri)
       val items = driver.compilationUnits.get(uri) match {
         case Some(unit) =>
-          Completion.completions(pos)(using ctx.fresh.setCompilationUnit(unit))._2
+          val path = Interactive.pathTo(driver.openedTrees(uri), pos)(using ctx)
+          val completions = Completion.completions(pos)(using ctx.fresh.setCompilationUnit(unit))._2
+          val completions2 = completionPosition(pos, path)(using ctx)
+          completions ++ completions2
         case None => Nil
       }
       new CompletionList(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -126,8 +126,8 @@ case class ScalaPresentationCompiler(
         case Some(unit) =>
           val path = Interactive.pathTo(driver.openedTrees(uri), pos)(using ctx)
           val completions = Completion.completions(pos)(using ctx.fresh.setCompilationUnit(unit))._2
-          val completions2 = completionPosition(pos, path)(using ctx)
-          completions ++ completions2
+          val metalsCompletions = completionPosition(pos, path)(using ctx)
+          completions ++ metalsCompletions
         case None => Nil
       }
       new CompletionList(

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -71,7 +71,8 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       assertSingleItem: Boolean = true,
       filter: String => Boolean = _ => true,
       command: Option[String] = None,
-      compat: Map[String, String] = Map.empty
+      compat: Map[String, String] = Map.empty,
+      assumeCond: Option[Boolean] = None
   )(implicit loc: Location): Unit = {
     val compatTemplate = compat.map { case (key, value) =>
       key -> template.replace("___", value)
@@ -84,7 +85,8 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       assertSingleItem = assertSingleItem,
       filter = filter,
       command = command,
-      compat = compatTemplate
+      compat = compatTemplate,
+      assumeCond = assumeCond
     )
   }
 
@@ -96,9 +98,11 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       assertSingleItem: Boolean = true,
       filter: String => Boolean = _ => true,
       command: Option[String] = None,
-      compat: Map[String, String] = Map.empty
+      compat: Map[String, String] = Map.empty,
+      assumeCond: Option[Boolean] = None
   )(implicit loc: Location): Unit = {
     test(name) {
+      assumeCond.foreach(assume(_))
       val items = getItems(original).filter(item => filter(item.getLabel))
       if (items.isEmpty) fail("obtained empty completions!")
       if (assertSingleItem && items.length != 1) {
@@ -162,9 +166,11 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       includeDetail: Boolean = true,
       filename: String = "A.scala",
       filter: String => Boolean = _ => true,
-      enablePackageWrap: Boolean = true
+      enablePackageWrap: Boolean = true,
+      assumeCond: Option[Boolean] = None
   )(implicit loc: Location): Unit = {
     test(name) {
+      assumeCond.foreach(assume(_))
       val out = new StringBuilder()
       val withPkg =
         if (original.contains("package") || !enablePackageWrap) original

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -71,8 +71,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       assertSingleItem: Boolean = true,
       filter: String => Boolean = _ => true,
       command: Option[String] = None,
-      compat: Map[String, String] = Map.empty,
-      assumeCond: Option[Boolean] = None
+      compat: Map[String, String] = Map.empty
   )(implicit loc: Location): Unit = {
     val compatTemplate = compat.map { case (key, value) =>
       key -> template.replace("___", value)
@@ -85,8 +84,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       assertSingleItem = assertSingleItem,
       filter = filter,
       command = command,
-      compat = compatTemplate,
-      assumeCond = assumeCond
+      compat = compatTemplate
     )
   }
 
@@ -98,11 +96,9 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       assertSingleItem: Boolean = true,
       filter: String => Boolean = _ => true,
       command: Option[String] = None,
-      compat: Map[String, String] = Map.empty,
-      assumeCond: Option[Boolean] = None
+      compat: Map[String, String] = Map.empty
   )(implicit loc: Location): Unit = {
     test(name) {
-      assumeCond.foreach(assume(_))
       val items = getItems(original).filter(item => filter(item.getLabel))
       if (items.isEmpty) fail("obtained empty completions!")
       if (assertSingleItem && items.length != 1) {
@@ -166,11 +162,9 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       includeDetail: Boolean = true,
       filename: String = "A.scala",
       filter: String => Boolean = _ => true,
-      enablePackageWrap: Boolean = true,
-      assumeCond: Option[Boolean] = None
+      enablePackageWrap: Boolean = true
   )(implicit loc: Location): Unit = {
     test(name) {
-      assumeCond.foreach(assume(_))
       val out = new StringBuilder()
       val withPkg =
         if (original.contains("package") || !enablePackageWrap) original

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -25,7 +25,6 @@ import scala.meta.pc.PresentationCompilerConfig
 import coursierapi.Dependency
 import coursierapi.Fetch
 import munit.Tag
-import munit.TestOptions
 import org.eclipse.lsp4j.MarkupContent
 import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
 
@@ -34,17 +33,9 @@ abstract class BasePCSuite extends BaseSuite {
   val executorService: ScheduledExecutorService =
     Executors.newSingleThreadScheduledExecutor()
   val scalaVersion = BuildInfoVersions.scalaVersion
-  val isScala3: Boolean = isScala3Version(scalaVersion)
   protected val index = new DelegatingGlobalSymbolIndex()
   protected val workspace = new TestingWorkspaceSearch
   val tmp: AbsolutePath = AbsolutePath(Files.createTempDirectory("metals"))
-
-  implicit class RichTestOptions(options: TestOptions) {
-    def ignoreIf(skip: Boolean): TestOptions = {
-      if (skip) options.ignore
-      else options
-    }
-  }
 
   /**
    * Note: (ckipp01) Normally this method comes from the `ExludedPackagesHandler`.
@@ -247,7 +238,7 @@ abstract class BasePCSuite extends BaseSuite {
     }
   }
 
-  object IgnoreScala3Version
+  object IgnoreScala3
       extends IgnoreScalaVersion(BuildInfoVersions.scala3Versions.toSet)
 
   case class RunForScalaVersion(versions: Set[String])

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -34,7 +34,7 @@ abstract class BasePCSuite extends BaseSuite {
   val executorService: ScheduledExecutorService =
     Executors.newSingleThreadScheduledExecutor()
   val scalaVersion = BuildInfoVersions.scalaVersion
-  val isScala3 = isScala3Version(scalaVersion)
+  val isScala3: Boolean = isScala3Version(scalaVersion)
   protected val index = new DelegatingGlobalSymbolIndex()
   protected val workspace = new TestingWorkspaceSearch
   val tmp: AbsolutePath = AbsolutePath(Files.createTempDirectory("metals"))

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -247,6 +247,9 @@ abstract class BasePCSuite extends BaseSuite {
     }
   }
 
+  object IgnoreScala3Version
+      extends IgnoreScalaVersion(BuildInfoVersions.scala3Versions.toSet)
+
   case class RunForScalaVersion(versions: Set[String])
       extends Tag("RunScalaVersion")
 

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -25,6 +25,7 @@ import scala.meta.pc.PresentationCompilerConfig
 import coursierapi.Dependency
 import coursierapi.Fetch
 import munit.Tag
+import munit.TestOptions
 import org.eclipse.lsp4j.MarkupContent
 import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
 
@@ -33,9 +34,17 @@ abstract class BasePCSuite extends BaseSuite {
   val executorService: ScheduledExecutorService =
     Executors.newSingleThreadScheduledExecutor()
   val scalaVersion = BuildInfoVersions.scalaVersion
+  val isScala3 = isScala3Version(scalaVersion)
   protected val index = new DelegatingGlobalSymbolIndex()
   protected val workspace = new TestingWorkspaceSearch
   val tmp: AbsolutePath = AbsolutePath(Files.createTempDirectory("metals"))
+
+  implicit class RichTestOptions(options: TestOptions) {
+    def ignoreIf(skip: Boolean): TestOptions = {
+      if (skip) options.ignore
+      else options
+    }
+  }
 
   /**
    * Note: (ckipp01) Normally this method comes from the `ExludedPackagesHandler`.

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -1,12 +1,11 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
-import munit.TestOptions
 
 class CompletionArgSuite extends BaseCompletionSuite {
 
   check(
-    TestOptions("arg").ignoreIf(isScala3),
+    "arg",
     s"""|object Main {
         |  assert(@@)
         |}
@@ -20,7 +19,8 @@ class CompletionArgSuite extends BaseCompletionSuite {
       "3.0" ->
         """|assertion = : Boolean
            |""".stripMargin
-    )
+    ),
+    assumeCond = Some(!isScala3)
   )
 
   check(
@@ -90,7 +90,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   check(
-    TestOptions("arg4").ignoreIf(isScala3),
+    "arg4",
     s"""|
         |$user
         |object Main {
@@ -107,7 +107,8 @@ class CompletionArgSuite extends BaseCompletionSuite {
         """|age = : Int
            |followers = : Int
            |""".stripMargin
-    )
+    ),
+    assumeCond = Some(!isScala3)
   )
 
   check(
@@ -133,7 +134,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   check(
-    TestOptions("arg6").ignoreIf(isScala3),
+    "arg6",
     s"""|
         |$user
         |object Main {
@@ -144,7 +145,8 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |age = : Int
        |followers = : Int
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(3),
+    assumeCond = Some(!isScala3)
   )
 
   check(
@@ -185,7 +187,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   check(
-    TestOptions("arg9").ignoreIf(isScala3),
+    "arg9",
     // `until` has multiple implicit conversion alternatives
     s"""|
         |object Main {
@@ -201,7 +203,8 @@ class CompletionArgSuite extends BaseCompletionSuite {
       "3.0" ->
         """|end = : Int
            |""".stripMargin
-    )
+    ),
+    assumeCond = Some(!isScala3)
   )
 
   check(
@@ -266,7 +269,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   check(
-    TestOptions("priority").ignoreIf(isScala3),
+    "priority",
     s"""|object Main {
         |  def foo(argument : Int) : Int = argument
         |  val argument = 5
@@ -277,11 +280,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |argument = : Int
        |argument = argument : Int
        |""".stripMargin,
-    topLines = Some(3)
+    topLines = Some(3),
+    assumeCond = Some(!isScala3)
   )
 
   check(
-    TestOptions("named-multiple").ignoreIf(isScala3),
+    "named-multiple",
     s"""|object Main {
         |  def foo(argument : Int) : Int = argument
         |  val number = 1
@@ -302,11 +306,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
       "3.0" ->
         """|argument = : Int
            |""".stripMargin
-    )
+    ),
+    assumeCond = Some(!isScala3)
   )
 
   checkEditLine(
-    TestOptions("auto-no-show").ignoreIf(isScala3),
+    "auto-no-show",
     s"""|object Main {
         |  def foo(argument : Int, other : String) : Int = argument
         |  val number = 5
@@ -316,11 +321,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "foo(rele@@)",
-    "foo(relevant)"
+    "foo(relevant)",
+    assumeCond = Some(!isScala3)
   )
 
   checkEditLine(
-    TestOptions("auto").ignoreIf(isScala3),
+    "auto",
     s"""|object Main {
         |  def foo(argument : Int, other : String) : Int = argument
         |  val number = 5
@@ -329,11 +335,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "foo(auto@@)",
-    "foo(argument = ${1:number}, other = ${2:hello})"
+    "foo(argument = ${1:number}, other = ${2:hello})",
+    assumeCond = Some(!isScala3)
   )
 
   checkEditLine(
-    TestOptions("auto-inheritance").ignoreIf(isScala3),
+    "auto-inheritance",
     s"""|object Main {
         |  trait Animal
         |  class Dog extends Animal
@@ -347,11 +354,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "foo(auto@@)",
-    "foo(animal = ${1:dog}, furniture = ${2:chair})"
+    "foo(animal = ${1:dog}, furniture = ${2:chair})",
+    assumeCond = Some(!isScala3)
   )
 
   checkEditLine(
-    TestOptions("auto-multiple-type").ignoreIf(isScala3),
+    "auto-multiple-type",
     s"""|object Main {
         |  def foo(argument : Int, other : String, last : String = "") : Int = argument
         |  val number = 5
@@ -361,11 +369,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "foo(auto@@)",
-    "foo(argument = ${1|???,argument,number|}, other = ${2:hello})"
+    "foo(argument = ${1|???,argument,number|}, other = ${2:hello})",
+    assumeCond = Some(!isScala3)
   )
 
   checkEditLine(
-    TestOptions("auto-not-found").ignoreIf(isScala3),
+    "auto-not-found",
     s"""|object Main {
         |  val number = 234
         |  val nothing = throw new Exception
@@ -375,11 +384,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "foo(auto@@)",
-    "foo(argument = ${1:number}, other = ${2:???}, isTrue = ${3:???}, opt = ${4:???})"
+    "foo(argument = ${1:number}, other = ${2:???}, isTrue = ${3:???}, opt = ${4:???})",
+    assumeCond = Some(!isScala3)
   )
 
   checkEditLine(
-    TestOptions("auto-list").ignoreIf(isScala3),
+    "auto-list",
     s"""|object Main {
         |  def foo(argument : List[String], other : List[Int]) : Int = 0
         |  val list1 = List(1,2,3)
@@ -390,7 +400,8 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "foo(auto@@)",
-    "foo(argument = ${1|???,list4,list3|}, other = ${2|???,list2,list1|})"
+    "foo(argument = ${1|???,list4,list3|}, other = ${2|???,list2,list1|})",
+    assumeCond = Some(!isScala3)
   )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -1,11 +1,12 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
+import munit.TestOptions
 
 class CompletionArgSuite extends BaseCompletionSuite {
 
   check(
-    "arg",
+    TestOptions("arg").ignoreIf(isScala3),
     s"""|object Main {
         |  assert(@@)
         |}
@@ -89,7 +90,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   check(
-    "arg4",
+    TestOptions("arg4").ignoreIf(isScala3),
     s"""|
         |$user
         |object Main {
@@ -132,7 +133,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   check(
-    "arg6",
+    TestOptions("arg6").ignoreIf(isScala3),
     s"""|
         |$user
         |object Main {
@@ -143,14 +144,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |age = : Int
        |followers = : Int
        |""".stripMargin,
-    topLines = Option(3),
-    compat = Map(
-      "3.0" ->
-        """|address = : String
-           |age = : Int
-           |followers = : Int
-           |""".stripMargin
-    )
+    topLines = Option(3)
   )
 
   check(
@@ -191,7 +185,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   check(
-    "arg9",
+    TestOptions("arg9").ignoreIf(isScala3),
     // `until` has multiple implicit conversion alternatives
     s"""|
         |object Main {
@@ -219,12 +213,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|address = : String
        |""".stripMargin,
-    topLines = Option(1),
-    compat = Map(
-      "3.0" ->
-        """|address = : String
-           |""".stripMargin
-    )
+    topLines = Option(1)
   )
 
   check(
@@ -277,7 +266,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   check(
-    "priority",
+    TestOptions("priority").ignoreIf(isScala3),
     s"""|object Main {
         |  def foo(argument : Int) : Int = argument
         |  val argument = 5
@@ -288,17 +277,11 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |argument = : Int
        |argument = argument : Int
        |""".stripMargin,
-    topLines = Some(3),
-    compat = Map(
-      "3.0" -> // sort not yet supported
-        """|argument = : Int
-           |argument: Int
-           |""".stripMargin
-    )
+    topLines = Some(3)
   )
 
   check(
-    "named-multiple",
+    TestOptions("named-multiple").ignoreIf(isScala3),
     s"""|object Main {
         |  def foo(argument : Int) : Int = argument
         |  val number = 1
@@ -323,7 +306,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   checkEditLine(
-    "auto-no-show",
+    TestOptions("auto-no-show").ignoreIf(isScala3),
     s"""|object Main {
         |  def foo(argument : Int, other : String) : Int = argument
         |  val number = 5
@@ -337,7 +320,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   checkEditLine(
-    "auto",
+    TestOptions("auto").ignoreIf(isScala3),
     s"""|object Main {
         |  def foo(argument : Int, other : String) : Int = argument
         |  val number = 5
@@ -350,7 +333,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   checkEditLine(
-    "auto-inheritance",
+    TestOptions("auto-inheritance").ignoreIf(isScala3),
     s"""|object Main {
         |  trait Animal
         |  class Dog extends Animal
@@ -368,7 +351,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   checkEditLine(
-    "auto-multiple-type",
+    TestOptions("auto-multiple-type").ignoreIf(isScala3),
     s"""|object Main {
         |  def foo(argument : Int, other : String, last : String = "") : Int = argument
         |  val number = 5
@@ -382,7 +365,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   checkEditLine(
-    "auto-not-found",
+    TestOptions("auto-not-found").ignoreIf(isScala3),
     s"""|object Main {
         |  val number = 234
         |  val nothing = throw new Exception
@@ -396,7 +379,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   checkEditLine(
-    "auto-list",
+    TestOptions("auto-list").ignoreIf(isScala3),
     s"""|object Main {
         |  def foo(argument : List[String], other : List[Int]) : Int = 0
         |  val list1 = List(1,2,3)

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -1,12 +1,8 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionArgSuite extends BaseCompletionSuite {
-
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
 
   check(
     "arg",
@@ -18,7 +14,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |Main arg
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(3),
+    compat = Map(
+      "3.0" ->
+        """|assertion = : Boolean
+           |""".stripMargin
+    )
   )
 
   check(
@@ -31,7 +32,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |Main arg1
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(3),
+    compat = Map( // findPossibleDefaults and fillAllFields not yet supported
+      "3.0" ->
+        """|message = : => Any
+           |""".stripMargin
+    )
   )
 
   check(
@@ -44,7 +50,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |Main arg2
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(3),
+    compat = Map( // findPossibleDefaults and fillAllFields not yet supported
+      "3.0" ->
+        """|message = : => Any
+           |""".stripMargin
+    )
   )
 
   def user: String =
@@ -68,7 +79,13 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |Main arg3
        |User arg3
        |""".stripMargin,
-    topLines = Option(4)
+    topLines = Option(4),
+    compat = Map( // findPossibleDefaults and fillAllFields not yet supported
+      "3.0" ->
+        """|age = : Int
+           |followers = : Int
+           |""".stripMargin
+    )
   )
 
   check(
@@ -83,7 +100,13 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |followers = : Int
        |Main arg4
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(3),
+    compat = Map(
+      "3.0" ->
+        """|age = : Int
+           |followers = : Int
+           |""".stripMargin
+    )
   )
 
   check(
@@ -99,7 +122,13 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |Main arg5
        |User arg5
        |""".stripMargin,
-    topLines = Option(4)
+    topLines = Option(4),
+    compat = Map(
+      "3.0" ->
+        """|age = : Int
+           |followers = : Int
+           |""".stripMargin
+    )
   )
 
   check(
@@ -114,7 +143,14 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |age = : Int
        |followers = : Int
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(3),
+    compat = Map(
+      "3.0" ->
+        """|address = : String
+           |age = : Int
+           |followers = : Int
+           |""".stripMargin
+    )
   )
 
   check(
@@ -127,7 +163,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
     """|x = : Int
        |Main arg7
        |""".stripMargin,
-    topLines = Option(2)
+    topLines = Option(2),
+    compat = Map(
+      "3.0" ->
+        """|x = : A
+           |""".stripMargin
+    )
   )
 
   check(
@@ -141,7 +182,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |Main arg8
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(3),
+    compat = Map(
+      "3.0" ->
+        """|suffix = : String
+           |""".stripMargin
+    )
   )
 
   check(
@@ -156,7 +202,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |Main arg9
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3)
+    topLines = Option(3),
+    compat = Map(
+      "3.0" ->
+        """|end = : Int
+           |""".stripMargin
+    )
   )
 
   check(
@@ -168,7 +219,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|address = : String
        |""".stripMargin,
-    topLines = Option(1)
+    topLines = Option(1),
+    compat = Map(
+      "3.0" ->
+        """|address = : String
+           |""".stripMargin
+    )
   )
 
   check(
@@ -212,7 +268,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|isResourceFile = : Boolean
        |isResourceFile = isLargeBanana : Boolean
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3.0" ->
+        """|isResourceFile = : Boolean
+           |""".stripMargin
+    )
   )
 
   check(
@@ -227,7 +288,13 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |argument = : Int
        |argument = argument : Int
        |""".stripMargin,
-    topLines = Some(3)
+    topLines = Some(3),
+    compat = Map(
+      "3.0" -> // sort not yet supported
+        """|argument = : Int
+           |argument: Int
+           |""".stripMargin
+    )
   )
 
   check(
@@ -247,7 +314,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |argument = number4 : Int
        |argument = number8 : Int
        |""".stripMargin,
-    topLines = Some(5)
+    topLines = Some(5),
+    compat = Map(
+      "3.0" ->
+        """|argument = : Int
+           |""".stripMargin
+    )
   )
 
   checkEditLine(

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -4,8 +4,12 @@ import tests.BaseCompletionSuite
 
 class CompletionArgSuite extends BaseCompletionSuite {
 
+  // In scala3, we get NoSymbol for `assert`, so we get no completions here.
+  // This might be because the `assert` method has multiple overloaded methods, and that's why we can't retrieve a specfic symbol.
+  // Might be good to fixed in Dotty.
+  // see: https://github.com/scalameta/metals/pull/2369
   check(
-    "arg",
+    "arg".tag(IgnoreScala3Version),
     s"""|object Main {
         |  assert(@@)
         |}
@@ -14,13 +18,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |Main arg
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3),
-    compat = Map(
-      "3.0" ->
-        """|assertion = : Boolean
-           |""".stripMargin
-    ),
-    assumeCond = Some(!isScala3)
+    topLines = Option(3)
   )
 
   check(
@@ -34,7 +32,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |:: scala.collection.immutable
        |""".stripMargin,
     topLines = Option(3),
-    compat = Map( // findPossibleDefaults and fillAllFields not yet supported
+    compat = Map(
       "3.0" ->
         """|message = : => Any
            |""".stripMargin
@@ -52,7 +50,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |:: scala.collection.immutable
        |""".stripMargin,
     topLines = Option(3),
-    compat = Map( // findPossibleDefaults and fillAllFields not yet supported
+    compat = Map(
       "3.0" ->
         """|message = : => Any
            |""".stripMargin
@@ -81,7 +79,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |User arg3
        |""".stripMargin,
     topLines = Option(4),
-    compat = Map( // findPossibleDefaults and fillAllFields not yet supported
+    compat = Map(
       "3.0" ->
         """|age = : Int
            |followers = : Int
@@ -89,8 +87,11 @@ class CompletionArgSuite extends BaseCompletionSuite {
     )
   )
 
+  // We should get NamedArg `address` from args in scala3, and remove `address` from completion, but it doesn't appear.
+  // This might be good to fix in Dotty.
+  // see: https://github.com/scalameta/metals/pull/2369
   check(
-    "arg4",
+    "arg4".tag(IgnoreScala3Version),
     s"""|
         |$user
         |object Main {
@@ -101,14 +102,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |followers = : Int
        |Main arg4
        |""".stripMargin,
-    topLines = Option(3),
-    compat = Map(
-      "3.0" ->
-        """|age = : Int
-           |followers = : Int
-           |""".stripMargin
-    ),
-    assumeCond = Some(!isScala3)
+    topLines = Option(3)
   )
 
   check(
@@ -134,7 +128,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   check(
-    "arg6",
+    "arg6".tag(IgnoreScala3Version),
     s"""|
         |$user
         |object Main {
@@ -145,8 +139,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |age = : Int
        |followers = : Int
        |""".stripMargin,
-    topLines = Option(3),
-    assumeCond = Some(!isScala3)
+    topLines = Option(3)
   )
 
   check(
@@ -186,8 +179,13 @@ class CompletionArgSuite extends BaseCompletionSuite {
     )
   )
 
+  // In scala3, we get NoSymbol for `until`, so we get no completions here.
+  // This might be because the `1.until` method has multiple overloaded methods, like `until(end: Long)` and `until(start: Long, end: Long)`,
+  // and that's why we can't retrieve a specfic symbol.
+  // Might be good to fixed in Dotty.
+  // see: https://github.com/scalameta/metals/pull/2369
   check(
-    "arg9",
+    "arg9".tag(IgnoreScala3Version),
     // `until` has multiple implicit conversion alternatives
     s"""|
         |object Main {
@@ -198,13 +196,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |Main arg9
        |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3),
-    compat = Map(
-      "3.0" ->
-        """|end = : Int
-           |""".stripMargin
-    ),
-    assumeCond = Some(!isScala3)
+    topLines = Option(3)
   )
 
   check(
@@ -281,7 +273,12 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |argument = argument : Int
        |""".stripMargin,
     topLines = Some(3),
-    assumeCond = Some(!isScala3)
+    compat = Map(
+      "3.0" ->
+        """|argument = : Int
+           |argument: Int
+           |""".stripMargin
+    )
   )
 
   check(
@@ -306,12 +303,11 @@ class CompletionArgSuite extends BaseCompletionSuite {
       "3.0" ->
         """|argument = : Int
            |""".stripMargin
-    ),
-    assumeCond = Some(!isScala3)
+    )
   )
 
   checkEditLine(
-    "auto-no-show",
+    "auto-no-show".tag(IgnoreScala3Version),
     s"""|object Main {
         |  def foo(argument : Int, other : String) : Int = argument
         |  val number = 5
@@ -321,12 +317,11 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "foo(rele@@)",
-    "foo(relevant)",
-    assumeCond = Some(!isScala3)
+    "foo(relevant)"
   )
 
   checkEditLine(
-    "auto",
+    "auto".tag(IgnoreScala3Version),
     s"""|object Main {
         |  def foo(argument : Int, other : String) : Int = argument
         |  val number = 5
@@ -335,12 +330,11 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "foo(auto@@)",
-    "foo(argument = ${1:number}, other = ${2:hello})",
-    assumeCond = Some(!isScala3)
+    "foo(argument = ${1:number}, other = ${2:hello})"
   )
 
   checkEditLine(
-    "auto-inheritance",
+    "auto-inheritance".tag(IgnoreScala3Version),
     s"""|object Main {
         |  trait Animal
         |  class Dog extends Animal
@@ -354,12 +348,11 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "foo(auto@@)",
-    "foo(animal = ${1:dog}, furniture = ${2:chair})",
-    assumeCond = Some(!isScala3)
+    "foo(animal = ${1:dog}, furniture = ${2:chair})"
   )
 
   checkEditLine(
-    "auto-multiple-type",
+    "auto-multiple-type".tag(IgnoreScala3Version),
     s"""|object Main {
         |  def foo(argument : Int, other : String, last : String = "") : Int = argument
         |  val number = 5
@@ -369,12 +362,11 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "foo(auto@@)",
-    "foo(argument = ${1|???,argument,number|}, other = ${2:hello})",
-    assumeCond = Some(!isScala3)
+    "foo(argument = ${1|???,argument,number|}, other = ${2:hello})"
   )
 
   checkEditLine(
-    "auto-not-found",
+    "auto-not-found".tag(IgnoreScala3Version),
     s"""|object Main {
         |  val number = 234
         |  val nothing = throw new Exception
@@ -384,12 +376,11 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "foo(auto@@)",
-    "foo(argument = ${1:number}, other = ${2:???}, isTrue = ${3:???}, opt = ${4:???})",
-    assumeCond = Some(!isScala3)
+    "foo(argument = ${1:number}, other = ${2:???}, isTrue = ${3:???}, opt = ${4:???})"
   )
 
   checkEditLine(
-    "auto-list",
+    "auto-list".tag(IgnoreScala3Version),
     s"""|object Main {
         |  def foo(argument : List[String], other : List[Int]) : Int = 0
         |  val list1 = List(1,2,3)
@@ -400,8 +391,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "foo(auto@@)",
-    "foo(argument = ${1|???,list4,list3|}, other = ${2|???,list2,list1|})",
-    assumeCond = Some(!isScala3)
+    "foo(argument = ${1|???,list4,list3|}, other = ${2|???,list2,list1|})"
   )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -9,7 +9,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   // Might be good to fixed in Dotty.
   // see: https://github.com/scalameta/metals/pull/2369
   check(
-    "arg".tag(IgnoreScala3Version),
+    "arg".tag(IgnoreScala3),
     s"""|object Main {
         |  assert(@@)
         |}
@@ -91,7 +91,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   // This might be good to fix in Dotty.
   // see: https://github.com/scalameta/metals/pull/2369
   check(
-    "arg4".tag(IgnoreScala3Version),
+    "arg4".tag(IgnoreScala3),
     s"""|
         |$user
         |object Main {
@@ -128,7 +128,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   check(
-    "arg6".tag(IgnoreScala3Version),
+    "arg6".tag(IgnoreScala3),
     s"""|
         |$user
         |object Main {
@@ -185,7 +185,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   // Might be good to fixed in Dotty.
   // see: https://github.com/scalameta/metals/pull/2369
   check(
-    "arg9".tag(IgnoreScala3Version),
+    "arg9".tag(IgnoreScala3),
     // `until` has multiple implicit conversion alternatives
     s"""|
         |object Main {
@@ -307,7 +307,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   checkEditLine(
-    "auto-no-show".tag(IgnoreScala3Version),
+    "auto-no-show".tag(IgnoreScala3),
     s"""|object Main {
         |  def foo(argument : Int, other : String) : Int = argument
         |  val number = 5
@@ -321,7 +321,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   checkEditLine(
-    "auto".tag(IgnoreScala3Version),
+    "auto".tag(IgnoreScala3),
     s"""|object Main {
         |  def foo(argument : Int, other : String) : Int = argument
         |  val number = 5
@@ -334,7 +334,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   checkEditLine(
-    "auto-inheritance".tag(IgnoreScala3Version),
+    "auto-inheritance".tag(IgnoreScala3),
     s"""|object Main {
         |  trait Animal
         |  class Dog extends Animal
@@ -352,7 +352,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   checkEditLine(
-    "auto-multiple-type".tag(IgnoreScala3Version),
+    "auto-multiple-type".tag(IgnoreScala3),
     s"""|object Main {
         |  def foo(argument : Int, other : String, last : String = "") : Int = argument
         |  val number = 5
@@ -366,7 +366,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   checkEditLine(
-    "auto-not-found".tag(IgnoreScala3Version),
+    "auto-not-found".tag(IgnoreScala3),
     s"""|object Main {
         |  val number = 234
         |  val nothing = throw new Exception
@@ -380,7 +380,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   checkEditLine(
-    "auto-list".tag(IgnoreScala3Version),
+    "auto-list".tag(IgnoreScala3),
     s"""|object Main {
         |  def foo(argument : List[String], other : List[Int]) : Int = 0
         |  val list1 = List(1,2,3)

--- a/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
@@ -50,7 +50,7 @@ class CompletionBacktickSuite extends BaseCompletionSuite {
   )
 
   check(
-    munit.TestOptions("named-arg").ignoreIf(isScala3),
+    "named-arg",
     """|object Main {
        |  def foo(`type`: Int) = 42
        |  foo(type@@)
@@ -61,7 +61,8 @@ class CompletionBacktickSuite extends BaseCompletionSuite {
     filterText = "type",
     compat = Map(
       "3.0" -> ""
-    )
+    ),
+    assumeCond = Some(!isScala3)
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
@@ -50,7 +50,7 @@ class CompletionBacktickSuite extends BaseCompletionSuite {
   )
 
   check(
-    "named-arg",
+    "named-arg".tag(IgnoreScala3Version),
     """|object Main {
        |  def foo(`type`: Int) = 42
        |  foo(type@@)
@@ -61,8 +61,7 @@ class CompletionBacktickSuite extends BaseCompletionSuite {
     filterText = "type",
     compat = Map(
       "3.0" -> ""
-    ),
-    assumeCond = Some(!isScala3)
+    )
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
@@ -50,7 +50,7 @@ class CompletionBacktickSuite extends BaseCompletionSuite {
   )
 
   check(
-    "named-arg",
+    munit.TestOptions("named-arg").ignoreIf(isScala3),
     """|object Main {
        |  def foo(`type`: Int) = 42
        |  foo(type@@)

--- a/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
@@ -50,7 +50,7 @@ class CompletionBacktickSuite extends BaseCompletionSuite {
   )
 
   check(
-    "named-arg".tag(IgnoreScala3Version),
+    "named-arg".tag(IgnoreScala3),
     """|object Main {
        |  def foo(`type`: Int) = 42
        |  foo(type@@)


### PR DESCRIPTION
Related https://github.com/scalameta/metals-feature-requests/issues/112

Though there're still some things to do, I'm submitting a draft PR because I want to ask for advice around the failing tests :pray:, or want to at least have this as a reference implementation for people who want to implement arg completion in the future.

![scala3-arg-minimum](https://user-images.githubusercontent.com/9353584/103643155-8c73fe00-4f97-11eb-9cd0-57ddda7e7662.gif)

I think it's ideal to fix all tests implemented in `cross`, but it might be ok to ship it because it's better than nothing 😅

---

## Some test cases that are failing
### arg / arg9
```scala
object Main {
  1.until(@@)
}
```

We get empty completion because `methodSym` in `ArgCompletion` always `NoSymbol`.
I guess this is because `assert(@@)` and `1.until(@@)` have multiple overloaded methods like `until(end: Long)` and `until(start: Long, end: Long)`, and that's why we can't retrieve a specific symbol.

```scala
val method = apply.fun
val methodSym = method.symbol
```

It looks like scala2 implementation somehow deals with this case (as `arg9`), but I have no idea how to deal with it in scala3 🤔 
(How to retrieve at least one possible symbol for the method).

### arg4
```scala
case class User(
    name: String = "John",
    age: Int = 42,
    address: String = "",
    followers: Int = 0
)
object Main {
  User("", @@, address = "")
}
```

- in scala2 implementation, the completion suggests `age` and `followers`
- in this impl, `age`, `address`, and `followers`
  - because `args` in ArgCompletion is `List(Literal(Constant("")), Select(Ident(User),$lessinit$greater$default$3), Select(Ident(User),$lessinit$greater$default$4))`, and the nemed arg `address` looks disappeared 🤔 :

### arg6
```scala
case class User(
    name: String = "John",
    age: Int = 42,
    address: String = "",
    followers: Int = 0
)
object Main {
  User("", @@ "")
}
```

- in scala2 implementation, the completion suggests `age`, `followers`, and `followers`
- in this impl `address` and `followers`
  - because `args` in ArgCompletion is `List(Literal(Constant("")), Literal(Constant("")), Select(Ident(User),$lessinit$greater$default$3), Select(Ident(User),$lessinit$greater$default$4))` and the second argument is still there, that's why `name` and `age` are dealed with as filled args.

## Things we're missing that implemented for scala2 (not to do in this PR)
- filtering and sorting completions
- `findPossibleDefaults` from scope
- `fillAllFields`



