### PR TITLE
Pass URI to `semanticdbTextDocument` method and fix possible issues

### DIFF
--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -96,7 +96,7 @@ public abstract class PresentationCompiler {
     /**
      * Returns the Protobuf byte array representation of a SemanticDB <code>TextDocument</code> for the given source.
      */
-    public abstract CompletableFuture<byte[]> semanticdbTextDocument(String filename, String code);
+    public abstract CompletableFuture<byte[]> semanticdbTextDocument(URI filename, String code);
 
     // =================================
     // Configuration and lifecycle APIs.

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -183,7 +183,7 @@ case class ScalaPresentationCompiler(
   }
 
   override def semanticdbTextDocument(
-      filename: String,
+      uri: URI,
       code: String
   ): CompletableFuture[Array[Byte]] = {
     compilerAccess.withInterruptableCompiler(
@@ -191,7 +191,7 @@ case class ScalaPresentationCompiler(
       EmptyCancelToken
     ) { pc =>
       new SemanticdbTextDocumentProvider(pc.compiler)
-        .textDocument(filename, code)
+        .textDocument(uri, code)
         .toByteArray
     }
   }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -170,7 +170,7 @@ case class ScalaPresentationCompiler(
 
   // TODO NOT IMPLEMENTED
   def semanticdbTextDocument(
-      filename: String,
+      filename: URI,
       code: String
   ): CompletableFuture[Array[Byte]] = {
     CompletableFuture.completedFuture(


### PR DESCRIPTION
Previously we would use string for `PresentationCompiler.semanticdbTextDocument` method, which is not neccessary as we need to turn it back into URI anyway. This seems to also cause possibly cause the issues with:
```
Feb 01, 2021 11:32:01 AM scala.meta.internal.pc.CompilerAccess handleError
SEVERE: null
java.nio.file.ProviderMismatchException
        at sun.nio.fs.UnixPath.toUnixPath(UnixPath.java:200)
        at sun.nio.fs.UnixPath.relativize(UnixPath.java:410)
        at sun.nio.fs.UnixPath.relativize(UnixPath.java:43)
        at scala.meta.internal.pc.SemanticdbTextDocumentProvider.$anonfun$textDocument$2(SemanticdbTextDocumentProvider.scala:38)
        at scala.Option.map(Option.scala:230)
        at scala.meta.internal.pc.SemanticdbTextDocumentProvider.textDocument(SemanticdbTextDocumentProvider.scala:37)
```
I also added a Try there just to be on the safe side and additional check when calculating semanticdb in InteractiveSemanticdb.