### PR TITLE
Add support for type decorations in for comprehensions and patterns

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -385,6 +385,14 @@ final class SyntheticsDecorationProvider(
 
     def visit(tree: m.Tree): List[s.Range] = {
       tree match {
+        case enumerator: m.Enumerator.Generator =>
+          explorePatterns(List(enumerator.pat)) ++ visit(enumerator.rhs)
+        case enumerator: m.Enumerator.CaseGenerator =>
+          explorePatterns(List(enumerator.pat)) ++ visit(enumerator.rhs)
+        case enumerator: m.Enumerator.Val =>
+          explorePatterns(List(enumerator.pat)) ++ visit(enumerator.rhs)
+        case cs: m.Case =>
+          explorePatterns(List(cs.pat)) ++ visit(cs.body)
         case vl: m.Defn.Val =>
           val values =
             if (vl.decltpe.isEmpty) explorePatterns(vl.pats) else Nil

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -379,13 +379,21 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
            |  val func0 = () => 2
            |  val func1 = (a : Int) => a + 2
            |  val func2 = (a : Int, b: Int) => a + b
+           |  val complex = tail.zip(1 to 12)
+           |  for{
+           |    i <- complex
+           |    c = func1
+           |  } i match {
+           |    case (b, c: Int) =>
+           |    case a =>
+           |  }
            |}
            |""".stripMargin
       )
       _ <- server.didChangeConfiguration(
         """{
-          |  "show-implicit-arguments": true,
-          |  "show-implicit-conversions": true,
+          |  "show-implicit-arguments": false,
+          |  "show-implicit-conversions": false,
           |  "show-inferred-type": true
           |}
           |""".stripMargin
@@ -421,6 +429,14 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
            |  val func0: () => Int = () => 2
            |  val func1: (Int) => Int = (a : Int) => a + 2
            |  val func2: (Int, Int) => Int = (a : Int, b: Int) => a + b
+           |  val complex: List[(Double, Int)] = tail.zip[Double, Int, List[(Double, Int)]](1 to 12)
+           |  for{
+           |    i: (Double, Int) <- complex
+           |    c: (Int) => Int = func1
+           |  } i match {
+           |    case (b: Double, c: Int) =>
+           |    case a: (Double, Int) =>
+           |  }
            |}
            |""".stripMargin
       )


### PR DESCRIPTION
Totally forgot about adding those and turns out it's not that hard to do. `CaseGenerator` is coming from Dotty and will not work for a while, but should start once we get symbol information inside semanticdb generated by the Scala 3 compiler.

If anyone has any ideas, what we might be missing still, let me know!