### PR TITLE
Fix issue with breakpoints in multiple files

### DIFF
--- a/tests/unit/src/main/scala/tests/BaseDapSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseDapSuite.scala
@@ -119,14 +119,7 @@ abstract class BaseDapSuite(suiteName: String) extends BaseLspSuite(suiteName) {
             |$workspaceLayout
             |""".stripMargin
 
-      val expectedBreakpoints = workspaceLayout.files.flatMap { file =>
-        file.breakpoints.map(b => Breakpoint(file.relativePath, b.startLine))
-      }
-
-      val navigator = expectedBreakpoints.foldLeft(StepNavigator(workspace)) {
-        (navigator, breakpoint) =>
-          navigator.at(breakpoint.relativePath, breakpoint.line + 1)(Continue)
-      }
+      val navigator = navigateExpectedBreakpoints(workspaceLayout)
 
       for {
         _ <- server.initialize(layout)
@@ -138,6 +131,20 @@ abstract class BaseDapSuite(suiteName: String) extends BaseLspSuite(suiteName) {
         _ <- debugger.configurationDone
         _ <- debugger.shutdown
       } yield ()
+    }
+  }
+
+  def navigateExpectedBreakpoints(
+      workspaceLayout: DebugWorkspaceLayout
+  ): StepNavigator = {
+
+    val expectedBreakpoints = workspaceLayout.files.flatMap { file =>
+      file.breakpoints.map(b => Breakpoint(file.relativePath, b.startLine))
+    }
+
+    expectedBreakpoints.foldLeft(StepNavigator(workspace)) {
+      (navigator, breakpoint) =>
+        navigator.at(breakpoint.relativePath, breakpoint.line + 1)(Continue)
     }
   }
 


### PR DESCRIPTION
Breakpoints need to be registered for each class file separately, so Metals takes care of translating source file locations to separate class file names displayed as for example `dap-fqcn:packageName.objectName$`.

Breakpoints for each file are send from the DAP client (like for example VS Code) separately and because of that we would remove breakpoints for the previously send files upon receiving another breakpoint request. Now, it's changed, so that specific breakpoints for classfiles are remembered separately for each file. This helps to to recognize when an empty request needs to be sent for a certain classfile.

This one was a bit tougher, but thanks for reporting @shaofengjiang!
