### PR TITLE
Include proper names when using implement all completion and code action

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -211,8 +211,17 @@ class CompletionProvider(
       }
 
       val completionItemDataKind = member match {
+        case _: ImplementAllMember =>
+          CompletionItemData.ImplementAllKind
         case o: OverrideDefMember if o.sym.isJavaDefined =>
           CompletionItemData.OverrideKind
+        case _ =>
+          null
+      }
+
+      val additionalSymbols = member match {
+        case oam: ImplementAllMember =>
+          oam.additionalSymbols.map(semanticdbSymbol).asJava
         case _ =>
           null
       }
@@ -221,7 +230,8 @@ class CompletionProvider(
         CompletionItemData(
           semanticdbSymbol(member.sym),
           buildTargetIdentifier,
-          kind = completionItemDataKind
+          kind = completionItemDataKind,
+          additionalSymbols
         ).toJson
       )
       item.setKind(completionItemKind(member))

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionItemData.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionItemData.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.pc
 
+import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
@@ -8,7 +9,8 @@ case class CompletionItemData(
     symbol: String,
     target: String,
     // The kind of the completion item, for example `override def`
-    kind: java.lang.Integer = null
+    kind: java.lang.Integer = null,
+    additionalSymbols: java.util.List[String] = null
 ) {
   def toJson: JsonElement = {
     val obj = new JsonObject()
@@ -16,6 +18,11 @@ case class CompletionItemData(
     obj.add("target", new JsonPrimitive(target))
     if (kind != null) {
       obj.add("kind", new JsonPrimitive(kind))
+    }
+    if (additionalSymbols != null) {
+      val arr = new JsonArray()
+      additionalSymbols.forEach(str => arr.add(new JsonPrimitive(str)))
+      obj.add("additionalSymbols", arr)
     }
     obj
   }
@@ -25,4 +32,6 @@ object CompletionItemData {
   def empty: CompletionItemData = CompletionItemData("", "")
   // This is an `override def` completion item.
   val OverrideKind: java.lang.Integer = 1
+  // This is a completion implementing all abstract members
+  val ImplementAllKind: java.lang.Integer = 2
 }

--- a/mtags/src/main/scala/scala/meta/internal/pc/ItemResolver.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ItemResolver.scala
@@ -25,9 +25,24 @@ trait ItemResolver {
         item.setDetail(replaceJavaParameters(info, item.getDetail))
       }
       if (
-        item.getTextEdit != null && data.kind == CompletionItemData.OverrideKind
+        item.getTextEdit != null && (
+          data.kind == CompletionItemData.OverrideKind ||
+            data.kind == CompletionItemData.ImplementAllKind
+        )
       ) {
         item.getTextEdit().asScala match {
+          case Left(textEdit)
+              if data.kind == CompletionItemData.ImplementAllKind =>
+            val editText = textEdit.getNewText()
+
+            val relatedEditOnly = editText.linesIterator
+              .filter(
+                _.contains(info.displayName() + "(")
+              )
+              .mkString
+            val newText =
+              replaceJavaParameters(info, relatedEditOnly)
+            textEdit.setNewText(editText.replace(relatedEditOnly, newText))
           case Left(textEdit) =>
             val newText =
               replaceJavaParameters(info, textEdit.getNewText())

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideAllSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideAllSuite.scala
@@ -373,4 +373,30 @@ class CompletionOverrideAllSuite extends BaseCompletionSuite {
        |""".stripMargin,
     filter = _.contains("Implement")
   )
+
+  checkEdit(
+    "java",
+    """|package example
+       |
+       |import java.io.Externalizable
+       |
+       |object Main extends Externalizable {
+       |  def@@ 
+       |}
+       |""".stripMargin,
+    """|package example
+       |
+       |import java.io.Externalizable
+       |import java.io.ObjectOutput
+       |import java.io.ObjectInput
+       |
+       |object Main extends Externalizable {
+       |  def writeExternal(out: ObjectOutput): Unit = ${0:???}
+       |
+       |  def readExternal(in: ObjectInput): Unit = ${0:???}
+       | 
+       |}
+       |""".stripMargin,
+    filter = _.contains("Implement")
+  )
 }

--- a/tests/unit/src/test/scala/tests/codeactions/ImplementAbstractMembersLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImplementAbstractMembersLspSuite.scala
@@ -219,4 +219,31 @@ class ImplementAbstractMembersLspSuite
        |}
        |""".stripMargin
   )
+
+  check(
+    "java",
+    """|package example
+       |
+       |import java.io.Externalizable
+       |
+       |object <<A>> extends Externalizable {
+       |}
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package example
+       |
+       |import java.io.Externalizable
+       |import java.io.ObjectOutput
+       |import java.io.ObjectInput
+       |
+       |object A extends Externalizable {
+       |
+       |  override def writeExternal(out: ObjectOutput): Unit = ???
+       |
+       |  override def readExternal(in: ObjectInput): Unit = ???
+       |
+       |}
+       |""".stripMargin
+  )
 }


### PR DESCRIPTION
Previously, we would use x$0 etc for Java parameter names, which was caused by completions not resolving documentation by design. Now, we resolve the names for 'implement all' completion and always resolve docs for 'implement all' code action.

This turned out much harder to fix than I estimated.