### PR TITLE
Pass -Xsource:3 to scalafix organize-imports action if present

### DIFF
--- a/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
@@ -206,6 +206,34 @@ class OrganizeImportsLspSuite
   )
 
   check(
+    "basic-source-3",
+    """
+      |package a
+      |import scala.concurrent.duration.*
+      |import scala.concurrent.{Future<<>> as ScalaFuture}
+      |import scala.concurrent.ExecutionContext.global
+      |
+      |object A {
+      |  val d = Duration(10, MICROSECONDS)
+      |  val k = ScalaFuture.successful(1)
+      |}
+      |""".stripMargin,
+    s"${SourceOrganizeImports.title}",
+    """
+      |package a
+      |import scala.concurrent.duration.*
+      |import scala.concurrent.{Future as ScalaFuture}
+      |
+      |object A {
+      |  val d = Duration(10, MICROSECONDS)
+      |  val k = ScalaFuture.successful(1)
+      |}
+      |""".stripMargin,
+    kind = List(sourceKind),
+    scalacOptions = scalacOption ++ List("-Xsource:3")
+  )
+
+  check(
     "on-unused",
     """|package a
        |


### PR DESCRIPTION
When using organize-imports on Scala 2 with `-Xsource:3` a crash would occur when using `as` import renaming:

```
2022.01.28 11:08:13 ERROR /..../ConfigReader.scala:8: error: } expected but identifier found
import pureconfig.{ConfigReader as PureConfigReader, ConfigSource}
```

This is because Scalafix tries to parse the file as Scala 2. Scalafix has support for `-Xsource:3` since https://github.com/scalacenter/scalafix/pull/1409 but it needs to be passed in the scalacOptions. With this fix `-Xsource:3` is passed to Scalafix if used, fixing the crash and letting Scalafix properly parse and fix the file.
