### PR TITLE
Don't set detail in completion if it's empty.

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -99,7 +99,7 @@ class CompletionProvider(
           }
       }
       val item = new CompletionItem(label)
-      if (metalsConfig.isCompletionItemDetailEnabled) {
+      if (metalsConfig.isCompletionItemDetailEnabled && !detail.isEmpty()) {
         item.setDetail(detail)
       }
       val templateSuffix =


### PR DESCRIPTION
This doesn't really cause problems per se, but I just hit on a case
where the completion given by Metals has an empty detail. Then when the
completionItemResolve request comes in, we actually make a check if
there detail is empty there, unless this check is false
https://github.com/scalameta/metals/blob/b5f79053b4e1f63259e9a044dcdef92f4937e43f/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionItemResolver.scala#L15,
then we just return the item, which contains the empty `detail`. This
then results in an empty window appearing for some clients. I ended up
fixing this downstream, so it's not a huge deal, but there is no use in
including the `detail` if it's empty.

Before:

<img width="282" alt="Screenshot 2021-07-10 at 11 21 38" src="https://user-images.githubusercontent.com/13974112/125159387-5b0f0180-e177-11eb-82fe-61f4ceda745a.png">

After:

<img width="282" alt="Screenshot 2021-07-10 at 11 24 55" src="https://user-images.githubusercontent.com/13974112/125159399-5fd3b580-e177-11eb-8a16-54414a44d5a0.png">
