### PR TITLE
Add code action to rename import

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -178,6 +178,29 @@ object ClientCommands {
        |""".stripMargin
   )
 
+  val SaveAndRename = new Command(
+    "metals-save-and-rename",
+    "Save file and run rename on a location",
+    "Move the cursor focus to the provided location",
+    """|First required parameter is LSP `Location` object with `uri` and `range` fields.
+       |Second parameter is optional and has signature `otherWindow: Boolean`. 
+       |It gives a hint to client that if possible it would be good to open location in
+       |another buffer/window.
+       |Example: 
+       |```json
+       |[{
+       |  "uri": "file://path/to/Definition.scala",
+       |  "range": {
+       |    "start": {"line": 194, "character": 0},
+       |    "end":   {"line": 194, "character": 1}
+       |  }
+       |},
+       |  false
+       |]
+       |```
+       |""".stripMargin
+  )
+
   val OpenFolder = new Command(
     "metals-open-folder",
     "Open a specified folder either in the same or new window",

--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -9,13 +9,15 @@ import scala.meta.internal.parsing.Trees
 import scala.meta.pc.CancelToken
 
 import org.eclipse.{lsp4j => l}
+import scala.meta.internal.mtags.Semanticdbs
 
 final class CodeActionProvider(
     compilers: Compilers,
     buffers: Buffers,
     buildTargets: BuildTargets,
     scalafixProvider: ScalafixProvider,
-    trees: Trees
+    trees: Trees,
+    semanticdbs: Semanticdbs
 )(implicit ec: ExecutionContext) {
   private val allActions: List[CodeAction] = List(
     new ImplementAbstractMembers(compilers),
@@ -23,7 +25,8 @@ final class CodeActionProvider(
     new CreateNewSymbol(),
     new StringActions(buffers, trees),
     new OrganizeImports(scalafixProvider, buildTargets),
-    new InsertInferredType(trees, compilers)
+    new InsertInferredType(trees, compilers),
+    new RenameImport(trees, semanticdbs)
   )
 
   def codeActions(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -639,7 +639,8 @@ class MetalsLanguageServer(
           buffers,
           buildTargets,
           scalafixProvider,
-          trees
+          trees,
+          semanticdbs
         )
         doctor = new Doctor(
           workspace,
@@ -1571,6 +1572,18 @@ class MetalsLanguageServer(
           languageClient.metalsExecuteClientCommand(
             new ExecuteCommandParams(
               ClientCommands.GotoLocation.id,
+              params.getArguments()
+            )
+          )
+        }.asJavaObject
+
+      case ServerCommands.RunRename() =>
+        Future {
+          // arguments are not checked but are of format:
+          // singletonList(location: Location, otherWindow: Boolean)
+          languageClient.metalsExecuteClientCommand(
+            new ExecuteCommandParams(
+              ClientCommands.SaveAndRename.id,
               params.getArguments()
             )
           )

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -387,6 +387,15 @@ object ServerCommands {
     "Stop Ammonite build server"
   )
 
+  val RunRename = new Command(
+    "run-rename",
+    "Save file and then send rename request to the client",
+    """|Save file and then send rename request to the client.
+       |
+       |""".stripMargin,
+    "[location], where the location is a lsp location object."
+  )
+
   def all: List[Command] =
     List(
       AnalyzeStacktrace,
@@ -411,7 +420,8 @@ object ServerCommands {
       StartAmmoniteBuildServer,
       StartDebugAdapter,
       StopAmmoniteBuildServer,
-      SuperMethodHierarchy
+      SuperMethodHierarchy,
+      RunRename
     )
 }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/RenameImport.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/RenameImport.scala
@@ -1,0 +1,117 @@
+package scala.meta.internal.metals.codeactions
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.Importee
+import scala.meta.Name
+import scala.meta.Tree
+import scala.meta.inputs.Position
+import scala.meta.internal.metals.CodeAction
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.parsing.Trees
+import scala.meta.pc.CancelToken
+
+import org.eclipse.lsp4j.TextEdit
+import org.eclipse.{lsp4j => l}
+import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.trees.Origin.Parsed
+import scala.meta.internal.mtags.Semanticdbs
+
+class RenameImport(trees: Trees, semanticdbs: Semanticdbs) extends CodeAction {
+
+  import RenameImport._
+  override def kind: String = l.CodeActionKind.Refactor
+
+  override def contribute(
+      params: l.CodeActionParams,
+      token: CancelToken
+  )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = Future {
+
+    def findLastEnclosingAtPos(tree: Tree, pos: Position): Option[Name] = {
+      tree.children.find { child =>
+        child.pos.start <= pos.start && pos.start <= child.pos.end
+      } match {
+        case None =>
+          tree match {
+            case name: Name => Some(name)
+            case _ => None
+          }
+        case Some(value) => findLastEnclosingAtPos(value, pos)
+      }
+    }
+
+    def renameImportCodeAction(name: Name): Option[l.CodeAction] =
+      name.parent.flatMap {
+        case nm @ Importee.Name(_) =>
+          val nameRange = nm.pos.toLSP
+          val uri = params.getTextDocument().getUri()
+          val renameKeyword = name.origin match {
+            case p: Parsed if p.dialect.allowAsForImportRename => "as"
+            case _ => "=>"
+          }
+
+          // TODO make sure it does not exists via .startwith
+          val randomName = s"Renamed${nm.name.value}"
+          val renamedOccurrencesEdits =
+            for {
+              doc <- semanticdbs
+                .textDocument(uri.toAbsolutePath)
+                .documentIncludingStale
+                .toIterable
+              occ <- doc.occurrences
+              // TODO make sure full imports are not renamed, probably check symbol
+              range <- occ.range
+              lspRange = range.toLSP
+              if lspRange != nameRange
+              // TODO inString should probably be a try, getting issues when tree doesn't parse
+              if range.inString(doc.text) == nm.name.value
+            } yield new TextEdit(lspRange, randomName)
+
+          val text = s"{ $name $renameKeyword $randomName }"
+          val goToRange = nameRange.copy()
+          val newEndChar =
+            text.length() - 3 + goToRange.getStart().getCharacter()
+          goToRange
+            .getEnd()
+            .setCharacter(newEndChar)
+          goToRange.setStart(goToRange.getEnd())
+
+          val edit = new TextEdit(nameRange, text)
+          val codeAction = new l.CodeAction()
+          codeAction.setTitle(title)
+          codeAction.setKind(l.CodeActionKind.RefactorRewrite)
+
+          val location =
+            new l.Location(params.getTextDocument().getUri(), goToRange)
+          codeAction.setCommand(
+            ServerCommands.RunRename.toLSP(
+              List(location)
+            )
+          )
+          codeAction.setEdit(
+            new l.WorkspaceEdit(
+              Map(uri -> (edit :: renamedOccurrencesEdits.toList).asJava).asJava
+            )
+          )
+
+          Some(codeAction)
+        case _ =>
+          None
+      }
+
+    val path = params.getTextDocument().getUri().toAbsolutePath
+    val action = for {
+      tree <- trees.get(path)
+      treePos = params.getRange().toMeta(tree.pos.input)
+      name <- findLastEnclosingAtPos(tree, treePos)
+      action <- renameImportCodeAction(name)
+    } yield action
+
+    action.toList
+  }
+}
+
+object RenameImport {
+  val title = "Rename import"
+}

--- a/tests/unit/src/test/scala/tests/codeactions/RenameImportLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/RenameImportLspSuite.scala
@@ -1,0 +1,53 @@
+package tests.codeactions
+
+import scala.meta.internal.metals.codeactions.RenameImport
+
+class RenameImportLspSuite
+    extends BaseCodeActionLspSuite("implementAbstractMembers") {
+
+  check(
+    "simple",
+    """|package a
+       |
+       |import java.util.<<List>>
+       |object A {
+       |  val alpha = 123
+       |}
+       |""".stripMargin,
+    s"""|${RenameImport.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |import java.util.{ List => NewRenamedSymbol }
+       |object A {
+       |  val alpha = 123
+       |}
+       |""".stripMargin,
+    expectNoDiagnostics = false
+  )
+
+  check(
+    "with-existing".only,
+    """|package a
+       |
+       |import java.util.<<List>>
+       |import java.util.LinkedList
+       |
+       |object A {
+       |  val alpha : List[Int] = new LinkedList[Int]()
+       |}
+       |""".stripMargin,
+    s"""|${RenameImport.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |import java.util.{ List => NewRenamedSymbol }
+       |import java.util.LinkedList
+       |
+       |object A {
+       |  val alpha : NewRenamedSymbol[Int] = new LinkedList[Int]()
+       |}
+       |""".stripMargin,
+    expectNoDiagnostics = false
+  )
+}


### PR DESCRIPTION
Created a quick WiP to gather some feedback. I found it often that I had to manually add braces and move the cursor to a correct place although it is pretty easy to add this code action.

![rename-import](https://user-images.githubusercontent.com/3807253/109991756-e7617180-7d0a-11eb-94eb-5ef287000fc1.gif)
