### PR TITLE
Wrap worksheets in object instead of a class

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -360,7 +360,11 @@ class WorksheetProvider(
     val input = path.toInputFromBuffers(buffers)
     val relativePath = path.toRelative(workspace)
     val evaluatedWorksheet =
-      mdoc.evaluateWorksheet(relativePath.toString(), input.value)
+      mdoc.evaluateWorksheet(
+        relativePath.toString(),
+        input.value,
+        "reset-object"
+      )
     val classpath = evaluatedWorksheet.classpath().asScala.toList
     val previousDigest = worksheetsDigests.getOrElse(path, "")
     val newDigest = calculateDigest(classpath)

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -179,7 +179,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
              |```
              |1.to(10).toVector
              |```scala
-             |res1: Vector[Int] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+             |res2: Vector[Int] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
              |```
              |val List(a, b) = List(42, 10)
              |```scala
@@ -205,7 +205,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
                  |```
                  |1.to(10).toVector
                  |```scala
-                 |res1: Vector[Int] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+                 |res2: Vector[Int] = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
                  |```
                  |val List(a, b) = List(42, 10)
                  |```scala
@@ -277,18 +277,36 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         getExpected(
-          """|a/src/main/scala/Main.worksheet.sc:2:1: error: java.lang.RuntimeException: boom
-             |	at repl.MdocSession$App.<init>(Main.worksheet.sc:11)
+          """|a/src/main/scala/Main.worksheet.sc:2:1: error: java.lang.ExceptionInInitializerError
+             |	at repl.MdocSession$App.<init>(Main.worksheet.sc:5)
              |	at repl.MdocSession$.app(Main.worksheet.sc:3)
+             |Caused by: java.lang.RuntimeException: boom
+             |	at repl.MdocSession$App0$.<init>(Main.worksheet.sc:14)
+             |	at repl.MdocSession$App0$.<clinit>(Main.worksheet.sc)
+             |	... 2 more
              |
              |throw new RuntimeException("boom")
              |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
              |""".stripMargin,
           Map(
             V.scala3 ->
-              """|a/src/main/scala/Main.worksheet.sc:2:1: error: java.lang.RuntimeException: boom
-                 |	at repl.MdocSession$App.<init>(Main.worksheet.sc:12)
+              """|a/src/main/scala/Main.worksheet.sc:2:1: error: java.lang.ExceptionInInitializerError
+                 |	at repl.MdocSession$App.<init>(Main.worksheet.sc:6)
                  |	at repl.MdocSession$.app(Main.worksheet.sc:3)
+                 |Caused by: java.lang.RuntimeException: boom
+                 |	at repl.MdocSession$App0$.<clinit>(Main.worksheet.sc:17)
+                 |	... 2 more
+                 |
+                 |throw new RuntimeException("boom")
+                 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                 |""".stripMargin,
+            V.scala213 ->
+              """|a/src/main/scala/Main.worksheet.sc:2:1: error: java.lang.ExceptionInInitializerError
+                 |	at repl.MdocSession$App.<init>(Main.worksheet.sc:5)
+                 |	at repl.MdocSession$.app(Main.worksheet.sc:3)
+                 |Caused by: java.lang.RuntimeException: boom
+                 |	at repl.MdocSession$App0$.<clinit>(Main.worksheet.sc:14)
+                 |	... 2 more
                  |
                  |throw new RuntimeException("boom")
                  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -572,7 +590,7 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
                  |""".stripMargin,
             V.scala3 ->
               """|a/src/main/scala/Main.worksheet.sc:5:1: error:
-                 |Found:    App.this.Structural
+                 |Found:    repl.MdocSession.App0.Structural
                  |Required: Selectable
                  |new Foo().asInstanceOf[Structural].foo()
                  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -605,25 +623,82 @@ abstract class BaseWorksheetLspSuite(scalaVersion: String)
       _ <- server.didOpen("a/src/main/scala/NoSuchMethodError.worksheet.sc")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
-        """|a/src/main/scala/IncompatibleClassChangeError.worksheet.sc:1:1: error: java.lang.IncompatibleClassChangeError
-           |	at repl.MdocSession$App.<init>(IncompatibleClassChangeError.worksheet.sc:8)
-           |	at repl.MdocSession$.app(IncompatibleClassChangeError.worksheet.sc:3)
-           |
-           |throw new IncompatibleClassChangeError()
-           |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-           |a/src/main/scala/NoSuchMethodError.worksheet.sc:1:1: error: java.lang.NoSuchMethodError
-           |	at repl.MdocSession$App.<init>(NoSuchMethodError.worksheet.sc:8)
-           |	at repl.MdocSession$.app(NoSuchMethodError.worksheet.sc:3)
-           |
-           |throw new NoSuchMethodError()
-           |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-           |a/src/main/scala/StackOverflowError.worksheet.sc:1:1: error: java.lang.StackOverflowError
-           |	at repl.MdocSession$App.<init>(StackOverflowError.worksheet.sc:8)
-           |	at repl.MdocSession$.app(StackOverflowError.worksheet.sc:3)
-           |
-           |throw new StackOverflowError()
-           |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-           |""".stripMargin
+        getExpected(
+          """|a/src/main/scala/IncompatibleClassChangeError.worksheet.sc:1:1: error: java.lang.IncompatibleClassChangeError
+             |	at repl.MdocSession$App0$.<clinit>(IncompatibleClassChangeError.worksheet.sc:11)
+             |	at repl.MdocSession$App.<init>(IncompatibleClassChangeError.worksheet.sc:5)
+             |	at repl.MdocSession$.app(IncompatibleClassChangeError.worksheet.sc:3)
+             |
+             |throw new IncompatibleClassChangeError()
+             |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             |a/src/main/scala/NoSuchMethodError.worksheet.sc:1:1: error: java.lang.NoSuchMethodError
+             |	at repl.MdocSession$App0$.<clinit>(NoSuchMethodError.worksheet.sc:11)
+             |	at repl.MdocSession$App.<init>(NoSuchMethodError.worksheet.sc:5)
+             |	at repl.MdocSession$.app(NoSuchMethodError.worksheet.sc:3)
+             |
+             |throw new NoSuchMethodError()
+             |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             |a/src/main/scala/StackOverflowError.worksheet.sc:1:1: error: java.lang.StackOverflowError
+             |	at repl.MdocSession$App0$.<clinit>(StackOverflowError.worksheet.sc:11)
+             |	at repl.MdocSession$App.<init>(StackOverflowError.worksheet.sc:5)
+             |	at repl.MdocSession$.app(StackOverflowError.worksheet.sc:3)
+             |
+             |throw new StackOverflowError()
+             |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             |""".stripMargin,
+          Map(
+            V.scala212 ->
+              """|a/src/main/scala/IncompatibleClassChangeError.worksheet.sc:1:1: error: java.lang.IncompatibleClassChangeError
+                 |	at repl.MdocSession$App0$.<init>(IncompatibleClassChangeError.worksheet.sc:11)
+                 |	at repl.MdocSession$App0$.<clinit>(IncompatibleClassChangeError.worksheet.sc)
+                 |	at repl.MdocSession$App.<init>(IncompatibleClassChangeError.worksheet.sc:5)
+                 |	at repl.MdocSession$.app(IncompatibleClassChangeError.worksheet.sc:3)
+                 |
+                 |throw new IncompatibleClassChangeError()
+                 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                 |a/src/main/scala/NoSuchMethodError.worksheet.sc:1:1: error: java.lang.NoSuchMethodError
+                 |	at repl.MdocSession$App0$.<init>(NoSuchMethodError.worksheet.sc:11)
+                 |	at repl.MdocSession$App0$.<clinit>(NoSuchMethodError.worksheet.sc)
+                 |	at repl.MdocSession$App.<init>(NoSuchMethodError.worksheet.sc:5)
+                 |	at repl.MdocSession$.app(NoSuchMethodError.worksheet.sc:3)
+                 |
+                 |throw new NoSuchMethodError()
+                 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                 |a/src/main/scala/StackOverflowError.worksheet.sc:1:1: error: java.lang.StackOverflowError
+                 |	at repl.MdocSession$App0$.<init>(StackOverflowError.worksheet.sc:11)
+                 |	at repl.MdocSession$App0$.<clinit>(StackOverflowError.worksheet.sc)
+                 |	at repl.MdocSession$App.<init>(StackOverflowError.worksheet.sc:5)
+                 |	at repl.MdocSession$.app(StackOverflowError.worksheet.sc:3)
+                 |
+                 |throw new StackOverflowError()
+                 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                 |""".stripMargin,
+            V.scala3 ->
+              """|a/src/main/scala/IncompatibleClassChangeError.worksheet.sc:1:1: error: java.lang.IncompatibleClassChangeError
+                 |	at repl.MdocSession$App0$.<clinit>(IncompatibleClassChangeError.worksheet.sc:13)
+                 |	at repl.MdocSession$App.<init>(IncompatibleClassChangeError.worksheet.sc:6)
+                 |	at repl.MdocSession$.app(IncompatibleClassChangeError.worksheet.sc:3)
+                 |
+                 |throw new IncompatibleClassChangeError()
+                 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                 |a/src/main/scala/NoSuchMethodError.worksheet.sc:1:1: error: java.lang.NoSuchMethodError
+                 |	at repl.MdocSession$App0$.<clinit>(NoSuchMethodError.worksheet.sc:13)
+                 |	at repl.MdocSession$App.<init>(NoSuchMethodError.worksheet.sc:6)
+                 |	at repl.MdocSession$.app(NoSuchMethodError.worksheet.sc:3)
+                 |
+                 |throw new NoSuchMethodError()
+                 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                 |a/src/main/scala/StackOverflowError.worksheet.sc:1:1: error: java.lang.StackOverflowError
+                 |	at repl.MdocSession$App0$.<clinit>(StackOverflowError.worksheet.sc:13)
+                 |	at repl.MdocSession$App.<init>(StackOverflowError.worksheet.sc:6)
+                 |	at repl.MdocSession$.app(StackOverflowError.worksheet.sc:3)
+                 |
+                 |throw new StackOverflowError()
+                 |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                 |""".stripMargin
+          ),
+          scalaVersion
+        )
       )
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
@@ -115,6 +115,53 @@ class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala212) {
     } yield ()
   }
 
+  // We use Mdoc with `reset-object` modifier which makes sure that object is used to wrap statements
+  test("reset-object") {
+    val path = "hi.worksheet.sc"
+    for {
+      _ <- server.initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {}
+           |}
+           |/${path}
+           |import scala.annotation.tailrec
+           |
+           |object Foo {
+           |  case class Bar(b: Int) extends AnyVal
+           |}
+           |
+           |@tailrec
+           |def factorial(n: BigInt, acc: BigInt): BigInt = {
+           |  if (n <=1) acc
+           |  else factorial(n-1, n*acc)
+           |}
+           |
+           |factorial(3,1)
+           |""".stripMargin
+      )
+      _ <- server.didOpen(path)
+      _ = assertNoDiff(
+        client.workspaceDecorations,
+        """|import scala.annotation.tailrec
+           |
+           |object Foo {
+           |  case class Bar(b: Int) extends AnyVal
+           |}
+           |
+           |@tailrec
+           |def factorial(n: BigInt, acc: BigInt): BigInt = {
+           |  if (n <=1) acc
+           |  else factorial(n-1, n*acc)
+           |}
+           |
+           |factorial(3,1) // : BigInt = 6
+           |""".stripMargin
+      )
+    } yield ()
+  }
+
   test("akka") {
     val path = "hi.worksheet.sc"
     for {


### PR DESCRIPTION
Previously, we would use the default mdoc modifier for worksheets, which uses a class to wrap statements. Now, we use `reset-object`, which wraps statements in an object and allows us to use some of the features not available in classes.

Fixes https://github.com/scalameta/metals/issues/2764 and fixes https://github.com/scalameta/metals/issues/2907