### PR TITLE
Completions: filter out non-existing symbols from SymbolSearch

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/WorkspaceSymbolSearch.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/WorkspaceSymbolSearch.scala
@@ -19,7 +19,6 @@ trait WorkspaceSymbolSearch { this: MetalsGlobal =>
       var added = 0
       for {
         sym <- loadSymbolFromClassfile(top)
-        if context.lookupSymbol(sym.name, _ => true).symbol != sym
       } {
         if (visitMember(sym)) {
           added += 1
@@ -53,7 +52,7 @@ trait WorkspaceSymbolSearch { this: MetalsGlobal =>
     def isAccessible(sym: Symbol): Boolean = {
       sym != NoSymbol && {
         sym.info // needed to fill complete symbol
-        sym.isPublic
+        sym.exists && sym.isPublic
       }
     }
     try {

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -131,7 +131,7 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
       "2.13" ->
         """|ArrayDeque[$0]
            |ArrayDeque
-           |ArrayDequeOps
+           |ArrayDequeOps[$0]
            |""".stripMargin
     )
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -269,7 +269,6 @@ class CompletionSuite extends BaseCompletionSuite {
        |ProcessBuilder - scala.sys.process
        |CertPathBuilder - java.security.cert
        |CertPathBuilderSpi - java.security.cert
-       |ProcessBuilderImpl - scala.sys.process
        |CertPathBuilderResult - java.security.cert
        |PKIXBuilderParameters - java.security.cert
        |PooledConnectionBuilder - javax.sql
@@ -288,14 +287,10 @@ class CompletionSuite extends BaseCompletionSuite {
     """|TrieMap scala.collection.concurrent
        |ParTrieMap - scala.collection.parallel.mutable
        |HashTrieMap - scala.collection.immutable.HashMap
-       |ParTrieMapCombiner - scala.collection.parallel.mutable
-       |ParTrieMapSplitter - scala.collection.parallel.mutable
-       |TrieMapSerializationEnd - scala.collection.concurrent
        |""".stripMargin,
     compat = Map(
       "2.13" ->
         """|TrieMap scala.collection.concurrent
-           |TrieMapSerializationEnd - scala.collection.concurrent
            |""".stripMargin,
       "3.0" -> "TrieMap scala.collection.concurrent"
     )

--- a/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
@@ -136,15 +136,11 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
         getExpected(
           """|HashTrieMap - scala.collection.immutable.HashMap
              |ParTrieMap - scala.collection.parallel.mutable
-             |ParTrieMapCombiner - scala.collection.parallel.mutable
-             |ParTrieMapSplitter - scala.collection.parallel.mutable
              |TrieMap - scala.collection.concurrent
-             |TrieMapSerializationEnd - scala.collection.concurrent
              |""".stripMargin,
           Map(
             "2.13" ->
               """|TrieMap - scala.collection.concurrent
-                 |TrieMapSerializationEnd - scala.collection.concurrent
                  |""".stripMargin
           ),
           scalaVersion


### PR DESCRIPTION
SymbolSearch tries symbols as term and as type but doesn't check the actual existence of the symbol.
That leads that completions might return some symbols that aren't public