### PR TITLE
Use workspace/didCreateFile for automatically filling package name

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -689,6 +689,15 @@ object MetalsEnrichments
         )
       } yield hierarchicalDocumentSymbolSupport.booleanValue).getOrElse(false)
 
+    def supportsDidCreateFiles: Boolean =
+      (for {
+        params <- initializeParams
+        capabilities <- Option(params.getCapabilities())
+        workspace <- Option(capabilities.getWorkspace())
+        fileOperations <- Option(workspace.getFileOperations())
+        didCreate <- Option(fileOperations.getDidCreate())
+      } yield didCreate.booleanValue).getOrElse(false)
+
     def supportsCompletionSnippets: Boolean =
       (for {
         params <- initializeParams

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -402,6 +402,9 @@ final class TestingServer(
     QuickBuild.bloopInstall(workspace)
     val params = new InitializeParams
     val workspaceCapabilities = new WorkspaceClientCapabilities()
+    val fileOpCapabilities = new l.FileOperationsWorkspaceCapabilities()
+    fileOpCapabilities.setDidCreate(true)
+    workspaceCapabilities.setFileOperations(fileOpCapabilities)
     val textDocumentCapabilities = new TextDocumentClientCapabilities
     textDocumentCapabilities.setFoldingRange(new FoldingRangeCapabilities)
     val documentSymbolCapabilities = new DocumentSymbolCapabilities()
@@ -595,6 +598,20 @@ final class TestingServer(
       )
       .asScala
   }
+
+  def createFile(relativePath: String, contents: String = ""): Future[Unit] =
+    Future {
+      Debug.printEnclosing(relativePath)
+      val path = workspace.resolve(relativePath)
+      path.toFile.createNewFile()
+      path.writeText(contents)
+      val uri = path.toURI.toString
+
+      val file = new l.FileCreate(uri)
+      val didCreateFileParams = new l.CreateFilesParams(List(file).asJava)
+      server
+        .didCreateFiles(didCreateFileParams)
+    }
 
   def didClose(filename: String): Future[Unit] = {
     Debug.printEnclosing(filename)

--- a/tests/unit/src/test/scala/tests/AddPackageLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/AddPackageLspSuite.scala
@@ -81,6 +81,7 @@ class AddPackageLspSuite extends BaseLspSuite("add-package") {
       cleanCompileCache("a")
       RecursivelyDelete(workspace.resolve("a"))
       Files.createDirectories(workspace.toNIO.resolve(parent))
+
       for {
         _ <- server.initialize(
           """|/metals.json
@@ -89,11 +90,7 @@ class AddPackageLspSuite extends BaseLspSuite("add-package") {
              |}
         """.stripMargin
         )
-        _ =
-          workspace
-            .resolve(fileToCreate)
-            .toFile
-            .createNewFile()
+        _ <- server.createFile(fileToCreate)
         _ <- server.didOpen(fileToCreate)
         _ = assertNoDiff(
           workspace.resolve(fileToCreate).readText,


### PR DESCRIPTION
Since 3.16 (I think) there is an ability to register for FileCreated notifications, which we can use for PackageProvider. This is a better way of doing it, because we now get that information from the editor and not assume a file is new if it's empty.

For any client that doesn't support these notifications we keep the old way of adding the package.

Connected to https://github.com/scalameta/metals/issues/2869, but doesn't fix it unfortunately.