### PR TITLE
fix: run doctor when `more information` button was clicked

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
@@ -92,7 +92,7 @@ final class Doctor(
    */
   def executeRunDoctor(): Unit = {
     executeDoctor(
-      ClientCommands.RunDoctor,
+      clientCommand = ClientCommands.RunDoctor,
       onServer = server => {
         Urls.openBrowser(server.address + "/doctor")
       }
@@ -116,7 +116,7 @@ final class Doctor(
 
   def executeRefreshDoctor(): Unit = {
     executeDoctor(
-      ClientCommands.ReloadDoctor,
+      clientCommand = ClientCommands.ReloadDoctor,
       onServer = server => {
         server.reload()
       }
@@ -174,6 +174,7 @@ final class Doctor(
           hasProblems.set(true)
           languageClient.showMessageRequest(params).asScala.foreach { item =>
             if (item == CheckDoctor.moreInformation) {
+              onVisibilityDidChange(true)
               executeRunDoctor()
             } else if (item == CheckDoctor.dismissForever) {
               notification.dismissForever()


### PR DESCRIPTION
closes https://github.com/scalameta/metals/issues/4006

https://github.com/scalameta/metals/pull/3768 introduced doctor visibility provider which prevents from calling metals doctor when it isn't necessary. Doctor status should be set to visible if user want to see more information (see doctor view).
