### PR TITLE
feat: add range to symbol definition

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/GlobalSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/GlobalSymbolIndex.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.mtags
 
 import scala.meta.Dialect
 import scala.meta.internal.mtags
+import scala.meta.internal.semanticdb
 import scala.meta.io.AbsolutePath
 
 /**
@@ -103,5 +104,6 @@ case class SymbolDefinition(
     querySymbol: Symbol,
     definitionSymbol: Symbol,
     path: AbsolutePath,
-    dialect: Dialect
+    dialect: Dialect,
+    range: Option[semanticdb.Range]
 )


### PR DESCRIPTION
Adding range to symbol definition will allow tests provider to not load semanticDB per each test suite. Instead, the position can be obtained from the aforementioned symbol definition.

credits: @tgodzik 