### PR TITLE
[Mtags releases] Send the latest semantidcb-plugin version to BSP

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspExtra.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspExtra.scala
@@ -1,0 +1,120 @@
+package scala.meta.internal.bsp
+
+import scala.jdk.CollectionConverters._
+
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.semver.SemVer
+
+/**
+ * When Metals establish bsp-connection it sends
+ *  the required semanticdb version and supportedScalaVersions (only scala2) to bsp-server
+ *  to prepare compiler plugin setup on its side.
+ *
+ * To have the actual state of this metadata use `BspExtra.discoverNewReleases`.
+ * It checks if there were scalameta/semanticdb releases that support newer Scala2 versions
+ *  that were published after the Metals release.
+ */
+final case class BspExtra(
+    semanticdbVersion: String,
+    supportedScalaVersions: java.util.List[String]
+)
+
+object BspExtra {
+
+  def apply(
+      semanticdbVersion: String,
+      supportedScalaVersions: Seq[String]
+  ): BspExtra =
+    BspExtra(semanticdbVersion, supportedScalaVersions.asJava)
+
+  val knownAtReleaseMoment: BspExtra =
+    BspExtra(
+      BuildInfo.semanticdbVersion,
+      BuildInfo.supportedScala2Versions
+    )
+
+  val allowedSemanticdbVersionPrefix = "4.4"
+
+  def discoverNewReleases(): BspExtra =
+    discoverNewReleases(knownAtReleaseMoment)
+
+  def discoverNewReleases(known: BspExtra): BspExtra = {
+
+    def semanticdbScalacPluginVersion(
+        scalaVersion: String
+    ): Option[SemVer.Version] = {
+      val versionsQuery =
+        s"org.scalameta:semanticdb-scalac_$scalaVersion:"
+
+      val completions = coursierapi.Complete
+        .create()
+        .withInput(versionsQuery)
+        .complete()
+        .getCompletions()
+        .asScala
+
+      completions
+        .filter(_.startsWith(allowedSemanticdbVersionPrefix))
+        .map(SemVer.Version.fromString)
+        .filter(_.isStable)
+        .sortWith(_ > _)
+        .headOption
+    }
+    // Having a known version, here we inc it's patch version and check if there
+    //  is semanticdb compiler plugin artifacts for this version.
+    def queryNextPatchVersions(
+        prev: SemVer.Version,
+        maxSemanticdbVersion: SemVer.Version,
+        acc: List[String]
+    ): (SemVer.Version, List[String]) = {
+      val next = prev.copy(patch = prev.patch + 1)
+      val pluginVersion = semanticdbScalacPluginVersion(next.toString)
+      pluginVersion match {
+        case Some(version) =>
+          val nextMax =
+            if (version > maxSemanticdbVersion) version
+            else maxSemanticdbVersion
+
+          queryNextPatchVersions(next, nextMax, next.toString :: acc)
+        case None => (maxSemanticdbVersion, acc)
+      }
+    }
+
+    def query(
+        semanticdbVersion: SemVer.Version,
+        lastMinorScalaVersion: Option[SemVer.Version]
+    ): (SemVer.Version, List[String]) =
+      lastMinorScalaVersion match {
+        case None => (semanticdbVersion, Nil)
+        case Some(last) => queryNextPatchVersions(last, semanticdbVersion, Nil)
+      }
+
+    val init = (Option.empty[SemVer.Version], Option.empty[SemVer.Version])
+    val (max212, max213) =
+      known.supportedScalaVersions.asScala
+        .map(SemVer.Version.fromString)
+        .foldLeft(init) {
+          case ((curr212, curr213), v) if v.minor == 12 =>
+            (curr212.filter(_ > v).orElse(Some(v)), curr213)
+          case ((curr212, curr213), v) if v.minor == 13 =>
+            (curr212, curr213.filter(_ > v).orElse(Some(v)))
+          case (acc, _) => acc
+        }
+
+    val semanticdbVersion = SemVer.Version.fromString(known.semanticdbVersion)
+
+    val (max212Semantic, added212) = query(semanticdbVersion, max212)
+    val (max213Semantic, added213) = query(semanticdbVersion, max213)
+
+    val finalSemanticdbVersion =
+      List(semanticdbVersion, max212Semantic, max213Semantic)
+        .sortWith(_ > _)
+        .head
+        .toString
+
+    BspExtra(
+      finalSemanticdbVersion,
+      known.supportedScalaVersions.asScala.toList ++ added212 ++ added213
+    )
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -61,7 +61,8 @@ final class BspServers(
 
   def newServer(
       projectDirectory: AbsolutePath,
-      details: BspConnectionDetails
+      details: BspConnectionDetails,
+      bspExtra: BspExtra
   ): Future[BuildServerConnection] = {
 
     def newConnection(): Future[SocketConnection] = {
@@ -104,7 +105,8 @@ final class BspServers(
       newConnection,
       tables.dismissedNotifications.ReconnectBsp,
       config,
-      details.getName()
+      details.getName(),
+      bspExtra
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
@@ -6,7 +6,6 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import scala.meta.internal.builds.Digest.Status
-import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.Confirmation
 import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -64,11 +63,7 @@ final class BloopInstall(
         args,
         workspace,
         buildTool.redirectErrorOutput,
-        Map(
-          "COURSIER_PROGRESS" -> "disable",
-          "METALS_ENABLED" -> "true",
-          "SCALAMETA_VERSION" -> BuildInfo.semanticdbVersion
-        )
+        Map("COURSIER_PROGRESS" -> "disable")
       )
       .map {
         case ExitCodes.Success => WorkspaceLoadedStatus.Installed

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -11,6 +11,7 @@ import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Future
 import scala.concurrent.Promise
 
+import scala.meta.internal.bsp.BspExtra
 import scala.meta.internal.bsp.BuildChange
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
@@ -63,7 +64,8 @@ final class BloopServers(
 
   def newServer(
       workspace: AbsolutePath,
-      userConfiguration: UserConfiguration
+      userConfiguration: UserConfiguration,
+      bspExtra: BspExtra
   ): Future[BuildServerConnection] = {
     val bloopVersion = userConfiguration.currentBloopVersion
     BuildServerConnection
@@ -74,7 +76,8 @@ final class BloopServers(
         () => connectToLauncher(bloopVersion, config.bloopPort),
         tables.dismissedNotifications.ReconnectBsp,
         config,
-        name
+        name,
+        bspExtra
       )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
@@ -18,6 +18,7 @@ import scala.util.Success
 import scala.util.control.NonFatal
 
 import scala.meta.inputs.Input
+import scala.meta.internal.bsp.BspExtra
 import scala.meta.internal.bsp.BuildChange
 import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -267,7 +268,8 @@ final class Ammonite(
               ),
           tables().dismissedNotifications.ReconnectAmmonite,
           config,
-          "Ammonite"
+          "Ammonite",
+          BspExtra.knownAtReleaseMoment
         )
         for {
           conn <- futureConn

--- a/mtags/src/main/scala/scala/meta/internal/semver/SemVer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/semver/SemVer.scala
@@ -46,6 +46,8 @@ object SemVer {
         .exists { case (a, b) => a > b }
     }
 
+    def isStable: Boolean = releaseCandidate.isEmpty && milestone.isEmpty
+
     override def toString: String =
       List(
         Some(s"$major.$minor.$patch"),

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -38,7 +38,7 @@ object TestGroups {
       "tests.debug.CompletionDapSuite", "tests.debug.EvaluationDapSuite",
       "tests.FindTextInDependencyJarsSuite", "tests.TestSuitesFinderSuite",
       "tests.classFinder.FindAllClassesSuite",
-      "tests.codeactions.ExtractValueLspSuite"),
+      "tests.codeactions.ExtractValueLspSuite", "tests.bsp.BspExtraSuite"),
     Set("tests.AmmoniteSuite", "tests.debug.BreakpointDapSuite",
       "tests.OnTypeFormattingSuite", "tests.ReferenceLspSuite",
       "tests.SuperMethodLspSuite", "tests.SyntaxErrorLspSuite",

--- a/tests/unit/src/test/scala/tests/bsp/BspExtraSuite.scala
+++ b/tests/unit/src/test/scala/tests/bsp/BspExtraSuite.scala
@@ -1,0 +1,27 @@
+package tests.bsp
+
+import scala.meta.internal.bsp.BspExtra
+import scala.meta.internal.metals.{BuildInfo => V}
+import scala.meta.internal.semver.SemVer
+
+import munit.FunSuite
+
+class BspExtraSuite extends FunSuite {
+
+  test("new releases") {
+    def decresePatchVersion(v: String): String = {
+      val parsed = SemVer.Version.fromString(v)
+      parsed.copy(patch = parsed.patch - 1).toString
+    }
+    val known =
+      BspExtra(
+        decresePatchVersion(V.scalametaVersion),
+        List(V.scala212, V.scala213).map(decresePatchVersion)
+      )
+
+    val result = BspExtra.discoverNewReleases(known)
+    assert(result.semanticdbVersion != known)
+    assert(result.supportedScalaVersions.contains(V.scala212))
+    assert(result.supportedScalaVersions.contains(V.scala213))
+  }
+}


### PR DESCRIPTION
This should be a final part #3281.
To avoid Metals release when new Scala2 version appears, we also need
to use the latest semanticdb-plugin version to correctly setup BSP
connection.

So, in case of new Scala2 version the release process will be:
- release scalameta
- release mtags for existing Metals version