### PR TITLE
Show parent scaladoc if implementation is returning empty

### DIFF
--- a/metals-bench/src/main/scala/bench/ClasspathOnlySymbolSearch.scala
+++ b/metals-bench/src/main/scala/bench/ClasspathOnlySymbolSearch.scala
@@ -6,6 +6,7 @@ import java.{util => ju}
 
 import scala.meta.internal.metals.ClasspathSearch
 import scala.meta.internal.metals.WorkspaceSymbolQuery
+import scala.meta.pc.ParentSymbols
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 import scala.meta.pc.SymbolSearchVisitor
@@ -19,7 +20,10 @@ import org.eclipse.lsp4j.Location
  */
 class ClasspathOnlySymbolSearch(classpath: ClasspathSearch)
     extends SymbolSearch {
-  override def documentation(symbol: String): Optional[SymbolDocumentation] =
+  override def documentation(
+      symbol: String,
+      parents: ParentSymbols
+  ): Optional[SymbolDocumentation] =
     Optional.empty()
 
   def definition(symbol: String, source: URI): ju.List[Location] =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsSymbolSearch.scala
@@ -9,6 +9,7 @@ import scala.collection.concurrent.TrieMap
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.mtags.Mtags
 import scala.meta.io.AbsolutePath
+import scala.meta.pc.ParentSymbols
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 import scala.meta.pc.SymbolSearchVisitor
@@ -34,8 +35,11 @@ class MetalsSymbolSearch(
     dependencySourceCache.clear()
   }
 
-  override def documentation(symbol: String): Optional[SymbolDocumentation] =
-    docs.documentation(symbol)
+  override def documentation(
+      symbol: String,
+      parents: ParentSymbols
+  ): Optional[SymbolDocumentation] =
+    docs.documentation(symbol, parents)
 
   def definition(symbol: String, source: URI): ju.List[Location] = {
     val sourcePath = Option(source).map(AbsolutePath.fromAbsoluteUri)

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -11,6 +11,7 @@ import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.parsing.Trees
 import scala.meta.io.AbsolutePath
+import scala.meta.pc.ParentSymbols
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 import scala.meta.pc.SymbolSearch.Result
@@ -57,11 +58,16 @@ class StandaloneSymbolSearch(
       saveSymbolFileToDisk
     )
 
-  def documentation(symbol: String): ju.Optional[SymbolDocumentation] =
+  def documentation(
+      symbol: String,
+      parents: ParentSymbols
+  ): ju.Optional[SymbolDocumentation] =
     docs
-      .documentation(symbol)
+      .documentation(symbol, parents)
       .asScala
-      .orElse(workspaceFallback.flatMap(_.documentation(symbol).asScala))
+      .orElse(
+        workspaceFallback.flatMap(_.documentation(symbol, parents).asScala)
+      )
       .asJava
 
   override def definition(x: String, source: URI): ju.List[Location] = {

--- a/mtags-interfaces/src/main/java/scala/meta/pc/ParentSymbols.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/ParentSymbols.java
@@ -1,0 +1,16 @@
+package scala.meta.pc;
+
+import java.util.List;
+
+/**
+ * Class used for including possible parent symbols in a scaladoc search, used for lazy evaluation.
+ */
+public abstract class ParentSymbols {
+  
+  	/**
+	 * Obtain a list of parents of the current symbol search symbol.
+	 * 
+	 * @return list of symbols
+	 */
+	abstract public List<String> parents();
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/SymbolSearch.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/SymbolSearch.java
@@ -13,7 +13,7 @@ public interface SymbolSearch {
     /**
      * Returns the documentation of this symbol, if any.
      */
-    Optional<SymbolDocumentation> documentation(String symbol);
+    Optional<SymbolDocumentation> documentation(String symbol, ParentSymbols parents);
 
     /**
      * Returns the definition of this symbol, if any.

--- a/mtags/src/main/scala/scala/meta/internal/pc/EmptySymbolSearch.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/EmptySymbolSearch.scala
@@ -4,6 +4,7 @@ import java.net.URI
 import java.util.Optional
 import java.{util => ju}
 
+import scala.meta.pc.ParentSymbols
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 import scala.meta.pc.SymbolSearchVisitor
@@ -30,6 +31,9 @@ object EmptySymbolSearch extends SymbolSearch {
     ju.Collections.emptyList()
   }
 
-  override def documentation(symbol: String): Optional[SymbolDocumentation] =
+  override def documentation(
+      symbol: String,
+      parents: ParentSymbols
+  ): Optional[SymbolDocumentation] =
     Optional.empty()
 }

--- a/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
@@ -5,6 +5,8 @@ import tests.pc.BaseHoverSuite
 class HoverDocSuite extends BaseHoverSuite {
   override def requiresJdkSources: Boolean = true
 
+  override protected def requiresScalaLibrarySources: Boolean = true
+
   check(
     "doc",
     """object a {
@@ -62,6 +64,46 @@ class HoverDocSuite extends BaseHoverSuite {
            |```
            |List<String> s = Collections.emptyList();
            |```
+           |""".stripMargin
+    )
+  )
+
+  check(
+    "doc-parent",
+    """object a {
+      |  <<List(12).hea@@dOption>>
+      |}
+      |""".stripMargin,
+    // Assert that the docstring is extracted.
+    """|```scala
+       |def headOption: Option[Int]
+       |```
+       |Optionally selects the first element.
+       | $orderDependent
+       |
+       |**Returns:** the first element of this traversable collection if it is nonempty,
+       |          `None` if it is empty.
+       |""".stripMargin,
+    compat = Map(
+      "2.13" ->
+        """|```scala
+           |override def headOption: Option[Int]
+           |```
+           |Optionally selects the first element.
+           | Note: might return different results for different runs, unless the underlying collection type is ordered.
+           |
+           |**Returns:** the first element of this iterable collection if it is nonempty,
+           |          `None` if it is empty.
+           |""".stripMargin,
+      "3" ->
+        """|```scala
+           |def headOption: Option[Int]
+           |```
+           |Optionally selects the first element.
+           | Note: might return different results for different runs, unless the underlying collection type is ordered.
+           |
+           |**Returns:** the first element of this iterable collection if it is nonempty,
+           |          `None` if it is empty.
            |""".stripMargin
     )
   )

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpDocSuite.scala
@@ -137,12 +137,64 @@ class SignatureHelpDocSuite extends BaseSignatureHelpSuite {
       |  }
       |}
     """.stripMargin,
-    """|
+    """|Applies a binary operator to a start value and all elements of this collection or iterator,
+       | going left to right.
+       |
+       | Note: will not terminate for infinite-sized collections.
+       | Note: might return different results for different runs, unless the
+       |underlying collection type is ordered or the operator is associative
+       |and commutative.
+       |
+       |
+       |**Type Parameters**
+       |- `B`: the result type of the binary operator.
+       |
+       |**Parameters**
+       |- `op`: the binary operator.
+       |- `z`: the start value.
+       |
+       |**Returns:** the result of inserting `op` between consecutive elements of this collection or iterator,
+       |          going left to right with the start value `z` on the left:
+       |
+       |```
+       |op(...op(z, x_1), x_2, ..., x_n)
+       |```
+       |          where `x, ..., x` are the elements of this collection or iterator.
+       |          Returns `z` if this collection or iterator is empty.
        |foldLeft[B](z: B)(op: (B, Int) => B): B
        |                  ^^^^^^^^^^^^^^^^^
        |  @param op (Int, Int) => Int
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "2.13" ->
+        """|Applies a binary operator to a start value and all elements of this collection,
+           | going left to right.
+           |
+           | Note: will not terminate for infinite-sized collections.
+           | Note: might return different results for different runs, unless the
+           |underlying collection type is ordered or the operator is associative
+           |and commutative.
+           |
+           |
+           |**Type Parameters**
+           |- `B`: the result type of the binary operator.
+           |
+           |**Parameters**
+           |- `z`: the start value.
+           |- `op`: the binary operator.
+           |
+           |**Returns:** the result of inserting `op` between consecutive elements of this collection,
+           |          going left to right with the start value `z` on the left:
+           |          `op(...op(z, x), x, ..., x)` where `x, ..., x`
+           |           are the elements of this collection.
+           |          Returns `z` if this collection is empty.
+           |foldLeft[B](z: B)(op: (B, Int) => B): B
+           |                  ^^^^^^^^^^^^^^^^^
+           |  @param op (Int, Int) => Int
+           |""".stripMargin
+    )
   )
+
   checkDoc(
     "curry4",
     """
@@ -163,13 +215,41 @@ class SignatureHelpDocSuite extends BaseSignatureHelpSuite {
       |  List(1).map(x => @@)
       |}
     """.stripMargin,
-    """|
+    """|Builds a new collection by applying a function to all elements of this general collection.
+       |
+       |
+       |**Type Parameters**
+       |- `That`: the class of the returned collection. Where possible, `That` is
+       |the same class as the current collection class `Repr`, but this
+       |depends on the element type `B` being admissible for that class,
+       |which means that an implicit instance of type `CanBuildFrom[Repr, B, That]`
+       |is found.
+       |- `B`: the element type of the returned collection.
+       |
+       |**Parameters**
+       |- `bf`: an implicit value of class `CanBuildFrom` which determines
+       |the result class `That` from the current representation type `Repr` and
+       |the new element type `B`.
+       |- `f`: the function to apply to each element.
+       |
+       |**Returns:** a new general collection resulting from applying the given function
+       |                 `f` to each element of this general collection and collecting the results.
        |map[B, That](f: Int => B)(implicit bf: CanBuildFrom[List[Int],B,That]): That
        |             ^^^^^^^^^^^
        |""".stripMargin,
     compat = Map(
       "2.13" ->
-        """|
+        """|Builds a new collection by applying a function to all elements of this collection.
+           |
+           |
+           |**Type Parameters**
+           |- `B`: the element type of the returned collection.
+           |
+           |**Parameters**
+           |- `f`: the function to apply to each element.
+           |
+           |**Returns:** a new collection resulting from applying the given function
+           |               `f` to each element of this collection and collecting the results.
            |map[B](f: Int => B): List[B]
            |       ^^^^^^^^^^^
            |""".stripMargin

--- a/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
+++ b/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
@@ -13,6 +13,7 @@ import scala.meta.internal.mtags.GlobalSymbolIndex
 import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.mtags.Symbol
+import scala.meta.pc.ParentSymbols
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 import scala.meta.pc.SymbolSearchVisitor
@@ -30,8 +31,11 @@ class TestingSymbolSearch(
     workspace: TestingWorkspaceSearch = TestingWorkspaceSearch.empty,
     index: GlobalSymbolIndex = OnDemandSymbolIndex.empty()
 ) extends SymbolSearch {
-  override def documentation(symbol: String): Optional[SymbolDocumentation] = {
-    docs.documentation(symbol)
+  override def documentation(
+      symbol: String,
+      parents: ParentSymbols
+  ): Optional[SymbolDocumentation] = {
+    docs.documentation(symbol, parents)
   }
 
   override def definition(symbol: String, source: URI): ju.List[Location] = {


### PR DESCRIPTION
Previously, we would only return docstring if the current method has them defined, which wouldn't work well in case of a lot of standard library methods. Now, we check parents for symbols so that we can print a proper scaladoc

Prompted by @kpodsiad , we can merge after https://github.com/scalameta/metals/pull/3865