### PR TITLE
Ensure a valid URI is returned for non-html analyze stacktrace.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
@@ -119,7 +119,7 @@ class StacktraceAnalyzer(
       }
       val fileStartPos = new l.Position(0, 0)
       val range = new l.Range(fileStartPos, fileStartPos)
-      val stackTraceLocation = new l.Location(pathStr, range)
+      val stackTraceLocation = new l.Location(path.toURI.toString(), range)
       Some(makeGotoCommandParams(stackTraceLocation))
     }
   }


### PR DESCRIPTION
`coc-metals` was crazy lenient with this. Nvim core LSP, not so much. Just ensure that the path in the location we are returning is a valid URI.