### PR TITLE
A bit of refactoring around BSP connection and Build Import.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspSession.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspSession.scala
@@ -7,7 +7,6 @@ import scala.meta.internal.metals.BloopServers
 import scala.meta.internal.metals.BuildServerConnection
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.ImportedBuild
-import scala.meta.internal.metals.MetalsLanguageServer
 
 case class BspSession(
     main: BuildServerConnection,
@@ -19,7 +18,7 @@ case class BspSession(
 
   def importBuilds(): Future[List[BspSession.BspBuild]] = {
     def importSingle(conn: BuildServerConnection): Future[BspSession.BspBuild] =
-      MetalsLanguageServer.importedBuild(conn).map(BspSession.BspBuild(conn, _))
+      ImportedBuild.fromConnection(conn).map(BspSession.BspBuild(conn, _))
 
     Future.sequence(connections.map(importSingle))
   }

--- a/metals/src/main/scala/scala/meta/internal/bsp/MetalsBspException.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/MetalsBspException.scala
@@ -1,0 +1,6 @@
+package scala.meta.internal.metals
+
+case class MetalsBspException(tryingToGet: String)
+    extends Exception(
+      s"BSP connection failed in the attempt to get: $tryingToGet"
+    )

--- a/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
@@ -92,12 +92,12 @@ final class Ammonite(
     buildServer0 match {
       case None =>
         Future.failed(new Exception("No Ammonite build server running"))
-      case Some(buildServer) =>
+      case Some(conn) =>
         compilers.cancel()
         for {
           build0 <- statusBar.trackFuture(
             "Importing Ammonite scripts",
-            MetalsLanguageServer.importedBuild(buildServer)
+            ImportedBuild.fromConnection(conn)
           )
           _ = {
             lastImportedBuild0 = build0

--- a/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
@@ -10,12 +10,12 @@ import scala.util.Random
 import scala.meta.internal.metals.DebugUnresolvedMainClassParams
 import scala.meta.internal.metals.DebugUnresolvedTestClassParams
 import scala.meta.internal.metals.JsonParser._
+import scala.meta.internal.metals.MetalsBspException
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.debug.WorkspaceErrorsException
 
 import ch.epfl.scala.bsp4j.DebugSessionParamsDataKind
 import ch.epfl.scala.bsp4j.ScalaMainClass
-import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 
 // note(@tgodzik) all test have `System.exit(0)` added to avoid occasional issue due to:
 // https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment
@@ -86,7 +86,7 @@ class DebugProtocolSuite extends BaseDapSuite("debug-protocol") {
            |""".stripMargin
       )
       failed = startDebugging()
-      debugger <- failed.recoverWith { case _: ResponseErrorException =>
+      debugger <- failed.recoverWith { case _: MetalsBspException =>
         server
           .didSave("a/src/main/scala/a/Main.scala") { text => text + "}" }
           .flatMap(_ => startDebugging())


### PR DESCRIPTION
So there is no user facing change in this, it's mainly just moving stuff
around a bit, and then trying to improve some logging. This is in
response to #2347 and should close it, unless we really want to do some
more refactoring. Mainly in that ticket there was a situation where we
were unable to get sources for a build target, and therefore the
connection to the build server didn't work, and the message was that the
connection failed, and check the logs for more details. However, the
logs aren't helpful at all:

```
2021.01.05 16:37:03 ERROR Failed to connect with build server, no functionality will work.
org.eclipse.lsp4j.jsonrpc.ResponseErrorException:
        at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleResponse(RemoteEndpoint.java:209)
        at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:193)
        at org.eclipse.lsp4j.jsonrpc.TracingMessageConsumer.consume(TracingMessageConsumer.java:114)
        at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:194)
        at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:94)
        at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:113)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

So in order to at least improve the logging in this scenario, I added
another case in the recover in our register Method that we wrap all the
BSP calls in to catch the class of what we are trying to get, and
instead of returning an exception like the above when we _do_ have info
about what may have failed replace it with a more useful exception like
the one below:

```
scala.meta.internal.metals.MetalsBspException: BSP connection failed in the attempt to get: SourcesResult
        at scala.meta.internal.metals.BuildServerConnection$$anonfun$1.applyOrElse(BuildServerConnection.scala:230)
        at scala.meta.internal.metals.BuildServerConnection$$anonfun$1.applyOrElse(BuildServerConnection.scala:223)
        at scala.concurrent.Future.$anonfun$recoverWith$1(Future.scala:417)
        at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)
        at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.lang.Thread.run(Thread.java:834)
```

Having this would have made figuring out the issue in #2347 _way_
easier. An argument _could_ be made to still maybe log out the original,
so let me know if you think I should do that.

The other change is just moving the `importedBuild` method out of the
`MetalsLanguageServer` companion object and into the companion object of
`ImportedBuild`. I think it makes a bit more sense there and also gets
rid of another thing in `MetalsLanguageServer`.

Closes #2347