### PR TITLE
Add in the parentUri when offering the newSymbol code action.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateNewSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateNewSymbol.scala
@@ -17,6 +17,9 @@ class CreateNewSymbol() extends CodeAction {
       token: CancelToken
   )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = {
 
+    lazy val parentUri =
+      params.getTextDocument.getUri.toAbsolutePath.parent.toURI
+
     def createNewSymbol(
         diagnostic: l.Diagnostic,
         name: String
@@ -25,7 +28,9 @@ class CreateNewSymbol() extends CodeAction {
       codeAction.setTitle(CreateNewSymbol.title(name))
       codeAction.setKind(l.CodeActionKind.QuickFix)
       codeAction.setDiagnostics(List(diagnostic).asJava)
-      codeAction.setCommand(ServerCommands.NewScalaFile.toLSP(List(null, name)))
+      codeAction.setCommand(
+        ServerCommands.NewScalaFile.toLSP(List(parentUri, name))
+      )
       codeAction
     }
 


### PR DESCRIPTION
Most clients don't have an issue with this, but I just hit on a case
where the server providing `null` here is causing issues when the client
then tries to encode the value to send back and it chokes on it. In this
specific case, we do this step later if it's passed in as null, but
since we already have what we need to fill in the parentUri where the
new file will be created, we just do that right away instead of passing
in `null`.