### PR TITLE
feature: [Scala 3] Add keyword completions

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -320,7 +320,14 @@ class CompletionProvider(
     }
     completions.foreach(visit)
     completion.contribute.foreach(visit)
-    buf ++= keywords(pos, editRange, latestParentTrees, completion, text)
+    buf ++= keywords(
+      pos,
+      editRange,
+      latestParentTrees,
+      completion,
+      text,
+      isAmmoniteScript
+    )
     val searchResults =
       if (kind == CompletionListKind.Scope) {
         workspaceSymbolListMembers(query, pos, visit)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
@@ -14,7 +14,8 @@ trait Keywords { this: MetalsGlobal =>
       editRange: l.Range,
       latestEnclosing: List[Tree],
       completion: CompletionPosition,
-      text: String
+      text: String,
+      isAmmoniteScript: Boolean
   ): List[Member] = {
 
     lazy val notInComment = checkIfNotInComment(pos, text)
@@ -42,6 +43,7 @@ trait Keywords { this: MetalsGlobal =>
         val isMethodBody = this.isMethodBody(latestEnclosing)
         val isTemplate = this.isTemplate(latestEnclosing)
         val isPackage = this.isPackage(latestEnclosing)
+        val isParam = this.isParam(latestEnclosing)
         Keyword.all.collect {
           case kw
               if kw.matchesPosition(
@@ -51,7 +53,10 @@ trait Keywords { this: MetalsGlobal =>
                 isDefinition = isDefinition,
                 isMethodBody = isMethodBody,
                 isTemplate = isTemplate,
-                isPackage = isPackage
+                isPackage = isPackage,
+                isParam = isParam,
+                isScala3 = false,
+                allowToplevel = isAmmoniteScript
               ) =>
             mkTextEditMember(kw, editRange)
         }
@@ -110,6 +115,13 @@ trait Keywords { this: MetalsGlobal =>
   private def isPackage(enclosing: List[Tree]): Boolean =
     enclosing match {
       case PackageDef(_, _) :: _ => true
+      case Nil => true
+      case _ => false
+    }
+
+  private def isParam(enclosing: List[Tree]): Boolean =
+    enclosing match {
+      case (_: DefDef) :: _ => true
       case _ => false
     }
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionProvider.scala
@@ -50,9 +50,8 @@ class CompletionProvider(
           .filterInteresting()
 
     val args = Completions.namedArgCompletions(pos, path)
-    val keywords = KeywordsCompletions.contribute(pos, path)
+    val keywords = KeywordsCompletions.contribute(path, completionPos)
     val all = completions ++ args ++ keywords
-
     val application = CompletionApplication.fromPath(path)
     val ordering = completionOrdering(application)
     val values = application.postProcess(all.sorted(ordering))

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionProvider.scala
@@ -4,6 +4,7 @@ import scala.collection.mutable
 
 import scala.meta.internal.mtags.MtagsEnrichments.*
 import scala.meta.internal.pc.IdentifierComparator
+import scala.meta.internal.pc.completions.KeywordsCompletions
 import scala.meta.pc.*
 
 import dotty.tools.dotc.ast.tpd.*
@@ -39,13 +40,18 @@ class CompletionProvider(
   def completions(): (List[CompletionValue], SymbolSearch.Result) =
     val (_, compilerCompletions) = Completion.completions(pos)
 
-    val (completions, result) =
-      compilerCompletions
-        .flatMap(CompletionValue.fromCompiler)
-        .filterInteresting()
+    val (completions, result) = path match
+      // should not show completions for toplevel
+      case Nil if pos.source.file.extension != "sc" =>
+        (List.empty, SymbolSearch.Result.COMPLETE)
+      case _ =>
+        compilerCompletions
+          .flatMap(CompletionValue.fromCompiler)
+          .filterInteresting()
 
     val args = Completions.namedArgCompletions(pos, path)
-    val all = completions ++ args
+    val keywords = KeywordsCompletions.contribute(pos, path)
+    val all = completions ++ args ++ keywords
 
     val application = CompletionApplication.fromPath(path)
     val ordering = completionOrdering(application)
@@ -112,6 +118,8 @@ class CompletionProvider(
         val id = head.kind match
           case CompletionValue.Kind.NamedArg =>
             sym.detailString + "="
+          case CompletionValue.Kind.Keyword =>
+            head.label
           case _ =>
             val name = SemanticdbSymbols.symbolName(sym)
             if sym.isClass || sym.is(Module) then
@@ -156,7 +164,8 @@ class CompletionProvider(
     defn.RootPackage,
     // NOTE(gabro) valueOf was added as a Predef member in 2.13. We filter it out since is a niche
     // use case and it would appear upon typing 'val'
-    defn.ValueOfClass.info.member(nme.valueOf).symbol
+    defn.ValueOfClass.info.member(nme.valueOf).symbol,
+    defn.ScalaPredefModule.requiredMethod(nme.valueOf)
   ).flatMap(_.alternatives.map(_.symbol)).toSet
 
   private def computeRelevancePenalty(
@@ -176,7 +185,7 @@ class CompletionProvider(
 
     // symbols defined in this file are more relevant
     if (pos.source != sym.source || sym.is(Package)) &&
-      completion.kind != CompletionValue.Kind.NamedArg
+      !completion.isCustom
     then relevance |= IsNotDefinedInFile
     // fields are more relevant than non fields
     if !hasGetter then relevance |= IsNotGetter
@@ -201,8 +210,8 @@ class CompletionProvider(
     completion.kind match
       case CompletionValue.Kind.Workspace =>
         relevance |= (IsWorkspaceSymbol + sym.name.show.length)
-      case CompletionValue.Kind.NamedArg =>
-        relevance |= IsNamedArg
+      case _ if completion.isCustom =>
+        relevance |= IsCustom
       case _ =>
     relevance
   end computeRelevancePenalty
@@ -275,8 +284,7 @@ class CompletionProvider(
         val s1 = o1.symbol
         val s2 = o2.symbol
         if s1.isLocal && s2.isLocal &&
-          o1.kind != CompletionValue.Kind.NamedArg &&
-          o2.kind != CompletionValue.Kind.NamedArg
+          !o1.isCustom && !o2.isCustom
         then
           if s1.srcPos.isAfter(s2.srcPos) then -1
           else 1
@@ -295,12 +303,16 @@ class CompletionProvider(
         val s1 = o1.symbol
         val s2 = o2.symbol
         val byLocalSymbol = compareLocalSymbols(o1, o2)
+        val bothHaveSymbols = o1.symbol != NoSymbol && o2.symbol != NoSymbol
         if byLocalSymbol != 0 then byLocalSymbol
         else
-          val byRelevance = Integer.compare(
-            computeRelevancePenalty(o1, application),
-            computeRelevancePenalty(o2, application)
-          )
+          val byRelevance =
+            if bothHaveSymbols then
+              Integer.compare(
+                computeRelevancePenalty(o1, application),
+                computeRelevancePenalty(o2, application)
+              )
+            else 0
           if byRelevance != 0 then byRelevance
           else
             val byFuzzy = Integer.compare(
@@ -313,7 +325,7 @@ class CompletionProvider(
                 s1.name.show,
                 s2.name.show
               )
-              if byIdentifier != 0 then byIdentifier
+              if byIdentifier != 0 || !bothHaveSymbols then byIdentifier
               else
                 val byOwner =
                   s1.owner.fullName.toString

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionValue.scala
@@ -2,25 +2,52 @@ package scala.meta.internal.pc
 
 import scala.meta.internal.pc.CompletionValue.Kind
 
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Flags.*
+import dotty.tools.dotc.core.Symbols.NoSymbol
 import dotty.tools.dotc.core.Symbols.Symbol
 import dotty.tools.dotc.interactive.Completion
+import org.eclipse.lsp4j.CompletionItemKind
 
 case class CompletionValue(
     label: String,
     symbol: Symbol,
-    kind: Kind
-)
+    kind: Kind,
+    isCustom: Boolean = false,
+    insertText: Option[String] = None
+):
+
+  def completionItemKind(using ctx: Context): CompletionItemKind =
+    if kind == CompletionValue.Kind.Keyword then CompletionItemKind.Keyword
+    else if symbol.is(Package) || symbol.is(Module) then
+      CompletionItemKind.Module // No CompletionItemKind.Package (https://github.com/Microsoft/language-server-protocol/issues/155)
+    else if symbol.isConstructor then CompletionItemKind.Constructor
+    else if symbol.isClass then CompletionItemKind.Class
+    else if symbol.is(Mutable) then CompletionItemKind.Variable
+    else if symbol.is(Method) then CompletionItemKind.Method
+    else CompletionItemKind.Field
+
+end CompletionValue
 
 object CompletionValue:
 
   enum Kind:
-    case NamedArg, Workspace, Compiler, Scope
+    case Keyword, NamedArg, Workspace, Compiler, Scope
 
   def fromCompiler(completion: Completion): List[CompletionValue] =
     completion.symbols.map(CompletionValue(completion.label, _, Kind.Compiler))
 
   def namedArg(label: String, sym: Symbol): CompletionValue =
-    CompletionValue(label, sym, Kind.NamedArg)
+    CompletionValue(label, sym, Kind.NamedArg, isCustom = true)
+
+  def keyword(label: String, insertText: String): CompletionValue =
+    CompletionValue(
+      label,
+      NoSymbol,
+      Kind.Keyword,
+      isCustom = true,
+      insertText = Some(insertText)
+    )
 
   def workspace(label: String, sym: Symbol): CompletionValue =
     CompletionValue(label, sym, Kind.Workspace)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
@@ -1,0 +1,159 @@
+package scala.meta.internal.pc.completions
+
+import scala.meta.internal.pc.CompletionValue
+import scala.meta.internal.pc.Keyword
+
+import dotty.tools.dotc.ast.tpd.Block
+import dotty.tools.dotc.ast.tpd.DefDef
+import dotty.tools.dotc.ast.tpd.Ident
+import dotty.tools.dotc.ast.tpd.PackageDef
+import dotty.tools.dotc.ast.tpd.Template
+import dotty.tools.dotc.ast.tpd.TermTree
+import dotty.tools.dotc.ast.tpd.Tree
+import dotty.tools.dotc.ast.tpd.TypeDef
+import dotty.tools.dotc.ast.tpd.ValDef
+import dotty.tools.dotc.ast.tpd.ValOrDefDef
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.util.SourcePosition
+import org.eclipse.{lsp4j as l}
+
+object KeywordsCompletions:
+
+  def contribute(
+      pos: SourcePosition,
+      path: List[Tree]
+  )(using ctx: Context): List[CompletionValue] =
+
+    lazy val notInComment = checkIfNotInComment(pos, path)
+    getIdentifierName(path, pos) match
+      case None =>
+        Keyword.all.collect {
+          case kw if kw.isPackage && path == Nil && notInComment =>
+            CompletionValue.keyword(kw.name, kw.insertText)
+        }
+      case Some(name) =>
+        val isExpression = this.isExpression(path)
+        val isBlock = this.isBlock(path)
+        val isDefinition = this.isDefinition(path, name, pos)
+        val isMethodBody = this.isMethodBody(path)
+        val isTemplate = this.isTemplate(path)
+        val isPackage = this.isPackage(path)
+        val isParam = this.isParam(path)
+        Keyword.all.collect {
+          case kw
+              if kw.matchesPosition(
+                name,
+                isExpression = isExpression,
+                isBlock = isBlock,
+                isDefinition = isDefinition,
+                isMethodBody = isMethodBody,
+                isTemplate = isTemplate,
+                isPackage = isPackage,
+                isParam = isParam,
+                isScala3 = true,
+                allowToplevel = true
+              ) && notInComment =>
+            CompletionValue.keyword(kw.name, kw.insertText)
+        }
+    end match
+  end contribute
+
+  private def checkIfNotInComment(
+      pos: SourcePosition,
+      path: List[Tree]
+  ): Boolean =
+    import scala.meta.*
+    val content = pos.source.content
+    val text = path.headOption
+      .map(t => content.slice(t.span.start, t.span.end))
+      .getOrElse(content)
+    val start = pos.start
+    val end = pos.end
+    val tokens = text.tokenize.toOption
+    val treeStart = path.headOption.map(_.span.start).getOrElse(0)
+    tokens
+      .flatMap(t =>
+        t.find {
+          case t: Token.Comment
+              if treeStart + t.pos.start < start && treeStart + t.pos.end >= end =>
+            true
+          case _ => false
+        }
+      )
+      .isEmpty
+  end checkIfNotInComment
+
+  private def getIdentifierName(
+      enclosing: List[Tree],
+      pos: SourcePosition
+  ): Option[String] =
+    enclosing match
+      case Ident(name) :: _ => Some(name.toString())
+      case (vd: ValDef) :: _ => Some(vd.name.toString())
+      case _ =>
+        getLeadingIdentifierText(pos)
+
+  private def getLeadingIdentifierText(pos: SourcePosition): Option[String] =
+    var i = pos.point - 1
+    val chars = pos.source.content
+    while i >= 0 && !chars(i).isWhitespace do i -= 1
+    if i < 0 then None
+    else Some(new String(chars, i + 1, pos.point - i - 1))
+
+  private def isPackage(enclosing: List[Tree]): Boolean =
+    enclosing match
+      case Nil => true
+      case _ => false
+
+  private def isParam(enclosing: List[Tree]): Boolean =
+    enclosing match
+      case (vd: ValDef) :: (dd: DefDef) :: _
+          if dd.paramss.exists(pc => pc.contains(vd) && pc.size == 1) =>
+        true
+      case _ => false
+
+  private def isTemplate(enclosing: List[Tree]): Boolean =
+    enclosing match
+      case Ident(_) :: (_: Template) :: _ => true
+      case Ident(_) :: (_: ValOrDefDef) :: _ => true
+      case (_: TypeDef) :: _ => true
+      case _ => false
+
+  private def isMethodBody(enclosing: List[Tree]): Boolean =
+    enclosing match
+      case Ident(_) :: (_: DefDef) :: _ => true
+      case _ => false
+
+  private def isDefinition(
+      enclosing: List[Tree],
+      name: String,
+      pos: SourcePosition
+  )(using ctx: Context): Boolean =
+    enclosing match
+      case (_: Ident) :: _ => false
+      case _ =>
+        // NOTE(olafur) in positions like "implicit obje@@" the parser discards the entire
+        // statement and `enclosing` is not helpful. In these situations we fallback to the
+        // diagnostics reported by the parser to see if it expected a definition here.
+        // This is admittedly not a great solution, but it's the best I can think of at this point.
+        val point = pos.withSpan(pos.span.withPoint(pos.point - name.length()))
+
+        val isExpectedStartOfDefinition =
+          ctx.reporter.allErrors.exists { info =>
+            info.pos.focus == point &&
+            info.message == "expected start of definition"
+          }
+        isExpectedStartOfDefinition
+
+  private def isBlock(enclosing: List[Tree]): Boolean =
+    enclosing match
+      case Ident(_) :: Block(_, _) :: _ => true
+      case _ => false
+
+  private def isExpression(enclosing: List[Tree]): Boolean =
+    enclosing match
+      case Ident(_) :: (_: Template) :: _ => true
+      case Ident(_) :: (_: ValOrDefDef) :: _ => true
+      case Ident(_) :: t :: _ if t.isTerm => true
+      case other => false
+end KeywordsCompletions

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -362,6 +362,28 @@ trait CommonMtagsEnrichments {
       content.setValue(doc)
       content
     }
+
+    def checkIfNotInComment(
+        treeStart: Int,
+        treeEnd: Int,
+        currentOffset: Int
+    ): Boolean = {
+      import scala.meta._
+      val text = doc.slice(treeStart, treeEnd)
+      val tokens = text.tokenize.toOption
+      tokens
+        .flatMap(t =>
+          t.find {
+            case t: Token.Comment
+                if treeStart + t.pos.start < currentOffset &&
+                  treeStart + t.pos.end >= currentOffset =>
+              true
+            case _ =>
+              false
+          }
+        )
+        .isEmpty
+    }
   }
 
   implicit class XtensionRelativePathMetals(file: RelativePath) {

--- a/mtags/src/main/scala/scala/meta/internal/pc/Keyword.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Keyword.scala
@@ -15,6 +15,10 @@ case class Keyword(
     isMethodBody: Boolean = false,
     // Does this keyword define a symbol? For example "def" or "class"
     isDefinition: Boolean = false,
+    // Is located in param definition
+    isParam: Boolean = false,
+    // Is this keyword only in Scala 3?
+    isScala3: Boolean = false,
     // Optional character to select this completion item, for example "."
     commitCharacter: Option[String] = None
 ) {
@@ -36,15 +40,21 @@ case class Keyword(
       isDefinition: Boolean,
       isMethodBody: Boolean,
       isTemplate: Boolean,
-      isPackage: Boolean
+      isPackage: Boolean,
+      isParam: Boolean,
+      isScala3: Boolean,
+      allowToplevel: Boolean
   ): Boolean = {
-    this.name.startsWith(name) && {
+    val isAllowedInThisScalaVersion = (this.isScala3 && isScala3) || !this.isScala3
+    this.name.startsWith(name) && isAllowedInThisScalaVersion && {
       (this.isExpression && isExpression) ||
       (this.isBlock && isBlock) ||
       (this.isDefinition && isDefinition) ||
       (this.isTemplate && isTemplate) ||
+      (this.isTemplate && allowToplevel && isPackage) ||
       (this.isPackage && isPackage) ||
-      (this.isMethodBody && isMethodBody)
+      (this.isMethodBody && isMethodBody) ||
+      (this.isParam && isParam)
     }
   }
 }
@@ -55,9 +65,14 @@ object Keyword {
     Keyword("def", isBlock = true, isTemplate = true, isDefinition = true),
     Keyword("val", isBlock = true, isTemplate = true, isDefinition = true),
     Keyword("lazy val", isBlock = true, isTemplate = true, isDefinition = true),
+    Keyword("inline", isBlock = true, isTemplate = true, isDefinition = true, isPackage = true, isScala3 = true),
+    Keyword("using", isParam = true, isScala3 = true),
     Keyword("var", isBlock = true, isTemplate = true, isDefinition = true),
+    Keyword("given", isBlock = true, isTemplate = true, isDefinition = true, isScala3 = true),
+    Keyword("extension", isBlock = true, isTemplate = true, isDefinition = true, isPackage = true, isScala3 = true),
     Keyword("type", isTemplate = true, isDefinition = true),
     Keyword("class", isTemplate = true, isPackage = true, isDefinition = true),
+    Keyword("enum", isTemplate = true, isPackage = true, isDefinition = true, isScala3 = true),
     Keyword("case class", isTemplate = true, isPackage = true, isDefinition = true),
     Keyword("trait", isTemplate = true, isPackage = true, isDefinition = true),
     Keyword("object", isTemplate = true, isPackage = true, isDefinition = true),
@@ -95,7 +110,8 @@ object Keyword {
     Keyword("with"),
     Keyword("catch"),
     Keyword("extends"),
-    Keyword("finally")
+    Keyword("finally"),
+    Keyword("then")
   )
 
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/MemberOrdering.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/MemberOrdering.scala
@@ -14,7 +14,7 @@ object MemberOrdering {
   val IsSynthetic: Int = 1 << 20
   val IsDeprecated: Int = 1 << 19
   val IsEvilMethod: Int = 1 << 18 // example: clone() and finalize()
-  val IsNamedArg: Int = 1 << 17
+  val IsCustom: Int = 1 << 17
 
   // OverrideDefMember
   val IsNotAbstract: Int = 1 << 30
@@ -35,7 +35,7 @@ object MemberOrdering {
       (IsDeprecated, "deprecated"),
       (IsEvilMethod, "evilMethod"),
       (IsNotAbstract, "notAbstract"),
-      (IsNamedArg, "namedArg")
+      (IsCustom, "custom")
     ).collect { case (i, name) if (value & i) > 0 => name }
       .mkString(", ")
   }

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -112,7 +112,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
 
   /**
    * Check the results of applying the first completion suggested at a cursor position
-   *     inicated by `@@`.
+   *     indicated by `@@`.
    *
    * @param name name of the test
    * @param original snippet to test with `@@` indicating the cursor position
@@ -164,7 +164,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
    *
    * @param name name of the test
    * @param original snippet to test with `@@` indicating the cursor position
-   * @param expected string with a lsit of obtained completions
+   * @param expected string with a list of obtained completions
    * @param compat additional compatibility map for different Scala versions
    */
   def checkSnippet(
@@ -206,7 +206,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
    * @param postAssert additional assertions to make on the results
    * @param topLines a number of completions to include, by default all
    * @param filterText filter returned completions according to text
-   * @param includeDetail include the copmpletion detail in the results, true by default
+   * @param includeDetail include the completion detail in the results, true by default
    * @param filename name of the file to run the test on, `A.scala` by default
    * @param filter similar to filterText, but uses a function
    * @param enablePackageWrap whether to wrap the code in a package, true by default

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -4,9 +4,6 @@ import tests.BaseCompletionSuite
 
 class CompletionKeywordSuite extends BaseCompletionSuite {
 
-  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
-    Some(IgnoreScala3)
-
   check(
     "super-template",
     """
@@ -39,7 +36,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |  // tr@@
       |}
       |""".stripMargin,
-    """|""".stripMargin,
+    "",
     includeCommitCharacter = true
   )
 
@@ -58,7 +55,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |  **/
       |}
       |""".stripMargin,
-    """|""".stripMargin,
+    "",
     includeCommitCharacter = true
   )
 
@@ -164,6 +161,11 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
            |override def equals(x$1: Object): Boolean
            |override def hashCode(): Int
            |override def finalize(): Unit
+           |""".stripMargin,
+      "3" ->
+        """|value: Int
+           |val
+           |var
            |""".stripMargin
     )
   )
@@ -185,6 +187,25 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
   )
 
   check(
+    "given-def",
+    """
+      |package foo
+      |
+      |object A {
+      |  def someMethod = {
+      |    gi@@
+      |  }
+      |}
+      |""".stripMargin,
+    """|given (commit: '')
+       |""".stripMargin,
+    includeCommitCharacter = true,
+    compat = Map(
+      "2" -> ""
+    )
+  )
+
+  check(
     "val-arg",
     """
       |package foo
@@ -196,7 +217,8 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|value: Int
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(1)
   )
 
   checkEditLine(
@@ -249,7 +271,10 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |""".stripMargin,
     """
       |override def toString(): String
-    """.stripMargin
+    """.stripMargin,
+    compat = Map(
+      "3" -> ""
+    )
   )
 
   check(
@@ -285,7 +310,9 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |class Foo {
       |}
       |""".stripMargin,
-    "", // you should not use the empty package
+    """|import (commit: '')
+       |""".stripMargin,
+    includeCommitCharacter = true,
     enablePackageWrap = false
   )
 
@@ -307,7 +334,10 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |
       |typ@@
     """.stripMargin,
-    ""
+    "",
+    compat = Map(
+      "3" -> "type"
+    )
   )
 
   check(
@@ -408,7 +438,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
   )
 
   check(
-    "topLevel".tag(IgnoreScala3),
+    "topLevel",
     "@@",
     """|abstract class
        |case class
@@ -423,6 +453,54 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
        |sealed class
        |sealed trait
        |trait
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3" -> """|def
+                |val
+                |lazy val
+                |inline
+                |var
+                |given
+                |extension
+                |type
+                |class
+                |enum
+                |case class
+                |trait
+                |object
+                |package
+                |import
+                |final
+                |private
+                |protected
+                |abstract class
+                |sealed trait
+                |sealed abstract class
+                |sealed class
+                |implicit
+                |""".stripMargin
+    )
   )
+
+  check(
+    "using",
+    """|object A{
+       |  def hello(u@@)
+       |}""".stripMargin,
+    """|using (commit: '')
+       |""".stripMargin,
+    includeCommitCharacter = true,
+    compat = Map(
+      "2" -> ""
+    )
+  )
+
+  check(
+    "not-using",
+    """|object A{
+       |  def hello(a: String, u@@)
+       |}""".stripMargin,
+    ""
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionParameterHintSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionParameterHintSuite.scala
@@ -16,6 +16,7 @@ class CompletionParameterHintSuite extends BaseCompletionSuite {
     PresentationCompilerConfigImpl(
       _parameterHintsCommand = Some("hello")
     )
+
   checkItems(
     "command",
     """
@@ -24,7 +25,7 @@ class CompletionParameterHintSuite extends BaseCompletionSuite {
       |}
     """.stripMargin,
     { case Seq(item) =>
-      assert(item.getCommand.getCommand == "hello")
+      item.getCommand.getCommand == "hello"
     }
   )
 
@@ -36,8 +37,8 @@ class CompletionParameterHintSuite extends BaseCompletionSuite {
       |}
     """.stripMargin,
     { case Seq(item1, item2) =>
-      assert(item1.getCommand == null)
-      assert(item2.getCommand.getCommand == "hello")
+      item1.getCommand == null &&
+        item2.getCommand.getCommand == "hello"
     }
   )
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1385,10 +1385,11 @@ class CompletionSuite extends BaseCompletionSuite {
     "select-ignores-next-line",
     s"""
        |object Main {
-       |  def hello =
+       |  def hello = {
        |    val name = Option("Bob")
        |    name.@@
        |    println(msg) 
+       |  }
        |}
        |""".stripMargin,
     _.nonEmpty


### PR DESCRIPTION
This also tweaks a couple of things with Scala 2:
- allow import without package (since we can have those)
- allow more keywords in ammonite files

We also add new keywords for Scala 3 except the `then` keyword which is complicated to add and would require some by hand parsing.