### PR TITLE
Add documentation for online IDEs

### DIFF
--- a/docs/editors/online-ides.md
+++ b/docs/editors/online-ides.md
@@ -1,0 +1,39 @@
+---
+id: online-ides
+title: Online IDEs
+---
+
+# Gitpod
+Aside from locally installed editors, Metals can be used in online development environments. One of them is Gitpod, 
+in which you can create the code editor setup that can be used directly in your browser 
+as well as shared with others without a need to explicitly set up the tools and settings required
+to run Scala project with Metals. We are going to provide the example setup for Metals with such an environment based on
+the Gitpod platform. You can read more about Gitpod [here](https://www.gitpod.io/docs/).
+
+## Example Gitpod repository for Metals
+The repository which is already set up and integrated with Gitpod can be found 
+[here](https://github.com/scalameta/metals-gitpod-sample). The project contains, out of the box,
+everything that you need to start experimenting with Metals in an online environment similar to Visual Studio Code. 
+The only thing that you need to do to set up the environment by yourself is to open the
+[link](https://gitpod.io/#https://github.com/scalameta/gitpod-sample) provided in the README of the project.
+The import prompt for Metals will show up (however, in general, it wouldn't be needed if the *.bloop* files existed).
+
+The moment that the import is completed, you will be able to run the code in *Main.scala* and tests in *SampleTest.scala*
+(using code lenses). You can also execute code using *Worksheet.worksheet.sc*.
+
+If you want to set up your own Gitpod project that already comes with all the necessary tools
+to run the Scala project with Metals, you can clone and customize this repository.
+
+Gitpod environment can be set up from scratch with the [setup assistant](https://www.gitpod.io/docs/configuration/).
+It helps you to create scripts that are then used by Gitpod to make fresh instances of the environment. These scripts are
+for example: 
+- **prebuild** that can be used to set up the environment on commit push even before opening it 
+- **init** invoked when the workspace is opened for the first time
+- **command** run every time when the workspace is run again after being stopped  
+
+The Gitpod configuration is located under *.gitpod.yml*. The minimal Gitpod setup requires in our case Scala and Metals 
+extensions to be provided which is already done in the example project.    
+
+## Open VSX
+Metals extension is available in the [Open VSX Registry](https://open-vsx.org/) which is used to provide extensions in Gitpod.  
+You can find the newest version of Metals in there.

--- a/docs/editors/online-ides.md
+++ b/docs/editors/online-ides.md
@@ -3,37 +3,67 @@ id: online-ides
 title: Online IDEs
 ---
 
+Metals can also be installed in some online environments, which enable users to
+work on their code inside of a browser. This can be a good option when users need
+to set up their workspace quickly or are lacking appropriate resources on their
+local machine.
+
 # Gitpod
-Aside from locally installed editors, Metals can be used in online development environments. One of them is Gitpod, 
-in which you can create the code editor setup that can be used directly in your browser 
-as well as shared with others without a need to explicitly set up the tools and settings required
-to run Scala project with Metals. We are going to provide the example setup for Metals with such an environment based on
-the Gitpod platform. You can read more about Gitpod [here](https://www.gitpod.io/docs/).
+
+One of such online environments is Gitpod, which can be used directly in your
+browser as well as shared with others without the need to explicitly set up the
+tools and settings needed to run Scala project with Metals. You can read more
+about Gitpod [here](https://www.gitpod.io/docs/).
+
+![example](https://imgur.com/2AiIN43.gif)
 
 ## Example Gitpod repository for Metals
-The repository which is already set up and integrated with Gitpod can be found 
-[here](https://github.com/scalameta/metals-gitpod-sample). The project contains, out of the box,
-everything that you need to start experimenting with Metals in an online environment similar to Visual Studio Code. 
-The only thing that you need to do to set up the environment by yourself is to open the
-[link](https://gitpod.io/#https://github.com/scalameta/gitpod-sample) provided in the README of the project.
-The import prompt for Metals will show up (however, in general, it wouldn't be needed if the *.bloop* files existed).
 
-The moment that the import is completed, you will be able to run the code in *Main.scala* and tests in *SampleTest.scala*
-(using code lenses). You can also execute code using *Worksheet.worksheet.sc*.
+An example repository, which is already set up and integrated with Gitpod, can
+be found [here](https://github.com/scalameta/metals-gitpod-sample). The project
+contains, out of the box, everything that you need to start experimenting with
+Metals in an online environment similar to Visual Studio Code. The only thing
+that you need to do to set up the environment by yourself is to open the
+[link](https://gitpod.io/#https://github.com/scalameta/gitpod-sample) provided
+in the README of the project. The import prompt for Metals will show up,
+however, in this case, _.bloop_ files normally generated during import were
+created in the gitpod init script, so import will not be needed.
 
-If you want to set up your own Gitpod project that already comes with all the necessary tools
-to run the Scala project with Metals, you can clone and customize this repository.
+The moment that the import is completed, you will be able to run the code in
+_Main.scala_ and tests in _SampleTest.scala_ (using code lenses). You can also
+execute code using _Worksheet.worksheet.sc_.
 
-Gitpod environment can be set up from scratch with the [setup assistant](https://www.gitpod.io/docs/configuration/).
-It helps you to create scripts that are then used by Gitpod to make fresh instances of the environment. These scripts are
-for example: 
-- **prebuild** that can be used to set up the environment on commit push even before opening it 
+If you want to set up your own Gitpod project that already comes with all the
+necessary tools to run the Scala project with Metals, you can fork and customize
+this repository.
+
+Gitpod environment can be set up from scratch with the
+[setup assistant](https://www.gitpod.io/docs/configuration/). It helps you to
+create scripts that are then used by Gitpod to make fresh instances of the
+environment. These scripts are for example:
+
+- **prebuild** that can be used to set up the environment on commit push even
+  before opening it
 - **init** invoked when the workspace is opened for the first time
-- **command** run every time when the workspace is run again after being stopped  
+- **command** run every time when the workspace is run again after being stopped
 
-The Gitpod configuration is located under *.gitpod.yml*. The minimal Gitpod setup requires in our case Scala and Metals 
-extensions to be provided which is already done in the example project.    
+The Gitpod configuration is located under _.gitpod.yml_. The minimal Gitpod
+setup requires in our case Scala and Metals extensions to be provided which is
+already done in the example project.
+
+Gitpod itself is based on the [Eclipse Theia project](https://theia-ide.org/),
+an editor which can be easily customized according to your needs and is backed
+by the [Eclipse Foundation](https://www.eclipse.org/org/foundation/). The Metals
+plugin will also work in an environment created within
+[Eclipse Che](https://www.eclipse.org/che/), which is a complementary project to
+Theia that helps companies and users create their own online workspace
+infrastructure. These topics should be especially interesting for larger
+companies that might want to increase their productivity by improving their
+developers' experience. With some additional setup it's possible using those
+tools to have a zero startup environments.
 
 ## Open VSX
-Metals extension is available in the [Open VSX Registry](https://open-vsx.org/) which is used to provide extensions in Gitpod.  
+
+Metals extension is available in the [Open VSX Registry](https://open-vsx.org/)
+which is used to provide extensions in Gitpod.  
 You can find the newest version of Metals in there.

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -17,15 +17,9 @@
       "build-tools/mill": {
         "title": "Mill"
       },
-      "build-tools/new-build-tool": {
-        "title": "Integrating a new build tool"
-      },
       "build-tools/overview": {
         "title": "Build Tools Overview",
         "sidebar_label": "Overview"
-      },
-      "build-tools/proxy": {
-        "title": "Proxy and mirrors"
       },
       "build-tools/sbt": {
         "title": "sbt"
@@ -39,22 +33,11 @@
       "contributors/releasing": {
         "title": "Making a release"
       },
-      "contributors/remote-language-server": {
-        "title": "Remote Language Servers"
-      },
       "contributors/tests": {
         "title": "Tests overview"
       },
       "contributors/updating-website": {
         "title": "Contributing to the website"
-      },
-      "editors/debug-adapter-protocol": {
-        "title": "Debug Adapter Protocol",
-        "sidebar_label": "Debug Adapter Protocol"
-      },
-      "editors/decoration-protocol": {
-        "title": "Decoration Protocol v0.2.0",
-        "sidebar_label": "Decoration Protocol"
       },
       "editors/eclipse": {
         "title": "Eclipse"
@@ -62,8 +45,8 @@
       "editors/emacs": {
         "title": "Emacs"
       },
-      "editors/new-editor": {
-        "title": "Integrating a new editor"
+      "editors/online-ides": {
+        "title": "Online IDEs"
       },
       "editors/overview": {
         "title": "Text Editors",
@@ -71,9 +54,6 @@
       },
       "editors/sublime": {
         "title": "Sublime Text"
-      },
-      "editors/tree-view-protocol": {
-        "title": "Tree View Protocol"
       },
       "editors/vim": {
         "title": "Vim"
@@ -99,17 +79,6 @@
         "title": "Remote Language Servers"
       },
       "integrations/tree-view-protocol": {
-        "title": "Tree View Protocol"
-      },
-      "lsp-extensions/debug-adapter-protocol": {
-        "title": "Debug Adapter Protocol",
-        "sidebar_label": "Debug Adapter Protocol"
-      },
-      "lsp-extensions/decoration-protocol": {
-        "title": "Decoration Protocol v0.2.0",
-        "sidebar_label": "Decoration Protocol"
-      },
-      "lsp-extensions/tree-view-protocol": {
         "title": "Tree View Protocol"
       },
       "troubleshooting/faq": {

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -31,28 +31,63 @@ class Button extends React.Component {
 
 class Dropdown extends React.Component {
   render() {
-    const gitpod = template => `https://gitpod.io/#template=${template}/https://github.com/MichalBednarz/gitpod-g8`
+    const gitpod = (template, organization) =>
+      `https://gitpod.io/#template=${template},organization=${organization}/https://github.com/scalameta/gitpod-g8`;
 
     const links = [
-      { template: "scala-seed", label: "Scala Seed"}, 
-      { template: "hello-world", label: "Hello World"}, 
-      { template: "scalatest-example", label: "Scalatest Example"}
-    ].map(({ template, label }) => <a target="_blank" rel="noopener noreferrer" href={gitpod(template)}>{label}</a>)
-    
-    return (
-      <div class="dropdown">
-        <Button>GITPOD EXAMPLES</Button>
-        <div class="dropdown-content">{links}</div>
-      </div>       
-    )
+      { organization: "scala", template: "hello-world", label: "Hello World!" },
+      { organization: "scala", template: "scala3", label: "Scala 3" },
+      {
+        organization: "scala",
+        template: "scalatest-example",
+        label: "Scalatest",
+      },
+      {
+        organization: "akka",
+        template: "akka-scala-seed",
+        label: "Akka",
+      },
+      {
+        organization: "zio",
+        template: "zio-project-seed",
+        label: "ZIO",
+      },
+      {
+        organization: "playframework",
+        template: "play-scala-seed",
+        label: "Play Framework",
+      },
+      {
+        organization: "scala-native",
+        template: "scala-native",
+        label: "Scala Native",
+      },
+    ].map(({ organization, template, label }) => (
+      <a
+        target="_blank"
+        rel="noopener noreferrer"
+        href={gitpod(template, organization)}
+      >
+        {label}
+      </a>
+    ));
+
+    if (this.props.show)
+      return (
+        <div className="dropdown">
+          <Button>TRY ONLINE WITH GITPOD</Button>
+          <div className="dropdown-content">{links}</div>
+        </div>
+      );
+    else return <div />;
   }
 }
 
 Button.defaultProps = {
-  target: "_self"
+  target: "_self",
 };
 
-const SplashContainer = props => (
+const SplashContainer = (props) => (
   <div className="homeContainer">
     <div className="homeSplashFade">
       <div className="wrapper homeWrapper">{props.children}</div>
@@ -60,14 +95,14 @@ const SplashContainer = props => (
   </div>
 );
 
-const ProjectTitle = props => (
+const ProjectTitle = (props) => (
   <h2 className="projectTitle">
     {siteConfig.title}
     <small>{siteConfig.tagline}</small>
   </h2>
 );
 
-const PromoSection = props => (
+const PromoSection = (props) => (
   <div className="section promoSection">
     <div className="promoRow">
       <div className="pluginRowBlock">{props.children}</div>
@@ -86,7 +121,7 @@ class HomeSplash extends React.Component {
             <Button href={docUrl("editors/overview.html", language)}>
               Get Started
             </Button>
-            <Dropdown/>
+            <Dropdown show="true" />
           </PromoSection>
         </div>
       </SplashContainer>
@@ -94,38 +129,31 @@ class HomeSplash extends React.Component {
   }
 }
 
-const Block = props => (
+const Block = (props) => (
   <Container
     padding={["bottom", "top"]}
     id={props.id}
     background={props.background}
   >
     <GridBlock align="left" contents={props.children} layout={props.layout} />
+    <Dropdown show={props.showDropdown} />
   </Container>
 );
 
-const Features = props => {
+const Features = (props) => {
   const features = [
-    {
-      title: "Try it out in an online IDE",
-      content: 
-        `With Gitpod online IDE, you can try out Metals with just one click. 
-         In the Gitpod Examples dropdown above, select Scala repository template that you want to set up.`,
-      image: "https://imgur.com/LmJRqVs.gif",
-      imageAlign: "right",
-    },
     {
       title: "Simple installation",
       content: "Open a directory, import your build and start coding.",
       image: "https://i.imgur.com/L5CurFG.png",
-      imageAlign: "left"
+      imageAlign: "left",
     },
     {
       title: "Accurate diagnostics",
       content:
         "Compile on file save and see errors from the build tool directly inside the editor. No more switching focus to the console.",
       image: "https://i.imgur.com/JYLQGrc.gif",
-      imageAlign: "right"
+      imageAlign: "right",
     },
     {
       title: "Rich build tool support",
@@ -134,14 +162,14 @@ const Features = props => {
         `Hot incremental compilation in the Bloop build server ensures compile errors appear as quickly as possible.`,
       image:
         "https://user-images.githubusercontent.com/1408093/68486864-dd9f2b00-01f6-11ea-9291-d3a7ce6ef225.png",
-      imageAlign: "left"
+      imageAlign: "left",
     },
     {
       title: "Goto definition",
       content:
         "Jump to symbol definitions in your project sources and Scala/Java library dependencies.",
       image: "https://i.imgur.com/bCIhFof.gif",
-      imageAlign: "right"
+      imageAlign: "right",
     },
     {
       title: "Completions",
@@ -149,42 +177,54 @@ const Features = props => {
         "Explore new library APIs, implement interfaces, generate exhaustive matches and more.",
       image:
         "https://user-images.githubusercontent.com/1408093/56036958-725bac00-5d2e-11e9-9cf7-46249125494a.gif",
-      imageAlign: "left"
+      imageAlign: "left",
     },
     {
       title: "Hover (aka. type at point)",
       content: "See the expression type and symbol signature under the cursor.",
       image: "https://i.imgur.com/2MfQvsM.gif",
-      imageAlign: "right"
+      imageAlign: "right",
     },
     {
       title: "Signature help (aka. parameter hints)",
       content:
         "View a method signature and method overloads as you fill in the arguments.",
       image: "https://i.imgur.com/DAWIrHu.gif",
-      imageAlign: "left"
+      imageAlign: "left",
     },
     {
       title: "Find symbol references",
       content: "Find all usages of a symbol in the workspace.",
       image:
         "https://user-images.githubusercontent.com/1408093/51089190-75fc8880-1769-11e9-819c-95262205e95c.png",
-      imageAlign: "right"
+      imageAlign: "right",
     },
     {
       title: "Fuzzy symbol search",
       content: "Search for symbols in the workspace or library dependencies.",
       image: "https://i.imgur.com/w5yrK1w.gif",
-      imageAlign: "left"
-    }
+      imageAlign: "left",
+    },
+    {
+      title: "Try it out in an online IDE",
+      content: `With Gitpod online IDE, you can try out Metals with just one click. 
+         In the Gitpod Examples dropdown above, select Scala repository template that you want to set up.`,
+      image: "https://imgur.com/2AiIN43.gif",
+      imageAlign: "right",
+      showDropdown: "true",
+    },
   ];
   return (
     <div
       className="productShowcaseSection paddingBottom"
       style={{ textAlign: "left" }}
     >
-      {features.map(feature => (
-        <Block key={feature.title}>{[feature]}</Block>
+      {features.map((feature) => (
+        <div>
+          <Block key={feature.title} showDropdown={feature.showDropdown}>
+            {[feature]}
+          </Block>
+        </div>
       ))}
     </div>
   );

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -29,6 +29,25 @@ class Button extends React.Component {
   }
 }
 
+class Dropdown extends React.Component {
+  render() {
+    const gitpod = template => `https://gitpod.io/#template=${template}/https://github.com/MichalBednarz/gitpod-g8`
+
+    const links = [
+      { template: "scala-seed", label: "Scala Seed"}, 
+      { template: "hello-world", label: "Hello World"}, 
+      { template: "scalatest-example", label: "Scalatest Example"}
+    ].map(({ template, label }) => <a target="_blank" rel="noopener noreferrer" href={gitpod(template)}>{label}</a>)
+    
+    return (
+      <div class="dropdown">
+        <Button>GITPOD EXAMPLES</Button>
+        <div class="dropdown-content">{links}</div>
+      </div>       
+    )
+  }
+}
+
 Button.defaultProps = {
   target: "_self"
 };
@@ -67,6 +86,7 @@ class HomeSplash extends React.Component {
             <Button href={docUrl("editors/overview.html", language)}>
               Get Started
             </Button>
+            <Dropdown/>
           </PromoSection>
         </div>
       </SplashContainer>
@@ -86,6 +106,14 @@ const Block = props => (
 
 const Features = props => {
   const features = [
+    {
+      title: "Try it out in an online IDE",
+      content: 
+        `With Gitpod online IDE, you can try out Metals with just one click. 
+         In the Gitpod Examples dropdown above, select Scala repository template that you want to set up.`,
+      image: "https://imgur.com/LmJRqVs.gif",
+      imageAlign: "right",
+    },
     {
       title: "Simple installation",
       content: "Open a directory, import your build and start coding.",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -6,7 +6,8 @@
       "editors/vim",
       "editors/sublime",
       "editors/emacs",
-      "editors/eclipse"
+      "editors/eclipse",
+      "editors/online-ides"
     ],
     "Build Tools": [
       "build-tools/overview",

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -2,6 +2,7 @@
   .dropdown {
     position: relative;
     display: inline-block;
+    color: #087E8B;
   }
   
   /* Dropdown Content (Hidden by Default) */
@@ -16,7 +17,7 @@
   
   /* Links inside the dropdown */
   .dropdown-content a {
-    color: black;
+    color: #087E8B;
     padding: 10px 10px;
     text-decoration: none;
     display: block;

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,0 +1,33 @@
+  /* The container <div> - needed to position the dropdown content */
+  .dropdown {
+    position: relative;
+    display: inline-block;
+  }
+  
+  /* Dropdown Content (Hidden by Default) */
+  .dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #f1f1f1;
+    min-width: 160px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+  }
+  
+  /* Links inside the dropdown */
+  .dropdown-content a {
+    color: black;
+    padding: 10px 10px;
+    text-decoration: none;
+    display: block;
+    font-size: 14px;
+  }
+  
+  /* Change color of dropdown links on hover */
+  .dropdown-content a:hover {background-color: #ddd;}
+  
+  /* Show the dropdown menu on hover */
+  .dropdown:hover .dropdown-content {display: block;}
+  
+  /* Change the background color of the dropdown button when the dropdown content is shown */
+  .dropdown:hover .dropbtn {background-color: #3e8e41;} 


### PR DESCRIPTION
Update(@tgodzik)

This adds the additional `online-ides` page together with an ability to run a custom workspace from the start page.

![demo](https://user-images.githubusercontent.com/3807253/112299849-83dabc00-8c98-11eb-8c40-1e6ed566979b.gif)
