### PR TITLE
Generate symbol information for standalone files, worksheets and sbt files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -83,7 +83,7 @@ final class Diagnostics(
       case Some(diagnostic) if !workspace.exists(path.isInReadonlyDirectory) =>
         syntaxError(path) = diagnostic
         publishDiagnostics(path)
-      case None =>
+      case _ =>
         onNoSyntaxError(path)
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -87,8 +87,7 @@ final class InteractiveSemanticdbs(
           if (existingDoc == null || existingDoc.md5 != sha) {
             val compiled = compile(path, text)
             Option(compiled).foreach(doc =>
-              // don't index dependency source files or worksheets, since their definitions are local
-              if (!source.isDependencySource(workspace) && !source.isWorksheet)
+              if (!source.isDependencySource(workspace))
                 semanticdbIndexer().onChange(source, doc)
             )
             compiled

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -992,6 +992,7 @@ class MetalsLanguageServer(
     val loadInteractive = Future {
       interactiveSemanticdbs.textDocument(path)
     }
+    parseTrees(path).flatMap(_ => syntheticsDecorator.publishSynthetics(path))
     if (path.isDependencySource(workspace)) {
       CancelTokens { _ =>
         // publish diagnostics
@@ -1008,9 +1009,6 @@ class MetalsLanguageServer(
         .sequence(
           List(
             loadInteractive,
-            parseTrees(path).flatMap(_ =>
-              syntheticsDecorator.publishSynthetics(path)
-            ),
             loadFuture,
             compileFuture
           )
@@ -1050,6 +1048,7 @@ class MetalsLanguageServer(
         // Don't trigger compilation on didFocus events under cascade compilation
         // because save events already trigger compile in inverse dependencies.
         if (path.isDependencySource(workspace)) {
+          syntheticsDecorator.publishSynthetics(path)
           CompletableFuture.completedFuture(DidFocusResult.NoBuildTarget)
         } else if (openedFiles.isRecentlyActive(path)) {
           CompletableFuture.completedFuture(DidFocusResult.RecentlyActive)

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -110,7 +110,6 @@ public interface PresentationCompilerConfig {
     static List<String> defaultSemanticdbCompilerOptions() {
         return Arrays.asList(
             "-P:semanticdb:synthetics:on",
-            "-P:semanticdb:symbols:none",
             "-P:semanticdb:text:on"
         );
     }

--- a/tests/cross/src/test/scala/tests/pc/PcSemanticdbSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcSemanticdbSuite.scala
@@ -39,11 +39,12 @@ class PcSemanticdbSuite extends BasePCSuite {
        |  val a = 123
        |  val b = a + 1
        |}""".stripMargin,
-    """|import $ivy.`org.kohsuke:github-api:1.114`
+    // local0 comes most likely from the script object use to wrap ScriptSource
+    """|/*local0*/import $ivy.`org.kohsuke:github-api:1.114`
        |
-       |object O/*local0*/ {
-       |  val a/*local1*/ = 123
-       |  val b/*local2*/ = a/*local1*/ +/*scala.Int#`+`(+4).*/ 1
+       |object O/*local1*/ {
+       |  val a/*local2*/ = 123
+       |  val b/*local3*/ = a/*local2*/ +/*scala.Int#`+`(+4).*/ 1
        |}
        |""".stripMargin,
     filename = "A.worksheet.sc",

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -311,10 +311,9 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
       _ <- server.didOpen("standalone/Main.scala")
       _ = assertNoDiagnostics()
       _ = assertNoDiff(
-        // currently interactive semanticdb doesn't produce symbol signatures
         client.workspaceDecorations,
         """|object Main{
-           |  val value = augmentString("asd.").stripSuffix(".")
+           |  val value: String = augmentString("asd.").stripSuffix(".")
            |}
            |""".stripMargin
       )


### PR DESCRIPTION
Previously, generated semanticdb would not contain symbol information. Now, it's enabled and allows for type decorations and implementations in worksheets, standalone files, dependencies and sbt files.

Should help with https://github.com/scalameta/metals-feature-requests/issues/190