### PR TITLE
Add CFR class file viewer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -204,6 +204,7 @@ lazy val V = new {
   val sbtBloop = bloop
   val gradleBloop = bloop
   val mavenBloop = bloop
+  val cfr = "0.151"
   val mdoc = "2.2.24"
   val scalafmt = "3.0.5"
   val munit = "0.7.29"
@@ -435,6 +436,8 @@ lazy val metals = project
       V.dap4j,
       // for producing SemanticDB from Java source files
       "com.thoughtworks.qdox" % "qdox" % "2.0.0",
+      // for decompiling class files
+      "org.benf" % "cfr" % V.cfr,
       // for finding paths of global log/cache directories
       "dev.dirs" % "directories" % "26",
       // ==================
@@ -475,6 +478,7 @@ lazy val metals = project
       "sbtBloopVersion" -> V.sbtBloop,
       "gradleBloopVersion" -> V.gradleBloop,
       "mavenBloopVersion" -> V.mavenBloop,
+      "cfrVersion" -> V.cfr,
       "scalametaVersion" -> V.scalameta,
       "semanticdbVersion" -> V.semanticdb,
       "scalafmtVersion" -> V.scalafmt,

--- a/build.sbt
+++ b/build.sbt
@@ -204,7 +204,6 @@ lazy val V = new {
   val sbtBloop = bloop
   val gradleBloop = bloop
   val mavenBloop = bloop
-  val cfr = "0.151"
   val mdoc = "2.2.24"
   val scalafmt = "3.0.5"
   val munit = "0.7.29"
@@ -436,8 +435,6 @@ lazy val metals = project
       V.dap4j,
       // for producing SemanticDB from Java source files
       "com.thoughtworks.qdox" % "qdox" % "2.0.0",
-      // for decompiling class files
-      "org.benf" % "cfr" % V.cfr,
       // for finding paths of global log/cache directories
       "dev.dirs" % "directories" % "26",
       // ==================
@@ -478,7 +475,6 @@ lazy val metals = project
       "sbtBloopVersion" -> V.sbtBloop,
       "gradleBloopVersion" -> V.gradleBloop,
       "mavenBloopVersion" -> V.mavenBloop,
-      "cfrVersion" -> V.cfr,
       "scalametaVersion" -> V.scalameta,
       "semanticdbVersion" -> V.semanticdb,
       "scalafmtVersion" -> V.scalafmt,

--- a/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
@@ -38,7 +38,11 @@ class ShellRunner(
       dependency: Dependency,
       main: String,
       dir: AbsolutePath,
-      arguments: List[String]
+      arguments: List[String],
+      redirectErrorOutput: Boolean = false,
+      processOut: String => Unit = scribe.info(_),
+      processErr: String => Unit = scribe.error(_),
+      propagateError: Boolean = false
   ): Future[Int] = {
 
     val classpathSeparator = if (Properties.isWin) ";" else ":"
@@ -55,7 +59,15 @@ class ShellRunner(
       classpath,
       main
     ) ::: arguments
-    run(main, cmd, dir, redirectErrorOutput = false)
+    run(
+      main,
+      cmd,
+      dir,
+      redirectErrorOutput,
+      processOut = processOut,
+      processErr = processErr,
+      propagateError = propagateError
+    )
   }
 
   def run(

--- a/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
@@ -80,7 +80,13 @@ class FileDecoderProviderLspSuite extends BaseLspSuite("fileDecoderProvider") {
     "app/src/main/scala/Main.scala",
     Some("foo/bar/example/Foo.class"),
     "cfr",
-    Right(FileDecoderProviderLspSuite.cfr)
+    Right(FileDecoderProviderLspSuite.cfr),
+    str =>
+      str
+        .replaceAll(
+          ".*(Decompiled with CFR )(\\d|.)*\\.",
+          " * Decompiled with CFR VERSION."
+        )
   )
 
   check(
@@ -98,7 +104,13 @@ class FileDecoderProviderLspSuite extends BaseLspSuite("fileDecoderProvider") {
     "app/src/main/java/foo/bar/example/Main.java",
     None,
     "cfr",
-    Right(FileDecoderProviderLspSuite.cfrJava)
+    Right(FileDecoderProviderLspSuite.cfrJava),
+    str =>
+      str
+        .replaceAll(
+          ".*(Decompiled with CFR )(\\d|.)*\\.",
+          " * Decompiled with CFR VERSION."
+        )
   )
 
   check(
@@ -110,7 +122,7 @@ class FileDecoderProviderLspSuite extends BaseLspSuite("fileDecoderProvider") {
         |  }
         |}
         |/app/src/main/java/foo/bar/example/Main.java
-        |package not.here;
+        |package foo.bar.example.not.here;
         |class Main {}
         |""".stripMargin,
     "app/src/main/java/foo/bar/example/Main.java",
@@ -121,7 +133,11 @@ class FileDecoderProviderLspSuite extends BaseLspSuite("fileDecoderProvider") {
       str
         .replace("\\", "/")
         .replaceAll(
-          "(No such file\\s|).*(\\/foo\\/bar\\/example\\/Main.class)",
+          "(No such file ).*(\\/foo\\/bar\\/example\\/Main\\.class)",
+          "$1$2"
+        )
+        .replaceAll(
+          "(CannotLoadClassException: ).*(\\/foo\\/bar\\/example\\/Main\\.class )",
           "$1$2"
         )
   )
@@ -143,7 +159,13 @@ class FileDecoderProviderLspSuite extends BaseLspSuite("fileDecoderProvider") {
     "app/src/main/scala/Main.scala",
     Some("foo/bar/example/Main$package.class"),
     "cfr",
-    Right(FileDecoderProviderLspSuite.cfrToplevel)
+    Right(FileDecoderProviderLspSuite.cfrToplevel),
+    str =>
+      str
+        .replaceAll(
+          ".*(Decompiled with CFR )(\\d|.)*\\.",
+          " * Decompiled with CFR VERSION."
+        )
   )
 
   check(
@@ -664,7 +686,7 @@ object FileDecoderProviderLspSuite {
 
   private val cfr =
     s"""|/*
-        | * Decompiled with CFR ${V.cfrVersion}.
+        | * Decompiled with CFR VERSION.
         | */
         |package foo.bar.example;
         |
@@ -674,7 +696,7 @@ object FileDecoderProviderLspSuite {
 
   private val cfrJava =
     s"""|/*
-        | * Decompiled with CFR ${V.cfrVersion}.
+        | * Decompiled with CFR VERSION.
         | */
         |package foo.bar.example;
         |
@@ -685,12 +707,13 @@ object FileDecoderProviderLspSuite {
         |""".stripMargin
 
   private val cfrMissing =
-    s"""|/foo/bar/example/Main.class
-        |No such file /foo/bar/example/Main.class""".stripMargin
+    s"""|Can't load the class specified:
+        |org.benf.cfr.reader.util.CannotLoadClassException: /foo/bar/example/Main.class - java.io.IOException: No such file /foo/bar/example/Main.class
+        |""".stripMargin
 
   private val cfrToplevel =
     s"""|/*
-        | * Decompiled with CFR ${V.cfrVersion}.
+        | * Decompiled with CFR VERSION.
         | */
         |package foo.bar.example;
         |

--- a/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
@@ -65,6 +65,45 @@ class FileDecoderProviderLspSuite extends BaseLspSuite("fileDecoderProvider") {
   )
 
   check(
+    "cfr",
+    s"""|/metals.json
+        |{
+        |  "app": {
+        |    "scalaVersion": "${V.scala3}"
+        |  }
+        |}
+        |/app/src/main/scala/Main.scala
+        |package foo.bar.example
+        |class Foo
+        |class Bar
+        |""".stripMargin,
+    "app/src/main/scala/Main.scala",
+    Some("foo/bar/example/Foo.class"),
+    "cfr",
+    Right(FileDecoderProviderLspSuite.cfr)
+  )
+
+  check(
+    "cfr-toplevel",
+    s"""|/metals.json
+        |{
+        |  "app": {
+        |    "scalaVersion": "${V.scala3}"
+        |  }
+        |}
+        |/app/src/main/scala/Main.scala
+        |package foo.bar.example
+        |class Foo
+        |class Bar
+        |def foo(): Unit = ()
+        |""".stripMargin,
+    "app/src/main/scala/Main.scala",
+    Some("foo/bar/example/Main$package.class"),
+    "cfr",
+    Right(FileDecoderProviderLspSuite.cfrToplevel)
+  )
+
+  check(
     "javap",
     s"""|/metals.json
         |{
@@ -543,6 +582,31 @@ object FileDecoderProviderLspSuite {
         |
         |
         | 0 comment bytes:
+        |""".stripMargin
+
+  private val cfr =
+    s"""|/*
+        | * Decompiled with CFR ${V.cfrVersion}.
+        | */
+        |package foo.bar.example;
+        |
+        |public class Foo {
+        |}
+        |""".stripMargin
+
+  private val cfrToplevel =
+    s"""|/*
+        | * Decompiled with CFR ${V.cfrVersion}.
+        | */
+        |package foo.bar.example;
+        |
+        |import foo.bar.example.Main$$package$$;
+        |
+        |public final class Main$$package {
+        |    public static void foo() {
+        |        Main$$package$$.MODULE$$.foo();
+        |    }
+        |}
         |""".stripMargin
 
   private val javap =


### PR DESCRIPTION
Adds a class file decompiler to the list of source analysis tools

@s5bug put me onto this while discussing an issue with Scala 3.  It was easier to understand what was going on than using `javap` so I thought it might help to integrate it into Metals

This includes a fix for using `javap` on java source files - it was looking in the wrong dir for the class file.  I haven't added any Java tests to `FileDecoderProviderLspSuite` because I don't think `didOpen` triggers a java file compilation with Metals yet, so it won't compile a single Java file and therefore can't test the analysis of the output - or am I wrong?

Other options besides [CFR](https://github.com/leibnitz27/cfr) are [fernflower](https://github.com/JetBrains/intellij-community/tree/master/plugins/java-decompiler/engine) and [procyon](https://github.com/mstrobel/procyon).  I figure if CFR isn't good enough then users can raise issues and other decompilers can be added/substituted.

I imagine this will also be handy for implementing https://github.com/scalameta/metals-feature-requests/issues/210

@ckipp01 Hopefully this is easy to add to VI.  In the VSCode PR I've also setup the `.cfr` file extension to use Java textmate grammar.  That's built into VSCode - hence I've just amended the language contribution point to use an additional extension.

License question: Do I have to include a reference to CFR in `NOTICE.md`?  I've added a dependency on CFR but not included source code.