### PR TITLE
Index non-scala target dependency sources

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -29,6 +29,7 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.control.NonFatal
 
+import scala.meta.dialects._
 import scala.meta.internal.bsp.BspConfigGenerationStatus._
 import scala.meta.internal.bsp.BspConfigGenerator
 import scala.meta.internal.bsp.BspConnector
@@ -2568,7 +2569,6 @@ class MetalsLanguageServer(
       _ = jdkSources.foreach(source =>
         buildTargets.addDependencySource(source, item.getTarget)
       )
-      scalaTarget <- buildTargets.scalaTarget(item.getTarget)
       sourceUri <- Option(item.getSources).toList.flatMap(_.asScala)
       path = sourceUri.toAbsolutePath
       _ = buildTargets.addDependencySource(path, item.getTarget)
@@ -2580,11 +2580,15 @@ class MetalsLanguageServer(
           usedJars += path
           addSourceJarSymbols(path)
         } else if (path.isDirectory) {
-          val dialect =
-            ScalaVersions.dialectForScalaVersion(
-              scalaTarget.scalaVersion,
-              includeSource3 = true
+          val dialect = buildTargets
+            .scalaTarget(item.getTarget)
+            .map(scalaTarget =>
+              ScalaVersions.dialectForScalaVersion(
+                scalaTarget.scalaVersion,
+                includeSource3 = true
+              )
             )
+            .getOrElse(Scala213)
           definitionIndex.addSourceDirectory(path, dialect)
         } else {
           scribe.warn(s"unexpected dependency: $path")


### PR DESCRIPTION
Java only targets don't get their dependency source jars indexed.  For comprehension didn't get past `scalaTarget <- buildTargets.scalaTarget(item.getTarget)`

I've assumed a 2.13 dialect for java-only targets - is that correct?