### PR TITLE
Run recent snapshot of scalafmt on Scala 3 sources

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -13,8 +13,11 @@ To fix this problem:
 project.excludeFilters = [
   "test-workspace"
   "metals-bench/src/main/resources"
-  "mtags/src/main/scala-0.26/"
-  "mtags/src/main/scala-0.27/"
+  "mtags/src/main/scala-3.0/"
+  "mtags/src/main/scala-3.0.0-M1/"
+  "mtags/src/main/scala-3.0.0-M2/"
+  "mtags/src/main/scala-3.0.0-M3/"
+  "mtags/src/main/scala-3.0.0-RC1/"
   "mtags/src/main/scala-3.0/"
   "mtags/src/main/scala-3/"
   "tests/unit/src/test/resources"

--- a/mtags/src/main/scala-3.0.0-M1/scala/meta/internal/mtags/VersionSpecificEnrichments.scala
+++ b/mtags/src/main/scala-3.0.0-M1/scala/meta/internal/mtags/VersionSpecificEnrichments.scala
@@ -9,7 +9,7 @@ import dotty.tools.dotc.util.NoSourcePosition
 
 trait VersionSpecificEnrichments {
 
-  extension(context: Context) {
+  extension (context: Context) {
     def findRef(name: Name): Type = {
       context.typer.findRef(
         name,

--- a/mtags/src/main/scala-3.0.0-M2/scala/meta/internal/mtags/VersionSpecificEnrichments.scala
+++ b/mtags/src/main/scala-3.0.0-M2/scala/meta/internal/mtags/VersionSpecificEnrichments.scala
@@ -9,7 +9,7 @@ import dotty.tools.dotc.util.NoSourcePosition
 
 trait VersionSpecificEnrichments {
 
-  extension(context: Context) {
+  extension (context: Context) {
     def findRef(name: Name): Type = {
       context.typer.findRef(
         name,

--- a/mtags/src/main/scala-3.0.0-M3/scala/meta/internal/mtags/VersionSpecificEnrichments.scala
+++ b/mtags/src/main/scala-3.0.0-M3/scala/meta/internal/mtags/VersionSpecificEnrichments.scala
@@ -9,7 +9,7 @@ import dotty.tools.dotc.util.NoSourcePosition
 
 trait VersionSpecificEnrichments {
 
-  extension(context: Context) {
+  extension (context: Context) {
     def findRef(name: Name): Type = {
       context.typer.findRef(
         name,

--- a/mtags/src/main/scala-3.0.0-RC1/scala/meta/internal/mtags/VersionSpecificEnrichments.scala
+++ b/mtags/src/main/scala-3.0.0-RC1/scala/meta/internal/mtags/VersionSpecificEnrichments.scala
@@ -9,7 +9,7 @@ import dotty.tools.dotc.util.NoSourcePosition
 
 trait VersionSpecificEnrichments {
 
-  extension(context: Context) {
+  extension (context: Context) {
     def findRef(name: Name): Type = {
       context.typer.findRef(
         name,

--- a/mtags/src/main/scala-3.0/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3.0/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -3,9 +3,11 @@ package scala.meta.internal.mtags
 import dotty.tools.dotc.util.SourcePosition
 import org.eclipse.{lsp4j => l}
 
-object MtagsEnrichments extends CommonMtagsEnrichments with VersionSpecificEnrichments{
+object MtagsEnrichments
+    extends CommonMtagsEnrichments
+    with VersionSpecificEnrichments {
 
-  extension(pos: SourcePosition)
+  extension (pos: SourcePosition)
     def toLSP: l.Range = {
       new l.Range(
         new l.Position(pos.startLine, pos.startColumn),

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionProvider.scala
@@ -20,173 +20,173 @@ class CompletionProvider(
     pos: SourcePosition,
     ctx: Context
 ) {
-    implicit val context: Context = ctx
-      
-    def completions() : List[Completion] = {
-        val (offset, completions) = Completion.completions(pos)
-        val query = String(pos.source.content.slice(offset, pos.endPos.point))
-        completions.filterInteresting.sorted(completionOrdering(pos, query))
-    }
+  implicit val context: Context = ctx
 
-    extension (c: Completion) {
-      // completionItem method either way takes only head symbol, so why can safely ignore the rest
-      def sym: Symbol = c.symbols.head
-    }
+  def completions(): List[Completion] = {
+    val (offset, completions) = Completion.completions(pos)
+    val query = String(pos.source.content.slice(offset, pos.endPos.point))
+    completions.filterInteresting.sorted(completionOrdering(pos, query))
+  }
 
-    extension (s: SrcPos) {
-      def isAfter(s1: SrcPos) = s.sourcePos.exists && s1.sourcePos.exists &&  s.sourcePos.point > s1.sourcePos.point
-    }
+  extension (c: Completion) {
+    // completionItem method either way takes only head symbol, so why can safely ignore the rest
+    def sym: Symbol = c.symbols.head
+  }
 
-    extension (l: List[Completion]) {
-      def filterInteresting: List[Completion] = {
-        val isSeen = mutable.Set.empty[String]
-        val buf = List.newBuilder[Completion]
-        def isInteresting(head: Completion): Boolean = {
-          val id = head.sym.show
-          def isNotLocalForwardReference: Boolean =
-            !head.sym.isLocalToBlock ||
-              !head.sym.srcPos.isAfter(pos) ||
-              head.sym.is(Param)
+  extension (s: SrcPos) {
+    def isAfter(s1: SrcPos) =
+      s.sourcePos.exists && s1.sourcePos.exists && s.sourcePos.point > s1.sourcePos.point
+  }
 
-          if (
-            !isSeen(id) &&
-            !isUninterestingSymbol(head.sym) &&
-            isNotLocalForwardReference
-          ) {
-            isSeen += id
-            buf += head
-            true
-          } else {
-            false
-          }
+  extension (l: List[Completion]) {
+    def filterInteresting: List[Completion] = {
+      val isSeen = mutable.Set.empty[String]
+      val buf = List.newBuilder[Completion]
+      def isInteresting(head: Completion): Boolean = {
+        val id = head.sym.show
+        def isNotLocalForwardReference: Boolean =
+          !head.sym.isLocalToBlock ||
+            !head.sym.srcPos.isAfter(pos) ||
+            head.sym.is(Param)
+
+        if (
+          !isSeen(id) &&
+          !isUninterestingSymbol(head.sym) &&
+          isNotLocalForwardReference
+        ) {
+          isSeen += id
+          buf += head
+          true
+        } else {
+          false
         }
-        l.filter(isInteresting)
       }
+      l.filter(isInteresting)
     }
+  }
 
-    private lazy val isUninterestingSymbol: Set[Symbol] = Set[Symbol](
-      defn.Any_==,
-      defn.Any_!=,
-      defn.Any_##,
-      defn.Object_eq,
-      defn.Object_ne,
-      defn.RepeatedParamClass,
-      defn.ByNameParamClass2x,
-      defn.Object_notify,
-      defn.Object_notifyAll,
-      defn.Object_notify,
-      defn.ObjectClass.info.member(nme.wait_).symbol,
-      // NOTE(olafur) IntelliJ does not complete the root package and without this filter
-      // then `_root_` would appear as a completion result in the code `foobar(_<COMPLETE>)`
-      defn.RootPackage,
-      // NOTE(gabro) valueOf was added as a Predef member in 2.13. We filter it out since is a niche
-      // use case and it would appear upon typing 'val'
-      defn.ValueOfClass.info.member(nme.valueOf).symbol
-    ).flatMap(_.alternatives.map(_.symbol)).toSet
+  private lazy val isUninterestingSymbol: Set[Symbol] = Set[Symbol](
+    defn.Any_==,
+    defn.Any_!=,
+    defn.Any_##,
+    defn.Object_eq,
+    defn.Object_ne,
+    defn.RepeatedParamClass,
+    defn.ByNameParamClass2x,
+    defn.Object_notify,
+    defn.Object_notifyAll,
+    defn.Object_notify,
+    defn.ObjectClass.info.member(nme.wait_).symbol,
+    // NOTE(olafur) IntelliJ does not complete the root package and without this filter
+    // then `_root_` would appear as a completion result in the code `foobar(_<COMPLETE>)`
+    defn.RootPackage,
+    // NOTE(gabro) valueOf was added as a Predef member in 2.13. We filter it out since is a niche
+    // use case and it would appear upon typing 'val'
+    defn.ValueOfClass.info.member(nme.valueOf).symbol
+  ).flatMap(_.alternatives.map(_.symbol)).toSet
 
-    private def computeRelevancePenalty(
+  private def computeRelevancePenalty(
       sym: Symbol
-    ): Int = {
-        import MemberOrdering._
-        var relevance = 0
-        // local symbols are more relevant
-        if (!sym.isLocalToBlock) relevance |= IsNotLocalByBlock
-        // symbols defined in this file are more relevant
-        if (pos.source != sym.source || sym.is(Package))
-        relevance |= IsNotDefinedInFile
-        // fields are more relevant than non fields
-        if (sym.isField) relevance |= IsNotGetter
-        // symbols whose owner is a base class are less relevant
-        if (sym.owner == defn.AnyClass || sym.owner == defn.ObjectClass)
-        relevance |= IsInheritedBaseMethod
-        // symbols not provided via an implicit are more relevant
-        if (sym.is(Implicit)) relevance |= IsImplicitConversion
-        if (sym.is(Package)) relevance |= IsPackage
-        // accessors of case class members are more relevant
-        if (!sym.is(CaseAccessor)) relevance |= IsNotCaseAccessor
-        // public symbols are more relevant
-        if (!sym.isPublic) relevance |= IsNotCaseAccessor
-        // synthetic symbols are less relevant (e.g. `copy` on case classes)
-        if (sym.is(Synthetic)) relevance |= IsSynthetic
-        if (sym.isDeprecated) relevance |= IsDeprecated
-        if (isEvilMethod(sym.name)) relevance |= IsEvilMethod
-        relevance
-    }
+  ): Int = {
+    import MemberOrdering._
+    var relevance = 0
+    // local symbols are more relevant
+    if (!sym.isLocalToBlock) relevance |= IsNotLocalByBlock
+    // symbols defined in this file are more relevant
+    if (pos.source != sym.source || sym.is(Package))
+      relevance |= IsNotDefinedInFile
+    // fields are more relevant than non fields
+    if (sym.isField) relevance |= IsNotGetter
+    // symbols whose owner is a base class are less relevant
+    if (sym.owner == defn.AnyClass || sym.owner == defn.ObjectClass)
+      relevance |= IsInheritedBaseMethod
+    // symbols not provided via an implicit are more relevant
+    if (sym.is(Implicit)) relevance |= IsImplicitConversion
+    if (sym.is(Package)) relevance |= IsPackage
+    // accessors of case class members are more relevant
+    if (!sym.is(CaseAccessor)) relevance |= IsNotCaseAccessor
+    // public symbols are more relevant
+    if (!sym.isPublic) relevance |= IsNotCaseAccessor
+    // synthetic symbols are less relevant (e.g. `copy` on case classes)
+    if (sym.is(Synthetic)) relevance |= IsSynthetic
+    if (sym.isDeprecated) relevance |= IsDeprecated
+    if (isEvilMethod(sym.name)) relevance |= IsEvilMethod
+    relevance
+  }
 
-    private lazy val isEvilMethod: Set[Name] = Set[Name](
-      nme.notifyAll_,
-      nme.notify_,
-      nme.wait_,
-      nme.clone_,
-      nme.finalize_
-    )
+  private lazy val isEvilMethod: Set[Name] = Set[Name](
+    nme.notifyAll_,
+    nme.notify_,
+    nme.wait_,
+    nme.clone_,
+    nme.finalize_
+  )
 
-    private def completionOrdering(
+  private def completionOrdering(
       position: SourcePosition,
       query: String
-  ): Ordering[Completion]
-    = new Ordering[Completion] {
-      val queryLower = query.toLowerCase()
-      val fuzzyCache = mutable.Map.empty[Symbol, Int]
-      def compareLocalSymbols(s1: Symbol, s2: Symbol): Int = {
-        if (s1.isLocal && s2.isLocal) {
-          if (s1.srcPos.isAfter(s2.srcPos)) -1
-          else 1
-        } else {
-          0
+  ): Ordering[Completion] = new Ordering[Completion] {
+    val queryLower = query.toLowerCase()
+    val fuzzyCache = mutable.Map.empty[Symbol, Int]
+    def compareLocalSymbols(s1: Symbol, s2: Symbol): Int = {
+      if (s1.isLocal && s2.isLocal) {
+        if (s1.srcPos.isAfter(s2.srcPos)) -1
+        else 1
+      } else {
+        0
+      }
+    }
+    def fuzzyScore(o: Symbol): Int = {
+      fuzzyCache.getOrElseUpdate(
+        o, {
+          val name = o.name.toString().toLowerCase()
+          if (name.startsWith(queryLower)) 0
+          else if (name.toLowerCase().contains(queryLower)) 1
+          else 2
         }
-      }
-      def fuzzyScore(o: Symbol): Int = {
-        fuzzyCache.getOrElseUpdate(
-          o, {
-            val name = o.name.toString().toLowerCase()
-            if (name.startsWith(queryLower)) 0
-            else if (name.toLowerCase().contains(queryLower)) 1
-            else 2
-          }
+      )
+    }
+    override def compare(o1: Completion, o2: Completion): Int = {
+      val s1 = o1.sym
+      val s2 = o2.sym
+      val byLocalSymbol = compareLocalSymbols(s1, s2)
+      if (byLocalSymbol != 0) byLocalSymbol
+      else {
+        val byRelevance = Integer.compare(
+          computeRelevancePenalty(s1),
+          computeRelevancePenalty(s2)
         )
-      }
-      override def compare(o1: Completion, o2: Completion): Int = {
-        val s1 = o1.sym
-        val s2 = o2.sym
-        val byLocalSymbol = compareLocalSymbols(s1, s2)
-          if (byLocalSymbol != 0) byLocalSymbol
+        if (byRelevance != 0) byRelevance
+        else {
+          val byFuzzy = Integer.compare(
+            fuzzyScore(s1),
+            fuzzyScore(s2)
+          )
+          if (byFuzzy != 0) byFuzzy
           else {
-            val byRelevance = Integer.compare(
-              computeRelevancePenalty(s1),
-              computeRelevancePenalty(s2)
+            val byIdentifier = IdentifierComparator.compare(
+              s1.name.toString,
+              s2.name.toString
             )
-            if (byRelevance != 0) byRelevance
+            if (byIdentifier != 0) byIdentifier
             else {
-              val byFuzzy = Integer.compare(
-                fuzzyScore(s1),
-                fuzzyScore(s2)
-              )
-              if (byFuzzy != 0) byFuzzy
+              val byOwner =
+                s1.owner.fullName.toString.compareTo(s2.owner.fullName.toString)
+              if (byOwner != 0) byOwner
               else {
-                val byIdentifier = IdentifierComparator.compare(
-                  s1.name.toString,
-                  s2.name.toString
+                val byParamCount = Integer.compare(
+                  s1.typeParams.size,
+                  s2.typeParams.size
                 )
-                if (byIdentifier != 0) byIdentifier
+                if (byParamCount != 0) byParamCount
                 else {
-                  val byOwner =
-                    s1.owner.fullName.toString.compareTo(s2.owner.fullName.toString)
-                  if (byOwner != 0) byOwner
-                  else {
-                    val byParamCount = Integer.compare(
-                      s1.typeParams.size,
-                      s2.typeParams.size
-                    )
-                    if (byParamCount != 0) byParamCount
-                    else {
-                      s1.show.compareTo(s2.show)
-                    }
-                  }
+                  s1.show.compareTo(s2.show)
                 }
               }
             }
           }
+        }
       }
     }
   }
+}

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
@@ -18,9 +18,11 @@ import scala.meta.io.AbsolutePath
 import scala.meta.internal.mtags.MD5
 import scala.meta.internal.mtags.MtagsEnrichments._
 
-class SemanticdbTextDocumentProvider(driver: InteractiveDriver, workspace: Option[Path]) 
-  extends WorksheetSemanticdbProvider {
-  
+class SemanticdbTextDocumentProvider(
+    driver: InteractiveDriver,
+    workspace: Option[Path]
+) extends WorksheetSemanticdbProvider {
+
   def textDocument(
       uri: URI,
       sourceCode: String
@@ -43,7 +45,7 @@ class SemanticdbTextDocumentProvider(driver: InteractiveDriver, workspace: Optio
         relativeUri.toString()
       }
       .getOrElse(filePath.toString)
-      
+
     val document = TextDocument(
       schema = Schema.SEMANTICDB4,
       language = Language.SCALA,


### PR DESCRIPTION
To test out the most recent version of scalafmt I created a standalone snapshot runner via these [instructions](https://scalameta.org/scalafmt/docs/installation.html#standalone)

The actual command was:
```
 coursier bootstrap org.scalameta:scalafmt-cli_2.13:2.7.5+159-c8fb1659-SNAPSHOT \      
                                   -r sonatype:snapshots --main org.scalafmt.cli.Cli \
                                   --standalone \
                                   -o scalafmt
```