### PR TITLE
Fix SBT version check in Doctor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -429,6 +429,7 @@ lazy val metals = project
       "sbtJdiToolsVersion" -> V.sbtJdiTools,
       "supportedScalaVersions" -> V.supportedScalaVersions,
       "supportedScala2Versions" -> V.scala2Versions,
+      "minimumSupportedSbtVersion" -> V.minimumSupportedSbtVersion,
       "supportedScala3Versions" -> V.scala3Versions,
       "supportedScalaBinaryVersions" -> V.supportedScalaBinaryVersions,
       "deprecatedScalaVersions" -> V.deprecatedScalaVersions,

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -694,11 +694,24 @@ object Messages {
     }
   }
 
+  object DeprecatedSbtVersion {
+    def message: String = {
+      s"You are using an old sbt version, navigation for which might not be supported in the future versions of Metals. " +
+        s"Please upgrade to at least sbt ${BuildInfo.minimumSupportedSbtVersion}."
+    }
+  }
+
   object UnsupportedSbtVersion {
     def message: String = {
-      val recommended = "1.3.2"
       s"You are using an old sbt version, navigation for which is not supported in this version of Metals. " +
-        s"Please upgrade to at least sbt $recommended."
+        s"Please upgrade to at least sbt ${BuildInfo.minimumSupportedSbtVersion}."
+    }
+  }
+
+  object FutureSbtVersion {
+    def message: String = {
+      s"You are using an sbt version not yet supported in this version of Metals." +
+        s"Please downgrade to sbt ${BuildInfo.sbtVersion}"
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -694,26 +694,11 @@ object Messages {
     }
   }
 
-  object DeprecatedSbtVersion {
-    def message: String = {
-      val recommended = "1.3.2"
-      s"You are using an old sbt version, navigation for which might not be supported in the future versions of Metals. " +
-        s"Please upgrade to at least sbt $recommended."
-    }
-  }
-
   object UnsupportedSbtVersion {
     def message: String = {
       val recommended = "1.3.2"
       s"You are using an old sbt version, navigation for which is not supported in this version of Metals. " +
         s"Please upgrade to at least sbt $recommended."
-    }
-  }
-
-  object FutureSbtVersion {
-    def message: String = {
-      s"You are using an sbt version not yet supported in this version of Metals." +
-        s"Please downgrade to sbt ${BuildInfo.sbtVersion}"
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/ScalaProblem.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/ScalaProblem.scala
@@ -72,17 +72,9 @@ case class MissingSourceRoot(sourcerootOption: String) extends ScalaProblem {
     s"Add the compiler option $sourcerootOption to ensure code navigation works."
 }
 
-case object UnsupportedSbtVersion extends ScalaProblem {
+case class UnsupportedSbtVersion(version: String) extends ScalaProblem {
   override def message: String =
-    "Code navigation is not supported for this sbt version, please upgrade to at least 1.3.2 and reimport the build"
-}
-case object DeprecatedSbtVersion extends ScalaProblem {
-  override def message: String =
-    "Code navigation might not be supported in the future for this sbt version, please upgrade to at least 1.3.2 and reimport the build"
-}
-case object FutureSbtVersion extends ScalaProblem {
-  override def message: String =
-    "Code navigation for this sbt version is not yet supported"
+    s"Code navigation might not be supported sbt $version, please upgrade to at least 1.3.2 and reimport the build"
 }
 
 case object OutdatedJunitInterfaceVersion extends ScalaProblem {

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/ScalaProblem.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/ScalaProblem.scala
@@ -72,9 +72,19 @@ case class MissingSourceRoot(sourcerootOption: String) extends ScalaProblem {
     s"Add the compiler option $sourcerootOption to ensure code navigation works."
 }
 
-case class UnsupportedSbtVersion(version: String) extends ScalaProblem {
+case object UnsupportedSbtVersion extends ScalaProblem {
   override def message: String =
-    s"Code navigation might not be supported sbt $version, please upgrade to at least 1.3.2 and reimport the build"
+    "Code navigation is not supported for this sbt version, please " +
+      s"upgrade to at least ${BuildInfo.minimumSupportedSbtVersion} and reimport the build"
+}
+case object DeprecatedSbtVersion extends ScalaProblem {
+  override def message: String =
+    "Code navigation might not be supported in the future for this sbt version, " +
+      s"please upgrade to at least ${BuildInfo.minimumSupportedSbtVersion} and reimport the build"
+}
+case object FutureSbtVersion extends ScalaProblem {
+  override def message: String =
+    "Code navigation for this sbt version is not yet supported"
 }
 
 case object OutdatedJunitInterfaceVersion extends ScalaProblem {

--- a/project/V.scala
+++ b/project/V.scala
@@ -83,6 +83,10 @@ object V {
   )
   def scala2Versions = nonDeprecatedScala2Versions ++ deprecatedScala2Versions
 
+  // The minimum sbt version that uses a non-deprecated Scala version.
+  // Currently uses Scala 2.12.12 - update upon deprecation.
+  def minimumSupportedSbtVersion = "1.4.0"
+
   // Scala 3
   def nonDeprecatedScala3Versions =
     Seq(nextScala3RC, scala3, "3.1.1", "3.1.0", "3.0.2")

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -7,9 +7,7 @@ import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ScalaTarget
 import scala.meta.internal.metals.ScalaVersions
-import scala.meta.internal.metals.doctor.DeprecatedSbtVersion
 import scala.meta.internal.metals.doctor.DeprecatedScalaVersion
-import scala.meta.internal.metals.doctor.FutureSbtVersion
 import scala.meta.internal.metals.doctor.FutureScalaVersion
 import scala.meta.internal.metals.doctor.MissingJdkSources
 import scala.meta.internal.metals.doctor.MissingSourceRoot
@@ -60,30 +58,16 @@ class ProblemResolverSuite extends FunSuite {
 
   checkRecommendation(
     "unsupported-sbt-version",
-    scalaVersion = "2.12.7",
-    UnsupportedSbtVersion.message,
+    scalaVersion = BuildInfo.scala212,
+    UnsupportedSbtVersion("1.2.0").message,
     sbtVersion = Some("1.2.0")
-  )
-
-  checkRecommendation(
-    "deprecated-sbt-version",
-    scalaVersion = "2.12.8",
-    DeprecatedSbtVersion.message,
-    sbtVersion = Some("1.3.0")
-  )
-
-  checkRecommendation(
-    "future-sbt-version",
-    scalaVersion = "2.12.51",
-    FutureSbtVersion.message,
-    sbtVersion = Some("1.6.0")
   )
 
   checkRecommendation(
     "ok-sbt-version",
     scalaVersion = BuildInfo.scala212,
     "",
-    sbtVersion = Some("1.6.0")
+    sbtVersion = Some("1.3.12")
   )
 
   checkRecommendation(

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -7,7 +7,9 @@ import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ScalaTarget
 import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.metals.doctor.DeprecatedSbtVersion
 import scala.meta.internal.metals.doctor.DeprecatedScalaVersion
+import scala.meta.internal.metals.doctor.FutureSbtVersion
 import scala.meta.internal.metals.doctor.FutureScalaVersion
 import scala.meta.internal.metals.doctor.MissingJdkSources
 import scala.meta.internal.metals.doctor.MissingSourceRoot
@@ -58,16 +60,30 @@ class ProblemResolverSuite extends FunSuite {
 
   checkRecommendation(
     "unsupported-sbt-version",
-    scalaVersion = BuildInfo.scala212,
-    UnsupportedSbtVersion("1.2.0").message,
+    scalaVersion = "2.12.7",
+    UnsupportedSbtVersion.message,
     sbtVersion = Some("1.2.0")
+  )
+
+  checkRecommendation(
+    "deprecated-sbt-version",
+    scalaVersion = "2.12.8",
+    DeprecatedSbtVersion.message,
+    sbtVersion = Some("1.3.0")
+  )
+
+  checkRecommendation(
+    "future-sbt-version",
+    scalaVersion = "2.12.51",
+    FutureSbtVersion.message,
+    sbtVersion = Some("1.6.0")
   )
 
   checkRecommendation(
     "ok-sbt-version",
     scalaVersion = BuildInfo.scala212,
     "",
-    sbtVersion = Some("1.3.12")
+    sbtVersion = Some("1.6.0")
   )
 
   checkRecommendation(


### PR DESCRIPTION
Previously, this sbt version error in Metals Doctor was wrongly suggesting I upgrade sbt to 1.3.2:

<img width="816" alt="image" src="https://user-images.githubusercontent.com/5240310/170129661-58bb3ff4-5109-4ae1-afe7-2f650ca29930.png">

This is also paired with a startup message saying "Multiple problems detected in your build."

~It looks like there was a bug where the sbt version check was doing the same thing as the Scala version check (checking `ScalaVersions.isDeprecatedScalaVersion(scalaVersion)`) . I updated this to check the `sbtVersion` against `1.3.2` as the error message implies.~

~**Note** I fixed the check for `UnsupportedSbtVersion` but removed the checks for `DeprecatedSbtVersion` and `FutureSbtVersion` since they were also broken and it isn't clear what those version bounds should be... I can add them back if those bounds exist~

---

Update: Turns out the message was just out of date and everything was working as expected 😃. I moved the minimum sbt version to a constant alongside the deprecated Scala 2 versions, so hopefully it will be more obvious to update in the future.