### PR TITLE
Group Scala versions in docs to make it easier to see which are supported

### DIFF
--- a/metals-docs/src/main/scala/docs/RequirementsModifier.scala
+++ b/metals-docs/src/main/scala/docs/RequirementsModifier.scala
@@ -2,6 +2,8 @@ package docs
 
 import scala.meta.inputs.Input
 import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.semver.SemVer
 
 import mdoc.Reporter
 import mdoc.StringModifier
@@ -9,9 +11,21 @@ import mdoc.StringModifier
 class RequirementsModifier extends StringModifier {
   override val name: String = "requirements"
 
-  def supportedScalaVersions: String =
-    BuildInfo.supportedScalaVersions.dropRight(1).mkString(", ") +
-      s" and ${BuildInfo.supportedScalaVersions.last}"
+  def supportedScalaVersions: String = {
+    val grouped = BuildInfo.supportedScalaVersions.groupBy { version =>
+      if (ScalaVersions.isScala3Version(version)) "3"
+      else ScalaVersions.scalaBinaryVersionFromFullVersion(version)
+    }
+
+    grouped
+      .map { case (binary, versions) =>
+        val versionString =
+          versions.sortWith(SemVer.isLaterVersion).reverse.mkString(", ")
+        s"""| - **Scala $binary**:
+            |   $versionString""".stripMargin
+      }
+      .mkString("\n\n")
+  }
 
   override def process(
       info: String,
@@ -28,7 +42,10 @@ class RequirementsModifier extends StringModifier {
        |**macOS, Linux or Windows**. Metals is developed on macOS and every PR is
        |tested on Ubuntu+Windows.
        |
-       |**Scala 2.13, 2.12, 2.11 and Scala 3**. Metals supports these Scala versions $supportedScalaVersions.
+       |**Scala 2.13, 2.12, 2.11 and Scala 3**. Metals supports these Scala versions:
+       |
+       |$supportedScalaVersions
+       |
        |Note that 2.11.x support is deprecated and it will be removed in future releases.
        |It's recommended to upgrade to Scala 2.12 or Scala 2.13
        |""".stripMargin

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -429,8 +429,7 @@ class CompletionSuite extends BaseCompletionSuite {
     "",
     compat = Map(
       "3.0" -> "Inner a.Outer",
-      /* TODO
-       * Seems that changes in 2.13.5 made this pop up and this
+      /* TODO Seems that changes in 2.13.5 made this pop up and this
        * might have been a bug in presentation compiler that we were using
        * https://github.com/scalameta/metals/issues/2546
        */


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3807253/118639283-059e2000-b7d8-11eb-8698-1f4fffd1dec1.png)
