### PR TITLE
Fix default version of Scala given to Ammonite.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -184,6 +184,8 @@ lazy val V = new {
   val scala210 = "2.10.7"
   val scala211 = "2.11.12"
   val sbtScala = "2.12.10"
+  // TODO https://github.com/scalameta/metals/issues/2392
+  val ammonite212Version = "2.12.12"
   val scala212 = "2.12.13"
   val scala213 = "2.13.4"
   val scalameta = "4.4.6"
@@ -480,6 +482,7 @@ lazy val metals = project
       "nonDeprecatedScalaVersions" -> V.nonDeprecatedScalaVersions,
       "scala211" -> V.scala211,
       "scala212" -> V.scala212,
+      "ammonite212" -> V.ammonite212Version,
       "scala213" -> V.scala213,
       "scala3" -> V.scala3
     )
@@ -575,8 +578,7 @@ def publishBinaryMtags =
           V.scala211,
           V.sbtScala,
           V.scala212,
-          // TODO https://github.com/scalameta/metals/issues/2392
-          "2.12.12",
+          V.ammonite212Version,
           V.scala213,
           V.scala3
         )

--- a/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
@@ -147,7 +147,7 @@ final class Ammonite(
       .getOrElse(
         AmmVersions(
           ammoniteVersion = BuildInfo.ammoniteVersion,
-          scalaVersion = BuildInfo.scala212
+          scalaVersion = BuildInfo.ammonite212
         )
       )
     val res = AmmoniteFetcher(versions)

--- a/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
@@ -4,5 +4,4 @@ import scala.meta.internal.metals.{BuildInfo => V}
 
 class Ammonite213Suite extends tests.BaseAmmoniteSuite(V.scala213)
 
-// TODO https://github.com/scalameta/metals/issues/2392
-class Ammonite212Suite extends tests.BaseAmmoniteSuite("2.12.12")
+class Ammonite212Suite extends tests.BaseAmmoniteSuite(V.ammonite212)


### PR DESCRIPTION
We are pulling the version of Ammonite from buildInfo and the version
of Ammonite we are using isn't available for 2.12.13 yet. We did fix
this is in the Ammonite tests, but we forgot to actually change it where
we get Ammonite.

Also I did check and there still isn't a new version published for for Ammonite and 2.12.13.

This was originally reported by @soronpo on [Gitter](https://gitter.im/scalameta/metals?at=6007952bdfdbc1437f9d42a5)