### PR TITLE
Code action to move classes to their own files if requirements are met

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -17,11 +17,15 @@ final class CodeActionProvider(
     scalafixProvider: ScalafixProvider,
     trees: Trees
 )(implicit ec: ExecutionContext) {
+
+  private val extractMemberAction = new ExtractRenameMember(buffers, trees)
+
   private val allActions: List[CodeAction] = List(
     new ImplementAbstractMembers(compilers),
     new ImportMissingSymbol(compilers),
     new CreateNewSymbol(),
     new StringActions(buffers, trees),
+    extractMemberAction,
     new OrganizeImports(scalafixProvider, buildTargets),
     new InsertInferredType(trees, compilers)
   )
@@ -46,4 +50,14 @@ final class CodeActionProvider(
     Future.sequence(actions).map(_.flatten)
   }
 
+  def executeCommands(
+      codeActionCommandData: CodeActionCommandData,
+      token: CancelToken
+  )(implicit ec: ExecutionContext): Future[CodeActionCommandResult] = {
+    codeActionCommandData match {
+      case data: ExtractMemberDefinitionData =>
+        extractMemberAction.executeCommand(data)
+      case data => Future.failed(new IllegalArgumentException(data.toString))
+    }
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -53,7 +53,7 @@ final class CodeActionProvider(
   def executeCommands(
       codeActionCommandData: CodeActionCommandData,
       token: CancelToken
-  )(implicit ec: ExecutionContext): Future[CodeActionCommandResult] = {
+  ): Future[CodeActionCommandResult] = {
     codeActionCommandData match {
       case data: ExtractMemberDefinitionData =>
         extractMemberAction.executeCommand(data)

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -100,6 +100,11 @@ object Messages {
     "Could not insert inferred type, please check the logs for more details or report an issue."
   )
 
+  val ExtractMemberDefinitionFailed = new MessageParams(
+    MessageType.Error,
+    "Could not extract the given definition, please check the logs for more details or report an issue."
+  )
+
   val ReloadProjectFailed = new MessageParams(
     MessageType.Error,
     "Reloading your project failed, no functionality will work. See the log for more details"

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -356,6 +356,12 @@ object MetalsEnrichments
       }
     }
 
+    def move(newPath: AbsolutePath, sco: Option[StandardCopyOption]): Path = {
+      if (sco.nonEmpty)
+        Files.move(path.toNIO, newPath.toNIO, sco.get)
+      else Files.move(path.toNIO, newPath.toNIO)
+    }
+
     def createDirectories(): AbsolutePath =
       AbsolutePath(Files.createDirectories(path.dealias.toNIO))
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -304,6 +304,17 @@ object ServerCommands {
     "[uri], the uri of the worksheet that you'd like to copy the contents of."
   )
 
+  val ExtractMemberDefinition = new Command(
+    "extract-member-definition",
+    "Extract member definition",
+    """|Whenever a user chooses a code action to extract a definition of a Class/Trait/Object/Enum this
+       |command is later ran to extract the code and create a new file with it
+       |""".stripMargin,
+    """|[uri, line, character], uri of the document that the command needs to be invoked on
+       |together with line number and character/column where the definition is.
+       |""".stripMargin
+  )
+
   val InsertInferredType = new Command(
     "insert-inferred-type",
     "Insert inferred type of a value",
@@ -396,6 +407,7 @@ object ServerCommands {
       CascadeCompile,
       CleanCompile,
       CopyWorksheetOutput,
+      ExtractMemberDefinition,
       GenerateBspConfig,
       GotoPosition,
       GotoSuperMethod,

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionCommandData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionCommandData.scala
@@ -1,0 +1,21 @@
+package scala.meta.internal.metals.codeactions
+
+import org.eclipse.lsp4j.ApplyWorkspaceEditParams
+import org.eclipse.lsp4j.Location
+import org.eclipse.lsp4j.TextDocumentPositionParams
+
+trait CodeActionCommandData {
+  val uri: String
+  val actionType: String
+}
+
+case class ExtractMemberDefinitionData(
+    uri: String,
+    params: TextDocumentPositionParams,
+    actionType: String = ExtractRenameMember.extractDefCommandDataType
+) extends CodeActionCommandData
+
+case class CodeActionCommandResult(
+    edits: ApplyWorkspaceEditParams,
+    goToLocation: Option[Location]
+)

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractRenameMember.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractRenameMember.scala
@@ -129,7 +129,7 @@ class ExtractRenameMember(
               case o: Defn.Object => o.name.value :: completePreName(o)
               case po: Pkg.Object => po.name.value :: completePreName(po)
               case _: Source => Nil
-              case _ => completePreName(t)
+              case _ => Nil
             }
           case None => Nil
         }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractRenameMember.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractRenameMember.scala
@@ -128,6 +128,7 @@ class ExtractRenameMember(
             t match {
               case o: Defn.Object => o.name.value :: completePreName(o)
               case po: Pkg.Object => po.name.value :: completePreName(po)
+              case tmpl: Template => completePreName(tmpl)
               case _: Source => Nil
               case _ => Nil
             }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractRenameMember.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractRenameMember.scala
@@ -1,0 +1,382 @@
+package scala.meta.internal.metals.codeactions
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.Defn
+import scala.meta.Import
+import scala.meta.Member
+import scala.meta.Mod
+import scala.meta.Pkg
+import scala.meta.Source
+import scala.meta.Template
+import scala.meta.Term
+import scala.meta.Tree
+import scala.meta.Type
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals._
+import scala.meta.internal.metals.codeactions.ExtractRenameMember.CodeActionCommandNotFoundException
+import scala.meta.internal.metals.codeactions.ExtractRenameMember.getMemberType
+import scala.meta.internal.parsing.Trees
+import scala.meta.io.AbsolutePath
+import scala.meta.pc.CancelToken
+import scala.meta.transversers.SimpleTraverser
+
+import org.eclipse.lsp4j.ApplyWorkspaceEditParams
+import org.eclipse.lsp4j.Location
+import org.eclipse.lsp4j.WorkspaceEdit
+import org.eclipse.{lsp4j => l}
+
+class ExtractRenameMember(
+    buffers: Buffers,
+    trees: Trees
+)(implicit ec: ExecutionContext)
+    extends CodeAction {
+
+  override def contribute(params: l.CodeActionParams, token: CancelToken)(
+      implicit ec: ExecutionContext
+  ): Future[Seq[l.CodeAction]] = Future {
+    val uri = params.getTextDocument.getUri
+    val path = uri.toAbsolutePath
+    val range = params.getRange
+
+    trees.get(path) match {
+      case Some(tree) =>
+        val fileName = uri.toAbsolutePath.filename.replaceAll("\\.scala$", "")
+
+        val definitions = membersDefinitions(tree)
+        val sldNames = sealedNames(tree)
+        val defnAtCursor =
+          definitions.find(_.name.pos.toLSP.overlapsWith(range))
+
+        def canRenameDefn(defn: Member): Boolean = {
+          val differentNames = defn.name.value != fileName
+          val newFileUri = newPathFromClass(uri, defn)
+
+          differentNames && !newFileUri.exists && defnAtCursor.exists(
+            _.equals(defn)
+          )
+        }
+
+        def canExtractDefn(defn: Member): Boolean = {
+          val differentNames = defn.name.value != fileName
+          val notExtendsSealedOrSealed = notSealed(defn, sldNames)
+          val companion = definitions.find(c => {
+            !c.equals(defn) && c.name.value.equals(defn.name.value)
+          })
+          val companionNotSealed =
+            companion.exists(notSealed(_, sldNames)) || companion.isEmpty
+
+          val newFileUri = newPathFromClass(uri, defn)
+
+          differentNames && notExtendsSealedOrSealed && companionNotSealed && !newFileUri.exists
+        }
+
+        definitions match {
+          case Nil => Nil
+          case head :: Nil if canRenameDefn(head) =>
+            Seq(renameFileAsMemberAction(uri, head))
+          case _ =>
+            val codeActionOpt = for {
+              defn <- defnAtCursor
+              if canExtractDefn(defn)
+              memberType <- getMemberType(defn)
+              title = ExtractRenameMember.title(memberType, defn.name.value)
+            } yield extractClassAction(uri, defn, title)
+
+            codeActionOpt.toList
+        }
+
+      case _ => Nil
+    }
+
+  }
+
+  private def membersDefinitions(tree: Tree): List[Member] = {
+    val nodes: ListBuffer[Member] = ListBuffer()
+
+    val traverser = new SimpleTraverser {
+      override def apply(tree: Tree): Unit = tree match {
+        case p: Pkg =>
+          super.apply(p)
+        case c: Defn.Class => nodes += c
+        case t: Defn.Trait => nodes += t
+        case o: Defn.Object => nodes += o
+        case e: Defn.Enum => nodes += e
+        case s: Source =>
+          super.apply(s)
+        case _ =>
+      }
+    }
+    traverser(tree)
+
+    nodes.toList
+  }
+
+  private def isSealed(t: Tree): Boolean = t match {
+    case node: Defn.Trait => node.mods.exists(_.isInstanceOf[Mod.Sealed])
+    case node: Defn.Class => node.mods.exists(_.isInstanceOf[Mod.Sealed])
+    case _ => false
+  }
+
+  private def sealedNames(tree: Tree): List[String] = tree.collect {
+    case node: Defn.Trait if isSealed(node) => node.name.value
+    case node: Defn.Class if isSealed(node) => node.name.value
+  }
+
+  private def notSealed(
+      member: Member,
+      sealedNames: List[String]
+  ): Boolean = {
+    val memberExtendsSealed: Boolean =
+      parents(member).exists(sealedNames.contains(_))
+
+    !memberExtendsSealed && !isSealed(member)
+  }
+
+  private def newFileContent(
+      tree: Tree,
+      range: l.Range,
+      member: Member,
+      companion: Option[Member]
+  ): String = {
+    // List of sequential packages or imports before the member definition
+    val packages: ListBuffer[Pkg] = ListBuffer()
+    val imports: ListBuffer[Import] = ListBuffer()
+
+    // Using a custom traverser to avoid hitting inner classes by stopping the recursion on the chosen members
+    object traverser extends SimpleTraverser {
+      override def apply(tree: Tree): Unit = tree match {
+        case p: Pkg if p.pos.toLSP.overlapsWith(range) =>
+          packages += Pkg(ref = p.ref, stats = Nil)
+          super.apply(p)
+        case i: Import =>
+          imports += i
+        case s: Source =>
+          super.apply(s)
+        case _ =>
+      }
+    }
+
+    traverser(tree)
+
+    def names(t: Term): List[Term.Name] = {
+      t match {
+        case s: Term.Select => names(s.qual) :+ s.name
+        case n: Term.Name => n :: Nil
+      }
+    }
+
+    def merge(n1: Term.Ref, n2: Term.Name): Term.Select = n1 match {
+      case s: Term.Select => Term.Select(qual = s, name = n2)
+      case n: Term.Name => Term.Select(qual = n, name = n2)
+    }
+
+    def mergeNames(ns: List[Term.Name]): Option[Term.Ref] = ns match {
+      case Nil => None
+      case head :: Nil => Some(head)
+      case head :: second :: xs => Some(xs.foldLeft(merge(head, second))(merge))
+    }
+
+    val termNames = packages
+      .flatMap(p => names(p.ref))
+
+    val mergedTermsOpt = mergeNames(termNames.toList)
+
+    val pkg: Option[Pkg] = mergedTermsOpt.map(t => Pkg(ref = t, stats = Nil))
+
+    val structure = pkg.toList.mkString("\n") ::
+      imports.mkString("\n") ::
+      member.toString ::
+      companion.map(_.toString).getOrElse("") :: Nil
+
+    structure
+      .filter(_.nonEmpty)
+      .mkString("\n\n")
+  }
+
+  private def parents(member: Member): List[String] = {
+
+    def namesFromTemplate(t: Template): List[String] = {
+      t.inits.flatMap {
+        _.tpe match {
+          case Type.Name(value) => Some(value)
+          case _ => None
+        }
+      }
+    }
+
+    member match {
+      case c: Defn.Class => namesFromTemplate(c.templ)
+      case t: Defn.Trait => namesFromTemplate(t.templ)
+      case o: Defn.Object => namesFromTemplate(o.templ)
+      case e: Defn.Enum => namesFromTemplate(e.templ)
+    }
+  }
+
+  private def renameFileAsMemberAction(
+      uri: String,
+      member: Member
+  ): l.CodeAction = {
+    val className = member.name.value
+    val newUri = newPathFromClass(uri, member).toURI.toString
+    val fileName = uri.toAbsolutePath.filename
+
+    val edits: List[Either[l.TextDocumentEdit, l.ResourceOperation]] = List(
+      Right(new l.RenameFile(uri, newUri))
+    )
+
+    val codeAction = new l.CodeAction()
+    codeAction.setTitle(
+      ExtractRenameMember.renameFileAsClassTitle(fileName, className)
+    )
+    codeAction.setKind(l.CodeActionKind.Refactor)
+    codeAction.setEdit(
+      new l.WorkspaceEdit(edits.map(_.asJava).asJava)
+    )
+
+    codeAction
+  }
+
+  private def extractClassAction(
+      uri: String,
+      member: Member,
+      title: String
+  ): l.CodeAction = {
+
+    val range = member.name.pos.toLSP
+
+    val codeAction = new l.CodeAction()
+    codeAction.setTitle(title)
+    codeAction.setKind(l.CodeActionKind.RefactorExtract)
+    codeAction.setCommand(
+      ServerCommands.ExtractMemberDefinition.toLSP(
+        List(
+          uri,
+          range.getStart.getLine(): java.lang.Integer,
+          range.getStart.getCharacter(): java.lang.Integer
+        )
+      )
+    )
+
+    codeAction
+  }
+
+  def executeCommand(
+      data: ExtractMemberDefinitionData
+  ): Future[CodeActionCommandResult] = Future {
+    val uri = data.uri
+    val params = data.params
+
+    def isCompanion(member: Member)(candidateCompanion: Member): Boolean = {
+      val differentMemberWithSameName = !candidateCompanion.equals(member) &&
+        candidateCompanion.name.value.equals(member.name.value)
+      member match {
+        case _: Defn.Object => differentMemberWithSameName
+        case _ =>
+          candidateCompanion
+            .isInstanceOf[Defn.Object] && differentMemberWithSameName
+      }
+    }
+
+    val pos = params.getPosition
+    val range = new l.Range(pos, pos)
+    val path = uri.toAbsolutePath
+
+    val opt = for {
+      tree <- trees.get(path)
+      definitions = membersDefinitions(tree)
+      memberDefn <- definitions.find(_.name.pos.toLSP.overlapsWith(range))
+      companion = definitions.find(isCompanion(memberDefn))
+      fileContent = newFileContent(
+        tree,
+        range,
+        memberDefn,
+        companion
+      )
+      newFilePath = newPathFromClass(uri, memberDefn)
+      if !newFilePath.exists
+
+    } yield {
+      val newFileUri = newFilePath.toURI.toString
+      val edits = extractClassCommand(
+        newFileUri,
+        fileContent,
+        memberDefn,
+        companion
+      )
+      val newFileMemberRange = new l.Range()
+      val workspaceEdit = new WorkspaceEdit(Map(uri -> edits.asJava).asJava)
+      CodeActionCommandResult(
+        new ApplyWorkspaceEditParams(workspaceEdit),
+        Option(new Location(newFileUri, newFileMemberRange))
+      )
+    }
+
+    opt.getOrElse(
+      throw CodeActionCommandNotFoundException(
+        s"Could not execute command ${data.actionType}"
+      )
+    )
+  }
+
+  private def newPathFromClass(uri: String, member: Member): AbsolutePath = {
+    val src = uri.toAbsolutePath
+    val classDefnName = member.name.value
+    src.parent.resolve(s"$classDefnName.scala")
+  }
+
+  override def kind: String = l.CodeActionKind.RefactorExtract
+
+  private def extractClassCommand(
+      newUri: String,
+      content: String,
+      member: Member,
+      companion: Option[Member]
+  ): List[l.TextEdit] = {
+    val newPath = newUri.toAbsolutePath
+
+    newPath.writeText(content)
+
+    def removeTreeEdits(t: Tree): List[l.TextEdit] =
+      List(new l.TextEdit(t.pos.toLSP, ""))
+
+    val packageEdit = member.parent
+      .flatMap {
+        case p: Pkg
+            if p.stats.forall(t =>
+              t.isInstanceOf[Import] || t.equals(member) || companion
+                .exists(_.equals(t))
+            ) =>
+          Some(p)
+        case _ => None
+      }
+      .map(removeTreeEdits)
+
+    packageEdit.getOrElse(
+      removeTreeEdits(member) ++ companion.map(removeTreeEdits).getOrElse(Nil)
+    )
+
+  }
+
+}
+
+object ExtractRenameMember {
+  case class CodeActionCommandNotFoundException(s: String) extends Exception(s)
+
+  def getMemberType(member: Member): Option[String] = Option(member).collect {
+    case _: Defn.Class => "class"
+    case _: Defn.Enum => "enum"
+    case _: Defn.Trait => "trait"
+    case _: Defn.Object => "object"
+  }
+
+  def title(memberType: String, name: String): String =
+    s"Extract $memberType '$name' to file $name.scala"
+
+  def renameFileAsClassTitle(fileName: String, memberName: String): String =
+    s"Rename file $fileName as $memberName.scala"
+
+  val extractDefCommandDataType = "extract-definition"
+}

--- a/tests/slow/src/test/scala/tests/feature/CrossCodeActionLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CrossCodeActionLspSuite.scala
@@ -1,7 +1,11 @@
 package tests.feature
 
 import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.codeactions.ExtractRenameMember
+import scala.meta.internal.mtags.MtagsEnrichments.XtensionAbsolutePath
 
+import munit.Location
+import munit.TestOptions
 import tests.codeactions.BaseCodeActionLspSuite
 
 class CrossCodeActionLspSuite
@@ -18,4 +22,61 @@ class CrossCodeActionLspSuite
        |}
        |""".stripMargin
   )
+
+  checkExtractedMember(
+    "extract-enum",
+    """|package a
+       |
+       |case class A()
+       |
+       |enum <<Color>>(val rgb: Int):
+       |   case Red   extends Color(0xFF0000)
+       |   case Green extends Color(0x00FF00)
+       |   case Blue  extends Color(0x0000FF)
+       |""".stripMargin,
+    s"""|${ExtractRenameMember.title("enum", "Color")}""".stripMargin,
+    """|package a
+       |
+       |case class A()
+       |
+       |""".stripMargin,
+    newFile = (
+      "Color.scala",
+      s"""|package a
+          |
+          |enum Color(val rgb: Int):
+          |   case Red   extends Color(0xFF0000)
+          |   case Green extends Color(0x00FF00)
+          |   case Blue  extends Color(0x0000FF)
+          |""".stripMargin
+    )
+  )
+
+  def checkExtractedMember(
+      name: TestOptions,
+      input: String,
+      expectedActions: String,
+      expectedCode: String,
+      newFile: (String, String),
+      selectedActionIndex: Int = 0
+  )(implicit loc: Location): Unit = {
+    check(
+      name,
+      input,
+      expectedActions,
+      expectedCode,
+      selectedActionIndex,
+      extraOperations = {
+        val (fileName, content) = newFile
+        val absolutePath = workspace.resolve(getPath(fileName))
+        assert(
+          absolutePath.exists,
+          s"File $absolutePath should have been created"
+        )
+        assertNoDiff(absolutePath.readText, content)
+      }
+    )
+  }
+  private def getPath(name: String) = s"a/src/main/scala/a/$name"
+
 }

--- a/tests/unit/src/main/scala/tests/ResourceOperations.scala
+++ b/tests/unit/src/main/scala/tests/ResourceOperations.scala
@@ -1,0 +1,92 @@
+package tests
+
+import java.nio.file.StandardCopyOption
+
+import scala.meta.internal.metals.MetalsEnrichments._
+
+import org.eclipse.lsp4j.CreateFile
+import org.eclipse.lsp4j.CreateFileOptions
+import org.eclipse.lsp4j.DeleteFile
+import org.eclipse.lsp4j.RenameFile
+import org.eclipse.lsp4j.RenameFileOptions
+import org.eclipse.lsp4j.ResourceOperation
+
+/**
+ * Client implementation of how to interpret `ResourceOperation` from LSP, used for testing purposes.
+ */
+object ResourceOperations {
+
+  def applyResourceOperation(resourceOperation: ResourceOperation): Unit = {
+    resourceOperation match {
+      case operation: CreateFile =>
+        createFile(operation)
+      case operation: RenameFile =>
+        renameFile(operation)
+      case operation: DeleteFile =>
+        deleteFile(operation)
+      case _ =>
+    }
+  }
+
+  /**
+   * This method should implement how to interpret the CreateFile operation
+   * there is no guarantee that is compliant with the LSP specs
+   * @param operation CreateFile operation
+   */
+  def createFile(operation: CreateFile): Unit = {
+    val uri = operation.getUri
+    val options: Option[CreateFileOptions] = Option(operation.getOptions)
+
+    val overwrite =
+      options
+        .map(opt => opt.getOverwrite: Boolean)
+        .getOrElse(false)
+    val ignoreIfExists = options
+      .map(opt => opt.getIgnoreIfExists: Boolean)
+      .getOrElse(true.booleanValue())
+
+    val path = uri.toAbsolutePath
+    val fileExists = path.exists
+
+    if (fileExists && !ignoreIfExists && overwrite) {
+      path.writeText("")
+    } else if (!fileExists) {
+      path.touch()
+    }
+
+  }
+
+  def renameFile(operation: RenameFile): Unit = {
+    val oldUri = operation.getOldUri
+    val newUri = operation.getNewUri
+    val options: Option[RenameFileOptions] = Option(operation.getOptions)
+
+    val overwrite = options
+      .map(opt => opt.getOverwrite: Boolean)
+      .getOrElse(false)
+    val ignoreIfExists = options
+      .map(opt => opt.getOverwrite: Boolean)
+      .getOrElse(false)
+
+    val oldPath = oldUri.toAbsolutePath
+    val newPath = newUri.toAbsolutePath
+    val fileExists = newPath.exists
+
+    if (fileExists && !ignoreIfExists && overwrite) {
+      oldPath.move(newPath, Some(StandardCopyOption.REPLACE_EXISTING))
+    } else {
+      oldPath.move(newPath, None)
+    }
+  }
+
+  /**
+   * This method definitely doesn't follow the DeleteFile operations' specs
+   * not taking into account the DeleteFileOptions
+   */
+  def deleteFile(operation: DeleteFile): Unit = {
+    val uri = operation.getUri
+    val path = uri.toAbsolutePath
+    path.delete()
+  }
+
+}

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -827,7 +827,7 @@ final class TestingServer(
     val input = m.Input.String(text)
     val path = root.resolve(filename)
     path.touch()
-    val pos = m.Position.Range(input, startOffset, endOffset - "<<>>".length())
+    val pos = m.Position.Range(input, startOffset, endOffset - "<<".length())
     for {
       _ <- didChange(filename)(_ => text)
     } yield {

--- a/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
@@ -3,6 +3,7 @@ package tests.codeactions
 import scala.meta.internal.metals.Messages.NewScalaFile
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.codeactions.CreateNewSymbol
+import scala.meta.internal.metals.codeactions.ExtractRenameMember
 import scala.meta.internal.metals.codeactions.ImportMissingSymbol
 
 import munit.Location
@@ -67,6 +68,10 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
         |${ImportMissingSymbol.title("Location", docToolName)}
         |${CreateNewSymbol.title("Missing")}
         |${CreateNewSymbol.title("Location")}
+        |${ExtractRenameMember.renameFileAsClassTitle(
+      fileName = "A.scala",
+      memberName = "School"
+    )}
         |""".stripMargin,
     selectedActionIndex = 4,
     pickedKind = "class",
@@ -79,8 +84,6 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
           |""".stripMargin,
     expectNoDiagnostics = false
   )
-
-  private def indent = "  "
 
   def checkNewSymbol(
       name: TestOptions,
@@ -131,5 +134,7 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
       } yield ()
     }
   }
+
+  private def indent = "  "
 
 }

--- a/tests/unit/src/test/scala/tests/codeactions/ExtractRenameMemberLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ExtractRenameMemberLspSuite.scala
@@ -1,0 +1,474 @@
+package tests.codeactions
+
+import java.nio.file.Paths
+
+import scala.meta.inputs.Input
+import scala.meta.internal.metals.Buffers
+import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.internal.metals.MetalsEnrichments.XtensionAbsolutePathBuffers
+import scala.meta.internal.metals.ScalaVersionSelector
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.codeactions.ExtractRenameMember
+import scala.meta.internal.metals.{BuildInfo => V}
+import scala.meta.internal.mtags.MtagsEnrichments.XtensionAbsolutePath
+import scala.meta.internal.mtags.MtagsEnrichments.XtensionMetaPosition
+import scala.meta.internal.parsing.Trees
+import scala.meta.io.AbsolutePath
+
+import munit.Location
+import munit.TestOptions
+import org.eclipse.lsp4j.CodeActionContext
+import org.eclipse.lsp4j.CodeActionParams
+
+class ExtractRenameMemberLspSuite
+    extends BaseCodeActionLspSuite("extractClass") {
+
+  val indent = "  "
+
+  checkActionProduced(
+    "extends-sealed-trait-no-codeAction",
+    """|package a
+       |
+       |case class A()
+       |
+       |sealed trait MyTrait
+       |case class <<B>>() extends MyTrait
+       |
+       |""".stripMargin,
+    codeActionExpected = false
+  )
+
+  checkActionProduced(
+    "with-sealed-trait-no-codeAction",
+    """|package a
+       |
+       |case class A()
+       |
+       |trait MyTrait
+       |sealed trait MySealedTrait
+       |case class <<B>>() extends MyTrait with MySealedTrait
+       |
+       |""".stripMargin,
+    codeActionExpected = false
+  )
+
+  checkActionProduced(
+    "extends-sealed-class-no-codeAction",
+    """|package a
+       |
+       |case class A()
+       |
+       |sealed class MyTrait
+       |case class <<B>>() extends MyTrait
+       |
+       |""".stripMargin,
+    codeActionExpected = false
+  )
+
+  checkActionProduced(
+    "with-sealed-class-and-trait-no-codeAction",
+    """|package a
+       |
+       |case class A()
+       |
+       |trait MyTrait
+       |sealed class MySealedTrait
+       |case class <<B>>() extends MySealedTrait with MyTrait
+       |
+       |""".stripMargin,
+    codeActionExpected = false
+  )
+
+  checkActionProduced(
+    "sealed-trait-no-codeAction",
+    """|package a
+       |
+       |case class A()
+       |
+       |sealed trait <<MySealedTrait>>
+       |
+       |""".stripMargin,
+    codeActionExpected = false
+  )
+
+  checkActionProduced(
+    "companion-of-sealed-class-no-codeAction",
+    """|package a
+       |
+       |case class A()
+       |
+       |sealed case class MySealedClass
+       |
+       |object <<MySealedClass>> {}
+       |
+       |""".stripMargin,
+    codeActionExpected = false
+  )
+
+  checkActionProduced(
+    "no-name-selection-no-codeAction",
+    """|package a
+       |
+       |case <<cl>>ass A()
+       |
+       |""".stripMargin,
+    codeActionExpected = false
+  )
+
+  checkActionProduced(
+    "inner-class-no-codeAction",
+    """|package a
+       |
+       |case class A() {
+       |  case class <<B>>()
+       |}
+       |
+       |""".stripMargin,
+    codeActionExpected = false
+  )
+
+  checkActionProduced(
+    "sealed-class-no-codeAction",
+    """|package a
+       |
+       |sealed case class <<A>>()
+       |
+       |""".stripMargin,
+    codeActionExpected = false
+  )
+
+  checkActionProduced(
+    "extract-class-extended",
+    """|package a
+       |
+       |abstract class A()
+       |class <<B>>() extends A
+       |""".stripMargin
+  )
+
+  checkActionProduced(
+    "extract-class-inner-package",
+    """|package a
+       |
+       |case class A()
+       |
+       |package b {
+       |  case class <<B>>()
+       |}
+       |""".stripMargin
+  )
+
+  checkActionProduced(
+    "extract-class-inner-package-no-subpackages",
+    """|package a
+       |
+       |case class A()
+       |
+       |package b {
+       |  case class <<B>>()
+       |  package c {
+       |    case class C()
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkActionProduced(
+    "extract-class-inner-subpackage",
+    """|package a
+       |
+       |case class A()
+       |
+       |package b {
+       |  case class B()
+       |  package c {
+       |    case class <<C>>()
+       |  }
+       |}
+       |""".stripMargin
+  )
+  checkActionProduced(
+    "extract-object-inner-package",
+    """|package a
+       |
+       |case class A()
+       |
+       |package b {
+       |  object <<B>>{}
+       |}
+       |
+       |package c {
+       |  case class C()
+       |}
+       |""".stripMargin
+  )
+
+  checkActionProduced(
+    "extract-object-inner-package",
+    """|package a
+       |
+       |case class A()
+       |
+       |package b {
+       |  object <<B>>{}
+       |}
+       |
+       |package c {
+       |  case class C()
+       |}
+       |""".stripMargin
+  )
+
+  checkActionProduced(
+    "extract-class-with-imports",
+    """|package a
+       |import scala.io.Source
+       |
+       |case class A()
+       |case class <<B>>() {
+       |  val s = Source.fromFile("A.scala")
+       |}
+       |""".stripMargin
+  )
+
+  checkNoAction(
+    "same-name-no-codeAction",
+    """|package a
+       |
+       |case class <<A>>()
+       |""".stripMargin
+  )
+
+  val renameCodeActionTitle: String = ExtractRenameMember
+    .renameFileAsClassTitle(fileName = "A.scala", memberName = "MyClass")
+
+  checkFileRenamed(
+    "only-one-class-with-inner-class-rename-file",
+    """|package a
+       |
+       |case class <<MyClass>>() {
+       |  case class B()
+       |}
+       |
+       |""".stripMargin,
+    renameCodeActionTitle,
+    newFileName = "MyClass.scala"
+  )
+
+  checkFileRenamed(
+    "only-one-class-rename-file",
+    """|package a
+       |
+       |case class <<MyClass>>() {
+       |}
+       |
+       |""".stripMargin,
+    renameCodeActionTitle,
+    newFileName = "MyClass.scala"
+  )
+
+  checkExtractedMember(
+    "extract-class",
+    """|package a
+       |
+       |case class A()
+       |class <<B>>()
+       |""".stripMargin,
+    expectedActions = ExtractRenameMember.title("class", "B"),
+    """|package a
+       |
+       |case class A()
+       |""".stripMargin,
+    fileName = "A.scala",
+    newFile = (
+      "B.scala",
+      s"""|package a
+          |
+          |class B()
+          |""".stripMargin
+    )
+  )
+
+  checkExtractedMember(
+    "extract-class-without-non-in-scope-imports",
+    """|package a
+       |import scala.io.Source
+       |
+       |case class A() {
+       |  import scala.concurrent.Future
+       |}
+       |case class <<B>>() {
+       |  val s = Source.fromFile("A.scala")
+       |}
+       |""".stripMargin,
+    expectedActions = ExtractRenameMember.title("class", "B"),
+    """|package a
+       |import scala.io.Source
+       |
+       |case class A() {
+       |  import scala.concurrent.Future
+       |}
+       |""".stripMargin,
+    fileName = "A.scala",
+    newFile = (
+      "B.scala",
+      s"""|package a
+          |
+          |import scala.io.Source
+          |
+          |case class B() {
+          |  val s = Source.fromFile("A.scala")
+          |}
+          |""".stripMargin
+    )
+  )
+
+  checkExtractedMember(
+    "extract-class-inner-subpackage-with-imports",
+    """|package a
+       |
+       |import scala.io.Source
+       |
+       |case class A()
+       |
+       |package b {
+       |  import scala.io.Codec
+       |  case class B()
+       |  package c {
+       |    case class <<C>>()
+       |  }
+       |}
+       |""".stripMargin,
+    expectedActions = ExtractRenameMember.title("class", "C"),
+    s"""|package a
+        |
+        |import scala.io.Source
+        |
+        |case class A()
+        |
+        |package b {
+        |  import scala.io.Codec
+        |  case class B()
+        |${indent}
+        |}
+        |""".stripMargin,
+    fileName = "A.scala",
+    newFile = (
+      "C.scala",
+      s"""|package a.b.c
+          |
+          |import scala.io.Source
+          |import scala.io.Codec
+          |
+          |case class C()
+          |""".stripMargin
+    )
+  )
+
+  def checkExtractedMember(
+      name: TestOptions,
+      input: String,
+      expectedActions: String,
+      expectedCode: String,
+      newFile: (String, String),
+      selectedActionIndex: Int = 0,
+      fileName: String = "A.scala"
+  )(implicit loc: Location): Unit = {
+    check(
+      name,
+      input,
+      expectedActions,
+      expectedCode,
+      selectedActionIndex,
+      extraOperations = {
+        val (fileName, content) = newFile
+        val absolutePath = workspace.resolve(testedFilePath(fileName))
+        assert(
+          absolutePath.exists,
+          s"File $absolutePath should have been created"
+        )
+        assertNoDiff(absolutePath.readText, content)
+      },
+      fileName = fileName
+    )
+  }
+
+  def checkFileRenamed(
+      name: TestOptions,
+      input: String,
+      expectedActions: String,
+      newFileName: String,
+      selectedActionIndex: Int = 0
+  )(implicit loc: Location): Unit = {
+    val renamedPath = testedFilePath(newFileName)
+    check(
+      name,
+      input,
+      expectedActions,
+      expectedCode = "",
+      selectedActionIndex,
+      renamePath = Some(renamedPath),
+      extraOperations = {
+        val oldAbsolutePath = workspace.resolve("a/src/main/scala/a/A.scala")
+        assert(
+          !oldAbsolutePath.exists,
+          s"File $oldAbsolutePath should have been renamed"
+        )
+      }
+    )
+
+  }
+
+  def checkActionProduced(
+      name: TestOptions,
+      original: String,
+      codeActionExpected: Boolean = true,
+      scalaVersion: String = V.scala213,
+      fileName: String = "A.scala"
+  ): Unit =
+    test(name) {
+      val buffers = Buffers()
+      val buildTargets = new BuildTargets(_ => None)
+      val selector = new ScalaVersionSelector(
+        () => UserConfiguration(fallbackScalaVersion = Some(scalaVersion)),
+        buildTargets
+      )
+      val trees = new Trees(buildTargets, buffers, selector)
+      val filename = fileName
+      val path = AbsolutePath(Paths.get(filename))
+      val startOffset = original.indexOf("<<")
+      val endOffset = original.indexOf(">>")
+      val sourceText =
+        original
+          .replace("<<", "")
+          .replace(">>", "")
+      val input = Input.VirtualFile(filename, sourceText)
+      val pos = scala.meta.Position
+        .Range(input, startOffset, endOffset - "<<".length())
+        .toLSP
+      val extractRenameMember = new ExtractRenameMember(buffers, trees)
+      buffers.put(path, sourceText)
+      val textDocumentIdentifier = path.toTextDocumentIdentifier
+      val codeActionParams = new CodeActionParams(
+        textDocumentIdentifier,
+        pos,
+        new CodeActionContext()
+      )
+      val cancelToken = EmptyCancelToken
+
+      val codeActionFut =
+        extractRenameMember.contribute(codeActionParams, cancelToken)
+
+      for {
+        codeActions <- codeActionFut
+        _ = {
+          if (codeActionExpected) assert(codeActions.nonEmpty)
+          else assert(codeActions.isEmpty)
+        }
+      } yield ()
+    }
+
+  // Same structure of path as in function `check`
+  private def testedFilePath(name: String) = s"a/src/main/scala/a/$name"
+}

--- a/tests/unit/src/test/scala/tests/codeactions/ExtractRenameMemberLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ExtractRenameMemberLspSuite.scala
@@ -54,6 +54,23 @@ class ExtractRenameMemberLspSuite
   )
 
   checkActionProduced(
+    "with-sealed-trait-in-object-no-codeAction",
+    """|package a
+       |
+       |case class A()
+       |
+       |object MyObject {
+       | sealed trait MySealedTrait
+       |}
+       |
+       |trait MyTrait
+       |case class <<B>>() extends MyTrait with MyObject.MySealedTrait
+       |
+       |""".stripMargin,
+    codeActionExpected = false
+  )
+
+  checkActionProduced(
     "extends-sealed-class-no-codeAction",
     """|package a
        |


### PR DESCRIPTION
This pull request should close #2691 
The "Extract Class" code action will appear on classes if:
- There is more than one class definition in the file. Inner classes are not counted
- The class doesn't extends Traits/classes defined as `sealed`  
- The class itself isn't `sealed`

The new file will have the name of the Class, if doesn't exists already (otherwise the file creation will fail and every other TextEdit action should not happen)
In the new file there will be all the package definition and imports definition that appear before the class definition in the source file, in the same order.

Another code action is added, as suggested in the issue: "Rename file as class".
This code action appears when there is a single class definition in the file, that has a different name than the file itself, and doesn't extends a Trait with the same filename.