### PR TITLE
Print exact type for expressions containing generics

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
@@ -40,11 +40,11 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
           params.offset(),
           params.endOffset()
         )
-        val tree = typedHoverTreeAt(pos)
+        val tree = typedHoverTreeAt(pos, unit)
         (pos, tree)
       case params: OffsetParams =>
         val pos = unit.position(params.offset())
-        val tree = typedHoverTreeAt(pos)
+        val tree = typedHoverTreeAt(pos, unit)
         (pos, tree)
     }
     tree match {
@@ -183,12 +183,7 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
       }
     lastVisitedParentTrees match {
       case head :: tail =>
-        tryTail(tail) match {
-          case Some(value) =>
-            typedTreeAt(value.pos)
-          case None =>
-            head
-        }
+        tryTail(tail).getOrElse(head)
       case _ =>
         EmptyTree
     }
@@ -287,8 +282,12 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
     sym.flagString(mask)
   }
 
-  private def typedHoverTreeAt(pos: Position): Tree = {
-    val typedTree = typedTreeAt(pos)
+  private def typedHoverTreeAt(
+      pos: Position,
+      unit: RichCompilationUnit
+  ): Tree = {
+    typeCheck(unit)
+    val typedTree = locateTree(pos)
     typedTree match {
       case Import(qual, _) if qual.pos.includes(pos) =>
         qual.findSubtree(pos)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -635,7 +635,15 @@ trait Completions { this: MetalsGlobal =>
       }
     }
 
-    protected def isEligible(t: Tree): Boolean = !t.pos.isTransparent
+    protected def isEligible(t: Tree): Boolean = {
+      !t.pos.isTransparent || {
+        t match {
+          // new User(age = 42, name = "") becomes transparent, which doesn't happen with normal methods
+          case Apply(Select(_: New, _), _) => true
+          case _ => false
+        }
+      }
+    }
     override def traverse(t: Tree): Unit = {
       t match {
         case tt: TypeTree

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -203,15 +203,12 @@ class HoverTermSuite extends BaseHoverSuite {
     """
       |class Foo(name: String, age: Int)
       |object a {
-      |  new Fo@@o("", 42) {
+      |  new <<Fo@@o>>("", 42) {
       |    val x = 2
       |  }
       |}
       |""".stripMargin,
-    "",
-    compat = Map(
-      "3" -> "class Foo: Foo".hover
-    )
+    "class Foo: Foo".hover
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/hover/RangeHoverSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/RangeHoverSuite.scala
@@ -21,10 +21,31 @@ class RangeHoverSuite extends BaseHoverSuite {
        |  }
        |}
        |""".stripMargin,
-    """|B
+    """|Int
        |def sum[B >: Int](implicit num: Numeric[B]): B""".stripMargin.hoverRange,
     compat = Map(
       "3" -> "def sum[B >: A](implicit num: Numeric[B]): B".hoverRange
+    )
+  )
+
+  check(
+    "range-sum-method-generic",
+    """|package helpers
+       |
+       |class XDClass[T] {
+       |  def xd: T = {
+       |    val l: List[T] = ???
+       |    <<l.%<%head%>%>>
+       |  }
+       |}
+       |""".stripMargin,
+    """|T
+       |override def head: T""".stripMargin.hoverRange,
+    compat = Map(
+      "3" -> "def head: T".hoverRange,
+      "2.13" ->
+        """|T
+           |def head: T""".stripMargin.hoverRange
     )
   )
 
@@ -45,7 +66,7 @@ class RangeHoverSuite extends BaseHoverSuite {
        |  }
        |}
        |""".stripMargin,
-    """|B
+    """|Int
        |def sum[B >: Int](implicit num: Numeric[B]): B""".stripMargin.hoverRange,
     compat = Map(
       "3" -> "val l: List[Int]".hoverRange
@@ -212,7 +233,7 @@ class RangeHoverSuite extends BaseHoverSuite {
        |  }
        |}
        |""".stripMargin,
-    """|B
+    """|Int
        |def sum[B >: Int](implicit num: Numeric[B]): B""".stripMargin.hoverRange,
     compat = Map(
       "3" -> "def sum[B >: A](implicit num: Numeric[B]): B".hoverRange
@@ -236,7 +257,7 @@ class RangeHoverSuite extends BaseHoverSuite {
        |  }
        |}
        |""".stripMargin,
-    """|B
+    """|Int
        |def sum[B >: Int](implicit num: Numeric[B]): B""".stripMargin.hoverRange,
     compat = Map(
       "3" -> "def xd: Int".hoverRange


### PR DESCRIPTION
Previously, we would print T for expression types of generic class, now we try to have an exact type.