### PR TITLE
Fix completions on dot in expression evaluator

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -288,13 +288,13 @@ class Compilers(
     val indentation = lineStart - metaPos.start
     // insert expression at the start of breakpoint's line and move the lines one down
     val modified =
-      s"${oldText.substring(0, lineStart)}${expression
+      s"${oldText.substring(0, lineStart)};${expression
         .getText()}\n${" " * indentation}${oldText.substring(lineStart)}"
 
     val offsetParams = CompilerOffsetParams(
       path.toURI,
       modified,
-      lineStart + expression.getColumn() - 1,
+      lineStart + expression.getColumn(),
       token
     )
     compiler
@@ -305,7 +305,7 @@ class Compilers(
           .map(
             toDebugCompletionItem(
               _,
-              indentation
+              indentation + 1
             )
           )
       )


### PR DESCRIPTION
Previously, we would show completions for the previous statement. Now, we block it by adding `;`

Fixes https://github.com/scalameta/metals/issues/3381