### PR TITLE
Fix wrong import when working with akka

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -720,11 +720,13 @@ trait Completions { this: MetalsGlobal =>
       imp.tree.selectors.foreach { sel =>
         if (sel.rename != null) {
           val member = pre.member(sel.name)
-          result(member) = sel.rename
+          if (member != NoSymbol)
+            result(member) = sel.rename
           member.companion match {
             case NoSymbol =>
             case companion =>
-              result(companion) = sel.rename
+              if (companion != NoSymbol)
+                result(companion) = sel.rename
           }
         }
       }

--- a/tests/cross/src/main/scala/tests/BaseAutoImportsSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseAutoImportsSuite.scala
@@ -1,0 +1,87 @@
+package tests
+
+import java.nio.file.Paths
+
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.CompilerOffsetParams
+import scala.meta.internal.metals.TextEdits
+import scala.meta.pc.AutoImportsResult
+
+import munit.Location
+import munit.TestOptions
+
+trait BaseAutoImportsSuite extends BaseCodeActionSuite {
+
+  def check(
+      name: String,
+      original: String,
+      expected: String,
+      compat: Map[String, String] = Map.empty
+  )(implicit loc: Location): Unit =
+    test(name) {
+      val imports = getAutoImports(original, "A.scala")
+      val obtained = imports.map(_.packageName()).mkString("\n")
+      assertNoDiff(
+        obtained,
+        getExpected(expected, compat, scalaVersion)
+      )
+    }
+
+  def checkEdit(
+      name: TestOptions,
+      original: String,
+      expected: String,
+      selection: Int = 0
+  )(implicit
+      loc: Location
+  ): Unit =
+    checkEditSelection(name, "A.scala", original, expected, selection)
+
+  def checkAmmoniteEdit(
+      name: TestOptions,
+      original: String,
+      expected: String,
+      selection: Int = 0
+  )(implicit
+      loc: Location
+  ): Unit =
+    checkEditSelection(name, "script.sc.scala", original, expected, selection)
+
+  def checkEditSelection(
+      name: TestOptions,
+      filename: String,
+      original: String,
+      expected: String,
+      selection: Int
+  )(implicit
+      loc: Location
+  ): Unit =
+    test(name) {
+      val imports = getAutoImports(original, filename)
+      if (imports.size <= selection) fail("obtained no expected imports")
+      val edits = imports(selection).edits().asScala.toList
+      val (code, _, _) = params(original)
+      val obtained = TextEdits.applyEdits(code, edits)
+      assertNoDiff(obtained, expected)
+    }
+
+  def getAutoImports(
+      original: String,
+      filename: String
+  ): List[AutoImportsResult] = {
+    val (code, symbol, offset) = params(original)
+    val result = presentationCompiler
+      .autoImports(
+        symbol,
+        CompilerOffsetParams(
+          Paths.get(filename).toUri(),
+          code,
+          offset,
+          cancelToken
+        )
+      )
+      .get()
+    result.asScala.toList
+  }
+
+}

--- a/tests/cross/src/test/scala/tests/pc/AutoImportsIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsIssueSuite.scala
@@ -1,0 +1,43 @@
+package tests.pc
+
+import coursierapi.Dependency
+import tests.BaseAutoImportsSuite
+import tests.BuildInfoVersions
+
+class AutoImportsIssueSuite extends BaseAutoImportsSuite {
+
+  override def excludedScalaVersions: Set[String] =
+    BuildInfoVersions.scala3Versions.toSet
+
+  override def extraDependencies(scalaVersion: String): Seq[Dependency] = {
+    val binaryVersion = createBinaryVersion(scalaVersion)
+    if (isScala3Version(scalaVersion)) { Seq.empty }
+    else {
+      Seq(
+        Dependency.of(
+          "com.typesafe.akka",
+          s"akka-actor-typed_$binaryVersion",
+          "2.6.13"
+        )
+      )
+    }
+  }
+
+  checkEdit(
+    "akka-import-2736",
+    """|import akka.io.Dns.Command
+       |
+       |object Greeter {
+       |  <<Address>>("http", "Test", "TestNodeHostName", 1234)
+       |}
+       |""".stripMargin,
+    """|import akka.io.Dns.Command
+       |import akka.actor.Address
+       |
+       |object Greeter {
+       |  Address("http", "Test", "TestNodeHostName", 1234)
+       |}
+       |""".stripMargin
+  )
+
+}

--- a/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
@@ -1,18 +1,9 @@
 package tests.pc
 
-import java.nio.file.Paths
-
-import scala.meta.internal.jdk.CollectionConverters._
-import scala.meta.internal.metals.CompilerOffsetParams
-import scala.meta.internal.metals.TextEdits
-import scala.meta.pc.AutoImportsResult
-
-import munit.Location
-import munit.TestOptions
-import tests.BaseCodeActionSuite
+import tests.BaseAutoImportsSuite
 import tests.BuildInfoVersions
 
-class AutoImportsSuite extends BaseCodeActionSuite {
+class AutoImportsSuite extends BaseAutoImportsSuite {
 
   override def excludedScalaVersions: Set[String] =
     BuildInfoVersions.scala3Versions.toSet
@@ -259,77 +250,5 @@ class AutoImportsSuite extends BaseCodeActionSuite {
         |$code
         |}
         |""".stripMargin
-
-  def check(
-      name: String,
-      original: String,
-      expected: String,
-      compat: Map[String, String] = Map.empty
-  )(implicit loc: Location): Unit =
-    test(name) {
-      val imports = getAutoImports(original, "A.scala")
-      val obtained = imports.map(_.packageName()).mkString("\n")
-      assertNoDiff(
-        obtained,
-        getExpected(expected, compat, scalaVersion)
-      )
-    }
-
-  def checkEdit(
-      name: TestOptions,
-      original: String,
-      expected: String,
-      selection: Int = 0
-  )(implicit
-      loc: Location
-  ): Unit =
-    checkEditSelection(name, "A.scala", original, expected, selection)
-
-  def checkAmmoniteEdit(
-      name: TestOptions,
-      original: String,
-      expected: String,
-      selection: Int = 0
-  )(implicit
-      loc: Location
-  ): Unit =
-    checkEditSelection(name, "script.sc.scala", original, expected, selection)
-
-  def checkEditSelection(
-      name: TestOptions,
-      filename: String,
-      original: String,
-      expected: String,
-      selection: Int
-  )(implicit
-      loc: Location
-  ): Unit =
-    test(name) {
-      val imports = getAutoImports(original, filename)
-      if (imports.size <= selection) fail("obtained no expected imports")
-      val edits = imports(selection).edits().asScala.toList
-      val (code, _, _) = params(original)
-      val obtained = TextEdits.applyEdits(code, edits)
-      assertNoDiff(obtained, expected)
-    }
-
-  def getAutoImports(
-      original: String,
-      filename: String
-  ): List[AutoImportsResult] = {
-    val (code, symbol, offset) = params(original)
-    val result = presentationCompiler
-      .autoImports(
-        symbol,
-        CompilerOffsetParams(
-          Paths.get(filename).toUri(),
-          code,
-          offset,
-          cancelToken
-        )
-      )
-      .get()
-    result.asScala.toList
-  }
 
 }


### PR DESCRIPTION
Previously, we would not check if the file renames were all working with an actual symbol. This was not a problem previously, but recently we added a check that would always try to use renamed imports, which would break in case of a NoSymbol. Now, we jsut check it before adding to the renames map.

Fixes https://github.com/scalameta/metals/issues/2736