### PR TITLE
Don't search for all symbols in go-to-parent code lenses

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -87,33 +87,6 @@ final class ImplementationProvider(
   }
 
   def defaultSymbolSearch(
-      textDocumentWithPath: TextDocumentWithPath
-  ): String => Option[SymbolInformation] =
-    defaultSymbolSearch(
-      textDocumentWithPath.filePath,
-      textDocumentWithPath.textDocument
-    )
-
-  def defaultSymbolSearchMemoize(
-      anyWorkspacePath: AbsolutePath,
-      textDocument: TextDocument
-  ): String => Option[SymbolInformation] = {
-    lazy val global =
-      globalTable.globalSymbolTableFor(anyWorkspacePath)
-    val textSymbolsMap = textDocument.symbols.map(s => s.symbol -> s).toMap
-    val memoized: mutable.Map[String, SymbolInformation] = mutable.Map.empty
-    symbol => {
-      val result = memoized
-        .get(symbol)
-        .orElse(textSymbolsMap.get(symbol))
-        .orElse(findSymbolInformation(symbol))
-        .orElse(global.flatMap(_.safeInfo(symbol)))
-      result.foreach(r => memoized.put(symbol, r))
-      result
-    }
-  }
-
-  def defaultSymbolSearch(
       anyWorkspacePath: AbsolutePath,
       textDocument: TextDocument
   ): String => Option[SymbolInformation] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
@@ -31,10 +31,8 @@ final class SuperMethodCodeLens(
     val textDocument = textDocumentWithPath.textDocument
     val path = textDocumentWithPath.filePath
 
-    val search = implementationProvider.defaultSymbolSearchMemoize(
-      path,
-      textDocument
-    )
+    def search(query: String) = textDocument.symbols.find(_.symbol == query)
+
     val distance = buffers.tokenEditDistance(path, textDocument.text, trees)
 
     for {


### PR DESCRIPTION
Previously, we would check all the symbols in a file if they don't have a parent, which is highly inefficient. Now, we only search in the local file, which contains all the definitions we are interested in. If there is no definition, we will never display those code lens.

This might have still been causing some issue for users. @kpodsiad reported an issue like that, this is probably the reason.