### PR TITLE
Avoid IllegalArgumentException when trying to get type of range.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -591,7 +591,7 @@ class Compilers(
       params: HoverExtParams
   )(fn: (PresentationCompiler, Position, AdjustLspData) => T): T = {
     val positionParams =
-      new TextDocumentPositionParams(params.textDocument, params.position)
+      new TextDocumentPositionParams(params.textDocument, params.getPosition)
     val path = params.textDocument.getUri.toAbsolutePath
     val compiler = loadCompiler(path).getOrElse(fallbackCompiler)
 


### PR DESCRIPTION
This is a follow-up to the work done in https://github.com/scalameta/metals/pull/3060, but since
position is now optional, we need to ensure to use `getPosition`
instead of position like we did here. This was causing the following
exception to be throw:

```
Caused by: java.lang.IllegalArgumentException: Property must not be null: position
        at org.eclipse.lsp4j.util.Preconditions.checkNotNull(Preconditions.java:29)
        at org.eclipse.lsp4j.TextDocumentPositionParams.<init>(TextDocumentPositionParams.java:49)
        at scala.meta.internal.metals.Compilers.withPCAndAdjustLsp(Compilers.scala:594)
        at scala.meta.internal.metals.Compilers.hover(Compilers.scala:365)
        at scala.meta.internal.metals.MetalsLanguageServer.$anonfun$hover$1(MetalsLanguageServer.scala:1359)
        at scala.meta.internal.metals.CancelTokens$.future(CancelTokens.scala:38)
        at scala.meta.internal.metals.MetalsLanguageServer.hover(MetalsLanguageServer.scala:1357)
        ... 17 more
```

I'm surprised the test didn't catch this, because this shouldn't work at
all without this change, but by quickly looking at the tests, it's
wasn't clear to me right away why that was the case. I'll need to look
further to understand the tests, but figured I'd send up this quick fix
right away because now it won't work at all without it. However we might
need to create a `HoverRangeLspSuite` to actually catch this.