### PR TITLE
Add better Scala CLI support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -380,6 +380,8 @@ lazy val metals = project
       // For reading classpaths.
       // for fetching ch.epfl.scala:bloop-frontend and other library dependencies
       "io.get-coursier" % "interface" % V.coursierInterfaces,
+      // for comparing versions
+      "io.get-coursier" %% "versions" % "0.3.1",
       // for logging
       "com.outr" %% "scribe" % V.scribe,
       "com.outr" %% "scribe-file" % V.scribe,

--- a/build.sbt
+++ b/build.sbt
@@ -395,6 +395,8 @@ lazy val metals = project
       "io.github.alexarchambault.ammonite" %% "ammonite-runner" % "0.3.3",
       "org.scala-lang.modules" %% "scala-xml" % "2.1.0",
       "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
+      ("org.virtuslab.scala-cli" % "scala-cli-bsp" % V.scalaCli)
+        .exclude("ch.epfl.scala", "bsp4j"),
     ),
     buildInfoPackage := "scala.meta.internal.metals",
     buildInfoKeys := Seq[BuildInfoKey](

--- a/build.sbt
+++ b/build.sbt
@@ -413,6 +413,7 @@ lazy val metals = project
       "javaSemanticdbVersion" -> V.javaSemanticdb,
       "scalafmtVersion" -> V.scalafmt,
       "ammoniteVersion" -> V.ammonite,
+      "scalaCliVersion" -> V.scalaCli,
       "organizeImportVersion" -> V.organizeImportRule,
       "millVersion" -> V.mill,
       "debugAdapterVersion" -> V.debugAdapter,
@@ -607,6 +608,7 @@ lazy val metalsDependencies = project
       "org.typelevel" % "kind-projector" % V.kindProjector cross CrossVersion.full,
       "com.olegpy" %% "better-monadic-for" % V.betterMonadicFor,
       "com.lihaoyi" % "mill-contrib-testng" % V.mill,
+      "org.virtuslab.scala-cli" % "cli_3" % V.scalaCli intransitive (),
     ),
   )
   .disablePlugins(ScalafixPlugin)

--- a/metals/src/main/scala/scala/meta/internal/bsp/MetalsBspException.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/MetalsBspException.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.metals
 
-case class MetalsBspException(tryingToGet: String, msg: String)
+final class MetalsBspException(val tryingToGet: String, cause: Throwable)
     extends Exception(
-      s"BSP connection failed in the attempt to get: $tryingToGet.  $msg"
+      s"BSP connection failed in the attempt to get: $tryingToGet",
+      cause,
     )

