### PR TITLE
Fix renaming named parameters in constructors

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -125,6 +125,21 @@ final class ReferenceProvider(
           info.symbol.owner,
           Descriptor.Type(info.displayName)
         )
+    // Returns true if `info` is a named parameter of the primary constructor
+    def isContructorParam(info: SymbolInformation): Boolean = {
+      info.isParameter &&
+      info.displayName == name &&
+      occ.symbol == (Symbol(info.symbol) match {
+        case GlobalSymbol(
+              // This means it's the primary constructor
+              GlobalSymbol(owner, Descriptor.Method("<init>", "()")),
+              Descriptor.Parameter(_)
+            ) =>
+          Symbols.Global(owner.value, Descriptor.Term(name))
+        case _ =>
+          ""
+      })
+    }
     // Returns true if `info` is a parameter of a synthetic `copy` or `apply` matching the occurrence field symbol.
     def isCopyOrApplyParam(info: SymbolInformation): Boolean =
       info.isParameter &&
@@ -174,7 +189,8 @@ final class ReferenceProvider(
       if {
         isVarSetter(info) ||
         isCompanionObject(info) ||
-        isCopyOrApplyParam(info)
+        isCopyOrApplyParam(info) ||
+        isContructorParam(info)
       }
     } yield info.symbol
     val isCandidate = candidates.toSet

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -594,15 +594,13 @@ class RenameLspSuite extends BaseRenameLspSuite("rename") {
     newName = "name"
   )
 
-  // tests currently not working correctly due to issues in SemanticDB
-  // https://github.com/scalameta/metals/issues/1086 - most likely due to scalameta bug
   renamed(
     "constructor",
     """|/a/src/main/scala/a/Main.scala
        |case class Name(<<va@@lue>>: String)
        |
        |object Main {
-       |  val name2 = new Name(value = "44")
+       |  val name2 = new Name(<<value>> = "44")
        |}
        |""".stripMargin,
     newName = "name"


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/1086

This however will not work the other way. Main parameter will not be renamed when rename is started from the named parameter. That needs to be fixed in https://github.com/scalameta/metals/issues/1553

At first I tried to change the occurrence of the named parameter inside scemanticdb, that however proved to be more difficult and I was not 100% sure if the current status is actually wrong. Since it involves quite a bit of changes for the other tools I decided against going that way.