### PR TITLE
Make sure that a correct targetroot is reported

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ Steps to reproduce the behavior:
 
 - Operating system: macOS/Windows/Linux
 - Editor: Visual Studio Code/Atom/Vim/Sublime/Emacs
-- Metals version: v0.10.0
+- Metals version: v0.10.1
 
 **Additional context**
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scala.collection.mutable
 import scala.sys.process._
 import Tests._
 
-def localSnapshotVersion = "0.10.1-SNAPSHOT"
+def localSnapshotVersion = "0.10.2-SNAPSHOT"
 def isCI = System.getenv("CI") != null
 
 def isScala211(v: Option[(Long, Long)]): Boolean = v.contains((2, 11))

--- a/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
@@ -34,6 +34,7 @@ final class Warnings(
     val isReported: Option[Unit] = for {
       buildTarget <- buildTargets.inverseSources(path)
       info <- buildTargets.scalaTarget(buildTarget)
+      scalacOptions <- buildTargets.scalacOptions(buildTarget)
     } yield {
       if (!info.isSemanticdbEnabled) {
         if (isSupportedScalaVersion(info.scalaVersion)) {
@@ -65,7 +66,9 @@ final class Warnings(
           )
           statusBar.addMessage(icons.info + tryAgain)
         } else if (!path.isSbt && !path.isWorksheet) {
-          val targetfile = info.classDirectory.toAbsolutePath
+
+          val targetRoot = scalacOptions.targetroot(info.scalaVersion)
+          val targetfile = targetRoot
             .resolve(SemanticdbClasspath.fromScala(path.toRelative(workspace)))
           logger.error(
             s"$doesntWorkBecause the SemanticDB file '$targetfile' doesn't exist. " +


### PR DESCRIPTION
Previously, when checking for semanticdb if it was missing we would report it based on the classes directory. Now, we report it based on the actual place we are looking for it using targetroot.