### PR TITLE
fix: create `new scala file` with a single NL

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
@@ -209,8 +209,7 @@ class NewFileProvider(
       .packageStatement(path)
       .map(_.fileContent)
       .getOrElse("")
-    val template = s"""|$pkg
-                       |@@""".stripMargin
+    val template = s"$pkg@@"
     createFileAndWriteText(path, NewFileTemplate(template))
   }
 
@@ -304,6 +303,7 @@ class NewFileProvider(
   }
 
   private def caseClassTemplate(name: String): NewFileTemplate =
-    NewFileTemplate(s"final case class $name(@@)")
+    NewFileTemplate(s"""|final case class $name(@@)
+                        |""".stripMargin)
 
 }

--- a/tests/mtest/src/main/scala/tests/Assertions.scala
+++ b/tests/mtest/src/main/scala/tests/Assertions.scala
@@ -53,6 +53,14 @@ trait Assertions extends munit.Assertions {
     }
   }
 
+  def assertLines(obtained: String, expected: String)(implicit
+      loc: Location
+  ): Unit = {
+    if (obtained.linesIterator.toList != expected.linesIterator.toList) {
+      fail(s"obtained:<\n$obtained>\nexpected:<\n$expected>")
+    }
+  }
+
   def assertIsNotDirectory(path: AbsolutePath)(implicit loc: Location): Unit = {
     if (path.isDirectory) {
       fail(s"directory exists: $path")

--- a/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
@@ -530,7 +530,9 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
       existingFiles: String = "",
       expectedException: List[Class[_]] = Nil,
       javaMinVersion: Option[String] = None
-  ): Unit = if (Properties.isJavaAtLeast(javaMinVersion.getOrElse("1.8")))
+  )(implicit loc: Location): Unit = if (
+    Properties.isJavaAtLeast(javaMinVersion.getOrElse("1.8"))
+  )
     check(testName)(
       directory,
       fileType,
@@ -552,7 +554,7 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
       existingFiles: String = "",
       expectedException: List[Class[_]] = Nil,
       scalaVersion: Option[String] = None
-  ): Unit = check(testName)(
+  )(implicit loc: Location): Unit = check(testName)(
     directory,
     fileType,
     fileName,
@@ -657,7 +659,7 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
             expectedMessages
           )
           assert(expectedFilePathAbsolute.exists)
-          assertNoDiff(
+          assertLines(
             expectedFilePathAbsolute.readText,
             expectedContent
           )


### PR DESCRIPTION
Previously there `New Scala File` -> `Empty File` were created with two
newlines between package and cursor instead of one