### PR TITLE
fix: skip extra search for main methods

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -305,13 +305,8 @@ class DebugProvider(
           symbol = symbolInfo.symbol
           testClass <- testClasses.get(symbol)
         } yield testClass
-        val mains = for {
-          symbolInfo <- textDocument.symbols
-          symbol = symbolInfo.symbol
-          mainClass <- classes.get(symbol)
-        } yield mainClass
-        if (mains.nonEmpty) {
-          verifyMain(buildTarget, mains.toList, params)
+        if (classes.nonEmpty) {
+          verifyMain(buildTarget, classes.values.toList, params)
         } else if (tests.nonEmpty) {
           Future(
             new b.DebugSessionParams(


### PR DESCRIPTION
Since we already have the mainClasses we can pass them right into
`verifyMain` just like we do when we use `run`. So this skips going
through the document symbols again and trying to get the main class. I'm
not 100% sure why this works for Scala 2 but not for Scala 2 using
`@main`, but this fixes it for me when using `@main`.

Closes #3458