### PR TITLE
fix: revert temporal changes in completions tests for 3.2.*-NIGHTLY

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -312,47 +312,6 @@ class CompletionSuite extends BaseCompletionSuite {
            |wait(): Unit
            |wait(x$0: Long): Unit
            |wait(x$0: Long, x$1: Int): Unit
-           |""".stripMargin,
-      "3.2" ->
-        """|empty[A]: List[A]
-           |from[B](coll: IterableOnce[B]): List[B]
-           |newBuilder[A]: Builder[A, List[A]]
-           |apply[A](elems: A*): List[A]
-           |concat[A](xss: Iterable[A]*): List[A]
-           |fill[A](n1: Int, n2: Int)(elem: => A): List[List[A] @uncheckedVariance]
-           |fill[A](n1: Int, n2: Int, n3: Int)(elem: => A): List[List[List[A]] @uncheckedVariance]
-           |fill[A](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => A): List[List[List[List[A]]] @uncheckedVariance]
-           |fill[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => A): List[List[List[List[List[A]]]] @uncheckedVariance]
-           |fill[A](n: Int)(elem: => A): List[A]
-           |iterate[A](start: A, len: Int)(f: A => A): List[A]
-           |range[A: Integral](start: A, end: A): List[A]
-           |range[A: Integral](start: A, end: A, step: A): List[A]
-           |tabulate[A](n1: Int, n2: Int)(f: (Int, Int) => A): List[List[A] @uncheckedVariance]
-           |tabulate[A](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => A): List[List[List[A]] @uncheckedVariance]
-           |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): List[List[List[List[A]]] @uncheckedVariance]
-           |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): List[List[List[List[List[A]]]] @uncheckedVariance]
-           |tabulate[A](n: Int)(f: Int => A): List[A]
-           |unapplySeq[A](x: List[A] @uncheckedVariance): UnapplySeqWrapper[A]
-           |unfold[A, S](init: S)(f: S => Option[(A, S)]): List[A]
-           |->[B](y: B): (A, B)
-           |ensuring(cond: Boolean): A
-           |ensuring(cond: A => Boolean): A
-           |ensuring(cond: Boolean, msg: => Any): A
-           |ensuring(cond: A => Boolean, msg: => Any): A
-           |nn: x.type & T
-           |formatted(fmtstr: String): String
-           |→[B](y: B): (A, B)
-           |iterableFactory[A]: Factory[A, CC[A]]
-           |asInstanceOf[X0]: X0
-           |equals(x$0: Any): Boolean
-           |getClass[X0 >: List.type](): Class[? <: X0]
-           |hashCode(): Int
-           |isInstanceOf[X0]: Boolean
-           |synchronized[X0](x$0: X0): X0
-           |toString(): String
-           |wait(): Unit
-           |wait(x$0: Long): Unit
-           |wait(x$0: Long, x$1: Int): Unit
            |""".stripMargin
     )
   )


### PR DESCRIPTION
The issue with missing members was fixed