### PR TITLE
Revert https://github.com/scalameta/metals/commit/519c6414797edcc35d5d714b220c7d7d140c4b4

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -928,8 +928,7 @@ class MetalsLanguageServer(
   @JsonNotification("textDocument/didOpen")
   def didOpen(params: DidOpenTextDocumentParams): CompletableFuture[Unit] = {
     val path = params.getTextDocument.getUri.toAbsolutePath
-    if (!clientConfig.isDidFocusProvider())
-      focusedDocument = Some(path)
+    focusedDocument = Some(path)
     openedFiles.add(path)
 
     // Update md5 fingerprint from file contents on disk


### PR DESCRIPTION
@tgodzik and I talked a bunch off line about this but the jist of the issue is that with this change if you open `test.worksheet.sc` directly now it won't evaluate. Even after that if you directly open another `second.worksheet.sc` it still won't evaluate since focused document isn't changed on the `didOpen` after the listed commit.

We need to rethink this a bit since the original issue with VS Code still exists.