### PR TITLE
Remove most soft keywords from being backticked.

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/KeywordWrapper.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/KeywordWrapper.scala
@@ -69,8 +69,7 @@ object KeywordWrapper {
     "import", "lazy", "match", "new", "null", "object", "override", "package",
     "private", "protected", "return", "sealed", "super", "then", "throw",
     "trait", "true", "try", "type", "val", "var", "while", "with", "yield", ":",
-    "=", "<-", "=>", "<:", ":>", "#", "@", "=>>", "?=>", "as", "derives", "end",
-    "extension", "infix", "inline", "opaque", "open", "transparent", "using",
+    "=", "<-", "=>", "<:", ":>", "#", "@", "=>>", "?=>", "extension", "inline",
     "|", "*", "+", "-"
   )
 


### PR DESCRIPTION
Most of the soft keyword do not need to be backticked. Follow issue for the more problematic ones  https://github.com/scalameta/metals/issues/2795