### PR TITLE
Update link to Mill's new website

### DIFF
--- a/docs/build-tools/mill.md
+++ b/docs/build-tools/mill.md
@@ -5,7 +5,7 @@ title: Mill
 
 Mill is a build tool developed by Li Haoyi in order to create something simpler
 and more intuitive than most of the other build tools today.  There is extensive
-documentation on the [Mill website](http://www.lihaoyi.com/mill/).
+documentation on the [Mill website](https://com-lihaoyi.github.io/mill/).
 
 ```scala mdoc:automatic-installation:Mill
 ```


### PR DESCRIPTION
This links to that new site for Mill which has moved to a new Github organization and as announced in the blog post [here](https://www.lihaoyi.com/post/IntroducingthecomlihaoyiGithubOrganization.html).