### PR TITLE
Compare only uppercase MD5

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/Semanticdbs.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/Semanticdbs.scala
@@ -70,8 +70,9 @@ object Semanticdbs {
       case Some(sdoc) =>
         val text = FileIO.slurp(scalaPath, charset)
         val md5 = MD5.compute(text)
-        if (sdoc.md5 != md5) {
-          fingerprints.lookupText(scalaPath, sdoc.md5) match {
+        val sdocMd5 = sdoc.md5.toUpperCase()
+        if (sdocMd5 != md5) {
+          fingerprints.lookupText(scalaPath, sdocMd5) match {
             case Some(oldText) =>
               TextDocumentLookup.Stale(scalaPath, md5, sdoc.withText(oldText))
             case None =>


### PR DESCRIPTION
Previously, when semanticdb had md5 with lower case letters we would not find the snapshot text for semanticdb. Now, we convert it always to upper case.

Fixes https://github.com/scalameta/metals/issues/3539

PS: So the logging might be a bit excesive, but it did help to find an issue :man_dancing: 