### PR TITLE
Add option to run everything in the current file

### DIFF
--- a/docs/integrations/debug-adapter-protocol.md
+++ b/docs/integrations/debug-adapter-protocol.md
@@ -92,14 +92,15 @@ a-b-key9=value 9   # will be ignored
 
 This option works a bit different than the other two param shapes as you don't
 specify a test or main class, but rather a `runType` of either `"run"`,
-`"testFile"`, or `"testTarget"` and a file URI representing your current location.
-`"run"` will automatically find any main method in the build target that belongs
-to the URI that was sent in. If multiple are found, you will be given the choice
-of which to run. The `"testFile"` option will check for any test classes in your
-current file and run them. Similarly, `"testTarget"` will run all test classes
-found in the build target that the URI belongs to. The `"args"`, `"jvmOptions"`,
-`"env"`, and `"envFile"` are all valid keys that can be sent as well with the
-same format as above.
+`"runOrTestFile"`, `"testFile"`, or `"testTarget"` and a file URI representing
+your current location. `"run"` will automatically find any main method in the
+build target that belongs to the URI that was sent in. If multiple are found,
+you will be given the choice of which to run. `"runOrTestFile"` will try to find
+a main or test class in your current file and run them. The `"testFile"` option
+will check for any test classes in your current file and run them. Similarly,
+`"testTarget"` will run all test classes found in the build target that the URI
+belongs to. The `"args"`, `"jvmOptions"`, `"env"`, and `"envFile"` are all valid
+keys that can be sent as well with the same format as above.
 
 ```json
 {

--- a/metals/src/main/scala/scala/meta/internal/metals/config/RunType.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/config/RunType.scala
@@ -3,12 +3,14 @@ package scala.meta.internal.metals.config
 object RunType {
   sealed trait RunType
   case object Run extends RunType
+  case object RunOrTestFile extends RunType
   case object TestFile extends RunType
   case object TestTarget extends RunType
 
   def fromString(string: String): Option[RunType] = {
     string match {
       case "run" => Some(Run)
+      case "runOrTestFile" => Some(RunOrTestFile)
       case "testFile" => Some(TestFile)
       case "testTarget" => Some(TestTarget)
       case _ => None


### PR DESCRIPTION
This will enable the possibility to run/debug without specifying the configuration in `launch.json`

Some further work can be done on the discovery so that we would be able to automatically feel new configurations for the user.

Related to https://github.com/scalameta/metals/issues/3272