### PR TITLE
actions: mtags release adjustments

### DIFF
--- a/.github/workflows/mtags-auto-release.yml
+++ b/.github/workflows/mtags-auto-release.yml
@@ -9,6 +9,10 @@ on:
         description: "Metals Version"
         required: true
         default: "v0.11.1"
+      metals_ref:
+        description: "Tag/branch-name from which run release"
+        required: true
+        default: "v0.11.1_mtags_release"
 jobs:
   test_and_release:
     runs-on: ubuntu-latest
@@ -16,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.metals_version }}
+          ref: ${{ github.event.inputs.metals_ref }}
           token: ${{ secrets.GH_TOKEN }}
       - uses: olafurpg/setup-scala@v13
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,21 +16,23 @@ jobs:
       - name: Publish
         run: |
           COMMAND="ci-release"
+          UPDATE_DOCS=true
           if [[ $GITHUB_REF == "refs/tags"* ]] && [[ $GITHUB_REF_NAME == "mtags_v"* ]]; then
-            METALS_VERSION=$(echo $GITHUB_REF_NAME | cut -d "_" -f2)
+            METALS_VERSION=$(echo $GITHUB_REF_NAME | cut -d "_" -f2 | cut -c2-)
             SCALA_VERSION=$(echo $GITHUB_REF_NAME | cut -d "_" -f3)
-
             if [ ! -z $METALS_VERSION ] && [ ! -z $SCALA_VERSION ]; then
               export CI_RELEASE="++$SCALA_VERSION mtags/publishSigned"
-              COMMAND="'; set mtags/version :=\"$METALS_VERSION\"; $COMMAND'"
+              UPDATE_DOCS=false
+              COMMAND="; set ThisBuild/version :=\"$METALS_VERSION\"; $COMMAND"
             else
               echo 'Invalid tag name for mtags. Expected: mtags_v${existing-metals-release}_${scala-version}'
               exit 1
             fi
           fi
-
-          sbt $COMMAND 
-          sbt docs/docusaurusPublishGhpages
+          sbt "$COMMAND"
+          if [ "$UPDATE_DOCS" = true ]; then
+            sbt docs/docusaurusPublishGhpages
+          fi
         env:
           GIT_USER: scalameta@scalameta.org
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
Finally, there is a working [job](https://github.com/scalameta/metals/runs/4895558191?check_suite_focus=true) that released `3.1.2-RC1-bin-20220119-2849aed-NIGHTLY`.
Artifacts [were published](https://repo1.maven.org/maven2/org/scalameta/mtags_3.1.2-RC1-bin-20220119-2849aed-NIGHTLY/0.11.1/) and I checked that `v0.11.1` is able to work with them.

Changes:
- Added a `metals_ref` to `mtags-auto-release`.
  Github action takes job configuration from the checkoutted commit.
  That means if there were issues at release moment we can fix them and
  change the base commit for mtags release.

  I created `v0.11.1_mtags_release` that contains changes in `release.yaml`.

- Final adjustments to `release.yml`: fix version parsing, do not publish docs.