### PR TITLE
Organize imports quickfix action

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -28,7 +28,13 @@ final class CodeActionProvider(
     new CreateNewSymbol(),
     new StringActions(buffers, trees),
     extractMemberAction,
-    new OrganizeImports(
+    new SourceOrganizeImports(
+      scalafixProvider,
+      buildTargets,
+      diagnostics,
+      languageClient
+    ),
+    new OrganizeImportsQuickFix(
       scalafixProvider,
       buildTargets,
       diagnostics,

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
@@ -162,5 +162,5 @@ class OrganizeImportsQuickFix(
 
 object OrganizeImportsQuickFix {
   final val kind: String = l.CodeActionKind.QuickFix
-  final val title: String = "Fix organize imports"
+  final val title: String = "Fix imports"
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
@@ -122,7 +122,7 @@ class SourceOrganizeImports(
 
 object SourceOrganizeImports {
   final val kind: String = l.CodeActionKind.SourceOrganizeImports
-  final val title: String = "Source organize imports"
+  final val title: String = "Organize imports"
 }
 
 class OrganizeImportsQuickFix(
@@ -162,5 +162,5 @@ class OrganizeImportsQuickFix(
 
 object OrganizeImportsQuickFix {
   final val kind: String = l.CodeActionKind.QuickFix
-  final val title: String = "Quick fix organize imports"
+  final val title: String = "Fix organize imports"
 }

--- a/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
@@ -3,7 +3,8 @@ package tests.feature
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.codeactions.ExtractRenameMember
 import scala.meta.internal.metals.codeactions.InsertInferredType
-import scala.meta.internal.metals.codeactions.OrganizeImports
+import scala.meta.internal.metals.codeactions.SourceOrganizeImports
+import scala.meta.internal.metals.codeactions.SourceOrganizeImports.kind
 import scala.meta.internal.mtags.MtagsEnrichments.XtensionAbsolutePath
 
 import munit.Location
@@ -38,7 +39,7 @@ class Scala3CodeActionLspSuite
       |  val tr = Try{ new Exception("name") }
       |}
       |""".stripMargin,
-    s"${OrganizeImports.title}",
+    s"${SourceOrganizeImports.title}",
     """|package a
        |import scala.concurrent.ExecutionContext
        |import scala.concurrent.Future
@@ -50,7 +51,7 @@ class Scala3CodeActionLspSuite
        |  val tr = Try{ new Exception("name") }
        |}
        |""".stripMargin,
-    kind = List(OrganizeImports.kind)
+    kind = List(SourceOrganizeImports.kind)
   )
 
   checkExtractedMember(

--- a/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -16,10 +16,19 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
 
   def checkNoAction(
       name: TestOptions,
-      input: String
+      input: String,
+      scalafixConf: String = "",
+      scalacOptions: List[String] = Nil
   ): Unit = {
     val fileContent = input.replace("<<", "").replace(">>", "")
-    check(name, input, "", fileContent)
+    check(
+      name,
+      input,
+      "",
+      fileContent,
+      scalafixConf = scalafixConf,
+      scalacOptions = scalacOptions
+    )
   }
 
   def check(

--- a/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
@@ -139,7 +139,7 @@ class OrganizeImportsLspSuite
        |  val a = "no one wants unused imports"
        |}
        |""".stripMargin,
-    s"${SourceOrganizeImports.title}",
+    s"${OrganizeImportsQuickFix.title}",
     """|package a
        |
        |
@@ -148,7 +148,7 @@ class OrganizeImportsLspSuite
        |  val a = "no one wants unused imports"
        |}
        |""".stripMargin,
-    kind = List(sourceKind),
+    kind = List(quickFixKind),
     scalafixConf = scalafixConf(),
     scalacOptions = scalacOption
   )
@@ -193,54 +193,12 @@ class OrganizeImportsLspSuite
     expectNoDiagnostics = false
   )
 
-  check(
-    "quickfix-available",
-    """
-      |import scala.util.Try<<>>
-      |
-      |object A {
-      |  val action = "quick should be available"
-      |}
-      |""".stripMargin,
-    s"${OrganizeImportsQuickFix.title}",
-    """
-      |
-      |
-      |object A {
-      |  val action = "quick should be available"
-      |}
-      |""".stripMargin,
-    kind = List(quickFixKind),
-    scalacOptions = scalacOption
-  )
-
-  check(
-    "quickfix-available-on-hover",
-    """
-      |import scala.@@util.Try
-      |
-      |object A {
-      |  <<val action = "quick should be available">>
-      |}
-      |""".stripMargin,
-    s"${OrganizeImportsQuickFix.title}",
-    """
-      |
-      |
-      |object A {
-      |  val action = "quick should be available"
-      |}
-      |""".stripMargin,
-    kind = List(quickFixKind),
-    scalacOptions = scalacOption
-  )
-
   checkNoAction(
-    "no-quickfix-availale",
+    "no-quickfix-available",
     """
       |<<>>
       |object A {
-      |  val action = "quick should not be available"
+      |  val action = "quick fix should not be available"
       |}
       |""".stripMargin
   )


### PR DESCRIPTION
Previously, our organize imports action supported only source.organizeImports kind (implemented in https://github.com/scalameta/metals/pull/1971) because code actions were filtered based on kind parameter (CodeActionProvider:50)
In order to show quickfix action vscode expects that kind of response is quickifx (hence in https://github.com/scalameta/metals/issues/2923 there was no action available although there was one in the response from the server but it was filtered out)

I extracted common logic to the abstract class and create a separate class per kind - IMO this is a good balance between DRY, single responsibility and code readability.   
Another option is to change `kind` in `CodeAction` to Set[String] and support multiple actions simultaneously but I'm not sure about this approach.  

I'll fix failing tests and implement new ones after receiving some feedback. 