### PR TITLE
Add support for `textDocument/selectionRange`.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -746,6 +746,7 @@ class MetalsLanguageServer(
           )
         )
         capabilities.setFoldingRangeProvider(true)
+        capabilities.setSelectionRangeProvider(true)
         capabilities.setCodeLensProvider(new CodeLensOptions(false))
         capabilities.setDefinitionProvider(true)
         capabilities.setImplementationProvider(true)
@@ -1512,6 +1513,15 @@ class MetalsLanguageServer(
           params.getTextDocument().getUri().toAbsolutePath
         )
       )
+    }
+  }
+
+  @JsonRequest("textDocument/selectionRange")
+  def selectionRange(
+      params: SelectionRangeParams
+  ): CompletableFuture[util.List[SelectionRange]] = {
+    CancelTokens.future { token =>
+      compilers.selectionRange(params, token)
     }
   }
 

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -12,7 +12,7 @@ import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
-import org.eclipse.lsp4j.FoldingRange;
+import org.eclipse.lsp4j.SelectionRange;
 
 import java.net.URI;
 import java.nio.file.Path;
@@ -102,6 +102,11 @@ public abstract class PresentationCompiler {
      * Returns the Protobuf byte array representation of a SemanticDB <code>TextDocument</code> for the given source.
      */
     public abstract CompletableFuture<byte[]> semanticdbTextDocument(URI filename, String code);
+
+    /**
+     * Return the selections ranges for the given positions. 
+     */
+    public abstract CompletableFuture<List<SelectionRange>> selectionRange(List<OffsetParams> params);
 
     // =================================
     // Configuration and lifecycle APIs.

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -466,6 +466,12 @@ class MetalsGlobal(
     onUnitOf(pos.source) { unit => new MetalsLocator(pos).locateIn(unit.body) }
   }
 
+  def locateUntyped(pos: Position): Tree = {
+    onUnitOf(pos.source) { unit =>
+      new MetalsLocator(pos).locateIn(parseTree(unit.source))
+    }
+  }
+
   def CURSOR = "_CURSOR_"
 
   def addCompilationUnit(

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -33,6 +33,7 @@ import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.Hover
+import org.eclipse.lsp4j.SelectionRange
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.TextEdit
 
@@ -204,6 +205,19 @@ case class ScalaPresentationCompiler(
       new SemanticdbTextDocumentProvider(pc.compiler())
         .textDocument(uri, code)
         .toByteArray
+    }
+  }
+
+  override def selectionRange(
+      params: ju.List[OffsetParams]
+  ): CompletableFuture[ju.List[SelectionRange]] = {
+    CompletableFuture.completedFuture {
+      compilerAccess.withSharedCompiler(List.empty[SelectionRange].asJava) {
+        pc =>
+          new SelectionRangeProvider(pc.compiler(), params)
+            .selectionRange()
+            .asJava
+      }
     }
   }
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SelectionRangeProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SelectionRangeProvider.scala
@@ -1,0 +1,64 @@
+package scala.meta.internal.pc
+
+import java.{util => ju}
+
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.pc.OffsetParams
+
+import org.eclipse.lsp4j.SelectionRange
+
+/**
+ * Provides the functionality necessary for the `textDocument/selectionRange` request.
+ *
+ * @param compiler Metals Global presentation compiler wrapper.
+ * @param params offset params converted from the selectionRange params.
+ */
+class SelectionRangeProvider(
+    val compiler: MetalsGlobal,
+    params: ju.List[OffsetParams]
+) {
+
+  /**
+   * Get the seletion ranges for the provider params
+   *
+   * @return selection ranges
+   */
+  def selectionRange(): List[SelectionRange] = {
+    import compiler._
+
+    val selectionRanges = params.asScala.toList.map { param =>
+      val unit = addCompilationUnit(
+        code = param.text(),
+        filename = param.uri().toString(),
+        cursor = None
+      )
+
+      val pos = unit.position(param.offset)
+
+      // NOTE that we locate the pos in the tree _only_ so that we have a fresh
+      // lastVisitedParentTrees that will contain the exact tree structure we
+      // need to create the selection range, starting from the position
+      val _ = locateUntyped(pos)
+
+      val bareRanges = lastVisitedParentTrees
+        .map { tree: Tree =>
+          val selectionRange = new SelectionRange()
+          selectionRange.setRange(tree.pos.toLSP)
+          selectionRange
+        }
+
+      bareRanges.reduceRight(setParent)
+    }
+
+    selectionRanges
+  }
+
+  private def setParent(
+      child: SelectionRange,
+      parent: SelectionRange
+  ): SelectionRange = {
+    child.setParent(parent)
+    child
+  }
+
+}

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SelectionRangeProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SelectionRangeProvider.scala
@@ -57,8 +57,31 @@ class SelectionRangeProvider(
       child: SelectionRange,
       parent: SelectionRange
   ): SelectionRange = {
-    child.setParent(parent)
-    child
+    // If the parent and the child have the same exact range we just skip it.
+    // This happens in a lot of various places. For example:
+    //
+    // val total = for {
+    //   a <- >>region>>Some(1)<<region<<
+    // } yield a
+    //
+    //Apply(
+    //  Select(Apply(Ident(Some), List(Literal(Constant(1)))), flatMap), <-- This range
+    //  List(
+    //    Function(
+    //      List(ValDef(Modifiers(8192L, , List()), a, <type ?>, <empty>)),
+    //      Apply(
+    //        Select(Apply(Ident(Some), List(Literal(Constant(2)))), map), <-- Same as this range
+    //        ...
+    //      )
+    //    )
+    //  )
+    //)
+    if (child.getRange() == parent.getRange()) {
+      parent
+    } else {
+      child.setParent(parent)
+      child
+    }
   }
 
 }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -600,6 +600,7 @@ trait Completions { this: MetalsGlobal =>
           None
       }
   }
