### PR TITLE
Add testframeworks back in to ensure tests run.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -529,6 +529,7 @@ lazy val testSettings: Seq[Def.Setting[_]] = List(
   Test / parallelExecution := false,
   publish / skip := true,
   fork := true,
+  testFrameworks := List(TestFrameworks.MUnit),
   Test / testOptions ++= {
     if (isCI) {
       // Enable verbose logging using sbt loggers in CI.


### PR DESCRIPTION
I removed this in https://github.com/scalameta/metals/pull/2703 and shouldn't have. It's causing no test to be detected and ran.