### PR TITLE
Avoid NPE when there is no `rootUri`.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -39,7 +39,6 @@ final class FormattingProvider(
     clientConfig: ClientConfiguration,
     statusBar: StatusBar,
     icons: Icons,
-    workspaceFolders: List[AbsolutePath],
     tables: Tables
 )(implicit ec: ExecutionContext)
     extends Cancelable {

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -18,6 +18,12 @@ import org.eclipse.lsp4j.ShowMessageRequestParams
  */
 object Messages {
 
+  val noRoot = new MessageParams(
+    MessageType.Error,
+    """|No rootUri or rootPath detected.
+       |Metals will not function correctly without either of these set since a workspace is needed.
+       |Try opening your project at the workspace root.""".stripMargin
+  )
   object Worksheets {
     def unsupportedScalaVersion(
         unsupportedVersion: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -426,12 +426,6 @@ class MetalsLanguageServer(
       clientConfig,
       statusBar,
       clientConfig.icons,
-      Option(params.getWorkspaceFolders) match {
-        case Some(folders) =>
-          folders.asScala.map(_.getUri.toAbsolutePath).toList
-        case _ =>
-          Nil
-      },
       tables
     )
     newFileProvider = new NewFileProvider(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -273,384 +273,397 @@ class MetalsLanguageServer(
   }
 
   private def updateWorkspaceDirectory(params: InitializeParams): Unit = {
-    workspace = AbsolutePath(Paths.get(URI.create(params.getRootUri))).dealias
-    MetalsLogger.setupLspLogger(workspace, redirectSystemOut)
-    val clientInfo = MetalsServerConfig.metalsClientType match {
-      case Some(clientType) => s"for client ${clientType}"
-      case None => ""
-    }
-    scribe.info(
-      s"Started: Metals version ${BuildInfo.metalsVersion} in workspace '$workspace' $clientInfo."
-    )
 
-    clientConfig.experimentalCapabilities =
-      ClientExperimentalCapabilities.from(params.getCapabilities)
-    clientConfig.initializationOptions = InitializationOptions.from(params)
+    // NOTE: we purposefully don't check workspaceFolders here
+    // since Metals technically doesn't support it. Once we implement
+    // https://github.com/scalameta/metals-feature-requests/issues/87 we'll
+    // have to change this.
+    val root =
+      Option(params.getRootUri()).orElse(Option(params.getRootPath()))
 
-    buildTargets.setWorkspaceDirectory(workspace)
-    tables = register(new Tables(workspace, time, clientConfig))
-    buildTargets.setTables(tables)
-    workspaceReload = new WorkspaceReload(
-      workspace,
-      languageClient,
-      tables
-    )
-    buildTools = new BuildTools(
-      workspace,
-      bspGlobalDirectories,
-      () => userConfig
-    )
-    fileSystemSemanticdbs = new FileSystemSemanticdbs(
-      buildTargets,
-      charset,
-      workspace,
-      fingerprints
-    )
-    interactiveSemanticdbs = register(
-      new InteractiveSemanticdbs(
-        workspace,
-        buildTargets,
-        charset,
-        languageClient,
-        tables,
-        statusBar,
-        () => compilers,
-        clientConfig
-      )
-    )
-    warnings = new Warnings(
-      workspace,
-      buildTargets,
-      statusBar,
-      clientConfig.icons,
-      buildTools,
-      compilations.isCurrentlyCompiling
-    )
-    diagnostics = new Diagnostics(
-      buildTargets,
-      buffers,
-      languageClient,
-      clientConfig.initialConfig.statistics,
-      () => userConfig
-    )
-    buildClient = new ForwardingMetalsBuildClient(
-      languageClient,
-      diagnostics,
-      buildTargets,
-      buildTargetClasses,
-      clientConfig,
-      statusBar,
-      time,
-      report => {
-        didCompileTarget(report)
-        compilers.didCompile(report)
-      },
-      () => treeView,
-      () => worksheetProvider,
-      () => ammonite
-    )
-    shellRunner = register(
-      new ShellRunner(languageClient, () => userConfig, time, statusBar)
-    )
-    bloopInstall = new BloopInstall(
-      workspace,
-      languageClient,
-      buildTools,
-      tables,
-      shellRunner
-    )
-    bspConfigGenerator = new BspConfigGenerator(
-      workspace,
-      languageClient,
-      buildTools,
-      shellRunner
-    )
-    newProjectProvider = new NewProjectProvider(
-      languageClient,
-      statusBar,
-      clientConfig,
-      shellRunner,
-      clientConfig.icons,
-      workspace
-    )
-    bloopServers = new BloopServers(
-      workspace,
-      buildClient,
-      languageClient,
-      tables,
-      clientConfig.initialConfig
-    )
-    bspServers = new BspServers(
-      workspace,
-      charset,
-      languageClient,
-      buildClient,
-      tables,
-      bspGlobalDirectories,
-      clientConfig.initialConfig
-    )
-    buildToolSelector = new BuildToolSelector(
-      languageClient,
-      tables
-    )
-    bspConnector = new BspConnector(
-      bloopServers,
-      bspServers,
-      buildTools,
-      languageClient,
-      tables,
-      () => userConfig,
-      statusBar
-    )
-    semanticdbs = AggregateSemanticdbs(
-      List(
-        fileSystemSemanticdbs,
-        interactiveSemanticdbs
-      )
-    )
-    definitionProvider = new DefinitionProvider(
-      workspace,
-      mtags,
-      buffers,
-      definitionIndex,
-      semanticdbs,
-      warnings,
-      () => compilers,
-      remote
-    )
-    formattingProvider = new FormattingProvider(
-      workspace,
-      buffers,
-      () => userConfig,
-      languageClient,
-      clientConfig,
-      statusBar,
-      clientConfig.icons,
-      tables
-    )
-    newFileProvider = new NewFileProvider(
-      workspace,
-      languageClient,
-      packageProvider,
-      () => focusedDocument
-    )
-    referencesProvider = new ReferenceProvider(
-      workspace,
-      semanticdbs,
-      buffers,
-      definitionProvider,
-      remote
-    )
-    implementationProvider = new ImplementationProvider(
-      semanticdbs,
-      workspace,
-      definitionIndex,
-      buildTargets,
-      buffers,
-      definitionProvider
-    )
+    root match {
+      case None =>
+        languageClient.showMessage(Messages.noRoot)
+      case Some(path) =>
+        workspace = AbsolutePath(Paths.get(URI.create(path))).dealias
+        MetalsLogger.setupLspLogger(workspace, redirectSystemOut)
+        val clientInfo = MetalsServerConfig.metalsClientType match {
+          case Some(clientType) => s"for client ${clientType}"
+          case None => ""
+        }
+        scribe.info(
+          s"Started: Metals version ${BuildInfo.metalsVersion} in workspace '$workspace' $clientInfo."
+        )
 
-    supermethods = new Supermethods(
-      languageClient,
-      definitionProvider,
-      implementationProvider
-    )
+        clientConfig.experimentalCapabilities =
+          ClientExperimentalCapabilities.from(params.getCapabilities)
+        clientConfig.initializationOptions = InitializationOptions.from(params)
 
-    val runTestLensProvider =
-      new RunTestCodeLens(
-        buildTargetClasses,
-        buffers,
-        buildTargets,
-        clientConfig,
-        () => bspSession.map(_.main.isBloop).getOrElse(false)
-      )
+        buildTargets.setWorkspaceDirectory(workspace)
+        tables = register(new Tables(workspace, time, clientConfig))
+        buildTargets.setTables(tables)
+        workspaceReload = new WorkspaceReload(
+          workspace,
+          languageClient,
+          tables
+        )
+        buildTools = new BuildTools(
+          workspace,
+          bspGlobalDirectories,
+          () => userConfig
+        )
+        fileSystemSemanticdbs = new FileSystemSemanticdbs(
+          buildTargets,
+          charset,
+          workspace,
+          fingerprints
+        )
+        interactiveSemanticdbs = register(
+          new InteractiveSemanticdbs(
+            workspace,
+            buildTargets,
+            charset,
+            languageClient,
+            tables,
+            statusBar,
+            () => compilers,
+            clientConfig
+          )
+        )
+        warnings = new Warnings(
+          workspace,
+          buildTargets,
+          statusBar,
+          clientConfig.icons,
+          buildTools,
+          compilations.isCurrentlyCompiling
+        )
+        diagnostics = new Diagnostics(
+          buildTargets,
+          buffers,
+          languageClient,
+          clientConfig.initialConfig.statistics,
+          () => userConfig
+        )
+        buildClient = new ForwardingMetalsBuildClient(
+          languageClient,
+          diagnostics,
+          buildTargets,
+          buildTargetClasses,
+          clientConfig,
+          statusBar,
+          time,
+          report => {
+            didCompileTarget(report)
+            compilers.didCompile(report)
+          },
+          () => treeView,
+          () => worksheetProvider,
+          () => ammonite
+        )
+        shellRunner = register(
+          new ShellRunner(languageClient, () => userConfig, time, statusBar)
+        )
+        bloopInstall = new BloopInstall(
+          workspace,
+          languageClient,
+          buildTools,
+          tables,
+          shellRunner
+        )
+        bspConfigGenerator = new BspConfigGenerator(
+          workspace,
+          languageClient,
+          buildTools,
+          shellRunner
+        )
+        newProjectProvider = new NewProjectProvider(
+          languageClient,
+          statusBar,
+          clientConfig,
+          shellRunner,
+          clientConfig.icons,
+          workspace
+        )
+        bloopServers = new BloopServers(
+          workspace,
+          buildClient,
+          languageClient,
+          tables,
+          clientConfig.initialConfig
+        )
+        bspServers = new BspServers(
+          workspace,
+          charset,
+          languageClient,
+          buildClient,
+          tables,
+          bspGlobalDirectories,
+          clientConfig.initialConfig
+        )
+        buildToolSelector = new BuildToolSelector(
+          languageClient,
+          tables
+        )
+        bspConnector = new BspConnector(
+          bloopServers,
+          bspServers,
+          buildTools,
+          languageClient,
+          tables,
+          () => userConfig,
+          statusBar
+        )
+        semanticdbs = AggregateSemanticdbs(
+          List(
+            fileSystemSemanticdbs,
+            interactiveSemanticdbs
+          )
+        )
+        definitionProvider = new DefinitionProvider(
+          workspace,
+          mtags,
+          buffers,
+          definitionIndex,
+          semanticdbs,
+          warnings,
+          () => compilers,
+          remote
+        )
+        formattingProvider = new FormattingProvider(
+          workspace,
+          buffers,
+          () => userConfig,
+          languageClient,
+          clientConfig,
+          statusBar,
+          clientConfig.icons,
+          tables
+        )
+        newFileProvider = new NewFileProvider(
+          workspace,
+          languageClient,
+          packageProvider,
+          () => focusedDocument
+        )
+        referencesProvider = new ReferenceProvider(
+          workspace,
+          semanticdbs,
+          buffers,
+          definitionProvider,
+          remote
+        )
+        implementationProvider = new ImplementationProvider(
+          semanticdbs,
+          workspace,
+          definitionIndex,
+          buildTargets,
+          buffers,
+          definitionProvider
+        )
 
-    val goSuperLensProvider = new SuperMethodCodeLens(
-      implementationProvider,
-      buffers,
-      () => userConfig,
-      clientConfig
-    )
+        supermethods = new Supermethods(
+          languageClient,
+          definitionProvider,
+          implementationProvider
+        )
 
-    stacktraceAnalyzer = new StacktraceAnalyzer(
-      workspace,
-      buffers,
-      definitionProvider,
-      clientConfig.icons,
-      clientConfig.isCommandInHtmlSupported
-    )
+        val runTestLensProvider =
+          new RunTestCodeLens(
+            buildTargetClasses,
+            buffers,
+            buildTargets,
+            clientConfig,
+            () => bspSession.map(_.main.isBloop).getOrElse(false)
+          )
 
-    codeLensProvider = new CodeLensProvider(
-      List(runTestLensProvider, goSuperLensProvider),
-      semanticdbs,
-      stacktraceAnalyzer
-    )
-    renameProvider = new RenameProvider(
-      referencesProvider,
-      implementationProvider,
-      definitionProvider,
-      workspace,
-      languageClient,
-      buffers,
-      compilations,
-      clientConfig
-    )
-    syntheticsDecorator = new SyntheticsDecorationProvider(
-      workspace,
-      semanticdbs,
-      buffers,
-      languageClient,
-      fingerprints,
-      charset,
-      diagnostics,
-      () => focusedDocument,
-      clientConfig,
-      () => userConfig
-    )
-    semanticDBIndexer = new SemanticdbIndexer(
-      referencesProvider,
-      implementationProvider,
-      syntheticsDecorator,
-      buildTargets,
-      interactiveSemanticdbs
-    )
-    documentHighlightProvider = new DocumentHighlightProvider(
-      definitionProvider,
-      semanticdbs
-    )
-    workspaceSymbols = new WorkspaceSymbolProvider(
-      workspace,
-      clientConfig.initialConfig.statistics,
-      buildTargets,
-      definitionIndex,
-      interactiveSemanticdbs.toFileOnDisk,
-      excludedPackageHandler.isExcludedPackage
-    )
-    symbolSearch = new MetalsSymbolSearch(
-      symbolDocs,
-      workspaceSymbols,
-      definitionProvider
-    )
-    compilers = register(
-      new Compilers(
-        workspace,
-        clientConfig,
-        () => userConfig,
-        () => ammonite,
-        buildTargets,
-        buffers,
-        symbolSearch,
-        embedded,
-        statusBar,
-        sh,
-        Option(params),
-        diagnostics,
-        excludedPackageHandler.isExcludedPackage
-      )
-    )
-    debugProvider = new DebugProvider(
-      workspace,
-      definitionProvider,
-      () => bspSession.map(_.mainConnection),
-      buildTargets,
-      buildTargetClasses,
-      compilations,
-      languageClient,
-      buildClient,
-      statusBar,
-      compilers,
-      definitionIndex,
-      stacktraceAnalyzer
-    )
-    scalafixProvider = ScalafixProvider(
-      buffers,
-      () => userConfig,
-      workspace,
-      embedded,
-      statusBar,
-      compilations,
-      clientConfig.icons(),
-      languageClient,
-      buildTargets
-    )
-    codeActionProvider = new CodeActionProvider(
-      compilers,
-      buffers,
-      buildTargets,
-      scalafixProvider
-    )
-    doctor = new Doctor(
-      workspace,
-      buildTargets,
-      languageClient,
-      () => bspSession,
-      () => bspConnector.resolve(),
-      () => httpServer,
-      tables,
-      clientConfig
-    )
-    popupChoiceReset = new PopupChoiceReset(
-      workspace,
-      tables,
-      languageClient,
-      doctor,
-      () => slowConnectToBuildServer(forceImport = true),
-      bspConnector,
-      () => quickConnectToBuildServer()
-    )
+        val goSuperLensProvider = new SuperMethodCodeLens(
+          implementationProvider,
+          buffers,
+          () => userConfig,
+          clientConfig
+        )
 
-    val worksheetPublisher =
-      if (clientConfig.isDecorationProvider)
-        new DecorationWorksheetPublisher()
-      else
-        new WorkspaceEditWorksheetPublisher(buffers)
-    worksheetProvider = register(
-      new WorksheetProvider(
-        workspace,
-        buffers,
-        buildTargets,
-        languageClient,
-        () => userConfig,
-        statusBar,
-        diagnostics,
-        embedded,
-        worksheetPublisher,
-        compilers,
-        compilations
-      )
-    )
-    ammonite = register(
-      new Ammonite(
-        buffers,
-        compilers,
-        compilations,
-        statusBar,
-        diagnostics,
-        doctor,
-        () => tables,
-        languageClient,
-        buildClient,
-        () => userConfig,
-        () => profiledIndexWorkspace(() => ()),
-        () => workspace,
-        () => focusedDocument,
-        buildTargets,
-        () => buildTools,
-        clientConfig.initialConfig
-      )
-    )
-    if (clientConfig.isTreeViewProvider) {
-      treeView = new MetalsTreeViewProvider(
-        () => workspace,
-        languageClient,
-        buildTargets,
-        () => buildClient.ongoingCompilations(),
-        definitionIndex,
-        clientConfig.initialConfig.statistics,
-        id => compilations.compileTarget(id),
-        sh,
-        () => bspSession.map(_.mainConnectionIsBloop).getOrElse(false)
-      )
+        stacktraceAnalyzer = new StacktraceAnalyzer(
+          workspace,
+          buffers,
+          definitionProvider,
+          clientConfig.icons,
+          clientConfig.isCommandInHtmlSupported
+        )
+
+        codeLensProvider = new CodeLensProvider(
+          List(runTestLensProvider, goSuperLensProvider),
+          semanticdbs,
+          stacktraceAnalyzer
+        )
+        renameProvider = new RenameProvider(
+          referencesProvider,
+          implementationProvider,
+          definitionProvider,
+          workspace,
+          languageClient,
+          buffers,
+          compilations,
+          clientConfig
+        )
+        syntheticsDecorator = new SyntheticsDecorationProvider(
+          workspace,
+          semanticdbs,
+          buffers,
+          languageClient,
+          fingerprints,
+          charset,
+          diagnostics,
+          () => focusedDocument,
+          clientConfig,
+          () => userConfig
+        )
+        semanticDBIndexer = new SemanticdbIndexer(
+          referencesProvider,
+          implementationProvider,
+          syntheticsDecorator,
+          buildTargets,
+          interactiveSemanticdbs
+        )
+        documentHighlightProvider = new DocumentHighlightProvider(
+          definitionProvider,
+          semanticdbs
+        )
+        workspaceSymbols = new WorkspaceSymbolProvider(
+          workspace,
+          clientConfig.initialConfig.statistics,
+          buildTargets,
+          definitionIndex,
+          interactiveSemanticdbs.toFileOnDisk,
+          excludedPackageHandler.isExcludedPackage
+        )
+        symbolSearch = new MetalsSymbolSearch(
+          symbolDocs,
+          workspaceSymbols,
+          definitionProvider
+        )
+        compilers = register(
+          new Compilers(
+            workspace,
+            clientConfig,
+            () => userConfig,
+            () => ammonite,
+            buildTargets,
+            buffers,
+            symbolSearch,
+            embedded,
+            statusBar,
+            sh,
+            Option(params),
+            diagnostics,
+            excludedPackageHandler.isExcludedPackage
+          )
+        )
+        debugProvider = new DebugProvider(
+          workspace,
+          definitionProvider,
+          () => bspSession.map(_.mainConnection),
+          buildTargets,
+          buildTargetClasses,
+          compilations,
+          languageClient,
+          buildClient,
+          statusBar,
+          compilers,
+          definitionIndex,
+          stacktraceAnalyzer
+        )
+        scalafixProvider = ScalafixProvider(
+          buffers,
+          () => userConfig,
+          workspace,
+          embedded,
+          statusBar,
+          compilations,
+          clientConfig.icons(),
+          languageClient,
+          buildTargets
+        )
+        codeActionProvider = new CodeActionProvider(
+          compilers,
+          buffers,
+          buildTargets,
+          scalafixProvider
+        )
+        doctor = new Doctor(
+          workspace,
+          buildTargets,
+          languageClient,
+          () => bspSession,
+          () => bspConnector.resolve(),
+          () => httpServer,
+          tables,
+          clientConfig
+        )
+        popupChoiceReset = new PopupChoiceReset(
+          workspace,
+          tables,
+          languageClient,
+          doctor,
+          () => slowConnectToBuildServer(forceImport = true),
+          bspConnector,
+          () => quickConnectToBuildServer()
+        )
+
+        val worksheetPublisher =
+          if (clientConfig.isDecorationProvider)
+            new DecorationWorksheetPublisher()
+          else
+            new WorkspaceEditWorksheetPublisher(buffers)
+        worksheetProvider = register(
+          new WorksheetProvider(
+            workspace,
+            buffers,
+            buildTargets,
+            languageClient,
+            () => userConfig,
+            statusBar,
+            diagnostics,
+            embedded,
+            worksheetPublisher,
+            compilers,
+            compilations
+          )
+        )
+        ammonite = register(
+          new Ammonite(
+            buffers,
+            compilers,
+            compilations,
+            statusBar,
+            diagnostics,
+            doctor,
+            () => tables,
+            languageClient,
+            buildClient,
+            () => userConfig,
+            () => profiledIndexWorkspace(() => ()),
+            () => workspace,
+            () => focusedDocument,
+            buildTargets,
+            () => buildTools,
+            clientConfig.initialConfig
+          )
+        )
+        if (clientConfig.isTreeViewProvider) {
+          treeView = new MetalsTreeViewProvider(
+            () => workspace,
+            languageClient,
+            buildTargets,
+            () => buildClient.ongoingCompilations(),
+            definitionIndex,
+            clientConfig.initialConfig.statistics,
+            id => compilations.compileTarget(id),
+            sh,
+            () => bspSession.map(_.mainConnectionIsBloop).getOrElse(false)
+          )
+        }
     }
   }
 


### PR DESCRIPTION
This is mainly to just get a conversation going about the best way to handle this. I've been digging into #2384 a bit, and I'm really unsure of how to handle that situation. This is an attempt to just not throw a NPE and handle it a bit more gracefully. The idea is that for some reason if a user opens a standalone `*.scala` file that isn't in any type of a workspace, and no `rootPath` or `rootUri` is set, then we show them an error and the functionality that would be provided by Metals is very minimal. However minimal, this would be better than forcing an exit like we saw in #2384 which leaves the user with no way to tell what's going on.

Part of the trouble is that a lot of extensions/clients handle this differently.

- In VS Code, https://github.com/scalameta/metals-vscode/blob/d7a76c3f8e61dab4911565f3117cd2cad23cdae5/src/extension.ts#L181-L186, we check to see if `workspaceFolders` is empty, and if so we don't even start Metals. This actually means that in VS Code, you can't just open a Scala file alone and get Metals to work. You can get it to work if you're in a valid workspace and then open a Scala file from another place that is standalone. I'd say this is actually confusing as our docs make it sound like this should work.
- In `coc-metals` coc.nvim will automatically always have this set. If it doesn't match any of the root patters, then it just defaults to the parent directory as the `rootUri`.
- In `nvim-metals` it actually explodes on the neovim side if no root is given, so you have to have some sort of root. So I did the same thing that coc.nvim did and just default to the parent directory if no root patterns are found https://github.com/scalameta/nvim-metals/pull/67.
- In Sublime, if you open a single Scala file, you're not blocked, but both the `rootPath` and the `rootUri` are empty.

In this pr I don't actually check the `workspaceFolders` primarily because Metals doesn't say that it supports `workspaceFolders`, so I don't think it even makes sense to start checking it until we do and say that in `serverCabailities`.

So really the only change of this pr would be in the Sublime case where the user should now see a warning that they need to open up a valid workspace. Ideally, instead it'd be great if they are just opening up a single file, they give the parent as the workspace. I'm not sure how hard that would be @ayoub-benali from the extension.

Finally, in general, it's hard to get rid of the idea of having a workspace, if no impossible with Metals. So much relies on it, and it's tied into everything. So making changes to still have functionality working correctly with no workspace being set would be a major overhaul from what I can tell. One that I'm not sure is worth it at all.