### PR TITLE
add navigation from doctor to build target

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DoctorResults.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DoctorResults.scala
@@ -46,6 +46,7 @@ object DoctorStatus {
 
 final case class DoctorTargetInfo(
     name: String,
+    gotoCommand: String,
     dataKind: String,
     baseDirectory: String,
     targetType: String,
@@ -60,6 +61,7 @@ final case class DoctorTargetInfo(
   def toJson: Obj =
     ujson.Obj(
       "buildTarget" -> name,
+      "gotoCommand" -> gotoCommand,
       "compilationStatus" -> compilationStatus.explanation,
       "targetType" -> targetType,
       "diagnostics" -> diagnosticsStatus.explanation,

--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.metals
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.net.URI
+import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import javax.annotation.Nullable
 
@@ -630,4 +631,14 @@ final class FileDecoderProvider(
           DecoderResponse.success(path.toURI, pathInfo.path.toURI.toString())
         )
     }
+}
+
+object FileDecoderProvider {
+  def createBuildTargetURI(
+      workspace: AbsolutePath,
+      buildTargetName: String
+  ): URI =
+    URI.create(
+      s"metalsDecode:${URLEncoder.encode(s"file:///${workspace.filename}/${buildTargetName}.metals-buildtarget")}"
+    )
 }

--- a/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
@@ -1,5 +1,6 @@
 package tests.feature
 
+import scala.meta.internal.metals.FileDecoderProvider
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.{BuildInfo => V}
 
@@ -438,12 +439,13 @@ trait FileDecoderProviderLspSpec { self: BaseLspSuite =>
       expected: Either[String, String],
       transformResult: String => String = identity
   ): Unit = {
-    val extension = "metals-buildtarget"
     test(testName) {
       for {
         _ <- initialize(input)
         result <- server.executeDecodeFileCommand(
-          s"metalsDecode:file://$workspace/$buildTarget.$extension"
+          FileDecoderProvider
+            .createBuildTargetURI(workspace, buildTarget)
+            .toString
         )
       } yield {
         assertEquals(


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5612295/160288483-19e4494c-827a-4e68-93d2-9e2dfa1a9c9a.png)

Adds html links to build target info from the Doctor as in image above.

Does the command to navigate to a uri have to include location?  Or is there another command instead of `metals-goto-location`?  Ideally it would just open the URI.

@ckipp01 Is the addition of `gotoCommand` to the Doctor JSON the best way to handle non vscode clients?
