### PR TITLE
docs: migrate gitter references to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Metals
 
-<a href="https://gitter.im/scalameta/metals">
-<img alt="Join the chat on Gitter" src="https://img.shields.io/gitter/room/scalameta/metals.svg?logo=gitter&color=F71263" />
+<a href="https://discord.gg/FaVDrJegEh">
+<img alt="Chat with us on discord" src="https://img.shields.io/discord/632642981228314653">
 </a>
 <a href="https://twitter.com/scalameta">
 <img alt="Follow scalameta on Twitter" src="https://img.shields.io/twitter/follow/scalameta.svg?logo=twitter&color=blue" />

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -4,7 +4,7 @@ title: Contributing to Metals
 ---
 
 Whenever you are stuck or unsure, please open an issue or
-[ask on Gitter](https://gitter.im/scalameta/metals). This project follows
+[ask us on Discord](https://discord.gg/DwTc8xbNDd). This project follows
 [Scalameta's contribution guidelines](https://github.com/scalameta/scalameta/blob/master/CONTRIBUTING.md).
 
 ## Requirements

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -111,5 +111,4 @@ title: Making a release
     "Publish release".
 
 - Announce the new release with the link to the release notes:
-  - on [Gitter](https://gitter.im/scalameta/metals) - tag everybody with `@/all`
   - on [Discord](https://discord.com/invite/RFpSVth)

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -449,12 +449,6 @@ object ServerCommands {
     "Open the Metals repository on GitHub"
   )
 
-  val ChatOnGitter = new OpenBrowserCommand(
-    "https://gitter.im/scalameta/metals",
-    "Chat on Gitter",
-    "Open the Metals channel on Gitter to discuss with other Metals users."
-  )
-
   val ChatOnDiscord = new OpenBrowserCommand(
     "https://discord.gg/RFpSVth",
     "Chat on Discord",

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -202,7 +202,6 @@ class MetalsTreeViewProvider(
           echoCommand(ServerCommands.GotoLog, "bug"),
           echoCommand(ServerCommands.ReadVscodeDocumentation, "book"),
           echoCommand(ServerCommands.ReadBloopDocumentation, "book"),
-          echoCommand(ServerCommands.ChatOnGitter, "gitter"),
           echoCommand(ServerCommands.ChatOnDiscord, "discord"),
           echoCommand(ServerCommands.OpenIssue, "issue-opened"),
           echoCommand(ServerCommands.MetalsGithub, "github"),

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -117,11 +117,6 @@ module.exports = {
                     </a>`
           },
           {
-            "html": `<a href = "https://gitter.im/scalameta/metals" target = "_blank" >
-                      <img src="https://img.shields.io/gitter/room/scalameta/metals.svg?logo=gitter&style=social" />
-                    </a>`
-          },
-          {
             "html": `<a href="https://twitter.com/scalameta" target="_blank">
                       <img src="https://img.shields.io/twitter/follow/scalameta.svg?logo=twitter&style=social" />
                     </a>`


### PR DESCRIPTION
Following the official announcement that Discord is now where the
official Scala chat is located, I think it makes sense to focus on
support efforts on Discord. Lately I've also noticed that our Gitter has
been much quieter with more people coming to Discord anyways. We don't
have to sunset Gitter or anything, but instead just remove the
references to it in various places since most seem to be heading to
Discord anyways.

What do you all think?