### PR TITLE
chore: Update lsp4j to 0.14.0

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -9,6 +9,7 @@ import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
 
 import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions
 import org.eclipse.lsp4j.FileSystemWatcher
+import org.eclipse.lsp4j.jsonrpc.messages.Either
 
 object Configs {
 
@@ -24,14 +25,18 @@ object Configs {
         else workspace.toURI.toString.stripSuffix("/")
       new DidChangeWatchedFilesRegistrationOptions(
         List(
-          new FileSystemWatcher(s"$root/*.sbt"),
-          new FileSystemWatcher(s"$root/pom.xml"),
-          new FileSystemWatcher(s"$root/*.sc"),
-          new FileSystemWatcher(s"$root/*?.gradle"),
-          new FileSystemWatcher(s"$root/*.gradle.kts"),
-          new FileSystemWatcher(s"$root/project/*.{scala,sbt}"),
-          new FileSystemWatcher(s"$root/project/project/*.{scala,sbt}"),
-          new FileSystemWatcher(s"$root/project/build.properties")
+          new FileSystemWatcher(Either.forLeft(s"$root/*.sbt")),
+          new FileSystemWatcher(Either.forLeft(s"$root/pom.xml")),
+          new FileSystemWatcher(Either.forLeft(s"$root/*.sc")),
+          new FileSystemWatcher(Either.forLeft(s"$root/*?.gradle")),
+          new FileSystemWatcher(Either.forLeft(s"$root/*.gradle.kts")),
+          new FileSystemWatcher(Either.forLeft(s"$root/project/*.{scala,sbt}")),
+          new FileSystemWatcher(
+            Either.forLeft(s"$root/project/project/*.{scala,sbt}")
+          ),
+          new FileSystemWatcher(
+            Either.forLeft(s"$root/project/build.properties")
+          )
         ).asJava
       )
     }

--- a/project/V.scala
+++ b/project/V.scala
@@ -23,7 +23,7 @@ object V {
   val java8Compat = "1.0.2"
   val javaSemanticdb = "0.7.4"
   val jsoup = "1.15.1"
-  val lsp4jV = "0.12.0"
+  val lsp4jV = "0.14.0"
   val mavenBloop = bloop
   val mill = "0.10.4"
   val mdoc = "2.3.2"


### PR DESCRIPTION
lsp4j 0.13.0 is compatible with LSP 3.17.0, which supports new features such as inlay hints.

From LSP 3.17.0, [SymbolInformation is deprecated](https://github.com/microsoft/language-server-protocol/issues/1389), but let's go with SymbolInformation for now (we can work on it in another PR).