### PR TITLE
Better support for mill BSP

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -317,7 +317,7 @@ lazy val V = new {
   val coursierInterfaces = "1.0.4"
   val coursier = "2.0.16"
   val ammonite = "2.4.1"
-  val mill = "0.9.10"
+  val mill = "0.10.0-M4"
   val organizeImportRule = "0.6.0"
 }
 

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
@@ -5,7 +5,6 @@ import scala.concurrent.Future
 
 import scala.meta.internal.bsp.BspConfigGenerationStatus._
 import scala.meta.internal.builds.BuildServerProvider
-import scala.meta.internal.builds.BuildTool
 import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.builds.ShellRunner
 import scala.meta.internal.metals.Messages.BspProvider
@@ -16,7 +15,7 @@ import scala.meta.io.AbsolutePath
 import org.eclipse.lsp4j.MessageActionItem
 
 /**
- * Runs a process to create a .bsp entry for a givev buildtool.
+ * Runs a process to create a .bsp entry for a given buildtool.
  */
 final class BspConfigGenerator(
     workspace: AbsolutePath,
@@ -25,12 +24,12 @@ final class BspConfigGenerator(
     shellRunner: ShellRunner
 )(implicit ec: ExecutionContext) {
   def runUnconditionally(
-      buildTool: BuildTool,
+      buildTool: BuildServerProvider,
       args: List[String]
   ): Future[BspConfigGenerationStatus] =
     shellRunner
       .run(
-        s"${buildTool.executableName} bspConfig",
+        s"${buildTool.getBuildServerName} bspConfig",
         args,
         workspace,
         buildTool.redirectErrorOutput
@@ -43,7 +42,7 @@ final class BspConfigGenerator(
    */
   def chooseAndGenerate(
       buildTools: List[BuildServerProvider]
-  ): Future[(BuildTool, BspConfigGenerationStatus)] = {
+  ): Future[(BuildServerProvider, BspConfigGenerationStatus)] = {
     for {
       Some(buildTool) <- chooseBuildServerProvider(buildTools)
       status <- buildTool.generateBspConfig(
@@ -61,7 +60,7 @@ final class BspConfigGenerator(
       .asScala
       .map { choice =>
         buildTools.find(buildTool =>
-          new MessageActionItem(buildTool.executableName) == choice
+          new MessageActionItem(buildTool.getBuildServerName) == choice
         )
       }
   }

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildServerProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildServerProvider.scala
@@ -32,5 +32,19 @@ trait BuildServerProvider extends BuildTool {
    */
   def createBspFileArgs(workspace: AbsolutePath): List[String]
 
+  /**
+   * Whether or not the build tool workspace supports BSP. Many times this is
+   * limited by the version of the build tool that introduces BSP support.
+   */
   def workspaceSupportsBsp(workspace: AbsolutePath): Boolean
+
+  /**
+   * Name of the build server if different than the actual build-tool that is
+   * serving as a build server.
+   *
+   * Ex. mill isn't mill, but rather mill-bsp
+   */
+  def buildServerName: Option[String] = None
+
+  def getBuildServerName: String = buildServerName.getOrElse(executableName)
 }

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -74,7 +74,7 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
 
   override def toString(): String = "Mill"
 
-  def executableName = "mill"
+  override def executableName = "mill"
 
   private def predefScript =
     "import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`".getBytes()
@@ -89,22 +89,23 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
   }
 
   override def workspaceSupportsBsp(workspace: AbsolutePath): Boolean = {
-    val minimVersionForBsp = "0.10.0-M4"
+    val minimumVersionForBsp = "0.10.0-M4"
     val millVersion = getMillVersion(workspace)
 
-    if (SemVer.isCompatibleVersion(minimVersionForBsp, millVersion)) {
+    if (SemVer.isCompatibleVersion(minimumVersionForBsp, millVersion)) {
       scribe.info(
         s"mill version ${millVersion} detected to use as a bsp server."
       )
       true
     } else {
       scribe.warn(
-        s"Unable to start mill bsp server. Make sure you are using >= mill $minimVersionForBsp."
+        s"Unable to start mill bsp server. Make sure you are using >= mill $minimumVersionForBsp."
       )
       false
     }
   }
 
+  override val buildServerName: Option[String] = Some("mill-bsp")
 }
 
 object MillBuildTool {

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -6,11 +6,27 @@ import scala.util.Properties
 
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
 
 case class MillBuildTool(userConfig: () => UserConfiguration)
     extends BuildTool
-    with BloopInstallProvider {
+    with BloopInstallProvider
+    with BuildServerProvider {
+
+  private def getMillVersion(workspace: AbsolutePath): String = {
+    import scala.meta.internal.jdk.CollectionConverters._
+    val millVersionPath = workspace.resolve(".mill-version")
+    if (millVersionPath.isFile) {
+      Files
+        .readAllLines(millVersionPath.toNIO)
+        .asScala
+        .headOption
+        .getOrElse(version)
+    } else {
+      version
+    }
+  }
 
   private val predefScriptName = "predef.sc"
 
@@ -25,31 +41,26 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
 
   override def redirectErrorOutput: Boolean = true
 
-  override def bloopInstallArgs(workspace: AbsolutePath): List[String] = {
-
-    import scala.meta.internal.jdk.CollectionConverters._
-    val millVersionPath = workspace.resolve(".mill-version")
-    val millVersion = if (millVersionPath.isFile) {
-      Files
-        .readAllLines(millVersionPath.toNIO)
-        .asScala
-        .headOption
-        .getOrElse(version)
-    } else {
-      version
-    }
+  private def putTogetherArgs(cmd: List[String], workspace: AbsolutePath) = {
+    val millVersion = getMillVersion(workspace)
 
     // In some environments (such as WSL or cygwin), mill must be run using interactive mode (-i)
-    val iOption = if (Properties.isWin) List("-i") else Nil
-    val cmd =
-      iOption ::: "--predef" :: predefScriptPath.toString :: "mill.contrib.Bloop/install" :: Nil
+    val fullcmd = if (Properties.isWin) "-i" :: cmd else cmd
 
     userConfig().millScript match {
       case Some(script) =>
         script :: cmd
       case None =>
-        embeddedMillWrapper.toString() :: "--mill-version" :: millVersion :: cmd
+        embeddedMillWrapper
+          .toString() :: "--mill-version" :: millVersion :: fullcmd
     }
+
+  }
+
+  override def bloopInstallArgs(workspace: AbsolutePath): List[String] = {
+    val cmd =
+      "--predef" :: predefScriptPath.toString :: "mill.contrib.Bloop/install" :: Nil
+    putTogetherArgs(cmd, workspace)
   }
 
   override def digest(workspace: AbsolutePath): Option[String] =
@@ -70,6 +81,28 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
 
   private def predefScriptPath: Path = {
     Files.write(tempDir.resolve(predefScriptName), predefScript)
+  }
+
+  override def createBspFileArgs(workspace: AbsolutePath): List[String] = {
+    val cmd = "mill.bsp.BSP/install" :: Nil
+    putTogetherArgs(cmd, workspace)
+  }
+
+  override def workspaceSupportsBsp(workspace: AbsolutePath): Boolean = {
+    val minimVersionForBsp = "0.10.0-M4"
+    val millVersion = getMillVersion(workspace)
+
+    if (SemVer.isCompatibleVersion(minimVersionForBsp, millVersion)) {
+      scribe.info(
+        s"mill version ${millVersion} detected to use as a bsp server."
+      )
+      true
+    } else {
+      scribe.warn(
+        s"Unable to start mill bsp server. Make sure you are using >= mill $minimVersionForBsp."
+      )
+      false
+    }
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1926,12 +1926,12 @@ class MetalsLanguageServer(
       }
 
     def ensureAndConnect(
-        buildTool: BuildTool,
+        buildTool: BuildServerProvider,
         status: BspConfigGenerationStatus
     ): Unit =
       status match {
         case Generated =>
-          tables.buildServers.chooseServer(buildTool.executableName)
+          tables.buildServers.chooseServer(buildTool.getBuildServerName)
           quickConnectToBuildServer().ignoreValue
         case Cancelled => ()
         case Failed(exit) =>
@@ -1973,7 +1973,7 @@ class MetalsLanguageServer(
           .chooseAndGenerate(buildTools)
           .map {
             case (
-                  buildTool: BuildTool,
+                  buildTool: BuildServerProvider,
                   status: BspConfigGenerationStatus
                 ) =>
               ensureAndConnect(buildTool, status)
@@ -2022,7 +2022,7 @@ class MetalsLanguageServer(
       possibleBuildTool <- supportedBuildTool
       chosenBuildServer = tables.buildServers.selectedServer()
       isBloopOrEmpty = chosenBuildServer.isEmpty || chosenBuildServer.exists(
-        _ == BspConnector.BLOOP_SELECTED
+        _ == BloopServers.name
       )
       buildChange <- possibleBuildTool match {
         case Some(buildTool) =>

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -160,6 +160,7 @@ object ServerCommands {
        |
        |The build servers that Metals knows how to detect and start:
        | - sbt
+       | - mill-bsp
        |
        |Note: while Metals does know how to start Bloop, Bloop will be started when you trigger a build
        |import or when you use `bsp-switch` to switch to Bloop.

--- a/mtags/src/main/scala/scala/meta/internal/semver/SemVer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/semver/SemVer.scala
@@ -12,17 +12,23 @@ object SemVer {
       milestone: Option[Int]
   ) {
     def >(that: Version): Boolean = {
+      lazy val baseVersionEqual =
+        this.major == this.major && this.minor == that.minor && this.patch == that.patch
+
       this.major > that.major ||
       (this.major == that.major && this.minor > that.minor) ||
       (this.major == that.major && this.minor == that.minor && this.patch > that.patch) ||
       // 3.0.0-RC1 > 3.0.0-M1
-      this.releaseCandidate.isDefined && that.milestone.isDefined ||
+      baseVersionEqual && this.releaseCandidate.isDefined && that.milestone.isDefined ||
       // 3.0.0 > 3.0.0-M2 and 3.0.0 > 3.0.0-RC1
-      (this.milestone.isEmpty && this.releaseCandidate.isEmpty && (that.milestone.isDefined || that.releaseCandidate.isDefined)) ||
+      baseVersionEqual && (this.milestone.isEmpty && this.releaseCandidate.isEmpty && (that.milestone.isDefined || that.releaseCandidate.isDefined)) ||
       // 3.0.0-RC2 > 3.0.0-RC1
-      comparePreRelease(that, (v: Version) => v.releaseCandidate) ||
+      baseVersionEqual && comparePreRelease(
+        that,
+        (v: Version) => v.releaseCandidate
+      ) ||
       // 3.0.0-M2 > 3.0.0-M1
-      comparePreRelease(that, (v: Version) => v.milestone)
+      baseVersionEqual && comparePreRelease(that, (v: Version) => v.milestone)
 
     }
 

--- a/tests/slow/src/test/scala/tests/mill/MillServerSuite.scala
+++ b/tests/slow/src/test/scala/tests/mill/MillServerSuite.scala
@@ -1,0 +1,73 @@
+package tests.mill
+
+import scala.meta.internal.builds.MillBuildTool
+import scala.meta.internal.builds.MillDigest
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.metals.{BuildInfo => V}
+import scala.meta.io.AbsolutePath
+
+import tests.BaseImportSuite
+import tests.MillBuildLayout
+import tests.MillServerInitializer
+
+/**
+ * Basic suite to ensure that a connection to sbt server can be made.
+ */
+class MillServerSuite
+    extends BaseImportSuite("mill-server", MillServerInitializer) {
+
+  val preBspVersion = "0.9.10"
+  val supportedBspVersion = V.millVersion
+  val scalaVersion = V.scala212
+  val buildTool: MillBuildTool = MillBuildTool(() => userConfig)
+
+  override def currentDigest(
+      workspace: AbsolutePath
+  ): Option[String] = MillDigest.current(workspace)
+
+  test("too-old") {
+    cleanWorkspace()
+    writeLayout(MillBuildLayout("", V.scala213, preBspVersion))
+    for {
+      _ <- server.initialize()
+      _ <- server.initialized()
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          importBuildMessage
+        ).mkString("\n")
+      )
+      _ = client.messageRequests.clear()
+      _ <- server.executeCommand(ServerCommands.GenerateBspConfig)
+    } yield {
+      assertNoDiff(
+        client.workspaceShowMessages,
+        Messages.NoBspSupport.toString
+      )
+    }
+  }
+
+  test("generate") {
+    def millBspConfig = workspace.resolve(".bsp/mill-bsp.json")
+    cleanWorkspace()
+    writeLayout(MillBuildLayout("", V.scala213, supportedBspVersion))
+    for {
+      _ <- server.initialize()
+      _ <- server.initialized()
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        // Project has no .bloop directory so user is asked to "import via bloop"
+        // since bloop is still the default
+        importBuildMessage
+      )
+      _ = client.messageRequests.clear() // restart
+      _ = assert(!millBspConfig.exists)
+      // At this point, we want to use mill-bsp server, so create the mill-bsp.json file.
+      _ <- server.executeCommand(ServerCommands.GenerateBspConfig)
+    } yield {
+      assert(millBspConfig.exists)
+    }
+  }
+}

--- a/tests/unit/src/main/scala/tests/BuildServerInitializer.scala
+++ b/tests/unit/src/main/scala/tests/BuildServerInitializer.scala
@@ -142,3 +142,26 @@ object SbtServerInitializer extends BuildServerInitializer {
     }
   }
 }
+
+object MillServerInitializer extends BuildServerInitializer {
+  this: BaseLspSuite =>
+  override def initialize(
+      workspace: AbsolutePath,
+      server: TestingServer,
+      client: TestingClient,
+      layout: String,
+      expectError: Boolean
+  )(implicit ec: ExecutionContext): Future[Unit] = {
+    for {
+      _ <- server.initialize()
+      _ <- server.initialized()
+      // choose mill-bsp as the Bsp Server
+      _ = client.selectBspServer = { _ => new MessageActionItem("mill-bsp") }
+      _ <- server.executeCommand(ServerCommands.BspSwitch)
+    } yield {
+      if (!expectError) {
+        server.assertBuildServerConnection()
+      }
+    }
+  }
+}

--- a/tests/unit/src/main/scala/tests/BuildServerLayout.scala
+++ b/tests/unit/src/main/scala/tests/BuildServerLayout.scala
@@ -41,3 +41,25 @@ object SbtBuildLayout extends BuildToolLayout {
         |""".stripMargin
   }
 }
+
+object MillBuildLayout extends BuildToolLayout {
+  override def apply(sourceLayout: String, scalaVersion: String): String =
+    s"""|/build.sc
+        |import mill._, scalalib._
+        |
+        |object MillMinimal extends ScalaModule {
+        |  def scalaVersion = "${scalaVersion}"
+        |}
+        |$sourceLayout
+        |""".stripMargin
+
+  def apply(
+      sourceLayout: String,
+      scalaVersion: String,
+      millVersion: String
+  ): String =
+    s"""|/.mill-version
+        |$millVersion
+        |${apply(sourceLayout, scalaVersion)}
+        |""".stripMargin
+}

--- a/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
@@ -137,6 +137,18 @@ class ScalaVersionsSuite extends BaseSuite {
     )
   }
 
+  test("0.9.10-not-compatible-with-0.10.0-M4") {
+    assert(
+      !SemVer.isCompatibleVersion("0.10.0-M4", "0.9.10")
+    )
+  }
+
+  test("0.9.10-not-compatible-with-0.10.0-RC2") {
+    assert(
+      !SemVer.isCompatibleVersion("0.10.0-RC2", "0.9.10")
+    )
+  }
+
   test("recommended-3") {
     assert(
       ScalaVersions.recommendedVersion("3.0.0-M1") ==


### PR DESCRIPTION
This adds the same type of functionality that we have with sbt where Mill can now also be a build server meaning that `metals.generate-bsp-config` and also `metals.bsp-switch` will apply to it. This also cleans up a few things that I did in #3304, fixes a bug in `Semver`, and also introduces a few small changes in `BuildServerProvider.scala` that are needed if a build tool and the name they use as a build server don't match.

Relates to https://github.com/com-lihaoyi/mill/issues/1546 and also closes #3307 