### PR TITLE
Ensure Bloop isn't offered as a server in an unsupported workspace.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.bsp
 
 import java.nio.file.Files
 
+import scala.collection.immutable.Nil
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -125,35 +126,20 @@ class BspConnector(
   }
 
   private def askUser(
-      bspServerConnections: List[BspConnectionDetails],
+      availableBspConnections: List[BspConnectionDetails],
       currentBsp: Option[String]
   ): Future[BspResolvedResult] = {
-    val bloop = new BspConnectionDetails(
-      "Bloop",
-      ImmutableList.of(),
-      userConfig().currentBloopVersion,
-      "",
-      ImmutableList.of()
-    )
-
     val query = Messages.SelectBspServer.request(
-      bloop :: bspServerConnections,
+      availableBspConnections,
       currentBsp
     )
     for {
       item <- client.showMessageRequest(query.params).asScala
     } yield {
       val chosenMaybe = Option(item).flatMap(i => query.details.get(i.getTitle))
-      val result = chosenMaybe
-        .map { chosen =>
-          if (chosen == bloop) {
-            ResolvedBloop
-          } else {
-            ResolvedBspOne(chosen)
-          }
-        }
+      chosenMaybe
+        .map(BspResolvedResult.fromDetails)
         .getOrElse(ResolvedNone)
-      result
     }
   }
 
