### PR TITLE
Fix highlighting overloaded methods

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DocumentHighlightProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DocumentHighlightProvider.scala
@@ -84,7 +84,7 @@ final class DocumentHighlightProvider(
     Symbol(info.symbol) match {
       case GlobalSymbol(
             GlobalSymbol(owner, descriptor),
-            Descriptor.Method(setter, _)
+            Descriptor.Method(setter, "()")
           ) =>
         generateAlternativeSymbols(
           setter.stripSuffix(setterSuffix),

--- a/tests/unit/src/test/scala/tests/DocumentHighlightLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DocumentHighlightLspSuite.scala
@@ -1,6 +1,7 @@
 package tests
 
 import munit.Location
+import munit.TestOptions
 
 class DocumentHighlightLspSuite extends BaseLspSuite("documentHighlight") {
 
@@ -88,7 +89,19 @@ class DocumentHighlightLspSuite extends BaseLspSuite("documentHighlight") {
       |}""".stripMargin
   )
 
-  def check(name: String, testCase: String)(implicit loc: Location): Unit = {
+  check(
+    "overloaded",
+    """
+      |object Main {
+      |  def hello() = ""
+      |  def <<hel@@lo>>(a : Int) = ""
+      |  def hello(a : Int, b : String) = ""
+      |}""".stripMargin
+  )
+
+  def check(name: TestOptions, testCase: String)(implicit
+      loc: Location
+  ): Unit = {
     val edit = testCase.replaceAll("(<<|>>)", "")
     val expected = testCase.replaceAll("@@", "")
     val base = testCase.replaceAll("(<<|>>|@@)", "")


### PR DESCRIPTION
PReviously, we would always highlight 0 parameter method when the cursor was on any other overlaoded method. Now, we only highlight the right occurrence.

Fixes https://github.com/scalameta/metals/issues/1704