### PR TITLE
Remove extra boolean from the `goto-position` server command in `StacktraceAnalyzer`

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1649,12 +1649,13 @@ class MetalsLanguageServer(
         }.asJavaObject
       case ServerCommands.GotoPosition(location) =>
         Future {
-          // arguments are not checked but are of format:
-          // singletonList(location: Location, otherWindow: Boolean)
           languageClient.metalsExecuteClientCommand(
             new ExecuteCommandParams(
               ClientCommands.GotoLocation.id,
-              List(location.asInstanceOf[AnyRef]).asJava
+              List(
+                location.asInstanceOf[AnyRef],
+                java.lang.Boolean.TRUE // TRUE for otherWindow
+              ).asJava
             )
           )
         }.asJavaObject

--- a/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
@@ -92,7 +92,7 @@ class StacktraceAnalyzer(
       new l.Command(
         s"${icons.findsuper} open",
         ServerCommands.GotoPosition.id,
-        List[Object](location: Object, java.lang.Boolean.TRUE).asJava
+        List[Object](location: Object).asJava
       ),
       null
     )


### PR DESCRIPTION
So I believe this has snuck under the radar for a long time until the
recent updates made in https://github.com/scalameta/metals/pull/3149
that does a much cleaner job at extracting the params. I believe this was
just a mistake with the `goto-position` server command and the
`goto-location` client command. The client one takes in the extra
boolean to represent `otherWindow`, however that setting doesn't apply
when it's the `goto-position` command being sent to the server. In the
past we sort of just let it slide and the boolean value was always
there, however according to our own spec, it shouldn't be. I found this
while using the `analyze-stacktrace` command since the code lenses it
provides have a `goto-position` command attatched to them that includes
the boolean. Since the boolean is attatched, the unapply no longer works
since we check for only 1 item, so then this falls into a whole other
case and the `goto-position` functionality no longer works. Instead, we
now remove the `TRUE` setting when we set the code lens so the
`goto-position`  unapply works, and then set it when we create the
`goto-location` client command.

Without this change you'd see the following when using the
`goto-position` command.

```
2021.10.03 17:14:16 ERROR Expected '[location], where the location is a lsp location object.', but got '[{"uri":"file:///Users/ckipp/Documents/scala-workspace/scalameta-org/metals/.metals/readonly/dependencies/bsp4j-2.0.0-M13-sources.jar/org/eclipse/lsp4j/util/Preconditions.java","range":{"end":{"line":28,"character":0},"start":{"line":28,"character":0}}}, true]'
```