### PR TITLE
Ignore UncheckedIOException coming from broken source jars

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -2773,11 +2773,11 @@ class MetalsLanguageServer(
         case e @ (_: ParseException | _: TokenizeException) =>
           scribe.error(e.toString)
         case e: IndexingExceptions.InvalidJarException =>
-          scribe.warn(s"invalid jar: ${e.path}")
+          scribe.warn(s"invalid jar: ${e.path}", e.underlying)
         case e: IndexingExceptions.PathIndexingException =>
-          scribe.error(s"issues while parsing: ${e.path}", e)
+          scribe.error(s"issues while parsing: ${e.path}", e.underlying)
         case e: IndexingExceptions.InvalidSymbolException =>
-          scribe.error(s"searching for `${e.symbol}` failed", e)
+          scribe.error(s"searching for `${e.symbol}` failed", e.underlying)
         case _: NoSuchFileException =>
         // only comes for badly configured jar with `/Users` path added.
         case NonFatal(e) =>


### PR DESCRIPTION
Since we only list files in jars there should not be any possibility for it to break and these are not sueful to the user.

This only happens in jars that have `/home` directory in the jar.

Fixes https://github.com/scalameta/metals/issues/3594