### PR TITLE
[Scala3] Fix ImportMissingSymbol code action

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -28,7 +28,8 @@ final class AutoImportsProvider(
     driver: InteractiveDriver,
     name: String,
     params: OffsetParams,
-    config: PresentationCompilerConfig
+    config: PresentationCompilerConfig,
+    buildTargetIdentifier: String
 ):
 
   def autoImports(): List[AutoImportsResult] =
@@ -65,7 +66,7 @@ final class AutoImportsProvider(
       sym.name.show == query
 
     val visitor = new CompilerSearchVisitor(name, visit)
-    search.search(name, "", visitor)
+    search.search(name, buildTargetIdentifier, visitor)
     val results = symbols.result.filter(isExactMatch(_, name))
 
     if results.nonEmpty then

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -251,7 +251,14 @@ case class ScalaPresentationCompiler(
       params.token
     ) { access =>
       val driver = access.compiler()
-      new AutoImportsProvider(search, driver, name, params, config)
+      new AutoImportsProvider(
+        search,
+        driver,
+        name,
+        params,
+        config,
+        buildTargetIdentifier
+      )
         .autoImports()
         .asJava
     }

--- a/tests/slow/src/test/scala/tests/feature/ImportMissingSymbolCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/ImportMissingSymbolCrossLspSuite.scala
@@ -1,0 +1,44 @@
+package tests.feature
+
+import scala.meta.internal.metals.codeactions.CreateNewSymbol
+import scala.meta.internal.metals.codeactions.ImportMissingSymbol
+import scala.meta.internal.metals.{BuildInfo => V}
+
+import tests.codeactions.BaseCodeActionLspSuite
+
+class ImportMissingSymbolCrossLspSuite
+    extends BaseCodeActionLspSuite("importMissingSymbol-cross") {
+
+  test("scala3-import-from-deps") {
+    val path = "b/src/main/scala/x/B.scala"
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a":{"scalaVersion" : "${V.scala3}"},
+            |  "b":{
+            |    "scalaVersion" : "${V.scala3}",
+            |    "dependsOn": ["a"]
+            |  }
+            |}
+            |/a/src/main/scala/example/A.scala
+            |package example
+            |trait A
+            |/$path
+            |package x
+            |class B(a: A)
+            |""".stripMargin
+      )
+      _ <- server.didOpen(path)
+      _ <- server.assertCodeAction(
+        path,
+        s"""|package x
+            |class B(a: <<A>>)
+            |""".stripMargin,
+        s"""|${ImportMissingSymbol.title("A", "example")}
+            |${CreateNewSymbol.title("A")}""".stripMargin,
+        Nil
+      )
+    } yield ()
+  }
+}


### PR DESCRIPTION
To get a proper results it's needed to specify buildTargetId from where
SymbolSearch is performed.