### PR TITLE
Update organize imports rule to 0.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -234,7 +234,7 @@ lazy val V = new {
   val coursier = "2.0.13"
   val ammonite = "2.3.8-36-1cce53f3"
   val mill = "0.9.3"
-  val organizeImportRule = "0.4.4"
+  val organizeImportRule = "0.5.0"
 }
 
 val genyVersion = Def.setting {


### PR DESCRIPTION
It seems like the rule was not updated automatically and there are some incompatibilities with 0.4.4

https://github.com/liancheng/scalafix-organize-imports/releases/tag/v0.5.0