### PR TITLE
Do not insert override twice

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -206,7 +206,8 @@ trait OverrideCompletions { this: MetalsGlobal =>
       )
 
       val overrideKeyword: String =
-        if (!sym.isAbstract || shouldAddOverrideKwd) "override "
+        if ((!sym.isAbstract || shouldAddOverrideKwd) && !sym.isOverride)
+          "override "
         // Don't insert `override` keyword if the supermethod is abstract and the
         // user did not explicitly type starting with o . See:
         // https://github.com/scalameta/metals/issues/565#issuecomment-472761240

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -945,4 +945,31 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin
   )
+
+  checkEdit(
+    "overriden-twice",
+    """
+      |trait A {
+      |  def close: Unit
+      |}
+      |trait B extends A{
+      |  override def close : Unit = {}
+      |}
+      |class C extends B{
+      |  clos@@
+      |}
+    """.stripMargin,
+    """|trait A {
+       |  def close: Unit
+       |}
+       |trait B extends A{
+       |  override def close : Unit = {}
+       |}
+       |class C extends B{
+       |  override def close: Unit = ${0:???}
+       |}
+       |""".stripMargin,
+    filter = (str) => str.contains("def")
+  )
+
 }


### PR DESCRIPTION
Previously, if a symbol was already overriden, we would add the override flag twice. Now, we check if that flag is already containe din parent.