### PR TITLE
feature: [Scala 3] Add snippet completions

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -17,9 +17,11 @@ import scala.meta.pc.SymbolSearch
 import dotty.tools.dotc.Driver
 import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.Contexts.*
+import dotty.tools.dotc.core.Denotations.*
 import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.NameOps.*
 import dotty.tools.dotc.core.Names.*
+import dotty.tools.dotc.core.SymDenotations.NoDenotation
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Types.Type
 import dotty.tools.dotc.interactive.Interactive
@@ -168,4 +170,16 @@ object MtagsEnrichments extends CommonMtagsEnrichments:
         (denot.info, sym.withUpdatedTpe(denot.info))
       catch case NonFatal(e) => (sym.info, sym)
   end extension
+
+  extension (denot: Denotation)
+    def allSymbols: List[Symbol] =
+      denot match
+        case MultiDenotation(denot1, denot2) =>
+          List(
+            denot1.allSymbols,
+            denot2.allSymbols
+          ).flatten
+        case NoDenotation => Nil
+        case _ =>
+          List(denot.symbol)
 end MtagsEnrichments

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -275,22 +275,19 @@ object MetalsInteractive:
     end match
   end enclosingSymbolsWithExpressionType
 
+  import scala.meta.internal.mtags.MtagsEnrichments.*
+
   private def recoverError(
       tree: Tree,
       indexed: IndexedContext
   ): List[Symbol] =
     import indexed.ctx
 
-    def extractSymbols(d: PreDenotation): List[Symbol] =
-      d match
-        case multi: MultiPreDenotation =>
-          extractSymbols(multi.denot1) ++ extractSymbols(multi.denot2)
-        case d: Denotation => List(d.symbol)
-        case _ => List.empty
-
     tree match
       case select: Select =>
-        extractSymbols(select.qualifier.typeOpt.member(select.name))
+        select.qualifier.typeOpt
+          .member(select.name)
+          .allSymbols
           .filter(_ != NoSymbol)
       case ident: Ident => indexed.findSymbol(ident.name).toList.flatten
       case _ => Nil

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -18,6 +18,7 @@ import org.eclipse.lsp4j.Range
 
 sealed trait CompletionValue:
   def label: String
+  def snippetSuffix: Option[String] = None
 
   final def completionItemKind(using Context): CompletionItemKind =
     this match
@@ -66,7 +67,11 @@ object CompletionValue:
   sealed trait Symbolic extends CompletionValue:
     def symbol: Symbol
 
-  case class Compiler(label: String, symbol: Symbol) extends Symbolic
+  case class Compiler(
+      label: String,
+      symbol: Symbol,
+      override val snippetSuffix: Option[String]
+  ) extends Symbolic
   case class Scope(label: String, symbol: Symbol) extends Symbolic
   case class Workspace(label: String, symbol: Symbol) extends Symbolic
 
@@ -90,11 +95,6 @@ object CompletionValue:
 
   case class NamedArg(label: String, tpe: Type) extends CompletionValue
   case class Keyword(label: String, insertText: String) extends CompletionValue
-
-  def fromCompiler(completion: Completion): List[CompletionValue] =
-    def undoBacktick(label: String): String =
-      label.stripPrefix("`").stripSuffix("`")
-    completion.symbols.map(Compiler(undoBacktick(completion.label), _))
 
   def namedArg(label: String, sym: Symbol)(using Context): CompletionValue =
     NamedArg(label, sym.info.widenTermRefExpr)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -73,7 +73,11 @@ object CompletionValue:
       override val snippetSuffix: Option[String]
   ) extends Symbolic
   case class Scope(label: String, symbol: Symbol) extends Symbolic
