### PR TITLE
Debug flaky `WorkspaceSymbolLspSuite.dependencies`

### DIFF
--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -10,6 +10,8 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import org.eclipse.lsp4j.SymbolInformation
 import org.eclipse.lsp4j.WorkspaceSymbolParams
 import tests.MetalsTestEnrichments._
+import scala.util.Failure
+import scala.meta.internal.io.FileIO
 
 class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
 
@@ -126,7 +128,7 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
 
   test("dependencies") {
     cleanWorkspace()
-    for {
+    val f = for {
       _ <- server.initialize(
         """
           |/metals.json
@@ -196,6 +198,16 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
             |""".stripMargin
       )
     } yield ()
+    f.transform { v =>
+      v match {
+        case Failure(_) =>
+          val depsDir = workspace.resolve(".metals").resolve("dependencies")
+          val all = FileIO.listAllFilesRecursively(depsDir).mkString("\n")
+          println(all)
+        case _ =>
+      }
+      v
+    }
   }
 
   test("workspace-only") {


### PR DESCRIPTION
It often fails on CI but I can't reproduce it locally - [example](https://github.com/scalameta/metals/pull/2998/checks?check_run_id=3180754434)
Just want to find the actual reason of this failure - do not review this pr.