### PR TITLE
chore(deps): add in other scalameta repos to steward job

### DIFF
--- a/.github/steward-repos.md
+++ b/.github/steward-repos.md
@@ -1,0 +1,8 @@
+- scalameta/mdoc
+- scalameta/metabrowse
+- scalameta/metals
+- scalameta/metals-gitpod-sample
+- scalameta/munit
+- scalameta/sbt-scalafmt
+- scalameta/scalafmt
+- scalameta/scalameta

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -16,3 +16,4 @@ jobs:
           github-token: ${{ secrets.SCALAMETA_BOT_GH_TOKEN }}
           author-email: scalameta@gmail.com
           author-name: Scalameta Bot
+          repos-file: .github/steward-repos.md


### PR DESCRIPTION
So this again is sort of temporary with the hopes that a public instance
gets added, but since we already have this up and running for Metals,
it's quite easy to just add the other scalameta repos into this job as
well. I copied the list of scalameta projects from
`scala-steward-org/repos`.