### PR TITLE
Add setting to enable indentation on paste

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -213,7 +213,7 @@ class MetalsLanguageServer(
   private val onTypeFormattingProvider =
     new OnTypeFormattingProvider(buffers, trees, () => userConfig)
   private val rangeFormattingProvider =
-    new RangeFormattingProvider(buffers, trees)
+    new RangeFormattingProvider(buffers, trees, () => userConfig)
   private val classFinder = new ClassFinder(trees)
   private val foldingRangeProvider = new FoldingRangeProvider(trees, buffers)
   // These can't be instantiated until we know the workspace root directory.

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -40,6 +40,7 @@ case class UserConfiguration(
     showImplicitConversionsAndClasses: Boolean = false,
     remoteLanguageServer: Option[String] = None,
     enableStripMarginOnTypeFormatting: Boolean = true,
+    enableIndentOnPaste: Boolean = false,
     excludedPackages: Option[List[String]] = None,
     fallbackScalaVersion: Option[String] = None
 ) {
@@ -209,6 +210,15 @@ object UserConfiguration {
         """|When this option is enabled, each place where an implicit method or class is used has it 
            |displayed either as additional decorations if they are supported by the editor or 
            |shown in the hover.
+           |""".stripMargin
+      ),
+      UserConfigurationOption(
+        "enable-indent-on-paste",
+        "false",
+        "false",
+        "Should try adjust indentation on range formatting.",
+        """|When this option is enabled, when user pastes any snippet into a Scala file, Metals
+           |will try to adjust the indentation to that of the current cursor.
            |""".stripMargin
       ),
       UserConfigurationOption(
@@ -384,6 +394,8 @@ object UserConfiguration {
       getStringKey("remote-language-server")
     val enableStripMarginOnTypeFormatting =
       getBooleanKey("enable-strip-margin-on-type-formatting").getOrElse(true)
+    val enableIndentOnPaste =
+      getBooleanKey("enable-indent-on-paste").getOrElse(true)
     val excludedPackages =
       getStringListKey("excluded-packages")
     // `automatic` should be treated as None
@@ -412,6 +424,7 @@ object UserConfiguration {
           showImplicitConversionsAndClasses,
           remoteLanguageServer,
           enableStripMarginOnTypeFormatting,
+          enableIndentOnPaste,
           excludedPackages,
           defaultScalaVersion
         )

--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/RangeFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/RangeFormattingProvider.scala
@@ -31,12 +31,12 @@ trait RangeFormatter {
 
 class RangeFormattingProvider(
     buffers: Buffers,
-    trees: Trees
+    trees: Trees,
+    userConfig: () => UserConfiguration
 ) {
   val formatters: List[RangeFormatter] = List(
-    // enableStripMargin is not used on rangeFormatting
-    MultilineString(() => UserConfiguration()),
-    IndentOnPaste
+    MultilineString(userConfig),
+    IndentOnPaste(userConfig)
   )
 
   def format(

--- a/tests/unit/src/test/scala/tests/rangeFormatting/IndentWhenPastingSuite.scala
+++ b/tests/unit/src/test/scala/tests/rangeFormatting/IndentWhenPastingSuite.scala
@@ -1,6 +1,7 @@
 package tests.rangeFormatting
 
 import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.UserConfiguration
 
 import munit.Location
 import munit.TestOptions
@@ -25,6 +26,9 @@ class IndentWhenPastingSuite
   )
 
   val blank = " "
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(enableIndentOnPaste = true)
 
   check(
     "single-line",

--- a/tests/unit/src/test/scala/tests/rangeFormatting/MultilineStringRangeFormattingWhenPastingSuite.scala
+++ b/tests/unit/src/test/scala/tests/rangeFormatting/MultilineStringRangeFormattingWhenPastingSuite.scala
@@ -1,5 +1,7 @@
 package tests.rangeFormatting
 
+import scala.meta.internal.metals.UserConfiguration
+
 import munit.Location
 import munit.TestOptions
 import org.eclipse.lsp4j.FormattingOptions
@@ -13,6 +15,9 @@ class MultilineStringRangeFormattingWhenPastingSuite
     /** insertSpaces */
     true
   )
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(enableIndentOnPaste = true)
 
   check(
     "lines",

--- a/tests/unit/src/test/scala/tests/rangeFormatting/MultilineStringRangeFormattingWhenSelectingSuite.scala
+++ b/tests/unit/src/test/scala/tests/rangeFormatting/MultilineStringRangeFormattingWhenSelectingSuite.scala
@@ -1,5 +1,7 @@
 package tests.rangeFormatting
 
+import scala.meta.internal.metals.UserConfiguration
+
 import munit.Location
 import munit.TestOptions
 import org.eclipse.lsp4j.FormattingOptions
@@ -7,6 +9,10 @@ import tests.BaseLspSuite
 
 class MultilineStringRangeFormattingWhenSelectingSuite
     extends BaseLspSuite("rangeFormatting") {
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(enableIndentOnPaste = true)
+
   check(
     "start-misindent-line",
     s"""


### PR DESCRIPTION
I think we pushed it too hard and although I am happy with the current state it's still a bit controvertial, so I'd rather have an easy way of turning it off and on.

Also it seems that turning off `Format on paste` doesn't do anything.

PS: The changes are mostly whitespace related, I recommend turning on `Ignore whitespace changes`