### PR TITLE
Fix renaming renamed imports when cursor is at the rename

### DIFF
--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -47,10 +47,10 @@ class RenameLspSuite extends BaseRenameLspSuite("rename") {
     """|/a/src/main/scala/a/Main.scala
        |package a
        |
-       |import a.{Main2 => <<OtherMain>>}
+       |import a.{Main2 => <<Ot@@herMain>>}
        |
        |object Main{
-       |  val toRename = <<Oth@@erMain>>.toRename
+       |  val toRename = <<OtherMain>>.toRename
        |}
        |/a/src/main/scala/a/Main2.scala
        |package a


### PR DESCRIPTION
Previously, we fixed renaming to also work with renamed imports in a local scope, however we haven't check if it works at the actual rename position. Now, the test is added and the case is fixed.