### PR TITLE
Reset diagnostics on build import

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -2179,6 +2179,7 @@ class MetalsLanguageServer(
       }
       _ <- profiledIndexWorkspace(() => doctor.check())
       _ = if (session.main.isBloop) checkRunningBloopVersion(session.version)
+      _ = diagnostics.reset()
     } yield {
       BuildChange.Reconnected
     }


### PR DESCRIPTION
This is a naive attempt to fix https://github.com/scalameta/metals/issues/3099.

With this, the reproduction of the original issue is no longer a case - the project is created via g8 template and there are no compilation errors right after the first import.

Although I'm not sure the exact place the diagnostics should be reset in: I saw `connectToNewBuildServer` and `autoConnectToBuildServer` as potential candidates.

Please advise (or feel free to close this if this is complete nonsense).