### PR TITLE
fix: reuse main annotation logic from code lens in debug provider

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -60,7 +60,6 @@ import scala.meta.internal.metals.codelenses.RunTestCodeLens
 import scala.meta.internal.metals.codelenses.SuperMethodCodeLens
 import scala.meta.internal.metals.codelenses.WorksheetCodeLens
 import scala.meta.internal.metals.debug.BuildTargetClasses
-import scala.meta.internal.metals.debug.DebugParametersJsonParsers
 import scala.meta.internal.metals.debug.DebugProvider
 import scala.meta.internal.metals.findfiles._
 import scala.meta.internal.metals.formatting.OnTypeFormattingProvider
@@ -1743,7 +1742,7 @@ class MetalsLanguageServer(
         }.asJavaObject
       case ServerCommands.StartDebugAdapter() =>
         val args = params.getArguments.asScala
-        import DebugParametersJsonParsers._
+        import DebugProvider.DebugParametersJsonParsers._
         val debugSessionParams: Future[b.DebugSessionParams] = args match {
           case Seq(debugSessionParamsParser.Jsonized(params))
               if params.getData != null =>

--- a/tests/unit/src/test/scala/tests/DebugDiscoverySuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugDiscoverySuite.scala
@@ -5,10 +5,10 @@ import java.util.concurrent.TimeUnit
 import scala.meta.internal.metals.DebugDiscoveryParams
 import scala.meta.internal.metals.JsonParser._
 import scala.meta.internal.metals.debug.BuildTargetContainsNoMainException
+import scala.meta.internal.metals.debug.DebugProvider.SemanticDbNotFoundException
+import scala.meta.internal.metals.debug.DebugProvider.WorkspaceErrorsException
 import scala.meta.internal.metals.debug.DotEnvFileParser.InvalidEnvFileException
 import scala.meta.internal.metals.debug.NoTestsFoundException
-import scala.meta.internal.metals.debug.SemanticDbNotFoundException
-import scala.meta.internal.metals.debug.WorkspaceErrorsException
 import scala.meta.io.AbsolutePath
 
 // note(@tgodzik) all test have `System.exit(0)` added to avoid occasional issue due to:

--- a/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
@@ -12,7 +12,7 @@ import scala.meta.internal.metals.DebugUnresolvedTestClassParams
 import scala.meta.internal.metals.JsonParser._
 import scala.meta.internal.metals.MetalsBspException
 import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.internal.metals.debug.WorkspaceErrorsException
+import scala.meta.internal.metals.debug.DebugProvider.WorkspaceErrorsException
 
 import ch.epfl.scala.bsp4j.DebugSessionParamsDataKind
 import ch.epfl.scala.bsp4j.ScalaMainClass


### PR DESCRIPTION
This closes #3458 and reuses the logic we had in the run/test code lens
to special case the top level `@main` annotation. We now use the same
logic in both places and it's moved into the `DebugProvider`.