### PR TITLE
Get rid of warning about setting -Xsemanticdb twice.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -537,9 +537,6 @@ lazy val input3 = project
   .in(file("tests/input3"))
   .settings(
     sharedSettings,
-    scalacOptions ++= List(
-      "-Xsemanticdb"
-    ),
     scalaVersion := V.scala3,
     publish / skip := true
   )


### PR DESCRIPTION
This is already set in the shared settings for Scala 3, so we don't
need it here as well