### PR TITLE
Improve the "(currently using)" message during bsp-switch.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -32,7 +32,8 @@ class BspConnector(
     tables: Tables,
     userConfig: () => UserConfiguration,
     statusBar: StatusBar,
-    bspConfigGenerator: BspConfigGenerator
+    bspConfigGenerator: BspConfigGenerator,
+    currentConnection: () => Option[BuildServerConnection]
 )(implicit ec: ExecutionContext) {
 
   /**
@@ -319,9 +320,11 @@ class BspConnector(
             )
             Future.successful(false)
         }
-
       case multipleServers =>
-        val currentSelectedServer = tables.buildServers.selectedServer()
+        val currentSelectedServer =
+          tables.buildServers
+            .selectedServer()
+            .orElse(currentConnection().map(_.name))
         askUser(multipleServers, currentSelectedServer).flatMap(choice =>
           handleServerChoice(choice, currentSelectedServer)
         )

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -471,7 +471,8 @@ class MetalsLanguageServer(
           tables,
           () => userConfig,
           statusBar,
-          bspConfigGenerator
+          bspConfigGenerator,
+          () => bspSession.map(_.mainConnection)
         )
         semanticdbs = AggregateSemanticdbs(
           List(


### PR DESCRIPTION
This is just a small change to improve the bsp-switch label that
includes the "(currently using)" message. Previously if you've never
made an explicit choice it wouldn't tell you which you were using. This
change defaults to the current connection if there is no explicit
choice made.