### PR TITLE
chore(docs): ensure metals_2.12 is replaced with metals_2.13

### DIFF
--- a/docs/integrations/new-editor.md
+++ b/docs/integrations/new-editor.md
@@ -16,7 +16,7 @@ Use [Coursier](https://github.com/coursier/coursier) to obtain the JVM classpath
 of Metals:
 
 ```sh
-coursier bootstrap org.scalameta:metals_2.12:@VERSION@ -o metals -f
+coursier bootstrap org.scalameta:metals_2.13:@VERSION@ -o metals -f
 ```
 
 (optional) It's recommended to enable JVM string de-duplication and provide a
@@ -28,7 +28,7 @@ coursier bootstrap \
   --java-opt -XX:+UseStringDeduplication  \
   --java-opt -Xss4m \
   --java-opt -Xms100m \
-  org.scalameta:metals_2.12:@VERSION@ -o metals -f
+  org.scalameta:metals_2.13:@VERSION@ -o metals -f
 ```
 
 See [Metals server properties](#metals-server-properties) for additional system

--- a/metals-docs/src/main/scala/docs/BootstrapModifier.scala
+++ b/metals-docs/src/main/scala/docs/BootstrapModifier.scala
@@ -28,7 +28,7 @@ class BootstrapModifier extends StringModifier {
            |  --java-opt -Xss4m \\
            |  --java-opt -Xms100m \\
            |  --java-opt -Dmetals.client=$client \\
-           |  org.scalameta:metals_2.12:${Docs.release.version} \\
+           |  org.scalameta:metals_2.13:${Docs.release.version} \\
            |  -r bintray:scalacenter/releases \\
            |  -r sonatype:snapshots \\
            |  -o /usr/local/bin/$binary -f


### PR DESCRIPTION
Since Metals is now published for 2.13, this replaces the last remaining
places in the docs where it mentions 2.12 in any instructions.