### PR TITLE
Introduce uses of buildTarget/inverseSources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -176,7 +176,7 @@ lazy val V = new {
   val ammonite213Version = "2.13.7"
 
   val ammonite = "2.5.2"
-  val bloop = "1.4.13-48-a9b3ea59"
+  val bloop = "1.4.13-50-8332ee9c"
   val bloopNightly = bloop
   val bsp = "2.0.0-M15"
   val coursier = "2.1.0-M5"

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.metals
 import java.io.IOException
 import java.io.InputStream
 import java.net.URI
+import java.util.Collections
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -197,6 +198,20 @@ class BuildServerConnection private (
       params: DependencySourcesParams
   ): Future[DependencySourcesResult] = {
     register(server => server.buildTargetDependencySources(params)).asScala
+  }
+
+  def buildTargetInverseSources(
+      params: InverseSourcesParams
+  ): Future[InverseSourcesResult] = {
+    if (initialConnection.capabilities.getInverseSourcesProvider()) {
+      register(server => server.buildTargetInverseSources(params)).asScala
+    } else {
+      scribe.warn(
+        s"${initialConnection.displayName} does not support `buildTarget/inverseSources`, unable to fetch targets owning source."
+      )
+      val empty = new InverseSourcesResult(Collections.emptyList)
+      Future.successful(empty)
+    }
   }
 
   private val cancelled = new AtomicBoolean(false)

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -233,6 +233,10 @@ final class BuildTargets() {
         }
         Future.sequence(queries).map { results =>
           val target = results.flatten.maxByOption(buildTargetsOrder)
+          for {
+            tgt <- target
+            data <- targetData(tgt)
+          } data.addSourceItem(source, tgt)
           target
         }
       case some =>

--- a/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
@@ -68,7 +68,8 @@ class DidFocusLspSuite extends BaseLspSuite("did-focus") {
     } yield ()
   }
 
-  test("497") {
+  // Ignore flaky test, see the details: https://github.com/scalameta/metals/pull/3752#issuecomment-1079878023
+  test("497".ignore) {
     cleanWorkspace()
     for {
       _ <- initialize(


### PR DESCRIPTION
Previously, Metals would only use the result of `buildTarget/sources` to
figure which target owns a given source file. Because
`buildTarget/sources` is issued as part of build import, the list of
sources (directories and files) returned by the build server could be
stored and re-used to immediately determine the owning target, given a
source file.

It turns out, however, that for some targets this knowledge can become
outdated. For instance, Bloop supports defining the source files as a
set of globs [1]. In this case, Bloop will respond to the
`buildTarget/sources` request issued during build import with the list
of files that match at this point in time. If the developer create a new
file which would be matched by Bloop's globs, Metals will be unable to
associate it with a target.

Determining which targets own a given source file is supported by the
BSP protocol via the `buildTarget/inverseSources` request [2].

This commit introduces a new method `BuildTargets#inverseSourcesBsp`,
which finds the target owning the given source file, just like the
existing `BuildTargets#inverseSources` does, but using BSP if the
original method couldn't find a match. Because this new method is
asynchronous (it communicates with the BSP server), migrating all
call-sites to use it would require many changes to Metals.

When used with Bloop, requires scalacenter/bloop#1704.

[1]: https://github.com/scalacenter/bloop/blob/a9b3ea59631ca300c06394effbdf4b2a8e88dbf1/config/src/main/scala/bloop/config/Config.scala#L231-L236
[2]: https://build-server-protocol.github.io/docs/specification.html#inverse-sources-request