### PR TITLE
Separate indentation on paste to a command instead of automatic

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Command.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Command.scala
@@ -18,6 +18,7 @@ case class Command(
 }
 
 object Argument {
+  lazy val rangeParser = new JsonParser.Of[l.Range]
 
   def getAsString(obj: AnyRef): Option[String] = {
     obj match {
@@ -29,6 +30,21 @@ object Argument {
   def getAsInt(obj: AnyRef): Option[Int] = {
     obj match {
       case p: JsonPrimitive if p.isNumber => Option(p.getAsInt())
+      case _ => None
+    }
+  }
+
+  def getAsBoolean(obj: AnyRef): Option[Boolean] = {
+    obj match {
+      case p: JsonPrimitive if p.isBoolean => Option(p.getAsBoolean())
+      case _ => None
+    }
+  }
+
+  def getAsRange(obj: AnyRef): Option[l.Range] = {
+    obj match {
+      case rangeParser.Jsonized(range) =>
+        Option(range)
       case _ => None
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -105,6 +105,11 @@ object Messages {
     "Could not extract the given definition, please check the logs for more details or report an issue."
   )
 
+  val PasteWithIndentationFailed = new MessageParams(
+    MessageType.Error,
+    "Could not paste with indentation, please check the metals.log for more details or report an issue."
+  )
+
   val ReloadProjectFailed = new MessageParams(
     MessageType.Error,
     "Reloading your project failed, no functionality will work. See the log for more details"

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -326,6 +326,18 @@ object ServerCommands {
        |""".stripMargin
   )
 
+  val PasteWithIndentation = new Command(
+    "paste-with-indentation",
+    "Automatically adjust the indentation of a pasted snippet",
+    """|Whenever a user send an indented snippet this command will adjust it
+       |to fit the last known indentation within a block.
+       |""".stripMargin,
+    """|[uri, range, tabSize, insertSpaces], uri to the document that the command needs to be invoked on 
+       |together with the range of where it's pasted, the size of a single tab and
+       |a flag stating whether the editor prefers spaces.
+       |""".stripMargin
+  )
+
   /**
    * Open the browser at the given url.
    */
@@ -416,6 +428,7 @@ object ServerCommands {
       InsertInferredType,
       NewScalaFile,
       NewScalaProject,
+      PasteWithIndentation,
       ResetChoicePopup,
       RestartBuildServer,
       RunDoctor,

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -698,6 +698,32 @@ final class TestingServer(
     }
   }
 
+  def indentOnPaste(
+      filename: String,
+      query: String,
+      expected: String,
+      paste: String,
+      root: AbsolutePath,
+      formattingOptions: Option[FormattingOptions]
+  ): Future[Unit] =
+    for {
+      (_, params) <- rangeFormattingParams(
+        filename,
+        query,
+        paste,
+        root,
+        formattingOptions
+      )
+      multiline <- executeCommand(
+        ServerCommands.PasteWithIndentation.id,
+        params.getTextDocument().getUri(),
+        params.getRange(),
+        params.getOptions().getTabSize().asInstanceOf[Integer],
+        params.getOptions().isInsertSpaces().asInstanceOf[java.lang.Boolean]
+      )
+      format = bufferContents(filename)
+    } yield Assertions.assertNoDiff(format, expected)
+
   def rangeFormatting(
       filename: String,
       query: String,

--- a/tests/unit/src/test/scala/tests/rangeFormatting/IndentWhenPastingSuite.scala
+++ b/tests/unit/src/test/scala/tests/rangeFormatting/IndentWhenPastingSuite.scala
@@ -478,7 +478,7 @@ class IndentWhenPastingSuite
       """.stripMargin + base
         )
         _ <- server.didOpen("a/src/main/scala/a/Main.scala")
-        _ <- server.rangeFormatting(
+        _ <- server.indentOnPaste(
           "a/src/main/scala/a/Main.scala",
           testCase, // bez @@
           expected,

--- a/tests/unit/src/test/scala/tests/rangeFormatting/MultilineStringRangeFormattingWhenPastingSuite.scala
+++ b/tests/unit/src/test/scala/tests/rangeFormatting/MultilineStringRangeFormattingWhenPastingSuite.scala
@@ -222,8 +222,8 @@ class MultilineStringRangeFormattingWhenPastingSuite
        |object Main {
        |  val str = '''
        |  |first line
-       |  second line
-       |   different indent
+       |second line
+       | different indent
        |  '''
        |}""".stripMargin
   )
@@ -327,6 +327,7 @@ class MultilineStringRangeFormattingWhenPastingSuite
        |object Main {
        |  val str = s'''
        |               |ok'''.stripMargin
+       |  
        |  val other = '''
        |              |  some text
        |              |'''.stripMargin


### PR DESCRIPTION
Previously, we will automatically adjust indentation whenever user pasted anything, which might have caused unexpected results. Now, we have a separate command that can be used whenever the user wants to explicitely adjust indentation (for example when pasting from another location with different indentation level). This is done the same in the Python LSP extension.

I will follow up soon with a VS Code PR, but wanted to get this into the next release if possible.