### PR TITLE
Fix rename/references for worksheets

### DIFF
--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -464,8 +464,8 @@ scripts.
   </tr>
   <tr>
     <td>Find references</td>
-    <td align="center"></td>
-    <td align="center"></td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
     <td align="center">✅</td>
     <td align="center">✅</td>
   </tr>
@@ -478,15 +478,15 @@ scripts.
   </tr>
   <tr>
     <td>Find implementations</td>
-    <td align="center"></td>
+    <td align="center">✅</td>
     <td align="center"></td>
     <td align="center">✅</td>
     <td align="center">✅</td>
   </tr>
   <tr>
     <td>Rename symbol</td>
-    <td align="center"></td>
-    <td align="center"></td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
     <td align="center">✅</td>
     <td align="center">✅</td>
   </tr>
@@ -506,8 +506,8 @@ scripts.
   </tr>
   <tr>
     <td>Workspace symbols</td>
-    <td align="center"></td>
-    <td align="center"></td>
+    <td align="center">✅</td>
+    <td align="center">All symbols are local</td>
     <td align="center">✅</td>
     <td align="center">✅</td>
   </tr>
@@ -521,14 +521,14 @@ scripts.
   <tr>
     <td>Folding</td>
     <td align="center">✅</td>
-    <td align="center"></td>
+    <td align="center">✅</td>
     <td align="center">✅</td>
     <td align="center">✅</td>
   </tr>
   <tr>
     <td>Highlight</td>
-    <td align="center"></td>
-    <td align="center"></td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
     <td align="center">✅</td>
     <td align="center">✅</td>
   </tr>
@@ -541,7 +541,7 @@ scripts.
   </tr>
   <tr>
     <td>Implicit decorations</td>
-    <td align="center"></td>
+    <td align="center">✅</td>
     <td align="center"></td>
     <td align="center">✅</td>
     <td align="center">✅</td>

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
@@ -16,17 +16,20 @@ import java.io.ByteArrayOutputStream
 
 import scala.meta.io.AbsolutePath
 import scala.meta.internal.mtags.MD5
+import scala.meta.internal.mtags.MtagsEnrichments._
 
-class SemanticdbTextDocumentProvider(driver: InteractiveDriver, workspace: Option[Path]) {
+class SemanticdbTextDocumentProvider(driver: InteractiveDriver, workspace: Option[Path]) 
+  extends WorksheetSemanticdbProvider {
   
   def textDocument(
       uri: URI,
       sourceCode: String
   ): Array[Byte] = {
     val filePath = Paths.get(uri)
+    val validCode = removeMagicImports(sourceCode, AbsolutePath(filePath))
     driver.run(
       uri,
-      SourceFile.virtual(filePath.toString, sourceCode)
+      SourceFile.virtual(filePath.toString, validCode)
     )
     val tree = driver.currentCtx.run.units.head.tpdTree
     val extract = ExtractSemanticDB()

--- a/mtags/src/main/scala/scala/meta/internal/pc/WorksheetSemanticdbProvider.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/WorksheetSemanticdbProvider.scala
@@ -1,0 +1,23 @@
+package scala.meta.internal.pc
+
+import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.io.AbsolutePath
+
+trait WorksheetSemanticdbProvider {
+
+  private val magicImportsRegex =
+    """import\s+(\$ivy|\$repo|\$dep|\$scalac)\..*""".r
+
+  def removeMagicImports(code: String, filePath: AbsolutePath): String = {
+    if (filePath.isWorksheet) {
+      code.linesIterator
+        .map {
+          case magicImportsRegex(_) => ""
+          case other => other
+        }
+        .mkString("\n")
+    } else {
+      code
+    }
+  }
+}

--- a/tests/cross/src/test/scala/tests/pc/PcSemanticdbSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcSemanticdbSuite.scala
@@ -31,14 +31,42 @@ class PcSemanticdbSuite extends BasePCSuite {
        |""".stripMargin
   )
 
+  check(
+    "worksheet",
+    """|import $ivy.`org.kohsuke:github-api:1.114`
+       |
+       |object O {
+       |  val a = 123
+       |  val b = a + 1
+       |}""".stripMargin,
+    """|import $ivy.`org.kohsuke:github-api:1.114`
+       |
+       |object O/*local0*/ {
+       |  val a/*local1*/ = 123
+       |  val b/*local2*/ = a/*local1*/ +/*scala.Int#`+`(+4).*/ 1
+       |}
+       |""".stripMargin,
+    filename = "A.worksheet.sc",
+    compat = Map(
+      "3.0" ->
+        """|import $ivy.`org.kohsuke:github-api:1.114`
+           |
+           |object O/*_empty_.O.*/ {
+           |  val a/*_empty_.O.a.*/ = 123
+           |  val b/*_empty_.O.b.*/ = a/*_empty_.O.a.*/ +/*scala.Int#`+`(+4).*/ 1
+           |}
+           |""".stripMargin
+    )
+  )
+
   def check(
       name: String,
       original: String,
       expected: String,
-      compat: Map[String, String] = Map.empty
+      compat: Map[String, String] = Map.empty,
+      filename: String = "A.scala"
   )(implicit loc: Location): Unit = {
     test(name) {
-      val filename = "A.scala"
       val uri = new URI(s"file:///$filename")
       val doc = presentationCompiler.semanticdbTextDocument(uri, original)
 

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -528,10 +528,10 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
                   |""".stripMargin,
             V.scala3 ->
               """|/Main.worksheet.sc
-                 |import java/*<no symbol>*/.time/*<no symbol>*/.Instant/*<no symbol>*/
+                 |import java/*<no symbol>*/.time/*<no symbol>*/.Instant/*Instant.java*/
                  |
-                 |val x/*L2*/ = Instant/*<no symbol>*/.now/*<no symbol>*/()
-                 |val y/*L3*/ = List/*<no symbol>*/.fill/*<no symbol>*/(2)(2)
+                 |val x/*L2*/ = Instant/*Instant.java*/.now/*Instant.java*/()
+                 |val y/*L3*/ = List/*package.scala*/.fill/*Factory.scala*/(2)(2)
                  |""".stripMargin
           ),
           scalaVersion

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -345,6 +345,16 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
        |""".stripMargin
   )
 
+  check(
+    "worksheet",
+    """|/a/src/main/scala/a/Main.worksheet.sc
+       |trait <<A@@A>>
+       |trait BB extends <<AA>>
+       |trait CC extends <<AA>>
+       |trait DD extends <<AA>>
+       |""".stripMargin
+  )
+
   override def assertCheck(
       filename: String,
       edit: String,


### PR DESCRIPTION
Thanks to the recent work on generating semanticdb for sbt, it's also possible to generate semanticdb for worksheets and in this way allow:
- references
- rename
- document highlight

The only thing missing is `Go to implementations` which doesn't work for anything that is not indexed globally. We don't want to index worksheets globally as their symbols are local to the file they exist in.

Fixes https://github.com/scalameta/metals/issues/2540