### PR TITLE
Fix expression type for inlined methods and show all flags for methods

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -156,6 +156,8 @@ object HoverProvider:
             case t: GenericApply
                 if t.fun.srcPos.span.contains(pos.span) && !t.tpe.isErroneous =>
               tryTail(tail).orElse(Some(enclosing))
+            case in: Inlined =>
+              tryTail(tail).orElse(Some(enclosing))
             case New(_) =>
               tail match
                 case Nil => None

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -229,6 +229,10 @@ object MetalsInteractive:
             select.name == StdNames.nme.apply =>
         List((head.symbol, head.typeOpt))
 
+      // for Inlined we don't have a symbol, but it's needed to show proper type
+      case (head @ Inlined(call, bindings, expansion)) :: _ =>
+        List((call.symbol, head.typeOpt))
+
       // for comprehension
       case (head @ ApplySelect(select)) :: _ if isForSynthetic(head) =>
         // If the cursor is on the qualifier, return the symbol for it

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -31,6 +31,21 @@ class MetalsPrinter(
     Context
 ):
 
+  private val methodFlags =
+    Flags.commonFlags(
+      Private,
+      Protected,
+      Final,
+      Implicit,
+      Given,
+      Override,
+      Transparent,
+      Erased,
+      Inline,
+      AbsOverride,
+      Lazy
+    )
+
   private val defaultWidth = 1000
 
   def expressionType(tpw: Type)(using Context): Option[String] =
