### PR TITLE
Don't watch entire workspace on MacOS

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -194,6 +194,7 @@ class MetalsLanguageServer(
   )
   private val fileWatcher = register(
     new FileWatcher(
+      initialConfig,
       () => workspace,
       buildTargets,
       fileWatchFilter,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -39,6 +39,7 @@ import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
  *                                       be turned off. By default this is on, but Metals only
  *                                       supports a small subset of this, so it may be problematic
  *                                       for certain clients.
+ * @param macOsMaxWatchRoots The maximum number of root directories to watch on MacOS.
  */
 final case class MetalsServerConfig(
     globSyntax: GlobSyntaxConfig = GlobSyntaxConfig.default,
@@ -89,7 +90,12 @@ final case class MetalsServerConfig(
     ),
     bloopPort: Option[Int] = Option(System.getProperty("metals.bloop-port"))
       .filter(_.forall(Character.isDigit(_)))
-      .map(_.toInt)
+      .map(_.toInt),
+    macOsMaxWatchRoots: Int =
+      Option(System.getProperty("metals.macos-max-watch-roots"))
+        .filter(_.forall(Character.isDigit(_)))
+        .map(_.toInt)
+        .getOrElse(32)
 ) {
   override def toString: String =
     List[String](
@@ -105,7 +111,8 @@ final case class MetalsServerConfig(
       s"ask-to-reconnect=$askToReconnect",
       s"icons=$icons",
       s"statistics=$statistics",
-      s"bloop-port=${bloopPort.map(_.toString()).getOrElse("default")}"
+      s"bloop-port=${bloopPort.map(_.toString()).getOrElse("default")}",
+      s"macos-max-watch-roots=${macOsMaxWatchRoots}"
     ).mkString("MetalsServerConfig(\n  ", ",\n  ", "\n)")
 }
 object MetalsServerConfig {

--- a/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
@@ -12,6 +12,7 @@ import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.io.AbsolutePath
 
 import com.swoval.files.FileTreeDataViews.CacheObserver
@@ -35,6 +36,7 @@ import com.swoval.files.FileTreeRepository
  *    get the notifications directly from the OS instead of through the editor via LSP.
  */
 final class FileWatcher(
+    config: MetalsServerConfig,
     workspaceDeferred: () => AbsolutePath,
     buildTargets: BuildTargets,
     watchFilter: Path => Boolean,
@@ -54,6 +56,7 @@ final class FileWatcher(
     disposeAction.map(_.apply())
 
     val newDispose = startWatch(
+      config,
       workspaceDeferred().toNIO,
       collectFilesToWatch(buildTargets),
       onFileWatchEvent,
@@ -104,6 +107,7 @@ object FileWatcher {
    *
    * Contains platform specific file watch initialization logic
    *
+   * @param config metals server configuration
    * @param workspace current project workspace directory
    * @param filesToWatch source files and directories to watch
    * @param callback to execute on FileWatchEvent
@@ -112,27 +116,39 @@ object FileWatcher {
    * @return a dispose action resources used by file watching
    */
   private def startWatch(
+      config: MetalsServerConfig,
       workspace: Path,
       filesToWatch: FilesToWatch,
       callback: FileWatcherEvent => Unit,
       watchFilter: Path => Boolean
   ): () => Unit = {
     if (scala.util.Properties.isMac) {
-      // Due to a hard limit on the number of FSEvents streams that can be opened on macOS,
-      // only the root workspace directory is registered for a recursive watch.
+      // Due to a hard limit on the number of FSEvents streams that can be
+      // opened on macOS, only up to 32 longest common prefixes of the files to
+      // watch are registered for a recursive watch.
       // However, the events are then filtered to receive only relevant events
-      // and also to hash only revelevant files when watching for changes
+      // and also to hash only relevant files when watching for changes
 
       val trie = PathTrie(
         filesToWatch.sourceFiles ++ filesToWatch.sourceDirectories ++ filesToWatch.semanticdDirectories
       )
       val isWatched = trie.containsPrefixOf _
 
+      // Select up to `maxRoots` longest prefixes of all files in the trie for
+      // watching. Watching the root of the workspace may have bad performance
+      // implications if it contains many other projects that we don't need to
+      // watch (eg. in a monorepo)
+      val watchRoots =
+        trie.longestPrefixes(workspace.getRoot(), config.macOsMaxWatchRoots)
+
       val repo = initFileTreeRepository(
         path => watchFilter(path) && isWatched(path),
         callback
       )
-      repo.register(workspace, Int.MaxValue)
+      watchRoots.foreach { root =>
+        scribe.debug(s"Registering root for file watching: $root")
+        repo.register(root, Int.MaxValue)
+      }
       () => repo.close()
     } else {
       // Other OSes register all the files and directories individually

--- a/tests/unit/src/test/scala/tests/PathTrieSuite.scala
+++ b/tests/unit/src/test/scala/tests/PathTrieSuite.scala
@@ -1,0 +1,62 @@
+package tests
+
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import scala.meta.internal.metals.watcher.PathTrie
+
+class PathTrieSuite extends BaseSuite {
+  private val root = Paths.get(".").toAbsolutePath().getRoot()
+  private val `/foo` = root.resolve("foo")
+  private val `/bar` = root.resolve("bar")
+  private val `/foo/bar` = `/foo`.resolve("bar")
+  private val `/foo/bar/src1.scala` = `/foo/bar`.resolve("src1.scala")
+  private val `/foo/bar/src2.scala` = `/foo/bar`.resolve("src2.scala")
+  private val `/foo/fizz/buzz.scala` =
+    `/foo`.resolve("fizz").resolve("buzz.scala")
+
+  test("longestPrefixes stops at terminal nodes") {
+    assertEquals(
+      rootsOf(
+        Set(
+          `/foo/bar`,
+          `/foo/bar/src1.scala`,
+          `/foo/bar/src2.scala`
+        )
+      ),
+      Set(`/foo/bar`)
+    )
+  }
+
+  test("longestPrefixes respects max roots") {
+    assertEquals(
+      rootsOf(
+        Set(
+          `/foo/bar/src1.scala`,
+          `/foo/bar/src2.scala`,
+          `/foo/fizz/buzz.scala`
+        ),
+        maxRoots = 2
+      ),
+      Set(`/foo/bar`, `/foo/fizz/buzz.scala`)
+    )
+  }
+
+  test("no common prefix") {
+    assertEquals(
+      rootsOf(
+        Set(
+          `/foo/bar/src1.scala`,
+          `/foo/bar/src2.scala`,
+          `/bar`
+        ),
+        maxRoots = 1
+      ),
+      Set(root)
+    )
+  }
+
+  private def rootsOf(paths: Set[Path], maxRoots: Int = 32): Set[Path] = {
+    PathTrie(paths).longestPrefixes(root, maxRoots).toSet
+  }
+}


### PR DESCRIPTION
Previously, on MacOS, the root of the workspace would be registered for
file watching. With this patch, up to 32 of the longest prefixes will be
registered.

This change improves the performance in large monorepos, where the
workspace is set to the root of the monorepo, but usually few
subdirectories are imported in the IDE.