### PR TITLE
Get behind unified slash syntax.

### DIFF
--- a/project/InputProperties.scala
+++ b/project/InputProperties.scala
@@ -32,17 +32,15 @@ object InputProperties extends AutoPlugin {
       resourceName: String
   ): Def.Initialize[Task[Seq[File]]] =
     Def.task {
-      val out = managedResourceDirectories
-        .in(Compile)
-        .value
-        .head / s"$resourceName.properties"
+      val out =
+        (Compile / managedResourceDirectories).value.head / s"$resourceName.properties"
       val props = new java.util.Properties()
       props.put(
         "sourceroot",
-        baseDirectory.in(ThisBuild).value.toString
+        (ThisBuild / baseDirectory).value.toString
       )
       val sourceJars = for {
-        configurationReport <- updateClassifiers.in(input).value.configurations
+        configurationReport <- (input / updateClassifiers).value.configurations
         moduleReport <- configurationReport.modules
         (artifact, file) <- moduleReport.artifacts
         if artifact.classifier.contains("sources")
@@ -54,15 +52,13 @@ object InputProperties extends AutoPlugin {
       props.put(
         "sourceDirectories",
         List(
-          unmanagedSourceDirectories.in(input, Compile).value,
-          unmanagedSourceDirectories.in(input, Test).value
+          (input / Compile / unmanagedSourceDirectories).value,
+          (input / Test / unmanagedSourceDirectories).value
         ).flatten.mkString(File.pathSeparator)
       )
       props.put(
         "classpath",
-        fullClasspath
-          .in(input, Test)
-          .value
+        (input / Test / fullClasspath).value
           .map(_.data)
           .mkString(File.pathSeparator)
       )


### PR DESCRIPTION
Seeing that the old style is now deprecated in sbt moving forward, I
figured it'd be best to just align everything behind the unified slash
syntax right away. I was playing around with the scalafix rule for this
that was created, and thought Metals was a good test.