### PR TITLE
Revert to recently focused document if the current one was immedietally closed

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ActiveFiles.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ActiveFiles.scala
@@ -27,4 +27,9 @@ final class ActiveFiles(time: Time) {
   def isRecentlyActive(path: AbsolutePath): Boolean = {
     paths.asScala.exists(p => p.isActive && p.path == path)
   }
+
+  def pollRecent(): Option[AbsolutePath] = {
+    paths.removeIf(_.isStale)
+    Option(paths.poll()).map(_.path)
+  }
 }


### PR DESCRIPTION
Some clients when using peek functionality might send didOpen and didClose notifications immediately one after the other. In this case we don't actually want to change the focused document so we revert to the one that was most recently focused.