### PR TITLE
fix: fix link to example configuration

### DIFF
--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -31,8 +31,7 @@ To get started with installation please see the `nvim-metals`
 
 Keep in mind that by default Neovim doesn't have default mappings for the
 functionality you'll want like, hovers, goto definition, method signatures, etc.
-Youc can find a full example configuration of these in the [example
-configuration](https://github.com/scalameta/nvim-metals/discussions/39).
+Youc can find a full example configuration of these in the [example configuration](https://github.com/scalameta/nvim-metals/discussions/39).
 
 For a guide on all the available features in `nvim-metals`, refer to the
 [features list](https://github.com/scalameta/nvim-metals/discussions/279).


### PR DESCRIPTION
Looks like if you break in the middle of the `[]()` it won't render the
link.