### PR TITLE
Fix indentation when pasting part of the line

### DIFF
--- a/tests/unit/src/test/scala/tests/rangeFormatting/IndentWhenPastingSuite.scala
+++ b/tests/unit/src/test/scala/tests/rangeFormatting/IndentWhenPastingSuite.scala
@@ -312,6 +312,21 @@ class IndentWhenPastingSuite
     formattingOptions
   )
 
+  check(
+    "breaking-code",
+    """
+      |object Main:
+      |  @@val outFile = ""
+      |end Main""".stripMargin,
+    "outFile",
+    """
+      |object Main:
+      |  outFileval outFile = ""
+      |end Main""".stripMargin,
+    scalaVersion,
+    formattingOptions
+  )
+
   def check(
       name: TestOptions,
       testCase: String,


### PR DESCRIPTION
Previously, we would duplicate the rest of the line that was not included in the pasted snippet. Now, we properly format the entire line.