### PR TITLE
DocumentSymbolProvider: set name as " " in case if it's empty.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
@@ -64,7 +64,7 @@ class DocumentSymbolProvider(trees: Trees) {
     ): Unit = {
       owner.getChildren.add(
         new DocumentSymbol(
-          name,
+          if (name.isEmpty) " " else name,
           kind,
           range.toLSP,
           selection.toLSP,

--- a/tests/input3/src/main/scala/example/GivenAlias.scala
+++ b/tests/input3/src/main/scala/example/GivenAlias.scala
@@ -1,3 +1,4 @@
 package example
 
 given intValue: Int = 4
+given String = "str"

--- a/tests/unit/src/test/resources/documentSymbol-scala3/example/GivenAlias.scala
+++ b/tests/unit/src/test/resources/documentSymbol-scala3/example/GivenAlias.scala
@@ -1,3 +1,4 @@
-/*example(Package):3*/package example
+/*example(Package):4*/package example
 
 /*example.intValue(Constant):3*/given intValue: Int = 4
+/*example. (Constant):4*/given String = "str"


### PR DESCRIPTION
VSCode client throws an error when it receives a symbol with an empty name.
<details>
  <summary>Log</summary>
  
  ```
  [2021-02-23 20:09:09.612] [renderer1] [error] name must not be falsy: Error: name must not be falsy
	at Function.validate (/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:546:315)
	at new T (/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:546:264)
	at new T (/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:531:904)
	at asDocumentSymbol (/home/dos65/.vscode/extensions/scalameta.metals-1.9.13/node_modules/vscode-languageclient/lib/protocolConverter.js:462:22)
	at asDocumentSymbol (/home/dos65/.vscode/extensions/scalameta.metals-1.9.13/node_modules/vscode-languageclient/lib/protocolConverter.js:466:31)
	at Array.map (<anonymous>)
	at Object.asDocumentSymbols (/home/dos65/.vscode/extensions/scalameta.metals-1.9.13/node_modules/vscode-languageclient/lib/protocolConverter.js:459:23)
	at /home/dos65/.vscode/extensions/scalameta.metals-1.9.13/node_modules/vscode-languageclient/lib/client.js:1085:70
  ```
</details>

Additionally, fixes `documentSymbol` for anonymous `GivenAlias`