### PR TITLE
Fix json rendering in documentation

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -124,7 +124,8 @@ object ClientCommands {
         |   data: {
         |      className: "com.foo.App"
         |   }
-        |}```
+        |}
+        |```
     """.stripMargin
   )
 
@@ -146,7 +147,8 @@ object ClientCommands {
         |   data: {
         |      className: "com.foo.App"
         |   }
-        |}```
+        |}
+        |```
     """.stripMargin
   )
 


### PR DESCRIPTION
It seems that my previous PR https://github.com/scalameta/metals/pull/3315 broke the json rendering in the doc.
This is the current look
![image](https://user-images.githubusercontent.com/1632384/143786752-7ca4e043-9228-4755-bd93-e88b199245f0.png)
