### PR TITLE
[WIP] Show parameter name decorations in methods

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -43,6 +43,7 @@ import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.{Position => LspPosition}
 import org.eclipse.lsp4j.{Range => LspRange}
 import org.eclipse.lsp4j.{debug => d}
+import scala.meta.pc.ParamNameHintResult
 
 /**
  * Manages lifecycle for presentation compilers in all build targets.
@@ -430,6 +431,18 @@ class Compilers(
         positions.map(CompilerOffsetParams.fromPos(_, token))
       pc.selectionRange(offsetPositions).asScala
     }.getOrElse(Future.successful(Nil.asJava))
+  }
+
+  def paramNameHints(
+      path: AbsolutePath
+  ): Future[ju.List[ParamNameHintResult]] = {
+    loadCompiler(path)
+      .map { pc =>
+        val input = path.toInputFromBuffers(buffers)
+        val params = CompilerVirtualFileParams(path.toNIO.toUri(), input.value)
+        pc.paramNameHints(params).asScala
+      }
+      .getOrElse(Future.successful(Nil.asJava))
   }
 
   def loadCompiler(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -98,6 +98,10 @@ import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
 import org.eclipse.{lsp4j => l}
+import scala.meta.internal.decorations.DecorationOptions
+import scala.collection.convert.AsScalaExtensions
+import scala.meta.internal.decorations.ThemableDecorationInstanceRenderOptions
+import scala.meta.internal.decorations.ThemableDecorationAttachmentRenderOptions
 
 class MetalsLanguageServer(
     ec: ExecutionContextExecutorService,
@@ -604,18 +608,6 @@ class MetalsLanguageServer(
           clientConfig,
           trees
         )
-        syntheticsDecorator = new SyntheticsDecorationProvider(
-          workspace,
-          semanticdbs,
-          buffers,
-          languageClient,
-          fingerprints,
-          charset,
-          () => focusedDocument,
-          clientConfig,
-          () => userConfig,
-          trees
-        )
         testProvider = new TestSuitesProvider(
           buildTargets,
           buildTargetClasses,
@@ -626,16 +618,6 @@ class MetalsLanguageServer(
           clientConfig,
           () => userConfig,
           languageClient
-        )
-        semanticDBIndexer = new SemanticdbIndexer(
-          List(
-            referencesProvider,
-            implementationProvider,
-            syntheticsDecorator,
-            testProvider
-          ),
-          buildTargets,
-          workspace
         )
         documentHighlightProvider = new DocumentHighlightProvider(
           definitionProvider,
@@ -671,6 +653,29 @@ class MetalsLanguageServer(
             mtagsResolver,
             sourceMapper
           )
+        )
+        syntheticsDecorator = new SyntheticsDecorationProvider(
+          workspace,
+          semanticdbs,
+          buffers,
+          languageClient,
+          fingerprints,
+          charset,
+          () => focusedDocument,
+          clientConfig,
+          () => userConfig,
+          trees,
+          compilers
+        )
+        semanticDBIndexer = new SemanticdbIndexer(
+          List(
+            referencesProvider,
+            implementationProvider,
+            syntheticsDecorator,
+            testProvider
+          ),
+          buildTargets,
+          workspace
         )
         debugProvider = new DebugProvider(
           workspace,

--- a/mtags-interfaces/src/main/java/scala/meta/pc/ParamNameHintResult.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/ParamNameHintResult.java
@@ -1,0 +1,9 @@
+package scala.meta.pc;
+
+import org.eclipse.lsp4j.Range;
+
+public interface ParamNameHintResult {
+  public Range range();
+  public String contentText();
+}
+

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -96,6 +96,14 @@ public abstract class PresentationCompiler {
     public abstract CompletableFuture<List<TextEdit>> insertInferredType(OffsetParams params);
 
     /**
+     * Return the list of parameter name hints in the given file.
+     * Intentionally avoid returning InlayHint, so the caller can transform the return value into
+     * either InlayHint or DecorationOption.
+     * When we moved to InlayHint, this method can return InlayHint.
+     */
+    public abstract CompletableFuture<List<ParamNameHintResult>> paramNameHints(VirtualFileParams param);
+
+    /**
      * The text contents of the fiven file changed.
      */
     public abstract CompletableFuture<List<Diagnostic>> didChange(VirtualFileParams params);

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -36,6 +36,7 @@ import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.SelectionRange
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.TextEdit
+import scala.meta.pc.ParamNameHintResult
 
 case class ScalaPresentationCompiler(
     buildTargetIdentifier: String = "",
@@ -47,6 +48,7 @@ case class ScalaPresentationCompiler(
     config: PresentationCompilerConfig = PresentationCompilerConfigImpl(),
     workspace: Option[Path] = None
 ) extends PresentationCompiler {
+
   implicit val executionContext: ExecutionContextExecutor = ec
 
   val scalaVersion = BuildInfo.scalaCompilerVersion
@@ -140,6 +142,12 @@ case class ScalaPresentationCompiler(
     compilerAccess.withInterruptableCompiler(empty, params.token) { pc =>
       new InferredTypeProvider(pc.compiler(), params).inferredTypeEdits().asJava
     }
+  }
+
+  override def paramNameHints(
+      param: VirtualFileParams
+  ): CompletableFuture[ju.List[ParamNameHintResult]] = {
+    CompletableFuture.completedFuture(new ju.ArrayList[ParamNameHintResult]())
   }
 
   override def autoImports(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ParamNameHintProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ParamNameHintProvider.scala
@@ -1,0 +1,69 @@
+package scala.meta.internal.pc
+
+import scala.meta.io.AbsolutePath
+import dotty.tools.dotc.interactive.InteractiveDriver
+import scala.meta.pc.PresentationCompilerConfig
+import java.nio.file.Paths
+import dotty.tools.dotc.util.SourceFile
+import dotty.tools.dotc.core.Flags
+import meta.internal.mtags.MtagsEnrichments.*
+import dotty.tools.dotc.interactive.Interactive
+import scala.meta.internal.pc.IndexedContext
+import scala.meta.internal.pc.MetalsInteractive
+import dotty.tools.dotc.ast.Trees.Apply
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.core.Contexts.Context
+import scala.meta.pc.ParamNameHintResult
+import scala.meta.pc.VirtualFileParams
+
+final class ParamNameHintProvider(
+    params: VirtualFileParams,
+    driver: InteractiveDriver,
+    config: PresentationCompilerConfig
+):
+
+  def paramNameHints: List[ParamNameHintResult] =
+    val uri = params.uri
+    val filePath = Paths.get(uri)
+    driver.run(
+      uri,
+      SourceFile.virtual(filePath.toString, params.text)
+    )
+    val unit = driver.currentCtx.run.units.head
+    val tree = unit.tpdTree
+    val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
+
+    def collectArgss(a: tpd.Apply): List[List[tpd.Tree]] =
+      a.fun match
+        case app: tpd.Apply => collectArgss(app) :+ a.args
+        case _ => List(a.args)
+
+    val result = collection.mutable.ListBuffer.empty[ParamNameHintResult]
+    val traverser = new tpd.TreeTraverser:
+      def traverse(tree: tpd.Tree)(using Context) = tree match
+        case app: tpd.Apply if app.span.exists =>
+          val argss = collectArgss(app)
+          if argss.flatten.filter(_.span.isSourceDerived).length < 3 then ()
+          else
+            val paramss = app.fun.symbol.rawParamss
+            val pairs = argss
+              .zip(paramss)
+              .flatMap { (args, params) =>
+                args.zip(params)
+              }
+              .foreach { (arg, param) =>
+                if arg.span.isSourceDerived then
+                  result.addOne(
+                    ParamNameHintResultImpl(
+                      arg.sourcePos.toLSP,
+                      s"${param.name.show} = "
+                    )
+                  )
+              }
+          end if
+        case t =>
+          traverseChildren(t)
+    traverser.traverse(tree)(using newctx)
+    result.result
+  end paramNameHints
+end ParamNameHintProvider

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -185,6 +185,20 @@ case class ScalaPresentationCompiler(
         .asJava
     }
 
+  override def paramNameHints(
+      params: VirtualFileParams
+  ): CompletableFuture[ju.List[ParamNameHintResult]] =
+    val empty: ju.List[ParamNameHintResult] =
+      new ju.ArrayList[ParamNameHintResult]()
+    compilerAccess.withInterruptableCompiler(empty, params.token) { pc =>
+      println("scalapc")
+      new ParamNameHintProvider(
+        params,
+        pc.compiler(),
+        config
+      ).paramNameHints.asJava
+    }
+
   override def selectionRange(
       params: ju.List[OffsetParams]
   ): CompletableFuture[ju.List[l.SelectionRange]] =

--- a/mtags/src/main/scala/scala/meta/internal/pc/ParamNameHintResultImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ParamNameHintResultImpl.scala
@@ -1,0 +1,8 @@
+package scala.meta.internal.pc
+
+import scala.meta.pc.ParamNameHintResult
+
+import org.eclipse.lsp4j.Range
+
+case class ParamNameHintResultImpl(range: Range, contentText: String)
+    extends ParamNameHintResult


### PR DESCRIPTION
https://github.com/scalameta/metals-feature-requests/issues/184

This PR enables Metals to show parameter name decorations, as [IntelliJ does](https://www.jetbrains.com/help/idea/inlay-hints.html).

<img width="561" alt="Screen Shot 2022-05-13 at 14 30 18" src="https://user-images.githubusercontent.com/9353584/168250155-4b8ea6d1-b046-4ea3-a960-2b92dc680fa1.png">

### TODOs
- [x] Support Scala3
- [ ] Support Scala2
- [ ] Add an server/client options to on/off this feature
- [ ] Should we show the decorations only for "simple" type?
  - How can we tell the type is "simple"?
- [ ] Refactoring (maybe we shouldn't add the logic into `SyntheticsDecorationProvider`, because it's not from SemanticDBs synthetics.
- [ ] Testing
- [ ] Cache the result, and try to reduce the number of calculation/profiling
- [ ] (Hopefully) migrate to Inlay Hint (but LSP4j doesn't support it until LSP4J 0.13.0), and support https://github.com/scalameta/metals/issues/4059
