### PR TITLE
Update Sourcegraph workflow to use `lsif-java index` command.

### DIFF
--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -11,18 +11,14 @@ jobs:
     name: "Upload LSIF"
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v13
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "1.15.6"
-      - run: |
+      - uses: coursier/setup-action@v1.1.1
+      - run: cs install --contrib lsif-java
+      - run: lsif-java index
+      - name: src lsif upload
+        run: |
           mkdir -p bin
           curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o bin/src
           chmod +x bin/src
-          export PATH="$PATH:$PWD/bin"
-          sbt \
-              'set every semanticdbEnabled := true' \
-              'set every semanticdbVersion := "4.4.24"' \
-              sourcegraphUpload
+          ./bin/src lsif upload -github-token $GITHUB_TOKEN
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,6 @@ addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.23")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.1")
-addSbtPlugin("com.sourcegraph" % "sbt-sourcegraph" % "0.3.3")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 


### PR DESCRIPTION
The workflow was previously disabled due to 404s that I'm unable to
reproduce now.