### PR TITLE
fix: unblock release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,18 +15,18 @@ jobs:
       - uses: coursier/cache-action@v6.3
       - name: Publish
         run: |
-          LOCKED=true
-          while [ $LOCKED = true ]; do
-            # if there are several release jobs at the same time
-            # allow to continue the one which id is less than others
-            FIRST_IN_PROGRESS=$(gh api /repos/scalameta/metals/actions/workflows/release.yml/runs?status=in_progress -q ".workflow_runs[].id" | sort | head -n 1)
-            if [ "$FIRST_IN_PROGRESS" == "$GITHUB_RUN_ID" ]; then
-              LOCKED=false
-            else
-              echo "Waiting the completion of other release job..."
-              sleep 20
-            fi
-          done
+          #LOCKED=true
+          #while [ $LOCKED = true ]; do
+          #  # if there are several release jobs at the same time
+          #  # allow to continue the one which id is less than others
+          #  FIRST_IN_PROGRESS=$(gh api /repos/scalameta/metals/actions/workflows/release.yml/runs?status=in_progress -q ".workflow_runs[].id" | sort | head -n 1)
+          #  if [ "$FIRST_IN_PROGRESS" == "$GITHUB_RUN_ID" ]; then
+          #    LOCKED=false
+          #  else
+          #    echo "Waiting the completion of other release job..."
+          #    sleep 20
+          #  fi
+          #done
 
           COMMAND="ci-release"
           UPDATE_DOCS=true


### PR DESCRIPTION
Currently, github actions have some issues with filtering `runs`.
`gh api/repos/scalameta/metals/actions/workflows/release.yml/runs?status=in_progress` doesn't return any results.
There are several issues about that in github community forum - https://github.community/t/bug-we-are-having-problems-searching-workflow-runs-the-results-may-not-be-complete/244650

The only option for now is disable this lock logic.