### PR TITLE
Bump sbt-debug-adapter to 1.1.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -511,7 +511,7 @@ lazy val `sbt-metals` = project
       "semanticdbVersion" -> V.semanticdb,
       "supportedScala2Versions" -> V.scala2Versions
     ),
-    addSbtPlugin("ch.epfl.scala" % "sbt-debug-adapter" % "1.1.1")
+    addSbtPlugin("ch.epfl.scala" % "sbt-debug-adapter" % "1.1.2")
   )
   .enablePlugins(BuildInfoPlugin)
   .disablePlugins(ScalafixPlugin)


### PR DESCRIPTION
Show static variables to fix #2482 (when sbt is used as build server).
Another bump will be needed for Bloop.