### PR TITLE
Fix error for remote debugging when missing build target

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -487,6 +487,13 @@ object Messages {
       show = true
     )
 
+  def DebugInvalidBuildTargetConf(): MessageParams = {
+    new MessageParams(
+      MessageType.Error,
+      s"Debugger configuration is missing 'buildTarget' param."
+    )
+  }
+
   object DebugClassNotFound {
 
     def invalidTargetClass(cls: String, target: String): MessageParams = {

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -487,13 +487,6 @@ object Messages {
       show = true
     )
 
-  def DebugInvalidBuildTargetConf(): MessageParams = {
-    new MessageParams(
-      MessageType.Error,
-      s"Debugger configuration is missing 'buildTarget' param."
-    )
-  }
-
   object DebugClassNotFound {
 
     def invalidTargetClass(cls: String, target: String): MessageParams = {

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
@@ -143,6 +143,9 @@ class BuildTargetClassesFinder(
 case class BuildTargetNotFoundException(buildTargetName: String)
     extends Exception(s"Build target not found: $buildTargetName")
 
+case class BuildTargetUndefinedException()
+    extends Exception("Debugger configuration is missing 'buildTarget' param.")
+
 case class ClassNotFoundInBuildTargetException(
     className: String,
     buildTarget: b.BuildTarget

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -404,7 +404,7 @@ class DebugProvider(
           )
         )
       case None =>
-        Future.failed(new ju.NoSuchElementException(params.buildTarget))
+        Future.failed(BuildTargetUndefinedException())
     }
     result.failed.foreach(reportErrors)
     result
@@ -443,9 +443,9 @@ class DebugProvider(
       languageClient.showMessage(
         Messages.errorMessageParams(e.getMessage())
       )
-    case _: ju.NoSuchElementException =>
+    case e: BuildTargetUndefinedException =>
       languageClient.showMessage(
-        Messages.DebugInvalidBuildTargetConf()
+        Messages.errorMessageParams(e.getMessage())
       )
     case e: NoTestsFoundException =>
       languageClient.showMessage(


### PR DESCRIPTION
This PR should close #2766  .
It was added a simple message when trying to attach a debugging session without a buildTarget.
Previously it just threw a `NoSuchElementException` error visible in the metals.log, without any other information.

The draft of the new error message is 
> "Debugger configuration is missing 'buildTarget' param." 