### PR TITLE
Show better message if no semanticdb is found for testFile.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -621,7 +621,8 @@ class MetalsLanguageServer(
           definitionIndex,
           stacktraceAnalyzer,
           clientConfig.icons(),
-          semanticdbs
+          semanticdbs,
+          clientConfig
         )
         scalafixProvider = ScalafixProvider(
           buffers,


### PR DESCRIPTION
Previously when there was no semanticdb found for the file you were
trying to test via `testFile` an exception would happen and the user
wouldn't be notified at all. Now they are shown a bit clearer message
similar to that of when navigation fails for a similar reason.

The second part of this adds in a check so when a user is using debug
functionality a check is made to ensure they have metals status enabled
before sending the status, and if not it handles messages and logs as
well.

Fixes #2598 