### PR TITLE
Scala Steward - ignore org.eclipse updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,5 @@
 pullRequests.frequency = "0 0 1,15 * ?"
+updates.ignore = [
+  { groupId = "org.eclipse.jdt" },
+  { groupId = "org.eclipse.platform" }
+]


### PR DESCRIPTION
We pinned eclipse deps versions and we aren't goint to update as long as we keep jdk8 support