### PR TITLE
[Scala3] Completions - fix `Renamed` and `specifyOwner` Autoimports application

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionPos.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionPos.scala
@@ -7,6 +7,7 @@ import scala.meta.internal.tokenizers.Chars
 
 import org.eclipse.{lsp4j => l}
 import dotty.tools.dotc.util.SourcePosition
+import dotty.tools.dotc.util.Spans
 
 enum CompletionKind {
   case Empty, Scope, Members
@@ -19,6 +20,8 @@ case class CompletionPos(
     query: String,
     cursorPos: SourcePosition
 ) {
+
+  def sourcePos: SourcePosition = cursorPos.withSpan(Spans.Span(start, end))
 
   def toEditRange: l.Range = {
     def toPos(offset: Int): l.Position =

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -610,4 +610,47 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |""".stripMargin,
     filter = _ == "Implicits - scala.concurrent.ExecutionContext"
   )
+
+  checkEdit(
+    "specify-owner",
+    """|object Main {
+       |  Map@@
+       |}
+       |""".stripMargin,
+    """|import scala.collection.mutable
+       |object Main {
+       |  mutable.Map
+       |}
+       |""".stripMargin,
+    filter = _ == "Map - scala.collection.mutable"
+  )
+
+  checkEdit(
+    "ju-import",
+    """|object Main {
+       |  Map@@
+       |}
+       |""".stripMargin,
+    """|import java.{util => ju}
+       |object Main {
+       |  ju.Map
+       |}
+       |""".stripMargin,
+    filter = _ == "Map - java.util"
+  )
+
+  checkEdit(
+    "ju-import-dup",
+    """|import java.{util => ju}
+       |object Main {
+       |  Map@@
+       |}
+       |""".stripMargin,
+    """|import java.{util => ju}
+       |object Main {
+       |  ju.Map
+       |}
+       |""".stripMargin,
+    filter = _ == "Map - java.util"
+  )
 }


### PR DESCRIPTION
Fixes the following cases related to  `renameConfig` 
- incorrect owner edit in completion
  ```scala
  object Main {
    StringBuilder@@ // StringBuilder - scala.collection.mutable
  }
  // --apply--
  object Main {
  mutable.StringStringBuilder
  }
  ```
- owner/renamed owner import duplication
  ```scala
  import scala.collection.mutable
  object Main {
     StringBuilder@@ // StringBuilder - scala.collection.mutable
  }
  // --apply--
  import scala.collection.mutable
  import scala.collection.mutable
  object Main {
     mutable.StringBuilder
  } 
  ```
 
~~Unfortunately, tests on these cases are ignored because it's needed to fix our `TextEdit.applyEdits` implementation. 
I've tried to fix it but it seems like a non-trivial task. I'm going to look at it but want to merge this PR to not include these bugs in the release.~~