### PR TITLE
Reduce file watcher memory usage

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -466,6 +466,9 @@ final class BuildTargets() {
     }
   }
 
+  def isSourceFile(source: AbsolutePath): Boolean =
+    data.iterator.exists(_.isSourceFile(source))
+
   def checkIfGeneratedSource(source: Path): Boolean =
     data.iterator.exists(_.checkIfGeneratedSource(source))
   def checkIfGeneratedDir(path: AbsolutePath): Boolean =

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -232,6 +232,7 @@ final case class Indexer(
         // note(@tgodzik) This is needed in case of ammonite
         // where it can rarely deletes directories while we are trying to watch them
         case NonFatal(e) =>
+          fileWatcher.cancel()
           scribe.warn("File watching failed, indexes will not be updated.", e)
       }
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -181,6 +181,8 @@ final case class Indexer(
   }
 
   private def indexWorkspace(check: () => Unit): Unit = {
+    fileWatcher.cancel()
+
     timerProvider.timedThunk(
       "reset stuff",
       clientConfig.initialConfig.statistics.isIndex
@@ -225,7 +227,7 @@ final case class Indexer(
       clientConfig.initialConfig.statistics.isIndex
     ) {
       try {
-        fileWatcher.restart()
+        fileWatcher.start()
       } catch {
         // note(@tgodzik) This is needed in case of ammonite
         // where it can rarely deletes directories while we are trying to watch them

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1241,7 +1241,7 @@ class MetalsLanguageServer(
         semanticdb = targetroot.resolve(Directories.semanticdb)
         generatedFile <- semanticdb.listRecursive
       } {
-        val event = FileWatcherEvent.modify(generatedFile.toNIO)
+        val event = FileWatcherEvent.createOrModify(generatedFile.toNIO)
         didChangeWatchedFiles(event).get()
       }
     }
@@ -1361,11 +1361,12 @@ class MetalsLanguageServer(
         diagnostics.didDelete(path)
       }.asJava
     } else if (
-      isScalaOrJava && !savedFiles.isRecentlyActive(path) && !buffers
-        .contains(path)
+      isScalaOrJava &&
+      !savedFiles.isRecentlyActive(path) &&
+      !buffers.contains(path)
     ) {
       event.eventType match {
-        case EventType.Create =>
+        case EventType.CreateOrModify =>
           buildTargets.onCreate(path)
         case _ =>
       }
@@ -1375,7 +1376,7 @@ class MetalsLanguageServer(
         event.eventType match {
           case EventType.Delete =>
             semanticDBIndexer.onDelete(event.path)
-          case EventType.Create | EventType.Modify =>
+          case EventType.CreateOrModify =>
             semanticDBIndexer.onChange(event.path)
           case EventType.Overflow =>
             semanticDBIndexer.onOverflow(event.path)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1377,6 +1377,8 @@ class MetalsLanguageServer(
             semanticDBIndexer.onDelete(event.path)
           case EventType.Create | EventType.Modify =>
             semanticDBIndexer.onChange(event.path)
+          case EventType.Overflow =>
+            semanticDBIndexer.onOverflow(event.path)
         }
       }.asJava
     } else if (path.isBuild) {

--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
@@ -43,6 +43,24 @@ class SemanticdbIndexer(
     providers.foreach(_.onDelete(absolutePath))
   }
 
+  /**
+   * Handle EventType.OVERFLOW
+   *
+   * The overflow events comes either with a non-null or null path.
+   *
+   * In case the path is not null, we walk up the file tree to the parent `META-INF/semanticdb`
+   * parent directory and re-index all of its `*.semanticdb` children.
+   *
+   * In case of a null path, we re-index `META-INF/semanticdb` for all targets
+   */
+  def onOverflow(path: Path): Unit = {
+    if (path == null) {
+      onTargetRoots()
+    } else {
+      path.semanticdbRoot.foreach(onChangeDirectory(_))
+    }
+  }
+
   private def onChangeDirectory(dir: Path): Unit = {
     if (Files.isDirectory(dir)) {
       val stream = Files.walk(dir)

--- a/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
@@ -1,8 +1,11 @@
 package scala.meta.internal.metals.watcher
 
-import java.io.IOException
 import java.nio.file.Path
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 
 import scala.meta.internal.metals.BuildTargets
@@ -12,11 +15,11 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.io.AbsolutePath
 
-import com.swoval.files.FileTreeDataViews.CacheObserver
-import com.swoval.files.FileTreeDataViews.Converter
-import com.swoval.files.FileTreeDataViews.Entry
-import com.swoval.files.FileTreeRepositories
-import com.swoval.files.FileTreeRepository
+import com.swoval.files.FileTreeViews
+import com.swoval.files.FileTreeViews.Observer
+import com.swoval.files.PathWatcher
+import com.swoval.files.PathWatchers
+import com.swoval.files.PathWatchers.Event.Kind
 
 /**
  * Watch selected files and execute  a callback on file events.
@@ -42,30 +45,24 @@ final class FileWatcher(
   import FileWatcher._
 
   @volatile
-  private var disposeAction: Option[() => Unit] = None
+  private var stopWatcher: () => Unit = () => ()
 
   override def cancel(): Unit = {
-    disposeAction.map(_.apply())
-    disposeAction = None
+    stopWatcher()
   }
 
-  def restart(): Unit = {
-    disposeAction.map(_.apply())
-
-    val newDispose = startWatch(
+  def start(): Unit = {
+    stopWatcher = startWatch(
       config,
       workspaceDeferred().toNIO,
       collectFilesToWatch(buildTargets),
       onFileWatchEvent,
       watchFilter
     )
-    disposeAction = Some(newDispose)
   }
 }
 
 object FileWatcher {
-  type Hash = Long
-
   private case class FilesToWatch(
       sourceFiles: Set[Path],
       sourceDirectories: Set[Path],
@@ -121,85 +118,125 @@ object FileWatcher {
       callback: FileWatcherEvent => Unit,
       watchFilter: Path => Boolean
   ): () => Unit = {
-    if (scala.util.Properties.isMac) {
-      // Due to a hard limit on the number of FSEvents streams that can be
-      // opened on macOS, only up to 32 longest common prefixes of the files to
-      // watch are registered for a recursive watch.
-      // However, the events are then filtered to receive only relevant events
-      // and also to hash only relevant files when watching for changes
+    val watchEventQueue: BlockingQueue[FileWatcherEvent] =
+      new LinkedBlockingQueue[FileWatcherEvent]
 
-      val trie = PathTrie(
-        filesToWatch.sourceFiles ++ filesToWatch.sourceDirectories ++ filesToWatch.semanticdDirectories
-      )
-      val isWatched = trie.containsPrefixOf _
+    val watcher: PathWatcher[PathWatchers.Event] = {
+      if (scala.util.Properties.isMac) {
+        // Due to a hard limit on the number of FSEvents streams that can be
+        // opened on macOS, only up to 32 longest common prefixes of the files to
+        // watch are registered for a recursive watch.
+        // However, the events are then filtered to receive only relevant events
 
-      // Select up to `maxRoots` longest prefixes of all files in the trie for
-      // watching. Watching the root of the workspace may have bad performance
-      // implications if it contains many other projects that we don't need to
-      // watch (eg. in a monorepo)
-      val watchRoots =
-        trie.longestPrefixes(workspace.getRoot(), config.macOsMaxWatchRoots)
+        val trie = PathTrie(
+          filesToWatch.sourceFiles ++ filesToWatch.sourceDirectories ++ filesToWatch.semanticdDirectories
+        )
+        val isWatched = trie.containsPrefixOf _
 
-      val repo = initFileTreeRepository(
-        path => watchFilter(path) && isWatched(path),
-        callback
-      )
-      watchRoots.foreach { root =>
-        scribe.debug(s"Registering root for file watching: $root")
-        repo.register(root, Int.MaxValue)
+        // Select up to `maxRoots` longest prefixes of all files in the trie for
+        // watching. Watching the root of the workspace may have bad performance
+        // implications if it contains many other projects that we don't need to
+        // watch (eg. in a monorepo)
+        val watchRoots =
+          trie.longestPrefixes(workspace.getRoot(), config.macOsMaxWatchRoots)
+
+        val watcher = initWatcher(
+          path => watchFilter(path) && isWatched(path),
+          watchEventQueue
+        )
+        watchRoots.foreach { root =>
+          scribe.debug(s"Registering root for file watching: $root")
+          watcher.register(root, Int.MaxValue)
+        }
+
+        watcher
+      } else {
+        // Other OSes register all the files and directories individually
+        val watcher = initWatcher(watchFilter, watchEventQueue)
+
+        filesToWatch.sourceDirectories.foreach(
+          watcher.register(_, Int.MaxValue)
+        )
+        filesToWatch.semanticdDirectories.foreach(
+          watcher.register(_, Int.MaxValue)
+        )
+        filesToWatch.sourceFiles.foreach(watcher.register(_, -1))
+
+        watcher
       }
-      () => repo.close()
-    } else {
-      // Other OSes register all the files and directories individually
-      val repo = initFileTreeRepository(watchFilter, callback)
+    }
 
-      filesToWatch.sourceDirectories.foreach(repo.register(_, Int.MaxValue))
-      filesToWatch.semanticdDirectories.foreach(repo.register(_, Int.MaxValue))
-      filesToWatch.sourceFiles.foreach(repo.register(_, -1))
+    val stopWatchingSignal: AtomicBoolean = new AtomicBoolean
 
-      () => repo.close()
+    // queue is processed serially to defensively prevent possible races
+    // when a file is created and then deleted in quick succesion.
+    // Upstream callbacks implicitly assume that events for a single file
+    // arrive and are processed serially.
+    // This consumption could be parallelized, but in case in indexing,
+    // compilation is usually the dominating bottleneck
+    val thread = new Thread("metals-watch-callback-thread") {
+      @tailrec def loop(): Unit = {
+        try callback(watchEventQueue.take)
+        catch { case _: InterruptedException => }
+        if (!stopWatchingSignal.get) loop()
+      }
+      override def run(): Unit = loop()
+      start()
+    }
+
+    () => {
+      watcher.close()
+      stopWatchingSignal.set(true)
+      thread.interrupt()
     }
   }
 
-  private def initFileTreeRepository(
+  /**
+   * Initialize file watcher
+   *
+   * File watch events are put into a queue which is processed separately
+   * to prevent callbacks to be executed on the thread that watches
+   * for file events.
+   *
+   * @param watchFilter for incoming file watch events
+   * @param queue for file events
+   * @return
+   */
+  private def initWatcher(
       watchFilter: Path => Boolean,
-      callback: FileWatcherEvent => Unit
-  ): FileTreeRepository[Hash] = {
-    val converter: Converter[Hash] = typedPath =>
-      hashFile(
-        typedPath.getPath(),
-        watchFilter
-      )
-    val repo = FileTreeRepositories.get(converter, /*follow symlinks*/ true)
+      queue: BlockingQueue[FileWatcherEvent]
+  ): PathWatcher[PathWatchers.Event] = {
+    val watcher = PathWatchers.get( /*follow symlinks*/ true)
 
-    repo.addCacheObserver(new CacheObserver[Hash] {
-      override def onCreate(entry: Entry[Hash]): Unit = {
-        val path = entry.getTypedPath().getPath()
-        if (watchFilter(path)) callback(FileWatcherEvent.create(path))
+    watcher.addObserver(new Observer[PathWatchers.Event] {
+      override def onError(t: Throwable): Unit = {
+        scribe.error(s"Error encountered during file watching", t)
       }
-      override def onDelete(entry: Entry[Hash]): Unit = {
-        val path = entry.getTypedPath().getPath()
-        if (watchFilter(path)) callback(FileWatcherEvent.delete(path))
-      }
-      override def onUpdate(
-          previous: Entry[Hash],
-          current: Entry[Hash]
-      ): Unit = {
-        val path = current.getTypedPath().getPath()
-        if (previous.getValue != current.getValue && watchFilter(path)) {
-          callback(FileWatcherEvent.modify(path))
+
+      override def onNext(event: PathWatchers.Event): Unit = {
+        val path = event.getTypedPath.getPath
+        if (watchFilter(path)) {
+          event.getKind match {
+            case Kind.Create => {
+              queue.add(FileWatcherEvent.create(path))
+            }
+            case Kind.Modify => {
+              queue.add(FileWatcherEvent.modify(path))
+            }
+            case Kind.Delete => {
+              queue.add(FileWatcherEvent.delete(path))
+            }
+            case Kind.Overflow => {
+              queue.add(FileWatcherEvent.overflow(path))
+            }
+            case Kind.Error => {
+              scribe.error("File watcher encountered an unknown error")
+            }
+          }
         }
       }
-      override def onError(ex: IOException) = {}
     })
-    repo
-  }
 
-  private def hashFile(path: Path, hashFilter: Path => Boolean): Hash = {
-    if (hashFilter(path)) {
-      path.toFile().lastModified()
-    } else {
-      0L
-    }
+    watcher
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
@@ -77,7 +77,7 @@ object FileWatcher {
       if (buildTargets.isInsideSourceRoot(path)) {
         () // Do nothing, already covered by a source root
       } else if (!buildTargets.checkIfGeneratedSource(path.toNIO)) {
-        if (path.isScalaOrJava) {
+        if (buildTargets.isSourceFile(path)) {
           sourceFilesToWatch.add(path.toNIO)
         } else {
           sourceDirectoriesToWatch.add(path.toNIO)

--- a/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcherEvent.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcherEvent.scala
@@ -11,16 +11,13 @@ object FileWatcherEvent {
   sealed trait EventType
 
   object EventType {
-    case object Create extends EventType
-    case object Modify extends EventType
+    case object CreateOrModify extends EventType
     case object Delete extends EventType
     case object Overflow extends EventType
   }
 
-  def create(path: Path): FileWatcherEvent =
-    FileWatcherEvent(EventType.Create, path)
-  def modify(path: Path): FileWatcherEvent =
-    FileWatcherEvent(EventType.Modify, path)
+  def createOrModify(path: Path): FileWatcherEvent =
+    FileWatcherEvent(EventType.CreateOrModify, path)
   def delete(path: Path): FileWatcherEvent =
     FileWatcherEvent(EventType.Delete, path)
   // indicates that file watching events may have been lost

--- a/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcherEvent.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcherEvent.scala
@@ -14,6 +14,7 @@ object FileWatcherEvent {
     case object Create extends EventType
     case object Modify extends EventType
     case object Delete extends EventType
+    case object Overflow extends EventType
   }
 
   def create(path: Path): FileWatcherEvent =
@@ -22,4 +23,8 @@ object FileWatcherEvent {
     FileWatcherEvent(EventType.Modify, path)
   def delete(path: Path): FileWatcherEvent =
     FileWatcherEvent(EventType.Delete, path)
+  // indicates that file watching events may have been lost
+  // for the given path, or for an unknown path if path is null
+  def overflow(path: Path): FileWatcherEvent =
+    FileWatcherEvent(EventType.Overflow, path)
 }


### PR DESCRIPTION
This PR replaces `FileTreeRepository` with `PathWatcher`. The former keeps a cached version of watched file trees while the latter does not. Since the implementation no longer hashes files, but looks only on modification time, we can only watch modifications without keeping any state.

This makes a huge difference especially on macOS, where in large projects the root of the project has to be watched. My motivation for this change is that from time to time, metals stopped working and threw OOM exceptions (I think I experienced something akin to https://github.com/scalameta/metals/issues/3020) and I had to delete the `.bloop` folder and restart metals. In a particular case, the cached paths took more than half of 4GB heap dedicated to metals.

Shoutout and huge thanks to @eatkins that fixed an issue https://github.com/swoval/swoval/issues/155 that I experienced while testing the change on Linux.