### PR TITLE
Remove sublime version from the doc

### DIFF
--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -26,7 +26,7 @@ functionality.
     <td />
     <td align="center">Visual Studio Code</td>
     <td align="center">Vim</td>
-    <td align="center">Sublime Text 3</td>
+    <td align="center">Sublime Text</td>
     <td align="center">Emacs</td>
     <td align="center">Eclipse</td>
   </tr>

--- a/docs/editors/sublime.md
+++ b/docs/editors/sublime.md
@@ -3,7 +3,7 @@ id: sublime
 title: Sublime Text
 ---
 
-Metals works with Sublime Text 3 thanks to the
+Metals works with Sublime Text (build 4000 or later) thanks to the
 [sublimelsp/LSP](https://github.com/sublimelsp/LSP) and [scalameta/metals-sublime](https://github.com/scalameta/metals-sublime) plugins.
 
 ![Sublime Text demo](https://i.imgur.com/vJKP0T3.gif)


### PR DESCRIPTION
After https://github.com/scalameta/metals-sublime/pull/57 only ST4 will be supported
Also technically the version number is dropped from the name now it is simply Sublime Text.