### PR TITLE
[Scala3] Fix go to defition for givens

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaMtags.scala
@@ -347,7 +347,6 @@ class ScalaMtags(val input: Input.VirtualFile, dialect: Dialect)
                 Some((t.name.value, t.name.pos))
             }
 
-          owner
           namePos.foreach { case (name, pos) =>
             enterGiven(name, pos, t.tparams, t.sparams)
           }

--- a/tests/input3/src/main/scala/example/GivenAlias.scala
+++ b/tests/input3/src/main/scala/example/GivenAlias.scala
@@ -2,7 +2,7 @@ package example
 
 given intValue: Int = 4
 given String = "str"
-given (using Int): Double = 4.0
+given (using i: Int): Double = 4.0
 given [T]: List[T] = Nil
 given given_Char: Char = '?'
 given `given_Float`: Float = 3.0

--- a/tests/input3/src/main/scala/example/GivenAlias.scala
+++ b/tests/input3/src/main/scala/example/GivenAlias.scala
@@ -2,12 +2,49 @@ package example
 
 given intValue: Int = 4
 given String = "str"
+given (using Int): Double = 4.0
+given [T]: List[T] = Nil
+given given_Char: Char = '?'
+given `given_Float`: Float = 3.0
+given `* *`: Long = 5
 
 def method(using Int) = ""
-
-val anonUsage = given_String
 
 object X {
   given Double = 4.0
   val double = given_Double
+
+  given of[A]: Option[A] = ???
 }
+
+trait Xg:
+  def doX: Int
+
+trait Yg:
+  def doY: String
+
+trait Zg[T]:
+  def doZ: List[T]
+
+given Xg with
+  def doX = 7
+
+given (using Xg): Yg with
+  def doY = "7"
+
+given [T]: Zg[T] with
+  def doZ: List[T] = Nil
+
+
+val a = intValue
+val b = given_String
+val c = X.given_Double
+val d = given_List_T[Int]
+val e = given_Char
+val f = given_Float
+val g = `* *`
+val i = X.of[Int]
+val x = given_Xg
+val y = given_Yg
+val z = given_Zg_T[String]
+

--- a/tests/unit/src/test/resources/definition-scala3/example/GivenAlias.scala
+++ b/tests/unit/src/test/resources/definition-scala3/example/GivenAlias.scala
@@ -2,12 +2,49 @@ package example
 
 given intValue/*GivenAlias.scala*/: Int/*Int.scala*/ = 4
 given String/*Predef.scala*/ = "str"
+given (using/*<no symbol>*/ Int/*Int.scala*/): Double/*Double.scala*/ = 4.0
+given [T/*GivenAlias.scala*/]: List/*package.scala*/[T/*GivenAlias.scala*/] = Nil/*package.scala*/
+given given_Char/*GivenAlias.scala*/: Char/*Char.scala*/ = '?'
+given `given_Float`/*<no symbol>*/: Float/*Float.scala*/ = 3.0
+given `* *`/*<no symbol>*/: Long/*Long.scala*/ = 5
 
 def method/*GivenAlias.scala*/(using/*<no symbol>*/ Int/*Int.scala*/) = ""
-
-val anonUsage/*GivenAlias.scala*/ = given_String/*GivenAlias.scala*/
 
 object X/*GivenAlias.scala*/ {
   given Double/*Double.scala*/ = 4.0
   val double/*GivenAlias.scala*/ = given_Double/*GivenAlias.scala*/
+
+  given of/*GivenAlias.scala*/[A/*GivenAlias.scala*/]: Option/*Option.scala*/[A/*GivenAlias.scala*/] = ???/*Predef.scala*/
 }
