### PR TITLE
Don't create file system when debugging

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
@@ -30,7 +30,7 @@ private[debug] final class SourcePathAdapter(
         relativePath <- sourcePath.toRelativeInside(
           dependencies.resolve(jarName)
         )
-      } yield FileIO.withJarFileSystem(jarFile, create = true)(root =>
+      } yield FileIO.withJarFileSystem(jarFile, create = false)(root =>
         root.resolve(relativePath.toString).toURI
       )
     }


### PR DESCRIPTION
This seems to be causing an exception to happen later on for the older URIs from previously opened file system (at least as far as I understand it):

```
SEVERE: Internal error: java.lang.reflect.InvocationTargetException
java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$null$0(GenericEndpoint.java:67)
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.request(GenericEndpoint.java:120)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleRequest(RemoteEndpoint.java:261)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:190)
	at org.eclipse.lsp4j.jsonrpc.TracingMessageConsumer.consume(TracingMessageConsumer.java:114)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:194)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:94)
	at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:113)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$null$0(GenericEndpoint.java:65)
	... 12 more
Caused by: java.nio.file.ClosedFileSystemException
	at com.sun.nio.zipfs.ZipFileSystem.ensureOpen(ZipFileSystem.java:1103)
	at com.sun.nio.zipfs.ZipFileSystem.getFileAttributes(ZipFileSystem.java:324)
	at com.sun.nio.zipfs.ZipPath.checkAccess(ZipPath.java:826)
	at com.sun.nio.zipfs.ZipFileSystemProvider.checkAccess(ZipFileSystemProvider.java:187)
	at java.nio.file.Files.exists(Files.java:2385)
	at scala.meta.internal.mtags.CommonMtagsEnrichments$XtensionAbsolutePath.exists(CommonMtagsEnrichments.scala:349)
	at scala.meta.internal.metals.DestinationProvider.$anonfun$definition$6(DefinitionProvider.scala:299)
	at scala.meta.internal.metals.DestinationProvider.$anonfun$definition$6$adapted(DefinitionProvider.scala:297)
	at scala.collection.TraversableLike.noneIn$1(TraversableLike.scala:319)
	at scala.collection.TraversableLike.filterImpl(TraversableLike.scala:385)
	at scala.collection.TraversableLike.filterImpl$(TraversableLike.scala:297)
	at scala.collection.AbstractTraversable.filterImpl(Traversable.scala:108)
	at scala.collection.TraversableLike.filter(TraversableLike.scala:395)
	at scala.collection.TraversableLike.filter$(TraversableLike.scala:395)
	at scala.collection.AbstractTraversable.filter(Traversable.scala:108)
	at scala.meta.internal.metals.DestinationProvider.definition(DefinitionProvider.scala:297)
	at scala.meta.internal.metals.DestinationProvider.fromSymbol(DefinitionProvider.scala:337)
	at scala.meta.internal.metals.DestinationProvider.fromSymbol(DefinitionProvider.scala:358)
	at scala.meta.internal.metals.DefinitionProvider.$anonfun$definitionFromSnapshot$1(DefinitionProvider.scala:204)
	at scala.Option.flatMap(Option.scala:271)
	at scala.meta.internal.metals.DefinitionProvider.definitionFromSnapshot(DefinitionProvider.scala:190)
	at scala.meta.internal.metals.DefinitionProvider.definition(DefinitionProvider.scala:78)
	at scala.meta.internal.metals.MetalsLanguageServer.$anonfun$definitionResult$1(MetalsLanguageServer.scala:2642)
	at scala.meta.internal.metals.TimerProvider.timedThunk(TimerProvider.scala:25)
	at scala.meta.internal.metals.MetalsLanguageServer.definitionResult(MetalsLanguageServer.scala:2642)
	at scala.meta.internal.metals.MetalsLanguageServer.definitionOrReferences(MetalsLanguageServer.scala:2610)
	at scala.meta.internal.metals.MetalsLanguageServer.$anonfun$definition$1(MetalsLanguageServer.scala:1335)
	at scala.meta.internal.metals.CancelTokens$.future(CancelTokens.scala:38)
	at scala.meta.internal.metals.MetalsLanguageServer.definition(MetalsLanguageServer.scala:1334)
	... 17 more

```

I am not sure how to reproduce this in tests, but it seems we only open the zip file system once when indexing, which should be the only place for it.

It looks like https://github.com/scalameta/metals/pull/3162 was not enough, though I could swear it was working. I might just be going crazy :sweat_smile: 