### PR TITLE
feat, test explorer: search for test methods in parent classes

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -48,7 +48,8 @@ final class TestSuitesProvider(
 
   private val index = new TestSuitesIndex
   private val junitTestFinder = new JunitTestFinder
-  private val munitTestFinder = new MunitTestFinder(trees)
+  private val munitTestFinder =
+    new MunitTestFinder(trees, symbolIndex, semanticdbs)
 
   private def isEnabled =
     clientConfig.isTestExplorerProvider() &&
@@ -184,7 +185,8 @@ final class TestSuitesProvider(
               munitTestFinder.findTests(
                 semanticdb,
                 path,
-                suite.fullyQualifiedName
+                suite.fullyQualifiedName,
+                suite.symbol
               )
             case Unknown => Vector.empty
           }

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/MunitTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/MunitTestFinder.scala
@@ -7,114 +7,218 @@ import scala.collection.mutable
 import scala.meta.Defn
 import scala.meta.Lit
 import scala.meta.Pkg
+import scala.meta.Template
 import scala.meta.Term
 import scala.meta.Tree
+import scala.meta.Type
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.testProvider.FullyQualifiedName
 import scala.meta.internal.metals.testProvider.TestCaseEntry
+import scala.meta.internal.mtags
+import scala.meta.internal.mtags.GlobalSymbolIndex
+import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.parsing.Trees
+import scala.meta.internal.semanticdb.ClassSignature
+import scala.meta.internal.semanticdb.SymbolInformation
 import scala.meta.internal.semanticdb.SymbolOccurrence
 import scala.meta.internal.semanticdb.TextDocument
+import scala.meta.internal.semanticdb.TypeRef
 import scala.meta.io.AbsolutePath
 
-class MunitTestFinder(trees: Trees) {
+class MunitTestFinder(
+    trees: Trees,
+    symbolIndex: GlobalSymbolIndex,
+    semanticdbs: Semanticdbs
+) {
 
+  // depending on the munit version test method symbol varies.
+  private val baseParentClasses = Set("munit/BaseFunSuite#", "munit/FunSuite#")
+  private val testMethodSymbols = baseParentClasses.map(_ + "test")
+
+  /**
+   * Find test cases for the given suite.
+   * Search includes helper methods which may be defined in parent classes.
+   * @param doc semanticDB which contains
+   * @param symbol semanticDB symbol of the suite
+   * @return Vector of test case entries
+   */
   def findTests(
       doc: TextDocument,
       path: AbsolutePath,
-      suiteName: FullyQualifiedName
+      suiteName: FullyQualifiedName,
+      symbol: mtags.Symbol
   ): Vector[TestCaseEntry] = {
     val uri = path.toURI
-    val testcases = new mutable.ArrayBuffer[TestCaseEntry]()
     // depending on the munit version test method is defined in different classes
-    val occurences = doc.occurrences
-      .filter(occ =>
-        occ.symbol.startsWith("munit/BaseFunSuite#test") ||
-          occ.symbol.startsWith("munit/FunSuite#test")
-      )
-      .toVector
+    val occurences = filterOccurences(doc)
 
-    /**
-     * Class definition is valid when package + class name is equal to one we are looking for
-     */
-    def isValid(cls: Defn.Class, currentPackage: Vector[String]): Boolean = {
-      val fullyQualifiedName =
-        currentPackage.appended(cls.name.value).mkString(".")
-      fullyQualifiedName == suiteName.value
-    }
-
-    def loop(tree: Tree, currentPackage: Vector[String]): Unit = {
-      tree match {
-        case cls: Defn.Class if isValid(cls, currentPackage) =>
-          /**
-           * In munit, it's very popular to define helper method for tests
-           * which prevents from code duplication. These method often looks like:
-           * def check(name: String, ...) = {
-           *   test(name) {
-           *     <test logic>
-           *   }
-           * }
-           * Finding these potential test methods will allow showing them to the user.
-           */
-          val potentialTests = cls.templ.children.collect {
-            case dfn: Defn.Def if hasTestCall(dfn, occurences) => dfn.name.value
-          }.toSet
-
-          def extractFunctionName(
-              appl0: Term.Apply
-          ): Option[(Term.Name, String)] =
-            appl0.fun match {
-              case helperName: Term.Name
-                  if potentialTests.contains(helperName.value) =>
-                appl0.args
-                  .collectFirst { case Lit.String(value) => value }
-                  .map(testName => (helperName, testName))
-              case appl: Term.Apply => extractFunctionName(appl)
-              case _ => None
-            }
-
-          // let's collect all tests candidates
-          cls.templ.children.foreach {
-            // test("testname".only|ignore|tag) {}
-            case appl: Term.Apply if hasTestCall(appl, occurences) =>
-              getTestCallWithTestName(appl).foreach { case (test, testname) =>
-                val location = test.pos.toLSP.toLocation(uri)
-                val entry = TestCaseEntry(testname.value, location)
-                testcases.addOne(entry)
-              }
-
-            // helper_function("testname", ...) where helper_function was previously found as a potential test function
-            case appl: Term.Apply =>
-              val nameOpt = extractFunctionName(appl)
-              nameOpt.foreach { case (helperFunction, testName) =>
-                val location = helperFunction.pos.toLSP.toLocation(uri)
-                val entry = TestCaseEntry(testName, location)
-                testcases.addOne(entry)
-              }
-
-            case _ => ()
-          }
-
-        case Pkg(ref, children) =>
-          val pkg = extractPackageName(ref)
-          children.foreach(loop(_, currentPackage ++ pkg))
-
-        case _ =>
-          tree.children.foreach(loop(_, currentPackage))
+    // format: off
+    // semanticDB contains information about parent classes of suite
+    val parents = doc.symbols
+      .collectFirst {
+        case SymbolInformation(symbolValue, _, _, _, _, sig: ClassSignature, _, _, _, _) if symbolValue == symbol.value =>
+          sig.parents.collect { 
+            case TypeRef(_, parentSymbol, _) if !baseParentClasses.contains(parentSymbol) => parentSymbol
+          }.toVector
       }
-    }
+      .getOrElse(Vector.empty)
+    // format: on
+
+    // extract helper methods from parents. In order to do that we need
+    // to get both Tree and semanticDB of parent class
+    val parentMethods = (for {
+      parent <- parents
+      definition <- symbolIndex.definition(mtags.Symbol(parent))
+      tree <- trees.get(definition.path)
+      doc <- semanticdbs.textDocument(definition.path).documentIncludingStale
+      parentClassName = parent
+        .stripPrefix("_empty_/")
+        .stripSuffix("#")
+        .replace("/", ".")
+      template <- extractTemplateFrom(tree, parentClassName)
+    } yield {
+      val occurences = filterOccurences(doc)
+      extractPotentialTestMethods(template, occurences)
+    }).flatten.toSet
 
     trees
       .get(path)
-      .map { tree =>
-        loop(tree, Vector.empty)
-        testcases.toVector
+      .flatMap(tree => extractTemplateFrom(tree, suiteName.value))
+      .map { template =>
+        val potentialTests =
+          extractPotentialTestMethods(template, occurences) ++ parentMethods
 
+        def extractFunctionName(
+            appl0: Term.Apply
+        ): Option[(Term.Name, String)] =
+          appl0.fun match {
+            case helperName: Term.Name
+                if potentialTests.contains(helperName.value) =>
+              appl0.args
+                .collectFirst { case Lit.String(value) => value }
+                .map(testName => (helperName, testName))
+            case appl: Term.Apply => extractFunctionName(appl)
+            case _ => None
+          }
+
+        // let's collect all tests candidates
+        val testcases = new mutable.ArrayBuffer[TestCaseEntry]()
+        template.children.foreach {
+          // test("testname".only|ignore|tag) {}
+          case appl: Term.Apply if hasTestCall(appl, occurences) =>
+            getTestCallWithTestName(appl).foreach { case (test, testname) =>
+              val location = test.pos.toLSP.toLocation(uri)
+              val entry = TestCaseEntry(testname.value, location)
+              testcases.addOne(entry)
+            }
+
+          // helper_function("testname", ...) where helper_function was previously found as a potential test function
+          case appl: Term.Apply =>
+            val nameOpt = extractFunctionName(appl)
+            nameOpt.foreach { case (helperFunction, testName) =>
+              val location = helperFunction.pos.toLSP.toLocation(uri)
+              val entry = TestCaseEntry(testName, location)
+              testcases.addOne(entry)
+            }
+
+          case _ => ()
+        }
+        testcases.toVector
       }
       .getOrElse(Vector.empty)
   }
 
-  def getTestCallWithTestName(
+  /**
+   * Leave only occurences which are connected to the munit test method
+   */
+  private def filterOccurences(doc: TextDocument): Vector[SymbolOccurrence] =
+    doc.occurrences
+      .filter(occ =>
+        testMethodSymbols.exists(testSymbol =>
+          occ.symbol.startsWith(testSymbol)
+        )
+      )
+      .toVector
+
+  /**
+   * Class definition is valid when package + class name is equal to one we are looking for
+   */
+  private def isValid(
+      name: Type.Name,
+      currentPackage: Vector[String],
+      searched: String
+  ): Boolean = {
+    val fullyQualifiedName = currentPackage.appended(name.value).mkString(".")
+    fullyQualifiedName == searched
+  }
+
+  /**
+   * Extract class/trait template from the given Tree.
+   * @param tree Tree which may contain Template
+   * @param fullyQualifiedName fully qualified class name of class/trait
+   * @return Template of a given class if present
+   */
+  private def extractTemplateFrom(
+      tree: Tree,
+      fullyQualifiedName: String
+  ): Option[Template] = {
+
+    /**
+     * Search loop with short circuiting when first matching result is obtained.
+     */
+    def loop(
+        t: Tree,
+        currentPackage: Vector[String]
+    ): Option[Template] = {
+      t match {
+        case cls: Defn.Class
+            if isValid(cls.name, currentPackage, fullyQualifiedName) =>
+          Some(cls.templ)
+        case trt: Defn.Trait
+            if isValid(trt.name, currentPackage, fullyQualifiedName) =>
+          Some(trt.templ)
+        // short-circuit to not go deeper into unuseful defns
+        case _: Defn => None
+        case Pkg(ref, children) =>
+          val pkg = extractPackageName(ref)
+          val newPackage = currentPackage ++ pkg
+          LazyList
+            .from(children)
+            .map(loop(_, newPackage))
+            .find(_.isDefined)
+            .flatten
+        case _ =>
+          LazyList
+            .from(t.children)
+            .map(loop(_, currentPackage))
+            .find(_.isDefined)
+            .flatten
+      }
+    }
+
+    loop(tree, Vector.empty)
+  }
+
+  /**
+   * Find test call (Term.Name("test")) and test name (Lit.String(...)) in a given tree.
+   *
+   * e.g.
+   * test("test-1") {...} is equal to the following tree and interesting part
+   * is marked by caret symbols
+   * Apply( Apply( Name("test", Lit.String("test-1") ) ), Block(...))
+   *               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   *
+   * However, for curried functions applies are more nested:
+   * test("test-2")(1) {...}
+   * Apply( Apply( Apply(Name("test", Lit.String("test-2")), ... ), Block(...) )
+   *                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   *
+   * Last case are calls like test("test3".ignore) {} when searched tree has no longer shape of
+   * Apply(Name, Lit.String) but rather Apply(Name, Select("test3", Name("ignore")))
+   * Apply( Apply(Name("test"), Select("test3", Name("ignore"))), Block(...) )
+   *              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   */
+  private def getTestCallWithTestName(
       tree: Tree
   ): Option[(Term.Name, Lit.String)] = {
 
@@ -129,6 +233,7 @@ class MunitTestFinder(trees: Trees) {
     }
 
     @tailrec
+    // find proper Apply in possibly multiple nested Applies
     def loop(acc: List[Tree]): Option[(Term.Name, Lit.String)] = acc match {
       case head :: tail =>
         head match {
@@ -142,10 +247,33 @@ class MunitTestFinder(trees: Trees) {
         }
       case immutable.Nil => None
     }
+
     loop(tree.children)
   }
 
-  def hasTestCall(
+  /**
+   * In munit, it's very popular to define helper method for tests
+   * which prevents from code duplication. These method often looks like:
+   * def check(name: String, ...) = {
+   *   test(name) {
+   *     <test logic>
+   *   }
+   * }
+   * Extract potential test methods from a given tree, provided that test call
+   * is verified using semanticdb.
+   */
+  private def extractPotentialTestMethods(
+      clsTemplate: Template,
+      occurences: Vector[SymbolOccurrence]
+  ): Set[String] = clsTemplate.children.collect {
+    case dfn: Defn.Def if hasTestCall(dfn, occurences) => dfn.name.value
+  }.toSet
+
+  /**
+   * Check if the given tree contains a test call.
+   * Test call is valid when there is test symbol with given range in semanticDB.
+   */
+  private def hasTestCall(
       tree: Tree,
       occurences: Vector[SymbolOccurrence]
   ): Boolean = {
@@ -164,6 +292,7 @@ class MunitTestFinder(trees: Trees) {
         }
       case immutable.Nil => false
     }
+
     loop(tree.children)
   }
 
@@ -184,7 +313,4 @@ class MunitTestFinder(trees: Trees) {
         extractPackageName(qual, value :: acc)
       case _ => Vector.empty
     }
-
 }
-
-object MunitTestFinder {}

--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -430,6 +430,80 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
     () => Some(classUriFor("app/src/main/scala/MunitTestSuite.scala"))
   )
 
+  testDiscover(
+    "munit-from-parent",
+    s"""|/metals.json
+        |{
+        |  "app": {
+        |    "libraryDependencies" : ["org.scalameta::munit:1.0.0-M3" ],
+        |    "scalaVersion": "${BuildInfo.scalaVersion}"
+        |  }
+        |}
+        |
+        |/app/src/main/scala/MunitTestSuite.scala
+        |package a {
+        |  trait FirstBaseMunitSuite extends munit.FunSuite {
+        |    def firstParentCheck(name: String) = test(name) {}
+        |  }
+        |}
+        |
+        |trait SecondBaseMunitSuite extends munit.FunSuite {
+        |  def secondParentCheck(name: String) = test(name) {}
+        |}
+        |
+        |class MunitTestSuite extends a.FirstBaseMunitSuite with SecondBaseMunitSuite {
+        |  test("test-1") {}
+        |  firstParentCheck("test-parent-1")
+        |  secondParentCheck("test-parent-2")
+        |}
+        |""".stripMargin,
+    List("app/src/main/scala/MunitTestSuite.scala"),
+    () => {
+      List(
+        BuildTargetUpdate(
+          "app",
+          targetUri,
+          List[TestExplorerEvent](
+            AddTestCases(
+              "MunitTestSuite",
+              "MunitTestSuite",
+              Vector(
+                TestCaseEntry(
+                  "test-1",
+                  QuickLocation(
+                    classUriFor(
+                      "app/src/main/scala/MunitTestSuite.scala"
+                    ),
+                    (11, 2, 11, 6)
+                  ).toLsp
+                ),
+                TestCaseEntry(
+                  "test-parent-1",
+                  QuickLocation(
+                    classUriFor(
+                      "app/src/main/scala/MunitTestSuite.scala"
+                    ),
+                    (12, 2, 12, 18)
+                  ).toLsp
+                ),
+                TestCaseEntry(
+                  "test-parent-2",
+                  QuickLocation(
+                    classUriFor(
+                      "app/src/main/scala/MunitTestSuite.scala"
+                    ),
+                    (13, 2, 13, 19)
+                  ).toLsp
+                )
+              ).asJava
+            )
+          ).asJava
+        )
+      )
+    },
+    () => Some(classUriFor("app/src/main/scala/MunitTestSuite.scala"))
+  )
+
   checkEvents(
     "check-events",
     s"""|/metals.json

--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -440,19 +440,26 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
         |  }
         |}
         |
-        |/app/src/main/scala/MunitTestSuite.scala
-        |package a {
-        |  trait FirstBaseMunitSuite extends munit.FunSuite {
-        |    def firstParentCheck(name: String) = test(name) {}
-        |  }
+        |/app/src/main/scala/a/BaseMunitSuite.scala
+        |package a
+        |trait BaseMunitSuite extends munit.FunSuite {
+        |  def baseParentCheck(name: String) = test(name) {}
         |}
         |
+        |/app/src/main/scala/a/b/FirstBaseMunitSuite.scala
+        |package a.b
+        |trait FirstBaseMunitSuite extends a.BaseMunitSuite {
+        |  def firstParentCheck(name: String) = test(name) {}
+        |}
+        |
+        |/app/src/main/scala/MunitTestSuite.scala
         |trait SecondBaseMunitSuite extends munit.FunSuite {
         |  def secondParentCheck(name: String) = test(name) {}
         |}
         |
-        |class MunitTestSuite extends a.FirstBaseMunitSuite with SecondBaseMunitSuite {
+        |class MunitTestSuite extends a.b.FirstBaseMunitSuite with SecondBaseMunitSuite {
         |  test("test-1") {}
+        |  baseParentCheck("test-base")
         |  firstParentCheck("test-parent-1")
         |  secondParentCheck("test-parent-2")
         |}
@@ -474,7 +481,16 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
                     classUriFor(
                       "app/src/main/scala/MunitTestSuite.scala"
                     ),
-                    (11, 2, 11, 6)
+                    (5, 2, 5, 6)
+                  ).toLsp
+                ),
+                TestCaseEntry(
+                  "test-base",
+                  QuickLocation(
+                    classUriFor(
+                      "app/src/main/scala/MunitTestSuite.scala"
+                    ),
+                    (6, 2, 6, 17)
                   ).toLsp
                 ),
                 TestCaseEntry(
@@ -483,7 +499,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
                     classUriFor(
                       "app/src/main/scala/MunitTestSuite.scala"
                     ),
-                    (12, 2, 12, 18)
+                    (7, 2, 7, 18)
                   ).toLsp
                 ),
                 TestCaseEntry(
@@ -492,7 +508,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
                     classUriFor(
                       "app/src/main/scala/MunitTestSuite.scala"
                     ),
-                    (13, 2, 13, 19)
+                    (8, 2, 8, 19)
                   ).toLsp
                 )
               ).asJava


### PR DESCRIPTION
I decided not to store helper methods obtained from parent classes as it may introduce a bit complexity. Instead, these helpers are being cmputed each time and I think this should be fine because:
- testcases are discovered lazily
- testcases are updated only for already discovered files
- testcases can be updated only if necessary (store MD5?)

If this happen to be too compute intensive, this feature can always be disabled for a while.

I didn't test if this PR works in normal project, only created unit test for it hence it's draft. However, I would like to receive some feedback on it.