### PR TITLE
Fallback Scala version - filter out `automatic` value

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -386,8 +386,10 @@ object UserConfiguration {
       getBooleanKey("enable-strip-margin-on-type-formatting").getOrElse(true)
     val excludedPackages =
       getStringListKey("excluded-packages")
+    // `automatic` should be treated as None
+    // It was added only to have a meaningful option value in vscode
     val defaultScalaVersion =
-      getStringKey("fallback-scala-version")
+      getStringKey("fallback-scala-version").filter(_ != "automatic")
     if (errors.isEmpty) {
       Right(
         UserConfiguration(


### PR DESCRIPTION
For vscode extension, this configuration option is defined as `enum`.
In order to have a way to select `default` behavior where this Scala version might be inferred from build targets, I've added [`automatic`](https://github.com/scalameta/metals-vscode/pull/494/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R195) value.