### PR TITLE
Clean up --version output.

### DIFF
--- a/metals/src/main/scala/scala/meta/metals/Main.scala
+++ b/metals/src/main/scala/scala/meta/metals/Main.scala
@@ -11,20 +11,33 @@ import scala.meta.internal.metals.GlobalTrace
 import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.internal.metals.MetalsLanguageServer
 import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.ScalaVersions
 
 import org.eclipse.lsp4j.jsonrpc.Launcher
 
 object Main {
   def main(args: Array[String]): Unit = {
     if (args.exists(Set("-v", "--version", "-version"))) {
-      val supportedScalaVersions =
-        BuildInfo.supportedScalaVersions.sorted.mkString(", ")
+      val supportedScala2Versions =
+        BuildInfo.supportedScala2Versions
+          .groupBy(ScalaVersions.scalaBinaryVersionFromFullVersion)
+          .toSeq
+          .sortBy(_._1)
+          .map { case (_, versions) => versions.mkString(", ") }
+          .mkString("\n#       ")
+
+      val supportedScala3Versions =
+        BuildInfo.supportedScala3Versions.sorted.mkString(", ")
 
       println(
         s"""|metals ${BuildInfo.metalsVersion}
             |
             |# Note:
-            |#   supported Scala versions: $supportedScalaVersions""".stripMargin
+            |#   Supported Scala versions:
+            |#     Scala 3: $supportedScala3Versions
+            |#     Scala 2:
+            |#       $supportedScala2Versions
+            |""".stripMargin
       )
 
       sys.exit(0)


### PR DESCRIPTION
So _maybe_ not the most important pr, but I was working on a nice way in `nvim-metals` to show the users what exact version of Metals they are using and what Scala version are supported. `metals --version` actually works pretty nicely for this, but with the current output, if you screen is split or anything the display isn't that nice. With this change it clearly differentiates between the Scala 2.x, and 3 versions and displays them a bit differently.

### Old

<img width="668" alt="Screenshot 2021-01-16 at 14 27 09" src="https://user-images.githubusercontent.com/13974112/104813146-a3bcb200-5807-11eb-80fc-60c23ef35e44.png">

### New

<img width="668" alt="Screenshot 2021-01-16 at 14 21 40" src="https://user-images.githubusercontent.com/13974112/104813157-af0fdd80-5807-11eb-8f7f-99b038745f5c.png">
