### PR TITLE
refactor: use "using" instead of "implicit" in Scala 3 signature help.

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -305,7 +305,7 @@ case class ScalaPresentationCompiler(
     val paramLists = signature.paramss
       .map { paramList =>
         val labels = paramList.map(_.show)
-        val prefix = if paramList.exists(_.isImplicit) then "implicit " else ""
+        val prefix = if paramList.exists(_.isImplicit) then "using " else ""
         labels.mkString(prefix, ", ", "")
       }
       .mkString("(", ")(", ")")

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -728,7 +728,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
        |""".stripMargin,
     compat = Map(
       "3" ->
-        """|map[G[_$3]](fn: A => G[A])(implicit T: last-arg3.TypeClass[F]): G[A]
+        """|map[G[_$3]](fn: A => G[A])(using T: last-arg3.TypeClass[F]): G[A]
            |            ^^^^^^^^^^^^^
            |""".stripMargin
     )
@@ -747,8 +747,8 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
     compat = Map(
       // TODO type signatures are not yet supported
       "3" ->
-        """|empty[T](implicit evidence$4: scala.reflect.ClassTag[T]): Array[T]
-           |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        """|empty[T](using evidence$4: scala.reflect.ClassTag[T]): Array[T]
+           |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            |""".stripMargin
     )
   )


### PR DESCRIPTION
This just aligns the usage of "using" since currently if you do a hover
on a method you'll see the implicit parameter using the "using" keyword
but then if you do a signature help on the same method you'll see
"implicit". This just ensure both are "using".