### PR TITLE
fix: ensure user gets warned of workspace error when running with lens

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1808,7 +1808,7 @@ class MetalsLanguageServer(
         val debugSessionParams: Future[b.DebugSessionParams] = args match {
           case Seq(debugSessionParamsParser.Jsonized(params))
               if params.getData != null =>
-            Future.successful(params)
+            debugProvider.ensureNoWorkspaceErrors(params)
 
           case Seq(mainClassParamsParser.Jsonized(params))
               if params.mainClass != null =>


### PR DESCRIPTION
Currently if the current workspace has an error but there is still a
code lens to run the project, we just forward the params and try to
start the debug server. This then fails since there are errors in the
workspace and doesn't really show anything to the user. This is just a
slight change that adds a check before that to see if there are
workspace errors and if so, show the warning.

#### Previous behavior

_Notice the user really has no feedback that something is wrong_.

![2022-03-16 10 31 58](https://user-images.githubusercontent.com/13974112/158560009-50c42a37-3508-45c8-a6f2-4354a1f332f7.gif)

#### New behavior

![2022-03-16 10 31 16](https://user-images.githubusercontent.com/13974112/158561557-bd159651-b2b5-49de-a43d-f1a0f960335c.gif)

