### PR TITLE
Handle changed but locked files on Windows

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals
 
+import java.nio.file.FileSystemException
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -106,6 +107,9 @@ class SemanticdbIndexer(
            * follow after it was finished.
            */
           case e: InvalidProtocolBufferException =>
+            scribe.debug(s"$file is not yet ready", e)
+          /* @note FileSystemException is thrown on Windows instead of InvalidProtocolBufferException */
+          case e: FileSystemException =>
             scribe.debug(s"$file is not yet ready", e)
           case NonFatal(e) =>
             scribe.warn(s"unexpected error processing the file $file", e)


### PR DESCRIPTION
This occurs when Metals attempts to read the file while Bloop is still writing to it here...
https://github.com/scalameta/metals/blob/dc0da653ead60396832d8b783e152acae368b38f/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala#L92

Linux/Mac seem to allow reading of the file but, as it's only partially written, `com.google.protobuf.InvalidProtocolBufferException` is thrown and handled by Metals

Windows doesn't allow access to a locked file so throws a different exception: `java.nio.file.FileSystemException` but this isn't handled.

I think this is just a case of having to handle `FileSystemException` in the same way as `InvalidProtocolBufferException`.

I've tried this PR locally and the exception no longer appears.  I guess there's a worry that handling this will mask other errors but I've not seen this Exception thrown for any other reason on Windows or at all on WSL2.

Fixes: #2078