### PR TITLE
Update cache-action to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: "adopt@1.${{ matrix.java }}"
-      - uses: coursier/cache-action@v5
+      - uses: coursier/cache-action@v6
       - name: Run unit tests
         run: |
           bin/test.sh unit/test
@@ -111,7 +111,7 @@ jobs:
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: "adopt@1.11"
-      - uses: coursier/cache-action@v5
+      - uses: coursier/cache-action@v6
       - name: ${{ matrix.command }}
         run: ${{ matrix.command }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
       - uses: olafurpg/setup-gpg@v3
-      - uses: coursier/cache-action@v5
+      - uses: coursier/cache-action@v6
       - name: Publish
         run: |
           sbt ci-release


### PR DESCRIPTION
~Just checking how this will work out.~ `v6` should work better out-of-the-box with multiple jobs and matrices (better isolation between the jobs and the matrix entries).