### PR TITLE
Exclude generated source items from FileWatcher (sbt BSP)

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -52,8 +52,8 @@ final class BuildTargets(
     TrieMap.empty[BuildTargetIdentifier, util.Set[AbsolutePath]]
   private val inverseDependencySources =
     TrieMap.empty[AbsolutePath, Set[BuildTargetIdentifier]]
-  private val buildTargetGeneratedDirs: mutable.Set[AbsolutePath] =
-    mutable.Set.empty
+  private val buildTargetGeneratedDirs: TrieMap[AbsolutePath, Unit] =
+    TrieMap.empty[AbsolutePath, Unit]
   private val sourceJarNameToJarFile = TrieMap.empty[String, AbsolutePath]
   private val isSourceRoot =
     ConcurrentHashSet.empty[AbsolutePath]
@@ -206,7 +206,7 @@ final class BuildTargets(
       sourceItem.getKind() == SourceItemKind.DIRECTORY &&
       sourceItem.getGenerated()
     ) {
-      buildTargetGeneratedDirs += sourceItemPath
+      buildTargetGeneratedDirs(sourceItemPath) = ()
     }
     addSourceItem(sourceItemPath, buildTarget)
   }
@@ -276,7 +276,7 @@ final class BuildTargets(
   }
 
   def checkIfGeneratedSource(source: Path): Boolean = {
-    buildTargetGeneratedDirs.exists(generatedDir =>
+    buildTargetGeneratedDirs.keys.exists(generatedDir =>
       source.startsWith(generatedDir.toNIO)
     )
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -2461,15 +2461,13 @@ class MetalsLanguageServer(
       worksheetProvider.reset()
       symbolSearch.reset()
       buildTargets.addWorkspaceBuildTargets(i.workspaceBuildTargets)
-      buildTargets.addWorkspaceBuildSources(i.sources)
       buildTargets.addScalacOptions(i.scalacOptions)
       buildTargets.addJavacOptions(i.javacOptions)
       for {
         item <- i.sources.getItems.asScala
         source <- item.getSources.asScala
       } {
-        val sourceItemPath = source.getUri.toAbsolutePath(followSymlink = false)
-        buildTargets.addSourceItem(sourceItemPath, item.getTarget)
+        buildTargets.addSourceItem(source, item.getTarget)
       }
       check()
       buildTools

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -2461,6 +2461,7 @@ class MetalsLanguageServer(
       worksheetProvider.reset()
       symbolSearch.reset()
       buildTargets.addWorkspaceBuildTargets(i.workspaceBuildTargets)
+      buildTargets.addWorkspaceBuildSources(i.sources)
       buildTargets.addScalacOptions(i.scalacOptions)
       buildTargets.addJavacOptions(i.javacOptions)
       for {

--- a/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
@@ -79,10 +79,12 @@ object FileWatcher {
     def collect(path: AbsolutePath): Unit = {
       if (buildTargets.isInsideSourceRoot(path)) {
         () // Do nothing, already covered by a source root
-      } else if (path.isScalaOrJava) {
-        sourceFilesToWatch.add(path.toNIO)
-      } else {
-        sourceDirectoriesToWatch.add(path.toNIO)
+      } else if (!buildTargets.checkIfGeneratedSource(path.toNIO)) {
+        if (path.isScalaOrJava) {
+          sourceFilesToWatch.add(path.toNIO)
+        } else {
+          sourceDirectoriesToWatch.add(path.toNIO)
+        }
       }
     }
     // Watch the source directories for "goto definition" index.


### PR DESCRIPTION
Fix https://github.com/scalameta/metals/issues/2183
Previously, when a project generate sources at compile-time, for example, if `bench-jmh` project generate source files at compile time

- 1. Metals sends a compileRequest on bench-jmh
- 2. sbt replies that bench-jmh is compiled successfully
- 3. Metals sends a scalaMainClasses request on bench-jmh
- 4. sbt runs discoveredMainClasses that generates new sources
- 5. sbt replies that bench-jmh contains no Main classes
- 6. Metals detects the new generated sources and goes to step 1

This PR prevents metals from going to step 6, by stopping watching the file events fired from generated sources.

- We can tell the file is generated or not via BSP request `buildTarget/sources` which provides us whether the file/directory is generated or not. https://build-server-protocol.github.io/docs/specification.html#build-target-sources-request
- And sbt BSP has an implementation of `generated` field
https://github.com/sbt/sbt/blob/fedf6af60d86ed39ae9c94161f13a79ffc4494e8/main/src/main/scala/sbt/internal/server/BuildServerProtocol.scala#L125-L129

---

This PR doesn't contain any unit/integration tests because I was not sure where and what to test... any advice?

---

Not related to the original issue, but I witness some wired behavior with sbt BSP

- Metals sends a compile request every time I open a new file (with sbt BSP)
- sbt compiles all projects on save (for example in metals, when I modify a file in `mtags` project, compilation against `intefaces` will be fired) 🤔 