### PR TITLE
[Scala2] PcDefinition fix

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -20,6 +20,7 @@ class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
         params.uri().toString(),
         None
       )
+      typeCheck(unit)
       val pos = unit.position(params.offset())
       val tree = definitionTypedTreeAt(pos)
       if (
@@ -95,7 +96,7 @@ class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
         case _ => tree
       }
     }
-    val typedTree = typedTreeAt(pos)
+    val typedTree = locateTree(pos)
     val tree0 = typedTree match {
       case sel @ Select(qual, _) if sel.tpe == ErrorType => qual
       case Import(expr, _) => expr
@@ -133,4 +134,5 @@ class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
         loop(tree)
     }
   }
+
 }

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -342,4 +342,13 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |}
        |""".stripMargin
   )
+
+  check(
+    "do-not-point-at ::",
+    """|
+       |class Main {
+       |  val all = Option(42)./*scala/Option#get(). Option.scala*/@@get :: List("1", "2")
+       |}
+       |""".stripMargin
+  )
 }


### PR DESCRIPTION
At least fixes the following problem that happens in 2.12:
```scala
// Prevously retuned location was /*List.::*/
Option(1).@@toInt :: List(1,2,3)
```