### PR TITLE
Create dependency files on step if they don't exist

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.metals.debug
 
 import java.net.URI
+import java.nio.file.Paths
 
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.metals.BuildTargets
@@ -39,14 +40,7 @@ private[debug] final class SourcePathAdapter(
     val sourceUri = URI.create(sourcePath)
     sourceUri.getScheme match {
       case "jar" =>
-        sourceUri.getRawSchemeSpecificPart.split("!/") match {
-          case Array(jarPath, relativeSourcePath) =>
-            val jarFile = jarPath.toAbsolutePath
-            Some(
-              dependencies.resolve(jarFile.filename).resolve(relativeSourcePath)
-            )
-          case _ => None
-        }
+        Option(AbsolutePath(Paths.get(sourceUri)).toFileOnDisk(workspace))
       case "file" => Some(sourcePath.toAbsolutePath)
       case _ => None
     }

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/StepNavigator.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/StepNavigator.scala
@@ -28,7 +28,11 @@ final class StepNavigator(
       val (expected, nextStep) = expectedSteps.dequeue()
 
       if (actualLine == expected.line && actualPath == expected.file) {
-        nextStep
+        if (expected.file.exists) {
+          nextStep
+        } else {
+          throw new Exception(s"${expected.file} does not exist")
+        }
       } else {
         val error =
           s"Obtained [$actualPath, $actualLine], expected [${expected.file}, ${expected.line}]"


### PR DESCRIPTION
Previously, we would only translate the URI to a local dependencies files. Now, we create the dependency file if it doesn't exist.