### PR TITLE
A few changes to docs including a User Configuration section.

### DIFF
--- a/docs/editors/user-configuration.md
+++ b/docs/editors/user-configuration.md
@@ -1,0 +1,12 @@
+---
+id: user-configuration
+title: Metals User Configuration
+sidebar_label: User Configuration
+---
+
+While each editor may have a different way to change the user configuration, the
+values should be more or less the same for all extensions. Below you'll find all
+the available configuration options and what they do.
+
+```scala mdoc:user-config:lsp-config-default
+```

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -412,7 +412,6 @@ install [coc-json](https://github.com/neoclide/coc-json).
 ```
 
 ```scala mdoc:new-project:vim
-
 ```
 
 ## Enable on type formatting for multiline string formatting

--- a/metals-docs/src/main/scala/docs/UserConfigurationModifier.scala
+++ b/metals-docs/src/main/scala/docs/UserConfigurationModifier.scala
@@ -14,50 +14,25 @@ class UserConfigurationModifier extends StringModifier {
       code: Input,
       reporter: Reporter
   ): String = {
-    info match {
-      case "lsp-config-default" =>
-        UserConfiguration.options
-          .map { option =>
-            s"""
-               |### ${option.title}
-               |
-               |${option.description}
-               |
-               |**Default**: ${option.default}
-               |
-               |**Example**:
-               |```json
-               |{
-               |  "metals": {
-               |    "${option.key}": ${option.example}
-               |  }
-               |}
-               |```
-               |""".stripMargin
-          }
-          .mkString("\n")
-      case "lsp-config-coc" =>
-        UserConfiguration.options
-          .map { option =>
-            s"""
-               |### ${option.title}
-               |
-               |${option.description}
-               |
-               |**Default**: ${option.default}
-               |
-               |**Example**:
-               |```json
-               |{
-               |  "metals.${option.camelCaseKey}": ${option.example}
-               |}
-               |```
-               |""".stripMargin
-          }
-          .mkString("\n")
-      case els =>
-        reporter.error(s"unknown user-config '$els'")
-        ""
-    }
+    UserConfiguration.options
+      .map { option =>
+        s"""
+           |### ${option.title}
+           |
+           |${option.description}
+           |
+           |**Default**: ${option.default}
+           |
+           |**Example**:
+           |```json
+           |{
+           |  "metals": {
+           |    "${option.camelCaseKey}": ${option.example}
+           |  }
+           |}
+           |```
+           |""".stripMargin
+      }
+      .mkString("\n")
   }
 }

--- a/metals-docs/src/main/scala/docs/WorksheetModifier.scala
+++ b/metals-docs/src/main/scala/docs/WorksheetModifier.scala
@@ -75,8 +75,14 @@ class WorksheetModifier extends StringModifier {
         |import $$ivy.`com.lihaoyi::scalatags:0.7.0`
         |```
         |
-        |:: is the same as %% in sbt, which will append the current Scala binary version
+        |`::` is the same as `%%` in sbt, which will append the current Scala binary version
         |to the artifact name.
+        |
+        |You can also import `scalac` options in a special `$$scalac` import like below:
+        |
+        |```scala
+        |import $$scalac.`-Ywarn-unused`
+        |```
         |""".stripMargin
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -81,7 +81,7 @@ object UserConfiguration {
         "gradle-script",
         """empty string `""`.""",
         """"/usr/local/bin/gradle"""",
-        "gradle script",
+        "Gradle script",
         """Optional absolute path to a `gradle` executable to use for running `gradle bloopInstall`.
           |By default, Metals uses gradlew with 5.3.1 gradle version. Update this setting if your `gradle` script requires more customizations
           |like using environment variables.
@@ -91,7 +91,7 @@ object UserConfiguration {
         "maven-script",
         """empty string `""`.""",
         """"/usr/local/bin/mvn"""",
-        "maven script",
+        "Maven script",
         """Optional absolute path to a `maven` executable to use for generating bloop config.
           |By default, Metals uses mvnw maven wrapper with 3.6.1 maven version. Update this setting if your `maven` script requires more customizations
           |""".stripMargin
@@ -100,7 +100,7 @@ object UserConfiguration {
         "mill-script",
         """empty string `""`.""",
         """"/usr/local/bin/mill"""",
-        "mill script",
+        "Mill script",
         """Optional absolute path to a `mill` executable to use for running `mill mill.contrib.Bloop/install`.
           |By default, Metals uses mill wrapper script with 0.5.0 mill version. Update this setting if your `mill` script requires more customizations
           |like using environment variables.

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -55,6 +55,10 @@
       "editors/sublime": {
         "title": "Sublime Text"
       },
+      "editors/user-configuration": {
+        "title": "Metals User Configuration",
+        "sidebar_label": "User Configuration"
+      },
       "editors/vim": {
         "title": "Vim"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -7,7 +7,8 @@
       "editors/sublime",
       "editors/emacs",
       "editors/eclipse",
-      "editors/online-ides"
+      "editors/online-ides",
+      "editors/user-configuration"
     ],
     "Build Tools": [
       "build-tools/overview",


### PR DESCRIPTION
This makes a few changes to the docs. Noticeably it adds two things:
  1. It adds a section for user configuration. I've gotten the request a
     few times to add something like this and have gotten comments in
     the past that it's not always clear what configuration options are
     available. We did have these in the site, but they were buried
     under integrating a new editor. I didn't remove them from there as
     they are still useful to someone creating a new extension, but made
     a more user-focused intro and added them to the forefront.
  2. Just add in an example of scalac imports.

Let me know what you think of this.