### PR TITLE
fix: ensure autoimports don't break scala-cli directives

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
@@ -62,6 +62,25 @@ class AutoImportsSuite extends BaseAutoImportsSuite {
   )
 
   checkEdit(
+    "basic-edit-directive",
+    """|// using scala 35
+       |// using something else
+       |
+       |object A {
+       |  <<Future>>.successful(2)
+       |}
+       |""".stripMargin,
+    """|// using scala 35
+       |// using something else
+       |import scala.concurrent.Future
+       |
+       |object A {
+       |  Future.successful(2)
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
     "symbol-no-prefix",
     """|package a
        |


### PR DESCRIPTION
This just adds a check in the situation where a file has no existing import
and no package to look and see if there are `//` comments in the beginning
of the file and if so, skip over them before we add the import. The main reason
for this is to avoid braking directives in scala-cli.

We don't do a more advanced check for this for other types of comments mainly
because it'll be more difficult without more extensive parsing to know if a comment
is a header or a scaladoc for example. So for now we just do a more naive check
on `//`.

Closes #3399