### PR TITLE
Add insert inferred type code action

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -22,7 +22,8 @@ final class CodeActionProvider(
     new ImportMissingSymbol(compilers),
     new CreateNewSymbol(),
     new StringActions(buffers, trees),
-    new OrganizeImports(scalafixProvider, buildTargets)
+    new OrganizeImports(scalafixProvider, buildTargets),
+    new InsertInferredType(trees, compilers)
   )
 
   def codeActions(

--- a/metals/src/main/scala/scala/meta/internal/metals/Command.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Command.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.metals
 
 import scala.meta.internal.metals.MetalsEnrichments._
 
+import com.google.gson.JsonPrimitive
 import org.eclipse.{lsp4j => l}
 
 case class Command(
@@ -14,4 +15,22 @@ case class Command(
 
   def toLSP(arguments: List[AnyRef]): l.Command =
     new l.Command(title, id, arguments.asJava)
+}
+
+object Argument {
+
+  def getAsString(obj: AnyRef): Option[String] = {
+    obj match {
+      case p: JsonPrimitive if p.isString => Option(p.getAsString())
+      case _ => None
+    }
+  }
+
+  def getAsInt(obj: AnyRef): Option[Int] = {
+    obj match {
+      case p: JsonPrimitive if p.isNumber => Option(p.getAsInt())
+      case _ => None
+    }
+  }
+
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -278,6 +278,19 @@ class Compilers(
     }
   }
 
+  def insertInferredType(
+      params: TextDocumentPositionParams,
+      token: CancelToken
+  ): Future[ju.List[TextEdit]] = {
+    withPCAndAdjustLsp(params) { (pc, pos, adjust) =>
+      pc.insertInferredType(CompilerOffsetParams.fromPos(pos, token))
+        .asScala
+        .map { edits =>
+          adjust.adjustTextEdits(edits)
+        }
+    }
+  }
+
   def implementAbstractMembers(
       params: TextDocumentPositionParams,
       token: CancelToken

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -89,6 +89,11 @@ object Messages {
       "See the logs for more details. "
   )
 
+  val InsertInferredTypeFailed = new MessageParams(
+    MessageType.Error,
+    "Could not insert inferred type, please check the logs for more details or report an issue."
+  )
+
   val ReloadProjectFailed = new MessageParams(
     MessageType.Error,
     "Reloading your project failed, no functionality will work. See the log for more details"

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -158,6 +158,9 @@ object MetalsEnrichments
 
     def ignoreValue(implicit ec: ExecutionContext): Future[Unit] =
       future.map(_ => ())
+    def withObjectValue: Future[Object] =
+      future.asInstanceOf[Future[Object]]
+
     def logErrorAndContinue(
         doingWhat: String
     )(implicit ec: ExecutionContext): Future[Unit] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -304,6 +304,17 @@ object ServerCommands {
     "[uri], the uri of the worksheet that you'd like to copy the contents of."
   )
 
+  val InsertInferredType = new Command(
+    "insert-inferred-type",
+    "Insert inferred type of a value",
+    """|Whenever a user chooses code action to insert the inferred type this command is later ran to 
+       |calculate the type and insert it in the correct location.
+       |""".stripMargin,
+    """|[uri, line, character], uri to the document that the command needs to be invoked on 
+       |together with line number and character/column.
+       |""".stripMargin
+  )
+
   /**
    * Open the browser at the given url.
    */
@@ -390,6 +401,7 @@ object ServerCommands {
       GotoSuperMethod,
       GotoSymbol,
       ImportBuild,
+      InsertInferredType,
       NewScalaFile,
       NewScalaProject,
       ResetChoicePopup,

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
@@ -1,0 +1,97 @@
+package scala.meta.internal.metals.codeactions
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.Defn
+import scala.meta.Enumerator
+import scala.meta.Pat
+import scala.meta.Term
+import scala.meta.Tree
+import scala.meta.inputs.Position
+import scala.meta.internal.metals.CodeAction
+import scala.meta.internal.metals.Compilers
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.parsing.Trees
+import scala.meta.pc.CancelToken
+
+import org.eclipse.{lsp4j => l}
+
+class InsertInferredType(trees: Trees, compilers: Compilers)
+    extends CodeAction {
+
+  import InsertInferredType._
+  override def kind: String = l.CodeActionKind.QuickFix
+
+  override def contribute(
+      params: l.CodeActionParams,
+      token: CancelToken
+  )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = Future {
+
+    def insertInferTypeAction(title: String): l.CodeAction = {
+      val codeAction = new l.CodeAction()
+      codeAction.setTitle(title)
+      codeAction.setKind(l.CodeActionKind.RefactorRewrite)
+      val range = params.getRange().getStart()
+      codeAction.setCommand(
+        ServerCommands.InsertInferredType.toLSP(
+          List(
+            params.getTextDocument().getUri(),
+            range.getLine(): java.lang.Integer,
+            range.getCharacter(): java.lang.Integer
+          )
+        )
+      )
+      codeAction
+    }
+
+    def findLastEnclosingAtPos(tree: Tree, pos: Position): Option[Term.Name] = {
+      tree.children.find { child =>
+        child.pos.start <= pos.start && pos.start <= child.pos.end
+      } match {
+        case None =>
+          tree match {
+            case name: Term.Name => Some(name)
+            case _ => None
+          }
+        case Some(value) => findLastEnclosingAtPos(value, pos)
+      }
+    }
+
+    def inferTypeTitle(name: Term.Name): Option[String] = name.parent.flatMap {
+      case pattern @ Pat.Var(_) =>
+        pattern.parent
+          .collect {
+            case Pat.Typed(_, _) => None
+            case Pat.Bind(lhs, _) if lhs != pattern => Some(insertTypeToPattern)
+            case _: Pat.Bind => None
+            case vl: Defn.Val if vl.decltpe.isEmpty => Some(insertType)
+            case vr: Defn.Var if vr.decltpe.isEmpty => Some(insertType)
+            case _: Pat | _: Enumerator => Some(insertTypeToPattern)
+          }
+          .getOrElse(None)
+      case Defn.Def(_, _, _, _, tpe, _) if tpe.isEmpty =>
+        Some(insertType)
+      case Term.Param(_, _, tpe, _) if tpe.isEmpty =>
+        Some(insertType)
+      case _ =>
+        None
+    }
+
+    val path = params.getTextDocument().getUri().toAbsolutePath
+    val actions = for {
+      tree <- trees.get(path)
+      treePos = params.getRange().toMeta(tree.pos.input)
+      name <- findLastEnclosingAtPos(tree, treePos)
+      title <- inferTypeTitle(name)
+    } yield insertInferTypeAction(title)
+
+    actions.toList
+  }
+}
+
+object InsertInferredType {
+  val insertType = "Insert type annotation"
+  val insertTypeToPattern = "Insert type annotation into pattern definition"
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -84,6 +84,11 @@ public abstract class PresentationCompiler {
     public abstract CompletableFuture<List<TextEdit>> implementAbstractMembers(OffsetParams params);
 
     /**
+     * Return the missing implements and imports for the symbol at the given position.
+     */
+    public abstract CompletableFuture<List<TextEdit>> insertInferredType(OffsetParams params);
+
+    /**
      * The text contents of the fiven file changed.
      */
     public abstract CompletableFuture<List<Diagnostic>> didChange(VirtualFileParams params);

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/InferredTypeProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/InferredTypeProvider.scala
@@ -1,0 +1,191 @@
+package scala.meta.internal.pc
+
+import scala.meta._
+import scala.meta.pc.OffsetParams
+import scala.meta.tokens.{Token => T}
+
+import org.eclipse.lsp4j.TextEdit
+
+/**
+ * Tries to calculate edits needed to insert the inferred type annotation
+ * in all the places that it is possible such as:
+ * - value or variable declaration
+ * - methods
+ * - pattern matches
+ * - for comprehensions
+ * - lambdas
+ *
+ * The provider will not check if the type does not exist, since there is no way to
+ * get that data from the presentation compiler. The actual check is being done via
+ * scalameta parser in InsertInferredType code action.
+ *
+ * @param compiler Metals presentation compiler
+ * @param params position and actual source
+ */
+final class InferredTypeProvider(
+    val compiler: MetalsGlobal,
+    params: OffsetParams
+) {
+  import compiler._
+
+  def inferredTypeEdits(): List[TextEdit] = {
+
+    val unit = addCompilationUnit(
+      code = params.text(),
+      filename = params.uri().toString(),
+      cursor = None
+    )
+
+    val pos = unit.position(params.offset)
+    val typedTree = typedTreeAt(pos)
+    val importPosition = autoImportPosition(pos, params.text())
+    val context = doLocateImportContext(pos, importPosition)
+    val history = new ShortenedNames(
+      lookupSymbol = name => context.lookupSymbol(name, _ => true) :: Nil
+    )
+
+    def additionalImports = importPosition match {
+      case None =>
+        // No import position means we can't insert an import without clashing with
+        // existing symbols in scope, so we just do nothing
+        Nil
+      case Some(importPosition) =>
+        history.autoImports(
+          pos,
+          context,
+          importPosition.offset,
+          importPosition.indent,
+          importPosition.padTop
+        )
+    }
+
+    def prettyType(tpe: Type) =
+      metalsToLongString(tpe.widen.finalResultType, history)
+
+    typedTree match {
+      /* `val a = 1` or `var b = 2`
+       *     turns into
+       * `val a: Int = 1` or `var b: Int = 2`
+       */
+      case vl @ ValDef(_, name, tpt, _) if !vl.symbol.isParameter =>
+        // dropLocal will remove a space that might appear at the of a name in some places
+        val nameEnd = tpt.pos.start + name.dropLocal.length()
+        val nameEndPos = tpt.pos.withEnd(nameEnd).withStart(nameEnd).toLSP
+        val typeNameEdit = new TextEdit(nameEndPos, ": " + prettyType(tpt.tpe))
+        typeNameEdit :: additionalImports
+
+      /* `.map(a => a + a)`
+       *     turns into
+       * `.map((a: Int) => a + a)`
+       */
+      case vl @ ValDef(_, name, tpt, _) if vl.symbol.isParameter =>
+        val nameEnd = vl.pos.start + name.length()
+        val namePos = tpt.pos.withEnd(nameEnd).withStart(nameEnd).toLSP
+
+        def leftParenStart = vl.pos.withEnd(vl.pos.start).toLSP
+        def leftParenEdit = new TextEdit(leftParenStart, "(")
+
+        def needsParens = lastVisitedParentTrees match {
+          /* Find how the function starts either with:
+           * - `(` - then we need braces
+           * - `{` - then we don't need braces
+           */
+          case _ :: (f: Function) :: (appl: Apply) :: _ =>
+            val alreadyExistingBrace = params.text()(f.pos.start) == '('
+            def needsNewBraces = params
+              .text()
+              .substring(appl.pos.start, vl.pos.start)
+              .tokenize
+              .toOption
+              .exists {
+                _.tokens.reverseIterator
+                  .find(t => t.is[T.LeftParen] || t.is[T.LeftBrace])
+                  .exists(_.is[T.LeftParen])
+              }
+            !alreadyExistingBrace && needsNewBraces
+          case _ => false
+        }
+
+        val typeNameEdit = {
+          val rightParen = if (needsParens) ")" else ""
+          new TextEdit(namePos, ": " + prettyType(tpt.tpe) + rightParen)
+        }
+
+        if (needsParens) {
+          leftParenEdit :: typeNameEdit :: additionalImports
+        } else {
+          typeNameEdit :: additionalImports
+        }
+
+      /* `def a[T](param : Int) = param`
+       *     turns into
+       * `def a[T](param : Int): Int = param`
+       */
+      case DefDef(_, name, _, _, tpt, rhs) =>
+        val nameEnd = tpt.pos.start + name.length()
+
+        // search for `)` or `]` or defaut to name's end to insert type
+        val searchString = params
+          .text()
+          .substring(nameEnd, rhs.pos.start) // cotains the parameters and =
+        val lastTokenPos = searchString.tokenize.toOption
+          .flatMap(tokens =>
+            tokens.tokens.reverseIterator
+              .find(t => t.is[T.RightParen] || t.is[T.RightBracket])
+              .map(t => nameEnd + t.pos.end)
+          )
+          .getOrElse(nameEnd)
+
+        val insertPos = rhs.pos.withStart(lastTokenPos).withEnd(lastTokenPos)
+        val typeNameEdit =
+          new TextEdit(insertPos.toLSP, ": " + prettyType(tpt.tpe))
+
+        typeNameEdit :: additionalImports
+
+      /* `case t =>`
+       *  turns into
+       * `case t: Int =>`
+       */
+      case bind @ Bind(name, body) =>
+        def openingParenPos = body.pos.withEnd(body.pos.start)
+        def openingParen = new TextEdit(openingParenPos.toLSP, "(")
+
+        val insertStart = bind.pos.start + name.length()
+        val insertPos = bind.pos.withEnd(insertStart).withStart(insertStart)
+
+        /* In case it's an infix pattern match
+         * we need to add () for example in:
+         * case (head : Int) :: tail =>
+         */
+        val needsParens = lastVisitedParentTrees match {
+          case _ :: Apply(_: Ident, args) :: _ if args.size > 1 =>
+            val firstEnd = args(0).pos.end
+            val secondStart = args(1).pos.start
+            val hasDot = params
+              .text()
+              .substring(firstEnd, secondStart)
+              .tokenize
+              .toOption
+              .exists(_.tokens.exists(_.is[T.Comma]))
+            !hasDot
+          case _ => false
+        }
+
+        val typeNameEdit = {
+          val rightParen = if (needsParens) ")" else ""
+          new TextEdit(
+            insertPos.toLSP,
+            ": " + prettyType(body.tpe) + rightParen
+          )
+        }
+
+        if (needsParens) {
+          openingParen :: typeNameEdit :: additionalImports
+        } else {
+          typeNameEdit :: additionalImports
+        }
+      case _ =>
+        Nil
+    }
+  }
+}

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -132,6 +132,15 @@ case class ScalaPresentationCompiler(
     }
   }
 
+  override def insertInferredType(
+      params: OffsetParams
+  ): CompletableFuture[ju.List[TextEdit]] = {
+    val empty: ju.List[TextEdit] = new ju.ArrayList[TextEdit]()
+    compilerAccess.withInterruptableCompiler(empty, params.token) { pc =>
+      new InferredTypeProvider(pc.compiler, params).inferredTypeEdits().asJava
+    }
+  }
+
   override def autoImports(
       name: String,
       params: OffsetParams

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -209,6 +209,15 @@ case class ScalaPresentationCompiler(
     )
   }
 
+  // TODO NOT IMPLEMENTED
+  override def insertInferredType(
+    params: OffsetParams
+  ): CompletableFuture[ju.List[TextEdit]] = {
+    CompletableFuture.completedFuture(
+      List.empty[TextEdit].asJava
+    )
+  }
+
   def hover(params: OffsetParams): CompletableFuture[ju.Optional[Hover]] =
     compilerAccess.withNonInterruptableCompiler(
       ju.Optional.empty[Hover](),

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -1,0 +1,284 @@
+package tests.pc
+
+import java.net.URI
+
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.CompilerOffsetParams
+import scala.meta.internal.metals.TextEdits
+
+import munit.TestOptions
+import org.eclipse.{lsp4j => l}
+import tests.BaseCodeActionSuite
+import tests.BuildInfoVersions
+
+class InsertInferredTypeSuite extends BaseCodeActionSuite {
+
+  override def excludedScalaVersions: Set[String] =
+    BuildInfoVersions.scala3Versions.toSet
+
+  checkEdit(
+    "val",
+    """|object A{
+       |  val <<alpha>> = 123
+       |}""".stripMargin,
+    """|object A{
+       |  val alpha: Int = 123
+       |}""".stripMargin
+  )
+
+  checkEdit(
+    "tuple",
+    """|object A{
+       |  val (<<alpha>>, beta) = (123, 12)
+       |}""".stripMargin,
+    """|object A{
+       |  val (alpha: Int, beta) = (123, 12)
+       |}""".stripMargin
+  )
+
+  checkEdit(
+    "var",
+    """|object A{
+       |  var <<alpha>> = (123, 12)
+       |}""".stripMargin,
+    """|object A{
+       |  var alpha: (Int, Int) = (123, 12)
+       |}""".stripMargin
+  )
+
+  checkEdit(
+    "def",
+    """|object A{
+       |  def <<alpha>> = (123, 12)
+       |}""".stripMargin,
+    """|object A{
+       |  def alpha: (Int, Int) = (123, 12)
+       |}""".stripMargin
+  )
+
+  checkEdit(
+    "def-comment",
+    """|object A{
+       |  def <<alpha>> /* [] */= (123, 12)
+       |}""".stripMargin,
+    """|object A{
+       |  def alpha: (Int, Int) /* [] */= (123, 12)
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "def-comment-param",
+    """|object A{
+       |  def <<alpha>>() /* [] */= (123, 12)
+       |}""".stripMargin,
+    """|object A{
+       |  def alpha(): (Int, Int) /* [] */= (123, 12)
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "def-param",
+    """|object A{
+       |  def <<alpha>>(a : String) = (123, 12)
+       |}""".stripMargin,
+    """|object A{
+       |  def alpha(a : String): (Int, Int) = (123, 12)
+       |}""".stripMargin
+  )
+
+  checkEdit(
+    "def-type-param",
+    """|object A{
+       |  def <<alpha>>[T] = (123, 12)
+       |}""".stripMargin,
+    """|object A{
+       |  def alpha[T]: (Int, Int) = (123, 12)
+       |}""".stripMargin
+  )
+
+  checkEdit(
+    "auto-import",
+    """|object A{
+       |  val <<buffer>> = List("").toBuffer
+       |}""".stripMargin,
+    """|import scala.collection.mutable.Buffer
+       |object A{
+       |  val buffer: Buffer[String] = List("").toBuffer
+       |}""".stripMargin
+  )
+
+  checkEdit(
+    "lambda",
+    """|object A{
+       |  val toStringList = List(1, 2, 3).map(<<int>> => int.toString)
+       |}""".stripMargin,
+    """|object A{
+       |  val toStringList = List(1, 2, 3).map((int: Int) => int.toString)
+       |}""".stripMargin
+  )
+
+  checkEdit(
+    "lambda-existing-brace",
+    """|object A{
+       |  val toStringList = List(1, 2, 3).map( /*{}*/(<<int>>) => int.toString)
+       |}""".stripMargin,
+    """|object A{
+       |  val toStringList = List(1, 2, 3).map( /*{}*/(int: Int) => int.toString)
+       |}""".stripMargin
+  )
+
+  checkEdit(
+    "lambda-brace",
+    """|object A{
+       |  val toStringList = List(1, 2, 3).map{<<int>> => int.toString}
+       |}""".stripMargin,
+    """|object A{
+       |  val toStringList = List(1, 2, 3).map{int: Int => int.toString}
+       |}""".stripMargin
+  )
+
+  checkEdit(
+    "pattern-match-paren",
+    """|object A{
+       |  val list = List(1, 2, 3) match {
+       |    case <<head>> :: tail => tail
+       |    case Nil => Nil
+       |  }
+       |}""".stripMargin,
+    """|object A{
+       |  val list = List(1, 2, 3) match {
+       |    case (head: Int) :: tail => tail
+       |    case Nil => Nil
+       |  }
+       |}""".stripMargin
+  )
+
+  checkEdit(
+    "pattern-match-tuple",
+    """|object A{
+       |  val list = (1, 2) match {
+       |    case (3, two) => 3
+       |    case (one, <<two>>) => 2
+       |  }
+       |}""".stripMargin,
+    """|object A{
+       |  val list = (1, 2) match {
+       |    case (3, two) => 3
+       |    case (one, two: Int) => 2
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "pattern-match-option",
+    """|object A{
+       |  Option(1) match {
+       |    case Some(<<t>>) => t
+       |    case None =>
+       |  }
+       |}""".stripMargin,
+    """|object A{
+       |  Option(1) match {
+       |    case Some(t: Int) => t
+       |    case None =>
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "pattern-match-list",
+    """|object A{
+       |  List(1, 2, 3, 4) match {
+       |    case List(<<t>>, next, other, _) => t
+       |    case _ =>
+       |  }
+       |}""".stripMargin,
+    """|object A{
+       |  List(1, 2, 3, 4) match {
+       |    case List(t: Int, next, other, _) => t
+       |    case _ =>
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "pattern-match",
+    """|object A{
+       |  val list = 1 match {
+       |    case 2 => "Two!"
+       |    case <<otherDigit>> => "Not two!"
+       |  }
+       |}""".stripMargin,
+    """|object A{
+       |  val list = 1 match {
+       |    case 2 => "Two!"
+       |    case otherDigit: Int => "Not two!"
+       |  }
+       |}""".stripMargin
+  )
+
+  checkEdit(
+    "for-comprehension",
+    """|object A{
+       |  for {
+       |    <<i>> <- 1 to 10
+       |    j <- 1 to 11
+       |  } yield (i, j)
+       |}""".stripMargin,
+    """|object A{
+       |  for {
+       |    i: Int <- 1 to 10
+       |    j <- 1 to 11
+       |  } yield (i, j)
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "for-comprehension",
+    """|object A{
+       |  for {
+       |    i <- 1 to 10
+       |    <<j>> = i
+       |  } yield (i, j)
+       |}""".stripMargin,
+    """|object A{
+       |  for {
+       |    i <- 1 to 10
+       |    j: Int = i
+       |  } yield (i, j)
+       |}
+       |""".stripMargin
+  )
+
+  def checkEdit(
+      name: TestOptions,
+      original: String,
+      expected: String
+  ): Unit =
+    test(name) {
+      val edits = getAutoImplement(original)
+      val (code, _, _) = params(original)
+      val obtained = TextEdits.applyEdits(code, edits)
+      assertNoDiff(obtained, expected)
+    }
+
+  def getAutoImplement(
+      original: String,
+      filename: String = "A.scala"
+  ): List[l.TextEdit] = {
+    val (code, _, offset) = params(original)
+    val result = presentationCompiler
+      .insertInferredType(
+        CompilerOffsetParams(URI.create(filename), code, offset, cancelToken)
+      )
+      .get()
+    result.asScala.toList
+  }
+
+}

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -391,16 +391,26 @@ final class TestingClient(workspace: AbsolutePath, buffers: Buffers)
   }
 
   def applyCodeAction(
-      codeAction: CodeAction,
+      selectedActionIndex: Int,
+      codeActions: List[CodeAction],
       server: TestingServer
   ): Future[Any] = {
-    val edit = codeAction.getEdit()
-    val command = codeAction.getCommand()
-    if (edit != null) {
-      applyWorkspaceEdit(edit)
-    }
-    if (command != null) {
-      executeServerCommand(command, server)
+    if (codeActions.nonEmpty) {
+      if (selectedActionIndex >= codeActions.length) {
+        Assertions.fail(
+          s"selectedActionIndex ($selectedActionIndex) is out of bounds"
+        )
+      }
+      val codeAction = codeActions(selectedActionIndex)
+      val edit = codeAction.getEdit()
+      val command = codeAction.getCommand()
+      if (edit != null) {
+        applyWorkspaceEdit(edit)
+      }
+      if (command != null) {
+        executeServerCommand(command, server)
+      } else Future.unit
+
     } else Future.unit
   }
 

--- a/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
@@ -106,9 +106,6 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
         codeActions <-
           server.assertCodeAction(path, input, expectedActions, Nil)
         _ <- {
-          if (selectedActionIndex >= codeActions.length) {
-            fail(s"selectedActionIndex ($selectedActionIndex) is out of bounds")
-          }
           def isSelectTheKindOfFile(params: ShowMessageRequestParams): Boolean =
             params.getMessage() == NewScalaFile.selectTheKindOfFileMessage
           client.showMessageRequestHandler = { params =>
@@ -118,7 +115,7 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
               None
             }
           }
-          client.applyCodeAction(codeActions(selectedActionIndex), server)
+          client.applyCodeAction(selectedActionIndex, codeActions, server)
         }
         _ <- server.didSave(path)(identity)
         _ = if (expectNoDiagnostics) assertNoDiagnostics() else ()

--- a/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
@@ -1,0 +1,209 @@
+package tests.codeactions
+
+import scala.meta.internal.metals.codeactions.InsertInferredType
+
+class InsertInferredTypeLspSuite
+    extends BaseCodeActionLspSuite("implementAbstractMembers") {
+
+  check(
+    "val",
+    """|package a
+       |
+       |object A {
+       |  val al<<>>pha = 123
+       |}
+       |""".stripMargin,
+    s"""|${InsertInferredType.insertType}
+        |""".stripMargin,
+    """|package a
+       |
+       |object A {
+       |  val alpha: Int = 123
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "def",
+    """|package a
+       |
+       |object A {
+       |  def al<<>>pha() = 123
+       |}
+       |""".stripMargin,
+    s"""|${InsertInferredType.insertType}
+        |""".stripMargin,
+    """|package a
+       |
+       |object A {
+       |  def alpha(): Int = 123
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "for-comprehension",
+    """|object A{
+       |  for {
+       |    fir<<>>st <- 1 to 10
+       |    second <- 1 to 11
+       |  } yield (first, second)
+       |}""".stripMargin,
+    s"""|${InsertInferredType.insertTypeToPattern}
+        |""".stripMargin,
+    """|object A{
+       |  for {
+       |    first: Int <- 1 to 10
+       |    second <- 1 to 11
+       |  } yield (first, second)
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "for-comprehension-var",
+    """|object A{
+       |  for {
+       |    first <- 1 to 10
+       |    sec<<>>ond = first
+       |  } yield (first, second)
+       |}""".stripMargin,
+    s"""|${InsertInferredType.insertTypeToPattern}
+        |""".stripMargin,
+    """|object A{
+       |  for {
+       |    first <- 1 to 10
+       |    second: Int = first
+       |  } yield (first, second)
+       |}
+       |""".stripMargin
+  )
+
+  checkNoAction(
+    "for-comprehension-existing",
+    """|object A{
+       |  for {
+       |    fir<<>>st: Int <- 1 to 10
+       |    second <- 1 to 11
+       |  } yield (first, second)
+       |}""".stripMargin
+  )
+
+  check(
+    "lambda",
+    """|object A{
+       |  val list = "123".map(c<<>>h => ch.toInt)
+       |}""".stripMargin,
+    s"""|${InsertInferredType.insertType}
+        |""".stripMargin,
+    """|object A{
+       |  val list = "123".map((ch: Char) => ch.toInt)
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "lambda-brace",
+    """|object A{
+       |  val list = "123".map{c<<>>h => ch.toInt}
+       |}""".stripMargin,
+    s"""|${InsertInferredType.insertType}
+        |""".stripMargin,
+    """|object A{
+       |  val list = "123".map{ch: Char => ch.toInt}
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "val-pattern",
+    """|object A{
+       |  val (fir<<>>st, second) = (List(1), List(""))
+       |}""".stripMargin,
+    s"""|${InsertInferredType.insertTypeToPattern}
+        |""".stripMargin,
+    """|object A{
+       |  val (first: List[Int], second) = (List(1), List(""))
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "match",
+    """|object A{
+       |  (List(1), List("")) match {
+       |    case (List(2), _) =>
+       |    case (first, se<<>>cond) =>
+       |  }
+       |}""".stripMargin,
+    s"""|${InsertInferredType.insertTypeToPattern}
+        |""".stripMargin,
+    """|object A{
+       |  (List(1), List("")) match {
+       |    case (List(2), _) =>
+       |    case (first, second: List[String]) =>
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "match-option",
+    """|object A{
+       |  Option(1) match {
+       |    case Some(<<t>>) => t
+       |    case None =>
+       |  }
+       |}""".stripMargin,
+    s"""|${InsertInferredType.insertTypeToPattern}
+        |""".stripMargin,
+    """|object A{
+       |  Option(1) match {
+       |    case Some(t: Int) => t
+       |    case None =>
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkNoAction(
+    "match-bind",
+    """|object A{
+       |  (1, 2) match {
+       |    case <<num>> @ (first, _) => "Two!"
+       |    case otherDigit => "Not two!"
+       |  }
+       |}""".stripMargin
+  )
+
+  checkNoAction(
+    "existing-type",
+    """|package a
+       |
+       |object A {
+       |  val al<<>>pha: Int = 123
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "auto-import",
+    """|package a
+       |
+       |object A {
+       |  var al<<>>pha = List(123).toBuffer
+       |}
+       |""".stripMargin,
+    s"""|${InsertInferredType.insertType}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.mutable.Buffer
+       |
+       |object A {
+       |  var alpha: Buffer[Int] = List(123).toBuffer
+       |}
+       |""".stripMargin
+  )
+
+}

--- a/tests/unit/src/test/scala/tests/codeactions/StringActionsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/StringActionsLspSuite.scala
@@ -59,19 +59,12 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
        |""".stripMargin.replace("'", "\"")
   )
 
-  check(
+  checkNoAction(
     "out-selection-no-codeAction",
     """|package a
        |
        |object A {
-       |  val <<str>> = "this is a string"
-       |}
-       |""".stripMargin,
-    "",
-    """|package a
-       |
-       |object A {
-       |  val str = "this is a string"
+       |  val <<str>>: String = "this is a string"
        |}
        |""".stripMargin
   )
@@ -171,53 +164,32 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
        |""".stripMargin.replace("'", "\"")
   )
 
-  check(
+  checkNoAction(
     "triple-quotes-no-codeAction",
     """|package a
        |
        |object A {
        |  val str = <<'''>>'''
        |}
-       |""".stripMargin.replace("'", "\""),
-    "",
-    """|package a
-       |
-       |object A {
-       |  val str = ''''''
-       |}
        |""".stripMargin.replace("'", "\"")
   )
 
-  check(
+  checkNoAction(
     "triple-quotes-interpolation-no-codeAction",
     """|package a
        |
        |object A {
        |  val str = s'''this <<is a>> string'''
        |}
-       |""".stripMargin.replace("'", "\""),
-    "",
-    """|package a
-       |
-       |object A {
-       |  val str = s'''this is a string'''
-       |}
        |""".stripMargin.replace("'", "\"")
   )
 
-  check(
+  checkNoAction(
     "mix-triple-quotes-no-codeAction",
     """|package a
        |
        |object A {
        |  val str = s'''|multiline'''.stripMargin + '''an <<other>> multiline'''
-       |}
-       |""".stripMargin.replace("'", "\""),
-    "",
-    """|package a
-       |
-       |object A {
-       |  val str = s'''|multiline'''.stripMargin + '''an other multiline'''
        |}
        |""".stripMargin.replace("'", "\"")
   )


### PR DESCRIPTION
Inferred type code action is responsible for adding type annotations for any place that might need it such as:
- val/var declaration
- method declaration
- pattern matches
- lambdas
- for comprehensions

The code action itself has two steps:

1. Using the scalameta parser we check if there is a name at a given position and if it belongs to a tree node that doesn't have the type declared. If both is true we return code action with the `insert-inferred-type` command.

2. When the `insert-inferred-type` code action is run we use the presentation compiler and the new provider `InferredTypeProvider` to calculate the needed edits that actually add the type. This also includes any imports that are needed.

To that purpose there are two suites that test this behaviour:
- InsertInferredTypeSuite - checks the presentation compiler implementation
- InsertInferredTypeLspSuite - checks the whole workflow from the client perspective

Demo on the scalafmt's Router class:

![insert-type-scalafmt](https://user-images.githubusercontent.com/3807253/107386741-6f7d9e00-6af4-11eb-81e7-b269672d9bf7.gif)

Fixes https://github.com/scalameta/metals/issues/2484