### PR TITLE
refactor: small build cleanups

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import scala.collection.mutable
 import scala.sys.process._
-import Tests._
 import Developers._
+import Tests._
 
 def localSnapshotVersion = "0.10.10-SNAPSHOT"
 def isCI = System.getenv("CI") != null
@@ -218,9 +218,12 @@ lazy val V = new {
   val ammonite212Version = scala212
   val ammonite213Version = scala213
 
+  val ammonite = "2.4.1"
   val bloop = "1.4.11-19-93ebe2c6"
   val bloopNightly = bloop
   val bsp = "2.0.0-M15"
+  val coursier = "2.0.16"
+  val coursierInterfaces = "1.0.4"
   val debugAdapter = "2.0.12"
   val genyVersion = "0.7.0"
   val gradleBloop = bloop
@@ -229,8 +232,10 @@ lazy val V = new {
   val jsoup = "1.14.3"
   val lsp4jV = "0.12.0"
   val mavenBloop = bloop
+  val mill = "0.10.0-M4"
   val mdoc = "2.2.24"
   val munit = "0.7.29"
+  val organizeImportRule = "0.6.0"
   val pprint = "0.7.1"
   val sbtBloop = bloop
   val sbtJdiTools = "1.1.1"
@@ -299,11 +304,6 @@ lazy val V = new {
   def guava = "com.google.guava" % "guava" % "31.0.1-jre"
   def lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % lsp4jV
   def dap4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j.debug" % lsp4jV
-  val coursierInterfaces = "1.0.4"
-  val coursier = "2.0.16"
-  val ammonite = "2.4.1"
-  val mill = "0.10.0-M4"
-  val organizeImportRule = "0.6.0"
 
   val quickPublishScalaVersions =
     Set(
@@ -492,8 +492,6 @@ lazy val metals = project
       V.lsp4j,
       // for DAP
       V.dap4j,
-      // for producing SemanticDB from Java source files
-      "com.thoughtworks.qdox" % "qdox" % V.qdox,
       // for finding paths of global log/cache directories
       "dev.dirs" % "directories" % "26",
       // for Java formatting
@@ -518,7 +516,6 @@ lazy val metals = project
       // ==================
       // Scala dependencies
       // ==================
-      "org.scala-lang.modules" %% "scala-java8-compat" % V.java8Compat,
       "org.scalameta" % "mdoc-interfaces" % V.mdoc,
       "org.scalameta" %% "scalafmt-dynamic" % V.scalafmt,
       "ch.epfl.scala" % "scalafix-interfaces" % V.scalafix,
@@ -529,8 +526,6 @@ lazy val metals = project
       "com.outr" %% "scribe" % V.scribe,
       "com.outr" %% "scribe-file" % V.scribe,
       "com.outr" %% "scribe-slf4j" % V.scribe, // needed for flyway database migrations
-      // for debugging purposes, not strictly needed but nice for productivity
-      "com.lihaoyi" %% "pprint" % V.pprint,
       // for JSON formatted doctor
       "com.lihaoyi" %% "ujson" % "1.4.3",
       // For remote language server
@@ -813,10 +808,7 @@ lazy val docs = project
     sharedSettings,
     publish / skip := true,
     moduleName := "metals-docs",
-    mdoc := (Compile / run).evaluated,
-    libraryDependencies ++= List(
-      "org.jsoup" % "jsoup" % V.jsoup
-    )
+    mdoc := (Compile / run).evaluated
   )
   .dependsOn(metals)
   .enablePlugins(DocusaurusPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import scala.collection.mutable
 import scala.sys.process._
 import Tests._
+import Developers._
 
 def localSnapshotVersion = "0.10.10-SNAPSHOT"
 def isCI = System.getenv("CI") != null
@@ -58,56 +59,7 @@ inThisBuild(
       "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
     ),
     homepage := Some(url("https://github.com/scalameta/metals")),
-    developers := List(
-      Developer(
-        "Arthurm1",
-        "Arthur McGibbon",
-        "",
-        url("https://github.com/Arthurm1")
-      ),
-      Developer(
-        "adpi2",
-        "Adrien Piquerez",
-        "adrien.piquerez@epfl.ch",
-        url("https://github.com/adpi2")
-      ),
-      Developer(
-        "ckipp01",
-        "Chris Kipp",
-        "ckipp@pm.me",
-        url("https://chris-kipp.io")
-      ),
-      Developer(
-        "gabro",
-        "Gabriele Petronella",
-        "gabriele@buildo.io",
-        url("https://github.com/gabro")
-      ),
-      Developer(
-        "kpodsiad",
-        "Kamil Podsiadło",
-        "kpodsiadlo@virtuslab.com ",
-        url("https://github.com/kpodsiad)")
-      ),
-      Developer(
-        "olafurpg",
-        "Ólafur Páll Geirsson",
-        "olafurpg@gmail.com",
-        url("https://geirsson.com")
-      ),
-      Developer(
-        "tgodzik",
-        "Tomasz Godzik",
-        "tgodzik@virtuslab.com",
-        url("https://github.com/tgodzik")
-      ),
-      Developer(
-        "dos65",
-        "Vadim Chelyshov",
-        "vchelyshov@virtuslab.com",
-        url("https://github.com/dos65")
-      )
-    ),
+    developers := metalsDevs,
     testFrameworks := List(),
     resolvers += Resolver.sonatypeRepo("public"),
     resolvers += Resolver.sonatypeRepo("snapshot"),
@@ -258,30 +210,36 @@ commands ++= Seq(
 lazy val V = new {
   val scala210 = "2.10.7"
   val scala211 = "2.11.12"
-  val sbtScala = "2.12.14"
   val scala212 = "2.12.15"
   val scala213 = "2.13.7"
-  val ammonite212Version = scala212
-  val ammonite213Version = scala213
-  val scalameta = "4.4.31"
-  val semanticdb = scalameta
-  val bsp = "2.0.0-M15"
-  val bloop = "1.4.11-19-93ebe2c6"
   val scala3 = "3.1.0"
   val nextScala3RC = "3.1.1-RC2"
-  val javaSemanticdb = "0.7.2"
+  val sbtScala = "2.12.14"
+  val ammonite212Version = scala212
+  val ammonite213Version = scala213
+
+  val bloop = "1.4.11-19-93ebe2c6"
   val bloopNightly = bloop
-  val sbtBloop = bloop
+  val bsp = "2.0.0-M15"
+  val debugAdapter = "2.0.12"
+  val genyVersion = "0.7.0"
   val gradleBloop = bloop
+  val java8Compat = "1.0.2"
+  val javaSemanticdb = "0.7.2"
+  val jsoup = "1.14.3"
+  val lsp4jV = "0.12.0"
   val mavenBloop = bloop
   val mdoc = "2.2.24"
-  val scalafmt = "3.0.5"
   val munit = "0.7.29"
-  val scalafix = "0.9.33"
-  val lsp4jV = "0.12.0"
+  val pprint = "0.7.1"
+  val sbtBloop = bloop
   val sbtJdiTools = "1.1.1"
-  val genyVersion = "0.7.0"
-  val debugAdapter = "2.0.12"
+  val scalafix = "0.9.33"
+  val scalafmt = "3.0.5"
+  val scalameta = "4.4.31"
+  val scribe = "3.6.3"
+  val semanticdb = scalameta
+  val qdox = "2.0.1"
 
   // List of supported Scala versions in SemanticDB. Needs to be manually updated
   // for every SemanticDB upgrade.
@@ -433,15 +391,15 @@ val mtagsSettings = List(
   Compile / doc / sources := Seq.empty,
   libraryDependencies ++= Seq(
     "com.lihaoyi" %% "geny" % V.genyVersion,
-    "com.thoughtworks.qdox" % "qdox" % "2.0.1", // for java mtags
-    "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2"
+    "com.thoughtworks.qdox" % "qdox" % V.qdox, // for java mtags
+    "org.scala-lang.modules" %% "scala-java8-compat" % V.java8Compat
   ),
   libraryDependencies ++= crossSetting(
     scalaVersion.value,
     if2 = List(
       // for token edit-distance used by goto definition
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
-      "org.jsoup" % "jsoup" % "1.14.3", // for extracting HTML from javadocs
+      "org.jsoup" % "jsoup" % V.jsoup, // for extracting HTML from javadocs
       "org.scalameta" % "semanticdb-scalac-core" % V.scalameta cross CrossVersion.full
     ),
     if3 = List(
@@ -467,7 +425,7 @@ val mtagsSettings = List(
     // NOTE(olafur) pprint is indispensable for me while developing, I can't
     // use println anymore for debugging because pprint.log is 100 times better.
     else {
-      List("com.lihaoyi" %% "pprint" % "0.7.1")
+      List("com.lihaoyi" %% "pprint" % V.pprint)
     }
   },
   buildInfoPackage := "scala.meta.internal.mtags",
@@ -535,7 +493,7 @@ lazy val metals = project
       // for DAP
       V.dap4j,
       // for producing SemanticDB from Java source files
-      "com.thoughtworks.qdox" % "qdox" % "2.0.1",
+      "com.thoughtworks.qdox" % "qdox" % V.qdox,
       // for finding paths of global log/cache directories
       "dev.dirs" % "directories" % "26",
       // for Java formatting
@@ -560,7 +518,7 @@ lazy val metals = project
       // ==================
       // Scala dependencies
       // ==================
-      "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2",
+      "org.scala-lang.modules" %% "scala-java8-compat" % V.java8Compat,
       "org.scalameta" % "mdoc-interfaces" % V.mdoc,
       "org.scalameta" %% "scalafmt-dynamic" % V.scalafmt,
       "ch.epfl.scala" % "scalafix-interfaces" % V.scalafix,
@@ -568,11 +526,11 @@ lazy val metals = project
       // for fetching ch.epfl.scala:bloop-frontend and other library dependencies
       "io.get-coursier" % "interface" % V.coursierInterfaces,
       // for logging
-      "com.outr" %% "scribe" % "3.6.3",
-      "com.outr" %% "scribe-file" % "3.6.3",
-      "com.outr" %% "scribe-slf4j" % "3.6.3", // needed for flyway database migrations
+      "com.outr" %% "scribe" % V.scribe,
+      "com.outr" %% "scribe-file" % V.scribe,
+      "com.outr" %% "scribe-slf4j" % V.scribe, // needed for flyway database migrations
       // for debugging purposes, not strictly needed but nice for productivity
-      "com.lihaoyi" %% "pprint" % "0.6.2",
+      "com.lihaoyi" %% "pprint" % V.pprint,
       // for JSON formatted doctor
       "com.lihaoyi" %% "ujson" % "1.4.3",
       // For remote language server
@@ -857,7 +815,7 @@ lazy val docs = project
     moduleName := "metals-docs",
     mdoc := (Compile / run).evaluated,
     libraryDependencies ++= List(
-      "org.jsoup" % "jsoup" % "1.14.3"
+      "org.jsoup" % "jsoup" % V.jsoup
     )
   )
   .dependsOn(metals)

--- a/project/Developers.scala
+++ b/project/Developers.scala
@@ -1,0 +1,54 @@
+import sbt._
+
+object Developers {
+  val metalsDevs = List(
+    Developer(
+      "arthurm1",
+      "arthur McGibbon",
+      "",
+      url("https://github.com/Arthurm1")
+    ),
+    Developer(
+      "adpi2",
+      "Adrien Piquerez",
+      "adrien.piquerez@epfl.ch",
+      url("https://github.com/adpi2")
+    ),
+    Developer(
+      "ckipp01",
+      "Chris Kipp",
+      "ckipp@pm.me",
+      url("https://chris-kipp.io")
+    ),
+    Developer(
+      "gabro",
+      "Gabriele Petronella",
+      "gabriele@buildo.io",
+      url("https://github.com/gabro")
+    ),
+    Developer(
+      "kpodsiad",
+      "Kamil Podsiadło",
+      "kpodsiadlo@virtuslab.com ",
+      url("https://github.com/kpodsiad)")
+    ),
+    Developer(
+      "olafurpg",
+      "Ólafur Páll Geirsson",
+      "olafurpg@gmail.com",
+      url("https://geirsson.com")
+    ),
+    Developer(
+      "tgodzik",
+      "Tomasz Godzik",
+      "tgodzik@virtuslab.com",
+      url("https://github.com/tgodzik")
+    ),
+    Developer(
+      "dos65",
+      "Vadim Chelyshov",
+      "vchelyshov@virtuslab.com",
+      url("https://github.com/dos65")
+    )
+  ),
+}


### PR DESCRIPTION
This pr just changes a few small things in the build:

- Moves the list of developers to `project/Developers.scala`
- Takes deps that we use in multiple places and give them a `V.name` variable to use
- Alphabetizes the versions in `V`
- Removes duplicated deps declared in both mtags and metals