@@ -165,18 +151,36 @@ class BspConnector(
       createBloopAndConnect: () => Future[BuildChange]
   ): Future[Boolean] = {
     val bloopPresent = buildTools.isBloop
-    bspServers.findAvailableServers() match {
+
+    val availableServers = {
+      val found = bspServers.findAvailableServers()
+      if (bloopPresent || buildTools.loadSupported().nonEmpty)
+        new BspConnectionDetails(
+          "Bloop",
+          ImmutableList.of(),
+          userConfig().currentBloopVersion,
+          "",
+          ImmutableList.of()
+        ) :: found
+      else found
+    }
+
+    availableServers match {
       case Nil =>
-        if (bloopPresent)
-          client.showMessage(BspSwitch.onlyOneServer(name = "Bloop"))
-        else
-          client.showMessage(BspSwitch.noInstalledServer)
+        client.showMessage(BspSwitch.noInstalledServer)
         Future.successful(false)
-      case availableServers =>
-        val currentBsp = tables.buildServers.selectedServer()
-        askUser(availableServers, currentBsp).map {
+      case singleServer :: Nil =>
+        client.showMessage(
+          BspSwitch.onlyOneServer(name = singleServer.getName())
+        )
+        Future.successful(false)
+      case multipleServers =>
+        val currentSelectedServer = tables.buildServers.selectedServer()
+        askUser(multipleServers, currentSelectedServer).map {
           case ResolvedBloop
-              if currentBsp.contains(BspConnector.BLOOP_SELECTED) =>
+              if currentSelectedServer.contains(
+                BspConnector.BLOOP_SELECTED
+              ) =>
             false
           case ResolvedBloop =>
             tables.buildServers.chooseServer(BspConnector.BLOOP_SELECTED)
@@ -193,7 +197,7 @@ class BspConnector(
               false
             }
           case ResolvedBspOne(details)
-              if !currentBsp.contains(details.getName) =>
+              if !currentSelectedServer.contains(details.getName) =>
             tables.buildServers.chooseServer(details.getName)
             true
           case _ =>

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -2,7 +2,6 @@ package scala.meta.internal.bsp
 
 import java.nio.file.Files
 
-import scala.collection.immutable.Nil
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -156,7 +155,7 @@ class BspConnector(
       val found = bspServers.findAvailableServers()
       if (bloopPresent || buildTools.loadSupported().nonEmpty)
         new BspConnectionDetails(
-          "Bloop",
+          BloopServers.name,
           ImmutableList.of(),
           userConfig().currentBloopVersion,
           "",

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspResolvedResult.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspResolvedResult.scala
@@ -1,5 +1,7 @@
 package scala.meta.internal.bsp
 
+import scala.meta.internal.metals.BloopServers
+
 import ch.epfl.scala.bsp4j.BspConnectionDetails
 
 /**
@@ -17,8 +19,8 @@ case class ResolvedMultiple(md5: String, details: List[BspConnectionDetails])
 
 object BspResolvedResult {
   def fromDetails(details: BspConnectionDetails): BspResolvedResult =
-    details.getName().toLowerCase() match {
-      case "bloop" => ResolvedBloop
+    details.getName() match {
+      case BloopServers.name => ResolvedBloop
       case _ => ResolvedBspOne(details)
     }
 }

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspResolvedResult.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspResolvedResult.scala
@@ -14,3 +14,11 @@ case class ResolvedBspOne(details: BspConnectionDetails)
     extends BspResolvedResult
 case class ResolvedMultiple(md5: String, details: List[BspConnectionDetails])
     extends BspResolvedResult
+
+object BspResolvedResult {
+  def fromDetails(details: BspConnectionDetails): BspResolvedResult =
+    details.getName().toLowerCase() match {
+      case "bloop" => ResolvedBloop
+      case _ => ResolvedBspOne(details)
+    }
+}

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -108,6 +108,11 @@ final class BspServers(
     )
   }
 
+  /**
+   * Returns a list of BspConnectionDetails from reading the .bsp/
+   *  entries. Notes that this will not return Bloop even though it
+   *  may be a server in the current workspace
+   */
   def findAvailableServers(): List[BspConnectionDetails] = {
     val jsonFiles = findJsonFiles(mainWorkspace)
     val gson = new Gson()

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspSession.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspSession.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.bsp
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import scala.meta.internal.metals.BloopServers
 import scala.meta.internal.metals.BuildServerConnection
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.ImportedBuild
@@ -30,7 +31,7 @@ case class BspSession(
 
   def mainConnection: BuildServerConnection = main
 
-  def mainConnectionIsBloop: Boolean = main.name == "Bloop"
+  def mainConnectionIsBloop: Boolean = main.name == BloopServers.name
 
   def version: String = main.version
 

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -4,6 +4,7 @@ import java.nio.file.Files
 import java.util.Properties
 
 import scala.meta.internal.io.PathIO
+import scala.meta.internal.metals.BloopServers
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.io.AbsolutePath
@@ -71,7 +72,7 @@ final class BuildTools(
 
   def all: List[String] = {
     val buf = List.newBuilder[String]
-    if (isBloop) buf += "Bloop"
+    if (isBloop) buf += BloopServers.name
     if (isSbt) buf += "sbt"
     if (isMill) buf += "Mill"
     if (isGradle) buf += "Gradle"

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -38,7 +38,7 @@ final class BloopServers(
     config: MetalsServerConfig
 )(implicit ec: ExecutionContextExecutorService) {
 
-  private val bloop = "Bloop"
+  import BloopServers._
 
   def shutdownServer(): Boolean = {
     val dummyIn = new ByteArrayInputStream(new Array(0))
@@ -72,7 +72,7 @@ final class BloopServers(
         () => connectToLauncher(bloopVersion, config.bloopPort),
         tables.dismissedNotifications.ReconnectBsp,
         config,
-        bloop
+        name
       )
   }
 
@@ -164,7 +164,7 @@ final class BloopServers(
 
     serverStarted.future.map { _ =>
       SocketConnection(
-        bloop,
+        name,
         clientOut,
         clientIn,
         List(
@@ -178,4 +178,8 @@ final class BloopServers(
       )
     }
   }
+}
+
+object BloopServers {
+  val name = "Bloop"
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -61,7 +61,7 @@ class BuildServerConnection private (
   // the name is set before when establishing conenction
   def name: String = initialConnection.socketConnection.serverName
 
-  def isBloop: Boolean = name == "Bloop"
+  def isBloop: Boolean = name == BloopServers.name
 
   def workspaceDirectory: AbsolutePath = workspace
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -402,7 +402,7 @@ object Messages {
     def onlyOneServer(name: String): MessageParams =
       new MessageParams(
         MessageType.Warning,
-        s"Unable to switch build server since there is only one installed build server '$name' on this computer."
+        s"Unable to switch build server since there is only one supported build server '$name' detected for this workspace."
       )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/troubleshoot/ProblemResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/troubleshoot/ProblemResolver.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.troubleshoot
 import scala.collection.mutable.ListBuffer
 
 import scala.meta.internal.bsp.BspSession
+import scala.meta.internal.metals.BloopServers
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -20,10 +21,11 @@ class ProblemResolver(
   def isUnsupportedBloopVersion(): Boolean = {
     currentBuildServer() match {
       case Some(bspSession) =>
-        bspSession.main.name == "Bloop" && !SemVer.isCompatibleVersion(
-          BuildInfo.bloopVersion,
-          bspSession.main.version
-        )
+        bspSession.main.name == BloopServers.name && !SemVer
+          .isCompatibleVersion(
+            BuildInfo.bloopVersion,
+            bspSession.main.version
+          )
       case None =>
         false
     }

--- a/tests/unit/src/test/scala/tests/BspSwitchLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BspSwitchLspSuite.scala
@@ -16,6 +16,18 @@ class BspSwitchLspSuite extends BaseLspSuite("bsp-switch") {
       _ = {
         client.messageRequests.clear()
         assertConnectedToBuildServer("Bill")
+      }
+      _ <- server.executeCommand(ServerCommands.BspSwitch.id)
+      _ = {
+        assertConnectedToBuildServer("Bill")
+        assertNoDiff(
+          client.workspaceShowMessages,
+          BspSwitch.onlyOneServer("Bill").getMessage()
+        )
+      }
+      _ = {
+        client.messageRequests.clear()
+        assertConnectedToBuildServer("Bill")
         Bill.installWorkspace(workspace.toNIO, "Bob")
       }
       _ <- server.executeCommand(ServerCommands.ConnectBuildServer.id)


### PR DESCRIPTION
Previously if a user would issue a `bsp-switch` command and there was an
entry in `.bsp/` for a server, then no matter what, Bloop was offered as
a choice. However, there may be a situation where a workspace is a
workspace that does have a `.bsp/` entry, but the build tools is one
that Bloop doesn't work with. In this scenario, Bloop shouldn't be
offered since it doesn't know how to import from this build tool.

An example. Let's say we have build tool `xyz` and server `xyz` with a
corresponding `.bsp/xyz.json` file. If a user open Metals in this
workspace, it will auto-connect to `xyz`. If the user issues a
`bsp-switch`, they will just see a warning now that says:

> Unable to switch build server since there is only one supported build
> server 'xyz' detected for this workspace.

Fixes #2424