### PR TITLE
Fix issues when importing in an empty package

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
@@ -217,6 +217,8 @@ object AutoImports {
           pkg.stats.takeWhile(_.isInstanceOf[Import]).lastOption
         val (lineNumber, padTop) = lastImportStatement match {
           case Some(stm) => (stm.endPos.line + 1, false)
+          case None if pkg.pid.symbol.isEmptyPackage =>
+            (0, false)
           case None =>
             val pos = pkg.pid.endPos
             val line =

--- a/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
@@ -41,6 +41,27 @@ class AutoImportsSuite extends BaseAutoImportsSuite {
   )
 
   checkEdit(
+    "basic-edit-comment",
+    """|/**
+       | * @param code
+       | * @return
+       |*/
+       |object A {
+       |  <<Future>>.successful(2)
+       |}
+       |""".stripMargin,
+    """|import scala.concurrent.Future
+       |/**
+       | * @param code
+       | * @return
+       |*/
+       |object A {
+       |  Future.successful(2)
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
     "symbol-no-prefix",
     """|package a
        |


### PR DESCRIPTION
Previously, the new import might end up in the middle of the comment. Now, if no package or import is defined, we put it into the first line.