### PR TITLE
Add support for Scala 2.13.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,9 +181,10 @@ lazy val V = new {
   val sbtScala = "2.12.10"
   // TODO https://github.com/scalameta/metals/issues/2392
   val ammonite212Version = "2.12.12"
+  val ammonite213Version = "2.13.4"
   val scala212 = "2.12.13"
-  val scala213 = "2.13.4"
-  val scalameta = "4.4.9"
+  val scala213 = "2.13.5"
+  val scalameta = "4.4.10"
   val semanticdb = scalameta
   val bsp = "2.0.0-M13"
   val bloop = "1.4.8"
@@ -210,9 +211,9 @@ lazy val V = new {
 
   // Scala 2
   def deprecatedScala2Versions =
-    Seq(scala211, "2.12.8", "2.12.9", "2.13.0", "2.13.1")
+    Seq(scala211, "2.12.8", "2.12.9", "2.13.0", "2.13.1", "2.13.2")
   def nonDeprecatedScala2Versions =
-    Seq(scala213, scala212, "2.12.12", "2.12.11", "2.12.10", "2.13.2", "2.13.3")
+    Seq(scala213, scala212, "2.12.12", "2.12.11", sbtScala, "2.13.3", "2.13.4")
   def scala2Versions = nonDeprecatedScala2Versions ++ deprecatedScala2Versions
 
   // Scala 3
@@ -473,6 +474,7 @@ lazy val metals = project
       "scala211" -> V.scala211,
       "scala212" -> V.scala212,
       "ammonite212" -> V.ammonite212Version,
+      "ammonite213" -> V.ammonite213Version,
       "scala213" -> V.scala213,
       "scala3" -> V.scala3
     )
@@ -580,6 +582,7 @@ def publishBinaryMtags =
           V.scala212,
           V.ammonite212Version,
           V.scala213,
+          V.ammonite213Version,
           V.scala3
         )
       )
