### PR TITLE
Fix process exiting

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
@@ -42,6 +42,7 @@ final class FileWatcher(
 ) extends Cancelable {
   import FileWatcher._
 
+  @volatile
   private var disposeAction: Option[() => Unit] = None
 
   override def cancel(): Unit = {

--- a/metals/src/main/scala/scala/meta/metals/Main.scala
+++ b/metals/src/main/scala/scala/meta/metals/Main.scala
@@ -73,6 +73,9 @@ object Main {
         sys.exit(1)
     } finally {
       server.cancelAll()
+      ec.shutdownNow()
+
+      sys.exit(0)
     }
   }
 


### PR DESCRIPTION
Use `sys.exit(0)` to stop all threads to avoid hanged process.

In some cases (if metals was closed just right after build import/
during import) there is some thread from unknown thread pool that keep
process alive.

I've checked all places in our codebase but haven't found anything.
Probably it starts somwehere in dependency so `sys.exit(0)` is the only
solution here.