### PR TITLE
feat: handle cats-effect async stacktrace in stacktrace analyzer

### DIFF
--- a/tests/unit/src/main/scala/tests/BaseAnalyzeStacktraceSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAnalyzeStacktraceSuite.scala
@@ -6,6 +6,7 @@ import scala.meta.internal.metals.JsonParser
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.{BuildInfo => V}
 
+import munit.TestOptions
 import org.eclipse.{lsp4j => l}
 
 abstract class BaseAnalyzeStacktraceSuite(name: String)
@@ -29,12 +30,13 @@ abstract class BaseAnalyzeStacktraceSuite(name: String)
   }
 
   def check(
-      name: String,
+      name: TestOptions,
       code: String,
       stacktrace: String,
       filename: String = "Main.scala",
-      scalaVersion: String = V.scala212
-  ): Unit = {
+      scalaVersion: String = V.scala213,
+      dependency: String = ""
+  )(implicit loc: munit.Location): Unit = {
     val locationParser = new JsonParser.Of[l.Location]
     test(name) {
       cleanWorkspace()
@@ -42,7 +44,12 @@ abstract class BaseAnalyzeStacktraceSuite(name: String)
         _ <- initialize(
           s"""
              |/metals.json
-             |{"a":{ "scalaVersion" : "$scalaVersion"}}
+             |{ 
+             |  "a": { 
+             |    "scalaVersion": "$scalaVersion",
+             |    "libraryDependencies": [ $dependency ]
+             |   }
+             |}
              |/a/src/main/scala/a/$filename
              |${prepare(code)}
              |""".stripMargin

--- a/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/AnalyzeStacktraceLspSuite.scala
@@ -74,6 +74,18 @@ class AnalyzeStacktraceLspSuite
        |""".stripMargin
   )
 
+  check(
+    "cat-effect-stactraces",
+    catsEffectCode,
+    """|java.lang.Exception
+       |        at a.Main$.$anonfun$run$1(Stacktraces.scala:10)
+       |        at apply @ a.Main$.<clinit>(Stacktraces.scala:7)
+       |        at map @ a.Main$.run(Stacktraces.scala:9)
+       |        at run$ @ a.Main$.run(Stacktraces.scala:6)
+       |""".stripMargin,
+    dependency = "\"org.typelevel::cats-effect:3.3.11\""
+  )
+
   private lazy val code: String =
     """|package a.b
        |
@@ -102,6 +114,22 @@ class AnalyzeStacktraceLspSuite
        |  val b = 4
        |}
        |
+       |""".stripMargin
+
+  private lazy val catsEffectCode =
+    """|package a
+       |
+       |import cats.effect.IOApp
+       |import cats.effect.IO
+       |
+       |<<4>>object Main extends IOApp.Simple {
+       |<<2>>  val io = IO(5)
+       |  override def run: IO[Unit] = io
+       |<<3>>      .map { _ => 
+       |<<1>>        throw new Exception
+       |        ()
+       |      }
+       |}
        |""".stripMargin
 
 }


### PR DESCRIPTION
Handles following:
```scala
//> using scala "2.13.8"
//> using lib "org.typelevel::cats-effect:3.3.11"
package a

import cats.effect.IOApp
import cats.effect.IO

object Main extends IOApp.Simple {
  val io = IO(5)
  override def run: IO[Unit] = io
      .map { _ => 
        throw new Exception
        ()
      }.void
}

```

```
java.lang.Exception
        at a.Main$.$anonfun$run$1(Stacktraces.scala:12)
        at apply @ a.Main$.<clinit>(Stacktraces.scala:9)
        at map @ a.Main$.run(Stacktraces.scala:11)
        at void @ a.Main$.run(Stacktraces.scala:11)
        at run$ @ a.Main$.run(Stacktraces.scala:8)
```