### PR TITLE
Remove dependency on io.methvin:directory-watcher.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -393,7 +393,6 @@ lazy val metals = project
       // for measuring memory footprint
       "org.openjdk.jol" % "jol-core" % "0.14",
       // for file watching
-      "io.methvin" % "directory-watcher" % "0.10.1",
       "com.swoval" % "file-tree-views" % "2.1.6",
       // for http client
       "io.undertow" % "undertow-core" % "2.2.3.Final",

--- a/metals/src/main/java/scala/meta/internal/watcher/DirectoryChangeEvent.java
+++ b/metals/src/main/java/scala/meta/internal/watcher/DirectoryChangeEvent.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTE: That this class is taken verbatim from io.methvin:directory-watcher.
+ * Seeing that we have replaced the directory-watcher functionality with swoval
+ * we are instead just re-utilizing the few DirectoryChangeEvent related
+ * classes.
+ */
+package scala.meta.internal.watcher;
+
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.util.Objects;
+
+public final class DirectoryChangeEvent {
+  public enum EventType {
+
+    /* A new file was created */
+    CREATE(StandardWatchEventKinds.ENTRY_CREATE),
+
+    /* An existing file was modified */
+    MODIFY(StandardWatchEventKinds.ENTRY_MODIFY),
+
+    /* A file was deleted */
+    DELETE(StandardWatchEventKinds.ENTRY_DELETE),
+
+    /* An overflow occurred; some events were lost */
+    OVERFLOW(StandardWatchEventKinds.OVERFLOW);
+
+    private WatchEvent.Kind<?> kind;
+
+    EventType(WatchEvent.Kind<?> kind) {
+      this.kind = kind;
+    }
+
+    public WatchEvent.Kind<?> getWatchEventKind() {
+      return kind;
+    }
+  }
+
+  private final EventType eventType;
+  private final Path path;
+  private final int count;
+
+  public DirectoryChangeEvent(EventType eventType, Path path, int count) {
+    this.eventType = eventType;
+    this.path = path;
+    this.count = count;
+  }
+
+  public EventType eventType() {
+    return eventType;
+  }
+
+  public Path path() {
+    return path;
+  }
+
+  public int count() {
+    return count;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    DirectoryChangeEvent that = (DirectoryChangeEvent) o;
+    return count == that.count && eventType == that.eventType && Objects.equals(path, that.path);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(eventType, path, count);
+  }
+
+  @Override
+  public String toString() {
+    return "DirectoryChangeEvent{"
+        + "eventType="
+        + eventType
+        + ", path="
+        + path
+        + ", count="
+        + count
+        + '}';
+  }
+}

--- a/metals/src/main/java/scala/meta/internal/watcher/hashing/FileHasher.java
+++ b/metals/src/main/java/scala/meta/internal/watcher/hashing/FileHasher.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTE: That this class is taken verbatim from io.methvin:directory-watcher.
+ * Seeing that we have replaced the directory-watcher functionality with swoval
+ * we are instead just re-utilizing the few DirectoryChangeEvent related
+ * classes.
+ */
+package scala.meta.internal.watcher.hashing;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+
+/**
+ * A function to convert a Path to a hash code used to check if the file content is changed. This is
+ * called by DirectoryWatcher after checking that the path exists and is not a directory. Therefore
+ * this hasher can generally assume that those two things are true.
+ *
+ * <p>By default, this hasher may throw an IOException, which will be treated as a `null` hash by
+ * the watcher, meaning the associated event will be ignored. If you want to handle that exception
+ * you can catch/rethrow it.
+ */
+@FunctionalInterface
+public interface FileHasher {
+  /** The default file hasher instance, which uses Murmur3. */
+  FileHasher DEFAULT_FILE_HASHER =
+      path -> {
+        Murmur3F murmur = new Murmur3F();
+        try (InputStream is = new BufferedInputStream(Files.newInputStream(path))) {
+          int b;
+          while ((b = is.read()) != -1) {
+            murmur.update(b);
+          }
+        }
+        return HashCode.fromBytes(murmur.getValueBytesBigEndian());
+      };
+
+  /**
+   * A file hasher that returns the last modified time provided by the OS.
+   *
+   * <p>This only works reliably on certain file systems and JDKs that support at least
+   * millisecond-level precision.
+   */
+  FileHasher LAST_MODIFIED_TIME =
+      path -> {
+        Instant modifyTime = Files.getLastModifiedTime(path).toInstant();
+        ByteBuffer buffer = ByteBuffer.allocate(2 * Long.BYTES);
+        buffer.putLong(modifyTime.getEpochSecond());
+        buffer.putLong(modifyTime.getNano());
+        return new HashCode(buffer.array());
+      };
+
+  HashCode hash(Path path) throws IOException;
+}

