### PR TITLE
Don't populate completion detail if it's an empty string.

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionItemResolver.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionItemResolver.scala
@@ -40,7 +40,11 @@ class CompletionItemResolver(
               .filterNot(_.isEmpty)
               .toSeq
             item.setLabel(replaceScalaDefaultParams(item.getLabel, defaults))
-            if (metalsConfig.isCompletionItemDetailEnabled) {
+            if (
+              metalsConfig.isCompletionItemDetailEnabled && !item
+                .getDetail()
+                .isEmpty()
+            ) {
               item.setDetail(
                 replaceScalaDefaultParams(item.getDetail, defaults)
               )


### PR DESCRIPTION
This probably isn't that important, but I noticed this recently and had
to fix it in a completion extension
https://github.com/hrsh7th/nvim-compe/pull/177.

The detail field is optional in the `CompletionItem` so it might be best
to just not set it if the detail is `""`. If not, it may cause weird
things like showing an empty resolve float if the client doesn't have
the logic to filter that out.