### PR TITLE
Add try in order not to break debugging session

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
@@ -38,7 +38,7 @@ private[debug] final class SourcePathAdapter(
     }
   }
 
-  def toMetalsPath(sourcePath: String): Option[AbsolutePath] = {
+  def toMetalsPath(sourcePath: String): Option[AbsolutePath] = try {
     val sourceUri =
       Try(URI.create(sourcePath)).getOrElse(Paths.get(sourcePath).toUri())
     sourceUri.getScheme match {
@@ -47,6 +47,10 @@ private[debug] final class SourcePathAdapter(
       case "file" => Some(AbsolutePath(Paths.get(sourceUri)))
       case _ => None
     }
+  } catch {
+    case e: Throwable =>
+      scribe.error(s"Could not resolve $sourcePath", e)
+      None
   }
 }
 


### PR DESCRIPTION
While testing on windows I encounter still some issues for classes within `src.zip` JDK sources.

It was throwing FileSytemNotFound exceptions and I was not able to figure out what was going on.

This is a quickfix for this release so that it's possible to use breakpoints properly on Windows, the only thing this will do is that it might sometimes be impossible to go to JDK sources.