### PR TITLE
[Scala3] Hover - improve tpe selection for signature and expression

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -12,6 +12,7 @@ import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.NameOps.*
 import dotty.tools.dotc.core.Names.*
 import dotty.tools.dotc.core.Symbols.*
+import dotty.tools.dotc.core.Types.Type
 import dotty.tools.dotc.interactive.Interactive
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.util.SourcePosition
@@ -80,6 +81,22 @@ object MtagsEnrichments extends CommonMtagsEnrichments:
 
     def nameBackticked: String =
       KeywordWrapper.Scala3.backtickWrap(sym.decodedName)
+
+    def withUpdatedTpe(tpe: Type): Symbol =
+      val upd = sym.copy(info = tpe)
+      val paramsWithFlags =
+        sym.paramSymss
+          .zip(upd.paramSymss)
+          .map((l1, l2) =>
+            l1.zip(l2)
+              .map((s1, s2) =>
+                s2.flags = s1.flags
+                s2
+              )
+          )
+      upd.rawParamss = paramsWithFlags
+      upd
+    end withUpdatedTpe
   end extension
 
   extension (name: Name)(using Context)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionProvider.scala
@@ -252,22 +252,7 @@ class CompletionProvider(
 
         private def substituteTypeVars(symbol: Symbol): Symbol =
           val denot = symbol.asSeenFrom(tpe)
-          val upd = symbol.copy(info = denot.info)
-
-          // denotation from `asSeenFrom` loses flags for parameter syms
-          val paramsWithFlags =
-            symbol.paramSymss
-              .zip(upd.paramSymss)
-              .map((l1, l2) =>
-                l1.zip(l2)
-                  .map((s1, s2) =>
-                    s2.flags = s1.flags
-                    s2
-                  )
-              )
-          upd.rawParamss = paramsWithFlags
-          upd
-        end substituteTypeVars
+          symbol.withUpdatedTpe(denot.info)
 
       end new
     end forSelect

--- a/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
@@ -46,7 +46,16 @@ class HoverDocSuite extends BaseHoverSuite {
            |List<String> s = Collections.emptyList();
            |```
            |""".stripMargin,
-      "3" -> "def emptyList[T]: java.util.List[T]".hover
+      "3" ->
+        """|**Expression type**:
+           |```scala
+           |java.util.List[Int]
+           |```
+           |**Symbol signature**:
+           |```scala
+           |def emptyList[T]: java.util.List[T]
+           |```
+           |""".stripMargin
     )
   )
 

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -152,7 +152,8 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |    "" <<%@@:>> 11
        |end Foo
        |""".stripMargin,
-    "extension [T](using A)(main: T) def %:[R](res: R)(using B)(using C): Int".hover
+    """|Int
+       |extension [T](using A)(main: T) def %:[R](res: R)(using B)(using C): R""".stripMargin.hover
   )
 
   check(
@@ -164,7 +165,8 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
       |  <<ap@@ply("test")>>
       |}
       |""".stripMargin,
-    """|def apply[T](a: T)(using Int): T
+    """|String
+       |def apply[T](a: T)(using Int): T
        |""".stripMargin.hover
   )
 }

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -14,7 +14,9 @@ class HoverTermSuite extends BaseHoverSuite {
        |final override def map[B, That](f: Int => B)(implicit bf: CanBuildFrom[List[Int],B,That]): That
        |""".stripMargin.hover,
     compat = Map(
-      "3" -> "def map[B](f: A => B): List[B]".hover
+      "3" ->
+        """|List[String]
+           |def map[B](f: Int => B): List[B]""".stripMargin.hover
     )
   )
 
@@ -42,7 +44,9 @@ class HoverTermSuite extends BaseHoverSuite {
         """|List[Int]
            |def apply[A](elems: A*): List[A]
            |""".stripMargin.hover,
-      "3" -> "def apply[A](elems: A*): Int".hover
+      "3" ->
+        """|List[Int]
+           |def apply[A](elems: A*): List[A]""".stripMargin.hover
     )
   )
 
@@ -56,7 +60,7 @@ class HoverTermSuite extends BaseHoverSuite {
     """|def apply(name: String): Person
        |""".stripMargin.hover,
     compat = Map(
-      "3" -> "case class Person: `case-apply`".hover
+      "3" -> "case class Person: Person".hover
     )
   )
 
@@ -122,10 +126,7 @@ class HoverTermSuite extends BaseHoverSuite {
       |""".stripMargin,
     """|Int
        |def apply[T](a: T)(implicit ev: Int): T
-       |""".stripMargin.hover,
-    compat = Map(
-      "3" -> "def apply[T](a: T)(implicit ev: Int): Int".hover
-    )
+       |""".stripMargin.hover
   )
 
   check(
@@ -178,7 +179,8 @@ class HoverTermSuite extends BaseHoverSuite {
        |def this(name: String, age: T): Foo[T]
        |""".stripMargin.hover,
     compat = Map(
-      "3" -> "class Foo: Int".hover
+      "3" ->
+        "class Foo: Foo".hover
     )
   )
 
@@ -276,10 +278,7 @@ class HoverTermSuite extends BaseHoverSuite {
       |""".stripMargin,
     """|Option[String]
        |def flatMap[B](f: Int => Option[B]): Option[B]
-       |""".stripMargin.hover,
-    compat = Map(
-      "3" -> "def flatMap[B](f: A => Option[B]): Option[String]".hover
-    )
+       |""".stripMargin.hover
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/hover/RangeHoverSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/RangeHoverSuite.scala
@@ -22,12 +22,7 @@ class RangeHoverSuite extends BaseHoverSuite {
        |}
        |""".stripMargin,
     """|Int
-       |def sum[B >: Int](implicit num: Numeric[B]): B""".stripMargin.hoverRange,
-    compat = Map(
-      "3" ->
-        """|Int
-           |def sum[B >: A](implicit num: Numeric[B]): B""".stripMargin.hoverRange
-    )
+       |def sum[B >: Int](implicit num: Numeric[B]): B""".stripMargin.hoverRange
   )
 
   check(
@@ -71,12 +66,7 @@ class RangeHoverSuite extends BaseHoverSuite {
        |}
        |""".stripMargin,
     """|Int
-       |def sum[B >: Int](implicit num: Numeric[B]): B""".stripMargin.hoverRange,
-    compat = Map(
-      "3" ->
-        """|Int
-           |def sum[B >: A](implicit num: Numeric[B]): B""".stripMargin.hoverRange
-    )
+       |def sum[B >: Int](implicit num: Numeric[B]): B""".stripMargin.hoverRange
   )
 
   check(
@@ -104,7 +94,7 @@ class RangeHoverSuite extends BaseHoverSuite {
            |override def flatMap[B](f: Int => IterableOnce[B]): IndexedSeq[B]""".stripMargin.hoverRange,
       "3" ->
         """|IndexedSeq[Int]
-           |def flatMap[B](f: A => IterableOnce[B]): IndexedSeq[Int]""".stripMargin.hoverRange
+           |def flatMap[B](f: Int => IterableOnce[B]): IndexedSeq[B]""".stripMargin.hoverRange
     )
   )
 
@@ -133,7 +123,7 @@ class RangeHoverSuite extends BaseHoverSuite {
            |def apply[A](elems: A*): List[A]""".stripMargin.hoverRange,
       "3" ->
         """|List[Int]
-           |def apply[A](elems: A*): List[Int]""".stripMargin.hoverRange
+           |def apply[A](elems: A*): List[A]""".stripMargin.hoverRange
     )
   )
 
@@ -236,12 +226,7 @@ class RangeHoverSuite extends BaseHoverSuite {
        |}
        |""".stripMargin,
     """|Int
-       |def sum[B >: Int](implicit num: Numeric[B]): B""".stripMargin.hoverRange,
-    compat = Map(
-      "3" ->
-        """|Int
-           |def sum[B >: A](implicit num: Numeric[B]): B""".stripMargin.hoverRange
-    )
+       |def sum[B >: Int](implicit num: Numeric[B]): B""".stripMargin.hoverRange
   )
 
   check(
@@ -262,11 +247,6 @@ class RangeHoverSuite extends BaseHoverSuite {
        |}
        |""".stripMargin,
     """|Int
-       |def sum[B >: Int](implicit num: Numeric[B]): B""".stripMargin.hoverRange,
-    compat = Map(
-      "3" ->
-        """|Int
-           |def sum[B >: A](implicit num: Numeric[B]): B""".stripMargin.hoverRange
-    )
+       |def sum[B >: Int](implicit num: Numeric[B]): B""".stripMargin.hoverRange
   )
 }


### PR DESCRIPTION
Adapted the `seenFrom` logic from Scala2.
Now types in hover are close to be in pair in both implementations.