### PR TITLE
Add classpath to CFR decompile

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -110,6 +110,11 @@ final class BuildTargets() {
   ): Option[List[AbsolutePath]] =
     data.fromOptions(_.targetJarClasspath(id))
 
+  def targetClasspath(
+      id: BuildTargetIdentifier
+  ): Option[List[String]] =
+    data.fromOptions(_.targetClasspath(id))
+
   def targetClassDirectories(
       id: BuildTargetIdentifier
   ): List[String] =

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
@@ -6,6 +6,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTarget
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import ch.epfl.scala.bsp4j.JavacOptionsItem
 
 case class JavaTarget(
@@ -33,6 +34,8 @@ case class JavaTarget(
   def isTargetrootDeclared: Boolean = javac.isTargetrootDeclared
 
   def classDirectory: String = javac.getClassDirectory()
+
+  def id: BuildTargetIdentifier = info.getId()
 
   def releaseVersion: Option[String] = javac.releaseVersion
 

--- a/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
@@ -187,11 +187,7 @@ class FileDecoderProviderLspSuite
       str
         .replace("\\", "/")
         .replaceAll(
-          "(No such file ).*(\\/foo\\/bar\\/example\\/Main\\.class)",
-          "$1$2"
-        )
-        .replaceAll(
-          "(CannotLoadClassException: ).*(\\/foo\\/bar\\/example\\/Main\\.class )",
+          "[\\s\\S]*(Can't load the class specified:)[\\s]*(org.benf.cfr.reader.util.CannotLoadClassException:.*foo\\/bar\\/example\\/Main\\.class)[\\s\\S]*",
           "$1$2"
         )
   )
@@ -882,9 +878,7 @@ object FileDecoderProviderLspSuite {
         |""".stripMargin
 
   private val cfrMissing =
-    s"""|Can't load the class specified:
-        |org.benf.cfr.reader.util.CannotLoadClassException: /foo/bar/example/Main.class - java.io.IOException: No such file /foo/bar/example/Main.class
-        |""".stripMargin
+    "Can't load the class specified:org.benf.cfr.reader.util.CannotLoadClassException: foo/bar/example/Main.class - java.io.IOException: No such file foo/bar/example/Main.class"
 
   private val cfrToplevel =
     s"""|/*


### PR DESCRIPTION
Adds the classpath to the args of CFR so the decompile is more accurate.