### PR TITLE
feature: [Scala 3] Show correct inferred type in signature help

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -89,7 +89,7 @@ object HoverProvider:
               case _ =>
                 val (tpe, sym) =
                   if symbol.isType then (symbol.typeRef, symbol)
-                  else seenFrom(enclosing.head, symbol)
+                  else enclosing.head.seenFrom(symbol)
 
                 val finalTpe =
                   if tpe != NoType then tpe
@@ -128,21 +128,6 @@ object HoverProvider:
 
   extension (pos: SourcePosition)
     private def isPoint: Boolean = pos.start == pos.end
-
-  private def qual(tree: Tree): Tree =
-    tree match
-      case Apply(q, _) => qual(q)
-      case TypeApply(q, _) => qual(q)
-      case AppliedTypeTree(q, _) => qual(q)
-      case Select(q, _) => q
-      case _ => tree
-
-  private def seenFrom(tree: Tree, sym: Symbol)(using Context): (Type, Symbol) =
-    try
-      val pre = qual(tree)
-      val denot = sym.denot.asSeenFrom(pre.tpe.widenTermRefExpr)
-      (denot.info, sym.withUpdatedTpe(denot.info))
-    catch case NonFatal(e) => (sym.info, sym)
 
   private def expandRangeToEnclosingApply(
       path: List[Tree],

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpDocSuite.scala
@@ -54,35 +54,24 @@ class SignatureHelpDocSuite extends BaseSignatureHelpSuite {
     """.stripMargin,
     s"""$foldLatestDocs
        |**Parameters**
-       |- `ifEmpty`: the expression to evaluate if empty.
        |- `f`: the function to apply if nonempty.
+       |- `ifEmpty`: the expression to evaluate if empty.
        |fold[B](ifEmpty: => B)(f: Int => B): B
        |                       ^^^^^^^^^^^
        |  @param ifEmpty the expression to evaluate if empty.
        |  @param f the function to apply if nonempty.
-    """.stripMargin,
+        """.stripMargin,
     compat = Map(
-      "2.12.8" -> foldOlderDocs1,
-      "2.13" ->
+      "2.12" ->
         s"""$foldLatestDocs
            |**Parameters**
-           |- `f`: the function to apply if nonempty.
            |- `ifEmpty`: the expression to evaluate if empty.
+           |- `f`: the function to apply if nonempty.
            |fold[B](ifEmpty: => B)(f: Int => B): B
            |                       ^^^^^^^^^^^
            |  @param ifEmpty the expression to evaluate if empty.
            |  @param f the function to apply if nonempty.
-        """.stripMargin,
-      "3" ->
-        s"""$foldLatestDocs
-           |**Parameters**
-           |- `f`: the function to apply if nonempty.
-           |- `ifEmpty`: the expression to evaluate if empty.
-           |fold[B](ifEmpty: => B)(f: A => B): B
-           |                       ^^^^^^^^^
-           |  @param ifEmpty the expression to evaluate if empty.
-           |  @param f the function to apply if nonempty.
-        """.stripMargin
+           |""".stripMargin
     )
   )
 
@@ -137,7 +126,7 @@ class SignatureHelpDocSuite extends BaseSignatureHelpSuite {
             |**Parameters**
             |- `f`: the function to apply if nonempty.
             |- `ifEmpty`: the expression to evaluate if empty.
-            |fold[B](ifEmpty: => B)(f: A => B): B
+            |fold[B](ifEmpty: => B)(f: Int => B): B
             |        ^^^^^^^^^^^^^
             |  @param ifEmpty the expression to evaluate if empty.
             |  @param f the function to apply if nonempty.
@@ -230,8 +219,8 @@ class SignatureHelpDocSuite extends BaseSignatureHelpSuite {
            |          `op(...op(z, x), x, ..., x)` where `x, ..., x`
            |           are the elements of this collection.
            |          Returns `z` if this collection is empty.
-           |foldLeft[B](z: B)(op: (B, A) => B): B
-           |                  ^^^^^^^^^^^^^^^
+           |foldLeft[B](z: B)(op: (B, Int) => B): B
+           |                  ^^^^^^^^^^^^^^^^^
            |""".stripMargin
     )
   )
@@ -258,58 +247,43 @@ class SignatureHelpDocSuite extends BaseSignatureHelpSuite {
       |  List(1).map(x => @@)
       |}
     """.stripMargin,
-    """|Builds a new collection by applying a function to all elements of this general collection.
+    """|Builds a new collection by applying a function to all elements of this collection.
        |
        |
        |**Type Parameters**
-       |- `That`: the class of the returned collection. Where possible, `That` is
-       |the same class as the current collection class `Repr`, but this
-       |depends on the element type `B` being admissible for that class,
-       |which means that an implicit instance of type `CanBuildFrom[Repr, B, That]`
-       |is found.
        |- `B`: the element type of the returned collection.
        |
        |**Parameters**
-       |- `bf`: an implicit value of class `CanBuildFrom` which determines
-       |the result class `That` from the current representation type `Repr` and
-       |the new element type `B`.
        |- `f`: the function to apply to each element.
        |
-       |**Returns:** a new general collection resulting from applying the given function
-       |                 `f` to each element of this general collection and collecting the results.
-       |map[B, That](f: Int => B)(implicit bf: CanBuildFrom[List[Int],B,That]): That
-       |             ^^^^^^^^^^^
+       |**Returns:** a new collection resulting from applying the given function
+       |               `f` to each element of this collection and collecting the results.
+       |map[B](f: Int => B): List[B]
+       |       ^^^^^^^^^^^
        |""".stripMargin,
     compat = Map(
-      "2.13" ->
-        """|Builds a new collection by applying a function to all elements of this collection.
+      "2.12" ->
+        """|Builds a new collection by applying a function to all elements of this general collection.
            |
            |
            |**Type Parameters**
+           |- `That`: the class of the returned collection. Where possible, `That` is
+           |the same class as the current collection class `Repr`, but this
+           |depends on the element type `B` being admissible for that class,
+           |which means that an implicit instance of type `CanBuildFrom[Repr, B, That]`
+           |is found.
            |- `B`: the element type of the returned collection.
            |
            |**Parameters**
+           |- `bf`: an implicit value of class `CanBuildFrom` which determines
+           |the result class `That` from the current representation type `Repr` and
+           |the new element type `B`.
            |- `f`: the function to apply to each element.
            |
-           |**Returns:** a new collection resulting from applying the given function
-           |               `f` to each element of this collection and collecting the results.
-           |map[B](f: Int => B): List[B]
-           |       ^^^^^^^^^^^
-           |""".stripMargin,
-      "3" ->
-        """|Builds a new collection by applying a function to all elements of this collection.
-           |
-           |
-           |**Type Parameters**
-           |- `B`: the element type of the returned collection.
-           |
-           |**Parameters**
-           |- `f`: the function to apply to each element.
-           |
-           |**Returns:** a new collection resulting from applying the given function
-           |               `f` to each element of this collection and collecting the results.
-           |map[B](f: A => B): List[B]
-           |       ^^^^^^^^^
+           |**Returns:** a new general collection resulting from applying the given function
+           |                 `f` to each element of this general collection and collecting the results.
+           |map[B, That](f: Int => B)(implicit bf: CanBuildFrom[List[Int],B,That]): That
+           |             ^^^^^^^^^^^
            |""".stripMargin
     )
   )

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
@@ -13,17 +13,13 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
       |  }
       |}
       |""".stripMargin,
-    """|map[B, That](f: ((Int, Int)) => B)(implicit bf: CanBuildFrom[List[(Int, Int)],B,That]): That
-       |             ^^^^^^^^^^^^^^^^^^^^
+    """|map[B](f: ((Int, Int)) => B): List[B]
+       |       ^^^^^^^^^^^^^^^^^^^^
        |""".stripMargin,
     compat = Map(
-      "2.13" ->
-        """|map[B](f: ((Int, Int)) => B): List[B]
-           |       ^^^^^^^^^^^^^^^^^^^^
-           |""".stripMargin,
-      "3" ->
-        """|map[B](f: A => B): List[B]
-           |       ^^^^^^^^^
+      "2.12" ->
+        """|map[B, That](f: ((Int, Int)) => B)(implicit bf: CanBuildFrom[List[(Int, Int)],B,That]): That
+           |             ^^^^^^^^^^^^^^^^^^^^
            |""".stripMargin
     )
   )

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpPatternSuite.scala
@@ -241,7 +241,9 @@ class SignatureHelpPatternSuite extends BaseSignatureHelpSuite {
   )
 
   check(
-    "pat4",
+    "pat4".tag(
+      IgnoreScalaVersion.for3LessThan("3.2.0-RC1-bin-20220519-ee9cc8f-NIGHTLY")
+    ),
     """
       |object & {
       |  def unapply[A](a: A): Some[(A, A)] = Some((a, a))

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -51,13 +51,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
     """.stripMargin,
     """|fold[B](ifEmpty: => B)(f: Int => B): B
        |                       ^^^^^^^^^^^
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|fold[B](ifEmpty: => B)(f: A => B): B
-           |                       ^^^^^^^^^
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   check(
@@ -67,17 +61,13 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       |  List(1).map(@@)
       |}
     """.stripMargin,
-    """|map[B, That](f: Int => B)(implicit bf: CanBuildFrom[List[Int],B,That]): That
-       |             ^^^^^^^^^^^
+    """|map[B](f: Int => B): List[B]
+       |       ^^^^^^^^^^^
        |""".stripMargin,
     compat = Map(
-      "2.13" ->
-        """|map[B](f: Int => B): List[B]
-           |       ^^^^^^^^^^^
-           |""".stripMargin,
-      "3" ->
-        """|map[B](f: A => B): List[B]
-           |       ^^^^^^^^^
+      "2.12" ->
+        """|map[B, That](f: Int => B)(implicit bf: CanBuildFrom[List[Int],B,That]): That
+           |             ^^^^^^^^^^^
            |""".stripMargin
     )
   )
