### PR TITLE
Fix nightlies tests and uncomment SignaturePat suite tests

### DIFF
--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -284,6 +284,14 @@ abstract class BasePCSuite extends BaseSuite {
       }
     }
 
+    def forLaterThan(version: String): IgnoreScalaVersion = {
+      val disableFrom = SemVer.Version.fromString(version)
+      IgnoreScalaVersion { v =>
+        val semver = SemVer.Version.fromString(v)
+        !(disableFrom > semver)
+      }
+    }
+
   }
 
   object IgnoreScala2 extends IgnoreScalaVersion(_.startsWith("2."))

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -312,6 +312,47 @@ class CompletionSuite extends BaseCompletionSuite {
            |wait: Unit
            |wait(x$0: Long): Unit
            |wait(x$0: Long, x$1: Int): Unit
+           |""".stripMargin,
+      "3.2" ->
+        """|empty[A]: List[A]
+           |from[B](coll: IterableOnce[B]): List[B]
+           |newBuilder[A]: Builder[A, List[A]]
+           |apply[A](elems: A*): List[A]
+           |concat[A](xss: Iterable[A]*): List[A]
+           |fill[A](n1: Int, n2: Int)(elem: => A): List[List[A] @uncheckedVariance]
+           |fill[A](n1: Int, n2: Int, n3: Int)(elem: => A): List[List[List[A]] @uncheckedVariance]
+           |fill[A](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => A): List[List[List[List[A]]] @uncheckedVariance]
+           |fill[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => A): List[List[List[List[List[A]]]] @uncheckedVariance]
+           |fill[A](n: Int)(elem: => A): List[A]
+           |iterate[A](start: A, len: Int)(f: A => A): List[A]
+           |range[A: Integral](start: A, end: A): List[A]
+           |range[A: Integral](start: A, end: A, step: A): List[A]
+           |tabulate[A](n1: Int, n2: Int)(f: (Int, Int) => A): List[List[A] @uncheckedVariance]
+           |tabulate[A](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => A): List[List[List[A]] @uncheckedVariance]
+           |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): List[List[List[List[A]]] @uncheckedVariance]
+           |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): List[List[List[List[List[A]]]] @uncheckedVariance]
+           |tabulate[A](n: Int)(f: Int => A): List[A]
+           |unapplySeq[A](x: List[A] @uncheckedVariance): UnapplySeqWrapper[A]
+           |unfold[A, S](init: S)(f: S => Option[(A, S)]): List[A]
+           |->[B](y: B): (A, B)
+           |ensuring(cond: Boolean): A
+           |ensuring(cond: A => Boolean): A
+           |ensuring(cond: Boolean, msg: => Any): A
+           |ensuring(cond: A => Boolean, msg: => Any): A
+           |nn: x.type & T
+           |formatted(fmtstr: String): String
+           |→[B](y: B): (A, B)
+           |iterableFactory[A]: Factory[A, CC[A]]
+           |asInstanceOf[X0]: X0
+           |equals(x$0: Any): Boolean
+           |getClass[X0 >: List.type]: Class[? <: X0]
+           |hashCode: Int
+           |isInstanceOf[X0]: Boolean
+           |synchronized[X0](x$0: X0): X0
+           |toString: String
+           |wait: Unit
+           |wait(x$0: Long): Unit
+           |wait(x$0: Long, x$1: Int): Unit
            |""".stripMargin
     )
   )

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
@@ -4,10 +4,6 @@ import tests.BaseSignatureHelpSuite
 
 class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
 
-  // @tgodzik docs not yet supported for Scala 3
-  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
-    Some(IgnoreScala3)
-
   check(
     "case",
     """
