### PR TITLE
Treat .srcjar as jars

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -309,7 +309,7 @@ object MetalsEnrichments
 
     def isJar: Boolean = {
       val filename = path.toNIO.getFileName.toString
-      filename.endsWith(".jar")
+      filename.endsWith(".jar") || filename.endsWith(".srcjar")
     }
 
     /**


### PR DESCRIPTION
I'm currently working on bloop config generation from bazel files.
And found difficulties with generated sources (scalapb for example).
Currently i'm attaching them as external dependencies with jars generated by bazel.
It's common in bazel world to place generated files inside `.srcjar` files but they are ignored by metals.

It's a bit hacky but i hope it will be accepted 😄 