### PR TITLE
Take into account trace files in .metals directory

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -280,9 +280,9 @@ object BuildServerConnection {
 
     def setupServer(): Future[LauncherConnection] = {
       connect().map { case conn @ SocketConnection(_, output, input, _, _) =>
-        val tracePrinter = GlobalTrace.setupTracePrinter("BSP")
+        val tracePrinter = Trace.setupTracePrinter("BSP", workspace)
         val launcher = new Launcher.Builder[MetalsBuildServer]()
-          .traceMessages(tracePrinter)
+          .traceMessages(tracePrinter.orNull)
           .setOutput(output)
           .setInput(input)
           .setLocalService(localClient)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsHttpClient.scala
@@ -193,11 +193,11 @@ final class MetalsHttpClient(
   // =======
   // Helpers
   // =======
-  private val lspTrace = GlobalTrace.protocolTracePath("LSP")
+  private val lspTrace = Trace.protocolTracePath("LSP")
   private val isLspTraceEnabled = lspTrace.isFile
-  private val bspTrace = GlobalTrace.protocolTracePath("BSP")
+
+  private val bspTrace = Trace.protocolTracePath("BSP")
   private val isBspTraceEnabled = bspTrace.isFile
-  private val globalLog = GlobalTrace.globalLog
 
   private def serverCommands(html: HtmlBuilder): HtmlBuilder = {
     ServerCommands.all.foreach { command =>
@@ -250,11 +250,10 @@ final class MetalsHttpClient(
         )
         .section(
           "Log files",
-          _.element("p")(_.text("Global log: ").path(globalLog))
-            .element("p")(
-              _.text(s"LSP trace (enabled=$isLspTraceEnabled):")
-                .path(lspTrace)
-            )
+          _.element("p")(
+            _.text(s"LSP trace (enabled=$isLspTraceEnabled):")
+              .path(lspTrace)
+          )
             .element("p")(
               _.text(s"BSP trace (enabled=$isBspTraceEnabled):")
                 .path(bspTrace)

--- a/metals/src/main/scala/scala/meta/internal/metals/Trace.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Trace.scala
@@ -4,35 +4,23 @@ import java.io.PrintWriter
 import java.nio.file.Files
 import java.nio.file.StandardOpenOption
 
-import scala.util.control.NonFatal
-
 import scala.meta.internal.io.PathIO
 import scala.meta.io.AbsolutePath
-
-import dev.dirs.ProjectDirectories
 
 /**
  * Manages JSON-RPC tracing of incoming/outgoing messages via BSP and LSP.
  */
 object Trace {
+  val metalsLog: AbsolutePath =
+    PathIO.workingDirectory.resolve(".metals/metals.log")
 
   def protocolTracePath(
       protocolName: String,
       workspace: AbsolutePath = PathIO.workingDirectory
   ): AbsolutePath = {
     val traceFilename = s"${protocolName.toLowerCase}.trace.json"
-    globalDirectory.resolve(".metals").resolve(traceFilename)
+    workspace.resolve(".metals").resolve(traceFilename)
   }
-
-  def setup(
-      protocolName: String,
-      workspace: AbsolutePath = PathIO.workingDirectory
-  ): Option[PrintWriter] = {
-    MetalsLogger.redirectSystemOut(globalLog)
-    setupTracePrinter(protocolName, workspace)
-  }
-
-  def globalLog: AbsolutePath = globalDirectory.resolve("global.log")
 
   def setupTracePrinter(
       protocolName: String,
@@ -54,26 +42,6 @@ object Trace {
           s"and outgoing JSON messages create an empty file at $path"
       )
       None
-    }
-  }
-
-  def globalDirectory: AbsolutePath = {
-    try {
-      val projectDirectories =
-        ProjectDirectories.from("org", "scalameta", "metals")
-      // NOTE(olafur): strictly speaking we should use `dataDir` instead of `cacheDir` but on
-      // macOS this maps to `$HOME/Library/Application Support` which has an annoying space in
-      // the path making it difficult to tail/cat from the terminal and cmd+click from VS Code.
-      // Instead, we use the `cacheDir` which has no spaces. The logs are safe to remove so
-      // putting them in the "cache directory" makes more sense compared to the "config directory".
-      AbsolutePath(projectDirectories.cacheDir)
-    } catch {
-      case NonFatal(_) =>
-        // jvm-directories can fail for less common OS versions: https://github.com/soc/directories-jvm/issues/17
-        // Fall back to the working directory instead of crashing the entire server.
-        val cwd = PathIO.workingDirectory.resolve(".metals")
-        Files.createDirectories(cwd.toNIO)
-        cwd
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Trace.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Trace.scala
@@ -14,7 +14,7 @@ import dev.dirs.ProjectDirectories
 /**
  * Manages JSON-RPC tracing of incoming/outgoing messages via BSP and LSP.
  */
-object GlobalTrace {
+object Trace {
 
   /**
    * Returns a printer to trace JSON messages if the user opts into it.

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -163,6 +163,7 @@ class DebugProvider(
         debugAdapter,
         stacktraceAnalyzer,
         compilers,
+        workspace,
         clientConfig.disableColorOutput()
       )
     }

--- a/metals/src/main/scala/scala/meta/metals/Main.scala
+++ b/metals/src/main/scala/scala/meta/metals/Main.scala
@@ -6,12 +6,13 @@ import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 
+import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.BuildInfo
-import scala.meta.internal.metals.GlobalTrace
 import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.internal.metals.MetalsLanguageServer
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.metals.Trace
 
 import org.eclipse.lsp4j.jsonrpc.Launcher
 
@@ -44,7 +45,7 @@ object Main {
     }
     val systemIn = System.in
     val systemOut = System.out
-    val tracePrinter = GlobalTrace.setup("LSP")
+    val tracePrinter = Trace.setup("LSP", PathIO.workingDirectory)
     val exec = Executors.newCachedThreadPool()
     val ec = ExecutionContext.fromExecutorService(exec)
     val initialConfig = MetalsServerConfig.default
@@ -55,9 +56,8 @@ object Main {
       initialConfig = initialConfig
     )
     try {
-      scribe.info(s"Starting Metals server with configuration: $initialConfig")
       val launcher = new Launcher.Builder[MetalsLanguageClient]()
-        .traceMessages(tracePrinter)
+        .traceMessages(tracePrinter.orNull)
         .setExecutorService(exec)
         .setInput(systemIn)
         .setOutput(systemOut)

--- a/metals/src/main/scala/scala/meta/metals/Main.scala
+++ b/metals/src/main/scala/scala/meta/metals/Main.scala
@@ -10,6 +10,7 @@ import scala.meta.internal.io.PathIO
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.internal.metals.MetalsLanguageServer
+import scala.meta.internal.metals.MetalsLogger
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.ScalaVersions
 import scala.meta.internal.metals.Trace
@@ -45,7 +46,8 @@ object Main {
     }
     val systemIn = System.in
     val systemOut = System.out
-    val tracePrinter = Trace.setup("LSP", PathIO.workingDirectory)
+    MetalsLogger.redirectSystemOut(Trace.metalsLog)
+    val tracePrinter = Trace.setupTracePrinter("LSP", PathIO.workingDirectory)
     val exec = Executors.newCachedThreadPool()
     val ec = ExecutionContext.fromExecutorService(exec)
     val initialConfig = MetalsServerConfig.default

--- a/tests/unit/src/main/scala/tests/BaseDapSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseDapSuite.scala
@@ -6,8 +6,8 @@ import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
 
-import scala.meta.internal.metals.GlobalTrace
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.Trace
 import scala.meta.internal.metals.debug.DebugProtocol
 import scala.meta.internal.metals.debug.DebugStep._
 import scala.meta.internal.metals.debug.DebugWorkspaceLayout
@@ -28,10 +28,8 @@ abstract class BaseDapSuite(
     buildToolLayout: BuildToolLayout
 ) extends BaseLspSuite(suiteName, initializer) {
 
-  private val dapClient =
-    GlobalTrace.protocolTracePath(DebugProtocol.clientName)
-  private val dapServer =
-    GlobalTrace.protocolTracePath(DebugProtocol.serverName)
+  private val dapClient = Trace.protocolTracePath(DebugProtocol.clientName)
+  private val dapServer = Trace.protocolTracePath(DebugProtocol.serverName)
 
   override def beforeEach(context: GenericBeforeEach[Future[Any]]): Unit = {
     super.beforeEach(context)


### PR DESCRIPTION
Previously, in order to log JSON-RPC traces, one has to create proper files in the cache directory. What's important, those files are global for every metals server.
Now, there is an additional option available. One can create those files in the `.metals` directory and opt-in/out logging per project. No more reloading specific metals instance in order to see logs from it!

closes https://github.com/scalameta/metals/issues/3098