### PR TITLE
Include parens on lambda in Scala 3 when inserting type in params with brace.

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -170,7 +170,13 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |}""".stripMargin,
     """|object A{
        |  val toStringList = List(1, 2, 3).map{int: Int => int.toString}
-       |}""".stripMargin
+       |}""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|object A{
+           |  val toStringList = List(1, 2, 3).map{(int: Int) => int.toString}
+           |}""".stripMargin
+    )
   )
 
   checkEdit(


### PR DESCRIPTION
In Scala 2 when given the following piece of code and using the insert
inferred type functionality to insert the type of `x`, there is no issue
not including the parens.

This:
```scala
List(1, 2, 3).map{<<x>> => x * 2}
```

Becomes this:
```scala
List(1, 2, 3).map{x: Int => x * 2}
```

However in Scala 3 the compiler will error on this:

```
Diagnostics:
1. parentheses are required around the parameter of a lambda
   This construct can be rewritten automatically under -rewrite -source 3.0-migration.
```

This change makes sure that in this scenario in Scala 3 that the parens
are added so that it becomes:

```scala
List(1, 2, 3).map{(x: Int) => x * 2}
```