### PR TITLE
Fix issues with references in standalone files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -1,7 +1,6 @@
 package scala.meta.internal.decorations
 
 import java.nio.charset.Charset
-import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.mutable
@@ -18,7 +17,6 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metap.PrinterSymtab
 import scala.meta.internal.mtags.Md5Fingerprints
-import scala.meta.internal.mtags.SemanticdbClasspath
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.parsing.TokenEditDistance
 import scala.meta.internal.parsing.Trees
@@ -85,21 +83,16 @@ final class SyntheticsDecorationProvider(
       Future.successful(())
   }
 
-  def onChange(textDocument: TextDocuments, path: Path): Unit = {
+  def onChange(textDocument: TextDocuments, path: AbsolutePath): Unit = {
     for {
       focused <- focusedDocument()
-      filePath = AbsolutePath(path)
-      sourcePath <-
-        if (!filePath.isScalaFilename)
-          SemanticdbClasspath.toScala(workspace, filePath)
-        else Some(filePath)
-      if sourcePath == focused || !clientConfig.isDidFocusProvider()
+      if path == focused || !clientConfig.isDidFocusProvider()
       textDoc <- textDocument.documents.headOption
-      source <- fingerprints.loadLastValid(sourcePath, textDoc.md5, charset)
+      source <- fingerprints.loadLastValid(path, textDoc.md5, charset)
     } {
       val docWithText = textDoc.withText(source)
       Document.set(docWithText)
-      publishSyntheticDecorations(sourcePath, docWithText)
+      publishSyntheticDecorations(path, docWithText)
     }
   }
 
@@ -377,7 +370,7 @@ final class SyntheticsDecorationProvider(
           explorePatterns(lhs :: pats)
         case m.Pat.Tuple(tuplePats) =>
           explorePatterns(tuplePats)
-        case m.Pat.Bind(lhs, rhs) =>
+        case m.Pat.Bind(_, rhs) =>
           explorePatterns(List(rhs))
         case _ => Nil
       }

--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -54,9 +54,9 @@ final class ImplementationProvider(
     implementationsInPath.remove(path)
   }
 
-  def onChange(docs: TextDocuments, path: Path): Unit = {
+  def onChange(docs: TextDocuments, path: AbsolutePath): Unit = {
     implementationsInPath.compute(
-      path,
+      path.toNIO,
       { (_, _) => computeInheritance(docs) }
     )
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -362,7 +362,8 @@ class MetalsLanguageServer(
             tables,
             statusBar,
             () => compilers,
-            clientConfig
+            clientConfig,
+            () => semanticDBIndexer
           )
         )
         warnings = new Warnings(
@@ -561,7 +562,7 @@ class MetalsLanguageServer(
           implementationProvider,
           syntheticsDecorator,
           buildTargets,
-          interactiveSemanticdbs
+          workspace
         )
         documentHighlightProvider = new DocumentHighlightProvider(
           definitionProvider,
@@ -1232,9 +1233,7 @@ class MetalsLanguageServer(
           Future(reindexWorkspaceSources(paths)),
           compilations.compileFiles(paths),
           onBuildChanged(paths).ignoreValue
-        ) ++ paths.map(f =>
-          Future(semanticDBIndexer.onStandaloneFilesChange(f))
-        )
+        ) ++ paths.map(f => Future(interactiveSemanticdbs.textDocument(f)))
       )
       .ignoreValue
   }

--- a/tests/unit/src/main/scala/tests/BaseRangesSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseRangesSuite.scala
@@ -3,6 +3,7 @@ package tests
 import scala.concurrent.Future
 
 import munit.Location
+import munit.TestOptions
 
 abstract class BaseRangesSuite(name: String) extends BaseLspSuite(name) {
 
@@ -16,8 +17,12 @@ abstract class BaseRangesSuite(name: String) extends BaseLspSuite(name) {
       base: Map[String, String]
   ): Future[Unit]
 
-  def check(name: String, input: String, scalaVersion: Option[String] = None)(
-      implicit loc: Location
+  def check(
+      name: TestOptions,
+      input: String,
+      scalaVersion: Option[String] = None
+  )(implicit
+      loc: Location
   ): Unit = {
     val files = FileLayout.mapFromString(input)
     val (filename, edit) = files

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -65,6 +65,21 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
     } yield ()
   }
 
+  check(
+    "references-standalone",
+    """|/Main.scala
+       |package a
+       |
+       |object Main{
+       |  def <<hel@@lo>>() = println("Hello world")
+       |  <<hello>>()
+       |  <<hello>>()
+       |  <<hello>>()
+       |}
+       |
+       |""".stripMargin
+  )
+
   test("synthetic") {
     cleanWorkspace()
     for {

--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -143,14 +143,48 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
       )
       _ <- server.didOpen("a/src/main/scala/a/A.scala")
       _ = server.workspaceSymbol("scala.None")
-      option = ".metals/readonly/scala/Option.scala"
-      _ <- server.didOpen(option)
-      references <- server.references(option, "object None")
+      _ <- server.didOpen(".metals/readonly/scala/Option.scala")
+      references <- server.references("a/src/main/scala/a/A.scala", " None")
       _ = assertNoDiff(
         references,
         """|a/src/main/scala/a/A.scala:4:24: info: reference
            |  val x: Option[Int] = None
            |                       ^^^^
+           |""".stripMargin
+      )
+      optionReferences <- server.references(
+        ".metals/readonly/scala/Option.scala",
+        " None"
+      )
+      _ = assertNoDiff(
+        optionReferences,
+        """|.metals/readonly/scala/Option.scala:29:50: info: reference
+           |  def apply[A](x: A): Option[A] = if (x == null) None else Some(x)
+           |                                                 ^^^^
+           |.metals/readonly/scala/Option.scala:34:30: info: reference
+           |  def empty[A] : Option[A] = None
+           |                             ^^^^
+           |.metals/readonly/scala/Option.scala:230:18: info: reference
+           |    if (isEmpty) None else Some(f(this.get))
+           |                 ^^^^
+           |.metals/readonly/scala/Option.scala:271:18: info: reference
+           |    if (isEmpty) None else f(this.get)
+           |                 ^^^^
+           |.metals/readonly/scala/Option.scala:274:18: info: reference
+           |    if (isEmpty) None else ev(this.get)
+           |                 ^^^^
+           |.metals/readonly/scala/Option.scala:289:43: info: reference
+           |    if (isEmpty || p(this.get)) this else None
+           |                                          ^^^^
+           |.metals/readonly/scala/Option.scala:304:44: info: reference
+           |    if (isEmpty || !p(this.get)) this else None
+           |                                           ^^^^
+           |.metals/readonly/scala/Option.scala:432:42: info: reference
+           |    if (!isEmpty) pf.lift(this.get) else None
+           |                                         ^^^^
+           |.metals/readonly/scala/Option.scala:527:13: info: reference
+           |case object None extends Option[Nothing] {
+           |            ^^^^
            |""".stripMargin
       )
     } yield ()

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -192,6 +192,7 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
            |}
            |""".stripMargin
       )
+      _ = client.decorations.clear()
       _ <- server.didChangeConfiguration(
         """{
           |  "show-implicit-arguments": false,
@@ -200,7 +201,6 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
           |}
           |""".stripMargin
       )
-      _ = client.decorations.clear()
       _ <- server.didOpen("a/src/main/scala/Main.scala")
       _ = assertNoDiff(
         client.workspaceDecorations,
@@ -214,6 +214,7 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
            |}
            |""".stripMargin
       )
