### PR TITLE
docs(test-explorer): add note about test-user-interface

### DIFF
--- a/docs/integrations/test-explorer.md
+++ b/docs/integrations/test-explorer.md
@@ -19,7 +19,10 @@ Test Explorer (TE) provides two ways to interact with it:
 
 ## Integration
 
-In order to use TE, the client has to set `InitializationOptions.testExplorerProvider`. This action will deactivate code lenses for test classes and enable TE to send updates.
+In order to use TE, the client has to set
+`InitializationOptions.testExplorerProvider` and also have the user
+configuration setting `test-user-interface` set to `test explorer`. This action
+will deactivate code lenses for test classes and enable TE to send updates.
 
 The preferred way to implement TE is to implement client's command `metals-update-test-explorer`. Using this request, Metals will push all necessary updates to the client.
 


### PR DESCRIPTION
This just adds an explicit note that if a client is trying to use the
test-explorer not only do they need the `initializationOption` set, but
they also need to ensure the `test-user-interface` user config is set to
`test explorer` or there will never be information about the tests sent
since the `TestSuitesProvider`'s check for `isEnabled` will be false.