### PR TITLE
Correctly paste extension groups

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/IndentOnPaste.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/IndentOnPaste.scala
@@ -8,8 +8,13 @@ import org.eclipse.lsp4j.TextEdit
 
 object IndentOnPaste extends RangeFormatter {
 
+  private val noEndClause = raw"((<!\bend\b\s*?)\b(if|while|for|match|try))"
+  private val ifThenClause = raw"(\bif\s+(?!.*?\bthen\b.*?$$)[^\s]*?)"
+  private val keywordClause = raw"\b(then|else|do|catch|finally|yield|case)"
+  private val openBraceClause = raw"""(^.*\{[^}"']*$$)"""
+  private val extensionClause = raw"""extension\s*((\(|\[).*(\)|\]))+"""
   val increaseIndentPatternRegex: Regex =
-    raw"""(((<!\bend\b\s*?)\b(if|while|for|match|try))|(\bif\s+(?!.*?\bthen\b.*?$$)[^\s]*?)|(\b(then|else|do|catch|finally|yield|case))|=|=>|<-|=>>|:)\s*?$$|(^.*\{[^}"']*$$)""".r
+    raw"""($noEndClause|$ifThenClause|$keywordClause|$extensionClause|=|=>|<-|=>>|:)\s*?$$|$openBraceClause""".r
   val indentRegex: Regex = raw"\S".r
 
   private def codeStartPosition(line: String): Option[Int] =

--- a/tests/unit/src/test/scala/tests/rangeFormatting/IndentWhenPastingSuite.scala
+++ b/tests/unit/src/test/scala/tests/rangeFormatting/IndentWhenPastingSuite.scala
@@ -272,6 +272,46 @@ class IndentWhenPastingSuite
     formattingOptions
   )
 
+  check(
+    "extension",
+    s"""
+       |object Main:
+       |  @@
+       |end Main""".stripMargin,
+    s"""
+       |extension [T](using b: B)(s: String)(using A)
+       |  def double = s * 2
+       |""".stripMargin,
+    """|object Main:
+       |  extension [T](using b: B)(s: String)(using A)
+       |    def double = s * 2
+       |end Main
+       |""".stripMargin,
+    scalaVersion,
+    formattingOptions
+  )
+
+  check(
+    "if-paren",
+    s"""
+       |object Main:
+       |  @@
+       |end Main""".stripMargin,
+    s"""
+       |if (cond)
+       |  def double = s * 2
+       |  double
+       |""".stripMargin,
+    """|object Main:
+       |  if (cond)
+       |    def double = s * 2
+       |    double
+       |end Main
+       |""".stripMargin,
+    scalaVersion,
+    formattingOptions
+  )
+
   def check(
       name: TestOptions,
       testCase: String,


### PR DESCRIPTION
Previously, extension groups would not be picked up when pasting and the indentation would be wrong. Now they are handled in the regex. I also split the original regex to make it more readable.