### PR TITLE
Update scribe to 3.6.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -200,7 +200,7 @@ lazy val V = new {
   val scalafix = "0.9.34"
   val scalafmt = "3.0.5"
   val scalameta = "4.4.33"
-  val scribe = "3.6.7"
+  val scribe = "3.6.10"
   val semanticdb = scalameta
   val qdox = "2.0.1"
 

--- a/tests/unit/src/test/scala/tests/BillLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BillLspSuite.scala
@@ -69,7 +69,7 @@ class BillLspSuite extends BaseLspSuite("bill") {
       _ <- server.executeCommand(ServerCommands.ConnectBuildServer)
       _ = {
         val logs = workspace
-          .resolve(Directories.log)
+          .resolve(Bill.logName)
           .readText
           .linesIterator
           .filter(_.startsWith("trace:"))
@@ -105,7 +105,7 @@ class BillLspSuite extends BaseLspSuite("bill") {
       _ <- server.executeCommand(ServerCommands.ConnectBuildServer)
       _ = {
         val logs = workspace
-          .resolve(Directories.log)
+          .resolve(Bill.logName)
           .readText
           .linesIterator
           .filter(_.startsWith("trace:"))

--- a/tests/unit/src/test/scala/tests/BspBuildChangedSuite.scala
+++ b/tests/unit/src/test/scala/tests/BspBuildChangedSuite.scala
@@ -2,7 +2,6 @@ package tests
 
 import scala.concurrent.Promise
 
-import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.MetalsEnrichments._
 
 import bill.Bill
@@ -43,7 +42,7 @@ class BspBuildChangedSuite extends BaseLspSuite("bsp-build-changed") {
       _ <- server.server.buildServerPromise.future
       _ = {
         val logs = workspace
-          .resolve(Directories.log)
+          .resolve(Bill.logName)
           .readText
           .linesIterator
           .filter(_.startsWith("trace:"))


### PR DESCRIPTION
I have a suspiction that we might be setting the logger twice and redirecting output, which might be failing on Windows.