### PR TITLE
add javap/semanticdb file viewer

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -1,0 +1,372 @@
+package scala.meta.internal.metals
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.net.URI
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.Properties
+import scala.util.Try
+import scala.util.control.NonFatal
+
+import scala.meta.cli.Reporter
+import scala.meta.internal.builds.ShellRunner
+import scala.meta.internal.io.FileIO
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metap.Main
+import scala.meta.internal.mtags.SemanticdbClasspath
+import scala.meta.io.AbsolutePath
+import scala.meta.metap.Format
+import scala.meta.metap.Settings
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+
+final case class DecoderResponse(
+    requestedUri: String,
+    value: String,
+    error: String
+)
+final class FileDecoderProvider(
+    workspace: AbsolutePath,
+    compilers: Compilers,
+    buildTargets: BuildTargets,
+    userConfig: () => UserConfiguration,
+    shellRunner: ShellRunner,
+    fileSystemSemanticdbs: FileSystemSemanticdbs
+)(implicit ec: ExecutionContext) {
+
+  private case class PathInfo(
+      targetId: Option[BuildTargetIdentifier],
+      path: AbsolutePath
+  )
+  private case class Finder(findFile: String => Option[PathInfo])
+  private case class Decoder(decode: PathInfo => Future[Option[String]])
+
+  /**
+   * URI format...
+   * metalsDecode:/fileUrl?decoder=decoderName&keyValueArguments
+   * jar:file:///jarPath/jar-sources.jar!/packagedir/file.java
+   *
+   * Examples...
+   * metalsDecode:file:///somePath/someFile.java.javap-verbose?decoder=javap&verbose=true
+   * metalsDecode:file:///somePath/someFile.scala.javap-verbose?decoder=javap&verbose=true
+   * metalsDecode:file:///somePath/someFile.class.javap-verbose?decoder=javap&verbose=true
+   *
+   * metalsDecode:file:///somePath/someFile.java.javap?decoder=java
+   * metalsDecode:file:///somePath/someFile.scala.javap?decoder=javap
+   * metalsDecode:file:///somePath/someFile.class.javap?decoder=javap
+   *
+   * metalsDecode:file:///somePath/someFile.java.semanticdb-compact?decoder=semanticdb&format=compact
+   * metalsDecode:file:///somePath/someFile.java.semanticdb-detailed?decoder=semanticdb
+   *
+   * metalsDecode:file:///somePath/someFile.scala.semanticdb-compact?decoder=semanticdb&format=compact
+   * metalsDecode:file:///somePath/someFile.scala.semanticdb-detailed?decoder=semanticdb
+   *
+   * metalsDecode:file:///somePath/someFile.java.semanticdb.semanticdb-compact?decoder=semanticdb&format=compact
+   * metalsDecode:file:///somePath/someFile.java.semanticdb.semanticdb-detailed?decoder=semanticdb
+   *
+   * metalsDecode:file:///somePath/someFile.scala.semanticdb.semanticdb-compact?decoder=semanticdb&format=compact
+   * metalsDecode:file:///somePath/someFile.scala.semanticdb.semanticdb-detailed?decoder=semanticdb
+   *
+   * metalsDecode:file:///somePath/someFile.scala.tasty-detailed?decoder=tasty
+   * metalsDecode:file:///somePath/someFile.tasty.tasty-detailed?decoder=tasty
+   *
+   * jar:file:///somePath/someFile-sources.jar!/somePackage/someFile.java
+   */
+  def decodedFileContents(uriAsStr: String): Future[DecoderResponse] = {
+    for {
+      check <- Future { getDecodeInfo(uriAsStr) }
+      output <- check match {
+        case None => Future.successful(None)
+        case Some((decoder, path)) => decoder.decode(path)
+      }
+      checkedOutput = output match {
+        case None => errorReponse(uriAsStr)
+        case Some(success) => DecoderResponse(uriAsStr, success, null)
+      }
+    } yield checkedOutput
+  }
+
+  def errorReponse(uriAsStr: String): DecoderResponse =
+    DecoderResponse(uriAsStr, null, errorMessage(uriAsStr))
+
+  private def errorMessage(input: String): String =
+    s"""|$input
+        |
+        |Unexpected uri, Metals accepts ones such as:
+        |
+        |metalsDecode:file:///somedir/someFile.scala.javap-verbose?decoder=javap
+        |
+        |Take a look at scala/meta/internal/metals/FileDecoderProvider for more information.
+        |
+        |Or wait for indexing/compiling to finish and re-try
+        |""".stripMargin
+
+  private def getDecodeInfo(
+      uriAsStr: String
+  ): Option[(Decoder, PathInfo)] = {
+    val uri = Try(URI.create(uriAsStr)).toOption
+    uri.flatMap(uri =>
+      uri.getScheme() match {
+        case "jar" => decodeJar(uri)
+        case "file" => decodeMetalsFile(uri)
+        case "metalsDecode" => getDecodeInfo(uri.getSchemeSpecificPart())
+        case _ => None
+      }
+    )
+  }
+
+  private def decodeJar(uri: URI): Option[(Decoder, PathInfo)] = {
+    Try {
+      // jar file system cannot cope with a heavily encoded uri
+      // hence the roundabout way of creating an AbsolutePath
+      // must have "jar:file:"" instead of "jar:file%3A"
+      val decodedUriStr = URLDecoder.decode(uri.toString(), "UTF-8")
+      val decodedUri = URI.create(decodedUriStr)
+      AbsolutePath(Paths.get(decodedUri))
+    }.toOption
+      .map(path =>
+        (
+          Decoder(path =>
+            Future {
+              Try(FileIO.slurp(path.path, StandardCharsets.UTF_8)).toOption
+            }
+          ),
+          PathInfo(None, path)
+        )
+      )
+  }
+
+  private def decodeMetalsFile(
+      uri: URI
+  ): Option[(Decoder, PathInfo)] = {
+    for {
+      query <- Option(uri.getQuery())
+      paramArr = query.split("&").map(_.split("=", 2))
+      if (paramArr.forall(_.length == 2))
+      params <- Try {
+        paramArr
+          .map(f => f.map(URLDecoder.decode(_, "UTF-8")))
+          .map(f => f(0) -> f(1))
+          .toMap
+      }.toOption
+      if (params.contains("decoder"))
+      (finder, decoder) <- getDecoder(params)
+      fileToDecode <- finder.findFile(uri.getPath())
+    } yield ((decoder, fileToDecode))
+  }
+
+  private def getDecoder(
+      params: Map[String, String]
+  ): Option[(Finder, Decoder)] = {
+    params("decoder") match {
+      case "javap" => Some(getJavapDecoder(params))
+      case "semanticdb" => Some(getSemanticdbDecoder(params))
+      case "tasty" => Some(getTastyDecoder(params))
+      case _ => None
+    }
+  }
+
+  private def boolParam(params: Map[String, String], name: String): Boolean =
+    params.get(name).map(_.toBoolean).getOrElse(false)
+
+  private def toFile(
+      uriPath: String,
+      suffixToRemove: String
+  ): Option[AbsolutePath] = {
+    Try {
+      s"file://${uriPath}".stripSuffix(suffixToRemove).toAbsolutePath
+    }.toOption.filter(_.exists)
+  }
+
+  private def getJavapDecoder(
+      params: Map[String, String]
+  ): (Finder, Decoder) = {
+    val verbose = boolParam(params, "verbose")
+    val suffix = if (verbose) ".javap-verbose" else ".javap"
+    val finder = Finder(uriPath =>
+      for {
+        path <- toFile(uriPath, suffix)
+        classesPath <-
+          if (path.isScalaOrJava) findClassesDirFileFromSource(path, "class")
+          else Some(PathInfo(None, path))
+      } yield classesPath
+    )
+    val decoder = Decoder(decodeJavapFromClassFile(_, verbose))
+    (finder, decoder)
+  }
+
+  private def getSemanticdbDecoder(
+      params: Map[String, String]
+  ): (Finder, Decoder) = {
+    val format = params
+      .get("format")
+      .map(_.toUpperCase match {
+        case "DETAILED" => Format.Detailed
+        case "COMPACT" => Format.Compact
+        case "PROTO" => Format.Proto
+      })
+      .getOrElse(Format.Detailed)
+    val suffix = format match {
+      case Format.Detailed => ".semanticdb-detailed"
+      case Format.Compact => ".semanticdb-compact"
+      case Format.Proto => ".semanticdb-proto"
+    }
+    val finder = Finder(uriPath =>
+      for {
+        path <- toFile(uriPath, suffix)
+        semanticPath <-
+          if (path.isScalaOrJava) findSemanticDBFileFromSource(path)
+          else Some(PathInfo(None, path))
+      } yield semanticPath
+    )
+    val decoder = Decoder(decodeFromSemanticDBFile(_, format))
+    (finder, decoder)
+  }
+
+  private def getTastyDecoder(
+      params: Map[String, String]
+  ): (Finder, Decoder) = {
+    val finder = Finder(uriPath =>
+      for {
+        path <- toFile(uriPath, ".tasty-detailed")
+        classesPath <-
+          if (path.isScalaOrJava) findClassesDirFileFromSource(path, "tasty")
+          else findPathInfoFromClassesPath(path)
+      } yield classesPath
+    )
+    val decoder = Decoder(decodeFromTastyFile(_))
+    (finder, decoder)
+  }
+
+  private def findPathInfoFromClassesPath(
+      path: AbsolutePath
+  ): Option[PathInfo] = {
+    val pathInfos = for {
+      scalaTarget <- buildTargets.all
+      classPath = scalaTarget.classDirectory.toAbsolutePath
+      if (path.isInside(classPath))
+    } yield PathInfo(Some(scalaTarget.id), path)
+    pathInfos.toList.headOption
+  }
+
+  private def findClassesDirFileFromSource(
+      sourceFile: AbsolutePath,
+      newExtension: String
+  ): Option[PathInfo] = {
+    for {
+      targetId <- buildTargets.sourceBuildTargets(sourceFile).headOption
+      target <- buildTargets.scalaTarget(targetId)
+      sourceRoot <- buildTargets.inverseSourceItem(sourceFile)
+      classDir = target.classDirectory.toAbsolutePath
+      oldExtension = sourceFile.extension
+      relativePath = sourceFile
+        .toRelative(sourceRoot)
+        .resolveSibling(_.stripSuffix(oldExtension) + newExtension)
+    } yield PathInfo(Some(targetId), classDir.resolve(relativePath))
+  }
+  private def findSemanticDBFileFromSource(
+      sourceFile: AbsolutePath
+  ): Option[PathInfo] = {
+    for {
+      targetId <- buildTargets.inverseSources(sourceFile)
+      target <- buildTargets.scalaTarget(targetId)
+      sourceRoot <- buildTargets.workspaceDirectory(targetId)
+      targetRoot = target.targetroot
+      relativePath = SemanticdbClasspath.fromScala(
+        sourceFile.toRelative(sourceRoot.dealias)
+      )
+      foundSemanticDbPath <- fileSystemSemanticdbs.findSemanticDb(
+        relativePath,
+        targetRoot,
+        sourceFile,
+        workspace
+      )
+    } yield PathInfo(Some(targetId), foundSemanticDbPath.path)
+  }
+
+  private def decodeJavapFromClassFile(
+      pathInfo: PathInfo,
+      verbose: Boolean
+  ): Future[Option[String]] = {
+    try {
+      val args = if (verbose) List("-verbose") else Nil
+      val sb = new StringBuilder()
+      shellRunner
+        .run(
+          "Decode using javap",
+          JavaBinary(userConfig().javaHome, "javap") :: args ::: List(
+            pathInfo.path.filename
+          ),
+          pathInfo.path.parent,
+          redirectErrorOutput = true,
+          Map.empty,
+          s => {
+            sb.append(s)
+            sb.append(Properties.lineSeparator)
+          },
+          s => (),
+          propagateError = true,
+          logInfo = false
+        )
+        .map(_ => Some(sb.toString))
+    } catch {
+      case NonFatal(_) => Future.successful(None)
+    }
+  }
+
+  private def decodeFromSemanticDBFile(
+      pathInfo: PathInfo,
+      format: Format
+  ): Future[Option[String]] = {
+    Future {
+      Try {
+        val out = new ByteArrayOutputStream()
+        val err = new ByteArrayOutputStream()
+        val psOut = new PrintStream(out)
+        val psErr = new PrintStream(err)
+        try {
+          val reporter =
+            Reporter().withOut(psOut).withErr(psErr)
+          val settings =
+            Settings()
+              .withPaths(List(pathInfo.path.toNIO))
+              .withFormat(format)
+          val main = new Main(settings, reporter)
+          main.process()
+          val output = new String(out.toByteArray);
+          val error = new String(err.toByteArray);
+          if (error.isEmpty)
+            output
+          else
+            error
+        } finally {
+          psOut.close()
+          psErr.close()
+        }
+      }.toOption
+    }
+  }
+
+  private def decodeFromTastyFile(
+      pathInfo: PathInfo
+  ): Future[Option[String]] = {
+    for {
+      pc <- Future {
+        for {
+          targetId <- pathInfo.targetId
+          pc <- compilers.loadCompiler(targetId)
+        } yield pc
+      }
+      output <- pc match {
+        case None => Future.successful(None)
+        case Some(pc) =>
+          pc.getTasty(pathInfo.path.toURI, false, false).asScala.map(Some(_))
+      }
+    } yield output
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/FileSystemSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileSystemSemanticdbs.scala
@@ -54,7 +54,7 @@ final class FileSystemSemanticdbs(
     }
   }
 
-  private def findSemanticDb(
+  def findSemanticDb(
       semanticdbRelativePath: RelativePath,
       targetroot: AbsolutePath,
       file: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
@@ -8,10 +8,17 @@ object JavaBinary {
    * Returns absolute path to the `java` binary of the configured Java Home directory.
    */
   def apply(javaHome: Option[String]): String = {
+    apply(javaHome, "java")
+  }
+
+  /**
+   * Returns absolute path to the `binaryName` binary of the configured Java Home directory.
+   */
+  def apply(javaHome: Option[String], binaryName: String): String = {
     javaHome
       .orElse(JdkSources.defaultJavaHome)
-      .map(AbsolutePath(_).resolve("bin").resolve("java").toString())
-      .getOrElse("java")
+      .map(AbsolutePath(_).resolve("bin").resolve(binaryName).toString())
+      .getOrElse(binaryName)
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -57,6 +57,20 @@ object ServerCommands {
        |""".stripMargin
   )
 
+  /** Decode a file e.g. javap, semanticdb */
+  val DecodeFile = new Command(
+    "file-decode",
+    "Decode file",
+    """|Decode a file into a human readable format.
+       |
+       |Compilation involves various binary files that can't be read directly
+       |in a text editor so they need to be decoded into a human readable format.
+       |Examples include `.class` and `.semanticdb`.
+       |""".stripMargin,
+    """|[uri], uri of the file with any parameters required for decoding.
+       |""".stripMargin
+  )
+
   val RunDoctor = new Command(
     "doctor-run",
     "Run doctor",
@@ -440,6 +454,7 @@ object ServerCommands {
       ResetChoicePopup,
       RestartBuildServer,
       RunDoctor,
+      DecodeFile,
       ScanWorkspaceSources,
       StartAmmoniteBuildServer,
       StartDebugAdapter,


### PR DESCRIPTION
Shows class files and semanticdb files in readable format.

This uses VSCode's Virtual Documents rather than the WebView as https://github.com/scalameta/metals/pull/3063 does for Tasty files.

There are pros and cons for both methods and I'm not sure what's best in this case.

Virtual Documents allow Metals to pass back only the plain text that should appear for the output from javap and metap in response to a command with a URI parameter.
This means no hyperlinks and no formatting, both of which the webview will allow but it does make it easily extendable to handle more file viewers (e.g. scalap?) without managing additional WebViews
Highlighting is done using textmate grammars which are pretty long-winded.  But I'm guessing this method is more portable across non-vscode clients?  Also - I don't see that javap or metap offer an HTML output

[jvm-bytecode-viewer](https://github.com/mnxn/vscode-jvm-bytecode-viewer) has some nice javap grammars which maybe could be used.  For now I've only spent spent 5 mins creating an example one.

https://user-images.githubusercontent.com/5612295/132593299-88fe69d0-73e5-48f1-b5e5-7c61ee093146.mp4