--- a/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.builds
 
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration.DurationInt
@@ -145,7 +146,7 @@ object ShellRunner {
       processErr: String => Unit = scribe.error(_),
       propagateError: Boolean = false,
       maybeJavaHome: Option[String],
-  ): Option[String] = {
+  )(implicit ec: ExecutionContext): Option[String] = {
 
     val sbOut = new StringBuilder()
     val env = additionalEnv ++ maybeJavaHome.map("JAVA_HOME" -> _).toMap

--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.collection.mutable
-import scala.collection.parallel.CollectionConverters._
 import scala.util.control.NonFatal
 
 import scala.meta.internal.metals.Buffers
@@ -288,7 +287,7 @@ final class ImplementationProvider(
         classContext,
         source.toNIO,
       )
-      file <- locationsByFile.keySet.toArray.par
+      file <- locationsByFile.keySet.toArray
       locations = locationsByFile(file)
       implPath = AbsolutePath(file)
       implDocument <- findSemanticdb(implPath).toIterable

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -292,12 +292,12 @@ class BuildServerConnection private (
             if implicitly[ClassTag[T]].runtimeClass.getSimpleName != "Object" =>
           onFail
             .map { case (defaultResult, message) =>
-              scribe.info(message)
+              scribe.info(message, t)
               Future.successful(defaultResult)
             }
             .getOrElse({
               val name = implicitly[ClassTag[T]].runtimeClass.getSimpleName
-              Future.failed(MetalsBspException(name, t.getMessage))
+              Future.failed(new MetalsBspException(name, t))
             })
       }
     CancelTokens.future(_ => actionFuture)

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -67,6 +67,12 @@ final class Diagnostics(
     keys.foreach { key => publishDiagnostics(key) }
   }
 
+  def reset(paths: Seq[AbsolutePath]): Unit =
+    for (path <- paths if diagnostics.contains(path)) {
+      diagnostics.remove(path)
+      publishDiagnostics(path)
+    }
+
   def resetAmmoniteScripts(): Unit =
     for (key <- diagnostics.keys if key.isAmmoniteScript) {
       diagnostics.remove(key)

--- a/metals/src/main/scala/scala/meta/internal/metals/DismissedNotifications.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DismissedNotifications.scala
@@ -20,6 +20,8 @@ final class DismissedNotifications(conn: () => Connection, time: Time) {
   val ReconnectAmmonite = new Notification(10)
   val UpdateScalafmtConf = new Notification(11)
   val UpdateBloopJson = new Notification(12)
+  val ReconnectScalaCli = new Notification(13)
+  val ScalaCliImportAuto = new Notification(14)
 
   val all: List[Notification] = List(
     Only212Navigation,
@@ -34,6 +36,8 @@ final class DismissedNotifications(conn: () => Connection, time: Time) {
     ReconnectAmmonite,
     UpdateScalafmtConf,
     UpdateBloopJson,
+    ReconnectScalaCli,
+    ScalaCliImportAuto,
   )
 
   def resetAll(): Unit = {

--- a/metals/src/main/scala/scala/meta/internal/metals/ImportedBuild.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ImportedBuild.scala
@@ -2,6 +2,8 @@ package scala.meta.internal.metals
 
 import java.{util => ju}
 
+import scala.build.bsp.WrappedSourcesParams
+import scala.build.bsp.WrappedSourcesResult
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -18,6 +20,7 @@ case class ImportedBuild(
     javacOptions: JavacOptionsResult,
     sources: SourcesResult,
     dependencySources: DependencySourcesResult,
+    wrappedSources: WrappedSourcesResult,
 ) {
   def ++(other: ImportedBuild): ImportedBuild = {
     val updatedBuildTargets = new WorkspaceBuildTargetsResult(
@@ -35,12 +38,16 @@ case class ImportedBuild(
     val updatedDependencySources = new DependencySourcesResult(
       (dependencySources.getItems.asScala ++ other.dependencySources.getItems.asScala).asJava
     )
+    val updatedWrappedSources = new WrappedSourcesResult(
+      (wrappedSources.getItems.asScala ++ other.wrappedSources.getItems.asScala).asJava
+    )
     ImportedBuild(
       updatedBuildTargets,
       updatedScalacOptions,
       updatedJavacOptions,
       updatedSources,
       updatedDependencySources,
+      updatedWrappedSources,
     )
   }
 
@@ -58,6 +65,7 @@ object ImportedBuild {
       new JavacOptionsResult(ju.Collections.emptyList()),
       new SourcesResult(ju.Collections.emptyList()),
       new DependencySourcesResult(ju.Collections.emptyList()),
+      new WrappedSourcesResult(ju.Collections.emptyList()),
     )
 
   def fromConnection(
@@ -76,6 +84,9 @@ object ImportedBuild {
       dependencySources <- conn.buildTargetDependencySources(
         new DependencySourcesParams(ids)
       )
+      wrappedSources <- conn.buildTargetWrappedSources(
+        new WrappedSourcesParams(ids)
+      )
     } yield {
       ImportedBuild(
         workspaceBuildTargets,
@@ -83,6 +94,7 @@ object ImportedBuild {
         javacOptions,
         sources,
         dependencySources,
+        wrappedSources,
       )
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -16,6 +16,7 @@ import scala.concurrent.Promise
 import scala.util.control.NonFatal
 
 import scala.meta.dialects._
+import scala.meta.inputs.Input
 import scala.meta.internal.bsp.BspSession
 import scala.meta.internal.bsp.BuildChange
 import scala.meta.internal.builds.BuildTool
@@ -35,6 +36,7 @@ import scala.meta.internal.worksheets.WorksheetProvider
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.{bsp4j => b}
+import org.eclipse.lsp4j.Position
 
 /**
  * Coordinates build target data fetching and caching, and the re-computation of various
@@ -193,6 +195,89 @@ final case class Indexer(
         data.addWorkspaceBuildTargets(importedBuild.workspaceBuildTargets)
         data.addScalacOptions(importedBuild.scalacOptions)
         data.addJavacOptions(importedBuild.javacOptions)
+
+        // For "wrapped sources", we create dedicated TargetData.MappedSource instances,
+        // able to convert back and forth positions from the user-facing file to
+        // the compiler-facing actual underlying source.
+        for {
+          item <- importedBuild.wrappedSources.getItems.asScala
+          sourceItem <- item.getSources.asScala
+        } {
+
+          /*
+
+            sourceItem tells us how the user-facing sources (typically, an *.sc file)
+            gets wrapped (to a .scala file), so that scalac can compile it fine.
+
+            sourceItem.getTopWrapper needs to be added before the content of the user-facing
+            code, and sourceItem.getBottomWrapper needs to be added after it.
+
+            In the case of Scala CLI, these typically look like, for a file named foo/hello.sc:
+
+                package foo
+                object hello {
+
+            at the top, and at the bottom:
+
+                  def args = hello_sc.args$
+                }
+                object hello_sc {
+                  private var args$opt = Option.empty[Array[String]]
+                  def args$ = args$opt.getOrElse(sys.error("No arguments passed to this script"))
+                  def main(args: Array[String]): Unit = {
+                    args$opt = Some(args)
+                    hello
+                  }
+                }
+
+             Here, we see that this puts the file in a package named 'foo', and this adds a method
+             called 'args', that users can call from their code (alongside with an object hello_sc
+             with a main class, that doesn't matter much from Metals here).
+
+             The toScala and fromScala methods below adjust positions, because of the code
+             added at the top that shifts lines.
+
+             mappedSource allows to wrap things on-the-fly, to pass not-yet-saved code to
+             the interactive compiler.
+           */
+
+          val path = sourceItem.getUri.toAbsolutePath
+          val generatedPath = sourceItem.getGeneratedUri.toAbsolutePath
+          val topWrapperLineCount = sourceItem.getTopWrapper.count(_ == '\n')
+          val toScala: Position => Position =
+            scPos =>
+              new Position(
+                topWrapperLineCount + scPos.getLine,
+                scPos.getCharacter,
+              )
+          val fromScala: Position => Position =
+            scalaPos =>
+              new Position(
+                scalaPos.getLine - topWrapperLineCount,
+                scalaPos.getCharacter,
+              )
+          val mappedSource: TargetData.MappedSource =
+            new TargetData.MappedSource {
+              def path = generatedPath
+              def update(
+                  content: String
+              ): (Input.VirtualFile, Position => Position, AdjustLspData) = {
+                val adjustLspData = AdjustedLspData.create(fromScala)
+                val updatedContent =
+                  sourceItem.getTopWrapper + content + sourceItem.getBottomWrapper
+                (
+                  Input.VirtualFile(
+                    generatedPath.toNIO.toString
+                      .stripSuffix(".scala") + ".sc.scala",
+                    updatedContent,
+                  ),
+                  toScala,
+                  adjustLspData,
+                )
+              }
+            }
+          data.addMappedSource(path, mappedSource)
+        }
         for {
           item <- importedBuild.sources.getItems.asScala
           source <- item.getSources.asScala

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
@@ -5,7 +5,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 import scala.concurrent.Await
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Properties
 import scala.util.Try
@@ -29,7 +29,7 @@ class JavaInteractiveSemanticdb(
     pluginJars: List[Path],
     workspace: AbsolutePath,
     buildTargets: BuildTargets,
-) {
+)(implicit ec: ExecutionContext) {
 
   private val readonly = workspace.resolve(Directories.readonly)
 
@@ -183,7 +183,7 @@ object JavaInteractiveSemanticdb {
       workspace: AbsolutePath,
       buildTargets: BuildTargets,
       jdkVersion: JdkVersion,
-  ): Option[JavaInteractiveSemanticdb] = {
+  )(implicit ec: ExecutionContext): Option[JavaInteractiveSemanticdb] = {
 
     def pathToJavac(p: AbsolutePath): AbsolutePath = {
       val binaryName = if (Properties.isWin) "javac.exe" else "javac"
@@ -230,7 +230,7 @@ object JdkVersion {
 
   def maybeJdkVersionFromJavaHome(
       maybeJavaHome: Option[AbsolutePath]
-  ): Option[JdkVersion] = {
+  )(implicit ec: ExecutionContext): Option[JdkVersion] = {
     maybeJavaHome.flatMap { javaHome =>
       fromReleaseFile(javaHome).orElse {
         fromShell(javaHome)
@@ -238,7 +238,9 @@ object JdkVersion {
     }
   }
 
-  def fromShell(javaHome: AbsolutePath): Option[JdkVersion] = {
+  def fromShell(
+      javaHome: AbsolutePath
+  )(implicit ec: ExecutionContext): Option[JdkVersion] = {
     ShellRunner
       .runSync(
         List(javaHome.resolve("bin/java").toString, "-version"),

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -794,15 +794,18 @@ object Messages {
     }
   }
 
-  object ImportAmmoniteScript {
-    val message: String = "Ammonite script detected."
-    val importAll: String = "Import scripts automatically"
-    val doImport: String = "Import"
+  object ImportScalaScript {
+    val message: String = "Scala script detected. Import it as…"
+    val doImportScalaCli: String = "Scala CLI"
+    val doImportAmmonite: String = "Ammonite"
     val dismiss: String = "Dismiss"
-
     def params(): ShowMessageRequestParams = {
       val params = new ShowMessageRequestParams(
-        List(importAll, doImport, dismiss)
+        List(
+          doImportScalaCli,
+          doImportAmmonite,
+          dismiss,
+        )
           .map(new MessageActionItem(_))
           .asJava
       )
@@ -810,12 +813,40 @@ object Messages {
       params.setType(MessageType.Info)
       params
     }
-
-    def ImportFailed(script: String) =
+    def ImportFailed(source: String) =
       new MessageParams(
         MessageType.Error,
-        s"Error importing $script. See the logs for more details.",
+        s"Error importing Scala script $source. See the logs for more details.",
       )
+    def ImportedScalaCli =
+      new MessageParams(
+        MessageType.Info,
+        "Scala CLI project imported.",
+      )
+    def ImportedAmmonite =
+      new MessageParams(
+        MessageType.Info,
+        "Ammonite project imported.",
+      )
+  }
+
+  object ImportAllScripts {
+    val message: String = "Should Metals automatically import scripts?"
+    val importAll: String = "Automatically import"
+    val dismiss: String = "Keep asking"
+    def params(): ShowMessageRequestParams = {
+      val params = new ShowMessageRequestParams(
+        List(
+          importAll,
+          dismiss,
+        )
+          .map(new MessageActionItem(_))
+          .asJava
+      )
+      params.setMessage(message)
+      params.setType(MessageType.Info)
+      params
+    }
   }
 
   object NewScalaProject {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsBuildServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsBuildServer.scala
@@ -1,8 +1,11 @@
 package scala.meta.internal.metals
 
+import scala.build.bsp.ScalaScriptBuildServer
+
 import ch.epfl.scala.{bsp4j => b}
 
 trait MetalsBuildServer
     extends b.BuildServer
     with b.ScalaBuildServer
     with b.JavaBuildServer
+    with ScalaScriptBuildServer

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1481,8 +1481,8 @@ class MetalsLanguageServer(
   def implementation(
       position: TextDocumentPositionParams
   ): CompletableFuture[util.List[Location]] =
-    CancelTokens { _ =>
-      implementationProvider.implementations(position).asJava
+    CancelTokens.future { _ =>
+      implementationProvider.implementations(position).map(_.asJava)
     }
 
   @JsonRequest("textDocument/hover")

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1257,7 +1257,7 @@ class MetalsLanguageServer(
     Future
       .sequence(
         List(
-          Future(renameProvider.runSave()),
+          renameProvider.runSave(),
           parseTrees(path),
           onChange(List(path)),
         )

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -552,6 +552,18 @@ object ServerCommands {
     "Stop Ammonite build server",
   )
 
+  val StartScalaCliServer = new Command(
+    "scala-cli-start",
+    "Start Scala CLI server",
+    "Start Scala CLI server",
+  )
+
+  val StopScalaCliServer = new Command(
+    "scala-cli-stop",
+    "Stop Scala CLI server",
+    "Stop Scala CLI server",
+  )
+
   def all: List[BaseCommand] =
     List(
       AnalyzeStacktrace,
@@ -587,6 +599,8 @@ object ServerCommands {
       StartDebugAdapter,
       StopAmmoniteBuildServer,
       SuperMethodHierarchy,
+      StartScalaCliServer,
+      StopScalaCliServer,
     )
 }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -52,6 +52,7 @@ case class UserConfiguration(
     testUserInterface: TestUserInterfaceKind = TestUserInterfaceKind.CodeLenses,
     javaFormatConfig: Option[JavaFormatConfig] = None,
     scalafixRulesDependencies: List[String] = Nil,
+    scalaCliLauncher: Option[String] = None,
 ) {
 
   def currentBloopVersion: String =
@@ -281,6 +282,17 @@ object UserConfiguration {
         "Eclipse Java formatting profile",
         """|If the Eclipse formatter file contains more than one profile then specify the required profile name.
            |""".stripMargin,
+      ),
+      UserConfigurationOption(
+        "scala-cli-launcher",
+        """empty string `""`.""",
+        """"/usr/local/bin/scala-cli"""",
+        "Scala CLI launcher",
+        """Optional absolute path to a `scala-cli` executable to use for running a Scala CLI BSP server.
+          |By default, Metals uses the scala-cli from the PATH, or it's not found, downloads and runs Scala
+          |CLI on the JVM (slower than native Scala CLI). Update this if you want to use a custom Scala CLI
+          |launcher, not available in PATH.
+          |""".stripMargin,
       ),
     )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -1,0 +1,57 @@
+package scala.meta.internal.metals.scalacli
+
+import java.io.File
+import java.nio.file.Paths
+
+import scala.jdk.CollectionConverters._
+import scala.util.Properties
+
+import scala.meta.internal.metals.BuildInfo
+
+object ScalaCli {
+
+  lazy val javaCommand: String = {
+
+    val defaultJvmId = "temurin:17"
+
+    val majorVersion = sys.props
+      .get("java.version")
+      .map(_.takeWhile(_.isDigit))
+      .filter(_.nonEmpty)
+      .flatMap(_.toIntOption)
+      .getOrElse(0)
+
+    val ext = if (Properties.isWin) ".exe" else ""
+    if (majorVersion >= 17)
+      Paths
+        .get(sys.props("java.home"))
+        .resolve(s"bin/java$ext")
+        .toAbsolutePath
+        .toString
+    else {
+      scribe.info(
+        s"Found Java version $majorVersion. " +
+          s"Scala CLI requires at least Java 17, getting a $defaultJvmId JVM via coursier-jvm."
+      )
+      val jvmManager = coursierapi.JvmManager.create()
+      val javaHome = jvmManager.get(defaultJvmId)
+      new File(javaHome, s"bin/java$ext").getAbsolutePath
+    }
+  }
+
+  def scalaCliClassPath(): Seq[String] =
+    coursierapi.Fetch
+      .create()
+      .addDependencies(
+        coursierapi.Dependency
+          .of("org.virtuslab.scala-cli", "cli_3", BuildInfo.scalaCliVersion)
+      )
+      .fetch()
+      .asScala
+      .toSeq
+      .map(_.getAbsolutePath)
+
+  def scalaCliMainClass: String =
+    "scala.cli.ScalaCli"
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -1,14 +1,320 @@
 package scala.meta.internal.metals.scalacli
 
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.InputStream
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicBoolean
 
-import scala.jdk.CollectionConverters._
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutorService
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Failure
 import scala.util.Properties
+import scala.util.Success
+import scala.util.control.NonFatal
 
+import scala.meta.internal.bsp.BuildChange
+import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.BuildServerConnection
+import scala.meta.internal.metals.Cancelable
+import scala.meta.internal.metals.ClosableOutputStream
+import scala.meta.internal.metals.Compilations
+import scala.meta.internal.metals.Compilers
+import scala.meta.internal.metals.Diagnostics
+import scala.meta.internal.metals.ImportedBuild
+import scala.meta.internal.metals.MetalsBuildClient
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.MutableCancelable
+import scala.meta.internal.metals.SocketConnection
+import scala.meta.internal.metals.StatusBar
+import scala.meta.internal.metals.Tables
+import scala.meta.internal.metals.TargetData
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.process.SystemProcess
+import scala.meta.io.AbsolutePath
+
+import coursier.version.Version
+import org.eclipse.lsp4j.services.LanguageClient
+
+class ScalaCli(
+    compilers: () => Compilers,
+    compilations: Compilations,
+    statusBar: () => StatusBar,
+    buffers: Buffers,
+    indexWorkspace: () => Future[Unit],
+    diagnostics: () => Diagnostics,
+    workspace: () => AbsolutePath,
+    tables: () => Tables,
+    buildClient: () => MetalsBuildClient,
+    languageClient: LanguageClient,
+    config: () => MetalsServerConfig,
+    userConfig: () => UserConfiguration,
+)(implicit ec: ExecutionContextExecutorService)
+    extends Cancelable {
+
+  private val cancelables = new MutableCancelable
+  private val isCancelled = new AtomicBoolean(false)
+  def cancel(): Unit =
+    if (isCancelled.compareAndSet(false, true))
+      try cancelables.cancel()
+      catch {
+        case NonFatal(_) =>
+      }
+
+  private var buildServer0 = Option.empty[BuildServerConnection]
+  private var lastImportedBuild0 = ImportedBuild.empty
+  private var roots0 = Seq.empty[AbsolutePath]
+
+  private def allSources(): Seq[AbsolutePath] = {
+    val sourceItems = lastImportedBuild0.sources.getItems.asScala.toVector
+    val sources = sourceItems.flatMap(_.getSources.asScala.map(_.getUri))
+    val roots = sourceItems
+      .flatMap(item => Option(item.getRoots).toSeq)
+      .flatMap(_.asScala)
+    (sources ++ roots).map(new URI(_)).map(AbsolutePath.fromAbsoluteUri(_))
+  }
+
+  val buildTargetsData = new TargetData
+  def lastImportedBuild: ImportedBuild =
+    lastImportedBuild0
+  def buildServer: Option[BuildServerConnection] =
+    buildServer0
+  def roots: Seq[AbsolutePath] =
+    roots0
+
+  def importBuild(): Future[Unit] =
+    buildServer0 match {
+      case None =>
+        Future.failed(new Exception("No Scala CLI server running"))
+      case Some(conn) =>
+        compilers().cancel()
+
+        for {
+          build0 <- statusBar().trackFuture(
+            "Importing Scala CLI sources",
+            ImportedBuild.fromConnection(conn),
+          )
+          _ = {
+            lastImportedBuild0 = build0
+            val targets = build0.workspaceBuildTargets.getTargets.asScala
+            val connections =
+              targets.iterator.map(_.getId).map((_, conn)).toList
+            buildTargetsData.resetConnections(connections)
+          }
+          _ <- indexWorkspace()
+          allSources0 = allSources()
+          toCompile = buffers.open.toSeq.filter(p =>
+            allSources0.exists(root =>
+              root == p || p.toNIO.startsWith(root.toNIO)
+            )
+          )
+          _ <- Future.sequence(
+            compilations
+              .cascadeCompileFiles(toCompile) ::
+              compilers().load(toCompile) ::
+              Nil
+          )
+        } yield ()
+    }
+
+  private def disconnectOldBuildServer(): Future[Unit] = {
+    if (buildServer0.isDefined)
+      scribe.info("disconnected: Scala CLI server")
+    buildServer0 match {
+      case None => Future.unit
+      case Some(value) =>
+        val allSources0 = allSources()
+        buildServer0 = None
+        lastImportedBuild0 = ImportedBuild.empty
+        roots0 = Nil
+        cancelables.cancel()
+        diagnostics().reset(allSources0)
+        value.shutdown()
+    }
+  }
+
+  private lazy val baseCommand = {
+
+    def endsWithCaseInsensitive(s: String, suffix: String): Boolean =
+      s.length >= suffix.length &&
+        s.regionMatches(
+          true,
+          s.length - suffix.length,
+          suffix,
+          0,
+          suffix.length,
+        )
+
+    def findInPath(app: String): Option[Path] = {
+      val asIs = Paths.get(app)
+      if (Paths.get(app).getNameCount >= 2) Some(asIs)
+      else {
+        def pathEntries =
+          Option(System.getenv("PATH")).iterator
+            .flatMap(_.split(File.pathSeparator).iterator)
+        def pathExts =
+          if (Properties.isWin)
+            Option(System.getenv("PATHEXT")).iterator
+              .flatMap(_.split(File.pathSeparator).iterator)
+          else Iterator("")
+        def matches = for {
+          dir <- pathEntries
+          ext <- pathExts
+          app0 = if (endsWithCaseInsensitive(app, ext)) app else app + ext
+          path = Paths.get(dir).resolve(app0)
+          if Files.isExecutable(path)
+        } yield path
+        matches.toStream.headOption
+      }
+    }
+
+    def readFully(is: InputStream): Array[Byte] = {
+      val b = new ByteArrayOutputStream
+      val buf = Array.ofDim[Byte](64)
+      var read = -1
+      while ({
+        read = is.read(buf)
+        read >= 0
+      })
+        if (read > 0)
+          b.write(buf, 0, read)
+      b.toByteArray
+    }
+
+    def requireMinVersion(executable: Path, minVersion: String): Boolean = {
+      // "scala-cli version" simply prints its version
+      val process =
+        new ProcessBuilder(executable.toAbsolutePath.toString, "version")
+          .redirectError(ProcessBuilder.Redirect.INHERIT)
+          .redirectOutput(ProcessBuilder.Redirect.PIPE)
+          .redirectInput(ProcessBuilder.Redirect.PIPE)
+          .start()
+
+      val b = readFully(process.getInputStream())
+      val version = Version(new String(b, "UTF-8").trim())
+      val minVersion0 = Version(minVersion)
+      minVersion0.compareTo(version) <= 0
+    }
+
+    val minVersion = "0.1.3"
+    val cliCommand = userConfig().scalaCliLauncher
+      .filter(_.trim.nonEmpty)
+      .map(Seq(_))
+      .orElse {
+        findInPath("scala-cli")
+          .filter(requireMinVersion(_, minVersion))
+          .map(p => Seq(p.toString))
+      }
+      .getOrElse {
+        scribe.warn(
+          s"scala-cli >= $minVersion not found in PATH, fetching and starting a JVM-based Scala CLI"
+        )
+        val cp = ScalaCli.scalaCliClassPath()
+        Seq(
+          ScalaCli.javaCommand,
+          "-cp",
+          cp.mkString(File.pathSeparator),
+          ScalaCli.scalaCliMainClass,
+        )
+      }
+    cliCommand ++ Seq("bsp")
+  }
+
+  def loaded(path: AbsolutePath): Boolean =
+    roots0.contains(path)
+
+  def start(roots: Seq[AbsolutePath]): Future[Unit] = {
+
+    disconnectOldBuildServer().onComplete {
+      case Failure(e) =>
+        scribe.warn("Error disconnecting old Scala CLI server", e)
+      case Success(()) =>
+    }
+
+    val command =
+      baseCommand ++ Seq(roots.head.toString) ++ roots.tail.flatMap(p =>
+        Seq(";", p.toString)
+      )
+
+    val futureConn = BuildServerConnection.fromSockets(
+      workspace(),
+      buildClient(),
+      languageClient,
+      () => ScalaCli.socketConn(command, workspace()),
+      tables().dismissedNotifications.ReconnectScalaCli,
+      config(),
+      "Scala CLI",
+      supportsWrappedSources = Some(true),
+    )
+
+    val f = futureConn.flatMap(connectToNewBuildServer(_, roots))
+
+    f.transform {
+      case Failure(ex) =>
+        scribe.error("Error starting Scala CLI", ex)
+        Success(())
+      case Success(_) =>
+        scribe.info("Scala CLI started")
+        Success(())
+    }
+  }
+
+  def stop(): CompletableFuture[Object] =
+    disconnectOldBuildServer().asJavaObject
+
+  private def connectToNewBuildServer(
+      build: BuildServerConnection,
+      roots: Seq[AbsolutePath],
+  ): Future[BuildChange] = {
+    scribe.info(s"Connected to Scala CLI server v${build.version}")
+    cancelables.add(build)
+    buildServer0 = Some(build)
+    roots0 = roots
+    importBuild().map { _ =>
+      BuildChange.Reconnected
+    }
+  }
+
+}
 
 object ScalaCli {
+
+  private def socketConn(
+      command: Seq[String],
+      workspace: AbsolutePath,
+  )(implicit ec: ExecutionContext): Future[SocketConnection] =
+    Future {
+      scribe.info(s"Running $command")
+      val proc = SystemProcess.run(
+        command.toList,
+        workspace,
+        redirectErrorOutput = false,
+        env = Map(),
+        processOut = None,
+        processErr = Some(line => scribe.info("Scala CLI: " + line)),
+        discardInput = false,
+        threadNamePrefix = "scala-cli",
+      )
+      val finished = Promise[Unit]()
+      proc.complete.ignoreValue.onComplete { res =>
+        finished.tryComplete(res)
+      }
+      SocketConnection(
+        "ScalaCli",
+        new ClosableOutputStream(proc.outputStream, "Scala CLI error stream"),
+        proc.inputStream,
+        List(Cancelable { () => proc.cancel }),
+        finished,
+      )
+    }
 
   lazy val javaCommand: String = {
 

--- a/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
+++ b/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
@@ -5,7 +5,7 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.util.concurrent.TimeUnit
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 import scala.sys.process.BasicIO
@@ -33,7 +33,7 @@ object SystemProcess {
       propagateError: Boolean = false,
       discardInput: Boolean = true,
       threadNamePrefix: String = "",
-  ): SystemProcess = {
+  )(implicit ec: ExecutionContext): SystemProcess = {
 
     try {
       val builder = new ProcessBuilder(cmd.asJava)
@@ -69,7 +69,7 @@ object SystemProcess {
       processErr: Option[String => Unit],
       discardInput: Boolean,
       threadNamePrefix: String,
-  ): SystemProcess = {
+  )(implicit ec: ExecutionContext): SystemProcess = {
     def readOutput(
         name: String,
         stream: InputStream,

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -95,159 +95,169 @@ final class RenameProvider(
   ): Future[WorkspaceEdit] = {
     val source = params.getTextDocument.getUri.toAbsolutePath
     compilations.compilationFinished(source).flatMap { _ =>
-      definitionProvider.definition(source, params, token).map { definition =>
-        val textParams = new TextDocumentPositionParams(
-          params.getTextDocument(),
-          params.getPosition(),
-        )
+      definitionProvider
+        .definition(source, params, token)
+        .flatMap { definition =>
+          val textParams = new TextDocumentPositionParams(
+            params.getTextDocument(),
+            params.getPosition(),
+          )
 
-        lazy val definitionTextParams =
-          definition.locations.asScala.map { l =>
-            new TextDocumentPositionParams(
-              new TextDocumentIdentifier(l.getUri()),
-              l.getRange().getStart(),
-            )
-          }
-
-        val symbolOccurrence =
-          definitionProvider
-            .symbolOccurrence(source, textParams.getPosition)
-            .orElse(
-              findRenamedImportOccurrenceAtPosition(
-                source,
-                params.getPosition(),
+          lazy val definitionTextParams =
+            definition.locations.asScala.map { l =>
+              new TextDocumentPositionParams(
+                new TextDocumentIdentifier(l.getUri()),
+                l.getRange().getStart(),
               )
-            )
+            }
 
-        val suggestedName = params.getNewName()
-        val withoutBackticks =
-          if (suggestedName.isBackticked)
-            suggestedName.stripBackticks
-          else suggestedName
-        val newName = Identifier.backtickWrap(withoutBackticks)
-
-        def isNotRenamedSymbol(
-            textDocument: TextDocument,
-            occ: SymbolOccurrence,
-        ): Boolean = {
-          def realName = occ.symbol.desc.name.value
-          def foundName =
-            occ.range
-              .flatMap(rng => rng.inString(textDocument.text))
-              .map(_.stripBackticks)
-          occ.symbol.isLocal ||
-          foundName.contains(realName)
-        }
-
-        def shouldCheckImplementation(
-            symbol: String,
-            path: AbsolutePath,
-            textDocument: TextDocument,
-        ) =
-          !symbol.desc.isType && !(symbol.isLocal && implementationProvider
-            .defaultSymbolSearch(path, textDocument)(symbol)
-            .exists(info => info.isTrait || info.isClass))
-
-        val allReferences = for {
-          (occurence, semanticDb) <- symbolOccurrence.toIterable
-          definitionLoc <- definition.locations.asScala.headOption.toIterable
-          definitionPath = definitionLoc.getUri().toAbsolutePath
-          defSemanticdb <- definition.semanticdb.toIterable
-          if canRenameSymbol(occurence.symbol, Option(newName)) &&
-            isWorkspaceSymbol(occurence.symbol, definitionPath) &&
-            isNotRenamedSymbol(semanticDb, occurence)
-          parentSymbols =
-            implementationProvider
-              .topMethodParents(occurence.symbol, defSemanticdb)
-          txtParams <- {
-            if (parentSymbols.nonEmpty) parentSymbols.map(toTextParams)
-            else if (definitionTextParams.nonEmpty) definitionTextParams
-            else List(textParams)
-          }
-          isJava = definitionPath.isJava
-          currentReferences =
-            referenceProvider
-              .references(
-                /**
-                 * isJava - in Java we can include declarations safely and we
-                 * also need to include contructors.
-                 */
-                toReferenceParams(
-                  txtParams,
-                  includeDeclaration = isJava,
-                ),
-                findRealRange = findRealRange(newName),
-                includeSynthetic,
+          val symbolOccurrence =
+            definitionProvider
+              .symbolOccurrence(source, textParams.getPosition)
+              .orElse(
+                findRenamedImportOccurrenceAtPosition(
+                  source,
+                  params.getPosition(),
+                )
               )
-              .flatMap(_.locations)
-          definitionLocation = {
-            if (parentSymbols.isEmpty)
-              definition.locations.asScala
-                .filter(_.getUri().isScalaOrJavaFilename)
-            else parentSymbols
+
+          val suggestedName = params.getNewName()
+          val withoutBackticks =
+            if (suggestedName.isBackticked)
+              suggestedName.stripBackticks
+            else suggestedName
+          val newName = Identifier.backtickWrap(withoutBackticks)
+
+          def isNotRenamedSymbol(
+              textDocument: TextDocument,
+              occ: SymbolOccurrence,
+          ): Boolean = {
+            def realName = occ.symbol.desc.name.value
+            def foundName =
+              occ.range
+                .flatMap(rng => rng.inString(textDocument.text))
+                .map(_.stripBackticks)
+            occ.symbol.isLocal ||
+            foundName.contains(realName)
           }
-          companionRefs = companionReferences(occurence.symbol, source, newName)
-          implReferences = implementations(
-            txtParams,
-            shouldCheckImplementation(
+
+          def shouldCheckImplementation(
+              symbol: String,
+              path: AbsolutePath,
+              textDocument: TextDocument,
+          ) =
+            !symbol.desc.isType && !(symbol.isLocal && implementationProvider
+              .defaultSymbolSearch(path, textDocument)(symbol)
+              .exists(info => info.isTrait || info.isClass))
+
+          val allReferences = for {
+            (occurence, semanticDb) <- symbolOccurrence.toIterable
+            definitionLoc <- definition.locations.asScala.headOption.toIterable
+            definitionPath = definitionLoc.getUri().toAbsolutePath
+            defSemanticdb <- definition.semanticdb.toIterable
+            if canRenameSymbol(occurence.symbol, Option(newName)) &&
+              isWorkspaceSymbol(occurence.symbol, definitionPath) &&
+              isNotRenamedSymbol(semanticDb, occurence)
+            parentSymbols =
+              implementationProvider
+                .topMethodParents(occurence.symbol, defSemanticdb)
+            txtParams <- {
+              if (parentSymbols.nonEmpty) parentSymbols.map(toTextParams)
+              else if (definitionTextParams.nonEmpty) definitionTextParams
+              else List(textParams)
+            }
+            isJava = definitionPath.isJava
+            currentReferences =
+              referenceProvider
+                .references(
+                  /**
+                   * isJava - in Java we can include declarations safely and we
+                   * also need to include contructors.
+                   */
+                  toReferenceParams(
+                    txtParams,
+                    includeDeclaration = isJava,
+                  ),
+                  findRealRange = findRealRange(newName),
+                  includeSynthetic,
+                )
+                .flatMap(_.locations)
+            definitionLocation = {
+              if (parentSymbols.isEmpty)
+                definition.locations.asScala
+                  .filter(_.getUri().isScalaOrJavaFilename)
+              else parentSymbols
+            }
+            companionRefs = companionReferences(
               occurence.symbol,
               source,
-              semanticDb,
-            ),
-            newName,
+              newName,
+            )
+            implReferences = implementations(
+              txtParams,
+              shouldCheckImplementation(
+                occurence.symbol,
+                source,
+                semanticDb,
+              ),
+              newName,
+            )
+          } yield implReferences.map(implLocs =>
+            currentReferences ++ implLocs ++ companionRefs ++ definitionLocation
           )
-          loc <-
-            currentReferences ++ implReferences ++ companionRefs ++ definitionLocation
-        } yield loc
-
-        def isOccurrence(fn: String => Boolean): Boolean = {
-          symbolOccurrence.exists { case (occ, _) =>
-            fn(occ.symbol)
-          }
+          Future
+            .sequence(allReferences)
+            .map(locs => (locs.flatten, symbolOccurrence, definition, newName))
         }
-
-        // If we didn't find any references then it might be a renamed symbol `import a.{ B => C }`
-        val fallbackOccurences =
-          if (allReferences.isEmpty)
-            renamedImportOccurrences(source, symbolOccurrence)
-          else allReferences
-
-        if (fallbackOccurences.isEmpty) {
-          scribe.debug(s"Symbol occurence was $symbolOccurrence")
-          scribe.debug(s"The definition found was $definition")
-        }
-
-        val allChanges = for {
-          (path, locs) <- fallbackOccurences.toList.distinct
-            .groupBy(_.getUri().toAbsolutePath)
-        } yield {
-          val textEdits = for (loc <- locs) yield {
-            textEdit(isOccurrence, loc, newName)
-          }
-          Seq(path -> textEdits.toList)
-        }
-        val fileChanges = allChanges.flatten.toMap
-        val shouldRenameInBackground =
-          !clientConfig.isOpenFilesOnRenameProvider || fileChanges.keySet.size >= clientConfig.renameFileThreshold
-        val (openedEdits, closedEdits) =
-          if (shouldRenameInBackground) {
-            if (clientConfig.isOpenFilesOnRenameProvider) {
-              client.showMessage(fileThreshold(fileChanges.keySet.size))
+        .map { case (allReferences, symbolOccurrence, definition, newName) =>
+          def isOccurrence(fn: String => Boolean): Boolean = {
+            symbolOccurrence.exists { case (occ, _) =>
+              fn(occ.symbol)
             }
-            fileChanges.partition { case (path, _) =>
-              buffers.contains(path)
-            }
-          } else {
-            (fileChanges, Map.empty[AbsolutePath, List[TextEdit]])
           }
 
-        awaitingSave.add(() => changeClosedFiles(closedEdits))
+          // If we didn't find any references then it might be a renamed symbol `import a.{ B => C }`
+          val fallbackOccurences =
+            if (allReferences.isEmpty)
+              renamedImportOccurrences(source, symbolOccurrence)
+            else allReferences
 
-        val edits = documentEdits(openedEdits)
-        val renames =
-          fileRenames(isOccurrence, fileChanges.keySet, newName)
-        new WorkspaceEdit((edits ++ renames).asJava)
-      }
+          if (fallbackOccurences.isEmpty) {
+            scribe.debug(s"Symbol occurence was $symbolOccurrence")
+            scribe.debug(s"The definition found was $definition")
+          }
+
+          val allChanges = for {
+            (path, locs) <- fallbackOccurences.toList.distinct
+              .groupBy(_.getUri().toAbsolutePath)
+          } yield {
+            val textEdits = for (loc <- locs) yield {
+              textEdit(isOccurrence, loc, newName)
+            }
+            Seq(path -> textEdits.toList)
+          }
+          val fileChanges = allChanges.flatten.toMap
+          val shouldRenameInBackground =
+            !clientConfig.isOpenFilesOnRenameProvider || fileChanges.keySet.size >= clientConfig.renameFileThreshold
+          val (openedEdits, closedEdits) =
+            if (shouldRenameInBackground) {
+              if (clientConfig.isOpenFilesOnRenameProvider) {
+                client.showMessage(fileThreshold(fileChanges.keySet.size))
+              }
+              fileChanges.partition { case (path, _) =>
+                buffers.contains(path)
+              }
+            } else {
+              (fileChanges, Map.empty[AbsolutePath, List[TextEdit]])
+            }
+
+          awaitingSave.add(() => changeClosedFiles(closedEdits))
+
+          val edits = documentEdits(openedEdits)
+          val renames =
+            fileRenames(isOccurrence, fileChanges.keySet, newName)
+          new WorkspaceEdit((edits ++ renames).asJava)
+        }
     }
   }
 
@@ -391,22 +401,26 @@ final class RenameProvider(
       textParams: TextDocumentPositionParams,
       shouldCheckImplementation: Boolean,
       newName: String,
-  ): Seq[Location] = {
+  ): Future[Seq[Location]] = {
     if (shouldCheckImplementation) {
       for {
-        implLoc <- implementationProvider.implementations(textParams)
-        locParams = toReferenceParams(implLoc, includeDeclaration = true)
-        loc <-
-          referenceProvider
-            .references(
-              locParams,
-              findRealRange = findRealRange(newName),
-              includeSynthetic,
-            )
-            .flatMap(_.locations)
-      } yield loc
+        implLocs <- implementationProvider.implementations(textParams)
+      } yield {
+        for {
+          implLoc <- implLocs
+          locParams = toReferenceParams(implLoc, includeDeclaration = true)
+          loc <-
+            referenceProvider
+              .references(
+                locParams,
+                findRealRange = findRealRange(newName),
+                includeSynthetic,
+              )
+              .flatMap(_.locations)
+        } yield loc
+      }
     } else {
-      Nil
+      Future.successful(Nil)
     }
   }
 

--- a/project/V.scala
+++ b/project/V.scala
@@ -35,6 +35,7 @@ object V {
   val pprint = "0.7.3"
   val sbtBloop = bloop
   val sbtJdiTools = "1.1.1"
+  val scalaCli = "0.1.9"
   val scalafix = "0.10.1"
   val scalafmt = "3.5.3"
   val scalameta = "4.5.9"

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -1,5 +1,6 @@
 package tests
 
+import scala.concurrent.Future
 import scala.concurrent.Promise
 
 import scala.meta.internal.metals.Messages
@@ -19,8 +20,8 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
   override def newServer(workspaceName: String): Unit = {
     super.newServer(workspaceName)
     server.client.showMessageRequestHandler = { params =>
-      if (params == Messages.ImportAmmoniteScript.params())
-        Some(new MessageActionItem(Messages.ImportAmmoniteScript.dismiss))
+      if (params == Messages.ImportScalaScript.params())
+        Some(new MessageActionItem(Messages.ImportScalaScript.dismiss))
       else
         None
     }
@@ -560,7 +561,9 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
            |""".stripMargin
       )
       _ <- server.didOpen("main.sc")
-      _ <- server.server.ammonite.maybeImport(server.toPath("main.sc"))
+      _ <- server.server
+        .maybeImportScript(server.toPath("main.sc"))
+        .getOrElse(Future.unit)
 
       messagesForScript = {
         val msgs = server.client.messageRequests.asScala.toVector
@@ -568,15 +571,17 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
         msgs
       }
       _ = assert(
-        messagesForScript.contains(Messages.ImportAmmoniteScript.message)
+        messagesForScript.contains(Messages.ImportScalaScript.message)
       )
 
       _ <- server.didOpen("build.sc")
-      _ <- server.server.ammonite.maybeImport(server.toPath("build.sc"))
+      _ <- server.server
+        .maybeImportScript(server.toPath("build.sc"))
+        .getOrElse(Future.unit)
 
       messagesForBuildSc = server.client.messageRequests.asScala.toVector
       _ = assert(
-        !messagesForBuildSc.contains(Messages.ImportAmmoniteScript.message)
+        !messagesForBuildSc.contains(Messages.ImportScalaScript.message)
       )
 
     } yield ()

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -404,7 +404,7 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
           |decode[Foozz](json)
           |       ^^^^^
           |""".stripMargin
-      
+
     for {
       _ <- initialize(
         s"""

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -391,12 +391,19 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
         """errored.sc:15:25: error: not found: type Fooz
           |val decodedFoo = decode[Fooz](json)
           |                        ^^^^
+          |errored.sc:18:8: error: not found: type Foozz
+          |decode[Foozz](json)
+          |       ^^^^^
           |""".stripMargin
       else
         """errored.sc:15:25: error: Not found: type Fooz
           |val decodedFoo = decode[Fooz](json)
           |                        ^^^^
+          |errored.sc:18:8: error: Not found: type Foozz
+          |decode[Foozz](json)
+          |       ^^^^^
           |""".stripMargin
+      
     for {
       _ <- initialize(
         s"""

--- a/tests/unit/src/main/scala/tests/BaseRangesSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseRangesSuite.scala
@@ -61,6 +61,7 @@ abstract class BaseRangesSuite(name: String) extends BaseLspSuite(name) {
           files.map(file => server.didOpen(s"${file._1}"))
         )
         _ <- assertCheck(filename, edit, expected, base)
+        _ <- server.shutdown()
       } yield ()
     }
   }

--- a/tests/unit/src/main/scala/tests/BaseScalaCliSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseScalaCliSuite.scala
@@ -1,0 +1,98 @@
+package tests
+
+import java.io.File
+
+import scala.concurrent.Future
+
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.scalacli.ScalaCli
+
+import org.eclipse.lsp4j.InitializeResult
+
+abstract class BaseScalaCliSuite(scalaVersion: String)
+    extends BaseLspSuite(s"scala-cli-$scalaVersion")
+    with ScriptsAssertions {
+
+  override def munitIgnore: Boolean =
+    !isValidScalaVersionForEnv(scalaVersion)
+
+  private def escape(s: String): String =
+    s.replace("\\", "\\\\")
+  private def bspLayout =
+    s"""/.bsp/scala-cli.json
+       |{
+       |  "name": "scala-cli",
+       |  "argv": [
+       |    "${escape(ScalaCli.javaCommand)}",
+       |    "-cp",
+       |    "${escape(ScalaCli.scalaCliClassPath().mkString(File.pathSeparator))}",
+       |    "${ScalaCli.scalaCliMainClass}",
+       |    "bsp",
+       |    "."
+       |  ],
+       |  "version": "${BuildInfo.scalaCliVersion}",
+       |  "bspVersion": "2.0.0",
+       |  "languages": [
+       |    "scala",
+       |    "java"
+       |  ]
+       |}
+       |
+       |/.scala-build/ide-inputs.json
+       |{
+       |  "args": [
+       |    "."
+       |  ]
+       |}
+       |
+       |""".stripMargin
+
+  private def scalaCliInitialize(layout: String): Future[InitializeResult] =
+    initialize(bspLayout + layout)
+
+  test("simple file") {
+    simpleFileTest()
+  }
+
+  def simpleFileTest(): Future[Unit] =
+    for {
+      _ <- scalaCliInitialize(
+        s"""/MyTests.scala
+           |//> using scala "$scalaVersion"
+           |//> using lib "com.lihaoyi::utest::0.7.9"
+           |//> using lib "com.lihaoyi::pprint::0.6.4"
+           |
+           |import utest._
+           |
+           |object MyTests extends TestSuite {
+           |  pprint.log(2)
+           |  val tests = Tests {
+           |    test("foo") {
+           |      assert(2 + 2 == 4)
+           |    }
+           |    test("nope") {
+           |      assert(2 + 2 == 5)
+           |    }
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("MyTests.scala")
+
+      // via Scala CLI-generated Semantic DB
+      _ <- assertDefinitionAtLocation(
+        "MyTests.scala",
+        "val tests = Test@@s",
+        "utest/Tests.scala",
+      )
+
+      // via presentation compiler, using the Scala CLI build target classpath
+      _ <- assertDefinitionAtLocation(
+        "utest/Tests.scala",
+        "import utest.framework.{TestCallTree, Tr@@ee}",
+        "utest/framework/Tree.scala",
+      )
+
+    } yield ()
+
+}

--- a/tests/unit/src/main/scala/tests/FileLayout.scala
+++ b/tests/unit/src/main/scala/tests/FileLayout.scala
@@ -13,7 +13,7 @@ object FileLayout {
     if (!layout.trim.isEmpty) {
       val lines = layout.replace("\r\n", "\n")
       lines
-        .split("(?=\n/)")
+        .split("(?=\n/[^/])")
         .map { row =>
           row.stripPrefix("\n").split("\n", 2).toList match {
             case path :: contents :: Nil =>

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -96,6 +96,9 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
   var slowTaskHandler: MetalsSlowTaskParams => Option[MetalsSlowTaskResult] = {
     _: MetalsSlowTaskParams => None
   }
+  var showMessageHandler: MessageParams => Unit = { _: MessageParams =>
+    ()
+  }
   var showMessageRequestHandler
       : ShowMessageRequestParams => Option[MessageActionItem] = {
     _: ShowMessageRequestParams => None
@@ -267,6 +270,7 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
       .incrementAndGet()
   }
   override def showMessage(params: MessageParams): Unit = {
+    showMessageHandler(params)
     showMessages.add(params)
   }
   override def showMessageRequest(

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1341,6 +1341,7 @@ final case class TestingServer(
       query: String,
       base: Map[String, String],
   ): Future[Map[String, String]] = {
+    Debug.printEnclosing()
     for {
       (_, params) <- offsetParams(filename, query, workspace)
       implementations <- server.implementation(params).asScala

--- a/tests/unit/src/test/scala/tests/JdkVersionSuite.scala
+++ b/tests/unit/src/test/scala/tests/JdkVersionSuite.scala
@@ -1,5 +1,7 @@
 package tests
 
+import scala.concurrent.ExecutionContext
+
 import scala.meta.AbsolutePath
 import scala.meta.internal.metals.JdkVersion
 
@@ -7,6 +9,7 @@ import munit.FunSuite
 
 class JdkVersionSuite extends FunSuite {
   val javaHome: AbsolutePath = AbsolutePath(System.getProperty("java.home"))
+  implicit val ctx: ExecutionContext = this.munitExecutionContext
   test("jdk-shell-version") {
     assertEquals(
       JdkVersion.fromShell(javaHome),

--- a/tests/unit/src/test/scala/tests/ScalaCliSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaCliSuite.scala
@@ -1,0 +1,5 @@
+package tests
+
+import scala.meta.internal.metals.{BuildInfo => V}
+
+class ScalaCliSuite extends tests.BaseScalaCliSuite(V.scala213)

--- a/tests/unit/src/test/scala/tests/SystemProcessSuite.scala
+++ b/tests/unit/src/test/scala/tests/SystemProcessSuite.scala
@@ -1,6 +1,7 @@
 package tests
 
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Properties
 
@@ -10,6 +11,8 @@ import scala.meta.io.AbsolutePath
 import munit.FunSuite
 
 class SystemProcessSuite extends FunSuite {
+
+  implicit val ctx: ExecutionContext = this.munitExecutionContext
 
   test("exit code") {
     val cmd =

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -3,6 +3,8 @@ package tests.troubleshoot
 import java.nio.file.Files
 import java.nio.file.Paths
 
+import scala.concurrent.ExecutionContext
+
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.JdkVersion
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -34,6 +36,8 @@ import munit.TestOptions
 import tests.TestMtagsResolver
 
 class ProblemResolverSuite extends FunSuite {
+
+  implicit val ctx: ExecutionContext = this.munitExecutionContext
 
   checkRecommendation(
     "unsupported-scala-version",


### PR DESCRIPTION
This PR makes Scala CLI support more reliable in two ways:
- it makes scripts (`.sc` files) work better in Scala CLI projects, by having Metals be aware of the way Scala CLI "wraps" those before passing them to scalac -  this is achieved by using a custom BSP endpoint, and relying on past work for Ammonite, in the commit `Handle pre-processed sources via BSP` (currently, https://github.com/scalameta/metals/pull/3790/commits/42253f62e19683ccb1a71aba311fc65fb7ec96a2)
- it adds non-BSP discovery based support for Scala CLI (that works alongside the existing 100% BSP-based one), in commit `Add non BSP-based Scala CLI project support` (currently, https://github.com/scalameta/metals/pull/3790/commits/6352c6d1027f2a909c43915a34cf5a6148bbf3d8)

Before these two commits, https://github.com/scalameta/metals/pull/3790/commits/dd657de7b0aaed564df09642f4d32fc382e8d318, https://github.com/scalameta/metals/pull/3790/commits/c4d7bde92ddebf6f3a25d1f1590c4219cf50f91d, and https://github.com/scalameta/metals/pull/3790/commits/98678b1eaefb98c3ed3f82c36dd07b08e0e131aa, are small refactorings that prepare the ground for the two others.

The non-BSP discovery based support allows to load Scala CLI projects *alongside* existing sbt or Mill projects (in the same VSCode window for example), just like it can be done with Ammonite scripts. This support loads whole directories at a time in Scala CLI, but could be made more atomic in the future when addressing https://github.com/VirtusLab/scala-cli/issues/1146 in Scala CLI (with it, loading a single file from Metals could automatically pull some other files it needs).