### PR TITLE
Fix goto definition for local synthetics

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -11,6 +11,7 @@ import scala.{meta => m}
 
 import scala.meta.inputs.Input
 import scala.meta.internal.metals.Buffers
+import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.ClientConfiguration
 import scala.meta.internal.metals.CommandHTMLFormat
 import scala.meta.internal.metals.HoverExtParams
@@ -328,8 +329,8 @@ final class SyntheticsDecorationProvider(
       range: s.Range,
       format: CommandHTMLFormat
   ): String = {
-    val location = new l.Location(uri, range.toLSP)
-    ServerCommands.GotoPosition.toCommandLink(location, format)
+    val location = ClientCommands.WindowLocation(uri, range.toLSP)
+    ClientCommands.GotoLocation.toCommandLink(location, format)
   }
 
   private def gotoSymbolUsingUri(

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -94,14 +94,14 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
         .toURI
         .toString()
       expectedParamsBoston = URLEncoder.encode(
-        s"""[{"uri":"$mainClassPath","range":{"start":{"line":9,"character":17},"end":{"line":9,"character":23}}}]"""
+        s"""[{"uri":"$mainClassPath","range":{"start":{"line":9,"character":17},"end":{"line":9,"character":23}},"otherWindow":false}]"""
       )
       _ <- server.assertHoverAtLine(
         "a/src/main/scala/Main.scala",
         "    hello()@@",
         s"""|**Synthetics**:
             |
-            |([andy](command:metals.goto?$expectedParamsAndy), [boston](command:metals.goto-position?$expectedParamsBoston))
+            |([andy](command:metals.goto?$expectedParamsAndy), [boston](command:metals.metals-goto-location?$expectedParamsBoston))
             |""".stripMargin
       )
       // Implicit conversions


### PR DESCRIPTION
Previously, we would GotoPosition, which is a server command and because of that got removed from the client. Now, we use GotoLocation instead, which serves the same purpose.