### PR TITLE
docs: add file ids to the docs for new file commands

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -6,6 +6,7 @@ import ch.epfl.scala.{bsp4j => b}
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentPositionParams
+import scala.meta.internal.metals.newScalaFile.NewFileTypes
 
 /**
  * LSP commands supported by the Metals language server.
@@ -338,10 +339,22 @@ object ServerCommands {
   val NewScalaFile = new ListParametrizedCommand[String](
     "new-scala-file",
     "Create new scala file",
-    """|Create and open new file with either scala class, object, trait, package object or worksheet.
-       |
-       |Note: requires 'metals/inputBox' capability from language client.
-       |""".stripMargin,
+    s"""|Create and open new Scala file.
+        |
+        |The currently allowed Scala file types that ca be passed in are:
+        |
+        | - ${NewFileTypes.ScalaFile.id} (${NewFileTypes.ScalaFile.label})
+        | - ${NewFileTypes.Class.id} (${NewFileTypes.Class.label})
+        | - ${NewFileTypes.CaseClass.id} (${NewFileTypes.CaseClass.label})
+        | - ${NewFileTypes.Enum.id} (${NewFileTypes.Enum.label})
+        | - ${NewFileTypes.Object.id} (${NewFileTypes.Object.label})
+        | - ${NewFileTypes.Trait.id} (${NewFileTypes.Trait.label})
+        | - ${NewFileTypes.PackageObject.id} (${NewFileTypes.PackageObject.label})
+        | - ${NewFileTypes.Worksheet.id} (${NewFileTypes.Worksheet.label})
+        | - ${NewFileTypes.AmmoniteScript.id} (${NewFileTypes.AmmoniteScript.label})
+        |
+        |Note: requires 'metals/inputBox' capability from language client.
+        |""".stripMargin,
     """|[string[]], where the first is a directory location for the new file.
        |The second and third positions correspond to the file name and file type to allow for quick
        |creation of a file if all are present.
@@ -351,10 +364,17 @@ object ServerCommands {
   val NewJavaFile = new ListParametrizedCommand[String](
     "new-java-file",
     "Create new java file",
-    """|Create and open new file with either java class, enum or interface.
-       |
-       |Note: requires 'metals/inputBox' capability from language client.
-       |""".stripMargin,
+    s"""|Create and open a new Java file.
+        |
+        |The currently allowed Java file types that ca be passed in are:
+        |
+        | - ${NewFileTypes.JavaClass.id} (${NewFileTypes.JavaClass.label})
+        | - ${NewFileTypes.JavaInterface.id} (${NewFileTypes.JavaInterface.label})
+        | - ${NewFileTypes.JavaEnum.id} (${NewFileTypes.JavaEnum.label})
+        | - ${NewFileTypes.JavaRecord.id} (${NewFileTypes.JavaRecord.label})
+        |
+        |Note: requires 'metals/inputBox' capability from language client.
+        |""".stripMargin,
     """|[string[]], where the first is a directory location for the new file.
        |The second and third positions correspond to the file name and file type to allow for quick
        |creation of a file if all are present.

--- a/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileTypes.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileTypes.scala
@@ -13,7 +13,7 @@ object NewFileTypes {
   case object ScalaFile extends NewFileType {
     override val id: String = "scala-file"
     override val syntax: Option[String] = None
-    override val label: String = "Scala file with automatically added package"
+    override val label: String = "Empty file"
   }
 
   case object Class extends NewFileType {


### PR DESCRIPTION
This pr adds the file ids and the label to the docs. I missed this in last PR where this changed from `worksheet` to `scala-worksheet` and this actually broke my implementation since I do have some commands that send in the filetype directly. Now these will be listed in the docs to be accessed without needing to dive into the code.