--- a/metals/src/main/java/scala/meta/internal/watcher/hashing/HashCode.java
+++ b/metals/src/main/java/scala/meta/internal/watcher/hashing/HashCode.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTE: That this class is taken verbatim from io.methvin:directory-watcher.
+ * Seeing that we have replaced the directory-watcher functionality with swoval
+ * we are instead just re-utilizing the few DirectoryChangeEvent related
+ * classes.
+ */
+package scala.meta.internal.watcher.hashing;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Formatter;
+
+/** A class representing the hash code of a file. */
+public class HashCode {
+  private final byte[] value;
+
+  public static HashCode fromBytes(byte[] value) {
+    return new HashCode(Arrays.copyOf(value, value.length));
+  }
+
+  public static HashCode fromLong(long value) {
+    ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+    buffer.putLong(value);
+    return new HashCode(buffer.array());
+  }
+
+  public static HashCode empty() {
+    return new HashCode(new byte[0]);
+  }
+
+  HashCode(byte[] value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    HashCode hashCode = (HashCode) o;
+    return Arrays.equals(value, hashCode.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(value);
+  }
+
+  @Override
+  public String toString() {
+    Formatter formatter = new Formatter();
+    for (byte b : value) {
+      formatter.format("%02x", b);
+    }
+    return formatter.toString();
+  }
+}

--- a/metals/src/main/java/scala/meta/internal/watcher/hashing/Murmur3F.java
+++ b/metals/src/main/java/scala/meta/internal/watcher/hashing/Murmur3F.java
@@ -1,0 +1,289 @@
+/*
+ * Code adapted from Greenrobot Essentials Murmur3F.java (https://git.io/fAG0Z)
+ *
+ * Copyright (C) 2014-2016 Markus Junginger, greenrobot (http://greenrobot.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTE: That this class is taken verbatim from io.methvin:directory-watcher.
+ * Seeing that we have replaced the directory-watcher functionality with swoval
+ * we are instead just re-utilizing the few DirectoryChangeEvent related
+ * classes.
+ */
+package scala.meta.internal.watcher.hashing;
+
+import java.math.BigInteger;
+import java.util.zip.Checksum;
+
+/** Murmur3F (MurmurHash3_x64_128) */
+public class Murmur3F implements Checksum {
+
+  private static final long C1 = 0x87c37b91114253d5L;
+  private static final long C2 = 0x4cf5ad432745937fL;
+
+  private final long seed;
+
+  private long h1;
+  private long h2;
+  private int length;
+
+  private int partialPos;
+  private long partialK1;
+  private long partialK2;
+
+  private boolean finished;
+  private long finishedH1;
+  private long finishedH2;
+
+  public Murmur3F() {
+    seed = 0;
+  }
+
+  public Murmur3F(int seed) {
+    this.seed = seed & 0xffffffffL; // unsigned 32 bit -> long
+    h1 = h2 = this.seed;
+  }
+
+  @Override
+  public void update(int b) {
+    finished = false;
+    switch (partialPos) {
+      case 0:
+        partialK1 = 0xff & b;
+        break;
+      case 1:
+        partialK1 |= (0xff & b) << 8;
+        break;
+      case 2:
+        partialK1 |= (0xff & b) << 16;
+        break;
+      case 3:
+        partialK1 |= (0xffL & b) << 24;
+        break;
+      case 4:
+        partialK1 |= (0xffL & b) << 32;
+        break;
+      case 5:
+        partialK1 |= (0xffL & b) << 40;
+        break;
+      case 6:
+        partialK1 |= (0xffL & b) << 48;
+        break;
+      case 7:
+        partialK1 |= (0xffL & b) << 56;
+        break;
+      case 8:
+        partialK2 = 0xff & b;
+        break;
+      case 9:
+        partialK2 |= (0xff & b) << 8;
+        break;
+      case 10:
+        partialK2 |= (0xff & b) << 16;
+        break;
+      case 11:
+        partialK2 |= (0xffL & b) << 24;
+        break;
+      case 12:
+        partialK2 |= (0xffL & b) << 32;
+        break;
+      case 13:
+        partialK2 |= (0xffL & b) << 40;
+        break;
+      case 14:
+        partialK2 |= (0xffL & b) << 48;
+        break;
+      case 15:
+        partialK2 |= (0xffL & b) << 56;
+        break;
+    }
+
+    partialPos++;
+    if (partialPos == 16) {
+      applyKs(partialK1, partialK2);
+      partialPos = 0;
+    }
+    length++;
+  }
+
+  public void update(byte[] b) {
+    update(b, 0, b.length);
+  }
+
+  @Override
+  public void update(byte[] b, int off, int len) {
+    finished = false;
+    while (partialPos != 0 && len > 0) {
+      update(b[off]);
+      off++;
+      len--;
+    }
+
+    int remainder = len & 0xF;
+    int stop = off + len - remainder;
+    for (int i = off; i < stop; i += 16) {
+      long k1 = getLongLE(b, i);
+      long k2 = getLongLE(b, i + 8);
+      applyKs(k1, k2);
+    }
+    length += stop - off;
+
+    for (int i = 0; i < remainder; i++) {
+      update(b[stop + i]);
+    }
+  }
+
+  private void applyKs(long k1, long k2) {
+    k1 *= C1;
+    k1 = Long.rotateLeft(k1, 31);
+    k1 *= C2;
+    h1 ^= k1;
+
+    h1 = Long.rotateLeft(h1, 27);
+    h1 += h2;
+    h1 = h1 * 5 + 0x52dce729;
+
+    k2 *= C2;
+    k2 = Long.rotateLeft(k2, 33);
+    k2 *= C1;
+    h2 ^= k2;
+
+    h2 = Long.rotateLeft(h2, 31);
+    h2 += h1;
+    h2 = h2 * 5 + 0x38495ab5;
+  }
+
+  private void checkFinished() {
+    if (!finished) {
+      finished = true;
+      finishedH1 = h1;
+      finishedH2 = h2;
+      if (partialPos > 0) {
+        if (partialPos > 8) {
+          long k2 = partialK2 * C2;
+          k2 = Long.rotateLeft(k2, 33);
+          k2 *= C1;
+          finishedH2 ^= k2;
+        }
+        long k1 = partialK1 * C1;
+        k1 = Long.rotateLeft(k1, 31);
+        k1 *= C2;
+        finishedH1 ^= k1;
+      }
+
+      finishedH1 ^= length;
+      finishedH2 ^= length;
+
+      finishedH1 += finishedH2;
+      finishedH2 += finishedH1;
+
+      finishedH1 = fmix64(finishedH1);
+      finishedH2 = fmix64(finishedH2);
+
+      finishedH1 += finishedH2;
+      finishedH2 += finishedH1;
+    }
+  }
+
+  private long fmix64(long k) {
+    k ^= k >>> 33;
+    k *= 0xff51afd7ed558ccdL;
+    k ^= k >>> 33;
+    k *= 0xc4ceb9fe1a85ec53L;
+    k ^= k >>> 33;
+    return k;
+  }
+
+  @Override
+  /**
+   * Returns the lower 64 bits of the 128 bit hash (you can use just this value this as a 64 bit
+   * hash).
+   */
+  public long getValue() {
+    checkFinished();
+    return finishedH1;
+  }
+
+  /** Returns the higher 64 bits of the 128 bit hash. */
+  public long getValueHigh() {
+    checkFinished();
+    return finishedH2;
+  }
+
+  /** Positive value. */
+  public BigInteger getValueBigInteger() {
+    byte[] bytes = getValueBytesBigEndian();
+    return new BigInteger(1, bytes);
+  }
+
+  /** Padded with leading 0s to ensure length of 32. */
+  public String getValueHexString() {
+    checkFinished();
+    return getPaddedHexString(finishedH2) + getPaddedHexString(finishedH1);
+  }
+
+  private String getPaddedHexString(long value) {
+    String string = Long.toHexString(value);
+    while (string.length() < 16) {
+      string = '0' + string;
+    }
+    return string;
+  }
+
+  public byte[] getValueBytesBigEndian() {
+    checkFinished();
+    byte[] bytes = new byte[16];
+    for (int i = 0; i < 8; i++) {
+      bytes[i] = (byte) ((finishedH2 >>> (56 - i * 8)) & 0xff);
+    }
+    for (int i = 0; i < 8; i++) {
+      bytes[8 + i] = (byte) ((finishedH1 >>> (56 - i * 8)) & 0xff);
+    }
+    return bytes;
+  }
+
+  public byte[] getValueBytesLittleEndian() {
+    checkFinished();
+    byte[] bytes = new byte[16];
+    for (int i = 0; i < 8; i++) {
+      bytes[i] = (byte) ((finishedH1 >>> (i * 8)) & 0xff);
+    }
+    for (int i = 0; i < 8; i++) {
+      bytes[8 + i] = (byte) ((finishedH2 >>> (i * 8)) & 0xff);
+    }
+    return bytes;
+  }
+
+  @Override
+  public void reset() {
+    h1 = h2 = seed;
+    length = 0;
+    partialPos = 0;
+    finished = false;
+
+    // The remainder is not really necessary, but looks nicer when debugging
+    partialK1 = partialK2 = 0;
+    finishedH1 = finishedH2 = 0;
+  }
+
+  private long getLongLE(byte[] bytes, int index) {
+    return (bytes[index] & 0xff)
+        | ((bytes[index + 1] & 0xff) << 8)
+        | ((bytes[index + 2] & 0xff) << 16)
+        | ((bytes[index + 3] & 0xffL) << 24)
+        | ((bytes[index + 4] & 0xffL) << 32)
+        | ((bytes[index + 5] & 0xffL) << 40)
+        | ((bytes[index + 6] & 0xffL) << 48)
+        | (((long) bytes[index + 7]) << 56);
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileWatcher.scala
@@ -7,6 +7,10 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.collection.mutable
 
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.watcher.DirectoryChangeEvent
+import scala.meta.internal.watcher.DirectoryChangeEvent.EventType
+import scala.meta.internal.watcher.hashing.FileHasher
+import scala.meta.internal.watcher.hashing.HashCode
 import scala.meta.io.AbsolutePath
 
 import com.swoval.files.FileTreeDataViews.CacheObserver
@@ -15,10 +19,6 @@ import com.swoval.files.FileTreeDataViews.Entry
 import com.swoval.files.FileTreeRepositories
 import com.swoval.files.FileTreeRepository
 import com.swoval.files.TypedPath
-import io.methvin.watcher.DirectoryChangeEvent
-import io.methvin.watcher.DirectoryChangeEvent.EventType
-import io.methvin.watcher.hashing.FileHasher
-import io.methvin.watcher.hashing.HashCode
 
 /**
  * Handles file watching of interesting files in this build.

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -67,6 +67,8 @@ import scala.meta.internal.rename.RenameProvider
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.semver.SemVer
 import scala.meta.internal.tvp._
+import scala.meta.internal.watcher.DirectoryChangeEvent
+import scala.meta.internal.watcher.DirectoryChangeEvent.EventType
 import scala.meta.internal.worksheets.DecorationWorksheetPublisher
 import scala.meta.internal.worksheets.WorksheetProvider
 import scala.meta.internal.worksheets.WorkspaceEditWorksheetPublisher
@@ -79,8 +81,6 @@ import ch.epfl.scala.bsp4j.CompileReport
 import ch.epfl.scala.{bsp4j => b}
 import com.google.gson.JsonElement
 import com.google.gson.JsonPrimitive
-import io.methvin.watcher.DirectoryChangeEvent
-import io.methvin.watcher.DirectoryChangeEvent.EventType
 import io.undertow.server.HttpServerExchange
 import org.eclipse.lsp4j._
 import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}


### PR DESCRIPTION
As of https://github.com/scalameta/metals/pull/2014 we replaced the
directory watching functionality with that of Swoval. However, we do
re-use some of the functionality of directory-watcher, mainly the
DirectoryChangeEvent and some hashing utils that it utilizes. This
change removes the full directory-watcher dependency but copies over the
few necessary classes from that library into a
scala.meta.internal.watcher package.

Closes #2365