### PR TITLE
Support Scala3-NIGHTLY releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - main 
+      - main
   pull_request:
 jobs:
   unit:
@@ -12,20 +12,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macOS-latest, ubuntu-latest]
-        java: ['adopt@1.11']
+        java: ["adopt@1.11"]
         shard: [1, 2]
         include:
           - os: ubuntu-latest
-            java: 'adopt@1.8'
+            java: "adopt@1.8"
             shard: 1
           - os: ubuntu-latest
-            java: 'adopt@1.8'
+            java: "adopt@1.8"
             shard: 2
           - os: ubuntu-latest
-            java: '17'
+            java: "17"
             shard: 1
           - os: ubuntu-latest
-            java: '17'
+            java: "17"
             shard: 2
           - os: ubuntu-latest
             CACHE_PATH: ~/.cache/coursier/v1
@@ -43,12 +43,9 @@ jobs:
         run: |
           bin/test.sh unit/test
         env:
-          TEST_SHARD:
-            ${{ matrix.shard }}
-          GOOGLE_APPLICATION_CREDENTIALS:
-            ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-          GOOGLE_APPLICATION_CREDENTIALS_JSON:
-            ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
+          TEST_SHARD: ${{ matrix.shard }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
         shell: bash
   integration:
     name: ${{ matrix.name }}
@@ -97,6 +94,10 @@ jobs:
             command: sbt +cross/test
             name: Scala cross tests
             os: ubuntu-latest
+          - type: cross-latest-nightly
+            command: sbt cross-test-latest-nightly
+            name: Scala3 latest NIGHTLY cross test
+            os: ubuntu-latest
           - type: scalafix
             command: sbt scalafixCheck docs/docusaurusCreateSite
             name: Scalafix and docs
@@ -114,10 +115,8 @@ jobs:
       - name: ${{ matrix.command }}
         run: ${{ matrix.command }}
         env:
-          GOOGLE_APPLICATION_CREDENTIALS:
-            ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-          GOOGLE_APPLICATION_CREDENTIALS_JSON:
-            ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
       - name: "test download dependencies"
         run: sbt downloadDependencies
         if: matrix.type == 'cross'

--- a/build.sbt
+++ b/build.sbt
@@ -181,10 +181,53 @@ addCommandAlias(
   "+publishLocal; metals/runMain scala.meta.metals.DownloadDependencies "
 )
 
-commands += Command.command("save-expect") { s =>
-  "unit/test:runMain tests.SaveExpect" ::
-    s
+def isNightliesEnabled: Boolean =
+  isCI || sys.env.get("NIGHTLIES").isDefined
+
+def configureMtagsScalaVersionDynamically(
+    state: State,
+    scalaV: String,
+    projectV: Option[String] = None
+): State = {
+  val scalaVersionSettings =
+    List(
+      mtest / scalaVersion := scalaV,
+      mtags / scalaVersion := scalaV,
+      cross / scalaVersion := scalaV
+    )
+  val versionSettings =
+    projectV.map(v => mtags / version := v)
+
+  val extracted = Project.extract(state)
+  extracted
+    .appendWithSession(
+      scalaVersionSettings ++ versionSettings,
+      state
+    )
 }
+
+def crossTestDyn(state: State, scalaV: String): State = {
+  val configured = configureMtagsScalaVersionDynamically(state, scalaV)
+  val (out, _) =
+    Project
+      .extract(configured)
+      .runTask(cross / Test / test, configured)
+  out
+}
+
+commands ++= Seq(
+  Command.command("save-expect") { s =>
+    "unit/test:runMain tests.SaveExpect" :: s
+  },
+  Command.command("cross-test-latest-nightly") { s =>
+    V.nightlyScala3Versions.lastOption match {
+      case Some(latest) => crossTestDyn(s, latest)
+      case None =>
+        println("No nightly versions was found. Skipping cross/test")
+        s
+    }
+  }
+)
 
 lazy val V = new {
   val scala210 = "2.10.7"
@@ -255,8 +298,12 @@ lazy val V = new {
   def nonDeprecatedScala3Versions = Seq(nextScala3RC, scala3, "3.0.2")
   def deprecatedScala3Versions = Seq("3.0.1", "3.0.0")
   def scala3Versions = nonDeprecatedScala3Versions ++ deprecatedScala3Versions
-  lazy val nigthtlyScala3Versions =
-    Scala3NightlyVersions.nightlyReleasesAfter(nextScala3RC)
+  lazy val nightlyScala3Versions = {
+    if (isNightliesEnabled)
+      Scala3NightlyVersions.nightlyReleasesAfter(nextScala3RC)
+    else
+      Nil
+  }
 
   def supportedScalaVersions = scala2Versions ++ scala3Versions
   def nonDeprecatedScalaVersions =
@@ -336,7 +383,7 @@ def multiScalaDirectories(root: File, scalaVersion: String) = {
 
 val mtagsSettings = List(
   crossScalaVersions := {
-    V.supportedScalaVersions ++ V.nigthtlyScala3Versions
+    V.supportedScalaVersions ++ V.nightlyScala3Versions
   },
   crossTarget := target.value / s"scala-${scalaVersion.value}",
   crossVersion := CrossVersion.full,
@@ -630,7 +677,7 @@ lazy val mtest = project
       "scala213" -> V.scala213,
       "scala3" -> V.scala3,
       "scala2Versions" -> V.scala2Versions,
-      "scala3Versions" -> (V.scala3Versions ++ V.nigthtlyScala3Versions),
+      "scala3Versions" -> (V.scala3Versions ++ V.nightlyScala3Versions),
       "scala2Versions" -> V.scala2Versions,
       "scalaVersion" -> scalaVersion.value
     ),
@@ -648,8 +695,7 @@ lazy val cross = project
   .settings(
     testSettings,
     sharedSettings,
-    crossScalaVersions :=
-      V.nonDeprecatedScalaVersions ++ V.nigthtlyScala3Versions.lastOption.toList
+    crossScalaVersions := V.nonDeprecatedScalaVersions
   )
   .dependsOn(mtest, mtags)
 

--- a/build.sbt
+++ b/build.sbt
@@ -255,6 +255,8 @@ lazy val V = new {
   def nonDeprecatedScala3Versions = Seq(nextScala3RC, scala3, "3.0.2")
   def deprecatedScala3Versions = Seq("3.0.1", "3.0.0")
   def scala3Versions = nonDeprecatedScala3Versions ++ deprecatedScala3Versions
+  lazy val nigthtlyScala3Versions =
+    Scala3NightlyVersions.nightlyReleasesAfter(nextScala3RC)
 
   def supportedScalaVersions = scala2Versions ++ scala3Versions
   def nonDeprecatedScalaVersions =
@@ -333,7 +335,9 @@ def multiScalaDirectories(root: File, scalaVersion: String) = {
 }
 
 val mtagsSettings = List(
-  crossScalaVersions := V.supportedScalaVersions,
+  crossScalaVersions := {
+    V.supportedScalaVersions ++ V.nigthtlyScala3Versions
+  },
   crossTarget := target.value / s"scala-${scalaVersion.value}",
   crossVersion := CrossVersion.full,
   Compile / unmanagedSourceDirectories ++= multiScalaDirectories(
@@ -626,7 +630,7 @@ lazy val mtest = project
       "scala213" -> V.scala213,
       "scala3" -> V.scala3,
       "scala2Versions" -> V.scala2Versions,
-      "scala3Versions" -> V.scala3Versions,
+      "scala3Versions" -> (V.scala3Versions ++ V.nigthtlyScala3Versions),
       "scala2Versions" -> V.scala2Versions,
       "scalaVersion" -> scalaVersion.value
     ),
@@ -644,7 +648,8 @@ lazy val cross = project
   .settings(
     testSettings,
     sharedSettings,
-    crossScalaVersions := V.nonDeprecatedScalaVersions
+    crossScalaVersions :=
+      V.nonDeprecatedScalaVersions ++ V.nigthtlyScala3Versions.lastOption.toList
   )
   .dependsOn(mtest, mtags)
 

--- a/project/Scala3NightlyVersions.scala
+++ b/project/Scala3NightlyVersions.scala
@@ -1,0 +1,88 @@
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+object Scala3NightlyVersions {
+
+  /**
+   * Fetches last 5 nightly releases.
+   * They should come at least after the last supported scala3 version
+   * otherwise there is no point to use these versions.
+   */
+  def nightlyReleasesAfter(version: String): List[String] = {
+
+    val lastVersion = DottyVersion.parse(version) match {
+      case Some(v) => v
+      case None =>
+        throw new Exception(s"Can't parse dotty versions from $version")
+    }
+
+    try {
+      coursierapi.Complete
+        .create()
+        .withInput("org.scala-lang:scala3-compiler_3:")
+        .complete()
+        .getCompletions()
+        .asScala
+        .filter(_.endsWith("NIGHTLY"))
+        .flatMap(DottyVersion.parse)
+        .collect {
+          case v if v > lastVersion => v
+        }
+        .toList
+        .sortWith(_ > _)
+        .map(_.original)
+        .takeRight(5)
+    } catch {
+      case e: Throwable =>
+        println("Fetching Scala3 nigthly versions failed")
+        e.printStackTrace()
+        Nil
+    }
+  }
+
+  case class DottyVersion(
+      major: Int,
+      minor: Int,
+      patch: Int,
+      rc: Option[Int],
+      nigthlyDate: Option[Int],
+      original: String
+  ) {
+
+    def >(o: DottyVersion): Boolean = {
+      val diff = toList
+        .zip(o.toList)
+        .collectFirst {
+          case (a, b) if a - b != 0 => a - b
+        }
+        .getOrElse(0)
+      diff > 0
+    }
+
+    private def toList: List[Int] =
+      List(
+        major,
+        minor,
+        patch,
+        rc.getOrElse(Int.MaxValue),
+        nigthlyDate.getOrElse(Int.MaxValue)
+      )
+  }
+
+  object DottyVersion {
+    def parse(v: String): Option[DottyVersion] = {
+      Try {
+        val parts = v.split("\\.|-RC|-")
+        if (parts.size < 3) None
+        else {
+          val Array(major, minor, patch) = parts.take(3).map(_.toInt)
+          val rc = parts.lift(3).map(_.toInt)
+          // format is "$major.$minor.$patch-RC$rc-bin-$date-hash-NIGHTLY"
+          val date = parts.lift(5).map(_.toInt)
+          Some(DottyVersion(major, minor, patch, rc, date, v))
+        }
+
+      }.toOption.flatten
+    }
+  }
+}


### PR DESCRIPTION
This introduces the following changes:
 - every release supports up to 5 of latest NIGHTLY Scala3 versions.
   Should be already valuable as every snapshot release will
   automatically catch new NIGHTLY releases.
 - `+cross/test` also run tests against the latest NIGHTLY release
  that should help with spotting issues earlier.