### PR TITLE
[Scalafmt] set proper dialect for sbt-metals

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -20,6 +20,9 @@ project.excludeFilters = [
 ]
 
 fileOverride {
+  "glob:**/sbt-metals/**" {
+    runner.dialect = scala212source3
+  },
   "glob:**/scala-3*/**" {
     runner.dialect = scala3
     rewrite.scala3.convertToNewSyntax = yes


### PR DESCRIPTION
`-XSource3` flag comes to sbt-metals from SbtPlugin and triggers Metals warning about improper configuration