### PR TITLE
Add type decorations for definitions

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
@@ -9,7 +9,8 @@ import scala.meta.metap.Format
 class SemanticdbTreePrinter(
     isHover: Boolean,
     printSymbol: String => String,
-    createSymtab: => PrinterSymtab
+    createSymtab: => PrinterSymtab,
+    rightArrow: String
 ) {
 
   lazy val symtab = createSymtab
@@ -79,7 +80,7 @@ class SemanticdbTreePrinter(
         typeArgs.map(printType).mkString("(", ", ", ")")
       case _ if isFunction =>
         val argTypes :+ returnType = typeArgs.map(printType)
-        argTypes.mkString("(", ", ", ")") + " => " + returnType
+        argTypes.mkString("(", ", ", ")") + s" $rightArrow $returnType"
       case _ =>
         typeArgs.map(printType).mkString("[", ", ", "]")
     }

--- a/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
@@ -6,115 +6,132 @@ import scala.meta.internal.semanticdb.Print
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.metap.Format
 
-object SemanticdbTreePrinter {
+class SemanticdbTreePrinter(
+    isHover: Boolean,
+    printSymbol: String => String,
+    createSymtab: => PrinterSymtab
+) {
+
+  lazy val symtab = createSymtab
+
+  def printType(t: s.Type): String =
+    t match {
+      case s.Type.Empty => ""
+      case s.RepeatedType(tpe) =>
+        s"${printType(tpe)}*"
+      case s.SingleType(prefix, symbol) =>
+        s"${printPrefix(prefix)}${printSymbol(symbol)}"
+      case s.TypeRef(prefix, symbol, typeArguments) =>
+        val isTuple = symbol.startsWith("scala/Tuple")
+        val isFunction = symbol.startsWith("scala/Function")
+        val sym = if (isTuple || isFunction) "" else printSymbol(symbol)
+        val typeArgs = printTypeArgs(typeArguments, isTuple, isFunction)
+        s"${printPrefix(prefix)}${sym}${typeArgs}"
+      case s.WithType(types) =>
+        types.map(printType).mkString(" with ")
+      case s.ConstantType(constant) =>
+        printConstant(constant)
+      case s.ByNameType(tpe) =>
+        s"=> ${printType(tpe)}"
+      case s.ThisType(symbol) =>
+        s"this.${printSymbol(symbol)}"
+      case s.IntersectionType(types) =>
+        types.map(printType).mkString(" & ")
+      case s.UnionType(types) =>
+        types.map(printType).mkString(" | ")
+      case s.SuperType(prefix, symbol) =>
+        s"super.${printPrefix(prefix)}${printSymbol(symbol)}"
+      case s.AnnotatedType(annots, tp) =>
+        val mapped = annots
+          .map(x => s"@${printType(x.tpe)}")
+          .reduceLeft((x, y) => s"$x $y")
+        s"$mapped ${printType(tp)}"
+      // this should not need to be printed but just in case we revert to semanticdb printer
+      case s.UniversalType(_, tpe) =>
+        if (isHover)
+          Print.tpe(Format.Detailed, t, symtab)
+        else s"[ ... ] => ${printType(tpe)}"
+      case s.ExistentialType(tpe, _) =>
+        if (isHover)
+          Print.tpe(Format.Detailed, t, symtab)
+        else s"${printType(tpe)} forSome { ... }"
+      case s.StructuralType(tpe, _) =>
+        if (isHover)
+          Print.tpe(Format.Detailed, t, symtab)
+        else s" ${printType(tpe)} { ... }"
+    }
+
+  def printPrefix(t: s.Type): String = {
+    printType(t) match {
+      case "" => ""
+      case s => s"$s."
+    }
+  }
+
+  def printTypeArgs(
+      typeArgs: Seq[s.Type],
+      isTuple: Boolean = false,
+      isFunction: Boolean = false
+  ): String =
+    typeArgs match {
+      case Nil => ""
+      case _ if isTuple =>
+        typeArgs.map(printType).mkString("(", ", ", ")")
+      case _ if isFunction =>
+        val argTypes :+ returnType = typeArgs.map(printType)
+        argTypes.mkString("(", ", ", ")") + " => " + returnType
+      case _ =>
+        typeArgs.map(printType).mkString("[", ", ", "]")
+    }
+
+  def printArgs(args: Seq[s.Tree]): String =
+    args match {
+      case Nil => ""
+      case _ => args.flatMap(printTree).mkString("(", ", ", ")")
+    }
+
+  def printConstant(c: s.Constant): String =
+    c match {
+      case s.FloatConstant(value) => value.toString
+      case s.LongConstant(value) => value.toString
+      case s.DoubleConstant(value) => value.toString
+      case s.NullConstant() => "null"
+      case s.IntConstant(value) => value.toString
+      case s.CharConstant(value) => value.toString
+      case s.ByteConstant(value) => value.toString
+      case s.UnitConstant() => "()"
+      case s.ShortConstant(value) => value.toString
+      case s.Constant.Empty => ""
+      case s.BooleanConstant(value) => value.toString
+      case s.StringConstant(value) => value
+    }
+
+  def printTree(t: s.Tree): Option[String] =
+    t match {
+      case s.Tree.Empty => None
+      case s.OriginalTree(_) => None
+      case s.TypeApplyTree(function, typeArguments) =>
+        Some(printTree(function).getOrElse("") + printTypeArgs(typeArguments))
+      case s.ApplyTree(function, arguments) =>
+        Some(printTree(function).getOrElse("") + printArgs(arguments))
+      case s.LiteralTree(constant) =>
+        Some(printConstant(constant))
+      case s.SelectTree(_, id) =>
+        id.flatMap(printTree)
+      case s.FunctionTree(parameters, body) =>
+        printTree(body).map(printed => printArgs(parameters) + "=>" + printed)
+      case s.IdTree(symbol) =>
+        Some(printSymbol(symbol))
+      case s.MacroExpansionTree(beforeExpansion, _) =>
+        printTree(beforeExpansion)
+    }
 
   def printSyntheticInfo(
       textDocument: s.TextDocument,
       synthetic: s.Synthetic,
-      printSymbol: String => String,
       userConfig: UserConfiguration,
-      isHover: Boolean,
       isInlineProvider: Boolean = false
   ): List[(String, s.Range)] = {
-
-    lazy val symtab = PrinterSymtab.fromTextDocument(textDocument)
-
-    def printTree(t: s.Tree): Option[String] =
-      t match {
-        case s.Tree.Empty => None
-        case s.OriginalTree(_) => None
-        case s.TypeApplyTree(function, typeArguments) =>
-          Some(printTree(function).getOrElse("") + printTypeArgs(typeArguments))
-        case s.ApplyTree(function, arguments) =>
-          Some(printTree(function).getOrElse("") + printArgs(arguments))
-        case s.LiteralTree(constant) =>
-          Some(printConstant(constant))
-        case s.SelectTree(_, id) =>
-          id.flatMap(printTree)
-        case s.FunctionTree(parameters, body) =>
-          printTree(body).map(printed => printArgs(parameters) + "=>" + printed)
-        case s.IdTree(symbol) =>
-          Some(printSymbol(symbol))
-        case s.MacroExpansionTree(beforeExpansion, _) =>
-          printTree(beforeExpansion)
-      }
-
-    def printPrefix(t: s.Type): String = {
-      printType(t) match {
-        case "" => ""
-        case s => s"$s."
-      }
-    }
-    def printTypeArgs(typeArgs: Seq[s.Type]): String =
-      typeArgs match {
-        case Nil => ""
-        case _ => typeArgs.map(printType).mkString("[", ", ", "]")
-      }
-
-    def printArgs(args: Seq[s.Tree]): String =
-      args match {
-        case Nil => ""
-        case _ => args.flatMap(printTree).mkString("(", ", ", ")")
-      }
-
-    def printType(t: s.Type): String =
-      t match {
-        case s.Type.Empty => ""
-        case s.RepeatedType(tpe) =>
-          s"${printType(tpe)}*"
-        case s.SingleType(prefix, symbol) =>
-          s"${printPrefix(prefix)}${printSymbol(symbol)}"
-        case s.TypeRef(prefix, symbol, typeArguments) =>
-          s"${printPrefix(prefix)}${printSymbol(symbol)}${printTypeArgs(typeArguments)}"
-        case s.WithType(types) =>
-          types.map(printType).mkString(" with ")
-        case s.ConstantType(constant) =>
-          printConstant(constant)
-        case s.ByNameType(tpe) =>
-          s"=> ${printType(tpe)}"
-        case s.ThisType(symbol) =>
-          s"this.${printSymbol(symbol)}"
-        case s.IntersectionType(types) =>
-          types.map(printType).mkString(" & ")
-        case s.UnionType(types) =>
-          types.map(printType).mkString(" | ")
-        case s.SuperType(prefix, symbol) =>
-          s"super.${printPrefix(prefix)}${printSymbol(symbol)}"
-        case s.AnnotatedType(annots, tp) =>
-          val mapped = annots
-            .map(x => s"@${printType(x.tpe)}")
-            .reduceLeft((x, y) => s"$x $y")
-          s"$mapped ${printType(tp)}"
-        // this should not need to be printed but just in case we revert to semanticdb printer
-        case s.UniversalType(_, tpe) =>
-          if (isHover)
-            Print.tpe(Format.Detailed, t, symtab)
-          else s"[ ... ] => ${printType(tpe)}"
-        case s.ExistentialType(tpe, _) =>
-          if (isHover)
-            Print.tpe(Format.Detailed, t, symtab)
-          else s"${printType(tpe)} forSome { ... }"
-        case s.StructuralType(tpe, _) =>
-          if (isHover)
-            Print.tpe(Format.Detailed, t, symtab)
-          else s" ${printType(tpe)} { ... }"
-      }
-
-    def printConstant(c: s.Constant): String =
-      c match {
-        case s.FloatConstant(value) => value.toString
-        case s.LongConstant(value) => value.toString
-        case s.DoubleConstant(value) => value.toString
-        case s.NullConstant() => "null"
-        case s.IntConstant(value) => value.toString
-        case s.CharConstant(value) => value.toString
-        case s.ByteConstant(value) => value.toString
-        case s.UnitConstant() => "()"
-        case s.ShortConstant(value) => value.toString
-        case s.Constant.Empty => ""
-        case s.BooleanConstant(value) => value.toString
-        case s.StringConstant(value) => value
-      }
 
     def gatherSynthetics(tree: s.Tree) = {
       for {

--- a/metals/src/main/scala/scala/meta/internal/metals/Icons.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Icons.scala
@@ -4,6 +4,7 @@ abstract class Icons {
   def rocket: String
   def sync: String
   def alert: String
+  def rightArrow: String
   def info: String
   def check: String
   def findsuper: String
@@ -46,6 +47,7 @@ object Icons {
     override def findsuper: String = "⏫ "
     override def folder: String = "📁 "
     override def github: String = ""
+    override def rightArrow: String = "⇒"
   }
   case object none extends Icons {
     override def rocket: String = ""
@@ -56,6 +58,7 @@ object Icons {
     override def findsuper: String = ""
     override def folder: String = ""
     override def github: String = ""
+    override def rightArrow: String = "=>"
   }
   // icons for vscode can be found here("Icons in Labels"):
   // https://code.visualstudio.com/api/references/icons-in-labels
@@ -68,6 +71,7 @@ object Icons {
     override def findsuper: String = "$(arrow-up)"
     override def folder: String = "$(folder)"
     override def github: String = "$(github) "
+    override def rightArrow: String = "⇒"
   }
   case object atom extends Icons {
     private def span(id: String) = s"<span class='icon icon-$id'></span> "
@@ -79,5 +83,6 @@ object Icons {
     override def findsuper: String = span("up-arrow")
     override def folder: String = span("file-directory")
     override def github: String = span("github")
+    override def rightArrow: String = "⇒"
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -710,7 +710,7 @@ object MetalsEnrichments
       tree.origin match {
         case Origin.Parsed(input, dialect, pos) =>
           val tokens = dialect(input).tokenize.get
-          tokens.slice(pos.end + 1, tokens.length).iterator
+          tokens.slice(pos.end, tokens.length).iterator
         case _ => Iterator.empty
       }
 

--- a/metals/src/main/scala/scala/meta/internal/parsing/TokenEditDistance.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/TokenEditDistance.scala
@@ -145,8 +145,8 @@ final class TokenEditDistance private (
     toRevised(pos.getLine, pos.getCharacter)
   }
 
-  def toRevisedStrict(range: s.Range): Option[l.Range] = {
-    if (isUnchanged) Some(range.toLSP)
+  def toRevisedStrict(range: s.Range): Option[s.Range] = {
+    if (isUnchanged) Some(range)
     else {
       (
         toRevised(range.startLine, range.startCharacter),
@@ -154,9 +154,11 @@ final class TokenEditDistance private (
       ) match {
         case (Right(start), Right(end)) =>
           Some(
-            new l.Range(
-              new l.Position(start.startLine, start.startColumn),
-              new l.Position(end.startLine, end.startColumn)
+            s.Range(
+              start.startLine,
+              start.startColumn,
+              end.startLine,
+              end.startColumn
             )
           )
         case _ => None
@@ -186,6 +188,27 @@ final class TokenEditDistance private (
           (mt, _) => compare(mt.original.pos, originalOffset)
         )
         .fold(EmptyResult.noMatch)(m => Right(m.revised.pos))
+    }
+  }
+
+  def toOriginalStrict(range: s.Range): Option[s.Range] = {
+    if (isUnchanged) Some(range)
+    else {
+      (
+        toOriginal(range.startLine, range.startCharacter),
+        toOriginal(range.endLine, range.endCharacter)
+      ) match {
+        case (Right(start), Right(end)) =>
+          Some(
+            s.Range(
+              start.startLine,
+              start.startColumn,
+              end.endLine,
+              end.endColumn
+            )
+          )
+        case _ => None
+      }
     }
   }
 

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -63,13 +63,13 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
         """|import scala.concurrent.Future
            |case class Location(city: String)
            |object Main{
-           |  def hello()(implicit name: String, from: Location) : Unit = {
+           |  def hello()(implicit name: String, from: Location): Unit = {
            |    println(s"Hello $name from ${from.city}")
            |  }
            |  implicit val andy : String = "Andy"
            |
-           |  def greeting() : Unit = {
-           |    implicit val boston : Location = Location("Boston")
+           |  def greeting(): Unit = {
+           |    implicit val boston: Location = Location("Boston")
            |    hello()(andy, boston)
            |    hello()(andy, boston);    hello()(andy, boston)
            |  }
@@ -205,7 +205,7 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
       _ = assertNoDiff(
         client.workspaceDecorations,
         """|object Main{
-           |  def hello()(implicit name: String) : Unit = {
+           |  def hello()(implicit name: String): Unit = {
            |    println(s"Hello $name!")
            |  }
            |  implicit val andy : String = "Andy"
@@ -360,7 +360,7 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
            |  val abc = 123
            |  val tupleBound @ (one, two) = ("1", "2")
            |  var variable = 123
-           |  val bcd : Int = 2
+           |  val bcd: Int = 2
            |  val (hello, bye) = ("hello", "bye")
            |  def method() = {
            |    val local = 1.0
@@ -396,31 +396,31 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
       _ = assertNoDiff(
         client.workspaceDecorations,
         """|object Main{
-           |  val head : Double :: tail : List[Double] = List(0.1, 0.2, 0.3)
-           |  val List(l1 : Int, l2 : Int) = List(12, 13)
+           |  val head: Double :: tail: List[Double] = List(0.1, 0.2, 0.3)
+           |  val List(l1: Int, l2: Int) = List(12, 13)
            |  println("Hello!")
-           |  val abc : Int = 123
-           |  val tupleBound : (String, String) @ (one : String, two : String) = ("1", "2")
-           |  var variable : Int = 123
-           |  val bcd : Int = 2
-           |  val (hello : String, bye : String) = ("hello", "bye")
-           |  def method() : Unit = {
-           |    val local : Double = 1.0
+           |  val abc: Int = 123
+           |  val tupleBound: (String, String) @ (one: String, two: String) = ("1", "2")
+           |  var variable: Int = 123
+           |  val bcd: Int = 2
+           |  val (hello: String, bye: String) = ("hello", "bye")
+           |  def method(): Unit = {
+           |    val local: Double = 1.0
            |  }
-           |  def methodNoParen : Unit = {
-           |    val (local : String, _) = ("", 1.0)
+           |  def methodNoParen: Unit = {
+           |    val (local: String, _) = ("", 1.0)
            |  }
-           |  def hello()(name: String) : Unit = {
+           |  def hello()(name: String): Unit = {
            |    println(s"Hello $name!")
            |  }
-           |  def hello2()(name: String = "") : Unit = {
+           |  def hello2()(name: String = ""): Unit = {
            |    println(s"Hello $name!")
            |  }
-           |  val tpl1 : (Int, Int) = (123, 1)
-           |  val tpl2 : (Int, Int, Int) = (123, 1, 3)
-           |  val func0 : () => Int = () => 2
-           |  val func1 : (Int) => Int = (a : Int) => a + 2
-           |  val func2 : (Int, Int) => Int = (a : Int, b: Int) => a + b
+           |  val tpl1: (Int, Int) = (123, 1)
+           |  val tpl2: (Int, Int, Int) = (123, 1, 3)
+           |  val func0: () => Int = () => 2
+           |  val func1: (Int) => Int = (a : Int) => a + 2
+           |  val func2: (Int, Int) => Int = (a : Int, b: Int) => a + b
            |}
            |""".stripMargin
       )
@@ -456,7 +456,7 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
       _ = assertNoDiff(
         client.workspaceDecorations,
         """|object Main{
-           |  val abc : Int = 123
+           |  val abc: Int = 123
            |}
            |""".stripMargin
       )
@@ -468,7 +468,7 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
         client.workspaceDecorations,
         """|
            |object Main{
-           |  val abc : Int = 123
+           |  val abc: Int = 123
            |}
            |""".stripMargin
       )
@@ -481,7 +481,7 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
         """|}
            |
            |object Main{
-           |  val abc : Int = 123
+           |  val abc: Int = 123
            |}
            |""".stripMargin
       )

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -63,13 +63,13 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
         """|import scala.concurrent.Future
            |case class Location(city: String)
            |object Main{
-           |  def hello()(implicit name: String, from: Location) = {
+           |  def hello()(implicit name: String, from: Location) : Unit = {
            |    println(s"Hello $name from ${from.city}")
            |  }
            |  implicit val andy : String = "Andy"
            |
-           |  def greeting() = {
-           |    implicit val boston = Location("Boston")
+           |  def greeting() : Unit = {
+           |    implicit val boston : Location = Location("Boston")
            |    hello()(andy, boston)
            |    hello()(andy, boston);    hello()(andy, boston)
            |  }
@@ -205,7 +205,7 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
       _ = assertNoDiff(
         client.workspaceDecorations,
         """|object Main{
-           |  def hello()(implicit name: String) = {
+           |  def hello()(implicit name: String) : Unit = {
            |    println(s"Hello $name!")
            |  }
            |  implicit val andy : String = "Andy"
@@ -337,6 +337,151 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
         """|object Main{
            |  augmentString("asd.").stripSuffix(".")
            |  augmentString("asd.").stripSuffix(".")
+           |}
+           |""".stripMargin
+      )
+    } yield ()
+  }
+
+  test("inferred-type-various") {
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {}
+           |}
+           |
+           |/a/src/main/scala/Main.scala
+           |object Main{
+           |  val head :: tail = List(0.1, 0.2, 0.3)
+           |  val List(l1, l2) = List(12, 13)
+           |  println("Hello!")
+           |  val abc = 123
+           |  val tupleBound @ (one, two) = ("1", "2")
+           |  var variable = 123
+           |  val bcd : Int = 2
+           |  val (hello, bye) = ("hello", "bye")
+           |  def method() = {
+           |    val local = 1.0
+           |  }
+           |  def methodNoParen = {
+           |    val (local, _) = ("", 1.0)
+           |  }
+           |  def hello()(name: String) = {
+           |    println(s"Hello $$name!")
+           |  }
+           |  def hello2()(name: String = "") = {
+           |    println(s"Hello $$name!")
+           |  }
+           |  val tpl1 = (123, 1)
+           |  val tpl2 = (123, 1, 3)
+           |  val func0 = () => 2
+           |  val func1 = (a : Int) => a + 2
+           |  val func2 = (a : Int, b: Int) => a + b
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didChangeConfiguration(
+        """{
+          |  "show-implicit-arguments": true,
+          |  "show-implicit-conversions": true,
+          |  "show-inferred-type": true
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      _ <- server.didSave("a/src/main/scala/Main.scala")(identity)
+      _ = assertNoDiagnostics()
+      _ = assertNoDiff(
+        client.workspaceDecorations,
+        """|object Main{
+           |  val head : Double :: tail : List[Double] = List(0.1, 0.2, 0.3)
+           |  val List(l1 : Int, l2 : Int) = List(12, 13)
+           |  println("Hello!")
+           |  val abc : Int = 123
+           |  val tupleBound : (String, String) @ (one : String, two : String) = ("1", "2")
+           |  var variable : Int = 123
+           |  val bcd : Int = 2
+           |  val (hello : String, bye : String) = ("hello", "bye")
+           |  def method() : Unit = {
+           |    val local : Double = 1.0
+           |  }
+           |  def methodNoParen : Unit = {
+           |    val (local : String, _) = ("", 1.0)
+           |  }
+           |  def hello()(name: String) : Unit = {
+           |    println(s"Hello $name!")
+           |  }
+           |  def hello2()(name: String = "") : Unit = {
+           |    println(s"Hello $name!")
+           |  }
+           |  val tpl1 : (Int, Int) = (123, 1)
+           |  val tpl2 : (Int, Int, Int) = (123, 1, 3)
+           |  val func0 : () => Int = () => 2
+           |  val func1 : (Int) => Int = (a : Int) => a + 2
+           |  val func2 : (Int, Int) => Int = (a : Int, b: Int) => a + b
+           |}
+           |""".stripMargin
+      )
+    } yield ()
+  }
+
+  test("inferred-type-changes") {
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {}
+           |}
+           |
+           |/a/src/main/scala/Main.scala
+           |object Main{
+           |  val abc = 123
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didChangeConfiguration(
+        """{
+          |  "show-implicit-arguments": true,
+          |  "show-implicit-conversions": true,
+          |  "show-inferred-type": true
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      _ <- server.didSave("a/src/main/scala/Main.scala")(identity)
+      _ = assertNoDiagnostics()
+      _ = assertNoDiff(
+        client.workspaceDecorations,
+        """|object Main{
+           |  val abc : Int = 123
+           |}
+           |""".stripMargin
+      )
+      // introduce a change
+      _ <- server.didChange("a/src/main/scala/Main.scala") { text =>
+        "\n" + text
+      }
+      _ = assertNoDiff(
+        client.workspaceDecorations,
+        """|
+           |object Main{
+           |  val abc : Int = 123
+           |}
+           |""".stripMargin
+      )
+      // introduce a parsing error
+      _ <- server.didChange("a/src/main/scala/Main.scala") { text =>
+        "}\n" + text
+      }
+      _ = assertNoDiff(
+        client.workspaceDecorations,
+        """|}
+           |
+           |object Main{
+           |  val abc : Int = 123
            |}
            |""".stripMargin
       )


### PR DESCRIPTION
Previously, we added inferred type for synthetic types, however it's also possible to use semanticdb to get type of definitions.

To that end in this PR showing type was implemented in the following steps:
1. Trees for the file are taken from the cache.
2. Tree is searched for any definitions that do not have a declared type and ranges for those are returned.
2a. If the definition is a method we additionally calculate the position for the type to be shown.
3. We go through occurences and if a symbol is a definition and range was found previously to not contain declared type, the new decoration is added.
3a. For methods we use the position previously calculated to show the type.

A better type printing for tuples and functions was also added to show:
- `(Int, String)` instead of `Tuple2[Int, String]`
- `(Int) => String` instead of `Function1[Int, String]`

Additionally, the new feature will work with any changes to the file including ones that break the parsing of the file.

And lastly, a demo!

![metals-sample-1611588594485](https://user-images.githubusercontent.com/3807253/105728289-45d94a00-5f2c-11eb-8e93-ada0f0f1074f.gif)

Connected to https://github.com/scalameta/metals-feature-requests/issues/21 - I think we can close that one once this is merged and create a feature request for showing named parameters as the last one.