### PR TITLE
Remove munit sbt plugin to fix CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -715,7 +715,6 @@ lazy val docs = project
     publish / skip := true,
     moduleName := "metals-docs",
     mdoc := (Compile / run).evaluated,
-    munitRepository := Some("scalameta/metals"),
     libraryDependencies ++= List(
       "org.jsoup" % "jsoup" % "1.13.1"
     )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.27")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
-addSbtPlugin("org.scalameta" % "sbt-munit" % "0.7.23")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.19")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.1")


### PR DESCRIPTION
I previously removed a bunch of settings, but I forgot about the munit-sbt plugin, which now fails on CI.

Most recent failures: https://github.com/scalameta/metals/actions/runs/771330085