### PR TITLE
Prepend `_empty_/` when searching for symbol without a package

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathProvider.scala
@@ -21,11 +21,12 @@ final class SourcePathProvider(
   }
 
   private def searchAsClassPathSymbol(source: Source): Option[AbsolutePath] = {
-    val symbolBase = source.getPath
+    val base = source.getPath
       .stripSuffix(".scala")
       .stripSuffix(".java")
       .replace("\\", "/") // adapt windows paths to the expected format
 
+    val symbolBase = if (base.contains("/")) base else "_empty_/" + base
     val symbols = for {
       symbol <- Set(symbolBase + ".", symbolBase + "#")
       definition <- definitionProvider.fromSymbol(symbol).asScala


### PR DESCRIPTION
This fixes https://github.com/scalameta/metals/issues/2425 which was caused by a very specific scenario trying to debug a class from test that has an empty package.

I tried to reproduce it in the tests, however it proved to be a bit difficult, since `QuickBuild` doesn't have `test` and main separate targets and to reproduce this we would need to rework the infrastructure.