### PR TITLE
Show an error to the user if they are using a bad dep in a worksheet.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -18,6 +18,11 @@ import org.eclipse.lsp4j.ShowMessageRequestParams
  */
 object Messages {
 
+  def errorMessageParams(msg: String) = new MessageParams(
+    MessageType.Error,
+    msg
+  )
+
   val noRoot = new MessageParams(
     MessageType.Error,
     """|No rootUri or rootPath detected.

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -48,6 +48,7 @@ import scala.meta.pc.CancelToken
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import coursierapi.Dependency
 import coursierapi.Fetch
+import coursierapi.error.SimpleResolutionError
 import mdoc.interfaces.EvaluatedWorksheet
 import mdoc.interfaces.Mdoc
 import org.eclipse.lsp4j.Hover
@@ -230,6 +231,12 @@ class WorksheetProvider(
     }
     val onError: PartialFunction[Throwable, Option[EvaluatedWorksheet]] = {
       case InterruptException() =>
+        None
+      case e: SimpleResolutionError =>
+        scribe.error(e.getMessage())
+        languageClient.showMessage(
+          Messages.errorMessageParams(e.getMessage().takeWhile(_ != '\n'))
+        )
         None
       case e: Throwable =>
         // NOTE(olafur): we catch all exceptions because of https://github.com/scalameta/metals/issues/1456

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
@@ -70,4 +70,25 @@ class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala212) {
       } yield ()
     }
   }
+
+  test("bad-dep") {
+    val path = "hi.worksheet.sc"
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {}
+           |}
+           |/${path}
+           |import $$dep.`com.lihaoyi::scalatags:0.999.0`
+           |""".stripMargin
+      )
+      _ <- server.didOpen(path)
+      _ = assertNoDiff(
+        client.workspaceErrorShowMessages,
+        "Error downloading com.lihaoyi:scalatags_2.12:0.999.0"
+      )
+    } yield ()
+  }
 }


### PR DESCRIPTION
I ran across this today and I knew to look in the logs right away to see
why my worksheet wasn't working, but I imagine in the situation where
someone is trying to use a dependency in their worksheet and it's not
the correct dep, it fails silently without any indication that something
is going wrong. So this change just captures if it's a resolution issue,
grabs the first line from coursier and actually shows it to the user.