### PR TITLE
Backtick types when neccessary

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -511,6 +511,53 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |""".stripMargin
   )
 
+  checkEdit(
+    "backticks-4".tag(IgnoreScala3),
+    """|case class `Foo-Foo`(i: Int)
+       |object O{
+       |  val <<foo>> = `Foo-Foo`(1)
+       |}""".stripMargin,
+    """|case class `Foo-Foo`(i: Int)
+       |object O{
+       |  val foo: `Foo-Foo` = `Foo-Foo`(1)
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "backticks-5".tag(IgnoreScala3),
+    """|object A{
+       |  case class `Foo-Foo`(i: Int)
+       |}
+       |object O{
+       |  val <<foo>> = A.`Foo-Foo`(1)
+       |}""".stripMargin,
+    """|object A{
+       |  case class `Foo-Foo`(i: Int)
+       |}
+       |object O{
+       |  val foo: A.`Foo-Foo` = A.`Foo-Foo`(1)
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "backticks-6".tag(IgnoreScala3),
+    """|object A{
+       |  case class `Foo-Foo`[A](i: A)
+       |}
+       |object O{
+       |  val <<foo>> = A.`Foo-Foo`(1)
+       |}""".stripMargin,
+    """|object A{
+       |  case class `Foo-Foo`[A](i: A)
+       |}
+       |object O{
+       |  val foo: A.`Foo-Foo`[Int] = A.`Foo-Foo`(1)
+       |}
+       |""".stripMargin
+  )
+
   def checkEdit(
       name: TestOptions,
       original: String,


### PR DESCRIPTION
This is backported from https://github.com/scalacenter/scalafix/pull/1578/files

Scalafix rule for explicit result types started of as a copy of Metals one.