### PR TITLE
Use bloop.json instead of .jvmopts for Bloop memory properties

### DIFF
--- a/bin/bloop.json
+++ b/bin/bloop.json
@@ -1,0 +1,3 @@
+{
+  "javaOptions": ["-Xmx1G", "-Xss16m"]
+}

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -5,9 +5,7 @@ function bloop_version {
 }
 
 mkdir -p ~/.bloop
-touch ~/.bloop/.jvmopts
-echo "-Xss16m" >> ~/.bloop/.jvmopts
-echo "-Xmx1G"  >> ~/.bloop/.jvmopts
+cp bin/bloop.json ~/.bloop/bloop.json
 curl -Lo coursier https://git.io/coursier-cli && chmod +x coursier
 ./coursier launch ch.epfl.scala:bloopgun-core_2.13:$(bloop_version) -- about
 

--- a/project/V.scala
+++ b/project/V.scala
@@ -12,7 +12,7 @@ object V {
   val ammonite213Version = "2.13.7"
 
   val ammonite = "2.5.2"
-  val bloop = "1.4.13-75-f9d1bef5"
+  val bloop = "1.5.0"
   val bloopNightly = bloop
   val bsp = "2.0.0+70-f6e47d42-SNAPSHOT"
   val coursier = "2.1.0-M5"


### PR DESCRIPTION
.jvmopts is now deprecated and cannot be used

also bump Bloop to 1.5.0