### PR TITLE
Handle modules in stacktrace analyzer

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
@@ -202,7 +202,11 @@ class StacktraceAnalyzer(
 object StacktraceAnalyzer {
 
   def toToplevelSymbol(symbolIn: String): List[String] = {
-    val symbol = symbolIn.split('.').init.mkString("/")
+    // remove module name. Module symbols are formatted as `moduleName/symbol`
+    val modulePos = symbolIn.indexOf("/")
+    val symbolPart =
+      if (modulePos > -1) symbolIn.substring(modulePos + 1) else symbolIn
+    val symbol = symbolPart.split('.').init.mkString("/")
     /* Symbol containing `$package$` is a toplevel method and we only need to
      * find any method contained in the same file even if overloaded
      */

--- a/tests/unit/src/test/scala/tests/StacktraceParseSuite.scala
+++ b/tests/unit/src/test/scala/tests/StacktraceParseSuite.scala
@@ -47,6 +47,17 @@ class StacktraceParseSuite extends BaseSuite {
   testConversion("p1.p2.Object$.foreach$mVc$sp", "p1/p2/Object.")
   testConversion("p1.p2.Class.foreach$mVc$sp", "p1/p2/Class#")
 
+  // non-module jdk
+  testConversion(
+    "java.util.concurrent.FutureTask.run",
+    "java/util/concurrent/FutureTask#"
+  )
+  // module jdk
+  testConversion(
+    "java.base/java.util.concurrent.FutureTask.run",
+    "java/util/concurrent/FutureTask#"
+  )
+
   def testConversion(line: String, expected: String): Unit = {
     test(line) {
       val obtained = StacktraceAnalyzer.toToplevelSymbol(line)


### PR DESCRIPTION
Currently the stacktrace analyzer will not show links for jdk classes when the jdk has modules

So this would get a hyperlink...
```java
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
```

But this would not...
```java
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
```

Now the module is removed before the symbol is searched for and the jdk classes get hyperlinks.