### PR TITLE
Fallback to Scala3 dialects when parsing library sources

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/ScalaMtags.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/ScalaMtags.scala
@@ -15,6 +15,7 @@ import scala.meta.Term
 import scala.meta.Tree
 import scala.meta.Type
 import scala.meta.dialects.Scala213
+import scala.meta.dialects.Scala3
 import scala.meta.inputs.Input
 import scala.meta.internal.semanticdb.Language
 import scala.meta.internal.semanticdb.Scala._
@@ -31,8 +32,14 @@ class ScalaMtags(val input: Input.VirtualFile)
     extends SimpleTraverser
     with MtagsIndexer {
 
-  private val root: Parsed[Source] = Scala213(input).parse[Source]
-
+  // This needs to be further improved with tests
+  // https://github.com/scalameta/metals/issues/2493
+  private val root: Parsed[Source] = {
+    Scala213(input).parse[Source] match {
+      case r @ Parsed.Success(_) => r
+      case _ => Scala3(input).parse[Source]
+    }
+  }
   def source: Source = root.get
   override def language: Language = Language.SCALA
   override def indexRoot(): Unit = {


### PR DESCRIPTION
To enable finding symbols in library sources we use the parser to find the exact symbol that we need. Previously it would not work for Scala 3 due to using the Scala213 dialect. Now, we fallback to Scala3 dialect in case of issues, which is a temporary workaround until https://github.com/scalameta/metals/issues/2493 is fixed.

I tried to do it here, but it turns out it's a much more compelx issue and would not want to merge it before the release.