### PR TITLE
test: Add test for completions of matchtype / higher-kinded type

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/CompletionScala3Suite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScala3Suite.scala
@@ -21,4 +21,25 @@ class CompletionScala3Suite extends BaseCompletionSuite {
        |""".stripMargin,
     topLines = Some(2)
   )
+
+  // https://github.com/scalameta/metals/issues/2810
+  check(
+    "higher-kinded-match-type".tag(IgnoreScalaVersion.forLessThan("3.1.3-RC2")),
+    """|package a
+       |
+       |trait Foo[A] {
+       |  def map[B](f: A => B): Foo[B] = ???
+       |}
+       |case class Bar[F[_]](bar: F[Int])
+       |type M[T] = T match {
+       |  case Int => Foo[Int]
+       |}
+       |object Test:
+       |  val x = Bar[M](new Foo[Int]{})
+       |  x.bar.m@@
+       |""".stripMargin,
+    """|map[B](f: A => B): Foo[B]
+       |""".stripMargin,
+    topLines = Some(1)
+  )
 }


### PR DESCRIPTION
resolve https://github.com/scalameta/metals/issues/2810

This issue is fixed by https://github.com/lampepfl/dotty/pull/14639 :tada: and it seems like released at least in 3.1.3-RC2 and newer.