### PR TITLE
Look for clientInfo in intializeParams instead of serverConfig.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -287,10 +287,13 @@ class MetalsLanguageServer(
       case Some(path) =>
         workspace = AbsolutePath(Paths.get(URI.create(path))).dealias
         MetalsLogger.setupLspLogger(workspace, redirectSystemOut)
-        val clientInfo = MetalsServerConfig.metalsClientType match {
-          case Some(clientType) => s"for client ${clientType}"
+
+        val clientInfo = Option(params.getClientInfo()) match {
+          case Some(info) =>
+            s"for client ${info.getName()} ${Option(info.getVersion).getOrElse("")}"
           case None => ""
         }
+
         scribe.info(
           s"Started: Metals version ${BuildInfo.metalsVersion} in workspace '$workspace' $clientInfo."
         )


### PR DESCRIPTION
The last couple versions of the LSP spec have included the clientInfo object
in the initializationParams. I think it's better if we just rely on this, especially
seeing that some clients won't have the client set via flags anymore, since it's
no longer necessary due to everything being configurable via intializationOptions.
Plus, doing it this way will also give us the version. All of the modern clients that
I looked into have these filled.

### Before (with the example of Nvim, since it's used without `-Dmetals.client`)
<img width="961" alt="Screenshot 2021-01-18 at 13 56 31" src="https://user-images.githubusercontent.com/13974112/104918669-5ff7b300-5995-11eb-9527-94352f23567d.png">

### After
<img width="1209" alt="Screenshot 2021-01-18 at 13 54 37" src="https://user-images.githubusercontent.com/13974112/104918740-7b62be00-5995-11eb-8e6f-c53762801c20.png">

