### PR TITLE
Set rangeHoverProvider under experimental capabilities

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsExperimental.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsExperimental.scala
@@ -1,0 +1,11 @@
+package scala.meta.internal.metals
+
+/**
+ * Language Server Protocol extensions that are declared as "server
+ * capabilities" in the initialize response.
+ */
+
+object MetalsExperimental {
+  // A workaround for https://github.com/microsoft/language-server-protocol/issues/377 until it is resolved
+  val rangeHoverProvider: java.lang.Boolean = true
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -839,6 +839,8 @@ class MetalsLanguageServer(
 
         capabilities.setTextDocumentSync(textDocumentSyncOptions)
 
+        capabilities.setExperimental(MetalsExperimental)
+
         val serverInfo = new ServerInfo("Metals", BuildInfo.metalsVersion)
         new InitializeResult(capabilities, serverInfo)
       })


### PR DESCRIPTION
A workaround for https://github.com/microsoft/language-server-protocol/issues/377 until it is resolved
this would allow LSP clients to explicitly know that they can send a range with `textDocument/hover` instead of a position

If someone has a better name for the field I am happy to change it :)

@ckipp01 should this be added to `new-editor.md` ? 