### PR TITLE
Make sure that worksheet decorations are shown again when the focused

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -932,6 +932,7 @@ class MetalsLanguageServer(
       CompletableFuture.completedFuture(DidFocusResult.RecentlyActive)
     } else {
       syntheticsDecorator.publishSynthetics(path)
+      worksheetProvider.onDidFocus(path)
       buildTargets.inverseSources(path) match {
         case Some(target) =>
           val isAffectedByCurrentCompilation =

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -110,6 +110,17 @@ class WorksheetProvider(
     reset()
   }
 
+  def onDidFocus(path: AbsolutePath): Future[Unit] = Future {
+    if (path.isWorksheet) {
+      val input = path.toInputFromBuffers(buffers)
+      exportableEvaluations.get(input) match {
+        case Some(evaluatedWorksheet) =>
+          publisher.publish(languageClient, path, evaluatedWorksheet)
+        case None =>
+      }
+    }
+  }
+
   def evaluateAndPublish(
       path: AbsolutePath,
       token: CancelToken


### PR DESCRIPTION
Previously, if the user switched an editor window the worksheet decorations would disappear and even when they went back, it would not appear until another evaluation was triggered. Now, it will just republish existing evalautions.