### PR TITLE
refactor: fix warning from Scala3 in ScaladocParser.scala

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/metals/docstrings/ScaladocParser.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/docstrings/ScaladocParser.scala
@@ -59,7 +59,10 @@ object ScaladocParser {
                 case Text(text) =>
                   text match {
                     case LinkPattern(link, _, _, title) =>
-                      Link(link, Option(title) map (Text) getOrElse Text(link))
+                      Link(
+                        link,
+                        Option(title) map (Text.apply) getOrElse Text(link)
+                      )
                     case text =>
                       Link(text, Text(text))
                   }
@@ -1292,7 +1295,7 @@ object ScaladocParser {
 
       link match {
         case LinkPattern(link, _, _, title) =>
-          Link(link, Option(title) map (Text) getOrElse Text(link))
+          Link(link, Option(title) map (Text.apply) getOrElse Text(link))
         case text =>
           Link(text, Text(text))
       }


### PR DESCRIPTION
This is a follow-up for https://github.com/scalameta/metals/pull/3865 (I left the warning from Scala3).

```
[warn] -- Warning: /Users/tanishiking/src/github.com/tanishiking/metals/mtags/src/main/scala/scala/meta/internal/metals/docstrings/ScaladocParser.scala:1295:40 
[warn] 1295 |          Link(link, Option(title) map (Text) getOrElse Text(link))
[warn]      |                                        ^^^^
[warn]      |The method `apply` is inserted. The auto insertion will be deprecated, please write `scala.meta.internal.docstrings.Text.apply` explicitly.
```