### PR TITLE
Upgrade to the latest sbt-sourcegraph

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.22")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.1")
-addSbtPlugin("com.sourcegraph" % "sbt-sourcegraph" % "0.2.0")
+addSbtPlugin("com.sourcegraph" % "sbt-sourcegraph" % "0.2.1")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 


### PR DESCRIPTION
This version includes a fix so that cross-repo navigation should work
after https://github.com/sourcegraph/sourcegraph/pull/22984 is merged.