### PR TITLE
SuperMethodCodeLens - do not show stale lenses

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
@@ -49,7 +49,7 @@ final class SuperMethodCodeLens(
       ).toIterable
       range <-
         occurrence.range
-          .flatMap(r => distance.toRevised(r.toLSP))
+          .flatMap(r => distance.toRevisedStrict(r).map(_.toLSP))
           .toList
     } yield new l.CodeLens(range, gotoSuperMethod, null)
   }


### PR DESCRIPTION
Previosuly, lenses wasn't erased if document was changed in buffer only.