### PR TITLE
[Scala3] Use symbol search for PC `definitions`.

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -47,12 +47,14 @@ class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
         )
       } else {
         val res = new ju.ArrayList[Location]()
-        tree.symbol.alternatives.foreach { alternative =>
-          val sym = semanticdbSymbol(alternative)
-          if (sym.isGlobal) {
-            res.addAll(search.definition(sym, params.uri()))
+        tree.symbol.alternatives
+          .map(semanticdbSymbol)
+          .sorted
+          .foreach { sym =>
+            if (sym.isGlobal) {
+              res.addAll(search.definition(sym, params.uri()))
+            }
           }
-        }
         DefinitionResultImpl(
           semanticdbSymbol(tree.symbol),
           res

--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -58,6 +58,13 @@ object MtagsEnrichments extends CommonMtagsEnrichments {
       )
     }
 
+    def toLocation: Option[l.Location] = {
+      for {
+        uri <- InteractiveDriver.toUriOption(pos.source)
+        range <- if (pos.exists) Some(pos.toLSP) else None
+      } yield new l.Location(uri.toString, range)
+    }
+
   extension (sym: Symbol)(using Context) {
     def fullNameBackticked: String = {
       @tailrec

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -113,11 +113,8 @@ class PcDefinitionProvider(
       // For a named arg, find the target `DefDef` and jump to the param
       case NamedArg(name, _) :: Apply(fn, _) :: _ =>
         val funSym = fn.symbol
-        if (
-          funSym.name == StdNames.nme.copy
-          && funSym.is(Synthetic)
-          && funSym.owner.is(CaseClass)
-        ) List(funSym.owner.info.member(name).symbol)
+        if (funSym.is(Synthetic) && funSym.owner.is(CaseClass))
+          List(funSym.owner.info.member(name).symbol)
         else {
           val classTree = funSym.topLevelClass.asClass.rootTree
           val paramSymbol =
@@ -163,7 +160,7 @@ class PcDefinitionProvider(
 
     def recoverDenot(d: Denotation): List[Symbol] = d match {
       case multi: MultiPreDenotation =>
-        List(multi.last, multi.first)
+        List(multi.first, multi.last)
           .map(_.symbol)
           .filter(_ != NoSymbol)
       case _ => List(d.symbol).filter(_ != NoSymbol)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -1,0 +1,197 @@
+package scala.meta.internal.pc
+
+import java.nio.file.Paths
+import java.util.ArrayList
+
+import scala.annotation.tailrec
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+
+import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.pc.DefinitionResult
+import scala.meta.pc.OffsetParams
+import scala.meta.pc.SymbolSearch
+
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.ast.tpd._
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Denotations
+import dotty.tools.dotc.core.Denotations.Denotation
+import dotty.tools.dotc.core.Denotations.MultiPreDenotation
+import dotty.tools.dotc.core.Flags._
+import dotty.tools.dotc.core.NameOps._
+import dotty.tools.dotc.core.Names
+import dotty.tools.dotc.core.Names._
+import dotty.tools.dotc.core.StdNames
+import dotty.tools.dotc.core.Symbols._
+import dotty.tools.dotc.core.Types.NamedType
+import dotty.tools.dotc.interactive.Interactive
+import dotty.tools.dotc.interactive.InteractiveDriver
+import dotty.tools.dotc.interactive.SourceTree
+import dotty.tools.dotc.transform.SymUtils._
+import dotty.tools.dotc.util.NoSourcePosition
+import dotty.tools.dotc.util.SourceFile
+import dotty.tools.dotc.util.SourcePosition
+import org.eclipse.lsp4j.Location
+
+class PcDefinitionProvider(
+    driver: InteractiveDriver,
+    params: OffsetParams,
+    search: SymbolSearch
+) {
+
+  def definitions(): DefinitionResult = {
+    val uri = params.uri
+    val filePath = Paths.get(uri)
+    val diagnostics = driver.run(
+      uri,
+      SourceFile.virtual(filePath.toString, params.text)
+    )
+    val unit = driver.currentCtx.run.units.head
+    val tree = unit.tpdTree
+
+    val pos = driver.sourcePosition(params)
+    val path =
+      Interactive.pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
+    given ctx: Context = driver.localContext(params)
+    val indexedContext = IndexedContext(ctx)
+    findDefinitions(tree, path, pos, driver, indexedContext)
+  }
+
+  private def findDefinitions(
+      tree: Tree,
+      path: List[Tree],
+      pos: SourcePosition,
+      driver: InteractiveDriver,
+      indexed: IndexedContext
+  ): DefinitionResult = {
+    import indexed.ctx
+    enclosingSymbols(path, pos, indexed) match {
+      case symbols @ (sym :: other) =>
+        val isLocal = sym.source == pos.source
+        if (isLocal)
+          val defs =
+            Interactive.findDefinitions(List(sym), driver, false, false)
+          defs.headOption match {
+            case Some(srcTree) =>
+              val pos = srcTree.namePos
+              pos.toLocation match {
+                case None => DefinitionResultImpl.empty
+                case Some(loc) =>
+                  DefinitionResultImpl(
+                    SemanticdbSymbols.symbolName(sym),
+                    List(loc).asJava
+                  )
+              }
+            case None =>
+              DefinitionResultImpl.empty
+          }
+        else {
+          val res = new ArrayList[Location]()
+          semanticSymbolsSorted(symbols)
+            .foreach { sym =>
+              res.addAll(search.definition(sym, params.uri()))
+            }
+          DefinitionResultImpl(
+            SemanticdbSymbols.symbolName(sym),
+            res
+          )
+        }
+      case Nil => DefinitionResultImpl.empty
+    }
+  }
+
+  @tailrec
+  private def enclosingSymbols(
+      path: List[Tree],
+      pos: SourcePosition,
+      indexed: IndexedContext
+  ): List[Symbol] = {
+    import indexed.ctx
+    path match {
+      // For a named arg, find the target `DefDef` and jump to the param
+      case NamedArg(name, _) :: Apply(fn, _) :: _ =>
+        val funSym = fn.symbol
+        if (
+          funSym.name == StdNames.nme.copy
+          && funSym.is(Synthetic)
+          && funSym.owner.is(CaseClass)
+        ) List(funSym.owner.info.member(name).symbol)
+        else {
+          val classTree = funSym.topLevelClass.asClass.rootTree
+          val paramSymbol =
+            for {
+              DefDef(_, paramss, _, _) <- tpd
+                .defPath(funSym, classTree)
+                .lastOption
+              param <- paramss.flatten.find(_.name == name)
+            } yield param.symbol
+          List(paramSymbol.getOrElse(fn.symbol))
+        }
+      case (_: untpd.ImportSelector) :: (imp: Import) :: _ =>
+        importedSymbols(imp, _.span.contains(pos.span))
+
+      case (imp: Import) :: _ =>
+        importedSymbols(imp, _.span.contains(pos.span))
+
+      // For constructor calls, return the `<init>` that was selected
+      case _ :: (_: New) :: (select: Select) :: _ =>
+        List(select.symbol)
+
+      // wildcard param
+      case head :: _ if (head.symbol.is(Param) && head.symbol.is(Synthetic)) =>
+        Nil
+
+      case head :: tl =>
+        if (head.symbol.is(Synthetic)) enclosingSymbols(tl, pos, indexed)
+        else if (head.symbol != NoSymbol) List(head.symbol)
+        else {
+          val recovered = recoverError(head, indexed)
+          if (recovered.isEmpty) enclosingSymbols(tl, pos, indexed)
+          else recovered
+        }
+      case Nil => Nil
+    }
+  }
+
+  private def recoverError(
+      tree: Tree,
+      indexed: IndexedContext
+  ): List[Symbol] = {
+    import indexed.ctx
+
+    def recoverDenot(d: Denotation): List[Symbol] = d match {
+      case multi: MultiPreDenotation =>
+        List(multi.last, multi.first)
+          .map(_.symbol)
+          .filter(_ != NoSymbol)
+      case _ => List(d.symbol).filter(_ != NoSymbol)
+    }
+
+    tree match {
+      case select: Select =>
+        recoverDenot(select.qualifier.typeOpt.member(select.name))
+      case ident: Ident => indexed.findSymbol(ident.name).toList.flatten
+      case _ => Nil
+    }
+  }
+
+  def semanticSymbolsSorted(
+      syms: List[Symbol]
+  )(using ctx: Context): List[String] = {
+    syms
+      .map { sym =>
+        // in case of having the same type and teerm symbol
+        // term comes first
+        // used only for ordering symbols that come from `Import`
+        val termFlag =
+          if (sym.is(ModuleClass)) sym.sourceModule.isTerm
+          else sym.isTerm
+        (termFlag, SemanticdbSymbols.symbolName(sym))
+      }
+      .sorted
+      .map(_._2)
+  }
+
+}

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -198,18 +198,7 @@ case class ScalaPresentationCompiler(
       params.token
     ) { access =>
       val driver = access.compiler()
-      val ctx = driver.currentCtx
-      val uri = params.uri
-      val sourceFile = CompilerInterfaces.toSource(params.uri, params.text)
-      driver.run(uri, sourceFile)
-      val pos = sourcePosition(driver, params, uri)
-      val path = Interactive.pathTo(driver.openedTrees(uri), pos)(using ctx)
-      val definitions = Interactive.findDefinitions(path, pos, driver).toList
-
-      DefinitionResultImpl(
-        "",
-        definitions.flatMap(d => location(d.namePos(using ctx))).asJava
-      )
+      PcDefinitionProvider(driver, params, search).definitions()
     }
   }
 
@@ -441,13 +430,6 @@ case class ScalaPresentationCompiler(
 
   def withWorkspace(workspace: Path): PresentationCompiler = {
     copy(workspace = Some(workspace))
-  }
-
-  private def location(p: SourcePosition): Option[Location] = {
-    for {
-      uri <- toUriOption(p.source)
-      r <- range(p)
-    } yield new Location(uri.toString, r)
   }
 
   private def sourcePosition(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
@@ -1,5 +1,9 @@
 package scala.meta.internal.pc
 
+import java.lang.Character.isJavaIdentifierPart
+import java.lang.Character.isJavaIdentifierStart
+
+import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 import dotty.tools.dotc.core.Contexts._
@@ -7,6 +11,7 @@ import dotty.tools.dotc.core.Definitions
 import dotty.tools.dotc.core.Flags._
 import dotty.tools.dotc.core.Names._
 import dotty.tools.dotc.core.Symbols._
+import dotty.tools.dotc.transform.SymUtils._
 
 object SemanticdbSymbols {
 
@@ -75,4 +80,67 @@ object SemanticdbSymbols {
       case NonFatal(e) => Nil
     }
   }
+
+  /** The semanticdb name of the given symbol */
+  def symbolName(sym: Symbol)(using Context): String =
+    val b = StringBuilder(20)
+    addSymName(b, sym)
+    b.toString
+
+  /**
+   *  Taken from https://github.com/lampepfl/dotty/blob/2db43dae1480825227eb30d291b0dd0f0494e0f6/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala#L293
+   *  In future might be replaced by usage of compiler implementation after merging https://github.com/lampepfl/dotty/pull/12885
+   */
+  private def addSymName(b: StringBuilder, sym: Symbol)(using Context): Unit =
+
+    import dotty.tools.dotc.semanticdb.Scala3.{_, given}
+
+    def addName(name: Name) =
+      val str = name.toString.unescapeUnicode
+      if str.isJavaIdent then b append str
+      else b append '`' append str append '`'
+
+    def addOwner(owner: Symbol): Unit =
+      if !owner.isRoot then addSymName(b, owner)
+
+    def addOverloadIdx(sym: Symbol): Unit =
+      val decls =
+        val decls0 = sym.owner.info.decls.lookupAll(sym.name)
+        if sym.owner.isAllOf(JavaModule) then
+          decls0 ++ sym.owner.companionClass.info.decls.lookupAll(sym.name)
+        else decls0
+      end decls
+      val alts = decls.filter(_.isOneOf(Method | Mutable)).toList.reverse
+      def find(filter: Symbol => Boolean) = alts match
+        case notSym :: rest if !filter(notSym) =>
+          val idx = rest.indexWhere(filter).ensuring(_ >= 0)
+          b.append('+').append(idx + 1)
+        case _ =>
+      end find
+      val sig = sym.signature
+      find(_.signature == sig)
+
+    def addDescriptor(sym: Symbol): Unit =
+      if sym.is(ModuleClass) then addDescriptor(sym.sourceModule)
+      else if sym.is(TypeParam) then
+        b.append('['); addName(sym.name); b.append(']')
+      else if sym.is(Param) then
+        b.append('('); addName(sym.name); b.append(')')
+      else if sym.isRoot then b.append(Symbols.RootPackage)
+      else if sym.isEmptyPackage then b.append(Symbols.EmptyPackage)
+      else if (sym.isScala2PackageObject) then
+        b.append(Symbols.PackageObjectDescriptor)
+      else
+        addName(sym.name)
+        if sym.is(Package) then b.append('/')
+        else if sym.isType || sym.isAllOf(JavaModule) then b.append('#')
+        else if sym.isOneOf(Method | Mutable)
+          && (!sym.is(StableRealizable) || sym.isConstructor)
+        then
+          b.append('('); addOverloadIdx(sym); b.append(").")
+        else b.append('.')
+
+    addOwner(sym.owner); addDescriptor(sym)
+  end addSymName
+
 }

--- a/tests/cross/src/main/scala/tests/pc/CrossTestEnrichments.scala
+++ b/tests/cross/src/main/scala/tests/pc/CrossTestEnrichments.scala
@@ -3,5 +3,12 @@ package tests.pc
 object CrossTestEnrichments {
   implicit class XtensionStringCross(s: String) {
     def triplequoted: String = s.replace("'''", "\"\"\"")
+
+    def removeRanges: String =
+      s.replace("<<", "")
+        .replace(">>", "")
+        .replaceAll("/\\*.+\\*/", "")
+
+    def removePos: String = s.replace("@@", "")
   }
 }

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -116,7 +116,13 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
       "2.13" ->
         """|
            |object Main {
-           |  /*scala/collection/immutable/List.apply(). List.scala*//*scala/collection/IterableFactory#apply(). Factory.scala*/List(1)
+           |  /*scala/collection/IterableFactory#apply(). Factory.scala*/List(1)
+           |}
+           |""".stripMargin,
+      "3.0" ->
+        """|
+           |object Main {
+           |  /*scala/collection/IterableFactory#apply(). Factory.scala*/List(1)
            |}
            |""".stripMargin
     )
@@ -126,7 +132,16 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
     "error",
     """|
        |object Main {
-       |  /*scala/Predef.assert(+1). Predef.scala*//*scala/Predef.assert(). Predef.scala*/@@assert
+       |  /*scala/Predef.assert(). Predef.scala*//*scala/Predef.assert(+1). Predef.scala*/@@assert
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "error2",
+    """|
+       |object Main {
+       |  Predef./*scala/Predef.assert(). Predef.scala*//*scala/Predef.assert(+1). Predef.scala*/@@assert
        |}
        |""".stripMargin
   )
@@ -137,7 +152,14 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |object Main {
        |  ne@@w java.io.File("")
        |}
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3.0" ->
+        """|object Main {
+           |  new/*java/io/File#`<init>`(+2). File.java*/ java.io.File("")
+           |}
+           |""".stripMargin
+    )
   )
 
   check(
@@ -161,7 +183,15 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |import scala.concurrent./*scala/concurrent/Future. Future.scala*/@@Future
        |object Main {
        |}
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3.0" ->
+        """|
+           |import scala.concurrent./*scala/concurrent/Future# Future.scala*//*scala/concurrent/Future. Future.scala*/@@Future
+           |object Main {
+           |}
+           |""".stripMargin
+    )
   )
 
   check(
@@ -211,7 +241,17 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |object Main {
        |  assert(/*scala/Predef.assert(). Predef.scala*/@@assertion = true)
        |}
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      // in 3.0 here we obtain patched assert
+      // see: https://github.com/scalameta/metals/issues/2918
+      "3.0" ->
+        """|
+           |object Main {
+           |  assert(/*scala/Predef.assert(+1). Predef.scala*/@@assertion = true)
+           |}
+           |""".stripMargin
+    )
   )
 
   check(
@@ -255,6 +295,22 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |object Main {
        |  List(1).map(@@_ + 2)
        |}
+       |""".stripMargin
+  )
+
+  check(
+    "result-type",
+    """|
+       |object Main {
+       |  def x: /*scala/Int# Int.scala*/@@Int = 42
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "constructor",
+    """|
+       |class Main(x: /*scala/Int# Int.scala*/@@Int)
        |""".stripMargin
   )
 }

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -313,4 +313,24 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |class Main(x: /*scala/Int# Int.scala*/@@Int)
        |""".stripMargin
   )
+
+  check(
+    "case-class-apply".tag(IgnoreScala2),
+    """|
+       |case class Foo(<<a>>: Int, b: String)
+       |class Main {
+       |  Foo(@@a = 3, b = "42")
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "case-class-copy".tag(IgnoreScala2),
+    """|
+       |case class Foo(<<a>>: Int, b: String)
+       |class Main {
+       |  Foo(2, "4").copy(@@a = 3, b = "42")
+       |}
+       |""".stripMargin
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -147,6 +147,15 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
   )
 
   check(
+    "error3",
+    """|
+       |object Main {
+       |  1./*scala/Predef.Ensuring#ensuring(). Predef.scala*//*scala/Predef.Ensuring#ensuring(+1). Predef.scala*//*scala/Predef.Ensuring#ensuring(+2). Predef.scala*//*scala/Predef.Ensuring#ensuring(+3). Predef.scala*/@@ensuring
+       |}
+       |""".stripMargin
+  )
+
+  check(
     "new",
     """|
        |object Main {

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -477,20 +477,10 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
       _ <- server.didOpen("a/src/main/scala/Main.worksheet.sc")
       _ = assertNoDiff(
         server.workspaceDefinitions,
-        getExpected(
-          """|/a/src/main/scala/Main.worksheet.sc
-             |val message/*L0*/ = "Hello World!"
-             |println/*Predef.scala*/(message/*L0*/)
-             |""".stripMargin,
-          Map(
-            V.scala3 ->
-              """|/a/src/main/scala/Main.worksheet.sc
-                 |val message/*L0*/ = "Hello World!"
-                 |println/*<no symbol>*/(message/*L0*/)
-                 |""".stripMargin
-          ),
-          scalaVersion
-        )
+        """|/a/src/main/scala/Main.worksheet.sc
+           |val message/*L0*/ = "Hello World!"
+           |println/*Predef.scala*/(message/*L0*/)
+           |""".stripMargin
       )
     } yield ()
   }
@@ -530,7 +520,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
                   |""".stripMargin,
             V.scala3 ->
               """|/Main.worksheet.sc
-                 |import java/*<no symbol>*/.time/*<no symbol>*/.Instant/*Instant.java*/
+                 |import java.time.Instant/*Instant.java*/
                  |
                  |val x/*L2*/ = Instant/*Instant.java*/.now/*Instant.java*/()
                  |val y/*L3*/ = List/*package.scala*/.fill/*Factory.scala*/(2)(2)


### PR DESCRIPTION
Also, fixes `PCDefitionSuite`. Previsously the checking of non-local location wasn't total.