### PR TITLE
fix: show test explorer misconfigurations

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
@@ -227,7 +227,7 @@ class ProblemResolver(
 
     // 1.0.0-M3 or higher is valid
     def outdatedMunitInterface =
-      if (!isTestExplorerProvider()) None
+      if (!isTestExplorerProvider() || scalaTarget.isSbt) None
       else {
         def isInvalid(
             major: Int,
@@ -242,7 +242,7 @@ class ProblemResolver(
           } else false
         }
 
-        val munit = raw".*org/scalameta/munit/(\d).(\d+).(\d+).*".r
+        val munit = raw".*org/scalameta/munit_.*/(\d).(\d+).(\d+).*".r
         scalaTarget.scalac.getClasspath().asScala.collectFirst {
           case dep @ munit(major, minor, patch)
               if isInvalid(major.toInt, minor.toInt, patch.toInt, dep) =>
@@ -251,7 +251,7 @@ class ProblemResolver(
       }
 
     def outdatedJunitInterface =
-      if (!isTestExplorerProvider()) None
+      if (!isTestExplorerProvider() || scalaTarget.isSbt) None
       else {
         val novocode = ".*com/novocode/junit-interface.*".r
         val junit = raw".*com/github/sbt/junit-interface/(\d).(\d+).(\d+).*".r

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -149,31 +149,49 @@ class ProblemResolverSuite extends FunSuite {
   )
 
   checkRecommendation(
-    "munit-0.x",
+    "no-test-explorer-for-sbt",
+    scalaVersion = BuildInfo.scala213,
+    "",
+    classpath = List(
+      "org/scalameta/munit_2.13/0.7.29/munit_2.13-0.7.29.jar",
+      "/com/github/sbt/junit-interface/0.13.2/"
+    ),
+    sbtVersion = Some(BuildInfo.sbtVersion)
+  )
+
+  checkRecommendation(
+    "munit_2.13-0.x",
     scalaVersion = BuildInfo.scala213,
     OutdatedMunitInterfaceVersion.message,
-    classpath = List("/org/scalameta/munit/0.7.29/")
+    classpath = List("org/scalameta/munit_2.13/0.7.29/munit_2.13-0.7.29.jar")
+  )
+
+  checkRecommendation(
+    "munit_3-0.x",
+    scalaVersion = BuildInfo.scala213,
+    OutdatedMunitInterfaceVersion.message,
+    classpath = List("org/scalameta/munit_3/0.7.29/munit_3-0.7.29.jar")
   )
 
   checkRecommendation(
     "munit-1.0.0-M2",
     scalaVersion = BuildInfo.scala213,
     OutdatedMunitInterfaceVersion.message,
-    classpath = List("/org/scalameta/munit/1.0.0-M2/")
+    classpath = List("org/scalameta/munit_2.13/1.0.0-M2/")
   )
 
   checkRecommendation(
     "munit-valid",
     scalaVersion = BuildInfo.scala213,
     "",
-    classpath = List("/org/scalameta/munit/1.0.0-M3/")
+    classpath = List("org/scalameta/munit_2.13/1.0.0-M3/")
   )
 
   checkRecommendation(
     "munit-valid-2",
     scalaVersion = BuildInfo.scala213,
     "",
-    classpath = List("/org/scalameta/munit/1.0.1/")
+    classpath = List("org/scalameta/munit_2.13/1.0.1/")
   )
 
   def checkRecommendation(


### PR DESCRIPTION
Take scala version suffix in munit.
Do not show warning for sbt targets.