### PR TITLE
[Scala3] Fix hover on interpolator-apply

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -66,6 +66,13 @@ object HoverProvider:
      */
     def isHoveringOnName(path: List[Tree], sourcePos: SourcePosition): Boolean =
       def contains(tree: Tree): Boolean = tree match
+        // e.g. interpolator-apply num"... $foo" has tree like
+        // Select(Select(Apply(Ident(Xtension), List(...)), num), apply)
+        case select: Select =>
+          source.fold(false) { s =>
+            SourceTree(select, s).namePos.contains(sourcePos)
+          }
+          || contains(select.qualifier)
         case tree: NameTree =>
           source.fold(false) { s =>
             SourceTree(tree, s).namePos.contains(sourcePos)

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -112,7 +112,7 @@ class HoverTermSuite extends BaseHoverSuite {
   )
 
   check(
-    "interpolator-apply".tag(IgnoreScala3),
+    "interpolator-apply",
     """
       |object a {
       |  implicit class Xtension(s: StringContext) {


### PR DESCRIPTION
https://github.com/scalameta/metals/pull/3792#discussion_r845286402

e.g. interpolator-apply `num"... $foo"` has tree-like

```
    Select(
      Select(
        Apply(
          Ident(Xtension),
          List(Apply(Select(Select(Select(Ident(_root_),scala),StringContext),apply),List(Typed(SeqLiteral(List(Literal(Constant(Hello )), Literal(Constant())),TypeTree[TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class scala)),object Predef),type String)]),TypeTree[AppliedType(TypeRef(ThisType(TypeRef(NoPrefix,module class scala)),class <repeated>),List(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class scala)),object Predef),type String)))]))))
        ),
        num
      ),
      apply
    ),

```

(where `Select` is a subclass of NameTree). To check the position of `num`, we have to take a look at` select.qualifier`.