### PR TITLE
Strip out [info] for stacktraces.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
@@ -78,10 +78,10 @@ class StacktraceAnalyzer(
   /**
    * Strip out the `[E]` when the line is coming from bloop-cli.
    * Or
-   * Strip out the `[error]` when the line is coming from sbt
+   * Strip out the `[error]` or `[info]` when the line is coming from sbt
    */
   private def stripErrorSignifier(line: String) =
-    line.replaceFirst("""(\[E\]|\[error\])""", "").trim
+    line.replaceFirst("""(\[E\]|\[error\]|\[info\])""", "").trim
 
   private def makeGotoLocationCodeLens(
       location: l.Location,

--- a/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
@@ -55,6 +55,28 @@ class AnalyzeStacktraceLspSuite extends BaseLspSuite("analyzestacktrace") {
        |""".stripMargin
   )
 
+  /**
+   * If you have a stack trace during test with sbt it won't actually be an
+   * `[error]` but rather `[info]` like in the case below... which I just ran
+   * into in real life.
+   *
+   * [info]   com.spotify.docker.client.exceptions.DockerException: java.util.concurrent.ExecutionException: javax.ws.rs.ProcessingException: java.lang.Abstract
+   * [info]   at com.spotify.docker.client.DefaultDockerClient.propagate(DefaultDockerClient.java:2812)
+   * [info]   at com.spotify.docker.client.DefaultDockerClient.request(DefaultDockerClient.java:2666)
+   * [info]   at com.spotify.docker.client.DefaultDockerClient.listImages(DefaultDockerClient.java:690)
+   */
+  check(
+    "sbt-info",
+    code,
+    """|[info] java.lang.Exception: error
+       |[info]         at a.b.ClassConstrError.<init>(Main.scala:24)
+       |[info]         at a.b.ObjectError$.raise(Main.scala:18)
+       |[info]         at a.b.ClassError.raise(Main.scala:12)
+       |[info]         at a.b.Main$.main(Main.scala:5)
+       |[info]         at a.b.Main.main(Main.scala)
+       |""".stripMargin
+  )
+
   def check(
       name: String,
       code: String,


### PR DESCRIPTION
This can happen at times when you are running tests and something explodes.
sbt will give you this information a la `[info]` instead of `[error]`. So
this allows the code lenses to work still without having to strip them out
manually