### PR TITLE
Send Code lens refresh when supported by client

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -157,6 +157,8 @@ object ClientCommands {
     "Refresh model",
     """|Notifies the client that the model has been updated and it 
        |should be refreshed (e.g. by resending code lens request)
+       |
+       |Note: Metals will favor instead [Code Lens Refresh Request](https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#codeLens_refresh) if the client has the capability.
        |""".stripMargin
   )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -155,10 +155,10 @@ object ClientCommands {
   val RefreshModel = new Command(
     "metals-model-refresh",
     "Refresh model",
-    """|Notifies the client that the model has been updated and it 
-       |should be refreshed (e.g. by resending code lens request)
+    """|**Note**: This request is deprecated and Metals will favor [Code Lens Refresh Request](https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#codeLens_refresh) if supported by the client.
        |
-       |Note: Metals will favor instead [Code Lens Refresh Request](https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#codeLens_refresh) if the client has the capability.
+       |Notifies the client that the model has been updated and it
+       |should be refreshed (e.g. by resending code lens request)
        |""".stripMargin
   )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -19,7 +19,7 @@ case class ClientConfiguration(initialConfig: MetalsServerConfig) {
   private var initializationOptions = InitializationOptions.Default
   private var refreshSupport = false
 
-  def update(params: InitializeParams) = {
+  def update(params: InitializeParams): Unit = {
     experimentalCapabilities =
       ClientExperimentalCapabilities.from(params.getCapabilities)
     initializationOptions = InitializationOptions.from(params)
@@ -171,5 +171,5 @@ case class ClientConfiguration(initialConfig: MetalsServerConfig) {
 }
 
 object ClientConfiguration {
-  def Default() = ClientConfiguration(MetalsServerConfig())
+  def Default(): ClientConfiguration = ClientConfiguration(MetalsServerConfig())
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -16,7 +16,8 @@ import scala.meta.internal.metals.config.StatusBarState
 class ClientConfiguration(
     var initialConfig: MetalsServerConfig,
     var experimentalCapabilities: ClientExperimentalCapabilities,
-    var initializationOptions: InitializationOptions
+    var initializationOptions: InitializationOptions,
+    var codeLenseRefreshSupport: Boolean
 ) {
 
   def extract[T](primary: Option[T], secondary: Option[T], default: T): T = {
@@ -160,6 +161,7 @@ object ClientConfiguration {
     new ClientConfiguration(
       MetalsServerConfig(),
       ClientExperimentalCapabilities.Default,
-      InitializationOptions.Default
+      InitializationOptions.Default,
+      false
     )
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
@@ -7,7 +7,7 @@ import org.eclipse.{lsp4j => l}
 
 /**
  * While all these values can be set here, they are here only for
- * compatablity with clients that were setting them this way. From
+ * compatibility with clients that were setting them this way. From
  * a client perspective it's preferable and recommended to use
  * InitializationOptions instead. From a development perspective
  * don't add something here unless it's truly a more "experimental"

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -19,7 +19,6 @@ final class Compilations(
     classes: BuildTargetClasses,
     workspace: () => AbsolutePath,
     languageClient: MetalsLanguageClient,
-    codeLenseRefreshSupport: () => Boolean,
     isCurrentlyFocused: b.BuildTargetIdentifier => Boolean,
     compileWorksheets: Seq[AbsolutePath] => Future[Unit]
 )(implicit ec: ExecutionContext) {
@@ -219,7 +218,7 @@ final class Compilations(
         // See https://github.com/scalacenter/bloop/issues/1067
         classes.rebuildIndex(targets).foreach { _ =>
           if (targets.exists(isCurrentlyFocused)) {
-            languageClient.refreshModel(codeLenseRefreshSupport())
+            languageClient.refreshModel()
           }
         }
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -19,6 +19,7 @@ final class Compilations(
     classes: BuildTargetClasses,
     workspace: () => AbsolutePath,
     languageClient: MetalsLanguageClient,
+    codeLenseRefreshSupport: () => Boolean,
     isCurrentlyFocused: b.BuildTargetIdentifier => Boolean,
     compileWorksheets: Seq[AbsolutePath] => Future[Unit]
 )(implicit ec: ExecutionContext) {
@@ -218,7 +219,7 @@ final class Compilations(
         // See https://github.com/scalacenter/bloop/issues/1067
         classes.rebuildIndex(targets).foreach { _ =>
           if (targets.exists(isCurrentlyFocused)) {
-            languageClient.refreshModel()
+            languageClient.refreshModel(codeLenseRefreshSupport())
           }
         }
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -82,6 +82,15 @@ final class ConfiguredLanguageClient(
     }
   }
 
+  override def refreshModel(): CompletableFuture[Unit] = {
+    if (clientConfig.codeLenseRefreshSupport)
+      this.refreshCodeLenses.thenApply(_ => ())
+    else {
+      val params = ClientCommands.RefreshModel.toExecuteCommandParams()
+      CompletableFuture.completedFuture(metalsExecuteClientCommand(params))
+    }
+  }
+
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams
   ): Unit = {

--- a/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConfiguredLanguageClient.scala
@@ -84,26 +84,19 @@ final class ConfiguredLanguageClient(
 
   override def refreshModel(): CompletableFuture[Unit] = {
     if (clientConfig.codeLenseRefreshSupport)
-      this.refreshCodeLenses.thenApply(_ => ())
-    else {
+      underlying.refreshCodeLenses.thenApply(_ => ())
+    else if (
+      clientConfig.isExecuteClientCommandProvider && clientConfig.isDebuggingProvider
+    ) {
       val params = ClientCommands.RefreshModel.toExecuteCommandParams()
       CompletableFuture.completedFuture(metalsExecuteClientCommand(params))
-    }
+    } else CompletableFuture.completedFuture(())
   }
 
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams
-  ): Unit = {
-    if (clientConfig.isExecuteClientCommandProvider) {
-      params match {
-        case ClientCommands.RefreshModel()
-            if !clientConfig.isDebuggingProvider =>
-          () // ignore
-        case _ =>
-          underlying.metalsExecuteClientCommand(params)
-      }
-    }
-  }
+  ): Unit =
+    underlying.metalsExecuteClientCommand(params)
 
   override def metalsInputBox(
       params: MetalsInputBoxParams

--- a/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DelegatingLanguageClient.scala
@@ -104,4 +104,6 @@ class DelegatingLanguageClient(var underlying: MetalsLanguageClient)
     underlying.metalsPublishDecorations(params)
   }
 
+  override def refreshModel(): CompletableFuture[Unit] =
+    underlying.refreshModel()
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
@@ -42,9 +42,18 @@ trait MetalsLanguageClient
   @JsonNotification("metals/executeClientCommand")
   def metalsExecuteClientCommand(params: ExecuteCommandParams): Unit
 
-  final def refreshModel(): Unit = {
-    val params = ClientCommands.RefreshModel.toExecuteCommandParams()
-    metalsExecuteClientCommand(params)
+  final def refreshModel(
+      codeLensRefreshSupport: Boolean
+  ): CompletableFuture[Void] = {
+    if (codeLensRefreshSupport) this.refreshCodeLenses
+    else {
+      val params = ClientCommands.RefreshModel.toExecuteCommandParams()
+      CompletableFuture.runAsync(
+        new Runnable {
+          def run(): Unit = metalsExecuteClientCommand(params)
+        }
+      )
+    }
   }
 
   /**

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageClient.scala
@@ -42,19 +42,7 @@ trait MetalsLanguageClient
   @JsonNotification("metals/executeClientCommand")
   def metalsExecuteClientCommand(params: ExecuteCommandParams): Unit
 
-  final def refreshModel(
-      codeLensRefreshSupport: Boolean
-  ): CompletableFuture[Void] = {
-    if (codeLensRefreshSupport) this.refreshCodeLenses
-    else {
-      val params = ClientCommands.RefreshModel.toExecuteCommandParams()
-      CompletableFuture.runAsync(
-        new Runnable {
-          def run(): Unit = metalsExecuteClientCommand(params)
-        }
-      )
-    }
-  }
+  def refreshModel(): CompletableFuture[Unit]
 
   /**
    * Opens an input box to ask the user for input.

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -272,13 +272,9 @@ class MetalsLanguageServer(
   var stacktraceAnalyzer: StacktraceAnalyzer = _
   var findTextInJars: FindTextInDependencyJars = _
 
-  private val clientConfig: ClientConfiguration =
-    new ClientConfiguration(
-      initialConfig,
-      ClientExperimentalCapabilities.Default,
-      InitializationOptions.Default,
-      false
-    )
+  private val clientConfig: ClientConfiguration = ClientConfiguration(
+    initialConfig
+  )
 
   def parseTreesAndPublishDiags(paths: Seq[AbsolutePath]): Future[Seq[Unit]] = {
     Future.traverse(paths.distinct) { path =>
@@ -340,15 +336,7 @@ class MetalsLanguageServer(
         scribe.info(
           s"Started: Metals version ${BuildInfo.metalsVersion} in workspace '$workspace' $clientInfo."
         )
-
-        clientConfig.experimentalCapabilities =
-          ClientExperimentalCapabilities.from(params.getCapabilities)
-        clientConfig.initializationOptions = InitializationOptions.from(params)
-        clientConfig.codeLenseRefreshSupport = params
-          .getCapabilities()
-          .getWorkspace()
-          .getCodeLens()
-          .getRefreshSupport()
+        clientConfig.update(params)
 
         foldingRangeProvider.setFoldOnlyLines(Option(params).foldOnlyLines)
         documentSymbolProvider.setSupportsHierarchicalDocumentSymbols(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -181,7 +181,6 @@ class MetalsLanguageServer(
     buildTargetClasses,
     () => workspace,
     languageClient,
-    () => clientConfig.codeLenseRefreshSupport,
     buildTarget => focusedDocumentBuildTarget.get() == buildTarget,
     worksheets => onWorksheetChanged(worksheets)
   )
@@ -2417,9 +2416,7 @@ class MetalsLanguageServer(
     val targets = buildTargets.all.map(_.id).toSeq
     buildTargetClasses
       .rebuildIndex(targets)
-      .foreach(_ =>
-        languageClient.refreshModel(clientConfig.codeLenseRefreshSupport)
-      )
+      .foreach(_ => languageClient.refreshModel())
   }
 
   private def checkRunningBloopVersion(bspServerVersion: String) = {

--- a/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/NoopLanguageClient.scala
@@ -50,6 +50,9 @@ abstract class NoopLanguageClient extends MetalsLanguageClient {
   override def metalsPublishDecorations(
       params: PublishDecorationsParams
   ): Unit = ()
+
+  override def refreshModel(): CompletableFuture[Unit] =
+    CompletableFuture.completedFuture(())
 }
 
 object NoopLanguageClient extends NoopLanguageClient

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/ClientConfigurationAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/ClientConfigurationAdapter.scala
@@ -63,7 +63,7 @@ private[debug] object ClientConfigurationAdapter {
   private val defaultLinesStartAt1 = false
 
   def default: ClientConfigurationAdapter = {
-    new ClientConfigurationAdapter(defautlPathFormat, defaultLinesStartAt1)
+    ClientConfigurationAdapter(defautlPathFormat, defaultLinesStartAt1)
   }
 
   def initialize(
@@ -74,6 +74,6 @@ private[debug] object ClientConfigurationAdapter {
     val linesStartAt1 = Option(initRequest.getLinesStartAt1)
       .map(_.booleanValue)
       .getOrElse(defaultLinesStartAt1)
-    new ClientConfigurationAdapter(pathFormat, linesStartAt1)
+    ClientConfigurationAdapter(pathFormat, linesStartAt1)
   }
 }


### PR DESCRIPTION
Instead of the custom `metals-model-refresh`

Fix https://github.com/scalameta/metals/issues/3354