### PR TITLE
Print better types on hover

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Signatures.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Signatures.scala
@@ -26,7 +26,17 @@ class ShortenedNames(context: Context) {
         val foundTpe = lookupSymbol(short)
         val syms = List(foundTpe.termSymbol, foundTpe.typeSymbol)
         val isOk = syms.filter(_ != NoSymbol) match {
-          case Nil => false
+          case Nil =>
+            if (
+              short.symbol.isStatic || // Java static
+              short.symbol.owner.ownersIterator.forall { s =>
+                // ensure the symbol can be referenced in a static manner, without any instance
+                s.is(Package) || s.is(Module)
+              }
+            ) {
+              history(short.name) = short
+              true
+            } else false
           case founds => founds.exists(_ == short.symbol)
         }
         if (isOk) {

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -52,7 +52,7 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |   case <<Re@@d>>, Green, Blue
        |
        |""".stripMargin,
-    """|val Red: enums.SimpleEnum.Color.Red
+    """|case Red: enums.SimpleEnum.Color.Red
        |""".stripMargin.hover
   )
 
@@ -67,7 +67,7 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |
        |
        |""".stripMargin,
-    """|val Green: Color
+    """|case Green: Color
        |""".stripMargin.hover
   )
 

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -103,9 +103,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |def f[A >: Any](args: A*): String = macro
        |""".stripMargin.hover,
     compat = Map(
-      "3.0" -> "def f[A >: Any](args: A*): String".hover,
-      "0." -> ("def f: String".stripMargin.hover +
-        "\nImplementation of scala.StringContext.f used in Dotty")
+      "3.0" -> "def f[A >: Any](args: A*): String".hover
     )
   )
 
@@ -212,7 +210,7 @@ class HoverTermSuite extends BaseHoverSuite {
       |""".stripMargin,
     "",
     compat = Map(
-      "3.0" -> "class Foo: new-anon.Foo".hover
+      "3.0" -> "class Foo: Foo".hover
     )
   )
 
@@ -337,7 +335,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |```
        |""".stripMargin,
     compat = Map(
-      "3.0" -> "object FileVisitResult: FileVisitResult".hover
+      "3.0" -> "enum FileVisitResult: FileVisitResult".hover
     )
   )
 
@@ -360,7 +358,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin,
     automaticPackage = false,
     compat = Map(
-      "3.0" -> "object Foo: app.Outer.Foo".hover
+      "3.0" -> "object Foo: Foo".hover
     )
   )
 
@@ -372,10 +370,7 @@ class HoverTermSuite extends BaseHoverSuite {
     """|```scala
        |package java.nio
        |```
-       |""".stripMargin,
-    compat = Map(
-      "3.0" -> "object nio: java.nio".hover
-    )
+       |""".stripMargin
   )
 
   check(
@@ -386,10 +381,7 @@ class HoverTermSuite extends BaseHoverSuite {
     """|```scala
        |package java
        |```
-       |""".stripMargin,
-    compat = Map(
-      "3.0" -> "object java: java".hover
-    )
+       |""".stripMargin
   )
 
   check(
@@ -400,10 +392,7 @@ class HoverTermSuite extends BaseHoverSuite {
     """|```scala
        |package java.nio.file
        |```
-       |""".stripMargin,
-    compat = Map(
-      "3.0" -> "object file: java.nio.file".hover
-    )
+       |""".stripMargin
   )
 
   check(
@@ -467,8 +456,7 @@ class HoverTermSuite extends BaseHoverSuite {
       |""".stripMargin,
     """final val CONTINUE: FileVisitResult""".hover,
     compat = Map(
-      "3.0" -> "val CONTINUE: java.nio.file.FileVisitResult".hover,
-      "0." -> "val CONTINUE: (CONTINUE : java.nio.file.FileVisitResult)".hover
+      "3.0" -> "case CONTINUE: FileVisitResult".hover
     )
   )
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -585,7 +585,7 @@ class CompletionSuite extends BaseCompletionSuite {
     """|concat[T: ClassTag](xss: Array[T]*): Array[T]
        |""".stripMargin,
     compat = Map(
-      "3.0" -> "concat[T: scala.reflect.ClassTag](xss: Array[T]*): Array[T]"
+      "3.0" -> "concat[T: ClassTag](xss: Array[T]*): Array[T]"
     )
   )
 
@@ -615,11 +615,11 @@ class CompletionSuite extends BaseCompletionSuite {
        |""".stripMargin,
     compat = Map(
       "3.0.0-RC1" ->
-        """|readAttributes(x$0: java.nio.file.Path, x$1: String, x$2: java.nio.file.LinkOption*): java.util.Map[String, Object]
+        """|readAttributes(x$0: Path, x$1: String, x$2: LinkOption*): java.util.Map[String, Object]
            |""".stripMargin,
       "3.0" ->
-        """|readAttributes(x$0: java.nio.file.Path, x$1: String, x$2: java.nio.file.LinkOption*): java.util.Map[String, Object]
-           |readAttributes[A <: java.nio.file.attribute.BasicFileAttributes](x$0: java.nio.file.Path, x$1: Class[A], x$2: java.nio.file.LinkOption*): A
+        """|readAttributes(x$0: Path, x$1: String, x$2: LinkOption*): java.util.Map[String, Object]
+           |readAttributes[A <: BasicFileAttributes](x$0: Path, x$1: Class[A], x$2: LinkOption*): A
            |""".stripMargin
     )
   )
@@ -869,8 +869,8 @@ class CompletionSuite extends BaseCompletionSuite {
     compat = Map(
       "3.0" ->
         """|Some scala
-           |SomeToExpr[T: quoted.Type: quoted.ToExpr]: scala.quoted.ToExpr.SomeToExpr[T]
-           |SomeFromExpr[T](using quoted.Type[T], quoted.FromExpr[T]): scala.quoted.FromExpr.SomeFromExpr[T]
+           |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
+           |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
            |""".stripMargin
     )
   )
@@ -887,8 +887,8 @@ class CompletionSuite extends BaseCompletionSuite {
     compat = Map(
       "3.0" ->
         """|Some scala
-           |SomeToExpr[T: quoted.Type: quoted.ToExpr]: scala.quoted.ToExpr.SomeToExpr[T]
-           |SomeFromExpr[T](using quoted.Type[T], quoted.FromExpr[T]): scala.quoted.FromExpr.SomeFromExpr[T]
+           |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
+           |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
            |""".stripMargin
     )
   )
@@ -991,7 +991,7 @@ class CompletionSuite extends BaseCompletionSuite {
     compat = Map(
       "3.0.0-RC1" ->
         """|NotString: Int
-           |Number: scala.util.matching.Regex
+           |Number: Regex
            |NegativeArraySizeException java.lang
            |""".stripMargin,
       "3.0" ->


### PR DESCRIPTION
This improves a couple of things:
- show shorter type if it's importable (also needed further on)
- when hovering on package it's full path is shown (the change was needed due to the previous one)
- show final modifier
- show enum and case instead of final object and final val

The first change was needed also for properly writing types when doing inferred type action or overrides. The other changes stemmed from that. I think we can still further improve the hover information later on, but I don't want to do everything in one PR