### PR TITLE
Fix ammonite type completions

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -285,8 +285,15 @@ class CompletionProvider(
       def isFileAmmoniteCompletion() =
         isAmmoniteScript && {
           head match {
-            case mem: TypeMember =>
-              mem.sym.owner.fullName.contains("$file")
+            /* By default Scala compiler tries to suggest completions based on
+             * generated file in `$file`, which is not valid from Ammonite point of view
+             * We create other completions as ScopeMember in AmmoniteFileCompletions and
+             * filter out the default ones here.
+             */
+            case _: TypeMember =>
+              latestParentTrees.headOption.exists(tree =>
+                isAmmoniteFileCompletionPosition(tree, pos)
+              )
             case _ =>
               false
           }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -503,10 +503,8 @@ trait Completions { this: MetalsGlobal =>
           ident.pos.start,
           _ => true
         )
-      case Import(select, selector) :: _
-          if pos.source.file.name.isAmmoniteGeneratedFile && select
-            .toString()
-            .startsWith("$file") =>
+      case (imp @ Import(select, selector)) :: _
+          if isAmmoniteFileCompletionPosition(imp, pos) =>
         AmmoniteFileCompletions(select, selector, pos, editRange)
       case _ =>
         inferCompletionPosition(
@@ -517,6 +515,16 @@ trait Completions { this: MetalsGlobal =>
           completions,
           editRange
         )
+    }
+  }
+
+  def isAmmoniteFileCompletionPosition(tree: Tree, pos: Position): Boolean = {
+    tree match {
+      case Import(select, _) =>
+        pos.source.file.name.isAmmoniteGeneratedFile && select
+          .toString()
+          .startsWith("$file")
+      case _ => false
     }
   }
 


### PR DESCRIPTION
Due to https://github.com/scalameta/metals/pull/1846 we were actually filtering out a lot of ammonite completions, these were all the scope completions. Now we should properly filer out the wrong compiler completions after $file, because we are using a much more specific condition and the same that we use for AmmoniteFileCompletions.

Fixes https://github.com/scalameta/metals/issues/2973 and fixes https://github.com/scalameta/metals/issues/2122