### PR TITLE
Release process: publish `mtags` for the latest Metals release

### DIFF
--- a/.github/workflows/mtags-auto-release.yml
+++ b/.github/workflows/mtags-auto-release.yml
@@ -1,0 +1,32 @@
+name: "Mtags auto release"
+on:
+  workflow_dispatch:
+    inputs:
+      scala_version:
+        description: "Scala Version"
+        required: true
+      metals_version:
+        description: "Metals Version"
+        required: true
+        default: "v0.10.9"
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.metals_version }}
+      - uses: olafurpg/setup-scala@v13
+      - uses: coursier/cache-action@v6.3
+      - name: "Test and push tag"
+        run: |
+          sbt test-mtags-dyn ${{ github.event.inputs.scala_version }}
+          if [ $? == 0]; then
+            git commit --allow-empty -m "Release mtags-${{ github.event.inputs.scala_version }} for ${{github.event.inputs.metals_version}}"
+            TAG_NAME="mtags_${{ github.event.inputs.metals_version }}_${{ github.event.inputs.scala_version }}"
+            git tag $TAG_NAME
+            git push origin $TAG_NAME 
+          fi
+        env:
+          GIT_USER: scalameta@scalameta.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,7 @@ jobs:
       - uses: coursier/cache-action@v6.3
       - name: Publish
         run: |
-          sbt ci-release
-          sbt docs/docusaurusPublishGhpages
+          sbt gh-actions-release
         env:
           GIT_USER: scalameta@scalameta.org
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
The goal of this PR is to simplify our release process.
Currently, Metals has a list of supported compiler versions and for every new compiler version, we have to make a new release of Metals.

That is a bit problematic because a full release preparation requires more actions than just adding support for a new compiler version: we need to check/do last fixes for all new merged features, prepare release notes, some tests should be reworked while overall it isn't required for having basic functionality. So all these things increase the delay between compiler release and when it will be supported by Metals.
The additional problem is that this mechanic doesn't allow us to support scala3-NIGHTLY releases.

I spit the required changes on several PR's:

 - First one - [ScalaVersion - discover new mtags version by coursier](https://github.com/scalameta/metals/pull/3278). Having it Metals starts to check if there are `mtags` artifacts for the required Scala version instead of rejecting new version that wasn't supported at the release moment.
 
 - This PR is about the release process.
    Now we would be able to release a single mtags artifact for the new compiler version by pushing a tag with a specific format:
    `mtags_v${metalsVersion}_${scalaVersion}`. This will trigger the publishing process.
    
    Also, a added a new workflow:`mtags-auto-release.yml` to do that automatically.
    It might be triggered manually or automatically from CI process that publishes scala-3 artifacts.
    In case if `cross/test` pass that will create a tag that will trigger the publishing process.
    
    After validating this approach I will add documentation about that thing.
    
There is related [PR about NIGHTLY support](https://github.com/scalameta/metals/pull/3280) that fixes cross tests for such versions.

Also, the current set of changes wouldn't work for new Scala 2 versions as they require semanticdb version upgrade but I'm going do follow-up fixes for that later.