-  case class Workspace(label: String, symbol: Symbol) extends Symbolic
+  case class Workspace(
+      label: String,
+      symbol: Symbol,
+      override val snippetSuffix: Option[String]
+  ) extends Symbolic
 
   /**
    * @param shortenedNames shortened type names by `Printer`. This field should be used for autoImports
@@ -101,9 +105,6 @@ object CompletionValue:
 
   def keyword(label: String, insertText: String): CompletionValue =
     Keyword(label, insertText)
-
-  def workspace(label: String, sym: Symbol): CompletionValue =
-    Workspace(label, sym)
 
   def scope(label: String, sym: Symbol): CompletionValue =
     Scope(label, sym)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
@@ -288,7 +288,12 @@ class CompletionsProvider(
       case CompletionValue.NamedArg(label, _) =>
         mkItem(ident, ident.replace("$", "$$")) // escape $ for snippet
       case CompletionValue.Keyword(label, text) => mkItem(label, text)
-      case _ => mkItem(ident, ident.backticked)
+      case _ =>
+        completion.snippetSuffix match
+          case Some(suffix) =>
+            mkItem(ident, ident.backticked + suffix)
+          case _ =>
+            mkItem(ident, ident.backticked)
     end match
   end completionItems
 end CompletionsProvider

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
@@ -232,8 +232,10 @@ class CompletionsProvider(
       mkItem(ident, value, isFromWorkspace = true, additionalEdits)
 
     val ident = completion.label
+
+    val completionTextSuffix = completion.snippetSuffix.getOrElse("")
     completion match
-      case CompletionValue.Workspace(label, sym) =>
+      case CompletionValue.Workspace(label, sym, suffix) =>
         path match
           case (_: Ident) :: (_: Import) :: _ =>
             mkWorkspaceItem(
@@ -254,7 +256,7 @@ class CompletionsProvider(
                   case _ =>
                     mkItem(
                       ident,
-                      ident.backticked,
+                      ident.backticked + completionTextSuffix,
                       isFromWorkspace = true,
                       edits.edits
                     )
@@ -262,8 +264,12 @@ class CompletionsProvider(
                 val r = indexedContext.lookupSym(sym)
                 r match
                   case IndexedContext.Result.InScope =>
-                    mkItem(ident, ident.backticked)
-                  case _ => mkWorkspaceItem(ident, sym.fullNameBackticked)
+                    mkItem(ident, ident.backticked + completionTextSuffix)
+                  case _ =>
+                    mkWorkspaceItem(
+                      ident,
+                      sym.fullNameBackticked + completionTextSuffix
+                    )
       case CompletionValue.Override(
             label,
             value,
@@ -289,11 +295,7 @@ class CompletionsProvider(
         mkItem(ident, ident.replace("$", "$$")) // escape $ for snippet
       case CompletionValue.Keyword(label, text) => mkItem(label, text)
       case _ =>
-        completion.snippetSuffix match
-          case Some(suffix) =>
-            mkItem(ident, ident.backticked + suffix)
-          case _ =>
-            mkItem(ident, ident.backticked)
+        mkItem(ident, ident.backticked + completionTextSuffix)
     end match
   end completionItems
 end CompletionsProvider

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -172,7 +172,8 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       original: String,
       expected: String,
       compat: Map[String, String] = Map.empty,
-      topLines: Option[Int] = None
+      topLines: Option[Int] = None,
+      includeDetail: Boolean = false
   )(implicit loc: Location): Unit = {
     test(name) {
       val baseItems = getItems(original)
@@ -182,11 +183,13 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       }
       val obtained = items
         .map { item =>
-          item
+          val results = item
             .getLeftTextEdit()
             .map(_.getNewText)
             .orElse(Option(item.getInsertText()))
             .getOrElse(item.getLabel)
+          if (includeDetail) results + " - " + item.getDetail()
+          else results
         }
         .mkString("\n")
       assertNoDiff(

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -434,13 +434,8 @@ class CompletionDocSuite extends BaseCompletionSuite {
             |""".stripMargin
     )
   )
-  check(
-    "scala6",
-    """
-      |object A {
-      |  scala.util.Try@@
-      |}
-    """.stripMargin,
+
+  val baseTryDocs: String =
     """|> The `Try` type represents a computation that may either result in an exception, or return a
        |successfully computed value. It's similar to, but semantically different from the [scala.util.Either](scala.util.Either) type.
        |
@@ -484,8 +479,23 @@ class CompletionDocSuite extends BaseCompletionSuite {
        |
        |`Try` comes to the Scala standard library after years of use as an integral part of Twitter's stack.
        |Try scala.util
-       |""".stripMargin,
-    includeDocs = true
+       |""".stripMargin
+  check(
+    "scala6",
+    """
+      |object A {
+      |  scala.util.Try@@
+      |}
+    """.stripMargin,
+    baseTryDocs,
+    includeDocs = true,
+    compat = Map(
+      "3" ->
+        s"""|$baseTryDocs> Constructs a `Try` using the by-name parameter.  This
+            |method will ensure any non-fatal exception is caught and a
+            |`Failure` object is returned.
+            |Try[T](r: => T): Try[T]""".stripMargin
+    )
   )
   check(
     "scala7",
@@ -639,7 +649,13 @@ class CompletionDocSuite extends BaseCompletionSuite {
     """.stripMargin,
     """|Failure scala.util
        |""".stripMargin,
-    includeDocs = true
+    includeDocs = true,
+    compat = Map(
+      "3" ->
+        """|Failure scala.util
+           |Failure[T](exception: Throwable): Failure[T]
+           |""".stripMargin
+    )
   )
 
   // New completions not yet implemented for Scala 3

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -527,7 +527,25 @@ class CompletionDocSuite extends BaseCompletionSuite {
                    |- ["Scala's Collection Library overview"](http://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#stringbuilders)
                    | section on `StringBuilders` for more information.
                    |StringBuilder scala.collection.mutable
-                   |""".stripMargin
+                   |""".stripMargin,
+      "3" ->
+        """|> A builder for mutable sequence of characters.  This class provides an API
+           |mostly compatible with `java.lang.StringBuilder`, except where there are
+           |conflicts with the Scala collections API (such as the `reverse` method.)
+           |
+           |$multipleResults
+           |
+           |
+           |**See**
+           |- ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections/concrete-mutable-collection-classes.html#stringbuilders)
+           |section on `StringBuilders` for more information.
+           |StringBuilder scala.collection.mutable
+           |StringBuilder(): StringBuilder
+           |StringBuilder(str: String): StringBuilder
+           |StringBuilder(underlying: StringBuilder): StringBuilder
+           |StringBuilder(capacity: Int): StringBuilder
+           |StringBuilder(initCapacity: Int, initValue: String): StringBuilder
+           |""".stripMargin
     )
   )
 
@@ -636,7 +654,7 @@ class CompletionDocSuite extends BaseCompletionSuite {
     includeDocs = true,
     compat = Map(
       "2.13" -> post212CatchDocs,
-      "3" -> post212CatchDocs
+      "3" -> s"${post212CatchDocs}Catch[T](pf: Catcher[T], fin: Option[Finally], rethrow: Throwable => Boolean): Catch[T]"
     )
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetNegSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetNegSuite.scala
@@ -43,13 +43,7 @@ class CompletionSnippetNegSuite extends BaseCompletionSuite {
       |""".stripMargin,
     """|println()
        |println
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|println
-           |println
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   checkSnippet(

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -53,7 +53,7 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
   )
 
   checkSnippet(
-    "nullary2",
+    "nilary",
     s"""|class Hello{
         |  def now() = 25
         |}
@@ -165,7 +165,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |""".stripMargin,
       // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
       "3" ->
-        """|ArrayDeque
+        """|ArrayDeque($0)
+           |ArrayDeque
            |ArrayDeque
            |ArrayDequeOps
            |""".stripMargin
@@ -357,6 +358,28 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |PropertiesTrait
            |Either
            |control
+           |""".stripMargin
+    )
+  )
+
+  checkSnippet(
+    "case-class3",
+    s"""|object Main {
+        |  Try@@
+        |}
+        |""".stripMargin,
+    """|Try
+       |Breaks.TryBlock
+       |""".stripMargin,
+    // additional completion when apply method is present
+    compat = Map(
+      "3" ->
+        """|Try
+           |Try($0)
+           |TryBlock
+           |TryModule
+           |TryMethods
+           |TryMethods
            |""".stripMargin
     )
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -312,47 +312,6 @@ class CompletionSuite extends BaseCompletionSuite {
            |wait(): Unit
            |wait(x$0: Long): Unit
            |wait(x$0: Long, x$1: Int): Unit
-           |""".stripMargin,
-      "3.2" ->
-        """|empty[A]: List[A]
-           |from[B](coll: IterableOnce[B]): List[B]
-           |newBuilder[A]: Builder[A, List[A]]
-           |apply[A](elems: A*): List[A]
-           |concat[A](xss: Iterable[A]*): List[A]
-           |fill[A](n1: Int, n2: Int)(elem: => A): List[List[A] @uncheckedVariance]
-           |fill[A](n1: Int, n2: Int, n3: Int)(elem: => A): List[List[List[A]] @uncheckedVariance]
-           |fill[A](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => A): List[List[List[List[A]]] @uncheckedVariance]
-           |fill[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => A): List[List[List[List[List[A]]]] @uncheckedVariance]
-           |fill[A](n: Int)(elem: => A): List[A]
-           |iterate[A](start: A, len: Int)(f: A => A): List[A]
-           |range[A: Integral](start: A, end: A): List[A]
-           |range[A: Integral](start: A, end: A, step: A): List[A]
-           |tabulate[A](n1: Int, n2: Int)(f: (Int, Int) => A): List[List[A] @uncheckedVariance]
-           |tabulate[A](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => A): List[List[List[A]] @uncheckedVariance]
-           |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): List[List[List[List[A]]] @uncheckedVariance]
-           |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): List[List[List[List[List[A]]]] @uncheckedVariance]
-           |tabulate[A](n: Int)(f: Int => A): List[A]
-           |unapplySeq[A](x: List[A] @uncheckedVariance): UnapplySeqWrapper[A]
-           |unfold[A, S](init: S)(f: S => Option[(A, S)]): List[A]
-           |->[B](y: B): (A, B)
-           |ensuring(cond: Boolean): A
-           |ensuring(cond: A => Boolean): A
-           |ensuring(cond: Boolean, msg: => Any): A
-           |ensuring(cond: A => Boolean, msg: => Any): A
-           |nn: x.type & T
-           |formatted(fmtstr: String): String
-           |→[B](y: B): (A, B)
-           |iterableFactory[A]: Factory[A, CC[A]]
-           |asInstanceOf[X0]: X0
-           |equals(x$0: Any): Boolean
-           |getClass[X0 >: List.type](): Class[? <: X0]
-           |hashCode(): Int
-           |isInstanceOf[X0]: Boolean
-           |synchronized[X0](x$0: X0): X0
-           |toString(): String
-           |wait(): Unit
-           |wait(x$0: Long): Unit
-           |wait(x$0: Long, x$1: Int): Unit
            |""".stripMargin
     )
   )
@@ -424,6 +383,7 @@ class CompletionSuite extends BaseCompletionSuite {
            |""".stripMargin,
       "3" ->
         """|TrieMap scala.collection.concurrent
+           |TrieMap[K, V](elems: (K, V)*): CC[K, V]
            |TrieMapSerializationEnd - scala.collection.concurrent
            |""".stripMargin
     )
@@ -777,7 +737,8 @@ class CompletionSuite extends BaseCompletionSuite {
     """|DelayedLazyVal scala.concurrent
        |""".stripMargin,
     compat = Map(
-      "3" -> "DelayedLazyVal scala.concurrent",
+      "3" -> """|DelayedLazyVal scala.concurrent
+                |DelayedLazyVal[T](f: () => T, body: => Unit)(exec: ExecutionContext): DelayedLazyVal[T]""".stripMargin,
       "2.13" -> "DelayedLazyVal - scala.concurrent"
     )
   )
@@ -989,6 +950,7 @@ class CompletionSuite extends BaseCompletionSuite {
     compat = Map(
       ">=3.1.0" ->
         """|Some scala
+           |Some[A](value: A): Some[A]
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
            |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
            |SomeToExpr - scala.quoted.ToExpr
@@ -996,6 +958,7 @@ class CompletionSuite extends BaseCompletionSuite {
            |""".stripMargin,
       "3" ->
         """|Some scala
+           |Some[A](value: A): Some[A]
            |SomeToExpr - scala.quoted.ToExpr
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
            |SomeFromExpr - scala.quoted.FromExpr
@@ -1016,6 +979,7 @@ class CompletionSuite extends BaseCompletionSuite {
     compat = Map(
       ">=3.1.0" ->
         """|Some scala
+           |Some[A](value: A): Some[A]
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
            |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
            |SomeToExpr - scala.quoted.ToExpr
@@ -1023,6 +987,7 @@ class CompletionSuite extends BaseCompletionSuite {
            |""".stripMargin,
       "3" ->
         """|Some scala
+           |Some[A](value: A): Some[A]
            |SomeToExpr - scala.quoted.ToExpr
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
            |SomeFromExpr - scala.quoted.FromExpr
@@ -1381,13 +1346,6 @@ class CompletionSuite extends BaseCompletionSuite {
        |  val a = List(1, 2)
        |    .map($0)
        |}""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|object O {
-           |  val a = List(1, 2)
-           |    .map
-           |}""".stripMargin
-    ),
     filter = _.contains("map["),
     assertSingleItem = false
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -31,7 +31,7 @@ class CompletionSuite extends BaseCompletionSuite {
            |List - java.awt
            |List - java.util
            |List - scala.collection.immutable
-           |JList - javax.swing
+           |List[A](elems: A*): CC[A]
            |""".stripMargin
     ),
     topLines = Some(5)
@@ -907,7 +907,13 @@ class CompletionSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|ListBuffer - scala.collection.mutable
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|ListBuffer[A](elems: A*): CC[A]
+           |ListBuffer - scala.collection.mutable
+           |""".stripMargin
+    )
   )
 
   check(
@@ -917,7 +923,13 @@ class CompletionSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|ListBuffer - scala.collection.mutable
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|ListBuffer[A](elems: A*): CC[A]
+           |ListBuffer - scala.collection.mutable
+           |""".stripMargin
+    )
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -681,7 +681,13 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """|Future scala.concurrent
        |Future - java.util.concurrent
        |""".stripMargin,
-    topLines = Some(2)
+    topLines = Some(2),
+    compat = Map(
+      "3" ->
+        """|Future scala.concurrent
+           |Future[T](body: => T)(implicit executor: ExecutionContext): Future[T]
+           |""".stripMargin
+    )
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -702,6 +702,12 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """|Future java.util.concurrent
        |Future - scala.concurrent
        |""".stripMargin,
-    topLines = Some(2)
+    topLines = Some(2),
+    compat = Map(
+      "3" ->
+        """|Future java.util.concurrent
+           |Future[T](body: => T)(implicit executor: ExecutionContext): scala.concurrent.Future[T]
+           |""".stripMargin
+    )
   )
 }

--- a/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
@@ -141,6 +141,7 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
                  |StreamResult - javax.xml.transform.stream
                  |StreamShape - scala.collection.convert.StreamExtensions
                  |StreamSource - javax.xml.transform.stream
+                 |Stream[A](elems: A*): CC[A]
                  |""".stripMargin
           ),
           scalaVersion
@@ -164,6 +165,7 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
             "3" ->
               """|TrieMap - scala.collection.concurrent
                  |TrieMapSerializationEnd - scala.collection.concurrent
+                 |TrieMap[K, V](elems: (K, V)*): CC[K, V]
                  |""".stripMargin
           ),
           scalaVersion


### PR DESCRIPTION
Previously, when completing a function we would only write the name even if the method needs parameters. Now if the client supports snippets we additionally add parenthesis where aplicable.

I also added a completion for apply in case of companion objects.

Fixes https://github.com/scalameta/metals/issues/3945