### PR TITLE
Fix go to parent code lenses for local symbols

### DIFF
--- a/tests/unit/src/main/scala/tests/CodeLensesTextEdits.scala
+++ b/tests/unit/src/main/scala/tests/CodeLensesTextEdits.scala
@@ -1,23 +1,46 @@
 package tests
 
+import scala.meta.internal.metals.MetalsEnrichments._
+
 import org.eclipse.{lsp4j => l}
 
 object CodeLensesTextEdits {
-  def apply(lenses: Seq[l.CodeLens]): Iterable[l.TextEdit] = {
+  def apply(
+      lenses: Seq[l.CodeLens],
+      printCommand: Boolean
+  ): Iterable[l.TextEdit] = {
+    def convert(line: Int, lenses: Seq[l.CodeLens]): l.TextEdit = {
+      val pos = new l.Position(line, 0)
+      val edit = lenses.map(print).mkString
+      new l.TextEdit(new l.Range(pos, pos), edit + System.lineSeparator())
+    }
+
+    def printArgument(arg: AnyRef) = {
+      arg match {
+        case loc: l.Location =>
+          val start = loc.getRange().getStart()
+          s"${loc.getUri()}:${start.getLine()}:${start.getCharacter()}"
+        case other => other.toString()
+      }
+    }
+
+    def print(lens: l.CodeLens): String = {
+      val command = lens.getCommand
+      if (printCommand) {
+        val arguments = command
+          .getArguments()
+          .asScala
+          .map(printArgument)
+          .mkString("[", ", ", "]")
+        s"<<${command.getTitle()} ${command.getCommand()}$arguments>>"
+      } else
+        s"<<${command.getTitle}>>"
+    }
+
     for {
       (line, lenses) <- lenses.groupBy(_.getRange.getStart.getLine)
       textEdit = convert(line, lenses)
     } yield textEdit
   }
 
-  private def convert(line: Int, lenses: Seq[l.CodeLens]): l.TextEdit = {
-    val pos = new l.Position(line, 0)
-    val edit = lenses.map(print).mkString
-    new l.TextEdit(new l.Range(pos, pos), edit + System.lineSeparator())
-  }
-
-  private def print(lens: l.CodeLens): String = {
-    val command = lens.getCommand
-    s"<<${command.getTitle}>>"
-  }
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -750,7 +750,9 @@ final class TestingServer(
     }
   }
 
-  def codeLenses(filename: String)(maxRetries: Int): Future[String] = {
+  def codeLenses(filename: String, printCommand: Boolean = false)(
+      maxRetries: Int
+  ): Future[String] = {
     val path = toPath(filename)
     val uri = path.toURI.toString
     val params = new CodeLensParams(new TextDocumentIdentifier(uri))
@@ -789,7 +791,7 @@ final class TestingServer(
       // first compilation, to trigger the handler
       _ <- server.compilations.compileFile(path)
       lenses <- codeLenses.future
-      textEdits = CodeLensesTextEdits(lenses)
+      textEdits = CodeLensesTextEdits(lenses, printCommand)
     } yield TextEdits.applyEdits(textContents(filename), textEdits.toList)
   }
 

--- a/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
@@ -194,7 +194,7 @@ class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
     } yield ()
   }
 
-  check("go-to-super-method-lenses")(
+  check("go-to-super-method-lenses", printCommand = true)(
     """package gameofthrones
       |
       |abstract class Lannister {
@@ -203,51 +203,52 @@ class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
       |}
       |
       |trait Tywin extends Lannister{
-      |<< payTheirDebts>>
+      |<< payTheirDebts goto[gameofthrones/Lannister#payTheirDebts().]>>
       |override def payTheirDebts = true
       |}
       |
       |trait Jamie extends Tywin {
-      |<< payTheirDebts>>
+      |<< payTheirDebts goto[gameofthrones/Tywin#payTheirDebts().]>>
       |override def payTheirDebts = true
       |}
       |
       |trait Tyrion extends Tywin {
-      |<< payTheirDebts>>
+      |<< payTheirDebts goto[gameofthrones/Tywin#payTheirDebts().]>>
       |override def payTheirDebts = true
       |}
       |
       |trait Cersei extends Tywin {
-      |<< payTheirDebts>>
+      |<< payTheirDebts goto[gameofthrones/Tywin#payTheirDebts().]>>
       |override def payTheirDebts = false
-      |<< trueLannister>>
+      |<< trueLannister goto[gameofthrones/Lannister#trueLannister().]>>
       |override def trueLannister = false
       |}
       |
       |class Joffrey extends Lannister with Jamie with Cersei {
-      |<< payTheirDebts>>
+      |<< payTheirDebts goto[gameofthrones/Cersei#payTheirDebts().]>>
       |override def payTheirDebts = false
       |}
       |
       |class Tommen extends Lannister with Cersei with Jamie {
-      |<< payTheirDebts>>
+      |<< payTheirDebts goto[gameofthrones/Jamie#payTheirDebts().]>>
       |override def payTheirDebts = true
       |}
       |""".stripMargin
   )
 
-  check("go-to-super-method-lenses-anonymous-class")(
-    """package a
-      |
-      |class A { def afx(): Unit = ??? }
-      |object X {
-      |  val t = new A {
-      |<< afx>>
-      |override def afx(): Unit = ???
-      |  }
-      |}
-      |
-    """.stripMargin
+  check("go-to-super-method-lenses-anonymous-class", printCommand = true)(
+    s"""|package a
+        |
+        |object X {
+        |  def main = {
+        |    class A { def afx(): Unit = ??? } 
+        |    val t = new A {
+        |<< afx goto-position[${workspace.toURI}a/src/main/scala/a/Foo.scala:4:18]>>
+        |    override def afx(): Unit = ???
+        |    }
+        |  }
+        |}
+        |""".stripMargin
   )
 
 }


### PR DESCRIPTION
Previously, we would point only to symbols in the commands for parent code lenses, which cannot work with the local symbols. Now, in case of local symbols we use the command to go to an exact position.