### PR TITLE
Update pprint to newest version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -351,15 +351,7 @@ val mtagsSettings = List(
     // NOTE(olafur) pprint is indispensable for me while developing, I can't
     // use println anymore for debugging because pprint.log is 100 times better.
     else
-      crossSetting(
-        scalaVersion.value,
-        if211 = List("com.lihaoyi" %% "pprint" % "0.6.5"),
-        ifLaterThan211 = List("com.lihaoyi" %% "pprint" % "0.6.2"),
-        if3 = List(
-          ("com.lihaoyi" %% "pprint" % "0.6.2")
-            .cross(CrossVersion.for3Use2_13)
-        )
-      )
+      List("com.lihaoyi" %% "pprint" % "0.6.6")
   },
   buildInfoPackage := "scala.meta.internal.mtags",
   buildInfoKeys := Seq[BuildInfoKey](


### PR DESCRIPTION
Newest pprint version now support 2.11, 2.12, 2.13 and 3.0.0. This also means that it will not work on the RC versions, but since we plan to remove those in the near future and CI tests do not add pprint, I think we are safe to simplify adding it.