+
+trait Xg/*GivenAlias.scala*/:
+  def doX/*GivenAlias.scala*/: Int/*Int.scala*/
+
+trait Yg/*GivenAlias.scala*/:
+  def doY/*GivenAlias.scala*/: String/*Predef.scala*/
+
+trait Zg/*GivenAlias.scala*/[T/*GivenAlias.scala*/]:
+  def doZ/*GivenAlias.scala*/: List/*package.scala*/[T/*GivenAlias.scala*/]
+
+given Xg/*GivenAlias.scala*/ with
+  def doX/*GivenAlias.scala*/ = 7
+
+given (using/*<no symbol>*/ Xg/*GivenAlias.scala*/): Yg/*GivenAlias.scala*/ with
+  def doY/*<no file>*/ = "7"
+
+given [T/*<no file>*/]: Zg/*GivenAlias.scala*/[T/*<no file>*/] with
+  def doZ/*<no file>*/: List/*package.scala*/[T/*<no file>*/] = Nil/*package.scala*/
+
+
+val a/*GivenAlias.scala*/ = intValue/*GivenAlias.scala*/
+val b/*GivenAlias.scala*/ = given_String/*GivenAlias.scala*/
+val c/*GivenAlias.scala*/ = X/*GivenAlias.scala*/.given_Double/*GivenAlias.scala*/
+val d/*GivenAlias.scala*/ = given_List_T/*GivenAlias.scala*/[Int/*Int.scala*/]
+val e/*GivenAlias.scala*/ = given_Char/*GivenAlias.scala*/
+val f/*GivenAlias.scala*/ = given_Float/*GivenAlias.scala*/
+val g/*GivenAlias.scala*/ = `* *`/*GivenAlias.scala*/
+val i/*GivenAlias.scala*/ = X/*GivenAlias.scala*/.of/*GivenAlias.scala*/[Int/*Int.scala*/]
+val x/*GivenAlias.scala*/ = given_Xg/*GivenAlias.scala*/
+val y/*GivenAlias.scala*/ = given_Yg/*GivenAlias.scala*/
+val z/*GivenAlias.scala*/ = given_Zg_T/*GivenAlias.scala*/[String/*Predef.scala*/]
+

--- a/tests/unit/src/test/resources/definition-scala3/example/GivenAlias.scala
+++ b/tests/unit/src/test/resources/definition-scala3/example/GivenAlias.scala
@@ -2,7 +2,7 @@ package example
 
 given intValue/*GivenAlias.scala*/: Int/*Int.scala*/ = 4
 given String/*Predef.scala*/ = "str"
-given (using/*<no symbol>*/ Int/*Int.scala*/): Double/*Double.scala*/ = 4.0
+given (using/*<no symbol>*/ i/*GivenAlias.scala*/: Int/*Int.scala*/): Double/*Double.scala*/ = 4.0
 given [T/*GivenAlias.scala*/]: List/*package.scala*/[T/*GivenAlias.scala*/] = Nil/*package.scala*/
 given given_Char/*GivenAlias.scala*/: Char/*Char.scala*/ = '?'
 given `given_Float`/*<no symbol>*/: Float/*Float.scala*/ = 3.0
@@ -30,10 +30,10 @@ given Xg/*GivenAlias.scala*/ with
   def doX/*GivenAlias.scala*/ = 7
 
 given (using/*<no symbol>*/ Xg/*GivenAlias.scala*/): Yg/*GivenAlias.scala*/ with
-  def doY/*<no file>*/ = "7"
+  def doY/*GivenAlias.scala*/ = "7"
 
-given [T/*<no file>*/]: Zg/*GivenAlias.scala*/[T/*<no file>*/] with
-  def doZ/*<no file>*/: List/*package.scala*/[T/*<no file>*/] = Nil/*package.scala*/
+given [T/*GivenAlias.scala*/]: Zg/*GivenAlias.scala*/[T/*GivenAlias.scala*/] with
+  def doZ/*GivenAlias.scala*/: List/*package.scala*/[T/*GivenAlias.scala*/] = Nil/*package.scala*/
 
 
 val a/*GivenAlias.scala*/ = intValue/*GivenAlias.scala*/

--- a/tests/unit/src/test/resources/documentSymbol-scala3/example/GivenAlias.scala
+++ b/tests/unit/src/test/resources/documentSymbol-scala3/example/GivenAlias.scala
@@ -2,7 +2,7 @@
 
 /*example.intValue(Constant):3*/given intValue: Int = 4
 /*example. (Constant):4*/given String = "str"
-/*example. (Constant):5*/given (using Int): Double = 4.0
+/*example. (Constant):5*/given (using i: Int): Double = 4.0
 /*example. (Constant):6*/given [T]: List[T] = Nil
 /*example.given_Char(Constant):7*/given given_Char: Char = '?'
 /*example.given_Float(Constant):8*/given `given_Float`: Float = 3.0

--- a/tests/unit/src/test/resources/documentSymbol-scala3/example/GivenAlias.scala
+++ b/tests/unit/src/test/resources/documentSymbol-scala3/example/GivenAlias.scala
@@ -1,13 +1,50 @@
-/*example(Package):13*/package example
+/*example(Package):49*/package example
 
 /*example.intValue(Constant):3*/given intValue: Int = 4
 /*example. (Constant):4*/given String = "str"
