### PR TITLE
docs: update vim docs to no longer point people to coc-metals

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -4,8 +4,9 @@ title: Contributing to Metals
 ---
 
 Whenever you are stuck or unsure, please open an issue or [ask us on
-Discord](https://discord.gg/DwTc8xbNDd). This project follows [Scalameta's
-contribution
+Discord](https://discord.gg/DwTc8xbNDd) or [on our Matrix
+bridge](https://matrix.to/#/#scalameta:metals-contributors). This project
+follows [Scalameta's contribution
 guidelines](https://github.com/scalameta/scalameta/blob/master/CONTRIBUTING.md)
 and the [Scala CoC](https://scala-lang.org/conduct/).
 
@@ -245,19 +246,13 @@ already set everything up.
   `:MetalsRestart`. NOTE: that every time you publish locally you'll want to
   trigger this again.
 
-If using `coc-metals`:
-
-- after the publish local set your `metals.serverVersion` in your
-  `:CocConfig`.
-- execute the `metals.restartServer command`
-
 If you are using another Vim client, write a `new-metals-vim` script that builds
 a new `metals-vim` bootstrap script using the locally published version.
 
 ```sh
 coursier bootstrap \
   --java-opt -Dmetals.client=<<NAME_OF_CLIENT>> \
-  org.scalameta:metals_2.12:@LOCAL_VERSION@ \ # double-check version here
+  org.scalameta:metals_2.13:@LOCAL_VERSION@ \ # double-check version here
   -r bintray:scalacenter/releases \
   -o /usr/local/bin/metals-vim -f
 ```

--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -282,9 +282,6 @@ buffer.
 
 ## Completions
 
-**✅ Vim**: auto-import and snippets require
-[coc.nvim](https://github.com/neoclide/coc.nvim) client.
-
 Use code completions to explore APIs, implement interfaces, generate exhaustive
 pattern matches and more.
 

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -4,410 +4,87 @@ sidebar_label: Vim
 title: Vim
 ---
 
-![Vim demo](https://i.imgur.com/4BYHCCL.gif)
+![nvim-metals demo](https://i.imgur.com/BglIFli.gif)
 
-Metals works with most LSP clients for Vim, but we recommend using one of the
-Metals-specific extensions to get the best experience since they offer
-Metals-specific commands and implement the Metals LSP extensions. 
-
-- [coc-metals](https://github.com/scalameta/coc-metals) An extension for
-    [`coc.nvim`](https://github.com/neoclide/coc.nvim) If you're already using
-    other coc.nvim plugins or you are using Vim instead of Neovim, then this is
-    probably the best option for you. Most of the documentation below refers to
-    coc-metals.
-- [nvim-metals](https://github.com/scalameta/nvim-metals) A Lua extension for
-    the [built-in LSP support](https://neovim.io/doc/user/lsp.html) in Neovim.
-    Note that this requires at least the 0.5.0 release of Neovim. You can find
-    the full documentation for nvim-metals
-    [here](https://github.com/scalameta/nvim-metals/blob/master/doc/metals.txt).
+While Metals works with most LSP clients for [Vim](https://www.vim.org/) and
+[Neovim](https://neovim.io/), we recommend using the dedicated Neovim plugin to
+get the best Metals support. Metals has many specific commands and LSP
+extensions that won't be available when not using the extension.
 
 ```scala mdoc:requirements
 
 ```
 
-## Installing Vim
+## nvim-metals
 
-The coc.nvim plugin requires either **Vim >= 8.1** or **Neovim >= 0.3.1**. Make
-sure you have the correct version installed. While it works with both Vim and
-Neovim, we recommend using Neovim since it provides a smoother experience with
-some of the features.
+[`nvim-metals`](https://github.com/scalameta/nvim-metals) Is the the dedicated
+Metals extension for the [built-in LSP
+support](https://neovim.io/doc/user/lsp.html) in Neovim.
 
-```sh
-# If using Vim
-vim --version | head
-VIM - Vi IMproved 8.2
-
-# If using Neovim
-nvim --version | head
-NVIM v0.4.3
-```
-## Installing Node
-
-`coc.nvim` requires [Node.js](https://nodejs.org/en/download/) in order to work.
-It also uses [Yarn](https://yarnpkg.com/en/docs/install#debian-stable) to manage
-extensions but you could opt-out of it and use `vim-plug` instead.
-
-For convenience we recommend installing both via your favorite package manager
-or manually:
-
-```sh
-curl -sL install-node.now.sh/lts | sh
-curl --compressed -o- -L https://yarnpkg.com/install.sh | bash
-```
-
-## Installing coc.nvim
-
-Once the requirements are satisfied, we can now proceed to install
-[`neoclide/coc.nvim`](https://github.com/neoclide/coc.nvim/), which provides
-Language Server Protocol support to Vim/Nvim  to communicate with the Metals
-language server.
-
-Assuming [`vim-plug`](https://github.com/junegunn/vim-plug) is used (another
-plugin manager like vundle works too, but requires slightly different configuration), update your `~/.vimrc` (or, in case of Neovim, `~/.config/nvim/init.vim`) to include the
-following settings.
-
-```vim
-Plug 'neoclide/coc.nvim', {'branch': 'release'}
-```
-
-Run `:PlugInstall` to install the plugin. If you already have `coc.nvim`
-installed, be sure to update to the latest version with `:PlugUpdate`.
-
-`coc.nvim` uses [jsonc](https://code.visualstudio.com/docs/languages/json) as a
-configuration file format. It's basically json with comment support.
-
-In order to get comment highlighting, please add:
-
-```vim
-autocmd FileType json syntax match Comment +\/\/.\+$+
-```
-### Recommended coc.nvim mappings
-
-`coc.nvim` doesn't come with a default key mapping for LSP commands, so you need
-to configure it yourself. You can see an example of default mappings
-[here](https://github.com/neoclide/coc.nvim#example-vim-configuration). Below
-you'll find examples of additional `coc-metals` specific mappings that you'll
-also want to ensure you have:
-
-```vim
-" Help Vim recognize *.sbt and *.sc as Scala files
-au BufRead,BufNewFile *.sbt,*.sc set filetype=scala
-
-" Used to expand decorations in worksheets
-nmap <Leader>ws <Plug>(coc-metals-expand-decoration)
-
-" Toggle panel with Tree Views
-nnoremap <silent> <space>t :<C-u>CocCommand metals.tvp<CR>
-" Toggle Tree View 'metalsPackages'
-nnoremap <silent> <space>tp :<C-u>CocCommand metals.tvp metalsPackages<CR>
-" Toggle Tree View 'metalsCompile'
-nnoremap <silent> <space>tc :<C-u>CocCommand metals.tvp metalsCompile<CR>
-" Toggle Tree View 'metalsBuild'
-nnoremap <silent> <space>tb :<C-u>CocCommand metals.tvp metalsBuild<CR>
-" Reveal current current class (trait or object) in Tree View 'metalsPackages'
-nnoremap <silent> <space>tf :<C-u>CocCommand metals.revealInTreeView metalsPackages<CR>
-```
-
-### Installing coc-metals
-
-Once you have `coc.nvim` installed, you can then install Metals a few different
-ways. The easiest is by running:
-
-```vim
-:CocInstall coc-metals
-```
-
-If you are using the latest stable release of coc.nvim, then this will
-automatically check for updates each day. However, if you're on the master
-branch of coc.nvim, this will no longer happen by default. You can read more
-about this [here](https://github.com/neoclide/coc.nvim/issues/1937).
-
-If you'd like to use the latest changes on master, you can also just build from
-source by using your vim plugin manager. Here is an example using `vim-plug`:
-
-```vim
-Plug 'scalameta/coc-metals', {'do': 'yarn install --frozen-lockfile'}
-```
-
-Then, issue a `:PlugInstall` to install the extension, and regularly a
-`:PlugUpdate` to update it and pull in the latest changes.
-
-**NOTE*** Make sure you don't have the extension installed both ways. So if you
-have installed it with the built-in extension management of coc.nvim first and
-are not switching, make sure to uninstall the old version first.
-
-```vim
-:CocUninstall coc-metals
-```
-
-```scala mdoc:editor:vim
-Update the `metals.sbtScript` setting to use a custom `sbt` script instead of the
-default Metals launcher if you need further customizations like reading environment
-variables.
-
-![Sbt Launcher](https://i.imgur.com/meciPTg.png)
-```
-
-## Configure Java version
-The `coc-metals` extension uses by default the `JAVA_HOME` environment variable
-(via [`find-java-home`](https://www.npmjs.com/package/find-java-home)) to locate
-the `java` executable.
-
-![No Java Home](https://i.imgur.com/clDfPMk.png)
-
-If no `JAVA_HOME` is detected you can then Open Settings by following the
-instructions or do it at a later time by using `:CocConfig` or `:CocConfigLocal`
-which will open up your configuration where you can manually enter your
-JAVA_HOME location.
-
-![Enter Java Home](https://i.imgur.com/wK07Vju.png)
-
-## Using latest Metals SNAPSHOT
-
-Update the "Server Version" setting to try out the latest pending Metals
-features.
+To get started with installation please see the `nvim-metals`
+[prerequisites](https://github.com/scalameta/nvim-metals#prerequisites) and
+[installation steps](https://github.com/scalameta/nvim-metals#installation).
 
 ```scala mdoc:releases
 
 ```
 
-After updating the version, you'll be triggered to reload the window.
-This will be necessary before the new version will be downloaded and used.
+Keep in mind that by default Neovim doesn't have default mappings for the
+functionality you'll want like, hovers, goto definition, method signatures, etc.
+Youc can find a full example configuration of these in the [example
+configuration](https://github.com/scalameta/nvim-metals/discussions/39).
 
-![Update Metals Version](https://i.imgur.com/VUCdQvi.png)
+For a guide on all the available features in `nvim-metals`, refer to the
+[features list](https://github.com/scalameta/nvim-metals/discussions/279).
 
-## List all workspace compile errors
+## Vim alternatives
 
-To list all compilation errors and warnings in the workspace, run the following
-command.
+There are multiple Vim alternatives if you're not a Neovim user. Metals did have
+a Metals-specific plugin that worked with Vim,
+[`coc-metals`](https://github.com/scalameta/coc-metals), but it doesn't work
+with the newest versions of Metals and is currently [deprecated and
+unmaintained](https://github.com/scalameta/coc-metals/issues/460).
 
-```vim
-:CocList diagnostics
-```
+### Using an alternative LSP Client
 
-Or use the default recommended mapping `<space> a`.
+There are multiple other LSP clients that work with Vim. Here are a few:
 
-This is helpful to see compilation errors in different files from your current
-open buffer.
+- [`natebosch/vim-lsc`](https://github.com/natebosch/vim-lsc/): simple installation and written in Vimscript.
+- [`vim-lsp`](https://github.com/prabirshrestha/vim-lsp): simple installation and written in
+    Vimscript.
+- [`yegappan/lsp`](https://github.com/yegappan/lsp): Very new and targeting
+    Vim9.
 
-![Diagnostics](https://i.imgur.com/cer22HW.png)
+Keep in mind that they have varying levels of LSP support, don't support Metals
+specific commands (like build import), or Metals specific LSP extensions (like
+tree view), and you need to manage the Metals installation yourself.
 
-```scala mdoc:worksheet:vim
-```
-![Decorations with worksheets](https://i.imgur.com/Bt6DMtH.png)
+There are two ways to install Metals yourself in order to work with an
+alternative client.
 
-## Tree View Protocol
-
-![Tree View Protocol](https://i.imgur.com/GvcU9Mu.gif)
-
-coc-metals has a built-in implementation of the [Tree View
-Protocol](https://scalameta.org/metals/docs/integrations/tree-view-protocol.html).
-If you have the [recommended mappings](vim.md#recommended-cocnvim-mappings) copied, you'll notice
-that in the bottom you'll have some TVP related settings. You can start by
-opening the TVP panel by using the default `<space> t`. Once open, you'll see
-there are three parts to the panel. The first being the `MetalsCompile` window
-where you can see ongoing compilations, the second is the `MetalsPackages`
-window where you are able to see a tree view of all your packages, and finally
-the `metalsBuild` window where you have build related commands.
-
-You are able to trigger the commands while being on top of the option you are
-attempting to trigger and pressing `r`. You can change this default in the
-settings. You can find all the relevant TVP settings below in the [Available
-Configuration Options](#tree-view-protocol-configuration-options).
-
-### Tree View Protocol configuration options
-
-   Configuration Option                         |      Description
-----------------------------                    |---------------------------
-`metals.treeviews.toggleNode`                   | Expand / Collapse tree node (default `<CR>`)
-`metals.treeviews.initialWidth`                 | Initial Tree Views panels (default `40`)
-`metals.treeviews.initialViews`                 | Initial views that the Tree View Panel displays. Don't mess with this unless you know what you're doing.
-`metals.treeviews.gotoLastChild`                | Go to the last child Node (default `J`)
-`metals.treeviews.gotoParentNode`               | Go to parent Node (default `p`)
-`metals.treeviews.gotoFirstChild`               | Go to first child Node (default `K`)
-`metals.treeviews.executeCommand`               | Execute command for node (default `r`)
-`metals.treeviews.gotoPrevSibling`              | Go to prev sibling (default `<C-k>`)
-`metals.treeviews.gotoNextSibling`              | Go to next sibling (default `<C-j>`)
-`metals.treeviews.forceChildrenReload`          | Force the reloading of the children of this node. May be useful when the wrong result is cached and tree contains invalid data. (default `f`)
-`metals.treeviews.executeCommandAndOpenTab`     | Execute command and open node under cursor in tab (if node is class, trait and so on) (default `t`)
-`metals.treeviews.executeCommandAndOpenSplit`   | Execute command and open node under cursor in horizontal split (if node is class, trait and so on) (default `s`)
-`metals.treeviews.executeCommandAndOpenVSplit`  | Execute command and open node under cursor in vertical split (if node is class, trait and so on) (default `v`)
-
-## Goto Super Method
-
-Depending on whether you're using Vim or Neovim, you'll have a slightly
-different behavior with this feature. If you're using Neovim, you'll want to
-ensure that you have `codeLens.enable` set to `true` in your `:CocConfig` since
-you'll be able to quickly see via code lenses which members are overridden.
-Then, you'll be able to simply trigger a code lens action on the line of the
-member that is overridden. The default mapping for this is `<leader> cl`.
-
-If you're using Vim, you'll still have access to this functionality, but you'll
-have to infer which members are overridden and utilize the
-`metals.go-to-super-method` command.
-
-There is also a `metals.super-method-hierarchy` command which will show you the
-entire hierarchy of the overridden method.
-
-![Goto super method](https://i.imgur.com/TkjolXq.png)
-
-If you don't utilize this feature you can disable it by setting
-`metals.superMethodLensesEnabled` to `false`.
-
-## Run doctor
-
-To troubleshoot problems with your build workspace, open your coc commands by either
-using `:CocCommand` or the recommend mapping `<space> c`. This will open your command
-window allowing you to search for `metals.doctor-run` command.
-
-![Run Doctor Command](https://i.imgur.com/QaqhxF7.png)
-
-This command opens an embedded doctor in your preview window. If you're not familiar with
-having multiple windows, you can use `<C-w> + w` to jump into it.
-
-![Embedded Doctor](https://i.imgur.com/McaAFv5.png)
-
-## Other Available Commands
-
-You can see a full list of the Metals server commands
-[here](https://scalameta.org/metals/docs/integrations/new-editor#metals-server-commands).
-
-## Show document symbols
-
-Run `:CocList outline` to show a symbol outline for the current file or use the
-default mapping `<space> o`.
-
-![Document Symbols](https://i.imgur.com/gEhAXV4.png)
-
-## Available Configuration Options
-
-The following configuration options are currently available. The easiest way to
-set these configurations is to enter `:CocConfig` or `:CocLocalConfig` to set
-your global or local configuration settings respectively.
-If you'd like to get autocompletion help for the configuration values you can
-install [coc-json](https://github.com/neoclide/coc-json).
-
-```scala mdoc:user-config:lsp-config-coc
-```
-
-```scala mdoc:new-project:vim
-```
-
-## Enable on type formatting for multiline string formatting
-
-![on-type](https://i.imgur.com/astTOKu.gif)
-
-To properly support some of the multiline string options like adding `|` in
-the multiline string, we are using the `onTypeFormatting` method. To enable the
-functionality you need to enable `coc.preferences.formatOnType` setting.
-
-![coc-preferences-formatOnType](https://i.imgur.com/RWPHt2q.png)
-
-## Close buffer without exiting
-
-To close a buffer and return to the previous buffer, run the following command.
-
-```vim
-:bd
-```
-
-This command is helpful when navigating in library dependency sources in the .metals/readonly directory.
-
-## Shut down the language server
-
-The Metals server is shutdown when you exit vim as usual.
-
-```vim
-:wq
-```
-
-## Statusline integration
-
-It's recommended to use a statusline integration with `coc-metals` in order to
-allow messages to be displayed in your status line rather than as a message.
-This will allow for a better experience as you can continue to get status
-information while entering a command or responding to a prompt. However, we
-realize that not everyone by default will have this setup, and since the user
-needs to see messages about the status of their build, the following is
-defaulted to false.
-
-```json
-"metals.statusBarEnabled": true
-```
-
-Again, it's recommended to make this active, and use a statusline plugin, or
-manually add the coc status information into your statusline. `coc.nvim` has
-multiple ways to integrate with various statusline plugins. You can find
-instructions for each of them located
-[here](https://github.com/neoclide/coc.nvim/wiki/Statusline-integration).  If
-you're unsure of what to use,
-[vim-airline](https://github.com/vim-airline/vim-airline) is a great minimal
-choice that will work out of the box.
-
-With [vim-airline](https://github.com/vim-airline/vim-airline) you'll notice
-two noteworthy things. The first will be that you'll have diagnostic
-information on the far right of your screen.
-
-![Diagnostic statusline](https://i.imgur.com/7uNYTYl.png)
-
-You'll also have metals status information in your status bar.
-
-![Status bar info](https://i.imgur.com/eCAgrCn.png)
-
-Without a statusline integration, you'll get messages like you see below.
-
-![No status line](https://i.imgur.com/XF7A1BJ.png)
-
-If you don't use a statusline plugin, but would still like to see this
-information, the easiest way is to make sure you have the following in your
-`.vimrc`.
-
-```vim
-set statusline^=%{coc#status()}%{get(b:,'coc_current_function','')}
-```
-
-## Formatting on save
-
-Add the following configuration to `:CocConfig` if you'd like to have `:w` format using Metals and
-Scalafmt.
-
-```json
-"coc.preferences.formatOnSaveFiletypes": ["scala"]
-```
-This step cleans up resources that are used by the server.
+1. Most easily is to just use [Coursier](https://get-coursier.io/) to do a `cs
+   install metals`.
+2. Generating a Metals binary yourself.
 
 ```scala mdoc:generic
 
 ```
 
-## Using an alternative LSP Client
-
-While we recommend using the `coc-metals` extension with `coc.nvim`, or
-`nvim-metals` with Neovim, Metals will work with these alternative LSP clients.
-Keep in mind that they have varying levels of LSP support, and you need to
-bootstrap Metals yourself.
-
-- [`vim-lsc`](https://github.com/natebosch/vim-lsc/): simple installation and written in Vimscript.
-- [`LanguageClient-neovim`](https://github.com/autozimu/LanguageClient-neovim/): client written in Rust.
-- [`vim-lsp`](https://github.com/prabirshrestha/vim-lsp): simple installation and written in
-    Vimscript.
-
-### Generating metals binary
-
-If you only want to use the latest stable version of Metals, the easiest way to
-install Metals is using [coursier](https://get-coursier.io/). Once installed you
-can simply do a `cs install metals` to install the latest stable version of
-Metals. You can then also do a `cs update metals` to update it.
-
-If you'd like to bootstrap your own Metals for a specific version, you're also
-able to do so like this:
-
 ```scala mdoc:bootstrap:metals-vim vim-lsc
 
 ```
+
 The `-Dmetals.client=vim-lsc` flag is there just as a helper to match your
 potential client. So make sure it matches your client name. This line isn't
-mandatory though as your client can fully be configured via
-`InitializationOptions`, which should be easily configurable by your client. You
-can read more about his
+mandatory though as your client should be able to fully be configured via
+`InitializationOptions`. You can read more about his
 [here](https://scalameta.org/metals/blog/2020/07/23/configuring-a-client#initializationoptions).
+
+## Getting help
+
+There is an active community using Vim and Metals. Apart from [creating an
+issue](https://github.com/scalameta/nvim-metals/issues/new/choose) or [starting
+a discussion](https://github.com/scalameta/nvim-metals/discussions) for
+`nvim-metals` users, you can also ask questions in our `#vim-users` [Discord
+Channel](https://discord.gg/FaVDrJegEh) or [Matrix
+Bridge](https://matrix.to/#/#scalameta:vim-users).

--- a/docs/troubleshooting/proxy.md
+++ b/docs/troubleshooting/proxy.md
@@ -14,10 +14,11 @@ everything, there are some steps that might need to be done manually.
 
 Everything inside Metals uses Coursier to download its dependencies:
 
-- The Visual Studio Code and coc-metals extensions use Coursier bootstrap to
-  download Metals server - Coursier boostrap is a minimal file, which only
-  purpose is to download a full Coursier version. It's used to keep the
-  extension size down to a minimum.
+- The Visual Studio Code and `nvim-metals` extensions both use Coursier to
+  download Metals server, although they do it slightly different. The VS Code
+  extension has a Coursier boostrap file, which is used to is to download a full
+  Coursier version. It's used to keep the extension size down to a minimum,
+  whereas `nvim-metals` requires Coursier to be installed on the users machine.
 - Metals uses Coursier api to download dependencies needed for a particular
   Scala version
 - Bloop uses Coursier api to download the SemanticDB plugin
@@ -88,15 +89,16 @@ In case you need to add custom repositories to resolve Metals server artifacts
 you can use the `COURSIER_REPOSITORIES` environment variable. This will tell
 Coursier to try to download artifacts from your private artifact repository.
 This is also available as a setting in the Metals Visual Studio Code and
-coc-metals extensions.
+`nvim-metals` extensions.
 
 ## Proxy settings
 
 In some cases, workspaces might require a proxy in order to resolve the needed
 artifacts. Depending on the way Metals server is started, proxy settings can be
 specified using properties inside a `.jvmopts` file and
-`metals.serverProperties` (for Visual Studio Code or coc-metals extensions) or
-via properties for Coursier and Metals invocations.
+`metals.serverProperties` for Visual Studio Code or `serverProperties` in your
+settings table for `nvim-metals`, or via properties for Coursier and Metals
+invocations.
 
 However, because proxy properties might vary between workspaces and a Bloop
 server must work for multiple clients at the same time they are not forwarded to

--- a/metals-docs/src/main/scala/docs/WorksheetModifier.scala
+++ b/metals-docs/src/main/scala/docs/WorksheetModifier.scala
@@ -18,19 +18,6 @@ class WorksheetModifier extends StringModifier {
       case "vscode" =>
         "as a decoration at the end of the line." ->
           "hover on the decoration to expand the decoration."
-      case "vim" =>
-        """|differently depending on whether you are using Neovim or Vim. If 
-           |using Vim, you will see them appear as comments at the end of
-           |the line. If you're using Nvim you will see this as virtual text.
-           |Keep in mind that if you're using coc-metals with Nvim you'll need
-           |to make sure `codeLens.enable` is set to `true`.""".stripMargin ->
-          """|hover on the comment if you're in Vim or expand the virtual text by
-             |using the `coc-metals-expand-decoration` command. The default for this
-             |is:
-             |```vim
-             |nmap <Leader>ws <Plug>(coc-metals-expand-decoration)
-             |```
-             |""".stripMargin
       case _ =>
         "as a comment as the end of the line." -> "hover on the comment to expand."
     }


### PR DESCRIPTION
As of this next release
[coc-metals](https://github.com/scalameta/coc-metals) will be officially
deprecated, meaning we shouldn't be pointing people to it in the docs,
and also shouldn't have all the features outlined be coc specific. This
makes those changes.

Note that this is much much more minimal than it previously was. This is
mainly because the docs for `nvim-metals` are pretty spread out, and I
don't have any intention of duplicating them.

- The main docs are in
  https://github.com/scalameta/nvim-metals/blob/main/doc/metals.txt and
  they are in a specific format necessary for Vim help docs.
- https://github.com/scalameta/nvim-metals/discussions/39 holds the
  example configuration
- https://github.com/scalameta/nvim-metals/discussions/279 holds the
  feature list and instructions on how to utilize everything.

All this is mentioned and linked on the vim page.