### PR TITLE
Publish scalameta parser diagnostics for Scala 3

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -268,10 +268,7 @@ class MetalsLanguageServer(
   def parseTreesAndPublishDiags(paths: Seq[AbsolutePath]): Future[Seq[Unit]] = {
     Future.traverse(paths.distinct) { path =>
       if (path.isScalaFilename) {
-        // diagnostics from the compiler are still needed for Scala 3
-        compilers.didChange(path).map { diags =>
-          diagnostics.onSyntaxError(path, diags ++ trees.didChange(path))
-        }
+        Future(diagnostics.onSyntaxError(path, trees.didChange(path)))
       } else {
         Future.successful(())
       }

--- a/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
@@ -75,17 +75,14 @@ final class Trees(
   }
 
   /**
-   * Parse file at the given path and return a list of errors if there are any and
-   * the file belongs to a Scala 2 target.
-   *
+   * Parse file at the given path and return a list of errors if there are any.
    * @param path file to parse
    * @return list of errors if the file failed to parse
    */
   def didChange(path: AbsolutePath): List[Diagnostic] = {
     val dialect = getDialect(path)
     parse(path, dialect) match {
-      // only publish parser diagnostics for Scala 2, which does not support significant indentation
-      case Some(parsed) if !dialect.allowSignificantIndentation =>
+      case Some(parsed) =>
         parsed match {
           case Parsed.Error(pos, message, _) =>
             List(
@@ -100,9 +97,7 @@ final class Trees(
             trees(path) = tree
             List()
         }
-      // don't publish diagnostics
-      case _ =>
-        List()
+      case _ => List()
     }
   }
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -395,16 +395,8 @@ case class ScalaPresentationCompiler(
 
   override def didChange(
       params: VirtualFileParams
-  ): CompletableFuture[ju.List[Diagnostic]] = {
-    compilerAccess.withNonInterruptableCompiler(
-      Nil.asJava,
-      params.token
-    ) { access =>
-      val driver = access.compiler()
-      val uri = params.uri
-      CompilerInterfaces.parseErrors(driver, uri, params.text)
-    }
-  }
+  ): CompletableFuture[ju.List[Diagnostic]] =
+    CompletableFuture.completedFuture(Nil.asJava)
 
   override def didClose(uri: URI): Unit = {
     compilerAccess.withNonInterruptableCompiler(

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -442,9 +442,9 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
              |""".stripMargin,
           Map(
             V.scala3 ->
-              """|a/src/main/scala/a/Main.worksheet.sc:1:8: error: expression expected but val found
-                 |def y = 
-                 |       ^
+              """|a/src/main/scala/a/Main.worksheet.sc:2:1: error: illegal start of simple expression
+                 |val x: Int = ""
+                 |^^^
                  |a/src/main/scala/a/Main.worksheet.sc:2:14: error:
                  |Found:    ("" : String)
                  |Required: Int


### PR DESCRIPTION
Previously, when the build was not imported and the fallback version set to Scala 3.0.0, we would get parsing errors in sbt files. Now, we added an explicit check to avoid it.

Fixes https://github.com/scalameta/metals/issues/2549