### PR TITLE
Add missing commands to client commands documentation

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -227,6 +227,10 @@ object ClientCommands {
       FocusDiagnostics,
       GotoLocation,
       EchoCommand,
-      RefreshModel
+      RefreshModel,
+      ShowStacktrace,
+      CopyWorksheetOutput,
+      StartRunSession,
+      StartDebugSession
     )
 }


### PR DESCRIPTION
I initially noticed that `ShowStacktrace` was missing but I added the other missing ones as well.