### PR TITLE
Add isCommandInHtmlSupported to InitializationOptions doc

### DIFF
--- a/docs/integrations/new-editor.md
+++ b/docs/integrations/new-editor.md
@@ -125,6 +125,7 @@ The currently available settings for `InitializationOptions` are listed below.
       "inputBoxProvider": boolean,
       "isExitOnShutdown" : boolean,
       "isHttpEnabled": boolean,
+      "isCommandInHtmlSupported": boolean,
       "openFilesOnRenameProvider": boolean,
       "openNewWindowProvider": boolean,
       "quickPickProvider": boolean,

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -235,7 +235,7 @@ object ServerCommands {
     """|Converts provided stacktrace in the parameter to a format that contains links
        |to locations of places where the exception was raised.
        |
-       |If the configuration parameter of the client (support-commands-in-html) is true
+       |If the configuration parameter of the client `isCommandInHtmlSupported` is true
        |then client is requested to display html with links
        |already pointing to proper locations in user codebase.
        |Otherwise client will display simple scala file


### PR DESCRIPTION
Noticed that it was missing while working on the sublime implementation of `analyze-stacktrace`