### PR TITLE
Always print stack traces when testing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -535,7 +535,7 @@ lazy val testSettings: Seq[Def.Setting[_]] = List(
       // Enable verbose logging using sbt loggers in CI.
       List(Tests.Argument(TestFrameworks.MUnit, "+l", "--verbose", "-F"))
     } else {
-      Nil
+      List(Tests.Argument(TestFrameworks.MUnit, "-F"))
     }
   }
 )


### PR DESCRIPTION
Previously, we would get:
```
==> X tests.codeactions.ExtractClassLspSuite.only-sourceFile  1.892s munit.ComparisonFailException: /home/tgodzik/Documents/metals/tests/unit/src/test/scala/tests/codeactions/ExtractClassLspSuite.scala:19 Obtained empty output!
18:
19:  check(
20:    "only-sourceFile",
```
it is impossible to say where the exception occurs in. Now it should be:
```
==> X tests.codeactions.ExtractClassLspSuite.only-sourceFile  1.889s munit.ComparisonFailException: /home/tgodzik/Documents/metals/tests/unit/src/test/scala/tests/codeactions/ExtractClassLspSuite.scala:19 Obtained empty output!
18:
19:  check(
20:    "only-sourceFile",
    at munit.Assertions.failComparison(Assertions.scala:275)
    ....
    at tests.Assertions$.assertNoDiff(Assertions.scala:73)
    at tests.TestingServer.$anonfun$assertCodeAction$2(TestingServer.scala:956)
    at scala.util.Success.$anonfun$map$1(Try.scala:255)
    at scala.util.Success.map(Try.scala:213)
    at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
    at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
    at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
    at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```