### PR TITLE
[Scala 3] Enable inferred type code action

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -631,6 +631,7 @@ lazy val mtest = project
       "scala213" -> V.scala213,
       "scala3" -> V.scala3,
       "scala2Versions" -> V.scala2Versions,
+      "scala3RCVersions" -> V.scala3RCVersions,
       "scala3Versions" -> V.scala3Versions,
       "scala2Versions" -> V.scala2Versions,
       "scalaVersion" -> scalaVersion.value

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
@@ -7,14 +7,11 @@ import scala.meta.Defn
 import scala.meta.Enumerator
 import scala.meta.Pat
 import scala.meta.Term
-import scala.meta.Tree
-import scala.meta.dialects
 import scala.meta.internal.metals.CodeAction
 import scala.meta.internal.metals.Compilers
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.parsing.Trees
-import scala.meta.internal.trees.Origin
 import scala.meta.pc.CancelToken
 
 import org.eclipse.{lsp4j => l}
@@ -67,18 +64,10 @@ class InsertInferredType(trees: Trees, compilers: Compilers)
         None
     }
 
-    def isScala2(tree: Tree) = {
-      tree.origin match {
-        case Origin.None => false
-        case Origin.Parsed(_, dialect, _) => dialect != dialects.Scala3
-      }
-    }
-
     val path = params.getTextDocument().getUri().toAbsolutePath
     val actions = for {
       name <- trees
         .findLastEnclosingAt[Term.Name](path, params.getRange().getStart())
-      if isScala2(name)
       title <- inferTypeTitle(name)
     } yield insertInferTypeAction(title)
 

--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -11,14 +11,11 @@ import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.core.NameOps._
 import dotty.tools.dotc.core.Names._
 import dotty.tools.dotc.core.Symbols._
+import dotty.tools.dotc.interactive.Interactive
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.util.Spans
 import org.eclipse.{lsp4j => l}
-import dotty.tools.dotc.interactive.Interactive
-import scala.meta.pc.OffsetParams
-
-import java.net.URI
 
 object MtagsEnrichments
     extends CommonMtagsEnrichments
