### PR TITLE
bugfix: Remove Wconf from scalac options in worksheets

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -436,6 +436,7 @@ class WorksheetProvider(
       } yield {
         val scalacOptions = info.scalac.getOptions.asScala
           .filterNot(_.contains("semanticdb"))
+          .filterNot(_.contains("-Wconf"))
           .asJava
         val mdoc = embedded
           .mdoc(


### PR DESCRIPTION
It seems to be breaking currently in worksheets and I don't think it's neccessary to fix that currently.