### PR TITLE
fix: override pprint in docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -808,7 +808,8 @@ lazy val docs = project
     sharedSettings,
     publish / skip := true,
     moduleName := "metals-docs",
-    mdoc := (Compile / run).evaluated
+    mdoc := (Compile / run).evaluated,
+    dependencyOverrides += "com.lihaoyi" %% "pprint" % "0.6.6"
   )
   .dependsOn(metals)
   .enablePlugins(DocusaurusPlugin)


### PR DESCRIPTION
I have no idea how this has been working, since locally I couldn't run this for a while it seems, but it still seems to be working in ci 🤷🏼 