### PR TITLE
Remove MunitReportPlugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -700,4 +700,4 @@ lazy val docs = project
     )
   )
   .dependsOn(metals)
-  .enablePlugins(DocusaurusPlugin, MUnitReportPlugin)
+  .enablePlugins(DocusaurusPlugin)

--- a/docs/contributors/tests.md
+++ b/docs/contributors/tests.md
@@ -5,6 +5,7 @@ title: Tests overview
 
 The following table is an overview of the test suites in the Metals codebase.
 
+<!-- 
 ```scala mdoc:munit
 
-```
+``` -->


### PR DESCRIPTION
It seems we are hitting on:
`com.google.cloud.storage.StorageException: The project to be billed is associated with a closed billing account.`
so porbably some issue with the storage for the reports. We can remove it for now I guess and fix/setup something later.

@olafurpg any idea what is going on?