### PR TITLE
Do not insert inferred type on variable bound to another

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
@@ -48,7 +48,6 @@ class InsertInferredType(trees: Trees, compilers: Compilers)
         pattern.parent
           .collect {
             case Pat.Typed(_, _) => None
-            case Pat.Bind(lhs, _) if lhs != pattern => Some(insertTypeToPattern)
             case _: Pat.Bind => None
             case vl: Defn.Val if vl.decltpe.isEmpty => Some(insertType)
             case vr: Defn.Var if vr.decltpe.isEmpty => Some(insertType)

--- a/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
@@ -180,6 +180,15 @@ class InsertInferredTypeLspSuite
   )
 
   checkNoAction(
+    "match-bind-true",
+    """|object A{
+       |  (1, 2) match {
+       |    case num @ <<first>> => "Two!"
+       |  }
+       |}""".stripMargin
+  )
+
+  checkNoAction(
     "existing-type",
     """|package a
        |


### PR DESCRIPTION
Previously, we would special case `case a @ b =>` to allow inserting type on b. This however was causing flakines in a tests (and possibly in real usage), it wasn't working properly and this edge case is unlikely (we would have a double pattern var). Now, we disable inferring type when parent of pattern variable is pattern bind.