### PR TITLE
bugfix: Properly show links to implicit parameters in decoration hovers

### DIFF
--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -761,6 +761,16 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
            |}
            |""".stripMargin
       )
+      expectedParams = URLEncoder.encode(
+        """["_empty_/Example.evidence."]"""
+      )
+      _ <- server.assertHoverAtLine(
+        "a/Main.scala",
+        "    num2 <- opts(2)@@",
+        s"""|**Synthetics**:
+            |
+            |([evidence](command:metals.goto?$expectedParams))""".stripMargin
+      )
     } yield ()
   }
 }


### PR DESCRIPTION
Previously, no links would be shown for implicit parameter decorations in for comprehension. Now it's properly showed for the user.

The issue was that we were filtering synthatic decorations for a line based on the toplevel synthetic range, which in case of for comprehensions would be the full for comprehensions tree.

Fixes https://github.com/scalameta/metals/issues/3997