### PR TITLE
EndpointLogger: close trace writer

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/EndpointLogger.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/EndpointLogger.scala
@@ -36,7 +36,10 @@ final class EndpointLogger(endpoint: RemoteEndpoint, logger: PrintWriter)
     }
   }
 
-  override def cancel(): Unit = endpoint.cancel()
+  override def cancel(): Unit = {
+    endpoint.cancel()
+    logger.close()
+  }
 
   private def log(direction: Direction, message: Message): Unit =
     synchronized {


### PR DESCRIPTION
Just a minor fix for [this thing](https://github.com/scalameta/metals/issues/3201#issuecomment-943704076)