### PR TITLE
fix: Rename extension parameter in Scala3

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -84,6 +84,13 @@ final class ReferenceProvider(
     }
   }
 
+  /**
+   * Find references for the given params.
+   *
+   * @return - All found list of references, it is a list of result because
+   *           in some cases, multiple symbols are attached to the given position.
+   *           (e.g. exntesion parameter). See: https://github.com/scalameta/scalameta/issues/2443
+   */
   def references(
       params: ReferenceParams,
       findRealRange: AdjustRange = noAdjustRange,

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -88,30 +88,29 @@ final class ReferenceProvider(
       params: ReferenceParams,
       findRealRange: AdjustRange = noAdjustRange,
       includeSynthetics: Synthetic => Boolean = _ => true
-  ): ReferencesResult = {
+  ): List[ReferencesResult] = {
     val source = params.getTextDocument.getUri.toAbsolutePath
     semanticdbs.textDocument(source).documentIncludingStale match {
       case Some(doc) =>
-        val ResolvedSymbolOccurrence(distance, maybeOccurrence) =
-          definition.positionOccurrence(source, params.getPosition, doc)
-        maybeOccurrence match {
-          case Some(occurrence) =>
-            val alternatives =
-              referenceAlternatives(occurrence.symbol, source, doc)
-            val locations = references(
-              source,
-              params,
-              doc,
-              distance,
-              occurrence,
-              alternatives,
-              params.getContext.isIncludeDeclaration,
-              findRealRange,
-              includeSynthetics
-            )
-            ReferencesResult(occurrence.symbol, locations)
-          case None =>
-            ReferencesResult.empty
+        val results: List[ResolvedSymbolOccurrence] =
+          definition.positionOccurrences(source, params.getPosition, doc)
+        results.map { result =>
+          val occurrence = result.occurrence.get
+          val distance = result.distance
+          val alternatives =
+            referenceAlternatives(occurrence.symbol, source, doc)
+          val locations = references(
+            source,
+            params,
+            doc,
+            distance,
+            occurrence,
+            alternatives,
+            params.getContext.isIncludeDeclaration,
+            findRealRange,
+            includeSynthetics
+          )
+          ReferencesResult(occurrence.symbol, locations)
         }
       case None =>
         // NOTE(olafur): we block here instead of returning a Future because it
@@ -119,7 +118,9 @@ final class ReferenceProvider(
         // its dependencies (including rename provider) asynchronous. The remote
         // language server returns `Future.successful(None)` when it's disabled
         // so this isn't even blocking for normal usage of Metals.
-        remote.referencesBlocking(params).getOrElse(ReferencesResult.empty)
+        List(
+          remote.referencesBlocking(params).getOrElse(ReferencesResult.empty)
+        )
     }
   }
 

--- a/tests/slow/src/test/scala/tests/feature/RenameCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/RenameCrossLspSuite.scala
@@ -22,4 +22,30 @@ class RenameCrossLspSuite extends BaseRenameLspSuite("rename-cross") {
     scalaVersion = Some(V.scala3)
   )
 
+  renamed(
+    "scala3-extension-params",
+    """|/a/src/main/scala/a/Main.scala
+       |
+       |extension (<<sb@@d>>: String)
+       |  def double = <<sbd>> + <<sbd>>
+       |  def double2 = <<sbd>> + <<sbd>>
+       |end extension
+       |""".stripMargin,
+    newName = "greeting",
+    scalaVersion = Some(V.scala3)
+  )
+
+  renamed(
+    "scala3-extension-params-ref",
+    """|/a/src/main/scala/a/Main.scala
+       |
+       |extension (<<sbd>>: String)
+       |  def double = <<sb@@d>> + <<sbd>>
+       |  def double2 = <<sbd>> + <<sbd>>
+       |end extension
+       |""".stripMargin,
+    newName = "greeting",
+    scalaVersion = Some(V.scala3)
+  )
+
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -435,9 +435,11 @@ final class TestingServer(
         new ReferenceContext(true)
       )
       val obtainedLocations = server.referencesResult(params)
-      references ++= obtainedLocations.locations.map(l =>
-        newRef(obtainedLocations.symbol, l)
-      )
+      references ++= obtainedLocations.flatMap { result =>
+        result.locations.map { l =>
+          newRef(result.symbol, l)
+        }
+      }
       definition ++= expectedLocations.map(l => newRef(ref.symbol, l))
     }
     WorkspaceSymbolReferences(


### PR DESCRIPTION
Fix https://github.com/scalameta/metals/issues/3133

![rename-extension](https://user-images.githubusercontent.com/9353584/162137906-78171a63-5e87-49c8-8394-89f5fbda2620.gif)

This PR enables Metals to rename all extension parameters.

Previously, when metals rename `sbd`  in `double` method.

```scala
  extension (sbd: String)
    def double = sbd + sbd
    def double2 = sbd + sbd
  end extension
```

Metals couldn't rename `sbd` in `double2` method because `sbd` in `double` and `sbd` in `double2` have different (semanticdb) symbols.

This PR fixes the issue by

- Make `ReferenceProvider` return multiple `ReferenceResult` because `find-references` may find references for multiple symbols.
  - For example, `sbd` in `extension (sbd: String)` is attached to two different symbols. see: https://github.com/scalameta/scalameta/issues/2443
  - Now `reference` returns all references for all symbols.
  - Therefore, this PR also fixes "find-references" for the extension parameter :+1:
- In RenameProvider, find all symbol occurrences (a reference to the symbol) from the definition site.
  - For example, while `sbd` in `double` has only one symbol,
  - `sbd` in `extension (sbd: String)` has two symbols, and we can find all references both in `double` and `double2`.