### PR TITLE
fix: actions, discover new scala3 nigtly properly

### DIFF
--- a/.github/workflows/check_scala3_nightly.yml
+++ b/.github/workflows/check_scala3_nightly.yml
@@ -13,9 +13,12 @@ jobs:
           apps: ""
       - name: "Query maven-central"
         run: |
-          TODAY_NIGHTLY=$(cs complete org.scala-lang:scala3-compiler_3: | { grep $(date '+%Y%m%d') || true; })
-          if [ ! -z $TODAY_NIGHTLY ]; then
-            gh workflow run mtags-auto-release.yml -f scala_version=$TODAY_NIGHTLY
-          fi
+          cs complete org.scala-lang:scala3-compiler_3: | grep NIGHTLY | sort > all_nightly
+          LAST_NIGHTLY_MTAG=$(cs complete org.scalameta:mtags_3 | grep NIGHTLY | sort | tail -n 1 | cut -d "_" -f2)
+          LAST_NIGHTLY_POS=$(grep -n $LAST_NIGHTLY_MTAG  all_nightly | cut -d ":" -f1)
+          NEW_NIGHTLIES=$(tail -n +$LAST_NIGHTLY_POS all_nightly)
+          while IFS= read -r version; do
+            gh workflow run mtags-auto-release.yml -f scala_version=$version
+          done <<< "$NEW_NIGHTLIES"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
The previous logic was invalid as usually nightly release date in version
doesn't match the today.
For example: `3.1.3-RC1-bin-20220214-4105afb-NIGHTLY` was released at
`2022-02-15`.

Also there might be more thant nightly release per day.

Now, the release will be triggered for all nightly versions that comes
after the last nightly mtags release.