### PR TITLE
 Fix DefinitionCrossLspSuite

### DIFF
--- a/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
@@ -29,10 +29,7 @@ class DefinitionCrossLspSuite
     }
   }
 
-  // TODO MIGRATE I can't reproduce this locally. In CI this fails every time,
-  // but I it always passes locally
-  // https://github.com/scalameta/metals/issues/3688
-  test("underscore".ignore) {
+  test("underscore") {
     cleanDatabase()
     for {
       _ <- initialize(
@@ -59,8 +56,9 @@ class DefinitionCrossLspSuite
            |}
            |""".stripMargin
       )
-      _ = server.didOpen("a/src/main/scala/a/Main.scala")
-      _ = server.didOpen("a/src/main/scala/a/Test.scala")
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      _ <- server.didOpen("a/src/main/scala/a/Test.scala")
+      _ = assertNoDiagnostics()
       _ = server.assertReferenceDefinitionBijection()
     } yield ()
   }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -371,8 +371,8 @@ final class TestingServer(
       loc: munit.Location
   ): Unit = {
     val compare = workspaceReferences()
-    assert(compare.definition.nonEmpty)
-    assert(compare.references.nonEmpty)
+    assert(compare.definition.nonEmpty, "Definitions should not be empty")
+    assert(compare.references.nonEmpty, "References should not be empty")
     Assertions.assertNoDiff(
       compare.referencesFormat,
       compare.definitionFormat


### PR DESCRIPTION
Previously, we were not waiting for the compilation to finish which was causing the semanticdb not to be available. Now we properly use the for comprehension.

Fixes https://github.com/scalameta/metals/issues/3688