### PR TITLE
Add support for Scala 3.0.1-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -198,6 +198,7 @@ lazy val V = new {
   val bsp = "2.0.0-M13"
   val bloop = "1.4.8-19-4d9f966b"
   val scala3 = "3.0.0"
+  val nextScala3RC = "3.0.1-RC1"
   val bloopNightly = bloop
   val sbtBloop = bloop
   val gradleBloop = bloop
@@ -239,7 +240,7 @@ lazy val V = new {
   // Scala 3
   def scala3RCVersions = Seq("3.0.0-RC3", "3.0.0-RC2", "3.0.0-RC1")
   def nonDeprecatedScala3Versions =
-    scala3 +: scala3RCVersions
+    scala3 +: scala3RCVersions :+ nextScala3RC
   def deprecatedScala3Versions = Seq()
   def scala3Versions = nonDeprecatedScala3Versions ++ deprecatedScala3Versions
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SymbolPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SymbolPrinter.scala
@@ -61,18 +61,24 @@ class SymbolPrinter(using ctx: Context) extends RefinedPrinter(ctx) {
    * - otherwise: its shortened type
    *   - e.g. ` java.lang.String` ` Symbols.Symbol`
    */
-  def infoString(
+  def hoverDetails(
       sym: Symbol,
       history: ShortenedNames,
-      info: Type
+      info: Type,
+      addFullDef: Boolean = true
   )(using Context): String = {
+    val fullDef = if (addFullDef) fullDefinition(sym, info) else ""
+    // info is dealiased, while sym is not
+    val typeSymbol = info.typeSymbol
     sym match {
+      case p if p.is(Flags.Package) => fullDef
+      case p if typeSymbol.is(Flags.Module) =>
+        fullDef.trim + " " + typeSymbol.owner.fullName.stripModuleClassSuffix.toString
       case m if m.is(Flags.Method) =>
-        defaultMethodSignature(sym, history, info)
-      case p if p.is(Flags.Package) => ""
+        fullDef + defaultMethodSignature(m, history, info)
       case _ =>
         val short = shortType(info, history)
-        s"${typeString(short)}"
+        fullDef + s"${typeString(short)}"
     }
   }
 

--- a/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
@@ -147,7 +147,7 @@ class HoverDefnSuite extends BaseHoverSuite {
       |""".stripMargin,
     "",
     compat = Map(
-      "3.0" -> "object MyObject: MyObject".hover
+      "3.0" -> "object MyObject: object".hover
     )
   )
 

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -52,7 +52,7 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |   case <<Re@@d>>, Green, Blue
        |
        |""".stripMargin,
-    """|case Red: enums.SimpleEnum.Color.Red
+    """|case Red: Red
        |""".stripMargin.hover
   )
 

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -56,7 +56,7 @@ class HoverTermSuite extends BaseHoverSuite {
     """|def apply(name: String): Person
        |""".stripMargin.hover,
     compat = Map(
-      "3.0" -> "case class Person: Person".hover
+      "3.0" -> "case class Person: case-apply".hover
     )
   )
 
@@ -147,7 +147,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin.hover,
     compat = Map(
       // https://github.com/lampepfl/dotty/issues/8835
-      "3.0" -> "object num: Xtension#num".hover
+      "3.0" -> "object num: interpolator-unapply.a$.Xtension".hover
     )
   )
 
@@ -335,7 +335,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |```
        |""".stripMargin,
     compat = Map(
-      "3.0" -> "enum FileVisitResult: FileVisitResult".hover
+      "3.0" -> "enum FileVisitResult: java.nio.file".hover
     )
   )
 
@@ -358,7 +358,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin,
     automaticPackage = false,
     compat = Map(
-      "3.0" -> "object Foo: Foo".hover
+      "3.0" -> "object Foo: app.Outer".hover
     )
   )
 
@@ -403,7 +403,7 @@ class HoverTermSuite extends BaseHoverSuite {
     """|class java.nio.file.Files
        |""".stripMargin.hover,
     compat = Map(
-      "3.0" -> "object Files: java.nio.file.Files".hover
+      "3.0" -> "object Files: java.nio.file".hover
     )
   )
 
@@ -415,7 +415,7 @@ class HoverTermSuite extends BaseHoverSuite {
     """|class java.nio.file.Paths
        |""".stripMargin.hover,
     compat = Map(
-      "3.0" -> "object Paths: java.nio.file.Paths".hover
+      "3.0" -> "object Paths: java.nio.file".hover
     )
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -28,7 +28,7 @@ class CompletionSuite extends BaseCompletionSuite {
            |JList - javax.swing
            |""".stripMargin,
       "3.0" ->
-        """|List: collection.immutable.List.type
+        """|List scala.collection.immutable
            |List - java.awt
            |List - java.util
            |List - scala.collection.immutable
@@ -127,8 +127,10 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    // @tgodzik different results might be returned on each run for Scala 3
-    "dot".tag(IgnoreScala3),
+    // before 3.0.1 completions with the same name were included in one completion in a random order
+    "dot".tag(
+      IgnoreScalaVersion(Set("3.0.0-RC1", "3.0.0-RC2", "3.0.0-RC3", "3.0.0"))
+    ),
     """
       |object A {
       |  List.@@
@@ -234,6 +236,50 @@ class CompletionSuite extends BaseCompletionSuite {
            |isInstanceOf[T0]: Boolean
            |synchronized[T0](x$1: T0): T0
            |toString(): String
+           |""".stripMargin,
+      "3.0" ->
+        """|->[B](y: B): (A, B)
+           |apply[A](elems: A*): CC[A]
+           |concat[A](xss: Iterable[A]*): CC[A]
+           |empty[A]: List[A]
+           |ensuring(cond: Boolean): A
+           |ensuring(cond: Boolean, msg: => Any): A
+           |ensuring(cond: A => Boolean): A
+           |ensuring(cond: A => Boolean, msg: => Any): A
+           |fill[A](n1: Int, n2: Int)(elem: => A): CC[CC[A] @uncheckedVariance]
+           |fill[A](n1: Int, n2: Int, n3: Int)(elem: => A): CC[CC[CC[A]] @uncheckedVariance]
+           |fill[A](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => A): CC[CC[CC[CC[A]]] @uncheckedVariance]
+           |fill[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => A): CC[CC[CC[CC[CC[A]]]] @uncheckedVariance]
+           |fill[A](n: Int)(elem: => A): CC[A]
+           |formatted(fmtstr: String): String
+           |from[B](coll: IterableOnce[B]): List[B]
+           |fromSpecific(from: From)(it: IterableOnce[A]): C
+           |fromSpecific(it: IterableOnce[A]): C
+           |iterate[A](start: A, len: Int)(f: A => A): CC[A]
+           |newBuilder[A]: Builder[A, List[A]]
+           |nn[T](x: T | Null): x.type & T
+           |range[A: Integral](start: A, end: A, step: A): CC[A]
+           |range[A: Integral](start: A, end: A): CC[A]
+           |tabulate[A](n1: Int, n2: Int)(f: (Int, Int) => A): CC[CC[A] @uncheckedVariance]
+           |tabulate[A](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => A): CC[CC[CC[A]] @uncheckedVariance]
+           |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): CC[CC[CC[CC[A]]] @uncheckedVariance]
+           |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): CC[CC[CC[CC[CC[A]]]] @uncheckedVariance]
+           |tabulate[A](n: Int)(f: Int => A): CC[A]
+           |toFactory(from: From): Factory[A, C]
+           |unapplySeq[A](x: CC[A] @uncheckedVariance): UnapplySeqWrapper[A]
+           |unfold[A, S](init: S)(f: S => Option[(A, S)]): CC[A]
+           |→[B](y: B): (A, B)
+           |iterableFactory[A]: Factory[A, CC[A]]
+           |asInstanceOf[X0]: X0
+           |equals(x$0: Any): Boolean
+           |getClass[X0 >: (Any.this : Any)]: Class[? <: X0]
+           |hashCode: Int
+           |isInstanceOf[X0]: Boolean
+           |synchronized[X0](x$0: X0): X0
+           |toString: String
+           |wait: Unit
+           |wait(x$0: Long): Unit
+           |wait(x$0: Long, x$1: Int): Unit
            |""".stripMargin
     )
   )
@@ -320,7 +366,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "import".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "import",
     """
       |import JavaCon@@
       |""".stripMargin,
@@ -344,7 +390,18 @@ class CompletionSuite extends BaseCompletionSuite {
       "2.11" -> """|JavaConverters - scala.collection
                    |JavaConversions - scala.collection
                    |JavaConversions - scala.concurrent
-                   |""".stripMargin
+                   |""".stripMargin,
+      "3" -> """|AsJavaConverters - scala.collection.convert
+                |JavaConverters - scala.collection
+                |JavaConversions - scala.concurrent
+                |AsJavaConsumer - scala.jdk.FunctionWrappers
+                |FromJavaConsumer - scala.jdk.FunctionWrappers
+                |AsJavaBiConsumer - scala.jdk.FunctionWrappers
+                |AsJavaIntConsumer - scala.jdk.FunctionWrappers
+                |AsJavaLongConsumer - scala.jdk.FunctionWrappers
+                |FromJavaBiConsumer - scala.jdk.FunctionWrappers
+                |FromJavaIntConsumer - scala.jdk.FunctionWrappers
+                |""".stripMargin
     )
   )
 
@@ -528,10 +585,36 @@ class CompletionSuite extends BaseCompletionSuite {
     // Scala 2.13.5 adds additional completions that actually fit, but are not useful for this test
     topLines = Some(25),
     compat = Map(
-      "3" ->
+      "3.0.0" ->
         """|Function scala
            |Function0 scala
            |Function1 scala
+           |Function1 scala
+           |Function2 scala
+           |Function3 scala
+           |Function4 scala
+           |Function5 scala
+           |Function6 scala
+           |Function7 scala
+           |Function8 scala
+           |Function9 scala
+           |Function10 scala
+           |Function11 scala
+           |Function12 scala
+           |Function13 scala
+           |Function14 scala
+           |Function15 scala
+           |Function16 scala
+           |Function17 scala
+           |Function18 scala
+           |Function19 scala
+           |Function20 scala
+           |Function21 scala
+           |Function22 scala
+           |""".stripMargin,
+      "3" ->
+        """|Function scala
+           |Function0 scala
            |Function1 scala
            |Function2 scala
            |Function3 scala
@@ -616,6 +699,10 @@ class CompletionSuite extends BaseCompletionSuite {
     compat = Map(
       "3.0.0-RC1" ->
         """|readAttributes(x$0: Path, x$1: String, x$2: LinkOption*): java.util.Map[String, Object]
+           |""".stripMargin,
+      "3.0.1" ->
+        """|readAttributes[A <: BasicFileAttributes](x$0: Path, x$1: Class[A], x$2: LinkOption*): A
+           |readAttributes(x$0: Path, x$1: String, x$2: LinkOption*): java.util.Map[String, Object]
            |""".stripMargin,
       "3.0" ->
         """|readAttributes(x$0: Path, x$1: String, x$2: LinkOption*): java.util.Map[String, Object]
@@ -870,7 +957,9 @@ class CompletionSuite extends BaseCompletionSuite {
       "3.0" ->
         """|Some scala
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
+           |SomeToExpr - scala.quoted.ToExpr
            |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
+           |SomeFromExpr - scala.quoted.FromExpr
            |""".stripMargin
     )
   )
@@ -888,7 +977,9 @@ class CompletionSuite extends BaseCompletionSuite {
       "3.0" ->
         """|Some scala
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
+           |SomeToExpr - scala.quoted.ToExpr
            |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
+           |SomeFromExpr - scala.quoted.FromExpr
            |""".stripMargin
     )
   )
@@ -906,8 +997,8 @@ class CompletionSuite extends BaseCompletionSuite {
     topLines = Some(2),
     compat = Map(
       "3.0" ->
-        """|NoClassDefFoundError java.lang
-           |NoManifest: reflect.NoManifest.type
+        """|NoManifest scala.reflect
+           |NoClassDefFoundError java.lang
            |""".stripMargin
     )
   )
@@ -930,10 +1021,15 @@ class CompletionSuite extends BaseCompletionSuite {
            |Seq scala.collection.immutable
            |Set scala.collection.immutable
            |""".stripMargin,
+      "3.0.0-RC1" ->
+        """|Seq scala.collection.immutable
+           |Set scala.collection.immutable
+           |StringBuilder scala.collection.mutable
+           |""".stripMargin,
       "3.0" ->
-        """|SafeVarargs java.lang
-           |SecurityException java.lang
-           |SecurityManager java.lang
+        """|Seq scala.collection.immutable
+           |Set scala.collection.immutable
+           |Stream scala.collection.immutable
            |""".stripMargin
     )
   )
@@ -956,15 +1052,15 @@ class CompletionSuite extends BaseCompletionSuite {
            |Seq scala.collection.immutable
            |Set scala.collection.immutable
            |""".stripMargin,
-      "3.0.0-RC1" ->
+      "3.0.1" ->
+        """|Seq scala.collection.immutable
+           |Set scala.collection.immutable
+           |Stream scala.collection.immutable
+           |""".stripMargin,
+      "3.0" ->
         """|SafeVarargs java.lang
            |SafeVarargs java.lang
            |ScalaReflectionException scala
-           |""".stripMargin,
-      "3.0" ->
-        """|String java.lang
-           |StringIndexOutOfBoundsException java.lang
-           |SafeVarargs java.lang
            |""".stripMargin
     )
   )
@@ -992,12 +1088,12 @@ class CompletionSuite extends BaseCompletionSuite {
       "3.0.0-RC1" ->
         """|NotString: Int
            |Number: Regex
-           |NegativeArraySizeException java.lang
+           |Nil scala.collection.immutable
            |""".stripMargin,
       "3.0" ->
         """|NotString: Int
-           |NegativeArraySizeException java.lang
-           |Nil: collection.immutable.Nil.type
+           |Nil scala.collection.immutable
+           |NoManifest scala.reflect
            |""".stripMargin
     )
   )
@@ -1016,10 +1112,10 @@ class CompletionSuite extends BaseCompletionSuite {
        |""".stripMargin,
     topLines = Option(3),
     compat = Map(
-      "3.0" ->
-        """|Nil: collection.immutable.Nil.type
-           |NoManifest: reflect.NoManifest.type
-           |None scala
+      "3.0.0" ->
+        """|Nil scala.collection.immutable
+           |NoManifest scala.reflect
+           |NegativeArraySizeException java.lang
            |""".stripMargin
     )
   )
@@ -1038,10 +1134,10 @@ class CompletionSuite extends BaseCompletionSuite {
        |""".stripMargin,
     topLines = Option(3),
     compat = Map(
-      "3.0" ->
-        """|Nil: collection.immutable.Nil.type
-           |NoManifest: reflect.NoManifest.type
-           |None scala
+      "3.0.0" ->
+        """|Nil scala.collection.immutable
+           |NoManifest scala.reflect
+           |NegativeArraySizeException java.lang
            |""".stripMargin
     )
   )
@@ -1068,6 +1164,10 @@ class CompletionSuite extends BaseCompletionSuite {
     filterText = "substring",
     compat = Map(
       "3.0.0-RC1" -> "substring(x$0: Int, x$1: Int): String",
+      "3.0.1" ->
+        """|substring(x$0: Int): String
+           |substring(x$0: Int, x$1: Int): String
+           |""".stripMargin,
       "3.0" ->
         """|substring(x$0: Int, x$1: Int): String
            |substring(x$0: Int): String

--- a/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
@@ -145,7 +145,7 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
                  |PrintStream - java.io
                  |Stream - java.util.stream
                  |Stream - scala.collection.immutable
-                 |Stream: collection.immutable.Stream.type
+                 |Stream scala.collection.immutable
                  |StreamFilter - javax.xml.stream
                  |StreamResult - javax.xml.transform.stream
                  |StreamShape - scala.collection.convert.StreamExtensions


### PR DESCRIPTION
This also includes a bunch of fixes that were kind of a chain reaction due to some tests failing for 3.0.1-RC1
- print outer type instead of singleton type for objects
- make sure to take method signature into account when filtering symbols
