### PR TITLE
[Scala 3] Fix insert type in case of type aliases

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/IndexedContext.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/IndexedContext.scala
@@ -28,13 +28,19 @@ sealed trait IndexedContext:
     findSymbol(sym.decodedName) match
       case Some(symbols) if symbols.exists(_ == sym) =>
         Result.InScope
-      case Some(_) => Result.Conflict
+      case Some(symbols) if symbols.exists(isTypeAliasOf(_, sym)) =>
+        Result.InScope
+      case Some(_) =>
+        Result.Conflict
       case None => Result.Missing
 
   final def hasRename(sym: Symbol, as: String): Boolean =
     rename(sym.name.toSimpleName) match
       case Some(v) => v == as
       case None => false
+
+  private def isTypeAliasOf(alias: Symbol, sym: Symbol) =
+    alias.isAliasType && alias.info.dealias.typeSymbol == sym
 
   final def isEmpty: Boolean = this match
     case IndexedContext.Empty => true

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -454,6 +454,30 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |""".stripMargin
   )
 
+  checkEdit(
+    "either",
+    """|object O{
+       |  def <<returnEither>>(value: String) = {
+       |    if (value == "left") Left("a") else Right("b")
+       |  }
+       |}""".stripMargin,
+    """|object O{
+       |  def returnEither(value: String): Either[String,String] = {
+       |    if (value == "left") Left("a") else Right("b")
+       |  }
+       |}
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|object O{
+           |  def returnEither(value: String): Either[String, String] = {
+           |    if (value == "left") Left("a") else Right("b")
+           |  }
+           |}
+           |""".stripMargin
+    )
+  )
+
   def checkEdit(
       name: TestOptions,
       original: String,


### PR DESCRIPTION
Previously, we would treat Either type alias from Predef as a separate entity than scala.util.Either. Now, we also check type aliases for conflicting imports.

Fixes https://github.com/scalameta/metals/issues/3454