### PR TITLE
Add code action to add/remove string interpolation

### DIFF
--- a/tests/unit/src/test/scala/tests/codeactions/StringActionsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/StringActionsLspSuite.scala
@@ -5,14 +5,15 @@ import scala.meta.internal.metals.codeactions.StringActions
 class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
 
   check(
-    "empty-string",
+    "empty-string-multiline",
     """|package a
        |
        |object A {
        |  val str = <<"">>
        |}
        |""".stripMargin,
-    s"${StringActions.title}",
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.interpolationTitle}""".stripMargin,
     """|package a
        |
        |object A {
@@ -22,14 +23,34 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
   )
 
   check(
-    "multi-strings-one-line",
+    "empty-string-interpolation",
+    """|package a
+       |
+       |object A {
+       |  val str = <<"">>
+       |}
+       |""".stripMargin,
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.interpolationTitle}""".stripMargin,
+    """|package a
+       |
+       |object A {
+       |  val str = s""
+       |}
+       |""".stripMargin.replace("'", "\""),
+    selectedActionIndex = 1
+  )
+
+  check(
+    "multi-strings-one-line-multiline",
     """|package a
        |
        |object A {
        |  val str = <<"">> + ""
        |}
        |""".stripMargin,
-    s"${StringActions.title}",
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.interpolationTitle}""".stripMargin,
     """|package a
        |
        |object A {
@@ -39,7 +60,26 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
   )
 
   check(
-    "multi-strings",
+    "multi-strings-one-line-interpolation",
+    """|package a
+       |
+       |object A {
+       |  val str = <<"">> + ""
+       |}
+       |""".stripMargin,
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.interpolationTitle}""".stripMargin,
+    """|package a
+       |
+       |object A {
+       |  val str = s"" + ""
+       |}
+       |""".stripMargin.replace("'", "\""),
+    selectedActionIndex = 1
+  )
+
+  check(
+    "multi-strings-multiline",
     """|package a
        |
        |object A {
@@ -48,7 +88,8 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
        |  val d = "hello"
        |}
        |""".stripMargin,
-    s"${StringActions.title}",
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.interpolationTitle}""".stripMargin,
     """|package a
        |
        |object A {
@@ -57,6 +98,29 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
        |  val d = "hello"
        |}
        |""".stripMargin.replace("'", "\"")
+  )
+
+  check(
+    "multi-strings-interpolation",
+    """|package a
+       |
+       |object A {
+       |  val e = "hello"
+       |  val c = "this <<is>> a string"
+       |  val d = "hello"
+       |}
+       |""".stripMargin,
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.interpolationTitle}""".stripMargin,
+    """|package a
+       |
+       |object A {
+       |  val e = "hello"
+       |  val c = s"this is a string"
+       |  val d = "hello"
+       |}
+       |""".stripMargin.replace("'", "\""),
+    selectedActionIndex = 1
   )
 
   checkNoAction(
@@ -78,7 +142,7 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
        |  val str = s"this <<is>> an ${other} string"
        |}
        |""".stripMargin,
-    s"${StringActions.title}",
+    s"${StringActions.multilineTitle}",
     """|package a
        |
        |object A {
@@ -89,14 +153,15 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
   )
 
   check(
-    "mix-strings-one-line",
+    "mix-strings-one-line-multiline",
     """|package a
        |
        |object A {
        |  val str = s"Hello " + " the <<cursor>> is actually here "
        |}
        |""".stripMargin,
-    s"${StringActions.title}",
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.interpolationTitle}""".stripMargin,
     """|package a
        |
        |object A {
@@ -106,14 +171,34 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
   )
 
   check(
-    "remix-strings-one-line",
+    "mix-strings-one-line-interpolation",
+    """|package a
+       |
+       |object A {
+       |  val str = s"Hello " + " the <<cursor>> is actually here "
+       |}
+       |""".stripMargin,
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.interpolationTitle}""".stripMargin,
+    """|package a
+       |
+       |object A {
+       |  val str = s"Hello " + s" the cursor is actually here "
+       |}
+       |""".stripMargin.replace("'", "\""),
+    selectedActionIndex = 1
+  )
+
+  check(
+    "remix-strings-one-line-multiline",
     """|package a
        |
        |object A {
        |  val str = "Hello" + s" the <<cursor>> is actually here "
        |}
        |""".stripMargin,
-    s"${StringActions.title}",
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.removeInterpolationTitle}""".stripMargin,
     """|package a
        |
        |object A {
@@ -123,7 +208,43 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
   )
 
   check(
-    "mix-strings",
+    "remix-strings-one-line-remove-interpolation",
+    """|package a
+       |
+       |object A {
+       |  val str = "Hello" + s" the <<cursor>> is actually here "
+       |}
+       |""".stripMargin,
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.removeInterpolationTitle}""".stripMargin,
+    """|package a
+       |
+       |object A {
+       |  val str = "Hello" + " the cursor is actually here "
+       |}
+       |""".stripMargin,
+    selectedActionIndex = 1
+  )
+
+  check(
+    "triple-quotes-remove-interpolation",
+    """|package a
+       |
+       |object A {
+       |  val str = s'''this <<is a>> string'''
+       |}
+       |""".stripMargin.replace("'", "\""),
+    s"${StringActions.removeInterpolationTitle}",
+    """|package a
+       |
+       |object A {
+       |  val str = '''this is a string'''
+       |}
+       |""".stripMargin.replace("'", "\"")
+  )
+
+  check(
+    "mix-strings-multiline",
     """|package a
        |
        |object A {
@@ -132,7 +253,8 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
        |  val d = s"hello ${} "
        |}
        |""".stripMargin,
-    s"${StringActions.title}",
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.interpolationTitle}""".stripMargin,
     """|package a
        |
        |object A {
@@ -141,6 +263,29 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
        |  val d = s"hello ${} "
        |}
        |""".stripMargin.replace("'", "\"")
+  )
+
+  check(
+    "mix-strings-interpolation",
+    """|package a
+       |
+       |object A {
+       |  val e = s"hello ${} "
+       |  val c = "this <<is>> a string"
+       |  val d = s"hello ${} "
+       |}
+       |""".stripMargin,
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.interpolationTitle}""".stripMargin,
+    """|package a
+       |
+       |object A {
+       |  val e = s"hello ${} "
+       |  val c = s"this is a string"
+       |  val d = s"hello ${} "
+       |}
+       |""".stripMargin,
+    selectedActionIndex = 1
   )
 
   check(
@@ -153,7 +298,7 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
        |  val d = s"hello ${} "
        |}
        |""".stripMargin,
-    s"${StringActions.title}",
+    s"${StringActions.multilineTitle}",
     """|package a
        |
        |object A {
@@ -164,12 +309,19 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
        |""".stripMargin.replace("'", "\"")
   )
 
-  checkNoAction(
-    "triple-quotes-no-codeAction",
+  check(
+    "triple-quotes",
     """|package a
        |
        |object A {
        |  val str = <<'''>>'''
+       |}
+       |""".stripMargin.replace("'", "\""),
+    s"${StringActions.interpolationTitle}",
+    """|package a
+       |
+       |object A {
+       |  val str = s''''''
        |}
        |""".stripMargin.replace("'", "\"")
   )
@@ -179,17 +331,24 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
     """|package a
        |
        |object A {
-       |  val str = s'''this <<is a>> string'''
+       |  val str = s'''this <<is a>> ${} string'''
        |}
        |""".stripMargin.replace("'", "\"")
   )
 
-  checkNoAction(
-    "mix-triple-quotes-no-codeAction",
+  check(
+    "mix-triple-quotes",
     """|package a
        |
        |object A {
        |  val str = s'''|multiline'''.stripMargin + '''an <<other>> multiline'''
+       |}
+       |""".stripMargin.replace("'", "\""),
+    s"${StringActions.interpolationTitle}",
+    """|package a
+       |
+       |object A {
+       |  val str = s'''|multiline'''.stripMargin + s'''an other multiline'''
        |}
        |""".stripMargin.replace("'", "\"")
   )


### PR DESCRIPTION
This pull request should close #2666, by adding two code actions: 

1. Quickly interpolate a string or a multiline string
2. Quickly remove an interpolated string, if the string doesn't contains "Splice" parts.

Fixed failing tests due to new code actions and also added some for the new features. 