### PR TITLE
Don't warn about sourceroot for Scala 3

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/troubleshoot/ProblemResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/troubleshoot/ProblemResolver.scala
@@ -162,7 +162,9 @@ class ProblemResolver(
             isUnsupportedBloopVersion()
           )
         )
-      case _ if !scalaTarget.isSourcerootDeclared =>
+      case _
+          if !scalaTarget.isSourcerootDeclared && !ScalaVersions
+            .isScala3Version(scalaTarget.scalaVersion) =>
         Some(MissingSourceRoot(workspace.sourcerootOption))
       case version
           if ScalaVersions.isDeprecatedScalaVersion(


### PR DESCRIPTION
This has been causing some confusion, and we shouldn't warn about this. From what I can tell looking at the semanticdb related stuff in Scala3, this pretty much always seems to just be generated from the target and then made relative. From playing around, while this warning appears, it's often a red herring since everything is fine, but people assume something may be wrong or incorrectly blame the sourcepath not being set.

It doesn't mention anything about it [here in the docs](https://docs.scala-lang.org/scala3/guides/migration/tutorial-prerequisites.html#semanticdb) and the few places I see where it's used, it's often put together:

https://github.com/lampepfl/dotty/blob/b7d2a122555a6aa44cc7590852a80f12512c535e/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala#L613

 https://github.com/lampepfl/dotty/blob/af0de81a9d005ddbab172421b15f39432a45ff86/compiler/test/dotty/tools/dotc/semanticdb/SemanticdbTests.scala#L66

I don't think we need to warn about this even though it is a valid setting. An alternative would be to just set it here: https://github.com/scalameta/metals/blob/195e88162d040462a7e51c603ce59881f940b9fa/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala#L69-L89, but since we aren't setting the targetroot, and going with the default, I think we should do the same for the sourceroot.

Relates to #2776 
Closes #2285 