### PR TITLE
fix: lsif-java -> scip-java

### DIFF
--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -19,8 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: coursier/setup-action@v1.2.0-M2
-      - run: cs install --contrib lsif-java
-      - run: lsif-java index
+      - run: cs launch --contrib scip-java -- index
       - name: src lsif upload
         run: |
           mkdir -p bin

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ website/.cache-loader
 
 project/metals.sbt
 coursier
+
+# Sourcegraph specific
+index.scip


### PR DESCRIPTION
The project was recently renamed to scip-java and lsif-java has been
[deprecated](https://github.com/coursier/apps/pull/153). I see we are
having an issue where no main class is being found, which was attempted
to be fixed [here](https://github.com/coursier/apps/pull/155), but I'm
still unable to run it locally. This just ensures that we are using the
most recent setup to ensure that our sourcegraph uploads are still
working.