### PR TITLE
refactor: take care of some deprecation warnings

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
@@ -128,7 +128,7 @@ class NewProjectProvider(
     def openWindow(newWindow: Boolean) = {
       val params = MetalsOpenWindowParams(
         projectPath.toURI.toString(),
-        new java.lang.Boolean(newWindow)
+        java.lang.Boolean.valueOf(newWindow)
       )
       val command = ClientCommands.OpenFolder.toExecuteCommandParams(params)
       client.metalsExecuteClientCommand(command)

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.metals
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -258,7 +259,7 @@ final class Doctor(
 
   private def resetChoiceCommand(choice: String): String = {
     val param = s"""["$choice"]"""
-    s"command:metals.reset-choice?${URLEncoder.encode(param)}"
+    s"command:metals.reset-choice?${URLEncoder.encode(param, StandardCharsets.UTF_8.name())}"
   }
 
   private def buildTargetsTable(html: HtmlBuilder): Unit = {

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.metals
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 import scala.meta.internal.metals.config.DoctorFormat
 import scala.meta.internal.metals.config.StatusBarState
@@ -239,7 +240,7 @@ object CommandHTMLFormat {
         if (arguments.isEmpty) ""
         else {
           val asArray = s"""[${arguments.mkString(", ")}]"""
-          s"?${URLEncoder.encode(asArray)}"
+          s"?${URLEncoder.encode(asArray, StandardCharsets.UTF_8.name())}"
         }
       s"command:metals.$commandId$encodedArguments"
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/JsonParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JsonParser.scala
@@ -13,7 +13,7 @@ object JsonParser {
 
   implicit class XtensionSerializedJson(string: String) {
     def parseJson: JsonElement = {
-      new com.google.gson.JsonParser().parse(string)
+      com.google.gson.JsonParser.parseString(string)
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersionSelector.scala
@@ -77,7 +77,8 @@ class ScalaVersionSelector(
           fallbackDialect(isAmmonite = path.isAmmoniteScript)
         )
         dialect
-          .copy(allowToplevelTerms = true, toplevelSeparator = "")
+          .withAllowToplevelTerms(true)
+          .withToplevelSeparator("")
       case _ => fallbackDialect(isAmmonite = false)
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/SetBreakpointsRequestHandler.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/SetBreakpointsRequestHandler.scala
@@ -96,7 +96,6 @@ private[debug] final class SetBreakpointsRequestHandler(
     val partition = new SetBreakpointsArguments
     partition.setBreakpoints(Array.empty)
     partition.setSource(source)
-    partition.setLines(Array.empty)
     partition.setSourceModified(request.getSourceModified)
     partition
   }
@@ -109,14 +108,9 @@ private[debug] final class SetBreakpointsRequestHandler(
     val source = DebugProtocol.copy(request.getSource)
     source.setPath(s"dap-fqcn:$fqcn")
 
-    val lines = breakpoints
-      .map(_.getLine: Int)
-      .distinct
-
     val partition = new SetBreakpointsArguments
     partition.setBreakpoints(breakpoints)
     partition.setSource(source)
-    partition.setLines(lines)
     partition.setSourceModified(request.getSourceModified)
 
     partition

--- a/mtags/src/main/scala-2/scala/meta/internal/docstrings/HtmlConverter.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/docstrings/HtmlConverter.scala
@@ -11,7 +11,7 @@ import org.jsoup.nodes.Entities.EscapeMode
 import org.jsoup.nodes.Node
 import org.jsoup.nodes.TextNode
 import org.jsoup.safety.Cleaner
-import org.jsoup.safety.Whitelist
+import org.jsoup.safety.Safelist
 
 // TODO - Add conversion of tables
 
@@ -53,8 +53,8 @@ object HtmlConverter {
     val cleanedCode = cleanCode(code)
 
     // Parse html in docstring
-    val whitelist = Whitelist.relaxed
-    val cleaner = new Cleaner(whitelist)
+    val safeList = Safelist.relaxed
+    val cleaner = new Cleaner(safeList)
     val doc = cleaner.clean(Jsoup.parse(cleanedCode))
     doc.outputSettings().escapeMode(EscapeMode.xhtml)
 

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Completer.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Completer.scala
@@ -20,5 +20,5 @@ final class Completer(expression: String) extends Stoppage.Handler {
     Complete(expression.replace("@@", ""), frameId, response = _, 1, column + 1)
   }
 
-  override def shutdown: Future[Unit] = Future.successful()
+  override def shutdown: Future[Unit] = Future.successful(())
 }

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/ExpressionEvaluator.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/ExpressionEvaluator.scala
@@ -15,5 +15,5 @@ final class ExpressionEvaluator(expression: String) extends Stoppage.Handler {
     Evaluate(expression, frameId, response = _, Continue)
   }
 
-  override def shutdown: Future[Unit] = Future.successful()
+  override def shutdown: Future[Unit] = Future.successful(())
 }

--- a/tests/unit/src/main/scala/tests/QuickBuild.scala
+++ b/tests/unit/src/main/scala/tests/QuickBuild.scala
@@ -342,7 +342,7 @@ object QuickBuild {
   val Half: Regex = "(.+)::(.+):(.+)".r
   val Java: Regex = "(.+):(.+):(.+)".r
   def parseJson(text: String): JsonObject = {
-    new JsonParser().parse(text).getAsJsonObject
+    JsonParser.parseString(text).getAsJsonObject()
   }
 
   def newDigest(workspace: AbsolutePath): Option[(AbsolutePath, String)] = {


### PR DESCRIPTION
I through in `-deprecation` and took care of most of the deprecation warnings. There are still a couple left, but they are situations where we actually need to use the deprecated methods (since we don't support workspaceFolders for example) or other things that take more thought, like not using `thread.stop`.