### PR TITLE
Update docs on system-properties and inline decorations.

### DIFF
--- a/docs/integrations/decoration-protocol.md
+++ b/docs/integrations/decoration-protocol.md
@@ -72,18 +72,20 @@ consists of a single JSON-RPC notification.
 
 ### `initialize`
 
-The Decoration Protocol is only enabled when both the client and server declare
-support for the protocol by adding an `decorationProvider: true` field to the
-experimental section of the server and client capabilities in the `initialize`
-response.
+The Decoration Protocol is only enabled when client declares support for the
+protocol by adding an `decorationProvider: true` field to the
+`initializationOptions` during the `initialize` request.
+
+Depending on your editor, it may also allow for inline decorations. This is used
+for features like showing implicit arguments and inferred types, both which are
+user configuration settings that a user can toggle. However, in order for those
+features to use decorations rather than just extra information in your hover,
+your client also needs to declare that it's an `inlineDecorationsProvider`.
 
 ```json
-{
-  "capabilities": {
-    "experimental": {
-      "decorationProvider": true
-    }
-  }
+"initializationOptions": {
+  "decorationProvider": true,
+  "inlineDecorationProvider": true
 }
 ```
 

--- a/docs/integrations/new-editor.md
+++ b/docs/integrations/new-editor.md
@@ -597,10 +597,6 @@ Default value is `-Dbloop.sbt.version=@SBT_BLOOP_VERSION@`.
 The below properties are also available as user configuration options. It's
 preferable to set these there:
 
-```scala mdoc:user-config:system-property
-
-```
-
 ### `-Dmetals.bloop-port`
 
 Port number of the Bloop server to connect to. Should only be used if Bloop

--- a/metals-docs/src/main/scala/docs/UserConfigurationModifier.scala
+++ b/metals-docs/src/main/scala/docs/UserConfigurationModifier.scala
@@ -15,20 +15,6 @@ class UserConfigurationModifier extends StringModifier {
       reporter: Reporter
   ): String = {
     info match {
-      case "system-property" =>
-        UserConfiguration.options
-          .map { option =>
-            s"""
-               |### `-Dmetals.${option.key}`
-               |
-               |${option.description}
-               |
-               |**Default**: ${option.default}
-               |
-               |**Note**: this property can also be defined as user configuration option [${option.title}](#${option.headerID}).
-               |""".stripMargin
-          }
-          .mkString("\n")
       case "lsp-config-default" =>
         UserConfiguration.options
           .map { option =>


### PR DESCRIPTION
This removes the generated system-properties fields for new user configuration
settings. The reason for this is that new user configuration settings aren't
actually available as system properties anymore.

This also adds in a small section about enabling inline decorations to the
decoration protocol page.

Fixes #2439