### PR TITLE
Add in sbt-sourcegraph to upload LSIF to Sourcegraph.

### DIFF
--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -1,0 +1,28 @@
+name: Sourcegraph
+on:
+  push:
+    branches:
+      - main
+    pull_request:
+
+jobs:
+  lsif:
+    runs-on: ubuntu-latest
+    name: "Upload LSIF"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v12
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.15.6"
+      - run: |
+          mkdir -p bin
+          curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o bin/src
+          chmod +x bin/src
+          export PATH="$PATH:$PWD/bin"
+          sbt \
+              'set every semanticdbEnabled := true' \
+              'set every semanticdbVersion := "4.4.24"' \
+              sourcegraphUpload
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,7 @@ addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.22")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.1")
+addSbtPlugin("com.sourcegraph" % "sbt-sourcegraph" % "0.2.0")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 


### PR DESCRIPTION
So I wanted to throw this up here to get others thoughts on this. I've noticed myself a lot more recently relying on Sourcegraph to quickly browse through code online at times especially if looking at a pr. Currently when you're looking at the Metals codebase all the results you're seeing are search-base:

<img width="642" alt="Screenshot 2021-07-30 at 12 38 40" src="https://user-images.githubusercontent.com/13974112/127645197-2f182628-6c3f-4898-b429-3f6ae1413499.png">

While this is already super helpful, it'd be amazing to have even [better code intelligence](https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence) when on GitHub. If I'm understanding everything correctly, we can do this by utilizing sbt-sourcegraph to turn the semanticDB created into LSIF for the project, and then upload it to Sourcegraph. @olafurpg am I understanding this correctly?

The necessary stuff is pretty minimal, and I did the actual command in a way that doesn't change our build definition at all, but the sbt command in the `sourcegraph.yml` takes care of everything. The only change would be adding the plugin.

The only thing I'm not fully sure of is if any org can just upload LSIF? Looking at the plugin I saw that it defaults to the main Sourcegraph, but am unsure how it's managed to ensure someone doesn't just randomly upload LSIF for a repo. Do we need an account or anything. Just throwing this up here to see if there is interest in it, since I know I'd use it.

