### PR TITLE
Run Scala 3 migrate on mtags sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -253,12 +253,12 @@ val sharedSettings = List(
   ),
   scalacOptions ++= crossSetting(
     scalaVersion.value,
-    if3 = List("-language:implicitConversions"),
+    if3 = List("-language:implicitConversions", "-Xtarget:8"),
     if211 = List("-Xexperimental", "-Ywarn-unused-import")
   ),
   scalacOptions --= crossSetting(
     scalaVersion.value,
-    if3 = "-Yrangepos" :: scala212CompilerOptions,
+    if3 = "-Yrangepos" :: "-target:jvm-1.8" :: scala212CompilerOptions,
     if211 = scala212CompilerOptions
   )
 )

--- a/mtags/src/main/scala-2/scala/meta/internal/docstrings/ScaladocParser.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/docstrings/ScaladocParser.scala
@@ -342,7 +342,9 @@ object ScaladocParser {
           javadoclessComment,
           { mtch =>
             java.util.regex.Matcher
-              .quoteReplacement(safeTagMarker + mtch.matched + safeTagMarker)
+              .quoteReplacement(
+                "" + safeTagMarker + mtch.matched + safeTagMarker
+              )
           }
         )
       markedTagComment.linesIterator.toList.map(cleanLine)
@@ -686,7 +688,7 @@ object ScaladocParser {
       else if (checkSkipInitWhitespace("----"))
         hrule()
       else if (checkList)
-        listBlock
+        listBlock()
       else if (checkTableRow)
         table()
       else {
@@ -734,7 +736,7 @@ object ScaladocParser {
        */
       def listLine(indent: Int, style: String): Option[Block] =
         if (countWhitespace > indent && checkList)
-          Some(listBlock)
+          Some(listBlock())
         else if (countWhitespace != indent || !checkSkipInitWhitespace(style))
           None
         else {
@@ -1181,7 +1183,7 @@ object ScaladocParser {
               ",,"
             ) || check(
               "[["
-            ) || isInlineEnd || checkParaEnded || char == endOfLine
+            ) || isInlineEnd || checkParaEnded() || char == endOfLine
           }
           Text(textTransform(str))
         }
@@ -1190,7 +1192,7 @@ object ScaladocParser {
       val inlines: List[Inline] = {
         val iss = mutable.ListBuffer.empty[Inline]
         iss += inline0()
-        while (!isInlineEnd && !checkParaEnded) {
+        while (!isInlineEnd && !checkParaEnded()) {
           val skipEndOfLine = if (char == endOfLine) {
             nextChar()
             true

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -46,7 +46,7 @@ final class AutoImportsProvider(
     def isExactMatch(sym: Symbol, name: String): Boolean =
       sym.name.dropLocal.decoded == name
 
-    symbols.result.collect {
+    symbols.result().collect {
       case sym if isExactMatch(sym, name) =>
         val pkg = sym.owner.fullName
         val edits = importPosition match {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Identifier.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Identifier.scala
@@ -62,7 +62,7 @@ object Identifier {
   def backtickWrap(s: String): String = {
     if (s.isEmpty) "``"
     else if (s(0) == '`' && s.last == '`') s
-    else if (needsBacktick(s)) '`' + s + '`'
+    else if (needsBacktick(s)) "" + ('`') + s + '`'
     else s
   }
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -121,14 +121,14 @@ case class ScalaPresentationCompiler(
     compilerAccess.withInterruptableCompiler(
       EmptyCompletionList(),
       params.token
-    ) { pc => new CompletionProvider(pc.compiler, params).completions() }
+    ) { pc => new CompletionProvider(pc.compiler(), params).completions() }
 
   override def implementAbstractMembers(
       params: OffsetParams
   ): CompletableFuture[ju.List[TextEdit]] = {
     val empty: ju.List[TextEdit] = new ju.ArrayList[TextEdit]()
     compilerAccess.withInterruptableCompiler(empty, params.token) { pc =>
-      new CompletionProvider(pc.compiler, params).implementAll()
+      new CompletionProvider(pc.compiler(), params).implementAll()
     }
   }
 
@@ -137,7 +137,7 @@ case class ScalaPresentationCompiler(
   ): CompletableFuture[ju.List[TextEdit]] = {
     val empty: ju.List[TextEdit] = new ju.ArrayList[TextEdit]()
     compilerAccess.withInterruptableCompiler(empty, params.token) { pc =>
-      new InferredTypeProvider(pc.compiler, params).inferredTypeEdits().asJava
+      new InferredTypeProvider(pc.compiler(), params).inferredTypeEdits().asJava
     }
   }
 
@@ -149,7 +149,7 @@ case class ScalaPresentationCompiler(
       List.empty[AutoImportsResult].asJava,
       params.token
     ) { pc =>
-      new AutoImportsProvider(pc.compiler, name, params).autoImports().asJava
+      new AutoImportsProvider(pc.compiler(), name, params).autoImports().asJava
     }
 
   // NOTE(olafur): hover and signature help use a "shared" compiler instance because
@@ -162,7 +162,7 @@ case class ScalaPresentationCompiler(
   ): CompletableFuture[CompletionItem] =
     CompletableFuture.completedFuture {
       compilerAccess.withSharedCompiler(item) { pc =>
-        new CompletionItemResolver(pc.compiler).resolve(item, symbol)
+        new CompletionItemResolver(pc.compiler()).resolve(item, symbol)
       }
     }
 
@@ -172,7 +172,7 @@ case class ScalaPresentationCompiler(
     compilerAccess.withNonInterruptableCompiler(
       new SignatureHelp(),
       params.token
-    ) { pc => new SignatureHelpProvider(pc.compiler).signatureHelp(params) }
+    ) { pc => new SignatureHelpProvider(pc.compiler()).signatureHelp(params) }
 
   override def hover(
       params: OffsetParams
@@ -181,14 +181,16 @@ case class ScalaPresentationCompiler(
       Optional.empty[Hover](),
       params.token
     ) { pc =>
-      Optional.ofNullable(new HoverProvider(pc.compiler, params).hover().orNull)
+      Optional.ofNullable(
+        new HoverProvider(pc.compiler(), params).hover().orNull
+      )
     }
 
   def definition(params: OffsetParams): CompletableFuture[DefinitionResult] = {
     compilerAccess.withNonInterruptableCompiler(
       DefinitionResultImpl.empty,
       params.token
-    ) { pc => new PcDefinitionProvider(pc.compiler, params).definition() }
+    ) { pc => new PcDefinitionProvider(pc.compiler(), params).definition() }
   }
 
   override def semanticdbTextDocument(
@@ -199,7 +201,7 @@ case class ScalaPresentationCompiler(
       Array.emptyByteArray,
       EmptyCancelToken
     ) { pc =>
-      new SemanticdbTextDocumentProvider(pc.compiler)
+      new SemanticdbTextDocumentProvider(pc.compiler())
         .textDocument(uri, code)
         .toByteArray
     }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -140,7 +140,7 @@ trait ArgCompletions { this: MetalsGlobal =>
       params.flatMap { param =>
         val allMemebers = matchingTypesInScope(param.tpe)
         allMemebers.map { memberName =>
-          val editText = param.name + " = " + memberName
+          val editText = "" + param.name + " = " + memberName
           val edit = new l.TextEdit(editRange, editText)
           new TextEditMember(
             filterText = param.name.toString(),

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -71,6 +71,21 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |""".stripMargin.hover
   )
 
+  // https://github.com/scalameta/metals/issues/1991
+  check(
+    "extension-methods",
+    """|
+       |object Foo:
+       |    extension (s: String):
+       |        def double = s + s
+       |        def double2 = s + s        
+       |    end extension
+       |    "".<<doub@@le2>>
+       |end Foo
+       |""".stripMargin,
+    ""
+  )
+
   // TODO: better printing for using
   // currently "def apply[T](a: T)(implicit x$2: Int): T"
   check(


### PR DESCRIPTION
While testing out https://github.com/scalacenter/scala3-migrate I decided to run it on mtags module to see if there is anything that we can improve.

This included:
- changes to scalac options for Scala 3
- scalafix rewrites that deals with 2.13 deprecations, which weren't sctrictly neccessary, but might be usful for the future if we decide to move some of the Scala 2 code
- I also added a test case for one of Scala 3 issues we had (hovers on extension methods)