### PR TITLE
Support brackets in multiline strings

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/FormatterParams.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/FormatterParams.scala
@@ -1,0 +1,7 @@
+package scala.meta.internal.metals.formatting
+
+trait FormatterParams {
+  def startPos: meta.Position
+  def endPos: meta.Position
+  def sourceText: String
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/OnTypeFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/OnTypeFormattingProvider.scala
@@ -12,13 +12,6 @@ import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.TextEdit
 
-class OnTypeFormatter {
-  def contribute(
-      onTypeformatterParams: OnTypeFormatterParams
-  ): Option[List[TextEdit]] = None
-
-}
-
 case class OnTypeFormatterParams(
     sourceText: String,
     position: Position,
@@ -26,9 +19,15 @@ case class OnTypeFormatterParams(
     startPos: meta.Position,
     endPos: meta.Position,
     tokens: Option[Tokens]
-) {
+) extends FormatterParams {
   lazy val splitLines: Array[String] = sourceText.split("\\r?\\n")
   val range = new Range(position, position)
+}
+
+class OnTypeFormatter {
+  def contribute(
+      onTypeformatterParams: OnTypeFormatterParams
+  ): Option[List[TextEdit]] = None
 }
 
 class OnTypeFormattingProvider(

--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/RangeFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/RangeFormattingProvider.scala
@@ -19,7 +19,7 @@ case class RangeFormatterParams(
     startPos: meta.Position,
     endPos: meta.Position,
     tokens: Option[Tokens]
-) {
+) extends FormatterParams {
   lazy val splitLines: Array[String] = sourceText.split("\\r?\\n")
 }
 

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -691,7 +691,7 @@ final class TestingServer(
       query: String,
       expected: String,
       autoIndent: String,
-      replaceWith: String,
+      triggerChar: String,
       root: AbsolutePath = workspace
   )(implicit loc: munit.Location): Future[Unit] = {
     for {
@@ -700,7 +700,7 @@ final class TestingServer(
         query,
         root,
         autoIndent,
-        replaceWith
+        triggerChar
       )
       multiline <- server.onTypeFormatting(params).asScala
       format = TextEdits.applyEdits(


### PR DESCRIPTION
Fixes #2502
Previously, newlines inserted by the editor (vscode) were misplacing brackets.
Now, after changes, brackets are indented correctly:
```scala
  val before = """|{@@}"""

  val shouldBe = """|{
                    |
                    |}""".stripMargin
```

```scala
  val before = s"""|{@@}""".stripMargin

  val shouldBe = """|{
                    |
                    |}""".stripMargin

```

```scala
  val before = s"""|{@@}
                   |""".stripMargin

  val shouldBe = """|{
                    |
                    |}
                    |""".stripMargin
```

### Edit
Second commit fixes #2983 