### PR TITLE
Offer organize imports when on an unused import.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
@@ -13,7 +13,7 @@ object ScalacDiagnostic {
       }
   }
   object MissingImplementation {
-    // https://github.com/scala/scala/blob/4c0f49c7de6ba48f2b0ae59e64ea94fabd82b4a7/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala#L566
+    // https://github.com/scala/scala/blob/fd69ef805d4ba217f3495c106f9c698094682ae8/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala#L547
     private val regex = """(?s).*needs to be abstract.*""".r
     def unapply(d: l.Diagnostic): Option[String] =
       d.getMessage() match {
@@ -22,8 +22,17 @@ object ScalacDiagnostic {
       }
   }
   object ObjectCreationImpossible {
-    // https://github.com/scala/scala/blob/4c0f49c7de6ba48f2b0ae59e64ea94fabd82b4a7/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala#L564
+    // https://github.com/scala/scala/blob/4c0f49c7de6ba48f2b0ae59e64ea94fabd82b4a7/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala#L566
     private val regex = """(?s).*object creation impossible.*""".r
+    def unapply(d: l.Diagnostic): Option[String] =
+      d.getMessage() match {
+        case regex() => Some(d.getMessage())
+        case _ => None
+      }
+  }
+
+  object UnusedImport {
+    private val regex = """(?i)Unused import""".r
     def unapply(d: l.Diagnostic): Option[String] =
       d.getMessage() match {
         case regex() => Some(d.getMessage())

--- a/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
@@ -126,4 +126,28 @@ class OrganizeImportsLspSuite
     scalafixConf = scalafixConf(),
     scalacOptions = scalacOption
   )
+
+  check(
+    "on-unused",
+    """|package a
+       |
+       |<<import java.time.Instant>>
+       |
+       |object A {
+       |  val a = "no one wants unused imports"
+       |}
+       |""".stripMargin,
+    s"${OrganizeImports.title}",
+    """|package a
+       |
+       |
+       |
+       |object A {
+       |  val a = "no one wants unused imports"
+       |}
+       |""".stripMargin,
+    kind = List(kind),
+    scalafixConf = scalafixConf(),
+    scalacOptions = scalacOption
+  )
 }


### PR DESCRIPTION
This just re-uses a lot of the logic that already existed for organize
imports, but now we just do a check to see if the diagnostics in the
codeaction params contain a message about unused import, and if so,
offer this as a code action.

Fixes #2687  (This was a great one to do on stream 😆 )