### PR TITLE
Bump Bloop with a fix for #3766

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -12,7 +12,7 @@ object V {
   val ammonite213Version = "2.13.7"
 
   val ammonite = "2.5.2"
-  val bloop = "1.4.13-69-805134a0"
+  val bloop = "1.4.13-72-bfcb7098"
   val bloopNightly = bloop
   val bsp = "2.0.0+70-f6e47d42-SNAPSHOT"
   val coursier = "2.1.0-M5"


### PR DESCRIPTION
This gets rid of the warnings about `-classpath` and `-bootclasspath`