@@ -218,8 +208,8 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
        |""".stripMargin,
     compat = Map(
       "3" ->
-        """|collect[B](pf: PartialFunction[A, B]): Option[B]
-           |           ^^^^^^^^^^^^^^^^^^^^^^^^^
+        """|collect[B](pf: PartialFunction[Int, B]): Option[B]
+           |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
            |""".stripMargin
     )
   )
@@ -242,13 +232,13 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       |  List(Opt@@ion(1))
       |}
     """.stripMargin,
-    """|apply[A](xs: A*): List[A]
-       |         ^^^^^^
+    """|apply[A](elems: A*): List[A]
+       |         ^^^^^^^^^
        |""".stripMargin,
     compat = Map(
-      "2.13" ->
-        """|apply[A](elems: A*): List[A]
-           |         ^^^^^^^^^
+      "2.12" ->
+        """|apply[A](xs: A*): List[A]
+           |         ^^^^^^
            |""".stripMargin,
       "3.0" ->
         """|apply[A](x: A): Option[A]
@@ -257,10 +247,6 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       "3.1" ->
         """|apply[A](x: A): Option[A]
            |         ^^^^
-           |""".stripMargin,
-      "3" ->
-        """|apply[A](elems: A*): CC[A]
-           |         ^^^^^^^^^
            |""".stripMargin
     )
   )
