### PR TITLE
Search also transitive sources when falling back from symbol search

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathProvider.scala
@@ -28,7 +28,7 @@ final class SourcePathProvider(
 
     val symbolBase = if (base.contains("/")) base else "_empty_/" + base
     val symbols = for {
-      symbol <- Set(symbolBase + ".", symbolBase + "#")
+      symbol <- Set(symbolBase + ".", symbolBase + "#").toIterator
       definition <- definitionProvider.fromSymbol(symbol).asScala
     } yield definition.getUri.toAbsolutePath
 
@@ -42,7 +42,7 @@ final class SourcePathProvider(
   private def searchAsSourceFile(source: Source): Option[AbsolutePath] = {
     val files = for {
       target <- targets.view
-      sourceFile <- buildTargets.buildTargetSources(target)
+      sourceFile <- buildTargets.buildTargetTransitiveSources(target)
       if sourceFile.filename == source.getName
     } yield sourceFile
 


### PR DESCRIPTION
It seems in cases where we have `package object myObject {}` inside `myObject.scala` file the path given to us will be `myObject/myObject`, but the actual symbol is `myObject/package.`. This normally works with a standard  naming where package objects are put into `package.scala` file, so the path would be `myObject/package`.

As a fallback for symbol search we also check workspace sources for the file, but we haven't done it transitively, so files in dependency project would not be found. This fixes it so that the fallback works in those cases too.