### PR TITLE
Use new `lsif-java index` command to upload Sourcegraph index

### DIFF
--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -11,18 +11,12 @@ jobs:
     name: "Upload LSIF"
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v12
-      - uses: actions/setup-go@v2
+      - uses: coursier/setup-action@v1
+      - run: cs install --contrib lsif-java
+      - run: lsif-java index
+      - name: Upload LSIF data
+        uses: sourcegraph/lsif-upload-action@master
         with:
-          go-version: "1.15.6"
-      - run: |
-          mkdir -p bin
-          curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o bin/src
-          chmod +x bin/src
-          export PATH="$PATH:$PWD/bin"
-          sbt \
-              'set every semanticdbEnabled := true' \
-              'set every semanticdbVersion := "4.4.24"' \
-              sourcegraphUpload
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          endpoint: https://sourcegraph.com
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dump.lsif

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,6 @@ addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.22")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.1")
-addSbtPlugin("com.sourcegraph" % "sbt-sourcegraph" % "0.3.3")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 


### PR DESCRIPTION
Previously, the CI step uploaded LSIF through the sbt-sourcegraph
plugin. Now, we use the built-in `lsif-java index` command that handles
everything for us we no longer need the sbt-sourcegraph plugin
dependency. The benefit of this change is that Java sources will also
get indexed!