### PR TITLE
Only set focusedDocument on `didOpen` without didFocusProvider

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -928,7 +928,8 @@ class MetalsLanguageServer(
   @JsonNotification("textDocument/didOpen")
   def didOpen(params: DidOpenTextDocumentParams): CompletableFuture[Unit] = {
     val path = params.getTextDocument.getUri.toAbsolutePath
-    focusedDocument = Some(path)
+    if (!clientConfig.isDidFocusProvider())
+      focusedDocument = Some(path)
     openedFiles.add(path)
 
     // Update md5 fingerprint from file contents on disk


### PR DESCRIPTION
It seems that in some cases clients like VS Code might actually open a document that `didDefinition` is made on, which would previously make focusedDocument point to the wrong thing. Now we only change focusedDocument on `didOpen` if the client does not support the didFocusProvider.

The change was done in https://github.com/scalameta/metals/commit/679cde2c8f12e6e86d75ab84be57de35fd622285 probably to make sure that focused document is set on open, however didFocus is sent properly at that time, so it's not really needed.