### PR TITLE
Add init option to strip color from DAP communication.

### DIFF
--- a/docs/integrations/new-editor.md
+++ b/docs/integrations/new-editor.md
@@ -116,6 +116,7 @@ The currently available settings for `InitializationOptions` are listed below.
       "debuggingProvider": boolean,
       "decorationProvider": boolean,
       "didFocusProvider": boolean,
+      "disableColorOutput" boolean,
       "doctorProvider": "json" | "html",
       "executeClientCommandProvider": boolean,
       "globSyntax": "vscode" | "uri"
@@ -250,6 +251,14 @@ Default value: `false`
 
 Boolean value to signify that the client supports the
 [`metals/didFocusTextDocument`](#metalsdidfocustextdocument) extension.
+
+Default value: `false`
+
+##### `disableColorOutput`
+
+Useful for certain DAP clients that are unable to handle color codes for output.
+This will remove the color codes coming from whatever DAP server is currently
+being used.
 
 Default value: `false`
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -147,6 +147,9 @@ class ClientConfiguration(
 
   def isCopyWorksheetOutputProvider(): Boolean =
     initializationOptions.copyWorksheetOutputProvider.getOrElse(false)
+
+  def disableColorOutput(): Boolean =
+    initializationOptions.disableColorOutput.getOrElse(false)
 }
 
 object ClientConfiguration {

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -39,6 +39,8 @@ import org.eclipse.{lsp4j => l}
  * @param openNewWindowProvider if the client can open a new window after new project creation.
  * @param copyWorksheetOutputProvider if the client can execute server CopyWorksheet command and
  *                                    copy results to the local buffer.
+ * @param disableColorOutput in the situation where your DAP client may not handle color codes in
+ *                            the output, you can enable this to strip them.
  */
 final case class InitializationOptions(
     compilerOptions: CompilerInitializationOptions,
@@ -61,7 +63,8 @@ final case class InitializationOptions(
     statusBarProvider: Option[String],
     treeViewProvider: Option[Boolean],
     openNewWindowProvider: Option[Boolean],
-    copyWorksheetOutputProvider: Option[Boolean]
+    copyWorksheetOutputProvider: Option[Boolean],
+    disableColorOutput: Option[Boolean]
 ) {
   def doctorFormat: Option[DoctorFormat.DoctorFormat] =
     doctorProvider.flatMap(DoctorFormat.fromString)
@@ -75,6 +78,7 @@ object InitializationOptions {
 
   val Default: InitializationOptions = InitializationOptions(
     CompilerInitializationOptions.default,
+    None,
     None,
     None,
     None,
@@ -143,7 +147,8 @@ object InitializationOptions {
       treeViewProvider = jsonObj.getBooleanOption("treeViewProvider"),
       openNewWindowProvider = jsonObj.getBooleanOption("openNewWindowProvider"),
       copyWorksheetOutputProvider =
-        jsonObj.getBooleanOption("copyWorksheetOutputProvider")
+        jsonObj.getBooleanOption("copyWorksheetOutputProvider"),
+      disableColorOutput = jsonObj.getBooleanOption("disableColorOutput")
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -620,9 +620,8 @@ class MetalsLanguageServer(
           classFinder,
           definitionIndex,
           stacktraceAnalyzer,
-          clientConfig.icons(),
-          semanticdbs,
-          clientConfig
+          clientConfig,
+          semanticdbs
         )
         scalafixProvider = ScalafixProvider(
           buffers,

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
@@ -162,8 +162,11 @@ object DebugProtocol {
   }
 
   object OutputNotification {
-    def unapply(notification: NotificationMessage): Boolean = {
-      notification.getMethod == "output"
+    def unapply(
+        notification: NotificationMessage
+    ): Option[OutputEventArguments] = {
+      if (notification.getMethod != "output") None
+      else parse[OutputEventArguments](notification.getParams).toOption
     }
   }
 


### PR DESCRIPTION
This is meant to address the situations where a DAP client may not be
able to handle color codes in the DAP output. Instead of trying to build
this into both sbt and Bloop I think it's just easier to strip it here
and put it behind a flag. The normal behavior is unchanged, but now a
client can set `stripDAPOutputColor = true` and get the color codes
stripped.

Closes #2061

### Before

<img width="568" alt="Screenshot 2021-03-15 at 15 44 53" src="https://user-images.githubusercontent.com/13974112/111172791-69248b00-85a6-11eb-8a47-fe1dbdefde29.png">
<img width="495" alt="Screenshot 2021-03-15 at 15 45 33" src="https://user-images.githubusercontent.com/13974112/111172796-6a55b800-85a6-11eb-8603-6639abfbbde2.png">

### After with `stripDAPOutputColor` set to true

<img width="562" alt="Screenshot 2021-03-15 at 15 48 11" src="https://user-images.githubusercontent.com/13974112/111172857-76da1080-85a6-11eb-8d64-55ee2274196c.png">
<img width="486" alt="Screenshot 2021-03-15 at 15 48 41" src="https://user-images.githubusercontent.com/13974112/111172860-7772a700-85a6-11eb-8e50-9421be8d5b41.png">


This should also take care of:

- https://github.com/scalameta/nvim-metals/issues/107
- https://github.com/scalacenter/bloop/issues/1478
