### PR TITLE
Ident on paste - bunch of fixes

### DIFF
--- a/tests/unit/src/test/scala/tests/rangeFormatting/IndentWhenPastingSuite.scala
+++ b/tests/unit/src/test/scala/tests/rangeFormatting/IndentWhenPastingSuite.scala
@@ -17,6 +17,12 @@ class IndentWhenPastingSuite
     /** insertSpaces */
     true
   )
+  val tabsFormattingOptions: FormattingOptions = new FormattingOptions(
+    /** tabSize: */
+    1,
+    /** insertSpaces */
+    false
+  )
 
   val blank = " "
 
@@ -174,9 +180,9 @@ class IndentWhenPastingSuite
        |object Main:
        |  object SubMain:
        |    enum                        Color(val rgb: Int):
-       |      case Red   extends Color(0xFF0000)
-       |      case Green extends Color(0x00FF00)
-       |      case Blue  extends Color(0x0000FF)
+       |       case Red   extends Color(0xFF0000)
+       |       case Green extends Color(0x00FF00)
+       |       case Blue  extends Color(0x0000FF)
        |  end SubMain
        |end Main""".stripMargin,
     scalaVersion,
@@ -208,11 +214,12 @@ class IndentWhenPastingSuite
        |    val a: String = \"\"\"| multiline
        |                     | string
        |                     |
-       |    |
-       |    |\"\"\".stripMargin
+       |                       |
+       |                       |\"\"\".stripMargin
+       |
        |    val b: String = \"\"\"| multiline
-       |   | string
-       |   |\"\"\".stripMargin
+       |                      | string
+       |                      |\"\"\".stripMargin
        |  end SubMain
        |end Main""".stripMargin,
     scalaVersion,
@@ -292,6 +299,65 @@ class IndentWhenPastingSuite
   )
 
   check(
+    "keep-empty-lines-inside-paste",
+    s"""
+       |object Main:
+       |  @@
+       |end Main""".stripMargin,
+    s"""
+       |trait X[A] {
+       |    def doX: A
+       |}
+       |
+       |
+       |def foo: X[A] = ???
+       |
+       |
+       |def bar: X[A] = ???
+       |
+       |""".stripMargin,
+    """|object Main:
+       |  trait X[A] {
+       |      def doX: A
+       |  }
+       |
+       |
+       |  def foo: X[A] = ???
+       |
+       |
+       |  def bar: X[A] = ???
+       |end Main
+       |""".stripMargin,
+    scalaVersion,
+    formattingOptions
+  )
+
+  check(
+    "keep-empty-lines-inside-paste2",
+    s"""
+       |object Main:
+       |  @@
+       |end Main""".stripMargin,
+    s"""
+       |trait X[A] {
+       |
+       |  def doX: A
+       |
+       |}
+       |""".stripMargin,
+    """|object Main:
+       |  trait X[A] {
+       |
+       |    def doX: A
+       |
+       |  }
+       |end Main
+       |""".stripMargin,
+    scalaVersion,
+    formattingOptions
+  )
+
+  check(
     "if-paren",
     s"""
        |object Main:
@@ -310,6 +376,71 @@ class IndentWhenPastingSuite
        |""".stripMargin,
     scalaVersion,
     formattingOptions
+  )
+
+  check(
+    "paste-without-leading-nl",
+    s"""
+       |object Main {
+       |  @@
+       |}""".stripMargin,
+    s"""trait X[A] {
+       |
+       |    def foo: X[A]
+       |}
+       |
+       |""".stripMargin,
+    """|object Main {
+       |  trait X[A] {
+       |
+       |      def foo: X[A]
+       |  }
+       |}
+       |""".stripMargin,
+    scalaVersion,
+    formattingOptions
+  )
+
+  check(
+    "normalize-tabs-to-spaces",
+    s"""
+       |object Main:
+       |@@
+       |end Main""".stripMargin,
+    s"""
+       |\tif (cond)
+       |\t\tdef double = s * 2
+       |\t\tdouble
+       |""".stripMargin,
+    """|object Main:
+       |  if (cond)
+       |    def double = s * 2
+       |    double
+       |end Main
+       |""".stripMargin,
+    scalaVersion,
+    formattingOptions
+  )
+
+  check(
+    "normalize-spaces-to-tabs",
+    s"""
+       |object Main:
+       |@@
+       |end Main""".stripMargin,
+    s"""
+       |if (cond)
+       |  def double = s * 2
+       |  double
+       |""".stripMargin,
+    """|object Main:
+       |\tif (cond)
+       |\t\tdef double = s * 2
+       |\t\tdouble
+       |end Main
+       |""".stripMargin,
+    scalaVersion,
+    tabsFormattingOptions
   )
 
   check(

--- a/tests/unit/src/test/scala/tests/rangeFormatting/MultilineStringRangeFormattingWhenPastingSuite.scala
+++ b/tests/unit/src/test/scala/tests/rangeFormatting/MultilineStringRangeFormattingWhenPastingSuite.scala
@@ -328,8 +328,8 @@ class MultilineStringRangeFormattingWhenPastingSuite
        |  val str = s'''
        |               |ok'''.stripMargin
        |  val other = '''
-       |  |  some text
-       |  |'''.stripMargin
+       |              |  some text
+       |              |'''.stripMargin
        |}""".stripMargin
   )
 

--- a/tests/unit/src/test/scala/tests/rangeFormatting/MultilineStringRangeFormattingWhenSelectingSuite.scala
+++ b/tests/unit/src/test/scala/tests/rangeFormatting/MultilineStringRangeFormattingWhenSelectingSuite.scala
@@ -3,6 +3,7 @@ package tests.rangeFormatting
 import munit.Location
 import org.eclipse.lsp4j.FormattingOptions
 import tests.BaseLspSuite
+import munit.TestOptions
 
 class MultilineStringRangeFormattingWhenSelectingSuite
     extends BaseLspSuite("rangeFormatting") {
@@ -119,18 +120,19 @@ class MultilineStringRangeFormattingWhenSelectingSuite
     s"""
        |object Main {
        |  val firstString = '''
-       |  |first line
-       |      |second line'''.stripMargin
+       |                        |first line
+       |                            |second line'''.stripMargin
+       |
        |  val str2 = '''
-       |  |first line
-       |  |second line'''.stripMargin
+       |               |first line
+       |               |second line'''.stripMargin
        |}""".stripMargin
   )
 
   val formattingOptions = new FormattingOptions(2, true)
 
   def check(
-      name: String,
+      name: TestOptions,
       testCase: String,
       expectedCase: String
   )(implicit loc: Location): Unit = {


### PR DESCRIPTION
There were several issues with ident on paste that is fixed by this
change:
- weird formatting if second line is empty of  overindented:
  ```scala
  // original
  trait X[A] {
      def foo: X[A] // 4 spaces instead of 2
  }
  // pasted
  object Main {
    trait X[A] {
      def foo: X[A]
  }                // <- wrong formatted
  }
  ```
- previous logic were removing all empty lines that wasn't convinient if
  you copy a large block of code like:
  ```scala
  // original
  trait X[A] {
    def foo: X[A]
  }

  def m1: Int = 32

  // pasted without whitespace between `X` and `m1`
  trait X[A] {
    def foo: X[A]
  }
  def m1: Int = 32
  ```
- normalization from tabs to spaces didn't work correctly