### PR TITLE
[Scala3] Don't show a tooltip on hover if cursor is not on a symbol

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -85,10 +85,8 @@ object HoverProvider:
     end isHoveringOnName
 
     if tp.isError || tpw == NoType || tpw.isError || path.isEmpty ||
-      (pos.start == pos.end && !isHoveringOnName(
-        enclosing,
-        pos
-      )) // don't check isHoveringOnName for RangeHover
+      (pos.isPoint // don't check isHoveringOnName for RangeHover
+        && !isHoveringOnName(enclosing, pos))
     then ju.Optional.empty()
     else
       Interactive.enclosingSourceSymbols(enclosing, pos) match
@@ -146,6 +144,9 @@ object HoverProvider:
           end match
     end if
   end hover
+
+  extension (pos: SourcePosition)
+    private def isPoint: Boolean = pos.start == pos.end
 
   private def qual(tree: Tree): Tree =
     tree match

--- a/tests/cross/src/test/scala/tests/hover/HoverNegativeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverNegativeSuite.scala
@@ -4,10 +4,6 @@ import tests.pc.BaseHoverSuite
 
 class HoverNegativeSuite extends BaseHoverSuite {
 
-  // @tgodzik Dotty seems to show the most enclosing symbol even if we hover on empty content
-  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
-    Some(IgnoreScala3)
-
   // Negative results should have an empty output.
   def checkNegative(
       name: String,

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -112,7 +112,7 @@ class HoverTermSuite extends BaseHoverSuite {
   )
 
   check(
-    "interpolator-apply",
+    "interpolator-apply".tag(IgnoreScala3),
     """
       |object a {
       |  implicit class Xtension(s: StringContext) {
@@ -228,7 +228,7 @@ class HoverTermSuite extends BaseHoverSuite {
   )
 
   check(
-    "for-flatMap",
+    "for-flatMap".tag(IgnoreScala3),
     """
       |object a {
       |  <<for {
@@ -240,14 +240,11 @@ class HoverTermSuite extends BaseHoverSuite {
       |""".stripMargin,
     """|Option[String]
        |def flatMap[B](f: Int => Option[B]): Option[B]
-       |""".stripMargin.hover,
-    compat = Map(
-      "3" -> "val <local a$>: (x: Int): Boolean".hover
-    )
+       |""".stripMargin.hover
   )
 
   check(
-    "for-map",
+    "for-map".tag(IgnoreScala3),
     """
       |object a {
       |  for {
@@ -259,14 +256,11 @@ class HoverTermSuite extends BaseHoverSuite {
       |""".stripMargin,
     """|Option[String]
        |final def map[B](f: Int => B): Option[B]
-       |""".stripMargin.hover,
-    compat = Map(
-      "3" -> "val <local a$>: (y: Int): String".hover
-    )
+       |""".stripMargin.hover
   )
 
   check(
-    "for-keyword",
+    "for-keyword".tag(IgnoreScala3),
     """
       |object a {
       |  <<fo@@r {
@@ -282,7 +276,7 @@ class HoverTermSuite extends BaseHoverSuite {
   )
 
   check(
-    "for-yield-keyword",
+    "for-yield-keyword".tag(IgnoreScala3),
     """
       |object a {
       |  for {
@@ -294,10 +288,7 @@ class HoverTermSuite extends BaseHoverSuite {
       |""".stripMargin,
     """|Option[String]
        |final def map[B](f: Long => B): Option[B]
-       |""".stripMargin.hover,
-    compat = Map(
-      "3" -> "val <local a$>: (y: Long): String".hover
-    )
+       |""".stripMargin.hover
   )
 
   check(


### PR DESCRIPTION
Partially fix https://github.com/scalameta/metals/issues/1707 (hover part of the issue), taking over from https://github.com/scalameta/metals/pull/3743

FYI @tdudzik I opened a PR to fix the issue on the Hover part, if you're interested in working on go-to-definition part, please let me know :) 

This PR fixes Scala3 HoverProvider not to show a tooltip on hover if the cursor is not on a symbol by checking the `namePos` (for example, `namePos` of `def foo(x: Int) = { ... }` is a position of `def <foo>(...) = { ... }` part, not a entire `<def foo(x: Int) = { ... }>`) of the enclosing tree actually contains the cursor position.

Calculate the `namePos` using [SourceTree#namePos](https://github.com/lampepfl/dotty/blob/d8e50f249ce0206faae35d5d3d28f45f1e0f58d1/compiler/src/dotty/tools/dotc/interactive/SourceTree.scala#L21-L22).


![no-hover-on-non-symbol](https://user-images.githubusercontent.com/9353584/161753516-4222a482-432b-4db1-adf1-d06fe1d00726.gif)

