### PR TITLE
Move inactive maintainers to a separate list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,21 @@ https://scalameta.org/metals/docs/contributors/getting-started.html
 The current maintainers (people who can merge pull requests) are:
 
 - Adrien Piquerez - [`@adpi2`](https://github.com/adpi2)
-- Alexey Alekhin - [`@laughedelic`](https://github.com/laughedelic)
 - Chris Kipp - [`@ckipp01`](https://github.com/ckipp01)
 - Gabriele Petronella - [`@gabro`](https://github.com/gabro)
+- Kamil Podsiadło - [`@kpodsiad`](https://github.com/kpodsiad)
+- Ólafur Páll Geirsson - [`@olafurpg`](https://github.com/olafurpg)
+- Tomasz Godzik - [`@tgodzik`](https://github.com/tgodzik)
+- Vadim Chelyshov - [`@dos65`](https://github.com/dos65)
+
+Past maintainers:
+
+- Alexey Alekhin - [`@laughedelic`](https://github.com/laughedelic)
 - Johan Mudsam - [`@mudsam`](https://github.com/mudsam)
 - Krzysztof Bochenek - [`@kpbochenek`](https://github.com/kpbochenek)
-- Kamil Podsiadło - [`@kpodsiad`](https://github.com/kpodsiad)
 - Jorge Vicente Cantero - [`@jvican`](https://github.com/jvican)
 - Marek Żarnowski - [`@marek1840`](https://github.com/marek1840)
-- Ólafur Páll Geirsson - [`@olafurpg`](https://github.com/olafurpg)
 - Shane Delmore - [`@ShaneDelmore`](https://github.com/ShaneDelmore)
-- Tomasz Godzik - [`@tgodzik`](https://github.com/tgodzik)
-- Vadim Chelyshov- [`@dos65`](https://github.com/dos65)
 
 ## Acknowledgement
 

--- a/build.sbt
+++ b/build.sbt
@@ -66,12 +66,6 @@ inThisBuild(
         url("https://github.com/adpi2")
       ),
       Developer(
-        "laughedelic",
-        "Alexey Alekhin",
-        "laughedelic@gmail.com",
-        url("https://github.com/laughedelic")
-      ),
-      Developer(
         "ckipp01",
         "Chris Kipp",
         "ckipp@pm.me",
@@ -84,46 +78,16 @@ inThisBuild(
         url("https://github.com/gabro")
       ),
       Developer(
-        "mudsam",
-        "Johan Mudsam",
-        "johan@mudsam.com",
-        url("https://github.com/mudsam")
-      ),
-      Developer(
-        "jvican",
-        "Jorge Vicente Cantero",
-        "jorgevc@fastmail.es",
-        url("https://jvican.github.io/")
-      ),
-      Developer(
-        "kpbochenek",
-        "Krzysztof Bochenek",
-        "kbochenek@virtuslab.com ",
-        url("https://github.com/kpbochenek")
-      ),
-      Developer(
         "kpodsiad",
         "Kamil Podsiadło",
         "kpodsiadlo@virtuslab.com ",
         url("https://github.com/kpodsiad)")
       ),
       Developer(
-        "marek1840",
-        "Marek Żarnowski",
-        "mzarnowski@virtuslab.com",
-        url("https://github.com/marek1840")
-      ),
-      Developer(
         "olafurpg",
         "Ólafur Páll Geirsson",
         "olafurpg@gmail.com",
         url("https://geirsson.com")
-      ),
-      Developer(
-        "ShaneDelmore",
-        "Shane Delmore",
-        "sdelmore@twitter.com",
-        url("http://delmore.io")
       ),
       Developer(
         "tgodzik",


### PR DESCRIPTION
There is a number of people, who haven't worked or interacted in any form with the Metals repository for over a year now. To avoid confusion and make it easier to know who can be pinged, I move them to a separate list.

I don't plan on modifying the permissions to go with it.