### PR TITLE
[Scala3] Replace `InteractiveDriver` by our own wrapper to dotc.Compiler

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -29,27 +29,6 @@ object MtagsEnrichments extends CommonMtagsEnrichments {
       val p = Spans.Span(offset)
       new SourcePosition(source, p)
 
-    def localContext(params: OffsetParams): Context = {
-      if (driver.currentCtx.run.units.isEmpty)
-        throw new RuntimeException(
-          "No source files were passed to the Scala 3 presentation compiler"
-        )
-      val unit = driver.currentCtx.run.units.head
-      val tree = unit.tpdTree
-      val pos = driver.sourcePosition(params)
-      val path =
-        Interactive.pathTo(driver.openedTrees(params.uri), pos)(using
-          driver.currentCtx
-        )
-
-      val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
-      val tpdPath =
-        Interactive.pathTo(newctx.compilationUnit.tpdTree, pos.span)(using
-          newctx
-        )
-      MetalsInteractive.contextOfPath(tpdPath)(using newctx)
-    }
-
   extension (pos: SourcePosition)
     def toLSP: l.Range = {
       new l.Range(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionProvider.scala
@@ -25,7 +25,6 @@ import dotty.tools.dotc.util.SrcPos
 
 class CompletionProvider(
     pos: SourcePosition,
-    ctx: Context,
     search: SymbolSearch,
     buildTargetIdentifier: String,
     completionPos: CompletionPos,
@@ -33,7 +32,7 @@ class CompletionProvider(
     path: List[Tree]
 ) {
 
-  implicit val context: Context = ctx
+  import indexedContext.ctx
 
   def completions(): (List[CompletionValue], SymbolSearch.Result) = {
     val (_, compilerCompletions) = Completion.completions(pos)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsDriver.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsDriver.scala
@@ -1,0 +1,100 @@
+package scala.meta.internal.pc
+
+import java.net.URI
+
+import scala.meta.internal.pc.MetalsDriver.TypecheckResult
+
+import dotty.tools.dotc.Compiler
+import dotty.tools.dotc.ScalacCommand
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.core.Comments._
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Contexts._
+import dotty.tools.dotc.core.Mode
+import dotty.tools.dotc.core.Phases.Phase
+import dotty.tools.dotc.interactive.Interactive
+import dotty.tools.dotc.interfaces.Diagnostic
+import dotty.tools.dotc.reporting.HideNonSensicalMessages
+import dotty.tools.dotc.reporting.Reporter
+import dotty.tools.dotc.reporting.StoreReporter
+import dotty.tools.dotc.reporting.UniqueMessagePositions
+import dotty.tools.dotc.transform.SetRootTree
+import dotty.tools.dotc.typer.FrontEnd
+import dotty.tools.dotc.typer.ImportInfo._
+import dotty.tools.dotc.util.SourceFile
+import dotty.tools.dotc.util.SourcePosition
+import dotty.tools.dotc.util.Spans
+
+class MetalsDriver(initCtx: Context, compiler: Compiler) {
+
+  def run(uri: URI, source: String): TypecheckResult = {
+    val sourceFile = CompilerInterfaces.toSource(uri, source)
+    run(uri, sourceFile)
+  }
+
+  def run(uri: URI, source: SourceFile): TypecheckResult = {
+    val reporter =
+      new StoreReporter(null)
+        with UniqueMessagePositions
+        with HideNonSensicalMessages
+    val runContext = initCtx.fresh.setReporter(reporter)
+    val run = compiler.newRun(using runContext)
+    val ctx = run.runContext.withRootImports
+    run.compileSources(List(source))
+    val unit =
+      if ctx.run.units.nonEmpty then ctx.run.units.head
+      else ctx.run.suspendedUnits.head
+    TypecheckResult(
+      ctx.fresh.setCompilationUnit(unit),
+      unit.tpdTree,
+      source,
+      reporter.removeBufferedMessages(using ctx)
+    )
+  }
+
+}
+
+object MetalsDriver {
+
+  def create(options: List[String]): MetalsDriver = {
+    new MetalsDriver(
+      initCtx(options),
+      new FrontendCompiler
+    )
+  }
+
+  private def initCtx(settings: List[String]): Context = {
+    val fresh = (new ContextBase).initialCtx.fresh
+    val rootCtx = fresh.addMode(Mode.ReadPositions).addMode(Mode.Interactive)
+    rootCtx.setSetting(rootCtx.settings.YretainTrees, true)
+    rootCtx.setSetting(rootCtx.settings.YdropComments, true)
+    val summary = ScalacCommand.distill(settings.toArray, rootCtx.settings)(
+      rootCtx.settingsState
+    )(using rootCtx)
+    rootCtx.setSettings(summary.sstate)
+    rootCtx.setProperty(ContextDoc, new ContextDocstrings)
+    rootCtx
+  }
+
+  case class TypecheckResult(
+      context: Context,
+      tree: tpd.Tree,
+      source: SourceFile,
+      diagnostic: List[Diagnostic]
+  ) {
+
+    def positionOf(offset: Int): SourcePosition = {
+      val p = Spans.Span(offset)
+      new SourcePosition(source, p)
+    }
+
+    def pathTo(offset: Int): List[tpd.Tree] =
+      Interactive.pathTo(tree, Spans.Span(offset))(using context)
+  }
+
+  class FrontendCompiler extends Compiler {
+    override def phases: List[List[Phase]] = List(
+      List(new FrontEnd)
+    )
+  }
+}

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
@@ -16,7 +16,6 @@ import scala.meta.internal.pc.ReporterAccess
 import scala.meta.pc.CancelToken
 import scala.meta.pc.PresentationCompilerConfig
 
-import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.reporting.StoreReporter
 
 class Scala3CompilerAccess(
@@ -24,7 +23,7 @@ class Scala3CompilerAccess(
     sh: Option[ScheduledExecutorService],
     newCompiler: () => Scala3CompilerWrapper
 )(using ec: ExecutionContextExecutor)
-    extends CompilerAccess[StoreReporter, InteractiveDriver](
+    extends CompilerAccess[StoreReporter, MetalsDriver](
       config,
       sh,
       newCompiler

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerWrapper.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerWrapper.scala
@@ -7,19 +7,16 @@ import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.reporting.StoreReporter
 
-class Scala3CompilerWrapper(driver: InteractiveDriver)
-    extends CompilerWrapper[StoreReporter, InteractiveDriver] {
+class Scala3CompilerWrapper(driver: MetalsDriver)
+    extends CompilerWrapper[StoreReporter, MetalsDriver] {
 
-  override def compiler(): InteractiveDriver = driver
+  override def compiler(): MetalsDriver = driver
 
-  override def resetReporter(): Unit = {
-    val ctx = driver.currentCtx
-    ctx.reporter.removeBufferedMessages(using ctx)
-  }
+  override def resetReporter(): Unit = ()
 
   override def reporterAccess: ReporterAccess[StoreReporter] =
     new ReporterAccess[StoreReporter] {
-      def reporter = driver.currentCtx.reporter.asInstanceOf[StoreReporter]
+      def reporter = new StoreReporter(null)
     }
 
   override def askShutdown(): Unit = {}

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SelectionRangeProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SelectionRangeProvider.scala
@@ -21,7 +21,7 @@ import org.eclipse.lsp4j.SelectionRange
  * @param params offset params converted from the selectionRange params.
  */
 class SelectionRangeProvider(
-    driver: InteractiveDriver,
+    driver: MetalsDriver,
     params: ju.List[OffsetParams]
 ) {
 
@@ -31,17 +31,14 @@ class SelectionRangeProvider(
    * @return selection ranges
    */
   def selectionRange(): List[SelectionRange] = {
-    given ctx: Context = driver.currentCtx
-
     val selectionRanges = params.asScala.toList.map { param =>
 
       val uri = param.uri
       val filePath = Paths.get(uri)
       val source = SourceFile.virtual(filePath.toString, param.text)
-      driver.run(uri, source)
-      val pos = driver.sourcePosition(param)
-      val path =
-        Interactive.pathTo(driver.openedTrees(uri), pos)(using ctx)
+      val result = driver.run(uri, param.text)
+      given Context = result.context
+      val path = result.pathTo(param.offset)
 
       val bareRanges = path
         .map { tree =>

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
@@ -19,7 +19,7 @@ import dotty.tools.dotc.semanticdb.internal.SemanticdbOutputStream
 import dotty.tools.dotc.util.SourceFile
 
 class SemanticdbTextDocumentProvider(
-    driver: InteractiveDriver,
+    driver: MetalsDriver,
     workspace: Option[Path]
 ) extends WorksheetSemanticdbProvider {
 
@@ -29,14 +29,13 @@ class SemanticdbTextDocumentProvider(
   ): Array[Byte] = {
     val filePath = Paths.get(uri)
     val validCode = removeMagicImports(sourceCode, AbsolutePath(filePath))
-    driver.run(
+    val result = driver.run(
       uri,
       SourceFile.virtual(filePath.toString, validCode)
     )
-    val tree = driver.currentCtx.run.units.head.tpdTree
     val extract = ExtractSemanticDB()
     val extractor = extract.Extractor()
-    extractor.traverse(tree)(using driver.currentCtx)
+    extractor.traverse(result.tree)(using result.context)
     val path = workspace
       .flatMap { workspacePath =>
         scala.util.Try(workspacePath.relativize(filePath)).toOption

--- a/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
@@ -180,11 +180,7 @@ class HoverDefnSuite extends BaseHoverSuite {
       |package b.pkg
       |```
       |""".stripMargin,
-    automaticPackage = false,
-    compat = Map(
-      // TODO hover doesn't show information on package
-      "3.0" -> "".hover
-    )
+    automaticPackage = false
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1078,8 +1078,8 @@ class CompletionSuite extends BaseCompletionSuite {
     compat = Map(
       "3.0" ->
         """|NotString: Int
+           |Number: Regex
            |Nil scala.collection.immutable
-           |NoManifest scala.reflect
            |""".stripMargin
     )
   )


### PR DESCRIPTION
`InteractiveDriver` was designed for dotty-language-server and we use it
improperly. For Metals we don't need to keep a buch of files in memory.
Also it might fix some problems(memory leaks + some pc tests) that might be caused of having a single
context that is passed trough all received sources.