### PR TITLE
Fix ClassFinder bug with inner classes

### DIFF
--- a/tests/unit/src/test/scala/tests/classFinder/FindAllClassesSuite.scala
+++ b/tests/unit/src/test/scala/tests/classFinder/FindAllClassesSuite.scala
@@ -13,7 +13,7 @@ class FindAllClassesSuite extends BaseClassFinderSuite {
   check(
     "only-toplevel",
     """|package a
-       |class Foo 
+       |class Foo
        |object Foo
        |class Bar {
        |  val x = 155
@@ -36,7 +36,7 @@ class FindAllClassesSuite extends BaseClassFinderSuite {
   check(
     "all",
     """|package a
-       |class Foo 
+       |class Foo
        |object Foo {
        |  class InnerClass
        |}
@@ -59,28 +59,58 @@ class FindAllClassesSuite extends BaseClassFinderSuite {
     scalaVersion = V.scala3
   )
 
-  check(
-    "inner-classes",
-    """|package a
-       |class Foo {
-       |  class InnerClass
-       |}
-       |object Foo
-       |
-       |object Bar {
-       |  class InnerClass
-       |}
-       |""".stripMargin,
-    List(
-      "Class Foo a.Foo.class",
-      "Class InnerClass a.Foo$InnerClass.class",
-      "Object Foo a.Foo$.class",
-      "Object Bar a.Bar$.class",
-      "Class InnerClass a.Bar$InnerClass.class"
-    ),
-    checkInnerClasses = true,
-    scalaVersion = V.scala3
-  )
+  for (scalaVer <- List(V.scala3, V.scala213, V.scala212, V.scala211)) {
+    check(
+      s"inner-classes (Scala ${scalaVer})",
+      """|package a
+         |class Foo {
+         |  class InnerClass
+         |  trait InnerTrait
+         |  object InnerObject
+         |  class Foo2 {
+         |    class Foo3 {
+         |      class VeryInnerClass
+         |      trait VeryInnerTrait
+         |      object VeryInnerObject
+         |    }
+         |  }
+         |}
+         |object Foo
+         |
+         |object Bar {
+         |  class InnerClass
+         |  trait InnerTrait
+         |  object InnerObject
+         |  object Bar2 {
+         |    object Bar3 {
+         |      class VeryInnerClass
+         |      trait VeryInnerTrait
+         |      object VeryInnerObject
+         |    }
+         |  }
+         |}
+         |""".stripMargin,
+      List(
+        "Class Foo a.Foo.class", "Class InnerClass a.Foo$InnerClass.class",
+        "Trait InnerTrait a.Foo$InnerTrait.class",
+        "Object InnerObject a.Foo$InnerObject$.class",
+        "Class Foo2 a.Foo$Foo2.class", "Class Foo3 a.Foo$Foo2$Foo3.class",
+        "Class VeryInnerClass a.Foo$Foo2$Foo3$VeryInnerClass.class",
+        "Trait VeryInnerTrait a.Foo$Foo2$Foo3$VeryInnerTrait.class",
+        "Object VeryInnerObject a.Foo$Foo2$Foo3$VeryInnerObject$.class",
+        "Object Foo a.Foo$.class", "Object Bar a.Bar$.class",
+        "Class InnerClass a.Bar$InnerClass.class",
+        "Trait InnerTrait a.Bar$InnerTrait.class",
+        "Object InnerObject a.Bar$InnerObject$.class",
+        "Object Bar2 a.Bar$Bar2$.class", "Object Bar3 a.Bar$Bar2$Bar3$.class",
+        "Class VeryInnerClass a.Bar$Bar2$Bar3$VeryInnerClass.class",
+        "Trait VeryInnerTrait a.Bar$Bar2$Bar3$VeryInnerTrait.class",
+        "Object VeryInnerObject a.Bar$Bar2$Bar3$VeryInnerObject$.class"
+      ),
+      checkInnerClasses = true,
+      scalaVersion = scalaVer
+    )
+  }
 
   def check(
       name: TestOptions,


### PR DESCRIPTION
When selecting "Metals Analyse Source", some inner classes/traits/objects has incorrect names like `A$B$B` instead of `A$B`. As a result, the editor can't open these, e.g., javap files. This PR fixes this.