### PR TITLE
Add file system support for jars

### DIFF
--- a/metals/src/main/resources/META-INF/services/java.nio.file.spi.FileSystemProvider
+++ b/metals/src/main/resources/META-INF/services/java.nio.file.spi.FileSystemProvider
@@ -1,0 +1,1 @@
+scala.meta.internal.metals.filesystem.MetalsFileSystemProvider

--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -282,12 +282,16 @@ final class SyntheticsDecorationProvider(
       textDocument: Option[s.TextDocument],
       path: AbsolutePath
   ): Option[TextDocument] = {
-    for {
-      doc <- textDocument
-      source <- fingerprints.loadLastValid(path, doc.md5, charset)
-      docWithText = doc.withText(source)
-      _ = Document.set(docWithText)
-    } yield docWithText
+    // TODO what does `enrichWithText` do and should it be run on readOnly files?  fingerprints causes slurping ;-(
+    if (path.isReadOnly)
+      textDocument
+    else
+      for {
+        doc <- textDocument
+        source <- fingerprints.loadLastValid(path, doc.md5, charset)
+        docWithText = doc.withText(source)
+        _ = Document.set(docWithText)
+      } yield docWithText
   }
 
   private def localSymbolName(symbol: String, textDoc: TextDocument): String = {

--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -395,11 +395,16 @@ final class ImplementationProvider(
     def isDefinitionOccurrence(occ: SymbolOccurrence) =
       occ.role.isDefinition && occ.symbol == symbol
 
+    val input =
+      if (source.isReadOnly)
+        source.toInputFromBuffers(buffer)
+      else
+        source.toInput
     semanticDb.occurrences
       .find(isDefinitionOccurrence)
       .orElse(
         Mtags
-          .allToplevels(source.toInput, scalaVersionSelector.getDialect(source))
+          .allToplevels(input, scalaVersionSelector.getDialect(source))
           .occurrences
           .find(isDefinitionOccurrence)
       )

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals
 
+import java.nio.file.Files
 import java.nio.file.Path
 
 import scala.collection.mutable.ListBuffer
@@ -154,7 +155,7 @@ class BuildTargetInfo(buildTargets: BuildTargets) {
     val sourceJarName = jarName.replace(".jar", "-sources.jar")
     buildTargets
       .sourceJarFile(sourceJarName)
-      .exists(_.toFile.exists())
+      .exists(path => path.exists)
   }
 
   private def getSingleClassPathInfo(
@@ -164,7 +165,7 @@ class BuildTargetInfo(buildTargets: BuildTargets) {
   ): String = {
     val filename = shortPath.toString()
     val padding = " " * (maxFilenameSize - filename.size)
-    val status = if (path.toFile.exists) {
+    val status = if (Files.exists(path)) {
       val blankWarning = " " * 9
       if (path.toFile().isDirectory() || jarHasSource(filename))
         blankWarning

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -241,6 +241,15 @@ object ClientCommands {
       |""".stripMargin
   )
 
+  val CreateLibraryFileSystem = new ParametrizedCommand[String](
+    "metals-create-library-filesystem",
+    "Create Library FS",
+    """|Notifies the client that it should create an empty
+       |filesystem to navigate jar dependencies
+       |""".stripMargin,
+    arguments = """`string`, the URI root of the filesystem.""".stripMargin
+  )
+
   val RefreshModel = new Command(
     "metals-model-refresh",
     "Refresh model",
@@ -325,6 +334,7 @@ object ClientCommands {
       FocusDiagnostics,
       GotoLocation,
       EchoCommand,
+      CreateLibraryFileSystem,
       RefreshModel,
       ShowStacktrace,
       CopyWorksheetOutput,

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -57,6 +57,9 @@ case class ClientConfiguration(initialConfig: MetalsServerConfig) {
   def isVirtualDocumentSupported(): Boolean =
     initializationOptions.isVirtualDocumentSupported.getOrElse(false)
 
+  def isLibraryFileSystemSupported(): Boolean = true
+  // initializationOptions.isLibraryFileSystemSupported.getOrElse(false)
+
   def icons(): Icons =
     initializationOptions.icons
       .map(Icons.fromString)

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals
 
+import java.nio.file.Paths
 import java.util.Collections
 import java.{util => ju}
 
@@ -8,6 +9,7 @@ import scala.concurrent.Future
 
 import scala.meta.inputs.Input
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.filesystem.MetalsFileSystem
 import scala.meta.internal.mtags.GlobalSymbolIndex
 import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.Semanticdbs
@@ -16,9 +18,11 @@ import scala.meta.internal.mtags.SymbolDefinition
 import scala.meta.internal.parsing.TokenEditDistance
 import scala.meta.internal.parsing.Trees
 import scala.meta.internal.remotels.RemoteLanguageServer
+import scala.meta.internal.semanticdb.Language
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.semanticdb.SymbolOccurrence
 import scala.meta.internal.semanticdb.TextDocument
+import scala.meta.internal.tvp.ClasspathSymbols
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.CancelToken
 
@@ -265,6 +269,7 @@ final class DefinitionProvider(
   }
 
   private def fromMtags(source: AbsolutePath, dirtyPos: Position) = {
+    // TODO why does a writable file use `source.toInput` instead of `source.toInputFromBuffers(buffers)`
     Mtags
       .allToplevels(source.toInput, scalaVersionSelector.getDialect(source))
       .occurrences
@@ -316,12 +321,28 @@ class DestinationProvider(
   private def bestTextDocument(
       symbolDefinition: SymbolDefinition
   ): TextDocument = {
-    val defnRevisedInput = symbolDefinition.path.toInput
+    val decodedClassfile =
+      if (symbolDefinition.path.isClassfile)
+        MetalsFileSystem.metalsFS
+          .decodeCFRFromClassFile(symbolDefinition.path.toNIO)
+          .map(text =>
+            Input.VirtualFile(symbolDefinition.path.toURI.toString(), text)
+          )
+      else None
+    val defnRevisedInput = decodedClassfile.getOrElse(
+      if (symbolDefinition.path.isReadOnly)
+        symbolDefinition.path.toInputFromBuffers(buffers)
+      else
+        symbolDefinition.path.toInput
+    )
     // Read text file from disk instead of editor buffers because the file
     // on disk is more likely to parse.
+    val language =
+      if (symbolDefinition.path.isClassfile) Language.JAVA
+      else symbolDefinition.path.toLanguage
     lazy val parsed =
       mtags.index(
-        symbolDefinition.path.toLanguage,
+        language,
         defnRevisedInput,
         symbolDefinition.dialect
       )
@@ -346,15 +367,46 @@ class DestinationProvider(
     definition(symbol, targets)
   }
 
+  private val classpathSymbols = new ClasspathSymbols(
+    isStatisticsEnabled = false
+  )
+
   def definition(
       symbol: String,
       allowedBuildTargets: Set[BuildTargetIdentifier]
   ): Option[SymbolDefinition] = {
-    val definitions = index.definitions(Symbol(symbol)).filter(_.path.exists)
+    val querySymbol: Symbol = Symbol(symbol)
+    val definitions = index.definitions(querySymbol).filter(_.path.exists)
+    val extraDefinitions = if (definitions.isEmpty) {
+      // search in all classpath, i.e. jars with no source
+      buildTargets
+        .inferBuildTarget(List(querySymbol.toplevel))
+        .flatMap(buildTarget => {
+          val metalsFSJar =
+            MetalsFileSystem.metalsFS
+              .getOrElseUpdateWorkspaceJar(buildTarget.jar)
+          classpathSymbols
+            .symbols(metalsFSJar, symbol)
+            .filter(_.symbol == symbol)
+            .flatMap(_.uri)
+            .headOption
+            .map(symbolFullURI => {
+              val fullJarPath = AbsolutePath(Paths.get(symbolFullURI))
+              SymbolDefinition(
+                querySymbol,
+                querySymbol,
+                fullJarPath,
+                scala.meta.dialects.Scala212Source3,
+                None
+              )
+            })
+        })
+        .toList
+    } else definitions
     if (allowedBuildTargets.isEmpty)
-      definitions.headOption
+      extraDefinitions.headOption
     else {
-      val matched = definitions.find { defn =>
+      val matched = extraDefinitions.find { defn =>
         sourceBuildTargets(defn.path).exists(id =>
           allowedBuildTargets.contains(id)
         )
@@ -362,7 +414,7 @@ class DestinationProvider(
       // Fallback to any definition - it's needed for worksheets
       // They might have dynamic `import $dep` and these sources jars
       // aren't registered in buildTargets
-      matched.orElse(definitions.headOption)
+      matched.orElse(extraDefinitions.headOption)
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -65,6 +65,7 @@ final case class InitializationOptions(
     isHttpEnabled: Option[Boolean],
     commandInHtmlFormat: Option[CommandHTMLFormat],
     isVirtualDocumentSupported: Option[Boolean],
+    isLibraryFileSystemSupported: Option[Boolean],
     openFilesOnRenameProvider: Option[Boolean],
     quickPickProvider: Option[Boolean],
     renameFileThreshold: Option[Int],
@@ -89,6 +90,7 @@ object InitializationOptions {
 
   val Default: InitializationOptions = InitializationOptions(
     CompilerInitializationOptions.default,
+    None,
     None,
     None,
     None,
@@ -155,6 +157,8 @@ object InitializationOptions {
         .flatMap(CommandHTMLFormat.fromString),
       isVirtualDocumentSupported =
         jsonObj.getBooleanOption("isVirtualDocumentSupported"),
+      isLibraryFileSystemSupported =
+        jsonObj.getBooleanOption("isLibraryFileSystemSupported"),
       openFilesOnRenameProvider =
         jsonObj.getBooleanOption("openFilesOnRenameProvider"),
       quickPickProvider = jsonObj.getBooleanOption("quickPickProvider"),

--- a/metals/src/main/scala/scala/meta/internal/metals/LSPFileSystemProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/LSPFileSystemProvider.scala
@@ -1,0 +1,105 @@
+package scala.meta.internal.metals
+
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.stream.Collectors
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.filesystem.MetalsFileSystem
+import scala.meta.internal.metals.filesystem.MetalsFileSystemProvider
+
+final case class FSReadDirectoryResponse(
+    name: String,
+    isFile: Boolean
+)
+final case class FSReadDirectoriesResponse(
+    name: String,
+    directories: Array[FSReadDirectoryResponse],
+    error: String
+)
+
+final case class FSReadFileResponse(
+    name: String,
+    value: String,
+    error: String
+)
+
+final case class FSStatResponse(
+    name: String,
+    isFile: Boolean,
+    error: String
+)
+
+final class LSPFileSystemProvider(
+    languageClient: MetalsLanguageClient,
+    clientConfig: ClientConfiguration
+)(implicit ec: ExecutionContext) {
+
+  private def getPath(uriAsStr: String): Path =
+    Paths.get(URI.create(uriAsStr))
+
+  def createLibraryFileSystem(): Unit =
+    if (clientConfig.isLibraryFileSystemSupported()) {
+      val params =
+        ClientCommands.CreateLibraryFileSystem.toExecuteCommandParams(
+          MetalsFileSystemProvider.rootURI.toString()
+        )
+      languageClient.metalsExecuteClientCommand(params)
+    }
+
+  def readDirectory(
+      uriAsStr: String
+  ): Future[FSReadDirectoriesResponse] = Future {
+    try {
+      val path = getPath(uriAsStr)
+      val subPaths = Files
+        .list(path)
+        .map(subPath =>
+          FSReadDirectoryResponse(
+            subPath.getFileName().toString(),
+            Files.isRegularFile(subPath)
+          )
+        )
+        .collect(Collectors.toList())
+        .asScala
+        .toArray
+      FSReadDirectoriesResponse(uriAsStr, subPaths, null)
+    } catch {
+      case NonFatal(e) => FSReadDirectoriesResponse(uriAsStr, null, e.toString)
+    }
+  }
+
+  def readFile(uriAsStr: String): Future[FSReadFileResponse] = Future {
+    try {
+      val path = getPath(uriAsStr)
+      val contents = if (path.isClassfile) {
+        MetalsFileSystem.metalsFS
+          .decodeCFRFromClassFile(path)
+          .getOrElse(s"Unable to decode class file ${path.toUri}")
+      } else
+        new String(Files.readAllBytes(path), StandardCharsets.UTF_8)
+      FSReadFileResponse(uriAsStr, contents, null)
+    } catch {
+      case NonFatal(e) => FSReadFileResponse(uriAsStr, null, e.toString)
+    }
+  }
+
+  def getSystemStat(uriAsStr: String): Future[FSStatResponse] = Future {
+    try {
+      val path = getPath(uriAsStr)
+      val filename = path.getFileName.toString
+      val isFile = Files.isRegularFile(path)
+      FSStatResponse(filename, isFile, null)
+    } catch {
+      case NonFatal(e) => FSStatResponse(uriAsStr, false, e.toString())
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -61,6 +61,7 @@ import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.metals.debug.DebugProvider
 import scala.meta.internal.metals.doctor.Doctor
 import scala.meta.internal.metals.doctor.DoctorVisibilityDidChangeParams
+import scala.meta.internal.metals.filesystem.MetalsFileSystem
 import scala.meta.internal.metals.findfiles._
 import scala.meta.internal.metals.formatting.OnTypeFormattingProvider
 import scala.meta.internal.metals.formatting.RangeFormattingProvider
@@ -274,6 +275,7 @@ class MetalsLanguageServer(
   private var compilers: Compilers = _
   private var scalafixProvider: ScalafixProvider = _
   private var fileDecoderProvider: FileDecoderProvider = _
+  private var lspFileSystemProvider: LSPFileSystemProvider = _
   private var testProvider: TestSuitesProvider = _
   private var workspaceReload: WorkspaceReload = _
   private var buildToolSelector: BuildToolSelector = _
@@ -442,6 +444,11 @@ class MetalsLanguageServer(
         )
         shellRunner = register(
           new ShellRunner(languageClient, () => userConfig, time, statusBar)
+        )
+        MetalsFileSystem.metalsFS.setShellRunner(
+          shellRunner,
+          buildTargets,
+          executionContext
         )
         bloopInstall = new BloopInstall(
           workspace,
@@ -736,6 +743,10 @@ class MetalsLanguageServer(
           languageClient,
           clientConfig,
           classFinder
+        )
+        lspFileSystemProvider = new LSPFileSystemProvider(
+          languageClient,
+          clientConfig
         )
         popupChoiceReset = new PopupChoiceReset(
           workspace,
@@ -1045,7 +1056,8 @@ class MetalsLanguageServer(
     recentlyOpenedFiles.add(path)
 
     // Update md5 fingerprint from file contents on disk
-    fingerprints.add(path, FileIO.slurp(path, charset))
+    if (!path.isReadOnly)
+      fingerprints.add(path, FileIO.slurp(path, charset))
     // Update in-memory buffer contents from LSP client
     buffers.put(path, params.getTextDocument.getText)
 
@@ -1060,7 +1072,14 @@ class MetalsLanguageServer(
      * that we don't try to generate it for project files
      */
     val interactive = buildServerPromise.future.map { _ =>
-      interactiveSemanticdbs.textDocument(path)
+      // reduce loading of readonly files by passing the contents directly in
+      if (path.isReadOnly)
+        interactiveSemanticdbs.textDocument(
+          path,
+          Some(params.getTextDocument.getText)
+        )
+      else
+        interactiveSemanticdbs.textDocument(path)
     }
     // We need both parser and semanticdb for synthetic decorations
     val publishSynthetics = for {
@@ -1737,6 +1756,12 @@ class MetalsLanguageServer(
             params.kind == "class"
           )
           .asJavaObject
+      case ServerCommands.FileSystemStat(uriAsStr) =>
+        lspFileSystemProvider.getSystemStat(uriAsStr).asJavaObject
+      case ServerCommands.FileSystemReadFile(uriAsStr) =>
+        lspFileSystemProvider.readFile(uriAsStr).asJavaObject
+      case ServerCommands.FileSystemReadDirectory(uriAsStr) =>
+        lspFileSystemProvider.readDirectory(uriAsStr).asJavaObject
       case ServerCommands.RunDoctor() =>
         Future {
           doctor.onVisibilityDidChange(true)
@@ -2345,6 +2370,7 @@ class MetalsLanguageServer(
   private val indexer = Indexer(
     () => workspaceReload,
     () => doctor,
+    () => lspFileSystemProvider,
     languageClient,
     () => bspSession,
     executionContext,
@@ -2452,7 +2478,7 @@ class MetalsLanguageServer(
       definitionOnly: Boolean = false
   ): Future[DefinitionResult] = {
     val source = positionParams.getTextDocument.getUri.toAbsolutePath
-    if (source.isScalaFilename || source.isJavaFilename) {
+    if (source.isScalaFilename || source.isJavaFilename || source.isClassfile) {
       val semanticDBDoc =
         semanticdbs.textDocument(source).documentIncludingStale
       (for {
@@ -2514,7 +2540,7 @@ class MetalsLanguageServer(
       token: CancelToken = EmptyCancelToken
   ): Future[DefinitionResult] = {
     val source = position.getTextDocument.getUri.toAbsolutePath
-    if (source.isScalaFilename || source.isJavaFilename) {
+    if (source.isScalaFilename || source.isJavaFilename || source.isClassfile) {
       val result =
         timerProvider.timedThunk(
           "definition",

--- a/metals/src/main/scala/scala/meta/internal/metals/PackageProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/PackageProvider.scala
@@ -45,7 +45,8 @@ class PackageProvider(private val buildTargets: BuildTargets) {
     }
 
     if (
-      path.isScalaOrJava && !path.isJarFileSystem && path.toFile.length() == 0
+      path.isScalaOrJava && !path.isMetalsFileSystem && path.toFile
+        .length() == 0
     ) {
       buildTargets
         .inverseSourceItem(path)

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -149,6 +149,42 @@ object ServerCommands {
        |""".stripMargin
   )
 
+  val FileSystemStat = new ParametrizedCommand[String](
+    "filesystem-stat",
+    "Read Directory",
+    """|Return information about the uri. E.g. uri is a directory
+       |
+       |Virtual File Systems allow client to display filesystem data
+       |in the format that Metals dictates.
+       |e.g. jar library dependencies
+       |""".stripMargin,
+    "[uri], uri of the file or directory."
+  )
+
+  val FileSystemReadDirectory = new ParametrizedCommand[String](
+    "filesystem-read-directory",
+    "Read Directory",
+    """|Return the contents of a virtual filesystem directory.
+       |
+       |Virtual File Systems allow client to display filesystem data
+       |in the format that Metals dictates.
+       |e.g. jar library dependencies
+       |""".stripMargin,
+    "[uri], uri of the directory."
+  )
+
+  val FileSystemReadFile = new ParametrizedCommand[String](
+    "filesystem-read-file",
+    "Read File",
+    """|Return the contents of a virtual filesystem file.
+       |
+       |Virtual File Systems allow client to display filesystem data
+       |in the format that Metals dictates.
+       |e.g. jar library dependencies
+       |""".stripMargin,
+    "[uri], uri of the file."
+  )
+
   val RunDoctor = new Command(
     "doctor-run",
     "Run doctor",

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -7,6 +7,7 @@ import java.{util => ju}
 import scala.collection.concurrent.TrieMap
 
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.filesystem.MetalsFileSystem
 import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.parsing.Trees
@@ -185,16 +186,25 @@ object StandaloneSymbolSearch {
     (missingScala, JdkSources(javaHome)) match {
       case (true, Left(_)) =>
         val (scalaSources, scalaClasspath) = getScala(scalaVersion)
-        (sources ++ scalaSources, classpath ++ scalaClasspath)
+        val mappedSources = scalaSources.map(source =>
+          MetalsFileSystem.metalsFS.getOrElseUpdateSourceJar(source)
+        )
+        (sources ++ mappedSources, classpath ++ scalaClasspath)
       case (true, Right(absPath)) =>
         val (scalaSources, scalaClasspath) = getScala(scalaVersion)
+        val mappedSources = scalaSources.map(source =>
+          MetalsFileSystem.metalsFS.getOrElseUpdateSourceJar(source)
+        )
+        val jdkPath = MetalsFileSystem.metalsFS.getOrElseUpdateJDK(absPath)
         (
-          (scalaSources :+ absPath) ++ sources,
+          (mappedSources :+ jdkPath) ++ sources,
           classpath ++ scalaClasspath
         )
-      case (false, Left(_)) => (sources, classpath)
+      case (false, Left(_)) =>
+        (sources, classpath)
       case (false, Right(absPath)) =>
-        (sources :+ absPath, classpath)
+        val jdkPath = MetalsFileSystem.metalsFS.getOrElseUpdateJDK(absPath)
+        (sources :+ jdkPath, classpath)
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/TargetData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/TargetData.scala
@@ -76,6 +76,8 @@ final class TargetData {
     val allTargetRoots = scalaTargetRoots.toSet ++ javaTargetRoots.toSet
     allTargetRoots.iterator
   }
+  def allJDKs: Iterator[String] = scalaTargetInfo.flatMap(_._2.jvmHome).iterator
+
   def all: Iterator[BuildTarget] =
     buildTargetInfo.values.toIterator
 

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/ClientConfigurationAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/ClientConfigurationAdapter.scala
@@ -53,7 +53,8 @@ private[debug] final case class ClientConfigurationAdapter(
   def adaptPathForClient(path: AbsolutePath): String = {
     pathFormat match {
       case InitializeRequestArgumentsPathFormat.PATH =>
-        if (path.isJarFileSystem) path.toURI.toString else path.toString
+        if (path.isJarFileSystem || path.isMetalsFileSystem) path.toURI.toString
+        else path.toString
       case InitializeRequestArgumentsPathFormat.URI => path.toURI.toString
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
@@ -10,6 +10,8 @@ import scala.meta.internal.io.FileIO
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.filesystem.MetalsFileSystem
+import scala.meta.internal.metals.filesystem.MetalsPath
 import scala.meta.internal.mtags.URIEncoderDecoder
 import scala.meta.io.AbsolutePath
 
@@ -34,20 +36,26 @@ private[debug] final class SourcePathAdapter(
         .stripPrefix("jar:")
       val decodedPath =
         URIEncoderDecoder.decode(sourceFileJarPath).toAbsolutePath
-      val parts = decodedPath.toNIO.iterator().asScala.map(_.toString).toVector
-      val jarPartIndex = parts.indexWhere(path => path.endsWith(".jar!"))
-      val jarPath = AbsolutePath(
-        parts
-          .take(jarPartIndex + 1)
-          .mkString(File.separator, File.separator, "")
-          .stripSuffix("!")
-      )
-      val relative = parts.drop(jarPartIndex + 1).mkString(File.separator)
+      decodedPath.toNIO match {
+        case metalsPath: MetalsPath => metalsPath.originalJarURI
+        case _ =>
+          val parts =
+            decodedPath.toNIO.iterator().asScala.map(_.toString).toVector
+          val jarPartIndex = parts.indexWhere(path => path.endsWith(".jar!"))
+          val jarPath = AbsolutePath(
+            parts
+              .take(jarPartIndex + 1)
+              .mkString(File.separator, File.separator, "")
+              .stripSuffix("!")
+          )
+          val relative = parts.drop(jarPartIndex + 1).mkString(File.separator)
 
-      val sourceURI = FileIO.withJarFileSystem(jarPath, create = false)(root =>
-        root.resolve(relative).toURI
-      )
-      Some(sourceURI)
+          val sourceURI =
+            FileIO.withJarFileSystem(jarPath, create = false)(root =>
+              root.resolve(relative).toURI
+            )
+          Some(sourceURI)
+      }
     } else {
       // if sourcePath is a dependency source file
       // we retrieve the original source jar and we build the uri innside the source jar filesystem
@@ -70,8 +78,11 @@ private[debug] final class SourcePathAdapter(
       Try(URI.create(sourcePath)).getOrElse(Paths.get(sourcePath).toUri())
     sourceUri.getScheme match {
       case "jar" =>
-        val path = sourceUri.toAbsolutePath
-        Some(if (saveJarFileToDisk) path.toFileOnDisk(workspace) else path)
+        MetalsFileSystem.metalsFS
+          .getMetalsJarPath(sourceUri)
+          .map(path =>
+            if (saveJarFileToDisk) path.toFileOnDisk(workspace) else path
+          )
       case "file" => Some(AbsolutePath(Paths.get(sourceUri)))
       case _ => None
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/filesystem/MetalsDirectoryStream.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/filesystem/MetalsDirectoryStream.scala
@@ -1,0 +1,18 @@
+package scala.meta.internal.metals.filesystem
+
+import java.nio.file.DirectoryStream
+import java.nio.file.Path
+import java.{util => ju}
+
+import scala.collection.JavaConverters._
+
+final case class MetalsDirectoryStream(
+    paths: Iterable[Path],
+    filter: DirectoryStream.Filter[_ >: Path]
+) extends DirectoryStream[Path] {
+
+  override def close(): Unit = {}
+
+  override def iterator(): ju.Iterator[Path] =
+    paths.filter(filter.accept).toIterator.asJava
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/filesystem/MetalsFileAttributes.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/filesystem/MetalsFileAttributes.scala
@@ -1,0 +1,31 @@
+package scala.meta.internal.metals.filesystem
+
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileTime
+import java.time.ZonedDateTime
+
+final case class MetalsFileAttributes(path: MetalsPath, isFile: Boolean)
+    extends BasicFileAttributes {
+
+  override def lastModifiedTime(): FileTime = MetalsFileAttributes.zeroTime
+
+  override def lastAccessTime(): FileTime = MetalsFileAttributes.zeroTime
+
+  override def creationTime(): FileTime = MetalsFileAttributes.zeroTime
+
+  override def isRegularFile(): Boolean = isFile
+
+  override def isDirectory(): Boolean = !isFile
+
+  override def isSymbolicLink(): Boolean = false
+
+  override def isOther(): Boolean = false
+
+  override def size(): Long = 0L
+
+  override def fileKey(): Object = path
+}
+
+object MetalsFileAttributes {
+  val zeroTime: FileTime = FileTime.from(ZonedDateTime.now().toInstant())
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/filesystem/MetalsFileSystem.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/filesystem/MetalsFileSystem.scala
@@ -1,0 +1,367 @@
+package scala.meta.internal.metals.filesystem
+
+import java.net.URI
+import java.net.URL
+import java.nio.file.FileStore
+import java.nio.file.FileSystem
+import java.nio.file.FileSystemNotFoundException
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import java.nio.file.PathMatcher
+import java.nio.file.Paths
+import java.nio.file.ProviderNotFoundException
+import java.nio.file.WatchService
+import java.nio.file.attribute.UserPrincipalLookupService
+import java.nio.file.spi.FileSystemProvider
+import java.{lang => jl}
+import java.{util => ju}
+
+import scala.annotation.tailrec
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+import scala.meta.internal.builds.ShellRunner
+import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.FileDecoderProvider
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+
+class MetalsFileSystem(fileSystemProvider: MetalsFileSystemProvider)
+    extends FileSystem {
+
+  // TODO work out when to reset this - on a new build import - or just built up as build targets gets new jars?
+  private val workspaceJars = TrieMap.empty[String, JarInfo]
+  private val sourceJars = TrieMap.empty[String, JarInfo]
+  private val jdks = TrieMap.empty[String, JarInfo]
+  private val metalsPathToJarInfo = TrieMap.empty[String, JarInfo]
+
+  private var shellRunner: ShellRunner = _
+  private var buildTargets: BuildTargets = _
+  private var executionContext: ExecutionContext = _
+
+  def setShellRunner(
+      shellRunner: ShellRunner,
+      buildTargets: BuildTargets,
+      executionContext: ExecutionContext
+  ): Unit = {
+    this.shellRunner = shellRunner
+    this.buildTargets = buildTargets
+    this.executionContext = executionContext
+  }
+
+  val rootPath: MetalsPath =
+    MetalsPath(this, MetalsFileSystemProvider.rootNames)
+
+  private val rootDirectories: jl.Iterable[Path] =
+    ju.Collections.singletonList(rootPath)
+
+  override def provider(): FileSystemProvider = fileSystemProvider
+
+  override def close(): Unit = {}
+
+  override def isOpen(): Boolean = true
+
+  override def isReadOnly(): Boolean = true
+
+  override def getSeparator(): String = MetalsFileSystemProvider.separator
+
+  override def getRootDirectories(): jl.Iterable[Path] = rootDirectories
+
+  override def getFileStores(): jl.Iterable[FileStore] = null
+
+  override def supportedFileAttributeViews(): ju.Set[String] = null
+
+  override def getPath(first: String, more: String*): Path = {
+    def tidyPath(path: String): String = {
+      if (!path.startsWith("//"))
+        path
+      else
+        tidyPath(path.stripPrefix("/"))
+    }
+    val pathAsStr = List(List(first), more).flatten
+      .mkString(MetalsFileSystemProvider.separator)
+    // handle both absolute paths "/root/foo/bar" and relative "foo/bar"
+    // URLs will request a path of "///xxxx" so remove additional "/"
+    val tidiedPath = tidyPath(pathAsStr)
+    val items = if (tidiedPath.startsWith(MetalsFileSystemProvider.separator)) {
+      val split = tidiedPath.drop(1).split(MetalsFileSystemProvider.separator)
+      split(0) = s"${MetalsFileSystemProvider.separator}${split(0)}"
+      split
+    } else
+      tidiedPath.split(MetalsFileSystemProvider.separator)
+    val names = new Array[String](items.length)
+    items.zipWithIndex.foreach(f => names(f._2) = f._1)
+    MetalsPath(this, names)
+  }
+
+  // TODO is default file system the right one to use? or re-implement
+  // https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher-java.lang.String-
+  override def getPathMatcher(syntaxAndPattern: String): PathMatcher =
+    FileSystems.getDefault().getPathMatcher(syntaxAndPattern)
+
+  override def getUserPrincipalLookupService(): UserPrincipalLookupService =
+    throw new UnsupportedOperationException("getUserPrincipalLookupService")
+
+  override def newWatchService(): WatchService =
+    throw new UnsupportedOperationException("newWatchService")
+
+  private def createJarInfo(
+      filename: String,
+      subName: String,
+      path: AbsolutePath
+  ): JarInfo = {
+    val names = new Array[String](3)
+    names(0) = MetalsFileSystemProvider.rootName
+    names(1) = subName
+    names(2) = filename
+    val metalsPath = MetalsPath(this, names)
+    JarInfo(
+      names.mkString(getSeparator),
+      URI.create(s"jar:${path.toNIO.toUri.toString}"),
+      path.toNIO.toUri.toURL.getPath,
+      metalsPath,
+      new ju.HashMap[String, Any]
+    )
+  }
+
+  private def getOrElseUpdateJar(
+      jarMap: TrieMap[String, JarInfo],
+      filename: String,
+      subName: String,
+      jarPath: AbsolutePath
+  ): AbsolutePath = {
+    val jarInfo = jarMap
+      .getOrElseUpdate(filename, createJarInfo(filename, subName, jarPath))
+    metalsPathToJarInfo.update(jarInfo.metalsJarPath, jarInfo)
+    jarInfo.metalsAbsolutePath
+  }
+
+  def getOrElseUpdateWorkspaceJar(path: AbsolutePath): AbsolutePath =
+    getOrElseUpdateJar(
+      workspaceJars,
+      path.filename,
+      MetalsFileSystem.workspaceJarSubName,
+      path
+    )
+
+  def getOrElseUpdateSourceJar(path: AbsolutePath): AbsolutePath =
+    getOrElseUpdateJar(
+      sourceJars,
+      path.filename,
+      MetalsFileSystem.sourceJarSubName,
+      path
+    )
+
+  def getOrElseUpdateJDK(path: AbsolutePath): AbsolutePath = {
+
+    def findDecentJDKName(path: AbsolutePath): AbsolutePath =
+      if (!path.hasParent || !List("lib", "src.zip").contains(path.filename))
+        path
+      else
+        findDecentJDKName(path.parent)
+
+    val filename = findDecentJDKName(path).filename
+    getOrElseUpdateJar(jdks, filename, MetalsFileSystem.jdkSubName, path)
+  }
+
+  def getWorkspaceJars: Iterable[String] = workspaceJars.keySet
+
+  def getSourceJars: Iterable[String] = sourceJars.keySet
+
+  def getJdks: Iterable[String] = jdks.keySet
+
+  def getWorkspaceJarPaths: Iterable[AbsolutePath] =
+    workspaceJars.values.map(_.metalsAbsolutePath)
+
+  // metalsfs:/xxx/name.jar#runtime -> jar:/yyy/name.jar#runtime
+  // metalsfs:/xxx/name.jar/package/class -> jar:/yyy/name.jar!/package/class
+  def getOriginalJarURL(url: URL): Option[URL] = {
+    // convert to uri this way to remove fragments
+    val metalsURI =
+      new URI(url.getProtocol(), url.getHost(), url.getPath(), null)
+    Paths.get(metalsURI) match {
+      case metalsPath: MetalsPath =>
+        getOriginalJarURI(metalsPath).map(uri => {
+          val uriWithFragments =
+            if (url.getRef != null && url.getRef.nonEmpty) {
+              val strippedPath = uri.getPath().stripSuffix("!/")
+              new URI(uri.getScheme(), uri.getHost(), strippedPath, url.getRef)
+            } else
+              uri
+          uriWithFragments.toURL()
+        })
+      case _ => throw new ProviderNotFoundException(url.toString())
+    }
+  }
+
+  // metalsfs:/xxx/name.jar/package/class -> jar:/yyy/name.jar!/package/class
+  // metalsfs:/xxx/name.jar -> jar:/yyy/name.jar
+  def getOriginalJarURI(metalsPath: MetalsPath): Option[URI] = {
+    metalsPath.jarName.flatMap(jarName => {
+      workspaceJars
+        .get(jarName)
+        .orElse(sourceJars.get(jarName))
+        .orElse(jdks.get(jarName))
+        .map(jarInfo => {
+          val jarDirs = metalsPath.jarDirs
+          URI.create(
+            s"jar:file://${jarInfo.jarURLFile}!/${jarDirs.mkString(jarInfo.jarFS.getSeparator)}"
+          )
+        })
+    })
+  }
+
+  // jar:/yyy/name.jar!/package/class -> metalsfs:/xxx/name.jar/package/class
+  def getMetalsJarPath(uri: URI): Option[AbsolutePath] = {
+    @tailrec
+    def resolve(path: Path, dirs: Seq[String]): Path =
+      if (dirs.isEmpty)
+        path
+      else
+        resolve(path.resolve(dirs.head), dirs.tail)
+    val path = uri.toAbsolutePath
+    path.jarPath.flatMap(jarPath => {
+      val jarName = jarPath.filename
+      workspaceJars
+        .get(jarName)
+        .orElse(sourceJars.get(jarName))
+        .orElse(jdks.get(jarName))
+        .map(jarInfo =>
+          jarInfo.metalsAbsolutePath.resolve(path.toString.stripPrefix("/"))
+        )
+    })
+  }
+
+  def accessLibrary[A](
+      path: MetalsPath,
+      convert: Path => A
+  ): Option[A] = {
+
+    @tailrec
+    def resolve(path: Path, dirs: Seq[String]): Path =
+      if (dirs.isEmpty)
+        path
+      else
+        resolve(path.resolve(dirs.head), dirs.tail)
+
+    if (!path.isAbsolute())
+      accessLibrary(path.toAbsolutePath(), convert)
+    else
+      path.jarName.flatMap(jarName => {
+        val jarDirs = path.jarDirs
+        workspaceJars
+          .get(jarName)
+          .orElse(sourceJars.get(jarName))
+          .orElse(jdks.get(jarName))
+          .map(jarInfo => {
+            val inJarPath = resolve(
+              jarInfo.jarFS.getPath(jarInfo.jarFS.getSeparator),
+              jarDirs
+            )
+            convert(inJarPath)
+          })
+      })
+  }
+
+  // cache the last few decompiled class files as they're repeatedly accessed by metals once opened or referenced
+  private val cache = LRUCache[Path, Some[String]](10)
+
+  def decodeCFRFromClassFile(path: Path): Option[String] = {
+    if (shellRunner == null) {
+      scribe.info("Wait for Metals to finish indexing")
+      None
+    } else {
+      val cacheResult = cache.get(path)
+      cacheResult.getOrElse({
+        val result =
+          FileDecoderProvider
+            .decodeCFRFromClassFile(
+              shellRunner,
+              buildTargets,
+              AbsolutePath(path)
+            )(executionContext)
+        val response = Await.result(result, Duration("10min"))
+        val success = Option(response.value)
+        success.foreach(content => cache += path -> Some(content))
+        success.orElse(Option(response.error))
+      })
+    }
+  }
+
+  def isMetalsFileSystem(path: Path): Boolean =
+    path match {
+      case _: MetalsPath => true
+      case _ => false
+    }
+}
+
+object MetalsFileSystem {
+  val jdkSubName: String = "jdk"
+  val workspaceJarSubName: String = "jar"
+  val sourceJarSubName: String = "source"
+
+  private var _metalsFS: MetalsFileSystem = _
+
+  def metalsFS: MetalsFileSystem = {
+    if (_metalsFS == null)
+      synchronized {
+        if (_metalsFS == null)
+          _metalsFS = FileSystems.newFileSystem(
+            MetalsFileSystemProvider.rootURI,
+            ju.Collections.emptyMap[String, String]
+          ) match {
+            case mfs: MetalsFileSystem => mfs
+            case _ =>
+              throw new ProviderNotFoundException(
+                MetalsFileSystemProvider.rootURI.toString()
+              )
+          }
+      }
+    _metalsFS
+  }
+}
+
+final case class JarInfo(
+    metalsAbsolutePath: AbsolutePath,
+    jarFS: FileSystem,
+    jarURLFile: String,
+    metalsJarPath: String
+)
+
+object JarInfo {
+  def apply(
+      metalsJarPath: String,
+      jarURI: URI,
+      jarURLFile: String,
+      metalsPath: MetalsPath,
+      envMap: ju.Map[String, Any]
+  ): JarInfo = {
+    val jarFS =
+      try {
+        FileSystems.getFileSystem(jarURI)
+      } catch {
+        case _: FileSystemNotFoundException =>
+          FileSystems.newFileSystem(jarURI, envMap)
+      }
+    JarInfo(AbsolutePath(metalsPath), jarFS, jarURLFile, metalsJarPath)
+  }
+}
+
+import scala.collection.mutable
+// TODO there must be one of these somewhere already in the Metals codebase
+// TODO this is not thread safe
+class LRUCache[K, V](maxEntries: Int)
+    extends java.util.LinkedHashMap[K, V](maxEntries, 1.0f, true) {
+
+  override def removeEldestEntry(eldest: java.util.Map.Entry[K, V]): Boolean =
+    size > maxEntries
+}
+
+object LRUCache {
+  def apply[K, V](maxEntries: Int): mutable.Map[K, V] = {
+    import scala.meta.internal.jdk.CollectionConverters._
+    new LRUCache[K, V](maxEntries).asScala
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/filesystem/MetalsFileSystemProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/filesystem/MetalsFileSystemProvider.scala
@@ -1,0 +1,263 @@
+package scala.meta.internal.metals.filesystem
+
+import java.io.IOException
+import java.io.InputStream
+import java.net.URI
+import java.nio.channels.SeekableByteChannel
+import java.nio.file.AccessMode
+import java.nio.file.CopyOption
+import java.nio.file.DirectoryStream
+import java.nio.file.FileStore
+import java.nio.file.FileSystemAlreadyExistsException
+import java.nio.file.FileSystemNotFoundException
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.OpenOption
+import java.nio.file.Path
+import java.nio.file.ProviderMismatchException
+import java.nio.file.ReadOnlyFileSystemException
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.FileAttribute
+import java.nio.file.attribute.FileAttributeView
+import java.nio.file.spi.FileSystemProvider
+import java.util.stream.Collectors
+import java.{util => ju}
+
+import scala.collection.JavaConverters._
+
+final case class MetalsFileSystemProvider() extends FileSystemProvider {
+
+  private var fileSystem: MetalsFileSystem = _
+
+  override def getScheme: String = MetalsFileSystemProvider.scheme
+
+  override def newFileSystem(
+      uri: URI,
+      env: ju.Map[String, _]
+  ): MetalsFileSystem = {
+    if (getScheme != uri.getScheme)
+      throw new ProviderMismatchException()
+    synchronized {
+      if (fileSystem != null)
+        throw new FileSystemAlreadyExistsException(uri.toString)
+      fileSystem = new MetalsFileSystem(this)
+      fileSystem
+    }
+  }
+
+  override def getFileSystem(uri: URI) = {
+    if (getScheme != uri.getScheme)
+      throw new ProviderMismatchException()
+    synchronized {
+      if (fileSystem == null)
+        throw new FileSystemNotFoundException(uri.toString)
+      else
+        fileSystem
+    }
+  }
+
+  override def getPath(uri: URI): Path = {
+    val pathStr = uri.getSchemeSpecificPart()
+    return getFileSystem(uri).getPath(pathStr)
+  }
+
+  override def newDirectoryStream(
+      dir: Path,
+      filter: DirectoryStream.Filter[_ >: Path]
+  ): DirectoryStream[Path] = {
+    dir match {
+      case metalsPath: MetalsPath =>
+        if (metalsPath == fileSystem.rootPath) {
+          MetalsDirectoryStream(
+            List(
+              MetalsFileSystem.workspaceJarSubName,
+              MetalsFileSystem.sourceJarSubName,
+              MetalsFileSystem.jdkSubName
+            ).map(name => metalsPath.resolve(name)),
+            filter
+          )
+        } else if (!metalsPath.isInJar) {
+          MetalsDirectoryStream(
+            {
+              metalsPath.getFileName().toString match {
+                case MetalsFileSystem.workspaceJarSubName =>
+                  fileSystem.getWorkspaceJars
+                case MetalsFileSystem.sourceJarSubName =>
+                  fileSystem.getSourceJars
+                case MetalsFileSystem.jdkSubName => fileSystem.getJdks
+              }
+            }.map(name => metalsPath.resolve(name)),
+            filter
+          )
+        } else
+          MetalsDirectoryStream(
+            fileSystem
+              .accessLibrary(
+                metalsPath,
+                path =>
+                  Files
+                    .list(path)
+                    .collect(Collectors.toList())
+                    .asScala
+                    .map(subPath =>
+                      metalsPath.resolve(path.relativize(subPath))
+                    )
+                    .toList
+              )
+              .getOrElse(List.empty),
+            filter
+          )
+      case _ => throw new ProviderMismatchException()
+    }
+  }
+
+  override def newInputStream(path: Path, options: OpenOption*): InputStream =
+    path match {
+      case metalsPath: MetalsPath =>
+        fileSystem
+          .accessLibrary(
+            metalsPath,
+            path => Files.newInputStream(path, options: _*)
+          )
+          .getOrElse(throw new IOException(s"Can't access $path"))
+      case _ => throw new ProviderMismatchException()
+    }
+
+  override def newByteChannel(
+      path: Path,
+      options: ju.Set[_ <: OpenOption],
+      attrs: FileAttribute[_]*
+  ): SeekableByteChannel = {
+    path match {
+      case metalsPath: MetalsPath =>
+        if (!metalsPath.isInJar)
+          throw new IOException(path.toUri.toString)
+        else
+          fileSystem
+            .accessLibrary(
+              metalsPath,
+              path => Files.newByteChannel(path, options, attrs: _*)
+            )
+            .getOrElse(throw new IOException(s"$path"))
+      case _ => throw new ProviderMismatchException()
+    }
+  }
+
+  override def createDirectory(dir: Path, attrs: FileAttribute[_]*): Unit =
+    throw new ReadOnlyFileSystemException()
+
+  override def delete(path: Path): Unit =
+    throw new ReadOnlyFileSystemException()
+
+  override def copy(source: Path, target: Path, options: CopyOption*): Unit =
+    throw new ReadOnlyFileSystemException()
+
+  override def move(source: Path, target: Path, options: CopyOption*): Unit =
+    throw new ReadOnlyFileSystemException()
+
+  override def isSameFile(path: Path, path2: Path): Boolean =
+    path.toAbsolutePath().equals(path2.toAbsolutePath())
+
+  override def isHidden(path: Path): Boolean = false
+
+  override def getFileStore(path: Path): FileStore = null
+
+  override def checkAccess(path: Path, modes: AccessMode*): Unit = {
+    if (modes.contains(AccessMode.WRITE))
+      throw new IOException(s"Read only filesystem $path")
+    path match {
+      case metalsPath: MetalsPath =>
+        if (metalsPath.isInJar)
+          fileSystem
+            .accessLibrary(
+              metalsPath,
+              path => path.getFileSystem().provider().checkAccess(path)
+            )
+      case _ => throw new ProviderMismatchException()
+    }
+  }
+
+  override def getFileAttributeView[V <: FileAttributeView](
+      path: Path,
+      _type: Class[V],
+      options: LinkOption*
+  ): V = {
+    path match {
+      case metalsPath: MetalsPath =>
+        if (!metalsPath.isInJar)
+          throw new IOException(path.toUri.toString)
+        else {
+          fileSystem
+            .accessLibrary(
+              metalsPath,
+              path => Files.getFileAttributeView(path, _type, options: _*)
+            )
+            .getOrElse(null.asInstanceOf[V])
+        }
+      case _ => throw new ProviderMismatchException()
+    }
+  }
+
+  override def readAttributes[A <: BasicFileAttributes](
+      path: Path,
+      _type: Class[A],
+      options: LinkOption*
+  ): A = {
+    path match {
+      case metalsPath: MetalsPath =>
+        if (!metalsPath.isInJar) {
+          if (_type != classOf[BasicFileAttributes])
+            throw new UnsupportedOperationException(
+              s"readAttributes ${path.toUri} ${_type}"
+            )
+          new MetalsFileAttributes(metalsPath, false).asInstanceOf[A]
+        } else
+          fileSystem
+            .accessLibrary(
+              metalsPath,
+              path => Files.readAttributes(path, _type, options: _*)
+            )
+            .getOrElse(throw new IOException(path.toUri.toString))
+      case _ => throw new ProviderMismatchException()
+    }
+  }
+
+  override def readAttributes(
+      path: Path,
+      attributes: String,
+      options: LinkOption*
+  ): ju.Map[String, Object] = {
+    path match {
+      case metalsPath: MetalsPath =>
+        if (!metalsPath.isInJar)
+          throw new IOException(path.toUri.toString)
+        else
+          fileSystem
+            .accessLibrary(
+              metalsPath,
+              path => Files.readAttributes(path, attributes, options: _*)
+            )
+            .getOrElse(throw new IOException(path.toUri.toString))
+      case _ => throw new ProviderMismatchException()
+    }
+  }
+
+  override def setAttribute(
+      path: Path,
+      attribute: String,
+      value: Object,
+      options: LinkOption*
+  ): Unit =
+    throw new ReadOnlyFileSystemException()
+}
+
+object MetalsFileSystemProvider {
+  val scheme: String = "metalsfs"
+  val rootName: String = "/metalsLibraries"
+  val separator: String = "/"
+  val rootURI: URI = URI.create(s"${scheme}:$rootName")
+  val rootNames: Array[String] = Array(rootName)
+  val buildTargetsKey: String = "BuildTargets"
+  val shellRunnerKey: String = "ShellRunner"
+  val executionContextKey: String = "ExecutionContext"
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/filesystem/MetalsPath.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/filesystem/MetalsPath.scala
@@ -1,0 +1,377 @@
+package scala.meta.internal.metals.filesystem
+
+import java.io.File
+import java.net.URI
+import java.nio.file.LinkOption
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.ProviderMismatchException
+import java.nio.file.WatchEvent
+import java.nio.file.WatchKey
+import java.nio.file.WatchService
+import java.{util => ju}
+
+import scala.collection.JavaConverters._
+import scala.annotation.tailrec
+import scala.meta.io.RelativePath
+
+final case class MetalsPath(
+    metalsFileSystem: MetalsFileSystem,
+    names: Array[String]
+) extends Path {
+
+  override def getFileSystem: MetalsFileSystem = metalsFileSystem
+
+  override def isAbsolute: Boolean =
+    names.nonEmpty && names(0) == MetalsFileSystemProvider.rootName
+
+  override def getRoot: MetalsPath =
+    if (isAbsolute())
+      metalsFileSystem.rootPath
+    else
+      null
+
+  override def getFileName: MetalsPath =
+    if (names.isEmpty)
+      null
+    else if (names.length == 1)
+      this
+    else MetalsPath(metalsFileSystem, Array(names.last))
+
+  override def getParent: MetalsPath =
+    if (names.length < 2)
+      null
+    else if (isAbsolute() && names.length == 2)
+      getRoot
+    else
+      MetalsPath(metalsFileSystem, names.take(names.length - 1))
+
+  override def getNameCount: Int = names.size
+
+  override def getName(index: Int): MetalsPath =
+    if (isAbsolute && names.length == 1 && index == 0)
+      getRoot
+    else if (index >= names.length)
+      throw new IllegalArgumentException()
+    else
+      MetalsPath(metalsFileSystem, Array(names(index)))
+
+  override def subpath(beginIndex: Int, endIndex: Int): MetalsPath =
+    if (isAbsolute && names.length == 1 && beginIndex == 0 && endIndex == 1)
+      getRoot
+    else if (beginIndex >= endIndex)
+      throw new IllegalArgumentException()
+    else if (beginIndex < 0)
+      throw new IllegalArgumentException()
+    else if (endIndex > names.length)
+      throw new IllegalArgumentException()
+    else if (beginIndex == 0 && endIndex == names.length)
+      this
+    else
+      MetalsPath(metalsFileSystem, names.slice(beginIndex, endIndex))
+
+  private def checkPath[F](path: Path, apply: MetalsPath => F): F =
+    if (path == null)
+      throw new NullPointerException()
+    else
+      path match {
+        case metalsPath: MetalsPath => apply(metalsPath)
+        case _ => throw new ProviderMismatchException()
+      }
+
+  override def startsWith(other: Path): Boolean =
+    checkPath(
+      other,
+      metalsPath => {
+        if (this == other)
+          true
+        else if (
+          isAbsolute() != metalsPath.isAbsolute() ||
+          names.length < metalsPath.names.length
+        )
+          false
+        else {
+          var idx = metalsPath.names.length - 1
+          var different = false
+          while (!different && idx >= 0) {
+            if (names(idx) != metalsPath.names(idx))
+              different = true
+            idx = idx - 1
+          }
+          !different
+        }
+      }
+    )
+
+  override def startsWith(other: String): Boolean =
+    startsWith(getFileSystem().getPath(other))
+
+  override def endsWith(other: Path): Boolean =
+    checkPath(
+      other,
+      metalsPath => {
+        if (this == other)
+          true
+        else if (
+          metalsPath.isAbsolute() ||
+          names.length < metalsPath.names.length
+        )
+          false
+        else {
+          var idx = metalsPath.names.length - 1
+          var different = false
+          while (!different && idx >= 0) {
+            if (
+              names(idx + names.length - metalsPath.names.length) != metalsPath
+                .names(idx)
+            )
+              different = true
+            idx = idx - 1
+          }
+          !different
+        }
+      }
+    )
+
+  override def endsWith(other: String): Boolean =
+    return endsWith(getFileSystem().getPath(other))
+
+  override def normalize(): MetalsPath = {
+    val count = names.count(f => f == "." || f == "..")
+    if (count == 0)
+      this
+    else {
+      val newNames = new Array[String](names.length - count)
+      var oldIdx = names.length - 1
+      var newIdx = newNames.length - 1
+      var doubleDotCount = 0
+      while (oldIdx >= 0) {
+        if (names(oldIdx) == ".")
+          oldIdx = oldIdx - 1
+        else if (names(oldIdx) == "..") {
+          doubleDotCount = doubleDotCount + 1
+          oldIdx = oldIdx - 1
+        } else if (doubleDotCount > 0) {
+          doubleDotCount = doubleDotCount - 1
+          oldIdx = oldIdx - 1
+        } else {
+          newNames(newIdx) = names(oldIdx)
+          oldIdx = oldIdx - 1
+          newIdx = newIdx - 1
+        }
+      }
+      MetalsPath(metalsFileSystem, newNames)
+    }
+  }
+
+  override def resolve(other: Path): MetalsPath =
+    if (other.isAbsolute()) {
+      other match {
+        case mp: MetalsPath => mp
+        case _ => throw new ProviderMismatchException()
+      }
+    } else {
+      val newNames = new Array[String](names.length + other.getNameCount)
+      var idx = 0
+      while (idx < names.length) {
+        newNames(idx) = names(idx)
+        idx = idx + 1
+      }
+      idx = 0
+      while (idx < other.getNameCount) {
+        newNames(idx + names.length) = other.getName(idx).toString
+        idx = idx + 1
+      }
+      MetalsPath(metalsFileSystem, newNames)
+    }
+
+  override def resolve(other: String): MetalsPath =
+    resolve(getFileSystem().getPath(other))
+
+  override def resolveSibling(other: Path): MetalsPath =
+    checkPath(
+      other,
+      metalsPath => {
+        val parent = getParent();
+        if (parent == null) metalsPath else parent.resolve(other)
+      }
+    )
+
+  override def resolveSibling(other: String): MetalsPath =
+    resolveSibling(getFileSystem().getPath(other))
+
+  override def relativize(other: Path): MetalsPath = {
+    if (isAbsolute() != other.isAbsolute())
+      throw new IllegalArgumentException(
+        s"Cannot relativize ${this.toUri()} with ${other.toUri()}"
+      )
+    if (getNameCount() > other.getNameCount())
+      throw new IllegalArgumentException(
+        s"Cannot relativize ${this.toUri()} with ${other.toUri()}"
+      )
+    // TODO both being !absolute is valid but what's it supposed to return?
+    if (!isAbsolute())
+      throw new UnsupportedOperationException("relativize")
+    checkPath(
+      other,
+      metalsPath => {
+        var i = 0
+        var matching = true
+        while (matching && i < names.length) {
+          if (names(i) != metalsPath.names(i))
+            matching = false
+          i = i + 1
+        }
+        if (!matching)
+          throw new IllegalArgumentException(
+            s"Cannot relativize ${this.toUri()} with ${other.toUri()}"
+          )
+        val newNames = new Array[String](metalsPath.names.length - names.length)
+        var idx = names.length
+        while (idx < metalsPath.names.length) {
+          newNames(idx - names.length) = metalsPath.names(idx)
+          idx = idx + 1
+        }
+        MetalsPath(metalsFileSystem, newNames)
+      }
+    )
+  }
+
+  override def toUri: URI = {
+    try {
+      if (isAbsolute()) {
+        if (names.lengthCompare(1) == 0)
+          MetalsFileSystemProvider.rootURI
+        else {
+          val uriAsStr =
+            s"${MetalsFileSystemProvider.scheme}:${names.mkString(MetalsFileSystemProvider.separator)}"
+          URI.create(uriAsStr)
+        }
+      } else
+        toAbsolutePath.toUri
+    } catch {
+      case e: Exception =>
+        scribe.error("toURI error ", e)
+        throw e
+    }
+  }
+
+  override def toAbsolutePath: MetalsPath =
+    if (isAbsolute())
+      this
+    else
+      metalsFileSystem.rootPath.resolve(this)
+
+  override def toRealPath(options: LinkOption*): MetalsPath =
+    toAbsolutePath.normalize
+
+  override def toFile: File = {
+    throw new UnsupportedOperationException("toFile")
+  }
+
+  override def register(
+      watcher: WatchService,
+      events: Array[WatchEvent.Kind[_]],
+      modifiers: WatchEvent.Modifier*
+  ) = throw new UnsupportedOperationException("register")
+
+  override def register(
+      watcher: WatchService,
+      events: WatchEvent.Kind[_]*
+  ): WatchKey = throw new UnsupportedOperationException("register")
+
+  override def iterator(): ju.Iterator[Path] = {
+    val paths = names
+      .map(name => MetalsPath(metalsFileSystem, Array(name)): Path)
+      .toIterator
+    if (isAbsolute())
+      paths.drop(1).asJava
+    else
+      paths.asJava
+  }
+
+  override def compareTo(other: Path): Int =
+    checkPath(
+      other,
+      metalsPath => {
+        var result = 0
+        var idx = 0
+        while (
+          result == 0 && idx < names.length && idx < metalsPath.names.length
+        ) {
+          val nameCompare = names(idx).compareTo(metalsPath.names(idx))
+          if (nameCompare != 0)
+            result = nameCompare
+          idx = idx + 1
+        }
+        if (result == 0)
+          names.length.compareTo(metalsPath.names.length)
+        else
+          result
+      }
+    )
+
+  override def hashCode: Int =
+    names.toSeq.hashCode
+
+  override def equals(other: Any): Boolean =
+    other match {
+      case otherPath: MetalsPath =>
+        metalsFileSystem == otherPath.metalsFileSystem &&
+        names.sameElements(otherPath.names)
+      case _ => false
+    }
+
+  override def toString(): String =
+    names.mkString(MetalsFileSystemProvider.separator)
+
+  def isJDK: Boolean =
+    names.lengthCompare(2) >= 0 && names(2) == MetalsFileSystem.jdkSubName
+
+  def isInJar: Boolean = names.lengthCompare(3) >= 0
+
+  // metalsfs:/xxx/name.jar/package/class -> metalsfs:/xxx/name.jar
+  def jarPath: Option[MetalsPath] = {
+    @tailrec
+    def jarPath(path: MetalsPath): MetalsPath =
+      if (path.names.lengthCompare(3) == 0)
+        path
+      else jarPath(path.getParent)
+    if (names.lengthCompare(2) < 0) None else Some(jarPath(this))
+  }
+
+  // metalsfs:/xxx/name.jar/package/class -> jar:/yyy/name.jar!/package/class
+  def originalJarURI: Option[URI] =
+    metalsFileSystem.getOriginalJarURI(this)
+
+  def jarName: Option[String] =
+    if (names.lengthCompare(3) < 0) None else Some(names(2))
+
+  def jarDirs: Seq[String] =
+    if (names.lengthCompare(3) < 0) Seq.empty else names.toSeq.drop(3)
+
+  def moduleName: Option[String] =
+    if (names.lengthCompare(3) < 0) None
+    else {
+      // jdk uses module/module-info.java
+      val moduleLocationNames = new Array[String](5)
+      var i = 0
+      while (i < 4) {
+        moduleLocationNames(i) = names(i)
+        i = i + 1
+      }
+      moduleLocationNames(4) = "module-info.java"
+      val moduleInfoLocation = MetalsPath(metalsFileSystem, moduleLocationNames)
+      val tmp = if (Files.exists(moduleInfoLocation)) {
+        Some(moduleLocationNames(3))
+      } else None
+      // TODO - how to find out module name from non-jdk jar??? We've only tested with src.zip
+      scribe.error(s"Module info for ${moduleInfoLocation.toUri()} is $tmp")
+      tmp
+    }
+
+}
+object MetalsPath {
+  def fromReadOnly(relativePath: RelativePath): MetalsPath =
+    MetalsFileSystem.metalsFS.rootPath.resolve(relativePath.toNIO)
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/urlstreamhandler/MetalsURLConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/urlstreamhandler/MetalsURLConnection.scala
@@ -1,0 +1,16 @@
+package scala.meta.internal.metals.urlstreamhandler
+
+import java.io.InputStream
+import java.net.URL
+import java.net.URLConnection
+
+final class MetalsURLConnection(jarURL: URL, metalsURL: URL)
+    extends URLConnection(metalsURL) {
+
+  private val jarURLConnection = jarURL.openConnection()
+
+  override def connect(): Unit = jarURLConnection.connect()
+
+  override def getInputStream(): InputStream =
+    jarURLConnection.getInputStream()
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/urlstreamhandler/MetalsURLStreamHandler.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/urlstreamhandler/MetalsURLStreamHandler.scala
@@ -1,0 +1,19 @@
+package scala.meta.internal.metals.urlstreamhandler
+
+import java.net.URL
+import java.net.URLConnection
+import java.net.URLStreamHandler
+
+import scala.meta.internal.metals.filesystem.MetalsFileSystem
+import scala.meta.internal.metals.filesystem.MetalsFileSystemProvider
+
+final object MetalsURLStreamHandler extends URLStreamHandler {
+
+  override protected def openConnection(url: URL): URLConnection =
+    if (MetalsFileSystemProvider.scheme == url.getProtocol)
+      MetalsFileSystem.metalsFS
+        .getOriginalJarURL(url)
+        .map(new MetalsURLConnection(_, url))
+        .orNull
+    else null
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/urlstreamhandler/MetalsURLStreamHandlerFactory.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/urlstreamhandler/MetalsURLStreamHandlerFactory.scala
@@ -1,0 +1,26 @@
+package scala.meta.internal.metals.urlstreamhandler
+
+import java.net.URL
+import java.net.URLStreamHandler
+import java.net.URLStreamHandlerFactory
+
+import scala.meta.internal.metals.filesystem.MetalsFileSystemProvider
+
+final object MetalsURLStreamHandlerFactory extends URLStreamHandlerFactory {
+
+  private var registered: Boolean = false
+
+  def register: Unit = {
+    if (!registered)
+      synchronized {
+        if (!registered) {
+          URL.setURLStreamHandlerFactory(MetalsURLStreamHandlerFactory);
+          registered = true
+        }
+      }
+  }
+
+  override def createURLStreamHandler(protocol: String): URLStreamHandler =
+    if (MetalsFileSystemProvider.scheme == protocol) MetalsURLStreamHandler
+    else null
+}

--- a/metals/src/main/scala/scala/meta/internal/tvp/ClasspathSymbols.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/ClasspathSymbols.scala
@@ -117,7 +117,8 @@ class ClasspathSymbols(isStatisticsEnabled: Boolean = false) {
                   buf += TreeViewSymbolInformation(
                     i.symbol,
                     i.kind,
-                    i.properties
+                    i.properties,
+                    Some(path.toURI)
                   )
                 }
               }
@@ -129,13 +130,8 @@ class ClasspathSymbols(isStatisticsEnabled: Boolean = false) {
 
         case _ =>
       }
-
     }
-    if (in.extension == "jar") {
-      FileIO.withJarFileSystem(in, create = false, close = true)(list)
-    } else {
-      list(in)
-    }
+    list(in)
     buf.result()
   }
 
@@ -173,7 +169,7 @@ class ClasspathSymbols(isStatisticsEnabled: Boolean = false) {
                     d.Package(path.filename.stripSuffix("/"))
                   )
               }
-              result += TreeViewSymbolInformation(dummySymbol, k.CLASS, 0)
+              result += TreeViewSymbolInformation(dummySymbol, k.CLASS, 0, None)
             }
             FileVisitResult.CONTINUE
           }

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -11,6 +11,7 @@ import scala.meta.dialects
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals._
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.filesystem.MetalsFileSystem
 import scala.meta.internal.mtags.GlobalSymbolIndex
 import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.Symbol
@@ -51,7 +52,7 @@ class MetalsTreeViewProvider(
     _.toAbsolutePath,
     _.filename,
     _.toString,
-    () => buildTargets.allWorkspaceJars,
+    () => MetalsFileSystem.metalsFS.getWorkspaceJarPaths.iterator,
     (path, symbol) => classpath.symbols(path, symbol)
   )
 

--- a/metals/src/main/scala/scala/meta/internal/tvp/TreeViewSymbolInformation.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/TreeViewSymbolInformation.scala
@@ -1,5 +1,7 @@
 package scala.meta.internal.tvp
 
+import java.net.URI
+
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.semanticdb.SymbolInformation
@@ -8,7 +10,8 @@ import scala.meta.internal.semanticdb.SymbolInformation.{Kind => k}
 case class TreeViewSymbolInformation(
     symbol: String,
     kind: SymbolInformation.Kind,
-    properties: Int = 0
+    properties: Int = 0,
+    uri: Option[URI]
 ) {
   def isVal: Boolean = kind.isMethod && properties.isVal
   def isVar: Boolean = kind.isMethod && properties.isVar
@@ -23,7 +26,8 @@ case class TreeViewSymbolInformation(
           else if (s.isType) k.CLASS
           else if (s.isTypeParameter) k.TYPE_PARAMETER
           else k.UNKNOWN_KIND,
-          0
+          0,
+          None
         )
         info :: loop(s.owner)
       }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/OpenClassLoader.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/OpenClassLoader.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.mtags
 
+import java.net.URL
 import java.net.URLClassLoader
 import java.nio.file.Paths
 
@@ -13,7 +14,10 @@ final class OpenClassLoader extends URLClassLoader(Array.empty) {
   private val isAdded = mutable.Set.empty[AbsolutePath]
   def addEntry(entry: AbsolutePath): Boolean = {
     if (!isAdded(entry)) {
-      super.addURL(entry.toNIO.toUri.toURL)
+      // url must end in "/" for the correct Loader to be selected for metalsfs:/somejar.jar
+      val url = entry.toNIO.toUri.toURL
+      val formattedURL = new URL(s"${url}/")
+      super.addURL(formattedURL)
       isAdded += entry
       true
     } else {

--- a/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.mtags
 
-import java.io.UncheckedIOException
 import java.nio.CharBuffer
 import java.nio.charset.StandardCharsets
 
@@ -58,18 +57,11 @@ class SymbolIndexBucket(
 
   def addSourceJar(jar: AbsolutePath): List[(String, AbsolutePath)] = {
     if (sourceJars.addEntry(jar)) {
-      FileIO.withJarFileSystem(jar, create = false) { root =>
-        try {
-          root.listRecursive.toList.flatMap {
-            case source if source.isScala =>
-              addSourceFile(source, None).map(sym => (sym, source))
-            case _ =>
-              List.empty
-          }
-        } catch {
-          // this happens in broken jars since file from FileWalker should exists
-          case _: UncheckedIOException => Nil
-        }
+      jar.listRecursive.toList.flatMap {
+        case source if source.isScala =>
+          addSourceFile(source, Some(jar)).map(sym => (sym, source))
+        case _ =>
+          List.empty
       }
     } else
       List.empty


### PR DESCRIPTION
An experiment in using the VSCode FileSystem API to explore library dependencies

Here's an example....
![image](https://user-images.githubusercontent.com/5612295/159544903-5f440ff5-336f-462a-96d6-a255ec4f3ba8.png)

Stuff that works...
1) auto population of libraries on indexing complete
2) file exploring
3) file opening
4) breadcrumbs

Stuff that doesn't work...
1) IDE functionality - i.e. Metals doesn't recognise these as scala (or java) files (because it doesn't understand the URI)
2) decompiling of class files from non-source jars - shouldn't be hard to add
3) searching using VSCode search - doesn't look possible
4) file explorer <-> current edited document sync - unsure yet

Weird stuff
1) the user can easily just delete the virtual `Metals - libraries` workspace folder.  Can't see a way to stop this.  It doesn't cause an error, it's just that the functionality is then lost.  It would be re-added on `Reload Window`

FileSystem API uses URIs to reference files.  With the flat approach taken here (i.e. `root/all_jars/XXX` path) the real jar URIs will not match with the flat URIs.
So `metalslibs:/scala-library-2.13.8-sources.jar!/scala/io/source.scala` != `jar:file:///localRepoPath/scala-library-2.13.8-sources.jar!/scala/io/source.scala`
Because of this VSCode thinks these are 2 different files.  Metals also doesn't recognise the former URI and code would have to be added to interpret this URI in the same way the `readonly` directory is handled.  Even so - VSCode would still think these were different files.

Another option would be to take a non-flat structure and have the real directory structure leading to all the jars (albeit only showing dirs with jars in).  I haven't checked if this will actually work as VSCode corrupts URIs given to it (e.g. root has to == `/` when I'd like it to be `file:///`).
This probably wouldn't be as easy to use and I'm still exploring if it's possible.

@kpodsiad Here's a working, but limited, jar explorer.