+/*example. (Constant):5*/given (using Int): Double = 4.0
+/*example. (Constant):6*/given [T]: List[T] = Nil
+/*example.given_Char(Constant):7*/given given_Char: Char = '?'
+/*example.given_Float(Constant):8*/given `given_Float`: Float = 3.0
+/*example.* *(Constant):9*/given `* *`: Long = 5
 
-/*example.method(Method):6*/def method(using Int) = ""
+/*example.method(Method):11*/def method(using Int) = ""
 
-/*example.anonUsage(Constant):8*/val anonUsage = given_String
+/*example.X(Module):18*/object X {
+  /*example.X. (Constant):14*/given Double = 4.0
+  /*example.X.double(Constant):15*/val double = given_Double
 
-/*example.X(Module):13*/object X {
-  /*example.X. (Constant):11*/given Double = 4.0
-  /*example.X.double(Constant):12*/val double = given_Double
+  /*example.X.of(Constant):17*/given of[A]: Option[A] = ???
 }
+
+/*example.Xg(Interface):21*/trait Xg:
+  /*example.Xg#doX(Method):21*/def doX: Int
+
+/*example.Yg(Interface):24*/trait Yg:
+  /*example.Yg#doY(Method):24*/def doY: String
+
+/*example.Zg(Interface):27*/trait Zg[T]:
+  /*example.Zg#doZ(Method):27*/def doZ: List[T]
+
+/*example. (Class):30*/given Xg with
+  /*example.` `#doX(Method):30*/def doX = 7
+
+/*example. (Class):33*/given (using Xg): Yg with
+  /*example.` `#doY(Method):33*/def doY = "7"
+
+/*example. (Class):36*/given [T]: Zg[T] with
+  /*example.` `#doZ(Method):36*/def doZ: List[T] = Nil
+
+
+/*example.a(Constant):39*/val a = intValue
+/*example.b(Constant):40*/val b = given_String
+/*example.c(Constant):41*/val c = X.given_Double
+/*example.d(Constant):42*/val d = given_List_T[Int]
+/*example.e(Constant):43*/val e = given_Char
+/*example.f(Constant):44*/val f = given_Float
+/*example.g(Constant):45*/val g = `* *`
+/*example.i(Constant):46*/val i = X.of[Int]
+/*example.x(Constant):47*/val x = given_Xg
+/*example.y(Constant):48*/val y = given_Yg
+/*example.z(Constant):49*/val z = given_Zg_T[String]
+

--- a/tests/unit/src/test/resources/expect/toplevels.expect
+++ b/tests/unit/src/test/resources/expect/toplevels.expect
@@ -18,6 +18,9 @@ example/FooEnum.scala -> example/FooEnum.
 example/ForComprehensions.scala -> example/ForComprehensions#
 example/GivenAlias.scala -> example/GivenAlias$package.
 example/GivenAlias.scala -> example/X.
+example/GivenAlias.scala -> example/Xg#
+example/GivenAlias.scala -> example/Yg#
+example/GivenAlias.scala -> example/Zg#
 example/ImplicitClasses.scala -> example/ImplicitClasses.
 example/ImplicitConversions.scala -> example/ImplicitConversions#
 example/Imports.scala -> example/Imports#

--- a/tests/unit/src/test/resources/semanticdb-scala3/example/GivenAlias.scala
+++ b/tests/unit/src/test/resources/semanticdb-scala3/example/GivenAlias.scala
@@ -2,12 +2,49 @@ package example
 
 given intValue/*example.GivenAlias$package.intValue.*/: Int/*scala.Int#*/ = 4
 given String/*scala.Predef.String#*/ = "str"
+given (using Int/*scala.Int#*/): Double/*scala.Double#*/ = 4.0
+given [T/*example.GivenAlias$package.given_List_T().[T]*/]: List/*scala.package.List#*/[T/*example.GivenAlias$package.given_List_T().[T]*/] = Nil/*scala.package.Nil.*/
+given given_Char/*example.GivenAlias$package.given_Char.*/: Char/*scala.Char#*/ = '?'
+given `given_Float/*example.GivenAlias$package.given_Float.*/`: Float/*scala.Float#*/ = 3.0
+given `* */*example.GivenAlias$package.`* *`.*/`: Long/*scala.Long#*/ = 5
 
 def method/*example.GivenAlias$package.method().*/(using Int/*scala.Int#*/) = ""
-
-val anonUsage/*example.GivenAlias$package.anonUsage.*/ = given_String/*example.GivenAlias$package.given_String.*/
 
 object X/*example.X.*/ {
   given Double/*scala.Double#*/ = 4.0
   val double/*example.X.double.*/ = given_Double/*example.X.given_Double.*/
+
+  given of/*example.X.of().*/[A/*example.X.of().[A]*/]: Option/*scala.Option#*/[A/*example.X.of().[A]*/] = ???/*scala.Predef.`???`().*/
 }
+
+trait Xg/*example.Xg#*/:
+  def doX/*example.Xg#doX().*/: Int/*scala.Int#*/
+
+trait Yg/*example.Yg#*/:
+  def doY/*example.Yg#doY().*/: String/*scala.Predef.String#*/
+
+trait Zg/*example.Zg#*/[T/*example.Zg#[T]*/]:
+  def doZ/*example.Zg#doZ().*/: List/*scala.package.List#*/[T/*example.Zg#[T]*/]
+
+given Xg/*example.Xg#*/ with
+  def doX/*example.GivenAlias$package.given_Xg.doX().*/ = 7
+
+given (using Xg/*example.Xg#*/): Yg/*example.Yg#*/ with
+  def doY/*example.GivenAlias$package.given_Yg#doY().*/ = "7"
+
+given [T/*example.GivenAlias$package.given_Zg_T#[T]*/]: Zg/*example.Zg#*/[T/*example.GivenAlias$package.given_Zg_T#[T]*/] with
+  def doZ/*example.GivenAlias$package.given_Zg_T#doZ().*/: List/*scala.package.List#*/[T/*example.GivenAlias$package.given_Zg_T#[T]*/] = Nil/*scala.package.Nil.*/
+
+
+val a/*example.GivenAlias$package.a.*/ = intValue/*example.GivenAlias$package.intValue.*/
+val b/*example.GivenAlias$package.b.*/ = given_String/*example.GivenAlias$package.given_String.*/
+val c/*example.GivenAlias$package.c.*/ = X/*example.X.*/.given_Double/*example.X.given_Double.*/
+val d/*example.GivenAlias$package.d.*/ = given_List_T/*example.GivenAlias$package.given_List_T().*/[Int/*scala.Int#*/]
+val e/*example.GivenAlias$package.e.*/ = given_Char/*example.GivenAlias$package.given_Char.*/
+val f/*example.GivenAlias$package.f.*/ = given_Float/*example.GivenAlias$package.given_Float.*/
+val g/*example.GivenAlias$package.g.*/ = `* *`/*example.GivenAlias$package.`* *`.*/
+val i/*example.GivenAlias$package.i.*/ = X/*example.X.*/.of/*example.X.of().*/[Int/*scala.Int#*/]
+val x/*example.GivenAlias$package.x.*/ = given_Xg/*example.GivenAlias$package.given_Xg.*/
+val y/*example.GivenAlias$package.y.*/ = given_Yg/*example.GivenAlias$package.given_Yg().*/
+val z/*example.GivenAlias$package.z.*/ = given_Zg_T/*example.GivenAlias$package.given_Zg_T().*/[String/*scala.Predef.String#*/]
+

--- a/tests/unit/src/test/resources/semanticdb-scala3/example/GivenAlias.scala
+++ b/tests/unit/src/test/resources/semanticdb-scala3/example/GivenAlias.scala
@@ -2,7 +2,7 @@ package example
 
 given intValue/*example.GivenAlias$package.intValue.*/: Int/*scala.Int#*/ = 4
 given String/*scala.Predef.String#*/ = "str"
-given (using Int/*scala.Int#*/): Double/*scala.Double#*/ = 4.0
+given (using i/*example.GivenAlias$package.given_Double().(i)*/: Int/*scala.Int#*/): Double/*scala.Double#*/ = 4.0
 given [T/*example.GivenAlias$package.given_List_T().[T]*/]: List/*scala.package.List#*/[T/*example.GivenAlias$package.given_List_T().[T]*/] = Nil/*scala.package.Nil.*/
 given given_Char/*example.GivenAlias$package.given_Char.*/: Char/*scala.Char#*/ = '?'
 given `given_Float/*example.GivenAlias$package.given_Float.*/`: Float/*scala.Float#*/ = 3.0


### PR DESCRIPTION
In semanticdb given is a term if there is no type/using pameters,
otherwise it's a method.
Also, fixes name inference for anonymous givens.