### PR TITLE
handles the removal of jvm properties case

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -288,7 +288,8 @@ final class BloopServers(
         )
       } yield
         if (
-          maybeRequestedBloopJvmProperties != maybeRunningBloopJvmProperties && requestedBloopJvmProperties.nonEmpty
+          maybeRequestedBloopJvmProperties != maybeRunningBloopJvmProperties &&
+          !(requestedBloopJvmProperties.isEmpty && maybeRunningBloopJvmProperties.isEmpty)
         ) { // the properties are updated
           if (
             bloopGlobalJsonFilePath.exists &&


### PR DESCRIPTION
Previously, when a Bloop JVM property was getting removed, if the new properties list were becoming empty, the Bloop settings were not getting updated!
This PR fixes that!