### PR TITLE
fix: release workflow - prevent parallel publishing to sonatype

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,17 @@ jobs:
       - uses: coursier/cache-action@v6.3
       - name: Publish
         run: |
+          LOCKED=true
+          while [ $LOCKED = true ]; do
+            IN_PROGRESS=$(gh api /repos/scalameta/metals/actions/workflows/release.yml/runs?status=in_progress -q ".total_count")
+            if [ $IN_PROGRESS == "0" ]; then
+              LOCKED=false
+            else
+              echo "Waiting the completion of other release job..."
+              sleep 20
+            fi
+          done
+
           COMMAND="ci-release"
           UPDATE_DOCS=true
           if [[ $GITHUB_REF == "refs/tags"* ]] && [[ $GITHUB_REF_NAME == "mtags_v"* ]]; then


### PR DESCRIPTION
Running this job in parallel ledads to issues with publishing process.
Only one job was completed from the bunch of tags that was created for scala3-nightly: [#1004-#1015 runs](https://github.com/scalameta/metals/actions/workflows/release.yml)

Unfortunately, there is no way to configure this using std settings.
There is `job.concurrent` setting but it automatically [cancels all pending jobs](https://github.com/github/feedback/discussions/5435) from the same group.