### PR TITLE
Make sure higher kinded functions in signatures are inferred properly

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -325,8 +325,15 @@ class MetalsGlobal(
             quantified.map(sym => sym.setInfo(loop(sym.info, None))),
             loop(underlying, None)
           )
-        case PolyType(tparams, resultType) =>
-          PolyType(tparams, resultType.map(t => loop(t, None)))
+        case PolyType(typeParams, resultType) =>
+          resultType.map(t => loop(t, None)) match {
+            // [x] => F[x] is not printable in the code, we need to use just `F`
+            case TypeRef(_, sym, args)
+                if typeParams == args.map(_.typeSymbol) =>
+              new PrettyType(sym.name.toString())
+            case otherType =>
+              PolyType(typeParams, otherType)
+          }
         case NullaryMethodType(resultType) =>
           loop(resultType, None)
         case TypeBounds(lo, hi) =>


### PR DESCRIPTION
Previously for a higher kinded type like:

```scala
TypeRef(
  pre = <noprefix>,
  sym = class Resource,
  args = List(
    PolyType(
      typeParams = List(type x),
      resultType = TypeRef(
        pre = <noprefix>,
        sym = type F,
        args = List(TypeRef(pre = <noprefix>, sym = type x, args = List()))
      )
    ),
    TypeRef(pre = <noprefix>, sym = class Unit, args = List())
  )
)
```

we would print:

```scala
Resource[[x]F[x],Unit]
```

Which is nothing that can actually work in the code. Instead, it should just be `Resource[F, Unit]` as the type constructors can't really appear in signatures (I think)

Fixes https://github.com/scalameta/metals/issues/2558

I am not 100% sure of this solution, but I this seems to work now. I anyone has a better idea about `PolyType` or higher kinded types do let me know. As it stands, this should not break anything, but can fix things.