### PR TITLE
Finer grained rules on build errors for debug discovery.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -294,7 +294,7 @@ class DebugProvider(
       buildTargetClasses.classesOf(bti).testClasses
 
     val result: Future[DebugSessionParams] = (runTypeO, buildTargetO) match {
-      case _ if buildClient.buildHasErrors =>
+      case (_, Some(buildTarget)) if buildClient.buildHasErrors(buildTarget) =>
         Future.failed(WorkspaceErrorsException)
       case (_, None) =>
         Future.failed(BuildTargetNotFoundForPathException(path))


### PR DESCRIPTION
This pr makes the check for errors in the build a bit more specific when
doing debug discovery. In the past if there was an error at all in the
build, we would error and notify the user they couldn't run/test the
file. However, instead of looking for errors in the entire build we can
instead use the build target and check that build target for errors
(which also checks the transitive build dependencies) which allows you
to run or test a file when there are unrelated errors.

Fixes #3219