### PR TITLE
feat: add more feedback to user when starting a debug session

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -689,7 +689,8 @@ class MetalsLanguageServer(
           clientConfig,
           semanticdbs,
           compilers,
-          () => bspSession.exists(_.main.isBloopOrSbt)
+          () => bspSession.exists(_.main.isBloopOrSbt),
+          statusBar
         )
         scalafixProvider = ScalafixProvider(
           buffers,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1838,11 +1838,15 @@ class MetalsLanguageServer(
         }
         val session = for {
           params <- debugSessionParams
-          server <- debugProvider.start(
-            params,
-            scalaVersionSelector
+          server <- statusBar.trackFuture(
+            "Starting debug server",
+            debugProvider.start(
+              params,
+              scalaVersionSelector
+            )
           )
         } yield {
+          statusBar.addMessage("Started debug server!")
           cancelables.add(server)
           DebugSession(server.sessionName, server.uri.toString)
         }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -39,6 +39,7 @@ import scala.meta.internal.metals.ScalaTestSuites
 import scala.meta.internal.metals.ScalaTestSuitesDebugRequest
 import scala.meta.internal.metals.ScalaVersionSelector
 import scala.meta.internal.metals.StacktraceAnalyzer
+import scala.meta.internal.metals.StatusBar
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.clients.language.MetalsQuickPickItem
 import scala.meta.internal.metals.clients.language.MetalsQuickPickParams
@@ -83,7 +84,8 @@ class DebugProvider(
     clientConfig: ClientConfiguration,
     semanticdbs: Semanticdbs,
     compilers: Compilers,
-    supportsTestSelection: () => Boolean
+    supportsTestSelection: () => Boolean,
+    statusBar: StatusBar
 ) {
 
   import DebugProvider._
@@ -179,7 +181,8 @@ class DebugProvider(
         stacktraceAnalyzer,
         compilers,
         workspace,
-        clientConfig.disableColorOutput()
+        clientConfig.disableColorOutput(),
+        statusBar
       )
     }
     val server = new DebugServer(sessionName, uri, proxyFactory)


### PR DESCRIPTION
So the idea here is to ensure the user knows that something isn't going wrong as they are waiting for the debug server and to provide more feedback to them. There seems to be a couple places where we can add some status messages in to help with this. One is while we are starting the debug server since this may take some time to fully compile your project, and then second one is during the initialize request which seems to take between 3-5 seconds. This adds a status message into both of those places tracking the futures. Here is an example of what it looks like:

![2022-03-17 12 09 57](https://user-images.githubusercontent.com/13974112/158796752-6468b0fc-e54d-4fcd-adaf-89444255401b.gif)

This is just a hello world project so the first message is quite quick, but this lengthens really quickly if you are developing in a real project. Either way, the entire time prior to this pr you don't get any feedback that something is happening while waiting for your output. Hopefully this helps a bit.

Fixes #3730 