### PR TITLE
Mtags: fix Scala3 parsing for Windows.

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/Scala3ToplevelMtags.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/Scala3ToplevelMtags.scala
@@ -1,7 +1,5 @@
 package scala.meta.internal.mtags
 
-import java.nio.file.Paths
-
 import scala.annotation.tailrec
 
 import scala.meta.Dialect
@@ -98,7 +96,7 @@ class Scala3ToplevelMtags(
         case DEF | VAL | VAR | GIVEN | TYPE if needEmitFileOwner(currRegion) =>
           sourceTopLevelAdded = true
           val pos = newPosition
-          val srcName = Paths.get(input.path).filename.stripSuffix(".scala")
+          val srcName = input.filename.stripSuffix(".scala")
           val name = s"$srcName$$package"
           withOwner(currRegion.owner) {
             term(name, pos, Kind.OBJECT, 0)

--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/ScalaMtags.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/ScalaMtags.scala
@@ -1,7 +1,5 @@
 package scala.meta.internal.mtags
 
-import java.nio.file.Paths
-
 import scala.meta.Ctor
 import scala.meta.Decl
 import scala.meta.Defn
@@ -58,8 +56,7 @@ class ScalaMtags(val input: Input.VirtualFile)
     _toplevelSourceRef match {
       case Some(v) => v
       case None =>
-        val filename = Paths.get(input.path).filename
-        val srcName = filename.stripSuffix(".scala")
+        val srcName = input.filename.stripSuffix(".scala")
         val name = s"$srcName$$package"
         val value = (s"$name.", new OverloadDisambiguator())
         _toplevelSourceRef = Some(value)

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.mtags
 
+import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
@@ -11,6 +12,7 @@ import java.{util => ju}
 
 import scala.annotation.tailrec
 import scala.collection.AbstractIterator
+import scala.util.Try
 import scala.util.control.NonFatal
 import scala.{meta => m}
 
@@ -266,6 +268,17 @@ trait CommonMtagsEnrichments {
         }
       }
       root(file)
+    }
+  }
+
+  implicit class XtensionInputVirtual(input: Input.VirtualFile) {
+    def filename: String = {
+      Try {
+        val uri = URI.create(input.path)
+        Paths.get(uri).filename
+      }.getOrElse {
+        Paths.get(input.path).filename
+      }
     }
   }
 

--- a/tests/input3/src/main/scala/example/ToplevelDefVal.scala
+++ b/tests/input3/src/main/scala/example/ToplevelDefVal.scala
@@ -3,3 +3,6 @@ package example
 def foo(): Int = 42
 
 val abc: String = "sds"
+
+// tests jar's indexing on Windows
+type SourceToplevelTypeFromDepsRef = EmptyTuple

--- a/tests/unit/src/test/resources/definition-scala3/example/ToplevelDefVal.scala
+++ b/tests/unit/src/test/resources/definition-scala3/example/ToplevelDefVal.scala
@@ -3,3 +3,6 @@ package example
 def foo/*ToplevelDefVal.scala*/(): Int/*Int.scala*/ = 42
 
 val abc/*ToplevelDefVal.scala*/: String/*Predef.scala*/ = "sds"
+
+// tests jar's indexing on Windows
+type SourceToplevelTypeFromDepsRef/*ToplevelDefVal.scala*/ = EmptyTuple/*Tuple.scala*/

--- a/tests/unit/src/test/resources/documentSymbol-scala3/example/ToplevelDefVal.scala
+++ b/tests/unit/src/test/resources/documentSymbol-scala3/example/ToplevelDefVal.scala
@@ -1,5 +1,8 @@
-/*example(Package):5*/package example
+/*example(Package):8*/package example
 
 /*example.foo(Method):3*/def foo(): Int = 42
 
 /*example.abc(Constant):5*/val abc: String = "sds"
+
+// tests jar's indexing on Windows
+/*example.SourceToplevelTypeFromDepsRef(TypeParameter):8*/type SourceToplevelTypeFromDepsRef = EmptyTuple

--- a/tests/unit/src/test/resources/semanticdb-scala3/example/ToplevelDefVal.scala
+++ b/tests/unit/src/test/resources/semanticdb-scala3/example/ToplevelDefVal.scala
@@ -3,3 +3,6 @@ package example
 /*example.ToplevelDefVal$package.*/def foo/*example.ToplevelDefVal$package.foo().*/(): Int/*scala.Int#*/ = 42
 
 val abc/*example.ToplevelDefVal$package.abc.*/: String/*scala.Predef.String#*/ = "sds"
+
+// tests jar's indexing on Windows
+type SourceToplevelTypeFromDepsRef/*example.ToplevelDefVal$package.SourceToplevelTypeFromDepsRef#*/ = EmptyTuple/*scala.Tuple$package.EmptyTuple#*/


### PR DESCRIPTION
`Paths.get("jar:file:...")` doesn't work on Windows.
