### PR TITLE
Change project directory to lower case when using New Scala Project

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
@@ -99,7 +99,7 @@ class NewProjectProvider(
       template: String,
       projectName: String
   ): Future[Unit] = {
-    val projectPath = inputPath.resolve(projectName)
+    val projectPath = inputPath.resolve(projectName.toLowerCase())
     val parent = projectPath.parent
     projectPath.createDirectories()
     val command = List(

--- a/tests/unit/src/test/scala/tests/NewProjectLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewProjectLspSuite.scala
@@ -76,7 +76,7 @@ class NewProjectLspSuite extends BaseLspSuite("new-project") {
 
   check("custom-template")(
     pickedProject = None,
-    name = Some("my-custom-name"),
+    name = Some("My-Custom-Name"),
     customTemplate = Some("scala/scalatest-example.g8"),
     expectedContent = scalatestTemplate("my-custom-name")
   )
@@ -289,12 +289,18 @@ class NewProjectLspSuite extends BaseLspSuite("new-project") {
               ServerCommands.NewScalaProject.id
             )
         output = directoryOutput(tmpDirectory)
-      } yield assertDiffEqual(
-        ignoreVersions(output),
-        ignoreVersions(expectedContent),
-        // note(@tgodzik) The template is pretty stable for last couple of years except for versions.
-        "This test is based on https://github.com/scala/scalatest-example.g8, it might have changed."
-      )
+      } yield {
+        if (name.nonEmpty) {
+          val newProjectDirectory = tmpDirectory.list.toList.map(_.filename)
+          assertDiffEqual(newProjectDirectory, name.toList.map(_.toLowerCase()))
+        }
+        assertDiffEqual(
+          ignoreVersions(output),
+          ignoreVersions(expectedContent),
+          // note(@tgodzik) The template is pretty stable for last couple of years except for versions.
+          "This test is based on https://github.com/scala/scalatest-example.g8, it might have changed."
+        )
+      }
 
       testFuture.onComplete { case _ =>
         RecursivelyDelete(tmpDirectory)


### PR DESCRIPTION
Giter8 templates make the directory names lower case by default, which was not handled in Metals and we would open a new empty directory.