### PR TITLE
fix: infer jdk without jdk in name

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
@@ -33,13 +33,16 @@ object JdkSources {
   private def candidates(userJavaHome: Option[String]): List[AbsolutePath] = {
     def isJdkCandidate(path: AbsolutePath): Boolean = {
       def containsJre = path.resolve("jre").exists
+      def containsRelease = path.resolve("release").exists
       val name = path.filename.toString
-      name.contains("jdk") || containsJre // e.g. jdk-8, java-openjdk-11
+      name.contains("jdk") || // e.g. jdk-8, java-openjdk-11
+      containsJre ||
+      containsRelease
     }
 
     for {
       javaHomeString <- userJavaHome.orElse(defaultJavaHome).toList
-      javaHome = AbsolutePath(Paths.get(javaHomeString))
+      javaHome = AbsolutePath(javaHomeString)
       jdkHome = {
         if (isJdkCandidate(javaHome)) {
           Nil


### PR DESCRIPTION
closes https://github.com/scalameta/metals/issues/3783