### PR TITLE
Fix issues with renames on Windows

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -139,12 +139,13 @@ final class RenameProvider(
         }
 
         val allChanges = for {
-          (uri, locs) <- allReferences.toList.distinct.groupBy(_.getUri())
+          (path, locs) <- allReferences.toList.distinct
+            .groupBy(_.getUri().toAbsolutePath)
         } yield {
           val textEdits = for (loc <- locs) yield {
             textEdit(isOccurrence, loc, newName)
           }
-          Seq(uri.toAbsolutePath -> textEdits.toList)
+          Seq(path -> textEdits.toList)
         }
         val fileChanges = allChanges.flatten.toMap
         val shouldRenameInBackground =


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/2537

Previously, renames would not work, because we would group locations by URI string, which might sometimes, especially on windows, be different:

`"file:///c%3A/Users/Tomasz/Documents/Work/scala-example/src/main/scala/Base.scala"`

vs

`"file:///C:/Users/Tomasz/Documents/Work/scala-example/src/main/scala/Base.scala"`

This fixes the issue by grouping via AbsoluteFile, which is the same for both cases.