### PR TITLE
fix: sbt-metals + java semanticdb issue on jdk17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,11 @@ jobs:
             command: bin/test.sh 'sbt-metals/scripted; slow/testOnly -- tests.sbt.*'
             name: Sbt integration
             os: ubuntu-latest
+          - type: sbt-metals jdk17
+            command: bin/test.sh sbt-metals/scripted
+            name: Sbt-metals/scripted jdk17
+            os: ubuntu-latest
+            java: "17"
           - type: maven
             command: bin/test.sh 'slow/testOnly -- tests.maven.*'
             name: Maven integration

--- a/sbt-metals/src/sbt-test/sbt-metals/semanticdb/a/src/main/java/test/JavaSample.java
+++ b/sbt-metals/src/sbt-test/sbt-metals/semanticdb/a/src/main/java/test/JavaSample.java
@@ -1,0 +1,7 @@
+package test;
+
+class JavaSample {
+	public static void main(String[] args) {
+		System.out.println("sample!");
+	}
+}

--- a/sbt-metals/src/sbt-test/sbt-metals/semanticdb/a/src/main/scala/test/ScalaSample.scala
+++ b/sbt-metals/src/sbt-test/sbt-metals/semanticdb/a/src/main/scala/test/ScalaSample.scala
@@ -1,0 +1,5 @@
+package test
+
+class ScalaSample {
+  def foo: Int = 42
+}

--- a/sbt-metals/src/sbt-test/sbt-metals/semanticdb/build.sbt
+++ b/sbt-metals/src/sbt-test/sbt-metals/semanticdb/build.sbt
@@ -8,7 +8,12 @@ lazy val a = project
   .in(file("a"))
   .settings(
     scalaVersion := "2.13.5",
-    inConfig(Compile) { checkSemanticdb := assertSemanticdbForScala2.value },
+    inConfig(Compile) {
+      checkSemanticdb := {
+        assertSemanticdbForScala2.value
+        compile.value
+      }
+    },
     inConfig(Test) { checkSemanticdb := assertSemanticdbForScala2.value }
   )
 


### PR DESCRIPTION
In case of jdk17, semanticdb-plugin requires `-J*` flags otherwise
compilation fails. These flags can be passed only at the JVM start.

Her, we explictly define `javaHome` for jdk >= 17.
It forces sbt to use `ForkJavaCompiler` that accepts `-J` flags instead
of `LocalJavaCompiler` which ignores them.