+      _ = client.decorations.clear()
       _ <- server.didChangeConfiguration(
         """{
           |  "show-implicit-arguments": false,
@@ -222,7 +223,6 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
           |}
           |""".stripMargin
       )
-      _ = client.decorations.clear()
       _ <- server.didOpen("a/src/main/scala/Main.scala")
       _ = assertNoDiff(
         client.workspaceDecorations,
@@ -297,28 +297,30 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
             |
             |/standalone/Main.scala
             |object Main{
-            |  "asd.".stripSuffix(".")
+            |  val value = "asd.".stripSuffix(".")
             |}
             |""".stripMargin
       )
       _ <- server.didChangeConfiguration(
         """|{
-           |  "show-implicit-conversions-and-classes": true
+           |  "show-implicit-conversions-and-classes": true,
+           |  "show-inferred-type": true
            |}
            |""".stripMargin
       )
       _ <- server.didOpen("standalone/Main.scala")
       _ = assertNoDiagnostics()
       _ = assertNoDiff(
+        // currently interactive semanticdb doesn't produce symbol signatures
         client.workspaceDecorations,
         """|object Main{
-           |  augmentString("asd.").stripSuffix(".")
+           |  val value = augmentString("asd.").stripSuffix(".")
            |}
            |""".stripMargin
       )
       _ <- server.assertHoverAtLine(
         "standalone/Main.scala",
-        "  @@\"asd.\".stripSuffix(\".\")",
+        "  val value = @@\"asd.\".stripSuffix(\".\")",
         """|**Synthetics**:
            |```scala
            |scala.Predef.augmentString


### PR DESCRIPTION
This fixes a number of issues:
- we would throw an exception when interactive semanticdb passed a Scala file path to ReferencesProvider
- no updates on sbt files would get indexed

Now instead of throwing an exception we just forward the scala path and additionally the current workflow was changed to:
| standalone file change -> create a text document in InteractiveSemanticdb -> if succesfull pass information to semanticdbIndexer -> pass information to all the need text documents