### PR TITLE
Don't offer to organize imports when there is an error in the file

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -15,7 +15,9 @@ final class CodeActionProvider(
     buffers: Buffers,
     buildTargets: BuildTargets,
     scalafixProvider: ScalafixProvider,
-    trees: Trees
+    trees: Trees,
+    diagnostics: Diagnostics,
+    languageClient: MetalsLanguageClient
 )(implicit ec: ExecutionContext) {
 
   private val extractMemberAction = new ExtractRenameMember(buffers, trees)
@@ -26,7 +28,12 @@ final class CodeActionProvider(
     new CreateNewSymbol(),
     new StringActions(buffers, trees),
     extractMemberAction,
-    new OrganizeImports(scalafixProvider, buildTargets),
+    new OrganizeImports(
+      scalafixProvider,
+      buildTargets,
+      diagnostics,
+      languageClient
+    ),
     new InsertInferredType(trees, compilers)
   )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -35,7 +35,6 @@ import org.eclipse.{lsp4j => l}
  * goto definition in stale buffers.
  */
 final class Diagnostics(
-    buildTargets: BuildTargets, // TODO this can be removed
     buffers: Buffers,
     languageClient: LanguageClient,
     statistics: StatisticsConfig,

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -35,7 +35,7 @@ import org.eclipse.{lsp4j => l}
  * goto definition in stale buffers.
  */
 final class Diagnostics(
-    buildTargets: BuildTargets,
+    buildTargets: BuildTargets, // TODO this can be removed
     buffers: Buffers,
     languageClient: LanguageClient,
     statistics: StatisticsConfig,
@@ -168,6 +168,19 @@ final class Diagnostics(
 
   def hasSyntaxError(path: AbsolutePath): Boolean =
     syntaxError.contains(path)
+
+  def hasDiagnosticError(path: AbsolutePath): Boolean = {
+    val fileDiagnostics = diagnostics
+      .get(path)
+
+    fileDiagnostics match {
+      case Some(diagnostics) =>
+        diagnostics.asScala.exists(
+          _.getSeverity() == l.DiagnosticSeverity.Error
+        )
+      case None => false
+    }
+  }
 
   private def publishDiagnostics(
       path: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -15,6 +15,7 @@ import scala.meta.internal.metals.ammonite.Ammonite
 import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.tvp._
 import scala.meta.internal.worksheets.WorksheetProvider
+import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j._
 import ch.epfl.scala.{bsp4j => b}
@@ -61,6 +62,14 @@ final class ForwardingMetalsBuildClient(
   def buildHasErrors(buildTargetId: BuildTargetIdentifier): Boolean = {
     buildTargets
       .buildTargetTransitiveDependencies(buildTargetId)
+      .exists(hasReportedError.contains(_))
+  }
+
+  def buildHasErrors(file: AbsolutePath): Boolean = {
+    buildTargets
+      .inverseSources(file)
+      .toIterable
+      .flatMap(buildTargets.buildTargetTransitiveDependencies)
       .exists(hasReportedError.contains(_))
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsBuildClient.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.metals
 
 import scala.meta.internal.tvp.TreeViewCompilations
+import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.{bsp4j => b}
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
@@ -33,6 +34,8 @@ trait MetalsBuildClient {
   def ongoingCompilations(): TreeViewCompilations
 
   def buildHasErrors(buildTargetId: b.BuildTargetIdentifier): Boolean
+
+  def buildHasErrors(file: AbsolutePath): Boolean
 
   def buildHasErrors: Boolean
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -376,7 +376,6 @@ class MetalsLanguageServer(
           compilations.isCurrentlyCompiling
         )
         diagnostics = new Diagnostics(
-          buildTargets,
           buffers,
           languageClient,
           clientConfig.initialConfig.statistics,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -636,14 +636,17 @@ class MetalsLanguageServer(
           compilations,
           clientConfig.icons(),
           languageClient,
-          buildTargets
+          buildTargets,
+          buildClient
         )
         codeActionProvider = new CodeActionProvider(
           compilers,
           buffers,
           buildTargets,
           scalafixProvider,
-          trees
+          trees,
+          diagnostics,
+          languageClient
         )
         doctor = new Doctor(
           workspace,

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -21,6 +21,7 @@ import org.eclipse.lsp4j.MessageType
 import org.eclipse.{lsp4j => l}
 import scalafix.interfaces.Scalafix
 import scalafix.interfaces.ScalafixEvaluation
+import scalafix.interfaces.ScalafixFileEvaluationError
 
 case class ScalafixProvider(
     buffers: Buffers,
@@ -31,7 +32,8 @@ case class ScalafixProvider(
     compilations: Compilations,
     icons: Icons,
     languageClient: MetalsLanguageClient,
-    buildTargets: BuildTargets
+    buildTargets: BuildTargets,
+    buildClinet: MetalsBuildClient
 )(implicit ec: ExecutionContext) {
   import ScalafixProvider._
   private val scalafixCache = TrieMap.empty[ScalaBinaryVersion, Scalafix]
@@ -84,6 +86,21 @@ case class ScalafixProvider(
               exception
             )
             Future.failed(exception)
+          case Success(results)
+              if !scalafixSucceded(results) && hasStaleSemanticdb(
+                results
+              ) && buildTargetHasError(file) =>
+            val msg = "Attempt to organize your imports failed. " +
+              "It looks like you have compilation issues causing your semanticdb to be stale. " +
+              "Ensure everything is compiling and try again."
+            scribe.warn(
+              msg
+            )
+            languageClient.showMessage(
+              MessageType.Warning,
+              msg
+            )
+            Future.successful(Nil)
           case Success(results) if !scalafixSucceded(results) =>
             val scalafixError = getMessageErrorFromScalafix(results)
             val exception = ScalafixRunException(scalafixError)
@@ -104,21 +121,53 @@ case class ScalafixProvider(
       }
     }
   }
+
+  /**
+   * Scalafix may be ran successfully, but that doesn't mean that every file
+   * evaluation also ran succesfully. This ensure that the scalafix run was successful
+   * and also that every file evaluation was successful.
+   *
+   * @param evaluation
+   * @return true only if the evaulation for every single file contains no errors
+   */
   private def scalafixSucceded(evaluation: ScalafixEvaluation): Boolean =
     evaluation.isSuccessful && evaluation
       .getFileEvaluations()
       .forall(_.isSuccessful)
 
+  // TODO move this out and refactor other places that also use this logic
+  private def buildTargetHasError(file: AbsolutePath): Boolean = {
+    buildTargets
+      .inverseSources(file)
+      .map(buildClinet.buildHasErrors(_))
+      .getOrElse(false)
+  }
+
+  private def hasStaleSemanticdb(evaluation: ScalafixEvaluation): Boolean = {
+    evaluation
+      .getFileEvaluations()
+      .headOption
+      .flatMap(_.getError().asScala)
+      .contains(ScalafixFileEvaluationError.StaleSemanticdbError)
+  }
+
+  /**
+   * Assumes that scalafixSucceded has been called and returned false
+   *
+   * @param evaluation
+   * @return
+   */
   private def getMessageErrorFromScalafix(
       evaluation: ScalafixEvaluation
   ): String = {
-    (if (!evaluation.isSuccessful)
+    (if (!evaluation.isSuccessful())
        evaluation.getErrorMessage().asScala
      else
        evaluation
          .getFileEvaluations()
          .headOption
-         .flatMap(_.getErrorMessage.asScala)).getOrElse(defaultErrorMessage)
+         .flatMap(_.getErrorMessage().asScala))
+      .getOrElse("Unexpected error while running Scalafix.")
   }
 
   private def scalafixConf: Option[Path] = {
@@ -142,7 +191,6 @@ case class ScalafixProvider(
       case _ => None
     }
   }
-
   private def scalafixEvaluate(
       file: AbsolutePath,
       scalaTarget: ScalaTarget
@@ -259,9 +307,6 @@ object ScalafixProvider {
 
   case class ScalafixRunException(msg: String) extends Exception(msg)
 
-  val defaultErrorMessage: String =
-    """|Unexpected error while running scalafix. Semanticdb might have been stale, which 
-       |would require successful compilation to be created.""".stripMargin
   val organizeImportRuleName = "OrganizeImports"
 
 }

--- a/tests/unit/src/main/scala/tests/TestingDiagnostics.scala
+++ b/tests/unit/src/main/scala/tests/TestingDiagnostics.scala
@@ -17,7 +17,6 @@ object TestingDiagnostics {
       trees: Trees
   ): Diagnostics = {
     new Diagnostics(
-      buildTargets,
       buffers,
       new TestingClient(workspace, buffers),
       StatisticsConfig.default,

--- a/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
@@ -150,4 +150,29 @@ class OrganizeImportsLspSuite
     scalafixConf = scalafixConf(),
     scalacOptions = scalacOption
   )
+
+  check(
+    "stale",
+    """|package a
+       |
+       |<<import java.time.Instant>>
+       |
+       |object A {
+       |  val a: Int = "no one wants unused imports"
+       |}
+       |""".stripMargin,
+    "", // This should give back no code action
+    """|package a
+       |
+       |import java.time.Instant
+       |
+       |object A {
+       |  val a: Int = "no one wants unused imports"
+       |}
+       |""".stripMargin,
+    kind = List(kind),
+    scalafixConf = scalafixConf(),
+    scalacOptions = scalacOption,
+    expectNoDiagnostics = false
+  )
 }


### PR DESCRIPTION
I need to figure out a good way to test this as the current framework for code actions don't really have a good way to test stuff while the file isn't compiling, _but_ I wanted to throw this up here right away to get any feedback. The point of this pr is to try to avoid a user seeing an error message all the time about state semanticdb when they refactoring a file. The reason this happens is because they at one point in time had a compiling file which produced semanticdb, and then when they start to refactor and come across unused imports, it tries to calculate the scalafix diff and errors out on stale semanticdb. This makes two changes:

1. The first change has to do when seeing if organize imports can be contributed or not. When a user has `-Ywarn-unused:imports` on and then go over a context that has an unused diagnostic it will now add an extra check to ensure that the file doesn't contain an error diagnostic. If it does, it simply doesn't offer it up as a code action and moves on. Again, this is only done _if_ it's in a valid context with an unused import there.
2. The second has to do when a user explicitly triggers the organize imports action from their editor. In this scenario it also does the same check and if the file has an error, it warns them via a message and doesn't try to do anything else.

Playing around with this I first actually put this check inside of the `ScalafixProvider`, but seeing that it's always called through `OrganizeImports` atm _and_ I wanted different behavior depending on whether it was explicitly called or it was just trying to generate the diff to contribute to the code action, I thought it made more sense to instead put it where I did. If you don't think that's a good idea, lemme know.

In some ways this is a temporaryish fix because ultimately I'd like to just be able to pass in the `TextDocument` we generate as a fallback or something to Scalafix, but seeing that the api doesn't allow for that atm, we'll go this route. 