### PR TITLE
Fix issues with old typesafe config in the worksheets

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -120,7 +120,21 @@ object Embedded {
     val jars = downloadMdoc(scalaVersion, scalaBinaryVersion, resolutionParams)
 
     val parent = new MdocClassLoader(this.getClass.getClassLoader)
-    val urls = jars.iterator.map(_.toUri().toURL()).toArray
+
+    // Full mdoc classpath seems to be causing some issue with akka
+    // We want to keep a minimal set of jars needed here
+    val runtimeClasspath = jars.filter { path =>
+      val pathString = path.toString
+      pathString.contains("scala-lang") ||
+      pathString.contains("fansi") ||
+      pathString.contains("pprint") ||
+      pathString.contains("sourcecode") ||
+      pathString.contains("mdoc") ||
+      pathString.contains("scalameta") ||
+      pathString.contains("metaconfig") ||
+      pathString.contains("diffutils")
+    }
+    val urls = runtimeClasspath.iterator.map(_.toUri().toURL()).toArray
     new URLClassLoader(urls, parent)
   }
 

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
@@ -114,4 +114,56 @@ class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala212) {
       )
     } yield ()
   }
+
+  test("akka") {
+    val path = "hi.worksheet.sc"
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {}
+           |}
+           |/${path}
+           |import $$dep.`com.typesafe.akka::akka-stream:2.6.13`
+           |
+           |import akka.actor.ActorSystem
+           |import akka.NotUsed
+           |import akka.stream.scaladsl.Source
+           |import akka.stream.scaladsl.Sink
+           |import java.io.File
+           |import scala.concurrent.Await
+           |import scala.concurrent.duration.DurationInt
+           |
+           |
+           |implicit val system: ActorSystem = ActorSystem("QuickStart")
+           |val source: Source[Int, NotUsed] = Source(1 to 2)
+           |val future = source.runWith(Sink.foreach(_ => ()))
+           |Await.result(future, 3.seconds)
+           |
+           |""".stripMargin
+      )
+      _ <- server.didOpen(path)
+      _ = assertNoDiff(
+        // it seems that part of the string is always different, so let's remove it
+        client.workspaceDecorations.replaceAll(".out\\(.*", ".out(..."),
+        """|import $dep.`com.typesafe.akka::akka-stream:2.6.13`
+           |
+           |import akka.actor.ActorSystem
+           |import akka.NotUsed
+           |import akka.stream.scaladsl.Source
+           |import akka.stream.scaladsl.Sink
+           |import java.io.File
+           |import scala.concurrent.Await
+           |import scala.concurrent.duration.DurationInt
+           |
+           |
+           |implicit val system: ActorSystem = ActorSystem("QuickStart") // : ActorSystem = akka://QuickStart
+           |val source: Source[Int, NotUsed] = Source(1 to 2) // : Source[Int, NotUsed] = Source(SourceShape(StatefulMapConcat.out(...
+           |val future = source.runWith(Sink.foreach(_ => ())) // : concurrent.Future[akka.Done] = Future(Success(Done))
+           |Await.result(future, 3.seconds) // : akka.Done = Done
+           |""".stripMargin
+      )
+    } yield ()
+  }
 }


### PR DESCRIPTION
It seems that somehow when using akka in worksheets the actual typesafe config lib that is being loaded is coming from mdoc, not from akka. Which means that akka will not work and throw ClassNotFound exceptions since mdoc has 1.2.1 version on the classpath. We should also fix it in mdoc, but I have currently no idea how to fix it (we should be using the correct classpath currently), so I decided to make the classpath a bit thiner as worksheets do not need everything that mdoc brings. Especially, as there are no config options, so no need for the typesafe config.

Fixes https://github.com/scalameta/metals/issues/2525 hopefully