### PR TITLE
Don't offer completions inside scaladoc and comments

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -255,7 +255,8 @@ class CompletionProvider(
       pos: Position,
       completion: CompletionPosition,
       editRange: l.Range,
-      latestParentTrees: List[Tree]
+      latestParentTrees: List[Tree],
+      text: String
   ): InterestingMembers = {
     lazy val isAmmoniteScript = pos.source.file.name.isAmmoniteGeneratedFile
     val isSeen = mutable.Set.empty[String]
@@ -312,7 +313,7 @@ class CompletionProvider(
     }
     completions.foreach(visit)
     completion.contribute.foreach(visit)
-    buf ++= keywords(pos, editRange, latestParentTrees, completion)
+    buf ++= keywords(pos, editRange, latestParentTrees, completion, text)
     val searchResults =
       if (kind == CompletionListKind.Scope) {
         workspaceSymbolListMembers(query, pos, visit)
@@ -457,7 +458,8 @@ class CompletionProvider(
         pos,
         completion,
         editRange,
-        latestParentTrees
+        latestParentTrees,
+        params.text()
       )
       params.checkCanceled()
       (items, completion, editRange, query)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
@@ -2,6 +2,9 @@ package scala.meta.internal.pc
 
 import scala.tools.nsc.reporters.StoreReporter
 
+import scala.meta.XtensionTokenizeInputLike
+import scala.meta.tokens.Token
+
 import org.eclipse.{lsp4j => l}
 
 trait Keywords { this: MetalsGlobal =>
@@ -10,8 +13,22 @@ trait Keywords { this: MetalsGlobal =>
       pos: Position,
       editRange: l.Range,
       latestEnclosing: List[Tree],
-      completion: CompletionPosition
+      completion: CompletionPosition,
+      text: String
   ): List[Member] = {
+    val start = pos.start
+    val end = pos.end
+    val tokens = text.tokenize.toOption
+    val notInComment = tokens
+      .flatMap(t =>
+        t.find {
+          case t: Token.Comment if t.pos.start < start && t.pos.end >= end =>
+            true
+          case _ => false
+        }
+      )
+      .isEmpty
+
     getIdentifierName(latestEnclosing, pos) match {
       case None =>
         completion match {
@@ -22,12 +39,13 @@ trait Keywords { this: MetalsGlobal =>
           // has already typed /* then they are going for the scaladoc, not the
           // other stuff.
           case _: ScaladocCompletion => List.empty
-          case _ =>
+          case _ if notInComment =>
             Keyword.all.collect {
               case kw if kw.isPackage => mkTextEditMember(kw, editRange)
             }
+          case _ => List.empty
         }
-      case Some(name) =>
+      case Some(name) if notInComment =>
         val isExpression = this.isExpression(latestEnclosing)
         val isBlock = this.isBlock(latestEnclosing)
         val isDefinition = this.isDefinition(latestEnclosing, name, pos)
@@ -47,6 +65,7 @@ trait Keywords { this: MetalsGlobal =>
               ) =>
             mkTextEditMember(kw, editRange)
         }
+      case _ => List.empty
     }
   }
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
@@ -2,7 +2,7 @@ package scala.meta.internal.pc
 
 import scala.tools.nsc.reporters.StoreReporter
 
-import scala.meta.XtensionTokenizeInputLike
+import scala.meta._
 import scala.meta.tokens.Token
 
 import org.eclipse.{lsp4j => l}
@@ -16,18 +16,8 @@ trait Keywords { this: MetalsGlobal =>
       completion: CompletionPosition,
       text: String
   ): List[Member] = {
-    val start = pos.start
-    val end = pos.end
-    val tokens = text.tokenize.toOption
-    val notInComment = tokens
-      .flatMap(t =>
-        t.find {
-          case t: Token.Comment if t.pos.start < start && t.pos.end >= end =>
-            true
-          case _ => false
-        }
-      )
-      .isEmpty
+
+    lazy val notInComment = checkIfNotInComment(pos, text)
 
     getIdentifierName(latestEnclosing, pos) match {
       case None =>
@@ -67,6 +57,21 @@ trait Keywords { this: MetalsGlobal =>
         }
       case _ => List.empty
     }
+  }
+
+  private def checkIfNotInComment(pos: Position, text: String): Boolean = {
+    val start = pos.start
+    val end = pos.end
+    val tokens = text.tokenize.toOption
+    tokens
+      .flatMap(t =>
+        t.find {
+          case t: Token.Comment if t.pos.start < start && t.pos.end >= end =>
+            true
+          case _ => false
+        }
+      )
+      .isEmpty
   }
 
   private def getIdentifierName(

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -28,6 +28,42 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
   )
 
   check(
+    "comment",
+    """
+      |package foo
+      |
+      |trait A {
+      |  final def superVisorStrategy = 1
+      |}
+      |
+      |object B extends A {
+      |  // tr@@
+      |}
+      |""".stripMargin,
+    """|""".stripMargin,
+    includeCommitCharacter = true
+  )
+
+  check(
+    "scala-doc",
+    """
+      |package foo
+      |
+      |trait A {
+      |  final def superVisorStrategy = 1
+      |}
+      |
+      |object B extends A {
+      |  /** tr@@
+      |  *
+      |  **/
+      |}
+      |""".stripMargin,
+    """|""".stripMargin,
+    includeCommitCharacter = true
+  )
+
+  check(
     "super-def",
     """
       |package foo


### PR DESCRIPTION
This PR should close #2775, removing the completions when inside comment lines, either multiline like scaladoc or single line `//`.

I am not sure the solution is an optimized one, but I added a similar check to the `isScaladocCompletion` to check whether the cursor is currently in a comment line. In this case it will return a `CommentCompletion` created equally to the `NoneCompletion`, the need to differentiate occurs when checking for possible Keywords completions: if it's a `CommentCompletion` it shouldn't propose the keywords either.

~~+: I need to fix something wrong with Keywords, then should be ready~~