### PR TITLE
[Actions] Trigger Scala3-nightly mtags publishing automatically

### DIFF
--- a/.github/workflows/check_scala3_nightly.yml
+++ b/.github/workflows/check_scala3_nightly.yml
@@ -1,0 +1,18 @@
+name: "Check Scala nightly release"
+on:
+  schedule:
+    - cron: 0 5 * * *
+jobs:
+  test_and_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v13
+      - name: "Query maven-central"
+        run: |
+          TODAY_NIGHTLY=$(./coursier complete org.scala-lang:scala3-compiler_3: | grep $(date '+%Y%m%d'))
+          if [ ! -z $TODAY_NIGHTLY ]; then
+            gh workflow run mtags-auto-release.yml -f scala_version=$TODAY_NIGHTLY
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
According to [maven-central](https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/) nightly versions
are published from 4:00AM to 4:30AM.

This job is scheduled at 5:00AM, to check if there were a nightly
release today and trigger mtags-publishing job.