### PR TITLE
Wait with loading compiler and compilation

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1018,14 +1018,20 @@ class MetalsLanguageServer(
     } else {
       if (path.isAmmoniteScript)
         ammonite.maybeImport(path)
-      val loadFuture = compilers.load(List(path))
-      val compileFuture = compilations.compileFile(path)
+
+      val compileAndLoad = buildServerPromise.future.flatMap { _ =>
+        Future.sequence(
+          List(
+            compilers.load(List(path)),
+            compilations.compileFile(path)
+          )
+        )
+      }
       Future
         .sequence(
           List(
-            publishSynthetics,
-            loadFuture,
-            compileFuture
+            compileAndLoad,
+            publishSynthetics
           )
         )
         .ignoreValue


### PR DESCRIPTION
Previously, we would load the compiler as sonn as the workspace was opened, which would cause us to load a rambo compiler and print an invalid warning. We would also run the compilation, which possibly be skipped as the build tool was not loaded.

Now, we wait with compilation and loading the presentation compiler until we have information about the build tool (or lack thereof).