### PR TITLE
fix: disable not supported Wconf for scala3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -171,7 +171,8 @@ def lintingOptions(scalaVersion: String) = {
     "-Wconf:src=*.JavaMtags.scala&msg=parameter value (ctor|method) in method (visitConstructor|visitMethod):silent",
     "-Wconf:src=*.MtagsIndexer.scala&msg=parameter value owner in method visitOccurrence:silent",
     // silence "The outer reference in this type test cannot be checked at run time."
-    "-Wconf:src=.*(CompletionProvider|ArgCompletions|Completions|Keywords|IndentOnPaste).scala&msg=The outer reference:silent"
+    "-Wconf:src=.*(CompletionProvider|ArgCompletions|Completions|Keywords|IndentOnPaste).scala&msg=The outer reference:silent",
+    "-Wconf:src=*.BasePCSuite.scala&msg=parameter value (scalaVersion|classpath) in method (extraDependencies|scalacOptions):silent"
   )
   // -Wconf is available only from 2.13.2
   val commonFiltered =
@@ -180,7 +181,7 @@ def lintingOptions(scalaVersion: String) = {
   crossSetting(
     scalaVersion,
     if213 = unused213 :: commonFiltered,
-    if3 = unused3 :: common,
+    if3 = unused3 :: Nil,
     if211 = List("-Ywarn-unused-import")
   )
 }

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -6,7 +6,6 @@ import java.nio.file.Path
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 
-import scala.annotation.nowarn
 import scala.collection.Seq
 import scala.util.control.NonFatal
 
@@ -108,11 +107,9 @@ abstract class BasePCSuite extends BaseSuite {
       snippetAutoIndent = false
     )
 
-  @nowarn("msg=parameter value scalaVersion")
   protected def extraDependencies(scalaVersion: String): Seq[Dependency] =
     Seq.empty
 
-  @nowarn("msg=parameter value classpath")
   protected def scalacOptions(classpath: Seq[Path]): Seq[String] = Seq.empty
 
   protected def ignoreScalaVersion: Option[IgnoreScalaVersion] = None


### PR DESCRIPTION
scala3 doesn't support `-Wconf=src` and compiling mtags on produced the following warnings:
```
[warn] Failed to parse `-Wconf` configuration: msg=parameter value .+ in anonymous function:silent,src=*.ScaladocParser.scala&msg=parameter value (pos|message) in method reportError:silent,src=*.Completions.scala&msg=parameter value (member|m) in method (isCandidate|isPrioritized):silent,src=*.JavaMtags.scala&msg=parameter value (ctor|method) in method (visitConstructor|visitMethod):silent,src=*.MtagsIndexer.scala&msg=parameter value owner in method visitOccurrence:silent,src=.*(CompletionProvider|ArgCompletions|Completions|Keywords|IndentOnPaste).scala&msg=The outer reference:silent
[warn] unknown filter: src
[warn] unknown filter: src
[warn] unknown filter: src
[warn] unknown filter: src
[warn] unknown filter: src
[warn] Note: for multiple filters, use `-Wconf:filter1:action1,filter2:action2`
[warn]       or alternatively          `-Wconf:filter1:action1 -Wconf:filter2:action2`
[warn] -- Warning: /home/dos65/projects/metals/metals/tests/cross/src/main/scala/tests/BasePCSuite.scala:111:3 
[warn] 111 |  @nowarn("msg=parameter value scalaVersion")
[warn]     |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[warn]     |  @nowarn annotation does not suppress any warnings
[warn] -- Warning: /home/dos65/projects/metals/metals/tests/cross/src/main/scala/tests/BasePCSuite.scala:115:3 
[warn] 115 |  @nowarn("msg=parameter value classpath")
[warn]     |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[warn]     |  @nowarn annotation does not suppress any warnings
```