### PR TITLE
fix: (Scala3) Don't navigate to enclosing symbols on go-to-definition if cursor is not on symbol

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -140,9 +140,16 @@ class PcDefinitionProvider(
         if sym.is(Synthetic) && sym.is(Module) then List(sym.companionClass)
         else List(target.symbol)
 
-      case head :: tl =>
+      case path @ head :: tl =>
         if head.symbol.is(Synthetic) then enclosingSymbols(tl, pos, indexed)
-        else if head.symbol != NoSymbol then List(head.symbol)
+        else if head.symbol != NoSymbol then
+          if MetalsInteractive.isOnName(
+              path,
+              pos,
+              indexed.ctx.source
+            ) || MetalsInteractive.isForSynthetic(head)
+          then List(head.symbol)
+          else Nil
         else
           val recovered = recoverError(head, indexed)
           if recovered.isEmpty then enclosingSymbols(tl, pos, indexed)

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -173,14 +173,7 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |object Main {
        |  ne@@w java.io.File("")
        |}
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|object Main {
-           |  new/*java/io/File#`<init>`(+2). File.java*/ java.io.File("")
-           |}
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   check(
@@ -188,14 +181,7 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
     """|
        |object Main ex@@tends java.io.Serializable {
        |}
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|
-           |object <<Main>> extends java.io.Serializable {
-           |}
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   check(
@@ -428,5 +414,41 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
            |}
            |""".stripMargin
     )
+  )
+  check(
+    "no-definition-1",
+    """|
+       |object Main {
+       |  @@
+       |  def foo() = {
+       |    // this is a comment
+       |  }
+       |  println(foo())
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "no-definition-2",
+    """|
+       |object Main {
+       |  def foo() = {
+       |    @@// this is a comment
+       |  }
+       |  println(foo())
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "no-definition-3",
+    """|
+       |object Main {
+       |  def foo() = {
+       |    // th@@is is a comment
+       |  }
+       |  println(foo())
+       |}
+       |""".stripMargin
   )
 }


### PR DESCRIPTION
https://github.com/scalameta/metals/issues/1707

![go-to-definition-no-sym](https://user-images.githubusercontent.com/9353584/162390063-16644b3d-e94c-4522-b46d-c3c64a002970.gif)

Basically the same strategy as https://github.com/scalameta/metals/pull/3792
But this PR checks `isOnName` inside `enclosingSymbols` because this Metals-version of `enclosingSymbols` well deals with synthetic symbols like for-flatMap and caseclass-apply. We check `isOnName` only if it's not on synthetic symbols or special cases (e.g. `NameArg` and `Import`).

Maybe we can make hover (for Scala3) better using this Metals-version of `enclosingSymbols` and it handles the issue https://github.com/scalameta/metals/pull/3792#discussion_r845286402

---

Remained issues around `go-to-definition` and hover are
- https://github.com/scalameta/metals/pull/3792#discussion_r845713388
- Ignored tests in HoverTermSuite for Scala3