### PR TITLE
Improve short names when importing

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImports.scala
@@ -25,7 +25,7 @@ trait AutoImports { this: MetalsGlobal =>
 
   def doLocateImportContext(
       pos: Position,
-      autoImport: Option[AutoImportPosition]
+      autoImport: Option[AutoImportPosition] = None
   ): Context = {
     try doLocateContext(
       autoImport.fold(pos)(i => pos.focus.withPoint(i.offset))

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -25,7 +25,7 @@ final class AutoImportsProvider(
     // make sure the compilation unit is loaded
     typedTreeAt(pos)
     val importPosition = autoImportPosition(pos, params.text())
-    val context = doLocateImportContext(pos, importPosition)
+    val context = doLocateImportContext(pos)
     val isSeen = mutable.Set.empty[String]
     val symbols = List.newBuilder[Symbol]
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -70,7 +70,7 @@ class CompletionProvider(
 
     val sorted = i.results.sorted(memberOrdering(query, history, completion))
     lazy val importPosition = autoImportPosition(pos, params.text())
-    lazy val context = doLocateImportContext(pos, importPosition)
+    lazy val context = doLocateImportContext(pos)
 
     val items = sorted.iterator.zipWithIndex.map { case (member, idx) =>
       params.checkCanceled()

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/InferredTypeProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/InferredTypeProvider.scala
@@ -39,9 +39,10 @@ final class InferredTypeProvider(
     val pos = unit.position(params.offset)
     val typedTree = typedTreeAt(pos)
     val importPosition = autoImportPosition(pos, params.text())
-    val context = doLocateImportContext(pos, importPosition)
+    val context = doLocateImportContext(pos)
     val history = new ShortenedNames(
-      lookupSymbol = name => context.lookupSymbol(name, _ => true) :: Nil
+      lookupSymbol = name =>
+        context.lookupSymbol(name, sym => !sym.isStale) :: Nil
     )
 
     def additionalImports = importPosition match {
@@ -50,13 +51,7 @@ final class InferredTypeProvider(
         // existing symbols in scope, so we just do nothing
         Nil
       case Some(importPosition) =>
-        history.autoImports(
-          pos,
-          context,
-          importPosition.offset,
-          importPosition.indent,
-          importPosition.padTop
-        )
+        history.autoImports(pos, importPosition)
     }
 
     def prettyType(tpe: Type) =

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -167,7 +167,7 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
       val tpe = prefix.widen.bounds.hi
       val members = ListBuffer.empty[TextEditMember]
       val importPos = autoImportPosition(pos, text)
-      val context = doLocateImportContext(pos, importPos)
+      val context = doLocateImportContext(pos)
       val subclassesResult = subclassesForType(tpe)
 
       // sort subclasses by declaration order

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -188,7 +188,9 @@ trait OverrideCompletions { this: MetalsGlobal =>
         }
 
       val history = new ShortenedNames(
-        lookupSymbol = { name => context.lookupSymbol(name, _ => true) :: Nil },
+        lookupSymbol = { name =>
+          context.lookupSymbol(name, sym => !sym.isStale) :: Nil
+        },
         config = renameConfig,
         renames = re,
         owners = owners

--- a/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
@@ -6,6 +6,7 @@ import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.CompilerOffsetParams
 import scala.meta.internal.metals.TextEdits
 
+import munit.TestOptions
 import org.eclipse.{lsp4j => l}
 import tests.BaseCodeActionSuite
 import tests.BuildInfoVersions
@@ -705,7 +706,7 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
   )
 
   def checkEdit(
-      name: String,
+      name: TestOptions,
       original: String,
       expected: String
   ): Unit =

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -366,13 +366,13 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |    cas@@
       |  }
       |}""".stripMargin,
-    """|case Nil => scala.collection.immutable
-       |case head :: tl => scala.collection.immutable
+    """|case head :: tl => scala.collection.immutable
+       |case Nil => scala.collection.immutable
        |""".stripMargin,
     compat = Map(
       "2.13" ->
-        """|case Nil => scala.collection.immutable
-           |case head :: next => scala.collection.immutable
+        """|case head :: next => scala.collection.immutable
+           |case Nil => scala.collection.immutable
            |""".stripMargin
     )
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -56,18 +56,16 @@ class CompletionIssueSuite extends BaseCompletionSuite {
       |object B {
       |  NestedLea@@
       |}""".stripMargin,
-    """
-      |package a
-      |
-      |import a.A.Nested.NestedLeaf
-      |object A {
-      |  object Nested{
-      |    object NestedLeaf
-      |  }
-      |}
-      |object B {
-      |  NestedLeaf
-      |}""".stripMargin
+    """|package a
+       |object A {
+       |  object Nested{
+       |    object NestedLeaf
+       |  }
+       |}
+       |object B {
+       |  A.Nested.NestedLeaf
+       |}
+       |""".stripMargin
   )
 
   checkEdit(
@@ -91,26 +89,25 @@ class CompletionIssueSuite extends BaseCompletionSuite {
       |object B {
       |  val allCountries = Sweden + France + USA + Norway@@
       |}""".stripMargin,
-    """
-      |package all
-      |import all.World.Countries.{
-      |  Sweden,
-      |  USA
-      |}
-      |import all.World.Countries.Norway
-      |
-      |object World {
-      |  object Countries{
-      |    object Sweden
-      |    object Norway
-      |    object France
-      |    object USA
-      |  }
-      |}
-      |import all.World.Countries.France
-      |object B {
-      |  val allCountries = Sweden + France + USA + Norway
-      |}""".stripMargin
+    """|package all
+       |import all.World.Countries.{
+       |  Sweden,
+       |  USA
+       |}
+       |
+       |object World {
+       |  object Countries{
+       |    object Sweden
+       |    object Norway
+       |    object France
+       |    object USA
+       |  }
+       |}
+       |import all.World.Countries.France
+       |object B {
+       |  val allCountries = Sweden + France + USA + World.Countries.Norway
+       |}
+       |""".stripMargin
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -56,7 +56,7 @@ class CompletionMatchSuite extends BaseCompletionSuite {
 
   // Assert that Workday/Weekend symbols from previous test don't appear in result.
   checkEdit(
-    "stale2".tag(IgnoreScalaVersion("2.11.12")),
+    "stale2",
     """package stale
       |sealed abstract class Weekday
       |object Weekday {
@@ -218,9 +218,8 @@ class CompletionMatchSuite extends BaseCompletionSuite {
     filter = _.contains("exhaustive")
   )
 
-  // https://github.com/scalameta/metals/issues/1253
   checkEdit(
-    "exhaustive-fully-qualify".fail,
+    "exhaustive-fully-qualify",
     """
       |package example
       |

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -236,7 +236,7 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
     includeDetail = false
   )
 
-  checkEditLine(
+  checkEdit(
     "conflict",
     s"""package a.b
        |abstract class Conflict {
@@ -245,12 +245,23 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
        |object Main {
        |  class Conflict
        |  new a.b.Conflict {
-       |    ___
+       |    def self@@
        |  }
        |}
        |""".stripMargin,
-    "def self@@",
-    "def self: a.b.Conflict = ${0:???}"
+    """|package a.b
+       |
+       |import a.b
+       |abstract class Conflict {
+       |  def self: Conflict
+       |}
+       |object Main {
+       |  class Conflict
+       |  new a.b.Conflict {
+       |    def self: b.Conflict = ${0:???}
+       |  }
+       |}
+       |""".stripMargin
   )
 
   check(
@@ -270,8 +281,8 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
        |  }
        |}
        |""".stripMargin,
-    """|def self: _root_.a.c.Conflict
-       |def selfArg: Option[_root_.a.c.Conflict]
+    """|def self: c.Conflict
+       |def selfArg: Option[c.Conflict]
        |def selfPath: Inner
        |Implement all members
        |""".stripMargin,
@@ -377,17 +388,23 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
     """  def foo: java.util.List[Int] = ${0:???}"""
   )
 
-  checkEditLine(
+  checkEdit(
     "jlang",
-    s"""|abstract class Mutable {
-        |  def foo: java.lang.StringBuilder
-        |}
-        |class Main extends Mutable {
-        |  ___
-        |}
-        |""".stripMargin,
-    "  def foo@@",
-    """  def foo: java.lang.StringBuilder = ${0:???}""".stripMargin
+    """|abstract class Mutable {
+       |  def foo: java.lang.StringBuilder
+       |}
+       |class Main extends Mutable {
+       |  def foo@@
+       |}
+       |""".stripMargin,
+    """|import java.lang
+       |abstract class Mutable {
+       |  def foo: java.lang.StringBuilder
+       |}
+       |class Main extends Mutable {
+       |  def foo: lang.StringBuilder = ${0:???}
+       |}
+       |""".stripMargin
   )
 
   checkEditLine(

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -195,7 +195,7 @@ class CompletionSuite extends BaseCompletionSuite {
            |apply(from: Any): Builder[A,List[A]]
            |asInstanceOf[T0]: T0
            |equals(obj: Object): Boolean
-           |getClass(): Class[_]
+           |getClass(): Class[_ <: Object]
            |hashCode(): Int
            |isInstanceOf[T0]: Boolean
            |synchronized[T0](x$1: T0): T0
@@ -245,7 +245,7 @@ class CompletionSuite extends BaseCompletionSuite {
       |  }
       |  Xtension@@
       |}""".stripMargin,
-    """|XtensionMethod(a: Int): XtensionMethod
+    """|XtensionMethod(a: Int): A.XtensionMethod
        |""".stripMargin,
     compat = Map(
       "3.0" -> "XtensionMethod(a: Int): implicit-class.A.XtensionMethod"

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -255,6 +255,40 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |}
        |""".stripMargin
   )
+  checkEdit(
+    "path",
+    """|import java.nio.file.Paths
+       |object ExplicitResultTypesPrefix {
+       |  class Path
+       |  def path = Paths.get("")
+       |  object inner {
+       |    val file = path
+       |    object inner {
+       |      val nio: java.nio.file.Path = path
+       |      object inner {
+       |        val <<java>> = path
+       |      }
+       |    }
+       |  }
+       |
+       |}""".stripMargin,
+    """|import java.nio.file.Paths
+       |object ExplicitResultTypesPrefix {
+       |  class Path
+       |  def path = Paths.get("")
+       |  object inner {
+       |    val file = path
+       |    object inner {
+       |      val nio: java.nio.file.Path = path
+       |      object inner {
+       |        val java: _root_.java.nio.file.Path = path
+       |      }
+       |    }
+       |  }
+       |
+       |}
+       |""".stripMargin
+  )
 
   def checkEdit(
       name: TestOptions,

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -94,7 +94,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
     """|<init>(): Random
        |<init>(seed: Int): Random
        |<init>(seed: Long): Random
-       |<init>(self: java.util.Random): Random
+       |<init>(self: util.Random): Random
        |""".stripMargin,
     compat = Map(
       "3.0" ->
@@ -630,6 +630,10 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
        |                ^^^^^^^^^^^
        |""".stripMargin,
     compat = Map(
+      "2.13" ->
+        """|computeIfAbsent(x$1: String, x$2: Function[_ >: String <: Object, _ <: Int]): Int
+           |                ^^^^^^^^^^^
+           |""".stripMargin,
       // TODO short names are not supported yet
       "3.0" ->
         """|computeIfAbsent(x$0: K, x$1: java.util.function.Function[? >: K, ? <: V]): V

--- a/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
@@ -195,7 +195,7 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
       // The default settings are no longer enabled.
       _ <- assertCompletion(
         "override def set@@",
-        """|def set: scala.collection.mutable.Set[Int]
+        """|def set: mutable.Set[Int]
            |""".stripMargin,
         includeDetail = false
       )


### PR DESCRIPTION
A while ago there were some changes to the scalafix implementation of printing types, which is actually based off Metals. While investigating some issues with importing, I decide to backport those fixes to Metals. That backported code is mainly the `MetalsGlobal.shortType`, `ShortenedNames.nameResolvesToSymbol` and `ShortenedNames.tryShortenName` methods.

Besides that:
- changed the location of where we get context to the actual place of the cursor, while keeping a separate context for the imports
- made sure that stale symbols are to looked up in relevant situations, which is anything that inserts code
- fixed the tests to adhere to these changes, where you can see most of the improvements/changes

This also fixes https://github.com/scalameta/metals/issues/1253 and some issues with insert type.