### PR TITLE
Update metals doctor hint to match exact 'Import build' instead of 'Build import'

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/troubleshoot/ScalaProblem.scala
+++ b/metals/src/main/scala/scala/meta/internal/troubleshoot/ScalaProblem.scala
@@ -15,7 +15,7 @@ sealed abstract class ScalaProblem {
    * Comprehensive message to be presented to the user.
    */
   def message: String
-  protected val hint = "run 'Build import' to enable code navigation."
+  protected val hint = "run 'Import build' to enable code navigation."
 }
 
 case class UnsupportedScalaVersion(version: String) extends ScalaProblem {


### PR DESCRIPTION
This was slightly confusing to see:

![image](https://user-images.githubusercontent.com/64685/109838567-22747f80-7bfb-11eb-9810-f1d80aea4c01.png)

