### PR TITLE
Update Algolia keys

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -129,7 +129,8 @@ module.exports = {
       }
     },
     "algolia": {
-      "apiKey": "c865f6d974a3072a35d4b53d48ac2307",
+      "appId": "DZKJ3Z5JFX",
+      "apiKey": "e8f55852e303f6374dfa716be910cf08",
       "indexName": "metals"
     },
     "gtag": {


### PR DESCRIPTION
@olafurpg  Is the apiKey and appId the same for all indexes? Or should it be different for Metals?