### PR TITLE
Integration of sbt-debug-adapter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -483,7 +483,8 @@ lazy val `sbt-metals` = project
     buildInfoKeys := Seq[BuildInfoKey](
       "semanticdbVersion" -> V.semanticdb,
       "supportedScala2Versions" -> V.scala2Versions
-    )
+    ),
+    addSbtPlugin("ch.epfl.scala" % "sbt-debug-adapter" % "1.0.0")
   )
   .enablePlugins(BuildInfoPlugin)
   .disablePlugins(ScalafixPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -197,6 +197,8 @@ lazy val V = new {
   val munit = "0.7.20"
   val scalafix = "0.9.25"
   val lsp4jV = "0.10.0"
+  val sbtJdiTools = "1.1.1"
+
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.
   def supportedScalaBinaryVersions =
@@ -460,6 +462,7 @@ lazy val metals = project
       "ammoniteVersion" -> V.ammonite,
       "organizeImportVersion" -> V.organizeImportRule,
       "millVersion" -> V.mill,
+      "sbtJdiToolsVersion" -> V.sbtJdiTools,
       "supportedScalaVersions" -> V.supportedScalaVersions,
       "supportedScala2Versions" -> V.scala2Versions,
       "supportedScala3Versions" -> V.scala3Versions,

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -66,12 +66,7 @@ class BspConnector(
           bloopServers.newServer(workspace, userConfiguration).map(Some(_))
         case ResolvedBspOne(details)
             if details.getName() == SbtBuildTool.name =>
-          SbtBuildTool.writeSingleSbtMetalsPlugin(
-            workspace.resolve("project"),
-            userConfig,
-            isBloop = false,
-            details.getVersion()
-          )
+          SbtBuildTool.writeSbtMetalsPlugins(workspace)
           val connectionF = bspServers.newServer(workspace, details)
           statusBar
             .trackFuture("Connecting to sbt", connectionF, showTimer = true)

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -64,6 +64,12 @@ class BuildServerConnection private (
 
   def isBloop: Boolean = name == BloopServers.name
 
+  def isSbt: Boolean = name == SbtBuildTool.name
+
+  // hasDebug is not yet available in BSP capabilities
+  // https://github.com/build-server-protocol/build-server-protocol/pull/161
+  def hasDebug: Boolean = isBloop || isSbt
+
   def workspaceDirectory: AbsolutePath = workspace
 
   def onReconnection(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -512,7 +512,7 @@ class MetalsLanguageServer(
             buffers,
             buildTargets,
             clientConfig,
-            () => bspSession.map(_.main.isBloop).getOrElse(false)
+            () => bspSession.map(_.main.hasDebug).getOrElse(false)
           )
 
         val goSuperLensProvider = new SuperMethodCodeLens(

--- a/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
@@ -61,6 +61,7 @@ class SbtServerSuite
   test("generate") {
     def sbtBspConfig = workspace.resolve(".bsp/sbt.json")
     def sbtBspPlugin = workspace.resolve("project/metals.sbt")
+    def sbtJdiPlugin = workspace.resolve("project/project/metals.sbt")
     cleanWorkspace()
     for {
       _ <- server.initialize(
@@ -87,6 +88,8 @@ class SbtServerSuite
     } yield {
       assert(sbtBspPlugin.exists)
       assert(sbtBspConfig.exists)
+      assert(sbtJdiPlugin.exists)
+      assert(sbtJdiPlugin.readText.contains("sbt-jdi-tools"))
     }
   }
 


### PR DESCRIPTION
- load [`sbt-debug-adapter`](https://github.com/scalacenter/scala-debug-adapter/releases/tag/v1.0.0) in the `sbt-metals` plugin 
- activate the `run` and `test` lenses on sbt
- add the `sbt-jdi-tools` plugin in the meta-meta build to ensure that the JDI jar is loaded in sbt. It's needed by `sbt-debug-adapter` as explained [here](https://github.com/scalacenter/scala-debug-adapter/releases/tag/v1.0.0). 