### PR TITLE
refactor: add a header object to json doctor output

### DIFF
--- a/docs/integrations/new-editor.md
+++ b/docs/integrations/new-editor.md
@@ -273,7 +273,8 @@ Possible values:
 
 - `html`: (default): Metals will return html that can be rendered directly in
   the browser or web view
-- `json`: json representation of the information returned by Doctor
+- `json`: json representation of the information returned by Doctor. See the
+    json format [here](#run-doctor).
 
 ##### `executeClientCommandProvider`
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -43,16 +43,14 @@ object ClientCommands {
         |  /**
         |   * Contains decisions that were made about what build tool or build server
         |   * the user has chosen. There is also other brief information about understanding
-        |   * the Doctor placed in here as well.
+        |   * the Doctor placed in here as well. (since version 3 (replaces headerText))
         |   */
-        |   headerText: string;
+        |   header: DoctorHeader;
         |   /**
         |    * If build targets are detected in your workspace, they will be listed here with
         |    * the status of related functionality of Metals for each build target.
         |    */
         |   targets?: DoctorBuildTarget[];
-        |   /** Messages given if build targets cannot be found */
-        |   messages?: DoctorRecommendation[];
         |   /** Messages given if build targets cannot be found */
         |   messages?: DoctorRecommendation[];
         |   /** Explanations for the various statuses present in the doctor */
@@ -61,10 +59,28 @@ object ClientCommands {
         |
         |```
         |```json
+        |export interface DoctorHeader {
+        |  /** if Metals detected multiple build tools, this specifies the one the user has chosen */
+        |  buildTool?: string;
+        |  /** the build server that is being used */
+        |  buildServer: string;
+        |  /** if the user has turned the import prompt off, this will include a message on
+        |   *  how to get it back.
+        |   */
+        |  importBuildStatus?: string;
+        |  /** java version and location information */
+        |  jdkInfo?: string;
+        |  /** the version of the server that is being used */
+        |  serverInfo: string;
+        |  /** small description on what a build target is */
+        |  buildTargetDescription: string;
+        |}
+        |```
+        |```json
         |export interface DoctorBuildTarget {
         |  /** Name of the build target */
         |  buildTarget: string;
-        |  /** Status of compilation for build this build target */
+        |  /** Status of compilation for build this build target (since version 2) */
         |  compilationStatus: string;
         |  /** Can contain Scala version, sbt version or Java */
         |  targetType: string;

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
@@ -266,20 +266,19 @@ final class Doctor(
     val importBuildHeading = selectedImportBuildMessage()
     val jdkInfo = getJdkInfo().map(info => s"$jdkVersionTitle$info")
     val serverInfo = s"$serverVersionTitle${BuildInfo.metalsVersion}"
-    val heading =
-      List(
+    val header =
+      DoctorHeader(
         buildToolHeading,
-        Some(buildServerHeading),
+        buildServerHeading,
         importBuildHeading,
         jdkInfo,
-        Some(serverInfo),
-        Some(doctorHeading)
-      ).flatten
-        .mkString("\n\n")
+        serverInfo,
+        buildTargetDescription
+      )
     val results = if (targetIds.isEmpty) {
       DoctorResults(
         doctorTitle,
-        heading,
+        header,
         Some(
           List(
             DoctorMessage(
@@ -307,7 +306,7 @@ final class Doctor(
 
       DoctorResults(
         doctorTitle,
-        heading,
+        header,
         None,
         Some(allTargetsInfo),
         explanations
@@ -397,7 +396,7 @@ final class Doctor(
 
     html
       .element("p")(
-        _.text(doctorHeading)
+        _.text(buildTargetDescription)
       )
 
     val targetIds = allTargetIds()
@@ -606,7 +605,7 @@ final class Doctor(
   private val doctorTitle = "Metals Doctor"
   private val jdkVersionTitle = "Metals Java: "
   private val serverVersionTitle = "Metals Server version: "
-  private val doctorHeading =
+  private val buildTargetDescription =
     "These are the installed build targets for this workspace. " +
       "One build target corresponds to one classpath. For example, normally one sbt project maps to " +
       "two build targets: main and test."

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/DoctorResults.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/DoctorResults.scala
@@ -6,7 +6,7 @@ import ujson.Obj
 
 final case class DoctorResults(
     title: String,
-    headerText: String,
+    header: DoctorHeader,
     messages: Option[List[DoctorMessage]],
     targets: Option[Seq[DoctorTargetInfo]],
     explanations: List[Obj]
@@ -14,7 +14,7 @@ final case class DoctorResults(
   def toJson: Obj = {
     val json = ujson.Obj(
       "title" -> title,
-      "headerText" -> headerText,
+      "header" -> header.toJson,
       "version" -> DoctorResults.version
     )
     messages.foreach(messageList =>
@@ -28,7 +28,7 @@ final case class DoctorResults(
 
 object DoctorResults {
   // Version of the Doctor json that is returned.
-  val version = 2
+  val version = 3
 }
 
 final case class DoctorMessage(title: String, recommendations: List[String]) {
@@ -74,4 +74,37 @@ final case class DoctorTargetInfo(
       "recommendation" -> recommenedFix
     )
 
+}
+
+/**
+ * @param buildTool if Metals detected multiple build tools, this specifies
+ *        the one the user has chosen
+ * @param buildServer the build server that is being used
+ * @param importBuildStatus if the user has turned the import prompt off, this
+ *        will include a message on how to get it back.
+ * @param jdkInfo java version and location information
+ * @param serverInfo the version of the server that is being used
+ * @param buildTargetDescription small description on what a build target is
+ */
+final case class DoctorHeader(
+    buildTool: Option[String],
+    buildServer: String,
+    importBuildStatus: Option[String],
+    jdkInfo: Option[String],
+    serverInfo: String,
+    buildTargetDescription: String
+) {
+  def toJson: Obj = {
+    val base =
+      ujson.Obj(
+        "buildServer" -> buildServer,
+        "serverInfo" -> serverInfo,
+        "buildTargetDescription" -> buildTargetDescription
+      )
+
+    buildTool.foreach { bt => base.update("buildTool", bt) }
+    importBuildStatus.foreach { ibs => base.update("importBuildStatus", ibs) }
+    jdkInfo.foreach { jdki => base.update("jdkInfo", jdki) }
+    base
+  }
 }


### PR DESCRIPTION
Previously everything was just contained in a `headerText` string. This
makes it a bit more structured now that we're getting a fair amount more
things in the header.
