### PR TITLE
fix: broken link display in vim docs

### DIFF
--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -29,9 +29,10 @@ To get started with installation please see the `nvim-metals`
 
 ```
 
+
 Keep in mind that by default Neovim doesn't have default mappings for the
 functionality you'll want like, hovers, goto definition, method signatures, etc.
-Youc can find a full example configuration of these in the [example
+You can find a full example configuration of these in the [example
 configuration](https://github.com/scalameta/nvim-metals/discussions/39).
 
 For a guide on all the available features in `nvim-metals`, refer to the


### PR DESCRIPTION
Not sure why but an extra space is needed after the table to ensure the
next paragraph gets wrapped in a `<p>` and the markdown renders correctly.