### PR TITLE
Add support for Scala 2.12.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -186,7 +186,7 @@ lazy val V = new {
   val sbtScala = "2.12.10"
   val scala212 = "2.12.12"
   val scala213 = "2.13.4"
-  val scalameta = "4.4.4"
+  val scalameta = "4.4.6"
   val semanticdb = scalameta
   val bsp = "2.0.0-M13"
   val bloop = "1.4.6-21-464e4ec4"
@@ -198,7 +198,7 @@ lazy val V = new {
   val mdoc = "2.2.14"
   val scalafmt = "2.7.4"
   val munit = "0.7.20"
-  val scalafix = "0.9.24"
+  val scalafix = "0.9.25"
   val lsp4jV = "0.10.0"
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.
@@ -213,7 +213,7 @@ lazy val V = new {
   def deprecatedScala2Versions =
     Seq(scala211, "2.12.8", "2.12.9", "2.13.0", "2.13.1")
   def nonDeprecatedScala2Versions =
-    Seq(scala213, scala212, "2.12.11", "2.12.10", "2.13.2", "2.13.3")
+    Seq(scala213, scala212, "2.12.13", "2.12.11", "2.12.10", "2.13.2", "2.13.3")
   def scala2Versions = nonDeprecatedScala2Versions ++ deprecatedScala2Versions
 
   // Scala 3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.0")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.24")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.25")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.5")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.14")
 addSbtPlugin("org.scalameta" % "sbt-munit" % "0.7.20")

--- a/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
@@ -580,12 +580,12 @@ class SbtBloopLspSuite
       _ <- server.didOpen("project/MetaValues.scala")
       _ = assertNoDiff(
         server.workspaceDefinitions,
-        """|/project/MetaValues.scala
-           |import scala.util.Success/*Try.scala*/
-           |object MetaValues/*L1*/ {
-           |  val scalaVersion/*L2*/ = "2.12.12"
-           |}
-           |""".stripMargin
+        s"""|/project/MetaValues.scala
+            |import scala.util.Success/*Try.scala*/
+            |object MetaValues/*L1*/ {
+            |  val scalaVersion/*L2*/ = "$scalaVersion"
+            |}
+            |""".stripMargin
       )
     } yield ()
 

--- a/tests/unit/src/main/scala/tests/QuickBuild.scala
+++ b/tests/unit/src/main/scala/tests/QuickBuild.scala
@@ -25,6 +25,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import coursierapi.Dependency
 import coursierapi.Fetch
+import coursierapi.MavenRepository
 import coursierapi.Repository
 
 /**
@@ -304,7 +305,13 @@ object QuickBuild {
 
     val repositories =
       Repository.defaults().asScala ++
-        List(Repository.central(), Repository.ivy2Local())
+        List(
+          Repository.central(),
+          Repository.ivy2Local(),
+          MavenRepository.of(
+            "https://oss.sonatype.org/content/repositories/public"
+          )
+        )
 
     Fetch
       .create()


### PR DESCRIPTION
Running it for now with a SNAPSHOT to make sure it makes sense to release a new semanticdb version.