### PR TITLE
Actions - set jdk11  for mtags auto release

### DIFF
--- a/.github/workflows/mtags-auto-release.yml
+++ b/.github/workflows/mtags-auto-release.yml
@@ -10,7 +10,7 @@ on:
         required: true
         default: "v0.10.9"
 jobs:
-  publish:
+  test_and_release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,6 +18,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.metals_version }}
       - uses: olafurpg/setup-scala@v13
+        with:
+          java-version: adopt@1.11
       - uses: coursier/cache-action@v6.3
       - name: "Test and push tag"
         run: |


### PR DESCRIPTION
Cross tests don't pass on jdk8.
The re some completions tests that contains some classes that aren't
presented in jdk 8