### PR TITLE
fix: handle the various enum hovers with more detail.

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -98,6 +98,7 @@ object HoverProvider:
                     expressionType
                   ) && !symbol.isType && !symbol.flags.isAllOf(EnumCase)
                 )
+
               val content = HoverMarkup(
                 expressionType,
                 hoverString,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SymbolPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SymbolPrinter.scala
@@ -64,11 +64,13 @@ class SymbolPrinter(using ctx: Context) extends RefinedPrinter(ctx):
     sym match
       case p if p.is(Flags.Package) =>
         s"package ${p.fullNameBackticked}"
-      case c if c.is(Flags.EnumVal) =>
+      // simple enum cases -> case A
+      // enum case classes -> case A(a: B)
+      case c if c.isAllOf(Flags.EnumCase) =>
         s"case $name: $shortTypeString"
       // enum
       case e if e.is(Flags.Enum) || sym.companionClass.is(Flags.Enum) =>
-        s"enum $name: $ownerTypeString"
+        s"enum $name: $shortTypeString"
       /* Type cannot be shown on the right since it is already a type
        * let's instead use that space to show the full path.
        */

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -63,7 +63,7 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |   case Red, Green, Blue
        |
        |""".stripMargin,
-    """|enum Color: enums2.SimpleEnum
+    """|enum Color: Color
        |""".stripMargin.hover
   )
 
@@ -76,7 +76,7 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |  val color = <<Col@@or>>.Red
        |
        |""".stripMargin,
-    """|enum Color: enums3.SimpleEnum
+    """|enum Color: Color
        |""".stripMargin.hover
   )
 
@@ -92,6 +92,17 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |
        |""".stripMargin,
     """|case Green: Color
+       |""".stripMargin.hover
+  )
+
+  check(
+    "enum-class",
+    """|
+       |object SimpleEnum:
+       |  enum Foo:
+       |    case <<Ba@@r(a: Int)>> extends Foo
+       |""".stripMargin,
+    """|case Bar: Bar
        |""".stripMargin.hover
   )
 

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -331,7 +331,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |```
        |""".stripMargin,
     compat = Map(
-      "3" -> "enum FileVisitResult: java.nio.file".hover
+      "3" -> "enum FileVisitResult: FileVisitResult".hover
     )
   )
 


### PR DESCRIPTION
This pr makes a couple small changes to the way the enum hover works for
Scala 3:

1. In the past when you'd hover on an actual enum we were returning the
   owner's full type string meaning that instead of showing the enum
   type, it'd show the containing class type. The first change changes
   this so it returns a shortened name of the actual enum.
2. The second change is handling enum case class instead of just vals.
   Previously they were displayed differently returning the same thing
   that they actual enum class was returning. Now this is aligned with
   the other cases and `case A(a: B)` will return the expected `case A:
   A` hover just like `case A, B, C` would.