### PR TITLE
Fix field ordering in completions

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionProvider.scala
@@ -148,13 +148,21 @@ class CompletionProvider(
     import MemberOrdering._
     var relevance = 0
     val sym = completion.value.sym
+
+    def hasGetter = try {
+      // isField returns true for some classes
+      sym.isField || sym.getter != NoSymbol
+    } catch {
+      case _ => false
+    }
+
     // local symbols are more relevant
     if (!sym.isLocalToBlock) relevance |= IsNotLocalByBlock
     // symbols defined in this file are more relevant
     if (pos.source != sym.source || sym.is(Package))
       relevance |= IsNotDefinedInFile
     // fields are more relevant than non fields
-    if (sym.isField) relevance |= IsNotGetter
+    if (!hasGetter) relevance |= IsNotGetter
     // symbols whose owner is a base class are less relevant
     if (sym.owner == defn.AnyClass || sym.owner == defn.ObjectClass)
       relevance |= IsInheritedBaseMethod

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -29,16 +29,8 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|message = : => Any
        |Main arg1
-       |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3),
-    compat = Map(
-      "3.0" ->
-        """|message = : => Any
-           |Main arg1
-           |ArrayCharSequence(arrayOfChars: Array[Char]): ArrayCharSequence
-           |""".stripMargin
-    )
+    topLines = Option(2)
   )
 
   check(
@@ -49,16 +41,8 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|message = : => Any
        |Main arg2
-       |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3),
-    compat = Map(
-      "3.0" ->
-        """|message = : => Any
-           |Main arg2
-           |ArrayCharSequence(arrayOfChars: Array[Char]): ArrayCharSequence
-           |""".stripMargin
-    )
+    topLines = Option(2)
   )
 
   def user: String =
@@ -170,16 +154,8 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|suffix = : String
        |Main arg8
-       |:: scala.collection.immutable
        |""".stripMargin,
-    topLines = Option(3),
-    compat = Map(
-      "3.0" ->
-        """|suffix = : String
-           |Main arg8
-           |ArrayCharSequence(arrayOfChars: Array[Char]): ArrayCharSequence
-           |""".stripMargin
-    )
+    topLines = Option(2)
   )
 
   // In scala3, we get NoSymbol for `until`, so we get no completions here.

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -527,8 +527,9 @@ class CompletionSuite extends BaseCompletionSuite {
     // Scala 2.13.5 adds additional completions that actually fit, but are not useful for this test
     topLines = Some(25),
     compat = Map(
-      "3.0" ->
-        """|Function0 scala
+      "3" ->
+        """|Function scala
+           |Function0 scala
            |Function1 scala
            |Function1 scala
            |Function2 scala
@@ -552,7 +553,6 @@ class CompletionSuite extends BaseCompletionSuite {
            |Function20 scala
            |Function21 scala
            |Function22 scala
-           |Function scala
            |""".stripMargin
     )
   )
@@ -904,8 +904,8 @@ class CompletionSuite extends BaseCompletionSuite {
     topLines = Some(2),
     compat = Map(
       "3.0" ->
-        """|NoManifest: reflect.NoManifest.type
-           |NoClassDefFoundError java.lang
+        """|NoClassDefFoundError java.lang
+           |NoManifest: reflect.NoManifest.type
            |""".stripMargin
     )
   )
@@ -929,9 +929,9 @@ class CompletionSuite extends BaseCompletionSuite {
            |Set scala.collection.immutable
            |""".stripMargin,
       "3.0" ->
-        """|Seq: collection.immutable.Seq.type
-           |SeqCharSequence(sequenceOfChars: scala.collection.IndexedSeq[Char]): SeqCharSequence
-           |Set: scala.collection.immutable.Set.type
+        """|SafeVarargs java.lang
+           |SecurityException java.lang
+           |SecurityManager java.lang
            |""".stripMargin
     )
   )
@@ -954,10 +954,15 @@ class CompletionSuite extends BaseCompletionSuite {
            |Seq scala.collection.immutable
            |Set scala.collection.immutable
            |""".stripMargin,
-      "3.0" ->
+      "3.0.0-RC1" ->
         """|SafeVarargs java.lang
            |SafeVarargs java.lang
            |ScalaReflectionException scala
+           |""".stripMargin,
+      "3.0" ->
+        """|String java.lang
+           |StringIndexOutOfBoundsException java.lang
+           |SafeVarargs java.lang
            |""".stripMargin
     )
   )
@@ -985,12 +990,12 @@ class CompletionSuite extends BaseCompletionSuite {
       "3.0.0-RC1" ->
         """|NotString: Int
            |Number: scala.util.matching.Regex
-           |Nil: collection.immutable.Nil.type
+           |NegativeArraySizeException java.lang
            |""".stripMargin,
       "3.0" ->
         """|NotString: Int
+           |NegativeArraySizeException java.lang
            |Nil: collection.immutable.Nil.type
-           |NoManifest: reflect.NoManifest.type
            |""".stripMargin
     )
   )
@@ -1010,9 +1015,9 @@ class CompletionSuite extends BaseCompletionSuite {
     topLines = Option(3),
     compat = Map(
       "3.0" ->
-        """|NegativeArraySizeException java.lang
-           |NegativeArraySizeException java.lang
-           |Nil: collection.immutable.Nil.type
+        """|Nil: collection.immutable.Nil.type
+           |NoManifest: reflect.NoManifest.type
+           |None scala
            |""".stripMargin
     )
   )
@@ -1032,9 +1037,9 @@ class CompletionSuite extends BaseCompletionSuite {
     topLines = Option(3),
     compat = Map(
       "3.0" ->
-        """|NegativeArraySizeException java.lang
-           |NegativeArraySizeException java.lang
-           |Nil: collection.immutable.Nil.type
+        """|Nil: collection.immutable.Nil.type
+           |NoManifest: reflect.NoManifest.type
+           |None scala
            |""".stripMargin
     )
   )
@@ -1134,6 +1139,24 @@ class CompletionSuite extends BaseCompletionSuite {
         """|intNumber: Int
            |""".stripMargin
     )
+  )
+
+  check(
+    "fields-first",
+    s"""|class Foo {
+        |  def yeti1: Int = 0
+        |  def yeti2: Int = 42
+        |  val yeti3 = ""
+        |}
+        |object Main {
+        |  new Foo().ye@@
+        |}
+        |""".stripMargin,
+    """|yeti3: String
+       |yeti1: Int
+       |yeti2: Int
+       |""".stripMargin,
+    topLines = Some(3)
   )
 
   check(


### PR DESCRIPTION
Previously, methods would be shown before field. Now, class fields are first.