### PR TITLE
refactor: check lowercase test-user-interface

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -39,7 +39,7 @@ import org.eclipse.{lsp4j => l}
  * @param slowTaskProvider if the client implements `metals/slowTask`.
  * @param statusBarProvider if the client implements `metals/status`.
  * @param treeViewProvider if the client implements the Metals Tree View Protocol.
- * @param textExplorerProvider if the client implements the Text Explorer UI.
+ * @param testExplorerProvider if the client implements the Test Explorer UI.
  * @param openNewWindowProvider if the client can open a new window after new project creation.
  * @param copyWorksheetOutputProvider if the client can execute server CopyWorksheet command and
  *                                    copy results to the local buffer.

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -252,7 +252,7 @@ object UserConfiguration {
       UserConfigurationOption(
         "test-user-interface",
         "Code Lenses",
-        "Test explorer",
+        "test explorer",
         "Test UI used for tests and test suites",
         "Default way of handling tests and test suites."
       ),
@@ -463,9 +463,9 @@ object UserConfiguration {
     val defaultScalaVersion =
       getStringKey("fallback-scala-version").filter(_ != "automatic")
     val disableTestCodeLenses = {
-      val isTextExplorerEnabled = clientConfiguration.isTestExplorerProvider()
-      getStringKey("test-user-interface") match {
-        case Some("Test Explorer") if isTextExplorerEnabled =>
+      val isTestExplorerEnabled = clientConfiguration.isTestExplorerProvider()
+      getStringKey("test-user-interface").map(_.toLowerCase()) match {
+        case Some("test explorer") if isTestExplorerEnabled =>
           TestUserInterfaceKind.TestExplorer
         case _ =>
           TestUserInterfaceKind.CodeLenses

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -179,7 +179,7 @@ final class RunTestCodeLens(
   }
 
   /**
-   * Do not return test code lenses if user declared text explorer as a test interface.
+   * Do not return test code lenses if user declared test explorer as a test interface.
    */
   private def testClasses(
       target: BuildTargetIdentifier,


### PR DESCRIPTION
I've started to play around with this in nvim-metals and just hit
on this and realized in the docs we say Test explorer as an example
but then we check on an exact match of Test Explorer. This just
calls .toLowerCase on the value and then we check that.