### PR TITLE
Add code lens to easily discover copy worksheet command

### DIFF
--- a/docs/integrations/new-editor.md
+++ b/docs/integrations/new-editor.md
@@ -112,6 +112,7 @@ The currently available settings for `InitializationOptions` are listed below.
         "parameterHintsCommand": string,
         "snippetAutoIndent": boolean,
       }
+      "copyWorksheetOutputProvider": boolean,
       "debuggingProvider": boolean,
       "decorationProvider": boolean,
       "didFocusProvider": boolean,
@@ -124,12 +125,12 @@ The currently available settings for `InitializationOptions` are listed below.
       "isExitOnShutdown" : boolean,
       "isHttpEnabled": boolean,
       "openFilesOnRenameProvider": boolean,
+      "openNewWindowProvider": boolean,
       "quickPickProvider": boolean,
       "renameFileThreshold": number,
       "slowTaskProvider": boolean,
       "statusBarProvider": "on" | "off" | "show-message" | "log-message",
       "treeViewProvider": boolean
-      "openNewWindowProvider": boolean
     }
 ```
 
@@ -222,6 +223,14 @@ Possible values:
   case for VS Code, Sublime, and coc.nvim.
 - `off`: the client does not add any indentation when receiving a multi-line
   textEdit
+
+##### `copyWorksheetOutputProvider`
+
+Boolean value signifying whether or not the client supports running
+CopyWorksheetOutput server command and copying it's results into the local
+buffer.
+
+Default value: `false`
 
 ##### `debuggingProvider`
 
@@ -334,6 +343,14 @@ rename.
 
 Default: `false`
 
+##### `openNewWindowProvider`
+
+Boolean value signifying whether or not the client supports opening up a new
+window with the newly created project. Used in conjunction with the New Project
+Provider.
+
+Default value: `false`
+
 ##### `quickPickProvider`
 
 Boolean value to signify whether or not the client implements the
@@ -373,14 +390,6 @@ Possible values:
 
 Boolean value signifying whether or not the client supports the
 [Tree View Protocol](../integrations/tree-view-protocol.md).
-
-Default value: `false`
-
-##### `openNewWindowProvider`
-
-Boolean value signifying whether or not the client supports opening up a new
-window with the newly created project. Used in conjunction with the New Project
-Provider.
 
 Default value: `false`
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -193,6 +193,19 @@ object ClientCommands {
        |""".stripMargin
   )
 
+  val CopyWorksheetOutput = new Command(
+    "metals.copy-worksheet-output",
+    "Copy Worksheet Output",
+    s"""|Copy the contents of a worksheet to your local buffer.
+        |
+        |Note: This command should execute the ${ServerCommands.CopyWorksheetOutput.id} 
+        |      server command to get the output to copy into the buffer.
+        |
+        |Server will attempt to create code lens with this command if `copyWorksheetOutputProvider` option is set.
+        |""".stripMargin,
+    "[uri], the uri of the worksheet that you'd like to copy the contents of."
+  )
+
   def all: List[Command] =
     List(
       OpenFolder,

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -144,6 +144,9 @@ class ClientConfiguration(
 
   def isOpenNewWindowProvider(): Boolean =
     initializationOptions.openNewWindowProvider.getOrElse(false)
+
+  def isCopyWorksheetOutputProvider(): Boolean =
+    initializationOptions.copyWorksheetOutputProvider.getOrElse(false)
 }
 
 object ClientConfiguration {

--- a/metals/src/main/scala/scala/meta/internal/metals/CodeLensProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeLensProvider.scala
@@ -17,14 +17,17 @@ final class CodeLensProvider(
     if (stacktraceAnalyzer.isStackTraceFile(path)) {
       stacktraceAnalyzer.stacktraceLenses(path)
     } else {
-      semanticdbs
+      val enabledCodelenses = codeLensProviders.filter(_.isEnabled)
+      val semanticdbCodeLenses = semanticdbs
         .textDocument(path)
         .documentIncludingStale
         .map { textDocument =>
           val doc = TextDocumentWithPath(textDocument, path)
-          codeLensProviders.filter(_.isEnabled).flatMap(_.codeLenses(doc))
+          enabledCodelenses.flatMap(_.codeLenses(doc))
         }
         .getOrElse(Seq.empty)
+      val otherCodeLenses = enabledCodelenses.flatMap(_.codeLenses(path))
+      semanticdbCodeLenses ++ otherCodeLenses
     }
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -37,6 +37,8 @@ import org.eclipse.{lsp4j => l}
  * @param statusBarProvider if the client implements `metals/status`.
  * @param treeViewProvider if the client implements the Metals Tree View Protocol.
  * @param openNewWindowProvider if the client can open a new window after new project creation.
+ * @param copyWorksheetOutputProvider if the client can execute server CopyWorksheet command and
+ *                                    copy results to the local buffer.
  */
 final case class InitializationOptions(
     compilerOptions: CompilerInitializationOptions,
@@ -58,7 +60,8 @@ final case class InitializationOptions(
     slowTaskProvider: Option[Boolean],
     statusBarProvider: Option[String],
     treeViewProvider: Option[Boolean],
-    openNewWindowProvider: Option[Boolean]
+    openNewWindowProvider: Option[Boolean],
+    copyWorksheetOutputProvider: Option[Boolean]
 ) {
   def doctorFormat: Option[DoctorFormat.DoctorFormat] =
     doctorProvider.flatMap(DoctorFormat.fromString)
@@ -72,6 +75,7 @@ object InitializationOptions {
 
   val Default: InitializationOptions = InitializationOptions(
     CompilerInitializationOptions.default,
+    None,
     None,
     None,
     None,
@@ -137,7 +141,9 @@ object InitializationOptions {
       slowTaskProvider = jsonObj.getBooleanOption("slowTaskProvider"),
       statusBarProvider = jsonObj.getStringOption("statusBarProvider"),
       treeViewProvider = jsonObj.getBooleanOption("treeViewProvider"),
-      openNewWindowProvider = jsonObj.getBooleanOption("openNewWindowProvider")
+      openNewWindowProvider = jsonObj.getBooleanOption("openNewWindowProvider"),
+      copyWorksheetOutputProvider =
+        jsonObj.getBooleanOption("copyWorksheetOutputProvider")
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -52,6 +52,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ammonite.Ammonite
 import scala.meta.internal.metals.codelenses.RunTestCodeLens
 import scala.meta.internal.metals.codelenses.SuperMethodCodeLens
+import scala.meta.internal.metals.codelenses.WorksheetCodeLens
 import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.metals.debug.DebugParametersJsonParsers
 import scala.meta.internal.metals.debug.DebugProvider
@@ -528,9 +529,9 @@ class MetalsLanguageServer(
           clientConfig.icons,
           clientConfig.isCommandInHtmlSupported
         )
-
+        val worksheetCodeLens = new WorksheetCodeLens(clientConfig)
         codeLensProvider = new CodeLensProvider(
-          List(runTestLensProvider, goSuperLensProvider),
+          List(runTestLensProvider, goSuperLensProvider, worksheetCodeLens),
           semanticdbs,
           stacktraceAnalyzer
         )

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/CodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/CodeLens.scala
@@ -1,10 +1,13 @@
 package scala.meta.internal.metals.codelenses
 
 import scala.meta.internal.implementation.TextDocumentWithPath
+import scala.meta.io.AbsolutePath
 
 import org.eclipse.{lsp4j => l}
 
 trait CodeLens {
   def isEnabled: Boolean
-  def codeLenses(textDocumentWithPath: TextDocumentWithPath): Seq[l.CodeLens]
+  def codeLenses(textDocumentWithPath: TextDocumentWithPath): Seq[l.CodeLens] =
+    Nil
+  def codeLenses(path: AbsolutePath): Seq[l.CodeLens] = Nil
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/WorksheetCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/WorksheetCodeLens.scala
@@ -1,0 +1,27 @@
+package scala.meta.internal.metals.codelenses
+
+import scala.meta.internal.metals.ClientCommands.CopyWorksheetOutput
+import scala.meta.internal.metals.ClientConfiguration
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+
+import org.eclipse.{lsp4j => l}
+
+class WorksheetCodeLens(clientConfig: ClientConfiguration) extends CodeLens {
+
+  override def isEnabled: Boolean = clientConfig.isCopyWorksheetOutputProvider
+
+  override def codeLenses(
+      path: AbsolutePath
+  ): Seq[l.CodeLens] = {
+    if (path.isWorksheet) {
+      val command = CopyWorksheetOutput.toLSP(List(path.toURI))
+      val startPosition = new l.Position(0, 0)
+      val range = new l.Range(startPosition, startPosition)
+      List(new l.CodeLens(range, command, null))
+    } else {
+      Nil
+    }
+  }
+
+}


### PR DESCRIPTION
Previously, only way to discover the copy worksheet command would be to run it manually, which is always an additional barier. Now, it's possible to use the code lense that is shown at the top of the file.

This is how it looks in VS Code:

![metals-sample-1612289058641](https://user-images.githubusercontent.com/3807253/106644334-435d9c80-658b-11eb-99f6-e63afd185297.gif)

What worries me is that we rely on the name of the command in the client to be `metals` + the actual command id. Otherwise, the server command might be invoked without handling it properly. It's kind of implicit requirement for the clients and there is no way to discover if a client actually contributes it. I have no idea currently how to work around it :/ 