### PR TITLE
chore: update scala3 version in welcome msg

### DIFF
--- a/project/Welcome.scala
+++ b/project/Welcome.scala
@@ -59,7 +59,7 @@ object Welcome {
     ),
     UsefulTask(
       "",
-      "++3.0.0 mtags/publishLocal",
+      s"++${V.scala3} mtags/publishLocal",
       "publish changes for a single Scala version, especially useful if working on a feature inside mtags module." +
         " `publishLocal` will still need to be run before at least once."
     )


### PR DESCRIPTION
Use current scala3 version instead of hardcoded `3.0.0`

<img width="555" alt="Screenshot 2022-05-14 at 10 47 05" src="https://user-images.githubusercontent.com/37124721/168418470-74841061-e9e4-4033-a6ff-c95ead09eee5.png">
