### PR TITLE
Fix issues with renames in Java files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
@@ -176,7 +176,7 @@ class SemanticdbTreePrinter(
   ): List[(String, s.Range)] = {
 
     def isExplicitTuple(range: s.Range) =
-      range.inString(textDocument.text).startsWith("Tuple")
+      range.inString(textDocument.text).exists(_.startsWith("Tuple"))
 
     def gatherSynthetics(tree: s.Tree) = {
       for {

--- a/metals/src/main/scala/scala/meta/internal/metals/FileSystemSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileSystemSemanticdbs.scala
@@ -47,7 +47,8 @@ final class FileSystemSemanticdbs(
             charset,
             fingerprints,
             semanticdbRelativePath =>
-              findSemanticDb(semanticdbRelativePath, targetroot, file, ws)
+              findSemanticDb(semanticdbRelativePath, targetroot, file, ws),
+            (warn: String) => scribe.warn(warn)
           )
         case None =>
           TextDocumentLookup.NotFound(file)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -668,7 +668,7 @@ object MetalsEnrichments
   }
 
   implicit class XtensionPositionRange(range: s.Range) {
-    def inString(text: String): String = {
+    def inString(text: String): Option[String] = {
       var i = 0
       var max = 0
       while (max < range.startLine) {
@@ -677,7 +677,10 @@ object MetalsEnrichments
       }
       val start = i + range.startCharacter
       val end = i + range.endCharacter
-      text.substring(start, end)
+      if (start < text.size && end <= text.size)
+        Some(text.substring(start, end))
+      else
+        None
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -597,7 +597,8 @@ class MetalsLanguageServer(
           buffers,
           compilations,
           clientConfig,
-          trees
+          trees,
+          semanticdbs
         )
         syntheticsDecorator = new SyntheticsDecorationProvider(
           workspace,

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -342,6 +342,8 @@ trait CommonMtagsEnrichments {
       doc.endsWith(".worksheet.sc")
     def isScalaFilename: Boolean =
       doc.isScala || isScalaScript || isSbt
+    def isScalaOrJavaFilename: Boolean =
+      doc.isScala || isScalaScript || isSbt || isJavaFilename
     def isJavaFilename: Boolean =
       doc.endsWith(".java")
     def isAmmoniteGeneratedFile: Boolean =

--- a/mtags/src/main/scala/scala/meta/internal/mtags/MD5.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/MD5.scala
@@ -6,6 +6,7 @@ import java.security.MessageDigest
 
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.io.AbsolutePath
+
 object MD5 {
   def compute(path: AbsolutePath, string: String): String = {
     if (path.isJava) MD5Java.digest(string)

--- a/mtags/src/main/scala/scala/meta/internal/mtags/Semanticdbs.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/Semanticdbs.scala
@@ -30,7 +30,8 @@ object Semanticdbs {
       sourceroot: AbsolutePath,
       charset: Charset,
       fingerprints: Md5Fingerprints,
-      loader: RelativePath => Option[FoundSemanticDbPath]
+      loader: RelativePath => Option[FoundSemanticDbPath],
+      log: String => Unit = (_) => ()
   ): TextDocumentLookup = {
     if (scalaOrJavaPath.toNIO.getFileSystem != sourceroot.toNIO.getFileSystem) {
       TextDocumentLookup.NotFound(scalaOrJavaPath)
@@ -47,7 +48,8 @@ object Semanticdbs {
             semanticdbPath.nonDefaultRelPath.getOrElse(scalaRelativePath),
             semanticdbPath.path,
             charset,
-            fingerprints
+            fingerprints,
+            log
           )
       }
     }
@@ -58,7 +60,8 @@ object Semanticdbs {
       scalaRelativePath: RelativePath,
       semanticdbPath: AbsolutePath,
       charset: Charset,
-      fingerprints: Md5Fingerprints
+      fingerprints: Md5Fingerprints,
+      log: String => Unit
   ): TextDocumentLookup = {
     val reluri = scalaRelativePath.toURI(false).toString
     val sdocs = loadTextDocuments(semanticdbPath)
@@ -72,6 +75,7 @@ object Semanticdbs {
             case Some(oldText) =>
               TextDocumentLookup.Stale(scalaPath, md5, sdoc.withText(oldText))
             case None =>
+              log("Could not load snapshot text for semanticdb")
               TextDocumentLookup.Stale(scalaPath, md5, sdoc)
           }
         } else {

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -444,11 +444,35 @@ class RenameLspSuite extends BaseRenameLspSuite("rename") {
   )
 
   renamed(
-    "java-unchanged",
+    "java-changed",
     """|/a/src/main/java/a/Other.java
        |package a;
-       |public class Other{
+       |public class <<Other>>{
        |
+       |  <<Other>> other;
+       |  public <<Other>>(){
+       |     
+       |  }
+       |}
+       |/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main{
+       |  val other = new <<Oth@@er>>()
+       |}
+       |""".stripMargin,
+    newName = "Renamed"
+  )
+
+  renamed(
+    "java-only",
+    """|/a/src/main/java/a/Other.java
+       |package a;
+       |public class <<Other>>{
+       |
+       |  <<Ot@@her>> other;
+       |  public <<Other>>(){
+       |     
+       |  }
        |}
        |/a/src/main/scala/a/Main.scala
        |package a
@@ -493,7 +517,7 @@ class RenameLspSuite extends BaseRenameLspSuite("rename") {
   )
 
   renamed(
-    "macro2",
+    "macro1",
     """|/a/src/main/scala/a/Main.scala
        |package a
        |import io.circe.generic.JsonCodec
@@ -508,7 +532,7 @@ class RenameLspSuite extends BaseRenameLspSuite("rename") {
   )
 
   renamed(
-    "macro1",
+    "macro2",
     """|/a/src/main/scala/a/Main.scala
        |package a
        |import io.circe.generic.JsonCodec
@@ -519,7 +543,7 @@ class RenameLspSuite extends BaseRenameLspSuite("rename") {
   )
 
   renamed(
-    "macro2",
+    "macro3",
     """|/a/src/main/scala/a/Main.scala
        |package a
        |import io.circe.generic.JsonCodec


### PR DESCRIPTION
This includes making sure that contructors are taken into account as well as some smaller overall improvements:
- fix inString method to not break if the text document string is empty
- log whenever text corresponding to semanticdb md5 string was not found