### PR TITLE
feature: [Scala 3] Add completion item resolution

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionItemResolver.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionItemResolver.scala
@@ -1,14 +1,10 @@
 package scala.meta.internal.pc
 
-import scala.meta.internal.jdk.CollectionConverters._
-import scala.meta.internal.mtags.MtagsEnrichments._
-import scala.meta.pc.SymbolDocumentation
-
 import org.eclipse.lsp4j.CompletionItem
 
 class CompletionItemResolver(
     val compiler: MetalsGlobal
-) {
+) extends ItemResolver {
   import compiler._
   def resolve(item: CompletionItem, msym: String): CompletionItem = {
     val gsym = inverseSemanticdbSymbol(msym)
@@ -17,90 +13,19 @@ class CompletionItemResolver(
         symbolDocumentation(gsym.companion)
       ) match {
         case Some(info) if item.getDetail != null =>
-          if (isJavaSymbol(gsym)) {
-            val data = item.data.getOrElse(CompletionItemData.empty)
-            item.setLabel(replaceJavaParameters(info, item.getLabel))
-            if (metalsConfig.isCompletionItemDetailEnabled) {
-              item.setDetail(replaceJavaParameters(info, item.getDetail))
-            }
-            if (
-              item.getTextEdit != null && data.kind == CompletionItemData.OverrideKind
-            ) {
-              item.getTextEdit().asScala match {
-                case Left(textEdit) =>
-                  val newText =
-                    replaceJavaParameters(info, textEdit.getNewText())
-                  textEdit.setNewText(newText)
-                // Right[InsertReplaceEdit] is currently not used in Metals
-                case _ =>
-              }
-              item.setLabel(replaceJavaParameters(info, item.getLabel))
-            }
-          } else {
-            val defaults = info
-              .parameters()
-              .asScala
-              .iterator
-              .map(_.defaultValue())
-              .filterNot(_.isEmpty)
-              .toSeq
-            item.setLabel(replaceScalaDefaultParams(item.getLabel, defaults))
-            if (
-              metalsConfig.isCompletionItemDetailEnabled && !item
-                .getDetail()
-                .isEmpty()
-            ) {
-              item.setDetail(
-                replaceScalaDefaultParams(item.getDetail, defaults)
-              )
-            }
-          }
-          if (metalsConfig.isCompletionItemDocumentationEnabled) {
-            val docstring = fullDocstring(gsym)
-            item.setDocumentation(docstring.toMarkupContent)
-          }
+          enrichDocs(
+            item,
+            info,
+            metalsConfig,
+            fullDocstring(gsym),
+            isJavaSymbol(gsym)
+          )
         case _ =>
+          item
       }
-      item
     } else {
       item
     }
-  }
-
-  def replaceScalaDefaultParams(base: String, defaults: Seq[String]): String = {
-    val matcher = "= \\{\\}".r.pattern.matcher(base)
-    val out = new StringBuffer()
-    val it = defaults.iterator
-    while (matcher.find()) {
-      if (it.hasNext) {
-        matcher.appendReplacement(out, s"= ${it.next()}")
-      }
-    }
-    matcher.appendTail(out)
-    out.toString
-  }
-
-  // NOTE(olafur): it's hacky to use `String.replace("x$1", paramName)`, ideally we would use the
-  // signature printer to pretty-print the signature from scratch with parameter names. However, that approach
-  // is tricky because it would require us to JSON serialize/deserialize Scala compiler types. The reason
-  // we don't print Java parameter names in `textDocument/completions` is because that requires parsing the
-  // library dependency sources which is slow and `Thread.interrupt` cancellation triggers the `*-sources.jar`
-  // to close causing other problems.
-  private def replaceJavaParameters(
-      info: SymbolDocumentation,
-      detail: String
-  ): String = {
-    info
-      .parameters()
-      .asScala
-      .iterator
-      .zipWithIndex
-      .foldLeft(detail) { case (accum, (param, i)) =>
-        accum.replace(
-          s"x$$${i + 1}",
-          param.displayName()
-        )
-      }
   }
 
   def fullDocstring(gsym: Symbol): String = {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Signatures.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Signatures.scala
@@ -405,7 +405,7 @@ trait Signatures { compiler: MetalsGlobal =>
           if (includeDefaultParam && param.isParamWithDefault) {
             val defaultValue = infoParams(index).map(_.defaultValue()) match {
               case Some(value) if !value.isEmpty => value
-              case _ => "{}"
+              case _ => "..."
             }
             s" = $defaultValue"
           } else {

--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -4,12 +4,18 @@ import java.net.URI
 
 import scala.annotation.tailrec
 
+import scala.meta.internal.jdk.CollectionConverters.*
 import scala.meta.internal.pc.MetalsInteractive
+import scala.meta.internal.pc.SemanticdbSymbols
 import scala.meta.pc.OffsetParams
+import scala.meta.pc.ParentSymbols
 import scala.meta.pc.RangeParams
+import scala.meta.pc.SymbolDocumentation
+import scala.meta.pc.SymbolSearch
 
 import dotty.tools.dotc.Driver
 import dotty.tools.dotc.core.Contexts.*
+import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.NameOps.*
 import dotty.tools.dotc.core.Names.*
 import dotty.tools.dotc.core.Symbols.*
@@ -94,6 +100,9 @@ object MtagsEnrichments extends CommonMtagsEnrichments:
 
     def decodedName: String = sym.name.decoded
 
+    def companion: Symbol =
+      if sym.is(Module) then sym.companionClass else sym.companionModule
+
     def nameBackticked: String =
       KeywordWrapper.Scala3.backtickWrap(sym.decodedName)
 
@@ -121,4 +130,25 @@ object MtagsEnrichments extends CommonMtagsEnrichments:
     def backticked: String =
       KeywordWrapper.Scala3.backtickWrap(s)
 
+  extension (search: SymbolSearch)
+    def symbolDocumentation(symbol: Symbol)(using
+        Context
+    ): Option[SymbolDocumentation] =
+      def toSemanticdbSymbol(symbol: Symbol) =
+        SemanticdbSymbols.symbolName(
+          if !symbol.is(JavaDefined) && symbol.isPrimaryConstructor then
+            symbol.owner
+          else symbol
+        )
+      val sym = toSemanticdbSymbol(symbol)
+      val documentation = search.documentation(
+        sym,
+        new ParentSymbols:
+          def parents(): java.util.List[String] =
+            symbol.allOverriddenSymbols.map(toSemanticdbSymbol).toList.asJava
+      )
+      if documentation.isPresent then Some(documentation.get())
+      else None
+    end symbolDocumentation
+  end extension
 end MtagsEnrichments

--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -143,9 +143,7 @@ object MtagsEnrichments extends CommonMtagsEnrichments:
       val sym = toSemanticdbSymbol(symbol)
       val documentation = search.documentation(
         sym,
-        new ParentSymbols:
-          def parents(): java.util.List[String] =
-            symbol.allOverriddenSymbols.map(toSemanticdbSymbol).toList.asJava
+        () => symbol.allOverriddenSymbols.map(toSemanticdbSymbol).toList.asJava
       )
       if documentation.isPresent then Some(documentation.get())
       else None

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionItemResolver.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionItemResolver.scala
@@ -1,0 +1,88 @@
+package scala.meta.internal.pc
+
+import scala.meta.internal.mtags.MtagsEnrichments.*
+import scala.meta.pc.PresentationCompilerConfig
+import scala.meta.pc.SymbolDocumentation
+import scala.meta.pc.SymbolSearch
+
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Flags.*
+import dotty.tools.dotc.core.Symbols.*
+import dotty.tools.dotc.core.Types.TermRef
+import org.eclipse.lsp4j.CompletionItem
+
+object CompletionItemResolver extends ItemResolver:
+
+  override def adjustIndexOfJavaParams = 0
+
+  def resolve(
+      item: CompletionItem,
+      msym: String,
+      search: SymbolSearch,
+      metalsConfig: PresentationCompilerConfig
+  )(using Context): CompletionItem =
+    SemanticdbSymbols.inverseSemanticdbSymbol(msym) match
+      case gsym :: _ if gsym != NoSymbol =>
+        search
+          .symbolDocumentation(gsym)
+          .orElse(
+            search.symbolDocumentation(gsym.companion)
+          ) match
+          case Some(info) if item.getDetail != null =>
+            enrichDocs(
+              item,
+              info,
+              metalsConfig,
+              fullDocstring(gsym, search),
+              gsym.is(JavaDefined)
+            )
+          case _ =>
+            item
+        end match
+
+      case _ => item
+    end match
+  end resolve
+
+  private def fullDocstring(gsym: Symbol, search: SymbolSearch)(using
+      Context
+  ): String =
+    def docs(gsym: Symbol): String =
+      search.symbolDocumentation(gsym).fold("")(_.docstring())
+    val gsymDoc = docs(gsym)
+    def keyword(gsym: Symbol): String =
+      if gsym.isClass then "class"
+      else if gsym.is(Trait) then "trait"
+      else if gsym.isAllOf(JavaInterface) then "interface"
+      else if gsym.is(Module) then "object"
+      else ""
+    val companion = gsym.companion
+    if companion == NoSymbol || gsym.is(JavaDefined) then
+      if gsymDoc.isEmpty then
+        if gsym.isAliasType then
+          fullDocstring(gsym.info.dealias.typeSymbol, search)
+        else if gsym.is(Method) then
+          gsym.info.finalResultType match
+            case tr @ TermRef(_, sym) =>
+              fullDocstring(tr.symbol, search)
+            case _ =>
+              ""
+        else ""
+      else gsymDoc
+    else
+      val companionDoc = docs(companion)
+      if companionDoc.isEmpty then gsymDoc
+      else if gsymDoc.isEmpty then companionDoc
+      else
+        List(
+          s"""|### ${keyword(companion)} ${companion.name}
+              |$companionDoc
+              |""".stripMargin,
+          s"""|### ${keyword(gsym)} ${gsym.name}
+              |${gsymDoc}
+              |""".stripMargin
+        ).sorted.mkString("\n")
+    end if
+  end fullDocstring
+
+end CompletionItemResolver

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/InferredTypeProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/InferredTypeProvider.scala
@@ -12,6 +12,7 @@ import scala.meta.internal.pc.printer.MetalsPrinter
 import scala.meta.internal.pc.printer.ShortenedNames
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.PresentationCompilerConfig
+import scala.meta.pc.SymbolSearch
 import scala.meta.tokens.{Token as T}
 
 import dotty.tools.dotc.ast.Trees.*
@@ -49,7 +50,8 @@ import org.eclipse.lsp4j.TextEdit
 final class InferredTypeProvider(
     params: OffsetParams,
     driver: InteractiveDriver,
-    config: PresentationCompilerConfig
+    config: PresentationCompilerConfig,
+    symbolSearch: SymbolSearch
 ):
 
   def inferredTypeEdits(): List[TextEdit] =
@@ -77,7 +79,12 @@ final class InferredTypeProvider(
       shortenedNames.imports(autoImportsGen)
 
     def printType(tpe: Type): String =
-      val printer = MetalsPrinter.forInferredType(shortenedNames, indexedCtx)
+      val printer = MetalsPrinter.forInferredType(
+        shortenedNames,
+        indexedCtx,
+        symbolSearch,
+        includeDefaultParam = false
+      )
       printer.tpe(tpe)
 
     /*

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -34,9 +34,6 @@ sealed trait CompletionValue:
         else CompletionItemKind.Field
   end completionItemKind
 
-  final def documentation(using Context): Option[String] =
-    forSymOnly(ParsedComment.docOf(_).map(_.renderAsMarkdown), None)
-
   final def lspTags(using Context): List[CompletionItemTag] =
     forSymOnly(
       sym =>

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
@@ -179,7 +179,7 @@ class CompletionsProvider(
 
       item.setAdditionalTextEdits(additionalEdits.asJava)
 
-      val doc = completion match
+      completion match
         case v: CompletionValue.Symbolic =>
           item.setData(
             CompletionItemData(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
@@ -136,7 +136,11 @@ class CompletionsProvider(
       path: List[Tree],
       indexedContext: IndexedContext
   )(using ctx: Context): CompletionItem =
-    val printer = MetalsPrinter.standard(indexedContext)
+    val printer = MetalsPrinter.standard(
+      indexedContext,
+      search,
+      includeDefaultParam = false
+    )
     val editRange = completionPos.toEditRange
 
     // For overloaded signatures we get multiple symbols, so we need
@@ -175,9 +179,15 @@ class CompletionsProvider(
 
       item.setAdditionalTextEdits(additionalEdits.asJava)
 
-      completion.documentation
-        .filter(_.nonEmpty)
-        .foreach(doc => item.setDocumentation(doc.toMarkupContent))
+      val doc = completion match
+        case v: CompletionValue.Symbolic =>
+          item.setData(
+            CompletionItemData(
+              SemanticdbSymbols.symbolName(v.symbol),
+              buildTargetIdentifier
+            ).toJson
+          )
+        case _ => None
 
       item.setTags(completion.lspTags.asJava)
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -2,9 +2,11 @@ package scala.meta.internal.pc.printer
 
 import scala.collection.mutable
 
+import scala.meta.internal.jdk.CollectionConverters.*
 import scala.meta.internal.mtags.MtagsEnrichments.*
 import scala.meta.internal.pc.IndexedContext
 import scala.meta.internal.pc.Params
+import scala.meta.pc.SymbolSearch
 
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Flags
@@ -20,7 +22,12 @@ import dotty.tools.dotc.printing.Printer
 import dotty.tools.dotc.printing.RefinedPrinter
 import dotty.tools.dotc.printing.Texts.Text
 
-class MetalsPrinter(names: ShortenedNames, dotcPrinter: DotcPrinter)(using
+class MetalsPrinter(
+    names: ShortenedNames,
+    dotcPrinter: DotcPrinter,
+    symbolSearch: SymbolSearch,
+    includeDefaultParam: Boolean = false
+)(using
     Context
 ):
 
@@ -120,19 +127,35 @@ class MetalsPrinter(names: ShortenedNames, dotcPrinter: DotcPrinter)(using
         implicitEvidenceParams.toList
       )
 
+    lazy val defaultValues =
+      symbolSearch.symbolDocumentation(gsym) match
+        case Some(info) =>
+          (info.parameters.asScala ++ info.typeParameters.asScala)
+            .map(_.defaultValue)
+            .toSeq
+        case _ =>
+          Seq.empty
+
     def label(paramss: List[List[Symbol]]) = {
+      var index = 0
       paramss.flatMap { params =>
         val labels = params.flatMap { param =>
           // Don't show implicit evidence params
           // e.g.
           // from [A: Ordering](a: A, b: A)(implicit evidence$1: Ordering[A])
           // to   [A: Ordering](a: A, b: A): A
-          if implicitEvidenceParams.contains(param) then Nil
-          else
-            paramLabel(
-              param,
-              implicitEvidencesByTypeParam
-            ) :: Nil
+          val lab =
+            if implicitEvidenceParams.contains(param) then Nil
+            else
+              paramLabel(
+                param,
+                implicitEvidencesByTypeParam,
+                index,
+                defaultValues
+              ) :: Nil
+          index += 1
+          lab
+
         }
         // Remove empty params
         if labels.isEmpty then Nil
@@ -237,7 +260,9 @@ class MetalsPrinter(names: ShortenedNames, dotcPrinter: DotcPrinter)(using
    */
   private def paramLabel(
       param: Symbol,
-      implicitEvidences: Map[Symbol, List[String]]
+      implicitEvidences: Map[Symbol, List[String]],
+      index: Int,
+      defaultValues: => Seq[String]
   ): String =
     val keywordName = dotcPrinter.name(param)
     val paramTypeString = tpe(param.info)
@@ -255,7 +280,18 @@ class MetalsPrinter(names: ShortenedNames, dotcPrinter: DotcPrinter)(using
       // print only type string
       // e.g. "using Ord[T]" instead of "using x$0: Ord[T]"
       paramTypeString
-    else s"${keywordName}: ${paramTypeString}"
+    else
+      val isDefaultParam = param.isAllOf(DefaultParameter)
+      val default =
+        if includeDefaultParam && isDefaultParam then
+          val defaultValue = defaultValues.lift(index) match
+            case Some(value) if includeDefaultParam && !value.isEmpty => value
+            case _ => "{}"
+          s" = $defaultValue"
+        // to be populated later, otherwise we would spend too much time in completions
+        else if isDefaultParam then " = {}"
+        else ""
+      s"$keywordName: ${paramTypeString}$default"
     end if
   end paramLabel
 
@@ -288,15 +324,31 @@ end MetalsPrinter
 
 object MetalsPrinter:
 
-  def standard(indexed: IndexedContext): MetalsPrinter =
+  def standard(
+      indexed: IndexedContext,
+      symbolSearch: SymbolSearch,
+      includeDefaultParam: Boolean
+  ): MetalsPrinter =
     import indexed.ctx
-    MetalsPrinter(new ShortenedNames(indexed), DotcPrinter.Std())
+    MetalsPrinter(
+      new ShortenedNames(indexed),
+      DotcPrinter.Std(),
+      symbolSearch,
+      includeDefaultParam
+    )
 
   def forInferredType(
       shortenedNames: ShortenedNames,
-      indexed: IndexedContext
+      indexed: IndexedContext,
+      symbolSearch: SymbolSearch,
+      includeDefaultParam: Boolean
   ): MetalsPrinter =
     import shortenedNames.indexedContext.ctx
-    MetalsPrinter(shortenedNames, DotcPrinter.ForInferredType(indexed))
+    MetalsPrinter(
+      shortenedNames,
+      DotcPrinter.ForInferredType(indexed),
+      symbolSearch,
+      includeDefaultParam
+    )
 
 end MetalsPrinter

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -285,11 +285,11 @@ class MetalsPrinter(
       val default =
         if includeDefaultParam && isDefaultParam then
           val defaultValue = defaultValues.lift(index) match
-            case Some(value) if includeDefaultParam && !value.isEmpty => value
-            case _ => "{}"
+            case Some(value) if !value.isEmpty => value
+            case _ => "..."
           s" = $defaultValue"
         // to be populated later, otherwise we would spend too much time in completions
-        else if isDefaultParam then " = {}"
+        else if isDefaultParam then " = ..."
         else ""
       s"$keywordName: ${paramTypeString}$default"
     end if

--- a/mtags/src/main/scala/scala/meta/internal/pc/ItemResolver.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ItemResolver.scala
@@ -1,0 +1,104 @@
+package scala.meta.internal.pc
+
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.pc.PresentationCompilerConfig
+import scala.meta.pc.SymbolDocumentation
+
+import org.eclipse.lsp4j.CompletionItem
+
+trait ItemResolver {
+
+  protected def adjustIndexOfJavaParams = 1
+
+  protected def enrichDocs(
+      item: CompletionItem,
+      info: SymbolDocumentation,
+      metalsConfig: PresentationCompilerConfig,
+      docstring: => String,
+      isJava: => Boolean
+  ): CompletionItem = {
+    if (isJava) {
+      val data = item.data.getOrElse(CompletionItemData.empty)
+      item.setLabel(replaceJavaParameters(info, item.getLabel))
+      if (metalsConfig.isCompletionItemDetailEnabled) {
+        item.setDetail(replaceJavaParameters(info, item.getDetail))
+      }
+      if (
+        item.getTextEdit != null && data.kind == CompletionItemData.OverrideKind
+      ) {
+        item.getTextEdit().asScala match {
+          case Left(textEdit) =>
+            val newText =
+              replaceJavaParameters(info, textEdit.getNewText())
+            textEdit.setNewText(newText)
+          // Right[InsertReplaceEdit] is currently not used in Metals
+          case _ =>
+        }
+        item.setLabel(replaceJavaParameters(info, item.getLabel))
+      }
+    } else {
+      val defaults = info
+        .parameters()
+        .asScala
+        .iterator
+        .map(_.defaultValue())
+        .filterNot(_.isEmpty)
+        .toSeq
+      item.setLabel(replaceScalaDefaultParams(item.getLabel, defaults))
+      if (
+        metalsConfig.isCompletionItemDetailEnabled && !item
+          .getDetail()
+          .isEmpty()
+      ) {
+        item.setDetail(
+          replaceScalaDefaultParams(item.getDetail, defaults)
+        )
+      }
+    }
+    if (metalsConfig.isCompletionItemDocumentationEnabled) {
+      item.setDocumentation(docstring.toMarkupContent)
+    }
+    item
+  }
+
+  // NOTE(olafur): it's hacky to use `String.replace("x$1", paramName)`, ideally we would use the
+  // signature printer to pretty-print the signature from scratch with parameter names. However, that approach
+  // is tricky because it would require us to JSON serialize/deserialize Scala compiler types. The reason
+  // we don't print Java parameter names in `textDocument/completions` is because that requires parsing the
+  // library dependency sources which is slow and `Thread.interrupt` cancellation triggers the `*-sources.jar`
+  // to close causing other problems.
+  protected def replaceJavaParameters(
+      info: SymbolDocumentation,
+      detail: String
+  ): String = {
+    info
+      .parameters()
+      .asScala
+      .iterator
+      .zipWithIndex
+      .foldLeft(detail) { case (accum, (param, i)) =>
+        accum.replace(
+          s"x$$${i + adjustIndexOfJavaParams}",
+          param.displayName()
+        )
+      }
+  }
+
+  protected def replaceScalaDefaultParams(
+      base: String,
+      defaults: Seq[String]
+  ): String = {
+    val matcher = "= \\{\\}".r.pattern.matcher(base)
+    val out = new StringBuffer()
+    val it = defaults.iterator
+    while (matcher.find()) {
+      if (it.hasNext) {
+        matcher.appendReplacement(out, s"= ${it.next()}")
+      }
+    }
+    matcher.appendTail(out)
+    out.toString
+  }
+
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/ItemResolver.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ItemResolver.scala
@@ -89,7 +89,7 @@ trait ItemResolver {
       base: String,
       defaults: Seq[String]
   ): String = {
-    val matcher = "= \\{\\}".r.pattern.matcher(base)
+    val matcher = "= \\.\\.\\.".r.pattern.matcher(base)
     val out = new StringBuffer()
     val it = defaults.iterator
     while (matcher.find()) {

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -653,6 +653,8 @@ class CompletionDocSuite extends BaseCompletionSuite {
        |""".stripMargin,
     includeDocs = true
   )
+
+  // New completions not yet implemented for Scala 3
   check(
     "scala11".tag(IgnoreScala3),
     """

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -702,8 +702,8 @@ class CompletionSuite extends BaseCompletionSuite {
        |""".stripMargin,
     compat = Map(
       "3" ->
-        """|readAttributes(x$0: Path, x$1: String, x$2: LinkOption*): java.util.Map[String, Object]
-           |readAttributes[A <: BasicFileAttributes](x$0: Path, x$1: Class[A], x$2: LinkOption*): A
+        """|readAttributes(path: Path, attributes: String, options: LinkOption*): java.util.Map[String, Object]
+           |readAttributes[A <: BasicFileAttributes](path: Path, type: Class[A], options: LinkOption*): A
            |""".stripMargin
     )
   )
@@ -1141,13 +1141,7 @@ class CompletionSuite extends BaseCompletionSuite {
     """substring(beginIndex: Int): String
       |substring(beginIndex: Int, endIndex: Int): String
       |""".stripMargin,
-    filterText = "substring",
-    compat = Map(
-      "3" ->
-        """|substring(x$0: Int): String
-           |substring(x$0: Int, x$1: Int): String
-           |""".stripMargin
-    )
+    filterText = "substring"
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -520,8 +520,8 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       |  User(age = 1, @@)
       |}
     """.stripMargin,
-    """|apply(<age: Int = {}>, <name: String = {}>): User
-       |                       ^^^^^^^^^^^^^^^^^^^
+    """|apply(<age: Int = ...>, <name: String = ...>): User
+       |                        ^^^^^^^^^^^^^^^^^^^^
        |""".stripMargin,
     compat = Map(
       "3" ->
@@ -539,8 +539,8 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       |  User(name = "", @@)
       |}
     """.stripMargin,
-    """|apply(name: String = {}, age: Int = {}): User
-       |                         ^^^^^^^^^^^^^
+    """|apply(name: String = ..., age: Int = ...): User
+       |                          ^^^^^^^^^^^^^^
        |""".stripMargin,
     compat = Map(
       "3" ->
@@ -604,7 +604,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       |  new scala.util.control.Exception.Catch(@@)
       |}
     """.stripMargin,
-    """|<init>(pf: Exception.Catcher[T], fin: Option[Exception.Finally] = {}, rethrow: Throwable => Boolean = {}): Exception.Catch[T]
+    """|<init>(pf: Exception.Catcher[T], fin: Option[Exception.Finally] = ..., rethrow: Throwable => Boolean = ...): Exception.Catch[T]
        |       ^^^^^^^^^^^^^^^^^^^^^^^^
        |""".stripMargin,
     compat = Map(

--- a/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
@@ -90,18 +90,9 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
       _ = assertNoDiagnostics()
       _ <- assertCompletion(
         "\"\".substrin@@",
-        getExpected(
-          """|substring(beginIndex: Int): String
-             |substring(beginIndex: Int, endIndex: Int): String
-             |""".stripMargin,
-          Map(
-            "3" ->
-              """|substring(x$0: Int): String
-                 |substring(x$0: Int, x$1: Int): String
-                 |""".stripMargin
-          ),
-          scalaVersion
-        )
+        """|substring(beginIndex: Int): String
+           |substring(beginIndex: Int, endIndex: Int): String
+           |""".stripMargin
       )
       _ <- assertCompletion(
         "Stream@@",


### PR DESCRIPTION
This code is mostly copied over from Scala 2 and adapted to Scala 3. I also moved a couple of parts to a common trait.

Now, in Scala 3 we get scaladoc and shows default values when moving accross completions. Previously, we would onlt show the ones from the compiler and eagerly, which is not needed.

![completion-resolve](https://user-images.githubusercontent.com/3807253/168320712-35bd85ea-4882-4649-b0b2-125d691f143a.gif)

You can see what is added on the right.