### PR TITLE
docs: fix broken documents (Integrating a new editor)

### DIFF
--- a/docs/integrations/new-editor.md
+++ b/docs/integrations/new-editor.md
@@ -71,7 +71,7 @@ during the
 process. While Metals will still work being fully configured by server
 properties, we strongly recommend that instead you rely on the
 `InitializationOptions` which are thoroughly covered below in the
-[`initialize`](#initialize] section.
+[`initialize`](#initialize) section.
 
 ## Language Server Protocol
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -126,7 +126,6 @@ object ServerCommands {
     """
       |Discovers all tests in project or a file.
       |See ClientCommands.UpdateTestExplorer to see how response looks like.
-      |```
       |""".stripMargin,
     """
       |An object with uri, when request is meant to discover test cases for uri


### PR DESCRIPTION

Under https://scalameta.org/metals/docs/integrations/new-editor#discover-tests since there was no matching triplequote, some contents were unintentionally blocked.

### before
<img width="1053" alt="Screen Shot 2022-05-09 at 20 19 06" src="https://user-images.githubusercontent.com/9353584/167400522-893545bd-8f34-459b-a74f-f6df54403085.png">

### after
<img width="1076" alt="Screen Shot 2022-05-09 at 20 23 05" src="https://user-images.githubusercontent.com/9353584/167400773-f9a7bee3-aac7-416d-b953-f1486ef49be9.png">
