### PR TITLE
ScalaVersion - discover new mtags version by coursier

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -62,7 +62,9 @@ final class BuildTargets(
       var score = 1
 
       val isSupportedScalaVersion = scalaInfo(t).exists(t =>
-        ScalaVersions.isSupportedScalaVersion(t.getScalaVersion())
+        ScalaVersions.isSupportedAtReleaseMomentScalaVersion(
+          t.getScalaVersion()
+        )
       )
       if (isSupportedScalaVersion) score <<= 2
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -31,12 +31,14 @@ final class Doctor(
     calculateNewBuildServer: () => BspResolvedResult,
     httpServer: () => Option[MetalsHttpServer],
     tables: Tables,
-    clientConfig: ClientConfiguration
+    clientConfig: ClientConfiguration,
+    mtagsResolver: MtagsResolver
 )(implicit ec: ExecutionContext) {
   private val hasProblems = new AtomicBoolean(false)
   private val problemResolver =
     new ProblemResolver(
       workspace,
+      mtagsResolver,
       currentBuildServer,
       clientConfig.isCommandInHtmlSupported()
     )
@@ -352,7 +354,7 @@ final class Doctor(
   private def extractTargetInfo(target: ScalaTarget) = {
     val scalaVersion = target.scalaVersion
     val definition: String =
-      if (ScalaVersions.isSupportedScalaVersion(scalaVersion)) {
+      if (mtagsResolver.isSupportedScalaVersion(scalaVersion)) {
         Icons.unicode.check
       } else {
         Icons.unicode.alert

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -107,7 +107,7 @@ class MetalsLanguageServer(
       BspServers.globalInstallDirectories,
     sh: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
     isReliableFileWatcher: Boolean = true,
-    allSupportedMtagsRequired: Boolean = true
+    mtagsResolver: MtagsResolver = MtagsResolver.default()
 ) extends Cancelable {
   ThreadPools.discardRejectedRunnables("MetalsLanguageServer.sh", sh)
   ThreadPools.discardRejectedRunnables("MetalsLanguageServer.ec", ec)
@@ -160,7 +160,6 @@ class MetalsLanguageServer(
   val excludedPackageHandler: ExcludedPackagesHandler =
     new ExcludedPackagesHandler(userConfig.excludedPackages)
   var ammonite: Ammonite = _
-  private val mtagsResolver = new MtagsResolver
   val buildTargets: BuildTargets = BuildTargets.withAmmonite(() => ammonite)
   private val buildTargetClasses =
     new BuildTargetClasses(buildTargets)

--- a/metals/src/main/scala/scala/meta/internal/metals/MtagsBinaries.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MtagsBinaries.scala
@@ -1,0 +1,19 @@
+package scala.meta.internal.metals
+
+import java.nio.file.Path
+
+import scala.meta.internal.mtags
+
+sealed trait MtagsBinaries {
+  def scalaVersion: String
+}
+object MtagsBinaries {
+  case object BuildIn extends MtagsBinaries {
+    val scalaVersion = mtags.BuildInfo.scalaCompilerVersion
+  }
+  case class Artifacts(scalaVersion: String, jars: List[Path])
+      extends MtagsBinaries
+
+  def isBuildIn(scalaVersion: String): Boolean =
+    ScalaVersions.dropVendorSuffix(scalaVersion) == BuildIn.scalaVersion
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
@@ -7,76 +7,86 @@ import scala.util.control.NonFatal
 
 import coursierapi.error.SimpleResolutionError
 
-class MtagsResolver {
-
-  private val states =
-    new ConcurrentHashMap[String, State]()
-
-  def resolve(scalaVersion: String): Option[MtagsBinaries] = {
-    def logError(e: Throwable): Unit = {
-      val msg = s"Failed to fetch mtags for ${scalaVersion}"
-      e match {
-        case _: SimpleResolutionError =>
-          // no need to log traces for coursier error
-          // all explanation is in message
-          scribe.error(msg + "\n" + e.getMessage())
-        case _ =>
-          scribe.error(msg, e)
-      }
-    }
-
-    def fetch(tries: Int = 0): State = {
-      try {
-        val jars = Embedded.downloadMtags(scalaVersion)
-        State.Success(MtagsBinaries.Artifacts(scalaVersion, jars))
-      } catch {
-        case NonFatal(e) =>
-          logError(e)
-          State.Failure(System.currentTimeMillis(), tries)
-      }
-    }
-    def shouldResolveAgain(failure: State.Failure): Boolean = {
-      failure.tries < State.maxTriesInARow ||
-      (System.currentTimeMillis() - failure.lastTryMillis) > 5.minutes.toMillis
-    }
-
-    // The metals_2.12 artifact depends on mtags_2.12.x where "x" matches
-    // `mtags.BuildInfo.scalaCompilerVersion`. In the case when
-    // `info.getScalaVersion == mtags.BuildInfo.scalaCompilerVersion` then we
-    // skip fetching the mtags module from Maven.
-    if (MtagsBinaries.isBuildIn(scalaVersion)) {
-      Some(MtagsBinaries.BuildIn)
-    } else {
-      val computed = states.compute(
-        scalaVersion,
-        (_, value) => {
-          value match {
-            case null => fetch()
-            case succ: State.Success => succ
-            case failure: State.Failure =>
-              if (shouldResolveAgain(failure))
-                fetch(failure.tries + 1)
-              else {
-                scribe.info(s"No mtags for ${scalaVersion}.")
-                failure
-              }
-          }
-        }
-      )
-      computed match {
-        case State.Success(v) => Some(v)
-        case _: State.Failure => None
-      }
-    }
-  }
-
-  def isSupportedScalaVersion(version: String): Boolean =
+trait MtagsResolver {
+  def resolve(scalaVersion: String): Option[MtagsBinaries]
+  final def isSupportedScalaVersion(version: String): Boolean =
     resolve(version).isDefined
+}
 
-  sealed trait State
-  object State {
-    val maxTriesInARow: Int = 2
-    case class Success(v: MtagsBinaries.Artifacts) extends State
-    case class Failure(lastTryMillis: Long, tries: Int) extends State
+object MtagsResolver {
+
+  def default(): MtagsResolver = new Default
+
+  class Default extends MtagsResolver {
+
+    private val states =
+      new ConcurrentHashMap[String, State]()
+
+    def resolve(scalaVersion: String): Option[MtagsBinaries] = {
+      def logError(e: Throwable): Unit = {
+        val msg = s"Failed to fetch mtags for ${scalaVersion}"
+        e match {
+          case _: SimpleResolutionError =>
+            // no need to log traces for coursier error
+            // all explanation is in message
+            scribe.error(msg + "\n" + e.getMessage())
+          case _ =>
+            scribe.error(msg, e)
+        }
+      }
+
+      def fetch(tries: Int = 0): State = {
+        try {
+          val jars = Embedded.downloadMtags(scalaVersion)
+          State.Success(MtagsBinaries.Artifacts(scalaVersion, jars))
+        } catch {
+          case NonFatal(e) =>
+            logError(e)
+            State.Failure(System.currentTimeMillis(), tries)
+        }
+      }
+      def shouldResolveAgain(failure: State.Failure): Boolean = {
+        failure.tries < State.maxTriesInARow ||
+        (System
+          .currentTimeMillis() - failure.lastTryMillis) > 5.minutes.toMillis
+      }
+
+      // The metals_2.12 artifact depends on mtags_2.12.x where "x" matches
+      // `mtags.BuildInfo.scalaCompilerVersion`. In the case when
+      // `info.getScalaVersion == mtags.BuildInfo.scalaCompilerVersion` then we
+      // skip fetching the mtags module from Maven.
+      if (MtagsBinaries.isBuildIn(scalaVersion)) {
+        Some(MtagsBinaries.BuildIn)
+      } else {
+        val computed = states.compute(
+          scalaVersion,
+          (_, value) => {
+            value match {
+              case null => fetch()
+              case succ: State.Success => succ
+              case failure: State.Failure =>
+                if (shouldResolveAgain(failure))
+                  fetch(failure.tries + 1)
+                else {
+                  scribe.info(s"No mtags for ${scalaVersion}.")
+                  failure
+                }
+            }
+          }
+        )
+        computed match {
+          case State.Success(v) => Some(v)
+          case _: State.Failure => None
+        }
+      }
+    }
+
+    sealed trait State
+    object State {
+      val maxTriesInARow: Int = 2
+      case class Success(v: MtagsBinaries.Artifacts) extends State
+      case class Failure(lastTryMillis: Long, tries: Int) extends State
+    }
   }
+
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
@@ -1,0 +1,82 @@
+package scala.meta.internal.metals
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+import coursierapi.error.SimpleResolutionError
+
+class MtagsResolver {
+
+  private val states =
+    new ConcurrentHashMap[String, State]()
+
+  def resolve(scalaVersion: String): Option[MtagsBinaries] = {
+    def logError(e: Throwable): Unit = {
+      val msg = s"Failed to fetch mtags for ${scalaVersion}"
+      e match {
+        case _: SimpleResolutionError =>
+          // no need to log traces for coursier error
+          // all explanation is in message
+          scribe.error(msg + "\n" + e.getMessage())
+        case _ =>
+          scribe.error(msg, e)
+      }
+    }
+
+    def fetch(tries: Int = 0): State = {
+      try {
+        val jars = Embedded.downloadMtags(scalaVersion)
+        State.Success(MtagsBinaries.Artifacts(scalaVersion, jars))
+      } catch {
+        case NonFatal(e) =>
+          logError(e)
+          State.Failure(System.currentTimeMillis(), tries)
+      }
+    }
+    def shouldResolveAgain(failure: State.Failure): Boolean = {
+      failure.tries < State.maxTriesInARow ||
+      (System.currentTimeMillis() - failure.lastTryMillis) > 5.minutes.toMillis
+    }
+
+    // The metals_2.12 artifact depends on mtags_2.12.x where "x" matches
+    // `mtags.BuildInfo.scalaCompilerVersion`. In the case when
+    // `info.getScalaVersion == mtags.BuildInfo.scalaCompilerVersion` then we
+    // skip fetching the mtags module from Maven.
+    if (MtagsBinaries.isBuildIn(scalaVersion)) {
+      Some(MtagsBinaries.BuildIn)
+    } else {
+      val computed = states.compute(
+        scalaVersion,
+        (_, value) => {
+          value match {
+            case null => fetch()
+            case succ: State.Success => succ
+            case failure: State.Failure =>
+              if (shouldResolveAgain(failure))
+                fetch(failure.tries + 1)
+              else {
+                scribe.info(s"No mtags for ${scalaVersion}.")
+                failure
+              }
+          }
+        }
+      )
+      computed match {
+        case State.Success(v) => Some(v)
+        case _: State.Failure => None
+      }
+    }
+  }
+
+  def isSupportedScalaVersion(version: String): Boolean =
+    resolve(version).isDefined
+
+  sealed trait State
+  object State {
+    val maxTriesInARow: Int = 2
+    case class Success(v: MtagsBinaries.Artifacts) extends State
+    case class Failure(lastTryMillis: Long, tries: Int) extends State
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
@@ -45,7 +45,7 @@ class ScalaVersionSelector(
       )
     )
       BuildInfo.ammonite213
-    else if (ScalaVersions.isSupportedScalaVersion(selected))
+    else if (ScalaVersions.isSupportedAtReleaseMomentScalaVersion(selected))
       selected
     else
       ScalaVersions.recommendedVersion(selected)

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -2,7 +2,6 @@ package scala.meta.internal.metals
 
 import scala.meta.Dialect
 import scala.meta.dialects._
-import scala.meta.internal.mtags
 import scala.meta.internal.semver.SemVer
 
 object ScalaVersions {
@@ -21,7 +20,7 @@ object ScalaVersions {
   private val _isSupportedScalaVersion: Set[String] =
     BuildInfo.supportedScalaVersions.toSet
 
-  def isSupportedScalaVersion(version: String): Boolean =
+  def isSupportedAtReleaseMomentScalaVersion(version: String): Boolean =
     _isSupportedScalaVersion(dropVendorSuffix(version))
 
   def isDeprecatedScalaVersion(version: String): Boolean =
@@ -75,11 +74,6 @@ object ScalaVersions {
       }
     !supportedScala3Versions(scalaVersion) && isFuture
   }
-
-  def isCurrentScalaCompilerVersion(version: String): Boolean =
-    ScalaVersions.dropVendorSuffix(
-      version
-    ) == mtags.BuildInfo.scalaCompilerVersion
 
   def scalaBinaryVersionFromFullVersion(scalaVersion: String): String = {
     if (scalaVersion.startsWith("3"))

--- a/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
@@ -37,7 +37,7 @@ final class Warnings(
       scalacOptions <- buildTargets.scalacOptions(buildTarget)
     } yield {
       if (!info.isSemanticdbEnabled) {
-        if (isSupportedScalaVersion(info.scalaVersion)) {
+        if (isSupportedAtReleaseMomentScalaVersion(info.scalaVersion)) {
           logger.error(
             s"$doesntWorkBecause the SemanticDB compiler plugin is not enabled for the build target ${info.displayName}."
           )

--- a/metals/src/main/scala/scala/meta/internal/troubleshoot/ScalaProblem.scala
+++ b/metals/src/main/scala/scala/meta/internal/troubleshoot/ScalaProblem.scala
@@ -55,7 +55,9 @@ case class SemanticDBDisabled(
     if (unsupportedBloopVersion) {
       s"""|The installed Bloop server version is $bloopVersion while Metals requires at least Bloop version ${BuildInfo.bloopVersion},
           |To fix this problem please update your Bloop server.""".stripMargin
-    } else if (ScalaVersions.isSupportedScalaVersion(scalaVersion)) {
+    } else if (
+      ScalaVersions.isSupportedAtReleaseMomentScalaVersion(scalaVersion)
+    ) {
       hint.capitalize
     } else {
       "Semanticdb is required for code navigation to work correctly in your project," +

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -408,7 +408,7 @@ class WorksheetProvider(
 
     def isSupportedScala2Version(scalaVersion: String) = {
       !ScalaVersions.isScala3Version(scalaVersion) && ScalaVersions
-        .isSupportedScalaVersion(scalaVersion)
+        .isSupportedAtReleaseMomentScalaVersion(scalaVersion)
     }
 
     val key = MdocKey.BuildTarget(target)

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -16,6 +16,7 @@ import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.MetalsLogger
 import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.MtagsResolver
 import scala.meta.internal.metals.RecursivelyDelete
 import scala.meta.internal.metals.SlowTaskConfig
 import scala.meta.internal.metals.Time
@@ -47,6 +48,9 @@ abstract class BaseLspSuite(
   var workspace: AbsolutePath = _
 
   protected def initializationOptions: Option[InitializationOptions] = None
+
+  protected def mtagsResolver: MtagsResolver =
+    new TestMtagsResolver
 
   override def afterAll(): Unit = {
     if (server != null) {
@@ -90,7 +94,8 @@ abstract class BaseLspSuite(
       bspGlobalDirectories,
       sh,
       time,
-      initializationOptions
+      initializationOptions,
+      mtagsResolver
     )(ex)
     server.server.userConfig = this.userConfig
   }

--- a/tests/unit/src/main/scala/tests/QuickBuild.scala
+++ b/tests/unit/src/main/scala/tests/QuickBuild.scala
@@ -133,7 +133,7 @@ case class QuickBuild(
     }
     val classpath = classDirectory :: allJars.filterNot(isSourceJar)
     val allPlugins =
-      if (ScalaVersions.isSupportedScalaVersion(scalaVersion))
+      if (ScalaVersions.isSupportedAtReleaseMomentScalaVersion(scalaVersion))
         s"org.scalameta:::semanticdb-scalac:${V.semanticdbVersion}" :: compilerPlugins.toList
       else compilerPlugins.toList
     val pluginDependencies = allPlugins.map(plugin =>

--- a/tests/unit/src/main/scala/tests/TestMtagsResolver.scala
+++ b/tests/unit/src/main/scala/tests/TestMtagsResolver.scala
@@ -1,0 +1,26 @@
+package tests
+
+import scala.meta.internal.metals.MtagsBinaries
+import scala.meta.internal.metals.MtagsResolver
+import scala.meta.internal.metals.ScalaVersions
+
+/**
+ * The default MtagsResolver always checks if mtags-artifacts for particular scala version exists.
+ * However this strict logic doesn't work for tests.
+ * For `unit` we don't publish mtags at all but there are some tests that trigger docker check.
+ * So for these cases, do fallback on previous mechanic by checking declared supported versions.
+ */
+class TestMtagsResolver extends MtagsResolver {
+
+  val default: MtagsResolver = MtagsResolver.default()
+  override def resolve(scalaVersion: String): Option[MtagsBinaries] = {
+    default.resolve(scalaVersion).orElse(fakeBinaries(scalaVersion))
+  }
+
+  private def fakeBinaries(scalaVersion: String): Option[MtagsBinaries] = {
+    if (ScalaVersions.isSupportedAtReleaseMomentScalaVersion(scalaVersion))
+      Some(MtagsBinaries.BuildIn)
+    else
+      None
+  }
+}

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -139,7 +139,8 @@ final class TestingServer(
     bspGlobalDirectories = bspGlobalDirectories,
     sh = sh,
     time = time,
-    isReliableFileWatcher = System.getenv("CI") != "true"
+    isReliableFileWatcher = System.getenv("CI") != "true",
+    allSupportedMtagsRequired = false
   )
   server.connectToLanguageClient(client)
 

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -42,6 +42,7 @@ import scala.meta.internal.metals.ListParametrizedCommand
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsLanguageServer
 import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.MtagsResolver
 import scala.meta.internal.metals.ParametrizedCommand
 import scala.meta.internal.metals.PositionSyntax._
 import scala.meta.internal.metals.ProgressTicks
@@ -126,7 +127,8 @@ final class TestingServer(
     bspGlobalDirectories: List[AbsolutePath],
     sh: ScheduledExecutorService,
     time: Time,
-    initializationOptions: Option[InitializationOptions]
+    initializationOptions: Option[InitializationOptions],
+    mtagsResolver: MtagsResolver
 )(implicit ex: ExecutionContextExecutorService) {
   import scala.meta.internal.metals.JsonParser._
 
@@ -140,7 +142,7 @@ final class TestingServer(
     sh = sh,
     time = time,
     isReliableFileWatcher = System.getenv("CI") != "true",
-    allSupportedMtagsRequired = false
+    mtagsResolver = mtagsResolver
   )
   server.connectToLanguageClient(client)
 

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -4,7 +4,6 @@ import java.nio.file.Files
 
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.BuildInfo
-import scala.meta.internal.metals.MtagsResolver
 import scala.meta.internal.metals.ScalaTarget
 import scala.meta.internal.metals.ScalaVersions
 import scala.meta.internal.troubleshoot.DeprecatedSbtVersion
@@ -26,6 +25,7 @@ import ch.epfl.scala.bsp4j.ScalaPlatform
 import ch.epfl.scala.bsp4j.ScalacOptionsItem
 import munit.FunSuite
 import munit.TestOptions
+import tests.TestMtagsResolver
 
 class ProblemResolverSuite extends FunSuite {
 
@@ -114,7 +114,7 @@ class ProblemResolverSuite extends FunSuite {
       workspace.toFile().deleteOnExit()
       val problemResolver = new ProblemResolver(
         AbsolutePath(workspace),
-        new MtagsResolver(),
+        new TestMtagsResolver,
         () => None,
         isClientCommandSupported = true
       )

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -4,6 +4,7 @@ import java.nio.file.Files
 
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.MtagsResolver
 import scala.meta.internal.metals.ScalaTarget
 import scala.meta.internal.metals.ScalaVersions
 import scala.meta.internal.troubleshoot.DeprecatedSbtVersion
@@ -113,6 +114,7 @@ class ProblemResolverSuite extends FunSuite {
       workspace.toFile().deleteOnExit()
       val problemResolver = new ProblemResolver(
         AbsolutePath(workspace),
+        new MtagsResolver(),
         () => None,
         isClientCommandSupported = true
       )


### PR DESCRIPTION
Prevously, the specific Metals version was able to work with only
specified list of Scala versions.

With these changes, in case if new Scala versions was released, we will
be able to realese only mtags artifact instead of making a full Metals
realease.

This isn't really usefull without additional release workflows but I'll
make separate PR for that later.