### PR TITLE
Bump Bloop and scala-debug-adapter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -197,7 +197,7 @@ lazy val V = new {
   val scalameta = "4.4.28"
   val semanticdb = scalameta
   val bsp = "2.0.0-M13"
-  val bloop = "1.4.9-31-1df4194d"
+  val bloop = "1.4.9-33-c93326ba"
   val scala3 = "3.0.2"
   val nextScala3RC = "3.1.0-RC3"
   val bloopNightly = bloop
@@ -507,7 +507,7 @@ lazy val `sbt-metals` = project
       "semanticdbVersion" -> V.semanticdb,
       "supportedScala2Versions" -> V.scala2Versions
     ),
-    addSbtPlugin("ch.epfl.scala" % "sbt-debug-adapter" % "2.0.5")
+    addSbtPlugin("ch.epfl.scala" % "sbt-debug-adapter" % "2.0.6")
   )
   .enablePlugins(BuildInfoPlugin)
   .disablePlugins(ScalafixPlugin)


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/3201

Also brings many bug fixes in the expression evaluator:
https://github.com/scalacenter/scala-debug-adapter/compare/v2.0.5...v2.0.6
