### PR TITLE
fix: symbolSearch - support encoded names from classpath

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/PackageIndex.scala
@@ -13,6 +13,7 @@ import java.util.jar.JarFile
 import java.util.logging.Level
 import java.util.logging.Logger
 
+import scala.reflect.NameTransformer
 import scala.util.Properties
 import scala.util.control.NonFatal
 
@@ -56,7 +57,7 @@ class PackageIndex() {
   def addMember(pkg: String, member: String): Unit = {
     if (!member.contains("module-info.class")) {
       val members = packages.computeIfAbsent(pkg, enterPackage)
-      members.add(member)
+      members.add(NameTransformer.decode(member))
     }
   }
 

--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -360,4 +360,24 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
       )
     } yield ()
   }
+
+  test("symbolic-from-classpath") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """
+          |/metals.json
+          |{
+          |  "a": {}
+          |}
+          |""".stripMargin
+      )
+      _ = assertNoDiff(
+        server.workspaceSymbol("<:<"),
+        """|scala.<:<
+           |scala.<:<
+           |""".stripMargin
+      )
+    } yield ()
+  }
 }


### PR DESCRIPTION
Classpath search is based on filenames inside jars which might be
encoded. Like: `<:<` -> `$less$colon$less`.