### PR TITLE
[Scala 3] Fix issues when type cannot be inferred by the compiler

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/InferredTypeProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/InferredTypeProvider.scala
@@ -73,9 +73,10 @@ final class InferredTypeProvider(
 
     def printType(tpe: Type): String =
       val short = shortType(tpe, shortenedNames)
-      val printer = ScopeAwareTypePrinter(indexedCtx)
-      printer.typeString(short)
-
+      if short.isErroneous then "Any"
+      else
+        val printer = ScopeAwareTypePrinter(indexedCtx)
+        printer.typeString(short)
     /*
      * Get the exact position in ValDef pattern for val (a, b) = (1, 2)
      * Suprisingly, val ((a, c), b) = ((1, 3), 2) will be covered by Bind

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -405,20 +405,24 @@ case class ScalaPresentationCompiler(
 
             val docString =
               docComments.map(_.renderAsMarkdown).mkString("\n")
-            val expressionType = printer.expressionTypeString(exprTpw, history)
-            val forceExpressionType =
-              !pos.span.isZeroExtent || (
-                !hoverString.endsWith(
-                  expressionType
-                ) && !symbol.isType && !symbol.flags.isAllOf(EnumCase)
-              )
-            val content = HoverMarkup(
-              expressionType,
-              hoverString,
-              docString,
-              forceExpressionType
-            )
-            ju.Optional.of(new Hover(content.toMarkupContent))
+            printer.expressionTypeString(exprTpw, history) match
+              case Some(expressionType) =>
+                val forceExpressionType =
+                  !pos.span.isZeroExtent || (
+                    !hoverString.endsWith(
+                      expressionType
+                    ) && !symbol.isType && !symbol.flags.isAllOf(EnumCase)
+                  )
+                val content = HoverMarkup(
+                  expressionType,
+                  hoverString,
+                  docString,
+                  forceExpressionType
+                )
+                ju.Optional.of(new Hover(content.toMarkupContent))
+              case _ =>
+                ju.Optional.empty
+            end match
 
       end if
     }

--- a/tests/cross/src/test/scala/tests/hover/HoverErrorSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverErrorSuite.scala
@@ -13,4 +13,20 @@ class HoverErrorSuite extends BaseHoverSuite {
        |""".stripMargin,
     ""
   )
+
+  check(
+    "error",
+    """|final case class Dependency(
+       |    org: String,
+       |    name: Option[String],
+       |    version: Option[String]
+       |)
+       |
+       |object Dependency {
+       |  def <<ap@@ply>>(org: String) = Dependency(org, None, None)
+       |}
+       |""".stripMargin,
+    "".stripMargin
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionErrorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionErrorSuite.scala
@@ -1,0 +1,43 @@
+package tests.pc
+
+import tests.BaseCompletionSuite
+
+class CompletionErrorSuite extends BaseCompletionSuite {
+
+  check(
+    "issue-3421",
+    """|object Main{
+       |  def thing() = thi@@
+       |  def run() = {
+       |    val thing = ???
+       |  }
+       |}
+       |""".stripMargin,
+    "thing(): Any",
+    topLines = Some(1),
+    compat = Map(
+      "3" -> "thing: Any"
+    )
+  )
+
+  check(
+    "issue-3421-match",
+    """|
+       |trait Dependency
+       |object InvalidDependency extends Dependency
+       |object Main{
+       |  def exists(dep: Dependency) = {
+       |    deps match {
+       |      case invalid @ InvalidDependency => println(inv@@)
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+    "invalid: Any",
+    topLines = Some(1),
+    compat = Map(
+      "2.12" -> "invalid: InvalidDependency.type"
+    )
+  )
+
+}

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -428,6 +428,32 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |""".stripMargin
   )
 
+  checkEdit(
+    "error",
+    """|final case class Dependency(
+       |    org: String,
+       |    name: Option[String],
+       |    version: Option[String]
+       |)
+       |
+       |object Dependency {
+       |  def <<apply>>(org: String) = Dependency(org, None, None)
+       |  def apply(org: String, name: String) = Dependency(org, Some(name), None)
+       |}
+       |""".stripMargin,
+    """|final case class Dependency(
+       |    org: String,
+       |    name: Option[String],
+       |    version: Option[String]
+       |)
+       |
+       |object Dependency {
+       |  def apply(org: String): Any = Dependency(org, None, None)
+       |  def apply(org: String, name: String) = Dependency(org, Some(name), None)
+       |}
+       |""".stripMargin
+  )
+
   def checkEdit(
       name: TestOptions,
       original: String,


### PR DESCRIPTION
Includes:
- print Any if type cannot be inferred
- don't show error methods on hover

This fixes https://github.com/scalameta/metals/issues/3422 and https://github.com/scalameta/metals/issues/3421