### PR TITLE
Remove println in SemanticdbTextDocumentProvider

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
@@ -20,7 +20,6 @@ class SemanticdbTextDocumentProvider(val compiler: MetalsGlobal)
     val filePath = AbsolutePath(Paths.get(uri))
     val validCode = removeMagicImports(code, filePath)
 
-    println(validCode)
     val unit = addCompilationUnit(
       code = validCode,
       filename = uri.toString(),


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/2556

I am so so very sorry about that. Tried to squeeze in too much into one release.