### PR TITLE
[Java] Support go-to-definition for `*.java` dependency sources

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -86,7 +86,7 @@ final class DefinitionProvider(
         Future.successful(fromSnapshot)
       }
     fromIndex.flatMap { result =>
-      if (result.isEmpty) {
+      if (result.isEmpty && path.isScalaFilename) {
         compilers().definition(params, token)
       } else {
         if (fromSemanticdb.isEmpty) {

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -261,6 +261,14 @@ object Embedded {
       semanticdbScalacDependency(scalaVersion),
       Some(scalaVersion)
     )
+
+  def downloadSemanticdbJavac: List[Path] = {
+    downloadDependency(
+      Dependency.of("com.sourcegraph", "semanticdb-javac", "0.7.3"),
+      None
+    )
+  }
+
   def downloadMtags(scalaVersion: String): List[Path] =
     downloadDependency(mtagsDependency(scalaVersion), Some(scalaVersion))
 

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
@@ -1,0 +1,250 @@
+package scala.meta.internal.metals
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.util.Properties
+import scala.util.Try
+import scala.util.control.NonFatal
+
+import scala.meta.internal.io.FileIO
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.mtags.MD5
+import scala.meta.internal.process.SystemProcess
+import scala.meta.internal.{semanticdb => s}
+import scala.meta.io.AbsolutePath
+
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigParseOptions
+import com.typesafe.config.ConfigSyntax
+
+class JavaInteractiveSemanticdb(
+    javac: AbsolutePath,
+    jdkVersion: JavaInteractiveSemanticdb.JdkVersion,
+    pluginJars: List[Path],
+    workspace: AbsolutePath,
+    buildTargets: BuildTargets
+) {
+
+  private val readonly = workspace.resolve(Directories.readonly)
+
+  def textDocument(source: AbsolutePath, text: String): s.TextDocument = {
+    val sourceRoot = source.parent
+    val workDir = AbsolutePath(
+      Files.createTempDirectory("metals-javac-semanticdb")
+    )
+    val targetRoot = workDir.resolve("target")
+    Files.createDirectory(targetRoot.toNIO)
+
+    val targetClasspath = buildTargets
+      .inferBuildTarget(sourceRoot)
+      .flatMap(buildTargets.targetJarClasspath)
+      .getOrElse(Nil)
+      .map(_.toString)
+
+    val jigsawOptions = addExportsFlags ++ patchModuleFlags(source, sourceRoot)
+    val mainOptions =
+      List(
+        javac.toString,
+        "-cp",
+        (pluginJars ++ targetClasspath).mkString(File.pathSeparator),
+        "-d",
+        targetRoot.toString
+      )
+    val pluginOption =
+      s"-Xplugin:semanticdb -sourceroot:${sourceRoot} -targetroot:${targetRoot}"
+    val cmd =
+      mainOptions ::: jigsawOptions ::: pluginOption :: source.toString :: Nil
+
+    val stdout = List.newBuilder[String]
+    val ps = SystemProcess.run(
+      cmd,
+      workDir,
+      false,
+      Map.empty,
+      outLine => stdout += outLine,
+      errLine => stdout += errLine
+    )
+
+    val future = ps.complete.recover { case NonFatal(e) =>
+      scribe.error(s"Running javac-semanticdb failed for $source", e)
+      1
+    }
+
+    val exitCode = Await.result(future, 10.seconds)
+    val semanticdbFile =
+      targetRoot
+        .resolve("META-INF")
+        .resolve("semanticdb")
+        .resolve(s"${source.filename}.semanticdb")
+
+    val doc = if (semanticdbFile.exists) {
+      FileIO
+        .readAllDocuments(semanticdbFile)
+        .headOption
+        .getOrElse(s.TextDocument())
+    } else {
+      val log = stdout.result()
+      if (exitCode != 0 || log.nonEmpty)
+        scribe.warn(
+          s"Running javac-semanticdb failed for $source. Output:\n${log.mkString("\n")}"
+        )
+      s.TextDocument()
+    }
+
+    val out = doc.copy(
+      uri = source.toURI.toString(),
+      text = text,
+      md5 = MD5.compute(text)
+    )
+
+    workDir.deleteRecursively()
+    out
+  }
+
+  private def patchModuleFlags(
+      source: AbsolutePath,
+      sourceRoot: AbsolutePath
+  ): List[String] = {
+    // Jigsaw doesn't allow compiling source with package
+    // that is declared in some existing module.
+    // It fails with: `error: package exists in another module: $packageName`
+    // but it might be fixed by passing `--patch-module $moduleName=$sourceRoot` option.
+    //
+    // Currently there is no infrastucture to detect if package belong to jigsaw module or not
+    // so this case is covered only for JDK sources.
+    if (jdkVersion.hasJigsaw) {
+      source.toRelativeInside(readonly) match {
+        case Some(rel) =>
+          val names = rel.toNIO.iterator().asScala.toList.map(_.filename)
+          names match {
+            case Directories.dependenciesName :: JdkSources.zipFileName :: moduleName :: _ =>
+              List("--patch-module", s"$moduleName=$sourceRoot")
+            case _ =>
+              Nil
+          }
+        case None => Nil
+      }
+    } else Nil
+  }
+
+  private def addExportsFlags: List[String] = {
+    if (jdkVersion.major >= 17) {
+      val compilerPackages = List(
+        "com.sun.tools.javac.api",
+        "com.sun.tools.javac.code",
+        "com.sun.tools.javac.model",
+        "com.sun.tools.javac.tree",
+        "com.sun.tools.javac.util"
+      )
+      compilerPackages.flatMap(pkg =>
+        List(s"-J--add-exports", s"-Jjdk.compiler/$pkg=ALL-UNNAMED")
+      )
+    } else Nil
+  }
+
+}
+
+object JavaInteractiveSemanticdb {
+
+  def create(
+      javaHome: AbsolutePath,
+      workspace: AbsolutePath,
+      buildTargets: BuildTargets
+  ): Option[JavaInteractiveSemanticdb] = {
+
+    def pathToJavac(p: AbsolutePath): AbsolutePath = {
+      val binaryName = if (Properties.isWin) "javac.exe" else "javac"
+      p.resolve("bin").resolve(binaryName)
+    }
+
+    val jdkHome =
+      // jdk 8 might point at ${JDK_HOME}/jre
+      if (!pathToJavac(javaHome).exists && javaHome.filename == "jre")
+        javaHome.parent
+      else
+        javaHome
+
+    val javac = pathToJavac(jdkHome)
+
+    getJavaVersionFromJavaHome(jdkHome) match {
+      case Some(version) if javac.exists =>
+        val pluginJars = Embedded.downloadSemanticdbJavac
+        val instance = new JavaInteractiveSemanticdb(
+          javac,
+          version,
+          pluginJars,
+          workspace,
+          buildTargets
+        )
+        Some(instance)
+      case value =>
+        scribe.warn(
+          s"Can't instantiate JavaInteractiveSemanticdb (version: ${value}, jdkHome: ${jdkHome}, javac exists: ${javac.exists})"
+        )
+        None
+    }
+  }
+
+  private def getJavaVersionFromJavaHome(
+      javaHome: AbsolutePath
+  ): Option[JdkVersion] = {
+
+    def fromReleaseFile: Option[JdkVersion] = {
+      val releaseFile = javaHome.resolve("release")
+      if (releaseFile.exists) {
+        val properties = ConfigFactory.parseFile(
+          releaseFile.toFile,
+          ConfigParseOptions.defaults().setSyntax(ConfigSyntax.PROPERTIES)
+        )
+        try {
+          val version = properties
+            .getString("JAVA_VERSION")
+            .stripPrefix("\"")
+            .stripSuffix("\"")
+          scribe.info(s"Parse release: ${version}")
+          JdkVersion.parse(version)
+        } catch {
+          case NonFatal(e) =>
+            scribe.error("Failed to read jdk version from `release` file", e)
+            None
+        }
+      } else None
+    }
+
+    def jdk8Fallback: Option[JdkVersion] = {
+      val rtJar = javaHome.resolve("jre").resolve("lib").resolve("rt.jar")
+      if (rtJar.exists) Some(JdkVersion(1, 8))
+      else None
+    }
+
+    fromReleaseFile.orElse(jdk8Fallback)
+  }
+
+  case class JdkVersion(
+      major: Int,
+      minor: Int
+  ) {
+
+    def hasJigsaw: Boolean = major >= 11 || (minor == 9 && major == 1)
+  }
+
+  object JdkVersion {
+
+    def parse(v: String): Option[JdkVersion] = {
+      val numbers = v.split('.').toList.take(3).map(s => Try(s.toInt).toOption)
+      numbers match {
+        case Some(single) :: Nil =>
+          if (single > 10) Some(JdkVersion(single, 0))
+          else Some(JdkVersion(1, single))
+        case Some(major) :: Some(minor) :: Some(_) :: Nil =>
+          Some(JdkVersion(major, minor))
+        case _ => None
+      }
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -368,6 +368,15 @@ class MetalsLanguageServer(
           workspace,
           fingerprints
         )
+        val javaInteractiveSemanticdb = {
+          val optJavaHome =
+            (userConfig.javaHome orElse JdkSources.defaultJavaHome)
+              .map(AbsolutePath(_))
+
+          optJavaHome.flatMap(
+            JavaInteractiveSemanticdb.create(_, workspace, buildTargets)
+          )
+        }
         interactiveSemanticdbs = register(
           new InteractiveSemanticdbs(
             workspace,
@@ -378,7 +387,8 @@ class MetalsLanguageServer(
             statusBar,
             () => compilers,
             clientConfig,
-            () => semanticDBIndexer
+            () => semanticDBIndexer,
+            javaInteractiveSemanticdb
           )
         )
         warnings = new Warnings(

--- a/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
+++ b/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
@@ -28,7 +28,8 @@ object DownloadDependencies {
     downloadMdoc()
     downloadScalafmt()
     downloadMtags()
-    downloadSemanticDB()
+    downloadSemanticDBScalac()
+    downloadSemanticDBJavac()
     downloadScala()
     // NOTE(olafur): important, Bloop comes last because it does System.exit()
     downloadBloop()
@@ -72,11 +73,16 @@ object DownloadDependencies {
     }
   }
 
-  def downloadSemanticDB(): Unit = {
+  def downloadSemanticDBScalac(): Unit = {
     scribe.info("Downloading semanticdb-scalac")
     BuildInfo.supportedScala2Versions.foreach { scalaVersion =>
       Embedded.downloadSemanticdbScalac(scalaVersion)
     }
+  }
+
+  def downloadSemanticDBJavac(): Unit = {
+    scribe.info("Downloading semanticdb-javac")
+    Embedded.downloadSemanticdbJavac
   }
 
   def downloadBloop(): Unit = {

--- a/mtags/src/main/scala-2/scala/meta/internal/metals/PositionSyntax.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/metals/PositionSyntax.scala
@@ -4,14 +4,19 @@ import scala.meta.Position
 
 object PositionSyntax {
 
-  def formatMessage(pos: Position, severity: String, message: String): String =
+  def formatMessage(
+      pos: Position,
+      severity: String,
+      message: String,
+      noPos: Boolean = false
+  ): String =
     pos match {
       case Position.None =>
         s"$severity: $message"
       case _ =>
-        new java.lang.StringBuilder()
-          .append(pos.lineInput)
-          .append(if (severity.isEmpty) "" else " ")
+        val sb = new java.lang.StringBuilder()
+        if (noPos) sb.append(pos.input.syntax) else sb.append(pos.lineInput)
+        sb.append(if (severity.isEmpty) "" else " ")
           .append(severity)
           .append(
             if (message.isEmpty) ""
@@ -32,8 +37,12 @@ object PositionSyntax {
       pos.end >= other.end
     }
 
-    def formatMessage(severity: String, message: String): String =
-      PositionSyntax.formatMessage(pos, severity, message)
+    def formatMessage(
+        severity: String,
+        message: String,
+        noPos: Boolean = false
+    ): String =
+      PositionSyntax.formatMessage(pos, severity, message, noPos)
 
     /**
      * Returns a formatted string of this position including filename/line/caret.

--- a/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
@@ -11,7 +11,8 @@ import scala.meta.io.RelativePath
  * Locates zip file on disk that contains the source code for the JDK.
  */
 object JdkSources {
-  private val sources = RelativePath(Paths.get("src.zip"))
+  val zipFileName = "src.zip"
+  private val sources = RelativePath(Paths.get(zipFileName))
   private val libSources = RelativePath(Paths.get("lib")).resolve(sources)
 
   def apply(userJavaHome: Option[String] = None): Option[AbsolutePath] = {

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -88,7 +88,7 @@ object TestGroups {
       "tests.debug.DotEnvFileParserSuite", "tests.SemanticdbScala3Suite",
       "tests.troubleshoot.ProblemResolverSuite", "tests.BspBuildChangedSuite",
       "tests.classFinder.ClassBreakpointSuite",
-      "tests.classFinder.ClassNameResolverSuite")
+      "tests.classFinder.ClassNameResolverSuite", "tests.JavaDefinitionSuite")
   )
 
 }

--- a/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
@@ -1,0 +1,159 @@
+package tests
+
+import java.net.URI
+import java.nio.charset.StandardCharsets
+
+import scala.util.Properties
+
+import scala.meta.internal.io.FileIO
+import scala.meta.internal.metals.Directories
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.PositionSyntax._
+import scala.meta.io.AbsolutePath
+
+import munit.Location
+import munit.TestOptions
+import org.eclipse.{lsp4j => l}
+
+class JavaDefinitionSuite extends BaseLspSuite("java-definition") {
+
+  val javaBasePrefix: String =
+    if (Properties.isJavaAtLeast("9")) "java.base/" else ""
+
+  check(
+    "jdk-String",
+    "java.lang.String",
+    s"""|${javaBasePrefix}java/lang/String.java
+        |public String replace(@@CharSequence target, CharSequence replacement) {
+        |""".stripMargin,
+    s"""|src.zip/${javaBasePrefix}java/lang/CharSequence.java info: result
+        |public interface CharSequence {
+        |                 ^^^^^^^^^^^^
+        |""".stripMargin
+  )
+
+  check(
+    "xnio1",
+    "org.xnio.nio.NioTcpServer",
+    s"""|/org/xnio/nio/NioTcpServer.java
+        |tcpServerLog.logf(FQCN, @@Logger.Level.TRACE, null, "Wake up accepts on %s", this);
+        |""".stripMargin,
+    """|jboss-logging-3.3.1.Final-sources.jar/org/jboss/logging/Logger.java info: result
+       |public abstract class Logger implements Serializable, BasicLogger {
+       |                      ^^^^^^
+       |""".stripMargin,
+    dependencies = List(
+      "org.jboss.xnio:xnio-nio:3.8.5.Final"
+    )
+  )
+
+  check(
+    "xnio2",
+    "org.xnio.nio.Log",
+    s"""|/org/xnio/nio/Log.java
+        |Log log = @@Logger.getMessageLogger(Log.class, "org.xnio.nio");
+        |""".stripMargin,
+    """|jboss-logging-3.3.1.Final-sources.jar/org/jboss/logging/Logger.java info: result
+       |public abstract class Logger implements Serializable, BasicLogger {
+       |                      ^^^^^^
+       |""".stripMargin,
+    dependencies = List(
+      "org.jboss.xnio:xnio-nio:3.8.5.Final"
+    )
+  )
+
+  def check(
+      name: TestOptions,
+      depSymbol: String,
+      input: String,
+      expected: String,
+      dependencies: List[String] = Nil
+  )(implicit loc: Location): Unit = {
+    test(name) {
+      val parsed = FileLayout.mapFromString(input)
+      assert(parsed.size == 1, "Input should have only one dep source file")
+      val (path, query) = parsed.head
+
+      val deps = dependencies
+        .map(s => s""""$s"""")
+        .mkString("[", ", ", "]")
+      val layout =
+        s"""|/metals.json
+            |{
+            |  "a": {
+            |    "libraryDependencies": $deps
+            |  }
+            |}
+            |""".stripMargin
+      for {
+        _ <- initialize(layout)
+        // trigger extraction into readonly
+        info = server.server.workspaceSymbol(depSymbol)
+        matchedInfo = info.find(_.getLocation().getUri().contains(path))
+        uri = matchedInfo match {
+          case None =>
+            fail(
+              s"Symbol ${depSymbol} with expected path ${path} has not been found"
+            )
+          case Some(info) =>
+            info.getLocation().getUri()
+        }
+        pos = depSourcePosition(uri, query)
+
+        locations <- server.server
+          .definition(
+            new l.TextDocumentPositionParams(
+              new l.TextDocumentIdentifier(uri),
+              uri,
+              pos
+            )
+          )
+          .asScala
+        rendered = locations.asScala.map(renderLocation).mkString("\n")
+        _ = assertNoDiff(rendered, expected)
+      } yield ()
+    }
+  }
+
+  private def depSourcePosition(
+      uri: String,
+      query: String
+  ): l.Position = {
+    val characterInc = query.indexOf("@@")
+    if (characterInc == -1) {
+      throw new Exception("Query must contain @@")
+    } else {
+      val path = AbsolutePath.fromAbsoluteUri(URI.create(uri))
+      val raw = query.replaceAll("@@", "").trim()
+      val result = FileIO
+        .slurp(path, StandardCharsets.UTF_8)
+        .linesIterator
+        .zipWithIndex
+        .find { case (line, _) =>
+          line.contains(raw)
+        }
+      result match {
+        case Some((line, idx)) =>
+          val firstCh = line.indexOf(raw)
+          val ch = firstCh + characterInc
+          new l.Position(idx, ch)
+        case None => throw new Exception(s"Query not found in $path")
+      }
+    }
+  }
+
+  private def renderLocation(loc: l.Location): String = {
+    val path = AbsolutePath.fromAbsoluteUri(URI.create(loc.getUri()))
+    val relativePath =
+      path
+        .toRelative(workspace.resolve(Directories.dependencies))
+        .toString()
+        .replace("\\", "/")
+
+    val input = path.toInput.copy(path = relativePath.toString)
+    loc
+      .getRange()
+      .toMeta(input)
+      .formatMessage("info", "result", noPos = true)
+  }
+}


### PR DESCRIPTION
Implemented using sourcegraph semanticdb compiler plugin.