### PR TITLE
Fix standalone Scala 3 worksheets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -293,6 +293,7 @@ def multiScalaDirectories(root: File, scalaVersion: String) = {
   if (isScala3(partialVersion)) {
     result += base / "scala-3"
   }
+  result += base / s"scala-$scalaVersion"
   result.toList
 }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -201,7 +201,7 @@ class MetalsLanguageServer(
       compilations.pauseables
   )
   private val timerProvider: TimerProvider = new TimerProvider(time)
-  private val trees = new Trees(buildTargets, buffers)
+  private val trees = new Trees(buildTargets, buffers, scalaVersionSelector)
   private val documentSymbolProvider = new DocumentSymbolProvider(trees)
   private val multilineStringFormattingProvider =
     new MultilineStringFormattingProvider(buffers, trees, () => userConfig)

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -22,13 +22,9 @@ case class ScalaTarget(
 ) {
 
   def dialect: Dialect = {
-    scalaBinaryVersion match {
+    scalaVersion match {
       case _ if info.getDataKind() == "sbt" => Sbt
-      case "2.11" => Scala211
-      case "2.12" => Scala212
-      case "2.13" => Scala213
-      case version if version.startsWith("3.") => Scala3
-      case _ => Scala213
+      case other => ScalaVersions.dialectForScalaVersion(other)
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
@@ -1,5 +1,7 @@
 package scala.meta.internal.metals
 
+import scala.meta.Dialect
+
 class ScalaVersionSelector(
     userConfig: () => UserConfiguration,
     buildTargets: BuildTargets
@@ -23,5 +25,9 @@ class ScalaVersionSelector(
       selected
     else
       ScalaVersions.recommendedVersion(selected)
+  }
+
+  def fallbackDialect(allowScala3: Boolean): Dialect = {
+    ScalaVersions.dialectForScalaVersion(fallbackScalaVersion(allowScala3))
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -1,5 +1,7 @@
 package scala.meta.internal.metals
 
+import scala.meta.Dialect
+import scala.meta.dialects._
 import scala.meta.internal.mtags
 import scala.meta.internal.semver.SemVer
 
@@ -83,5 +85,16 @@ object ScalaVersions {
       scalaVersion
     else
       scalaVersion.split('.').take(2).mkString(".")
+  }
+
+  def dialectForScalaVersion(scalaVersion: String): Dialect = {
+    val scalaBinaryVersion = scalaBinaryVersionFromFullVersion(scalaVersion)
+    scalaBinaryVersion match {
+      case "2.11" => Scala211
+      case "2.12" => Scala212
+      case "2.13" => Scala213
+      case version if version.startsWith("3.") => Scala3
+      case _ => Scala213
+    }
   }
 }

--- a/tests/slow/src/test/scala/tests/feature/WorksheetCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/WorksheetCrossLspSuite.scala
@@ -3,7 +3,10 @@ package tests.feature
 import scala.meta.internal.metals.{BuildInfo => V}
 
 class Worksheet211LspSuite extends tests.BaseWorksheetLspSuite(V.scala211)
-class Worksheet3LspSuite extends tests.BaseWorksheetLspSuite(V.scala3)
+class Worksheet3LspSuite extends tests.BaseWorksheetLspSuite(V.scala3) {
+  override def versionSpecificCodeToValidate: String =
+    """given str: String = """""
+}
 class Worksheet213LspSuite extends tests.BaseWorksheetLspSuite(V.scala213) {
 
   test("literals") {

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -17,6 +17,8 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
     super.userConfig.copy(worksheetScreenWidth = 40, worksheetCancelTimeout = 1)
   override def munitIgnore: Boolean = !isValidScalaVersionForEnv(scalaVersion)
 
+  def versionSpecificCodeToValidate: String = ""
+
   // sourcecode is not yet published for Scala 3
   if (!ScalaVersions.isScala3Version(scalaVersion))
     test("completion") {
@@ -87,7 +89,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
            |println(greeting + "\\nHow are you?")
            |1.to(10).toVector
            |val List(a, b) = List(42, 10)
-           |""".stripMargin
+           |""".stripMargin + versionSpecificCodeToValidate
       )
       _ <- server.didOpen("a/Main.worksheet.sc")
       _ = assertNoDiagnostics()
@@ -109,6 +111,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
                  |println(greeting + "\nHow are you?") // Hello Susan…
                  |1.to(10).toVector // : Vector[Int] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
                  |val List(a, b) = List(42, 10) // a: Int = 42, b: Int = 10
+                 |given str: String = ""
                  |""".stripMargin
           ),
           scalaVersion

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -29,7 +29,6 @@ import scala.meta.internal.implementation.Supermethods.formatMethodSymbolForQuic
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.Buffers
-import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.Debug
 import scala.meta.internal.metals.DebugSession
@@ -125,7 +124,6 @@ final class TestingServer(
 )(implicit ex: ExecutionContextExecutorService) {
   import scala.meta.internal.metals.JsonParser._
 
-  val testTrees = new Trees(new BuildTargets(_ => None), buffers)
   val server = new MetalsLanguageServer(
     ex,
     buffers = buffers,

--- a/tests/unit/src/test/scala/tests/FoldingRangeSuite.scala
+++ b/tests/unit/src/test/scala/tests/FoldingRangeSuite.scala
@@ -5,7 +5,9 @@ import java.util.UUID
 
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.ScalaVersionSelector
 import scala.meta.internal.metals.TextEdits
+import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.parsing.FoldingRangeProvider
 import scala.meta.internal.parsing.Trees
 import scala.meta.io.AbsolutePath
@@ -15,7 +17,10 @@ import tests.BuildInfo.testResourceDirectory
 
 class FoldingRangeSuite extends DirectoryExpectSuite("foldingRange/expect") {
   private val buffers = Buffers()
-  private val trees = new Trees(new BuildTargets(_ => None), buffers)
+  private val buildTargets = new BuildTargets(_ => None)
+  private val selector =
+    new ScalaVersionSelector(() => UserConfiguration(), buildTargets)
+  private val trees = new Trees(buildTargets, buffers, selector)
   private val foldingRangeProvider = new FoldingRangeProvider(trees, buffers)
 
   override def testCases(): List[ExpectTestCase] = {


### PR DESCRIPTION
In one of the previous PRs we changed the parser to take into account the real dialect of the code to parse based on the build target the file is located in. Recently, we also added the possibility to change the default Scala version, which allowed users to use standalone Scala 3 worksheets. We haven't however changed the parser dialect that is used for those worksheets, which results in Scala 3 specific code to be marked as an error. In this PR I am making the parser use the correct parser dialect.