@@ -34,6 +31,10 @@ object MtagsEnrichments
       new SourcePosition(source, p)
 
     def localContext(params: OffsetParams): Context = {
+      if (driver.currentCtx.run.units.isEmpty)
+        throw new RuntimeException(
+          "No source files were passed to the Scala 3 presentation compiler"
+        )
       val unit = driver.currentCtx.run.units.head
       val tree = unit.tpdTree
       val pos = driver.sourcePosition(params)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
@@ -64,8 +64,7 @@ object AutoImports {
         val fullName = from.stripSuffix("/").replace("/", ".")
         val pkg = requiredPackage(fullName)
         (pkg.name.toSimpleName, to.stripSuffix(".").stripSuffix("#"))
-      }.toMap
-
+      }.toMap ++ namesInScope.renames
     new AutoImportsGenerator(pos, importPos, namesInScope, renameConfig)
   }
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
@@ -166,7 +166,7 @@ object AutoImports {
     private def importName(sym: Symbol): String = {
       @tailrec
       def toplevelClashes(sym: Symbol): Boolean = {
-        if (sym.owner == NoSymbol || sym.owner.isRoot)
+        if (sym == NoSymbol || sym.owner == NoSymbol || sym.owner.isRoot)
           namesInScope.lookupSym(sym).exists
         else
           toplevelClashes(sym.owner)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/InferredTypeProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/InferredTypeProvider.scala
@@ -1,0 +1,261 @@
+package scala.meta.internal.pc
+
+import scala.meta.pc.OffsetParams
+import scala.meta.pc.PresentationCompilerConfig
+import scala.meta.tokens.{Token => T}
+
+import org.eclipse.lsp4j.TextEdit
+import java.nio.file.Paths
+import dotty.tools.dotc.interactive.InteractiveDriver
+import dotty.tools.dotc.util.SourceFile
+import dotty.tools.dotc.core.Contexts._
+import dotty.tools.dotc.interactive.Interactive
+import java.net.URI
+import dotty.tools.dotc.util.SourcePosition
+import dotty.tools.dotc.util.Spans
+import dotty.tools.dotc.ast.Trees._
+import dotty.tools.dotc.core.Types._
+import scala.meta.internal.mtags.MtagsEnrichments._
+import dotty.tools.dotc.core.Symbols.NoSymbol
+import scala.meta as m
+import scala.meta.internal.pc.AutoImports.AutoImportsGenerator
+import dotty.tools.dotc.ast.untpd
+
+/**
+ * Tries to calculate edits needed to insert the inferred type annotation
+ * in all the places that it is possible such as:
+ * - value or variable declaration
+ * - methods
+ * - pattern matches
+ * - for comprehensions
+ * - lambdas
+ *
+ * The provider will not check if the type does not exist, since there is no way to
+ * get that data from the presentation compiler. The actual check is being done via
+ * scalameta parser in InsertInferredType code action.
+ *
+ * @param params position and actual source
+ * @param driver Scala 3 interactive compiler driver
+ * @param config presentation compielr configuration
+ */
+final class InferredTypeProvider(
+    params: OffsetParams,
+    driver: InteractiveDriver,
+    config: PresentationCompilerConfig
+) {
+
+  def inferredTypeEdits(): List[TextEdit] = {
+    val uri = params.uri
+    val filePath = Paths.get(uri)
+    val source = SourceFile.virtual(filePath.toString, params.text)
+    driver.run(uri, source)
+    val unit = driver.currentCtx.run.units.head
+    val pos = driver.sourcePosition(params)
+    val path =
+      Interactive.pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
+
+    given locatedCtx: Context = driver.localContext(params)
+    val symbolPrinter = new SymbolPrinter()
+    val namesInScope = NamesInScope.build(unit.tpdTree)
+    val autoImportsGen = AutoImports.generator(
+      pos,
+      params.text,
+      unit.tpdTree,
+      namesInScope,
+      config
+    )
+    val history = new ShortenedNames(locatedCtx)
+
+    /*
+     * Get the exact position in ValDef pattern for val (a, b) = (1, 2)
+     * Suprisingly, val ((a, c), b) = ((1, 3), 2) will be covered by Bind
+     * https://github.com/lampepfl/dotty/issues/12627
+     */
+    def findTuplePart(
+        applied: AppliedType,
+        metaPattern: m.Pat,
+        valdefOffset: Int
+    )(using ctx: Context) = {
+      import scala.meta._
+      metaPattern match {
+        case tpl: m.Pat.Tuple =>
+          val newOffset = params.offset - valdefOffset + 4
+          val tupleIndex = tpl.args.indexWhere { p =>
+            p.pos.start <= newOffset && p.pos.end >= newOffset
+          }
+          if (tupleIndex >= 0) {
+            val tuplePartTpe = applied.args(tupleIndex)
+            val imports =
+              autoImportsGen
+                .forSymbol(tuplePartTpe.typeSymbol)
+                .getOrElse(Nil)
+            val short = shortType(tuplePartTpe, history)
+            val typeEndPos = tpl.args(tupleIndex).pos.end
+            val namePos = typeEndPos + valdefOffset - 4
+            val lspPos = driver.sourcePosition(params.uri, namePos).toLSP
+            val typeNameEdit =
+              new TextEdit(
+                lspPos,
+                ": " + symbolPrinter.typeString(short)
+              )
+            typeNameEdit :: imports
+          } else Nil
+        case _ => Nil
+      }
+    }
+
+    path.headOption match {
+      /* `val a = 1` or `var b = 2`
+       *     turns into
+       * `val a: Int = 1` or `var b: Int = 2`
+       *
+       *`.map(a => a + a)`
+       *     turns into
+       * `.map((a: Int) => a + a)`
+       */
+      case Some(vl @ ValDef(sym, tpt, _)) =>
+        val isParam = path.tail.headOption.exists(_.symbol.isAnonymousFunction)
+        def baseEdit(withParens: Boolean) = {
+          val nameEnd =
+            if (isParam) vl.endPos
+            else
+              tpt.endPos
+          val short = shortType(tpt.tpe, history)
+          new TextEdit(
+            nameEnd.toLSP,
+            ": " + symbolPrinter.typeString(short) + {
+              if (withParens) ")" else ""
+            }
+          )
+        }
+
+        def typeNameEdit: List[TextEdit] = {
+          path match {
+            // lambda `{a => ??? }` block and `map{a => ??? }` apply
+            case _ :: _ :: (block: untpd.Block) :: (appl: untpd.Apply) :: _
+                if isParam =>
+              val isParensFunction =
+                params.text.toString()(appl.fun.endPos.end) == '('
+              val alreadyHasParens =
+                params.text.toString()(block.startPos.start) == '('
+              if (isParensFunction && !alreadyHasParens)
+                new TextEdit(block.startPos.toLSP, "(") :: baseEdit(withParens =
+                  true
+                ) :: Nil
+              else
+                baseEdit(withParens = false) :: Nil
+
+            case _ => baseEdit(withParens = false) :: Nil
+          }
+
+        }
+        def simpleType = {
+          val imports =
+            autoImportsGen.forSymbol(tpt.tpe.typeSymbol).getOrElse(Nil)
+          typeNameEdit ::: imports
+        }
+
+        def tupleType(applied: AppliedType) = {
+          import scala.meta._
+          val pattern =
+            params.text.substring(vl.startPos.start, tpt.startPos.start)
+
+          dialects.Scala3("val " + pattern + "???").parse[Source] match {
+            case Parsed.Success(Source(List(valDef: m.Defn.Val))) =>
+              findTuplePart(
+                applied,
+                valDef.pats.head,
+                vl.startPos.start
+              )
+            case _ => simpleType
+          }
+        }
+        tpt.tpe match {
+          case applied: AppliedType =>
+            tupleType(applied)
+          case _ =>
+            simpleType
+        }
+
+      /* `def a[T](param : Int) = param`
+       *     turns into
+       * `def a[T](param : Int): Int = param`
+       */
+      case Some(DefDef(name, _, tpt, rhs)) =>
+        val short = shortType(tpt.tpe, history)
+        val typeNameEdit =
+          new TextEdit(
+            tpt.endPos.toLSP,
+            ": " + symbolPrinter.typeString(short)
+          )
+        val imports =
+          autoImportsGen.forSymbol(tpt.tpe.typeSymbol).getOrElse(Nil)
+        typeNameEdit :: imports
+
+      /* `case t =>`
+       *  turns into
+       * `case t: Int =>`
+       */
+      case Some(bind @ Bind(name, body)) =>
+        val short = shortType(body.tpe, history)
+
+        def baseEdit(withParens: Boolean) = {
+          val short = shortType(body.tpe, history)
+
+          new TextEdit(
+            bind.endPos.toLSP,
+            ": " + symbolPrinter.typeString(short) + {
+              if (withParens) ")" else ""
+            }
+          )
+        }
+        val imports =
+          autoImportsGen.forSymbol(body.tpe.typeSymbol).getOrElse(Nil)
+        val typeNameEdit = path match {
+          /* In case it's an infix pattern match
+           * we need to add () for example in:
+           * case (head : Int) :: tail =>
+           */
+          case _ :: (unappl @ UnApply(_, _, patterns)) :: _
+              if patterns.size > 1 =>
+            import scala.meta._
+            val firstEnd = patterns(0).endPos.end
+            val secondStart = patterns(1).startPos.start
+            val hasDot = params
+              .text()
+              .substring(firstEnd, secondStart)
+              .tokenize
+              .toOption
+              .exists(_.tokens.exists(_.is[T.Comma]))
+            if (!hasDot) {
+              val leftParen = new TextEdit(body.startPos.toLSP, "(")
+              leftParen :: baseEdit(withParens = true) :: Nil
+            } else baseEdit(withParens = false) :: Nil
+
+          case _ =>
+            baseEdit(withParens = false) :: Nil
+        }
+        typeNameEdit ::: imports
+
+      /* `for(t <- 0 to 10)`
+       *  turns into
+       * `for(t: Int <- 0 to 10)`
+       */
+      case Some(i @ Ident(name)) =>
+        val short = shortType(i.tpe, history)
+        val typeNameEdit = new TextEdit(
+          i.endPos.toLSP,
+          ": " + symbolPrinter.typeString(short.widen)
+        )
+
+        val imports =
+          autoImportsGen.forSymbol(i.tpe.typeSymbol).getOrElse(Nil)
+        typeNameEdit :: imports
+
+      case _ =>
+        Nil
+    }
+
+  }
+
+}

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -273,13 +273,15 @@ case class ScalaPresentationCompiler(
     )
   }
 
-  // TODO NOT IMPLEMENTED
   override def insertInferredType(
       params: OffsetParams
   ): CompletableFuture[ju.List[TextEdit]] = {
-    CompletableFuture.completedFuture(
-      List.empty[TextEdit].asJava
-    )
+    val empty: ju.List[TextEdit] = new ju.ArrayList[TextEdit]()
+    compilerAccess.withInterruptableCompiler(empty, params.token) { pc =>
+      new InferredTypeProvider(params, pc.compiler(), config)
+        .inferredTypeEdits()
+        .asJava
+    }
   }
 
   def hover(params: OffsetParams): CompletableFuture[ju.Optional[Hover]] =

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Signatures.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Signatures.scala
@@ -38,7 +38,10 @@ class ShortenedNames(context: Context) {
               history(short.name) = short
               true
             } else false
-          case founds => founds.exists(_ == short.symbol)
+          case founds =>
+            founds.exists(s =>
+              s == short.symbol || s.typeRef.dealias.typeSymbol == short.symbol
+            )
         }
         if (isOk) {
           history(short.name) = short

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -121,7 +121,10 @@ abstract class BasePCSuite extends BaseSuite {
   }
 
   protected def createBinaryVersion(scalaVersion: String): String = {
-    scalaVersion.split('.').take(2).mkString(".")
+    if (isScala3Version(scalaVersion))
+      "3"
+    else
+      scalaVersion.split('.').take(2).mkString(".")
   }
 
   private def indexScalaLibrary(

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -370,7 +370,7 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
-    "renamed".tag(IgnoreScala3),
+    "renamed",
     """|import java.time.{Instant => I}
        |
        |trait Main {
@@ -390,7 +390,7 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
-    "renamed-package".tag(IgnoreScala3),
+    "renamed-package",
     """|import java.{ time => t }
        |
        |trait Main {
@@ -409,7 +409,7 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
-    "renamed-package-long".tag(IgnoreScala3),
+    "renamed-package-long",
     """|import scala.{ concurrent => c }
        |
        |trait Main {
@@ -430,13 +430,14 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   def checkEdit(
       name: TestOptions,
       original: String,
-      expected: String
+      expected: String,
+      compat: Map[String, String] = Map.empty
   )(implicit location: Location): Unit =
     test(name) {
       val edits = getAutoImplement(original)
       val (code, _, _) = params(original)
       val obtained = TextEdits.applyEdits(code, edits)
-      assertNoDiff(obtained, expected)
+      assertNoDiff(obtained, getExpected(expected, compat, scalaVersion))
     }
 
   def getAutoImplement(

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -7,6 +7,7 @@ import scala.meta.internal.metals.CompilerOffsetParams
 import scala.meta.internal.metals.TextEdits
 
 import coursierapi.Dependency
+import munit.Location
 import munit.TestOptions
 import org.eclipse.{lsp4j => l}
 import tests.BaseCodeActionSuite
@@ -14,18 +15,16 @@ import tests.BuildInfoVersions
 
 class InsertInferredTypeSuite extends BaseCodeActionSuite {
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
-
   override def extraDependencies(scalaVersion: String): Seq[Dependency] = {
     val binaryVersion = createBinaryVersion(scalaVersion)
-    if (isScala3Version(scalaVersion)) { Seq.empty }
-    else {
-      Seq(
-        Dependency.of("org.typelevel", s"cats-effect_$binaryVersion", "2.4.0")
-      )
-    }
+    Seq(
+      Dependency.of("org.typelevel", s"cats-effect_$binaryVersion", "3.1.1")
+    )
   }
+
+  // To avoid dealing with different cats-effect versions
+  override protected def excludedScalaVersions: Set[String] =
+    BuildInfoVersions.scala3RCVersions.toSet
 
   checkEdit(
     "val",
@@ -38,12 +37,41 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
+    "toplevel".tag(IgnoreScala2),
+    """|def <<alpha>> = List("")
+       |""".stripMargin,
+    """|def alpha: List[String] = List("")
+       |""".stripMargin
+  )
+
+  checkEdit(
     "tuple",
     """|object A{
        |  val (<<alpha>>, beta) = (123, 12)
        |}""".stripMargin,
     """|object A{
        |  val (alpha: Int, beta) = (123, 12)
+       |}""".stripMargin
+  )
+
+  checkEdit(
+    "tuple-inner",
+    """|object A{
+       |  val ((<<alpha>>, gamma), beta) = ((123, 1), 12)
+       |}""".stripMargin,
+    """|object A{
+       |  val ((alpha: Int, gamma), beta) = ((123, 1), 12)
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "tuple-var",
+    """|object A{
+       |  var (<<alpha>>, beta) = (123, 12)
+       |}""".stripMargin,
+    """|object A{
+       |  var (alpha: Int, beta) = (123, 12)
        |}""".stripMargin
   )
 
@@ -267,56 +295,47 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |""".stripMargin
   )
 
+  val additionalSpace: String = if (isScala3Version(scalaVersion)) " " else ""
   checkEdit(
     "higher-kinded-types",
     """|package io
        |
-       |import cats.Parallel
-       |import cats.effect.ConcurrentEffect
-       |import cats.effect.ContextShift
-       |import cats.effect.IOApp
        |import cats.effect.Resource
-       |import cats.effect.Timer
        |
        |object Main2 extends IOApp {
        |
        |  trait Logger[T[_]]
        |
-       |  def mkLogger[F[_]: ConcurrentEffect: Timer: ContextShift]: Resource[F, Logger[F]] = ???
+       |  def mkLogger[F[_]]: Resource[F, Logger[F]] = ???
        |
-       |  def <<serve>>[F[_]: ConcurrentEffect: ContextShift: Timer: Parallel]() =
+       |  def <<serve>>[F[_]]() =
        |    for {
        |      logger <- mkLogger[F]
        |    } yield ()
        |
        |}
        |""".stripMargin,
-    """|package io
-       |
-       |import cats.Parallel
-       |import cats.effect.ConcurrentEffect
-       |import cats.effect.ContextShift
-       |import cats.effect.IOApp
-       |import cats.effect.Resource
-       |import cats.effect.Timer
-       |
-       |object Main2 extends IOApp {
-       |
-       |  trait Logger[T[_]]
-       |
-       |  def mkLogger[F[_]: ConcurrentEffect: Timer: ContextShift]: Resource[F, Logger[F]] = ???
-       |
-       |  def serve[F[_]: ConcurrentEffect: ContextShift: Timer: Parallel](): Resource[F,Unit] =
-       |    for {
-       |      logger <- mkLogger[F]
-       |    } yield ()
-       |
-       |}
-       |""".stripMargin
+    s"""|package io
+        |
+        |import cats.effect.Resource
+        |
+        |object Main2 extends IOApp {
+        |
+        |  trait Logger[T[_]]
+        |
+        |  def mkLogger[F[_]]: Resource[F, Logger[F]] = ???
+        |
+        |  def serve[F[_]](): Resource[F,${additionalSpace}Unit] =
+        |    for {
+        |      logger <- mkLogger[F]
+        |    } yield ()
+        |
+        |}
+        |""".stripMargin
   )
 
   checkEdit(
-    "path",
+    "path".tag(IgnoreScala3),
     """|import java.nio.file.Paths
        |object ExplicitResultTypesPrefix {
        |  class Path
@@ -351,7 +370,7 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
-    "renamed",
+    "renamed".tag(IgnoreScala3),
     """|import java.time.{Instant => I}
        |
        |trait Main {
@@ -371,7 +390,7 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
-    "renamed-package",
+    "renamed-package".tag(IgnoreScala3),
     """|import java.{ time => t }
        |
        |trait Main {
@@ -390,7 +409,7 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
-    "renamed-package-long",
+    "renamed-package-long".tag(IgnoreScala3),
     """|import scala.{ concurrent => c }
        |
        |trait Main {
@@ -412,7 +431,7 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
       name: TestOptions,
       original: String,
       expected: String
-  ): Unit =
+  )(implicit location: Location): Unit =
     test(name) {
       val edits = getAutoImplement(original)
       val (code, _, _) = params(original)
@@ -422,7 +441,7 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
 
   def getAutoImplement(
       original: String,
-      filename: String = "A.scala"
+      filename: String = "file:/A.scala"
   ): List[l.TextEdit] = {
     val (code, _, offset) = params(original)
     val result = presentationCompiler

--- a/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
@@ -3,13 +3,14 @@ package tests.feature
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.codeactions.ExtractRenameMember
 import scala.meta.internal.metals.codeactions.OrganizeImports
+import scala.meta.internal.metals.codeactions.InsertInferredType
 import scala.meta.internal.mtags.MtagsEnrichments.XtensionAbsolutePath
 
 import munit.Location
 import munit.TestOptions
 import tests.codeactions.BaseCodeActionLspSuite
 
-class CrossCodeActionLspSuite
+class Scala3CodeActionLspSuite
     extends BaseCodeActionLspSuite("cross-code-actions") {
 
   override protected val scalaVersion: String = BuildInfo.scala3
@@ -19,7 +20,7 @@ class CrossCodeActionLspSuite
     """|package a
        |
        |object A {
-       |  val al<<>>pha = 123
+       |  val al<<>>pha: Int = 123
        |}
        |""".stripMargin
   )
@@ -79,6 +80,41 @@ class CrossCodeActionLspSuite
           |   case Blue  extends Color(0x0000FF)
           |""".stripMargin
     )
+  )
+
+  check(
+    "val-pattern",
+    """|package a
+       |
+       |object A:
+       |  val (fir<<>>st, second) = (List(1), List(""))
+       |""".stripMargin,
+    s"""|${InsertInferredType.insertTypeToPattern}
+        |""".stripMargin,
+    """|package a
+       |
+       |object A:
+       |  val (first: List[Int], second) = (List(1), List(""))
+       |""".stripMargin
+  )
+
+  check(
+    "auto-import",
+    """|package a
+       |
+       |object A:
+       |  var al<<>>pha = List(123).toBuffer
+       |
+       |""".stripMargin,
+    s"""|${InsertInferredType.insertType}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.mutable.Buffer
+       |
+       |object A:
+       |  var alpha: Buffer[Int] = List(123).toBuffer
+       |""".stripMargin
   )
 
   def checkExtractedMember(

--- a/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
@@ -2,8 +2,8 @@ package tests.feature
 
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.codeactions.ExtractRenameMember
-import scala.meta.internal.metals.codeactions.OrganizeImports
 import scala.meta.internal.metals.codeactions.InsertInferredType
+import scala.meta.internal.metals.codeactions.OrganizeImports
 import scala.meta.internal.mtags.MtagsEnrichments.XtensionAbsolutePath
 
 import munit.Location


### PR DESCRIPTION
This was actually easier to do for some parts, however there are some issues still:
- tuples are not shown correctly when using the presentation compiler, I am working around it by using scalameta to parse the tuple Val and match the type. This doesn't seem to be an issue for more advanced patterns.
- ~~import renames are not correctly picked up, we might need to still fix it in auto imports/signatures~~ this currently works
- type names in case of conflicts do not currently work, I will look into that later on 

Most other things seem to be working fine for now and I believe this is a good step forward.