### PR TITLE
Use sbt-debug-adapter explicity in metals.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -211,6 +211,7 @@ lazy val V = new {
   val lsp4jV = "0.12.0"
   val sbtJdiTools = "1.1.1"
   val genyVersion = "0.6.10"
+  val debugAdapter = "2.0.6"
 
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.
@@ -480,6 +481,7 @@ lazy val metals = project
       "ammoniteVersion" -> V.ammonite,
       "organizeImportVersion" -> V.organizeImportRule,
       "millVersion" -> V.mill,
+      "debugAdapterVersion" -> V.debugAdapter,
       "sbtJdiToolsVersion" -> V.sbtJdiTools,
       "supportedScalaVersions" -> V.supportedScalaVersions,
       "supportedScala2Versions" -> V.scala2Versions,
@@ -506,7 +508,6 @@ lazy val `sbt-metals` = project
       "semanticdbVersion" -> V.semanticdb,
       "supportedScala2Versions" -> V.scala2Versions
     ),
-    addSbtPlugin("ch.epfl.scala" % "sbt-debug-adapter" % "2.0.6"),
     scriptedLaunchOpts ++= Seq(s"-Dplugin.version=${version.value}")
   )
   .enablePlugins(BuildInfoPlugin, SbtPlugin)

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -213,7 +213,7 @@ object SbtBuildTool {
   def writeSbtMetalsPlugins(workspace: AbsolutePath): Unit = {
     val mainMeta = workspace.resolve("project")
     val metaMeta = workspace.resolve("project").resolve("project")
-    writePlugins(mainMeta, metalsPluginDetails)
+    writePlugins(mainMeta, metalsPluginDetails, debugAdapterPluginDetails)
     writePlugins(metaMeta, metalsPluginDetails, jdiToolsPluginDetails)
   }
 
@@ -260,6 +260,19 @@ object SbtBuildTool {
       resolver
     )
   }
+
+  /**
+   * The sbt-debug-adpater plugin needs sbt-jdi-tool in its meta-build
+   * (in project/project/metals.sbt)
+   */
+  private def debugAdapterPluginDetails: PluginDetails =
+    PluginDetails(
+      Seq(
+        "This plugin adds the BSP debug capability to sbt server."
+      ),
+      s""""ch.epfl.scala" % "sbt-debug-adapter" % "${BuildInfo.debugAdapterVersion}"""",
+      resolver = None
+    )
 
   /**
    * Short description and artifact for the sbt-jdi-tools plugin


### PR DESCRIPTION
The sbt-debug-adapter was added as a dependency of sbt-metals.
That was fine until sbt-metals is used in `project/project/metals.sbt` (https://github.com/scalameta/metals/pull/3194), because  the sbt-debug-adapter is not useful in the meta-build and it prints a warning in sbt logs:
```
[warn] The sbt-debug-adapter cannot work because the JDI tools are not loaded.
[warn]
[warn] Consider adding the sbt-jdi-tools plugin to your `./project/project/plugins.sbt` file:
[warn] addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "x.y.z")
[warn]
```

So I removed sbt-debug-adapter from the dependencies of sbt-metals.
Instead we can write `sbt-debug-adapter` explicitly in `project/metals.sbt` but we don't write it in `project/project/metals.sbt`.