### PR TITLE
fix: Make signature help work properly with a non-tuple result

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -489,12 +489,16 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
       case TypeRef(
             _,
             cls,
-            TypeRef(_, _, args) :: Nil
+            TypeRef(_, symbol, args) :: Nil
           )
           if isUnapplyMethod &&
-            (cls == definitions.OptionClass || cls == definitions.SomeClass) &&
-            args.nonEmpty =>
-        List(args.map(_.typeSymbol))
+            (cls == definitions.OptionClass || cls == definitions.SomeClass) =>
+        // tuple unapply results
+        if (args.nonEmpty && definitions.isTupleSymbol(symbol))
+          List(args.map(_.typeSymbol))
+        // otherwise it's a single unapply result
+        else
+          List(List(symbol))
       case _ =>
         if (method.typeParams.isEmpty) method.paramLists
         else method.typeParams :: method.paramLists

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -494,7 +494,7 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
           if isUnapplyMethod &&
             (cls == definitions.OptionClass || cls == definitions.SomeClass) =>
         // tuple unapply results
-        if (args.nonEmpty && definitions.isTupleSymbol(symbol))
+        if (definitions.isTupleSymbol(symbol))
           List(args.map(_.typeSymbol))
         // otherwise it's a single unapply result
         else

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
@@ -37,8 +37,8 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
       |  }
       |}
       |""".stripMargin,
-    """|(value: A)
-       | ^^^^^^^^
+    """|(A)
+       | ^
        |""".stripMargin
   )
 
@@ -150,9 +150,8 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
       |  }
       |}
     """.stripMargin,
-    """|(String)
-       | ^^^^^^
-       |(Char)
+    """|(List[A])
+       | ^^^^^^^
        |""".stripMargin
   )
 
@@ -192,6 +191,57 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
     // `pat3` without regressing signature help in othere cases like partial functions that
     // generate qualifiers with offset positions.
     ""
+  )
+
+  check(
+    "pat5",
+    """
+      |object OpenBrowserCommand {
+      |  def unapply(command: String): Option[Int] = {
+      |    Some(1)
+      |  }
+      |
+      |  "" match {
+      |    case OpenBrowserCommand(@@) =>
+      |  }
+      |}
+    """.stripMargin,
+    """|(Int)
+       | ^^^
+       |""".stripMargin
+  )
+
+  check(
+    "pat6",
+    """
+      |object OpenBrowserCommand {
+      |  def unapply(command: String): Option[Option[Int]] = {
+      |    Some(Some(1))
+      |  }
+      |
+      |  "" match {
+      |    case OpenBrowserCommand(@@) =>
+      |  }
+      |}
+    """.stripMargin,
+    """|(Option[A])
+       | ^^^^^^^^^
+       |""".stripMargin
+  )
+
+  check(
+    "pat-negative",
+    """
+      |object And {
+      |  def unapply[A](a: A): Some[(A, A)] = Some((a, a))
+      |}
+      |object a {
+      |  And.unapply(@@)
+      |}
+    """.stripMargin,
+    """|unapply[A](a: A): Some[(A, A)]
+       |           ^^^^
+       | """.stripMargin
   )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -886,19 +886,4 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
     )
   )
 
-  check(
-    "explicit-unapply",
-    """
-      |object And {
-      |  def unapply[A](a: A): Some[(A, A)] = Some((a, a))
-      |}
-      |object a {
-      |  And.unapply(@@)
-      |}
-  """.stripMargin,
-    """|unapply[A](a: A): Some[(A, A)]
-       |           ^^^^
-       | """.stripMargin
-  )
-
 }


### PR DESCRIPTION
Previously, we would always assume unapply returns a tuple, which would result in wrong signature help for single parameter unapply. Now, we take into account situations where the returned value is not an Option of tuple.