### PR TITLE
Add information about source of exceptions

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -2687,8 +2687,12 @@ class MetalsLanguageServer(
       onError = {
         case e @ (_: ParseException | _: TokenizeException) =>
           scribe.error(e.toString)
-        case e: InvalidJarException =>
+        case e: IndexingExceptions.InvalidJarException =>
           scribe.warn(s"invalid jar: ${e.path}")
+        case e: IndexingExceptions.PathIndexingException =>
+          scribe.error(s"issues while parsing: ${e.path}", e)
+        case e: IndexingExceptions.InvalidSymbolException =>
+          scribe.error(s"searching for `${e.symbol}` failed", e)
         case _: NoSuchFileException =>
         // only comes for badly configured jar with `/Users` path added.
         case NonFatal(e) =>

--- a/mtags/src/main/scala/scala/meta/internal/mtags/IndexingExceptions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/IndexingExceptions.scala
@@ -1,0 +1,14 @@
+package scala.meta.internal.mtags
+
+import scala.meta.io.AbsolutePath
+
+object IndexingExceptions {
+  case class InvalidJarException(path: AbsolutePath, underlying: Throwable)
+      extends Exception(path.toString)
+
+  case class InvalidSymbolException(symbol: String, underlying: Throwable)
+      extends Exception(symbol)
+
+  case class PathIndexingException(path: AbsolutePath, underlying: Throwable)
+      extends Exception(path.toString())
+}

--- a/mtags/src/main/scala/scala/meta/internal/mtags/InvalidJarException.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/InvalidJarException.scala
@@ -1,6 +1,0 @@
-package scala.meta.internal.mtags
-
-import scala.meta.io.AbsolutePath
-
-case class InvalidJarException(path: AbsolutePath, underlying: Throwable)
-    extends Exception(path.toString)


### PR DESCRIPTION
Previously, users would report an issue, but we would not be able to point to any particular path or dependency. Now, we try to print much more information for the users in exceptional cases.

The issue popped up for example here: https://gitter.im/scalameta/metals?at=61a8d7a98853d31640283bf5