### PR TITLE
Log BSP server stderr

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -21,6 +21,7 @@ import scala.meta.internal.metals.SocketConnection
 import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.mtags.MD5
+import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BspConnectionDetails
@@ -65,23 +66,31 @@ final class BspServers(
   ): Future[BuildServerConnection] = {
 
     def newConnection(): Future[SocketConnection] = {
-      val process = new ProcessBuilder(details.getArgv)
-        .directory(projectDirectory.toFile)
-        .start()
+      scribe.info(s"Running BSP server ${details.getArgv}")
+
+      val proc = SystemProcess.run(
+        details.getArgv.asScala.toList,
+        projectDirectory,
+        redirectErrorOutput = false,
+        Map(),
+        processOut = None,
+        processErr = Some(l => scribe.info("BSP server: " + l)),
+        discardInput = false,
+        threadNamePrefix = s"bsp-${details.getName}"
+      )
 
       val output = new ClosableOutputStream(
-        process.getOutputStream,
+        proc.outputStream,
         s"${details.getName} output stream"
       )
       val input = new QuietInputStream(
-        process.getInputStream,
+        proc.inputStream,
         s"${details.getName} input stream"
       )
 
       val finished = Promise[Unit]()
-      Future {
-        process.waitFor()
-        finished.success(())
+      proc.complete.ignoreValue.onComplete { res =>
+        finished.tryComplete(res)
       }
 
       Future.successful {
@@ -90,7 +99,7 @@ final class BspServers(
           output,
           input,
           List(
-            Cancelable(() => process.destroy())
+            Cancelable(() => proc.cancel)
           ),
           finished
         )

--- a/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
@@ -89,8 +89,8 @@ class ShellRunner(
       directory,
       redirectErrorOutput,
       env,
-      processOut,
-      processErr,
+      Some(processOut),
+      Some(processErr),
       propagateError
     )
     // NOTE(olafur): older versions of VS Code don't respect cancellation of

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
@@ -78,8 +78,8 @@ class JavaInteractiveSemanticdb(
       workDir,
       false,
       Map.empty,
-      outLine => stdout += outLine,
-      errLine => stdout += errLine
+      Some(outLine => stdout += outLine),
+      Some(errLine => stdout += errLine)
     )
 
     val future = ps.complete.recover { case NonFatal(e) =>

--- a/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
+++ b/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.process
 
 import java.io.IOException
 import java.io.InputStream
+import java.io.OutputStream
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -15,6 +16,8 @@ import scala.meta.io.AbsolutePath
 
 trait SystemProcess {
   def complete: Future[Int]
+  def inputStream: InputStream
+  def outputStream: OutputStream
   def cancel: Unit
 }
 
@@ -25,9 +28,10 @@ object SystemProcess {
       cwd: AbsolutePath,
       redirectErrorOutput: Boolean,
       env: Map[String, String],
-      processOut: String => Unit = scribe.info(_),
-      processErr: String => Unit = scribe.error(_),
+      processOut: Option[String => Unit] = Some(scribe.info(_)),
+      processErr: Option[String => Unit] = Some(scribe.error(_)),
       propagateError: Boolean = false,
+      discardInput: Boolean = true,
       threadNamePrefix: String = ""
   ): SystemProcess = {
 
@@ -44,6 +48,7 @@ object SystemProcess {
         redirectErrorOutput,
         processOut,
         processErr,
+        discardInput,
         threadNamePrefix
       )
     } catch {
@@ -60,8 +65,9 @@ object SystemProcess {
   def wrapProcess(
       ps: Process,
       redirectErrorOutput: Boolean,
-      processOut: String => Unit,
-      processErr: String => Unit,
+      processOut: Option[String => Unit],
+      processErr: Option[String => Unit],
+      discardInput: Boolean,
       threadNamePrefix: String
   ): SystemProcess = {
     def readOutput(
@@ -90,14 +96,17 @@ object SystemProcess {
       thread.start()
       thread
     }
-    // sbt might ask - Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? (default: r)
-    // and stuck there
-    ps.getOutputStream().close
+
+    if (discardInput) {
+      // sbt might ask - Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? (default: r)
+      // and stuck there
+      ps.getOutputStream().close
+    }
 
     val outReaders = List(
-      Some(readOutput("stdout", ps.getInputStream(), processOut(_))),
+      processOut.map(f => readOutput("stdout", ps.getInputStream(), f)),
       if (redirectErrorOutput) None
-      else Some(readOutput("stderr", ps.getErrorStream(), processErr(_)))
+      else processErr.map(f => readOutput("stderr", ps.getErrorStream(), f))
     ).flatten
 
     new SystemProcess {
@@ -109,6 +118,11 @@ object SystemProcess {
           exitCode
         }
       }
+
+      override def inputStream: InputStream =
+        ps.getInputStream
+      override def outputStream: OutputStream =
+        ps.getOutputStream
 
       override def cancel: Unit = {
         ps.destroy()
@@ -126,6 +140,16 @@ object SystemProcess {
   val Failed: SystemProcess =
     new SystemProcess {
       override def complete: Future[Int] = Future.successful(1)
+      override def inputStream: InputStream =
+        new InputStream {
+          override def read() = -1
+          override def read(b: Array[Byte], off: Int, len: Int) = -1
+        }
+      override def outputStream: OutputStream =
+        new OutputStream {
+          override def write(value: Int) = {}
+          override def write(b: Array[Byte], off: Int, len: Int): Unit = {}
+        }
       override def cancel: Unit = ()
     }
 }


### PR DESCRIPTION
This PR redirects the stderr of BSP servers to the logs of Metals. It can be helpful when anything goes wrong with a BSP server, giving Metals users any message that the BSP server printed.