### PR TITLE
chore(fmt): bump scalafmt to 3.4.0

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.0.5"
+version = "3.4.0"
 runner.dialect = scala212
 project.git = true
 align.preset = none

--- a/build.sbt
+++ b/build.sbt
@@ -30,11 +30,8 @@ def crossSetting[A](
 // -Xlint is unusable because of
 // https://github.com/scala/bug/issues/10448
 val scala212CompilerOptions = List(
-  "-Ywarn-unused:imports",
-  "-Ywarn-unused:privates",
-  "-Ywarn-unused:locals",
-  "-Ywarn-unused:patvars",
-  "-Ywarn-unused:implicits"
+  "-Ywarn-unused:imports", "-Ywarn-unused:privates", "-Ywarn-unused:locals",
+  "-Ywarn-unused:patvars", "-Ywarn-unused:implicits"
 )
 
 logo := Welcome.logo
@@ -198,7 +195,7 @@ lazy val V = new {
   val sbtBloop = bloop
   val sbtJdiTools = "1.1.1"
   val scalafix = "0.9.34"
-  val scalafmt = "3.0.5"
+  val scalafmt = "3.4.0"
   val scalameta = "4.4.33"
   val scribe = "3.6.10"
   val semanticdb = scalameta

--- a/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
@@ -50,7 +50,7 @@ class NewProjectProvider(
         ) {
           // Matches:
           // - [jimschubert/finatra.g8](https://github.com/jimschubert/finatra.g8)
-          //(A simple Finatra 2.5 template with sbt-revolver and sbt-native-packager)
+          // (A simple Finatra 2.5 template with sbt-revolver and sbt-native-packager)
           val all = for {
             result <- Try(requests.get(templatesUrl)).toOption.toIterable
             _ = if (result.statusCode != 200)

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -553,11 +553,9 @@ object FormattingProvider {
 
   }
 
-  def newScalafmt(respectVersion: Boolean = true): Scalafmt =
+  def newScalafmt(): Scalafmt =
     Scalafmt
       .create(this.getClass.getClassLoader)
       .withReporter(EmptyScalafmtReporter)
-      .withDefaultVersion(BuildInfo.scalafmtVersion)
-      .withRespectVersion(respectVersion)
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
@@ -135,10 +135,8 @@ class JavaInteractiveSemanticdb(
   private def addExportsFlags: List[String] = {
     if (jdkVersion.major >= 17) {
       val compilerPackages = List(
-        "com.sun.tools.javac.api",
-        "com.sun.tools.javac.code",
-        "com.sun.tools.javac.model",
-        "com.sun.tools.javac.tree",
+        "com.sun.tools.javac.api", "com.sun.tools.javac.code",
+        "com.sun.tools.javac.model", "com.sun.tools.javac.tree",
         "com.sun.tools.javac.util"
       )
       compilerPackages.flatMap(pkg =>

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -165,9 +165,7 @@ object UserConfiguration {
             |""".stripMargin
       ),
       UserConfigurationOption(
-        "bloop-sbt-already-installed",
-        "false",
-        "false",
+        "bloop-sbt-already-installed", "false", "false",
         "Don't generate Bloop plugin file for sbt",
         "If true, Metals will not generate `metals.sbt` files under the assumption that sbt-bloop is already manually installed in the sbt build. Build import will fail with a 'not valid command bloopInstall' error in case Bloop is not manually installed in the build when using this option."
       ),
@@ -250,9 +248,7 @@ object UserConfiguration {
         """.stripMargin
       ),
       UserConfigurationOption(
-        "test-user-interface",
-        "Code Lenses",
-        "test explorer",
+        "test-user-interface", "Code Lenses", "test explorer",
         "Test UI used for tests and test suites",
         "Default way of handling tests and test suites."
       ),

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
@@ -20,7 +20,7 @@ class BuildTargetClassesFinder(
     index: OnDemandSymbolIndex
 ) {
 
-  //In case of success returns non-empty list
+  // In case of success returns non-empty list
   def findMainClassAndItsBuildTarget(
       className: String,
       buildTarget: Option[String]
@@ -49,7 +49,7 @@ class BuildTargetClassesFinder(
     }
   }
 
-  //In case of success returns non-empty list
+  // In case of success returns non-empty list
   def findTestClassAndItsBuildTarget(
       className: String,
       buildTarget: Option[String]

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -445,8 +445,8 @@ class DebugProvider(
           Option(params.envFile)
         )
 
-      //should not really happen due to
-      //`findMainClassAndItsBuildTarget` succeeding with non-empty list
+      // should not really happen due to
+      // `findMainClassAndItsBuildTarget` succeeding with non-empty list
       case Nil => Future.failed(new ju.NoSuchElementException(params.mainClass))
     }
     result.failed.foreach(reportErrors)
@@ -481,8 +481,8 @@ class DebugProvider(
             singletonList(clazz).toJson
           )
         )
-      //should not really happen due to
-      //`findMainClassAndItsBuildTarget` succeeding with non-empty list
+      // should not really happen due to
+      // `findMainClassAndItsBuildTarget` succeeding with non-empty list
       case Nil => Future.failed(new ju.NoSuchElementException(params.testClass))
     }
     result.failed.foreach(reportErrors)

--- a/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
@@ -181,7 +181,7 @@ class NewFileProvider(
       ext: String
   ): Future[(AbsolutePath, Range)] = {
     val path = directory.getOrElse(workspace).resolve(name + ext)
-    //name can be actually be "foo/Name", where "foo" is a folder to create
+    // name can be actually be "foo/Name", where "foo" is a folder to create
     val className = Identifier.backtickWrap(
       directory.getOrElse(workspace).resolve(name).filename
     )

--- a/metals/src/main/scala/scala/meta/internal/worksheets/DecorationWorksheetPublisher.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/DecorationWorksheetPublisher.scala
@@ -31,7 +31,7 @@ class DecorationWorksheetPublisher(isInlineDecorationProvider: Boolean)
   }
 
   override def hover(path: AbsolutePath, position: Position): Option[Hover] =
-    //publish'ed Decorations handle hover, so nothing to return here
+    // publish'ed Decorations handle hover, so nothing to return here
     None
 
   private def render(

--- a/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
+++ b/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
@@ -58,9 +58,14 @@ object DownloadDependencies {
 
   def downloadScalafmt(): Unit = {
     scribe.info("Downloading scalafmt")
-    val scalafmt = FormattingProvider.newScalafmt(respectVersion = false)
+    val scalafmt = FormattingProvider.newScalafmt()
     val tmp = Files.createTempFile("scalafmt", "Foo.scala")
     val config = Files.createTempFile("scalafmt", ".scalafmt.conf")
+    Files.write(
+      config,
+      s"""|version = ${BuildInfo.scalafmtVersion}
+          |runner.dialect = scala3""".stripMargin.getBytes
+    )
     scalafmt.format(config, tmp, "object Foo { }")
     Files.deleteIfExists(tmp)
     Files.deleteIfExists(config)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImports.scala
@@ -11,9 +11,10 @@ trait AutoImports { this: MetalsGlobal =>
       pos: Position,
       autoImport: Option[AutoImportPosition] = None
   ): Context = {
-    try doLocateContext(
-      autoImport.fold(pos)(i => pos.focus.withPoint(i.offset))
-    )
+    try
+      doLocateContext(
+        autoImport.fold(pos)(i => pos.focus.withPoint(i.offset))
+      )
     catch {
       case _: FatalError =>
         (for {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SelectionRangeProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SelectionRangeProvider.scala
@@ -64,7 +64,7 @@ class SelectionRangeProvider(
     //   a <- >>region>>Some(1)<<region<<
     // } yield a
     //
-    //Apply(
+    // Apply(
     //  Select(Apply(Ident(Some), List(Literal(Constant(1)))), flatMap), <-- This range
     //  List(
     //    Function(
@@ -75,7 +75,7 @@ class SelectionRangeProvider(
     //      )
     //    )
     //  )
-    //)
+    // )
     if (child.getRange() == parent.getRange()) {
       parent
     } else {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -108,7 +108,7 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
                 val isAlignedTypes = toZip.lengthCompare(params.length) == 0 &&
                   toZip.zip(params).forall { case (a, b) =>
                     a == b.tpe ||
-                      b.tpe.typeSymbol.isTypeParameter
+                    b.tpe.typeSymbol.isTypeParameter
                   }
                 if (isAlignedTypes) {
                   ctor.info

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -398,14 +398,15 @@ trait Completions { this: MetalsGlobal =>
     // the implementation of completionPositionUnsafe does a lot of `typedTreeAt(pos).tpe`
     // which often causes null pointer exceptions, it's easier to catch the error here than
     // enforce discipline in the code.
-    try completionPositionUnsafe(
-      pos,
-      source,
-      text,
-      editRange,
-      completions,
-      latestEnclosing
-    )
+    try
+      completionPositionUnsafe(
+        pos,
+        source,
+        text,
+        editRange,
+        completions,
+        latestEnclosing
+      )
     catch {
       case NonFatal(e) =>
         logger.log(Level.SEVERE, e.getMessage(), e)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/FilenameCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/FilenameCompletions.scala
@@ -45,7 +45,7 @@ trait FilenameCompletions { this: MetalsGlobal =>
         val siblings = pkg.stats.count {
           case d: DefTree =>
             d.name.toString() == name &&
-              d.name.isTermName == isTermName
+            d.name.isTermName == isTermName
           case _ => false
         }
         if (

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ScaladocCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ScaladocCompletions.scala
@@ -202,8 +202,8 @@ trait ScaladocCompletions { this: MetalsGlobal =>
       val isEligible = associatedDef match {
         case Some(cur) =>
           t.pos.isDefined &&
-            cur.pos.isDefined &&
-            t.pos.point <= cur.pos.point
+          cur.pos.isDefined &&
+          t.pos.point <= cur.pos.point
         case None =>
           true
       }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionPos.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionPos.scala
@@ -79,8 +79,8 @@ object CompletionPos:
             head match
               case i: Ident => i.sourcePos.point
               case s: Select =>
-                if s.name.toTermName == nme.ERROR || pos.span.point < s.span.point then
-                  fallback
+                if s.name.toTermName == nme.ERROR || pos.span.point < s.span.point
+                then fallback
                 else s.span.point
               case _ => fallback
     loop(path)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SelectionRangeProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SelectionRangeProvider.scala
@@ -67,7 +67,7 @@ class SelectionRangeProvider(
     //   a <- >>region>>Some(1)<<region<<
     // } yield a
     //
-    //Apply(
+    // Apply(
     //  Select(Apply(Ident(Some), List(Literal(Constant(1)))), flatMap), <-- This range
     //  List(
     //    Function(
@@ -78,7 +78,7 @@ class SelectionRangeProvider(
     //      )
     //    )
     //  )
-    //)
+    // )
     if child.getRange() == parent.getRange() then parent
     else
       child.setParent(parent)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
@@ -52,11 +52,11 @@ object SemanticdbSymbols:
                   owner.info.decl(termName(value)).symbol :: Nil
                 case Descriptor.Parameter(value) =>
                   // TODO - need to check how to implement this properly
-                  //owner.paramSymss.flatten.filter(_.name.containsName(value))
+                  // owner.paramSymss.flatten.filter(_.name.containsName(value))
                   Nil
                 case Descriptor.TypeParameter(value) =>
                   // TODO - need to check how to implement this properly
-                  //owner.typeParams.filter(_.name.containsName(value))
+                  // owner.typeParams.filter(_.name.containsName(value))
                   Nil
                 case Descriptor.Method(value, _) =>
                   // TODO - need to check how to implement this properly

--- a/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
@@ -34,7 +34,7 @@ object JdkSources {
     def isJdkCandidate(path: AbsolutePath): Boolean = {
       def containsJre = path.resolve("jre").exists
       val name = path.filename.toString
-      name.contains("jdk") || containsJre //e.g. jdk-8, java-openjdk-11
+      name.contains("jdk") || containsJre // e.g. jdk-8, java-openjdk-11
     }
 
     for {

--- a/mtags/src/main/scala/scala/meta/internal/mtags/KeywordWrapper.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/KeywordWrapper.scala
@@ -20,11 +20,11 @@ trait KeywordWrapper {
     }
     val validChunks = chunks.zipWithIndex.forall { case (chunk, index) =>
       chunk.forall(c => c.isLetter || c.isDigit || c == '$') ||
-        (chunk.forall(validOperator) &&
-          // operators can only come last
-          index == chunks.length - 1 &&
-          // but cannot be preceded by only a _
-          !(chunks.lift(index - 1).contains("") && index - 1 == 0))
+      (chunk.forall(validOperator) &&
+        // operators can only come last
+        index == chunks.length - 1 &&
+        // but cannot be preceded by only a _
+        !(chunks.lift(index - 1).contains("") && index - 1 == 0))
     }
 
     val firstLetterValid =

--- a/tests/cross/src/test/scala/tests/pc/CompletionParameterHintSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionParameterHintSuite.scala
@@ -38,7 +38,7 @@ class CompletionParameterHintSuite extends BaseCompletionSuite {
     """.stripMargin,
     { case Seq(item1, item2) =>
       item1.getCommand == null &&
-        item2.getCommand.getCommand == "hello"
+      item2.getCommand.getCommand == "hello"
     }
   )
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1397,7 +1397,7 @@ final class TestingServer(
         else Some(Symbols.Multi(symbols.sorted))
       } else {
         if (symbols.isEmpty) None // OK, expected
-        else if (last == symbols) None //OK, expected
+        else if (last == symbols) None // OK, expected
         else Some(s"unexpected: ${Symbols.Multi(symbols.sorted)}")
       }
       occurrences ++= occurrence.map { symbol =>

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -18,11 +18,7 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
    */
   val expectedLibraries: SortedSet[String] = {
     lazy val jdk8Libraries = SortedSet(
-      "charsets",
-      "jce",
-      "jsse",
-      "resources",
-      "rt"
+      "charsets", "jce", "jsse", "resources", "rt"
     )
 
     val otherLibraries = SortedSet(

--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -45,7 +45,9 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
           |        "fullyQualifiedName": "NoPackage",
           |        "className": "NoPackage",
           |        "location": {
-          |          "uri": "${classUriFor("app/src/main/scala/NoPackage.scala")}",
+          |          "uri": "${classUriFor(
+        "app/src/main/scala/NoPackage.scala"
+      )}",
           |          "range": {
           |            "start": {
           |              "line": 0,
@@ -119,7 +121,9 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
           |        "fullyQualifiedName": "NoPackage",
           |        "className": "NoPackage",
           |        "location": {
-          |          "uri": "${classUriFor("app/src/main/scala/NoPackage.scala")}",
+          |          "uri": "${classUriFor(
+        "app/src/main/scala/NoPackage.scala"
+      )}",
           |          "range": {
           |            "start": {
           |              "line": 0,


### PR DESCRIPTION
I mainly wanted to bump the scalafmt version that by default gets included in a new project if you don't have a .scalafmt file, since the 3.0.5 version has some issues with significant whitespace that I keep hitting on, so I always update it anyways.

Just to align them, I also then bumped the version that we are using for our project as well. There is only one place I really don't like the new formatting, but it does align with other formatting in the same file. I'll comment there.