### PR TITLE
Try to fix flaky test by adding a delay in compilation

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -22,7 +22,8 @@ final class Compilations(
     languageClient: MetalsLanguageClient,
     refreshTestSuites: () => Unit,
     isCurrentlyFocused: b.BuildTargetIdentifier => Boolean,
-    compileWorksheets: Seq[AbsolutePath] => Future[Unit]
+    compileWorksheets: Seq[AbsolutePath] => Future[Unit],
+    onStartCompilation: () => Unit
 )(implicit ec: ExecutionContext) {
 
   // we are maintaining a separate queue for cascade compilation since those must happen ASAP
@@ -210,7 +211,6 @@ final class Compilations(
         CancelableFuture.sequence(futures).map(_.flatten.toMap)
     }
   }
-
   private def compile(
       connection: BuildServerConnection,
       targets: Seq[b.BuildTargetIdentifier]
@@ -218,6 +218,8 @@ final class Compilations(
     val params = new b.CompileParams(targets.asJava)
     targets.foreach(target => isCompiling(target) = true)
     val compilation = connection.compile(params)
+
+    onStartCompilation()
 
     val result = compilation.asScala
       .andThen { case result =>

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -108,7 +108,8 @@ class MetalsLanguageServer(
       BspServers.globalInstallDirectories,
     sh: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
     isReliableFileWatcher: Boolean = true,
-    mtagsResolver: MtagsResolver = MtagsResolver.default()
+    mtagsResolver: MtagsResolver = MtagsResolver.default(),
+    onStartCompilation: () => Unit = () => ()
 ) extends Cancelable {
   ThreadPools.discardRejectedRunnables("MetalsLanguageServer.sh", sh)
   ThreadPools.discardRejectedRunnables("MetalsLanguageServer.ec", ec)
@@ -185,7 +186,8 @@ class MetalsLanguageServer(
     languageClient,
     () => testProvider.refreshTestSuites(),
     buildTarget => focusedDocumentBuildTarget.get() == buildTarget,
-    worksheets => onWorksheetChanged(worksheets)
+    worksheets => onWorksheetChanged(worksheets),
+    onStartCompilation
   )
   private val fileWatcher = register(
     new FileWatcher(

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -47,6 +47,7 @@ abstract class BaseLspSuite(
   var server: TestingServer = _
   var client: TestingClient = _
   var workspace: AbsolutePath = _
+  var onStartCompilation: () => Unit = () => ()
 
   protected def initializationOptions: Option[InitializationOptions] = None
 
@@ -118,7 +119,8 @@ abstract class BaseLspSuite(
       sh,
       time,
       initOptions,
-      mtagsResolver
+      mtagsResolver,
+      onStartCompilation
     )(ex)
     server.server.userConfig = this.userConfig
   }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -130,7 +130,8 @@ final class TestingServer(
     sh: ScheduledExecutorService,
     time: Time,
     initializationOptions: Option[InitializationOptions],
-    mtagsResolver: MtagsResolver
+    mtagsResolver: MtagsResolver,
+    onStartCompilation: () => Unit = () => ()
 )(implicit ex: ExecutionContextExecutorService) {
   import scala.meta.internal.metals.JsonParser._
 
@@ -144,7 +145,8 @@ final class TestingServer(
     sh = sh,
     time = time,
     isReliableFileWatcher = System.getenv("CI") != "true",
-    mtagsResolver = mtagsResolver
+    mtagsResolver = mtagsResolver,
+    onStartCompilation = onStartCompilation
   )
   server.connectToLanguageClient(client)
 

--- a/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
@@ -89,7 +89,9 @@ class DidFocusWhileCompilingLspSuite
     super.beforeEach(context)
   }
 
-  test("497") {
+  test(
+    "Trigger compilation by didFocus when current compile may affect focused buffer"
+  ) {
     cleanWorkspace()
     for {
       _ <- initialize(

--- a/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
@@ -1,7 +1,5 @@
 package tests
 
-import scala.concurrent.Future
-
 import scala.meta.internal.metals.DidFocusResult._
 import scala.meta.internal.metals.Time
 
@@ -79,8 +77,8 @@ class DidFocusWhileCompilingLspSuite
   val compileDelayMillis = 5000
   override def time: Time = fakeTime
 
-  // sleep 10s during the compilation, so that we can make sure
-  // invoking `didFocus` during compilation.
+  // sleep 5s during the compilation, so that we can make sure
+  // calling `didFocus` during compilation.
   override def beforeEach(context: BeforeEach): Unit = {
     fakeTime = new FakeTime()
     onStartCompilation = () => {
@@ -145,7 +143,7 @@ class DidFocusWhileCompilingLspSuite
         _.replace("Int", "String")
       )
       // Wait until compilation against project a is started (before we invoke didFocus on project b)
-      _ <- Future { Thread.sleep(compileDelayMillis / 2) }
+      _ <- server.waitFor(compileDelayMillis / 2)
       // Focus before compilation of A.scala is complete.
       // And make sure didFocus during the compilation causes compilation against project b.
       didCompile <- server.didFocus("b/src/main/scala/b/B.scala")
@@ -165,5 +163,4 @@ class DidFocusWhileCompilingLspSuite
       )
     } yield ()
   }
-
 }

--- a/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
@@ -1,5 +1,7 @@
 package tests
 
+import scala.concurrent.Future
+
 import scala.meta.internal.metals.DidFocusResult._
 import scala.meta.internal.metals.Time
 
@@ -10,6 +12,7 @@ class DidFocusLspSuite extends BaseLspSuite("did-focus") {
     fakeTime = new FakeTime()
     super.beforeEach(context)
   }
+
   test("is-compiled") {
     cleanWorkspace()
     for {
@@ -67,9 +70,26 @@ class DidFocusLspSuite extends BaseLspSuite("did-focus") {
       )
     } yield ()
   }
+}
 
-  // Ignore flaky test, see the details: https://github.com/scalameta/metals/pull/3752#issuecomment-1079878023
-  test("497".ignore) {
+// https://github.com/scalameta/metals/issues/497
+class DidFocusWhileCompilingLspSuite
+    extends BaseLspSuite("did-focus-while-compiling") {
+  var fakeTime: FakeTime = _
+  val compileDelayMillis = 5000
+  override def time: Time = fakeTime
+
+  // sleep 10s during the compilation, so that we can make sure
+  // invoking `didFocus` during compilation.
+  override def beforeEach(context: BeforeEach): Unit = {
+    fakeTime = new FakeTime()
+    onStartCompilation = () => {
+      Thread.sleep(compileDelayMillis)
+    }
+    super.beforeEach(context)
+  }
+
+  test("497") {
     cleanWorkspace()
     for {
       _ <- initialize(
@@ -122,10 +142,16 @@ class DidFocusLspSuite extends BaseLspSuite("did-focus") {
       didSaveA = server.didSave("a/src/main/scala/a/A.scala")(
         _.replace("Int", "String")
       )
+      // Wait until compilation against project a is started (before we invoke didFocus on project b)
+      _ <- Future { Thread.sleep(compileDelayMillis / 2) }
       // Focus before compilation of A.scala is complete.
+      // And make sure didFocus during the compilation causes compilation against project b.
       didCompile <- server.didFocus("b/src/main/scala/b/B.scala")
       _ <- didSaveA
-      _ = assert(didCompile == Compiled)
+      _ = assert(
+        didCompile == Compiled,
+        s"expect 'Compiled', actual: ${didCompile}"
+      )
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|b/src/main/scala/b/B.scala:3:16: error: type mismatch;
@@ -137,4 +163,5 @@ class DidFocusLspSuite extends BaseLspSuite("did-focus") {
       )
     } yield ()
   }
+
 }


### PR DESCRIPTION
Follow up for https://github.com/scalameta/metals/pull/3752

We encountered the flaky test result of `DidFocusLspSuite` in the PR, because
we expect the test suite invokes `didFocus("b/.../B.scala")`
**during the compilation by `server.didSave("a/.../A.scala")`**, and
didFocus triggers a compilation.

However, we didn't have a way to control the timing of compilation
start, end, and when we invoke `didFocus`. That's why the test was flaky.
see more details: https://github.com/scalameta/metals/pull/3752#issuecomment-1079878023

This PR ensure that we call `server.didFocus("b/.../B.scala")` during
the compilation by `server.didSave("a/.../A.scala")` by

- Adding 5 seconds of delay during the compilation
  - to make sure we invoke `didFocus` before the compilation completed.
- Wait for 2.5 seconds before invoking `didFocus`
  - to make sure we invoke `didFocus` after the compilation started.