@@ -174,12 +189,16 @@ class MetalsPrinter(
     val paramssSignature = paramssString(paramLabelss, methodParams)
       .mkString("", "", s": ${returnType}")
 
+    val flags = (gsym.flags & methodFlags)
+    val flagString =
+      if !flags.isEmpty then Flags.flagsString(flags) + " " else ""
+
     if onlyMethodParams then paramssSignature
     else
       // For Scala2 compatibility, show "this" instead of <init> for constructor
       val name = if gsym.isConstructor then StdNames.nme.this_ else gsym.name
       extensionSignatureString +
-        s"def $name" +
+        s"${flagString}def $name" +
         paramssSignature
   end defaultMethodSignature
 

--- a/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
@@ -55,7 +55,7 @@ class HoverDocSuite extends BaseHoverSuite {
            |```
            |**Symbol signature**:
            |```scala
-           |def emptyList[T]: java.util.List[T]
+           |final def emptyList[T]: java.util.List[T]
            |```
            |Returns an empty list (immutable).  This list is serializable.
            |
@@ -75,34 +75,25 @@ class HoverDocSuite extends BaseHoverSuite {
       |}
       |""".stripMargin,
     // Assert that the docstring is extracted.
+
     """|```scala
-       |def headOption: Option[Int]
+       |override def headOption: Option[Int]
        |```
        |Optionally selects the first element.
-       | $orderDependent
+       | Note: might return different results for different runs, unless the underlying collection type is ordered.
        |
-       |**Returns:** the first element of this traversable collection if it is nonempty,
+       |**Returns:** the first element of this iterable collection if it is nonempty,
        |          `None` if it is empty.
        |""".stripMargin,
     compat = Map(
-      "2.13" ->
-        """|```scala
-           |override def headOption: Option[Int]
-           |```
-           |Optionally selects the first element.
-           | Note: might return different results for different runs, unless the underlying collection type is ordered.
-           |
-           |**Returns:** the first element of this iterable collection if it is nonempty,
-           |          `None` if it is empty.
-           |""".stripMargin,
-      "3" ->
+      "2.12" ->
         """|```scala
            |def headOption: Option[Int]
            |```
            |Optionally selects the first element.
-           | Note: might return different results for different runs, unless the underlying collection type is ordered.
+           | $orderDependent
            |
-           |**Returns:** the first element of this iterable collection if it is nonempty,
+           |**Returns:** the first element of this traversable collection if it is nonempty,
            |          `None` if it is empty.
            |""".stripMargin
     )

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -16,7 +16,7 @@ class HoverTermSuite extends BaseHoverSuite {
     compat = Map(
       "3" ->
         """|List[String]
-           |def map[B](f: Int => B): List[B]""".stripMargin.hover
+           |override final def map[B](f: Int => B): List[B]""".stripMargin.hover
     )
   )
 
@@ -248,7 +248,7 @@ class HoverTermSuite extends BaseHoverSuite {
     compat = Map(
       "3" ->
         """|Option[Int]#WithFilter
-           |def withFilter(p: A => Boolean): Option.this.WithFilter
+           |final def withFilter(p: A => Boolean): Option.this.WithFilter
            |""".stripMargin.hover
     )
   )
@@ -270,7 +270,7 @@ class HoverTermSuite extends BaseHoverSuite {
     compat = Map(
       "3" ->
         """|Option[String]
-           |def map[B](f: A => B): Option[B]
+           |final def map[B](f: A => B): Option[B]
            |""".stripMargin.hover
     )
   )
@@ -308,7 +308,7 @@ class HoverTermSuite extends BaseHoverSuite {
     compat = Map(
       "3" ->
         """|Option[String]
-           |def map[B](f: A => B): Option[B]
+           |final def map[B](f: A => B): Option[B]
            |""".stripMargin.hover
     )
   )
@@ -329,7 +329,7 @@ class HoverTermSuite extends BaseHoverSuite {
     compat = Map(
       "3" ->
         """|Option[Int]#WithFilter
-           |def withFilter(p: A => Boolean): Option.this.WithFilter
+           |final def withFilter(p: A => Boolean): Option.this.WithFilter
            """.stripMargin.hover
     )
   )
@@ -351,7 +351,7 @@ class HoverTermSuite extends BaseHoverSuite {
            |""".stripMargin.hover,
       "3" ->
         """|Option[Int]
-           |def headOption: Option[A]
+           |override def headOption: Option[A]
            |""".stripMargin.hover
     )
   )

--- a/tests/cross/src/test/scala/tests/hover/RangeHoverSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/RangeHoverSuite.scala
@@ -86,15 +86,12 @@ class RangeHoverSuite extends BaseHoverSuite {
        |  }
        |}
        |""".stripMargin,
-    """|immutable.IndexedSeq[Int]
-       |def flatMap[B, That](f: Int => GenTraversableOnce[B])(implicit bf: CanBuildFrom[immutable.IndexedSeq[Int],B,That]): That""".stripMargin.hoverRange,
+    """|IndexedSeq[Int]
+       |override def flatMap[B](f: Int => IterableOnce[B]): IndexedSeq[B]""".stripMargin.hoverRange,
     compat = Map(
-      "2.13" ->
-        """|IndexedSeq[Int]
-           |override def flatMap[B](f: Int => IterableOnce[B]): IndexedSeq[B]""".stripMargin.hoverRange,
-      "3" ->
-        """|IndexedSeq[Int]
-           |def flatMap[B](f: Int => IterableOnce[B]): IndexedSeq[B]""".stripMargin.hoverRange
+      "2.12" ->
+        """|immutable.IndexedSeq[Int]
+           |def flatMap[B, That](f: Int => GenTraversableOnce[B])(implicit bf: CanBuildFrom[immutable.IndexedSeq[Int],B,That]): That""".stripMargin.hoverRange
     )
   )
 
@@ -248,5 +245,17 @@ class RangeHoverSuite extends BaseHoverSuite {
        |""".stripMargin,
     """|Int
        |def sum[B >: Int](implicit num: Numeric[B]): B""".stripMargin.hoverRange
+  )
+
+  check(
+    "transparent".tag(IgnoreScala2),
+    """|trait Foo
+       |class Bar extends Foo
+       |
+       |transparent inline def foo(i: Int): Foo = new Bar
+       |val bar = <<%<%foo(1)%>%>>
+       |""".stripMargin,
+    """|Bar
+       |inline transparent def foo(i: Int): Foo""".stripMargin.hoverRange
   )
 }


### PR DESCRIPTION
Previously, when an expression was inlined and was transparent we would not show the proper type as indicated by transparent. Besides that no flags were shown for methods. Now, we also check for Inlined tree node when expanding and also show the proper flag string.

Fixes https://github.com/scalameta/metals/issues/3929