### PR TITLE
Find alternative symbol references when not searching from the definition file

### DIFF
--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -165,9 +165,9 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
        |""".stripMargin
   )
 
-  checkInSamePackage( // FIXME: doesn't find the case class declaration: https://github.com/scalameta/metals/issues/1553#issuecomment-617884934
+  checkInSamePackage(
     "simple-case-class-starting-elsewhere",
-    """|case class Main(name: String) // doesn't find this
+    """|case class Main(name: String)
        |object F {
        |  val ma = <<Main>>("a")
        |}
@@ -195,7 +195,7 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
   checkInSamePackage( // FIXME: should, but doesn't find the class declaration: https://github.com/scalameta/metals/issues/1553#issuecomment-617884934
     "case-class-unapply-starting-elsewhere",
     """|sealed trait Stuff
-       |case class Foo(n: Int) extends Stuff // doesn't find this
+       |case class <<Foo>>(n: Int) extends Stuff // doesn't find this
        |""".stripMargin,
     """|
        |object ByTheWay {
@@ -212,10 +212,10 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
        |""".stripMargin
   )
 
-  checkInSamePackage( // FIXME: doesn't find the class declaration: https://github.com/scalameta/metals/issues/1553#issuecomment-617884934
+  checkInSamePackage(
     "explicit-unapply",
     """|sealed trait Stuff
-       |class Foo(val n: Int) extends Stuff // doesn't find this; but should it?
+       |class Foo(val n: Int) extends Stuff
        |object Foo {
        |  def apply(n: Int): Foo = new Foo(n)
        |  def <<un@@apply>>(foo: Foo): Option[Int] = Some(foo.n)
@@ -352,6 +352,45 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
        |trait BB extends <<AA>>
        |trait CC extends <<AA>>
        |trait DD extends <<AA>>
+       |""".stripMargin
+  )
+
+  check(
+    "case-class-separate-reference",
+    """|/a/src/main/scala/a/Main.scala
+       |case class <<Main>>(name: String)
+       |object F {
+       |  val ma = <<Main>>("a")
+       |}
+       |/a/src/main/scala/a/Other.scala
+       |object Other {
+       |  val mb = new <<M@@ain>>("b")
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "synthetic-object-reference",
+    """|/a/src/main/scala/a/Main.scala
+       |case class <<Main>>(name: String)
+       |object F {
+       |  val ma = <<Ma@@in>>("a")
+       |}
+       |/a/src/main/scala/a/Other.scala
+       |object Other {
+       |  val mb = new <<Main>>("b")
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "constructor",
+    """|/a/src/main/scala/a/Main.scala
+       |case class Name(<<value>>: String)
+       |
+       |object Main {
+       |  val name2 = new Name(<<va@@lue>> = "44")
+       |}
        |""".stripMargin
   )
 


### PR DESCRIPTION
Previously, we would search the current file, when searching for references, for alternative references such as object reference of a case class. This caused us to get different results depending on where we invoked textDocument/references. Now we check those alternatives in the definition file.

Additionally, we now also:
- check for case classes if searching from an object, which is synthetic
- check for field if searching from constructor parameter

Fixes https://github.com/scalameta/metals/issues/1553