### PR TITLE
scala3 - exclude 3.2.0-NIGHTLY and align tests cases

### DIFF
--- a/.github/workflows/check_scala3_nightly.yml
+++ b/.github/workflows/check_scala3_nightly.yml
@@ -13,12 +13,15 @@ jobs:
           apps: ""
       - name: "Query maven-central"
         run: |
-          cs complete org.scala-lang:scala3-compiler_3: | grep NIGHTLY | sort > all_nightly
-          LAST_NIGHTLY_MTAG=$(cs complete org.scalameta:mtags_3 | grep NIGHTLY | sort | tail -n 1 | cut -d "_" -f2)
+          echo "3.2.0-RC1-bin-20220307-6dc591a-NIGHTLY" > broken
+          echo "3.2.0-RC1-bin-20220308-29073f1-NIGHTLY" >> broken
+
+          cs complete org.scala-lang:scala3-compiler_3: | grep NIGHTLY | grep -v -f partial.list | sort > all_nightly
+          LAST_NIGHTLY_MTAG=$(cs complete org.scalameta:mtags_3 | grep NIGHTLY | grep -v -f broken | sort | tail -n 1 | cut -d "_" -f2)
           LAST_NIGHTLY_POS=$(grep -n $LAST_NIGHTLY_MTAG  all_nightly | cut -d ":" -f1)
           LAST_NIGHTLY_POS=$(($LAST_NIGHTLY_POS+1))
           NEW_NIGHTLIES=$(tail -n +$LAST_NIGHTLY_POS all_nightly)
-          if [ ! -z $NEW_NIGHTLIES ]; then
+          if [ ! -z "$NEW_NIGHTLIES" ]; then
             while IFS= read -r version; do
               gh workflow run mtags-auto-release.yml -f scala_version=$version
             done <<< "$NEW_NIGHTLIES"

--- a/project/Scala3NightlyVersions.scala
+++ b/project/Scala3NightlyVersions.scala
@@ -3,6 +3,12 @@ import scala.util.Try
 
 object Scala3NightlyVersions {
 
+  val broken =
+    Set(
+      "3.2.0-RC1-bin-20220307-6dc591a-NIGHTLY",
+      "3.2.0-RC1-bin-20220308-29073f1-NIGHTLY"
+    ).flatMap(DottyVersion.parse)
+
   /**
    * Fetches last 5 nightly releases.
    * They should come at least after the last supported scala3 version
@@ -26,7 +32,7 @@ object Scala3NightlyVersions {
         .filter(_.endsWith("NIGHTLY"))
         .flatMap(DottyVersion.parse)
         .collect {
-          case v if v > lastVersion => v
+          case v if v > lastVersion && !broken.contains(v) => v
         }
         .toList
         .sorted

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -304,7 +304,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
     s"""|case class A(argument: Int)
         |object Main {
         |  def foo(argument: Int): A =
-        |    A(arg@@)
+        |    A(argu@@)
         |}
         |""".stripMargin,
     """|argument: Int
@@ -328,7 +328,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |  val number2 = 2
         |  val number4 = 4
         |  val number8 = 8
-        |  foo(ar@@)
+        |  foo(argu@@)
         |}
         |""".stripMargin,
     """|argument = : Int
@@ -341,7 +341,6 @@ class CompletionArgSuite extends BaseCompletionSuite {
     compat = Map(
       "3" ->
         """|argument = : Int
-           |Calendar - java.util
            |""".stripMargin
     )
   )


### PR DESCRIPTION
The existing `3.2.0` nightlies were published with incorrect version.
Current versions are published with `3.1.3-RC1*` prefix. So, to fix issues with ordering (these two looks like they are latest) I had to exclude them.


