### PR TITLE
Fix issue with empty string in completions

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
@@ -89,7 +89,7 @@ object SemanticdbSymbols:
 
     def addName(name: Name) =
       val str = name.toString.unescapeUnicode
-      if str.isJavaIdent then b append str
+      if str.nonEmpty && str.isJavaIdent then b append str
       else b append '`' append str append '`'
 
     def addOwner(owner: Symbol): Unit =


### PR DESCRIPTION
Encountered stack trace when trying empty scope completions

```
Exception in thread "pool-4-thread-1" java.util.NoSuchElementException: head of empty String
	at scala.collection.StringOps$.head$extension(StringOps.scala:1129)
	at dotty.tools.dotc.semanticdb.Scala3$StringOps$.isJavaIdent(Scala3.scala:405)
	at scala.meta.internal.pc.SemanticdbSymbols$.addName$1(SemanticdbSymbols.scala:92)
	at scala.meta.internal.pc.SemanticdbSymbols$.addDescriptor$1(SemanticdbSymbols.scala:127)
	at scala.meta.internal.pc.SemanticdbSymbols$.addSymName(SemanticdbSymbols.scala:137)
	at scala.meta.internal.pc.SemanticdbSymbols$.symbolName(SemanticdbSymbols.scala:79)
	at scala.meta.internal.pc.CompletionProvider.visit$1(CompletionProvider.scala:116)
	at scala.meta.internal.pc.CompletionProvider.$anonfun$5(CompletionProvider.scala:138)
	at scala.meta.internal.pc.CompletionProvider.enrichWithSymbolSearch$$anonfun$1(CompletionProvider.scala:70)
	at scala.collection.immutable.List.map(List.scala:246)
	at scala.meta.internal.pc.CompletionProvider.enrichWithSymbolSearch(CompletionProvider.scala:70)
	at scala.meta.internal.pc.CompletionProvider.filterInteresting(CompletionProvider.scala:138)
	at scala.meta.internal.pc.CompletionProvider.completions(CompletionProvider.scala:44)
	at scala.meta.internal.pc.ScalaPresentationCompiler.complete$$anonfun$1(ScalaPresentationCompiler.scala:166)
	at scala.meta.internal.pc.CompilerAccess.withSharedCompiler(CompilerAccess.scala:137)
	at scala.meta.internal.pc.CompilerAccess.$anonfun$1(CompilerAccess.scala:87)
	at scala.meta.internal.pc.CompilerAccess.onCompilerJobQueue$$anonfun$1(CompilerAccess.scala:197)
	at scala.meta.internal.pc.CompilerJobQueue$Job.run(CompilerJobQueue.scala:139)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```