### PR TITLE
Lazily get explicit choice.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -25,7 +25,7 @@ final class BuildTools(
     workspace: AbsolutePath,
     bspGlobalDirectories: List[AbsolutePath],
     userConfig: () => UserConfiguration,
-    explicitChoiceMade: Boolean
+    explicitChoiceMade: () => Boolean
 ) {
   // NOTE: We do a couple extra check here before we say a workspace with a
   // `.bsp` is auto-connectable, and we ensure that a user has explicity chosen
@@ -36,7 +36,7 @@ final class BuildTools(
   // Bloop since Metals thinks it's in state that's auto-connectable before the
   // user is even prompted.
   def isAutoConnectable: Boolean = {
-    isBloop || (isBsp && all.isEmpty) || (isBsp && explicitChoiceMade)
+    isBloop || (isBsp && all.isEmpty) || (isBsp && explicitChoiceMade())
   }
   def isBloop: Boolean = {
     hasJsonFile(workspace.resolve(".bloop"))
@@ -128,6 +128,6 @@ object BuildTools {
       workspace,
       Nil,
       () => UserConfiguration(),
-      explicitChoiceMade = false
+      explicitChoiceMade = () => false
     )
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -346,7 +346,7 @@ class MetalsLanguageServer(
           workspace,
           bspGlobalDirectories,
           () => userConfig,
-          tables.buildServers.selectedServer().nonEmpty
+          () => tables.buildServers.selectedServer().nonEmpty
         )
         fileSystemSemanticdbs = new FileSystemSemanticdbs(
           buildTargets,


### PR DESCRIPTION
This fixes #2866 where with a very fresh project if you don't do a
BloopInstall and then you do a `generate-bsp-config` the explicit choice
gets inserted but the value we have is still the old one. This will
lazily get it to ensure we have the latest.

Note I didn't add an explicit test for this since we do a `bloopInstall`
right away in the build initialize in the Testing Server so it's hard to
actually test without making some large changes to that (which I'd like
to do in a separate pr).