### PR TITLE
Make sure that classpath does not contain invalid files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -1,7 +1,6 @@
 package scala.meta.internal.metals
 
 import java.nio.file.Path
-import java.{util => ju}
 
 import scala.meta.Dialect
 import scala.meta.dialects._
@@ -53,8 +52,16 @@ case class ScalaTarget(
     if (baseDir != null) baseDir else ""
   }
 
-  def fullClasspath: ju.List[Path] = {
-    scalac.getClasspath().map(_.toAbsolutePath.toNIO)
+  def fullClasspath: List[Path] = {
+    scalac
+      .getClasspath()
+      .map(_.toAbsolutePath)
+      .asScala
+      .collect {
+        case path if path.isJar || path.isDirectory =>
+          path.toNIO
+      }
+      .toList
   }
 
   def jarClasspath: List[AbsolutePath] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -278,7 +278,7 @@ case class ScalafixProvider(
     // It seems that Scalafix ignores the targetroot parameter and searches the classpath
     // Prepend targetroot to make sure that it's picked up first always
     val classpath =
-      (targetRoot.toList ++ scalaTarget.fullClasspath.asScala).asJava
+      (targetRoot.toList ++ scalaTarget.fullClasspath).asJava
 
     for {
       api <- getScalafix(scalaBinaryVersion)

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -439,7 +439,7 @@ class WorksheetProvider(
             info.scalaVersion,
             ScalaVersions.scalaBinaryVersionFromFullVersion(info.scalaVersion)
           )
-          .withClasspath(info.fullClasspath.asScala.distinct.asJava)
+          .withClasspath(info.fullClasspath.distinct.asJava)
           .withScalacOptions(scalacOptions)
         mdocs(key) = MdocRef(scalaVersion, mdoc)
         mdoc


### PR DESCRIPTION
This fixes issues with organize imports in some projects such as Bloop.

Fixes https://github.com/scalameta/metals/issues/2903

Previously if there was a file on classpath that was not a jar Scalafix would fail. Now we filter the classpath to only send jars or directories.