### PR TITLE
Automatically convert $ to $$ when changing to string interpolation

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -474,7 +474,7 @@ object MetalsEnrichments
       if (index < safeLowerBound) -1 else index
     }
 
-    private def indicesOf(str: String): List[Int] = {
+    def indicesOf(str: String): List[Int] = {
       val b = new mutable.ListBuffer[Int]
       var idx = 0
       while (idx < value.length && idx >= 0) {

--- a/tests/unit/src/test/scala/tests/codeactions/StringActionsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/StringActionsLspSuite.scala
@@ -106,7 +106,7 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
        |
        |object A {
        |  val e = "hello"
-       |  val c = "this <<is>> a string"
+       |  val c = "this $ <<is>> a string"
        |  val d = "hello"
        |}
        |""".stripMargin,
@@ -116,11 +116,32 @@ class StringActionsLspSuite extends BaseCodeActionLspSuite("stringActions") {
        |
        |object A {
        |  val e = "hello"
-       |  val c = s"this is a string"
+       |  val c = s"this $$ is a string"
        |  val d = "hello"
        |}
-       |""".stripMargin.replace("'", "\""),
+       |""".stripMargin,
     selectedActionIndex = 1
+  )
+
+  check(
+    "multiline-string-interpolation",
+    """|package a
+       |
+       |object A {
+       |  val c = '''hello
+       |  this $ <<is>> a string
+       |  '''
+       |}
+       |""".stripMargin.replace("'", "\""),
+    s"${StringActions.interpolationTitle}",
+    """|package a
+       |
+       |object A {
+       |  val c = s'''hello
+       |  this $$ is a string
+       |  '''
+       |}
+       |""".stripMargin.replace("'", "\"")
   )
 
   checkNoAction(


### PR DESCRIPTION
Previously, we wouldn't do anything about $ which would break the code.