### PR TITLE
Fix issues where created files should use backticks

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
@@ -15,6 +15,7 @@ import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.internal.metals.MetalsQuickPickParams
 import scala.meta.internal.metals.PackageProvider
 import scala.meta.internal.metals.newScalaFile.NewFileTypes._
+import scala.meta.internal.pc.Identifier
 import scala.meta.io.AbsolutePath
 
 import org.eclipse.lsp4j.ExecuteCommandParams
@@ -140,7 +141,9 @@ class NewFileProvider(
   ): Future[(AbsolutePath, Range)] = {
     val path = directory.getOrElse(workspace).resolve(name + ".scala")
     //name can be actually be "foo/Name", where "foo" is a folder to create
-    val className = directory.getOrElse(workspace).resolve(name).filename
+    val className = Identifier.backtickWrap(
+      directory.getOrElse(workspace).resolve(name).filename
+    )
     val template = kind match {
       case CaseClass => caseClassTemplate(className)
       case _ => classTemplate(kind.id, className)

--- a/tests/unit/src/test/scala/tests/AddPackageLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/AddPackageLspSuite.scala
@@ -1,11 +1,12 @@
 package tests
 
 import java.nio.file.Files
+import java.nio.file.Paths
 
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.RecursivelyDelete
+
 import munit.TestOptions
-import java.nio.file.Paths
 
 class AddPackageLspSuite extends BaseLspSuite("add-package") {
 
@@ -39,9 +40,9 @@ class AddPackageLspSuite extends BaseLspSuite("add-package") {
 
   check("multilevel")(
     "a/src/main/scala/a/b/c/Main.scala",
-    """
-      |package a.b.c
-        """.stripMargin
+    """|
+       |package a.b.c
+       |  """.stripMargin
   )
 
   check("no-package")(
@@ -54,10 +55,27 @@ class AddPackageLspSuite extends BaseLspSuite("add-package") {
     ""
   )
 
+  check("escaped-name")(
+    "a/src/main/scala/type/a/this/Main.scala",
+    """|
+       |package `type`.a.`this`
+       |  """.stripMargin
+  )
+
+  check("escaped-name-object")(
+    "a/src/main/scala/type/a/this/package.scala",
+    """|package `type`.a
+       |
+       |package object `this` {
+       |  
+       |}
+       |""".stripMargin
+  )
+
   def check(name: TestOptions)(
       fileToCreate: String,
       expectedContent: String
-  ) = {
+  ): Unit = {
     test(name) {
       val parent = Paths.get(fileToCreate).getParent()
       cleanCompileCache("a")

--- a/tests/unit/src/test/scala/tests/AddPackageLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/AddPackageLspSuite.scala
@@ -4,177 +4,84 @@ import java.nio.file.Files
 
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.RecursivelyDelete
+import munit.TestOptions
+import java.nio.file.Paths
 
 class AddPackageLspSuite extends BaseLspSuite("add-package") {
 
-  test("single-level") {
-    cleanCompileCache("a")
-    RecursivelyDelete(workspace.resolve("a"))
-    Files.createDirectories(
-      workspace.resolve("a/src/main/scala/a").toNIO
-    )
-    for {
-      _ <- server.initialize(
-        """|/metals.json
-           |{
-           |  "a": { }
-           |}
-        """.stripMargin
-      )
-      _ =
-        workspace
-          .resolve("a/src/main/scala/a/Main.scala")
-          .toFile
-          .createNewFile()
-      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
-      _ = assertNoDiff(
-        workspace.resolve("a/src/main/scala/a/Main.scala").readText,
-        """
-          |package a
-        """.stripMargin
-      )
-    } yield ()
-  }
+  check("single-level")(
+    "a/src/main/scala/a/Main.scala",
+    """|
+       |package a
+       |""".stripMargin
+  )
 
-  test("package-file") {
-    cleanCompileCache("a")
-    RecursivelyDelete(workspace.resolve("a"))
-    Files.createDirectories(
-      workspace.resolve("a/src/main/scala/a").toNIO
-    )
-    for {
-      _ <- server.initialize(
-        """|/metals.json
-           |{
-           |  "a": { }
-           |}
-        """.stripMargin
-      )
-      _ =
-        workspace
-          .resolve("a/src/main/scala/a/package.scala")
-          .toFile
-          .createNewFile()
-      _ <- server.didOpen("a/src/main/scala/a/package.scala")
-      _ = assertNoDiff(
-        workspace.resolve("a/src/main/scala/a/package.scala").readText,
-        "package object a {\n  \n}\n"
-      )
-    } yield ()
-  }
+  check("package-file")(
+    "a/src/main/scala/a/package.scala",
+    """|
+       |package object a {
+       |  
+       |}
+       |
+       |""".stripMargin
+  )
 
-  test("package-file-multi") {
-    cleanCompileCache("a")
-    RecursivelyDelete(workspace.resolve("a"))
-    Files.createDirectories(
-      workspace.resolve("a/src/main/scala/a/b/c").toNIO
-    )
-    for {
-      _ <- server.initialize(
-        """|/metals.json
-           |{
-           |  "a": { }
-           |}
-        """.stripMargin
-      )
-      _ =
-        workspace
-          .resolve("a/src/main/scala/a/b/c/package.scala")
-          .toFile
-          .createNewFile()
-      _ <- server.didOpen("a/src/main/scala/a/b/c/package.scala")
-      _ = assertNoDiff(
-        workspace.resolve("a/src/main/scala/a/b/c/package.scala").readText,
-        """|package a.b
-           |
-           |package object c {
-           |  
-           |}
-           |""".stripMargin
-      )
-    } yield ()
-  }
+  check("package-file-multi")(
+    "a/src/main/scala/a/b/c/package.scala",
+    """|package a.b
+       |
+       |package object c {
+       |  
+       |}
+       |
+       |""".stripMargin
+  )
 
-  test("multilevel") {
-    cleanCompileCache("a")
-    RecursivelyDelete(workspace.resolve("a"))
-    Files.createDirectories(
-      workspace.resolve("a/src/main/scala/a/b/c").toNIO
-    )
-    for {
-      _ <- server.initialize(
-        """|/metals.json
-           |{
-           |  "a": { }
-           |}
+  check("multilevel")(
+    "a/src/main/scala/a/b/c/Main.scala",
+    """
+      |package a.b.c
         """.stripMargin
-      )
-      _ =
-        workspace
-          .resolve("a/src/main/scala/a/b/c/Main.scala")
-          .toFile
-          .createNewFile()
-      _ <- server.didOpen("a/src/main/scala/a/b/c/Main.scala")
-      _ = assertNoDiff(
-        workspace.resolve("a/src/main/scala/a/b/c/Main.scala").readText,
-        """
-          |package a.b.c
-        """.stripMargin
-      )
-    } yield ()
-  }
+  )
 
-  test("no-package") {
-    cleanCompileCache("a")
-    RecursivelyDelete(workspace.resolve("a"))
-    Files.createDirectories(
-      workspace.resolve("a/src/main/scala").toNIO
-    )
-    for {
-      _ <- server.initialize(
-        """|/metals.json
-           |{
-           |  "a": { }
-           |}
-        """.stripMargin
-      )
-      _ =
-        workspace
-          .resolve("a/src/main/scala/Main.scala")
-          .toFile
-          .createNewFile()
-      _ <- server.didOpen("a/src/main/scala/Main.scala")
-      _ = assertNoDiff(
-        workspace.resolve("a/src/main/scala/Main.scala").readText,
-        ""
-      )
-    } yield ()
-  }
+  check("no-package")(
+    "a/src/main/scala/Main.scala",
+    ""
+  )
 
-  test("java-file") {
-    cleanCompileCache("a")
-    RecursivelyDelete(workspace.resolve("a"))
-    Files.createDirectories(
-      workspace.resolve("a/src/main/java/a").toNIO
-    )
-    for {
-      _ <- server.initialize(
-        """|/metals.json
-           |{
-           |  "a": { }
-           |}
+  check("java-file")(
+    "a/src/main/scala/Main.java",
+    ""
+  )
+
+  def check(name: TestOptions)(
+      fileToCreate: String,
+      expectedContent: String
+  ) = {
+    test(name) {
+      val parent = Paths.get(fileToCreate).getParent()
+      cleanCompileCache("a")
+      RecursivelyDelete(workspace.resolve("a"))
+      Files.createDirectories(workspace.toNIO.resolve(parent))
+      for {
+        _ <- server.initialize(
+          """|/metals.json
+             |{
+             |  "a": { }
+             |}
         """.stripMargin
-      )
-      _ =
-        workspace
-          .resolve("a/src/main/java/a/Main.java")
-          .toFile
-          .createNewFile()
-      _ <- server.didOpen("a/src/main/java/a/Main.java")
-      _ = assertNoDiff(
-        workspace.resolve("a/src/main/java/a/Main.java").readText,
-        ""
-      )
-    } yield ()
+        )
+        _ =
+          workspace
+            .resolve(fileToCreate)
+            .toFile
+            .createNewFile()
+        _ <- server.didOpen(fileToCreate)
+        _ = assertNoDiff(
+          workspace.resolve(fileToCreate).readText,
+          expectedContent
+        )
+      } yield ()
+    }
   }
 }

--- a/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
@@ -81,6 +81,19 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
                           |""".stripMargin
   )
 
+  check("new-class-backticked")(
+    directory = Some("a/src/main/scala/this/"),
+    fileType = Right(Class),
+    fileName = Right("type"),
+    expectedFilePath = "a/src/main/scala/this/type.scala",
+    expectedContent = s"""|package `this`
+                          |
+                          |class `type` {
+                          |$indent
+                          |}
+                          |""".stripMargin
+  )
+
   check("new-class-name-provided")(
     directory = Some("a/src/main/scala/foo/"),
     fileType = Right(Class),


### PR DESCRIPTION
Previously, we would not any backticks when generating files from the `New Scala File` command or when a file was created with a package name inserted automatically. Now, we wrap each part in backticks if needed.

Fixes #2375