### PR TITLE
Always enable semanticdb for users in sbt (when using sbt BSP).

### DIFF
--- a/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
+++ b/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
@@ -56,11 +56,7 @@ object MetalsPlugin extends AutoPlugin {
            } else None)).distinct
       }
     },
-    semanticdbEnabled := {
-      val old = semanticdbEnabled.value
-      if (ScalaInstance.isDotty(scalaVersion.value)) true
-      else old
-    },
+    semanticdbEnabled := true,
     semanticdbTargetRoot := {
       val in = semanticdbIncludeInJar.value
       if (in) classDirectory.value


### PR DESCRIPTION
Note that we still check the users version of sbt before we
get to this point so it shoulnd't be a risk to just simplify
this and always turn it on.