### PR TITLE
fix: Ensure the "no run or test" message is shown to user.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -595,6 +595,11 @@ class DebugProvider(
       )
     case e @ DotEnvFileParser.InvalidEnvFileException(_) =>
       languageClient.showMessage(Messages.errorMessageParams(e.getMessage()))
+
+    case e @ NoRunOptionException =>
+      languageClient.showMessage(
+        Messages.errorMessageParams(e.getMessage())
+      )
   }
 
   private def parseSessionName(


### PR DESCRIPTION
This just ensures that when a user triggers a `runOrTest` for debug
discovery that if nothing is found the error is actually shown to the
user, which now it just quietly fails without notifying the user.