### PR TITLE
Properly infer types for unapply signature help

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -99,8 +99,8 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
       case termNames.unapply =>
         symbol.paramLists match {
           case (head :: Nil) :: Nil =>
-            symbol.info.finalResultType match {
-              case TypeRef(
+            qual.tpe.finalResultType match {
+              case tp @ TypeRef(
                     _,
                     cls,
                     tpe @ TypeRef(_, _, args) :: Nil
@@ -117,13 +117,13 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
                     a == b.tpe ||
                     b.tpe.typeSymbol.isTypeParameter
                   }
-                if (isAlignedTypes) {
-                  ctor.info
+                if (isAlignedTypes && ctor.owner.isCaseClass) {
+                  tp.memberType(ctor)
                 } else {
-                  symbol.info
+                  qual.tpe
                 }
               case _ =>
-                symbol.info
+                qual.tpe
             }
           case _ =>
             symbol.info
@@ -461,7 +461,7 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
         toSignatureInformation(
           t,
           method,
-          tpe,
+          if (!t.call.isUnapplyMethod) tpe else method.info,
           paramss,
           isActiveSignature,
           shortenedNames
@@ -499,6 +499,8 @@ class SignatureHelpProvider(val compiler: MetalsGlobal) {
         // otherwise it's a single unapply result
         else
           List(List(symbol))
+      case _ if isUnapplyMethod =>
+        method.paramLists.map(_.map(_.tpe.typeSymbol))
       case _ =>
         if (method.typeParams.isEmpty) method.paramLists
         else method.typeParams :: method.paramLists

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
@@ -37,8 +37,8 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
       |  }
       |}
       |""".stripMargin,
-    """|(A)
-       | ^
+    """|(Int)
+       | ^^^
        |""".stripMargin
   )
 
@@ -52,8 +52,8 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
       |  }
       |}
       |""".stripMargin,
-    """|(a: T, b: T)
-       | ^^^^
+    """|(Any, Any)
+       | ^^^
        |""".stripMargin
   )
 
@@ -67,8 +67,43 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
       |  }
       |}
       |""".stripMargin,
-    """|(a: C[T])
-       | ^^^^^^^
+    """|(Any)
+       | ^^^
+       |""".stripMargin
+  )
+
+  check(
+    "generic4",
+    """
+      |  case class Two[A, B](a: A, b: B)
+      |  object Main {
+      |    new Two(1, "") match {
+      |      case Two(@@) =>
+      |    }
+      |  }
+      |""".stripMargin,
+    """|(Int, String)
+       | ^^^
+       |""".stripMargin
+  )
+
+  check(
+    "generic5",
+    """
+      |class Two[A, B](a: A, b: B)
+      |object Two {
+      |  def unapply[A, B](t: Two[A, B]): Option[(A, B)] = None
+      |}
+      |
+      |object Main {
+      |  val tp = new Two(1, "") 
+      |  tp match {
+      |    case Two(@@) =>
+      |  }
+      |}
+      |""".stripMargin,
+    """|(Int, String)
+       | ^^^
        |""".stripMargin
   )
 
@@ -117,8 +152,8 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
       |    case Person(@@)
       |}
     """.stripMargin,
-    """|(name: String, age: Int)
-       | ^^^^^^^^^^^^
+    """|(String, Int)
+       | ^^^^^^
        | """.stripMargin
   )
 
@@ -135,8 +170,8 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
       |  }
       |}
     """.stripMargin,
-    """|(name: String, age: Int)
-       | ^^^^^^^^^^^^
+    """|(String, Int)
+       | ^^^^^^
        | """.stripMargin
   )
 
@@ -166,10 +201,10 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
       |    case And("", s@@)
       |  }
       |}
-  """.stripMargin,
-    """|(A, A)
-       |    ^
-       | """.stripMargin
+      |""".stripMargin,
+    """|(String, String)
+       |         ^^^^^^
+       |""".stripMargin
   )
 
   check(


### PR DESCRIPTION
The only regression seems to be that a couple of test cases changed to `Any`, however this is a proper type and having `T` or `C[T]` probably looks a bit better, but doesn't actually show the real type.