### PR TITLE
chore: update version for v0.11.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,7 +52,7 @@ body:
     id: version
     attributes:
       label: Version of Metals
-      placeholder: v0.11.5
+      placeholder: v0.11.6
     validations:
       required: true
 

--- a/.github/workflows/mtags-auto-release.yml
+++ b/.github/workflows/mtags-auto-release.yml
@@ -8,11 +8,11 @@ on:
       metals_version:
         description: "Metals Version"
         required: true
-        default: "v0.11.5"
+        default: "v0.11.6"
       metals_ref:
         description: "Tag/branch-name from which run release"
         required: true
-        default: "v0.11.5_mtags_release"
+        default: "v0.11.6"
 jobs:
   test_and_release:
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import Tests._
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-def localSnapshotVersion = "0.11.6-SNAPSHOT"
+def localSnapshotVersion = "0.11.7-SNAPSHOT"
 def isCI = System.getenv("CI") != null
 
 def isScala211(v: Option[(Long, Long)]): Boolean = v.contains((2, 11))


### PR DESCRIPTION
Bump the versions for v0.11.6, following the release guide https://scalameta.org/metals/docs/contributors/releasing
Let's merge after we confirm that v0.11.6 is out on Maven central.
