### PR TITLE
View source jar files as virtual docs

### DIFF
--- a/metals-bench/src/main/scala/bench/Inflated.scala
+++ b/metals-bench/src/main/scala/bench/Inflated.scala
@@ -35,7 +35,7 @@ object Inflated {
       var lines = 0L
       val buf = List.newBuilder[Input.VirtualFile]
       FileIO.listAllFilesRecursively(root).foreach { file =>
-        val path = file.toString()
+        val path = file.toURI.toString()
         val text = FileIO.slurp(file, StandardCharsets.UTF_8)
         lines += text.linesIterator.length
         buf += Input.VirtualFile(path, text)

--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -519,10 +519,11 @@ final class SyntheticsDecorationProvider(
     } yield pos
 
     val allMissingTypeRanges = declarationsWithoutTypes.toSet
+    val uri = path.toURI.toString
     val typeDecorations = for {
       tree <- trees.get(path).toIterable
-      textDocumentInput = Input.VirtualFile(textDocument.uri, textDocument.text)
-      treeInput = Input.VirtualFile(textDocument.uri, tree.pos.input.text)
+      textDocumentInput = Input.VirtualFile(uri, textDocument.text)
+      treeInput = Input.VirtualFile(uri, tree.pos.input.text)
       semanticDbToTreeEdit = TokenEditDistance(
         textDocumentInput,
         treeInput,

--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -59,10 +59,11 @@ final class ImplementationProvider(
   }
 
   override def onChange(docs: TextDocuments, path: AbsolutePath): Unit = {
-    implementationsInPath.compute(
-      path.toNIO,
-      { (_, _) => computeInheritance(docs) }
-    )
+    if (!path.isJarFileSystem)
+      implementationsInPath.compute(
+        path.toNIO,
+        { (_, _) => computeInheritance(docs) }
+      )
   }
 
   private def computeInheritance(
@@ -313,10 +314,14 @@ final class ImplementationProvider(
     allLocations.asScala
   }
 
-  private def findSemanticdb(fileSource: AbsolutePath): Option[TextDocument] =
-    semanticdbs
-      .textDocument(fileSource)
-      .documentIncludingStale
+  private def findSemanticdb(fileSource: AbsolutePath): Option[TextDocument] = {
+    if (fileSource.isJarFileSystem)
+      None
+    else
+      semanticdbs
+        .textDocument(fileSource)
+        .documentIncludingStale
+  }
 
   private def findImplementation(
       symbol: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -54,6 +54,9 @@ case class ClientConfiguration(initialConfig: MetalsServerConfig) {
   def commandInHtmlFormat(): Option[CommandHTMLFormat] =
     initializationOptions.commandInHtmlFormat
 
+  def isVirtualDocumentSupported(): Boolean =
+    initializationOptions.isVirtualDocumentSupported.getOrElse(false)
+
   def icons(): Icons =
     initializationOptions.icons
       .map(Icons.fromString)

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -146,7 +146,8 @@ class Compilers(
                   isExcludedPackage,
                   userConfig,
                   trees,
-                  buildTargets
+                  buildTargets,
+                  saveSymbolFileToDisk = !config.isVirtualDocumentSupported()
                 )
               ).getOrElse(EmptySymbolSearch),
               "default",
@@ -482,6 +483,7 @@ class Compilers(
             isExcludedPackage,
             trees,
             buildTargets,
+            saveSymbolFileToDisk = !config.isVirtualDocumentSupported(),
             workspaceFallback = Some(search)
           )
           newCompiler(
@@ -512,7 +514,8 @@ class Compilers(
               isExcludedPackage,
               userConfig,
               trees,
-              buildTargets
+              buildTargets,
+              saveSymbolFileToDisk = !config.isVirtualDocumentSupported()
             ),
             path.toString(),
             path

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -53,7 +53,8 @@ final class DefinitionProvider(
     remote: RemoteLanguageServer,
     trees: Trees,
     buildTargets: BuildTargets,
-    scalaVersionSelector: ScalaVersionSelector
+    scalaVersionSelector: ScalaVersionSelector,
+    saveDefFileToDisk: Boolean
 )(implicit ec: ExecutionContext) {
 
   val destinationProvider = new DestinationProvider(
@@ -63,7 +64,8 @@ final class DefinitionProvider(
     workspace,
     Some(semanticdbs),
     trees,
-    buildTargets
+    buildTargets,
+    saveDefFileToDisk
   )
 
   def definition(
@@ -270,7 +272,8 @@ class DestinationProvider(
     workspace: AbsolutePath,
     semanticdbsFallback: Option[Semanticdbs],
     trees: Trees,
-    buildTargets: BuildTargets
+    buildTargets: BuildTargets,
+    saveSymbolFileToDisk: Boolean
 ) {
 
   private def bestTextDocument(
@@ -350,7 +353,9 @@ class DestinationProvider(
   ): Option[DefinitionDestination] = {
     definition(symbol, allowedBuildTargets).map { defn =>
       val destinationDoc = bestTextDocument(defn)
-      val destinationPath = defn.path.toFileOnDisk(workspace)
+      val destinationPath =
+        if (saveSymbolFileToDisk) defn.path.toFileOnDisk(workspace)
+        else defn.path
       val destinationDistance =
         buffers.tokenEditDistance(destinationPath, destinationDoc.text, trees)
       DefinitionDestination(

--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -3,9 +3,7 @@ package scala.meta.internal.metals
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.net.URI
-import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
-import java.nio.file.Paths
 import javax.annotation.Nullable
 
 import scala.annotation.tailrec
@@ -170,12 +168,7 @@ final class FileDecoderProvider(
 
   private def decodeJar(uri: URI): DecoderResponse = {
     Try {
-      // jar file system cannot cope with a heavily encoded uri
-      // hence the roundabout way of creating an AbsolutePath
-      // must have "jar:file:"" instead of "jar:file%3A"
-      val decodedUriStr = URLDecoder.decode(uri.toString(), "UTF-8")
-      val decodedUri = URI.create(decodedUriStr)
-      val path = AbsolutePath(Paths.get(decodedUri))
+      val path = uri.toAbsolutePath
       FileIO.slurp(path, StandardCharsets.UTF_8)
     } match {
       case Failure(exception) => DecoderResponse.failed(uri, exception)

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -32,6 +32,9 @@ import org.eclipse.{lsp4j => l}
  * @param inputBoxProvider if the client implements `metals/inputBox`.
  * @param isExitOnShutdown whether the client needs Metals to shut down manually on exit.
  * @param isHttpEnabled whether the client needs Metals to start an HTTP client interface.
+ * @param isVirtualDocumentSupported whether the client supports VirtualDocuments.
+ *                                   For opening source jars in read-only
+ * `*                    https://code.visualstudio.com/api/extension-guides/virtual-documents
  * @param openFilesOnRenameProvider whether or not the client supports opening files on rename.
  * @param quickPickProvider if the client implements `metals/quickPick`.
  * @param renameFileThreshold amount of files that should be opened during rename if client
@@ -60,6 +63,7 @@ final case class InitializationOptions(
     isExitOnShutdown: Option[Boolean],
     isHttpEnabled: Option[Boolean],
     commandInHtmlFormat: Option[CommandHTMLFormat],
+    isVirtualDocumentSupported: Option[Boolean],
     openFilesOnRenameProvider: Option[Boolean],
     quickPickProvider: Option[Boolean],
     renameFileThreshold: Option[Int],
@@ -83,6 +87,7 @@ object InitializationOptions {
 
   val Default: InitializationOptions = InitializationOptions(
     CompilerInitializationOptions.default,
+    None,
     None,
     None,
     None,
@@ -145,6 +150,8 @@ object InitializationOptions {
       commandInHtmlFormat = jsonObj
         .getStringOption("commandInHtmlFormat")
         .flatMap(CommandHTMLFormat.fromString),
+      isVirtualDocumentSupported =
+        jsonObj.getBooleanOption("isVirtualDocumentSupported"),
       openFilesOnRenameProvider =
         jsonObj.getBooleanOption("openFilesOnRenameProvider"),
       quickPickProvider = jsonObj.getBooleanOption("quickPickProvider"),

--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -75,7 +75,7 @@ final class InteractiveSemanticdbs(
           source.isSbt || // sbt files
           source.isWorksheet || // worksheets
           doesNotBelongToBuildTarget // standalone files
-      )
+      ) || source.isJarFileSystem // dependencies
     }
 
     // anything aside from `*.scala`, `*.sbt`, `*.sc`, `*.java` file

--- a/metals/src/main/scala/scala/meta/internal/metals/JarTopLevels.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JarTopLevels.scala
@@ -9,6 +9,7 @@ import java.util.zip.ZipError
 
 import scala.meta.internal.io.PlatformFileIO
 import scala.meta.internal.metals.JdbcEnrichments._
+import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.mtags.MD5
 import scala.meta.io.AbsolutePath
 
@@ -29,7 +30,14 @@ final class JarTopLevels(conn: () => Connection) {
       path: AbsolutePath
   ): Option[List[(String, AbsolutePath)]] =
     try {
-      val fs = PlatformFileIO.newJarFileSystem(path, create = false)
+      val fs = path.jarPath
+        .map(jarPath =>
+          PlatformFileIO.newFileSystem(
+            jarPath.toURI,
+            new java.util.HashMap[String, String]()
+          )
+        )
+        .getOrElse(PlatformFileIO.newJarFileSystem(path, create = false))
       val toplevels = List.newBuilder[(String, AbsolutePath)]
       conn()
         .query(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -27,7 +27,9 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
+import scala.util.Failure
 import scala.util.Properties
+import scala.util.Success
 import scala.util.Try
 import scala.util.control.NonFatal
 import scala.{meta => m}
@@ -289,7 +291,7 @@ object MetalsEnrichments
     }
     def isDependencySource(workspace: AbsolutePath): Boolean = {
       (isLocalFileSystem(workspace) &&
-      isInReadonlyDirectory(workspace))
+        isInReadonlyDirectory(workspace)) || isJarFileSystem
     }
 
     def isWorkspaceSource(workspace: AbsolutePath): Boolean =
@@ -300,7 +302,8 @@ object MetalsEnrichments
     def isLocalFileSystem(workspace: AbsolutePath): Boolean =
       workspace.toNIO.getFileSystem == path.toNIO.getFileSystem
 
-    def isJarFileSystem: Boolean = path.toURI.getScheme() == "jar"
+    def isJarFileSystem: Boolean =
+      path.toNIO.getFileSystem().provider().getScheme().equals("jar")
 
     def isInReadonlyDirectory(workspace: AbsolutePath): Boolean =
       path.toNIO.startsWith(
@@ -395,7 +398,7 @@ object MetalsEnrichments
         AbsolutePath(out)
       }
 
-      // prevent inifinity loop
+      // prevent infinity loop
       if (retryCount > 5) {
         throw new Exception(s"Unable to save $path in workspace")
       } else if (path.toNIO.getFileSystem == workspace.toNIO.getFileSystem) {
@@ -530,6 +533,32 @@ object MetalsEnrichments
 
   }
 
+  implicit class XtensionURI(value: URI) {
+    def toAbsolutePath: AbsolutePath = toAbsolutePath(followSymlink = true)
+    def toAbsolutePath(followSymlink: Boolean): AbsolutePath = {
+      val path =
+        if (value.getScheme() == "jar")
+          Try {
+            AbsolutePath(Paths.get(value))
+          } match {
+            case Success(path) => path
+            case Failure(_) =>
+              // don't close - put up with the resource staying open so all AbsolutePath methods don't have to be wrapped
+              m.internal.io.PlatformFileIO.newFileSystem(
+                value,
+                new java.util.HashMap[String, String]()
+              )
+              AbsolutePath(Paths.get(value))
+          }
+        else
+          AbsolutePath(Paths.get(value))
+      if (followSymlink)
+        path.dealias
+      else
+        path
+    }
+  }
+
   implicit class XtensionString(value: String) {
 
     /**
@@ -588,17 +617,12 @@ object MetalsEnrichments
     def toAbsolutePath(followSymlink: Boolean): AbsolutePath = {
       // jar schemes must have "jar:file:"" instead of "jar:file%3A" or jar file system won't recognise the URI.
       // but don't overdecode as URIs may not be recognised e.g. "com-microsoft-java-debug-core-0.32.0%2B1.jar" is correct
-      val decodedUriStr =
-        if (value.toUpperCase.startsWith("JAR:FILE%3A"))
-          URLDecoder.decode(value, "UTF-8")
-        else value
-      val path = AbsolutePath(
-        Paths.get(URI.create(decodedUriStr.stripPrefix("metals:")))
-      )
-      if (followSymlink)
-        path.dealias
+      if (value.toUpperCase.startsWith("JAR%3AFILE"))
+        URLDecoder.decode(value, "UTF-8").toAbsolutePath(followSymlink)
+      else if (value.toUpperCase.startsWith("JAR:FILE%3A"))
+        URLDecoder.decode(value, "UTF-8").toAbsolutePath(followSymlink)
       else
-        path
+        URI.create(value.stripPrefix("metals:")).toAbsolutePath(followSymlink)
     }
 
     def indexToLspPosition(index: Int): l.Position = {
@@ -737,7 +761,7 @@ object MetalsEnrichments
   implicit class XtensionClasspath(classpath: List[String]) {
     def toAbsoluteClasspath: Iterator[AbsolutePath] = {
       classpath.iterator
-        .map(uri => AbsolutePath(Paths.get(URI.create(uri))))
+        .map(_.toAbsolutePath)
         .filter(p => Files.exists(p.toNIO))
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -311,9 +311,14 @@ object MetalsEnrichments
       )
 
     def toRelativeInside(prefix: AbsolutePath): Option[RelativePath] = {
-      val relative = path.toRelative(prefix)
-      if (relative.toNIO.getName(0).filename != "..") Some(relative)
-      else None
+      // windows throws an exception on toRelative when on different drives
+      if (path.toNIO.getRoot() != prefix.toNIO.getRoot())
+        None
+      else {
+        val relative = path.toRelative(prefix)
+        if (relative.toNIO.getName(0).filename != "..") Some(relative)
+        else None
+      }
     }
 
     def isInside(prefix: AbsolutePath): Boolean =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -333,7 +333,7 @@ class MetalsLanguageServer(
       case None =>
         languageClient.showMessage(Messages.noRoot)
       case Some(path) =>
-        workspace = AbsolutePath(Paths.get(URI.create(path))).dealias
+        workspace = path.toAbsolutePath
         MetalsLogger.setupLspLogger(workspace, redirectSystemOut)
 
         val clientInfo = Option(params.getClientInfo()) match {
@@ -506,7 +506,8 @@ class MetalsLanguageServer(
           remote,
           trees,
           buildTargets,
-          scalaVersionSelector
+          scalaVersionSelector,
+          saveDefFileToDisk = !clientConfig.isVirtualDocumentSupported()
         )
         formattingProvider = new FormattingProvider(
           workspace,
@@ -642,6 +643,7 @@ class MetalsLanguageServer(
           workspace,
           buildTargets,
           definitionIndex,
+          saveClassFileToDisk = !clientConfig.isVirtualDocumentSupported(),
           excludedPackageHandler.isExcludedPackage
         )
         symbolSearch = new MetalsSymbolSearch(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -803,7 +803,8 @@ class MetalsLanguageServer(
         findTextInJars = new FindTextInDependencyJars(
           buildTargets,
           () => workspace,
-          languageClient
+          languageClient,
+          saveJarFileToDisk = !clientConfig.isVirtualDocumentSupported()
         )
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/PackageProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/PackageProvider.scala
@@ -44,7 +44,9 @@ class PackageProvider(private val buildTargets: BuildTargets) {
       }
     }
 
-    if (path.isScalaOrJava && path.toFile.length() == 0) {
+    if (
+      path.isScalaOrJava && !path.isJarFileSystem && path.toFile.length() == 0
+    ) {
       buildTargets
         .inverseSourceItem(path)
         .map(path.toRelative)

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -26,6 +26,7 @@ class StandaloneSymbolSearch(
     isExcludedPackage: String => Boolean,
     trees: Trees,
     buildTargets: BuildTargets,
+    saveSymbolFileToDisk: Boolean,
     workspaceFallback: Option[SymbolSearch] = None
 ) extends SymbolSearch {
 
@@ -52,7 +53,8 @@ class StandaloneSymbolSearch(
       workspace,
       semanticdbsFallback = None,
       trees,
-      buildTargets
+      buildTargets,
+      saveSymbolFileToDisk
     )
 
   def documentation(symbol: String): ju.Optional[SymbolDocumentation] =
@@ -109,7 +111,8 @@ object StandaloneSymbolSearch {
       isExcludedPackage: String => Boolean,
       userConfig: () => UserConfiguration,
       trees: Trees,
-      buildTargets: BuildTargets
+      buildTargets: BuildTargets,
+      saveSymbolFileToDisk: Boolean
   ): StandaloneSymbolSearch = {
     val (sourcesWithExtras, classpathWithExtras) =
       addScalaAndJava(
@@ -126,7 +129,8 @@ object StandaloneSymbolSearch {
       buffers,
       isExcludedPackage,
       trees,
-      buildTargets
+      buildTargets,
+      saveSymbolFileToDisk
     )
   }
   def apply(
@@ -136,7 +140,8 @@ object StandaloneSymbolSearch {
       isExcludedPackage: String => Boolean,
       userConfig: () => UserConfiguration,
       trees: Trees,
-      buildTargets: BuildTargets
+      buildTargets: BuildTargets,
+      saveSymbolFileToDisk: Boolean
   ): StandaloneSymbolSearch = {
     val (sourcesWithExtras, classpathWithExtras) =
       addScalaAndJava(scalaVersion, Nil, Nil, userConfig().javaHome)
@@ -148,7 +153,8 @@ object StandaloneSymbolSearch {
       buffers,
       isExcludedPackage,
       trees,
-      buildTargets
+      buildTargets,
+      saveSymbolFileToDisk
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSearchVisitor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSearchVisitor.scala
@@ -30,7 +30,8 @@ class WorkspaceSearchVisitor(
     workspace: AbsolutePath,
     query: WorkspaceSymbolQuery,
     token: CancelChecker,
-    index: GlobalSymbolIndex
+    index: GlobalSymbolIndex,
+    saveClassFileToDisk: Boolean
 ) extends SymbolSearchVisitor {
   private val fromWorkspace = new ju.ArrayList[l.SymbolInformation]()
   private val fromClasspath = new ju.ArrayList[l.SymbolInformation]()
@@ -132,7 +133,10 @@ class WorkspaceSearchVisitor(
       val input = defn.path.toInput
       SemanticdbDefinition.foreach(input, defn.dialect) { semanticDefn =>
         if (query.matches(semanticDefn.info)) {
-          val uri = defn.path.toFileOnDisk(workspace).toURI.toString
+          val path =
+            if (saveClassFileToDisk) defn.path.toFileOnDisk(workspace)
+            else defn.path
+          val uri = path.toURI.toString
           fromClasspath.add(semanticDefn.toLSP(uri))
           isHit = true
         }

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -24,6 +24,7 @@ final class WorkspaceSymbolProvider(
     val workspace: AbsolutePath,
     val buildTargets: BuildTargets,
     val index: GlobalSymbolIndex,
+    saveClassFileToDisk: Boolean,
     isExcludedPackage: String => Boolean,
     bucketSize: Int = CompressedPackageIndex.DefaultBucketSize
 ) {
@@ -142,7 +143,13 @@ final class WorkspaceSymbolProvider(
   ): Seq[l.SymbolInformation] = {
     val query = WorkspaceSymbolQuery.fromTextQuery(textQuery)
     val visitor =
-      new WorkspaceSearchVisitor(workspace, query, token, index)
+      new WorkspaceSearchVisitor(
+        workspace,
+        query,
+        token,
+        index,
+        saveClassFileToDisk
+      )
     search(query, visitor, None)
     visitor.allResults()
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractRenameMember.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractRenameMember.scala
@@ -43,7 +43,7 @@ class ExtractRenameMember(
 
     trees.get(path) match {
       case Some(tree) =>
-        val fileName = uri.toAbsolutePath.filename.replaceAll("\\.scala$", "")
+        val fileName = path.filename.replaceAll("\\.scala$", "")
 
         val definitions = membersDefinitions(tree)
         val sldNames = sealedNames(tree)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/ClientConfigurationAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/ClientConfigurationAdapter.scala
@@ -52,7 +52,8 @@ private[debug] final case class ClientConfigurationAdapter(
 
   def adaptPathForClient(path: AbsolutePath): String = {
     pathFormat match {
-      case InitializeRequestArgumentsPathFormat.PATH => path.toString
+      case InitializeRequestArgumentsPathFormat.PATH =>
+        if (path.isJarFileSystem) path.toURI.toString else path.toString
       case InitializeRequestArgumentsPathFormat.URI => path.toURI.toString
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -152,7 +152,8 @@ class DebugProvider(
         if (buildServer.usesScalaDebugAdapter2x) {
           MetalsDebugAdapter.`2.x`(
             buildTargets,
-            targets
+            targets,
+            saveJarFileToDisk = !clientConfig.isVirtualDocumentSupported()
           )
         } else {
           MetalsDebugAdapter.`1.x`(

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/MetalsDebugAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/MetalsDebugAdapter.scala
@@ -63,9 +63,11 @@ private[debug] object MetalsDebugAdapter {
 
   def `2.x`(
       buildTargets: BuildTargets,
-      targets: Seq[BuildTargetIdentifier]
+      targets: Seq[BuildTargetIdentifier],
+      saveJarFileToDisk: Boolean
   ): MetalsDebugAdapter2x = {
-    val sourcePathAdapter = SourcePathAdapter(buildTargets, targets)
+    val sourcePathAdapter =
+      SourcePathAdapter(buildTargets, targets, saveJarFileToDisk)
     new MetalsDebugAdapter2x(sourcePathAdapter)
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/findfiles/FindTextInDependencyJars.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/findfiles/FindTextInDependencyJars.scala
@@ -24,7 +24,8 @@ import org.eclipse.lsp4j.Range
 class FindTextInDependencyJars(
     buildTargets: BuildTargets,
     workspace: () => AbsolutePath,
-    languageClient: MetalsLanguageClient
+    languageClient: MetalsLanguageClient,
+    saveJarFileToDisk: Boolean
 )(implicit ec: ExecutionContext) {
   import FindTextInDependencyJars._
 
@@ -111,7 +112,9 @@ class FindTextInDependencyJars(
           .flatMap { absPath =>
             val fileRanges: List[Range] = visitFileInsideJar(absPath, pattern)
             if (fileRanges.nonEmpty) {
-              val result = absPath.toFileOnDisk(workspace())
+              val result =
+                if (saveJarFileToDisk) absPath.toFileOnDisk(workspace())
+                else absPath
               fileRanges
                 .map(range => new Location(result.toURI.toString, range))
             } else Nil

--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/OnTypeFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/OnTypeFormattingProvider.scala
@@ -51,7 +51,7 @@ class OnTypeFormattingProvider(
     buffers
       .get(path)
       .map { sourceText =>
-        val virtualFile = Input.VirtualFile(path.toString(), sourceText)
+        val virtualFile = Input.VirtualFile(path.toURI.toString(), sourceText)
         val startPos = range.getStart.toMeta(virtualFile)
         val endPos = range.getEnd.toMeta(virtualFile)
         val tokensOpt = trees.tokenized(virtualFile).toOption

--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/RangeFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/RangeFormattingProvider.scala
@@ -48,7 +48,7 @@ class RangeFormattingProvider(
     buffers
       .get(path)
       .map { sourceText =>
-        val virtualFile = Input.VirtualFile(path.toString(), sourceText)
+        val virtualFile = Input.VirtualFile(path.toURI.toString(), sourceText)
         val startPos = range.getStart.toMeta(virtualFile)
         val endPos = range.getEnd.toMeta(virtualFile)
         val tokensOpt = trees.tokenized(virtualFile).toOption

--- a/metals/src/main/scala/scala/meta/internal/parsing/FoldingRangeProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/FoldingRangeProvider.scala
@@ -32,8 +32,9 @@ final class FoldingRangeProvider(
       if filePath.isScala
       tree <- trees.get(filePath)
     } yield {
-      val revised = Input.VirtualFile(filePath.toString(), code)
-      val fromTree = Input.VirtualFile(filePath.toString(), tree.pos.input.text)
+      val revised = Input.VirtualFile(filePath.toURI.toString(), code)
+      val fromTree =
+        Input.VirtualFile(filePath.toURI.toString(), tree.pos.input.text)
       val distance = TokenEditDistance(fromTree, revised, trees)
       val extractor = new FoldingRangeExtractor(distance, foldOnlyLines.get())
       extractor.extract(tree)

--- a/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
@@ -108,7 +108,7 @@ final class Trees(
   }
 
   def tokenized(input: inputs.Input.VirtualFile): Tokenized =
-    scalaVersionSelector.getDialect(AbsolutePath(input.path))(input).tokenize
+    scalaVersionSelector.getDialect(input.path.toAbsolutePath)(input).tokenize
 
   private def parse(
       path: AbsolutePath,
@@ -117,7 +117,7 @@ final class Trees(
     for {
       text <- buffers.get(path).orElse(path.readTextOpt)
     } yield {
-      val input = Input.VirtualFile(path.toString(), text)
+      val input = Input.VirtualFile(path.toURI.toString(), text)
       dialect(input).parse[Source]
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -284,7 +284,7 @@ class MetalsTreeViewProvider(
         (!isLeading, distance)
       }
       val result =
-        if (path.isDependencySource(workspace())) {
+        if (path.isDependencySource(workspace()) || path.isJarFileSystem) {
           buildTargets
             .inferBuildTarget(List(Symbol(closestSymbol.symbol).toplevel))
             .map { inferred =>

--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.mtags
 
 import java.net.URI
+import java.net.URLDecoder
 import java.nio.file.Paths
 import java.util.concurrent.CancellationException
 
@@ -95,8 +96,17 @@ trait MtagsEnrichments extends CommonMtagsEnrichments {
     def stripBackticks: String = value.stripPrefix("`").stripSuffix("`")
     def isBackticked: Boolean =
       value.size > 1 && value.head == '`' && value.last == '`'
-    def toAbsolutePath: AbsolutePath =
-      AbsolutePath(Paths.get(URI.create(value.stripPrefix("metals:")))).dealias
+    def toAbsolutePath: AbsolutePath = toAbsolutePath(true)
+    def toAbsolutePath(followSymlink: Boolean): AbsolutePath = {
+      val decodedUriStr =
+        URLDecoder.decode(value.stripPrefix("metals:"), "UTF-8")
+      val decodedUri = URI.create(decodedUriStr)
+      val path = AbsolutePath(Paths.get(decodedUri))
+      if (followSymlink)
+        path.dealias
+      else
+        path
+    }
     def lastIndexBetween(
         char: Char,
         lowerBound: Int,

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -519,9 +519,8 @@ trait CommonMtagsEnrichments {
     }
     def toInput: Input.VirtualFile = {
       val text = FileIO.slurp(path, StandardCharsets.UTF_8)
-      val file = path.toString()
-      val input = Input.VirtualFile(file, text)
-      input
+      val file = path.toURI.toString()
+      Input.VirtualFile(file, text)
     }
   }
 

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -9,7 +9,7 @@ import scala.meta.internal.semver.SemVer
 import munit.Flaky
 import munit.Tag
 
-class BaseSuite extends munit.FunSuite with Assertions {
+abstract class BaseSuite extends munit.FunSuite with Assertions {
 
   /**
    * Tests that are only flaky on Windows

--- a/tests/slow/src/test/scala/tests/feature/ClasspathSymbolRegressionSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/ClasspathSymbolRegressionSuite.scala
@@ -8,7 +8,7 @@ import scala.meta.io.AbsolutePath
 import tests.BaseWorkspaceSymbolSuite
 import tests.Library
 
-class ClasspathSymbolRegressionSuite extends BaseWorkspaceSymbolSuite {
+abstract class ClasspathSymbolRegressionSuite extends BaseWorkspaceSymbolSuite {
   var tmp: AbsolutePath = AbsolutePath(Files.createTempDirectory("metals"))
   override def libraries: List[Library] = Library.allScala2
   def workspace: AbsolutePath = tmp
@@ -194,4 +194,14 @@ class ClasspathSymbolRegressionSuite extends BaseWorkspaceSymbolSuite {
        |""".stripMargin
   )
 
+}
+
+class VirtualDocsClasspathSymbolRegressionSuite
+    extends ClasspathSymbolRegressionSuite {
+  override def saveClassFileToDisk: Boolean = false
+}
+
+class SaveToDiskClasspathSymbolRegressionSuite
+    extends ClasspathSymbolRegressionSuite {
+  override def saveClassFileToDisk: Boolean = true
 }

--- a/tests/slow/src/test/scala/tests/feature/WorksheetCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/WorksheetCrossLspSuite.scala
@@ -2,45 +2,14 @@ package tests.feature
 
 import scala.meta.internal.metals.{BuildInfo => V}
 
-abstract class Worksheet211LspSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends tests.BaseWorksheetLspSuite(
-      V.scala211,
-      useVirtualDocuments,
-      suiteNameSuffix
-    )
-class Worksheet211LspSaveToDiskSuite
-    extends Worksheet211LspSuite(false, "save-to-disk")
+class Worksheet211LspSuite extends tests.BaseWorksheetLspSuite(V.scala211)
 
-class Worksheet211LspVirtualDocSuite
-    extends Worksheet211LspSuite(true, "virtual-docs")
-
-abstract class Worksheet3LspSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends tests.BaseWorksheetLspSuite(
-      V.scala3,
-      useVirtualDocuments,
-      suiteNameSuffix
-    ) {
+class Worksheet3LspSuite extends tests.BaseWorksheetLspSuite(V.scala3) {
   override def versionSpecificCodeToValidate: String =
     """given str: String = """""
 }
 
-class Worksheet3LspSaveToDiskSuite
-    extends Worksheet3LspSuite(false, "save-to-disk")
-
-class Worksheet3LspVirtualDocSuite
-    extends Worksheet3LspSuite(true, "virtual-docs")
-abstract class Worksheet213LspSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends tests.BaseWorksheetLspSuite(
-      V.scala213,
-      useVirtualDocuments,
-      suiteNameSuffix
-    ) {
+class Worksheet213LspSuite extends tests.BaseWorksheetLspSuite(V.scala213) {
 
   test("literals") {
     for {
@@ -59,9 +28,3 @@ abstract class Worksheet213LspSuite(
   }
 
 }
-
-class Worksheet213LspSaveToDiskSuite
-    extends Worksheet213LspSuite(false, "save-to-disk")
-
-class Worksheet213LspVirtualDocSuite
-    extends Worksheet213LspSuite(true, "virtual-docs")

--- a/tests/slow/src/test/scala/tests/feature/WorksheetCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/WorksheetCrossLspSuite.scala
@@ -2,12 +2,45 @@ package tests.feature
 
 import scala.meta.internal.metals.{BuildInfo => V}
 
-class Worksheet211LspSuite extends tests.BaseWorksheetLspSuite(V.scala211)
-class Worksheet3LspSuite extends tests.BaseWorksheetLspSuite(V.scala3) {
+abstract class Worksheet211LspSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends tests.BaseWorksheetLspSuite(
+      V.scala211,
+      useVirtualDocuments,
+      suiteNameSuffix
+    )
+class Worksheet211LspSaveToDiskSuite
+    extends Worksheet211LspSuite(false, "save-to-disk")
+
+class Worksheet211LspVirtualDocSuite
+    extends Worksheet211LspSuite(true, "virtual-docs")
+
+abstract class Worksheet3LspSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends tests.BaseWorksheetLspSuite(
+      V.scala3,
+      useVirtualDocuments,
+      suiteNameSuffix
+    ) {
   override def versionSpecificCodeToValidate: String =
     """given str: String = """""
 }
-class Worksheet213LspSuite extends tests.BaseWorksheetLspSuite(V.scala213) {
+
+class Worksheet3LspSaveToDiskSuite
+    extends Worksheet3LspSuite(false, "save-to-disk")
+
+class Worksheet3LspVirtualDocSuite
+    extends Worksheet3LspSuite(true, "virtual-docs")
+abstract class Worksheet213LspSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends tests.BaseWorksheetLspSuite(
+      V.scala213,
+      useVirtualDocuments,
+      suiteNameSuffix
+    ) {
 
   test("literals") {
     for {
@@ -26,3 +59,9 @@ class Worksheet213LspSuite extends tests.BaseWorksheetLspSuite(V.scala213) {
   }
 
 }
+
+class Worksheet213LspSaveToDiskSuite
+    extends Worksheet213LspSuite(false, "save-to-disk")
+
+class Worksheet213LspVirtualDocSuite
+    extends Worksheet213LspSuite(true, "virtual-docs")

--- a/tests/slow/src/test/scala/tests/feature/WorkspaceSymbolRegressionSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/WorkspaceSymbolRegressionSuite.scala
@@ -5,7 +5,7 @@ import scala.meta.io.AbsolutePath
 import bench.Corpus
 import tests.BaseWorkspaceSymbolSuite
 
-class WorkspaceSymbolRegressionSuite extends BaseWorkspaceSymbolSuite {
+abstract class WorkspaceSymbolRegressionSuite extends BaseWorkspaceSymbolSuite {
   def workspace: AbsolutePath = Corpus.akka()
   check("Actor", "1009 results")
   check("Actor(", "")
@@ -128,4 +128,14 @@ class WorkspaceSymbolRegressionSuite extends BaseWorkspaceSymbolSuite {
     """.stripMargin
   )
 
+}
+
+class VirtualDocsWorkspaceSymbolRegressionSuite
+    extends WorkspaceSymbolRegressionSuite {
+  override def saveClassFileToDisk: Boolean = false
+}
+
+class SaveToDiskWorkspaceSymbolRegressionSuite
+    extends WorkspaceSymbolRegressionSuite {
+  override def saveClassFileToDisk: Boolean = true
 }

--- a/tests/slow/src/test/scala/tests/sbt/SbtStepDapSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtStepDapSuite.scala
@@ -4,18 +4,9 @@ import tests.SbtBuildLayout
 import tests.SbtServerInitializer
 import tests.debug.BaseStepDapSuite
 
-abstract class SbtStepDapSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseStepDapSuite(
-      useVirtualDocuments,
-      s"sbt-debug-step-$suiteNameSuffix",
+class SbtStepDapSuite
+    extends BaseStepDapSuite(
+      s"sbt-debug-step",
       SbtServerInitializer,
       SbtBuildLayout
     )
-
-class SbtStepDapSuiteSaveToDiskSuite
-    extends SbtStepDapSuite(false, "save-to-disk")
-
-class SbtStepDapSuiteVirtualDocSuite
-    extends SbtStepDapSuite(true, "virtual-docs")

--- a/tests/slow/src/test/scala/tests/sbt/SbtStepDapSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtStepDapSuite.scala
@@ -4,9 +4,18 @@ import tests.SbtBuildLayout
 import tests.SbtServerInitializer
 import tests.debug.BaseStepDapSuite
 
-class SbtStepDapSuite
-    extends BaseStepDapSuite(
-      "sbt-debug-step",
+abstract class SbtStepDapSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends BaseStepDapSuite(
+      useVirtualDocuments,
+      s"sbt-debug-step-$suiteNameSuffix",
       SbtServerInitializer,
       SbtBuildLayout
     )
+
+class SbtStepDapSuiteSaveToDiskSuite
+    extends SbtStepDapSuite(false, "save-to-disk")
+
+class SbtStepDapSuiteVirtualDocSuite
+    extends SbtStepDapSuite(true, "virtual-docs")

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/StepNavigator.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/StepNavigator.scala
@@ -27,9 +27,7 @@ final class StepNavigator(
 
       val (expected, nextStep) = expectedSteps.dequeue()
 
-      if (
-        actualLine == expected.line && expected.pathEqualsActual(actualPath)
-      ) {
+      if (actualLine == expected.line && expected.pathEquals(actualPath)) {
         if (actualPath.toAbsolutePath.exists) {
           nextStep
         } else {
@@ -77,15 +75,15 @@ object StepNavigator {
     new StepNavigator(root, root.resolve(Directories.dependencies), Nil)
 
   sealed trait Location {
-    def pathEqualsActual(actual: String): Boolean
+    def pathEquals(actual: String): Boolean
     def file: String
     def line: Long
   }
   case class WorkspaceLocation(root: AbsolutePath, path: String, lineNum: Long)
       extends Location {
 
-    override def pathEqualsActual(actual: String): Boolean =
-      actual.stripPrefix("file://") == file.toString
+    override def pathEquals(actual: String): Boolean =
+      actual.toAbsolutePath.toString == file.toString
     override def file: String = root.resolve(path).toString
     override def line: Long = lineNum
     override def toString: String = s"$root$file:$line"
@@ -96,12 +94,7 @@ object StepNavigator {
       lineNum: Long
   ) extends Location {
 
-    override def pathEqualsActual(actual: String): Boolean = {
-      if (actual.startsWith("jar:"))
-        actual.endsWith(path)
-      else
-        actual.stripPrefix("file://") == file.toString
-    }
+    override def pathEquals(actual: String): Boolean = actual.endsWith(path)
     override def file: String = dependencies.resolve(path).toString
     override def line: Long = lineNum
     override def toString: String = s"$dependencies$file:$line"

--- a/tests/unit/src/main/scala/tests/BaseCodeLensLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCodeLensLspSuite.scala
@@ -5,7 +5,7 @@ import scala.concurrent.Future
 import munit.Location
 import munit.TestOptions
 
-class BaseCodeLensLspSuite(name: String) extends BaseLspSuite(name) {
+abstract class BaseCodeLensLspSuite(name: String) extends BaseLspSuite(name) {
 
   def check(
       name: TestOptions,

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -25,7 +25,6 @@ import scala.meta.io.AbsolutePath
 
 import munit.Ignore
 import munit.Location
-import munit.Tag
 import munit.TestOptions
 
 /**
@@ -50,8 +49,6 @@ abstract class BaseLspSuite(
   var workspace: AbsolutePath = _
 
   protected def initializationOptions: Option[InitializationOptions] = None
-
-  private val virtualDocTag = new Tag("UseVirtualDocs")
 
   private var useVirtualDocs = false
 
@@ -93,7 +90,7 @@ abstract class BaseLspSuite(
       test(
         testOpts
           .withName(s"${testOpts.name}-virtualdoc")
-          .withTags(Set(virtualDocTag))
+          .withTags(Set(TestingServer.virtualDocTag))
       ) { fn }
     } else {
       test(testOpts)(fn)
@@ -135,7 +132,7 @@ abstract class BaseLspSuite(
   override def beforeEach(context: BeforeEach): Unit = {
     cancelServer()
     if (context.test.tags.contains(Ignore)) return
-    useVirtualDocs = context.test.tags.contains(virtualDocTag)
+    useVirtualDocs = context.test.tags.contains(TestingServer.virtualDocTag)
     newServer(context.test.name)
   }
 

--- a/tests/unit/src/main/scala/tests/BaseRenameLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseRenameLspSuite.scala
@@ -7,7 +7,7 @@ import scala.meta.internal.pc.Identifier
 import munit.Location
 import munit.TestOptions
 
-class BaseRenameLspSuite(name: String) extends BaseLspSuite(name) {
+abstract class BaseRenameLspSuite(name: String) extends BaseLspSuite(name) {
 
   protected def libraryDependencies: List[String] = Nil
   protected def compilerPlugins: List[String] = Nil

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -492,7 +492,7 @@ abstract class BaseWorksheetLspSuite(
     } yield ()
   }
 
-  test("definition".only, withoutVirtualDocs = true) {
+  test("definition", withoutVirtualDocs = true) {
     // NOTE(olafur) this test fails unpredicatly on Windows with
     //      """|/a/src/main/scala/Main.worksheet.sc
     //         |val message/*<no symbol>*/ = "Hello World!"

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -29,6 +29,7 @@ abstract class BaseWorksheetLspSuite(
   if (!ScalaVersions.isScala3Version(scalaVersion))
     test("completion") {
       assume(!isWindows, "This test is flaky on Windows")
+      cleanWorkspace()
       for {
         _ <- initialize(
           s"""
@@ -83,6 +84,7 @@ abstract class BaseWorksheetLspSuite(
     }
 
   test("outside-target") {
+    cleanWorkspace()
     for {
       _ <- initialize(
         s"""
@@ -127,6 +129,7 @@ abstract class BaseWorksheetLspSuite(
   }
 
   test("render") {
+    cleanWorkspace()
     for {
       _ <- initialize(
         s"""
@@ -227,6 +230,7 @@ abstract class BaseWorksheetLspSuite(
   }
 
   test("cancel") {
+    cleanWorkspace()
     val cancelled = Promise[Unit]()
     client.slowTaskHandler = { _ =>
       cancelled.trySuccess(())
@@ -262,6 +266,7 @@ abstract class BaseWorksheetLspSuite(
   }
 
   test("crash") {
+    cleanWorkspace()
     for {
       _ <- initialize(
         s"""
@@ -307,6 +312,7 @@ abstract class BaseWorksheetLspSuite(
   }
 
   test("dependsOn") {
+    cleanWorkspace()
     for {
       _ <- initialize(
         s"""
@@ -340,6 +346,7 @@ abstract class BaseWorksheetLspSuite(
   }
 
   test("no-worksheet".flaky) {
+    cleanWorkspace()
     for {
       _ <- initialize(
         s"""|/metals.json
@@ -363,6 +370,7 @@ abstract class BaseWorksheetLspSuite(
   }
 
   test("update-classpath") {
+    cleanWorkspace()
     client.slowTaskHandler = _ => None
     for {
       _ <- initialize(
@@ -401,6 +409,7 @@ abstract class BaseWorksheetLspSuite(
   }
 
   test("syntax-error") {
+    cleanWorkspace()
     for {
       _ <- initialize(
         s"""|/metals.json
@@ -464,39 +473,13 @@ abstract class BaseWorksheetLspSuite(
     } yield ()
   }
 
-  test("definition") {
+  test("definition", withoutVirtualDocs = false) {
     // NOTE(olafur) this test fails unpredicatly on Windows with
     //      """|/a/src/main/scala/Main.worksheet.sc
     //         |val message/*<no symbol>*/ = "Hello World!"
     //         |println/*<no symbol>*/(message/*<no symbol>*/)
     assume(!isWindows, "This test fails unpredictably on Window")
-    for {
-      _ <- initialize(
-        s"""
-           |/metals.json
-           |{"a": {"scalaVersion": "$scalaVersion"}}
-           |/a/src/main/scala/Main.worksheet.sc
-           |val message = "Hello World!"
-           |println(message)
-           |""".stripMargin
-      )
-      _ <- server.didOpen("a/src/main/scala/Main.worksheet.sc")
-      _ = assertNoDiff(
-        server.workspaceDefinitions,
-        """|/a/src/main/scala/Main.worksheet.sc
-           |val message/*L0*/ = "Hello World!"
-           |println/*Predef.scala*/(message/*L0*/)
-           |""".stripMargin
-      )
-    } yield ()
-  }
-
-  test("definition", withoutVirtualDocs = true) {
-    // NOTE(olafur) this test fails unpredicatly on Windows with
-    //      """|/a/src/main/scala/Main.worksheet.sc
-    //         |val message/*<no symbol>*/ = "Hello World!"
-    //         |println/*<no symbol>*/(message/*<no symbol>*/)
-    assume(!isWindows, "This test fails unpredictably on Window")
+    cleanWorkspace()
     for {
       _ <- initialize(
         s"""
@@ -520,7 +503,7 @@ abstract class BaseWorksheetLspSuite(
 
   test("root-outside-definition") {
     assume(!isWindows, "This test fails unpredictably on Window")
-
+    cleanWorkspace()
     for {
       _ <- initialize(
         s"""
@@ -566,6 +549,7 @@ abstract class BaseWorksheetLspSuite(
   }
 
   test("no-position") {
+    cleanWorkspace()
     for {
       _ <- initialize(
         s"""
@@ -608,6 +592,7 @@ abstract class BaseWorksheetLspSuite(
   }
 
   test("fatal-exception") {
+    cleanWorkspace()
     for {
       _ <- initialize(
         s"""
@@ -653,6 +638,7 @@ abstract class BaseWorksheetLspSuite(
 
   test("export") {
     assume(!isWindows, "This test is flaky on Windows")
+    cleanWorkspace()
     for {
       _ <- initialize(
         s"""

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -8,11 +8,16 @@ import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.clients.language.MetalsSlowTaskResult
 import scala.meta.internal.metals.{BuildInfo => V}
 
-abstract class BaseWorksheetLspSuite(scalaVersion: String)
-    extends BaseLspSuite("worksheet") {
-  override def initializationOptions: Option[InitializationOptions] =
+abstract class BaseWorksheetLspSuite(
+    scalaVersion: String,
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends BaseLspSuite(s"worksheet-$suiteNameSuffix") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
+        isVirtualDocumentSupported = Some(useVirtualDocuments),
         decorationProvider = Some(true)
       )
     )

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -15,7 +15,6 @@ abstract class BaseWorksheetLspSuite(
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
         decorationProvider = Some(true)
       )
     )

--- a/tests/unit/src/main/scala/tests/BaseWorkspaceSymbolSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorkspaceSymbolSuite.scala
@@ -12,8 +12,9 @@ abstract class BaseWorkspaceSymbolSuite extends BaseSuite {
   def workspace: AbsolutePath
   def libraries: List[Library] = Nil
   def dialect: Dialect = dialects.Scala213
+  def saveClassFileToDisk: Boolean
   lazy val symbols: WorkspaceSymbolProvider = {
-    val p = TestingWorkspaceSymbolProvider(workspace)
+    val p = TestingWorkspaceSymbolProvider(workspace, saveClassFileToDisk)
     p.indexWorkspace(dialect)
     p.indexLibraries(libraries)
     p.indexClasspath()

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -196,7 +196,7 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
       .mkString("\n")
   }
   private def toPath(filename: String): AbsolutePath =
-    TestingServer.toPath(workspace, filename)
+    TestingServer.toPath(workspace, filename, TrieMap.empty)
   def workspaceMessageRequests: String = {
     messageRequests.asScala.mkString("\n")
   }
@@ -207,7 +207,10 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
     val isDeleted = !path.isFile
     val diags = diagnostics.getOrElse(path, Nil).sortBy(_.getRange)
     val relpath =
-      path.toRelative(workspace).toURI(isDirectory = false).toString
+      if (path.isJarFileSystem)
+        path.toString.stripPrefix("/")
+      else
+        path.toRelative(workspace).toURI(isDirectory = false).toString
     val input =
       if (isDeleted) {
         Input.VirtualFile(relpath + " (deleted)", "\n <deleted>" * 1000)

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -282,7 +282,7 @@ final class TestingServer(
           val path = longPath.toAbsolutePath.toRelativeInside(
             workspace.resolve(Directories.dependencies)
           )
-          path.map(_.toString).getOrElse(longPath)
+          path.map(_.toString).getOrElse(longPath).replace("\\", "/")
         }
         val shortenedObtained = gotoExecutedCommandPositions.map {
           case (position, location) => (position, shortenJarPath(location))

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -69,6 +69,7 @@ import scala.meta.io.RelativePath
 import _root_.org.eclipse.lsp4j.DocumentSymbolCapabilities
 import ch.epfl.scala.{bsp4j => b}
 import com.google.gson.JsonElement
+import munit.Tag
 import org.eclipse.lsp4j.ClientCapabilities
 import org.eclipse.lsp4j.CodeActionContext
 import org.eclipse.lsp4j.CodeActionParams
@@ -457,13 +458,7 @@ final class TestingServer(
     val documentSymbolCapabilities = new DocumentSymbolCapabilities()
     documentSymbolCapabilities.setHierarchicalDocumentSymbolSupport(true)
     textDocumentCapabilities.setDocumentSymbol(documentSymbolCapabilities)
-    val initOptions = initializationOptions.getOrElse(
-      InitializationOptions.Default.copy(
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    val initOptions = initializationOptions.getOrElse(TestingServer.TestDefault)
 
     // Yes, this is a bit gross :/
     // However, I want to only get the existing fields that are being set
@@ -1674,4 +1669,15 @@ object TestingServer {
         throw new IllegalArgumentException(s"no such file: $filename")
       }
   }
+
+  val virtualDocTag = new Tag("UseVirtualDocs")
+
+  val TestDefault: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(
+        debuggingProvider = Some(true),
+        treeViewProvider = Some(true),
+        slowTaskProvider = Some(true)
+      )
+    )
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -458,7 +458,8 @@ final class TestingServer(
     val documentSymbolCapabilities = new DocumentSymbolCapabilities()
     documentSymbolCapabilities.setHierarchicalDocumentSymbolSupport(true)
     textDocumentCapabilities.setDocumentSymbol(documentSymbolCapabilities)
-    val initOptions = initializationOptions.getOrElse(TestingServer.TestDefault)
+    val initOptions: InitializationOptions =
+      initializationOptions.getOrElse(TestingServer.TestDefault)
 
     // Yes, this is a bit gross :/
     // However, I want to only get the existing fields that are being set
@@ -1672,12 +1673,10 @@ object TestingServer {
 
   val virtualDocTag = new Tag("UseVirtualDocs")
 
-  val TestDefault: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
+  val TestDefault: InitializationOptions =
+    InitializationOptions.Default.copy(
+      debuggingProvider = Some(true),
+      treeViewProvider = Some(true),
+      slowTaskProvider = Some(true)
     )
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -156,7 +156,7 @@ final class TestingServer(
     )
   )
 
-  private val readonlySources = TrieMap.empty[String, AbsolutePath]
+  private val virtualDocSources = TrieMap.empty[String, AbsolutePath]
   def statusBarHistory: String = {
     // collect both published items in the client and pending items from the server.
     val all = List(
@@ -172,6 +172,11 @@ final class TestingServer(
       includeFilename: Boolean = false
   ): String = {
     val infos = server.workspaceSymbol(query)
+    infos.foreach(info => {
+      val path = info.getLocation().getUri().toAbsolutePath
+      if (path.isJarFileSystem)
+        virtualDocSources(path.toString.stripPrefix("/")) = path
+    })
     infos
       .map { info =>
         val kind =
@@ -258,10 +263,42 @@ final class TestingServer(
         case ClientCommands.GotoLocation(location) =>
           (location.range.getStart, location.uri)
       }
-      Assertions.assertEquals(
-        gotoExecutedCommandPositions,
-        expectedGotoPositions
-      )
+      if (
+        initializationOptions
+          .flatMap(_.isVirtualDocumentSupported)
+          .getOrElse(false)
+      ) {
+
+        def shortenJarPath(longPath: String): String = {
+          val revSplitPath = longPath.reverse.split("!")
+          if (revSplitPath.length == 2) {
+            val path = revSplitPath(0).reverse
+            val jarPath =
+              revSplitPath(1).replace("\\", "/").takeWhile(_ != '/').reverse
+            s"$jarPath$path"
+          } else longPath
+        }
+        def shortenReadOnlyPath(longPath: String): String = {
+          val path = longPath.toAbsolutePath.toRelativeInside(
+            workspace.resolve(Directories.dependencies)
+          )
+          path.map(_.toString).getOrElse(longPath)
+        }
+        val shortenedObtained = gotoExecutedCommandPositions.map {
+          case (position, location) => (position, shortenJarPath(location))
+        }
+        val shortenedExpected = expectedGotoPositions.map {
+          case (position, location) => (position, shortenReadOnlyPath(location))
+        }
+        Assertions.assertEquals(
+          shortenedObtained,
+          shortenedExpected
+        )
+      } else
+        Assertions.assertEquals(
+          gotoExecutedCommandPositions,
+          expectedGotoPositions
+        )
     }
   }
 
@@ -472,7 +509,7 @@ final class TestingServer(
   }
 
   def toPath(filename: String): AbsolutePath =
-    TestingServer.toPath(workspace, filename)
+    TestingServer.toPath(workspace, filename, virtualDocSources)
 
   def executeCommand[T](
       command: ParametrizedCommand[T],
@@ -1320,9 +1357,12 @@ final class TestingServer(
       r.asScala
         .map { l =>
           val path = l.getUri.toAbsolutePath
+          val shortPath =
+            if (path.isJarFileSystem) path.toString.replace("\\", "/")
+            else path.toRelative(workspace).toURI(false).toString
           val input = path
             .toInputFromBuffers(buffers)
-            .copy(path = path.toRelative(workspace).toURI(false).toString)
+            .copy(path = shortPath)
           val pos = l.getRange.toMeta(input)
           pos.formatMessage("info", "reference")
         }
@@ -1376,8 +1416,8 @@ final class TestingServer(
         .asJava
         .get()
       definition.definition.foreach { path =>
-        if (path.isDependencySource(workspace)) {
-          readonlySources(path.toNIO.getFileName.toString) = path
+        if (path.isJarFileSystem) {
+          virtualDocSources(path.toString.stripPrefix("/")) = path
         }
       }
       val locations = definition.locations.asScala.toList
@@ -1617,7 +1657,11 @@ final class TestingServer(
 }
 
 object TestingServer {
-  def toPath(workspace: AbsolutePath, filename: String): AbsolutePath = {
+  def toPath(
+      workspace: AbsolutePath,
+      filename: String,
+      virtualDocSources: TrieMap[String, AbsolutePath]
+  ): AbsolutePath = {
     val path = RelativePath(filename)
     val base = List(workspace, workspace.resolve(Directories.readonly))
     val dependencies = workspace.resolve(Directories.dependencies).list.toList
@@ -1625,6 +1669,7 @@ object TestingServer {
     all
       .map(_.resolve(path))
       .find(p => Files.exists(p.toNIO))
+      .orElse(virtualDocSources.get(filename))
       .getOrElse {
         throw new IllegalArgumentException(s"no such file: $filename")
       }

--- a/tests/unit/src/main/scala/tests/TestingWorkspaceSymbolProvider.scala
+++ b/tests/unit/src/main/scala/tests/TestingWorkspaceSymbolProvider.scala
@@ -10,6 +10,7 @@ import scala.meta.io.AbsolutePath
 object TestingWorkspaceSymbolProvider {
   def apply(
       workspace: AbsolutePath,
+      saveClassFileToDisk: Boolean = true,
       index: OnDemandSymbolIndex = OnDemandSymbolIndex.empty(),
       bucketSize: Int = CompressedPackageIndex.DefaultBucketSize
   ): WorkspaceSymbolProvider = {
@@ -17,6 +18,7 @@ object TestingWorkspaceSymbolProvider {
       workspace = workspace,
       buildTargets = BuildTargets.withoutAmmonite,
       index = index,
+      saveClassFileToDisk = saveClassFileToDisk,
       new ExcludedPackagesHandler().isExcludedPackage,
       bucketSize = bucketSize
     )

--- a/tests/unit/src/main/scala/tests/debug/BaseStepDapSuite.scala
+++ b/tests/unit/src/main/scala/tests/debug/BaseStepDapSuite.scala
@@ -14,7 +14,6 @@ import tests.BuildToolLayout
 // note(@tgodzik) all test have `System.exit(0)` added to avoid occasional issue due to:
 // https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment
 abstract class BaseStepDapSuite(
-    useVirtualDocuments: Boolean,
     suiteName: String,
     initializer: BuildServerInitializer,
     buildToolLayout: BuildToolLayout
@@ -23,7 +22,7 @@ abstract class BaseStepDapSuite(
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        isVirtualDocumentSupported = Some(true),
         debuggingProvider = Some(true),
         treeViewProvider = Some(true),
         slowTaskProvider = Some(true)
@@ -101,7 +100,7 @@ abstract class BaseStepDapSuite(
         .at("a/src/main/scala/a/ScalaMain.scala", line = 6)(Continue)
   )
 
-  assertSteps("step-into-scala-lib")(
+  assertSteps("step-into-scala-lib", withoutVirtualDocs = true)(
     sources = """|/a/src/main/scala/Main.scala
                  |package a
                  |
@@ -122,7 +121,7 @@ abstract class BaseStepDapSuite(
     }
   )
 
-  assertSteps("step-into-java-lib")(
+  assertSteps("step-into-java-lib", withoutVirtualDocs = true)(
     sources = """|/a/src/main/scala/Main.scala
                  |package a
                  |
@@ -172,12 +171,12 @@ abstract class BaseStepDapSuite(
         .at("a/src/main/scala/a/Main.scala", line = 13)(Continue)
   )
 
-  def assertSteps(name: TestOptions)(
+  def assertSteps(name: TestOptions, withoutVirtualDocs: Boolean = false)(
       sources: String,
       main: String,
       instrument: StepNavigator => StepNavigator
   )(implicit loc: Location): Unit = {
-    test(name) {
+    test(name, withoutVirtualDocs) {
       cleanWorkspace()
       val debugLayout = DebugWorkspaceLayout(sources)
       val workspaceLayout = buildToolLayout(debugLayout.toString, scalaVersion)

--- a/tests/unit/src/main/scala/tests/debug/BaseStepDapSuite.scala
+++ b/tests/unit/src/main/scala/tests/debug/BaseStepDapSuite.scala
@@ -10,6 +10,7 @@ import munit.TestOptions
 import tests.BaseDapSuite
 import tests.BuildServerInitializer
 import tests.BuildToolLayout
+import tests.TestingServer
 
 // note(@tgodzik) all test have `System.exit(0)` added to avoid occasional issue due to:
 // https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment
@@ -20,14 +21,7 @@ abstract class BaseStepDapSuite(
 ) extends BaseDapSuite(suiteName, initializer, buildToolLayout) {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    TestingServer.TestDefault
 
   private val scalaLibDependency = s"scala-library-$scalaVersion-sources.jar"
   private val javaLibDependency = s"src.zip"

--- a/tests/unit/src/main/scala/tests/debug/BaseStepDapSuite.scala
+++ b/tests/unit/src/main/scala/tests/debug/BaseStepDapSuite.scala
@@ -21,7 +21,7 @@ abstract class BaseStepDapSuite(
 ) extends BaseDapSuite(suiteName, initializer, buildToolLayout) {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    TestingServer.TestDefault
+    Some(TestingServer.TestDefault)
 
   private val scalaLibDependency = s"scala-library-$scalaVersion-sources.jar"
   private val javaLibDependency = s"src.zip"

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -4,15 +4,12 @@ import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.StatisticsConfig
 
-abstract class DefinitionLspSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseLspSuite(s"definition-$suiteNameSuffix") {
+class DefinitionLspSuite extends BaseLspSuite("definition") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        isVirtualDocumentSupported = Some(true),
         debuggingProvider = Some(true),
         treeViewProvider = Some(true),
         slowTaskProvider = Some(true)
@@ -310,7 +307,7 @@ abstract class DefinitionLspSuite(
     } yield ()
   }
 
-  test("rambo") {
+  test("rambo", withoutVirtualDocs = true) {
     cleanDatabase()
     for {
       _ <- initialize(
@@ -405,9 +402,3 @@ abstract class DefinitionLspSuite(
   }
 
 }
-
-class DefinitionLspSaveToDiskSuite
-    extends DefinitionLspSuite(false, "save-to-disk")
-
-class DefinitionLspVirtualDocSuite
-    extends DefinitionLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -1,9 +1,24 @@
 package tests
 
+import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.StatisticsConfig
 
-class DefinitionLspSuite extends BaseLspSuite("definition") {
+abstract class DefinitionLspSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends BaseLspSuite(s"definition-$suiteNameSuffix") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(
+        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        debuggingProvider = Some(true),
+        treeViewProvider = Some(true),
+        slowTaskProvider = Some(true)
+      )
+    )
+
   override def serverConfig: MetalsServerConfig =
     super.serverConfig.copy(
       statistics = new StatisticsConfig("diagnostics")
@@ -390,3 +405,9 @@ class DefinitionLspSuite extends BaseLspSuite("definition") {
   }
 
 }
+
+class DefinitionLspSaveToDiskSuite
+    extends DefinitionLspSuite(false, "save-to-disk")
+
+class DefinitionLspVirtualDocSuite
+    extends DefinitionLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -7,14 +7,7 @@ import scala.meta.internal.metals.StatisticsConfig
 class DefinitionLspSuite extends BaseLspSuite("definition") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    TestingServer.TestDefault
 
   override def serverConfig: MetalsServerConfig =
     super.serverConfig.copy(

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -7,7 +7,7 @@ import scala.meta.internal.metals.StatisticsConfig
 class DefinitionLspSuite extends BaseLspSuite("definition") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    TestingServer.TestDefault
+    Some(TestingServer.TestDefault)
 
   override def serverConfig: MetalsServerConfig =
     super.serverConfig.copy(

--- a/tests/unit/src/test/scala/tests/FileWatcherLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/FileWatcherLspSuite.scala
@@ -5,22 +5,19 @@ import java.nio.file.Files
 import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.RecursivelyDelete
 
-abstract class FileWatcherLspSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseLspSuite(s"file-watcher-$suiteNameSuffix") {
+class FileWatcherLspSuite extends BaseLspSuite("file-watcher") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        isVirtualDocumentSupported = Some(true),
         debuggingProvider = Some(true),
         treeViewProvider = Some(true),
         slowTaskProvider = Some(true)
       )
     )
 
-  test("basic") {
+  test("basic", withoutVirtualDocs = true) {
     cleanCompileCache("a")
     cleanCompileCache("b")
     cleanCompileCache("c")
@@ -130,9 +127,3 @@ abstract class FileWatcherLspSuite(
     } yield ()
   }
 }
-
-class FileWatcherLspSaveToDiskSuite
-    extends FileWatcherLspSuite(false, "save-to-disk")
-
-class FileWatcherLspVirtualDocSuite
-    extends FileWatcherLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/FileWatcherLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/FileWatcherLspSuite.scala
@@ -2,9 +2,24 @@ package tests
 
 import java.nio.file.Files
 
+import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.RecursivelyDelete
 
-class FileWatcherLspSuite extends BaseLspSuite("file-watcher") {
+abstract class FileWatcherLspSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends BaseLspSuite(s"file-watcher-$suiteNameSuffix") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(
+        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        debuggingProvider = Some(true),
+        treeViewProvider = Some(true),
+        slowTaskProvider = Some(true)
+      )
+    )
+
   test("basic") {
     cleanCompileCache("a")
     cleanCompileCache("b")
@@ -115,3 +130,9 @@ class FileWatcherLspSuite extends BaseLspSuite("file-watcher") {
     } yield ()
   }
 }
+
+class FileWatcherLspSaveToDiskSuite
+    extends FileWatcherLspSuite(false, "save-to-disk")
+
+class FileWatcherLspVirtualDocSuite
+    extends FileWatcherLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/FileWatcherLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/FileWatcherLspSuite.scala
@@ -8,14 +8,7 @@ import scala.meta.internal.metals.RecursivelyDelete
 class FileWatcherLspSuite extends BaseLspSuite("file-watcher") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    TestingServer.TestDefault
 
   test("basic", withoutVirtualDocs = true) {
     cleanCompileCache("a")

--- a/tests/unit/src/test/scala/tests/FileWatcherLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/FileWatcherLspSuite.scala
@@ -8,7 +8,7 @@ import scala.meta.internal.metals.RecursivelyDelete
 class FileWatcherLspSuite extends BaseLspSuite("file-watcher") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    TestingServer.TestDefault
+    Some(TestingServer.TestDefault)
 
   test("basic", withoutVirtualDocs = true) {
     cleanCompileCache("a")

--- a/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
+++ b/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
@@ -10,24 +10,25 @@ import scala.meta.io.AbsolutePath
 
 import org.eclipse.lsp4j.Location
 
-abstract class FindTextInDependencyJarsSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseLspSuite(s"find-text-in-dependency-jars-$suiteNameSuffix") {
+class FindTextInDependencyJarsSuite
+    extends BaseLspSuite("find-text-in-dependency-jars") {
 
   val akkaVersion = "2.6.16"
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        isVirtualDocumentSupported = Some(true),
         debuggingProvider = Some(true),
         treeViewProvider = Some(true),
         slowTaskProvider = Some(true)
       )
     )
 
-  test("find exact string match in .conf file inside jar") {
+  test(
+    "find exact string match in .conf file inside jar",
+    withoutVirtualDocs = true
+  ) {
     val isJavaAtLeast9 = scala.util.Properties.isJavaAtLeast(9.toString)
     val isJavaAtLeast17 = scala.util.Properties.isJavaAtLeast(17.toString)
 
@@ -119,9 +120,3 @@ abstract class FindTextInDependencyJarsSuite(
     assertNoDiff(rendered, expected)
   }
 }
-
-class FindTextInDependencyJarsSaveToDiskSuite
-    extends FindTextInDependencyJarsSuite(false, "save-to-disk")
-
-class FindTextInDependencyJarsVirtualDocSuite
-    extends FindTextInDependencyJarsSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
+++ b/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
@@ -16,7 +16,7 @@ class FindTextInDependencyJarsSuite
   val akkaVersion = "2.6.16"
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    TestingServer.TestDefault
+    Some(TestingServer.TestDefault)
 
   test(
     "find exact string match in .conf file inside jar",

--- a/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
+++ b/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
@@ -16,14 +16,7 @@ class FindTextInDependencyJarsSuite
   val akkaVersion = "2.6.16"
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    TestingServer.TestDefault
 
   test(
     "find exact string match in .conf file inside jar",

--- a/tests/unit/src/test/scala/tests/HoverLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/HoverLspSuite.scala
@@ -1,9 +1,24 @@
 package tests
 
 import scala.meta.internal.metals.Directories
+import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.{BuildInfo => V}
 
-class HoverLspSuite extends BaseLspSuite("hover") with TestHovers {
+abstract class HoverLspSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends BaseLspSuite(s"hover-$suiteNameSuffix")
+    with TestHovers {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(
+        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        debuggingProvider = Some(true),
+        treeViewProvider = Some(true),
+        slowTaskProvider = Some(true)
+      )
+    )
 
   test("basic".tag(FlakyWindows)) {
     for {
@@ -154,3 +169,7 @@ class HoverLspSuite extends BaseLspSuite("hover") with TestHovers {
   }
 
 }
+
+class HoverLspSaveToDiskSuite extends HoverLspSuite(false, "save-to-disk")
+
+class HoverLspVirtualDocSuite extends HoverLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/HoverLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/HoverLspSuite.scala
@@ -4,16 +4,12 @@ import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.{BuildInfo => V}
 
-abstract class HoverLspSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseLspSuite(s"hover-$suiteNameSuffix")
-    with TestHovers {
+class HoverLspSuite extends BaseLspSuite("hover-") with TestHovers {
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        isVirtualDocumentSupported = Some(true),
         debuggingProvider = Some(true),
         treeViewProvider = Some(true),
         slowTaskProvider = Some(true)
@@ -141,7 +137,7 @@ abstract class HoverLspSuite(
     } yield ()
   }
 
-  test("dependencies".tag(FlakyWindows)) {
+  test("dependencies".tag(FlakyWindows), withoutVirtualDocs = true) {
     for {
       _ <- initialize(
         """/metals.json
@@ -169,7 +165,3 @@ abstract class HoverLspSuite(
   }
 
 }
-
-class HoverLspSaveToDiskSuite extends HoverLspSuite(false, "save-to-disk")
-
-class HoverLspVirtualDocSuite extends HoverLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/HoverLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/HoverLspSuite.scala
@@ -7,14 +7,7 @@ import scala.meta.internal.metals.{BuildInfo => V}
 class HoverLspSuite extends BaseLspSuite("hover-") with TestHovers {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    TestingServer.TestDefault
 
   test("basic".tag(FlakyWindows)) {
     for {

--- a/tests/unit/src/test/scala/tests/HoverLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/HoverLspSuite.scala
@@ -7,7 +7,7 @@ import scala.meta.internal.metals.{BuildInfo => V}
 class HoverLspSuite extends BaseLspSuite("hover-") with TestHovers {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    TestingServer.TestDefault
+    Some(TestingServer.TestDefault)
 
   test("basic".tag(FlakyWindows)) {
     for {

--- a/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
@@ -26,8 +26,11 @@ abstract class JavaDefinitionSuite(
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
-      InitializationOptions.Default.copy(isVirtualDocumentSupported =
-        Some(useVirtualDocuments)
+      InitializationOptions.Default.copy(
+        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        debuggingProvider = Some(true),
+        treeViewProvider = Some(true),
+        slowTaskProvider = Some(true)
       )
     )
 

--- a/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
@@ -16,10 +16,7 @@ import munit.Location
 import munit.TestOptions
 import org.eclipse.{lsp4j => l}
 
-abstract class JavaDefinitionSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseLspSuite(s"java-definition-$suiteNameSuffix") {
+class JavaDefinitionSuite extends BaseLspSuite("java-definition") {
 
   val javaBasePrefix: String =
     if (Properties.isJavaAtLeast("9")) "java.base/" else ""
@@ -27,7 +24,7 @@ abstract class JavaDefinitionSuite(
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        isVirtualDocumentSupported = Some(true),
         debuggingProvider = Some(true),
         treeViewProvider = Some(true),
         slowTaskProvider = Some(true)
@@ -43,7 +40,8 @@ abstract class JavaDefinitionSuite(
     s"""|src.zip/${javaBasePrefix}java/lang/CharSequence.java info: result
         |public interface CharSequence {
         |                 ^^^^^^^^^^^^
-        |""".stripMargin
+        |""".stripMargin,
+    withoutVirtualDocs = true
   )
 
   check(
@@ -105,9 +103,10 @@ abstract class JavaDefinitionSuite(
       depSymbol: String,
       input: String,
       expected: String,
-      dependencies: List[String] = Nil
+      dependencies: List[String] = Nil,
+      withoutVirtualDocs: Boolean = false
   )(implicit loc: Location): Unit = {
-    test(name) {
+    test(name, withoutVirtualDocs) {
       val parsed = FileLayout.mapFromString(input)
       assert(parsed.size == 1, "Input should have only one dep source file")
       val (path, query) = parsed.head
@@ -197,9 +196,3 @@ abstract class JavaDefinitionSuite(
       .formatMessage("info", "result", noPos = true)
   }
 }
-
-class JavaDefinitionSaveToDiskSuite
-    extends JavaDefinitionSuite(false, "save-to-disk")
-
-class JavaDefinitionVirtualDocSuite
-    extends JavaDefinitionSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
@@ -22,7 +22,7 @@ class JavaDefinitionSuite extends BaseLspSuite("java-definition") {
     if (Properties.isJavaAtLeast("9")) "java.base/" else ""
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    TestingServer.TestDefault
+    Some(TestingServer.TestDefault)
 
   check(
     "jdk-String",

--- a/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
@@ -22,14 +22,7 @@ class JavaDefinitionSuite extends BaseLspSuite("java-definition") {
     if (Properties.isJavaAtLeast("9")) "java.base/" else ""
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    TestingServer.TestDefault
 
   check(
     "jdk-String",

--- a/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
@@ -22,7 +22,7 @@ import org.eclipse.lsp4j.ShowMessageRequestParams
 
 class NewFileLspSuite extends BaseLspSuite("new-file") {
 
-  override def initializationOptions: Option[InitializationOptions] =
+  override protected def initializationOptions: Option[InitializationOptions] =
     Some(InitializationOptions.Default.copy(inputBoxProvider = Some(true)))
 
   checkScala("new-worksheet-picked")(

--- a/tests/unit/src/test/scala/tests/NewProjectLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewProjectLspSuite.scala
@@ -23,7 +23,7 @@ import org.eclipse.lsp4j.ShowMessageRequestParams
 
 class NewProjectLspSuite extends BaseLspSuite("new-project") {
 
-  override def initializationOptions: Option[InitializationOptions] =
+  override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default
         .copy(inputBoxProvider = Some(true), openNewWindowProvider = Some(true))

--- a/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
+++ b/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
@@ -2,22 +2,19 @@ package tests
 
 import scala.meta.internal.metals.InitializationOptions
 
-abstract class QuickBuildSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseLspSuite(s"quick-build-$suiteNameSuffix") {
+class QuickBuildSuite extends BaseLspSuite(s"quick-build") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        isVirtualDocumentSupported = Some(true),
         debuggingProvider = Some(true),
         treeViewProvider = Some(true),
         slowTaskProvider = Some(true)
       )
     )
 
-  test("basic") {
+  test("basic", withoutVirtualDocs = true) {
     cleanCompileCache("b")
     for {
       _ <- initialize(
@@ -89,7 +86,3 @@ abstract class QuickBuildSuite(
     } yield ()
   }
 }
-
-class QuickBuildSaveToDiskSuite extends QuickBuildSuite(false, "save-to-disk")
-
-class QuickBuildVirtualDocSuite extends QuickBuildSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
+++ b/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
@@ -1,6 +1,22 @@
 package tests
 
-class QuickBuildSuite extends BaseLspSuite("quick-build") {
+import scala.meta.internal.metals.InitializationOptions
+
+abstract class QuickBuildSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends BaseLspSuite(s"quick-build-$suiteNameSuffix") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(
+        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        debuggingProvider = Some(true),
+        treeViewProvider = Some(true),
+        slowTaskProvider = Some(true)
+      )
+    )
+
   test("basic") {
     cleanCompileCache("b")
     for {
@@ -73,3 +89,7 @@ class QuickBuildSuite extends BaseLspSuite("quick-build") {
     } yield ()
   }
 }
+
+class QuickBuildSaveToDiskSuite extends QuickBuildSuite(false, "save-to-disk")
+
+class QuickBuildVirtualDocSuite extends QuickBuildSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
+++ b/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
@@ -5,14 +5,7 @@ import scala.meta.internal.metals.InitializationOptions
 class QuickBuildSuite extends BaseLspSuite(s"quick-build") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    TestingServer.TestDefault
 
   test("basic", withoutVirtualDocs = true) {
     cleanCompileCache("b")

--- a/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
+++ b/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
@@ -5,7 +5,7 @@ import scala.meta.internal.metals.InitializationOptions
 class QuickBuildSuite extends BaseLspSuite(s"quick-build") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    TestingServer.TestDefault
+    Some(TestingServer.TestDefault)
 
   test("basic", withoutVirtualDocs = true) {
     cleanCompileCache("b")

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -2,9 +2,23 @@ package tests
 
 import scala.concurrent.Future
 
+import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.ServerCommands
 
-class ReferenceLspSuite extends BaseRangesSuite("reference") {
+class ReferenceLspSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends BaseRangesSuite(s"reference-$suiteNameSuffix") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(
+        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        debuggingProvider = Some(true),
+        treeViewProvider = Some(true),
+        slowTaskProvider = Some(true)
+      )
+    )
 
   test("case-class") {
     cleanWorkspace()
@@ -403,3 +417,9 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
     server.assertReferences(filename, edit, expected, base)
   }
 }
+
+class ReferenceLspSaveToDiskSuite
+    extends ReferenceLspSuite(false, "save-to-disk")
+
+class ReferenceLspVirtualDocSuite
+    extends ReferenceLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -5,7 +5,7 @@ import scala.concurrent.Future
 import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.ServerCommands
 
-class ReferenceLspSuite(
+abstract class ReferenceLspSuite(
     useVirtualDocuments: Boolean,
     suiteNameSuffix: String
 ) extends BaseRangesSuite(s"reference-$suiteNameSuffix") {

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -5,15 +5,12 @@ import scala.concurrent.Future
 import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.ServerCommands
 
-abstract class ReferenceLspSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseRangesSuite(s"reference-$suiteNameSuffix") {
+class ReferenceLspSuite extends BaseRangesSuite("reference") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        isVirtualDocumentSupported = Some(true),
         debuggingProvider = Some(true),
         treeViewProvider = Some(true),
         slowTaskProvider = Some(true)
@@ -417,9 +414,3 @@ abstract class ReferenceLspSuite(
     server.assertReferences(filename, edit, expected, base)
   }
 }
-
-class ReferenceLspSaveToDiskSuite
-    extends ReferenceLspSuite(false, "save-to-disk")
-
-class ReferenceLspVirtualDocSuite
-    extends ReferenceLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -8,7 +8,7 @@ import scala.meta.internal.metals.ServerCommands
 class ReferenceLspSuite extends BaseRangesSuite("reference") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    TestingServer.TestDefault
+    Some(TestingServer.TestDefault)
 
   test("case-class") {
     cleanWorkspace()

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -8,14 +8,7 @@ import scala.meta.internal.metals.ServerCommands
 class ReferenceLspSuite extends BaseRangesSuite("reference") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    TestingServer.TestDefault
 
   test("case-class") {
     cleanWorkspace()

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -1,6 +1,21 @@
 package tests
 
-class RenameLspSuite extends BaseRenameLspSuite("rename") {
+import scala.meta.internal.metals.InitializationOptions
+
+abstract class RenameLspSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends BaseRenameLspSuite(s"rename-$suiteNameSuffix") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(
+        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        debuggingProvider = Some(true),
+        treeViewProvider = Some(true),
+        slowTaskProvider = Some(true)
+      )
+    )
 
   renamed(
     "basic",
@@ -813,3 +828,7 @@ class RenameLspSuite extends BaseRenameLspSuite("rename") {
   override protected def compilerPlugins: List[String] =
     List("org.scalamacros:::paradise:2.1.1")
 }
+
+class RenameLspSaveToDiskSuite extends RenameLspSuite(false, "save-to-disk")
+
+class RenameLspVirtualDocSuite extends RenameLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -2,15 +2,12 @@ package tests
 
 import scala.meta.internal.metals.InitializationOptions
 
-abstract class RenameLspSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseRenameLspSuite(s"rename-$suiteNameSuffix") {
+abstract class RenameLspSuite extends BaseRenameLspSuite(s"rename") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        isVirtualDocumentSupported = Some(true),
         debuggingProvider = Some(true),
         treeViewProvider = Some(true),
         slowTaskProvider = Some(true)
@@ -828,7 +825,3 @@ abstract class RenameLspSuite(
   override protected def compilerPlugins: List[String] =
     List("org.scalamacros:::paradise:2.1.1")
 }
-
-class RenameLspSaveToDiskSuite extends RenameLspSuite(false, "save-to-disk")
-
-class RenameLspVirtualDocSuite extends RenameLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -5,7 +5,7 @@ import scala.meta.internal.metals.InitializationOptions
 abstract class RenameLspSuite extends BaseRenameLspSuite(s"rename") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    TestingServer.TestDefault
+    Some(TestingServer.TestDefault)
 
   renamed(
     "basic",

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -5,14 +5,7 @@ import scala.meta.internal.metals.InitializationOptions
 abstract class RenameLspSuite extends BaseRenameLspSuite(s"rename") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    TestingServer.TestDefault
 
   renamed(
     "basic",

--- a/tests/unit/src/test/scala/tests/SuperHierarchyLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SuperHierarchyLspSuite.scala
@@ -2,9 +2,24 @@ package tests
 
 import scala.concurrent.Future
 
+import scala.meta.internal.metals.InitializationOptions
+
 import org.eclipse.lsp4j.Position
 
-class SuperHierarchyLspSuite extends BaseLspSuite("super-method-hierarchy") {
+abstract class SuperHierarchyLspSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends BaseLspSuite(s"super-method-hierarchy-$suiteNameSuffix") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(
+        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        debuggingProvider = Some(true),
+        treeViewProvider = Some(true),
+        slowTaskProvider = Some(true)
+      )
+    )
 
   test("simple") {
     val code =
@@ -165,3 +180,9 @@ class SuperHierarchyLspSuite extends BaseLspSuite("super-method-hierarchy") {
   }
 
 }
+
+class SuperHierarchyLspSaveToDiskSuite
+    extends SuperHierarchyLspSuite(false, "save-to-disk")
+
+class SuperHierarchyLspVirtualDocSuite
+    extends SuperHierarchyLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/SuperHierarchyLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SuperHierarchyLspSuite.scala
@@ -6,15 +6,12 @@ import scala.meta.internal.metals.InitializationOptions
 
 import org.eclipse.lsp4j.Position
 
-abstract class SuperHierarchyLspSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseLspSuite(s"super-method-hierarchy-$suiteNameSuffix") {
+class SuperHierarchyLspSuite extends BaseLspSuite("super-method-hierarchy") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        isVirtualDocumentSupported = Some(true),
         debuggingProvider = Some(true),
         treeViewProvider = Some(true),
         slowTaskProvider = Some(true)
@@ -88,7 +85,7 @@ abstract class SuperHierarchyLspSuite(
     )
   }
 
-  test("with external dep") {
+  test("with external dep", withoutVirtualDocs = true) {
     val code =
       """
         |package a
@@ -180,9 +177,3 @@ abstract class SuperHierarchyLspSuite(
   }
 
 }
-
-class SuperHierarchyLspSaveToDiskSuite
-    extends SuperHierarchyLspSuite(false, "save-to-disk")
-
-class SuperHierarchyLspVirtualDocSuite
-    extends SuperHierarchyLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/SuperHierarchyLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SuperHierarchyLspSuite.scala
@@ -9,7 +9,7 @@ import org.eclipse.lsp4j.Position
 class SuperHierarchyLspSuite extends BaseLspSuite("super-method-hierarchy") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    TestingServer.TestDefault
+    Some(TestingServer.TestDefault)
 
   test("simple") {
     val code =

--- a/tests/unit/src/test/scala/tests/SuperHierarchyLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SuperHierarchyLspSuite.scala
@@ -9,14 +9,7 @@ import org.eclipse.lsp4j.Position
 class SuperHierarchyLspSuite extends BaseLspSuite("super-method-hierarchy") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    TestingServer.TestDefault
 
   test("simple") {
     val code =

--- a/tests/unit/src/test/scala/tests/SuperMethodLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SuperMethodLspSuite.scala
@@ -2,9 +2,24 @@ package tests
 
 import scala.concurrent.Future
 
+import scala.meta.internal.metals.InitializationOptions
+
 import org.eclipse.lsp4j.Position
 
-class SuperMethodLspSuite extends BaseLspSuite("gotosupermethod") {
+abstract class SuperMethodLspSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends BaseLspSuite(s"gotosupermethod-$suiteNameSuffix") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(
+        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        debuggingProvider = Some(true),
+        treeViewProvider = Some(true),
+        slowTaskProvider = Some(true)
+      )
+    )
 
   test("simple") {
     val code =
@@ -342,3 +357,9 @@ class SuperMethodLspSuite extends BaseLspSuite("gotosupermethod") {
     (result.toMap, expected.toMap)
   }
 }
+
+class SuperMethodLspSaveToDiskSuite
+    extends SuperMethodLspSuite(false, "save-to-disk")
+
+class SuperMethodLspVirtualDocSuite
+    extends SuperMethodLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/SuperMethodLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SuperMethodLspSuite.scala
@@ -6,15 +6,12 @@ import scala.meta.internal.metals.InitializationOptions
 
 import org.eclipse.lsp4j.Position
 
-abstract class SuperMethodLspSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseLspSuite(s"gotosupermethod-$suiteNameSuffix") {
+class SuperMethodLspSuite extends BaseLspSuite("gotosupermethod") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        isVirtualDocumentSupported = Some(true),
         debuggingProvider = Some(true),
         treeViewProvider = Some(true),
         slowTaskProvider = Some(true)
@@ -223,7 +220,7 @@ abstract class SuperMethodLspSuite(
     )
   }
 
-  test("jump-to-external-dependency") {
+  test("jump-to-external-dependency", withoutVirtualDocs = true) {
     val code =
       """
         |package a
@@ -357,9 +354,3 @@ abstract class SuperMethodLspSuite(
     (result.toMap, expected.toMap)
   }
 }
-
-class SuperMethodLspSaveToDiskSuite
-    extends SuperMethodLspSuite(false, "save-to-disk")
-
-class SuperMethodLspVirtualDocSuite
-    extends SuperMethodLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/SuperMethodLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SuperMethodLspSuite.scala
@@ -9,7 +9,7 @@ import org.eclipse.lsp4j.Position
 class SuperMethodLspSuite extends BaseLspSuite("gotosupermethod") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    TestingServer.TestDefault
+    Some(TestingServer.TestDefault)
 
   test("simple") {
     val code =

--- a/tests/unit/src/test/scala/tests/SuperMethodLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SuperMethodLspSuite.scala
@@ -9,14 +9,7 @@ import org.eclipse.lsp4j.Position
 class SuperMethodLspSuite extends BaseLspSuite("gotosupermethod") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    TestingServer.TestDefault
 
   test("simple") {
     val code =

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -12,7 +12,7 @@ import scala.meta.internal.tvp.TreeViewProvider
 class TreeViewLspSuite extends BaseLspSuite("tree-view") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    TestingServer.TestDefault
+    Some(TestingServer.TestDefault)
 
   /**
    * The libraries we expect to find for tests in this file.

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -9,15 +9,12 @@ import scala.meta.internal.tvp.TreeViewProvider
  * @note This suite will fail on openjdk8 < 262)
  *       due to https://mail.openjdk.java.net/pipermail/jdk8u-dev/2020-July/012143.html
  */
-abstract class TreeViewLspSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseLspSuite(s"tree-view-$suiteNameSuffix") {
+class TreeViewLspSuite extends BaseLspSuite("tree-view") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        isVirtualDocumentSupported = Some(true),
         debuggingProvider = Some(true),
         treeViewProvider = Some(true),
         slowTaskProvider = Some(true)
@@ -151,7 +148,7 @@ abstract class TreeViewLspSuite(
     } yield ()
   }
 
-  test("libraries") {
+  test("libraries", withoutVirtualDocs = true) {
     for {
       _ <- initialize(
         """
@@ -548,7 +545,3 @@ abstract class TreeViewLspSuite(
     } yield ()
   }
 }
-
-class TreeViewLspSaveToDiskSuite extends TreeViewLspSuite(false, "save-to-disk")
-
-class TreeViewLspVirtualDocSuite extends TreeViewLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -2,13 +2,27 @@ package tests
 
 import scala.collection.SortedSet
 
+import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.tvp.TreeViewProvider
 
 /**
  * @note This suite will fail on openjdk8 < 262)
  *       due to https://mail.openjdk.java.net/pipermail/jdk8u-dev/2020-July/012143.html
  */
-class TreeViewLspSuite extends BaseLspSuite("tree-view") {
+abstract class TreeViewLspSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends BaseLspSuite(s"tree-view-$suiteNameSuffix") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(
+        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        debuggingProvider = Some(true),
+        treeViewProvider = Some(true),
+        slowTaskProvider = Some(true)
+      )
+    )
 
   /**
    * The libraries we expect to find for tests in this file.
@@ -534,3 +548,7 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
     } yield ()
   }
 }
+
+class TreeViewLspSaveToDiskSuite extends TreeViewLspSuite(false, "save-to-disk")
+
+class TreeViewLspVirtualDocSuite extends TreeViewLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -12,14 +12,7 @@ import scala.meta.internal.tvp.TreeViewProvider
 class TreeViewLspSuite extends BaseLspSuite("tree-view") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    TestingServer.TestDefault
 
   /**
    * The libraries we expect to find for tests in this file.

--- a/tests/unit/src/test/scala/tests/UnsupportedDebuggingLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/UnsupportedDebuggingLspSuite.scala
@@ -13,7 +13,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 class UnsupportedDebuggingLspSuite
     extends BaseLspSuite("unsupported-debugging") {
 
-  override val initializationOptions: Some[InitializationOptions] =
+  override protected def initializationOptions: Some[InitializationOptions] =
     Some(
       // NOTE: Default is fine here since they default to off
       InitializationOptions.Default

--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -12,15 +12,12 @@ import org.eclipse.lsp4j.SymbolInformation
 import org.eclipse.lsp4j.WorkspaceSymbolParams
 import tests.MetalsTestEnrichments._
 
-abstract class WorkspaceSymbolLspSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseLspSuite(s"workspace-symbol-$suiteNameSuffix") {
+class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(useVirtualDocuments),
+        isVirtualDocumentSupported = Some(true),
         debuggingProvider = Some(true),
         treeViewProvider = Some(true),
         slowTaskProvider = Some(true)
@@ -139,7 +136,7 @@ abstract class WorkspaceSymbolLspSuite(
     } yield ()
   }
 
-  test("dependencies") {
+  test("dependencies", withoutVirtualDocs = true) {
     cleanWorkspace()
     for {
       _ <- initialize(
@@ -344,9 +341,3 @@ abstract class WorkspaceSymbolLspSuite(
     } yield ()
   }
 }
-
-class WorkspaceSymbolLspSaveToDiskSuite
-    extends WorkspaceSymbolLspSuite(false, "save-to-disk")
-
-class WorkspaceSymbolLspVirtualDocSuite
-    extends WorkspaceSymbolLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -15,14 +15,7 @@ import tests.MetalsTestEnrichments._
 class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(
-      InitializationOptions.Default.copy(
-        isVirtualDocumentSupported = Some(true),
-        debuggingProvider = Some(true),
-        treeViewProvider = Some(true),
-        slowTaskProvider = Some(true)
-      )
-    )
+    TestingServer.TestDefault
 
   test("basic") {
     cleanWorkspace()

--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -15,7 +15,7 @@ import tests.MetalsTestEnrichments._
 class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    TestingServer.TestDefault
+    Some(TestingServer.TestDefault)
 
   test("basic") {
     cleanWorkspace()

--- a/tests/unit/src/test/scala/tests/debug/StepDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/StepDapSuite.scala
@@ -3,16 +3,9 @@ package tests.debug
 import tests.QuickBuildInitializer
 import tests.QuickBuildLayout
 
-abstract class StepDapSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends BaseStepDapSuite(
-      useVirtualDocuments,
-      s"debug-step-$suiteNameSuffix",
+class StepDapSuite
+    extends BaseStepDapSuite(
+      s"debug-step",
       QuickBuildInitializer,
       QuickBuildLayout
-    ) {}
-
-class StepDapSaveToDiskSuite extends StepDapSuite(false, "save-to-disk")
-
-class StepDapVirtualDocSuite extends StepDapSuite(true, "virtual-docs")
+    )

--- a/tests/unit/src/test/scala/tests/debug/StepDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/StepDapSuite.scala
@@ -3,9 +3,16 @@ package tests.debug
 import tests.QuickBuildInitializer
 import tests.QuickBuildLayout
 
-class StepDapSuite
-    extends BaseStepDapSuite(
-      "debug-step",
+abstract class StepDapSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends BaseStepDapSuite(
+      useVirtualDocuments,
+      s"debug-step-$suiteNameSuffix",
       QuickBuildInitializer,
       QuickBuildLayout
-    )
+    ) {}
+
+class StepDapSaveToDiskSuite extends StepDapSuite(false, "save-to-disk")
+
+class StepDapVirtualDocSuite extends StepDapSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/debug/StepDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/StepDapSuite.scala
@@ -5,7 +5,7 @@ import tests.QuickBuildLayout
 
 class StepDapSuite
     extends BaseStepDapSuite(
-      s"debug-step",
+      "debug-step",
       QuickBuildInitializer,
       QuickBuildLayout
     )

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -9,7 +9,7 @@ import tests.BaseLspSuite
 
 class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
 
-  override def initializationOptions: Option[InitializationOptions] =
+  override protected def initializationOptions: Option[InitializationOptions] =
     Some(
       InitializationOptions.Default.copy(
         inlineDecorationProvider = Some(true),

--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -18,9 +18,10 @@ import munit.TestOptions
 import org.eclipse.{lsp4j => l}
 
 class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
-  override val initializationOptions: Some[InitializationOptions] = Some(
-    InitializationOptions.Default.copy(testExplorerProvider = Some(true))
-  )
+  override protected def initializationOptions: Some[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(testExplorerProvider = Some(true))
+    )
 
   override val userConfig: UserConfiguration =
     UserConfiguration(testUserInterface = TestUserInterfaceKind.TestExplorer)

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
@@ -4,14 +4,7 @@ import scala.meta.internal.metals.{BuildInfo => V}
 
 import munit.TestOptions
 
-abstract class WorksheetLspSuite(
-    useVirtualDocuments: Boolean,
-    suiteNameSuffix: String
-) extends tests.BaseWorksheetLspSuite(
-      V.scala212,
-      useVirtualDocuments,
-      suiteNameSuffix
-    ) {
+class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala212) {
 
   checkWorksheetDeps(
     "imports-inside",
@@ -174,9 +167,3 @@ abstract class WorksheetLspSuite(
     } yield ()
   }
 }
-
-class WorksheetLspSaveToDiskSuite
-    extends WorksheetLspSuite(false, "save-to-disk")
-
-class WorksheetLspVirtualDocSuite
-    extends WorksheetLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
@@ -4,7 +4,14 @@ import scala.meta.internal.metals.{BuildInfo => V}
 
 import munit.TestOptions
 
-class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala212) {
+abstract class WorksheetLspSuite(
+    useVirtualDocuments: Boolean,
+    suiteNameSuffix: String
+) extends tests.BaseWorksheetLspSuite(
+      V.scala212,
+      useVirtualDocuments,
+      suiteNameSuffix
+    ) {
 
   checkWorksheetDeps(
     "imports-inside",
@@ -167,3 +174,9 @@ class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala212) {
     } yield ()
   }
 }
+
+class WorksheetLspSaveToDiskSuite
+    extends WorksheetLspSuite(false, "save-to-disk")
+
+class WorksheetLspVirtualDocSuite
+    extends WorksheetLspSuite(true, "virtual-docs")

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
@@ -15,6 +15,7 @@ class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala212) {
 
   def checkWorksheetDeps(opts: TestOptions, path: String): Unit = {
     test(opts) {
+      cleanWorkspace()
       for {
         _ <- initialize(
           s"""
@@ -72,6 +73,7 @@ class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala212) {
   }
 
   test("bad-dep") {
+    cleanWorkspace()
     val path = "hi.worksheet.sc"
     for {
       _ <- initialize(
@@ -95,6 +97,7 @@ class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala212) {
   // classloader including things like the java.sql module.
   // https://github.com/scalameta/metals/issues/2187
   test("classloader") {
+    cleanWorkspace()
     val path = "hi.worksheet.sc"
     for {
       _ <- initialize(
@@ -116,6 +119,7 @@ class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala212) {
   }
 
   test("akka") {
+    cleanWorkspace()
     val path = "hi.worksheet.sc"
     for {
       _ <- initialize(


### PR DESCRIPTION
Currently when the client wants to browse files in source jars, the files are extracted and saved to `.metals/readonly/dependencies`
e.g.
`file:///workspacePath/.metals/readonly/dependencies/src.zip/java.base/java/nio/file/Path.java`
`file:///workspacePath/.metals/readonly/dependencies/trees_2.12-4.4.28-sources.jar/scala/meta/io/AbsolutePath.scala`

Current downsides:  The extracted source files aren't read only and they have to be written and cleared up.
Virtual doc downsides: These files won't be re-opened when VSCode is shutdown and re-opened

This PR means jar/jdk sources are read directly and passed back to the client as text.  This method uses the original URIs...
e.g.
`jar:file:///usr/lib/jvm/adoptopenjdk-11-hotspot-amd64/src.zip!/java.base/java/nio/file/Path.java`
`jar:file:///userPath/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scalameta/trees_2.12/4.4.28/trees_2.12-4.4.28-sources.jar!/scala/meta/io/AbsolutePath.scala`

This setting can be set per client in `MetalsServerConfig#isVirtualDocumentSupported`

There are a number of places that URIs are passed around as text and transformed into `AbsolutePath`.  That's fine for  `/somepath` but not `jar:file:///jarpath!package/file.java` so these transforms have to go through URI.  I may have missed some of these as I don't know all the code paths from VSCode->Metals.

Also - I'm working around https://github.com/coursier/coursier/issues/2186 (although if this issue is correct then I don't need to work around) but I think the workaround in `MetalsEnrichments#XtensionString#toAbsolutePath` can be left as is.

This PR depends on #3107
