### PR TITLE
docs(ammonite): add note about ammonite support

### DIFF
--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -446,7 +446,7 @@ scripts.
     <td />
     <td align="center">sbt scripts</td>
     <td align="center">Worksheets</td>
-    <td align="center">Ammonite scripts</td>
+    <td align="center">Ammonite scripts*</td>
     <td align="center">Standalone Scala files</td>
   </tr>
 </thead>
@@ -580,11 +580,9 @@ scripts.
 </tbody>
 </table>
 
+\* Note that there are some specific Ammonite features that aren't supported
+like [multi-stage](https://ammonite.io/#Multi-stageScripts) scripts. Currently
+Ammonite support is also limited to Scala 2.
+
 \* Diagnostics for sbt script and standalone Scala files will only show parsing
 errors, but not diagnostics coming from the compiler.
-
-## Unsupported features
-
-Metals does not support the following features:
-
-- Refactoring: move class, extract/inline value, convert to block


### PR DESCRIPTION
This comes from the comment in #2595. I add a small note about our
Ammonite not supporting multi-stage scripts and also not currrently
supporting Scala 3.

I also noticed we had a small "Unsupported features" section which was
out of date, but also very minimal. So I don't really think it's useful
unless we have a more exhaustive list of what is not supported.