@@ -285,18 +271,13 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       |  List(1, 2@@
       |}
     """.stripMargin,
-    """|apply[A](xs: A*): List[A]
-       |         ^^^^^^
+    """|apply[A](elems: A*): List[A]
+       |         ^^^^^^^^^
        |""".stripMargin,
     compat = Map(
-      "2.13" ->
-        """|apply[A](elems: A*): List[A]
-           |         ^^^^^^^^^
-           |""".stripMargin,
-      "3" ->
-        """|apply[A](elems: A*): CC[A]
-           |         ^^^^^^^^^
-           |""".stripMargin
+      "2.12" -> """|apply[A](xs: A*): List[A]
+                   |         ^^^^^^
+                   |""".stripMargin
     )
   )
 
@@ -480,17 +461,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
     """.stripMargin,
     """|applyOrElse[K1 <: Int, V1 >: String](x: K1, default: K1 => V1): V1
        |                                     ^^^^^
-       |""".stripMargin,
-    compat = Map(
-      "2.11" ->
-        """|applyOrElse[A1 <: Int, B1 >: String](x: A1, default: A1 => B1): B1
-           |                                     ^^^^^
-           |""".stripMargin,
-      "3" ->
-        """|applyOrElse[K1 <: K, V1 >: V](x: K1, default: K1 => V1): V1
-           |                              ^^^^^
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   check(
@@ -635,8 +606,8 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
            |""".stripMargin,
       // TODO short names are not supported yet
       "3" ->
-        """|computeIfAbsent(x$0: K, x$1: java.util.function.Function[? >: K, ? <: V]): V
-           |                ^^^^^^
+        """|computeIfAbsent(x$0: String, x$1: java.util.function.Function[? >: String, ? <: Int]): Int
+           |                ^^^^^^^^^^^
            |""".stripMargin
     )
   )
