### PR TITLE
feature: don't show unsupported quickfix in Scala3

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeAction.scala
@@ -16,6 +16,8 @@ trait CodeAction {
    */
   def kind: String
 
+  def supportScala3: Boolean
+
   def contribute(
       params: l.CodeActionParams,
       token: CancelToken

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateCompanionObjectCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateCompanionObjectCodeAction.scala
@@ -32,6 +32,8 @@ class CreateCompanionObjectCodeAction(
 ) extends CodeAction {
   override def kind: String = l.CodeActionKind.RefactorRewrite
 
+  override def supportScala3: Boolean = true
+
   override def contribute(params: CodeActionParams, token: CancelToken)(implicit
       ec: ExecutionContext
   ): Future[Seq[l.CodeAction]] = Future {

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateNewSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateNewSymbol.scala
@@ -12,6 +12,8 @@ import org.eclipse.{lsp4j => l}
 class CreateNewSymbol() extends CodeAction {
   override def kind: String = l.CodeActionKind.QuickFix
 
+  override def supportScala3: Boolean = true
+
   override def contribute(
       params: l.CodeActionParams,
       token: CancelToken

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractRenameMember.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractRenameMember.scala
@@ -33,6 +33,8 @@ class ExtractRenameMember(
 )(implicit ec: ExecutionContext)
     extends CodeAction {
 
+  override def supportScala3: Boolean = true
+
   override def contribute(params: l.CodeActionParams, token: CancelToken)(
       implicit ec: ExecutionContext
   ): Future[Seq[l.CodeAction]] = Future {

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractValueCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractValueCodeAction.scala
@@ -27,6 +27,8 @@ class ExtractValueCodeAction(
 ) extends CodeAction {
   override def kind: String = l.CodeActionKind.RefactorExtract
 
+  override def supportScala3: Boolean = true
+
   override def contribute(params: CodeActionParams, token: CancelToken)(implicit
       ec: ExecutionContext
   ): Future[Seq[l.CodeAction]] = Future {

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImplementAbstractMembers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImplementAbstractMembers.scala
@@ -13,6 +13,8 @@ class ImplementAbstractMembers(compilers: Compilers) extends CodeAction {
 
   override def kind: String = l.CodeActionKind.QuickFix
 
+  override def supportScala3: Boolean = false
+
   override def contribute(
       params: l.CodeActionParams,
       token: CancelToken

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
@@ -13,6 +13,8 @@ class ImportMissingSymbol(compilers: Compilers) extends CodeAction {
 
   override def kind: String = l.CodeActionKind.QuickFix
 
+  override def supportScala3: Boolean = true
+
   override def contribute(
       params: l.CodeActionParams,
       token: CancelToken

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
@@ -20,6 +20,8 @@ class InsertInferredType(trees: Trees) extends CodeAction {
   import InsertInferredType._
   override def kind: String = l.CodeActionKind.QuickFix
 
+  override def supportScala3: Boolean = true
+
   override def contribute(
       params: l.CodeActionParams,
       token: CancelToken

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
@@ -85,6 +85,8 @@ class SourceOrganizeImports(
     ) {
 
   override val kind: String = SourceOrganizeImports.kind
+
+  override def supportScala3: Boolean = false
   override protected val title: String = SourceOrganizeImports.title
 
   override protected def isCallAllowed(
@@ -132,6 +134,8 @@ class OrganizeImportsQuickFix(
     ) {
 
   override val kind: String = OrganizeImportsQuickFix.kind
+
+  override def supportScala3: Boolean = false
   override protected val title: String = OrganizeImportsQuickFix.title
   override protected def isCallAllowed(
       file: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/PatternMatchRefactor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/PatternMatchRefactor.scala
@@ -16,6 +16,8 @@ class PatternMatchRefactor(trees: Trees) extends CodeAction {
 
   override val kind: String = l.CodeActionKind.RefactorRewrite
 
+  override def supportScala3: Boolean = true
+
   private def convert(
       block: Term.Block,
       patternMatch: Term.Match,

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/RewriteBracesParensCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/RewriteBracesParensCodeAction.scala
@@ -34,6 +34,8 @@ class RewriteBracesParensCodeAction(
 ) extends CodeAction {
   override def kind: String = l.CodeActionKind.RefactorRewrite
 
+  override def supportScala3: Boolean = true
+
   override def contribute(params: CodeActionParams, token: CancelToken)(implicit
       ec: ExecutionContext
   ): Future[Seq[l.CodeAction]] = Future {

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/StringActions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/StringActions.scala
@@ -16,6 +16,8 @@ class StringActions(buffers: Buffers) extends CodeAction {
 
   override def kind: String = l.CodeActionKind.Refactor
 
+  override def supportScala3: Boolean = true
+
   override def contribute(
       params: l.CodeActionParams,
       token: CancelToken


### PR DESCRIPTION
fix https://github.com/scalameta/metals/issues/3878

As reported in https://github.com/scalameta/metals/issues/3877 and https://github.com/scalameta/metals/issues/1692, in Scala3, Metals show a quickfix command "implement all members" but when we click it, nothing happens (because it's not yet available in Scala3).

This is confusing behavior for users: they don't have any clues whether this is expected behavior, this is a bug, or it's not yet an available feature.

This PR disable Metals to show quickfix command if it's not yet available in Scala3:

<img width="979" alt="Screen Shot 2022-04-28 at 18 13 36" src="https://user-images.githubusercontent.com/9353584/165722643-2f4854f8-ee5e-4156-922c-222d2929d4f2.png">