@@ -591,13 +594,7 @@ lazy val mtest = project
     testSettings,
     sharedSettings,
     libraryDependencies ++= List(
-      // munit had to drop support for 3.0.0-M1 and 0.27.0-RC1
-      if (
-        scalaVersion.value == "0.27.0-RC1" || scalaVersion.value == "3.0.0-M1"
-      )
-        "org.scalameta" %% "munit" % "0.7.19"
-      else
-        "org.scalameta" %% "munit" % V.munit,
+      "org.scalameta" %% "munit" % V.munit,
       "io.get-coursier" % "interface" % V.coursierInterfaces
     ),
     buildInfoPackage := "tests",

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -109,7 +109,7 @@ class Compilers(
       PresentationCompilerKey.Default,
       (_, value) => {
         val scalaVersion =
-          scalaVersionSelector.fallbackScalaVersion(allowScala3 = true)
+          scalaVersionSelector.fallbackScalaVersion(isAmmonite = false)
         val existingPc = Option(value).flatMap { pc =>
           if (pc.scalaVersion == scalaVersion) {
             Some(pc)
@@ -418,7 +418,7 @@ class Compilers(
       jworksheetsCache.put(
         path, {
           val scalaVersion =
-            scalaVersionSelector.fallbackScalaVersion(allowScala3 = true)
+            scalaVersionSelector.fallbackScalaVersion(isAmmonite = false)
           createStandaloneCompiler(
             scalaVersion,
             classpath,

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
@@ -1,13 +1,14 @@
 package scala.meta.internal.metals
 
 import scala.meta.Dialect
+import scala.meta.internal.semver.SemVer
 
 class ScalaVersionSelector(
     userConfig: () => UserConfiguration,
     buildTargets: BuildTargets
 ) {
 
-  def fallbackScalaVersion(allowScala3: Boolean): String = {
+  def fallbackScalaVersion(isAmmonite: Boolean): String = {
     val selected = userConfig().fallbackScalaVersion match {
       case Some(v) => v
       case None =>
@@ -18,16 +19,31 @@ class ScalaVersionSelector(
           .getOrElse(BuildInfo.scala212)
     }
 
+    val binary = ScalaVersions.scalaBinaryVersionFromFullVersion(selected)
     // ammonite doesn't support Scala3 yet
-    if (!allowScala3 && ScalaVersions.isScala3Version(selected))
+    if (isAmmonite && ScalaVersions.isScala3Version(selected))
       BuildInfo.scala213
+    else if (
+      isAmmonite && binary == "2.12" && SemVer.isLaterVersion(
+        BuildInfo.ammonite212,
+        selected
+      )
+    )
+      BuildInfo.ammonite212
+    else if (
+      isAmmonite && binary == "2.13" && SemVer.isLaterVersion(
+        BuildInfo.ammonite213,
+        selected
+      )
+    )
+      BuildInfo.ammonite213
     else if (ScalaVersions.isSupportedScalaVersion(selected))
       selected
     else
       ScalaVersions.recommendedVersion(selected)
   }
 
-  def fallbackDialect(allowScala3: Boolean): Dialect = {
-    ScalaVersions.dialectForScalaVersion(fallbackScalaVersion(allowScala3))
+  def fallbackDialect(isAmmonite: Boolean): Dialect = {
+    ScalaVersions.dialectForScalaVersion(fallbackScalaVersion(isAmmonite))
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
@@ -149,7 +149,7 @@ final class Ammonite(
         AmmVersions(
           ammoniteVersion = BuildInfo.ammoniteVersion,
           scalaVersion =
-            scalaVersionSelector.fallbackScalaVersion(allowScala3 = false)
+            scalaVersionSelector.fallbackScalaVersion(isAmmonite = true)
         )
       )
     val res = AmmoniteFetcher(versions)

--- a/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
@@ -91,17 +91,19 @@ final class Trees(
     Option(path.extension) match {
       case Some("scala") =>
         dialectFromBuildTarget.getOrElse(
-          scalaVersionSelector.fallbackDialect(allowScala3 = true)
+          scalaVersionSelector.fallbackDialect(isAmmonite = false)
         )
       case Some("sbt") => dialects.Sbt
       case Some("sc") =>
         // worksheets support Scala 3, but ammonite scripts do not
         val dialect = dialectFromBuildTarget.getOrElse(
-          scalaVersionSelector.fallbackDialect(allowScala3 = path.isWorksheet)
+          scalaVersionSelector.fallbackDialect(isAmmonite =
+            path.isAmmoniteScript
+          )
         )
         dialect
           .copy(allowToplevelTerms = true, toplevelSeparator = "")
-      case _ => scalaVersionSelector.fallbackDialect(allowScala3 = true)
+      case _ => scalaVersionSelector.fallbackDialect(isAmmonite = false)
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -91,7 +91,7 @@ class WorksheetProvider(
 
   private def fallabackMdoc: Mdoc = {
     val scalaVersion =
-      scalaVersionSelector.fallbackScalaVersion(allowScala3 = true)
+      scalaVersionSelector.fallbackScalaVersion(isAmmonite = false)
     mdocs
       .get(MdocKey.Default)
       .flatMap(ref =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -80,8 +80,8 @@ trait ArgCompletions { this: MetalsGlobal =>
       }
 
       completions match {
-        case CompletionResult.ScopeMembers(_, results, _) =>
-          results
+        case members: CompletionResult.ScopeMembers =>
+          members.results
             .collect {
               case mem
                   if mem.sym.tpe <:< paramType && notNothingOrNull(

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -230,99 +230,111 @@ class CompletionDocSuite extends BaseCompletionSuite {
         s"""
            |${predefDocString(commonlyUsedTypesPost2134)}
            |Predef scala
+           |""".stripMargin,
+      "2.13.5" ->
+        s"""
+           |${predefDocString(commonlyUsedTypesPost2134)}
+           |Predef scala
            |""".stripMargin
     )
   )
 
-  val iteratorDocs213: String =
-    """|> Iterators are data structures that allow to iterate over a sequence
-       |of elements. They have a `hasNext` method for checking
-       |if there is a next element available, and a `next` method
-       |which returns the next element and advances the iterator.
-       |
-       |An iterator is mutable: most operations on it change its state. While it is often used
-       |to iterate through the elements of a collection, it can also be used without
-       |being backed by any collection (see constructors on the companion object).
-       |
-       |It is of particular importance to note that, unless stated otherwise, *one should never
-       |use an iterator after calling a method on it*. The two most important exceptions
-       |are also the sole abstract methods: `next` and `hasNext`.
-       |
-       |Both these methods can be called any number of times without having to discard the
-       |iterator. Note that even `hasNext` may cause mutation -- such as when iterating
-       |from an input stream, where it will block until the stream is closed or some
-       |input becomes available.
-       |
-       |Consider this example for safe and unsafe use:
-       |
-       |```
-       |def f[A](it: Iterator[A]) = {
-       |  if (it.hasNext) {            // Safe to reuse "it" after "hasNext"
-       |    it.next                    // Safe to reuse "it" after "next"
-       |    val remainder = it.drop(2) // it is *not* safe to use "it" again after this line!
-       |    remainder.take(2)          // it is *not* safe to use "remainder" after this line!
-       |  } else it
-       |}
-       |```
-       |Iterator scala.collection
-       |> Explicit instantiation of the `Iterator` trait to reduce class file size in subclasses.
-       |AbstractIterator scala.collection
-       |> Buffered iterators are iterators which provide a method `head`
-       | that inspects the next element without discarding it.
-       |BufferedIterator scala.collection
-       |> A specialized Iterator for LinearSeqs that is lazy enough for Stream and LazyList. This is accomplished by not
-       |evaluating the tail after returning the current head.
-       |LinearSeqIterator scala.collection
-       |> Base trait for companion objects of collections that require an implicit `ClassTag`.
-       |
-       |**Type Parameters**
-       |- `CC`: Collection type constructor (e.g. `ArraySeq`)
-       |ClassTagIterableFactory scala.collection
-       |> Base trait for companion objects of collections that require an implicit evidence.
-       |
-       |**Type Parameters**
-       |- `Ev`: Unary type constructor for the implicit evidence required for an element type
-       |           (typically `Ordering` or `ClassTag`)
-       |- `CC`: Collection type constructor (e.g. `ArraySeq`)
-       |EvidenceIterableFactory scala.collection
-       |> This trait provides default implementations for the factory methods `fromSpecific` and
-       |`newSpecificBuilder` that need to be refined when implementing a collection type that refines
-       |the `CC` and `C` type parameters. It is used for collections that have an additional constraint,
-       |expressed by the `evidenceIterableFactory` method.
-       |
-       |The default implementations in this trait can be used in the common case when `CC[A]` is the
-       |same as `C`.
-       |EvidenceIterableFactoryDefaults scala.collection
-       |> Base trait for companion objects of unconstrained collection types that may require
-       |multiple traversals of a source collection to build a target collection `CC`.
-       |
-       |
-       |**Type Parameters**
-       |- `CC`: Collection type constructor (e.g. `List`)
-       |IterableFactory scala.collection
-       |> This trait provides default implementations for the factory methods `fromSpecific` and
-       |`newSpecificBuilder` that need to be refined when implementing a collection type that refines
-       |the `CC` and `C` type parameters.
-       |
-       |The default implementations in this trait can be used in the common case when `CC[A]` is the
-       |same as `C`.
-       |IterableFactoryDefaults scala.collection
-       |> Base trait for companion objects of collections that require an implicit `Ordering`.
-       |
-       |**Type Parameters**
-       |- `CC`: Collection type constructor (e.g. `SortedSet`)
-       |SortedIterableFactory scala.collection
-       |> **Type Parameters**
-       |- `A`: Type of elements (e.g. `Int`, `Boolean`, etc.)
-       |- `C`: Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
-       |SpecificIterableFactory scala.collection
-       |""".stripMargin
+  def iteratorDocs213(withLinearSeqIterator: Boolean = true): String = {
+    val linearSeqIteratorDocs =
+      if (withLinearSeqIterator) {
+        "\n" +
+          """|> A specialized Iterator for LinearSeqs that is lazy enough for Stream and LazyList. This is accomplished by not
+             |evaluating the tail after returning the current head.
+             |LinearSeqIterator scala.collection""".stripMargin
+      } else {
+        ""
+      }
+    s"""|> Iterators are data structures that allow to iterate over a sequence
+        |of elements. They have a `hasNext` method for checking
+        |if there is a next element available, and a `next` method
+        |which returns the next element and advances the iterator.
+        |
+        |An iterator is mutable: most operations on it change its state. While it is often used
+        |to iterate through the elements of a collection, it can also be used without
+        |being backed by any collection (see constructors on the companion object).
+        |
+        |It is of particular importance to note that, unless stated otherwise, *one should never
+        |use an iterator after calling a method on it*. The two most important exceptions
+        |are also the sole abstract methods: `next` and `hasNext`.
+        |
+        |Both these methods can be called any number of times without having to discard the
+        |iterator. Note that even `hasNext` may cause mutation -- such as when iterating
+        |from an input stream, where it will block until the stream is closed or some
+        |input becomes available.
+        |
+        |Consider this example for safe and unsafe use:
+        |
+        |```
+        |def f[A](it: Iterator[A]) = {
+        |  if (it.hasNext) {            // Safe to reuse "it" after "hasNext"
+        |    it.next()                  // Safe to reuse "it" after "next"
+        |    val remainder = it.drop(2) // it is *not* safe to use "it" again after this line!
+        |    remainder.take(2)          // it is *not* safe to use "remainder" after this line!
+        |  } else it
+        |}
+        |```
+        |Iterator scala.collection
+        |> Explicit instantiation of the `Iterator` trait to reduce class file size in subclasses.
+        |AbstractIterator scala.collection
+        |> Buffered iterators are iterators which provide a method `head`
+        | that inspects the next element without discarding it.
+        |BufferedIterator scala.collection$linearSeqIteratorDocs
+        |> Base trait for companion objects of collections that require an implicit `ClassTag`.
+        |
+        |**Type Parameters**
+        |- `CC`: Collection type constructor (e.g. `ArraySeq`)
+        |ClassTagIterableFactory scala.collection
+        |> Base trait for companion objects of collections that require an implicit evidence.
+        |
+        |**Type Parameters**
+        |- `Ev`: Unary type constructor for the implicit evidence required for an element type
+        |           (typically `Ordering` or `ClassTag`)
+        |- `CC`: Collection type constructor (e.g. `ArraySeq`)
+        |EvidenceIterableFactory scala.collection
+        |> This trait provides default implementations for the factory methods `fromSpecific` and
+        |`newSpecificBuilder` that need to be refined when implementing a collection type that refines
+        |the `CC` and `C` type parameters. It is used for collections that have an additional constraint,
+        |expressed by the `evidenceIterableFactory` method.
+        |
+        |The default implementations in this trait can be used in the common case when `CC[A]` is the
+        |same as `C`.
+        |EvidenceIterableFactoryDefaults scala.collection
+        |> Base trait for companion objects of unconstrained collection types that may require
+        |multiple traversals of a source collection to build a target collection `CC`.
+        |
+        |
+        |**Type Parameters**
+        |- `CC`: Collection type constructor (e.g. `List`)
+        |IterableFactory scala.collection
+        |> This trait provides default implementations for the factory methods `fromSpecific` and
+        |`newSpecificBuilder` that need to be refined when implementing a collection type that refines
+        |the `CC` and `C` type parameters.
+        |
+        |The default implementations in this trait can be used in the common case when `CC[A]` is the
+        |same as `C`.
+        |IterableFactoryDefaults scala.collection
+        |> Base trait for companion objects of collections that require an implicit `Ordering`.
+        |
+        |**Type Parameters**
+        |- `CC`: Collection type constructor (e.g. `SortedSet`)
+        |SortedIterableFactory scala.collection
+        |> **Type Parameters**
+        |- `A`: Type of elements (e.g. `Int`, `Boolean`, etc.)
+        |- `C`: Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
+        |SpecificIterableFactory scala.collection
+        |""".stripMargin
+  }
 
   check(
     "scala4",
     """
       |object A {
-      |  scala.collection.Iterator@@
+      |  import scala.collection.Iterator@@
       |}
     """.stripMargin,
     """|
@@ -368,9 +380,10 @@ class CompletionDocSuite extends BaseCompletionSuite {
        |""".stripMargin,
     includeDocs = true,
     compat = Map(
-      "2.13.2" -> iteratorDocs213,
-      "2.13.3" -> iteratorDocs213.replace("it.next  ", "it.next()"),
-      "2.13.4" -> iteratorDocs213.replace("it.next  ", "it.next()")
+      "2.13.3" -> iteratorDocs213(),
+      "2.13.4" -> iteratorDocs213(),
+      // LinearSeqIterator should actually not be added since it's private and it's fixed in 2.13.5
+      "2.13.5" -> iteratorDocs213(withLinearSeqIterator = false)
     )
   )
 
@@ -404,6 +417,9 @@ class CompletionDocSuite extends BaseCompletionSuite {
                     |global: ExecutionContextExecutor
                     |""".stripMargin,
       "2.13.4" -> s"""|$executionDocstringPost2134
+                      |global: ExecutionContext
+                      |""".stripMargin,
+      "2.13.5" -> s"""|$executionDocstringPost2134
                       |global: ExecutionContext
                       |""".stripMargin
     )
@@ -480,6 +496,19 @@ class CompletionDocSuite extends BaseCompletionSuite {
        |""".stripMargin,
     includeDocs = true,
     compat = Map(
+      "2.13.5" ->
+        """|> A builder for mutable sequence of characters.  This class provides an API
+           |mostly compatible with `java.lang.StringBuilder`, except where there are
+           |conflicts with the Scala collections API (such as the `reverse` method.)
+           |
+           |$multipleResults
+           |
+           |
+           |**See**
+           |- ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#stringbuilders)
+           |section on `StringBuilders` for more information.
+           |StringBuilder scala.collection.mutable
+           |""".stripMargin,
       "2.13" ->
         """|> A builder for mutable sequence of characters.  This class provides an API
            |mostly compatible with `java.lang.StringBuilder`, except where there are
@@ -557,7 +586,8 @@ class CompletionDocSuite extends BaseCompletionSuite {
     compat = Map(
       "2.13.2" -> vectorDocs213,
       "2.13.3" -> vectorDocs213,
-      "2.13.4" -> vectorDocs213
+      "2.13.4" -> vectorDocs213,
+      "2.13.5" -> vectorDocs213
     )
   )
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -426,7 +426,12 @@ class CompletionSuite extends BaseCompletionSuite {
       |""".stripMargin,
     "",
     compat = Map(
-      "3.0" -> "Inner: a.Outer.Inner$"
+      "3.0" -> "Inner: a.Outer.Inner$",
+      /* TODO seems that changes in 2.13.5 made this pop up and this
+       * might have been a bug in presentation compiler that we were using
+       * https://github.com/scalameta/metals/issues/2546
+       */
+      "2.13.5" -> "Inner a.Outer"
     )
   )
 
@@ -493,7 +498,7 @@ class CompletionSuite extends BaseCompletionSuite {
       |package a
       |
       |object Main{
-      |  scala.Function@@
+      |  import scala.Function@@
       |}
       |""".stripMargin,
     // assert that we don't sort lexicographically: Function1, Function11, ..., Function2, ...
@@ -523,10 +528,34 @@ class CompletionSuite extends BaseCompletionSuite {
        |Function22 scala
        |PartialFunction scala
        |""".stripMargin,
+    // Scala 2.13.5 adds additional completions that actually fit, but are not useful for this test
+    topLines = Some(25),
     compat = Map(
       "3.0" ->
-        """|Function: Function$
-           |Function1: Function1$
+        """|Function0: scala.Function0
+           |Function1: trait and object Function1
+           |Function2: scala.Function2
+           |Function3: scala.Function3
+           |Function4: scala.Function4
+           |Function5: scala.Function5
+           |Function6: scala.Function6
+           |Function7: scala.Function7
+           |Function8: scala.Function8
+           |Function9: scala.Function9
+           |Function10: scala.Function10
+           |Function11: scala.Function11
+           |Function12: scala.Function12
+           |Function13: scala.Function13
+           |Function14: scala.Function14
+           |Function15: scala.Function15
+           |Function16: scala.Function16
+           |Function17: scala.Function17
+           |Function18: scala.Function18
+           |Function19: scala.Function19
+           |Function20: scala.Function20
+           |Function21: scala.Function21
+           |Function22: scala.Function22
+           |Function: Function$
            |""".stripMargin
     )
   )
@@ -608,7 +637,8 @@ class CompletionSuite extends BaseCompletionSuite {
        |""".stripMargin,
     compat = Map(
       "3.0" -> """|DelayedLazyVal: scala.concurrent.DelayedLazyVal$
-                  |""".stripMargin
+                  |""".stripMargin,
+      "2.13.5" -> "DelayedLazyVal - scala.concurrent"
     )
   )
 

--- a/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
@@ -2,6 +2,30 @@ package tests.feature
 
 import scala.meta.internal.metals.{BuildInfo => V}
 
-class Ammonite213Suite extends tests.BaseAmmoniteSuite(V.scala213)
+class Ammonite213Suite extends tests.BaseAmmoniteSuite(V.ammonite213)
 
-class Ammonite212Suite extends tests.BaseAmmoniteSuite(V.ammonite212)
+class Ammonite212Suite extends tests.BaseAmmoniteSuite(V.ammonite212) {
+
+  test("global-version-fallback") {
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "${V.scala212}"
+           |  }
+           |}
+           |/main.sc
+           |
+           |val cantStandTheHeat = "stay off the street"
+           |""".stripMargin
+      )
+      _ <- server.didOpen("main.sc")
+      _ <- server.didSave("main.sc")(identity)
+      _ <- server.executeCommand("ammonite-start")
+    } yield {
+      assertEmpty(client.workspaceErrorShowMessages)
+    }
+  }
+}

--- a/tests/unit/src/test/resources/documentSymbol-scala3/example/Extension.scala
+++ b/tests/unit/src/test/resources/documentSymbol-scala3/example/Extension.scala
@@ -1,6 +1,6 @@
 /*example(Package):9*/package example
 
-/*example.extension Int(Module):6*/extension (i: Int)
+/*example.extension Int(Module):4*/extension (i: Int)
   /*example.`extension Int`.asString(Method):4*/def asString: String = i.toString
 
 /*example.extension String(Module):9*/extension (s: String) {

--- a/tests/unit/src/test/resources/documentSymbol-scala3/example/Ord.scala
+++ b/tests/unit/src/test/resources/documentSymbol-scala3/example/Ord.scala
@@ -1,10 +1,10 @@
 /*example(Package):12*/package example
 
-/*example.Ord(Interface):6*/trait Ord[T]:
+/*example.Ord(Interface):4*/trait Ord[T]:
    /*example.Ord#compare(Method):4*/def compare(x: T, y: T): Int
 
-/*example.intOrd(Class):10*/given intOrd: Ord[Int] with
-   /*example.intOrd#compare(Method):10*/def compare(x: Int, y: Int) =
+/*example.intOrd(Class):8*/given intOrd: Ord[Int] with
+   /*example.intOrd#compare(Method):8*/def compare(x: Int, y: Int) =
      if x < y then -1 else if x > y then +1 else 0
 
 /*example. (Class):12*/given Ord[String] with


### PR DESCRIPTION
Issues encountered during the update:
- Scala presentation compiler will no longer complete type symbols on `a.b.Name` in positions where type is not allowed, which is actually a bugix, but we needed to change some test
- Ammonite does not have support for 2.13.5 yet and even if it has we can't currently update. In order to make the experience smoother for the users I added the logic in VersionSelector that will fallback to the last Ammonite supported Scala version instead of just failing
- there was a fix in scalameta for indented regions that changed their ends, which needed to be updated in the expect tests
- one test started to fail with 2.13.5 - is unclear if the behaviour was ever fixed in Metals or whether we relied on the compiler #2546