### PR TITLE
[Scala 3] Support extension methods in hover

### DIFF
--- a/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
@@ -147,7 +147,7 @@ class HoverDefnSuite extends BaseHoverSuite {
       |""".stripMargin,
     "",
     compat = Map(
-      "3.0" -> "object MyObject: object".hover
+      "3.0" -> "object MyObject: `object`".hover
     )
   )
 

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -56,7 +56,7 @@ class HoverTermSuite extends BaseHoverSuite {
     """|def apply(name: String): Person
        |""".stripMargin.hover,
     compat = Map(
-      "3.0" -> "case class Person: case-apply".hover
+      "3.0" -> "case class Person: `case-apply`".hover
     )
   )
 
@@ -147,7 +147,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin.hover,
     compat = Map(
       // https://github.com/lampepfl/dotty/issues/8835
-      "3.0" -> "object num: interpolator-unapply.a$.Xtension".hover
+      "3.0" -> "object num: `interpolator-unapply`.a.Xtension".hover
     )
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -257,7 +257,7 @@ class CompletionSuite extends BaseCompletionSuite {
            |fromSpecific(it: IterableOnce[A]): C
            |iterate[A](start: A, len: Int)(f: A => A): CC[A]
            |newBuilder[A]: Builder[A, List[A]]
-           |nn[T](x: T | Null): x.type & T
+           |nn: x.type & T
            |range[A: Integral](start: A, end: A, step: A): CC[A]
            |range[A: Integral](start: A, end: A): CC[A]
            |tabulate[A](n1: Int, n2: Int)(f: (Int, Int) => A): CC[CC[A] @uncheckedVariance]


### PR DESCRIPTION
Previously, hover would show extension methods as a simple method. Now, we try to show the extension signature next to the actual extension method signature. This isn't yet perfect as it will not work if a method has a using param as the first one. This is not a big issue though as parameter in both places will work exactly the same.