### PR TITLE
actions: return release job lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,18 +15,18 @@ jobs:
       - uses: coursier/cache-action@v6.3
       - name: Publish
         run: |
-          #LOCKED=true
-          #while [ $LOCKED = true ]; do
-          #  # if there are several release jobs at the same time
-          #  # allow to continue the one which id is less than others
-          #  FIRST_IN_PROGRESS=$(gh api /repos/scalameta/metals/actions/workflows/release.yml/runs?status=in_progress -q ".workflow_runs[].id" | sort | head -n 1)
-          #  if [ "$FIRST_IN_PROGRESS" == "$GITHUB_RUN_ID" ]; then
-          #    LOCKED=false
-          #  else
-          #    echo "Waiting the completion of other release job..."
-          #    sleep 20
-          #  fi
-          #done
+          LOCKED=true
+          while [ $LOCKED = true ]; do
+            # if there are several release jobs at the same time
+            # allow to continue the one which id is less than others
+            FIRST_IN_PROGRESS=$(gh api /repos/scalameta/metals/actions/workflows/release.yml/runs?status=in_progress -q ".workflow_runs[].id" | sort | head -n 1)
+            if [ "$FIRST_IN_PROGRESS" == "$GITHUB_RUN_ID" ]; then
+              LOCKED=false
+            else
+              echo "Waiting the completion of other release job..."
+              sleep 20
+            fi
+          done
 
           COMMAND="ci-release"
           UPDATE_DOCS=true


### PR DESCRIPTION
The issue on Github Api side related to filtering job by status was fixed