### PR TITLE
Move gabro to "past maintainers" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ The current maintainers (people who can merge pull requests) are:
 - Adrien Piquerez - [`@adpi2`](https://github.com/adpi2)
 - Arthur McGibbon - [`@Arthurm1`](https://github.com/Arthurm1)
 - Chris Kipp - [`@ckipp01`](https://github.com/ckipp01)
-- Gabriele Petronella - [`@gabro`](https://github.com/gabro)
 - Kamil Podsiadło - [`@kpodsiad`](https://github.com/kpodsiad)
 - Ólafur Páll Geirsson - [`@olafurpg`](https://github.com/olafurpg)
 - Tomasz Godzik - [`@tgodzik`](https://github.com/tgodzik)
@@ -35,6 +34,7 @@ The current maintainers (people who can merge pull requests) are:
 Past maintainers:
 
 - Alexey Alekhin - [`@laughedelic`](https://github.com/laughedelic)
+- Gabriele Petronella - [`@gabro`](https://github.com/gabro)
 - Johan Mudsam - [`@mudsam`](https://github.com/mudsam)
 - Krzysztof Bochenek - [`@kpbochenek`](https://github.com/kpbochenek)
 - Jorge Vicente Cantero - [`@jvican`](https://github.com/jvican)


### PR DESCRIPTION
It's been a while since I've actively contributed to the project, let alone some reviews on the VS Code extension here and there.

I've also not been working with Scala at work for a while now, and I probably won't in the near future (I've been having lots of fun with design systems and UI architectures, in case anyone's curious 😅), so I haven't been able to justify much time spent on Scala OSS projects.

That said, nothing changes in practice (I'll be around Discord as always), but I think it's only fair to clarify my Metals maintainer status 🙂

Do absolutely feel free to keep asking for my review for the VS Code extension PRs if you feel it's valuable, I'll keep up with those as best as I can!