### PR TITLE
feat(doctor): add in explanations to the json doctor output

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DoctorExplanation.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DoctorExplanation.scala
@@ -1,0 +1,234 @@
+package scala.meta.internal.metals
+
+import ujson.Obj
+
+/**
+ * Various explanations to help explain the various sections of a Build Target
+ * in the Doctor.
+ */
+sealed trait DoctorExplanation {
+
+  /**
+   * Title of the explanation
+   */
+  def title: String
+
+  /**
+   * Message explaining what support for this means.
+   */
+  def correctMessage: String
+
+  /**
+   * Message explaining what you'll be missing if this is incorrect.
+   */
+  def incorrectMessage: String
+
+  /**
+   * Whether or not the incorrect message needs to be shown along witht he
+   * correct one.
+   *
+   * @param allTargetsInfo
+   */
+  def show(allTargetsInfo: Seq[DoctorTargetInfo]): Boolean
+
+  /**
+   * Takes in a builder and returns a builder with the explanations attatched.
+   *
+   * @param html The builder your're working with.
+   * @param allTargetsInfo
+   */
+  def toHtml(html: HtmlBuilder, allTargetsInfo: Seq[DoctorTargetInfo])
+
+  /**
+   * Take the results and return them in Json
+   *
+   * @param allTargetsInfo
+   * @return
+   */
+  def toJson(allTargetsInfo: Seq[DoctorTargetInfo]): Obj
+
+  /**
+   * Take the values and creates an html explanation for them.
+   */
+  def explanation(
+      html: HtmlBuilder,
+      title: String,
+      correctMessage: String,
+      incorrectMessage: String,
+      show: Boolean
+  ): HtmlBuilder = {
+    html.element("div")(
+      _.element("p")(_.text(title)).element("ul") { ul =>
+        ul.element("li")(_.text(correctMessage))
+        if (show)
+          ul.element("li")(_.text(incorrectMessage))
+      }
+    )
+
+  }
+
+  /**
+   * Take the values and creates a json explanation.
+   */
+  def explanation(
+      title: String,
+      correctMessage: String,
+      incorrectMessage: String,
+      show: Boolean
+  ): Obj = {
+    val explanations =
+      if (show)
+        List(correctMessage, incorrectMessage)
+      else
+        List(correctMessage)
+
+    ujson.Obj(
+      "title" -> title,
+      "explanations" -> explanations
+    )
+  }
+}
+
+object DoctorExplanation {
+  case object Diagnostics extends DoctorExplanation {
+    val title = "Diagnostics:"
+    val correctMessage: String =
+      s"${Icons.unicode.check} - diagnostics correctly being reported by the build server"
+    val incorrectMessage: String =
+      s"${Icons.unicode.alert} - only syntactic errors being reported"
+
+    def show(allTargetsInfo: Seq[DoctorTargetInfo]): Boolean =
+      allTargetsInfo.exists(_.diagnosticsStatus.isCorrect == false)
+
+    def toHtml(html: HtmlBuilder, allTargetsInfo: Seq[DoctorTargetInfo]): Unit =
+      explanation(
+        html,
+        title,
+        correctMessage,
+        incorrectMessage,
+        show(allTargetsInfo)
+      )
+
+    def toJson(allTargetsInfo: Seq[DoctorTargetInfo]): Obj =
+      explanation(
+        title,
+        correctMessage,
+        incorrectMessage,
+        show(allTargetsInfo)
+      )
+  }
+
+  case object Interactive extends DoctorExplanation {
+    val title = "Interactive features (completions, hover):"
+    val correctMessage: String =
+      s"${Icons.unicode.check} - supported Scala version"
+    val incorrectMessage: String =
+      s"${Icons.unicode.error} - interactive features are unsupported for Java and older Scala versions"
+
+    def show(allTargetsInfo: Seq[DoctorTargetInfo]): Boolean =
+      allTargetsInfo.exists(_.interactiveStatus.isCorrect == false)
+
+    def toHtml(html: HtmlBuilder, allTargetsInfo: Seq[DoctorTargetInfo]): Unit =
+      explanation(
+        html,
+        title,
+        correctMessage,
+        incorrectMessage,
+        show(allTargetsInfo)
+      )
+
+    def toJson(allTargetsInfo: Seq[DoctorTargetInfo]): Obj =
+      explanation(
+        title,
+        correctMessage,
+        incorrectMessage,
+        show(allTargetsInfo)
+      )
+  }
+
+  case object SemanticDB extends DoctorExplanation {
+    val title =
+      "Semanticdb features (references, renames, go to implementation):"
+    val correctMessage: String =
+      s"${Icons.unicode.check} - build tool automatically creating needed semanticdb files"
+    val incorrectMessage: String =
+      s"${Icons.unicode.error} - semanticdb not being produced"
+
+    def show(allTargetsInfo: Seq[DoctorTargetInfo]): Boolean =
+      allTargetsInfo.exists(_.indexesStatus.isCorrect == false)
+
+    def toHtml(html: HtmlBuilder, allTargetsInfo: Seq[DoctorTargetInfo]): Unit =
+      explanation(
+        html,
+        title,
+        correctMessage,
+        incorrectMessage,
+        show(allTargetsInfo)
+      )
+
+    def toJson(allTargetsInfo: Seq[DoctorTargetInfo]): Obj =
+      explanation(
+        title,
+        correctMessage,
+        incorrectMessage,
+        show(allTargetsInfo)
+      )
+  }
+
+  case object Debugging extends DoctorExplanation {
+    val title = "Debugging (run/test, breakpoints, evaluation):"
+    val correctMessage: String =
+      s"${Icons.unicode.check} - users can run or test their code with debugging capabilities"
+    val incorrectMessage: String =
+      s"${Icons.unicode.error} - the tool does not support debugging in this target"
+
+    def show(allTargetsInfo: Seq[DoctorTargetInfo]): Boolean =
+      allTargetsInfo.exists(_.debuggingStatus.isCorrect == false)
+
+    def toHtml(html: HtmlBuilder, allTargetsInfo: Seq[DoctorTargetInfo]): Unit =
+      explanation(
+        html,
+        title,
+        correctMessage,
+        incorrectMessage,
+        show(allTargetsInfo)
+      )
+
+    def toJson(allTargetsInfo: Seq[DoctorTargetInfo]): Obj =
+      explanation(
+        title,
+        correctMessage,
+        incorrectMessage,
+        show(allTargetsInfo)
+      )
+  }
+
+  case object JavaSupport extends DoctorExplanation {
+    val title = "Java Support:"
+    val correctMessage: String =
+      s"${Icons.unicode.check} - working non-interactive features (references, rename etc.)"
+    val incorrectMessage: String =
+      s"${Icons.unicode.error} - missing semanticdb plugin, might not be added automatically by the build server (work for Bloop only)"
+
+    def show(allTargetsInfo: Seq[DoctorTargetInfo]): Boolean =
+      allTargetsInfo.exists(_.javaStatus.isCorrect == false)
+
+    def toHtml(html: HtmlBuilder, allTargetsInfo: Seq[DoctorTargetInfo]): Unit =
+      explanation(
+        html,
+        title,
+        correctMessage,
+        incorrectMessage,
+        show(allTargetsInfo)
+      )
+
+    def toJson(allTargetsInfo: Seq[DoctorTargetInfo]): Obj =
+      explanation(
+        title,
+        correctMessage,
+        incorrectMessage,
+        show(allTargetsInfo)
+      )
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/DoctorResults.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DoctorResults.scala
@@ -6,7 +6,8 @@ final case class DoctorResults(
     title: String,
     headerText: String,
     messages: Option[List[DoctorMessage]],
-    targets: Option[Seq[DoctorTargetInfo]]
+    targets: Option[Seq[DoctorTargetInfo]],
+    explanations: List[Obj]
 ) {
   private val version = 1
   def toJson: Obj = {
@@ -19,6 +20,7 @@ final case class DoctorResults(
       json("messages") = messageList.map(_.toJson)
     )
     targets.foreach(targetList => json("targets") = targetList.map(_.toJson))
+    json("explanations") = explanations
     json
   }
 }
@@ -37,6 +39,7 @@ object DoctorStatus {
   object alert extends DoctorStatus(Icons.unicode.alert, false)
   object error extends DoctorStatus(Icons.unicode.error, false)
 }
+
 final case class DoctorTargetInfo(
     name: String,
     dataKind: String,


### PR DESCRIPTION
This is a follow-up to the work done in
https://github.com/scalameta/metals/pull/3426.

This extracts out the explanation logic into the `DoctorExplanation` ADT
so that we can re-use it both for html and for json.

The old output of the json doctor was:

```json
{
  "title": "Metals Doctor",
  "headerText": "Build server currently being used is Bloop v1.4.11.\n\nThese are the installed build targets for this workspace. One build target corresponds to one classpath. For example, normally one sbt project maps to two build targets: main and test.",
  "version": 1,
  "targets": [
    {
      "buildTarget": "Sanity",
      "targetType": "Scala 2.12.15",
      "diagnostics": "✅ ",
      "interactive": "✅ ",
      "semanticdb": "✅ ",
      "debugging": "✅ ",
      "java": "✅ ",
      "recommendation": ""
    },
    {
      "buildTarget": "Sanity.test",
      "targetType": "Scala 2.12.15",
      "diagnostics": "✅ ",
      "interactive": "✅ ",
      "semanticdb": "✅ ",
      "debugging": "✅ ",
      "java": "✅ ",
      "recommendation": ""
    }
  ]
}
````

Where now the new format for the same build would be:

```json
{
  "title": "Metals Doctor",
  "headerText": "Build server currently being used is Bloop v1.4.11.\n\nThese are the installed build targets for this workspace. One build target corresponds to one classpath. For example, normally one sbt project maps to two build targets: main and test.",
  "version": 1,
  "targets": [
    {
      "buildTarget": "Sanity",
      "targetType": "Scala 2.12.15",
      "diagnostics": "✅ ",
      "interactive": "✅ ",
      "semanticdb": "✅ ",
      "debugging": "✅ ",
      "java": "✅ ",
      "recommendation": ""
    },
    {
      "buildTarget": "Sanity.test",
      "targetType": "Scala 2.12.15",
      "diagnostics": "✅ ",
      "interactive": "✅ ",
      "semanticdb": "✅ ",
      "debugging": "✅ ",
      "java": "✅ ",
      "recommendation": ""
    }
  ],
  "explanations": [
    {
      "title": "Diagnostics:",
      "explanations": [
        "✅  - diagnostics correctly being reported by the build server"
      ]
    },
    {
      "title": "Interactive features (completions, hover):",
      "explanations": [
        "✅  - supported Scala version"
      ]
    },
    {
      "title": "Semanticdb features (references, renames, go to implementation):",
      "explanations": [
        "✅  - build tool automatically creating needed semanticdb files"
      ]
    },
    {
      "title": "Debugging (run/test, breakpoints, evaluation):",
      "explanations": [
        "✅  - users can run or test their code with debugging capabilities"
      ]
    },
    {
      "title": "Java Support:",
      "explanations": [
        "✅  - working non-interactive features (references, rename etc.)"
      ]
    }
  ]
}

```