### PR TITLE
fix: support Scala 2.11 PC on jdk higher than 8

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/PresentationCompilerClassLoader.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/PresentationCompilerClassLoader.scala
@@ -14,7 +14,8 @@ class PresentationCompilerClassLoader(parent: ClassLoader)
     val isShared =
       name.startsWith("org.eclipse.lsp4j") ||
         name.startsWith("com.google.gson") ||
-        name.startsWith("scala.meta.pc")
+        name.startsWith("scala.meta.pc") ||
+        name.startsWith("javax")
     if (isShared) {
       parent.loadClass(name)
     } else {


### PR DESCRIPTION
There was an error during PC <init>: ` java.lang.NoClassDefFoundError: javax/tools/DiagnosticListener`.