### PR TITLE
Add ConvertToNamedArguments code action

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -44,7 +44,8 @@ final class CodeActionProvider(
     new PatternMatchRefactor(trees),
     new RewriteBracesParensCodeAction(trees),
     new ExtractValueCodeAction(trees, buffers),
-    new CreateCompanionObjectCodeAction(trees, buffers)
+    new CreateCompanionObjectCodeAction(trees, buffers),
+    new ConvertToNamedArguments(trees, compilers)
   )
 
   def codeActions(

--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -45,7 +45,7 @@ final class CodeActionProvider(
     new RewriteBracesParensCodeAction(trees),
     new ExtractValueCodeAction(trees, buffers),
     new CreateCompanionObjectCodeAction(trees, buffers),
-    new ConvertToNamedArguments(trees, compilers)
+    new ConvertToNamedArguments(trees)
   )
 
   def codeActions(

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -10,6 +10,7 @@ import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Future
 import scala.util.Try
 
+import scala.meta.Term
 import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import scala.meta.internal.metals.Compilers.PresentationCompilerKey
@@ -359,14 +360,14 @@ class Compilers(
   }.getOrElse(Future.successful(Nil.asJava))
 
   def convertToNamedArguments(
-      params: TextDocumentPositionParams,
-      numUnnamedArgs: Int,
+      position: TextDocumentPositionParams,
+      argIndices: ju.List[Integer],
       token: CancelToken
   ): Future[ju.List[TextEdit]] = {
-    withPCAndAdjustLsp(params) { (pc, pos, adjust) =>
+    withPCAndAdjustLsp(position) { (pc, pos, adjust) =>
       pc.convertToNamedArguments(
         CompilerOffsetParams.fromPos(pos, token),
-        numUnnamedArgs
+        argIndices,
       ).asScala
         .map { edits =>
           adjust.adjustTextEdits(edits)

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -360,13 +360,13 @@ class Compilers(
 
   def convertToNamedArguments(
       position: TextDocumentPositionParams,
-      argIndices: ju.List[Integer],
+      numUnnamedArgs: Int,
       token: CancelToken
   ): Future[ju.List[TextEdit]] = {
     withPCAndAdjustLsp(position) { (pc, pos, adjust) =>
       pc.convertToNamedArguments(
         CompilerOffsetParams.fromPos(pos, token),
-        argIndices,
+        numUnnamedArgs
       ).asScala
         .map { edits =>
           adjust.adjustTextEdits(edits)

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -360,13 +360,13 @@ class Compilers(
 
   def convertToNamedArguments(
       position: TextDocumentPositionParams,
-      numUnnamedArgs: Int,
+      argIndices: ju.List[Integer],
       token: CancelToken
   ): Future[ju.List[TextEdit]] = {
     withPCAndAdjustLsp(position) { (pc, pos, adjust) =>
       pc.convertToNamedArguments(
         CompilerOffsetParams.fromPos(pos, token),
-        numUnnamedArgs
+        argIndices
       ).asScala
         .map { edits =>
           adjust.adjustTextEdits(edits)

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -358,6 +358,22 @@ class Compilers(
     }
   }.getOrElse(Future.successful(Nil.asJava))
 
+  def convertToNamedArguments(
+      params: TextDocumentPositionParams,
+      numUnnamedArgs: Int,
+      token: CancelToken
+  ): Future[ju.List[TextEdit]] = {
+    withPCAndAdjustLsp(params) { (pc, pos, adjust) =>
+      pc.convertToNamedArguments(
+        CompilerOffsetParams.fromPos(pos, token),
+        numUnnamedArgs
+      ).asScala
+        .map { edits =>
+          adjust.adjustTextEdits(edits)
+        }
+    }
+  }.getOrElse(Future.successful(Nil.asJava))
+
   def implementAbstractMembers(
       params: TextDocumentPositionParams,
       token: CancelToken

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -10,7 +10,6 @@ import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Future
 import scala.util.Try
 
-import scala.meta.Term
 import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import scala.meta.internal.metals.Compilers.PresentationCompilerKey

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1983,11 +1983,17 @@ class MetalsLanguageServer(
           } yield ().asInstanceOf[Object]
         }
 
-      case ServerCommands.ConvertToNamedArguments(ServerCommands.ConvertToNamedArgsRequest(position, numUnnamedArgs)) =>
+      case ServerCommands.ConvertToNamedArguments(
+            ServerCommands.ConvertToNamedArgsRequest(position, numUnnamedArgs)
+          ) =>
         CancelTokens.future { token =>
           val uri = position.getTextDocument().getUri()
           for {
-            edits <- compilers.convertToNamedArguments(position, numUnnamedArgs, token)
+            edits <- compilers.convertToNamedArguments(
+              position,
+              numUnnamedArgs,
+              token
+            )
             if (!edits.isEmpty())
             workspaceEdit = new l.WorkspaceEdit(Map(uri -> edits).asJava)
             _ <- languageClient

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1983,6 +1983,19 @@ class MetalsLanguageServer(
           } yield ().asInstanceOf[Object]
         }
 
+      case ServerCommands.ConvertToNamedArguments(ServerCommands.ConvertToNamedArgsRequest(position, argIndices)) =>
+        CancelTokens.future { token =>
+          val uri = position.getTextDocument().getUri()
+          for {
+            edits <- compilers.convertToNamedArguments(position, argIndices, token)
+            if (!edits.isEmpty())
+            workspaceEdit = new l.WorkspaceEdit(Map(uri -> edits).asJava)
+            _ <- languageClient
+              .applyEdit(new ApplyWorkspaceEditParams(workspaceEdit))
+              .asScala
+          } yield ().asInstanceOf[Object]
+        }
+
       case ServerCommands.ExtractMemberDefinition(textDocumentParams) =>
         val data = ExtractMemberDefinitionData(textDocumentParams)
         val future = for {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1984,14 +1984,14 @@ class MetalsLanguageServer(
         }
 
       case ServerCommands.ConvertToNamedArguments(
-            ServerCommands.ConvertToNamedArgsRequest(position, numUnnamedArgs)
+            ServerCommands.ConvertToNamedArgsRequest(position, argIndices)
           ) =>
         CancelTokens.future { token =>
           val uri = position.getTextDocument().getUri()
           for {
             edits <- compilers.convertToNamedArguments(
               position,
-              numUnnamedArgs,
+              argIndices,
               token
             )
             if (!edits.isEmpty())

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1983,11 +1983,11 @@ class MetalsLanguageServer(
           } yield ().asInstanceOf[Object]
         }
 
-      case ServerCommands.ConvertToNamedArguments(ServerCommands.ConvertToNamedArgsRequest(position, argIndices)) =>
+      case ServerCommands.ConvertToNamedArguments(ServerCommands.ConvertToNamedArgsRequest(position, numUnnamedArgs)) =>
         CancelTokens.future { token =>
           val uri = position.getTextDocument().getUri()
           for {
-            edits <- compilers.convertToNamedArguments(position, argIndices, token)
+            edits <- compilers.convertToNamedArguments(position, numUnnamedArgs, token)
             if (!edits.isEmpty())
             workspaceEdit = new l.WorkspaceEdit(Map(uri -> edits).asJava)
             _ <- languageClient

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals
 
+import java.{util => ju}
 import javax.annotation.Nullable
 
 import scala.meta.internal.metals.newScalaFile.NewFileTypes
@@ -8,7 +9,6 @@ import ch.epfl.scala.{bsp4j => b}
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentPositionParams
-import java.{util => ju}
 
 /**
  * LSP commands supported by the Metals language server.

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -478,7 +478,7 @@ object ServerCommands {
       """|Whenever a user chooses code action to convert to named arguments, this command is later ran to 
          |determine the parameter names of all unnamed arguments and insert names at the correct locations.
          |""".stripMargin,
-      """|This command should be sent in with the LSP [`TextDocumentPositionParams`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams)
+      """|Object with `position` of type [TextDocumentPositionParams](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentPositionParams) and `numUnnamedArgs` (int)
          |""".stripMargin
     )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.metals
 
-import java.{util => ju}
 import javax.annotation.Nullable
 
 import scala.meta.internal.metals.newScalaFile.NewFileTypes
@@ -468,7 +467,7 @@ object ServerCommands {
        |""".stripMargin
   )
 
-  final case class ConvertToNamedArgsRequest(position: TextDocumentPositionParams, argIndices: ju.List[Integer])
+  final case class ConvertToNamedArgsRequest(position: TextDocumentPositionParams, numUnnamedArgs: Int)
   val ConvertToNamedArguments = new ParametrizedCommand[ConvertToNamedArgsRequest](
     "convert-to-named-arguments",
     "Convert positional arguments to named ones",

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -467,16 +467,20 @@ object ServerCommands {
        |""".stripMargin
   )
 
-  final case class ConvertToNamedArgsRequest(position: TextDocumentPositionParams, numUnnamedArgs: Int)
-  val ConvertToNamedArguments = new ParametrizedCommand[ConvertToNamedArgsRequest](
-    "convert-to-named-arguments",
-    "Convert positional arguments to named ones",
-    """|Whenever a user chooses code action to convert to named arguments, this command is later ran to 
-       |determine the parameter names of all unnamed arguments and insert names at the correct locations.
-       |""".stripMargin,
-    """|This command should be sent in with the LSP [`TextDocumentPositionParams`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams)
-       |""".stripMargin
+  final case class ConvertToNamedArgsRequest(
+      position: TextDocumentPositionParams,
+      numUnnamedArgs: Int
   )
+  val ConvertToNamedArguments =
+    new ParametrizedCommand[ConvertToNamedArgsRequest](
+      "convert-to-named-arguments",
+      "Convert positional arguments to named ones",
+      """|Whenever a user chooses code action to convert to named arguments, this command is later ran to 
+         |determine the parameter names of all unnamed arguments and insert names at the correct locations.
+         |""".stripMargin,
+      """|This command should be sent in with the LSP [`TextDocumentPositionParams`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams)
+         |""".stripMargin
+    )
 
   val GotoLog = new Command(
     "goto-log",

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -8,6 +8,7 @@ import ch.epfl.scala.{bsp4j => b}
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentPositionParams
+import java.{util => ju}
 
 /**
  * LSP commands supported by the Metals language server.
@@ -462,6 +463,17 @@ object ServerCommands {
     "Insert inferred type of a value",
     """|Whenever a user chooses code action to insert the inferred type this command is later ran to 
        |calculate the type and insert it in the correct location.
+       |""".stripMargin,
+    """|This command should be sent in with the LSP [`TextDocumentPositionParams`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams)
+       |""".stripMargin
+  )
+
+  final case class ConvertToNamedArgsRequest(position: TextDocumentPositionParams, argIndices: ju.List[Integer])
+  val ConvertToNamedArguments = new ParametrizedCommand[ConvertToNamedArgsRequest](
+    "convert-to-named-arguments",
+    "Convert positional arguments to named ones",
+    """|Whenever a user chooses code action to convert to named arguments, this command is later ran to 
+       |determine the parameter names of all unnamed arguments and insert names at the correct locations.
        |""".stripMargin,
     """|This command should be sent in with the LSP [`TextDocumentPositionParams`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams)
        |""".stripMargin

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -475,10 +475,10 @@ object ServerCommands {
     new ParametrizedCommand[ConvertToNamedArgsRequest](
       "convert-to-named-arguments",
       "Convert positional arguments to named ones",
-      """|Whenever a user chooses code action to convert to named arguments, this command is later ran to 
+      """|Whenever a user chooses code action to convert to named arguments, this command is later run to 
          |determine the parameter names of all unnamed arguments and insert names at the correct locations.
          |""".stripMargin,
-      """|Object with `position` of type [TextDocumentPositionParams](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentPositionParams) and `numUnnamedArgs` (int)
+      """|Object with [TextDocumentPositionParams](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentPositionParams) of the target Apply and `numUnnamedArgs` (int)
          |""".stripMargin
     )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -8,6 +8,7 @@ import ch.epfl.scala.{bsp4j => b}
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentPositionParams
+import java.{util => ju}
 
 /**
  * LSP commands supported by the Metals language server.
@@ -469,7 +470,7 @@ object ServerCommands {
 
   final case class ConvertToNamedArgsRequest(
       position: TextDocumentPositionParams,
-      numUnnamedArgs: Int
+      argIndices: ju.List[Integer]
   )
   val ConvertToNamedArguments =
     new ParametrizedCommand[ConvertToNamedArgsRequest](

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
@@ -29,13 +29,10 @@ class ConvertToNamedArguments(trees: Trees)
       .findLastEnclosingAt[Term.Apply](path, range.getStart())
       .map { apply =>
         {
-          // TODO: Skip block args
           // TODO: Go to parent apply, if current has no candidates
-          pprint.log(apply)
-          val argIndices = apply.args.zipWithIndex.filterNot { case (arg, _) => arg.isInstanceOf[Term.Assign]}.map(_._2)
-          pprint.log(argIndices)
-          //val numUnnamedArgs =
-            //apply.args.takeWhile(!_.isInstanceOf[Term.Assign]).length
+          val argIndices = apply.args.zipWithIndex.filterNot { case (arg, _) => 
+            arg.isInstanceOf[Term.Assign] || arg.isInstanceOf[Term.Block]
+          }.map(_._2)
           if (argIndices.isEmpty) Future.successful(Nil)
           else {
             val codeAction = new l.CodeAction(title)

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
@@ -1,0 +1,55 @@
+package scala.meta.internal.metals.codeactions
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.Term
+import scala.meta.internal.metals.CodeAction
+import scala.meta.internal.metals.Compilers
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.parsing.Trees
+import scala.meta.pc.CancelToken
+
+import org.eclipse.{lsp4j => l}
+
+class ConvertToNamedArguments(trees: Trees, compilers: Compilers)
+    extends CodeAction {
+  override val kind: String = l.CodeActionKind.RefactorRewrite
+
+  override def contribute(params: l.CodeActionParams, token: CancelToken)(
+      implicit ec: ExecutionContext
+  ): Future[Seq[l.CodeAction]] = {
+
+    val path = params.getTextDocument().getUri().toAbsolutePath
+    val range = params.getRange()
+
+    trees
+      .findLastEnclosingAt[Term.Apply](path, range.getStart())
+      .map { apply =>
+        {
+          val numUnnamedArgs =
+            apply.args.takeWhile(!_.isInstanceOf[Term.Assign]).length
+          if (numUnnamedArgs == 0) Future.successful(Nil)
+          else {
+            val textDocumentPositionParams = new l.TextDocumentPositionParams(
+              params.getTextDocument(),
+              new l.Position(apply.pos.endLine, apply.pos.endColumn)
+            )
+            val edits = compilers.convertToNamedArguments(
+              textDocumentPositionParams,
+              numUnnamedArgs,
+              token
+            )
+            edits.map(e => {
+              val codeAction = new l.CodeAction("Convert to named arguments")
+              codeAction.setEdit(
+                new l.WorkspaceEdit(Map(path.toURI.toString -> e).asJava)
+              )
+              Seq(codeAction)
+            })
+          }
+        }
+      }
+      .getOrElse(Future.successful(Nil))
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
@@ -44,7 +44,7 @@ class ConvertToNamedArguments(trees: Trees) extends CodeAction {
     val range = params.getRange()
 
     val maybeApply = for {
-      term <- trees.findLastEnclosingAt[Term.Apply](path, range.getStart())
+      term <- trees.findLastEnclosingAt[Term.Apply](path, range.getStart(), term => !term.fun.pos.encloses(range))
       apply <- firstApplyWithUnnamedArgs(Some(term))
     } yield apply
 

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
@@ -44,7 +44,11 @@ class ConvertToNamedArguments(trees: Trees) extends CodeAction {
     val range = params.getRange()
 
     val maybeApply = for {
-      term <- trees.findLastEnclosingAt[Term.Apply](path, range.getStart(), term => !term.fun.pos.encloses(range))
+      term <- trees.findLastEnclosingAt[Term.Apply](
+        path,
+        range.getStart(),
+        term => !term.fun.pos.encloses(range)
+      )
       apply <- firstApplyWithUnnamedArgs(Some(term))
     } yield apply
 
@@ -75,5 +79,5 @@ class ConvertToNamedArguments(trees: Trees) extends CodeAction {
 
 object ConvertToNamedArguments {
   case class ApplyTermWithArgIndices(app: Term.Apply, argIndices: List[Int])
-  def title(funcName: String) = s"Convert $funcName to named arguments"
+  def title(funcName: String): String = s"Convert $funcName to named arguments"
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
@@ -23,8 +23,11 @@ class ConvertToNamedArguments(trees: Trees) extends CodeAction {
   ): Option[ApplyTermWithArgIndices] = {
     term match {
       case Some(apply: Term.Apply) =>
-        val argIndices = apply.args.zipWithIndex.collect { 
-          case (arg, index) if !arg.isInstanceOf[Term.Assign] && !arg.isInstanceOf[Term.Block] => index
+        val argIndices = apply.args.zipWithIndex.collect {
+          case (arg, index)
+              if !arg.isInstanceOf[Term.Assign] && !arg
+                .isInstanceOf[Term.Block] =>
+            index
         }
         if (argIndices.isEmpty) firstApplyWithUnnamedArgs(apply.parent)
         else Some(ApplyTermWithArgIndices(apply, argIndices))
@@ -57,7 +60,10 @@ class ConvertToNamedArguments(trees: Trees) extends CodeAction {
           codeAction.setCommand(
             ServerCommands.ConvertToNamedArguments.toLSP(
               ServerCommands
-                .ConvertToNamedArgsRequest(position, apply.argIndices.map(new Integer(_)).asJava)
+                .ConvertToNamedArgsRequest(
+                  position,
+                  apply.argIndices.map(new Integer(_)).asJava
+                )
             )
           )
           Future.successful(Seq(codeAction))

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
@@ -48,11 +48,11 @@ class ConvertToNamedArguments(trees: Trees) extends CodeAction {
     maybeApply
       .map { apply =>
         {
-          val codeAction = new l.CodeAction(title)
+          val codeAction = new l.CodeAction(title(apply.app.fun.syntax))
           codeAction.setKind(l.CodeActionKind.RefactorRewrite)
           val position = new l.TextDocumentPositionParams(
             params.getTextDocument(),
-            new l.Position(apply.term.pos.endLine, apply.term.pos.endColumn)
+            new l.Position(apply.app.pos.endLine, apply.app.pos.endColumn)
           )
           codeAction.setCommand(
             ServerCommands.ConvertToNamedArguments.toLSP(
@@ -68,6 +68,6 @@ class ConvertToNamedArguments(trees: Trees) extends CodeAction {
 }
 
 object ConvertToNamedArguments {
-  case class ApplyTermWithNumArgs(term: Term.Apply, numUnnamedArgs: Int)
-  val title = "Convert to named arguments"
+  case class ApplyTermWithNumArgs(app: Term.Apply, numUnnamedArgs: Int)
+  def title(funcName: String) = s"Convert $funcName to named arguments"
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
@@ -14,6 +14,8 @@ import org.eclipse.{lsp4j => l}
 
 class ConvertToNamedArguments(trees: Trees, compilers: Compilers)
     extends CodeAction {
+
+  import ConvertToNamedArguments._
   override val kind: String = l.CodeActionKind.RefactorRewrite
 
   override def contribute(params: l.CodeActionParams, token: CancelToken)(
@@ -41,7 +43,7 @@ class ConvertToNamedArguments(trees: Trees, compilers: Compilers)
               token
             )
             edits.map(e => {
-              val codeAction = new l.CodeAction("Convert to named arguments")
+              val codeAction = new l.CodeAction(title)
               codeAction.setEdit(
                 new l.WorkspaceEdit(Map(path.toURI.toString -> e).asJava)
               )
@@ -52,4 +54,8 @@ class ConvertToNamedArguments(trees: Trees, compilers: Compilers)
       }
       .getOrElse(Future.successful(Nil))
   }
+}
+
+object ConvertToNamedArguments {
+  val title = "Convert to named arguments"
 }

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -98,7 +98,7 @@ public abstract class PresentationCompiler {
     /**
      * Return named arguments for the apply method that encloses the given position.
      */
-    public abstract CompletableFuture<List<TextEdit>> convertToNamedArguments(OffsetParams params, List<Integer> numUnnamedArgs);
+    public abstract CompletableFuture<List<TextEdit>> convertToNamedArguments(OffsetParams params, List<Integer> argIndices);
 
     /**
      * The text contents of the fiven file changed.

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -98,7 +98,7 @@ public abstract class PresentationCompiler {
     /**
      * Return named arguments for the apply method that encloses the given position.
      */
-    public abstract CompletableFuture<List<TextEdit>> convertToNamedArguments(OffsetParams params, List<Integer> argIndices);
+    public abstract CompletableFuture<List<TextEdit>> convertToNamedArguments(OffsetParams params, int numUnnamedArgs);
 
     /**
      * The text contents of the fiven file changed.

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -96,6 +96,11 @@ public abstract class PresentationCompiler {
     public abstract CompletableFuture<List<TextEdit>> insertInferredType(OffsetParams params);
 
     /**
+     * Return named arguments for the apply method that encloses the given position.
+     */
+    public abstract CompletableFuture<List<TextEdit>> convertToNamedArguments(OffsetParams params, int numUnnamedArgs);
+
+    /**
      * The text contents of the fiven file changed.
      */
     public abstract CompletableFuture<List<Diagnostic>> didChange(VirtualFileParams params);

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -98,7 +98,7 @@ public abstract class PresentationCompiler {
     /**
      * Return named arguments for the apply method that encloses the given position.
      */
-    public abstract CompletableFuture<List<TextEdit>> convertToNamedArguments(OffsetParams params, int numUnnamedArgs);
+    public abstract CompletableFuture<List<TextEdit>> convertToNamedArguments(OffsetParams params, List<Integer> numUnnamedArgs);
 
     /**
      * The text contents of the fiven file changed.

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -98,7 +98,7 @@ public abstract class PresentationCompiler {
     /**
      * Return named arguments for the apply method that encloses the given position.
      */
-    public abstract CompletableFuture<List<TextEdit>> convertToNamedArguments(OffsetParams params, int numUnnamedArgs);
+    public abstract CompletableFuture<List<TextEdit>> convertToNamedArguments(OffsetParams params, List<Integer> argIndices);
 
     /**
      * The text contents of the fiven file changed.

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
@@ -21,8 +21,7 @@ final class ConvertToNamedArgumentsProvider(
     val typedTree = typedTreeAt(unit.position(params.offset))
     typedTree match {
       case Apply(fun, args) =>
-        args
-          .zipWithIndex
+        args.zipWithIndex
           .zip(fun.tpe.params)
           .collect {
             case ((arg, index), param) if argIndices.contains(index) => {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
@@ -7,8 +7,10 @@ import org.eclipse.{lsp4j => l}
 final class ConvertToNamedArgumentsProvider(
     val compiler: MetalsGlobal,
     params: OffsetParams,
-    numUnnamedArgs: Int
+    argIndices: Seq[Int]
 ) {
+
+  private val argIndexSet = argIndices.toSet
   import compiler._
   def convertToNamedArguments: List[l.TextEdit] = {
     val unit = addCompilationUnit(
@@ -20,7 +22,12 @@ final class ConvertToNamedArgumentsProvider(
     val typedTree = typedTreeAt(unit.position(params.offset))
     typedTree match {
       case Apply(fun, args) =>
-        args.take(numUnnamedArgs).zip(fun.tpe.params).map {
+        pprint.log(fun)
+        args.zipWithIndex.filter { case (_, index) => argIndexSet.contains(index) }
+          .map(_._1)
+          .zip(fun.tpe.params)
+        //args.take(numUnnamedArgs).zip(fun.tpe.params)
+          .map {
           case (arg, param) => {
             val position = arg.pos.toLSP
             position.setEnd(position.getStart())
@@ -29,5 +36,8 @@ final class ConvertToNamedArgumentsProvider(
         }
       case _ => Nil
     }
+  }
+  object Something {
+    def f(x: Seq[Int]) = x.map ( _.toLong )
   }
 }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
@@ -22,11 +22,9 @@ final class ConvertToNamedArgumentsProvider(
     val typedTree = typedTreeAt(unit.position(params.offset))
     typedTree match {
       case Apply(fun, args) =>
-        pprint.log(fun)
         args.zipWithIndex.filter { case (_, index) => argIndexSet.contains(index) }
           .map(_._1)
           .zip(fun.tpe.params)
-        //args.take(numUnnamedArgs).zip(fun.tpe.params)
           .map {
           case (arg, param) => {
             val position = arg.pos.toLSP
@@ -36,8 +34,5 @@ final class ConvertToNamedArgumentsProvider(
         }
       case _ => Nil
     }
-  }
-  object Something {
-    def f(x: Seq[Int]) = x.map ( _.toLong )
   }
 }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
@@ -21,15 +21,16 @@ final class ConvertToNamedArgumentsProvider(
     val typedTree = typedTreeAt(unit.position(params.offset))
     typedTree match {
       case Apply(fun, args) =>
-        args.take(numUnnamedArgs)
+        args
+          .take(numUnnamedArgs)
           .zip(fun.tpe.params)
           .map {
-          case (arg, param) => {
-            val position = arg.pos.toLSP
-            position.setEnd(position.getStart())
-            new l.TextEdit(position, s"${param.nameString} = ")
+            case (arg, param) => {
+              val position = arg.pos.toLSP
+              position.setEnd(position.getStart())
+              new l.TextEdit(position, s"${param.nameString} = ")
+            }
           }
-        }
       case _ => Nil
     }
   }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
@@ -1,0 +1,33 @@
+package scala.meta.internal.pc
+
+import scala.meta.pc.OffsetParams
+
+import org.eclipse.{lsp4j => l}
+
+final class ConvertToNamedArgumentsProvider(
+    val compiler: MetalsGlobal,
+    params: OffsetParams,
+    numUnnamedArgs: Int
+) {
+  import compiler._
+  def convertToNamedArguments: List[l.TextEdit] = {
+    val unit = addCompilationUnit(
+      code = params.text(),
+      filename = params.uri().toString(),
+      cursor = None
+    )
+
+    val typedTree = typedTreeAt(unit.position(params.offset))
+    typedTree match {
+      case Apply(fun, args) =>
+        args.take(numUnnamedArgs).zip(fun.tpe.params).map {
+          case (arg, param) => {
+            val position = arg.pos.toLSP
+            position.setEnd(position.getStart())
+            new l.TextEdit(position, s"${param.nameString} = ")
+          }
+        }
+      case _ => Nil
+    }
+  }
+}

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
@@ -7,10 +7,9 @@ import org.eclipse.{lsp4j => l}
 final class ConvertToNamedArgumentsProvider(
     val compiler: MetalsGlobal,
     params: OffsetParams,
-    argIndices: Seq[Int]
+    numUnnamedArgs: Int
 ) {
 
-  private val argIndexSet = argIndices.toSet
   import compiler._
   def convertToNamedArguments: List[l.TextEdit] = {
     val unit = addCompilationUnit(
@@ -22,8 +21,7 @@ final class ConvertToNamedArgumentsProvider(
     val typedTree = typedTreeAt(unit.position(params.offset))
     typedTree match {
       case Apply(fun, args) =>
-        args.zipWithIndex.filter { case (_, index) => argIndexSet.contains(index) }
-          .map(_._1)
+        args.take(numUnnamedArgs)
           .zip(fun.tpe.params)
           .map {
           case (arg, param) => {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
@@ -7,7 +7,7 @@ import org.eclipse.{lsp4j => l}
 final class ConvertToNamedArgumentsProvider(
     val compiler: MetalsGlobal,
     params: OffsetParams,
-    numUnnamedArgs: Int
+    argIndices: Set[Int]
 ) {
 
   import compiler._
@@ -22,10 +22,10 @@ final class ConvertToNamedArgumentsProvider(
     typedTree match {
       case Apply(fun, args) =>
         args
-          .take(numUnnamedArgs)
+          .zipWithIndex
           .zip(fun.tpe.params)
-          .map {
-            case (arg, param) => {
+          .collect {
+            case ((arg, index), param) if argIndices.contains(index) => {
               val position = arg.pos.toLSP
               position.setEnd(position.getStart())
               new l.TextEdit(position, s"${param.nameString} = ")

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -144,14 +144,14 @@ case class ScalaPresentationCompiler(
 
   override def convertToNamedArguments(
       params: OffsetParams,
-      numUnnamedArgs: Int
+      argIndices: ju.List[Integer]
   ): CompletableFuture[ju.List[TextEdit]] = {
     val empty: ju.List[TextEdit] = new ju.ArrayList[TextEdit]()
     compilerAccess.withInterruptableCompiler(empty, params.token) { pc =>
       new ConvertToNamedArgumentsProvider(
         pc.compiler(),
         params,
-        numUnnamedArgs
+        argIndices.asScala.map(_.toInt).toSet
       ).convertToNamedArguments.asJava
     }
   }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -144,14 +144,14 @@ case class ScalaPresentationCompiler(
 
   override def convertToNamedArguments(
       params: OffsetParams,
-      argIndices: ju.List[Integer]
+      numUnnamedArgs: Int
   ): CompletableFuture[ju.List[TextEdit]] = {
     val empty: ju.List[TextEdit] = new ju.ArrayList[TextEdit]()
     compilerAccess.withInterruptableCompiler(empty, params.token) { pc =>
       new ConvertToNamedArgumentsProvider(
         pc.compiler(),
         params,
-        argIndices.asScala.toSeq.map(_.toInt)
+        numUnnamedArgs
       ).convertToNamedArguments.asJava
     }
   }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -142,6 +142,20 @@ case class ScalaPresentationCompiler(
     }
   }
 
+  override def convertToNamedArguments(
+      params: OffsetParams,
+      numUnnamedArgs: Int
+  ): CompletableFuture[ju.List[TextEdit]] = {
+    val empty: ju.List[TextEdit] = new ju.ArrayList[TextEdit]()
+    compilerAccess.withInterruptableCompiler(empty, params.token) { pc =>
+      new ConvertToNamedArgumentsProvider(
+        pc.compiler(),
+        params,
+        numUnnamedArgs
+      ).convertToNamedArguments.asJava
+    }
+  }
+
   override def autoImports(
       name: String,
       params: OffsetParams

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -144,14 +144,14 @@ case class ScalaPresentationCompiler(
 
   override def convertToNamedArguments(
       params: OffsetParams,
-      numUnnamedArgs: Int
+      argIndices: ju.List[Integer]
   ): CompletableFuture[ju.List[TextEdit]] = {
     val empty: ju.List[TextEdit] = new ju.ArrayList[TextEdit]()
     compilerAccess.withInterruptableCompiler(empty, params.token) { pc =>
       new ConvertToNamedArgumentsProvider(
         pc.compiler(),
         params,
-        numUnnamedArgs
+        argIndices.asScala.toSeq.map(_.toInt)
       ).convertToNamedArguments.asJava
     }
   }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -194,7 +194,8 @@ case class ScalaPresentationCompiler(
   override def convertToNamedArguments(
       params: OffsetParams,
       numUnnamedArgs: Int
-  ): CompletableFuture[ju.List[l.TextEdit]] = CompletableFuture.completedFuture(Nil.asJava)
+  ): CompletableFuture[ju.List[l.TextEdit]] =
+    CompletableFuture.completedFuture(Nil.asJava)
 
   override def selectionRange(
       params: ju.List[OffsetParams]

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -193,7 +193,7 @@ case class ScalaPresentationCompiler(
 
   override def convertToNamedArguments(
       params: OffsetParams,
-      numUnnamedArgs: Int
+      argIndices: ju.List[Integer]
   ): CompletableFuture[ju.List[l.TextEdit]] = CompletableFuture.completedFuture(Nil.asJava)
 
   override def selectionRange(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -193,7 +193,7 @@ case class ScalaPresentationCompiler(
 
   override def convertToNamedArguments(
       params: OffsetParams,
-      numUnnamedArgs: Int
+      argIndices: ju.List[Integer]
   ): CompletableFuture[ju.List[l.TextEdit]] =
     CompletableFuture.completedFuture(Nil.asJava)
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -191,6 +191,11 @@ case class ScalaPresentationCompiler(
         .asJava
     }
 
+  override def convertToNamedArguments(
+      params: OffsetParams,
+      numUnnamedArgs: Int
+  ): CompletableFuture[ju.List[l.TextEdit]] = CompletableFuture.completedFuture(Nil.asJava)
+
   override def selectionRange(
       params: ju.List[OffsetParams]
   ): CompletableFuture[ju.List[l.SelectionRange]] =

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -193,7 +193,7 @@ case class ScalaPresentationCompiler(
 
   override def convertToNamedArguments(
       params: OffsetParams,
-      argIndices: ju.List[Integer]
+      numUnnamedArgs: Int
   ): CompletableFuture[ju.List[l.TextEdit]] = CompletableFuture.completedFuture(Nil.asJava)
 
   override def selectionRange(

--- a/tests/cross/src/test/scala/tests/pc/ConvertToNamedArgumentsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/ConvertToNamedArgumentsSuite.scala
@@ -1,0 +1,58 @@
+package tests.pc
+
+import java.net.URI
+
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.CompilerOffsetParams
+import scala.meta.internal.metals.TextEdits
+
+import munit.Location
+import munit.TestOptions
+import org.eclipse.{lsp4j => l}
+import tests.BaseCodeActionSuite
+
+class ConvertToNamedArgumentsSuite extends BaseCodeActionSuite {
+
+  override protected def requiresScalaLibrarySources: Boolean = true
+
+  checkEdit(
+    "scala-std-lib",
+    """|object A{
+      |  val a = <<scala.math.max(1, 2)>>
+       |}""".stripMargin,
+       List(0, 1),
+    """|object A{
+       |  val a = scala.math.max(x = 1, y = 2)
+       |}""".stripMargin
+  )
+
+  def checkEdit(
+      name: TestOptions,
+      original: String,
+      argIndices: List[Int],
+      expected: String,
+      compat: Map[String, String] = Map.empty
+  )(implicit location: Location): Unit =
+    test(name) {
+      val edits = convertToNamedArgs(original, argIndices)
+      val (code, _, _) = params(original)
+      val obtained = TextEdits.applyEdits(code, edits)
+      assertNoDiff(obtained, getExpected(expected, compat, scalaVersion))
+    }
+
+  def convertToNamedArgs(
+      original: String,
+      argIndices: List[Int],
+      filename: String = "file:/A.scala"
+  ): List[l.TextEdit] = {
+    val (code, _, offset) = params(original)
+    val result = presentationCompiler
+      .convertToNamedArguments(
+        CompilerOffsetParams(URI.create(filename), code, offset, cancelToken),
+        argIndices.map(new Integer(_)).asJava
+      )
+      .get()
+    result.asScala.toList
+  }
+
+}

--- a/tests/cross/src/test/scala/tests/pc/ConvertToNamedArgumentsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/ConvertToNamedArgumentsSuite.scala
@@ -13,7 +13,9 @@ import tests.BaseCodeActionSuite
 
 class ConvertToNamedArgumentsSuite extends BaseCodeActionSuite {
 
-  override protected def ignoreScalaVersion: Option[IgnoreScalaVersion] = Some(IgnoreScala3)
+  override protected def ignoreScalaVersion: Option[IgnoreScalaVersion] = Some(
+    IgnoreScala3
+  )
   override protected def requiresScalaLibrarySources: Boolean = true
 
   checkEdit(

--- a/tests/cross/src/test/scala/tests/pc/ConvertToNamedArgumentsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/ConvertToNamedArgumentsSuite.scala
@@ -18,9 +18,9 @@ class ConvertToNamedArgumentsSuite extends BaseCodeActionSuite {
   checkEdit(
     "scala-std-lib",
     """|object A{
-      |  val a = <<scala.math.max(1, 2)>>
+       |  val a = <<scala.math.max(1, 2)>>
        |}""".stripMargin,
-       List(0, 1),
+    List(0, 1),
     """|object A{
        |  val a = scala.math.max(x = 1, y = 2)
        |}""".stripMargin

--- a/tests/cross/src/test/scala/tests/pc/ConvertToNamedArgumentsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/ConvertToNamedArgumentsSuite.scala
@@ -13,6 +13,7 @@ import tests.BaseCodeActionSuite
 
 class ConvertToNamedArgumentsSuite extends BaseCodeActionSuite {
 
+  override protected def ignoreScalaVersion: Option[IgnoreScalaVersion] = Some(IgnoreScala3)
   override protected def requiresScalaLibrarySources: Boolean = true
 
   checkEdit(

--- a/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
@@ -1,6 +1,7 @@
 package tests.feature
 
 import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
 import scala.meta.internal.metals.codeactions.CreateCompanionObjectCodeAction
 import scala.meta.internal.metals.codeactions.ExtractRenameMember
 import scala.meta.internal.metals.codeactions.ExtractValueCodeAction
@@ -130,7 +131,9 @@ class Scala3CodeActionLspSuite
        |  }
        |}
        |""".stripMargin,
-    ExtractValueCodeAction.title,
+    s"""|${ExtractValueCodeAction.title}
+        |${ConvertToNamedArguments.title("method2")}
+        |""".stripMargin,
     """|object Main {
        |  def method2(i: Int) = ???
        |  def main = {
@@ -151,7 +154,9 @@ class Scala3CodeActionLspSuite
        |    def inner(i : Int) = method2(i + 23 + <<123>>)
        |
        |""".stripMargin,
-    ExtractValueCodeAction.title,
+    s"""|${ExtractValueCodeAction.title}
+        |${ConvertToNamedArguments.title("method2")}
+        |""".stripMargin,
     """|object Main:
        |  def method2(i: Int) = ???
        |  def main =
@@ -170,7 +175,9 @@ class Scala3CodeActionLspSuite
        |    method2(i + 23 + <<123>>)
        |}
        |""".stripMargin,
-    ExtractValueCodeAction.title,
+    s"""|${ExtractValueCodeAction.title}
+        |${ConvertToNamedArguments.title("method2")}
+        |""".stripMargin,
     """|object Main {
        |  def method2(i: Int) = ???
        |  
@@ -191,7 +198,9 @@ class Scala3CodeActionLspSuite
        |  method2(i + 23 + <<123>>)
        |
        |""".stripMargin,
-    ExtractValueCodeAction.title,
+    s"""|${ExtractValueCodeAction.title}
+        |${ConvertToNamedArguments.title("method2")}
+        |""".stripMargin,
     """|object Main:
        |  def method2(i: Int) = ???
        |  
@@ -213,7 +222,9 @@ class Scala3CodeActionLspSuite
        |def main(i : Int) = method2(i + 23 + <<123>>)
        |
        |""".stripMargin,
-    ExtractValueCodeAction.title,
+    s"""|${ExtractValueCodeAction.title}
+        |${ConvertToNamedArguments.title("method2")}
+        |""".stripMargin,
     """|def method2(i: Int) = {
        |  val a = 1
        |  a + 2

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1145,7 +1145,7 @@ final class TestingServer(
       query: String,
       expectedExcluded: String,
       kind: List[String],
-      root: AbsolutePath = workspace,
+      root: AbsolutePath = workspace
   )(implicit loc: munit.Location): Future[List[l.CodeAction]] =
     for {
       (codeActions, codeActionString) <- codeAction(filename, query, root, kind)

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1140,6 +1140,20 @@ final class TestingServer(
       codeActions
     }
 
+  def assertCodeActionExcluded(
+      filename: String,
+      query: String,
+      expectedExcluded: String,
+      kind: List[String],
+      root: AbsolutePath = workspace,
+  )(implicit loc: munit.Location): Future[List[l.CodeAction]] =
+    for {
+      (codeActions, codeActionString) <- codeAction(filename, query, root, kind)
+    } yield {
+      Assertions.assertNotContains(codeActionString, expectedExcluded)
+      codeActions
+    }
+
   def hover(
       filename: String,
       query: String,

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1135,7 +1135,13 @@ final class TestingServer(
       filterAction: l.CodeAction => Boolean = _ => true
   )(implicit loc: munit.Location): Future[List[l.CodeAction]] =
     for {
-      (codeActions, codeActionString) <- codeAction(filename, query, root, kind, filterAction)
+      (codeActions, codeActionString) <- codeAction(
+        filename,
+        query,
+        root,
+        kind,
+        filterAction
+      )
     } yield {
       Assertions.assertNoDiff(codeActionString, expected)
       codeActions
@@ -1175,7 +1181,10 @@ final class TestingServer(
           if (kind.nonEmpty) kind.asJava else null
         )
       )
-      codeActions <- server.codeAction(params).asScala.map(_.asScala.filter(filterAction))
+      codeActions <- server
+        .codeAction(params)
+        .asScala
+        .map(_.asScala.filter(filterAction))
     } yield (
       codeActions.toList,
       codeActions.map(_.getTitle()).mkString("\n")

--- a/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -10,8 +10,10 @@ import munit.TestOptions
 import tests.BaseLspSuite
 import org.eclipse.lsp4j.CodeAction
 
-abstract class BaseCodeActionLspSuite(suiteName: String, filterAction: CodeAction => Boolean = _ => true)
-    extends BaseLspSuite(suiteName) {
+abstract class BaseCodeActionLspSuite(
+    suiteName: String,
+    filterAction: CodeAction => Boolean = _ => true
+) extends BaseLspSuite(suiteName) {
 
   protected val scalaVersion: String = V.scala213
 

--- a/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -7,8 +7,8 @@ import scala.meta.internal.metals.{BuildInfo => V}
 
 import munit.Location
 import munit.TestOptions
-import tests.BaseLspSuite
 import org.eclipse.lsp4j.CodeAction
+import tests.BaseLspSuite
 
 abstract class BaseCodeActionLspSuite(
     suiteName: String

--- a/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -42,7 +42,7 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
       configuration: => Option[String] = None,
       scalaVersion: String = scalaVersion,
       fileName: String = "A.scala",
-      changeFile: String => String = identity,
+      changeFile: String => String = identity
   )(implicit loc: Location): Unit = {
     val scalacOptionsJson =
       if (scalacOptions.nonEmpty)
@@ -75,12 +75,11 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
               path,
               changeFile(input),
               expectedMissing,
-              kind,
+              kind
             )
       } yield ()
     }
   }
-
 
   def check(
       name: TestOptions,

--- a/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -11,8 +11,7 @@ import tests.BaseLspSuite
 import org.eclipse.lsp4j.CodeAction
 
 abstract class BaseCodeActionLspSuite(
-    suiteName: String,
-    filterAction: CodeAction => Boolean = _ => true
+    suiteName: String
 ) extends BaseLspSuite(suiteName) {
 
   protected val scalaVersion: String = V.scala213
@@ -21,7 +20,8 @@ abstract class BaseCodeActionLspSuite(
       name: TestOptions,
       input: String,
       scalafixConf: String = "",
-      scalacOptions: List[String] = Nil
+      scalacOptions: List[String] = Nil,
+      filterAction: CodeAction => Boolean = _ => true
   )(implicit loc: Location): Unit = {
     val fileContent = input.replace("<<", "").replace(">>", "")
     check(
@@ -30,7 +30,8 @@ abstract class BaseCodeActionLspSuite(
       "",
       fileContent,
       scalafixConf = scalafixConf,
-      scalacOptions = scalacOptions
+      scalacOptions = scalacOptions,
+      filterAction = filterAction
     )
   }
 
@@ -50,7 +51,8 @@ abstract class BaseCodeActionLspSuite(
       extraOperations: => Unit = (),
       fileName: String = "A.scala",
       changeFile: String => String = identity,
-      expectError: Boolean = false
+      expectError: Boolean = false,
+      filterAction: CodeAction => Boolean = _ => true
   )(implicit loc: Location): Unit = {
     val scalacOptionsJson =
       if (scalacOptions.nonEmpty)

--- a/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -8,8 +8,9 @@ import scala.meta.internal.metals.{BuildInfo => V}
 import munit.Location
 import munit.TestOptions
 import tests.BaseLspSuite
+import org.eclipse.lsp4j.CodeAction
 
-abstract class BaseCodeActionLspSuite(suiteName: String)
+abstract class BaseCodeActionLspSuite(suiteName: String, filterAction: CodeAction => Boolean = _ => true)
     extends BaseLspSuite(suiteName) {
 
   protected val scalaVersion: String = V.scala213
@@ -29,56 +30,6 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
       scalafixConf = scalafixConf,
       scalacOptions = scalacOptions
     )
-  }
-
-  // Checks that a code action is not in the actions recieved from the server
-  def checkActionMissing(
-      name: TestOptions,
-      input: String,
-      expectedMissing: String,
-      scalafixConf: String = "",
-      scalacOptions: List[String] = Nil,
-      kind: List[String] = Nil,
-      configuration: => Option[String] = None,
-      scalaVersion: String = scalaVersion,
-      fileName: String = "A.scala",
-      changeFile: String => String = identity
-  )(implicit loc: Location): Unit = {
-    val scalacOptionsJson =
-      if (scalacOptions.nonEmpty)
-        s""""scalacOptions": ["${scalacOptions.mkString("\",\"")}"],"""
-      else ""
-    val path = s"a/src/main/scala/a/$fileName"
-    val fileContent = input.replace("<<", "").replace(">>", "")
-
-    test(name) {
-      cleanWorkspace()
-      for {
-        _ <- initialize(
-          s"""/metals.json
-             |{"a":{$scalacOptionsJson "scalaVersion" : "$scalaVersion"}}
-             |$scalafixConf
-             |/$path
-             |$fileContent""".stripMargin
-        )
-        _ <- server.didOpen(path)
-        _ <- {
-          configuration match {
-            case Some(conf) => server.didChangeConfiguration(conf)
-            case None => Future {}
-          }
-        }
-        _ <- server.didChange(path)(txt => changeFile(txt))
-        codeActions <-
-          server
-            .assertCodeActionExcluded(
-              path,
-              changeFile(input),
-              expectedMissing,
-              kind
-            )
-      } yield ()
-    }
   }
 
   def check(
@@ -133,7 +84,8 @@ abstract class BaseCodeActionLspSuite(suiteName: String)
               path,
               changeFile(input),
               expectedActions,
-              kind
+              kind,
+              filterAction = filterAction
             )
             .recover {
               case _: Throwable if expectError => Nil

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertPatternMatchLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertPatternMatchLspSuite.scala
@@ -4,7 +4,10 @@ import scala.meta.internal.metals.codeactions.PatternMatchRefactor
 import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
 
 class ConvertPatternMatchLspSuite
-    extends BaseCodeActionLspSuite("convertPatternMatch", filterAction = _.getTitle() == PatternMatchRefactor.convertPatternMatch) {
+    extends BaseCodeActionLspSuite(
+      "convertPatternMatch",
+      filterAction = _.getTitle() == PatternMatchRefactor.convertPatternMatch
+    ) {
 
   check(
     "with-placeholder",

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertPatternMatchLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertPatternMatchLspSuite.scala
@@ -2,12 +2,14 @@ package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.PatternMatchRefactor
 import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
+import org.eclipse.lsp4j.CodeAction
 
 class ConvertPatternMatchLspSuite
     extends BaseCodeActionLspSuite(
-      "convertPatternMatch",
-      filterAction = _.getTitle() == PatternMatchRefactor.convertPatternMatch
+      "convertPatternMatch"
     ) {
+
+  val filterAction = { act: CodeAction => act.getTitle() == PatternMatchRefactor.convertPatternMatch }
 
   check(
     "with-placeholder",
@@ -79,7 +81,8 @@ class ConvertPatternMatchLspSuite
        |    case 3 => x = 3; Nil
        |  }
        |}
-       |""".stripMargin
+       |""".stripMargin,
+       filterAction = filterAction
   )
 
   checkNoAction(
@@ -90,7 +93,8 @@ class ConvertPatternMatchLspSuite
        |    case 2 => 2
        |  }
        |}
-       |""".stripMargin
+       |""".stripMargin,
+       filterAction = filterAction
   )
 
 }

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertPatternMatchLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertPatternMatchLspSuite.scala
@@ -4,7 +4,7 @@ import scala.meta.internal.metals.codeactions.PatternMatchRefactor
 import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
 
 class ConvertPatternMatchLspSuite
-    extends BaseCodeActionLspSuite("convertPatternMatch") {
+    extends BaseCodeActionLspSuite("convertPatternMatch", filterAction = _.getTitle() == PatternMatchRefactor.convertPatternMatch) {
 
   check(
     "with-placeholder",
@@ -61,7 +61,6 @@ class ConvertPatternMatchLspSuite
        |}
        |""".stripMargin,
     s"""|${PatternMatchRefactor.convertPatternMatch}
-        |${RewriteBracesParensCodeAction.toParens("map")}
         |""".stripMargin,
     """|object Main {
        |  var x = 0

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertPatternMatchLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertPatternMatchLspSuite.scala
@@ -1,7 +1,7 @@
 package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.PatternMatchRefactor
-import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
+
 import org.eclipse.lsp4j.CodeAction
 
 class ConvertPatternMatchLspSuite
@@ -9,7 +9,9 @@ class ConvertPatternMatchLspSuite
       "convertPatternMatch"
     ) {
 
-  val filterAction = { act: CodeAction => act.getTitle() == PatternMatchRefactor.convertPatternMatch }
+  val filterAction: CodeAction => Boolean = { act: CodeAction =>
+    act.getTitle() == PatternMatchRefactor.convertPatternMatch
+  }
 
   check(
     "with-placeholder",
@@ -82,7 +84,7 @@ class ConvertPatternMatchLspSuite
        |  }
        |}
        |""".stripMargin,
-       filterAction = filterAction
+    filterAction = filterAction
   )
 
   checkNoAction(
@@ -94,7 +96,7 @@ class ConvertPatternMatchLspSuite
        |  }
        |}
        |""".stripMargin,
-       filterAction = filterAction
+    filterAction = filterAction
   )
 
 }

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsLspSuite.scala
@@ -3,8 +3,10 @@ package tests.codeactions
 import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
 
 class ConvertToNamedArgumentsLspSuite
-    extends BaseCodeActionLspSuite("convertToNamedArguments", filterAction = ConvertToNamedArguments.title(".*").r matches _.getTitle() ) {
-
+    extends BaseCodeActionLspSuite(
+      "convertToNamedArguments",
+      filterAction = ConvertToNamedArguments.title(".*").r matches _.getTitle()
+    ) {
 
   check(
     "basic",
@@ -146,7 +148,7 @@ class ConvertToNamedArgumentsLspSuite
        |  case class Foo(param1: Int, param2: Int, param3: String)
        |  Foo(1, 2, 3.t<<>>oString())
        |}""".stripMargin,
-      s"${ConvertToNamedArguments.title("Foo")}",
+    s"${ConvertToNamedArguments.title("Foo")}",
     """|object Something {
        |  case class Foo(param1: Int, param2: Int, param3: String)
        |  Foo(param1 = 1, param2 = 2, param3 = 3.toString())

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsLspSuite.scala
@@ -1,12 +1,14 @@
 package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
+import org.eclipse.lsp4j.CodeAction
 
 class ConvertToNamedArgumentsLspSuite
     extends BaseCodeActionLspSuite(
-      "convertToNamedArguments",
-      filterAction = ConvertToNamedArguments.title(".*").r matches _.getTitle()
+      "convertToNamedArguments"
     ) {
+
+  val filterAction = { act: CodeAction => ConvertToNamedArguments.title(".*").r matches act.getTitle() }
 
   check(
     "basic",
@@ -83,7 +85,8 @@ class ConvertToNamedArgumentsLspSuite
     """|object Something {
        |  def foo(param1: Int, param2: Int, param3: Int)(param4: Int) = None
        |  foo(1, 2, param3 = 3)(param4 = 4)
-       |}""".stripMargin
+       |}""".stripMargin,
+       filterAction = filterAction
   )
 
   check(
@@ -98,7 +101,8 @@ class ConvertToNamedArgumentsLspSuite
        |  def foo(param1: Int, param2: Int)(implicit param3: Int) = None
        |  implicit val x = 3
        |  foo(param1 = 1, param2 = 2)
-       |}""".stripMargin
+       |}""".stripMargin,
+       filterAction = filterAction
   )
 
   check(
@@ -111,7 +115,8 @@ class ConvertToNamedArgumentsLspSuite
     """|object Something {
        |  def foo(param1: Int, param2: Int)(implicit param3: Int) = None
        |  foo(1, 2)(param3 = 3)
-       |}""".stripMargin
+       |}""".stripMargin,
+       filterAction = filterAction
   )
 
   check(
@@ -152,6 +157,7 @@ class ConvertToNamedArgumentsLspSuite
     """|object Something {
        |  case class Foo(param1: Int, param2: Int, param3: String)
        |  Foo(param1 = 1, param2 = 2, param3 = 3.toString())
-       |}""".stripMargin
+       |}""".stripMargin,
+       filterAction = filterAction
   )
 }

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsLspSuite.scala
@@ -160,4 +160,13 @@ class ConvertToNamedArgumentsLspSuite
        |}""".stripMargin,
        filterAction = filterAction
   )
+
+  checkNoAction(
+    "cursor-outside-func",
+    """|object Something {
+       |  import scala.concurrent.Future
+       |  F<<u>>ture.successful(1)
+       |}""".stripMargin,
+    filterAction = filterAction
+  )
 }

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsLspSuite.scala
@@ -2,7 +2,7 @@ package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
 
-class ConvertToNamedArgumentsSuite
+class ConvertToNamedArgumentsLspSuite
     extends BaseCodeActionLspSuite("convertToNamedArguments", filterAction = ConvertToNamedArguments.title(".*").r matches _.getTitle() ) {
 
 

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsLspSuite.scala
@@ -1,6 +1,7 @@
 package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
+
 import org.eclipse.lsp4j.CodeAction
 
 class ConvertToNamedArgumentsLspSuite
@@ -8,7 +9,9 @@ class ConvertToNamedArgumentsLspSuite
       "convertToNamedArguments"
     ) {
 
-  val filterAction = { act: CodeAction => ConvertToNamedArguments.title(".*").r matches act.getTitle() }
+  val filterAction: CodeAction => Boolean = { act: CodeAction =>
+    ConvertToNamedArguments.title(".*").r matches act.getTitle()
+  }
 
   check(
     "basic",
@@ -86,7 +89,7 @@ class ConvertToNamedArgumentsLspSuite
        |  def foo(param1: Int, param2: Int, param3: Int)(param4: Int) = None
        |  foo(1, 2, param3 = 3)(param4 = 4)
        |}""".stripMargin,
-       filterAction = filterAction
+    filterAction = filterAction
   )
 
   check(
@@ -102,7 +105,7 @@ class ConvertToNamedArgumentsLspSuite
        |  implicit val x = 3
        |  foo(param1 = 1, param2 = 2)
        |}""".stripMargin,
-       filterAction = filterAction
+    filterAction = filterAction
   )
 
   check(
@@ -116,7 +119,7 @@ class ConvertToNamedArgumentsLspSuite
        |  def foo(param1: Int, param2: Int)(implicit param3: Int) = None
        |  foo(1, 2)(param3 = 3)
        |}""".stripMargin,
-       filterAction = filterAction
+    filterAction = filterAction
   )
 
   check(
@@ -158,7 +161,7 @@ class ConvertToNamedArgumentsLspSuite
        |  case class Foo(param1: Int, param2: Int, param3: String)
        |  Foo(param1 = 1, param2 = 2, param3 = 3.toString())
        |}""".stripMargin,
-       filterAction = filterAction
+    filterAction = filterAction
   )
 
   checkNoAction(

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
@@ -7,7 +7,7 @@ class ConvertToNamedArgumentsSuite
     extends BaseCodeActionLspSuite("convertToNamedArguments") {
 
   check(
-    "convert-to-named-args-basic",
+    "basic",
     """|object Something {
        |  case class Foo(param1: Int, param2: Int, param3: Int)
        |  Foo<<(>>1, 2, param3 = 3)
@@ -22,7 +22,7 @@ class ConvertToNamedArgumentsSuite
   )
 
   checkNoAction(
-    "convert-to-named-args-no-unnamed-args",
+    "no-unnamed-args",
     """|object Something {
        |  case class Foo(param1: Int, param2: Int, param3: Int)
        |  Foo<<(>>param1 = 1, param2 = <<>>2, param3 = 3)
@@ -30,7 +30,7 @@ class ConvertToNamedArgumentsSuite
   )
 
   checkActionMissing(
-    "convert-to-named-args-block",
+    "block",
     """|object Something {
        |  def f(x: Seq[Int]) = x.map <<{>> _.toLong }
        |}""".stripMargin,
@@ -38,7 +38,7 @@ class ConvertToNamedArgumentsSuite
   )
 
   check(
-    "convert-to-named-go-to-parent-apply",
+    "go-to-parent-apply",
     """|object Something {
        |  case class Foo(param1: Int, param2: Int, param3: String)
        |  Foo(1, 2, 3.t<<>>oString())

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
@@ -1,6 +1,7 @@
 package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
+import scala.meta.internal.metals.codeactions.ExtractValueCodeAction
 
 class ConvertToNamedArgumentsSuite extends BaseCodeActionLspSuite("convertToNamedArguments") {
 
@@ -33,5 +34,21 @@ class ConvertToNamedArgumentsSuite extends BaseCodeActionLspSuite("convertToName
        |  def f(x: Seq[Int]) = x.map <<{>> _.toLong }
        |}""".stripMargin,
     ConvertToNamedArguments.title
+  )
+
+  check(
+    "convert-to-named-go-to-parent-apply",
+    """|object Something {
+       |  case class Foo(param1: Int, param2: Int, param3: String)
+       |  Foo(1, 2, 3.t<<>>oString())
+       |}""".stripMargin,
+    s"""|${ExtractValueCodeAction.title}
+        |${ConvertToNamedArguments.title}
+        |""".stripMargin,
+    """|object Something {
+       |  case class Foo(param1: Int, param2: Int, param3: String)
+       |  Foo(param1 = 1, param2 = 2, param3 = 3.toString())
+       |}""".stripMargin,
+    selectedActionIndex = 1
   )
 }

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
@@ -1,0 +1,29 @@
+package tests.codeactions
+
+import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
+
+class ConvertToNamedArgumentsSuite extends BaseCodeActionLspSuite("convertToNamedArguments") {
+
+  check(
+    "convert-to-named-args-basic",
+    """|object Something {
+       |  case class Foo(param1: Int, param2: Int, param3: Int)
+       |  Foo<<(>>1, 2, param3 = 3)
+       |}""".stripMargin,
+    s"""|${ConvertToNamedArguments.title}
+        |""".stripMargin,
+    """|object Something {
+       |  case class Foo(param1: Int, param2: Int, param3: Int)
+       |  Foo(param1 = 1, param2 = 2, param3 = 3)
+       |}""".stripMargin,
+    selectedActionIndex = 0
+  )
+
+  checkNoAction(
+    "convert-to-named-args-no-unnamed-args",
+    """|object Something {
+       |  case class Foo(param1: Int, param2: Int, param3: Int)
+       |  Foo<<(>>param1 = 1, param2 = <<>>2, param3 = 3)
+       |}""".stripMargin,
+  )
+}

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
@@ -20,6 +20,99 @@ class ConvertToNamedArgumentsSuite
   )
 
   check(
+    "named-arg-first-position",
+    """|object Something {
+       |  case class Foo(param1: Int, param2: Int, param3: Int)
+       |  Foo<<(>>param1 = 1, 2, 3)
+       |}""".stripMargin,
+    s"${ConvertToNamedArguments.title("Foo")}",
+    """|object Something {
+       |  case class Foo(param1: Int, param2: Int, param3: Int)
+       |  Foo(param1 = 1, param2 = 2, param3 = 3)
+       |}""".stripMargin
+  )
+
+  check(
+    "def",
+    """|object Something {
+       |  def foo(param1: Int, param2: Int, param3: Int) = None
+       |  foo<<(>>1, 2, param3 = 3)
+       |}""".stripMargin,
+    s"${ConvertToNamedArguments.title("foo")}",
+    """|object Something {
+       |  def foo(param1: Int, param2: Int, param3: Int) = None
+       |  foo(param1 = 1, param2 = 2, param3 = 3)
+       |}""".stripMargin
+  )
+
+  check(
+    "multiple-arg-lists",
+    """|object Something {
+       |  def foo(param1: Int, param2: Int, param3: Int)(param4: Int) = None
+       |  foo<<(>>1, 2, param3 = 3)(4)
+       |}""".stripMargin,
+    s"${ConvertToNamedArguments.title("foo")}",
+    """|object Something {
+       |  def foo(param1: Int, param2: Int, param3: Int)(param4: Int) = None
+       |  foo(param1 = 1, param2 = 2, param3 = 3)(4)
+       |}""".stripMargin
+  )
+
+  check(
+    "multiple-arg-lists-start-of-2nd",
+    """|object Something {
+       |  def foo(param1: Int, param2: Int, param3: Int)(param4: Int) = None
+       |  foo(1, 2, param3 = 3)<<(>>4)
+       |}""".stripMargin,
+    s"${ConvertToNamedArguments.title("foo")}",
+    """|object Something {
+       |  def foo(param1: Int, param2: Int, param3: Int)(param4: Int) = None
+       |  foo(param1 = 1, param2 = 2, param3 = 3)(4)
+       |}""".stripMargin
+  )
+
+  check(
+    "multiple-arg-lists-only-2nd",
+    """|object Something {
+       |  def foo(param1: Int, param2: Int, param3: Int)(param4: Int) = None
+       |  foo(1, 2, param3 = 3)(<<4>>)
+       |}""".stripMargin,
+    s"${ConvertToNamedArguments.title("foo(1, 2, param3 = 3)")}",
+    """|object Something {
+       |  def foo(param1: Int, param2: Int, param3: Int)(param4: Int) = None
+       |  foo(1, 2, param3 = 3)(param4 = 4)
+       |}""".stripMargin
+  )
+
+  check(
+    "implicit-param",
+    """|object Something {
+       |  def foo(param1: Int, param2: Int)(implicit param3: Int) = None
+       |  implicit val x = 3
+       |  foo(1, <<2>>)
+       |}""".stripMargin,
+    s"${ConvertToNamedArguments.title("foo")}",
+    """|object Something {
+       |  def foo(param1: Int, param2: Int)(implicit param3: Int) = None
+       |  implicit val x = 3
+       |  foo(param1 = 1, param2 = 2)
+       |}""".stripMargin
+  )
+
+  check(
+    "implicit-passed-explicitly",
+    """|object Something {
+       |  def foo(param1: Int, param2: Int)(implicit param3: Int) = None
+       |  foo(1, 2)(<<3>>)
+       |}""".stripMargin,
+    s"${ConvertToNamedArguments.title("foo(1, 2)")}",
+    """|object Something {
+       |  def foo(param1: Int, param2: Int)(implicit param3: Int) = None
+       |  foo(1, 2)(param3 = 3)
+       |}""".stripMargin
+  )
+
+  check(
     "named-arg-in-middle",
     """|object Something {
        |  case class Foo(param1: Int, param2: Int, param3: Int)

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
@@ -12,7 +12,7 @@ class ConvertToNamedArgumentsSuite
        |  case class Foo(param1: Int, param2: Int, param3: Int)
        |  Foo<<(>>1, 2, param3 = 3)
        |}""".stripMargin,
-    s"""|${ConvertToNamedArguments.title}
+    s"""|${ConvertToNamedArguments.title("Foo")}
         |""".stripMargin,
     """|object Something {
        |  case class Foo(param1: Int, param2: Int, param3: Int)
@@ -34,7 +34,7 @@ class ConvertToNamedArgumentsSuite
     """|object Something {
        |  def f(x: Seq[Int]) = x.map <<{>> _.toLong }
        |}""".stripMargin,
-    ConvertToNamedArguments.title
+    ConvertToNamedArguments.title("map")
   )
 
   check(
@@ -44,7 +44,7 @@ class ConvertToNamedArgumentsSuite
        |  Foo(1, 2, 3.t<<>>oString())
        |}""".stripMargin,
     s"""|${ExtractValueCodeAction.title}
-        |${ConvertToNamedArguments.title}
+        |${ConvertToNamedArguments.title("Foo")}
         |""".stripMargin,
     """|object Something {
        |  case class Foo(param1: Int, param2: Int, param3: String)

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
@@ -30,7 +30,7 @@ class ConvertToNamedArgumentsSuite
   )
 
   checkActionMissing(
-    "convert-to-named-args-no-unnamed-args",
+    "convert-to-named-args-block",
     """|object Something {
        |  def f(x: Seq[Int]) = x.map <<{>> _.toLong }
        |}""".stripMargin,

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
@@ -26,4 +26,12 @@ class ConvertToNamedArgumentsSuite extends BaseCodeActionLspSuite("convertToName
        |  Foo<<(>>param1 = 1, param2 = <<>>2, param3 = 3)
        |}""".stripMargin,
   )
+
+  checkActionMissing(
+    "convert-to-named-args-no-unnamed-args",
+    """|object Something {
+       |  def f(x: Seq[Int]) = x.map <<{>> _.toLong }
+       |}""".stripMargin,
+    ConvertToNamedArguments.title
+  )
 }

--- a/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ConvertToNamedArgumentsSuite.scala
@@ -3,7 +3,8 @@ package tests.codeactions
 import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
 import scala.meta.internal.metals.codeactions.ExtractValueCodeAction
 
-class ConvertToNamedArgumentsSuite extends BaseCodeActionLspSuite("convertToNamedArguments") {
+class ConvertToNamedArgumentsSuite
+    extends BaseCodeActionLspSuite("convertToNamedArguments") {
 
   check(
     "convert-to-named-args-basic",
@@ -25,7 +26,7 @@ class ConvertToNamedArgumentsSuite extends BaseCodeActionLspSuite("convertToName
     """|object Something {
        |  case class Foo(param1: Int, param2: Int, param3: Int)
        |  Foo<<(>>param1 = 1, param2 = <<>>2, param3 = 3)
-       |}""".stripMargin,
+       |}""".stripMargin
   )
 
   checkActionMissing(

--- a/tests/unit/src/test/scala/tests/codeactions/ExtractValueLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ExtractValueLspSuite.scala
@@ -1,6 +1,7 @@
 package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.ExtractValueCodeAction
+import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
 
 class ExtractValueLspSuite
     extends BaseCodeActionLspSuite("extractValueRewrite") {
@@ -15,7 +16,8 @@ class ExtractValueLspSuite
        |
        |}
        |""".stripMargin,
-    ExtractValueCodeAction.title,
+    s"""|${ExtractValueCodeAction.title}
+        |${ConvertToNamedArguments.title("method2")}""".stripMargin,
     """|object Main {
        |  def method2(i: Int) = ???
        |  def method1(s: String): Unit = {
@@ -41,7 +43,8 @@ class ExtractValueLspSuite
        |  }
        |}
        |""".stripMargin,
-    ExtractValueCodeAction.title,
+    s"""|${ExtractValueCodeAction.title}
+        |${ConvertToNamedArguments.title("method2")}""".stripMargin,
     """|object Main {
        |  def method2(i: Int) = ???
        |  
@@ -70,7 +73,8 @@ class ExtractValueLspSuite
        |  }
        |}
        |""".stripMargin,
-    ExtractValueCodeAction.title,
+    s"""|${ExtractValueCodeAction.title}
+        |${ConvertToNamedArguments.title("method2")}""".stripMargin,
     """|object Main {
        |  def method2(i: Int): Option[String]  = ???
        |  
@@ -116,7 +120,8 @@ class ExtractValueLspSuite
        |    method2(i + 23 + <<123>>)
        |}
        |""".stripMargin,
-    ExtractValueCodeAction.title,
+    s"""|${ExtractValueCodeAction.title}
+        |${ConvertToNamedArguments.title("method2")}""".stripMargin,
     """|object Main {
        |  def method2(i: Int) = ???
        |  
@@ -137,7 +142,8 @@ class ExtractValueLspSuite
        |  }
        |}
        |""".stripMargin,
-    ExtractValueCodeAction.title,
+    s"""|${ExtractValueCodeAction.title}
+        |${ConvertToNamedArguments.title("method2")}""".stripMargin,
     """|object Main {
        |  def method2(i: Int) : Int = ???
        |  def method1(s: String): Unit = {
@@ -175,7 +181,8 @@ class ExtractValueLspSuite
         |\tmethod2(<<List>>(1, 2, 3).map(_ + 1).sum)
         |}
         |""".stripMargin,
-    ExtractValueCodeAction.title,
+    s"""|${ExtractValueCodeAction.title}
+        |${ConvertToNamedArguments.title("method2")}""".stripMargin,
     s"""|object Main {
         |\tdef method2(i: Int) = ???
         |\tval newValue = List(1, 2, 3).map(_ + 1).sum

--- a/tests/unit/src/test/scala/tests/codeactions/ExtractValueLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ExtractValueLspSuite.scala
@@ -1,7 +1,7 @@
 package tests.codeactions
 
-import scala.meta.internal.metals.codeactions.ExtractValueCodeAction
 import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
+import scala.meta.internal.metals.codeactions.ExtractValueCodeAction
 
 class ExtractValueLspSuite
     extends BaseCodeActionLspSuite("extractValueRewrite") {

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -1,8 +1,8 @@
 package tests.codeactions
 
+import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
 import scala.meta.internal.metals.codeactions.CreateNewSymbol
 import scala.meta.internal.metals.codeactions.ImportMissingSymbol
-import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
 
 class ImportMissingSymbolLspSuite
     extends BaseCodeActionLspSuite("importMissingSymbol") {

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -2,6 +2,7 @@ package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.CreateNewSymbol
 import scala.meta.internal.metals.codeactions.ImportMissingSymbol
+import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
 
 class ImportMissingSymbolLspSuite
     extends BaseCodeActionLspSuite("importMissingSymbol") {
@@ -87,6 +88,7 @@ class ImportMissingSymbolLspSuite
         |${ImportMissingSymbol.title("Instant", "java.time")}
         |${CreateNewSymbol.title("Future")}
         |${CreateNewSymbol.title("Instant")}
+        |${ConvertToNamedArguments.title("Future.successful")}
         |""".stripMargin,
     """|package a
        |
@@ -116,6 +118,7 @@ class ImportMissingSymbolLspSuite
         |${ImportMissingSymbol.title("ListBuffer", "scala.collection.mutable")}
         |${CreateNewSymbol.title("Instant")}
         |${CreateNewSymbol.title("ListBuffer")}
+        |${ConvertToNamedArguments.title("Future.successful")}
         |""".stripMargin,
     """|package a
        |
@@ -148,6 +151,7 @@ class ImportMissingSymbolLspSuite
         |${CreateNewSymbol.title("Future")}
         |${CreateNewSymbol.title("Instant")}
         |${CreateNewSymbol.title("ListBuffer")}
+        |${ConvertToNamedArguments.title("Future.successful")}
         |""".stripMargin,
     """|package a
        |
@@ -180,6 +184,7 @@ class ImportMissingSymbolLspSuite
         |${CreateNewSymbol.title("Future")}
         |${CreateNewSymbol.title("Instant")}
         |${CreateNewSymbol.title("ListBuffer")}
+        |${ConvertToNamedArguments.title("Future.successful")}
         |""".stripMargin,
     """|package a
        |
@@ -208,6 +213,7 @@ class ImportMissingSymbolLspSuite
        |""".stripMargin,
     s"""|${ImportMissingSymbol.title("Instant", "java.time")}
         |${CreateNewSymbol.title("Instant")}
+        |${ConvertToNamedArguments.title("Future.successful")}
         |""".stripMargin,
     """|package a
        |

--- a/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
@@ -4,7 +4,8 @@ import scala.meta.internal.metals.codeactions.InsertInferredType
 import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
 
 class InsertInferredTypeLspSuite
-    extends BaseCodeActionLspSuite("insertInferredType") {
+    extends BaseCodeActionLspSuite("insertInferredType",
+      filterAction = act => act.getTitle() == InsertInferredType.insertType || act.getTitle() == InsertInferredType.insertTypeToPattern) {
 
   check(
     "val",
@@ -96,7 +97,6 @@ class InsertInferredTypeLspSuite
        |  val list = "123".map(c<<>>h => ch.toInt)
        |}""".stripMargin,
     s"""|${InsertInferredType.insertType}
-        |${RewriteBracesParensCodeAction.toBraces("map")}
         |""".stripMargin,
     """|object A{
        |  val list = "123".map((ch: Char) => ch.toInt)
@@ -110,7 +110,6 @@ class InsertInferredTypeLspSuite
        |  val list = "123".map{c<<>>h => ch.toInt}
        |}""".stripMargin,
     s"""|${InsertInferredType.insertType}
-        |${RewriteBracesParensCodeAction.toParens("map")}
         |""".stripMargin,
     """|object A{
        |  val list = "123".map{ch: Char => ch.toInt}

--- a/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
@@ -4,8 +4,12 @@ import scala.meta.internal.metals.codeactions.InsertInferredType
 import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
 
 class InsertInferredTypeLspSuite
-    extends BaseCodeActionLspSuite("insertInferredType",
-      filterAction = act => act.getTitle() == InsertInferredType.insertType || act.getTitle() == InsertInferredType.insertTypeToPattern) {
+    extends BaseCodeActionLspSuite(
+      "insertInferredType",
+      filterAction = act =>
+        act.getTitle() == InsertInferredType.insertType || act
+          .getTitle() == InsertInferredType.insertTypeToPattern
+    ) {
 
   check(
     "val",

--- a/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
@@ -1,7 +1,7 @@
 package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.InsertInferredType
-import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
+
 import org.eclipse.lsp4j.CodeAction
 
 class InsertInferredTypeLspSuite
@@ -9,7 +9,10 @@ class InsertInferredTypeLspSuite
       "insertInferredType"
     ) {
 
-  val filterAction = { act: CodeAction => act.getTitle() == InsertInferredType.insertType || act.getTitle() == InsertInferredType.insertTypeToPattern }
+  val filterAction: CodeAction => Boolean = { act: CodeAction =>
+    act.getTitle() == InsertInferredType.insertType || act
+      .getTitle() == InsertInferredType.insertTypeToPattern
+  }
 
   check(
     "val",
@@ -106,7 +109,7 @@ class InsertInferredTypeLspSuite
        |  val list = "123".map((ch: Char) => ch.toInt)
        |}
        |""".stripMargin,
-      filterAction = filterAction
+    filterAction = filterAction
   )
 
   check(
@@ -120,7 +123,7 @@ class InsertInferredTypeLspSuite
        |  val list = "123".map{ch: Char => ch.toInt}
        |}
        |""".stripMargin,
-       filterAction = filterAction
+    filterAction = filterAction
   )
 
   check(

--- a/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
@@ -2,14 +2,14 @@ package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.InsertInferredType
 import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
+import org.eclipse.lsp4j.CodeAction
 
 class InsertInferredTypeLspSuite
     extends BaseCodeActionLspSuite(
-      "insertInferredType",
-      filterAction = act =>
-        act.getTitle() == InsertInferredType.insertType || act
-          .getTitle() == InsertInferredType.insertTypeToPattern
+      "insertInferredType"
     ) {
+
+  val filterAction = { act: CodeAction => act.getTitle() == InsertInferredType.insertType || act.getTitle() == InsertInferredType.insertTypeToPattern }
 
   check(
     "val",
@@ -105,7 +105,8 @@ class InsertInferredTypeLspSuite
     """|object A{
        |  val list = "123".map((ch: Char) => ch.toInt)
        |}
-       |""".stripMargin
+       |""".stripMargin,
+      filterAction = filterAction
   )
 
   check(
@@ -118,7 +119,8 @@ class InsertInferredTypeLspSuite
     """|object A{
        |  val list = "123".map{ch: Char => ch.toInt}
        |}
-       |""".stripMargin
+       |""".stripMargin,
+       filterAction = filterAction
   )
 
   check(

--- a/tests/unit/src/test/scala/tests/codeactions/RewriteBracesParensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/RewriteBracesParensLspSuite.scala
@@ -1,9 +1,9 @@
 package tests.codeactions
 
+import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
 import scala.meta.internal.metals.codeactions.ExtractValueCodeAction
 import scala.meta.internal.metals.codeactions.PatternMatchRefactor
 import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
-import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
 
 class RewriteBracesParensLspSuite
     extends BaseCodeActionLspSuite("rewriteBracesParens") {

--- a/tests/unit/src/test/scala/tests/codeactions/RewriteBracesParensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/RewriteBracesParensLspSuite.scala
@@ -3,6 +3,7 @@ package tests.codeactions
 import scala.meta.internal.metals.codeactions.ExtractValueCodeAction
 import scala.meta.internal.metals.codeactions.PatternMatchRefactor
 import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
+import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
 
 class RewriteBracesParensLspSuite
     extends BaseCodeActionLspSuite("rewriteBracesParens") {
@@ -15,7 +16,8 @@ class RewriteBracesParensLspSuite
        |}
        |""".stripMargin,
     s"""|${RewriteBracesParensCodeAction.toBraces("foo")}
-        |${ExtractValueCodeAction.title}""".stripMargin,
+        |${ExtractValueCodeAction.title}
+        |${ConvertToNamedArguments.title("foo")}""".stripMargin,
     """|object Main {
        |  def foo(n: Int) = ???
        |  foo{5}
@@ -30,7 +32,8 @@ class RewriteBracesParensLspSuite
        |  List(1,2).map ( a => <<>>a )
        |}
        |""".stripMargin,
-    RewriteBracesParensCodeAction.toBraces("map"),
+    s"""|${RewriteBracesParensCodeAction.toBraces("map")}
+        |${ConvertToNamedArguments.title("List(1,2).map")}""".stripMargin,
     """|object Main {
        |  var x = 0
        |  List(1,2).map { a => a }
@@ -48,7 +51,8 @@ class RewriteBracesParensLspSuite
        |  })
        |}
        |""".stripMargin,
-    RewriteBracesParensCodeAction.toBraces("map"),
+    s"""|${RewriteBracesParensCodeAction.toBraces("map")}
+        |${ConvertToNamedArguments.title("x.map")}""".stripMargin,
     """|object Main {
        |  val x = List(1, 2, 3)
        |  x.map{_ match {


### PR DESCRIPTION
@ maintainers thanks for all the work you do! This is my first PR, I appreciate any feedback :slightly_smiling_face: 

Fixes https://github.com/scalameta/metals-feature-requests/issues/229

Adds a code action which converts all positional arguments in the enclosing `apply` method to named args.
![metals-convert-to-named-args](https://user-images.githubusercontent.com/46980357/171309818-97dff848-1e2c-4e13-a95a-77b5c5e12aae.gif)

TODOS/open questions:
[ ] - Scala 3 support
[ ] - tests. I started by trying to extend `BasicCodeActionLspSuite`, but ran into this error with the presentation compiler. I'd appreciate some direction here :)
```
Caused by: java.lang.AbstractMethodError: Missing implementation of resolved method 'abstract java.util.concurrent.CompletableFuture convertToNamedArguments(scala.meta.pc.OffsetParams, int)' of abstract class scala.meta.pc.PresentationCompiler.
```
[ ] - Currently, if there are no args in the enclosing `apply` the code action is not available which means if my cursor were on `params.text()` in the gif above, I'd see no code action. Maybe we'd want to consider the next enclosing `apply` (ie `addCompilationUnit`) as a candidate?
[ ] - There's probably some edge cases that I haven't considered. One is when the `apply` is inside a block which can't have named args.

