### PR TITLE
[Build] Fix quick-publish-local

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -193,7 +193,7 @@ commands ++= Seq(
     val publishMtags = V.quickPublishScalaVersions.foldLeft(s) { case (st, v) =>
       runMtagsPublishLocal(st, v, localSnapshotVersion)
     }
-    "interfaces/publishLocal" :: "metals/publishLocal" :: publishMtags
+    "interfaces/publishLocal" :: s"++${V.scala212} metals/publishLocal" :: publishMtags
   },
   Command.command("cross-test-latest-nightly") { s =>
     V.nightlyScala3Versions.lastOption match {


### PR DESCRIPTION
Without specifying scala version for `metals` its publishing in command
fails with the following error:
```
[error] Modules were resolved with conflicting cross-version suffixes in ProjectRef(uri("file:/home/dos65/projects/metals/metals/"), "metals"):
[error]    org.scalameta:mtags _2.12.15, _2.12.14

```