### PR TITLE
Use correct parent classloader for worksheets.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetClassLoader.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetClassLoader.scala
@@ -8,7 +8,8 @@ package scala.meta.internal.worksheets
  * allowing the Metals server to call mdoc instances from different Scala
  * versions.
  */
-class MdocClassLoader(parent: ClassLoader) extends ClassLoader(null) {
+class MdocClassLoader(parent: ClassLoader)
+    extends ClassLoader(ClassLoader.getSystemClassLoader.getParent) {
   override def findClass(name: String): Class[_] = {
     val isShared =
       name.startsWith("mdoc.interfaces") || name.startsWith("coursierapi")


### PR DESCRIPTION
Instead of passing in `null` when we extend ClassLoader in our
MdocClassLoader this passes in the actual parent since on Java +9 when
using `null` that's the bootstrap classloader which doesn't contain
modules like java.sql.

Big thanks to @smarter pointing this out in https://github.com/lampepfl/dotty/pull/11658.

Fixes #2187