### PR TITLE
Fix: Docusaurus Edit URL is broken

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -19,7 +19,7 @@ module.exports = {
           "path": "../website/target/docs",
           "showLastUpdateAuthor": true,
           "showLastUpdateTime": true,
-          "editUrl": "https://github.com/scalameta/metals/edit/main/docs/",
+          "editUrl": ({docPath}) => `https://github.com/scalameta/metals/edit/main/docs/${docPath}`,
           "sidebarPath": "../website/sidebars.json"
         },
         "blog": {


### PR DESCRIPTION
According to the documentation of the [plugin-content-docs](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#editUrl),
the actual URL used is `computed by editUrl + relativeDocPath.`

When using a string value for the editUrl, then the edit URL is `editUrl` + `target/docs` + `docPath` in your case.
The `target/docs` is added but not needed.

Again, according to the [documentation](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#ex-config), is is possible
to use a function instead of a plan string for the `editUrl`, and this is what this change is all about: docusaurus now ignored the `target/docs` to construct the path.