### PR TITLE
Migrate to the newest H2 version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -443,7 +443,7 @@ lazy val metals = project
       "org.jboss.xnio" % "xnio-nio" % "3.8.5.Final",
       // for persistent data like "dismissed notification"
       "org.flywaydb" % "flyway-core" % "8.4.3",
-      "com.h2database" % "h2" % "1.4.200",
+      "com.h2database" % "h2" % "2.0.206",
       // for BSP
       "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.4.0",
       "ch.epfl.scala" % "bsp4j" % V.bsp,

--- a/metals/src/main/resources/db/migration/V3__Jar_symbols.sql
+++ b/metals/src/main/resources/db/migration/V3__Jar_symbols.sql
@@ -1,6 +1,6 @@
 -- Indexed jars, the MD5 digest of path, modified time and size as key
 create table indexed_jar(
-  id int auto_increment,
+  id int auto_increment unique,
   md5 varchar primary key
 );
 -- Top Level Symbols per jar, allow for multiple jars with same symbols and paths


### PR DESCRIPTION
This version has removed support for all PageStore format, so a totally new file will get create. I also needed to add `unique` to id, which is used as a foreign key.