### PR TITLE
Automatically backtick symbols when renaming

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -171,6 +171,9 @@ trait MtagsEnrichments extends CommonMtagsEnrichments {
 
   implicit class XtensionStringMtags(value: String) {
 
+    def stripBackticks: String = value.stripPrefix("`").stripSuffix("`")
+    def isBackticked: Boolean =
+      value.size > 1 && value.head == '`' && value.last == '`'
     def toAbsolutePath: AbsolutePath =
       AbsolutePath(Paths.get(URI.create(value.stripPrefix("metals:")))).dealias
     def lastIndexBetween(

--- a/tests/unit/src/main/scala/tests/BaseRenameLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseRenameLspSuite.scala
@@ -2,6 +2,8 @@ package tests
 
 import scala.concurrent.Future
 
+import scala.meta.internal.pc.Identifier
+
 import munit.Location
 import munit.TestOptions
 
@@ -58,11 +60,12 @@ class BaseRenameLspSuite(name: String) extends BaseLspSuite(name) {
       cleanWorkspace()
       val allMarkersRegex = "(<<|>>|@@|##.*##)"
       val files = FileLayout.mapFromString(input)
+      val expectedName = Identifier.backtickWrap(newName)
       val expectedFiles = files.map { case (file, code) =>
         fileRenames.getOrElse(file, file) -> {
           val expected = if (!notRenamed) {
             code
-              .replaceAll("\\<\\<\\S*\\>\\>", newName)
+              .replaceAll("\\<\\<\\S*\\>\\>", expectedName)
               .replaceAll("(##|@@)", "")
           } else {
             code.replaceAll(allMarkersRegex, "")

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -23,11 +23,11 @@ class RenameLspSuite extends BaseRenameLspSuite("rename") {
     """|/a/src/main/scala/a/Main.scala
        |package a
        |
-       |import java.util.{List => `<<J-List>>`}
+       |import java.util.{List => <<`J-List`>>}
        |
        |object Main{
-       |  val toRename: `<<J-L@@ist>>`[Int] = ???
-       |  val toRename2: `<<J-List>>`[Int] = ???
+       |  val toRename: <<`J-L@@ist`>>[Int] = ???
+       |  val toRename2: <<`J-List`>>[Int] = ???
        |  val toRename3: java.util.List[Int] = ???
        |}
        |/a/src/main/scala/a/Main2.scala
@@ -288,7 +288,7 @@ class RenameLspSuite extends BaseRenameLspSuite("rename") {
        |  "" <<::>> user
        |}
        |""".stripMargin,
-    newName = "method:"
+    newName = "+++:"
   )
 
   same(
@@ -563,6 +563,36 @@ class RenameLspSuite extends BaseRenameLspSuite("rename") {
   )
 
   renamed(
+    "backtick-new-name",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main{
+       |  val <<toRename>> = 123
+       |}
+       |/a/src/main/scala/a/Main2.scala
+       |package a
+       |object Main2{
+       |  val toRename = Main.<<toR@@ename>>
+       |}
+       |""".stripMargin,
+    newName = "other-rename"
+  )
+
+  renamed(
+    "backtick-old-and-new-name",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main{
+       |  val <<`to-Rename`>> = 123
+       |}
+       |object Main2{
+       |  val toRename = Main.<<`to-R@@ename`>>
+       |}
+       |""".stripMargin,
+    newName = "`other-rename`"
+  )
+
+  renamed(
     "backtick",
     """|/a/src/main/scala/a/Main.scala
        |package a
@@ -574,6 +604,20 @@ class RenameLspSuite extends BaseRenameLspSuite("rename") {
        |}
        |""".stripMargin,
     newName = "other"
+  )
+
+  renamed(
+    "double-backtick",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main{
+       |  val <<greet@@ing>> = "Hello"
+       |  "" match {
+       |    case <<`greeting`>> =>
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "greeting-!"
   )
 
   renamed(


### PR DESCRIPTION
In cases where a symbol name is not valid we should automatically wrap it in backticks