### PR TITLE
Don't close source jars

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
@@ -29,7 +29,7 @@ private[debug] final class SourcePathAdapter(
         relativePath <- sourcePath.toRelativeInside(
           dependencies.resolve(jarName)
         )
-      } yield FileIO.withJarFileSystem(jarFile, true, true)(root =>
+      } yield FileIO.withJarFileSystem(jarFile, create = true)(root =>
         root.resolve(relativePath.toString).toURI
       )
     }


### PR DESCRIPTION
Previously, when running/debugging we would close previously opened source jars, which would cause all the existing paths to inside of that jar to stop working. Now we don't close them.