### PR TITLE
Fix named arg completion when parameter contains $

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -84,7 +84,7 @@ class CompletionProvider(
       }
       val label = member match {
         case _: NamedArgMember =>
-          val escaped = if (isSnippet) ident.replace("$", "\\$") else ident
+          val escaped = if (isSnippet) ident.replace("$", "$$") else ident
           s"$escaped = "
         case o: OverrideDefMember =>
           o.label

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -198,7 +198,8 @@ class CompletionProvider(
           case _: NamedArgMember => item.getLabel
           case _ => ident
         }
-        item.setTextEdit(textEdit(editText))
+        val escaped = if (isSnippet) editText.replace("$", "\\$") else editText
+        item.setTextEdit(textEdit(escaped))
       }
 
       member match {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -84,7 +84,8 @@ class CompletionProvider(
       }
       val label = member match {
         case _: NamedArgMember =>
-          s"$ident = "
+          val escaped = if (isSnippet) ident.replace("$", "\\$") else ident
+          s"$escaped = "
         case o: OverrideDefMember =>
           o.label
         case o: TextEditMember =>
@@ -198,8 +199,7 @@ class CompletionProvider(
           case _: NamedArgMember => item.getLabel
           case _ => ident
         }
-        val escaped = if (isSnippet) editText.replace("$", "\\$") else editText
-        item.setTextEdit(textEdit(escaped))
+        item.setTextEdit(textEdit(editText))
       }
 
       member match {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -40,7 +40,7 @@ trait ArgCompletions { this: MetalsGlobal =>
     lazy val allParams: List[Symbol] = {
       baseParams.iterator.filterNot { param =>
         isNamed(param.name) ||
-        param.name.containsChar('$') // exclude synthetic parameters
+        param.isSynthetic
       }.toList
     }
     lazy val params: List[Symbol] =

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -120,7 +120,7 @@ trait ArgCompletions { this: MetalsGlobal =>
         val editText = allParams.zipWithIndex
           .collect {
             case (param, index) if !param.hasDefault => {
-              s"${Identifier.backtickWrap(param.name).replace("$", "\\$")} = $${${index + 1}${findDefaultValue(param)}}"
+              s"${Identifier.backtickWrap(param.name).replace("$", "$$")} = $${${index + 1}${findDefaultValue(param)}}"
             }
           }
           .mkString(", ")

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -123,7 +123,8 @@ trait ArgCompletions { this: MetalsGlobal =>
               s"${Identifier.backtickWrap(param.name)} = $${${index + 1}${findDefaultValue(param)}}"
           }
           .mkString(", ")
-        val edit = new l.TextEdit(editRange, editText)
+        val escaped = editText.replace("$", "\\$") // escape for snippet
+        val edit = new l.TextEdit(editRange, escaped)
         List(
           new TextEditMember(
             filterText = s"$prefix-$suffix",

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -119,12 +119,12 @@ trait ArgCompletions { this: MetalsGlobal =>
       ) {
         val editText = allParams.zipWithIndex
           .collect {
-            case (param, index) if !param.hasDefault =>
-              s"${Identifier.backtickWrap(param.name)} = $${${index + 1}${findDefaultValue(param)}}"
+            case (param, index) if !param.hasDefault => {
+              s"${Identifier.backtickWrap(param.name).replace("$", "\\$")} = $${${index + 1}${findDefaultValue(param)}}"
+            }
           }
           .mkString(", ")
-        val escaped = editText.replace("$", "\\$") // escape for snippet
-        val edit = new l.TextEdit(editRange, escaped)
+        val edit = new l.TextEdit(editRange, editText)
         List(
           new TextEditMember(
             filterText = s"$prefix-$suffix",

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
@@ -238,7 +238,7 @@ class CompletionsProvider(
                     mkItem(ident, ident.backticked)
                   case _ => mkWorkspaceItem(ident, sym.fullNameBackticked)
       case CompletionValue.NamedArg(label, _) =>
-        mkItem(ident, ident.replace("$", "\\$")) // escape $ for snippet
+        mkItem(ident, ident.replace("$", "$$")) // escape $ for snippet
       case CompletionValue.Keyword(label, text) => mkItem(label, text)
       case _ => mkItem(ident, ident.backticked)
     end match

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
@@ -237,7 +237,7 @@ class CompletionsProvider(
                   case IndexedContext.Result.InScope =>
                     mkItem(ident, ident.backticked)
                   case _ => mkWorkspaceItem(ident, sym.fullNameBackticked)
-      case CompletionValue.NamedArg(label, _) => mkItem(ident, ident)
+      case CompletionValue.NamedArg(label, _) => mkItem(ident, ident.replace("$", "\\$")) // escape $ for snippet
       case CompletionValue.Keyword(label, text) => mkItem(label, text)
       case _ => mkItem(ident, ident.backticked)
     end match

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
@@ -237,7 +237,8 @@ class CompletionsProvider(
                   case IndexedContext.Result.InScope =>
                     mkItem(ident, ident.backticked)
                   case _ => mkWorkspaceItem(ident, sym.fullNameBackticked)
-      case CompletionValue.NamedArg(label, _) => mkItem(ident, ident.replace("$", "\\$")) // escape $ for snippet
+      case CompletionValue.NamedArg(label, _) =>
+        mkItem(ident, ident.replace("$", "\\$")) // escape $ for snippet
       case CompletionValue.Keyword(label, text) => mkItem(label, text)
       case _ => mkItem(ident, ident.backticked)
     end match

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -171,10 +171,15 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       name: TestOptions,
       original: String,
       expected: String,
-      compat: Map[String, String] = Map.empty
+      compat: Map[String, String] = Map.empty,
+      topLines: Option[Int] = None,
   )(implicit loc: Location): Unit = {
     test(name) {
-      val items = getItems(original)
+      val baseItems = getItems(original)
+      val items = topLines match {
+        case Some(top) => baseItems.take(top)
+        case None => baseItems
+      }
       val obtained = items
         .map { item =>
           item

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -172,7 +172,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       original: String,
       expected: String,
       compat: Map[String, String] = Map.empty,
-      topLines: Option[Int] = None,
+      topLines: Option[Int] = None
   )(implicit loc: Location): Unit = {
     test(name) {
       val baseItems = getItems(original)

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -244,7 +244,9 @@ class CompletionArgSuite extends BaseCompletionSuite {
     topLines = Option(1)
   )
 
-  checkSnippet( // known issue: the second parameter with $ become | (returned from compiler)
+  // known issue: the second parameter with $ become | (returned from compiler)
+  // see: https://github.com/scalameta/metals/issues/3690
+  checkSnippet(
     "explicit-dollar-autofill".tag(IgnoreScala3),
     """
       |object Main {

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -231,6 +231,18 @@ class CompletionArgSuite extends BaseCompletionSuite {
     ""
   )
 
+  check( // see: https://github.com/scalameta/metals/issues/2400
+    "explicit-dollar",
+    """|object Main {
+       |  def test($foo: Int, $bar: Int): Int = ???
+       |  test($f@@)
+       |}
+       |""".stripMargin,
+    """|$foo = : Int
+       |""".stripMargin,
+    topLines = Option(1)
+  )
+
   check(
     "arg14",
     s"""|object Main {

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -231,14 +231,15 @@ class CompletionArgSuite extends BaseCompletionSuite {
     ""
   )
 
-  check( // see: https://github.com/scalameta/metals/issues/2400
+  checkSnippet( // see: https://github.com/scalameta/metals/issues/2400
     "explicit-dollar",
-    """|object Main {
-       |  def test($foo: Int, $bar: Int): Int = ???
-       |  test($f@@)
-       |}
-       |""".stripMargin,
-    """|$foo = : Int
+    """
+      |object Main {
+      |  def test($foo: Int, $bar: Int): Int = ???
+      |  test($f@@)
+      |}
+      |""".stripMargin,
+    """|\$foo = 
        |""".stripMargin,
     topLines = Option(1)
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -244,6 +244,20 @@ class CompletionArgSuite extends BaseCompletionSuite {
     topLines = Option(1)
   )
 
+  checkSnippet( // known issue: the second parameter with $ become | (returned from compiler)
+    "explicit-dollar-autofill".tag(IgnoreScala3),
+    """
+      |object Main {
+      |  def test($foo: Int, $bar: Int): Int = ???
+      |  test($f@@)
+      |}
+      |""".stripMargin,
+    """|\$foo = 
+       |\$foo = ${1:???}, | = ${2:???}
+       |""".stripMargin,
+    topLines = Option(2)
+  )
+
   check(
     "arg14",
     s"""|object Main {

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -239,7 +239,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
       |  test($f@@)
       |}
       |""".stripMargin,
-    """|\$foo = 
+    """|$$foo = 
        |""".stripMargin,
     topLines = Option(1)
   )
@@ -254,8 +254,8 @@ class CompletionArgSuite extends BaseCompletionSuite {
       |  test($f@@)
       |}
       |""".stripMargin,
-    """|\$foo = 
-       |\$foo = ${1:???}, | = ${2:???}
+    """|$$foo = 
+       |$$foo = ${1:???}, | = ${2:???}
        |""".stripMargin,
     topLines = Option(2)
   )


### PR DESCRIPTION
Fix https://github.com/scalameta/metals/issues/2400

![dollar-arg-completion](https://user-images.githubusercontent.com/9353584/157230214-63540147-cb3b-4b62-b881-a24ab6f70593.gif)

- Check the parameter is synthetic by `.isSynthetic` instead of $
- Escape `$` from text edit. Otherwise, `$foo will be treated as a parameter in snippet mode.
  - https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax

