### PR TITLE
Upgrade file-tree-views to 2.1.8. See #3379.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -262,7 +262,7 @@ commands ++= Seq(
         case _ =>
           val message =
             s"""|Skip release. Invalid tag name.
-                |It should be either: 
+                |It should be either:
                 | - "v$$num.$$num.$$num" - usual Metals release
                 | - "mtags_v$${existing-metals-release}_$${scala-version}" - mtags artifact release
                 |""".stripMargin
@@ -537,7 +537,7 @@ lazy val metals = project
       // for measuring memory footprint
       "org.openjdk.jol" % "jol-core" % "0.16",
       // for file watching
-      "com.swoval" % "file-tree-views" % "2.1.7",
+      "com.swoval" % "file-tree-views" % "2.1.8",
       // for http client
       "io.undertow" % "undertow-core" % "2.2.14.Final",
       "org.jboss.xnio" % "xnio-nio" % "3.8.5.Final",

--- a/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
@@ -138,29 +138,9 @@ object FileWatcher {
       // Other OSes register all the files and directories individually
       val repo = initFileTreeRepository(watchFilter, callback)
 
-      // TODO(@pvid) swoval's FileTreeRepository should be able to create watch
-      // for files/directories that do not exist yet. However, there is an issue
-      // with watching **semanticdb** files when not creating source directories.
-      // I was not able to diagnose the issue.
-      // If you'd like to dive deeper into, try to remove the file creation and deletion
-      // and run some tests with `-Dswoval.log.level=debug` to see which files are registered
-      // and which file events are received.
-      val directoriesToCreate =
-        filesToWatch.sourceDirectories ++ filesToWatch.sourceFiles.map(
-          _.getParent()
-        )
-
-      val createdDirectories = directoriesToCreate.flatMap(path =>
-        AbsolutePath(path).createAndGetDirectories()
-      )
-
       filesToWatch.sourceDirectories.foreach(repo.register(_, Int.MaxValue))
       filesToWatch.semanticdDirectories.foreach(repo.register(_, Int.MaxValue))
       filesToWatch.sourceFiles.foreach(repo.register(_, -1))
-
-      createdDirectories.toSeq.sortBy(_.toNIO).reverse.foreach { dir =>
-        if (dir.isEmptyDirectory) dir.delete()
-      }
 
       () => repo.close()
     }


### PR DESCRIPTION
Upstream was incredibly responsive and provided a fix in file-tree-views 2.1.8 in record time.

This supersedes the workaround in PR #3404 for issue #3379.