### PR TITLE
[Actions] One more fix to check_scala3_nightly job

### DIFF
--- a/.github/workflows/check_scala3_nightly.yml
+++ b/.github/workflows/check_scala3_nightly.yml
@@ -1,5 +1,6 @@
 name: "Check Scala nightly release"
 on:
+  workflow_dispatch:
   schedule:
     - cron: 0 5 * * *
 jobs:


### PR DESCRIPTION
Having only `schedule` doesn't allow to trigger this job manually.