### PR TITLE
Make the SemanticDB compiler options used by mtags configurable.

### DIFF
--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -1,6 +1,8 @@
 package scala.meta.pc;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -97,5 +99,20 @@ public interface PresentationCompilerConfig {
      * The unit to use for <code>timeoutDelay</code>.
      */
     TimeUnit timeoutUnit();
+
+    /**
+     * The SemanticDB compiler options to use for the <code>semanticdbTextDocument</code> method.
+     *
+     * The full list of supported options is documented here https://scalameta.org/docs/semanticdb/guide.html#scalac-compiler-plugin
+     */
+    List<String> semanticdbCompilerOptions();
+
+    static List<String> defaultSemanticdbCompilerOptions() {
+        return Arrays.asList(
+            "-P:semanticdb:synthetics:on",
+            "-P:semanticdb:symbols:none",
+            "-P:semanticdb:text:on"
+        );
+    }
 
 }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -202,7 +202,10 @@ case class ScalaPresentationCompiler(
       Array.emptyByteArray,
       EmptyCancelToken
     ) { pc =>
-      new SemanticdbTextDocumentProvider(pc.compiler())
+      new SemanticdbTextDocumentProvider(
+        pc.compiler(),
+        config.semanticdbCompilerOptions().asScala.toList
+      )
         .textDocument(uri, code)
         .toByteArray
     }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
@@ -9,8 +9,10 @@ import scala.meta.internal.semanticdb.scalac.SemanticdbConfig
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.AbsolutePath
 
-class SemanticdbTextDocumentProvider(val compiler: MetalsGlobal)
-    extends WorksheetSemanticdbProvider {
+class SemanticdbTextDocumentProvider(
+    val compiler: MetalsGlobal,
+    semanticdbCompilerOptions: List[String]
+) extends WorksheetSemanticdbProvider {
   import compiler._
 
   def textDocument(
@@ -31,11 +33,7 @@ class SemanticdbTextDocumentProvider(val compiler: MetalsGlobal)
     // This cache is never updated in semanticdb and will contain the old source
     gSourceFileInputCache.remove(unit.source)
     semanticdbOps.config = SemanticdbConfig.parse(
-      List(
-        "-P:semanticdb:synthetics:on",
-        "-P:semanticdb:symbols:none",
-        "-P:semanticdb:text:on"
-      ),
+      semanticdbCompilerOptions,
       _ => (),
       compiler.reporter,
       SemanticdbConfig.default

--- a/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -24,7 +24,9 @@ case class PresentationCompilerConfigImpl(
     isCompletionItemResolve: Boolean = true,
     _isStripMarginOnTypeFormattingEnabled: () => Boolean = () => true,
     timeoutDelay: Long = 20,
-    timeoutUnit: TimeUnit = TimeUnit.SECONDS
+    timeoutUnit: TimeUnit = TimeUnit.SECONDS,
+    semanticdbCompilerOptions: util.List[String] =
+      PresentationCompilerConfig.defaultSemanticdbCompilerOptions()
 ) extends PresentationCompilerConfig {
 
   override def isStripMarginOnTypeFormattingEnabled(): Boolean =


### PR DESCRIPTION
Previously, mtags used a hardcoded list of SemanticDB compiler options
to produce SemanticDB text documents from source. This commit makes the
options configurable via PresentationCompilerConfig. The motivation for
this change is that we recently started using mtags for LSIF indexing
Scala projects. To render Scala method/class signatures we need SemanticDB
`SymbolInformation`, which are not emitted by default in mtags since
they are not used by Metals.