### PR TITLE
Introduce a `metals/listBuildTargets` LSP extension.

### DIFF
--- a/docs/integrations/debug-adapter-protocol.md
+++ b/docs/integrations/debug-adapter-protocol.md
@@ -5,12 +5,16 @@ title: Debug Adapter Protocol
 ---
 
 Metals implements the Debug Adapter Protocol, which can be used by the editor to
-communicate with JVM to run and debug code.
+communicate with the JVM to run and debug code.
 
 ## How to add support for debugging in my editor?
 
 There are two main ways to add support for debugging depending on the
-capabilities exposed by the client.
+capabilities exposed by the client. However, for both of them you'll want to
+make sure that your client sets the `debuggingProvider` key to `true` in the
+`initializationOptions` to ensure that the correct client commands can be sent
+to the client, and so that requests to populate the code lens (if your editor
+supports them) will be answered correct for debugging related features.
 
 ### Via code lenses
 
@@ -18,7 +22,7 @@ The editor needs to handle two commands in its language client extension:
 [`metals-run-session-start`](https://github.com/scalameta/metals/blob/main/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala#L56)
 and
 [`metals-debug-session-start`](https://github.com/scalameta/metals/blob/main/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala#L78).
-Those commands should get executed automatically by the lsp client once the user
+These commands should get executed automatically by the lsp client once the user
 activates a code lens. The difference between them is that the former ignores
 all breakpoints being set while the latter respects them. The procedure of
 starting the run/debug session is as follows:

--- a/docs/integrations/new-editor.md
+++ b/docs/integrations/new-editor.md
@@ -667,10 +667,7 @@ When the port 5031 is taken the next free increment is chosen instead (5032,
 Editor clients can opt into receiving Metals-specific JSON-RPC requests and
 notifications. Metals extensions are not defined in LSP and are not strictly
 required for the Metals server to function but it is recommended to implement
-them to improve the user experience.
-
-To enable Metals extensions, start the main process with the system property
-`-Dmetals.extensions=true`.
+them to improve the user experience or provide extra functionality.
 
 ### Debug Adapter Protocol
 
@@ -968,3 +965,24 @@ interface MetalsOpenWindowParams {
   openNewWindow: boolean;
 }
 ```
+
+### `metals/listBuildTargets`
+
+The Metals list build targets request is sent from the client to the server to
+get information about the build targets of the current workspace.
+
+_Request_:
+
+- method: `metals/listBuildTargets`
+- params: There are no params.
+
+_Response_:
+
+- result: An array of `ScalaTarget`s. The Metals Scala Target is defined
+    [here](https://github.com/scalameta/metals/blob/main/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala).
+    It includs the BSP
+    [`BuildTarget`](https://build-server-protocol.github.io/docs/specification.html#build-target),
+    [`ScalaBuildTarget`](https://build-server-protocol.github.io/docs/extensions/scala.html#scala-build-target),
+    [`ScalacOptionsItem`](https://build-server-protocol.github.io/docs/extensions/scala.html#scalac-options-request),
+    and a couple other values unique to Metals.
+

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1708,6 +1708,13 @@ class MetalsLanguageServer(
     }
   }
 
+  @JsonRequest("metals/listBuildTargets")
+  def listBuildTargets(): CompletableFuture[ju.List[ScalaTarget]] = {
+    Future {
+      buildTargets.all.toList.asJava
+    }.asJava
+  }
+
   @JsonRequest("metals/treeViewChildren")
   def treeViewChildren(
       params: TreeViewChildrenParams

--- a/tests/unit/src/test/scala/tests/BuildTargetsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BuildTargetsLspSuite.scala
@@ -1,29 +1,32 @@
 package tests
 
+import scala.meta.internal.metals.MetalsEnrichments._
+
 class BuildTargetsLspSuite
     extends BaseLspSuite("build-targets")
     with TestHovers {
 
   override def munitIgnore: Boolean = isWindows
 
+  val workspaceBuildTargets: String =
+    s"""/metals.json
+       |{
+       |  "a": {
+       |    "scalaVersion": "2.10.6",
+       |    "libraryDependencies": ["com.lihaoyi::sourcecode:0.1.7"],
+       |    "additionalSources": [ "shared/Main.scala" ]
+       |  },
+       |  "b": {
+       |    "scalaVersion": "${BuildInfo.scalaVersion}",
+       |    "libraryDependencies": ["com.lihaoyi::sourcecode:0.1.7"],
+       |    "additionalSources": [ "shared/Main.scala" ]
+       |  }
+       |}
+        """.stripMargin
+
   test("scala-priority") {
     for {
-      _ <- server.initialize(
-        s"""/metals.json
-           |{
-           |  "a": {
-           |    "scalaVersion": "2.10.6",
-           |    "libraryDependencies": ["com.lihaoyi::sourcecode:0.1.7"],
-           |    "additionalSources": [ "shared/Main.scala" ]
-           |  },
-           |  "b": {
-           |    "scalaVersion": "${BuildInfo.scalaVersion}",
-           |    "libraryDependencies": ["com.lihaoyi::sourcecode:0.1.7"],
-           |    "additionalSources": [ "shared/Main.scala" ]
-           |  }
-           |}
-        """.stripMargin
-      )
+      _ <- server.initialize(workspaceBuildTargets)
       // Assert that a supported Scala version target is picked over 2.10.
       _ <- server.assertHover(
         "shared/Main.scala",
@@ -33,6 +36,24 @@ class BuildTargetsLspSuite
           |}""".stripMargin,
         """val value: Int""".hover
       )
+    } yield ()
+  }
+  test("metals/listBuildTargets") {
+    for {
+      _ <- server.initialize(workspaceBuildTargets)
+      buildTargets <- server.server.listBuildTargets().asScala
+      _ = {
+        assert(buildTargets.size == 2)
+        buildTargets.forEach {
+          case a if a.displayName == "a" =>
+            assertNoDiff(a.scalaVersion, "2.10.6")
+            assert(a.id.getUri().endsWith("a?id=a"))
+          case b if b.displayName == "b" =>
+            assert(b.scalaVersion == BuildInfo.scalaVersion)
+            assert(b.id.getUri().endsWith("b?id=b"))
+          case _ => fail("This should only detect build targets 'a' and 'b'")
+        }
+      }
     } yield ()
   }
 }


### PR DESCRIPTION
You can find more of my mindset behind this in this discussion:
https://github.com/scalameta/metals/discussions/2479, but I'd like to
propose that we expose this info. One concrete thing that I'm planning
on using this for is having `nvim-metals` be able to quickly get the
build targets for a workspace, which then the user can just quickly
choose the one they want, and that is how the debug process or run
process starts without the need to manually add the build target or rely
on code lenses.

After playing around with this a bit, I'm also quite excited about other
possibilities that this opens up. There is _so much_ information in here
that client extensions can use. Everything from simple things like
`javaHome` or Scala versions to more complex things like the full
classpath for a build target can be accessed by extensions to do all
sorts of things. I'm excited to play around with this more.