### PR TITLE
Fix expression for selection range in Ammonite

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -343,9 +343,8 @@ object SbtBuildTool {
   def sbtInputPosAdjustment(
       originInput: Input.VirtualFile,
       autoImports: Seq[String],
-      uri: String,
-      position: Position
-  ): (Input.VirtualFile, Position, AdjustLspData) = {
+      uri: String
+  ): (Input.VirtualFile, Position => Position, AdjustLspData) = {
 
     val appendLineSize = autoImports.size
 
@@ -353,7 +352,7 @@ object SbtBuildTool {
       originInput.copy(value =
         prependAutoImports(originInput.value, autoImports)
       )
-    val pos = new Position(
+    def adjustRequest(position: Position) = new Position(
       appendLineSize + position.getLine(),
       position.getCharacter()
     )
@@ -363,7 +362,7 @@ object SbtBuildTool {
       },
       filterOutLocations = { loc => !loc.getUri().isSbt }
     )
-    (modifiedInput, pos, adjustLspData)
+    (modifiedInput, adjustRequest, adjustLspData)
   }
 
   def prependAutoImports(text: String, autoImports: Seq[String]): String = {

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
@@ -30,7 +30,7 @@ class ScalaVersionSelector(
     val binary = ScalaVersions.scalaBinaryVersionFromFullVersion(selected)
     // ammonite doesn't support Scala3 yet
     if (isAmmonite && ScalaVersions.isScala3Version(selected))
-      BuildInfo.scala213
+      BuildInfo.ammonite213
     else if (
       isAmmonite && binary == "2.12" && SemVer.isLaterVersion(
         BuildInfo.ammonite212,

--- a/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
@@ -304,9 +304,8 @@ final class Ammonite(
 
   def generatedScalaInputForPc(
       targetId: BuildTargetIdentifier,
-      source: AbsolutePath,
-      position: Position
-  ): Option[(Input.VirtualFile, Position)] =
+      source: AbsolutePath
+  ): Option[(Input.VirtualFile, Position => Position)] =
     generatedScalaPath(targetId, source)
       .map { scalaPath =>
         val scInput = source.toInputFromBuffers(buffers)
@@ -357,7 +356,7 @@ final class Ammonite(
         val scriptStartIdx =
           updatedContent.indexOf(Ammonite.startTag) + Ammonite.startTag.length
         val addedLineCount = updatedContent.lineAtIndex(scriptStartIdx)
-        val updatedPos =
+        def updatedPos(position: Position) =
           new Position(addedLineCount + position.getLine, position.getCharacter)
         (updatedInput, updatedPos)
       }

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -486,16 +486,15 @@ object WorksheetProvider {
 
   def worksheetScala3Adjustments(
       originInput: Input.VirtualFile,
-      uri: String,
-      position: Position
-  ): Option[(Input.VirtualFile, Position, AdjustLspData)] = {
+      uri: String
+  ): Option[(Input.VirtualFile, Position => Position, AdjustLspData)] = {
     worksheetScala3Adjustments(originInput, uri.toAbsolutePath).map {
       case (input, adjust) =>
-        val pos = new Position(
+        def adjustRequest(position: Position) = new Position(
           position.getLine() + 1,
           position.getCharacter() + 2
         )
-        (input, pos, adjust)
+        (input, adjustRequest, adjust)
 
     }
   }


### PR DESCRIPTION
Ammonite generates additional file which we use in the presentation compiler for anything that requires types, so we neeed to adjust all request to actually point to a position in that generated file.

Previously, we would not adjust ranges when invoking hover and only positions. Now, we adjust both.

Also fixed the fallback version in case of Scala 3 for ammonite to be the last Ammonite suppored Scala 2.13 version instead of hte last Scala 2.13 version.

Fixes https://github.com/scalameta/metals/issues/3300