### PR TITLE
Allow organize imports on unsaved code

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
@@ -6,6 +6,8 @@ object Directories {
     RelativePath(".metals").resolve("metals.h2.db")
   def readonly: RelativePath =
     RelativePath(".metals").resolve("readonly")
+  def tmp: RelativePath =
+    RelativePath(".metals").resolve(".tmp")
   def dependencies: RelativePath =
     readonly.resolve(dependenciesName)
   def log: RelativePath =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -477,6 +477,10 @@ object MetalsEnrichments
       Files.delete(path.dealias.toNIO)
     }
 
+    def deleteRecursively(): Unit = {
+      path.listRecursive.toList.reverse.foreach(_.delete())
+    }
+
     def writeText(text: String): Unit = {
       path.parent.createDirectories()
       val tmp = Files.createTempFile("metals", path.filename)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -641,7 +641,8 @@ class MetalsLanguageServer(
           clientConfig.icons(),
           languageClient,
           buildTargets,
-          buildClient
+          buildClient,
+          interactiveSemanticdbs
         )
         codeActionProvider = new CodeActionProvider(
           compilers,

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
@@ -3,6 +3,8 @@ package scala.meta.internal.pc
 import java.net.URI
 import java.nio.file.Paths
 
+import scala.util.Properties
+
 import scala.meta.dialects
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.semanticdb.scalac.SemanticdbConfig
@@ -52,7 +54,10 @@ class SemanticdbTextDocumentProvider(
         scala.util.Try(workspacePath.relativize(filePath.toNIO)).toOption
       }
       .map { relativeUri =>
-        document.withUri(relativeUri.toString())
+        val relativeString =
+          if (Properties.isWin) relativeUri.toString().replace("\\", "/")
+          else relativeUri.toString()
+        document.withUri(relativeString)
       }
       .getOrElse(document)
   }

--- a/tests/unit/src/test/scala/tests/AddPackageLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/AddPackageLspSuite.scala
@@ -3,7 +3,6 @@ package tests
 import java.nio.file.Files
 import java.nio.file.Paths
 
-import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.RecursivelyDelete
 
 import munit.TestOptions
@@ -12,18 +11,16 @@ class AddPackageLspSuite extends BaseLspSuite("add-package") {
 
   check("single-level")(
     "a/src/main/scala/a/Main.scala",
-    """|
-       |package a
+    """|package a
+       |
        |""".stripMargin
   )
 
   check("package-file")(
     "a/src/main/scala/a/package.scala",
-    """|
-       |package object a {
+    """|package object a {
        |  
        |}
-       |
        |""".stripMargin
   )
 
@@ -34,15 +31,14 @@ class AddPackageLspSuite extends BaseLspSuite("add-package") {
        |package object c {
        |  
        |}
-       |
        |""".stripMargin
   )
 
   check("multilevel")(
     "a/src/main/scala/a/b/c/Main.scala",
-    """|
-       |package a.b.c
-       |  """.stripMargin
+    """|package a.b.c
+       |
+       |""".stripMargin
   )
 
   check("no-package")(
@@ -57,9 +53,9 @@ class AddPackageLspSuite extends BaseLspSuite("add-package") {
 
   check("escaped-name")(
     "a/src/main/scala/type/a/this/Main.scala",
-    """|
-       |package `type`.a.`this`
-       |  """.stripMargin
+    """|package `type`.a.`this`
+       |
+       |""".stripMargin
   )
 
   check("escaped-name-object")(
@@ -96,7 +92,7 @@ class AddPackageLspSuite extends BaseLspSuite("add-package") {
             .createNewFile()
         _ <- server.didOpen(fileToCreate)
         _ = assertNoDiff(
-          workspace.resolve(fileToCreate).readText,
+          client.buffers.get(workspace.resolve(fileToCreate)).getOrElse(""),
           expectedContent
         )
       } yield ()

--- a/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
@@ -60,6 +60,82 @@ class OrganizeImportsLspSuite
   )
 
   check(
+    "basic-unsaved",
+    """
+      |package a
+      |import scala.concurrent.duration._
+      |import scala.concurrent.Future<<>>
+      |import scala.concurrent.ExecutionContext.global
+      |
+      |object A {
+      |  val d = Duration(10, MICROSECONDS)
+      |  val k = Future.successful(1)
+      |}
+      |""".stripMargin,
+    s"${SourceOrganizeImports.title}",
+    """|package a
+       |import scala.concurrent.Future
+       |import scala.concurrent.duration._
+       |// comment
+       |
+       |object A {
+       |  val d = Duration(10, MICROSECONDS)
+       |  val k = Future.successful(1)
+       |}
+       |""".stripMargin,
+    kind = List(sourceKind),
+    scalacOptions = scalacOption,
+    changeFile = (txt: String) => {
+      txt.replace(
+        """|import scala.concurrent.ExecutionContext.global""".stripMargin,
+        """|import scala.concurrent.ExecutionContext.global
+           |import java.nio.file.Path
+           |// comment""".stripMargin
+      )
+    }
+  )
+
+  check(
+    "basic-unsaved-error",
+    """
+      |package a
+      |import scala.concurrent.duration._
+      |import scala.concurrent.Future<<>>
+      |import scala.concurrent.ExecutionContext.global
+      |
+      |object A {
+      |  val d = Duration(10, MICROSECONDS)
+      |  val k = Future.successful(1)
+      |}
+      |""".stripMargin,
+    s"${SourceOrganizeImports.title}",
+    """|package a
+       |import java.nio.file.ClassDoNotExist
+       |import scala.concurrent.ExecutionContext.global
+       |import scala.concurrent.Future
+       |import scala.concurrent.duration._
+       |// comment
+       |
+       |object A {
+       |  val d = Duration(10, MICROSECONDS)
+       |  val k = Future.successful(1)
+       |}
+       |""".stripMargin,
+    kind = List(sourceKind),
+    scalacOptions = scalacOption,
+    changeFile = (txt: String) => {
+      txt.replace(
+        """|import scala.concurrent.ExecutionContext.global""".stripMargin,
+        """|import scala.concurrent.ExecutionContext.global
+           |import java.nio.file.ClassDoNotExist
+           |// comment""".stripMargin
+      )
+    },
+    expectError = true,
+    expectNoDiagnostics = false
+  )
+
+  check(
     "basic-with-custom-config",
     """
       |package a


### PR DESCRIPTION
Previously, if a file was not saved it wouldn't be possible to run the organize imports rule.

Now, we try to produce a new semanticdb, save it to disk and point scalafix to it. It might be better to transfer this directly, but scalafix is currently lacking an API for it. We can change once it's supported.

Fixes https://github.com/scalameta/metals/issues/2120

![metals-sample-1629736205938](https://user-images.githubusercontent.com/3807253/130483777-e7e15cae-6f27-4cb5-8d79-c433d8092097.gif)
