### PR TITLE
Add `generated` info to `Source Directories `section of `Display build target info`

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
@@ -218,11 +218,18 @@ class BuildTargetInfo(buildTargets: BuildTargets) {
       .toList
   }
 
-  private def getSources(target: BuildTarget): List[AbsolutePath] = {
+  case class SourceItem(path: AbsolutePath, generated: Boolean) {
+    override def toString: String =
+      s"$path${if (generated) " (generated)" else ""}"
+  }
+  private def getSources(target: BuildTarget): List[String] = {
     buildTargets.sourceItemsToBuildTargets
       .filter(_._2.iterator.asScala.contains(target.getId()))
-      .map(_._1)
       .toList
-      .sortBy(_.toString)
+      .map { case (path, _) =>
+        val generated = buildTargets.checkIfGeneratedDir(path)
+        s"$path${if (generated) " (generated)" else ""}"
+      }
+      .sorted
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
@@ -5,7 +5,6 @@ import java.nio.file.Path
 import scala.collection.mutable.ListBuffer
 
 import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTarget
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
@@ -218,10 +217,6 @@ class BuildTargetInfo(buildTargets: BuildTargets) {
       .toList
   }
 
-  case class SourceItem(path: AbsolutePath, generated: Boolean) {
-    override def toString: String =
-      s"$path${if (generated) " (generated)" else ""}"
-  }
   private def getSources(target: BuildTarget): List[String] = {
     buildTargets.sourceItemsToBuildTargets
       .filter(_._2.iterator.asScala.contains(target.getId()))

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -280,6 +280,8 @@ final class BuildTargets(
       source.startsWith(generatedDir.toNIO)
     )
   }
+  def checkIfGeneratedDir(path: AbsolutePath): Boolean =
+    buildTargetGeneratedDirs.contains(path)
 
   def addScalacOptions(result: ScalacOptionsResult): Unit = {
     result.getItems.asScala.foreach { scalac =>

--- a/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
@@ -402,7 +402,7 @@ class FileDecoderProviderSbtLspSuite
     result =>
       FileDecoderProviderLspSuite.filterSections(
         result,
-        Set("Target", "Scala Version", "Base Directory")
+        Set("Target", "Scala Version", "Base Directory", "Source Directories")
       )
   )
 }
@@ -1301,5 +1301,11 @@ object FileDecoderProviderLspSuite {
         |  ${V.scala3}
         |
         |Base Directory
-        |  file:@workspace/a/""".stripMargin // sbt return "files:/...""
+        |  file:@workspace/a/
+        |
+        |Source Directories
+        |  @workspace/a/src/main/java
+        |  @workspace/a/src/main/scala
+        |  @workspace/a/src/main/scala-3
+        |  @workspace/a/target/scala-${V.scala3}/src_managed/main (generated)""".stripMargin
 }

--- a/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
@@ -5,6 +5,7 @@ import scala.meta.internal.metals.{BuildInfo => V}
 
 import munit.TestOptions
 import tests.BaseLspSuite
+import tests.SbtBuildLayout
 
 class FileDecoderProviderLspSuite extends BaseLspSuite("fileDecoderProvider") {
 
@@ -337,6 +338,71 @@ class FileDecoderProviderLspSuite extends BaseLspSuite("fileDecoderProvider") {
     Right(FileDecoderProviderLspSuite.semanticdbDetailed)
   )
 
+  checkBuildTarget(
+    "buildtarget",
+    SbtBuildLayout(
+      s"""|/metals.json
+          |{
+          |  "a": {
+          |    "scalaVersion": "${V.scala3}"
+          |  },
+          |  "b": {
+          |    "scalaVersion": "${V.scala3}"
+          |  }
+          |}
+          |/a/src/main/scala/Main.scala
+          |package a
+          |class A {
+          |  def foo(): Unit = ()
+          |}
+          |/b/src/main/scala/Main.scala
+          |package b
+          |class B {
+          |  def foo(): Unit = ()
+          |}
+          |""".stripMargin,
+      V.scala3
+    ),
+    "a", // buildTarget, see: SbtBuildLayout
+    Right(FileDecoderProviderLspSuite.buildTargetResponse),
+    result =>
+      FileDecoderProviderLspSuite.filterSections(
+        result,
+        Set("Target", "Scala Version", "Base Directory")
+      )
+  )
+
+  /**
+   * @param expected - we can use "@workspace" to represent the workspace directory
+   *                  (can't receive it via params because it will be set at "initialize" request)
+   */
+  def checkBuildTarget(
+      testName: TestOptions,
+      input: String,
+      buildTarget: String,
+      expected: Either[String, String],
+      transformResult: String => String = identity
+  ): Unit = {
+    val extension = "metals-buildtarget"
+    test(testName) {
+      for {
+        _ <- initialize(input)
+        result <- server.executeDecodeFileCommand(
+          s"metalsDecode:file://$workspace/$buildTarget.$extension"
+        )
+      } yield {
+        assertEquals(
+          if (result.value != null) Right(transformResult(result.value))
+          else Left(transformResult(result.error)),
+          expected.fold(
+            e => Left(e),
+            v => Right(v.replaceAll("@workspace", workspace.toString))
+          )
+        )
+      }
+    }
+  }
+
   def check(
       testName: TestOptions,
       input: String,
@@ -373,6 +439,20 @@ class FileDecoderProviderLspSuite extends BaseLspSuite("fileDecoderProvider") {
 }
 
 object FileDecoderProviderLspSuite {
+  def filterSections(
+      buildTargetResult: String,
+      sections: Set[String]
+  ): String = {
+    val sep = System.lineSeparator()
+    buildTargetResult
+      .split(s"$sep$sep")
+      .filter { section =>
+        val title = section.split(sep).head
+        sections.contains(title)
+      }
+      .mkString(s"$sep$sep")
+  }
+
   private val tastySingle =
     s"""|Names:
         |   0: ASTs
@@ -1165,4 +1245,14 @@ object FileDecoderProviderLspSuite {
        |    }
        |}
        |""".stripMargin
+
+  def buildTargetResponse: String =
+    s"""|Target
+        |  a
+        |
+        |Scala Version
+        |  ${V.scala3}
+        |
+        |Base Directory
+        |  file://@workspace/a/""".stripMargin
 }


### PR DESCRIPTION
Fix: https://github.com/scalameta/metals/issues/3718

With sbt BSP, `src_managed` directory has `(generated)` in `Source Directories` section for `metals-buildtarget`.
<img width="1175" alt="Screen Shot 2022-03-15 at 20 39 55" src="https://user-images.githubusercontent.com/9353584/158370362-c208aa99-e14a-4978-8c5c-b2a75f8412c5.png">

(bloop is not supported because it doesn't support [generated flag](https://build-server-protocol.github.io/docs/specification.html#build-target-sources-request) at this moment).

---

~Test with sbt server doesn't work now 🤔~