### PR TITLE
Don't use `window/showMessage` to report generic Scalafix error

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -111,10 +111,7 @@ case class ScalafixProvider(
         case Success(results) if !scalafixSucceded(results) =>
           val scalafixError = getMessageErrorFromScalafix(results)
           val exception = ScalafixRunException(scalafixError)
-          reportScalafixError(
-            scalafixError,
-            exception
-          )
+          scribe.error(scalafixError, exception)
           if (!retried && hasStaleSemanticdb(results)) {
             // Retry, since the semanticdb might be stale
             organizeImports(file, scalaTarget, retried = true)


### PR DESCRIPTION
Previously, generic Scalafix error messages were reported using
LSP `window/showMessage`. This was problematic because `showMessage`
should only be used for actionable high-signal error messages, whereas
Scalafix can report non-actionable error messages. This commit changes
the behavior to just log the message instead.