@@ -673,17 +644,13 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       |  List[Int]("").map(a => @@)
       |}
     """.stripMargin,
-    """|map[B, That](f: Int => B)(implicit bf: CanBuildFrom[List[Int],B,That]): That
-       |             ^^^^^^^^^^^
+    """|map[B](f: Int => B): List[B]
+       |       ^^^^^^^^^^^
        |""".stripMargin,
     compat = Map(
-      "2.13" ->
-        """|map[B](f: Int => B): List[B]
-           |       ^^^^^^^^^^^
-           |""".stripMargin,
-      "3" ->
-        """|map[B](f: A => B): List[B]
-           |       ^^^^^^^^^
+      "2.12" ->
+        """|map[B, That](f: Int => B)(implicit bf: CanBuildFrom[List[Int],B,That]): That
+           |             ^^^^^^^^^^^
            |""".stripMargin
     )
   )
@@ -695,17 +662,13 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       |  List(1).map(a => 2 @@)
       |}
     """.stripMargin,
-    """|map[B, That](f: Int => B)(implicit bf: CanBuildFrom[List[Int],B,That]): That
-       |             ^^^^^^^^^^^
+    """|map[B](f: Int => B): List[B]
+       |       ^^^^^^^^^^^
        |""".stripMargin,
     compat = Map(
-      "2.13" ->
-        """|map[B](f: Int => B): List[B]
-           |       ^^^^^^^^^^^
-           |""".stripMargin,
-      "3" ->
-        """|map[B](f: A => B): List[B]
-           |       ^^^^^^^^^
+      "2.12" ->
+        """|map[B, That](f: Int => B)(implicit bf: CanBuildFrom[List[Int],B,That]): That
+           |             ^^^^^^^^^^^
            |""".stripMargin
     )
   )
@@ -729,8 +692,8 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
        |""".stripMargin,
     compat = Map(
       "3" ->
-        """|map[G[_$3]](fn: A => G[A])(using T: last-arg3.TypeClass[F]): G[A]
-           |            ^^^^^^^^^^^^^
+        """|map[G[_$3]](fn: Int => G[Int])(using T: last-arg3.TypeClass[F]): G[Int]
+           |            ^^^^^^^^^^^^^^^^^
            |""".stripMargin
     )
   )
@@ -841,13 +804,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       |""".stripMargin,
     """|fold[B](ifEmpty: => B)(f: Int => B): B
        |        ^^^^^^^^^^^^^
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|fold[B](ifEmpty: => B)(f: A => B): B
-           |        ^^^^^^^^^^^^^
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   check(
@@ -861,13 +818,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       |""".stripMargin,
     """|fold[B](ifEmpty: => B)(f: Int => B): B
        |                       ^^^^^^^^^^^
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|fold[B](ifEmpty: => B)(f: A => B): B
-           |                       ^^^^^^^^^
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -239,14 +239,6 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       "2.12" ->
         """|apply[A](xs: A*): List[A]
            |         ^^^^^^
-           |""".stripMargin,
-      "3.0" ->
-        """|apply[A](x: A): Option[A]
-           |         ^^^^
-           |""".stripMargin,
-      "3.1" ->
-        """|apply[A](x: A): Option[A]
-           |         ^^^^
            |""".stripMargin
     )
   )
@@ -472,17 +464,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       |  }
       |}
     """.stripMargin,
-    "",
-    compat = Map(
-      "3.0" ->
-        """|->[B](y: B): (A, B)
-           |      ^^^^
-           |""".stripMargin,
-      "3.1" ->
-        """|->[B](y: B): (A, B)
-           |      ^^^^
-           |""".stripMargin
-    )
+    ""
   )
 
   check(


### PR DESCRIPTION
Previously, we would show the generic type of a method signature without trying to resolve the exact types. Now, we properly resolve types based on the qualifier.
