### PR TITLE
Use quick pick instead of message requests for debug discovery

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -10,7 +10,6 @@ import scala.meta.internal.metals.clients.language.MetalsStatusParams
 import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
 
-import ch.epfl.scala.bsp4j.ScalaMainClass
 import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.MessageType
@@ -168,18 +167,6 @@ object Messages {
 
   object MainClass {
     val message = "Multiple main classes found. Which would you like to run?"
-    def params(
-        mainClasses: List[ScalaMainClass]
-    ): ShowMessageRequestParams = {
-      val messageActionItems =
-        mainClasses
-          .map(mc => new MessageActionItem(mc.getClassName()))
-      val params = new ShowMessageRequestParams()
-      params.setMessage(message)
-      params.setType(MessageType.Info)
-      params.setActions(messageActionItems.asJava)
-      params
-    }
   }
 
   object ChooseBuildTool {

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -38,6 +38,8 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ScalaVersionSelector
 import scala.meta.internal.metals.StacktraceAnalyzer
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.clients.language.MetalsQuickPickItem
+import scala.meta.internal.metals.clients.language.MetalsQuickPickParams
 import scala.meta.internal.metals.clients.language.MetalsStatusParams
 import scala.meta.internal.metals.config.RunType
 import scala.meta.internal.metals.config.RunType._
@@ -52,7 +54,6 @@ import ch.epfl.scala.bsp4j.ScalaMainClass
 import ch.epfl.scala.{bsp4j => b}
 import com.google.common.net.InetAddresses
 import com.google.gson.JsonElement
-import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.MessageType
 
@@ -187,13 +188,19 @@ class DebugProvider(
       mainClasses: List[ScalaMainClass]
   )(implicit ec: ExecutionContext): Future[ScalaMainClass] = {
     languageClient
-      .showMessageRequest(
-        Messages.MainClass.params(mainClasses)
+      .metalsQuickPick(
+        new MetalsQuickPickParams(
+          mainClasses.map { m =>
+            val cls = m.getClassName()
+            new MetalsQuickPickItem(cls, cls)
+          }.asJava,
+          placeHolder = Messages.MainClass.message
+        )
       )
       .asScala
-      .map { choice =>
+      .collect { case Some(choice) =>
         mainClasses.find { clazz =>
-          new MessageActionItem(clazz.getClassName()) == choice
+          clazz.getClassName() == choice.itemId
         }
       }
       .collect { case Some(main) => main }


### PR DESCRIPTION
Previously, we would use message request when asking for user input about which main class to run. Now, we instead use quick pick to accomodate a larger number of main classes possible. This is also a much nicer UI in VS Code as there is no need to select anything with a mouse. Quick pick still falls back to messageRequests if the client doesn't support it.

https://user-images.githubusercontent.com/3807253/146952326-d398138c-1fda-401f-93d4-917681f5a37a.mp4


