### PR TITLE
Display build target info

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -197,6 +197,7 @@ lazy val V = new {
   val ammonite213Version = scala213
   val scalameta = "4.4.27"
   val semanticdb = scalameta
+  val javaSemanticdb = "0.6.8"
   val bsp = "2.0.0-M13"
   val bloop = "1.4.8-114-e47368ed"
   val scala3 = "3.0.2"
@@ -477,6 +478,7 @@ lazy val metals = project
       "mavenBloopVersion" -> V.mavenBloop,
       "scalametaVersion" -> V.scalameta,
       "semanticdbVersion" -> V.semanticdb,
+      "javaSemanticdbVersion" -> V.javaSemanticdb,
       "scalafmtVersion" -> V.scalafmt,
       "ammoniteVersion" -> V.ammonite,
       "organizeImportVersion" -> V.organizeImportRule,

--- a/build.sbt
+++ b/build.sbt
@@ -438,6 +438,8 @@ lazy val metals = project
       "com.thoughtworks.qdox" % "qdox" % "2.0.0",
       // for finding paths of global log/cache directories
       "dev.dirs" % "directories" % "26",
+      // for Java formatting
+      "org.eclipse.jdt" % "org.eclipse.jdt.core" % "3.26.0",
       // ==================
       // Scala dependencies
       // ==================

--- a/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
@@ -84,7 +84,7 @@ object Digest {
     val ext = PathIO.extension(path.toNIO)
     val isScala = Set("sbt", "scala", "sc")(ext)
     // we can have both gradle and gradle.kts and build plugins can be written in any of three languages
-    val isGradle =
+    val isGeneralJVM =
       Set("gradle", "groovy", "gradle.kts", "java", "kts").exists(
         path.toString().endsWith(_)
       )
@@ -92,7 +92,7 @@ object Digest {
 
     if (isScala && path.isFile) {
       digestScala(path, digest)
-    } else if (isGradle && path.isFile) {
+    } else if (isGeneralJVM && path.isFile) {
       digestGeneralJvm(path, digest)
     } else if (isXml) {
       digestXml(path, digest)

--- a/metals/src/main/scala/scala/meta/internal/implementation/GlobalClassTable.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/GlobalClassTable.scala
@@ -40,8 +40,8 @@ final class GlobalClassTable(
     synchronized {
       for {
         buildTargetId <- buildTargets.inverseSources(source)
-        scalaTarget <- buildTargets.scalaTarget(buildTargetId)
-        classpath = new Classpath(scalaTarget.jarClasspath)
+        jarClasspath <- buildTargets.targetJarClasspath(buildTargetId)
+        classpath = new Classpath(jarClasspath)
       } yield {
         buildTargetsIndexes.getOrElseUpdate(
           buildTargetId,

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
@@ -1,0 +1,307 @@
+package scala.meta.internal.metals
+
+import java.io.File
+import java.net.URI
+import java.net.URLEncoder
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import scala.meta.io.AbsolutePath
+import scala.meta.internal.metals.MetalsEnrichments._
+
+class BuildTargetInfo(buildTargets: BuildTargets) {
+  def buildTargetDetailsHtml(targetName: String): String = {
+    val targetIds = buildTargets.allCommon
+      .filter(target => target.displayName == targetName)
+      .map(_.id)
+      .toSeq
+    new HtmlBuilder()
+      .element("p")(html => buildTargetDetailsHtml(html, targetIds))
+      .render
+  }
+  private def buildTargetDetailsHtml(
+      html: HtmlBuilder,
+      targetIds: Seq[BuildTargetIdentifier]
+  ): Unit = {
+    targetIds
+      .flatMap(extractTargetDetail)
+      .sortBy(f =>
+        (f.common.baseDirectory, f.common.displayName, f.common.dataKind)
+      )
+      .foreach(buildTargetDetailHtml(html, _))
+  }
+  private def convertClasspathEntry(
+      classpathEntry: String,
+      html: HtmlBuilder
+  ): Unit = {
+    val file = new File(URI.create(classpathEntry))
+    if (file.exists && file.isFile) {
+      val param = s"""["${classpathEntry}"]"""
+      html.link(
+        s"command:metals.reveal-uri?${URLEncoder.encode(param)}",
+        file.getName()
+      )
+    } else html.text(classpathEntry)
+  }
+  private def convertOption(option: String, html: HtmlBuilder): Unit = {
+    html.text(if (option.isEmpty) "[BLANK]" else option)
+  }
+  private def convertTarget(
+      buildTargetName: String,
+      html: HtmlBuilder
+  ): Unit = {
+    val param = s"""["$buildTargetName"]"""
+    val link = s"command:target-info-display?${URLEncoder.encode(param)}"
+    html.link(link, buildTargetName)
+  }
+  private def buildTargetDetailHtml(
+      html: HtmlBuilder,
+      detail: TargetDetail
+  ): Unit = {
+    html
+      .element("h2")(_.text(detail.common.displayName))
+      .element("p")(_.link("command:doctor-run", "Run Doctor"))
+      .element("p")(html => {
+        html.element("strong")(_.text("Tags"))
+        if (detail.common.tags.isEmpty)
+          html.unorderedList(List("None")) { html.text(_) }
+        html.unorderedList(detail.common.tags) { html.text(_) }
+      })
+      .element("p")(html => {
+        html.element("strong")(_.text("Languages"))
+        if (detail.common.languageIds.isEmpty)
+          html.unorderedList(List("None")) { html.text(_) }
+        html.unorderedList(detail.common.languageIds) { html.text(_) }
+      })
+      .element("p")(html => {
+        html.element("strong")(_.text("Capabilities"))
+        if (detail.common.capabilities.isEmpty)
+          html.unorderedList(List("None")) { html.text(_) }
+        html.unorderedList(detail.common.capabilities) { html.text(_) }
+      })
+      .element("p")(html => {
+        html.element("strong")(_.text("Dependencies"))
+        if (detail.common.dependencies.isEmpty)
+          html.unorderedList(List("None")) { html.text(_) }
+        html.unorderedList(detail.common.dependencies) { f =>
+          convertTarget(f, html)
+        }
+      })
+      .element("p")(html => {
+        html.element("strong")(_.text("Dependent Targets"))
+        if (detail.common.dependentTargets.isEmpty)
+          html.unorderedList(List("None")) { html.text(_) }
+        html.unorderedList(detail.common.dependentTargets) { f =>
+          convertTarget(f, html)
+        }
+      })
+    detail.java.foreach { j =>
+      html.element("p")(html => {
+        html.element("strong")(
+          _.link(
+            "https://docs.oracle.com/en/java/javase/16/docs/specs/man/javac.html#options",
+            "Javac Options"
+          )
+        )
+        if (j.options.isEmpty)
+          html.unorderedList(List("None")) { html.text(_) }
+        html.unorderedList(j.options) { f => convertOption(f, html) }
+      })
+    }
+    detail.scala.foreach { s =>
+      html.element("p")(html => {
+        html.element("strong")(
+          _.link(
+            "https://docs.scala-lang.org/overviews/compiler-options/index.html#Standard_Settings",
+            "Scalac Options"
+          )
+        )
+        if (s.options.isEmpty)
+          html.unorderedList(List("None")) { html.text(_) }
+        html.unorderedList(s.options) { f => convertOption(f, html) }
+      })
+      html.element("p")(html => {
+        html.element("strong")(_.text("Scala Version"))
+        html.unorderedList(List(s.scalaVersion)) { html.text(_) }
+      })
+      html.element("p")(html => {
+        html.element("strong")(_.text("Scala Binary Version"))
+        html.unorderedList(List(s.scalaBinaryVersion)) { html.text(_) }
+      })
+    }
+    html
+      .element("p")(html => {
+        html.element("strong")(_.text("Build Target base directory"))
+        html.unorderedList(List(detail.common.baseDirectory)) { html.text(_) }
+      })
+      .element("p")(html => {
+        html.element("strong")(_.text("Source directories"))
+        if (detail.common.sources.isEmpty)
+          html.unorderedList(List("None")) { html.text(_) }
+        html.unorderedList(detail.common.sources) { f => html.text(f.toString) }
+      })
+    if (detail.sameJavaScalaClassesDir)
+      detail.java.foreach { j =>
+        html.element("p")(html => {
+          html.element("strong")(_.text("Classes directory"))
+          html.unorderedList(List(j.classesDirectory)) { html.text(_) }
+        })
+      }
+    else {
+      detail.java.foreach { j =>
+        html.element("p")(html => {
+          html.element("strong")(_.text("Java Classes directory"))
+          html.unorderedList(List(j.classesDirectory)) { html.text(_) }
+        })
+      }
+      detail.scala.foreach { s =>
+        html.element("p")(html => {
+          html.element("strong")(_.text("Scala Classes directory"))
+          html.unorderedList(List(s.classesDirectory)) { html.text(_) }
+        })
+      }
+    }
+    if (detail.sameJavaScalaClasspaths)
+      detail.java.foreach { j =>
+        html.element("p")(html => {
+          html.element("strong")(_.text("Classpath"))
+          if (j.classPath.isEmpty)
+            html.unorderedList(List("None")) { html.text(_) }
+          html.unorderedList(j.classPath) { f =>
+            convertClasspathEntry(f, html)
+          }
+        })
+      }
+    else {
+      detail.java.foreach { j =>
+        html.element("p")(html => {
+          html.element("strong")(_.text("Java Classpath"))
+          if (j.classPath.isEmpty)
+            html.unorderedList(List("None")) { html.text(_) }
+          html.unorderedList(j.classPath) { f =>
+            convertClasspathEntry(f, html)
+          }
+        })
+      }
+      detail.scala.foreach { s =>
+        html.element("p")(html => {
+          html.element("strong")(_.text("Scala Classpath"))
+          if (s.classPath.isEmpty)
+            html.unorderedList(List("None")) { html.text(_) }
+          html.unorderedList(s.classPath) { f =>
+            convertClasspathEntry(f, html)
+          }
+        })
+      }
+    }
+  }
+  private case class TargetDetail(
+      common: CommonTargetDetail,
+      java: Option[JavaTargetDetail],
+      scala: Option[ScalaTargetDetail]
+  ) {
+    def sameJavaScalaClasspaths: Boolean =
+      java.nonEmpty && scala.nonEmpty && java.get.classPath == scala.get.classPath
+    def sameJavaScalaClassesDir: Boolean =
+      java.nonEmpty && scala.nonEmpty && java.get.classesDirectory == scala.get.classesDirectory
+  }
+  private case class CommonTargetDetail(
+      id: BuildTargetIdentifier,
+      displayName: String,
+      baseDirectory: String,
+      tags: List[String],
+      languageIds: List[String],
+      dataKind: String,
+      dependencies: List[String],
+      dependentTargets: List[String],
+      capabilities: List[String],
+      sources: Iterable[AbsolutePath]
+  )
+  private case class JavaTargetDetail(
+      classesDirectory: String,
+      classPath: List[String],
+      options: List[String]
+  )
+  private case class ScalaTargetDetail(
+      classesDirectory: String,
+      classPath: List[String],
+      options: List[String],
+      scalaVersion: String,
+      scalaBinaryVersion: String
+  )
+  private def extractTargetDetail(
+      targetId: BuildTargetIdentifier
+  ): List[TargetDetail] = {
+    val commonInfo =
+      buildTargets.commonTarget(targetId).map(extractCommonTargetDetail)
+    val scalaInfo =
+      buildTargets.scalaTarget(targetId).map(extractScalaTargetDetail)
+    val javaInfo =
+      buildTargets.javaTarget(targetId).map(extractJavaTargetDetail)
+    commonInfo.map(f => TargetDetail(f, javaInfo, scalaInfo)).toList
+  }
+  private def extractDependencies(target: CommonTarget) = {
+    target.dependencies
+      .map(f =>
+        buildTargets
+          .commonTarget(f)
+          .map(_.displayName)
+          .getOrElse("Unknown target")
+      )
+  }
+  private def extractDependentTargets(target: CommonTarget) = {
+    buildTargets.allCommon
+      .filter(dependentTarget =>
+        dependentTarget.dependencies.contains(target.id)
+      )
+      .map(_.displayName)
+      .toList
+  }
+  private def extractCapabilities(target: CommonTarget) = {
+    var capabilities = List.empty[String]
+    if (target.capabilities.getCanCompile)
+      capabilities = "Compile" :: capabilities
+    if (target.capabilities.getCanRun())
+      capabilities = "Run" :: capabilities
+    if (target.capabilities.getCanTest())
+      capabilities = "Test" :: capabilities
+    capabilities
+  }
+  private def extractCommonTargetDetail(target: CommonTarget) = {
+    val dependencies = extractDependencies(target).sorted
+    val dependentTargets = extractDependentTargets(target).sorted
+    val capabilities = extractCapabilities(target).sorted
+    val sources = buildTargets.sourceItemsToBuildTargets
+      .filter(_._2.iterator.asScala.contains(target.id))
+      .map(_._1)
+      .toList
+      .sortBy(_.toString)
+    CommonTargetDetail(
+      target.id,
+      target.displayName,
+      target.baseDirectory,
+      target.tags.sorted,
+      target.languageIds.sorted,
+      target.dataKind,
+      dependencies,
+      dependentTargets,
+      capabilities,
+      sources
+    )
+  }
+  private def extractJavaTargetDetail(target: JavaTarget) = {
+    JavaTargetDetail(
+      target.classDirectory,
+      target.classpath,
+      target.options
+    )
+  }
+  private def extractScalaTargetDetail(target: ScalaTarget) = {
+    ScalaTargetDetail(
+      target.classDirectory,
+      target.classpath,
+      target.options,
+      target.scalaVersion,
+      target.scalaBinaryVersion
+    )
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetProvider.scala
@@ -1,0 +1,67 @@
+package scala.meta.internal.metals
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.Messages.DisplayBuildTarget
+import org.eclipse.lsp4j.ExecuteCommandParams
+
+final class BuildTargetProvider(
+    buildTargets: BuildTargets,
+    languageClient: MetalsLanguageClient
+)(implicit ec: ExecutionContext) {
+
+  private def toQuickPickItem(target: CommonTarget): MetalsQuickPickItem = {
+    MetalsQuickPickItem(target.displayName, target.displayName)
+  }
+
+  def askForBuildTargetAndDisplayBuildTargetInfo: Future[Unit] = {
+    askForBuildTarget.flatMap(f =>
+      f.map(displayBuildTargetInfo).getOrElse(Future.successful(Unit))
+    )
+  }
+
+  def displayBuildTargetInfo(param: String): Future[Unit] = {
+    Future {
+      // handle param as buildTarget name or "projects:file/..../id=buildTargetName!..." url
+      val buildTarget = if (param.startsWith("projects:")) {
+        val start = param.lastIndexOf("/?id=")
+        if (start < 0) ""
+        else {
+          val end = param.indexOf("!/", start)
+          if (end < 0) ""
+          else
+            param.substring(start + 5, end)
+        }
+      } else param
+      val command = new ExecuteCommandParams(
+        ClientCommands.TargetInfoDisplay.id,
+        List[Object](
+          new BuildTargetInfo(buildTargets).buildTargetDetailsHtml(buildTarget)
+        ).asJava
+      )
+      languageClient.metalsExecuteClientCommand(command)
+    }
+  }
+
+  private def askForBuildTarget: Future[Option[String]] = {
+    val allCommon = buildTargets.allCommon
+    if (allCommon.hasNext) {
+      val quickPicks = allCommon.map(toQuickPickItem).toList.sortBy(_.id)
+      languageClient
+        .metalsQuickPick(
+          MetalsQuickPickParams(
+            quickPicks.asJava,
+            placeHolder = DisplayBuildTarget.selectTheBuildTargetMessage
+          )
+        )
+        .asScala
+        .map {
+          case target if !target.cancelled => Option(target.itemId)
+          case _ => None
+        }
+    } else {
+      Future.successful(None)
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -20,6 +20,8 @@ import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTarget
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import ch.epfl.scala.bsp4j.JavacOptionsItem
+import ch.epfl.scala.bsp4j.JavacOptionsResult
 import ch.epfl.scala.bsp4j.ScalaBuildTarget
 import ch.epfl.scala.bsp4j.ScalacOptionsItem
 import ch.epfl.scala.bsp4j.ScalacOptionsResult
@@ -40,6 +42,8 @@ final class BuildTargets(
     TrieMap.empty[AbsolutePath, ConcurrentLinkedQueue[BuildTargetIdentifier]]
   private val buildTargetInfo =
     TrieMap.empty[BuildTargetIdentifier, BuildTarget]
+  private val javacTargetInfo =
+    TrieMap.empty[BuildTargetIdentifier, JavacOptionsItem]
   private val scalacTargetInfo =
     TrieMap.empty[BuildTargetIdentifier, ScalacOptionsItem]
   private val inverseDependencies =
@@ -65,6 +69,9 @@ final class BuildTargets(
       )
       if (isSupportedScalaVersion) score <<= 2
 
+      val usesJavac = javacOptions(t).nonEmpty
+      if (usesJavac) score <<= 1
+
       val isJVM = scalacOptions(t).exists(_.isJVM)
       if (isJVM) score <<= 1
 
@@ -85,33 +92,88 @@ final class BuildTargets(
     sourceItemsToBuildTarget.values.foreach(_.clear())
     sourceItemsToBuildTarget.clear()
     buildTargetInfo.clear()
+    javacTargetInfo.clear()
     scalacTargetInfo.clear()
     inverseDependencies.clear()
     buildTargetSources.clear()
     inverseDependencySources.clear()
     isSourceRoot.clear()
   }
-  def sourceItems: Iterable[AbsolutePath] =
-    sourceItemsToBuildTarget.keys
+  def sourceItems: Iterable[AbsolutePath] = sourceItemsToBuildTarget.keys
   def sourceItemsToBuildTargets
       : Iterator[(AbsolutePath, JIterable[BuildTargetIdentifier])] =
     sourceItemsToBuildTarget.iterator
-  def scalacOptions: Iterable[ScalacOptionsItem] =
-    scalacTargetInfo.values
 
-  def allBuildTargetIds: Seq[BuildTargetIdentifier] =
-    all.toSeq.map(_.info.getId())
-  def all: Iterator[ScalaTarget] =
-    for {
-      (_, target) <- buildTargetInfo.iterator
-      scalaTarget <- toScalaTarget(target)
-    } yield scalaTarget
+  private def scalacOptions: Iterable[ScalacOptionsItem] =
+    scalacTargetInfo.values
+  private def javacOptions: Iterable[JavacOptionsItem] = javacTargetInfo.values
+
+  def allTargets: Iterator[BuildTarget] = buildTargetInfo.values.iterator
+
+  def allBuildTargetIds: Seq[BuildTargetIdentifier] = buildTargetInfo.keys.toSeq
+
+  def allTargetRoots: Iterator[AbsolutePath] = {
+    val scalaTargetRoots = for {
+      item <- scalacOptions
+      scalaInfo <- scalaInfo(item.getTarget)
+    } yield (item.targetroot(scalaInfo.getScalaVersion))
+    val javaTargetRoots = javacOptions.map(_.targetroot)
+    // targets can appear in both javacOptions and scalacOptions
+    val allTargetRoots = scalaTargetRoots.toSet ++ javaTargetRoots.toSet
+    allTargetRoots.iterator
+  }
+
+  def allCommon: Iterator[CommonTarget] =
+    allTargets.map(CommonTarget.apply)
+
+  def allScala: Iterator[ScalaTarget] =
+    allTargets.flatMap(toScalaTarget)
+
+  def allJava: Iterator[JavaTarget] =
+    allTargets.flatMap(toJavaTarget)
+
+  def commonTarget(id: BuildTargetIdentifier): Option[CommonTarget] =
+    buildTargetInfo.get(id).map(CommonTarget.apply)
 
   def scalaTarget(id: BuildTargetIdentifier): Option[ScalaTarget] =
-    for {
-      target <- buildTargetInfo.get(id)
-      scalaTarget <- toScalaTarget(target)
-    } yield scalaTarget
+    buildTargetInfo.get(id).flatMap(toScalaTarget)
+
+  def javaTarget(id: BuildTargetIdentifier): Option[JavaTarget] =
+    buildTargetInfo.get(id).flatMap(toJavaTarget)
+
+  def targetJarClasspath(
+      id: BuildTargetIdentifier
+  ): Option[List[AbsolutePath]] = {
+    val scalacData = scalacTargetInfo.get(id).map(_.jarClasspath)
+    val javacData = javacTargetInfo.get(id).map(_.jarClasspath)
+    scalacData
+      .flatMap(s => javacData.map(j => (s ::: j).distinct).orElse(scalacData))
+      .orElse(javacData)
+  }
+
+  private def targetClasspath(
+      id: BuildTargetIdentifier
+  ): Option[List[String]] = {
+    val scalacData = scalacTargetInfo.get(id).map(_.classpath)
+    val javacData = javacTargetInfo.get(id).map(_.classpath)
+    scalacData
+      .flatMap(s => javacData.map(j => (s ::: j).distinct).orElse(scalacData))
+      .orElse(javacData)
+  }
+
+  def targetClassDirectories(
+      id: BuildTargetIdentifier
+  ): Option[Iterator[String]] = {
+    val scalacData = scalacTargetInfo.get(id).map(_.getClassDirectory)
+    val javacData = javacTargetInfo.get(id).map(_.getClassDirectory)
+    scalacData
+      .flatMap(s =>
+        javacData
+          .map(j => List(s, j).distinct.iterator)
+          .orElse(scalacData.map(Iterator(_)))
+      )
+      .orElse(javacData.map(Iterator(_)))
+  }
 
   private def toScalaTarget(target: BuildTarget): Option[ScalaTarget] = {
     for {
@@ -124,18 +186,25 @@ final class BuildTargets(
         scalaTarget,
         scalac,
         autoImports,
-        target.getDataKind() == "sbt"
+        target.isSbtBuild
       )
     }
   }
 
+  private def toJavaTarget(target: BuildTarget): Option[JavaTarget] = {
+    for {
+      javac <- javacTargetInfo.get(target.getId)
+    } yield JavaTarget(target, javac)
+  }
+
   def allWorkspaceJars: Iterator[AbsolutePath] = {
     val isVisited = new ju.HashSet[AbsolutePath]()
+
     Iterator(
       for {
-        target <- all
-        classpathEntry <- target.scalac.classpath
-        if classpathEntry.isJar
+        targetId <- allBuildTargetIds
+        classpathEntries <- targetJarClasspath(targetId).toList
+        classpathEntry <- classpathEntries
         if isVisited.add(classpathEntry)
       } yield classpathEntry,
       PackageIndex.bootClasspath.iterator
@@ -227,6 +296,12 @@ final class BuildTargets(
     }
   }
 
+  def addJavacOptions(result: JavacOptionsResult): Unit = {
+    result.getItems.asScala.foreach { item =>
+      javacTargetInfo(item.getTarget) = item
+    }
+  }
+
   def info(
       buildTarget: BuildTargetIdentifier
   ): Option[BuildTarget] =
@@ -236,10 +311,39 @@ final class BuildTargets(
   ): Option[ScalaBuildTarget] =
     info(buildTarget).flatMap(_.asScalaBuildTarget)
 
+  def targetRoots(
+      buildTarget: BuildTargetIdentifier
+  ): List[AbsolutePath] = {
+    val javaRoot = javaTargetRoot(buildTarget).toList
+    val scalaRoot = scalaTargetRoot(buildTarget).toList
+    (javaRoot ++ scalaRoot).distinct
+  }
+
+  def javaTargetRoot(
+      buildTarget: BuildTargetIdentifier
+  ): Option[AbsolutePath] =
+    javacTargetInfo.get(buildTarget).map(_.targetroot)
+
+  def scalaTargetRoot(
+      buildTarget: BuildTargetIdentifier
+  ): Option[AbsolutePath] =
+    scalacTargetInfo
+      .get(buildTarget)
+      .flatMap(scalacOptions => {
+        scalaInfo(scalacOptions.getTarget).map(scalaBuildTarget =>
+          scalacOptions.targetroot(scalaBuildTarget.getScalaVersion)
+        )
+      })
+
   def scalacOptions(
       buildTarget: BuildTargetIdentifier
   ): Option[ScalacOptionsItem] =
     scalacTargetInfo.get(buildTarget)
+
+  def javacOptions(
+      buildTarget: BuildTargetIdentifier
+  ): Option[JavacOptionsItem] =
+    javacTargetInfo.get(buildTarget)
 
   def workspaceDirectory(
       buildTarget: BuildTargetIdentifier
@@ -317,11 +421,10 @@ final class BuildTargets(
         // else it can be a source file inside a jar
         val fromJar = jarPath(source)
           .flatMap { jar =>
-            all.find { scalaTarget =>
-              scalaTarget.jarClasspath.contains(jar)
+            allBuildTargetIds.find { id =>
+              targetJarClasspath(id).exists(_.contains(jar))
             }
           }
-          .map(_.id)
         fromJar.foreach(addSourceItem(source, _))
         fromJar
     }
@@ -351,7 +454,7 @@ final class BuildTargets(
       if (file.isSbt) file.parent.resolve("project") else file.parent
     buildTargetInfo.values
       .find { target =>
-        val isMetaBuild = target.getDataKind == "sbt"
+        val isMetaBuild = target.isSbtBuild
         if (isMetaBuild) {
           workspaceDirectory(target.getId)
             .map(_ == targetMetaBuildDir)
@@ -375,8 +478,13 @@ final class BuildTargets(
       allWorkspaceJars.map(_.toNIO.toUri().toURL()).toArray,
       null
     )
-    lazy val classpaths =
-      all.map(i => i.id -> i.scalac.classpath.toSeq).toSeq
+    lazy val classpaths: Seq[(BuildTargetIdentifier, Seq[AbsolutePath])] =
+      allBuildTargetIds.map(id =>
+        id -> targetClasspath(id)
+          .map(_.toAbsoluteClasspath.toSeq)
+          .getOrElse(Seq.empty)
+      )
+
     try {
       toplevels.foldLeft(Option.empty[InferredBuildTarget]) {
         case (Some(x), _) => Some(x)

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -85,6 +85,15 @@ object ClientCommands {
       """`string`, the HTML to display in the focused window.""".stripMargin
   )
 
+  val TargetInfoDisplay = new Command(
+    "metals-target-info-display",
+    "Display target info",
+    """|Focus on a window displaying build target info.
+       |""".stripMargin,
+    arguments =
+      """`string`, the HTML to display in the focused window.""".stripMargin
+  )
+
   val ToggleLogs = new Command(
     "metals-logs-toggle",
     "Toggle logs",
@@ -211,6 +220,7 @@ object ClientCommands {
       OpenFolder,
       RunDoctor,
       ReloadDoctor,
+      TargetInfoDisplay,
       ToggleLogs,
       FocusDiagnostics,
       GotoLocation,

--- a/metals/src/main/scala/scala/meta/internal/metals/CommonTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CommonTarget.scala
@@ -1,0 +1,17 @@
+package scala.meta.internal.metals
+
+import scala.meta.internal.metals.MetalsEnrichments._
+
+import ch.epfl.scala.bsp4j.BuildTarget
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+
+case class CommonTarget(val info: BuildTarget) {
+
+  def id: BuildTargetIdentifier = info.getId()
+
+  def dataKind: String = info.dataKind
+
+  def baseDirectory: String = info.baseDirectory
+
+  def displayName: String = info.getDisplayName()
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/CommonTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CommonTarget.scala
@@ -4,6 +4,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 
 import ch.epfl.scala.bsp4j.BuildTarget
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import ch.epfl.scala.bsp4j.BuildTargetCapabilities
 
 case class CommonTarget(val info: BuildTarget) {
 
@@ -14,4 +15,15 @@ case class CommonTarget(val info: BuildTarget) {
   def baseDirectory: String = info.baseDirectory
 
   def displayName: String = info.getDisplayName()
+
+  def tags: List[String] = info.getTags().asScala.toList
+
+  def languageIds: List[String] = info.getLanguageIds().asScala.toList
+
+  def dependencies: List[BuildTargetIdentifier] =
+    info.getDependencies().asScala.toList
+
+  def capabilities: BuildTargetCapabilities = info.getCapabilities()
+
+  def data = info.getData()
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -601,7 +601,7 @@ class Compilers(
       target: ScalaTarget,
       search: SymbolSearch
   ): PresentationCompiler = {
-    val classpath = scalac.classpath.map(_.toNIO).toSeq
+    val classpath = scalac.classpath.toAbsoluteClasspath.map(_.toNIO).toSeq
     newCompiler(scalac, target, classpath, search)
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -18,6 +18,7 @@ import scala.meta.internal.metals.config.DoctorFormat
 import scala.meta.internal.troubleshoot.ProblemResolver
 import scala.meta.io.AbsolutePath
 
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import org.eclipse.lsp4j.ExecuteCommandParams
 
 /**
@@ -123,7 +124,9 @@ final class Doctor(
    * Checks if there are any potential problems and if any, notifies the user.
    */
   def check(): Unit = {
-    val summary = problemResolver.problemMessage(allTargets())
+    val scalaTargets = buildTargets.allScala.toList
+    val javaTargets = buildTargets.allJava.toList
+    val summary = problemResolver.problemMessage(scalaTargets, javaTargets)
     executeReloadDoctor(summary)
     summary match {
       case Some(problem) =>
@@ -146,7 +149,8 @@ final class Doctor(
     }
   }
 
-  def allTargets(): List[ScalaTarget] = buildTargets.all.toList
+  private def allTargetIds(): Seq[BuildTargetIdentifier] =
+    buildTargets.allBuildTargetIds
 
   private def selectedBuildToolMessage(): Option[String] = {
     tables.buildTool.selectedBuildTool().map { value =>
@@ -212,7 +216,7 @@ final class Doctor(
   }
 
   private def buildTargetsJson(): String = {
-    val targets = allTargets()
+    val targetIds = allTargetIds()
     val buildToolHeading = selectedBuildToolMessage()
     val (buildServerHeading, _) = selectedBuildServerMessage()
     val importBuildHeading = selectedImportBuildMessage()
@@ -225,7 +229,7 @@ final class Doctor(
       ).flatten
         .mkString("\n\n")
 
-    val results = if (targets.isEmpty) {
+    val results = if (targetIds.isEmpty) {
       DoctorResults(
         doctorTitle,
         heading,
@@ -239,10 +243,10 @@ final class Doctor(
         ),
         None
       ).toJson
-
     } else {
-      val targetResults =
-        targets.sortBy(_.baseDirectory).map(extractTargetInfo)
+      val targetResults = targetIds
+        .flatMap(extractTargetInfo)
+        .sortBy(f => (f.baseDirectory, f.name, f.dataKind))
       DoctorResults(doctorTitle, heading, None, Some(targetResults)).toJson
     }
     ujson.write(results)
@@ -298,8 +302,8 @@ final class Doctor(
         _.text(doctorHeading)
       )
 
-    val targets = allTargets()
-    if (targets.isEmpty) {
+    val targetIds = allTargetIds()
+    if (targetIds.isEmpty) {
       html
         .element("p")(
           _.text(noBuildTargetsTitle)
@@ -324,33 +328,43 @@ final class Doctor(
                 .element("th")(_.text("Find references"))
                 .element("th")(_.text("Recommendation"))
             )
-          ).element("tbody")(html => buildTargetRows(html, targets))
+          ).element("tbody")(html => buildTargetRows(html, targetIds))
         )
     }
   }
 
   private def buildTargetRows(
       html: HtmlBuilder,
-      targets: List[ScalaTarget]
+      targetIds: Seq[BuildTargetIdentifier]
   ): Unit = {
-    targets.sortBy(_.baseDirectory).foreach { target =>
-      val targetInfo = extractTargetInfo(target)
-      val center = "style='text-align: center'"
-      html.element("tr")(
-        _.element("td")(_.text(targetInfo.name))
-          .element("td")(_.text(targetInfo.scalaVersion))
-          .element("td", center)(_.text(Icons.unicode.check))
-          .element("td", center)(_.text(targetInfo.definitionStatus))
-          .element("td", center)(_.text(targetInfo.completionsStatus))
-          .element("td", center)(_.text(targetInfo.referencesStatus))
-          .element("td")(
-            _.raw(targetInfo.recommenedFix)
-          )
-      )
-    }
+    targetIds
+      .flatMap(extractTargetInfo)
+      .sortBy(f => (f.baseDirectory, f.name, f.dataKind))
+      .foreach { targetInfo =>
+        val center = "style='text-align: center'"
+        html.element("tr")(
+          _.element("td")(_.text(targetInfo.name))
+            .element("td")(_.text(targetInfo.scalaVersion))
+            .element("td", center)(_.text(Icons.unicode.check))
+            .element("td", center)(_.text(targetInfo.definitionStatus))
+            .element("td", center)(_.text(targetInfo.completionsStatus))
+            .element("td", center)(_.text(targetInfo.referencesStatus))
+            .element("td")(_.raw(targetInfo.recommenedFix))
+        )
+      }
   }
 
-  private def extractTargetInfo(target: ScalaTarget) = {
+  private def extractTargetInfo(
+      targetId: BuildTargetIdentifier
+  ): List[DoctorTargetInfo] = {
+    val scalaDoctorInfo =
+      buildTargets.scalaTarget(targetId).map(extractScalaTargetInfo).toList
+    val javaDoctorInfo =
+      buildTargets.javaTarget(targetId).map(extractJavaTargetInfo).toList
+    scalaDoctorInfo ::: javaDoctorInfo
+  }
+
+  private def extractScalaTargetInfo(target: ScalaTarget) = {
     val scalaVersion = target.scalaVersion
     val definition: String =
       if (ScalaVersions.isSupportedScalaVersion(scalaVersion)) {
@@ -366,14 +380,40 @@ final class Doctor(
       } else {
         Icons.unicode.check
       }
-    val recommenedFix = problemResolver.recommendation(target)
+    val recommendedFix = problemResolver.recommendation(target)
     DoctorTargetInfo(
       target.displayName,
+      target.dataKind,
+      target.baseDirectory,
       scalaVersion,
       definition,
       completions,
       references,
-      recommenedFix
+      recommendedFix
+    )
+  }
+
+  private def extractJavaTargetInfo(target: JavaTarget) = {
+    val scalaVersion = "Java"
+    val definition: String = Icons.unicode.check
+    val completions: String = Icons.unicode.alert
+    val isSemanticdbNeeded = !target.isSemanticdbEnabled
+    val references: String =
+      if (isSemanticdbNeeded) {
+        Icons.unicode.alert
+      } else {
+        Icons.unicode.check
+      }
+    val recommendedFix = problemResolver.recommendation(target)
+    DoctorTargetInfo(
+      target.displayName,
+      target.dataKind,
+      target.baseDirectory,
+      scalaVersion,
+      definition,
+      completions,
+      references,
+      recommendedFix
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -333,6 +333,11 @@ final class Doctor(
     }
   }
 
+  private def convertTarget(targetName: String): String = {
+    val param = s"""["$targetName"]"""
+    s"command:target-info-display?${URLEncoder.encode(param)}"
+  }
+
   private def buildTargetRows(
       html: HtmlBuilder,
       targetIds: Seq[BuildTargetIdentifier]
@@ -343,7 +348,9 @@ final class Doctor(
       .foreach { targetInfo =>
         val center = "style='text-align: center'"
         html.element("tr")(
-          _.element("td")(_.text(targetInfo.name))
+          _.element("td")(
+            _.link(convertTarget(targetInfo.name), targetInfo.name)
+          )
             .element("td")(_.text(targetInfo.scalaVersion))
             .element("td", center)(_.text(Icons.unicode.check))
             .element("td", center)(_.text(targetInfo.definitionStatus))

--- a/metals/src/main/scala/scala/meta/internal/metals/DoctorResults.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DoctorResults.scala
@@ -6,7 +6,7 @@ final case class DoctorResults(
     title: String,
     headerText: String,
     messages: Option[List[DoctorMessage]],
-    targets: Option[List[DoctorTargetInfo]]
+    targets: Option[Seq[DoctorTargetInfo]]
 ) {
   def toJson: Obj = {
     val json = ujson.Obj(
@@ -31,6 +31,8 @@ final case class DoctorMessage(title: String, recommendations: List[String]) {
 
 final case class DoctorTargetInfo(
     name: String,
+    dataKind: String,
+    baseDirectory: String,
     scalaVersion: String,
     definitionStatus: String,
     completionsStatus: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/FileSystemSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileSystemSemanticdbs.scala
@@ -23,7 +23,7 @@ final class FileSystemSemanticdbs(
 
   override def textDocument(file: AbsolutePath): TextDocumentLookup = {
     if (
-      !file.toLanguage.isScala ||
+      (!file.toLanguage.isScala && !file.toLanguage.isJava) ||
       file.toNIO.getFileSystem != mainWorkspace.toNIO.getFileSystem
     ) {
       TextDocumentLookup.NotFound(file)
@@ -31,11 +31,12 @@ final class FileSystemSemanticdbs(
 
       val paths = for {
         buildTarget <- buildTargets.inverseSources(file)
-        scalaInfo <- buildTargets.scalaInfo(buildTarget)
         workspace <- buildTargets.workspaceDirectory(buildTarget)
-        scalacOptions <- buildTargets.scalacOptions(buildTarget)
+        targetroot <-
+          if (file.toLanguage.isScala) buildTargets.scalaTargetRoot(buildTarget)
+          else buildTargets.javaTargetRoot(buildTarget)
       } yield {
-        (workspace, scalacOptions.targetroot(scalaInfo.getScalaVersion))
+        (workspace, targetroot)
       }
 
       paths match {
@@ -69,7 +70,7 @@ final class FileSystemSemanticdbs(
         relativeSourceRoot = sourceRoot.toRelative(workspace)
         relativeFile = file.toRelative(sourceRoot.dealias)
         fullRelativePath = relativeSourceRoot.resolve(relativeFile)
-        alternativeRelativePath = SemanticdbClasspath.fromScala(
+        alternativeRelativePath = SemanticdbClasspath.fromScalaOrJava(
           fullRelativePath
         )
         alternativeSemanticdbPath = targetroot.resolve(

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -298,7 +298,7 @@ final class FormattingProvider(
       val (items, dialects) = itemsRequiresUpgrade.unzip
       val directories = items.map(_.toRelative(workspace))
 
-      val nonSbtTargets = buildTargets.all.toList.filter(!_.isSbt)
+      val nonSbtTargets = buildTargets.allScala.toList.filter(!_.isSbt)
       val needFileOverride =
         nonSbtTargets.map(_.fmtDialect).distinct.size > 1
       val upgradeType =

--- a/metals/src/main/scala/scala/meta/internal/metals/ImportedBuild.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ImportedBuild.scala
@@ -15,6 +15,7 @@ import ch.epfl.scala.bsp4j._
 case class ImportedBuild(
     workspaceBuildTargets: WorkspaceBuildTargetsResult,
     scalacOptions: ScalacOptionsResult,
+    javacOptions: JavacOptionsResult,
     sources: SourcesResult,
     dependencySources: DependencySourcesResult
 ) {
@@ -25,6 +26,9 @@ case class ImportedBuild(
     val updatedScalacOptions = new ScalacOptionsResult(
       (scalacOptions.getItems.asScala ++ other.scalacOptions.getItems.asScala).asJava
     )
+    val updatedJavacOptions = new JavacOptionsResult(
+      (javacOptions.getItems.asScala ++ other.javacOptions.getItems.asScala).asJava
+    )
     val updatedSources = new SourcesResult(
       (sources.getItems.asScala ++ other.sources.getItems.asScala).asJava
     )
@@ -34,6 +38,7 @@ case class ImportedBuild(
     ImportedBuild(
       updatedBuildTargets,
       updatedScalacOptions,
+      updatedJavacOptions,
       updatedSources,
       updatedDependencySources
     )
@@ -50,6 +55,7 @@ object ImportedBuild {
     ImportedBuild(
       new WorkspaceBuildTargetsResult(ju.Collections.emptyList()),
       new ScalacOptionsResult(ju.Collections.emptyList()),
+      new JavacOptionsResult(ju.Collections.emptyList()),
       new SourcesResult(ju.Collections.emptyList()),
       new DependencySourcesResult(ju.Collections.emptyList())
     )
@@ -63,6 +69,9 @@ object ImportedBuild {
       scalacOptions <- conn.buildTargetScalacOptions(
         new ScalacOptionsParams(ids)
       )
+      javacOptions <- conn.buildTargetJavacOptions(
+        new JavacOptionsParams(ids)
+      )
       sources <- conn.buildTargetSources(new SourcesParams(ids))
       dependencySources <- conn.buildTargetDependencySources(
         new DependencySourcesParams(ids)
@@ -71,6 +80,7 @@ object ImportedBuild {
       ImportedBuild(
         workspaceBuildTargets,
         scalacOptions,
+        javacOptions,
         sources,
         dependencySources
       )

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaFormattingProvider.scala
@@ -1,0 +1,230 @@
+package scala.meta.internal.metals
+
+import java.util
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import scala.xml.Node
+
+import scala.meta._
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+import scala.meta.{inputs => m}
+
+import org.eclipse.jdt.core.JavaCore
+import org.eclipse.jdt.core.ToolFactory
+import org.eclipse.jdt.core.formatter.CodeFormatter
+import org.eclipse.jdt.internal.formatter.DefaultCodeFormatterOptions
+import org.eclipse.jface.text.BadLocationException
+import org.eclipse.jface.text.Document
+import org.eclipse.text.edits.MalformedTreeException
+import org.eclipse.{lsp4j => l}
+
+final class JavaFormattingProvider(
+    workspace: AbsolutePath,
+    buffers: Buffers,
+    userConfig: () => UserConfiguration,
+    buildTargets: BuildTargets
+)(implicit
+    ec: ExecutionContext
+) {
+  // TODO cache formatting file and reload on change?
+  // TODO progress monitor?
+  // TODO onTypeFormatting - wait until presentation compiler is integrated
+
+  private def decodeProfile(node: Node): Map[String, String] = {
+    val settings = for {
+      child <- node.child
+      id <- child.attribute("id")
+      value <- child.attribute("value")
+    } yield (id.text, value.text)
+    settings.toMap
+  }
+
+  private def parseEclipseFormatFile(
+      text: String
+  ): Try[Map[String, String]] = {
+    val profileName = userConfig().eclipseFormatProfile
+    import scala.xml.XML
+    Try {
+      val node = XML.loadString(text)
+      val profiles = node.child.filter(child => {
+        val foundKind = child.attributes
+          .get("kind")
+          .map(_.text)
+          .contains("CodeFormatterProfile")
+        val foundProfile = profileName.isEmpty || child.attributes
+          .get("name")
+          .map(_.text) == profileName
+
+        foundKind && foundProfile
+      })
+      if (profiles.isEmpty) {
+        if (profileName.isEmpty)
+          scribe.error("No Java formatting profiles found")
+        else
+          scribe.error(s"Java formatting profile ${profileName.get} not found")
+        defaultSettings
+      } else
+        decodeProfile(profiles.head)
+    }
+  }
+
+  private lazy val defaultSettings =
+    DefaultCodeFormatterOptions.getEclipseDefaultSettings.getMap.asScala.toMap
+
+  private def loadEclipseFormatConfig: Map[String, String] = {
+    userConfig().eclipseFormatConfigPath
+      .map(eclipseFormatFile => {
+        if (eclipseFormatFile.exists) {
+          val text = eclipseFormatFile.toInputFromBuffers(buffers).text
+          parseEclipseFormatFile(text) match {
+            case Failure(e) =>
+              scribe.error(
+                s"Failed to parse $eclipseFormatFile. Using default formatting",
+                e
+              )
+              defaultSettings
+            case Success(values) =>
+              values
+          }
+        } else {
+          scribe.warn(
+            s"$eclipseFormatFile not found.  Using default java formatting"
+          )
+          defaultSettings
+        }
+      })
+      .getOrElse(defaultSettings)
+  }
+
+  def format(
+      params: l.DocumentFormattingParams
+  ): Future[util.List[l.TextEdit]] = {
+    Future {
+      val options = params.getOptions
+      val path = params.getTextDocument.getUri.toAbsolutePath
+      val input = path.toInputFromBuffers(buffers)
+      runFormat(path, input, options, fromLSP(input)).asJava
+    }
+  }
+
+  private def fromLSP(input: Input, range: l.Range): m.Position.Range =
+    m.Position.Range(
+      input,
+      range.getStart().getLine(),
+      range.getStart().getCharacter(),
+      range.getEnd().getLine(),
+      range.getEnd().getCharacter()
+    )
+
+  private def fromLSP(input: Input): m.Position.Range =
+    m.Position.Range(input, 0, input.chars.length)
+
+  def format(
+      params: l.DocumentRangeFormattingParams
+  ): util.List[l.TextEdit] = {
+    val options = params.getOptions
+    val range = params.getRange
+    val path = params.getTextDocument.getUri.toAbsolutePath
+    val input = path.toInputFromBuffers(buffers)
+    runFormat(path, input, options, fromLSP(input, range)).asJava
+  }
+
+  def format(
+      params: l.DocumentOnTypeFormattingParams
+  ): util.List[l.TextEdit] = {
+    Nil.asJava
+  }
+
+  private def runFormat(
+      path: AbsolutePath,
+      input: Input,
+      formattingOptions: l.FormattingOptions,
+      range: m.Position.Range
+  ): List[l.TextEdit] = {
+    // if source/target/compliance versions aren't defined by the user then fallback on the build target info
+    var options = loadEclipseFormatConfig
+    if (
+      !options.contains(JavaCore.COMPILER_SOURCE) ||
+      !options.contains(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM) ||
+      !options.contains(JavaCore.COMPILER_COMPLIANCE)
+    ) {
+
+      val version = for {
+        targetID <- buildTargets.sourceBuildTargets(path)
+        java <- buildTargets.javaTarget(targetID)
+        sourceVersion <- java.sourceVersion
+        targetVersion <- java.targetVersion
+      } yield ((sourceVersion, targetVersion))
+
+      version
+        .take(1)
+        .foreach(version => {
+          val (sourceVersion, targetVersion) = version
+          val complianceVersion =
+            if (sourceVersion.toDouble > targetVersion.toDouble) sourceVersion
+            else targetVersion
+
+          if (!options.contains(JavaCore.COMPILER_SOURCE))
+            options += JavaCore.COMPILER_SOURCE -> sourceVersion
+          if (!options.contains(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM))
+            options += JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM -> targetVersion
+          if (!options.contains(JavaCore.COMPILER_COMPLIANCE))
+            options += JavaCore.COMPILER_COMPLIANCE -> complianceVersion
+        })
+    }
+
+    if (!options.contains(JavaCore.FORMATTER_TAB_SIZE))
+      Option(formattingOptions.getTabSize).foreach(f =>
+        options += JavaCore.FORMATTER_TAB_SIZE -> f.toString
+      )
+    if (!options.contains(JavaCore.FORMATTER_TAB_CHAR))
+      options += JavaCore.FORMATTER_TAB_CHAR -> {
+        if (formattingOptions.isInsertSpaces) JavaCore.SPACE else JavaCore.TAB
+      }
+
+    val codeFormatter = ToolFactory.createCodeFormatter(options.asJava)
+
+    val kind = {
+      if (userConfig().enableFormatJavaComments)
+        CodeFormatter.F_INCLUDE_COMMENTS
+      else 0
+    } | CodeFormatter.K_COMPILATION_UNIT
+    val code = input.text
+    val doc = new Document(code)
+    val codeOffset = range.start
+    val codeLength = range.end - range.start
+    val indentationLevel = 0
+    val lineSeparator: String = null
+    val textEdit = codeFormatter.format(
+      kind,
+      code,
+      codeOffset,
+      codeLength,
+      indentationLevel,
+      lineSeparator
+    )
+    val formatted =
+      try {
+        textEdit.apply(doc)
+        doc.get
+      } catch {
+        case e: MalformedTreeException =>
+          scribe.error("Unable to format", e)
+          code
+        case e: BadLocationException =>
+          scribe.error("Unable to format", e)
+          code
+      }
+
+    val fullDocumentRange = fromLSP(input).toLSP
+    if (formatted != code)
+      List(new l.TextEdit(fullDocumentRange, formatted))
+    else
+      Nil
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
@@ -1,0 +1,23 @@
+package scala.meta.internal.metals
+
+import scala.meta.internal.metals.MetalsEnrichments._
+
+import ch.epfl.scala.bsp4j.BuildTarget
+import ch.epfl.scala.bsp4j.JavacOptionsItem
+
+case class JavaTarget(
+    info: BuildTarget,
+    javac: JavacOptionsItem
+) {
+  def displayName: String = info.getDisplayName()
+
+  def dataKind: String = info.dataKind
+
+  def baseDirectory: String = info.baseDirectory
+
+  def isSemanticdbEnabled: Boolean = javac.isSemanticdbEnabled
+
+  def isSourcerootDeclared: Boolean = javac.isSourcerootDeclared
+
+  def isTargetrootDeclared: Boolean = javac.isTargetrootDeclared
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
@@ -15,6 +15,12 @@ case class JavaTarget(
 
   def baseDirectory: String = info.baseDirectory
 
+  def classDirectory: String = javac.getClassDirectory()
+
+  def classpath: List[String] = javac.classpath
+
+  def options: List[String] = javac.getOptions().asScala.toList
+
   def isSemanticdbEnabled: Boolean = javac.isSemanticdbEnabled
 
   def isSourcerootDeclared: Boolean = javac.isSourcerootDeclared

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
@@ -20,4 +20,10 @@ case class JavaTarget(
   def isSourcerootDeclared: Boolean = javac.isSourcerootDeclared
 
   def isTargetrootDeclared: Boolean = javac.isTargetrootDeclared
+
+  def releaseVersion: Option[String] = javac.releaseVersion
+
+  def targetVersion: Option[String] = javac.targetVersion
+
+  def sourceVersion: Option[String] = javac.sourceVersion
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -598,6 +598,10 @@ object Messages {
 
   }
 
+  object DisplayBuildTarget {
+    def selectTheBuildTargetMessage = "Select the build target to display"
+  }
+
   private def usingString(usingNow: Iterable[String]): String = {
     if (usingNow.size == 1)
       s"Scala version ${usingNow.head}"

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsBuildServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsBuildServer.scala
@@ -6,7 +6,10 @@ import ch.epfl.scala.bsp4j.DebugSessionParams
 import ch.epfl.scala.{bsp4j => b}
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
 
-trait MetalsBuildServer extends b.BuildServer with b.ScalaBuildServer {
+trait MetalsBuildServer
+    extends b.BuildServer
+    with b.ScalaBuildServer
+    with b.JavaBuildServer {
   @JsonRequest("debugSession/start")
   def startDebugSession(
       params: DebugSessionParams

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -777,6 +777,24 @@ object MetalsEnrichments
       classpath
         .filter(_.endsWith(".jar"))
         .map(_.toAbsolutePath)
+
+    def releaseVersion: Option[String] =
+      item.getOptions.asScala
+        .dropWhile(_ != "--release")
+        .drop(1)
+        .headOption
+
+    def sourceVersion: Option[String] =
+      item.getOptions.asScala
+        .dropWhile(f => f != "--source" && f != "-source" && f != "--release")
+        .drop(1)
+        .headOption
+
+    def targetVersion: Option[String] =
+      item.getOptions.asScala
+        .dropWhile(f => f != "--target" && f != "-target" && f != "--release")
+        .drop(1)
+        .headOption
   }
 
   implicit class XtensionScalacOptions(item: b.ScalacOptionsItem) {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -74,7 +74,17 @@ object MetalsEnrichments
   implicit class XtensionBuildTarget(buildTarget: b.BuildTarget) {
 
     def isSbtBuild: Boolean =
-      buildTarget.getDataKind == "sbt"
+      dataKind == "sbt"
+
+    def baseDirectory: String = {
+      val baseDir = buildTarget.getBaseDirectory()
+      if (baseDir != null) baseDir else ""
+    }
+
+    def dataKind: String = {
+      val dataking = buildTarget.getDataKind()
+      if (dataking != null) dataking else ""
+    }
 
     def asScalaBuildTarget: Option[b.ScalaBuildTarget] = {
       if (isSbtBuild) {
@@ -272,7 +282,10 @@ object MetalsEnrichments
   }
   implicit class XtensionAbsolutePathBuffers(path: AbsolutePath) {
 
-    def sourcerootOption: String = s""""-P:semanticdb:sourceroot:$path""""
+    def scalaSourcerootOption: String = s""""-P:semanticdb:sourceroot:$path""""
+
+    def javaSourcerootOption: String =
+      s""""-Xplugin:semanticdb -sourceroot:$path""""
 
     /**
      * Resolve each path segment individually to prevent FileSystem mismatch errors.
@@ -712,12 +725,61 @@ object MetalsEnrichments
     def getQuery(key: String): Option[String] =
       Option(exchange.getQueryParameters.get(key)).flatMap(_.asScala.headOption)
   }
-  implicit class XtensionScalacOptions(item: b.ScalacOptionsItem) {
-    def classpath: Iterator[AbsolutePath] = {
-      item.getClasspath.asScala.iterator
+  implicit class XtensionClasspath(classpath: List[String]) {
+    def toAbsoluteClasspath: Iterator[AbsolutePath] = {
+      classpath.iterator
         .map(uri => AbsolutePath(Paths.get(URI.create(uri))))
         .filter(p => Files.exists(p.toNIO))
     }
+  }
+  implicit class XtensionJavacOptions(item: b.JavacOptionsItem) {
+    def targetroot: AbsolutePath = {
+      item.getOptions.asScala
+        .find(_.startsWith("-Xplugin:semanticdb"))
+        .map(arg => {
+          // TODO(arthurm1) improve args parsing
+          val targetrootPos = arg.indexOf("-targetroot:")
+          val sourcerootPos = arg.indexOf("-sourceroot:")
+          if (targetrootPos > sourcerootPos)
+            arg.substring(targetrootPos + 12).trim()
+          else
+            arg.substring(sourcerootPos + 12, targetrootPos - 1).trim()
+        })
+        .filter(_ != "javac-classes-directory")
+        .map(AbsolutePath(_))
+        .getOrElse(item.getClassDirectory.toAbsolutePath)
+    }
+
+    def isSemanticdbEnabled: Boolean = {
+      item.getOptions.asScala.exists { opt =>
+        opt.startsWith("-Xplugin:semanticdb")
+      }
+    }
+
+    def isSourcerootDeclared: Boolean = {
+      item.getOptions.asScala
+        .find(_.startsWith("-Xplugin:semanticdb"))
+        .map(_.contains("-sourceroot:"))
+        .getOrElse(false)
+    }
+
+    def isTargetrootDeclared: Boolean = {
+      item.getOptions.asScala
+        .find(_.startsWith("-Xplugin:semanticdb"))
+        .map(_.contains("-targetroot:"))
+        .getOrElse(false)
+    }
+
+    def classpath: List[String] =
+      item.getClasspath.asScala.toList
+
+    def jarClasspath: List[AbsolutePath] =
+      classpath
+        .filter(_.endsWith(".jar"))
+        .map(_.toAbsolutePath)
+  }
+
+  implicit class XtensionScalacOptions(item: b.ScalacOptionsItem) {
     def targetroot(scalaVersion: String): AbsolutePath = {
       if (ScalaVersions.isScala3Version(scalaVersion)) {
         val options = item.getOptions.asScala
@@ -772,6 +834,13 @@ object MetalsEnrichments
         .map(_.stripPrefix(flag))
     }
 
+    def classpath: List[String] =
+      item.getClasspath.asScala.toList
+
+    def jarClasspath: List[AbsolutePath] =
+      classpath
+        .filter(_.endsWith(".jar"))
+        .map(_.toAbsolutePath)
   }
 
   implicit class XtensionClientCapabilities(

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -1,15 +1,12 @@
 package scala.meta.internal.metals
 
 import java.nio.file.Path
-import java.{util => ju}
 
 import scala.meta.Dialect
 import scala.meta.dialects._
 import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTarget
-import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import ch.epfl.scala.bsp4j.ScalaBuildTarget
 import ch.epfl.scala.bsp4j.ScalacOptionsItem
 
@@ -23,7 +20,7 @@ case class ScalaTarget(
 
   def dialect: Dialect = {
     scalaVersion match {
-      case _ if info.getDataKind() == "sbt" => Sbt
+      case _ if info.isSbtBuild => Sbt
       case other =>
         val dialect =
           ScalaVersions.dialectForScalaVersion(other, includeSource3 = false)
@@ -37,6 +34,12 @@ case class ScalaTarget(
     }
   }
 
+  def displayName: String = info.getDisplayName()
+
+  def dataKind: String = info.dataKind
+
+  def baseDirectory: String = info.baseDirectory
+
   def fmtDialect: ScalafmtDialect =
     ScalaVersions.fmtDialectForScalaVersion(scalaVersion, containsSource3)
 
@@ -44,33 +47,9 @@ case class ScalaTarget(
 
   def isSourcerootDeclared: Boolean = scalac.isSourcerootDeclared(scalaVersion)
 
-  def id: BuildTargetIdentifier = info.getId()
-
-  def targetroot: AbsolutePath = scalac.targetroot(scalaVersion)
-
-  def baseDirectory: String = {
-    val baseDir = info.getBaseDirectory()
-    if (baseDir != null) baseDir else ""
-  }
-
-  def fullClasspath: ju.List[Path] = {
-    scalac.getClasspath().map(_.toAbsolutePath.toNIO)
-  }
-
-  def jarClasspath: List[AbsolutePath] = {
-    scalac
-      .getClasspath()
-      .asScala
-      .toList
-      .filter(_.endsWith(".jar"))
-      .map(_.toAbsolutePath)
-  }
+  def fullClasspath: List[Path] = scalac.classpath.map(_.toAbsolutePath.toNIO)
 
   def scalaVersion: String = scalaInfo.getScalaVersion()
-
-  def classDirectory: String = scalac.getClassDirectory()
-
-  def displayName: String = info.getDisplayName()
 
   def scalaBinaryVersion: String = scalaInfo.getScalaBinaryVersion()
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -17,7 +17,6 @@ case class ScalaTarget(
     autoImports: Option[Seq[String]],
     isSbt: Boolean
 ) {
-
   def dialect: Dialect = {
     scalaVersion match {
       case _ if info.isSbtBuild => Sbt
@@ -39,6 +38,12 @@ case class ScalaTarget(
   def dataKind: String = info.dataKind
 
   def baseDirectory: String = info.baseDirectory
+
+  def classDirectory: String = scalac.getClassDirectory()
+
+  def classpath: List[String] = scalac.classpath
+
+  def options: List[String] = scalac.getOptions().asScala.toList
 
   def fmtDialect: ScalafmtDialect =
     ScalaVersions.fmtDialectForScalaVersion(scalaVersion, containsSource3)

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
@@ -14,7 +14,7 @@ class ScalaVersionSelector(
     val selected = userConfig().fallbackScalaVersion match {
       case Some(v) => v
       case None =>
-        buildTargets.all.toList
+        buildTargets.allScala.toList
           .map(_.scalaInfo.getScalaVersion)
           .sorted
           .lastOption

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -48,9 +48,10 @@ case class ScalafixProvider(
   def load(): Unit = {
     if (!Testing.isEnabled) {
       try {
-        val targets = buildTargets.all.toList.groupBy(_.scalaVersion).flatMap {
-          case (_, targets) => targets.headOption
-        }
+        val targets =
+          buildTargets.allScala.toList.groupBy(_.scalaVersion).flatMap {
+            case (_, targets) => targets.headOption
+          }
         val tmp = workspace
           .resolve(Directories.tmp)
           .resolve(s"Main${Random.nextLong()}.scala")
@@ -154,7 +155,8 @@ case class ScalafixProvider(
             semanticdb
         val dir = workspace.resolve(Directories.tmp)
         file.toRelativeInside(workspace).flatMap { relativePath =>
-          val writeTo = dir.resolve(SemanticdbClasspath.fromScala(relativePath))
+          val writeTo =
+            dir.resolve(SemanticdbClasspath.fromScalaOrJava(relativePath))
           writeTo.parent.createDirectories()
           val docs = TextDocuments(Seq(toSave))
           Files.write(writeTo.toNIO, docs.toByteArray)
@@ -278,7 +280,7 @@ case class ScalafixProvider(
     // It seems that Scalafix ignores the targetroot parameter and searches the classpath
     // Prepend targetroot to make sure that it's picked up first always
     val classpath =
-      (targetRoot.toList ++ scalaTarget.fullClasspath.asScala).asJava
+      (targetRoot.toList ++ scalaTarget.fullClasspath).asJava
 
     for {
       api <- getScalafix(scalaBinaryVersion)

--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
@@ -14,6 +14,7 @@ import scala.meta.internal.semanticdb.TextDocument
 import scala.meta.internal.semanticdb.TextDocuments
 import scala.meta.io.AbsolutePath
 
+import ch.epfl.scala.bsp4j.JavacOptionsResult
 import ch.epfl.scala.bsp4j.ScalacOptionsResult
 import com.google.protobuf.InvalidProtocolBufferException
 
@@ -31,6 +32,15 @@ class SemanticdbIndexer(
       scalaInfo <- buildTargets.scalaInfo(item.getTarget)
     } {
       val targetroot = item.targetroot(scalaInfo.getScalaVersion)
+      onChangeDirectory(targetroot.resolve(Directories.semanticdb).toNIO)
+    }
+  }
+
+  def onJavacOptions(javacOptions: JavacOptionsResult): Unit = {
+    for {
+      item <- javacOptions.getItems.asScala
+    } {
+      val targetroot = item.targetroot
       onChangeDirectory(targetroot.resolve(Directories.semanticdb).toNIO)
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -56,6 +56,15 @@ object ServerCommands {
        |""".stripMargin
   )
 
+  val TargetInfoDisplay = new Command(
+    "target-info-display",
+    "Display target info",
+    """|Choose a Build Target and view information about its configuration.
+       |""".stripMargin,
+    """|[string], name of the Build Target.
+       |""".stripMargin
+  )
+
   val RunDoctor = new Command(
     "doctor-run",
     "Run doctor",
@@ -419,6 +428,7 @@ object ServerCommands {
       ResetChoicePopup,
       RestartBuildServer,
       RunDoctor,
+      TargetInfoDisplay,
       ScanWorkspaceSources,
       StartAmmoniteBuildServer,
       StartDebugAdapter,

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -41,7 +41,10 @@ case class UserConfiguration(
     remoteLanguageServer: Option[String] = None,
     enableStripMarginOnTypeFormatting: Boolean = true,
     excludedPackages: Option[List[String]] = None,
-    fallbackScalaVersion: Option[String] = None
+    fallbackScalaVersion: Option[String] = None,
+    eclipseFormatConfigPath: Option[AbsolutePath] = None,
+    enableFormatJavaComments: Boolean = true,
+    eclipseFormatProfile: Option[String] = None
 ) {
 
   def currentBloopVersion: String =
@@ -231,6 +234,32 @@ object UserConfiguration {
            |doesn't belong to any build target or the specified Scala version isn't supported by Metals.
            |This applies to standalone Scala files, worksheets, and Ammonite scripts.
         """.stripMargin
+      ),
+      UserConfigurationOption(
+        "eclipse-format-config-path",
+        """empty string `""`.""",
+        """"formatters/eclipse-formatter.xml"""",
+        "Eclipse formatter config path",
+        """Optional custom path to the eclipse-formatter.xml file.
+          |Should be an absolute path and use forward slashes `/` for file separators (even on Windows).
+          |""".stripMargin
+      ),
+      UserConfigurationOption(
+        "format-java-comments",
+        "false",
+        "false",
+        "Should format Java comments as well as code",
+        """|Default formatting of Java files only formats code.
+           |Select this to also format comments.
+           |""".stripMargin
+      ),
+      UserConfigurationOption(
+        "eclipse-format-profile",
+        """empty string `""`.""",
+        """"GoogleStyle"""",
+        "Eclipse formatting profile",
+        """|If the Eclipse formatter file contains more than one profile then specify the required profile name.
+           |""".stripMargin
       )
     )
 
@@ -390,6 +419,12 @@ object UserConfiguration {
     // It was added only to have a meaningful option value in vscode
     val defaultScalaVersion =
       getStringKey("fallback-scala-version").filter(_ != "automatic")
+    val eclipseFormatConfigPath =
+      getStringKey("eclipse-format-config-path").map(AbsolutePath(_))
+    val shouldFormatJavaComments =
+      getBooleanKey("enable-format-java-comments").getOrElse(false)
+    val eclipseFormatProfile = getStringKey("eclipse-format-profile")
+
     if (errors.isEmpty) {
       Right(
         UserConfiguration(
@@ -413,7 +448,10 @@ object UserConfiguration {
           remoteLanguageServer,
           enableStripMarginOnTypeFormatting,
           excludedPackages,
-          defaultScalaVersion
+          defaultScalaVersion,
+          eclipseFormatConfigPath,
+          shouldFormatJavaComments,
+          eclipseFormatProfile
         )
       )
     } else {

--- a/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
@@ -33,6 +33,7 @@ final class Warnings(
     }
     val isReported: Option[Unit] = for {
       buildTarget <- buildTargets.inverseSources(path)
+      // TODO(arthurm1) add javaTarget warnings (targetroot, sourceroot, semanticDB etc.)
       info <- buildTargets.scalaTarget(buildTarget)
       scalacOptions <- buildTargets.scalacOptions(buildTarget)
     } yield {
@@ -53,7 +54,7 @@ final class Warnings(
         }
       } else {
         if (!info.isSourcerootDeclared) {
-          val option = workspace.sourcerootOption
+          val option = workspace.scalaSourcerootOption
           logger.error(
             s"$doesntWorkBecause the build target ${info.displayName} is missing the compiler option $option. " +
               s"To fix this problems, update the build settings to include this compiler option."
@@ -66,10 +67,11 @@ final class Warnings(
           )
           statusBar.addMessage(icons.info + tryAgain)
         } else if (!path.isSbt && !path.isWorksheet) {
-
           val targetRoot = scalacOptions.targetroot(info.scalaVersion)
           val targetfile = targetRoot
-            .resolve(SemanticdbClasspath.fromScala(path.toRelative(workspace)))
+            .resolve(
+              SemanticdbClasspath.fromScalaOrJava(path.toRelative(workspace))
+            )
           logger.error(
             s"$doesntWorkBecause the SemanticDB file '$targetfile' doesn't exist. " +
               s"There can be many reasons for this error. "

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -553,10 +553,10 @@ class DebugProvider(
           result <- Future.fromTry(f())
         } yield result
       case _: ClassNotFoundException =>
-        val allTargets = buildTargets.allBuildTargetIds
+        val allTargetIds = buildTargets.allBuildTargetIds
         for {
-          _ <- compilations.compileTargets(allTargets)
-          _ <- buildTargetClasses.rebuildIndex(allTargets)
+          _ <- compilations.compileTargets(allTargetIds)
+          _ <- buildTargetClasses.rebuildIndex(allTargetIds)
           result <- Future.fromTry(f())
         } yield result
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
@@ -87,13 +87,9 @@ object FileWatcher {
     // Watch the source directories for "goto definition" index.
     buildTargets.sourceRoots.foreach(collect)
     buildTargets.sourceItems.foreach(collect)
-    val semanticdbs = buildTargets.scalacOptions.flatMap { item =>
-      for {
-        scalaInfo <- buildTargets.scalaInfo(item.getTarget)
-        targetroot = item.targetroot(scalaInfo.getScalaVersion)
-        path = targetroot.resolve(Directories.semanticdb) if !targetroot.isJar
-      } yield path.toNIO
-    }
+    val semanticdbs = buildTargets.allTargetRoots
+      .filterNot(_.isJar)
+      .map(_.resolve(Directories.semanticdb).toNIO)
 
     FilesToWatch(
       sourceFilesToWatch.toSet,

--- a/metals/src/main/scala/scala/meta/internal/troubleshoot/JavaProblem.scala
+++ b/metals/src/main/scala/scala/meta/internal/troubleshoot/JavaProblem.scala
@@ -1,0 +1,44 @@
+package scala.meta.internal.troubleshoot
+
+import scala.meta.internal.metals.BuildInfo
+
+/**
+ * Class describing different issues that a build target can have that might influence
+ * features available to a user. For example without the semanticdb option
+ * "find references" feature will not work. Those problems will be reported to a user
+ * with an explanation on how to fix it.
+ */
+sealed abstract class JavaProblem {
+
+  /**
+   * Comprehensive message to be presented to the user.
+   */
+  def message: String
+  protected val hint = "run 'Import build' to enable code navigation."
+}
+
+case class JavaSemanticDBDisabled(
+    bloopVersion: String,
+    unsupportedBloopVersion: Boolean
+) extends JavaProblem {
+  override def message: String = {
+    if (unsupportedBloopVersion) {
+      s"""|The installed Bloop server version is $bloopVersion while Metals requires at least Bloop version ${BuildInfo.bloopVersion},
+          |To fix this problem please update your Bloop server.""".stripMargin
+    } else {
+      "Semanticdb is required for code navigation to work correctly in your project," +
+        " however the Java semanticdb plugin doesn't seem to be enabled. " +
+        "Please enable the Java semanticdb plugin for this project in order for code navigation to work correctly"
+    }
+  }
+}
+
+case class MissingJavaSourceRoot(sourcerootOption: String) extends JavaProblem {
+  override def message: String =
+    s"Add the compiler option $sourcerootOption to ensure code navigation works."
+}
+
+case class MissingJavaTargetRoot(targetrootOption: String) extends JavaProblem {
+  override def message: String =
+    s"Add the compiler option $targetrootOption to ensure code navigation works."
+}

--- a/metals/src/main/scala/scala/meta/internal/tvp/ClasspathTreeView.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/ClasspathTreeView.scala
@@ -20,6 +20,7 @@ class ClasspathTreeView[Value, Key](
     scheme: String,
     title: String,
     id: Value => Key,
+    context: String,
     encode: Key => String,
     decode: String => Key,
     valueTitle: Value => String,
@@ -33,7 +34,8 @@ class ClasspathTreeView[Value, Key](
       viewId,
       rootUri,
       title + s" (${toplevels().size})",
-      collapseState = MetalsTreeItemCollapseState.collapsed
+      collapseState = MetalsTreeItemCollapseState.collapsed,
+      contextValue = "root"
     )
 
   def matches(uri: String): Boolean = uri.startsWith(rootUri)
@@ -164,7 +166,8 @@ class ClasspathTreeView[Value, Key](
       uri,
       valueTitle(value),
       tooltip = valueTooltip(value),
-      collapseState = MetalsTreeItemCollapseState.collapsed
+      collapseState = MetalsTreeItemCollapseState.collapsed,
+      contextValue = context
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/tvp/TreeViewNode.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/TreeViewNode.scala
@@ -14,7 +14,8 @@ case class TreeViewNode(
     @Nullable icon: String = null,
     @Nullable tooltip: String = null,
     // One of "collapsed", "expanded" or "none"
-    @Nullable collapseState: String = null
+    @Nullable collapseState: String = null,
+    @Nullable contextValue: String = null
 ) {
   def isDirectory: Boolean = label.endsWith("/")
   def isCollapsed: Boolean =

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -439,7 +439,7 @@ class WorksheetProvider(
             info.scalaVersion,
             ScalaVersions.scalaBinaryVersionFromFullVersion(info.scalaVersion)
           )
-          .withClasspath(info.fullClasspath.asScala.distinct.asJava)
+          .withClasspath(info.fullClasspath.distinct.asJava)
           .withScalacOptions(scalacOptions)
         mdocs(key) = MdocRef(scalaVersion, mdoc)
         mdoc

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -295,6 +295,8 @@ trait CommonMtagsEnrichments {
       doc.endsWith(".worksheet.sc")
     def isScalaFilename: Boolean =
       doc.isScala || isScalaScript || isSbt
+    def isJavaFilename: Boolean =
+      doc.endsWith(".java")
     def isAmmoniteGeneratedFile: Boolean =
       doc.endsWith(".sc.scala")
     def isAmmoniteScript: Boolean =
@@ -316,6 +318,8 @@ trait CommonMtagsEnrichments {
   implicit class XtensionRelativePathMetals(file: RelativePath) {
     def filename: String = file.toNIO.filename
     def isScalaFilename: Boolean = filename.isScalaFilename
+    def isJavaFilename: Boolean = filename.isJavaFilename
+    def isScalaOrJavaFilename: Boolean = isScalaFilename || isJavaFilename
   }
 
   implicit class XtensionStream[A](stream: java.util.stream.Stream[A]) {
@@ -416,6 +420,9 @@ trait CommonMtagsEnrichments {
       isScalaScript && !isWorksheet
     def isWorksheet: Boolean = {
       filename.endsWith(".worksheet.sc")
+    }
+    def isJavaFilename: Boolean = {
+      filename.isJavaFilename
     }
     def isScalaFilename: Boolean = {
       filename.isScalaFilename

--- a/mtags/src/main/scala/scala/meta/internal/mtags/SemanticdbClasspath.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/SemanticdbClasspath.scala
@@ -19,20 +19,22 @@ final case class SemanticdbClasspath(
   val loader = new ClasspathLoader()
   loader.addClasspath(classpath)
 
-  def getSemanticdbPath(scalaPath: AbsolutePath): AbsolutePath = {
-    semanticdbPath(scalaPath).getOrElse(
-      throw new NoSuchElementException(scalaPath.toString())
+  def getSemanticdbPath(scalaOrJavaPath: AbsolutePath): AbsolutePath = {
+    semanticdbPath(scalaOrJavaPath).getOrElse(
+      throw new NoSuchElementException(scalaOrJavaPath.toString())
     )
   }
-  def resourcePath(scalaPath: AbsolutePath): RelativePath = {
-    mtags.SemanticdbClasspath.fromScala(scalaPath.toRelative(sourceroot))
+  def resourcePath(scalaOrJavaPath: AbsolutePath): RelativePath = {
+    mtags.SemanticdbClasspath.fromScalaOrJava(
+      scalaOrJavaPath.toRelative(sourceroot)
+    )
   }
-  def semanticdbPath(scalaPath: AbsolutePath): Option[AbsolutePath] = {
-    loader.load(resourcePath(scalaPath))
+  def semanticdbPath(scalaOrJavaPath: AbsolutePath): Option[AbsolutePath] = {
+    loader.load(resourcePath(scalaOrJavaPath))
   }
-  def textDocument(scalaPath: AbsolutePath): TextDocumentLookup = {
+  def textDocument(scalaOrJavaPath: AbsolutePath): TextDocumentLookup = {
     Semanticdbs.loadTextDocument(
-      scalaPath,
+      scalaOrJavaPath,
       sourceroot,
       charset,
       fingerprints,
@@ -60,8 +62,8 @@ object SemanticdbClasspath {
         .dealias
     }
   }
-  def fromScala(path: RelativePath): RelativePath = {
-    require(path.isScalaFilename, path.toString)
+  def fromScalaOrJava(path: RelativePath): RelativePath = {
+    require(path.isScalaOrJavaFilename, path.toString)
     val semanticdbSibling = path.resolveSibling(_ + ".semanticdb")
     val semanticdbPrefix = RelativePath("META-INF").resolve("semanticdb")
     semanticdbPrefix.resolve(semanticdbSibling)

--- a/mtags/src/main/scala/scala/meta/internal/mtags/Semanticdbs.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/Semanticdbs.scala
@@ -26,24 +26,24 @@ object Semanticdbs {
   }
 
   def loadTextDocument(
-      scalaPath: AbsolutePath,
+      scalaOrJavaPath: AbsolutePath,
       sourceroot: AbsolutePath,
       charset: Charset,
       fingerprints: Md5Fingerprints,
       loader: RelativePath => Option[FoundSemanticDbPath]
   ): TextDocumentLookup = {
-    if (scalaPath.toNIO.getFileSystem != sourceroot.toNIO.getFileSystem) {
-      TextDocumentLookup.NotFound(scalaPath)
+    if (scalaOrJavaPath.toNIO.getFileSystem != sourceroot.toNIO.getFileSystem) {
+      TextDocumentLookup.NotFound(scalaOrJavaPath)
     } else {
-      val scalaRelativePath = scalaPath.toRelative(sourceroot.dealias)
+      val scalaRelativePath = scalaOrJavaPath.toRelative(sourceroot.dealias)
       val semanticdbRelativePath =
-        SemanticdbClasspath.fromScala(scalaRelativePath)
+        SemanticdbClasspath.fromScalaOrJava(scalaRelativePath)
       loader(semanticdbRelativePath) match {
         case None =>
-          TextDocumentLookup.NotFound(scalaPath)
+          TextDocumentLookup.NotFound(scalaOrJavaPath)
         case Some(semanticdbPath) =>
           loadResolvedTextDocument(
-            scalaPath,
+            scalaOrJavaPath,
             semanticdbPath.nonDefaultRelPath.getOrElse(scalaRelativePath),
             semanticdbPath.path,
             charset,

--- a/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
+++ b/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
@@ -104,6 +104,7 @@ object MetalsTestEnrichments {
         libraries.flatMap(_.classpath.entries).map(_.toURI.toString).asJava,
         ""
       )
+      // TODO(@arthurm1) test javacOptions?
       wsp.buildTargets.addScalacOptions(
         new ScalacOptionsResult(List(item).asJava)
       )

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1347,7 +1347,7 @@ final class TestingServer(
       .map(_.getId().getUri())
       .getOrElse {
         val alternatives =
-          server.buildTargets.all.map(_.displayName).mkString(" ")
+          server.buildTargets.allTargets.map(_.getDisplayName()).mkString(" ")
         throw new NoSuchElementException(
           s"$displayName (alternatives: ${alternatives}"
         )

--- a/tests/unit/src/test/scala/tests/DefinitionDirectorySuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionDirectorySuite.scala
@@ -5,7 +5,7 @@ import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.mtags.Symbol
 
 class DefinitionDirectorySuite extends BaseSuite {
-  test("basic") {
+  test("basicScala") {
     val index = OnDemandSymbolIndex.empty()
     def assertDefinition(sym: String): Unit = {
       val definition = index.definition(Symbol(sym))
@@ -22,5 +22,21 @@ class DefinitionDirectorySuite extends BaseSuite {
     index.addSourceDirectory(root, dialects.Scala213)
     assertDefinition("com/foo/Foo#")
     assertDefinition("com/foo/Bar.")
+  }
+  test("basicJava") {
+    val index = OnDemandSymbolIndex.empty()
+    def assertDefinition(sym: String): Unit = {
+      val definition = index.definition(Symbol(sym))
+      if (definition.isEmpty) throw new NoSuchElementException(sym)
+    }
+    val root = FileLayout.fromString(
+      """
+        |/com/foo/Foo.java
+        |package com.foo;
+        |public class Foo {}
+        |""".stripMargin
+    )
+    index.addSourceDirectory(root, dialects.Scala213)
+    assertDefinition("com/foo/Foo.")
   }
 }


### PR DESCRIPTION
Displays detailed target info.

This depends on some of #2520 because of the target refactor and javacoptions additions

This is my first change to the VSCode extension and I don't really know where the line is drawn in expanding the API by adding commands and where the split in functionality between the extension and Metals should lie especially due to none-vscode clients.

I've commandeered the Doctor webview because of the navigation between it and the targets.  I was going to use the [Virtual Document](https://code.visualstudio.com/api/extension-guides/virtual-documents) API as it seems a lot simpler, more lightweight and usable across non-vscode clients but I don't see that navigation is possible with it.

It doesn't seem possible to reveal a directory/folder in the VSCode file explorer which I'd like to navigate to when clicking on the various classes/classpath/source folders as the VSCode file explorer doesn't seem to have much of a public API.  Has anyone seen a way to do this?

It also looks as though Metals doesn't request `resources` directories from BSP - I assume because it doesn't need them - or is this stored somewhere outside `scala.meta.internal.metals.BuildTargets`?

The motivation for this was not having to keep navigating and perusing the json files in the .bloop folder for build setup and also viewing the additional javac/scalac options that Bloop adds (e.g. semanticdb)

Here's an example...

https://user-images.githubusercontent.com/5612295/131269946-3ec903ca-bcb2-41b1-b4db-892f94b2fdd5.mp4





