### PR TITLE
[UNTESTED] Fix Gradle detection, multimodule proj

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -63,10 +63,11 @@ final class BuildTools(
     }
   }
   def isMill: Boolean = workspace.resolve("build.sc").isFile
-  def isGradle: Boolean =
+  def isGradle: Boolean = {
     val defaultGradlePaths = List("settings.gradle", "settings.gradle.kts",
-      "build.gradle", "build.gradle.kts", "./app/build.gradle", "./app/build.gradle.kts")
+                                  "build.gradle", "build.gradle.kts")
     defaultGradlePaths.exists(workspace.resolve(_).isFile)
+  }
   def isMaven: Boolean = workspace.resolve("pom.xml").isFile
   def isPants: Boolean = workspace.resolve("pants.ini").isFile
   def isBazel: Boolean = workspace.resolve("WORKSPACE").isFile

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -64,8 +64,12 @@ final class BuildTools(
   }
   def isMill: Boolean = workspace.resolve("build.sc").isFile
   def isGradle: Boolean = {
-    val defaultGradlePaths = List("settings.gradle", "settings.gradle.kts",
-                                  "build.gradle", "build.gradle.kts")
+    val defaultGradlePaths = List(
+      "settings.gradle",
+      "settings.gradle.kts",
+      "build.gradle",
+      "build.gradle.kts"
+    )
     defaultGradlePaths.exists(workspace.resolve(_).isFile)
   }
   def isMaven: Boolean = workspace.resolve("pom.xml").isFile

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -64,9 +64,9 @@ final class BuildTools(
   }
   def isMill: Boolean = workspace.resolve("build.sc").isFile
   def isGradle: Boolean =
-    workspace.resolve("build.gradle").isFile || workspace
-      .resolve("build.gradle.kts")
-      .isFile
+    val defaultGradlePaths = List("settings.gradle", "settings.gradle.kts",
+      "build.gradle", "build.gradle.kts", "./app/build.gradle", "./app/build.gradle.kts")
+    defaultGradlePaths.exists(workspace.resolve(_).isFile)
   def isMaven: Boolean = workspace.resolve("pom.xml").isFile
   def isPants: Boolean = workspace.resolve("pants.ini").isFile
   def isBazel: Boolean = workspace.resolve("WORKSPACE").isFile


### PR DESCRIPTION
I think something like this should be right.

The only guaranteed file to exist in a Gradle project I think is `settings.gradle(.kts)` in the root. Subprojects can be nested arbitrarily + named anything:

https://docs.gradle.org/current/userguide/declaring_dependencies_between_subprojects.html#sec:project_jar_dependencies

Currently, Metals fails to detect Gradle projects like the ones created by `gradle init -> "Application (Scala)"` because the directory layout is:

```
settings.gradle(.kts)
/app
  build.gradle(.kts)
  /src
```

![image](https://user-images.githubusercontent.com/26604994/146646529-f2ef4ae3-6766-4a62-8aed-15f4044742b1.png)

