### PR TITLE
Cross tests - fix ignorance for `test-mtags-dyn`

### DIFF
--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -111,7 +111,7 @@ abstract class BasePCSuite extends BaseSuite {
 
   protected def scalacOptions(classpath: Seq[Path]): Seq[String] = Nil
 
-  protected def excludedScalaVersions: Set[String] = Set.empty
+  protected def ignoreScalaVersion: Option[IgnoreScalaVersion] = None
 
   protected def requiresJdkSources: Boolean = false
 
@@ -163,7 +163,8 @@ abstract class BasePCSuite extends BaseSuite {
     executorService.shutdown()
   }
 
-  override def munitIgnore: Boolean = excludedScalaVersions(scalaVersion)
+  override def munitIgnore: Boolean =
+    ignoreScalaVersion.exists(_.ignored(scalaVersion))
 
   override def munitTestTransforms: List[TestTransform] =
     super.munitTestTransforms ++ List(
@@ -262,11 +263,8 @@ abstract class BasePCSuite extends BaseSuite {
       extends Tag("NoScalaVersion")
 
   object IgnoreScalaVersion {
-    def apply(versions: Seq[String]): IgnoreScalaVersion =
-      IgnoreScalaVersion(versions.toSet)
-
     def apply(version: String): IgnoreScalaVersion = {
-      IgnoreScalaVersion(Set(version))
+      IgnoreScalaVersion(_ == version)
     }
 
     def for3LessThan(version: String): IgnoreScalaVersion = {
@@ -279,11 +277,9 @@ abstract class BasePCSuite extends BaseSuite {
 
   }
 
-  object IgnoreScala2
-      extends IgnoreScalaVersion(BuildInfoVersions.scala2Versions.toSet)
+  object IgnoreScala2 extends IgnoreScalaVersion(_.startsWith("2."))
 
-  object IgnoreScala3
-      extends IgnoreScalaVersion(BuildInfoVersions.scala3Versions.toSet)
+  object IgnoreScala3 extends IgnoreScalaVersion(_.startsWith("3."))
 
   case class RunForScalaVersion(versions: Set[String])
       extends Tag("RunScalaVersion")

--- a/tests/cross/src/test/scala/tests/hover/HoverNegativeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverNegativeSuite.scala
@@ -1,13 +1,12 @@
 package tests.hover
 
-import tests.BuildInfoVersions
 import tests.pc.BaseHoverSuite
 
 class HoverNegativeSuite extends BaseHoverSuite {
 
   // @tgodzik Dotty seems to show the most enclosing symbol even if we hover on empty content
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   // Negative results should have an empty output.
   def checkNegative(

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -1,12 +1,11 @@
 package tests.hover
 
-import tests.BuildInfoVersions
 import tests.pc.BaseHoverSuite
 
 class HoverScala3TypeSuite extends BaseHoverSuite {
 
-  override protected def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala2Versions.toSet
+  override protected def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala2)
 
   check(
     "union",

--- a/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
@@ -9,12 +9,11 @@ import scala.meta.internal.metals.TextEdits
 import munit.TestOptions
 import org.eclipse.{lsp4j => l}
 import tests.BaseCodeActionSuite
-import tests.BuildInfoVersions
 
 class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   checkEdit(
     "classdef",

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -4,12 +4,11 @@ import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.pc.PresentationCompilerConfig
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionCaseSuite extends BaseCompletionSuite {
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   def paramHint: Option[String] = Some("param-hint")
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -1,14 +1,13 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionDocSuite extends BaseCompletionSuite {
   override def requiresJdkSources: Boolean = true
   override def requiresScalaLibrarySources: Boolean = true
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   check(
     "java",

--- a/tests/cross/src/test/scala/tests/pc/CompletionFilenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionFilenameSuite.scala
@@ -1,12 +1,11 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionFilenameSuite extends BaseCompletionSuite {
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   check(
     "class",

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -1,13 +1,12 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 import tests.pc.CrossTestEnrichments._
 
 class CompletionInterpolatorSuite extends BaseCompletionSuite {
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   checkEdit(
     "string",

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -1,12 +1,11 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionIssueSuite extends BaseCompletionSuite {
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   check(
     "mutate",

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -1,12 +1,11 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionKeywordSuite extends BaseCompletionSuite {
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   check(
     "super-template",
@@ -409,7 +408,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
   )
 
   check(
-    "topLevel".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "topLevel".tag(IgnoreScala3),
     "@@",
     """|abstract class
        |case class

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -1,14 +1,13 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionMatchSuite extends BaseCompletionSuite {
 
   override def requiresScalaLibrarySources: Boolean = true
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   check(
     "match",

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideAllSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideAllSuite.scala
@@ -1,13 +1,11 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionOverrideAllSuite extends BaseCompletionSuite {
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
-
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
   override def requiresJdkSources: Boolean = true
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
@@ -5,13 +5,11 @@ import scala.meta.pc.PresentationCompilerConfig
 import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionOverrideConfigSuite extends BaseCompletionSuite {
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
-
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
   override def config: PresentationCompilerConfig =
     PresentationCompilerConfigImpl().copy(
       _symbolPrefixes = Map(

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -1,14 +1,13 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionOverrideSuite extends BaseCompletionSuite {
 
   override def requiresJdkSources: Boolean = true
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   checkEdit(
     "basic",

--- a/tests/cross/src/test/scala/tests/pc/CompletionParameterHintSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionParameterHintSuite.scala
@@ -6,12 +6,11 @@ import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.pc.PresentationCompilerConfig
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionParameterHintSuite extends BaseCompletionSuite {
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   override def config: PresentationCompilerConfig =
     PresentationCompilerConfigImpl(

--- a/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
@@ -1,12 +1,11 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionScaladocSuite extends BaseCompletionSuite {
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
   check(
     "methoddef-label",
     """

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetNegSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetNegSuite.scala
@@ -4,7 +4,6 @@ import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.pc.PresentationCompilerConfig
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionSnippetNegSuite extends BaseCompletionSuite {
 
@@ -74,7 +73,7 @@ class CompletionSnippetNegSuite extends BaseCompletionSuite {
   )
 
   checkSnippet(
-    "type".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "type".tag(IgnoreScala3),
     s"""|object Main {
         |  val x: scala.IndexedSe@@
         |}

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -1,12 +1,11 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionSnippetSuite extends BaseCompletionSuite {
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   checkSnippet(
     "member",

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1,7 +1,6 @@
 package tests.pc
 
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class CompletionSuite extends BaseCompletionSuite {
 
@@ -926,7 +925,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "type2".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "type2".tag(IgnoreScala3),
     s"""|object Main {
         |  new scala.Iterable@@
         |}

--- a/tests/cross/src/test/scala/tests/pc/HKSignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/HKSignatureHelpSuite.scala
@@ -2,7 +2,6 @@ package tests.pc
 
 import coursierapi._
 import tests.BaseSignatureHelpSuite
-import tests.BuildInfoVersions
 
 class HKSignatureHelpSuite extends BaseSignatureHelpSuite {
 
@@ -14,8 +13,8 @@ class HKSignatureHelpSuite extends BaseSignatureHelpSuite {
     }
   }
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   check(
     "foldmap",

--- a/tests/cross/src/test/scala/tests/pc/InterruptPresentationCompilerSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InterruptPresentationCompilerSuite.scala
@@ -15,7 +15,6 @@ import scala.meta.pc.PresentationCompiler
 
 import munit.Location
 import tests.BasePCSuite
-import tests.BuildInfoVersions
 import tests.DelegatingGlobalSymbolIndex
 
 class InterruptPresentationCompilerSuite extends BasePCSuite {
@@ -34,8 +33,8 @@ class InterruptPresentationCompilerSuite extends BasePCSuite {
   }
 
   // @tgodzik currently not handled for Dotty
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   override def beforeEach(context: BeforeEach): Unit = {
     index.asInstanceOf[InterruptSymbolIndex].reset()

--- a/tests/cross/src/test/scala/tests/pc/MacroCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/MacroCompletionSuite.scala
@@ -6,7 +6,6 @@ import scala.collection.Seq
 
 import coursierapi.Dependency
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class MacroCompletionSuite extends BaseCompletionSuite {
 
@@ -39,8 +38,8 @@ class MacroCompletionSuite extends BaseCompletionSuite {
   }
 
   // @tgodzik macros will not work in Dotty
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   override def scalacOptions(classpath: Seq[Path]): Seq[String] =
     classpath

--- a/tests/cross/src/test/scala/tests/pc/PrettyPrintSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PrettyPrintSuite.scala
@@ -2,12 +2,11 @@ package tests.pc
 
 import munit.Location
 import tests.BaseCompletionSuite
-import tests.BuildInfoVersions
 
 class PrettyPrintSuite extends BaseCompletionSuite {
 
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   def checkSignature(
       name: String,

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpDocSuite.scala
@@ -1,7 +1,6 @@
 package tests.pc
 
 import tests.BaseSignatureHelpSuite
-import tests.BuildInfoVersions
 
 class SignatureHelpDocSuite extends BaseSignatureHelpSuite {
 
@@ -10,8 +9,8 @@ class SignatureHelpDocSuite extends BaseSignatureHelpSuite {
   override def requiresScalaLibrarySources: Boolean = true
 
   // @tgodzik docs not yet supported for Scala 3
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   val foldLatestDocs: String =
     """|Returns the result of applying `f` to this [scala.Option](scala.Option)'s

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
@@ -1,13 +1,12 @@
 package tests.pc
 
 import tests.BaseSignatureHelpSuite
-import tests.BuildInfoVersions
 
 class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
 
   // @tgodzik docs not yet supported for Scala 3
-  override def excludedScalaVersions: Set[String] =
-    BuildInfoVersions.scala3Versions.toSet
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala3)
 
   check(
     "case",

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -1,7 +1,6 @@
 package tests.pc
 
 import tests.BaseSignatureHelpSuite
-import tests.BuildInfoVersions
 
 class SignatureHelpSuite extends BaseSignatureHelpSuite {
 
@@ -309,7 +308,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "tparam2".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "tparam2".tag(IgnoreScala3),
     """
       |object a {
       |  Option.empty[I@@]
@@ -339,7 +338,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
     )
   )
   check(
-    "tparam4".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "tparam4".tag(IgnoreScala3),
     """
       |object a {
       |  Map.empty[I@@]
@@ -778,7 +777,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "type".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "type".tag(IgnoreScala3),
     """
       |object a {
       |  val x: Map[Int, Stri@@ng]
@@ -790,7 +789,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "type1".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "type1".tag(IgnoreScala3),
     """
       |object a {
       |  val x: Map[Int, Stri@@]
@@ -802,7 +801,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "pat".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "pat".tag(IgnoreScala3),
     """
       |case class Person(name: String, age: Int)
       |object a {
@@ -816,7 +815,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "pat1".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "pat1".tag(IgnoreScala3),
     """
       |class Person(name: String, age: Int)
       |object Person {
@@ -834,7 +833,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "pat2".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "pat2".tag(IgnoreScala3),
     """
       |object a {
       |  val Number = "$a, $b".r
@@ -860,7 +859,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "pat3".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "pat3".tag(IgnoreScala3),
     """
       |object And {
       |  def unapply[A](a: A): Some[(A, A)] = Some((a, a))
@@ -876,7 +875,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "pat4".tag(IgnoreScalaVersion(BuildInfoVersions.scala3Versions)),
+    "pat4".tag(IgnoreScala3),
     """
       |object & {
       |  def unapply[A](a: A): Some[(A, A)] = Some((a, a))


### PR DESCRIPTION
`test-mtags-dyn` might be called with a versions that isn't specified in
BuildInfo