+
   class MetalsLocator(pos: Position) extends Traverser {
     def locateIn(root: Tree): Tree = {
       lastVisitedParentTrees = Nil
@@ -616,7 +617,7 @@ trait Completions { this: MetalsGlobal =>
             if tt.original != null && (tt.pos includes tt.original.pos) =>
           traverse(tt.original)
         case _ =>
-          if (t.pos includes pos) {
+          if (t.pos.includes(pos)) {
             if (isEligible(t)) {
               lastVisitedParentTrees ::= t
             }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -76,6 +76,7 @@ import org.eclipse.lsp4j.MarkupContent
 import org.eclipse.lsp4j.ParameterInformation
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.SelectionRange
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.SignatureInformation
 import org.eclipse.lsp4j.TextEdit
@@ -282,6 +283,14 @@ case class ScalaPresentationCompiler(
         .inferredTypeEdits()
         .asJava
     }
+  }
+
+  override def selectionRange(
+      params: ju.List[OffsetParams]
+  ): CompletableFuture[ju.List[SelectionRange]] = {
+    CompletableFuture.completedFuture(
+      List.empty[SelectionRange].asJava
+    )
   }
 
   def hover(params: OffsetParams): CompletableFuture[ju.Optional[Hover]] =

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -288,9 +288,15 @@ case class ScalaPresentationCompiler(
   override def selectionRange(
       params: ju.List[OffsetParams]
   ): CompletableFuture[ju.List[SelectionRange]] = {
-    CompletableFuture.completedFuture(
-      List.empty[SelectionRange].asJava
-    )
+    CompletableFuture.completedFuture {
+      compilerAccess.withSharedCompiler(List.empty[SelectionRange].asJava) {
+        pc =>
+          new SelectionRangeProvider(
+            pc.compiler(),
+            params
+          ).selectionRange().asJava
+      }
+    }
   }
 
   def hover(params: OffsetParams): CompletableFuture[ju.Optional[Hover]] =

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SelectionRangeProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SelectionRangeProvider.scala
@@ -60,8 +60,31 @@ class SelectionRangeProvider(
       child: SelectionRange,
       parent: SelectionRange
   ): SelectionRange = {
-    child.setParent(parent)
-    child
+    // If the parent and the child have the same exact range we just skip it.
+    // This happens in a lot of various places. For example:
+    //
+    // val total = for {
+    //   a <- >>region>>Some(1)<<region<<
+    // } yield a
+    //
+    //Apply(
+    //  Select(Apply(Ident(Some), List(Literal(Constant(1)))), flatMap), <-- This range
+    //  List(
+    //    Function(
+    //      List(ValDef(Modifiers(8192L, , List()), a, <type ?>, <empty>)),
+    //      Apply(
+    //        Select(Apply(Ident(Some), List(Literal(Constant(2)))), map), <-- Same as this range
+    //        ...
+    //      )
+    //    )
+    //  )
+    //)
+    if (child.getRange() == parent.getRange()) {
+      parent
+    } else {
+      child.setParent(parent)
+      child
+    }
   }
 
 }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SelectionRangeProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SelectionRangeProvider.scala
@@ -1,0 +1,67 @@
+package scala.meta.internal.pc
+
+import java.nio.file.Paths
+import java.{util => ju}
+
+import scala.collection.JavaConverters._
+
+import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.pc.OffsetParams
+
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.interactive.Interactive
+import dotty.tools.dotc.interactive.InteractiveDriver
+import dotty.tools.dotc.util.SourceFile
+import org.eclipse.lsp4j.SelectionRange
+
+/**
+ * Provides the functionality necessary for the `textDocument/selectionRange` request.
+ *
+ * @param compiler Metals Global presentation compiler wrapper.
+ * @param params offset params converted from the selectionRange params.
+ */
+class SelectionRangeProvider(
+    driver: InteractiveDriver,
+    params: ju.List[OffsetParams]
+) {
+
+  /**
+   * Get the seletion ranges for the provider params
+   *
+   * @return selection ranges
+   */
+  def selectionRange(): List[SelectionRange] = {
+    given ctx: Context = driver.currentCtx
+
+    val selectionRanges = params.asScala.toList.map { param =>
+
+      val uri = param.uri
+      val filePath = Paths.get(uri)
+      val source = SourceFile.virtual(filePath.toString, param.text)
+      driver.run(uri, source)
+      val pos = driver.sourcePosition(param)
+      val path =
+        Interactive.pathTo(driver.openedTrees(uri), pos)(using ctx)
+
+      val bareRanges = path
+        .map { tree =>
+          val selectionRange = new SelectionRange()
+          selectionRange.setRange(tree.sourcePos.toLSP)
+          selectionRange
+        }
+
+      bareRanges.reduceRight(setParent)
+    }
+
+    selectionRanges
+  }
+
+  private def setParent(
+      child: SelectionRange,
+      parent: SelectionRange
+  ): SelectionRange = {
+    child.setParent(parent)
+    child
+  }
+
+}

--- a/tests/cross/src/main/scala/tests/pc/BaseSelectionRangeSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BaseSelectionRangeSuite.scala
@@ -1,0 +1,88 @@
+package tests.pc
+
+import java.nio.file.Paths
+import java.{util => ju}
+
+import scala.meta.inputs.Input
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.CompilerOffsetParams
+import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.pc.OffsetParams
+
+import munit.TestOptions
+import org.eclipse.{lsp4j => l}
+import tests.Assertions
+import tests.BasePCSuite
+
+abstract class BaseSelectionRangeSuite extends BasePCSuite {
+
+  def check(
+      name: TestOptions,
+      original: String,
+      expectedRanges: List[String],
+      compat: Map[String, String] = Map.empty
+  ): Unit = {
+    test(name) {
+      val (code, offset) = params(original)
+      val offsetParams: ju.List[OffsetParams] = List[OffsetParams](
+        CompilerOffsetParams(
+          Paths.get("SelectionRange.scala").toUri(),
+          code,
+          offset,
+          EmptyCancelToken
+        )
+      ).asJava
+
+      val selectionRanges = presentationCompiler
+        .selectionRange(offsetParams)
+        .get()
+        .asScala
+        .toList
+
+      // Note that this takes some liberty since the spec isn't the clearest on
+      // the way this is done and different LSP clients seems to impliment this
+      // differently. Mainly, we mimic what VS Code does and what other servers
+      // like jdtls do and we send in a single position. Once that positions is
+      // recieved we check the Selection range and all the parents in that range
+      // to ensure it contains the positions we'd expect it to contain. In the
+      // case of VS Code, they never make a second request, and instead they
+      // just rely on the tree to continue selecting. So we mimic that here in
+      // the tests.
+      assertSelectionRanges(
+        selectionRanges.headOption,
+        expectedRanges,
+        code
+      )
+    }
+  }
+
+  private def assertSelectionRanges(
+      range: Option[l.SelectionRange],
+      expected: List[String],
+      original: String
+  ): Unit = {
+    assert(range.nonEmpty)
+    expected.headOption.foreach { expectedRange =>
+      val withRange = applyRanges(original, range.get)
+      Assertions.assertNoDiff(withRange, expectedRange)
+      assertSelectionRanges(range.map(_.getParent()), expected.tail, original)
+    }
+  }
+
+  private def applyRanges(
+      text: String,
+      selectionRange: l.SelectionRange
+  ): String = {
+    val input = Input.String(text)
+
+    val pos = selectionRange.getRange().toMeta(input)
+    val out = new java.lang.StringBuilder()
+    out.append(text, 0, pos.start)
+    out.append(">>region>>")
+    out.append(text, pos.start, pos.end)
+    out.append("<<region<<")
+    out.append(text, pos.end, text.length)
+    out.toString
+  }
+}

--- a/tests/cross/src/main/scala/tests/pc/BaseSelectionRangeSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BaseSelectionRangeSuite.scala
@@ -21,7 +21,7 @@ abstract class BaseSelectionRangeSuite extends BasePCSuite {
       name: TestOptions,
       original: String,
       expectedRanges: List[String],
-      compat: Map[String, String] = Map.empty
+      compat: Map[String, List[String]] = Map.empty
   ): Unit = {
     test(name) {
       val (code, offset) = params(original)
@@ -51,7 +51,7 @@ abstract class BaseSelectionRangeSuite extends BasePCSuite {
       // the tests.
       assertSelectionRanges(
         selectionRanges.headOption,
-        expectedRanges,
+        compatOrDefault(expectedRanges, compat, scalaVersion),
         code
       )
     }

--- a/tests/cross/src/test/scala/tests/pc/SelectionRangeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SelectionRangeSuite.scala
@@ -65,12 +65,6 @@ class SelectionRangeSuite extends BaseSelectionRangeSuite {
              |}""".stripMargin,
           """|object Main extends App {
              |  Option("chris") match {
-             |    case >>region>>Some(name)<<region<< => println("Hello! " + name)
-             |    case None =>
-             |  }
-             |}""".stripMargin,
-          """|object Main extends App {
-             |  Option("chris") match {
              |    >>region>>case Some(name) => println("Hello! " + name)<<region<<
              |    case None =>
              |  }
@@ -118,13 +112,6 @@ class SelectionRangeSuite extends BaseSelectionRangeSuite {
          |    b <- Some(2)
          |  } yield a + b
          |}""".stripMargin,
-      // TODO we have a duplicate here, figure out why
-      """|object Main extends App {
-         |  val total = for {
-         |    a <- >>region>>Some(1)<<region<<
-         |    b <- Some(2)
-         |  } yield a + b
-         |}""".stripMargin,
       """|object Main extends App {
          |  val total = >>region>>for {
          |    a <- Some(1)
@@ -152,29 +139,9 @@ class SelectionRangeSuite extends BaseSelectionRangeSuite {
     ),
     Map(
       "3" -> List(
-        // TODO Figure out whyt his comes twice in a row
         """|object Main extends App {
            |  val total = for {
            |    a <- >>region>>Some<<region<<(1)
-           |    b <- Some(2)
-           |  } yield a + b
-           |}""".stripMargin,
-        """|object Main extends App {
-           |  val total = for {
-           |    a <- >>region>>Some<<region<<(1)
-           |    b <- Some(2)
-           |  } yield a + b
-           |}""".stripMargin,
-        // TODO not twice, but thrice!
-        """|object Main extends App {
-           |  val total = for {
-           |    a <- >>region>>Some(1)<<region<<
-           |    b <- Some(2)
-           |  } yield a + b
-           |}""".stripMargin,
-        """|object Main extends App {
-           |  val total = for {
-           |    a <- >>region>>Some(1)<<region<<
            |    b <- Some(2)
            |  } yield a + b
            |}""".stripMargin,
@@ -196,7 +163,6 @@ class SelectionRangeSuite extends BaseSelectionRangeSuite {
            |    b <- Some(2)
            |  } yield a + b<<region<<
            |}""".stripMargin,
-        // TODO this looks funky, is this right?
         """|object Main extends >>region>>App {
            |  val total = for {
            |    a <- Some(1)

--- a/tests/cross/src/test/scala/tests/pc/SelectionRangeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SelectionRangeSuite.scala
@@ -1,0 +1,108 @@
+package tests.pc
+
+class SelectionRangeSuite extends BaseSelectionRangeSuite {
+
+  check(
+    "match".tag(IgnoreScala3),
+    """|object Main extends App {
+       |  Option("chris") match {
+       |    case Some(n@@ame) => println("Hello! " + name)
+       |    case None =>
+       |  }
+       |}""".stripMargin,
+    List(
+      """|object Main extends App {
+         |  Option("chris") match {
+         |    case Some(>>region>>name<<region<<) => println("Hello! " + name)
+         |    case None =>
+         |  }
+         |}""".stripMargin,
+      """|object Main extends App {
+         |  Option("chris") match {
+         |    case >>region>>Some(name)<<region<< => println("Hello! " + name)
+         |    case None =>
+         |  }
+         |}""".stripMargin,
+      """|object Main extends App {
+         |  Option("chris") match {
+         |    case >>region>>Some(name) => println("Hello! " + name)<<region<<
+         |    case None =>
+         |  }
+         |}""".stripMargin,
+      """|object Main extends App {
+         |  >>region>>Option("chris") match {
+         |    case Some(name) => println("Hello! " + name)
+         |    case None =>
+         |  }<<region<<
+         |}""".stripMargin,
+      """|object Main >>region>>extends App {
+         |  Option("chris") match {
+         |    case Some(name) => println("Hello! " + name)
+         |    case None =>
+         |  }
+         |}<<region<<""".stripMargin,
+      """|>>region>>object Main extends App {
+         |  Option("chris") match {
+         |    case Some(name) => println("Hello! " + name)
+         |    case None =>
+         |  }
+         |}<<region<<""".stripMargin
+    )
+  )
+
+  check(
+    "for".tag(IgnoreScala3),
+    """|object Main extends App {
+       |  val total = for {
+       |    a <- S@@ome(1)
+       |    b <- Some(2)
+       |  } yield a + b
+       |}""".stripMargin,
+    List(
+      """|object Main extends App {
+         |  val total = for {
+         |    a <- >>region>>Some<<region<<(1)
+         |    b <- Some(2)
+         |  } yield a + b
+         |}""".stripMargin,
+      """|object Main extends App {
+         |  val total = for {
+         |    a <- >>region>>Some(1)<<region<<
+         |    b <- Some(2)
+         |  } yield a + b
+         |}""".stripMargin,
+      // TODO we have a duplicate here, figure out why
+      """|object Main extends App {
+         |  val total = for {
+         |    a <- >>region>>Some(1)<<region<<
+         |    b <- Some(2)
+         |  } yield a + b
+         |}""".stripMargin,
+      """|object Main extends App {
+         |  val total = >>region>>for {
+         |    a <- Some(1)
+         |    b <- Some(2)
+         |  } yield a + b<<region<<
+         |}""".stripMargin,
+      """|object Main extends App {
+         |  >>region>>val total = for {
+         |    a <- Some(1)
+         |    b <- Some(2)
+         |  } yield a + b<<region<<
+         |}""".stripMargin,
+      """|object Main >>region>>extends App {
+         |  val total = for {
+         |    a <- Some(1)
+         |    b <- Some(2)
+         |  } yield a + b
+         |}<<region<<""".stripMargin,
+      """|>>region>>object Main extends App {
+         |  val total = for {
+         |    a <- Some(1)
+         |    b <- Some(2)
+         |  } yield a + b
+         |}<<region<<""".stripMargin
+    )
+  )
+
+}

--- a/tests/cross/src/test/scala/tests/pc/SelectionRangeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SelectionRangeSuite.scala
@@ -3,7 +3,7 @@ package tests.pc
 class SelectionRangeSuite extends BaseSelectionRangeSuite {
 
   check(
-    "match".tag(IgnoreScala3),
+    "match",
     """|object Main extends App {
        |  Option("chris") match {
        |    case Some(n@@ame) => println("Hello! " + name)
@@ -47,11 +47,58 @@ class SelectionRangeSuite extends BaseSelectionRangeSuite {
          |    case None =>
          |  }
          |}<<region<<""".stripMargin
+    ),
+    Map(
+      "3" ->
+        List(
+          """|object Main extends App {
+             |  Option("chris") match {
+             |    case Some(>>region>>name<<region<<) => println("Hello! " + name)
+             |    case None =>
+             |  }
+             |}""".stripMargin,
+          """|object Main extends App {
+             |  Option("chris") match {
+             |    case >>region>>Some(name)<<region<< => println("Hello! " + name)
+             |    case None =>
+             |  }
+             |}""".stripMargin,
+          """|object Main extends App {
+             |  Option("chris") match {
+             |    case >>region>>Some(name)<<region<< => println("Hello! " + name)
+             |    case None =>
+             |  }
+             |}""".stripMargin,
+          """|object Main extends App {
+             |  Option("chris") match {
+             |    >>region>>case Some(name) => println("Hello! " + name)<<region<<
+             |    case None =>
+             |  }
+             |}""".stripMargin,
+          """|object Main extends App {
+             |  >>region>>Option("chris") match {
+             |    case Some(name) => println("Hello! " + name)
+             |    case None =>
+             |  }<<region<<
+             |}""".stripMargin,
+          """|object Main extends >>region>>App {
+             |  Option("chris") match {
+             |    case Some(name) => println("Hello! " + name)
+             |    case None =>
+             |  }<<region<<
+             |}""".stripMargin,
+          """|>>region>>object Main extends App {
+             |  Option("chris") match {
+             |    case Some(name) => println("Hello! " + name)
+             |    case None =>
+             |  }
+             |}<<region<<""".stripMargin
+        )
     )
   )
 
   check(
-    "for".tag(IgnoreScala3),
+    "for",
     """|object Main extends App {
        |  val total = for {
        |    a <- S@@ome(1)
@@ -102,6 +149,67 @@ class SelectionRangeSuite extends BaseSelectionRangeSuite {
          |    b <- Some(2)
          |  } yield a + b
          |}<<region<<""".stripMargin
+    ),
+    Map(
+      "3" -> List(
+        // TODO Figure out whyt his comes twice in a row
+        """|object Main extends App {
+           |  val total = for {
+           |    a <- >>region>>Some<<region<<(1)
+           |    b <- Some(2)
+           |  } yield a + b
+           |}""".stripMargin,
+        """|object Main extends App {
+           |  val total = for {
+           |    a <- >>region>>Some<<region<<(1)
+           |    b <- Some(2)
+           |  } yield a + b
+           |}""".stripMargin,
+        // TODO not twice, but thrice!
+        """|object Main extends App {
+           |  val total = for {
+           |    a <- >>region>>Some(1)<<region<<
+           |    b <- Some(2)
+           |  } yield a + b
+           |}""".stripMargin,
+        """|object Main extends App {
+           |  val total = for {
+           |    a <- >>region>>Some(1)<<region<<
+           |    b <- Some(2)
+           |  } yield a + b
+           |}""".stripMargin,
+        """|object Main extends App {
+           |  val total = for {
+           |    a <- >>region>>Some(1)<<region<<
+           |    b <- Some(2)
+           |  } yield a + b
+           |}""".stripMargin,
+        """|object Main extends App {
+           |  val total = >>region>>for {
+           |    a <- Some(1)
+           |    b <- Some(2)
+           |  } yield a + b<<region<<
+           |}""".stripMargin,
+        """|object Main extends App {
+           |  >>region>>val total = for {
+           |    a <- Some(1)
+           |    b <- Some(2)
+           |  } yield a + b<<region<<
+           |}""".stripMargin,
+        // TODO this looks funky, is this right?
+        """|object Main extends >>region>>App {
+           |  val total = for {
+           |    a <- Some(1)
+           |    b <- Some(2)
+           |  } yield a + b<<region<<
+           |}""".stripMargin,
+        """|>>region>>object Main extends App {
+           |  val total = for {
+           |    a <- Some(1)
+           |    b <- Some(2)
+           |  } yield a + b
+           |}<<region<<""".stripMargin
+      )
     )
   )
 

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -60,15 +60,23 @@ class BaseSuite extends munit.FunSuite with Assertions {
       }
       .getOrElse(identity[String] _)
 
-    val result = compat
+    val result = compatOrDefault(default, compat, scalaVersion)
+
+    postProcess(result)
+  }
+
+  def compatOrDefault[A](
+      default: A,
+      compat: Map[String, A],
+      scalaVersion: String
+  ): A =
+    compat
       .collect {
-        case (ver, code) if scalaVersion.startsWith(ver) => code
+        case (ver, compatCode) if scalaVersion.startsWith(ver) => compatCode
       }
       .headOption
       .getOrElse(default)
 
-    postProcess(result)
-  }
   protected def toJsonArray(list: List[String]): String = {
     if (list.isEmpty) "[]"
     else s"[${list.mkString("\"", """", """", "\"")}]"

--- a/tests/unit/src/main/scala/tests/RangesTextEdits.scala
+++ b/tests/unit/src/main/scala/tests/RangesTextEdits.scala
@@ -7,9 +7,15 @@ import scala.meta.internal.jdk.CollectionConverters._
 import org.eclipse.lsp4j.TextEdit
 import org.eclipse.{lsp4j => l}
 
-object FoldingRangesTextEdits {
-  def apply(ranges: util.List[l.FoldingRange]): List[l.TextEdit] = {
+object RangesTextEdits {
+  def fromFoldingRanges(ranges: util.List[l.FoldingRange]): List[l.TextEdit] = {
     ranges.asScala.flatMap(convert).toList
+  }
+
+  def fromSelectionRanges(
+      ranges: List[l.SelectionRange]
+  ): List[l.TextEdit] = {
+    ranges.flatMap(convert).toList
   }
 
   private def convert(range: l.FoldingRange): List[l.TextEdit] = {
@@ -18,6 +24,16 @@ object FoldingRangesTextEdits {
     List(
       new TextEdit(new l.Range(start, start), s">>${range.getKind}>>"),
       new TextEdit(new l.Range(end, end), s"<<${range.getKind}<<")
+    )
+  }
+
+  private def convert(selectionRange: l.SelectionRange): List[l.TextEdit] = {
+    val range = selectionRange.getRange()
+    val start = range.getStart()
+    val end = range.getEnd()
+    List(
+      new TextEdit(new l.Range(start, start), s">>region>>"),
+      new TextEdit(new l.Range(end, end), s"<<region<<")
     )
   }
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -12,6 +12,7 @@ import java.nio.file.attribute.BasicFileAttributes
 import java.util
 import java.util.Collections
 import java.util.concurrent.ScheduledExecutorService
+import java.{util => ju}
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
@@ -640,7 +641,7 @@ final class TestingServer(
     val params = new FoldingRangeRequestParams(new TextDocumentIdentifier(uri))
     for {
       ranges <- server.foldingRange(params).asScala
-      textEdits = FoldingRangesTextEdits(ranges)
+      textEdits = RangesTextEdits.fromFoldingRanges(ranges)
     } yield TextEdits.applyEdits(textContents(filename), textEdits)
   }
 
@@ -651,6 +652,36 @@ final class TestingServer(
       folded <- foldingRange(filename)
       _ = Assertions.assertNoDiff(folded, expected)
     } yield ()
+
+  def retrieveRanges(
+      filename: String,
+      expected: String
+  ): Future[ju.List[l.SelectionRange]] = {
+    val path = toPath(filename)
+    val input = path.toInputFromBuffers(buffers)
+    val offset = expected.indexOf("@@")
+    if (offset < 0) sys.error("missing @@")
+    val start = input.text.indexOf(expected.replace("@@", ""))
+    val point = start + offset
+    val pos = m.Position.Range(input, point, point)
+    val params =
+      new l.SelectionRangeParams(
+        path.toTextDocumentIdentifier,
+        List(pos.toLSP.getStart).asJava
+      )
+
+    server.selectionRange(params).asScala
+  }
+
+  def assertSelectionRanges(
+      filename: String,
+      expected: String,
+      ranges: List[l.SelectionRange]
+  ): Unit = {
+    val edits = RangesTextEdits.fromSelectionRanges(ranges)
+    val edited = TextEdits.applyEdits(textContents(filename), edits)
+    Assertions.assertNoDiff(edited, expected)
+  }
 
   def onTypeFormatting(
       filename: String,

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -675,12 +675,15 @@ final class TestingServer(
 
   def assertSelectionRanges(
       filename: String,
-      expected: String,
-      ranges: List[l.SelectionRange]
+      ranges: List[l.SelectionRange],
+      expected: List[String]
   ): Unit = {
-    val edits = RangesTextEdits.fromSelectionRanges(ranges)
-    val edited = TextEdits.applyEdits(textContents(filename), edits)
-    Assertions.assertNoDiff(edited, expected)
+    expected.headOption.foreach { expectedRange =>
+      val edits = RangesTextEdits.fromSelectionRanges(ranges)
+      val edited = TextEdits.applyEdits(textContents(filename), edits)
+      Assertions.assertNoDiff(edited, expectedRange)
+      assertSelectionRanges(filename, ranges.map(_.getParent()), expected.tail)
+    }
   }
 
   def onTypeFormatting(

--- a/tests/unit/src/test/scala/tests/FoldingRangeSuite.scala
+++ b/tests/unit/src/test/scala/tests/FoldingRangeSuite.scala
@@ -50,7 +50,7 @@ abstract class FoldingRangeSuite(
     val scalaSource = file.input.text
 
     val actualRanges = findFoldingRangesFor(scalaSource)
-    val edits = FoldingRangesTextEdits.apply(actualRanges)
+    val edits = RangesTextEdits.fromFoldingRanges(actualRanges)
     TextEdits.applyEdits(scalaSource, edits)
   }
 

--- a/tests/unit/src/test/scala/tests/SelectionRangeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SelectionRangeLspSuite.scala
@@ -42,35 +42,27 @@ class SelectionRangeLspSuite extends BaseLspSuite("selectionRange") {
       )
       _ = server.assertSelectionRanges(
         "a/src/main/scala/a/Main.scala",
-        """|object Main extends App {
-           |  >>region>>def double(a: Int) = {
-           |    a * 2
-           |  }<<region<<
-           |}
-           |""".stripMargin,
-        ranges.asScala.toList
-      )
-      parents = ranges.asScala.toList.map(_.getParent())
-      _ = server.assertSelectionRanges(
-        "a/src/main/scala/a/Main.scala",
-        """|object Main >>region>>extends App {
-           |  def double(a: Int) = {
-           |    a * 2
-           |  }
-           |}<<region<<
-           |""".stripMargin,
-        parents
-      )
-      parantsParents = parents.map(_.getParent())
-      _ = server.assertSelectionRanges(
-        "a/src/main/scala/a/Main.scala",
-        """|>>region>>object Main extends App {
-           |  def double(a: Int) = {
-           |    a * 2
-           |  }
-           |}<<region<<
-           |""".stripMargin,
-        parantsParents
+        ranges.asScala.toList,
+        List(
+          """|object Main extends App {
+             |  >>region>>def double(a: Int) = {
+             |    a * 2
+             |  }<<region<<
+             |}
+             |""".stripMargin,
+          """|object Main >>region>>extends App {
+             |  def double(a: Int) = {
+             |    a * 2
+             |  }
+             |}<<region<<
+             |""".stripMargin,
+          """|>>region>>object Main extends App {
+             |  def double(a: Int) = {
+             |    a * 2
+             |  }
+             |}<<region<<
+             |""".stripMargin
+        )
       )
 
     } yield ()
@@ -104,46 +96,33 @@ class SelectionRangeLspSuite extends BaseLspSuite("selectionRange") {
       )
       _ = server.assertSelectionRanges(
         "a/src/main/scala/a/Main.scala",
-        """|object Main extends App {
-           |  def double(>>region>>a: Int<<region<<) = {
-           |    * 2
-           |  }
-           |}
-           |""".stripMargin,
-        ranges.asScala.toList
-      )
-      parents = ranges.asScala.toList.map(_.getParent())
-      _ = server.assertSelectionRanges(
-        "a/src/main/scala/a/Main.scala",
-        """|object Main extends App {
-           |  >>region>>def double(a: Int) = {
-           |    * 2
-           |  }<<region<<
-           |}
-           |""".stripMargin,
-        parents
-      )
-      parentsParents = parents.map(_.getParent())
-      _ = server.assertSelectionRanges(
-        "a/src/main/scala/a/Main.scala",
-        """|object Main >>region>>extends App {
-           |  def double(a: Int) = {
-           |    * 2
-           |  }
-           |}<<region<<
-           |""".stripMargin,
-        parentsParents
-      )
-      parantsParentsParents = parentsParents.map(_.getParent())
-      _ = server.assertSelectionRanges(
-        "a/src/main/scala/a/Main.scala",
-        """|>>region>>object Main extends App {
-           |  def double(a: Int) = {
-           |    * 2
-           |  }
-           |}<<region<<
-           |""".stripMargin,
-        parantsParentsParents
+        ranges.asScala.toList,
+        List(
+          """|object Main extends App {
+             |  def double(>>region>>a: Int<<region<<) = {
+             |    * 2
+             |  }
+             |}
+             |""".stripMargin,
+          """|object Main extends App {
+             |  >>region>>def double(a: Int) = {
+             |    * 2
+             |  }<<region<<
+             |}
+             |""".stripMargin,
+          """|object Main >>region>>extends App {
+             |  def double(a: Int) = {
+             |    * 2
+             |  }
+             |}<<region<<
+             |""".stripMargin,
+          """|>>region>>object Main extends App {
+             |  def double(a: Int) = {
+             |    * 2
+             |  }
+             |}<<region<<
+             |""".stripMargin
+        )
       )
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/SelectionRangeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SelectionRangeLspSuite.scala
@@ -1,0 +1,150 @@
+package tests
+import scala.collection.JavaConverters._
+
+/**
+ *  Suite for testing selection ranges. Note that this takes some liberty
+ *  since the spec isn't the clearest on the way this is done and different
+ *  LSP clients seems to impliment this differently. Mainly, we mimic what VS
+ *  Code does and what other servers like jdtls do and we send in a single
+ *  position. Once that positions is recieved we check the Selection range and
+ *  all the parents in that range to ensure it contains the positions we'd
+ *  expect it to contain. In the case of VS Code, they never make a second
+ *  request, and instead they just rely on the tree to continue selecting. So
+ *  we mimic that here in the tests.
+ */
+class SelectionRangeLspSuite extends BaseLspSuite("selectionRange") {
+
+  test("basic") {
+    for {
+      _ <- server.initialize(
+        """|
+           |/metals.json
+           |{
+           |  "a": { }
+           |}
+           |/a/src/main/scala/a/Main.scala
+           |object Main extends App {
+           |  def double(a: Int) = {
+           |    a * 2
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      ranges <- server.retrieveRanges(
+        "a/src/main/scala/a/Main.scala",
+        """|object Main extends App {
+           |  def double(a: Int) = {
+           |  @@  a * 2
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ = server.assertSelectionRanges(
+        "a/src/main/scala/a/Main.scala",
+        """|object Main extends App {
+           |  >>region>>def double(a: Int) = {
+           |    a * 2
+           |  }<<region<<
+           |}
+           |""".stripMargin,
+        ranges.asScala.toList
+      )
+      parents = ranges.asScala.toList.map(_.getParent())
+      _ = server.assertSelectionRanges(
+        "a/src/main/scala/a/Main.scala",
+        """|object Main >>region>>extends App {
+           |  def double(a: Int) = {
+           |    a * 2
+           |  }
+           |}<<region<<
+           |""".stripMargin,
+        parents
+      )
+      parantsParents = parents.map(_.getParent())
+      _ = server.assertSelectionRanges(
+        "a/src/main/scala/a/Main.scala",
+        """|>>region>>object Main extends App {
+           |  def double(a: Int) = {
+           |    a * 2
+           |  }
+           |}<<region<<
+           |""".stripMargin,
+        parantsParents
+      )
+
+    } yield ()
+  }
+
+  test("non-compiling") {
+    for {
+      _ <- server.initialize(
+        """|
+           |/metals.json
+           |{
+           |  "a": { }
+           |}
+           |/a/src/main/scala/a/Main.scala
+           |object Main extends App {
+           |  def double(a: Int) = {
+           |    * 2
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      ranges <- server.retrieveRanges(
+        "a/src/main/scala/a/Main.scala",
+        """|object Main extends App {
+           |  def double(a:@@ Int) = {
+           |    * 2
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ = server.assertSelectionRanges(
+        "a/src/main/scala/a/Main.scala",
+        """|object Main extends App {
+           |  def double(>>region>>a: Int<<region<<) = {
+           |    * 2
+           |  }
+           |}
+           |""".stripMargin,
+        ranges.asScala.toList
+      )
+      parents = ranges.asScala.toList.map(_.getParent())
+      _ = server.assertSelectionRanges(
+        "a/src/main/scala/a/Main.scala",
+        """|object Main extends App {
+           |  >>region>>def double(a: Int) = {
+           |    * 2
+           |  }<<region<<
+           |}
+           |""".stripMargin,
+        parents
+      )
+      parentsParents = parents.map(_.getParent())
+      _ = server.assertSelectionRanges(
+        "a/src/main/scala/a/Main.scala",
+        """|object Main >>region>>extends App {
+           |  def double(a: Int) = {
+           |    * 2
+           |  }
+           |}<<region<<
+           |""".stripMargin,
+        parentsParents
+      )
+      parantsParentsParents = parentsParents.map(_.getParent())
+      _ = server.assertSelectionRanges(
+        "a/src/main/scala/a/Main.scala",
+        """|>>region>>object Main extends App {
+           |  def double(a: Int) = {
+           |    * 2
+           |  }
+           |}<<region<<
+           |""".stripMargin,
+        parantsParentsParents
+      )
+    } yield ()
+  }
+}


### PR DESCRIPTION
While I still have a couple things yet to figure out with this, I wanted to through it up here to get any thoughts. Mainly because I'm hitting on (what I would call) unclarity in the spec about how this is exactly supposed to work. The interesting part is that according to the [spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_selectionRange), the client can send in multiple positions in the `selectionRangeParams`. From this point, things get interesting. I'll outline the two editors that I was testing in because they behave pretty differently even though the result is pretty much the same.

## VS Code

![2021-06-07 15 51 59](https://user-images.githubusercontent.com/13974112/121028775-605be380-c7a8-11eb-99f1-948ce0b730ab.gif)

The steps it follows:
- Grabs the position your cursor is in, and sends that in as a single position
- The selection range is returned and each range has the parent filled in. So you get the entire tree
- When you continue the selection range, no further requests are made to the server. This is actually all done with one request, and it seems that if the full tree is there, then it just skips making any additional requests

This works pretty well and is actually pretty great that no other requests are necessary. However, it then begs the question of when should VS Code ever send in more than a single position for this request? I actually have no clue. Even selecting a range and triggering it from the range has VS Code sending in the start of the range, not the entire range or multiple positions.

So contrast this with coc-metals utilizing coc.nvim

## coc-metals

![2021-06-07 15 56 09](https://user-images.githubusercontent.com/13974112/121031086-59ce6b80-c7aa-11eb-95a4-2c489c1fd1e3.gif)

So while this looks very similar, it's radically different in the LSP communication.

The steps it follows:
- Grabs the position your cursor is in, and sends that in as a single position
- The selection range is returned and each range has the parent filled in. So you get the entire tree
- When you continue the selection range an entire new request is sent, this time with first returned range split. Meaning the first position in the array was the start position of the returned range, and the second positions is the end position in the returned range
- Now there are two different selection ranges returned. In some scenarios (most scenarios from what I can tell) the actually return the same tree since the closes enclosing tree is the same whether you approach it from the start or the end. - It somehow intelligently skips the first enclosing tree if it's the same that was highlighted before and then continues on.
- Again, the further you expand, new requests are sent every time, but never containing more than 2 positions.

## Some thoughts

If you watch closely, you'll notice a very slight difference in the VS Code gif where it has one more selection range that goes to the beginning of the line. That's actually not part of the selection range returned, so I have no idea why it does that. It's almost seems like they are doing a bit more behind the scenes than the spec outlines, but still mainly following the full tree that is returned.

It doesn't bother me that much since this works pretty well in both editors, but it matters in how we test this. I'm a bit stuck at the moment how to test the step after the initial expansion since there never is a next step in VS Code, and in coc.nvim it also seems to be doing some stuff behind the scenes to choose the next range correctly. I've a snippet of trace code in the test file if you're curious what it looks like. I see a couple options.

1. We can only do an initial call, get the full selection range tree, and then just ensure that all the ranges are the logical ones that we expect.
2. Somehow create another request after the initial one with the returned position split similar to how coc.nvim is doing it. Although then we'll have to make some opinionated decisions about how to handle the multiple returned selection ranges.

Any opinions or thoughts on this?

From looking at [eclipse.jdt.ls](https://github.com/eclipse/eclipse.jdt.ls/blob/64b15c5a9e5b11f62ceb5163ceb6930d5dea7129/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SelectionRangeHandlerTest.java) it looks like they just pass in a single position and then ensures all the positions in the selection range are as expected. I'm tempted to take this approach as well.

Closes #2861