### PR TITLE
Show more information in the doctor

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -259,14 +259,14 @@ final class BuildTargets(
     result.getItems.asScala.foreach { scalac =>
       info(scalac.getTarget()).foreach { info =>
         info.asScalaBuildTarget.foreach { scalaBuildTarget =>
-          val autoImports =
-            info.asSbtBuildTarget.map(_.getAutoImports.asScala)
+          val sbtTarget = info.asSbtBuildTarget
+          val autoImports = sbtTarget.map(_.getAutoImports.asScala)
           scalaTargetInfo(scalac.getTarget) = ScalaTarget(
             info,
             scalaBuildTarget,
             scalac,
             autoImports,
-            info.isSbtBuild
+            sbtTarget.map(_.getSbtVersion())
           )
         }
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Doctor.scala
@@ -354,7 +354,7 @@ final class Doctor(
         title = "Interactive features (completions, hover):",
         correctMessage = s"${Icons.unicode.check} - supported Scala version",
         incorrectMessage =
-          s"${Icons.unicode.error} - unsupported Scala version",
+          s"${Icons.unicode.error} - interactive features are unsupported for Java and older Scala versions",
         show = allTargetsInfo.exists(_.interactiveStatus.isCorrect == false)
       )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/DoctorResults.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DoctorResults.scala
@@ -29,24 +29,29 @@ final case class DoctorMessage(title: String, recommendations: List[String]) {
     )
 }
 
+case class DoctorStatus(explanation: String, isCorrect: Boolean)
 final case class DoctorTargetInfo(
     name: String,
     dataKind: String,
     baseDirectory: String,
-    scalaVersion: String,
-    definitionStatus: String,
-    completionsStatus: String,
-    referencesStatus: String,
+    targetType: String,
+    diagnosticsStatus: DoctorStatus,
+    interactiveStatus: DoctorStatus,
+    indexesStatus: DoctorStatus,
+    debuggingStatus: DoctorStatus,
+    javaStatus: DoctorStatus,
     recommenedFix: String
 ) {
   def toJson: Obj =
     ujson.Obj(
       "buildTarget" -> name,
-      "scalaVersion" -> scalaVersion,
-      "diagnostics" -> Icons.unicode.check,
-      "gotoDefinition" -> definitionStatus,
-      "completions" -> completionsStatus,
-      "findReferences" -> referencesStatus,
+      "targetType" -> targetType,
+      "diagnostics" -> diagnosticsStatus.explanation,
+      "interactive" -> interactiveStatus.explanation,
+      "semanticdb" -> indexesStatus.explanation,
+      "debugging" -> debuggingStatus.explanation,
+      "java" -> javaStatus.explanation,
       "recommendation" -> recommenedFix
     )
+
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/DoctorResults.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DoctorResults.scala
@@ -8,10 +8,12 @@ final case class DoctorResults(
     messages: Option[List[DoctorMessage]],
     targets: Option[Seq[DoctorTargetInfo]]
 ) {
+  private val version = 1
   def toJson: Obj = {
     val json = ujson.Obj(
       "title" -> title,
-      "headerText" -> headerText
+      "headerText" -> headerText,
+      "version" -> version
     )
     messages.foreach(messageList =>
       json("messages") = messageList.map(_.toJson)
@@ -29,7 +31,12 @@ final case class DoctorMessage(title: String, recommendations: List[String]) {
     )
 }
 
-case class DoctorStatus(explanation: String, isCorrect: Boolean)
+sealed case class DoctorStatus(explanation: String, isCorrect: Boolean)
+object DoctorStatus {
+  object check extends DoctorStatus(Icons.unicode.check, true)
+  object alert extends DoctorStatus(Icons.unicode.alert, false)
+  object error extends DoctorStatus(Icons.unicode.error, false)
+}
 final case class DoctorTargetInfo(
     name: String,
     dataKind: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -16,8 +16,10 @@ case class ScalaTarget(
     scalaInfo: ScalaBuildTarget,
     scalac: ScalacOptionsItem,
     autoImports: Option[Seq[String]],
-    isSbt: Boolean
+    sbtVersion: Option[String]
 ) {
+
+  def isSbt = sbtVersion.isDefined
 
   def dialect(path: AbsolutePath): Dialect = {
     scalaVersion match {

--- a/metals/src/main/scala/scala/meta/internal/troubleshoot/ProblemResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/troubleshoot/ProblemResolver.scala
@@ -35,16 +35,12 @@ class ProblemResolver(
     }
   }
 
-  def recommendation(java: JavaTarget): String = {
-    findProblem(java)
-      .map(_.message)
-      .getOrElse("")
+  def recommendation(java: JavaTarget): Option[String] = {
+    findProblem(java).map(_.message)
   }
 
-  def recommendation(scala: ScalaTarget): String = {
-    findProblem(scala)
-      .map(_.message)
-      .getOrElse("")
+  def recommendation(scala: ScalaTarget): Option[String] = {
+    findProblem(scala).map(_.message)
   }
 
   def problemMessage(

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -58,28 +58,28 @@ class ProblemResolverSuite extends FunSuite {
     "unsupported-sbt-version",
     scalaVersion = "2.12.7",
     UnsupportedSbtVersion.message,
-    isSbt = true
+    sbtVersion = Some("1.2.0")
   )
 
   checkRecommendation(
     "deprecated-sbt-version",
     scalaVersion = "2.12.8",
     DeprecatedSbtVersion.message,
-    isSbt = true
+    sbtVersion = Some("1.3.0")
   )
 
   checkRecommendation(
     "future-sbt-version",
     scalaVersion = "2.12.51",
     FutureSbtVersion.message,
-    isSbt = true
+    sbtVersion = Some("1.6.0")
   )
 
   checkRecommendation(
     "ok-sbt-version",
     scalaVersion = BuildInfo.scala212,
     "",
-    isSbt = true
+    sbtVersion = Some("1.6.0")
   )
 
   checkRecommendation(
@@ -104,7 +104,7 @@ class ProblemResolverSuite extends FunSuite {
     "missing-jdk-sources",
     scalaVersion = BuildInfo.scala212,
     MissingJdkSources.message,
-    isSbt = true,
+    sbtVersion = Some("1.6.0"),
     invalidJavaHome = true
   )
 
@@ -116,7 +116,7 @@ class ProblemResolverSuite extends FunSuite {
         "-Xplugin:/semanticdb-scalac_2.12.12-4.4.2.jar",
         "-P:semanticdb:sourceroot:/tmp/metals"
       ),
-      isSbt: Boolean = false,
+      sbtVersion: Option[String] = None,
       invalidJavaHome: Boolean = false
   ): Unit = {
     test(name) {
@@ -135,8 +135,8 @@ class ProblemResolverSuite extends FunSuite {
         () => javaHome
       )
 
-      val target = scalaTarget(name.name, scalaVersion, scalacOpts, isSbt)
-      val message = problemResolver.recommendation(target)
+      val target = scalaTarget(name.name, scalaVersion, scalacOpts, sbtVersion)
+      val message = problemResolver.recommendation(target).getOrElse("")
 
       assertNoDiff(
         message,
@@ -149,7 +149,7 @@ class ProblemResolverSuite extends FunSuite {
       id: String,
       scalaVersion: String,
       scalacOptions: List[String],
-      isSbt: Boolean = false
+      sbtVersion: Option[String] = None
   ): ScalaTarget = {
     val scalaBinaryVersion =
       ScalaVersions.scalaBinaryVersionFromFullVersion(scalaVersion)
@@ -182,7 +182,7 @@ class ProblemResolverSuite extends FunSuite {
       scalaBuildTarget,
       scalacOptionsItem,
       autoImports = None,
-      isSbt = isSbt
+      sbtVersion
     )
   }
 }


### PR DESCRIPTION
We haven't revamped the doctor in a while and I feel with the upcoming Java support this is as good a chance as any.

What was changed:
- instead of scala version we now have sbt version writen under `Type` in case of sbt targets
- Java targets were moved to another column instead of being a separate entity
- merged definition and completions into one column called `Interactive` to indicate that Scala version is supported
- renamed `references` to semanticdb since there is currently a huge number of features that actually depend on it
- added explanations for different statuses underneath
- added a deubgging column and marked it disable explicitely for sbt targets

I would love to hear your opinions especially:
- will it work with other editors
- what else could we add
- do the new names and explanations make sense


Also related to https://github.com/scalameta/metals/issues/3398#issuecomment-1001158421

Example:

![image](https://user-images.githubusercontent.com/3807253/147833931-97d623f3-cbe8-457a-852c-23f636b20d6e.png)

I was thinking of alternatively showing these things while hovering, but that can be easily missed.