### PR TITLE
Support MatchType in SemanticdbTreePrinter

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
@@ -86,8 +86,8 @@ class SemanticdbTreePrinter(
         } else {
           s"${printType(tpe)} {${printScope(scope)}}"
         }
-      case s.MatchType(scrutinee, _) =>
-        s"${printType(scrutinee)} match { ... }"
+      case s.MatchType(scrutinee, cases) =>
+        s"${printType(scrutinee)} match { ${cases.size} cases }"
     }
 
   def printScope(scope: Option[s.Scope]): String = {

--- a/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
@@ -86,6 +86,13 @@ class SemanticdbTreePrinter(
         } else {
           s"${printType(tpe)} {${printScope(scope)}}"
         }
+      case s.MatchType(scrutinee, cases) =>
+        val casesStr = cases
+          .map { caseType =>
+            s"${printType(caseType.key)} => ${printType(caseType.body)}"
+          }
+          .mkString(", ")
+        s"${printType(scrutinee)} match { ${casesStr} }"
     }
 
   def printScope(scope: Option[s.Scope]): String = {

--- a/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
@@ -86,13 +86,8 @@ class SemanticdbTreePrinter(
         } else {
           s"${printType(tpe)} {${printScope(scope)}}"
         }
-      case s.MatchType(scrutinee, cases) =>
-        val casesStr = cases
-          .map { caseType =>
-            s"${printType(caseType.key)} => ${printType(caseType.body)}"
-          }
-          .mkString(", ")
-        s"${printType(scrutinee)} match { ${casesStr} }"
+      case s.MatchType(scrutinee, _) =>
+        s"${printType(scrutinee)} match { ... }"
     }
 
   def printScope(scope: Option[s.Scope]): String = {


### PR DESCRIPTION
- scalameta 4.5.1 supports [MatchType](https://dotty.epfl.ch/docs/reference/new-types/match-types.html) in SemanticDB  https://github.com/scalameta/scalameta/releases/tag/v4.5.1 
- The next version of Scala3 [will support MatchType](https://github.com/lampepfl/dotty/pull/14608) in SemanticDB

This PR should enable metals to show inferred `MatchType` with the latest Scala3 compiler.


I tried to test it locally, but I guess this change won't affect the behavior at this moment because
- `SemanticdbTreePrinter` is used only for showing the inferred type (in Scala3 at least, at this moment).
- However, I'm not sure about the situation where MatchType is inferred.

So this PR is safe to merge :)


