### PR TITLE
Add extra check before auto-connecting to server.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -346,7 +346,8 @@ class MetalsLanguageServer(
         buildTools = new BuildTools(
           workspace,
           bspGlobalDirectories,
-          () => userConfig
+          () => userConfig,
+          tables.buildServers.selectedServer().nonEmpty
         )
         fileSystemSemanticdbs = new FileSystemSemanticdbs(
           buildTargets,


### PR DESCRIPTION
This fixes #2341, which causes a user to get an error message from Bloop
if the user attempts to use Metals for the first time on an sbt
workspace that already contains a `.bsp/sbt.json` file. The issue is
that Metals would think that since there is a `.bsp/<entry>` already
there, it's auto-connectable. So even though it realizes it should use
Bloop, instead of waiting for the users choice via the prompt, it will
try auto-connecting to Bloop right away causing the error outlined in
the issue.

We know add another check to ensure that if there is a `.bsp/sbt.json`
file in the workspace the first time Metals is opened that we don't
attempt to auto-connect _unless_ there was a specific decision made
(which will be never if it truly is the first time a user is opening
this workspace). Then after that initial open there will either be a
`.bloop/` present making it auto-connectable or a user will use the
`bsp-swich` command,  which saves the choice, and also makes it
auto-connectable which ensure the behavior stays the same for
everything else.