### PR TITLE
Don't focus diagnotics if compialtion returned with error

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -12,7 +12,6 @@ import scala.util.Success
 
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.Cancelable
-import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.ClientConfiguration
 import scala.meta.internal.metals.ConcurrentHashSet
 import scala.meta.internal.metals.Diagnostics
@@ -215,8 +214,7 @@ final class ForwardingMetalsBuildClient(
             hasReportedError.add(target)
             statusBar.addMessage(
               MetalsStatusParams(
-                message,
-                command = ClientCommands.FocusDiagnostics.id
+                message
               )
             )
           }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -513,9 +513,6 @@ class DebugProvider(
       languageClient.metalsStatus(
         Messages.DebugErrorsPresent(clientConfig.icons())
       )
-      languageClient.metalsExecuteClientCommand(
-        ClientCommands.FocusDiagnostics.toExecuteCommandParams()
-      )
     case t: ClassNotFoundException =>
       languageClient.showMessage(
         Messages.DebugClassNotFound.invalidClass(t.getMessage())


### PR DESCRIPTION
Previously, we would focus diagnotics every time a compilation finished with an error, which means we could steal focus from the user multiple times. Now, the only palce we focus diagnostics is when running/debugging and the debug session failed to run due to compilation errors.

This has surfaced due to fixing an issue in the VS Code client.