### PR TITLE
Fix issues with DAP tests

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -15,6 +15,7 @@ import scala.concurrent.Promise
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+import scala.util.control.NonFatal
 
 import scala.meta.internal.metals.BuildServerConnection
 import scala.meta.internal.metals.BuildTargets
@@ -493,14 +494,39 @@ class DebugProvider(
         parameters
     }
   }
+
   private def connect(uri: URI): Socket = {
     val socket = new Socket()
-
-    val address = new InetSocketAddress(uri.getHost, uri.getPort)
-    val timeout = TimeUnit.SECONDS.toMillis(20).toInt
-    socket.connect(address, timeout)
-
-    socket
+    /* Using "0.0.0.0" seems to be sometimes causing issues
+     * and it does not seem to be a standard across systems
+     * This made tests extremely flaky.
+     */
+    val host = uri.getHost match {
+      case "0.0.0.0" => "127.0.0.1"
+      case other => other
+    }
+    val address = new InetSocketAddress(host, uri.getPort)
+    val timeout = TimeUnit.SECONDS.toMillis(10).toInt
+    try {
+      socket.connect(address, timeout)
+      socket
+    } catch {
+      case NonFatal(e) =>
+        scribe.warn(
+          s"Could not connect to java process via ${address.getHostName()}:${address.getPort()}"
+        )
+        if (uri.getHost() != host) {
+          val alternateAddress =
+            new InetSocketAddress(uri.getHost(), uri.getPort)
+          scribe.warn(
+            s"Retrying with ${alternateAddress.getHostName()}:${alternateAddress.getPort()}"
+          )
+          socket.connect(alternateAddress, timeout)
+          socket
+        } else {
+          throw e
+        }
+    }
   }
 
   private def withRebuildRetry[A](


### PR DESCRIPTION
Change 0.0.0.0 to 127.0.0.1 to avoid socket connection timeouts

Previously, tests would often fail for DAP and the only way to fix it seems to force 127.0.0.1, which seems a much safer option.

Thanks to @dos65 for the hint!