### PR TITLE
Support more scenarios with 'replace () with {}' code action

### DIFF
--- a/tests/unit/src/test/scala/tests/codeactions/BracesParensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/BracesParensLspSuite.scala
@@ -1,12 +1,28 @@
 package tests.codeactions
 
+import scala.meta.internal.metals.codeactions.PatternMatchRefactor
 import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
 
 class BracesParensLspSuite
-    extends BaseCodeActionLspSuite("implementAbstractMembers") {
+    extends BaseCodeActionLspSuite("bracesParensRewrite") {
 
   check(
-    "to-braces",
+    "to-braces-1",
+    """|object Main {
+       |  def foo(n: Int) = ???
+       |  foo(<<>>5)
+       |}
+       |""".stripMargin,
+    RewriteBracesParensCodeAction.toBraces,
+    """|object Main {
+       |  def foo(n: Int) = ???
+       |  foo{5}
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "to-braces-2",
     """|object Main {
        |  var x = 0
        |  List(1,2).map ( a => <<>>a )
@@ -21,7 +37,43 @@ class BracesParensLspSuite
   )
 
   check(
-    "to-parens",
+    "to-braces-3",
+    """|object Main {
+       |  val x = List(1, 2, 3)
+       |  x.map(_ ma<<>>tch {
+       |    case 1 => 0
+       |    case _ => 1
+       |  })
+       |}
+       |""".stripMargin,
+    RewriteBracesParensCodeAction.toBraces,
+    """|object Main {
+       |  val x = List(1, 2, 3)
+       |  x.map{_ match {
+       |    case 1 => 0
+       |    case _ => 1
+       |  }}
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "to-parens-1",
+    """|object Main {
+       |  def foo(n: Int) = ???
+       |  foo{<<>>5}
+       |}
+       |""".stripMargin,
+    RewriteBracesParensCodeAction.toParens,
+    """|object Main {
+       |  def foo(n: Int) = ???
+       |  foo(5)
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "to-parens-2",
     """|object Main {
        |  var x = 0
        |  List(1,2).map { a => <<>>a }
@@ -36,12 +88,35 @@ class BracesParensLspSuite
   )
 
   check(
-    "to-parens",
+    "to-parens-3",
+    """|object Main {
+       |  val x = List(1, 2, 3)
+       |  x.map{_ ma<<>>tch {
+       |    case 1 => 0
+       |    case _ => 1
+       |  }}
+       |}
+       |""".stripMargin,
+    s"""|${PatternMatchRefactor.convertPatternMatch}
+        |${RewriteBracesParensCodeAction.toParens}""".stripMargin,
+    """|object Main {
+       |  val x = List(1, 2, 3)
+       |  x.map(_ match {
+       |    case 1 => 0
+       |    case _ => 1
+       |  })
+       |}
+       |""".stripMargin,
+    selectedActionIndex = 1
+  )
+
+  check(
+    "to-parens-noop",
     """|object Main {
        |  var x = 0
        |  List(1,2).map { a =>
-       |  <<println(a)>>
-       |    a 
+       |    println(a)
+       |    <<>>a 
        |  }
        |}
        |""".stripMargin,
@@ -49,7 +124,7 @@ class BracesParensLspSuite
     """|object Main {
        |  var x = 0
        |  List(1,2).map { a =>
-       |  println(a)
+       |    println(a)
        |    a 
        |  }
        |}

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertPatternMatchLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertPatternMatchLspSuite.scala
@@ -3,7 +3,7 @@ package tests.codeactions
 import scala.meta.internal.metals.codeactions.PatternMatchRefactor
 
 class PatternMatchRefactorLspSuite
-    extends BaseCodeActionLspSuite("implementAbstractMembers") {
+    extends BaseCodeActionLspSuite("patternMatchRefactor") {
 
   check(
     "with-placeholder",

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertPatternMatchLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertPatternMatchLspSuite.scala
@@ -1,6 +1,7 @@
 package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.PatternMatchRefactor
+import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
 
 class PatternMatchRefactorLspSuite
     extends BaseCodeActionLspSuite("patternMatchRefactor") {
@@ -59,7 +60,9 @@ class PatternMatchRefactorLspSuite
        |  }}
        |}
        |""".stripMargin,
-    PatternMatchRefactor.convertPatternMatch,
+    s"""|${PatternMatchRefactor.convertPatternMatch}
+        |${RewriteBracesParensCodeAction.toParens}
+        |""".stripMargin,
     """|object Main {
        |  var x = 0
        |  List(1,2).map { 

--- a/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
@@ -4,7 +4,7 @@ import scala.meta.internal.metals.codeactions.InsertInferredType
 import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
 
 class InsertInferredTypeLspSuite
-    extends BaseCodeActionLspSuite("implementAbstractMembers") {
+    extends BaseCodeActionLspSuite("insertInferredType") {
 
   check(
     "val",


### PR DESCRIPTION
Aims to close https://github.com/scalameta/metals-feature-requests/issues/233.

I've found a scenario when rewrite parens action didn't work. Then I found an issue created by @agilesteel so I fed two birds with one seed :D