### PR TITLE
Fix showing virtual docs in jars with paths that need escaping

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -147,7 +147,7 @@ final class FileDecoderProvider(
     Try(URI.create(uriAsStr)) match {
       case Success(uri) =>
         uri.getScheme() match {
-          case "jar" => Future { decodeJar(uri) }
+          case "jar" => Future { decodeJar(uriAsStr) }
           case "file" => decodeMetalsFile(uri)
           case "metalsDecode" =>
             decodedFileContents(uri.getSchemeSpecificPart())
@@ -166,7 +166,13 @@ final class FileDecoderProvider(
     }
   }
 
-  private def decodeJar(uri: URI): DecoderResponse = {
+  private def decodeJar(uriAsStr: String): DecoderResponse = {
+
+    /**
+     *  URI.create will decode the string, which means ZipFileSystemProvider will not work
+     *  Related stack question: https://stackoverflow.com/questions/9873845/java-7-zip-file-system-provider-doesnt-seem-to-accept-spaces-in-uri
+     */
+    val uri = new URI("jar", uriAsStr.stripPrefix("jar:"), null)
     Try {
       val path = uri.toAbsolutePath
       FileIO.slurp(path, StandardCharsets.UTF_8)

--- a/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
@@ -26,6 +26,37 @@ class FileDecoderProviderLspSuite extends BaseLspSuite("fileDecoderProvider") {
     Right(FileDecoderProviderLspSuite.tastySingle)
   )
 
+  val userHome: String = System.getProperty("user.home")
+  check(
+    "decode-jar",
+    s"""
+       |/metals.json
+       |{
+       |  "a": {
+       |    "scalaVersion": "${scala.meta.internal.metals.BuildInfo.scala212}",
+       |    "libraryDependencies": [
+       |      "ch.epfl.scala:com-microsoft-java-debug-core:0.21.0+1-7f1080f1"
+       |    ]
+       |  }
+       |}
+       |/a/src/main/scala/a/Main.scala
+       |package a
+       |import com.microsoft.java.debug.core.protocol.Events._
+       |
+       |object Main {
+       |  val a : ExitedEvent = null
+       |  println(a)
+       |}
+       |""".stripMargin,
+    "a/src/main/scala/a/Main.scala",
+    None,
+    "file-decode",
+    Right(FileDecoderProviderLspSuite.EventsJarFile),
+    customUri = Some(
+      s"jar:file://${userHome}/.cache/coursier/v1/https/repo1.maven.org/maven2/ch/epfl/scala/com-microsoft-java-debug-core/0.21.0%2B1-7f1080f1/com-microsoft-java-debug-core-0.21.0%2B1-7f1080f1-sources.jar!/com/microsoft/java/debug/core/protocol/Events.java"
+    )
+  )
+
   check(
     "tasty-multiple",
     s"""|/metals.json
@@ -314,7 +345,8 @@ class FileDecoderProviderLspSuite extends BaseLspSuite("fileDecoderProvider") {
       picked: Option[String],
       extension: String,
       expected: Either[String, String],
-      transformResult: String => String = identity
+      transformResult: String => String = identity,
+      customUri: Option[String] = None
   ): Unit = {
     test(testName) {
       picked.foreach { pickedItem =>
@@ -326,7 +358,9 @@ class FileDecoderProviderLspSuite extends BaseLspSuite("fileDecoderProvider") {
         _ <- initialize(input)
         _ <- server.didOpen(filePath)
         result <- server.executeDecodeFileCommand(
-          s"metalsDecode:file://$workspace/$filePath.$extension"
+          customUri.getOrElse(
+            s"metalsDecode:file://$workspace/$filePath.$extension"
+          )
         )
       } yield {
         assertEquals(
@@ -882,4 +916,254 @@ object FileDecoderProviderLspSuite {
         |[3:6..3:9) <= foo/bar/example/Bar#foo().
         |[3:13..3:17) => scala/Unit#
         |""".stripMargin
+
+  val EventsJarFile: String =
+    """|/*******************************************************************************
+       |* Copyright (c) 2017 Microsoft Corporation and others.
+       |* All rights reserved. This program and the accompanying materials
+       |* are made available under the terms of the Eclipse Public License v1.0
+       |* which accompanies this distribution, and is available at
+       |* http://www.eclipse.org/legal/epl-v10.html
+       |*
+       |* Contributors:
+       |*     Microsoft Corporation - initial API and implementation
+       |*******************************************************************************/
+       |
+       |package com.microsoft.java.debug.core.protocol;
+       |
+       |import com.microsoft.java.debug.core.protocol.Types.Source;
+       |
+       |/**
+       | * The event types defined by VSCode Debug Protocol.
+       | */
+       |public class Events {
+       |    public static class DebugEvent {
+       |        public String type;
+       |
+       |        public DebugEvent(String type) {
+       |            this.type = type;
+       |        }
+       |    }
+       |
+       |    public static class InitializedEvent extends DebugEvent {
+       |        public InitializedEvent() {
+       |            super("initialized");
+       |        }
+       |    }
+       |
+       |    public static class StoppedEvent extends DebugEvent {
+       |        public long threadId;
+       |        public String reason;
+       |        public String description;
+       |        public String text;
+       |        public boolean allThreadsStopped;
+       |
+       |        /**
+       |         * Constructor.
+       |         */
+       |        public StoppedEvent(String reason, long threadId) {
+       |            super("stopped");
+       |            this.reason = reason;
+       |            this.threadId = threadId;
+       |            allThreadsStopped = false;
+       |        }
+       |
+       |        /**
+       |         * Constructor.
+       |         */
+       |        public StoppedEvent(String reason, long threadId, boolean allThreadsStopped) {
+       |            this(reason, threadId);
+       |            this.allThreadsStopped = allThreadsStopped;
+       |        }
+       |
+       |        /**
+       |         * Constructor.
+       |         */
+       |        public StoppedEvent(String reason, long threadId, boolean allThreadsStopped, String description, String text) {
+       |            this(reason, threadId, allThreadsStopped);
+       |            this.description = description;
+       |            this.text = text;
+       |        }
+       |    }
+       |
+       |    public static class ContinuedEvent extends DebugEvent {
+       |        public long threadId;
+       |        public boolean allThreadsContinued;
+       |
+       |        /**
+       |         * Constructor.
+       |         */
+       |        public ContinuedEvent(long threadId) {
+       |            super("continued");
+       |            this.threadId = threadId;
+       |        }
+       |
+       |        /**
+       |         * Constructor.
+       |         */
+       |        public ContinuedEvent(long threadId, boolean allThreadsContinued) {
+       |            this(threadId);
+       |            this.allThreadsContinued = allThreadsContinued;
+       |        }
+       |
+       |        /**
+       |         * Constructor.
+       |         */
+       |        public ContinuedEvent(boolean allThreadsContinued) {
+       |            super("continued");
+       |            this.allThreadsContinued = allThreadsContinued;
+       |        }
+       |    }
+       |
+       |    public static class ExitedEvent extends DebugEvent {
+       |        public int exitCode;
+       |
+       |        public ExitedEvent(int code) {
+       |            super("exited");
+       |            this.exitCode = code;
+       |        }
+       |    }
+       |
+       |    public static class TerminatedEvent extends DebugEvent {
+       |        public boolean restart;
+       |
+       |        public TerminatedEvent() {
+       |            super("terminated");
+       |        }
+       |
+       |        public TerminatedEvent(boolean restart) {
+       |            this();
+       |            this.restart = restart;
+       |        }
+       |    }
+       |
+       |    public static class ThreadEvent extends DebugEvent {
+       |        public String reason;
+       |        public long threadId;
+       |
+       |        /**
+       |         * Constructor.
+       |         */
+       |        public ThreadEvent(String reason, long threadId) {
+       |            super("thread");
+       |            this.reason = reason;
+       |            this.threadId = threadId;
+       |        }
+       |    }
+       |
+       |    public static class OutputEvent extends DebugEvent {
+       |        public enum Category {
+       |            console, stdout, stderr, telemetry
+       |        }
+       |
+       |        public Category category;
+       |        public String output;
+       |        public int variablesReference;
+       |        public Source source;
+       |        public int line;
+       |        public int column;
+       |        public Object data;
+       |
+       |        /**
+       |         * Constructor.
+       |         */
+       |        public OutputEvent(Category category, String output) {
+       |            super("output");
+       |            this.category = category;
+       |            this.output = output;
+       |        }
+       |
+       |        /**
+       |         * Constructor.
+       |         */
+       |        public OutputEvent(Category category, String output, Source source, int line) {
+       |            super("output");
+       |            this.category = category;
+       |            this.output = output;
+       |            this.source = source;
+       |            this.line = line;
+       |        }
+       |
+       |        public static OutputEvent createConsoleOutput(String output) {
+       |            return new OutputEvent(Category.console, output);
+       |        }
+       |
+       |        public static OutputEvent createStdoutOutput(String output) {
+       |            return new OutputEvent(Category.stdout, output);
+       |        }
+       |
+       |        /**
+       |         * Construct an stdout output event with source info.
+       |         */
+       |        public static OutputEvent createStdoutOutputWithSource(String output, Source source, int line) {
+       |            return new OutputEvent(Category.stdout, output, source, line);
+       |        }
+       |
+       |        public static OutputEvent createStderrOutput(String output) {
+       |            return new OutputEvent(Category.stderr, output);
+       |        }
+       |
+       |        /**
+       |         * Construct an stderr output event with source info.
+       |         */
+       |        public static OutputEvent createStderrOutputWithSource(String output, Source source, int line) {
+       |            return new OutputEvent(Category.stderr, output, source, line);
+       |        }
+       |
+       |        public static OutputEvent createTelemetryOutput(String output) {
+       |            return new OutputEvent(Category.telemetry, output);
+       |        }
+       |    }
+       |
+       |    public static class BreakpointEvent extends DebugEvent {
+       |        public String reason;
+       |        public Types.Breakpoint breakpoint;
+       |
+       |        /**
+       |         * Constructor.
+       |         */
+       |        public BreakpointEvent(String reason, Types.Breakpoint breakpoint) {
+       |            super("breakpoint");
+       |            this.reason = reason;
+       |            this.breakpoint = breakpoint;
+       |        }
+       |    }
+       |
+       |    public static class HotCodeReplaceEvent extends DebugEvent {
+       |        public enum ChangeType {
+       |            ERROR, WARNING, STARTING, END, BUILD_COMPLETE
+       |        }
+       |
+       |        public ChangeType changeType;
+       |        public String message;
+       |
+       |        /**
+       |         * Constructor.
+       |         */
+       |        public HotCodeReplaceEvent(ChangeType changeType, String message) {
+       |            super("hotcodereplace");
+       |            this.changeType = changeType;
+       |            this.message = message;
+       |        }
+       |    }
+       |
+       |    public static class UserNotificationEvent extends DebugEvent {
+       |        public enum NotificationType {
+       |            ERROR, WARNING, INFORMATION
+       |        }
+       |
+       |        public NotificationType notificationType;
+       |        public String message;
+       |
+       |        /**
+       |         * Constructor.
+       |         */
+       |        public UserNotificationEvent(NotificationType notifyType, String message) {
+       |            super("usernotification");
+       |            this.notificationType = notifyType;
+       |            this.message = message;
+       |        }
+       |    }
+       |}
+       |""".stripMargin
 }


### PR DESCRIPTION
There is an issue within ZipFileSytemProvider that will use the decoded path of the jar, which will not work in case of any special characters.

There is stack overflow question related to that:

https://stackoverflow.com/questions/9873845/java-7-zip-file-system-provider-doesnt-seem-to-accept-spaces-in-uri