### PR TITLE
Don't assume locations are modified in place

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -359,7 +359,7 @@ object SbtBuildTool {
       pos => {
         new Position(pos.getLine() - appendLineSize, pos.getCharacter())
       },
-      filterOutLocations = { loc => !loc.getUri().isSbt }
+      doAdjust = { loc => loc.getUri().isSbt }
     )
     (modifiedInput, adjustRequest, adjustLspData)
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
@@ -74,17 +74,18 @@ trait AdjustLspData {
 
 case class AdjustedLspData(
     adjustPosition: Position => Position,
-    filterOutLocations: Location => Boolean
+    doAdjust: Location => Boolean
 ) extends AdjustLspData {
 
   override def adjustLocations(
       locations: ju.List[Location]
   ): ju.List[Location] = {
-    locations.asScala.collect {
-      case loc if !filterOutLocations(loc) =>
+    locations.asScala.foreach { loc =>
+      if (doAdjust(loc))
         loc.setRange(adjustRange(loc.getRange()))
-        loc
-    }.asJava
+    }
+
+    locations
   }
   override def adjustPos(pos: Position): Position = adjustPosition(pos)
 
@@ -121,7 +122,7 @@ object AdjustedLspData {
 
   def create(
       f: Position => Position,
-      filterOutLocations: Location => Boolean = _ => false
+      doAdjust: Location => Boolean = _ => true
   ): AdjustLspData =
     AdjustedLspData(
       pos => {
@@ -130,7 +131,7 @@ object AdjustedLspData {
           pos
         else newPos
       },
-      filterOutLocations
+      doAdjust
     )
 
   val default: AdjustLspData = DefaultAdjustedData

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -390,9 +390,8 @@ class Compilers(
       pc.definition(CompilerOffsetParams.fromPos(pos, token))
         .asScala
         .map { c =>
-          adjust.adjustLocations(c.locations())
-          val definitionPaths = c
-            .locations()
+          val locations = adjust.adjustLocations(c.locations())
+          val definitionPaths = locations
             .map { loc =>
               loc.getUri().toAbsolutePath
             }
@@ -405,7 +404,7 @@ class Compilers(
             None
           }
           DefinitionResult(
-            c.locations(),
+            locations,
             c.symbol(),
             definitionPath,
             None

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -480,7 +480,7 @@ object WorksheetProvider {
       pos => {
         new Position(pos.getLine() - 1, pos.getCharacter() - ident.size)
       },
-      filterOutLocations = { loc => !loc.getUri().isWorksheet }
+      doAdjust = { loc => loc.getUri().isWorksheet }
     )
     Some((modifiedInput, adjustLspData))
   }


### PR DESCRIPTION
That seems to be implied by the `AdjustLspData` API, and by the main `adjustLocations` implementation, that filters out some locations. Yet it seems that makes some tests fail, `tests.feature.Worksheet3LspSuite.definition` without the changes proposed here.