### PR TITLE
docs: add a small note about decode not working on extra file types.

### DIFF
--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -444,7 +444,7 @@ scripts.
 <thead>
   <tr>
     <td />
-    <td align="center">Sbt scripts</td>
+    <td align="center">sbt scripts</td>
     <td align="center">Worksheets</td>
     <td align="center">Ammonite scripts</td>
     <td align="center">Standalone Scala files</td>
@@ -570,10 +570,17 @@ scripts.
     <td align="center">✅</td>
     <td align="center">✅</td>
   </tr>
+  <tr>
+    <td>Decode file (cfr, semanticdb, tasty, javap)</td>
+    <td align="center"></td>
+    <td align="center"></td>
+    <td align="center"></td>
+    <td align="center"></td>
+  </tr>
 </tbody>
 </table>
 
-\* Diagnostics for Sbt script and standalone Scala files will only show parsing
+\* Diagnostics for sbt script and standalone Scala files will only show parsing
 errors, but not diagnostics coming from the compiler.
 
 ## Unsupported features

--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -247,7 +247,12 @@ final class FileDecoderProvider(
         decode(p.path)
       )
     else
-      Future.successful(DecoderResponse.failed(path.toURI, "Invalid extension"))
+      Future.successful(
+        DecoderResponse.failed(
+          path.toURI,
+          """Invalid extension. Metals can only decode ".java" or ".scala" files."""
+        )
+      )
   }
 
   private def decodeSemanticDb(


### PR DESCRIPTION
This also improves the message that a user sees if they accidentally try
to use one of these while in a worksheet or something. I hit on this
today and tried using cfr quickly while in a worksheet and all I saw as
an error that said:

```
Invalid extension
```