### PR TITLE
[JavaInteractiveSemanticdb] Add test-case to cover --patch-module flag usage

### DIFF
--- a/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
@@ -33,6 +33,18 @@ class JavaDefinitionSuite extends BaseLspSuite("java-definition") {
   )
 
   check(
+    "jdk-String-patch-module",
+    "java.lang.String",
+    s"""|${javaBasePrefix}java/lang/String.java
+        |private boolean nonSyncContentEquals(@@AbstractStringBuilder sb) {
+        |""".stripMargin,
+    s"""|src.zip/${javaBasePrefix}java/lang/AbstractStringBuilder.java info: result
+        |abstract class AbstractStringBuilder implements Appendable, CharSequence {
+        |               ^^^^^^^^^^^^^^^^^^^^^
+        |""".stripMargin
+  )
+
+  check(
     "xnio1",
     "org.xnio.nio.NioTcpServer",
     s"""|/org/xnio/nio/NioTcpServer.java


### PR DESCRIPTION
Just an additional test that doesn't work on jdk11+ without `--patch-module $module` flag