### PR TITLE
[Scalafmt] Fixes for automatic dialect rewrite

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -515,10 +515,9 @@ object Messages {
 
     def letUpdate = new MessageActionItem("Let Metals update .scalafmt.conf")
 
-    val beginning = "Some source directories can't be formatted by scalafmt"
-
     def createMessage(dialect: ScalafmtDialect): String = {
-      s"$beginning because they require the `runner.dialect = ${dialect.value}` setting." +
+      s"Some source directories can't be formatted by scalafmt " +
+        s"because they require the `runner.dialect = ${dialect.value}` setting." +
         "[See scalafmt docs](https://scalameta.org/scalafmt/docs/configuration.html#scala-3)" +
         " and logs for more details"
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -514,9 +514,11 @@ object Messages {
   object UpdateScalafmtConf {
 
     def letUpdate = new MessageActionItem("Let Metals update .scalafmt.conf")
+
+    val beginning = "Some source directories can't be formatted by scalafmt"
+
     def createMessage(dialect: ScalafmtDialect): String = {
-      s"Some source directories can't be formatted by scalafmt " +
-        s"because they require the `runner.dialect = ${dialect.value}` setting." +
+      s"$beginning because they require the `runner.dialect = ${dialect.value}` setting." +
         "[See scalafmt docs](https://scalameta.org/scalafmt/docs/configuration.html#scala-3)" +
         " and logs for more details"
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -110,9 +110,14 @@ object ScalaVersions {
       scalaVersion: String,
       includeSource3: Boolean
   ): ScalafmtDialect = {
-    if (isScala3Version(scalaVersion)) ScalafmtDialect.Scala3
-    else if (includeSource3) ScalafmtDialect.Scala213Source3
-    else ScalafmtDialect.Scala213
+    ScalaVersions.scalaBinaryVersionFromFullVersion(scalaVersion) match {
+      case "3" => ScalafmtDialect.Scala3
+      case "2.13" if includeSource3 => ScalafmtDialect.Scala213Source3
+      case "2.13" => ScalafmtDialect.Scala213
+      case "2.12" if includeSource3 => ScalafmtDialect.Scala212Source3
+      case "2.12" => ScalafmtDialect.Scala212
+      case "2.11" => ScalafmtDialect.Scala211
+    }
   }
 
   private val scalaVersionRegex =

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafmtDialect.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafmtDialect.scala
@@ -2,9 +2,12 @@ package scala.meta.internal.metals
 
 sealed abstract class ScalafmtDialect(val value: String)
 object ScalafmtDialect {
+  case object Scala3 extends ScalafmtDialect("scala3")
   case object Scala213 extends ScalafmtDialect("scala213")
   case object Scala213Source3 extends ScalafmtDialect("scala213source3")
-  case object Scala3 extends ScalafmtDialect("scala3")
+  case object Scala212 extends ScalafmtDialect("scala212")
+  case object Scala212Source3 extends ScalafmtDialect("scala212source3")
+  case object Scala211 extends ScalafmtDialect("scala211")
 
   implicit val ord: Ordering[ScalafmtDialect] = new Ordering[ScalafmtDialect] {
 
@@ -12,14 +15,20 @@ object ScalafmtDialect {
       prio(x) - prio(y)
 
     private def prio(d: ScalafmtDialect): Int = d match {
-      case Scala213 => 1
-      case Scala213Source3 => 2
-      case Scala3 => 3
+      case Scala211 => 1
+      case Scala212 => 2
+      case Scala212Source3 => 3
+      case Scala213 => 4
+      case Scala213Source3 => 5
+      case Scala3 => 6
     }
   }
 
   def fromString(v: String): Option[ScalafmtDialect] = v.toLowerCase match {
     case "default" => Some(Scala213)
+    case "scala211" => Some(Scala211)
+    case "scala212" => Some(Scala212)
+    case "scala212source3" => Some(Scala212Source3)
     case "scala213" => Some(Scala213)
     case "scala213source3" => Some(Scala213Source3)
     case "scala3" => Some(Scala3)

--- a/tests/unit/src/test/scala/tests/FormattingLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/FormattingLspSuite.scala
@@ -6,7 +6,6 @@ import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.Messages.MissingScalafmtConf
 import scala.meta.internal.metals.Messages.MissingScalafmtVersion
-import scala.meta.internal.metals.ScalafmtDialect
 import scala.meta.internal.metals.{BuildInfo => V}
 
 import com.google.gson.JsonObject
@@ -343,14 +342,8 @@ class FormattingLspSuite extends BaseLspSuite("formatting") {
   test("rewrite-dialect-global") {
     cleanWorkspace()
     client.showMessageRequestHandler = { params =>
-      val expected =
-        Messages.UpdateScalafmtConf.createMessage(ScalafmtDialect.Scala3)
-      if (params.getMessage() == expected) {
-        params.getActions.asScala
-          .find(_ == Messages.UpdateScalafmtConf.letUpdate)
-      } else {
-        None
-      }
+      params.getActions.asScala
+        .find(_ == Messages.UpdateScalafmtConf.letUpdate)
     }
     for {
       _ <- initialize(
@@ -379,16 +372,8 @@ class FormattingLspSuite extends BaseLspSuite("formatting") {
   test("rewrite-dialect-global-xsource3") {
     cleanWorkspace()
     client.showMessageRequestHandler = { params =>
-      val expected =
-        Messages.UpdateScalafmtConf.createMessage(
-          ScalafmtDialect.Scala213Source3
-        )
-      if (params.getMessage() == expected) {
-        params.getActions.asScala
-          .find(_ == Messages.UpdateScalafmtConf.letUpdate)
-      } else {
-        None
-      }
+      params.getActions.asScala
+        .find(_ == Messages.UpdateScalafmtConf.letUpdate)
     }
     for {
       _ <- initialize(
@@ -418,14 +403,8 @@ class FormattingLspSuite extends BaseLspSuite("formatting") {
   test("rewrite-dialect-ignore-sbt") {
     cleanWorkspace()
     client.showMessageRequestHandler = { params =>
-      if (
-        params.getMessage().startsWith(Messages.UpdateScalafmtConf.beginning)
-      ) {
-        params.getActions.asScala
-          .find(_ == Messages.UpdateScalafmtConf.letUpdate)
-      } else {
-        None
-      }
+      params.getActions.asScala
+        .find(_ == Messages.UpdateScalafmtConf.letUpdate)
     }
     for {
       _ <- initialize(
@@ -462,14 +441,8 @@ class FormattingLspSuite extends BaseLspSuite("formatting") {
   test("rewrite-dialect-file-override") {
     cleanWorkspace()
     client.showMessageRequestHandler = { params =>
-      val expected =
-        Messages.UpdateScalafmtConf.createMessage(ScalafmtDialect.Scala3)
-      if (params.getMessage() == expected) {
-        params.getActions.asScala
-          .find(_ == Messages.UpdateScalafmtConf.letUpdate)
-      } else {
-        None
-      }
+      params.getActions.asScala
+        .find(_ == Messages.UpdateScalafmtConf.letUpdate)
     }
     for {
       _ <- initialize(


### PR DESCRIPTION
I've noticed that on snapshot version the wrong suggestion
about improper `.scalafmt.conf` appears in Metals repo.

Changes:
- support more dialects. Previsously any Scala2 target had `scala213` formatting dialect
- ignore sbt targets in rewrite `.scalafmt.conf` suggestions