### PR TITLE
docs: update user config docs

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -241,8 +241,8 @@ object UserConfiguration {
       ),
       UserConfigurationOption(
         "fallback-scala-version",
-        BuildInfo.scala212,
-        BuildInfo.scala212,
+        BuildInfo.scala3,
+        BuildInfo.scala3,
         "Default fallback Scala version",
         """|The Scala compiler version that is used as the default or fallback in case a file 
            |doesn't belong to any build target or the specified Scala version isn't supported by Metals.
@@ -252,7 +252,7 @@ object UserConfiguration {
       UserConfigurationOption(
         "test-user-interface",
         "Code Lenses",
-        """{ "testUserInterface" : "Test explorer" } """,
+        "Test explorer",
         "Test UI used for tests and test suites",
         "Default way of handling tests and test suites."
       ),


### PR DESCRIPTION
This updates the default fallbackScalaVersion which is Scala3, but we
are still showing Scala 2.12. This also updates the `testUserInface` to
only have the value since it's dynamically put together. Right now it
shows:
```json
{
  "metals": {
    "testUserInterface": { "testUserInterface" : "Test explorer" }
  }
}
```
So this fixes that.