### PR TITLE
Make sure generate-sources phase is always run for Maven

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -22,6 +22,7 @@ case class MavenBuildTool(userConfig: () => UserConfiguration)
   def bloopInstallArgs(workspace: AbsolutePath): List[String] = {
     def command(versionToUse: String) =
       List(
+        "generate-sources",
         s"ch.epfl.scala:maven-bloop_2.13:$versionToUse:bloopInstall",
         "-DdownloadSources=true"
       )


### PR DESCRIPTION
Related to https://github.com/scalacenter/bloop/issues/1573

I haven't added a test for it, because protobuf mentioned in the issue needs to be installed locally.