### PR TITLE
docs: remove status-bar as option for slowTaskProvider

### DIFF
--- a/docs/integrations/new-editor.md
+++ b/docs/integrations/new-editor.md
@@ -384,8 +384,6 @@ Possible values:
 
 - `off` (default): the `metals/slowTask` request is not supported.
 - `on`: the `metals/slowTask` request is fully supported.
-- `status-bar`: the `metals/slowTask` request is not supported, but send updates
-  about slow tasks via `metals/status`.
 
 ##### `statusBarProvider`
 


### PR DESCRIPTION
This is documented, but looking at the implementation there is no
`status-bar` option anymore. This just removes this from the docs to not
confuse anyone.