### PR TITLE
feature: Allow to run all scalafix rules on a file

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -299,11 +299,7 @@ final class BloopServers(
                 requested != maybeBloopGlobalJsonJvmProperties
               )
           ) Some(BloopJsonUpdateCause.JVM_OPTS)
-          else if (
-            maybeRequestedMetalsJavaHome.exists(
-              _ != maybeBloopGlobalJsonJavaHome
-            )
-          )
+          else if (maybeRequestedMetalsJavaHome != maybeBloopGlobalJsonJavaHome)
             Some(BloopJsonUpdateCause.JAVA_HOME)
           else None
         maybeBloopJvmProperties = maybeRequestedBloopJvmProperties.getOrElse(

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -299,7 +299,11 @@ final class BloopServers(
                 requested != maybeBloopGlobalJsonJvmProperties
               )
           ) Some(BloopJsonUpdateCause.JVM_OPTS)
-          else if (maybeRequestedMetalsJavaHome != maybeBloopGlobalJsonJavaHome)
+          else if (
+            maybeRequestedMetalsJavaHome.exists(
+              _ != maybeBloopGlobalJsonJavaHome
+            )
+          )
             Some(BloopJsonUpdateCause.JAVA_HOME)
           else None
         maybeBloopJvmProperties = maybeRequestedBloopJvmProperties.getOrElse(

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -281,13 +281,11 @@ object Embedded {
       resolution = resolutionParams
     )
 
-  def organizeImportRule(scalaBinaryVersion: String): List[Path] = {
-    val dep = Dependency.of(
-      "com.github.liancheng",
-      s"organize-imports_$scalaBinaryVersion",
-      BuildInfo.organizeImportVersion
-    )
-    downloadDependency(dep, scalaVersion = None)
+  def rulesClasspath(dependencies: List[Dependency]): List[Path] = {
+    for {
+      dep <- dependencies
+      path <- downloadDependency(dep, scalaVersion = None)
+    } yield path
   }
 
   def toClassLoader(

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -95,6 +95,12 @@ object Messages {
     s"Metals is unable to start ${buildTool}. Please try to connect after starting it manually."
   )
 
+  def unknownScalafixRules(unknownRules: Set[String]) =
+    new MessageParams(
+      MessageType.Warning,
+      s"Metals is unable to run ${unknownRules.mkString(", ")}. Please add the rule dependency to `metals.scalafixRulesDependencies`."
+    )
+
   val ImportProjectFailed = new MessageParams(
     MessageType.Error,
     "Import project failed, no functionality will work. See the logs for more details"

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -95,11 +95,18 @@ object Messages {
     s"Metals is unable to start ${buildTool}. Please try to connect after starting it manually."
   )
 
-  def unknownScalafixRules(unknownRules: Set[String]) =
+  def unknownScalafixRules(unknownRuleMessage: String): MessageParams = {
+    // To match: "Rule not found 'ARuleName'"
+    val regex = ".*'(.*)'.*".r
+    val rule = unknownRuleMessage match {
+      case regex(rule) => rule
+      case _ => "a rule"
+    }
     new MessageParams(
       MessageType.Warning,
-      s"Metals is unable to run ${unknownRules.mkString(", ")}. Please add the rule dependency to `metals.scalafixRulesDependencies`."
+      s"Metals is unable to run ${rule}. Please add the rule dependency to `metals.scalafixRulesDependencies`."
     )
+  }
 
   val ImportProjectFailed = new MessageParams(
     MessageType.Error,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1740,6 +1740,22 @@ class MetalsLanguageServer(
             Option(params.uri).map(_.toAbsolutePath)
           )
         }.asJavaObject
+      case ServerCommands.RunScalafix(params) =>
+        val uri = params.getTextDocument().getUri()
+        scalafixProvider
+          .runAllRules(
+            uri.toAbsolutePath
+          )
+          .flatMap { edits =>
+            languageClient
+              .applyEdit(
+                new l.ApplyWorkspaceEditParams(
+                  new l.WorkspaceEdit(Map(uri -> edits.asJava).asJava)
+                )
+              )
+              .asScala
+          }
+          .asJavaObject
       case ServerCommands.ChooseClass(params) =>
         fileDecoderProvider
           .chooseClassFromFile(

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -164,6 +164,7 @@ object ServerCommands {
     """|Run all the supported scalafix rules in your codebase.
        |
        |If the rules are missing please add them to user configuration `metals.scalafixRulesDependencies`.
+       |Their format is the coursier one https://get-coursier.io/
        |""".stripMargin,
     """|This command should be sent in with the LSP [`TextDocumentPositionParams`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams)
        |""".stripMargin

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -158,6 +158,17 @@ object ServerCommands {
        |""".stripMargin
   )
 
+  val RunScalafix = new ParametrizedCommand[TextDocumentPositionParams](
+    "scalafix-run",
+    "Run all Scalafix Rules",
+    """|Run all the supported scalafix rules in your codebase.
+       |
+       |If the rules are missing please add them to user configuration `metals.scalafixRulesDependencies`.
+       |""".stripMargin,
+    """|This command should be sent in with the LSP [`TextDocumentPositionParams`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams)
+       |""".stripMargin
+  )
+
   val CascadeCompile = new Command(
     "compile-cascade",
     "Cascade compile",
@@ -539,6 +550,7 @@ object ServerCommands {
       ResetChoicePopup,
       RestartBuildServer,
       RunDoctor,
+      RunScalafix,
       DecodeFile,
       DisconnectBuildServer,
       ListBuildTargets,

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -50,7 +50,8 @@ case class UserConfiguration(
     excludedPackages: Option[List[String]] = None,
     fallbackScalaVersion: Option[String] = None,
     testUserInterface: TestUserInterfaceKind = TestUserInterfaceKind.CodeLenses,
-    javaFormatConfig: Option[JavaFormatConfig] = None
+    javaFormatConfig: Option[JavaFormatConfig] = None,
+    scalafixRulesDependencies: Map[String, String] = Map.empty
 ) {
 
   def currentBloopVersion: String =
@@ -490,6 +491,10 @@ object UserConfiguration {
         )
       )
 
+    val scalafixRulesDependencies =
+      getStringMap("scalafix-rules-dependencies")
+        .getOrElse(Map.empty)
+
     if (errors.isEmpty) {
       Right(
         UserConfiguration(
@@ -517,7 +522,8 @@ object UserConfiguration {
           excludedPackages,
           defaultScalaVersion,
           disableTestCodeLenses,
-          javaFormatConfig
+          javaFormatConfig,
+          scalafixRulesDependencies
         )
       )
     } else {

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -51,7 +51,7 @@ case class UserConfiguration(
     fallbackScalaVersion: Option[String] = None,
     testUserInterface: TestUserInterfaceKind = TestUserInterfaceKind.CodeLenses,
     javaFormatConfig: Option[JavaFormatConfig] = None,
-    scalafixRulesDependencies: Map[String, String] = Map.empty
+    scalafixRulesDependencies: List[String] = Nil
 ) {
 
   def currentBloopVersion: String =
@@ -492,8 +492,7 @@ object UserConfiguration {
       )
 
     val scalafixRulesDependencies =
-      getStringMap("scalafix-rules-dependencies")
-        .getOrElse(Map.empty)
+      getStringListKey("scalafix-rules-dependencies").getOrElse(Nil)
 
     if (errors.isEmpty) {
       Right(

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -85,7 +85,7 @@ abstract class BaseLspSuite(
 
   def test(testOpts: TestOptions, withoutVirtualDocs: Boolean)(
       fn: => Future[Unit]
-  )(implicit loc: Location) {
+  )(implicit loc: Location): Unit = {
     if (withoutVirtualDocs) {
       test(testOpts.withName(s"${testOpts.name}-readonly")) { fn }
       test(

--- a/tests/unit/src/test/scala/tests/scalafix/ScalafixProviderLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/scalafix/ScalafixProviderLspSuite.scala
@@ -1,0 +1,239 @@
+package tests.scalafix
+
+import scala.meta.internal.metals.ServerCommands
+
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextDocumentPositionParams
+import tests.BaseLspSuite
+
+class ScalafixProviderLspSuite extends BaseLspSuite("scalafix-provider") {
+
+  def scalafixConf(path: String = "/.scalafix.conf"): String =
+    s"""|$path
+        |rules = [
+        |  OrganizeImports,
+        |  ExplicitResultTypes,
+        |  RemoveUnused
+        |]
+        |
+        |ExplicitResultTypes.rewriteStructuralTypesToNamedSubclass = false
+        |
+        |RemoveUnused.imports = false
+        |
+        |OrganizeImports.groupedImports = Explode
+        |OrganizeImports.expandRelative = true
+        |OrganizeImports.removeUnused = true
+        |OrganizeImports.groups = [
+        |  "scala."
+        |  "re:javax?\\\\."
+        |  "*"
+        |]
+        |
+        |""".stripMargin
+
+  test("base-all") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""/metals.json
+           |{"a":{"scalacOptions": ["-Wunused"] }}
+           |${scalafixConf()}
+           |/a/src/main/scala/Main.scala
+           | // remove this import
+           |import java.io.File
+           |class A
+           |object Main{
+           |  def debug { println("debug") } // ProcedureSyntax rule is not defined, should not be changed
+           |  val addTypeHere = new A{}
+           |  private val notUsed = 123 
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      _ = assertNoDiff(
+        // we need warnings for scalafix rules
+        client.workspaceDiagnostics,
+        """|a/src/main/scala/Main.scala:2:1: warning: Unused import
+           |import java.io.File
+           |^^^^^^^^^^^^^^^^^^^
+           |a/src/main/scala/Main.scala:7:15: warning: private val notUsed in object Main is never used
+           |  private val notUsed = 123 
+           |              ^^^^^^^
+           |""".stripMargin
+      )
+      textParams =
+        new TextDocumentPositionParams(
+          new TextDocumentIdentifier(
+            workspace.resolve("a/src/main/scala/Main.scala").toURI.toString()
+          ),
+          new Position(0, 0)
+        )
+      // run the actual scalafix command
+      _ <- server.executeCommand(
+        ServerCommands.RunScalafix,
+        textParams
+      )
+      contents = server.bufferContents("a/src/main/scala/Main.scala")
+      _ = assertNoDiff(
+        contents,
+        """|// remove this import
+           |
+           |class A
+           |object Main{
+           |  def debug { println("debug") } // ProcedureSyntax rule is not defined, should not be changed
+           |  val addTypeHere: A = new A{}
+           |   
+           |}
+           |""".stripMargin
+      )
+      // add a new rule to scalafix configuration
+      _ <- server.didSave(".scalafix.conf") { old =>
+        old.replace(
+          "ExplicitResultTypes,",
+          "ExplicitResultTypes,\n  ProcedureSyntax,"
+        )
+      }
+      // execute the scalafix command again
+      _ <- server.executeCommand(
+        ServerCommands.RunScalafix,
+        textParams
+      )
+      contentsAfterConfigChange = server.bufferContents(
+        "a/src/main/scala/Main.scala"
+      )
+      // make sure that the newly added rule works
+      _ = assertNoDiff(
+        contentsAfterConfigChange,
+        """|// remove this import
+           |
+           |class A
+           |object Main{
+           |  def debug: Unit = { println("debug") } // ProcedureSyntax rule is not defined, should not be changed
+           |  val addTypeHere: A = new A{}
+           |   
+           |}
+           |""".stripMargin
+      ),
+
+    } yield ()
+  }
+
+  // make sure that a proper warning is show for unknown rules
+  test("no-rule") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""/metals.json
+           |{"a":{"scalacOptions": ["-Wunused"] }}
+           |/.scalafix.conf
+           |rules = [
+           |  NotARule
+           |]
+           |
+           |/a/src/main/scala/Main.scala
+           |object Main{
+           |  val addTypeHere = new A{}
+           |  private val notUsed = 123 
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      textParams =
+        new TextDocumentPositionParams(
+          new TextDocumentIdentifier(
+            workspace.resolve("a/src/main/scala/Main.scala").toURI.toString()
+          ),
+          new Position(0, 0)
+        )
+      _ <- server.executeCommand(
+        ServerCommands.RunScalafix,
+        textParams
+      )
+      _ = assertNoDiff(
+        client.workspaceShowMessages,
+        "Metals is unable to run NotARule. Please add the rule dependency to `metals.scalafixRulesDependencies`."
+      )
+      contents = server.bufferContents("a/src/main/scala/Main.scala")
+      _ = assertNoDiff(
+        contents,
+        """|object Main{
+           |  val addTypeHere = new A{}
+           |  private val notUsed = 123 
+           |}
+           |""".stripMargin
+      )
+    } yield ()
+  }
+
+  // add a rule in the settings and test if it works
+  test("custom-rule") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""/metals.json
+           |{"a":{"scalacOptions": ["-Wunused"] }}
+           |${scalafixConf()}
+           |/a/src/main/scala/Main.scala
+           |class A
+           |object Main{
+           |  private val notUsed = 123 
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      textParams =
+        new TextDocumentPositionParams(
+          new TextDocumentIdentifier(
+            workspace.resolve("a/src/main/scala/Main.scala").toURI.toString()
+          ),
+          new Position(0, 0)
+        )
+      _ <- server.executeCommand(
+        ServerCommands.RunScalafix,
+        textParams
+      )
+      contents = server.bufferContents("a/src/main/scala/Main.scala")
+      _ = assertNoDiff(
+        contents,
+        """|
+           |class A
+           |object Main{
+           |   
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didChangeConfiguration(
+        """{
+          |  "scalafix-rules-dependencies": {
+          |     "class:fix.Examplescalafixrule_v1" : "ch.epfl.scala::example-scalafix-rule:1.4.0"
+          |  }
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didSave(".scalafix.conf") { old =>
+        old.replace(
+          "ExplicitResultTypes,",
+          "ExplicitResultTypes,\n   \"class:fix.Examplescalafixrule_v1\","
+        )
+      }
+      _ <- server.executeCommand(
+        ServerCommands.RunScalafix,
+        textParams
+      )
+      contentsAfterConfigChange = server.bufferContents(
+        "a/src/main/scala/Main.scala"
+      )
+      _ = assertNoDiff(
+        contentsAfterConfigChange,
+        """|class A
+           |object Main{
+           |   
+           |}
+           |// Hello world!
+           |""".stripMargin
+      )
+    } yield ()
+  }
+
+}

--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -579,7 +579,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       uri: () => Option[String] = () => None
   )(implicit
       loc: munit.Location
-  ) {
+  ): Unit = {
     test(name) {
       for {
         _ <- Future.successful(cleanWorkspace())
@@ -598,7 +598,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       expected: () => List[BuildTargetUpdate]
   )(implicit
       loc: munit.Location
-  ) {
+  ): Unit = {
     test(name) {
       for {
         _ <- Future.successful(cleanWorkspace())


### PR DESCRIPTION
Previously, it would not be possible to run sclafix inside metals aside from organize imports. Now, it's possible to run a list of predefined rules and ones added in settings.

Fixes https://github.com/scalameta/metals/issues/4005