### PR TITLE
Fix printed inferred type for complex types

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -121,7 +121,8 @@ final class SyntheticsDecorationProvider(
             isHover = true,
             toHoverString(textDocument),
             PrinterSymtab.fromTextDocument(textDocument),
-            clientConfig.icons().rightArrow
+            clientConfig.icons().rightArrow,
+            clientConfig.icons().ellipsis
           )
           val syntheticsAtLine = for {
             synthetic <- textDocument.synthetics
@@ -329,7 +330,8 @@ final class SyntheticsDecorationProvider(
         isHover = false,
         toDecorationString(textDocument),
         PrinterSymtab.fromTextDocument(textDocument),
-        clientConfig.icons().rightArrow
+        clientConfig.icons().rightArrow,
+        clientConfig.icons().ellipsis
       )
 
       val decorations = for {

--- a/metals/src/main/scala/scala/meta/internal/metals/Icons.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Icons.scala
@@ -5,6 +5,7 @@ abstract class Icons {
   def sync: String
   def alert: String
   def rightArrow: String
+  def ellipsis: String
   def info: String
   def check: String
   def findsuper: String
@@ -48,6 +49,7 @@ object Icons {
     override def folder: String = "📁 "
     override def github: String = ""
     override def rightArrow: String = "⇒"
+    override def ellipsis: String = "…"
   }
   case object none extends Icons {
     override def rocket: String = ""
@@ -59,6 +61,7 @@ object Icons {
     override def folder: String = ""
     override def github: String = ""
     override def rightArrow: String = "=>"
+    override def ellipsis: String = "..."
   }
   // icons for vscode can be found here("Icons in Labels"):
   // https://code.visualstudio.com/api/references/icons-in-labels
@@ -72,6 +75,7 @@ object Icons {
     override def folder: String = "$(folder)"
     override def github: String = "$(github) "
     override def rightArrow: String = "⇒"
+    override def ellipsis: String = "…"
   }
   case object atom extends Icons {
     private def span(id: String) = s"<span class='icon icon-$id'></span> "
@@ -84,5 +88,6 @@ object Icons {
     override def folder: String = span("file-directory")
     override def github: String = span("github")
     override def rightArrow: String = "⇒"
+    override def ellipsis: String = "…"
   }
 }


### PR DESCRIPTION
While browsing Metals with the new feature I came upon some issues in non-obvious cases. I try to fix them all here:

- existential types are not that useful to show in the type decorations, so I changed to show the base type only. It happens in a situation like:
```scala
   val job = ec.submit(new Runnable {
      override def run(): Unit = {
        launcher.runLauncher(
          bloopVersion,
          skipBspConnection = false,
          Nil
        )
        finished.success(())
      }
    })
```
aside from existential type in the above example we also had an issue with a locally defined type. Instead of `local123` we now just print `_`, which is also returned by normal hover.

- structural types now show with `...` only if there is something contained in them
- with types like `new A with B {}` no longer show `AnyRef` as first type