### PR TITLE
fix: don't discover already discovered tests

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -262,7 +262,9 @@ final class TestSuitesProvider(
       symbolsPerTarget: List[SymbolsPerTarget]
   ): Map[BuildTarget, List[TestEntry]] = {
     val entries = symbolsPerTarget.flatMap { currentTarget =>
-      val cachedSuites = mutable.Set.empty[FullyQualifiedName]
+      // index will be updated later
+      val currentlyCached = index.getSuiteNames(currentTarget.target)
+      val cachedSuites = mutable.Set.from(currentlyCached)
       currentTarget.testSymbols
         .readOnlySnapshot()
         .toList


### PR DESCRIPTION
`mutable.Set.empty[FullyQualifiedName]` was always empty so every test suite in the build target was discovered even though it has been discovered in previous run already