### PR TITLE
Don't override testSettings in unit tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -643,7 +643,7 @@ lazy val unit = project
   .in(file("tests/unit"))
   .settings(
     testSettings,
-    Test / testOptions := Seq(Tests.Filter(name => isInTestShard(name))),
+    Test / testOptions ++= Seq(Tests.Filter(name => isInTestShard(name))),
     sharedSettings,
     Test / javaOptions += "-Xmx2G",
     libraryDependencies ++= List(


### PR DESCRIPTION
I haven't noticed this one in the previous PR, because the failed test came from slow tests :/