### PR TITLE
bugfix: Reset diagnostics before connecting to new server

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -2321,6 +2321,7 @@ class MetalsLanguageServer(
   }
 
   private def disconnectOldBuildServer(): Future[Unit] = {
+    diagnostics.reset()
     bspSession.foreach(connection =>
       scribe.info(s"Disconnecting from ${connection.main.name} session...")
     )
@@ -2329,7 +2330,6 @@ class MetalsLanguageServer(
       case None => Future.successful(())
       case Some(session) =>
         bspSession = None
-        diagnostics.reset()
         mainBuildTargetsData.resetConnections(List.empty)
         session.shutdown()
     }
@@ -2360,7 +2360,6 @@ class MetalsLanguageServer(
       }
       _ <- indexer.profiledIndexWorkspace(() => doctor.check())
       _ = if (session.main.isBloop) checkRunningBloopVersion(session.version)
-      _ = diagnostics.reset()
     } yield {
       BuildChange.Reconnected
     }


### PR DESCRIPTION
Previously, we would reset diagnotics when connecting to build server which cause issues if the build server published some diagnostics in the meantine, for example ScalaCLI will send info about any issues right away. Now, we only reset in one place before connecting to the build server.

![image](https://user-images.githubusercontent.com/3807253/173114486-730ce5f1-2701-456a-8978-e5759e8219e9.png)
