### PR TITLE
fix: Open other window when using Analyze Stacktrace

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/implementation/Supermethods.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/Supermethods.scala
@@ -29,7 +29,11 @@ class Supermethods(
       commandParams: TextDocumentPositionParams
   ): Option[ExecuteCommandParams] = {
     getGoToSuperMethodLocation(commandParams)
-      .map(ClientCommands.GotoLocation.toExecuteCommandParams(_, false))
+      .map(location =>
+        ClientCommands.GotoLocation.toExecuteCommandParams(
+          ClientCommands.WindowLocation(location.getUri(), location.getRange())
+        )
+      )
   }
 
   def jumpToSelectedSuperMethod(
@@ -42,7 +46,12 @@ class Supermethods(
       askUserToSelectSuperMethod(methodSymbols)
         .map(
           _.flatMap(findDefinitionLocation(_, path))
-            .map(ClientCommands.GotoLocation.toExecuteCommandParams(_, false))
+            .map(location =>
+              ClientCommands.GotoLocation.toExecuteCommandParams(
+                ClientCommands
+                  .WindowLocation(location.getUri(), location.getRange())
+              )
+            )
             .foreach(client.metalsExecuteClientCommand)
         )
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -180,8 +180,13 @@ object ClientCommands {
        |""".stripMargin
   )
 
+  case class WindowLocation(
+      uri: String,
+      range: l.Range,
+      otherWindow: Boolean = false
+  )
   object GotoLocation
-      extends ParametrizedCommand2[l.Location, Boolean](
+      extends ParametrizedCommand[WindowLocation](
         "metals-goto-location",
         "Goto location",
         "Move the cursor focus to the provided location",
@@ -196,9 +201,9 @@ object ClientCommands {
            |  "range": {
            |    "start": {"line": 194, "character": 0},
            |    "end":   {"line": 194, "character": 1}
-           |  }
+           |  },
+           |  "otherWindow" : true
            |},
-           |  false
            |]
            |```
            |""".stripMargin

--- a/metals/src/main/scala/scala/meta/internal/metals/Command.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Command.scala
@@ -100,61 +100,6 @@ case class ParametrizedCommand[T: ClassTag](
   }
 }
 
-case class ParametrizedCommand2[T1: ClassTag, T2: ClassTag](
-    id: String,
-    title: String,
-    description: String,
-    arguments: String
-) extends BaseCommand {
-
-  private val parser1 = new JsonParser.Of[T1]
-  private val parser2 = new JsonParser.Of[T2]
-
-  def unapply(params: l.ExecuteCommandParams): Option[(T1, T2)] = {
-    val args = Option(params.getArguments()).toList.flatMap(_.asScala)
-    if (args.size != 2 || !isApplicableCommand(params)) None
-    else {
-      (args(0), args(1)) match {
-        case (parser1.Jsonized(t1), parser2.Jsonized(t2)) =>
-          Option((t1, t2))
-        case _ => None
-      }
-    }
-  }
-
-  def toLSP(argument1: T1, argument2: T2): l.Command =
-    new l.Command(
-      title,
-      id,
-      List(
-        argument1.toJson.asInstanceOf[AnyRef],
-        argument2.toJson.asInstanceOf[AnyRef]
-      ).asJava
-    )
-
-  def toExecuteCommandParams(
-      argument1: T1,
-      argument2: T2
-  ): l.ExecuteCommandParams = {
-    new l.ExecuteCommandParams(
-      id,
-      List[Object](
-        argument1.toJson,
-        argument2.toJson
-      ).asJava
-    )
-  }
-
-  def toCommandLink(
-      argument1: T1,
-      argument2: T2,
-      commandInHtmlFormat: CommandHTMLFormat
-  ): String = commandInHtmlFormat.createLink(
-    id,
-    List(argument1, argument2).map(_.toJson.toString())
-  )
-}
-
 case class ListParametrizedCommand[T: ClassTag](
     id: String,
     title: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1722,8 +1722,10 @@ class MetalsLanguageServer(
         Future {
           languageClient.metalsExecuteClientCommand(
             ClientCommands.GotoLocation.toExecuteCommandParams(
-              location,
-              true
+              ClientCommands.WindowLocation(
+                location.getUri(),
+                location.getRange()
+              )
             )
           )
         }.asJavaObject
@@ -1738,8 +1740,10 @@ class MetalsLanguageServer(
           } {
             languageClient.metalsExecuteClientCommand(
               ClientCommands.GotoLocation.toExecuteCommandParams(
-                location,
-                false
+                ClientCommands.WindowLocation(
+                  location.getUri(),
+                  location.getRange()
+                )
               )
             )
           }
@@ -1754,7 +1758,12 @@ class MetalsLanguageServer(
             new l.Range(pos, pos)
           )
           languageClient.metalsExecuteClientCommand(
-            ClientCommands.GotoLocation.toExecuteCommandParams(location, false)
+            ClientCommands.GotoLocation.toExecuteCommandParams(
+              ClientCommands.WindowLocation(
+                location.getUri(),
+                location.getRange()
+              )
+            )
           )
         }.asJavaObject
       case ServerCommands.StartDebugAdapter() =>
@@ -1885,8 +1894,12 @@ class MetalsLanguageServer(
           } yield {
             result.goToLocation.foreach { location =>
               languageClient.metalsExecuteClientCommand(
-                ClientCommands.GotoLocation
-                  .toExecuteCommandParams(location, false)
+                ClientCommands.GotoLocation.toExecuteCommandParams(
+                  ClientCommands.WindowLocation(
+                    location.getUri(),
+                    location.getRange()
+                  )
+                )
               )
             }
           }

--- a/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
@@ -122,8 +122,11 @@ class StacktraceAnalyzer(
       location: Location
   ): l.ExecuteCommandParams = {
     ClientCommands.GotoLocation.toExecuteCommandParams(
-      location,
-      true
+      ClientCommands.WindowLocation(
+        location.getUri(),
+        location.getRange(),
+        otherWindow = true
+      )
     )
   }
 
@@ -186,9 +189,12 @@ class StacktraceAnalyzer(
       format: CommandHTMLFormat
   ): String = {
     val pos = new l.Position(line, 0)
-    val location = new l.Location(uri, new l.Range(pos, pos))
-    ServerCommands.GotoPosition.toCommandLink(
-      location,
+    ClientCommands.GotoLocation.toCommandLink(
+      ClientCommands.WindowLocation(
+        uri,
+        new l.Range(pos, pos),
+        otherWindow = true
+      ),
       format
     )
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
@@ -274,7 +274,9 @@ class NewFileProvider(
   private def openFile(path: AbsolutePath, cursorRange: Range): Unit = {
     val location = new Location(path.toURI.toString(), cursorRange)
     client.metalsExecuteClientCommand(
-      ClientCommands.GotoLocation.toExecuteCommandParams(location, false)
+      ClientCommands.GotoLocation.toExecuteCommandParams(
+        ClientCommands.WindowLocation(location.getUri(), location.getRange())
+      )
     )
   }
 

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -255,8 +255,8 @@ final class TestingServer(
         case Some(pos) => pos
       }
       val gotoExecutedCommandPositions = client.clientCommands.asScala.collect {
-        case ClientCommands.GotoLocation(location, _) =>
-          (location.getRange.getStart, location.getUri)
+        case ClientCommands.GotoLocation(location) =>
+          (location.range.getStart, location.uri)
       }
       Assertions.assertEquals(
         gotoExecutedCommandPositions,


### PR DESCRIPTION
When reworking the links and adding support for Sublime I forgot to test out if the stacktrace opens files in another window and it turns out this got broken.

Because of that, I reworked the GotoLocation command to take in an additional parameter, which makes it a bit easier to handle and always send it tpo the client.

Needs https://github.com/scalameta/metals-vscode/pull/828