### PR TITLE
fix: return an error when trying to decode tasty in Scala 2

### DIFF
--- a/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
@@ -31,6 +31,24 @@ class FileDecoderProviderLspSuite
   )
 
   check(
+    "tasty-single-not-for-scala2",
+    s"""|/metals.json
+        |{
+        |  "app": {
+        |    "scalaVersion": "${V.scala213}"
+        |  }
+        |}
+        |/app/src/main/scala/Main.scala
+        |package foo.bar.example
+        |object Main
+        |""".stripMargin,
+    "app/src/main/scala/Main.scala",
+    None,
+    "tasty-decoded",
+    Left("Decoding tasty is only supported in Scala 3 for now.")
+  )
+
+  check(
     "decode-jar",
     s"""
        |/metals.json


### PR DESCRIPTION
Since this isn't supported for now we should correctly return an error
for this. Right now you can still trigger this in Scala 2 and it just
returns an empty string not really giving the user much information
about why it didn't work. This way clients can now handle this situation
better.