### PR TITLE
Fix issues with non alpha numeric build target names

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
@@ -100,7 +100,10 @@ class BuildTargetInfo(buildTargets: BuildTargets) {
       )
     })
     commonInfo.foreach(info => {
-      output ++= getSection("Base Directory", List(info.baseDirectory))
+      output ++= getSection(
+        "Base Directory",
+        List(URIEncoderDecoder.decode(info.baseDirectory))
+      )
       output ++= getSection("Source Directories", getSources(info))
     })
 

--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -144,7 +144,7 @@ final class FileDecoderProvider(
    * metalsDecode:file:///workspacePath/buildTargetName.metals-buildtarget
    */
   def decodedFileContents(uriAsStr: String): Future[DecoderResponse] = {
-    Try(URI.create(uriAsStr)) match {
+    Try(URI.create(URIEncoderDecoder.encode(uriAsStr))) match {
       case Success(uri) =>
         uri.getScheme() match {
           case "jar" => Future { decodeJar(uriAsStr) }
@@ -268,7 +268,9 @@ final class FileDecoderProvider(
 
   private def decodeBuildTarget(uri: URI): DecoderResponse = {
     val targetName =
-      uri.toString.stripSuffix(".metals-buildtarget").split('/').last
+      URIEncoderDecoder.decode(
+        uri.toString.stripSuffix(".metals-buildtarget").split('/').last
+      )
     val text =
       new BuildTargetInfo(buildTargets).buildTargetDetails(targetName)
     DecoderResponse.success(uri, text)

--- a/metals/src/main/scala/scala/meta/internal/metals/URIEncoderDecoder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/URIEncoderDecoder.scala
@@ -1,0 +1,47 @@
+package scala.meta.internal.metals
+
+object URIEncoderDecoder {
+
+  private val toEscape: Map[Char, String] =
+    Set('"', '<', '>', '&', '\'', '[', ']', '{', '}', ' ')
+      .map(char => char -> ("%" + char.toHexString))
+      .toMap
+
+  private val toDecode: Map[String, Char] = toEscape.map { case (k, v) =>
+    v -> k
+  }
+
+  def encode(args: String): String = {
+    args.flatMap { char =>
+      toEscape.getOrElse(char, char.toString())
+    }
+  }
+
+  def decode(args: String): String = {
+    val it = args.iterator
+    var ch: Char = 'a'
+    val buffer = new StringBuilder()
+    while (it.hasNext) {
+      ch = it.next()
+      if (ch == '%') {
+        if (it.hasNext) {
+          val first = it.next()
+          if (it.hasNext) {
+            val second = it.next()
+            val value = s"%$first$second"
+            buffer.append(toDecode.getOrElse(value.toLowerCase(), value))
+          } else {
+            buffer.append("%")
+            buffer.append(first)
+          }
+        } else {
+          buffer.append(ch)
+        }
+
+      } else {
+        buffer.append(ch)
+      }
+    }
+    buffer.toString()
+  }
+}

--- a/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
@@ -5,6 +5,7 @@ import scala.meta.internal.metals.{BuildInfo => V}
 
 import munit.TestOptions
 import tests.BaseLspSuite
+import tests.QuickBuildLayout
 import tests.SbtBuildLayout
 import tests.SbtServerInitializer
 
@@ -343,17 +344,17 @@ class FileDecoderProviderLspSuite
 
   checkBuildTarget(
     "buildtarget",
-    SbtBuildLayout(
+    QuickBuildLayout(
       s"""|/metals.json
           |{
-          |  "a": {
+          |  "a[2.13.8]": {
           |    "scalaVersion": "${V.scala3}"
           |  },
           |  "b": {
           |    "scalaVersion": "${V.scala3}"
           |  }
           |}
-          |/a/src/main/scala/Main.scala
+          |/a[2.13.8]/src/main/scala/Main.scala
           |package a
           |class A {
           |  def foo(): Unit = ()
@@ -366,7 +367,7 @@ class FileDecoderProviderLspSuite
           |""".stripMargin,
       V.scala3
     ),
-    "a", // buildTarget, see: SbtBuildLayout
+    "a[2.13.8]", // buildTarget, see: SbtBuildLayout
     Right(FileDecoderProviderLspSuite.buildTargetResponse),
     result =>
       FileDecoderProviderLspSuite.filterSections(
@@ -1285,13 +1286,13 @@ object FileDecoderProviderLspSuite {
 
   def buildTargetResponse: String =
     s"""|Target
-        |  a
+        |  a[2.13.8]
         |
         |Scala Version
         |  ${V.scala3}
         |
         |Base Directory
-        |  file://@workspace/a/""".stripMargin
+        |  file://@workspace/a[2.13.8]/""".stripMargin
 
   def sbtBuildTargetResponse: String =
     s"""|Target

--- a/tests/unit/src/test/scala/tests/UriEncoderDecoderSuite.scala
+++ b/tests/unit/src/test/scala/tests/UriEncoderDecoderSuite.scala
@@ -1,0 +1,44 @@
+package tests
+
+import scala.meta.internal.metals.URIEncoderDecoder
+
+class UriEncoderDecoderSuite extends BaseSuite {
+
+  test("encode") {
+    val entry =
+      "metalsDecode:file:///home/user/metals/tests/slow/target/e2e/fileDecoderProvider/buildtarget/a[2.13.8].metals-buildtarget"
+    val expected =
+      "metalsDecode:file:///home/user/metals/tests/slow/target/e2e/fileDecoderProvider/buildtarget/a%5b2.13.8%5d.metals-buildtarget"
+
+    val obtained = URIEncoderDecoder.encode(entry)
+    assertEquals(
+      obtained,
+      expected
+    )
+  }
+
+  test("decode") {
+    val entry =
+      "metalsDecode:file:///home/user/metals/tests/slow/target/e2e/fileDecoderProvider/buildtarget/a%5b2.13.8%5d.metals-buildtarget"
+    val expected =
+      "metalsDecode:file:///home/user/metals/tests/slow/target/e2e/fileDecoderProvider/buildtarget/a[2.13.8].metals-buildtarget"
+    val obtained = URIEncoderDecoder.decode(entry)
+    assertEquals(
+      obtained,
+      expected
+    )
+  }
+
+  test("decode-uppercase") {
+    val entry =
+      "file:///home/user/metals/tests/slow/target/e2e/fileDecoderProvider/buildtarget/a%5B2.13.8%5D/"
+    val expected =
+      "file:///home/user/metals/tests/slow/target/e2e/fileDecoderProvider/buildtarget/a[2.13.8]/"
+    val obtained = URIEncoderDecoder.decode(entry)
+    assertEquals(
+      obtained,
+      expected
+    )
+  }
+
+}


### PR DESCRIPTION
This issues shows up for example in Mill projects which have the `[2.13.8]` added to indicate the version of the target.