### PR TITLE
[Scala3] Show correct tooltip on hover methods in for comprehension

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -100,9 +100,10 @@ object HoverProvider:
             case Some(expressionType) =>
               val forceExpressionType =
                 !pos.span.isZeroExtent || (
-                  !hoverString.endsWith(
-                    expressionType
-                  ) && !symbol.isType && !symbol.flags.isAllOf(EnumCase)
+                  !hoverString.endsWith(expressionType) &&
+                    !symbol.isType &&
+                    !symbol.is(Module) &&
+                    !symbol.flags.isAllOf(EnumCase)
                 )
               val content = HoverMarkup(
                 expressionType,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -62,9 +62,8 @@ object HoverProvider:
       ) match
         case Nil =>
           ju.Optional.empty()
-        case symbols @ (symbolWithTpe :: _) =>
-          val symbol = symbolWithTpe._1
-          val exprTpw = symbolWithTpe._2.widenTermRefExpr
+        case symbols @ ((symbol, tpe) :: _) =>
+          val exprTpw = tpe.widenTermRefExpr
           val docComments =
             symbols.map(_._1).flatMap(ParsedComment.docOf(_))
           val printerContext =

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -10,7 +10,6 @@ import scala.meta.pc.OffsetParams
 
 import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.Contexts.*
-import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.NameKinds.*
 import dotty.tools.dotc.core.NameOps.*
@@ -57,7 +56,6 @@ object HoverProvider:
     else
       val skipCheckOnName =
         !pos.isPoint // don't check isHoveringOnName for RangeHover
