### PR TITLE
chore: Fix errors for kind projector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -566,7 +566,9 @@ lazy val mtest = project
       "scala2Versions" -> V.scala2Versions,
       "scala3Versions" -> (V.scala3Versions ++ V.nightlyScala3Versions),
       "scala2Versions" -> V.scala2Versions,
-      "scalaVersion" -> scalaVersion.value
+      "scalaVersion" -> scalaVersion.value,
+      "kindProjector" -> V.kindProjector,
+      "betterMonadicFor" -> V.betterMonadicFor
     ),
     crossScalaVersions := V.nonDeprecatedScalaVersions,
     Compile / unmanagedSourceDirectories ++= multiScalaDirectories(
@@ -619,6 +621,8 @@ lazy val unit = project
       // The dependencies listed below are only listed so Scala Steward
       // will pick them up and update them. They aren't actually used.
       "com.lihaoyi" %% "ammonite-util" % V.ammonite intransitive (),
+      "org.typelevel" % "kind-projector" % V.kindProjector cross CrossVersion.full intransitive (),
+      "com.olegpy" %% "better-monadic-for" % V.betterMonadicFor intransitive (),
       "com.lihaoyi" % "mill-contrib-testng" % V.mill intransitive ()
     ),
     buildInfoPackage := "tests",

--- a/project/V.scala
+++ b/project/V.scala
@@ -12,6 +12,7 @@ object V {
   val ammonite213Version = "2.13.7"
 
   val ammonite = "2.5.4"
+  val betterMonadicFor = "0.3.1"
   val bloop = "1.5.0-22-91111c15"
   val bloopNightly = bloop
   val bsp = "2.1.0-M1"
@@ -23,6 +24,7 @@ object V {
   val java8Compat = "1.0.2"
   val javaSemanticdb = "0.7.4"
   val jsoup = "1.15.1"
+  val kindProjector = "0.13.2"
   val lsp4jV = "0.14.0"
   val mavenBloop = bloop
   val mill = "0.10.4"

--- a/tests/cross/src/test/scala/tests/pc/MacroCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/MacroCompletionSuite.scala
@@ -6,6 +6,7 @@ import scala.collection.Seq
 
 import coursierapi.Dependency
 import tests.BaseCompletionSuite
+import tests.BuildInfoVersions
 
 class MacroCompletionSuite extends BaseCompletionSuite {
 
@@ -25,9 +26,17 @@ class MacroCompletionSuite extends BaseCompletionSuite {
     } else {
       Seq(
         Dependency
-          .of("com.olegpy", s"better-monadic-for_$scalaBinaryVersion", "0.3.1"),
+          .of(
+            "com.olegpy",
+            s"better-monadic-for_$scalaBinaryVersion",
+            BuildInfoVersions.betterMonadicFor
+          ),
         Dependency
-          .of("org.typelevel", s"kind-projector_$scalaBinaryVersion", "0.10.3"),
+          .of(
+            "org.typelevel",
+            s"kind-projector_$scalaVersion",
+            BuildInfoVersions.kindProjector
+          ),
         Dependency
           .of("org.typelevel", s"simulacrum_$scalaBinaryVersion", "1.0.0"),
         Dependency
@@ -141,32 +150,12 @@ class MacroCompletionSuite extends BaseCompletionSuite {
     ""
   )
 
-  /* Starting with Scala 2.12.16 we are getting
-   * Select(
-   *   TypeApply(
-   *     Ident(baz),
-   *     List(
-   *       ExistentialTypeTree(
-   *         AppliedTypeTree(Ident(Either), List(Ident(Int), Ident($qmark$1))),
-   *         List(
-   *           TypeDef(Modifiers(2097168L, , List()), $qmark$1, List(), TypeBoundsTree(<empty>, <empty>))
-   *         )
-   *       ),
-   *       Ident(String)
-   *     )
-   *   ),
-   *   fold_CURSOR_
-   * )
-   *
-   * The compiler seems unable to deal with getting type members of ExistentialTypeTree.
-   * This requires a fix in the compiler, but I doubt anyone will have the time to take a look.
-   */
   check(
-    "kind-projector".tag(IgnoreScalaVersion("2.12.16")),
+    "kind-projector",
     """
       |object a {
       |  def baz[F[_], A]: F[A] = ???
-      |  baz[Either[Int, ?], String].fold@@
+      |  baz[Either[Int, *], String].fold@@
       |}
     """.stripMargin,
     """|fold[C](fa: Int => C, fb: String => C): C


### PR DESCRIPTION
Previously, we were testing kind projector with `?` and since Scala 2.12.16 allows to use instead of `_`, the test stopped working. Now, the test case is updated to work with `*` instead and kind projector is updated to newest. I also the compiler plugins in tests to update automatically.