@@ -24,12 +20,18 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
       "2.13" ->
         """|map[B](f: ((Int, Int)) => B): List[B]
            |       ^^^^^^^^^^^^^^^^^^^^
+           |""".stripMargin,
+      "3" ->
+        """|map[B](f: A => B): List[B]
+           |       ^^^^^^^^^
            |""".stripMargin
     )
   )
 
   check(
-    "generic1",
+    "generic1".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |object Main {
       |  Option(1) match {
@@ -43,7 +45,8 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "generic2",
+    // https://github.com/lampepfl/dotty/issues/15248
+    "generic2".tag(IgnoreScala3),
     """
       |case class Two[T](a: T, b: T)
       |object Main {
@@ -58,7 +61,8 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "generic3",
+    // https://github.com/lampepfl/dotty/issues/15248
+    "generic3".tag(IgnoreScala3),
     """
       |case class HKT[C[_], T](a: C[T])
       |object Main {
@@ -73,7 +77,9 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "generic4",
+    "generic4".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |  case class Two[A, B](a: A, b: B)
       |  object Main {
@@ -84,11 +90,19 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
       |""".stripMargin,
     """|(Int, String)
        | ^^^
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|(a: Int, b: String)
+           | ^^^^^^
+           |""".stripMargin
+    )
   )
 
   check(
-    "generic5",
+    "generic5".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |class Two[A, B](a: A, b: B)
       |object Two {
@@ -108,7 +122,9 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "non-synthetic-unapply",
+    "non-synthetic-unapply".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |class HKT[C[_], T](a: C[T])
       |object HKT {
@@ -126,7 +142,9 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "non-synthetic-unapply-second",
+    "non-synthetic-unapply-second".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |class HKT[C[_], T](a: C[T])
       |object HKT {
@@ -144,7 +162,9 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "pat",
+    "pat".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |case class Person(name: String, age: Int)
       |object a {
@@ -154,11 +174,19 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
     """.stripMargin,
     """|(String, Int)
        | ^^^^^^
-       | """.stripMargin
+       | """.stripMargin,
+    compat = Map(
+      "3" ->
+        """|(name: String, age: Int)
+           | ^^^^^^^^^^^^
+           |""".stripMargin
+    )
   )
 
   check(
-    "pat1",
+    "pat1".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |class Person(name: String, age: Int)
       |object Person {
@@ -176,7 +204,9 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "pat2",
+    "pat2".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |object a {
       |  val Number = "$a, $b".r
@@ -187,11 +217,18 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
     """.stripMargin,
     """|(List[A])
        | ^^^^^^^
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3" -> """|(String)
+                | ^^^^^^
+                |""".stripMargin
+    )
   )
 
   check(
-    "pat3",
+    "pat3".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |object And {
       |  def unapply[A](a: A): Some[(A, A)] = Some((a, a))
@@ -229,7 +266,9 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "pat5",
+    "pat5".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |object OpenBrowserCommand {
       |  def unapply(command: String): Option[Int] = {
@@ -247,7 +286,8 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "pat6",
+    // https://github.com/lampepfl/dotty/issues/15248
+    "pat6".tag(IgnoreScala3),
     """
       |object OpenBrowserCommand {
       |  def unapply(command: String): Option[Option[Int]] = {
@@ -265,7 +305,8 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "pat-negative",
+    // https://github.com/lampepfl/dotty/issues/15248
+    "pat-negative".tag(IgnoreScala3),
     """
       |object And {
       |  def unapply[A](a: A): Some[(A, A)] = Some((a, a))

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -250,9 +250,17 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
         """|apply[A](elems: A*): List[A]
            |         ^^^^^^^^^
            |""".stripMargin,
-      "3" ->
+      "3.0" ->
         """|apply[A](x: A): Option[A]
            |         ^^^^
+           |""".stripMargin,
+      "3.1" ->
+        """|apply[A](x: A): Option[A]
+           |         ^^^^
+           |""".stripMargin,
+      "3" ->
+        """|apply[A](elems: A*): CC[A]
+           |         ^^^^^^^^^
            |""".stripMargin
     )
   )
@@ -268,7 +276,10 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
        |""".stripMargin
   )
   check(
-    "vararg",
+    // https://github.com/lampepfl/dotty/issues/15244
+    "vararg".tag(
+      IgnoreScalaVersion.forLaterThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |object a {
       |  List(1, 2@@
@@ -288,8 +299,10 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
            |""".stripMargin
     )
   )
+
   check(
-    "tparam",
+    // https://github.com/lampepfl/dotty/issues/15249
+    "tparam".tag(IgnoreScala3),
     """
       |object a {
       |  identity[I@@]
@@ -297,17 +310,11 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
     """.stripMargin,
     """|identity[A](x: A): A
        |         ^
-       |""".stripMargin,
-    compat = Map(
-      // TODO type signatures aren't handled
-      "3" ->
-        """|identity[A](x: A): A
-           |            ^^^^
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   check(
+    // https://github.com/lampepfl/dotty/issues/15249
     "tparam2".tag(IgnoreScala3),
     """
       |object a {
@@ -320,7 +327,8 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "tparam3",
+    // https://github.com/lampepfl/dotty/issues/15249
+    "tparam3".tag(IgnoreScala3),
     """
       |object a {
       |  Option[I@@]
@@ -328,16 +336,10 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
     """.stripMargin,
     """|apply[A](x: A): Option[A]
        |      ^
-       |""".stripMargin,
-    // TODO type signatures aren't handled
-    compat = Map(
-      "3" ->
-        """|apply[A](x: A): Option[A]
-           |         ^^^^
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
   check(
+    // https://github.com/lampepfl/dotty/issues/15249
     "tparam4".tag(IgnoreScala3),
     """
       |object a {
@@ -380,20 +382,16 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "error1",
+    "error1".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |object a {
       |  Map[Int](1 @@-> "").map {
       |  }
       |}
     """.stripMargin,
-    "",
-    compat = Map(
-      "3" ->
-        """|->[B](y: B): (A, B)
-           |      ^^^^
-           |""".stripMargin
-    )
+    ""
   )
   check(
     "for",
@@ -505,7 +503,11 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
     """.stripMargin,
     "",
     compat = Map(
-      "3" ->
+      "3.0" ->
+        """|->[B](y: B): (A, B)
+           |      ^^^^
+           |""".stripMargin,
+      "3.1" ->
         """|->[B](y: B): (A, B)
            |      ^^^^
            |""".stripMargin
@@ -734,7 +736,8 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "evidence",
+    // https://github.com/lampepfl/dotty/issues/15249
+    "evidence".tag(IgnoreScala3),
     """
       |object a {
       |  Array.empty[@@]
@@ -742,14 +745,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
     """.stripMargin,
     """|empty[T: ClassTag]: Array[T]
        |      ^^^^^^^^^^^
-       | """.stripMargin,
-    compat = Map(
-      // TODO type signatures are not yet supported
-      "3" ->
-        """|empty[T](using evidence$4: scala.reflect.ClassTag[T]): Array[T]
-           |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-           |""".stripMargin
-    )
+       | """.stripMargin
   )
 
   check(
@@ -776,6 +772,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
+    // https://github.com/lampepfl/dotty/issues/15249
     "type".tag(IgnoreScala3),
     """
       |object a {
@@ -800,19 +797,15 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "off-by-one",
+    "off-by-one".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |object a {
       |  identity(42)@@
       |}
       |""".stripMargin,
-    "",
-    compat = Map(
-      "3" ->
-        """|identity[A](x: A): A
-           |            ^^^^
-           |""".stripMargin
-    )
+    ""
   )
 
   check(
@@ -828,19 +821,15 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "between-parens",
+    "between-parens".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |object a {
       |  Option(1).fold(2)@@(_ + 1)
       |}
       |""".stripMargin,
-    "",
-    compat = Map(
-      "3" ->
-        """|fold[B](ifEmpty: => B)(f: A => B): B
-           |        ^^^^^^^^^^^^^
-           |""".stripMargin
-    )
+    ""
   )
 
   check(
@@ -862,7 +851,9 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "between-parens3",
+    "between-parens3".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |object a {
       |  Option(1).fold(2)(@@_ + 1)
@@ -873,15 +864,8 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
        |""".stripMargin,
     compat = Map(
       "3" ->
-        """|+(x: Double): Double
-           |+(x: Float): Float
-           |+(x: Long): Long
-           |+(x: Int): Int
-           |  ^^^^^^
-           |+(x: Char): Int
-           |+(x: Short): Int
-           |+(x: Byte): Int
-           |+(x: String): String
+        """|fold[B](ifEmpty: => B)(f: A => B): B
+           |                       ^^^^^^^^^
            |""".stripMargin
     )
   )


### PR DESCRIPTION
Two main changes here:
- updates to the signature help and Scala 3 (a lot of fixes and a bug reported upstream)
- fixed the failing test for CompletionSuite (it will probably fail once again when the proper fix is introduced into Dotty, but I hoped the fix would be made much sooner)
- added testing for Scala 3 unapply signature help with some more bugs reported upstream