### PR TITLE
Use full range when using go-to definition for synthetics

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -310,7 +310,7 @@ final class SyntheticsDecorationProvider(
       textDocument.occurrences.collectFirst {
         case s.SymbolOccurrence(Some(range), `symbol`, role)
             if role.isDefinition =>
-          gotoLocationUsingUri(uri, range.startLine, range.startCharacter)
+          gotoLocationUsingUri(uri, range)
       }
     } else {
       Some(gotoSymbolUsingUri(symbol))
@@ -319,11 +319,9 @@ final class SyntheticsDecorationProvider(
 
   private def gotoLocationUsingUri(
       uri: String,
-      line: Int,
-      character: Int
+      range: s.Range
   ): String = {
-    val pos = new l.Position(line, character)
-    val location = new l.Location(uri, new l.Range(pos, pos))
+    val location = new l.Location(uri, range.toLSP)
     ServerCommands.GotoPosition.toCommandLink(location)
   }
 

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -93,7 +93,7 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
         .toURI
         .toString()
       expectedParamsBoston = URLEncoder.encode(
-        s"""[{"uri":"$mainClassPath","range":{"start":{"line":9,"character":17},"end":{"line":9,"character":17}}}]"""
+        s"""[{"uri":"$mainClassPath","range":{"start":{"line":9,"character":17},"end":{"line":9,"character":23}}}]"""
       )
       _ <- server.assertHoverAtLine(
         "a/src/main/scala/Main.scala",


### PR DESCRIPTION
Previously, we would only point to the first character, which would work differently to how normally go to definition works. Now, we point to the full range.