### PR TITLE
Compilers: try to fix NPE

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -534,7 +534,7 @@ class Compilers(
           }
         }
       )
-      Some(out)
+      Option(out)
     }
   }
 


### PR DESCRIPTION
Today I got NPE several times by accessing presentation compiler.
It's hard to reproduce now, but @tgodzik suggested that it's probably might
be the reason. `computeIfAbsent` might return null in some cases.