### PR TITLE
Simplify usage of sbt server when no .bsp/sbt.json exists

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
@@ -42,7 +42,7 @@ final class BspConfigGenerator(
    * choose the desired build server and then connect to it.
    */
   def chooseAndGenerate(
-      buildTools: List[BuildTool with BuildServerProvider]
+      buildTools: List[BuildServerProvider]
   ): Future[(BuildTool, BspConfigGenerationStatus)] = {
     for {
       Some(buildTool) <- chooseBuildServerProvider(buildTools)
@@ -54,8 +54,8 @@ final class BspConfigGenerator(
   }
 
   private def chooseBuildServerProvider(
-      buildTools: List[BuildTool with BuildServerProvider]
-  ): Future[Option[BuildTool with BuildServerProvider]] = {
+      buildTools: List[BuildServerProvider]
+  ): Future[Option[BuildServerProvider]] = {
     languageClient
       .showMessageRequest(BspProvider.params(buildTools))
       .asScala

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
@@ -48,7 +48,6 @@ final class BspConfigGenerator(
       Some(buildTool) <- chooseBuildServerProvider(buildTools)
       status <- buildTool.generateBspConfig(
         workspace,
-        languageClient,
         args => runUnconditionally(buildTool, args)
       )
     } yield (buildTool, status)

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -202,7 +202,7 @@ class BspConnector(
     // These are buildTools in the workspace that can serve as a build servers
     // and don't already have a .bsp entry
     val possibleServers: Map[String, Either[
-      BuildTool with BuildServerProvider,
+      BuildServerProvider,
       BspConnectionDetails
     ]] = buildTools
       .loadSupported()
@@ -212,17 +212,14 @@ class BspConnector(
               .exists(details =>
                 details.getName() == buildTool.executableName
               ) =>
-          buildTool
-      }
-      .map { possible =>
-        possible.executableName -> Left(possible)
+          buildTool.executableName -> Left(buildTool)
       }
       .toMap
 
     // These are build servers that already have a .bsp entry plus bloop if
     // it's an option.
     val availableServers: Map[String, Either[
-      BuildTool with BuildServerProvider,
+      BuildServerProvider,
       BspConnectionDetails
     ]] = {
       if (bloopPresent || buildTools.loadSupported().nonEmpty)

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -2,9 +2,13 @@ package scala.meta.internal.bsp
 
 import java.nio.file.Files
 
+import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import scala.meta.internal.bsp.BspConfigGenerationStatus._
+import scala.meta.internal.builds.BuildServerProvider
+import scala.meta.internal.builds.BuildTool
 import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.builds.SbtBuildTool
 import scala.meta.internal.metals.BloopServers
@@ -28,7 +32,8 @@ class BspConnector(
     client: LanguageClient,
     tables: Tables,
     userConfig: () => UserConfiguration,
-    statusBar: StatusBar
+    statusBar: StatusBar,
+    bspConfigGenerator: BspConfigGenerator
 )(implicit ec: ExecutionContext) {
 
   def resolve(): BspResolvedResult = {
@@ -80,7 +85,9 @@ class BspConnector(
             Some(item) <- client
               .showMessageRequest(query.params)
               .asScala
-              .map(item => query.details.get(item.getTitle))
+              .map(item =>
+                Option(item).flatMap(item => query.details.get(item.getTitle))
+              )
             conn <- bspServers.newServer(workspace, item)
           } yield Some(conn)
       }
@@ -119,22 +126,30 @@ class BspConnector(
     recursive(root, List.empty)
   }
 
+  /**
+   * Have the user choose what server they'd like to use out of a list of
+   * possible servers that are available to them in the workspace.
+   *
+   * @param possibleServers This could be servers that already have a bsp
+   * entry or just build tools that the user is using that can also be a build
+   * server. This is why we're working with strings instead of
+   * bspConnectionDetails.
+   * @param currentBsp a possible current choice they've made to explicit use
+   * this server in the past.
+   * @return
+   */
   private def askUser(
-      availableBspConnections: List[BspConnectionDetails],
-      currentBsp: Option[String]
-  ): Future[BspResolvedResult] = {
-    val query = Messages.SelectBspServer.request(
-      availableBspConnections,
-      currentBsp
+      possibleServers: List[String],
+      currentSelectedServer: Option[String]
+  ): Future[Option[String]] = {
+    val params = Messages.ChooseBspServer.request(
+      possibleServers,
+      currentSelectedServer
     )
+
     for {
-      item <- client.showMessageRequest(query.params).asScala
-    } yield {
-      val chosenMaybe = Option(item).flatMap(i => query.details.get(i.getTitle))
-      chosenMaybe
-        .map(BspResolvedResult.fromDetails)
-        .getOrElse(ResolvedNone)
-    }
+      item <- client.showMessageRequest(params.params).asScala
+    } yield Option(item).map(_.getTitle()).map(params.mapping(_))
   }
 
   /**
@@ -144,10 +159,36 @@ class BspConnector(
       workspace: AbsolutePath,
       createBloopAndConnect: () => Future[BuildChange]
   ): Future[Boolean] = {
-    val bloopPresent = buildTools.isBloop
 
+    val foundServers = bspServers.findAvailableServers()
+    val bloopPresent: Boolean = buildTools.isBloop
+
+    // TODO do we want this type or not
+    val possibleServerMapping = mutable.Map.empty[String, Either[
+      BuildTool with BuildServerProvider,
+      BspConnectionDetails
+    ]]
+
+    // These are buildTools in the workspace that can serve as a build servers
+    // and don't already have a .bsp entry
+    val possibleServers = buildTools
+      .loadSupported()
+      .collect {
+        case buildTool: BuildServerProvider
+            if !foundServers
+              .exists(details =>
+                details.getName() == buildTool.executableName
+              ) =>
+          buildTool
+      }
+      .map { possible =>
+        possibleServerMapping(possible.executableName) = Left(possible)
+        possible.executableName
+      }
+
+    // These are build servers that already have a .bsp entry plus bloop if
+    // it's an option.
     val availableServers = {
-      val found = bspServers.findAvailableServers()
       if (bloopPresent || buildTools.loadSupported().nonEmpty)
         new BspConnectionDetails(
           BloopServers.name,
@@ -155,48 +196,107 @@ class BspConnector(
           userConfig().currentBloopVersion,
           "",
           ImmutableList.of()
-        ) :: found
-      else found
+        ) :: foundServers
+      else foundServers
+    }.map { details =>
+      possibleServerMapping(details.getName) = Right(details)
+      details.getName()
     }
 
-    availableServers match {
+    /**
+     * Handles showing the user what they need to know after an attempt to
+     * generate a bsp config has happened.
+     */
+    def handleGenerationStatus(
+        buildTool: BuildTool,
+        status: BspConfigGenerationStatus
+    ): Boolean = status match {
+      case BspConfigGenerationStatus.Generated =>
+        tables.buildServers.chooseServer(buildTool.executableName)
+        true
+      case Cancelled => false
+      case Failed(exit) =>
+        exit match {
+          case Left(exitCode) =>
+            scribe.error(
+              s"Creation of .bsp/${buildTool.executableName} failed with exit code: $exitCode"
+            )
+            client.showMessage(
+              Messages.BspProvider.genericUnableToCreateConfig
+            )
+          case Right(message) =>
+            client.showMessage(
+              Messages.BspProvider.unableToCreateConfigFromMessage(
+                message
+              )
+            )
+        }
+        false
+    }
+
+    def handleServerChoice(
+        possibleChoice: Option[String],
+        currentSelectedServer: Option[String]
+    ) = {
+      possibleChoice match {
+        case Some(choice) =>
+          possibleServerMapping(choice) match {
+            case Left(buildTool) =>
+              buildTool
+                .generateBspConfig(
+                  workspace,
+                  args => bspConfigGenerator.runUnconditionally(buildTool, args)
+                )
+                .map(status => handleGenerationStatus(buildTool, status))
+            case Right(connectionDetails)
+                if connectionDetails.getName == BloopServers.name && currentSelectedServer
+                  .contains(
+                    BspConnector.BLOOP_SELECTED
+                  ) =>
+              Future.successful(false)
+            case Right(details) if details.getName == BloopServers.name =>
+              tables.buildServers.chooseServer(BspConnector.BLOOP_SELECTED)
+              if (bloopPresent) {
+                Future.successful(true)
+              } else {
+                createBloopAndConnect().ignoreValue
+                Future.successful(false)
+              }
+            case Right(details)
+                if !currentSelectedServer.contains(details.getName) =>
+              tables.buildServers.chooseServer(details.getName)
+              Future.successful(true)
+          }
+        case _ =>
+          Future.successful(false)
+      }
+    }
+
+    (possibleServers ::: availableServers) match {
       case Nil =>
         client.showMessage(BspSwitch.noInstalledServer)
         Future.successful(false)
       case singleServer :: Nil =>
-        client.showMessage(
-          BspSwitch.onlyOneServer(name = singleServer.getName())
-        )
-        Future.successful(false)
+        possibleServerMapping(singleServer) match {
+          case Left(buildTool) =>
+            buildTool
+              .generateBspConfig(
+                workspace,
+                args => bspConfigGenerator.runUnconditionally(buildTool, args)
+              )
+              .map(status => handleGenerationStatus(buildTool, status))
+          case Right(connectionDetails) =>
+            client.showMessage(
+              BspSwitch.onlyOneServer(name = connectionDetails.getName())
+            )
+            Future.successful(false)
+        }
+
       case multipleServers =>
         val currentSelectedServer = tables.buildServers.selectedServer()
-        askUser(multipleServers, currentSelectedServer).map {
-          case ResolvedBloop
-              if currentSelectedServer.contains(
-                BspConnector.BLOOP_SELECTED
-              ) =>
-            false
-          case ResolvedBloop =>
-            tables.buildServers.chooseServer(BspConnector.BLOOP_SELECTED)
-            // If a .bloop/ is already in the workspace, then we can just
-            // return true for a build change and let the bsp connection be
-            // made. However, if not, then we do a createBloopAndConnect()
-            // instead to first generate the .bloop/ to ensure a connection can
-            // be made. We return false since the the method will take care of
-            // connecting after the .bloop/ dir is made
-            if (bloopPresent) {
-              true
-            } else {
-              createBloopAndConnect().ignoreValue
-              false
-            }
-          case ResolvedBspOne(details)
-              if !currentSelectedServer.contains(details.getName) =>
-            tables.buildServers.chooseServer(details.getName)
-            true
-          case _ =>
-            false
-        }
+        askUser(multipleServers, currentSelectedServer).flatMap(choice =>
+          handleServerChoice(choice, currentSelectedServer)
+        )
     }
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildServerProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildServerProvider.scala
@@ -9,7 +9,7 @@ import scala.meta.io.AbsolutePath
 /**
  * Helper trait for build tools that also impliment bsp
  */
-trait BuildServerProvider { this: BuildTool =>
+trait BuildServerProvider extends BuildTool {
 
   /**
    * Method used to generate a bsp config file for the build

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildServerProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildServerProvider.scala
@@ -4,7 +4,6 @@ import scala.concurrent.Future
 
 import scala.meta.internal.bsp.BspConfigGenerationStatus._
 import scala.meta.internal.metals.Messages
-import scala.meta.internal.metals.MetalsLanguageClient
 import scala.meta.io.AbsolutePath
 
 /**
@@ -18,7 +17,6 @@ trait BuildServerProvider { this: BuildTool =>
    */
   def generateBspConfig(
       workspace: AbsolutePath,
-      languageClient: MetalsLanguageClient,
       systemProcess: List[String] => Future[BspConfigGenerationStatus]
   ): Future[BspConfigGenerationStatus] =
     if (workspaceSupportsBsp(workspace)) {

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -67,7 +67,7 @@ object Messages {
     )
     val genericUnableToCreateConfig = new MessageParams(
       MessageType.Error,
-      "Unable to create bsp config."
+      "Unable to create bsp config. Please check your log for more details."
     )
 
     def unableToCreateConfigFromMessage(message: String) = new MessageParams(
@@ -370,6 +370,39 @@ object Messages {
     }
   }
 
+  // TODO what extra stuff do we maybe need to pull from SelectBspServer later
+  object ChooseBspServer {
+    case class Request(
+        params: ShowMessageRequestParams,
+        mapping: Map[String, String]
+    )
+
+    def request(
+        possibleBuildServers: List[String],
+        currentBsp: Option[String]
+    ): Request = {
+      val mapping = mutable.Map.empty[String, String]
+      val messageActionItems =
+        possibleBuildServers.map { bs =>
+          val title = if (currentBsp.exists(_ == bs)) {
+            bs + " (currently selected)"
+          } else {
+            bs
+          }
+          mapping(title) = bs
+          new MessageActionItem(title)
+        }
+      val params = new ShowMessageRequestParams()
+      params.setMessage(
+        "Multiple build servers detected, which one do you want to use?"
+      )
+      params.setType(MessageType.Info)
+      params.setActions(messageActionItems.asJava)
+      Request(params, mapping.toMap)
+    }
+  }
+
+  // TODO can we just get rid of all of this and simplify
   // Don't confuse this with the "multiple build tools that can be servers"
   // message up above.  That one focuses not on multiple .bsp/<tool>.json
   // entries, but rather having multiple build tools in a workspace that could

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -384,13 +384,13 @@ object Messages {
     ): Request = {
       val mapping = mutable.Map.empty[String, String]
       val messageActionItems =
-        possibleBuildServers.map { bs =>
-          val title = if (currentBsp.exists(_ == bs)) {
-            bs + " (currently using)"
+        possibleBuildServers.map { buildServer =>
+          val title = if (currentBsp.exists(_ == buildServer)) {
+            buildServer + " (currently using)"
           } else {
-            bs
+            buildServer
           }
-          mapping(title) = bs
+          mapping(title) = buildServer
           new MessageActionItem(title)
         }
       val params = new ShowMessageRequestParams()

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -370,7 +370,6 @@ object Messages {
     }
   }
 
-  // TODO what extra stuff do we maybe need to pull from SelectBspServer later
   object ChooseBspServer {
     case class Request(
         params: ShowMessageRequestParams,
@@ -385,7 +384,7 @@ object Messages {
       val messageActionItems =
         possibleBuildServers.map { bs =>
           val title = if (currentBsp.exists(_ == bs)) {
-            bs + " (currently selected)"
+            bs + " (currently using)"
           } else {
             bs
           }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1920,7 +1920,7 @@ class MetalsLanguageServer(
   }
 
   private def generateBspConfig(): Future[Unit] = {
-    val servers: List[BuildTool with BuildServerProvider] =
+    val servers: List[BuildServerProvider] =
       buildTools.loadSupported().collect {
         case buildTool: BuildServerProvider => buildTool
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -471,7 +471,8 @@ class MetalsLanguageServer(
           languageClient,
           tables,
           () => userConfig,
-          statusBar
+          statusBar,
+          bspConfigGenerator
         )
         semanticdbs = AggregateSemanticdbs(
           List(
@@ -1960,7 +1961,6 @@ class MetalsLanguageServer(
         buildTool
           .generateBspConfig(
             workspace,
-            languageClient,
             args =>
               bspConfigGenerator.runUnconditionally(
                 buildTool,

--- a/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
@@ -188,7 +188,7 @@ class SbtServerSuite
         client.workspaceMessageRequests,
         List(
           importBuildMessage,
-          Messages.SelectBspServer.message
+          Messages.BspSwitch.message
         ).mkString("\n")
       )
       // assert contains the meta-build-target-build

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -294,7 +294,7 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
           restartBloop
         } else if (CheckDoctor.isDoctor(params)) {
           getDoctorInformation
-        } else if (SelectBspServer.isSelectBspServer(params)) {
+        } else if (BspSwitch.isSelectBspServer(params)) {
           selectBspServer(params.getActions.asScala)
         } else if (isSameMessageFromList(ChooseBuildTool.params)) {
           chooseBuildTool(params.getActions.asScala)

--- a/tests/unit/src/test/scala/tests/BillLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BillLspSuite.scala
@@ -201,7 +201,7 @@ class BillLspSuite extends BaseLspSuite("bill") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          Messages.SelectBspServer.message,
+          Messages.BspSwitch.message,
           Messages.CheckDoctor.allProjectsMisconfigured
         ).mkString("\n")
       )

--- a/tests/unit/src/test/scala/tests/BspSwitchLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BspSwitchLspSuite.scala
@@ -35,7 +35,7 @@ class BspSwitchLspSuite extends BaseLspSuite("bsp-switch") {
         assertConnectedToBuildServer("Bob")
         assertNoDiff(
           client.workspaceMessageRequests,
-          SelectBspServer.message
+          BspSwitch.message
         )
         assertNoDiff(client.workspaceShowMessages, "")
 

--- a/tests/unit/src/test/scala/tests/SelectBspServerSuite.scala
+++ b/tests/unit/src/test/scala/tests/SelectBspServerSuite.scala
@@ -14,7 +14,10 @@ class SelectBspServerSuite extends BaseSuite {
       expected: String
   )(implicit loc: Location): Unit = {
     test(name) {
-      val query = Messages.SelectBspServer.request(candidates, currentlyUsing)
+      val query = Messages.BspSwitch.chooseServerRequest(
+        candidates.map(_.getName()),
+        currentlyUsing
+      )
       val obtained =
         query.params.getActions.asScala.map(_.getTitle).mkString("\n")
       assertNoDiff(obtained, expected)
@@ -52,28 +55,14 @@ class SelectBspServerSuite extends BaseSuite {
   )
 
   check(
-    "version",
+    "default-newest",
     None,
     List(
       name("Bloop", "1.0"),
       name("Bloop", "2.0")
     ),
     """
-      |Bloop v1.0
-      |Bloop v2.0
-      |""".stripMargin
-  )
-
-  check(
-    "conflict",
-    None,
-    List(
-      name("Bloop", "1.0"),
-      name("Bloop", "1.0")
-    ),
-    """
-      |Bloop v1.0 (a)
-      |Bloop v1.0 (b)
+      |Bloop
       |""".stripMargin
   )
 }

--- a/tests/unit/src/test/scala/tests/SelectBspServerSuite.scala
+++ b/tests/unit/src/test/scala/tests/SelectBspServerSuite.scala
@@ -53,16 +53,4 @@ class SelectBspServerSuite extends BaseSuite {
       |Mill
       |""".stripMargin
   )
-
-  check(
-    "default-newest",
-    None,
-    List(
-      name("Bloop", "1.0"),
-      name("Bloop", "2.0")
-    ),
-    """
-      |Bloop
-      |""".stripMargin
-  )
 }


### PR DESCRIPTION
This relates to the conversation we had in
https://github.com/scalameta/metals/discussions/3255 and essentially
gets rid of the need for a user to remember they need to run
`metals.generate-bsp-config` if no `.bsp/sbt.json` exists. Now, instead
a user is able to use the `metals.bsp-switch` command and it will detect
if the build tool can be a build server even if there is no
`.bsp/<entry>` that exists, shows it to them during the user choice, and
then if selected generates the entry and then connects to it.

The old behavior of the `metals.generate-bsp-config` is still the same
and can be used _if_ you want a fresh `.bsp/<entry>`.

![2021-11-22 18 39 50](https://user-images.githubusercontent.com/13974112/142909678-f9362fe9-de0f-4c91-943f-d90bf12c3e04.gif)
_notice sbt is given as a choice even though no `.bsp/sbt.json` exists`_.

