### PR TITLE
Update org.eclipse.lsp4j to 0.12.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -208,7 +208,7 @@ lazy val V = new {
   val scalafmt = "2.7.4"
   val munit = "0.7.23"
   val scalafix = "0.9.27"
-  val lsp4jV = "0.10.0"
+  val lsp4jV = "0.12.0"
   val sbtJdiTools = "1.1.1"
   val genyVersion = "0.6.7"
 

--- a/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
@@ -56,7 +56,7 @@ trait AdjustLspData {
 
   def adjustCompletionListInPlace(list: CompletionList): Unit = {
     for (item <- list.getItems.asScala) {
-      for (textEdit <- Option(item.getTextEdit))
+      for (textEdit <- item.getLeftTextEdit())
         textEdit.setRange(adjustRange(textEdit.getRange))
       for (l <- Option(item.getAdditionalTextEdits); textEdit <- l.asScala)
         textEdit.setRange(adjustRange(textEdit.getRange))

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionItemResolver.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionItemResolver.scala
@@ -26,9 +26,14 @@ class CompletionItemResolver(
             if (
               item.getTextEdit != null && data.kind == CompletionItemData.OverrideKind
             ) {
-              item.getTextEdit.setNewText(
-                replaceJavaParameters(info, item.getTextEdit.getNewText)
-              )
+              item.getTextEdit().asScala match {
+                case Left(textEdit) =>
+                  val newText =
+                    replaceJavaParameters(info, textEdit.getNewText())
+                  textEdit.setNewText(newText)
+                // Right[InsertReplaceEdit] is currently not used in Metals
+                case _ =>
+              }
               item.setLabel(replaceJavaParameters(info, item.getLabel))
             }
           } else {

--- a/mtags/src/main/scala/scala/meta/internal/metals/TextEdits.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/TextEdits.scala
@@ -33,7 +33,7 @@ object TextEdits {
     }
   }
   def applyEdits(text: String, item: CompletionItem): String = {
-    val edits = Option(item.getTextEdit).toList ++
+    val edits = item.getLeftTextEdit().toList ++
       Option(item.getAdditionalTextEdits).toList.flatMap(_.asScala)
     applyEdits(text, edits)
   }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -155,6 +155,17 @@ trait CommonMtagsEnrichments {
         case data =>
           decodeJson(data, classOf[CompletionItemData])
       }
+
+    def setTextEdit(edit: l.TextEdit): Unit = {
+      item.setTextEdit(JEither.forLeft(edit))
+    }
+
+    def getLeftTextEdit(): Option[l.TextEdit] = {
+      for {
+        either <- Option(item.getTextEdit)
+        textEdit <- Option(either.getLeft())
+      } yield textEdit
+    }
   }
 
   implicit class XtensionLspPosition(pos: l.Position) {

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -134,7 +134,8 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       val items = getItems(original)
       val obtained = items
         .map { item =>
-          Option(item.getTextEdit)
+          item
+            .getLeftTextEdit()
             .map(_.getNewText)
             .orElse(Option(item.getInsertText()))
             .getOrElse(item.getLabel)


### PR DESCRIPTION
CompletionItem.textEdit is no longer just `TextEdit`, but now is `Either[TextEdit, InsertReplaceEdit]` - this was the main issue with migration.

Supersedes https://github.com/scalameta/metals/pull/2657 

Actually `0.12.0` just got released, so updating to that.