### PR TITLE
[Scala3] DocumentSymbols - use proper dialect for tree rendering

### DIFF
--- a/tests/input3/src/main/scala/example/OrType.scala
+++ b/tests/input3/src/main/scala/example/OrType.scala
@@ -1,0 +1,3 @@
+package example
+
+type X = String | Int

--- a/tests/unit/src/test/resources/documentSymbol-scala3/example/OrType.scala
+++ b/tests/unit/src/test/resources/documentSymbol-scala3/example/OrType.scala
@@ -1,0 +1,3 @@
+/*example(Package):3*/package example
+
+/*example.X(TypeParameter):3*/type X = String | Int


### PR DESCRIPTION
Fixes #2551