### PR TITLE
Search for symbol references in workspace

### DIFF
--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -163,7 +163,10 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
         .replace("\\", "/")
       _ = assertNoDiff(
         optionReferences,
-        s"""|$optionSourcePath:29:50: info: reference
+        s"""|a/src/main/scala/a/A.scala:4:24: info: reference
+            |  val x: Option[Int] = None
+            |                       ^^^^
+            |$optionSourcePath:29:50: info: reference
             |  def apply[A](x: A): Option[A] = if (x == null) None else Some(x)
             |                                                 ^^^^
             |$optionSourcePath:34:30: info: reference


### PR DESCRIPTION
Resolves https://github.com/scalameta/metals-feature-requests/issues/211
Tried locally in VSCode and it works, though it shows local file results (in the same library file) before workspace ones despite me returning workspace references in a list specifically before local ones (and in tests they are returned in the correct order). Not sure if that's OK and how to fix it otherwise, may need some advice.