### PR TITLE
WorkspaceSearchVisitior - make search more predictable.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSearchVisitor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSearchVisitor.scala
@@ -86,10 +86,14 @@ class WorkspaceSearchVisitor(
   ): Option[SymbolDefinition] = {
     val nme = Classfile.name(filename)
     val tpe = Symbol(Symbols.Global(pkg, Descriptor.Type(nme)))
-    index.definition(tpe).orElse {
+
+    val forTpe = index.definitions(tpe)
+    val defs = if (forTpe.isEmpty) {
       val term = Symbol(Symbols.Global(pkg, Descriptor.Term(nme)))
-      index.definition(term)
-    }
+      index.definitions(term)
+    } else forTpe
+
+    defs.sortBy(_.path.toURI.toString).headOption
   }
   override def shouldVisitPackage(pkg: String): Boolean = true
   override def visitWorkspaceSymbol(


### PR DESCRIPTION
Fixes flaky `ClasspathSymbolRegressionSuite.Map#Entry` test.

Testing classpath is messed by netty artifacts that spotted [this problem](https://github.com/scalameta/metals/pull/2814/checks?check_run_id=2763907639#step:5:1187):
- `io:netty.netty-all:4.0.43.Final` - `io.netty.util.collection.IntObjectMap#Entry`
- `io.netty.netty-common:4.1.17.Final` - `io.netty.util.collection.IntObjectMap#PrimitiveEntry`