### PR TITLE
Correct dialect for standalone scripts.

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
@@ -36,7 +36,13 @@ class SemanticdbTextDocumentProvider(val compiler: MetalsGlobal) {
       SemanticdbConfig.default
     )
 
-    val explicitDialect = if (filename.isSbt) Some(dialects.Sbt1) else None
+    val explicitDialect = if (filename.isSbt) {
+      Some(dialects.Sbt1)
+    } else if (filename.isScalaScript) {
+      Some(dialects.Scala213.withAllowToplevelStatements(true))
+    } else {
+      None
+    }
     val document = unit.toTextDocument(explicitDialect)
     val fileUri = Paths.get(new URI(filename))
     compiler.workspace


### PR DESCRIPTION
Ensure that we have the correct dialect when creating semanticdb for
standalone .sc files. This was causing exceptions to be thrown for .sc
files since it wasn't recognizing the top level definitions.

Fixes #2430