### PR TITLE
Fix comments erasing all later variables in .env file

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
@@ -30,7 +30,7 @@ object DotEnvFileParser {
       [^\r\n]*                # unquoted value    
     )
     \s*                       # trailing whitespace
-    (?:\#.*)?                 # optional comment
+    (?:\#[^\n]*)?                 # optional comment
     $                         # end of line
   """.r
 

--- a/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
@@ -186,7 +186,7 @@ class DebugProtocolSuite
         workspace
           .resolve(Random.alphanumeric.take(10).mkString.toLowerCase + ".env")
           .toNIO,
-        "MIDDLE_NAME=Emily\nLAST_NAME=Morris".getBytes()
+        "MIDDLE_NAME=Emily\n#comment\nLAST_NAME=Morris".getBytes()
       )
 
     for {


### PR DESCRIPTION
Previously, regex used for .env files would cover all characters after any comments, so effectively until end of file and miss all the later variables. Now, we only match comment without any newlines.