### PR TITLE
fix: use maybeOwner instead of owner when looking for shortened name

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Signatures.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Signatures.scala
@@ -43,7 +43,7 @@ class ShortenedNames(
         val isOk = syms.filter(_ != NoSymbol) match
           case Nil =>
             if short.symbol.isStatic || // Java static
-              short.symbol.owner.ownersIterator.forall { s =>
+              short.symbol.maybeOwner.ownersIterator.forall { s =>
                 // ensure the symbol can be referenced in a static manner, without any instance
                 s.is(Package) || s.is(Module)
               }


### PR DESCRIPTION
Instead of using `symbol.owner` since from the code:

> /** The owner of the symbol; overridden in NoDenotation */

we instead use `maybeOwner` which will not be overriden in
`NoDenotation`. This avoids the `NoDenotation.owner` assertion error.

I'm not 100% sure on a test for this or what a good example would be.

Closes #3461