### PR TITLE
Go to definition of synthetic symbols.

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -42,7 +42,7 @@ class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
         DefinitionResultImpl(
           semanticdbSymbol(tree.symbol),
           ju.Collections.singletonList(
-            new Location(params.uri().toString(), tree.symbol.pos.toLSP)
+            new Location(params.uri().toString(), tree.symbol.pos.focus.toLSP)
           )
         )
       } else {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -26,8 +26,7 @@ class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
       if (
         tree.symbol == null ||
         tree.symbol == NoSymbol ||
-        tree.symbol.isErroneous ||
-        tree.symbol.isSynthetic
+        tree.symbol.isErroneous
       ) {
         DefinitionResultImpl.empty
       } else if (tree.symbol.hasPackageFlag) {

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -136,7 +136,6 @@ class PcDefinitionProvider(
 
       case (head @ Select(target, name)) :: _
           if head.symbol.is(Synthetic) && name == StdNames.nme.apply =>
-        println(head)
         val sym = target.symbol
         if sym.is(Synthetic) && sym.is(Module) then List(sym.companionClass)
         else List(target.symbol)

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -30,13 +30,25 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
     """|
        |object Main {
        |  for {
-       |    <<x>> <- List(1)
+       |    <<>>x <- List(1)
        |    y <- 1.to(x)
        |    z = y + x
        |    if y < @@x
        |  } yield y
        |}
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|object Main {
+           |  for {
+           |    <<x>> <- List(1)
+           |    y <- 1.to(x)
+           |    z = y + x
+           |    if y < x
+           |  } yield y
+           |}
+           |""".stripMargin
+    )
   )
 
   check(
@@ -225,7 +237,7 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
     "named-arg-local",
     """|
        |object Main {
-       |  <<def foo(arg: Int): Unit = ()>>
+       |  def <<>>foo(arg: Int): Unit = ()
        |
        |  foo(a@@rg = 42)
        |}
@@ -295,7 +307,15 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |object Main {
        |  val n = ma@@th.max(1, 2)
        |}
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|
+           |object Main {
+           |  val n = ma@@th.max(1, 2)
+           |}
+           |""".stripMargin
+    )
   )
 
   check(
@@ -304,14 +324,22 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |object Main {
        |  List(1).map(<<>>@@_ + 2)
        |}
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|
+           |object Main {
+           |  List(1).map(@@_ + 2)
+           |}
+           |""".stripMargin
+    )
   )
 
   check(
     "eta-2",
     """|
        |object Main {
-       |  List(1).foldLeft(0)(_ + <<>>@@_)
+       |  List(1).foldLeft(0)(_ + @@_)
        |}
        |""".stripMargin
   )
@@ -369,7 +397,16 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |  def hello(u: User): Unit = ()
        |  hello(Us@@er())
        |}
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|class Main {
+           |  case class User(name: String, age: Int)
+           |  def <<hello>>(u: User): Unit = ()
+           |  hello(User())
+           |}
+           |""".stripMargin
+    )
   )
 
   check(
@@ -380,6 +417,15 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |  def hello(u: User): Unit = ()
        |  hello(new Us@@er())
        |}
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|class Main {
+           |  class User(name: String, age: Int)
+           |  def hello(u: User): Unit = ()
+           |  hello(new User())
+           |}
+           |""".stripMargin
+    )
   )
 }

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -351,4 +351,26 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |}
        |""".stripMargin
   )
+
+  check(
+    "synthetic-definition-case-class",
+    """|
+       |class Main {
+       |  case class <<>>User(name: String, age: Int)
+       |  def hello(u: User): Unit = ()
+       |  hello(Us@@er())
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "synthetic-definition-class-constructor",
+    """|
+       |class Main {
+       |  <<class User(name: String, age: Int)>>
+       |  def hello(u: User): Unit = ()
+       |  hello(new Us@@er())
+       |}
+       |""".stripMargin
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -376,7 +376,7 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
     "synthetic-definition-class-constructor",
     """|
        |class Main {
-       |  <<class User(name: String, age: Int)>>
+       |  class <<>>User(name: String, age: Int)
        |  def hello(u: User): Unit = ()
        |  hello(new Us@@er())
        |}

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -307,15 +307,7 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |object Main {
        |  val n = ma@@th.max(1, 2)
        |}
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|
-           |object Main {
-           |  val n = ma@@th.max(1, 2)
-           |}
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -302,7 +302,16 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
     "eta",
     """|
        |object Main {
-       |  List(1).map(@@_ + 2)
+       |  List(1).map(<<>>@@_ + 2)
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "eta-2",
+    """|
+       |object Main {
+       |  List(1).foldLeft(0)(_ + <<>>@@_)
        |}
        |""".stripMargin
   )


### PR DESCRIPTION
Previously, Metals didn't go the definition of symbols that the
presentation compiler defines as synthetic. These symbols include
auto-generated case class `apply` methods and regular class
constructors. Now, we ignore the `isSynthetic` bit on the definition
symbol so that "Go to definition" works as expected for cases where it
didn't before.