### PR TITLE
fix: avoid out of bounds for editors that treat \n as a line end

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
@@ -209,7 +209,8 @@ class NewFileProvider(
       .packageStatement(path)
       .map(_.fileContent)
       .getOrElse("")
-    val template = s"$pkg@@"
+    val template = s"""|$pkg@@
+                       |""".stripMargin
     createFileAndWriteText(path, NewFileTemplate(template))
   }
 

--- a/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
@@ -352,6 +352,7 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
     expectedFilePath = "a/src/main/scala/foo/Foo.scala",
     expectedContent = s"""|package foo
                           |
+                          |
                           |""".stripMargin
   )
 


### PR DESCRIPTION
So this isn't really a bug, but sort of an interesting difference in how
different editors handle \n -- whether they treat it as a line
terminator or an actual new blank line when at the end of a file.

Currently when you use the new scala file provider the text you end up
getting is just the package followed by multiple new lines. Some editors
will interpret this as the package line and then two new blank lines,
while others (like vim) will treat this as a package line, one blank
line, and then a line ending. Then when the Metals calculates the
position of the cursor it will be out of bounds for vim. This small
change just ensures the `@@` for the new blank file template is not on
the last line meaning it won't be out of bounds. There will be a slight
difference in VS Code though as there will be an extra new line, but the
cursor won't be on that new line. I figured this was a fair compromise
to ensure it still worked on all editors. Is this alright?

refs: #3937