### PR TITLE
Exclude Jmh and Scalafix from the list of build targets in sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ inThisBuild(
       "-Yrangepos"
     ) ::: scala212CompilerOptions,
     scalafixDependencies += "com.github.liancheng" %% "organize-imports" % V.organizeImportRule,
+    ScalafixConfig / bspEnabled := false,
     organization := "org.scalameta",
     licenses := Seq(
       "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
@@ -724,7 +725,8 @@ lazy val bench = project
       "org.spire-math" %% "clouseau" % "0.2.2"
     ),
     buildInfoKeys := Seq[BuildInfoKey](scalaVersion),
-    buildInfoPackage := "bench"
+    buildInfoPackage := "bench",
+    Jmh / bspEnabled := false
   )
   .dependsOn(unit)
   .enablePlugins(JmhPlugin)


### PR DESCRIPTION
When importing Metals build with sbt as the build server, it creates:
- a `bench-jmh` build target, corresponding to the `bench / Jmh` scope
- many `<project>-scalafix` build targets, corresponding to the `<project> / Scalafix` scopes. 

Those are not very useful in the code editor because the user cannot really modify there sources, and the `bench-jmh` build target is very time consuming to import (it triggers the compilation of `bench` to generate the sources).

By setting `bspEnabled` in those scopes, we remove those build targets.

Before:
![image](https://user-images.githubusercontent.com/13123162/122890449-f9abfd80-d343-11eb-9e1c-2fcc606c981f.png)

After:
![image](https://user-images.githubusercontent.com/13123162/122890593-1e07da00-d344-11eb-993a-d7fc71178d1c.png)