-      // println(enclosing.headOption)
       MetalsInteractive.enclosingSymbols(
         enclosing,
         pos,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -57,6 +57,7 @@ object HoverProvider:
     else
       val skipCheckOnName =
         !pos.isPoint // don't check isHoveringOnName for RangeHover
+      // println(enclosing.headOption)
       MetalsInteractive.enclosingSymbols(
         enclosing,
         pos,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -1,16 +1,17 @@
 package scala.meta.internal.pc
 
 import scala.annotation.tailrec
+
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.ast.untpd
 import dotty.tools.dotc.core.ContextOps.*
-import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.CyclicReference
 import dotty.tools.dotc.core.Denotations.Denotation
 import dotty.tools.dotc.core.Denotations.MultiPreDenotation
 import dotty.tools.dotc.core.Denotations.PreDenotation
+import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.Names.Name
 import dotty.tools.dotc.core.StdNames
 import dotty.tools.dotc.core.Symbols.*

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -132,12 +132,10 @@ object MetalsInteractive:
       case tree: NameTree =>
         SourceTree(tree, source).namePos.contains(sourcePos)
       // TODO: check the positions for NamedArg and Import
-      // case ident: Ident =>
-      //   ident.sourcePos.contains
       case _: NamedArg => true
       case _: Import => true
       case app: (Apply | TypeApply) => contains(app.fun)
-      case other => false
+      case _ => false
     end contains
 
     val enclosing = path
@@ -173,9 +171,10 @@ object MetalsInteractive:
     enclosingSymbolsWithExpressionType(path, pos, indexed, skipCheckOnName)
       .map(_._1)
 
-  /** Returns the list of tuple enclosing symbol and
-    * the symbol's expression type if possible.
-    */
+  /**
+   * Returns the list of tuple enclosing symbol and
+   * the symbol's expression type if possible.
+   */
   @tailrec
   def enclosingSymbolsWithExpressionType(
       path: List[Tree],

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -225,8 +225,8 @@ object MetalsInteractive:
 
       // L@@ft(...)
       case (head @ ApplySelect(select)) :: _
-          if (select.qualifier.sourcePos.contains(pos) &&
-            select.name == StdNames.nme.apply) =>
+          if select.qualifier.sourcePos.contains(pos) &&
+            select.name == StdNames.nme.apply =>
         List((head.symbol, head.typeOpt))
 
       // for comprehension
@@ -243,18 +243,6 @@ object MetalsInteractive:
           if target.span.isSourceDerived &&
             target.sourcePos.contains(pos) =>
         List((target.symbol, target.typeOpt))
-
-      // Anonymous class definition
-      // class Foo(...)
-      // new F@@oo(...) {
-      //   val x = ...
-      // }
-      // returns the symbols of `Foo` class instead of its constructor
-      // for Scala2 compatibility, see HoverTermSuite#new-anon
-      case (ApplySelect(Select(New(ident), _))) ::
-          (_: Template) ::(TypeDef(name, _)) :: _
-          if name == StdNames.tpnme.ANON_CLASS =>
-        List((ident.symbol, ident.typeOpt))
 
       case path @ head :: tl =>
         if head.symbol.is(Synthetic) then

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -220,7 +220,7 @@ object MetalsInteractive:
 
       // f@@oo.bar
       case Select(target, _) :: _
-          if target.symbol.isDefinedInSource &&
+          if target.span.isSourceDerived &&
             target.sourcePos.contains(pos) =>
         List(target.symbol)
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -203,6 +203,11 @@ object MetalsInteractive:
         if sym.is(Synthetic) && sym.is(Module) then List(sym.companionClass)
         else List(target.symbol)
 
+      // L@@ft(...)
+      case (head @ Apply(TypeApply(Select(target, name), _), _)) :: _
+          if target.sourcePos.contains(pos) && name == StdNames.nme.apply =>
+        List(head.symbol)
+
       // f@@oo.bar
       case Select(target, _) :: _
           if target.symbol.isDefinedInSource &&
@@ -226,6 +231,7 @@ object MetalsInteractive:
           if recovered.isEmpty then
             enclosingSymbols(tl, pos, indexed, skipCheckOnName)
           else recovered
+        end if
       case Nil => Nil
     end match
   end enclosingSymbols

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -1,9 +1,16 @@
 package scala.meta.internal.pc
 
+import scala.annotation.tailrec
+import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.ast.untpd
 import dotty.tools.dotc.core.ContextOps.*
+import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.CyclicReference
+import dotty.tools.dotc.core.Denotations.Denotation
+import dotty.tools.dotc.core.Denotations.MultiPreDenotation
+import dotty.tools.dotc.core.Denotations.PreDenotation
 import dotty.tools.dotc.core.Names.Name
 import dotty.tools.dotc.core.StdNames
 import dotty.tools.dotc.core.Symbols.*
@@ -149,4 +156,83 @@ object MetalsInteractive:
       case gtree: Select if isForComprehensionSyntheticName(gtree) => true
       case _ => false
 
+
+  @tailrec
+  def enclosingSymbols(
+      path: List[Tree],
+      pos: SourcePosition,
+      indexed: IndexedContext
+  ): List[Symbol] =
+    import indexed.ctx
+    println(path.headOption)
+    path match
+      // For a named arg, find the target `DefDef` and jump to the param
+      case NamedArg(name, _) :: Apply(fn, _) :: _ =>
+        val funSym = fn.symbol
+        if funSym.is(Synthetic) && funSym.owner.is(CaseClass) then
+          List(funSym.owner.info.member(name).symbol)
+        else
+          val classTree = funSym.topLevelClass.asClass.rootTree
+          val paramSymbol =
+            for
+              DefDef(_, paramss, _, _) <- tpd
+                .defPath(funSym, classTree)
+                .lastOption
+              param <- paramss.flatten.find(_.name == name)
+            yield param.symbol
+          List(paramSymbol.getOrElse(fn.symbol))
+      case (_: untpd.ImportSelector) :: (imp: Import) :: _ =>
+        importedSymbols(imp, _.span.contains(pos.span))
+
+      case (imp: Import) :: _ =>
+        importedSymbols(imp, _.span.contains(pos.span))
+
+      // wildcard param
+      case head :: _ if (head.symbol.is(Param) && head.symbol.is(Synthetic)) =>
+        List(head.symbol)
+
+      case (head @ Select(target, name)) :: _
+          if head.symbol.is(Synthetic) && name == StdNames.nme.apply =>
+        val sym = target.symbol
+        if sym.is(Synthetic) && sym.is(Module) then List(sym.companionClass)
+        else List(target.symbol)
+
+      case path @ head :: tl =>
+        if head.symbol.is(Synthetic) then enclosingSymbols(tl, pos, indexed)
+        else if head.symbol != NoSymbol then
+          if MetalsInteractive.isOnName(
+              path,
+              pos,
+              indexed.ctx.source
+            ) || MetalsInteractive.isForSynthetic(head)
+          then List(head.symbol)
+          else Nil
+        else
+          val recovered = recoverError(head, indexed)
+          if recovered.isEmpty then enclosingSymbols(tl, pos, indexed)
+          else recovered
+      case Nil => Nil
+    end match
+  end enclosingSymbols
+
+  private def recoverError(
+      tree: Tree,
+      indexed: IndexedContext
+  ): List[Symbol] =
+    import indexed.ctx
+
+    def extractSymbols(d: PreDenotation): List[Symbol] =
+      d match
+        case multi: MultiPreDenotation =>
+          extractSymbols(multi.denot1) ++ extractSymbols(multi.denot2)
+        case d: Denotation => List(d.symbol)
+        case _ => List.empty
+
+    tree match
+      case select: Select =>
+        extractSymbols(select.qualifier.typeOpt.member(select.name))
+          .filter(_ != NoSymbol)
+      case ident: Ident => indexed.findSymbol(ident.name).toList.flatten
+      case _ => Nil
+  end recoverError
 end MetalsInteractive

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -205,7 +205,8 @@ object MetalsInteractive:
 
       // f@@oo.bar
       case Select(target, _) :: _
-          if !target.symbol.is(Synthetic) && target.sourcePos.contains(pos) =>
+          if target.symbol.isDefinedInSource &&
+            target.sourcePos.contains(pos) =>
         List(target.symbol)
 
       case path @ head :: tl =>

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -12,6 +12,7 @@ import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.NameKinds.EvidenceParamName
 import dotty.tools.dotc.core.NameOps.*
 import dotty.tools.dotc.core.Names.Name
+import dotty.tools.dotc.core.StdNames
 import dotty.tools.dotc.core.Symbols.Symbol
 import dotty.tools.dotc.core.Types.Type
 import dotty.tools.dotc.core.Types.*
@@ -152,8 +153,10 @@ class MetalsPrinter(names: ShortenedNames, dotcPrinter: DotcPrinter)(using
 
     if onlyMethodParams then paramssSignature
     else
+      // For Scala2 compatibility, show "this" instead of <init> for constructor
+      val name = if gsym.isConstructor then StdNames.nme.this_ else gsym.name
       extensionSignatureString +
-        s"def ${gsym.name}" +
+        s"def $name" +
         paramssSignature
   end defaultMethodSignature
 

--- a/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
@@ -96,10 +96,7 @@ class HoverDefnSuite extends BaseHoverSuite {
     """|```scala
        |def this(x: Int): a
        |```
-       |""".stripMargin,
-    compat = Map(
-      "3" -> "def <init>(x: Int): a".hover
-    )
+       |""".stripMargin
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -96,8 +96,7 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |  val color = <<Col@@or>>.Red
        |
        |""".stripMargin,
-    """|Color
-       |enum Color: enums3.SimpleEnum
+    """|enum Color: enums3.SimpleEnum
        |""".stripMargin.hover
   )
 

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -96,7 +96,8 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |  val color = <<Col@@or>>.Red
        |
        |""".stripMargin,
-    """|enum Color: enums3.SimpleEnum
+    """|Color
+       |enum Color: enums3.SimpleEnum
        |""".stripMargin.hover
   )
 

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -194,7 +194,8 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
     "toplevel-left",
     """|def foo = <<L@@eft>>("")
        |""".stripMargin,
-    """|final case class Left: Left
+    """|Left[String, Nothing]
+       |def apply[A, B](value: A): Left[A, B]
        |""".stripMargin.hover
   )
 }

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -166,7 +166,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin.hover,
     compat = Map(
       "3" ->
-        """|def <init>(name: String, age: Int): Foo
+        """|def this(name: String, age: Int): Foo
            |""".stripMargin.hover
     )
   )
@@ -185,7 +185,7 @@ class HoverTermSuite extends BaseHoverSuite {
     compat = Map(
       "3" ->
         """|Foo[Int]
-           |def <init>[T](name: String, age: T): Foo[T]
+           |def this[T](name: String, age: T): Foo[T]
            |""".stripMargin.hover
     )
   )

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -163,12 +163,7 @@ class HoverTermSuite extends BaseHoverSuite {
       |}
       |""".stripMargin,
     """|def this(name: String, age: Int): Foo
-       |""".stripMargin.hover,
-    compat = Map(
-      "3" ->
-        """|def this(name: String, age: Int): Foo
-           |""".stripMargin.hover
-    )
+       |""".stripMargin.hover
   )
 
   check(
@@ -181,7 +176,13 @@ class HoverTermSuite extends BaseHoverSuite {
       |""".stripMargin,
     """|Foo[Int]
        |def this(name: String, age: T): Foo[T]
-       |""".stripMargin.hover
+       |""".stripMargin.hover,
+    compat = Map(
+      "3" ->
+        """|Foo[Int]
+           |def this[T](name: String, age: T): Foo[T]
+           |""".stripMargin.hover
+    )
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -217,10 +217,7 @@ class HoverTermSuite extends BaseHoverSuite {
       |  }
       |}
       |""".stripMargin,
-    "class Foo: Foo".hover,
-    compat = Map(
-      "3" -> "def <init>(name: String, age: Int): Foo".hover
-    )
+    "class Foo: Foo".hover
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -148,7 +148,16 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin.hover,
     compat = Map(
       // https://github.com/lampepfl/dotty/issues/8835
-      "3" -> "object num: `interpolator-unapply`.a.Xtension".hover
+      "3" ->
+        """|**Expression type**:
+           |```scala
+           |Xtension#num
+           |```
+           |**Symbol signature**:
+           |```scala
+           |object num: `interpolator-unapply`.a.Xtension
+           |```
+           |""".stripMargin.hover
     )
   )
 
@@ -163,7 +172,11 @@ class HoverTermSuite extends BaseHoverSuite {
     """|def this(name: String, age: Int): Foo
        |""".stripMargin.hover,
     compat = Map(
-      "3" -> "class Foo: Foo".hover
+      "3" ->
+        """|```scala
+           |def <init>(name: String, age: Int): Foo
+           |```
+           |""".stripMargin.hover
     )
   )
 
@@ -180,7 +193,15 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin.hover,
     compat = Map(
       "3" ->
-        "class Foo: Foo".hover
+        """|**Expression type**:
+           |```scala
+           |Foo[Int]
+           |```
+           |**Symbol signature**:
+           |```scala
+           |def <init>[T](name: String, age: T): Foo[T]
+           |```
+           |""".stripMargin.hover
     )
   )
 
@@ -210,7 +231,10 @@ class HoverTermSuite extends BaseHoverSuite {
       |  }
       |}
       |""".stripMargin,
-    "class Foo: Foo".hover
+    "class Foo: Foo".hover,
+    compat = Map(
+      "3" -> "def <init>(name: String, age: Int): Foo".hover
+    )
   )
 
   check(
@@ -228,7 +252,7 @@ class HoverTermSuite extends BaseHoverSuite {
   )
 
   check(
-    "for-flatMap".tag(IgnoreScala3),
+    "for-flatMap",
     """
       |object a {
       |  <<for {
@@ -240,11 +264,17 @@ class HoverTermSuite extends BaseHoverSuite {
       |""".stripMargin,
     """|Option[String]
        |def flatMap[B](f: Int => Option[B]): Option[B]
-       |""".stripMargin.hover
+       |""".stripMargin.hover,
+    compat = Map(
+      "3" ->
+        """|Boolean
+           |def withFilter(p: A => Boolean): Option.this.WithFilter
+           |""".stripMargin.hover
+    )
   )
 
   check(
-    "for-map".tag(IgnoreScala3),
+    "for-map",
     """
       |object a {
       |  for {
@@ -256,11 +286,17 @@ class HoverTermSuite extends BaseHoverSuite {
       |""".stripMargin,
     """|Option[String]
        |final def map[B](f: Int => B): Option[B]
-       |""".stripMargin.hover
+       |""".stripMargin.hover,
+    compat = Map(
+      "3" ->
+        """|String
+           |def map[B](f: A => B): Option[B]
+           |""".stripMargin.hover
+    )
   )
 
   check(
-    "for-keyword".tag(IgnoreScala3),
+    "for-keyword",
     """
       |object a {
       |  <<fo@@r {
@@ -276,7 +312,7 @@ class HoverTermSuite extends BaseHoverSuite {
   )
 
   check(
-    "for-yield-keyword".tag(IgnoreScala3),
+    "for-yield-keyword",
     """
       |object a {
       |  for {
@@ -288,7 +324,13 @@ class HoverTermSuite extends BaseHoverSuite {
       |""".stripMargin,
     """|Option[String]
        |final def map[B](f: Long => B): Option[B]
-       |""".stripMargin.hover
+       |""".stripMargin.hover,
+    compat = Map(
+      "3" ->
+        """|String
+           |def map[B](f: A => B): Option[B]
+           |""".stripMargin.hover
+    )
   )
 
   check(
@@ -305,7 +347,10 @@ class HoverTermSuite extends BaseHoverSuite {
     """|final def withFilter(p: Int => Boolean): Option[Int]#WithFilter
        |""".stripMargin.hover,
     compat = Map(
-      "3" -> "val <local a$>: (x: Int): Boolean".hover
+      "3" ->
+        """|Boolean
+           |def withFilter(p: A => Boolean): Option.this.WithFilter
+           """.stripMargin.hover
     )
   )
 
@@ -322,7 +367,10 @@ class HoverTermSuite extends BaseHoverSuite {
        |```
        |""".stripMargin,
     compat = Map(
-      "3" -> "enum FileVisitResult: java.nio.file".hover
+      "3" ->
+        """|FileVisitResult
+           |enum FileVisitResult: java.nio.file
+           |""".stripMargin.hover
     )
   )
 
@@ -345,7 +393,10 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin,
     automaticPackage = false,
     compat = Map(
-      "3" -> "object Foo: app.Outer".hover
+      "3" ->
+        """|Foo
+           |object Foo: app.Outer
+           |""".stripMargin.hover
     )
   )
 

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -211,7 +211,10 @@ class HoverTermSuite extends BaseHoverSuite {
       |  }
       |}
       |""".stripMargin,
-    "class Foo: Foo".hover
+    "class Foo: Foo".hover,
+    compat = Map(
+      "3" -> "def this(name: String, age: Int): Foo".hover
+    )
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -355,6 +355,25 @@ class HoverTermSuite extends BaseHoverSuite {
   )
 
   check(
+    "for-method",
+    """
+      |object a {
+      |  for {
+      |    x <- <<List(1).headOp@@tion>>
+      |  } yield x
+      |}
+      |""".stripMargin,
+    """|override def headOption: Option[Int]
+       |""".stripMargin.hover,
+    compat = Map(
+      "3" ->
+        """|Option[Int]
+           |def headOption: Option[A]
+           |""".stripMargin.hover
+    )
+  )
+
+  check(
     "object",
     """
       |import java.nio.file._

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -181,13 +181,7 @@ class HoverTermSuite extends BaseHoverSuite {
       |""".stripMargin,
     """|Foo[Int]
        |def this(name: String, age: T): Foo[T]
-       |""".stripMargin.hover,
-    compat = Map(
-      "3" ->
-        """|Foo[Int]
-           |def this[T](name: String, age: T): Foo[T]
-           |""".stripMargin.hover
-    )
+       |""".stripMargin.hover
   )
 
   check(
@@ -348,6 +342,9 @@ class HoverTermSuite extends BaseHoverSuite {
     """|override def headOption: Option[Int]
        |""".stripMargin.hover,
     compat = Map(
+      "2.12" ->
+        """|def headOption: Option[Int]
+           |""".stripMargin.hover,
       "3" ->
         """|Option[Int]
            |def headOption: Option[A]

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -249,7 +249,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin.hover,
     compat = Map(
       "3" ->
-        """|Boolean
+        """|Option[Int]#WithFilter
            |def withFilter(p: A => Boolean): Option.this.WithFilter
            |""".stripMargin.hover
     )
@@ -271,7 +271,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin.hover,
     compat = Map(
       "3" ->
-        """|String
+        """|Option[String]
            |def map[B](f: A => B): Option[B]
            |""".stripMargin.hover
     )
@@ -309,7 +309,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin.hover,
     compat = Map(
       "3" ->
-        """|String
+        """|Option[String]
            |def map[B](f: A => B): Option[B]
            |""".stripMargin.hover
     )
@@ -330,7 +330,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin.hover,
     compat = Map(
       "3" ->
-        """|Boolean
+        """|Option[Int]#WithFilter
            |def withFilter(p: A => Boolean): Option.this.WithFilter
            """.stripMargin.hover
     )

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -149,14 +149,8 @@ class HoverTermSuite extends BaseHoverSuite {
     compat = Map(
       // https://github.com/lampepfl/dotty/issues/8835
       "3" ->
-        """|**Expression type**:
-           |```scala
-           |Xtension#num
-           |```
-           |**Symbol signature**:
-           |```scala
+        """|Xtension#num
            |object num: `interpolator-unapply`.a.Xtension
-           |```
            |""".stripMargin.hover
     )
   )
@@ -173,9 +167,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin.hover,
     compat = Map(
       "3" ->
-        """|```scala
-           |def <init>(name: String, age: Int): Foo
-           |```
+        """|def <init>(name: String, age: Int): Foo
            |""".stripMargin.hover
     )
   )
@@ -193,14 +185,8 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin.hover,
     compat = Map(
       "3" ->
-        """|**Expression type**:
-           |```scala
-           |Foo[Int]
-           |```
-           |**Symbol signature**:
-           |```scala
+        """|Foo[Int]
            |def <init>[T](name: String, age: T): Foo[T]
-           |```
            |""".stripMargin.hover
     )
   )

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -149,8 +149,7 @@ class HoverTermSuite extends BaseHoverSuite {
     compat = Map(
       // https://github.com/lampepfl/dotty/issues/8835
       "3" ->
-        """|Xtension#num
-           |object num: `interpolator-unapply`.a.Xtension
+        """|object num: `interpolator-unapply`.a.Xtension
            |""".stripMargin.hover
     )
   )
@@ -370,8 +369,7 @@ class HoverTermSuite extends BaseHoverSuite {
        |""".stripMargin,
     compat = Map(
       "3" ->
-        """|FileVisitResult
-           |enum FileVisitResult: java.nio.file
+        """|enum FileVisitResult: java.nio.file
            |""".stripMargin.hover
     )
   )
@@ -396,8 +394,7 @@ class HoverTermSuite extends BaseHoverSuite {
     automaticPackage = false,
     compat = Map(
       "3" ->
-        """|Foo
-           |object Foo: app.Outer
+        """|object Foo: app.Outer
            |""".stripMargin.hover
     )
   )


### PR DESCRIPTION
fix https://github.com/scalameta/metals/issues/3852



## before
### Incorrect hover tooltip when the cursor is on methods (in for comprehension)
Before this change, https://github.com/scalameta/metals/pull/3792 made Metals to show the hover tooltip for "for-synthetic methods" such as "withFilter", "map", and "flatMap" even if the cursor is on methods.

<img width="549" alt="Screen Shot 2022-04-20 at 13 40 19" src="https://user-images.githubusercontent.com/9353584/164152438-06175031-1ad3-43bd-9fd5-643f398af5de.png">

### There was no tooltip for "for-synthetic methods" on hover "<-"
When we hover on "<-" in for comprehension, Metals with Scala2 shows the tooltip for "map" method, but Metals with Scala3 didn't.

```scala
for {
  x <@@- List(x).headOption
}
```

## after
### Correct onHover tooltip
Now, when we hover on methods in for comprehension, Metals shows the tooltip for the correct symbol.
<img width="556" alt="Screen Shot 2022-04-20 at 21 17 03" src="https://user-images.githubusercontent.com/9353584/164230332-47ec1360-3496-42f6-8fae-ca07b17ab303.png">

### onHover "for-synthetic methods"
This PR also fixes missing "for-synthetic methods" tooltip in Scala3.
 
<img width="474" alt="Screen Shot 2022-04-20 at 21 17 24" src="https://user-images.githubusercontent.com/9353584/164230369-ce6d1496-6424-4eb8-b253-71dcd3a3c45b.png">

## Changes outline
- Moved `enclosingSymbols` defined in `PcDefinitionProvider` to `MetalsInteractive` so that `HoverProvider` can use it too.
- Now, `HoverProvider` uses `MetalsInteractive.enclosingSymbols` instead of `Interactive.enclosingSourceSymbols`.
  - `MetalsInteractive.enclosingSymbols` is more metals-customized version of `enclosingSymbol` method.
- Add some cases to `enclosingSymbols` to return correct symbols on hover.