### PR TITLE
feat: OverrideCompletion can handle symbolPrefix

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
@@ -71,8 +71,6 @@ object AutoImports:
         Context
     ): Map[Symbol, String] =
       config.symbolPrefixes.asScala.flatMap { (from, to) =>
-        val fullName = from.stripSuffix("/").replace("/", ".")
-        // val pkg = requiredPackage(fullName)
         val pkg = SemanticdbSymbols.inverseSemanticdbSymbol(from)
         val rename = to.stripSuffix(".").stripSuffix("#")
         List(pkg, pkg.map(_.moduleClass)).flatten

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
@@ -30,7 +30,7 @@ object AutoImports:
 
     /**
      * Rename symbol owner and add renamed prefix to tpe symbol.
-     * For example, `Reanmed(sym = <java.util.Map>, ownerRename = "ju")` represents
+     * For example, `Renamed(sym = <java.util.Map>, ownerRename = "ju")` represents
      * complete `ju.Map` while auto import `import java.{util => ju}`.
      * `toEdits` method convert `Renamed` to
      * AutoImportEdits(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
@@ -29,14 +29,27 @@ object AutoImports:
     case Simple(sym: Symbol)
 
     /**
-     * Rename symbol owner and add renamed prefix to tpe symbol
-     * `Map -> (ju.Map, import java.{util => ju})`
+     * Rename symbol owner and add renamed prefix to tpe symbol.
+     * For example, `Reanmed(sym = <java.util.Map>, ownerRename = "ju")` represents
+     * complete `ju.Map` while auto import `import java.{util => ju}`.
+     * `toEdits` method convert `Renamed` to
+     * AutoImportEdits(
+     *  nameEdit = "ju.Map",
+     *  importEdit = "import java.{util => ju})"
+     * )
      */
     case Renamed(sym: Symbol, ownerRename: String)
 
     /**
      * Rename symbol itself, import only.
-     * `Map -> ("", import java.{util => ju})`
+     * For example, `SelfRenamed(sym = <java.util>, name = "ju")` represents
+     * auto import `import java.{util => ju}` without completing anything, unlike `Renamed`.
+     *
+     * `toEdits` method convert `SelfRenamed` to
+     * AutoImportEdits(
+     *  nameEdit = None,
+     *  importEdit = "import java.{util => ju})"
+     * )
      */
     case SelfRenamed(sym: Symbol, name: String)
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
@@ -281,7 +281,7 @@ class CompletionsProvider(
         val additionalEdits =
           shortNames
             .sortBy(nme => nme.name)
-            .flatMap(name => autoImports.forSymbol(name.symbol))
+            .flatMap(name => autoImports.forShortName(name))
             .flatten
         mkItem(
           label,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -6,6 +6,7 @@ import java.{util as ju}
 import scala.collection.JavaConverters.*
 
 import scala.meta.internal.mtags.MtagsEnrichments.*
+import scala.meta.internal.pc.AutoImports.AutoImport
 import scala.meta.internal.pc.AutoImports.AutoImportsGenerator
 import scala.meta.internal.pc.printer.MetalsPrinter
 import scala.meta.pc.OffsetParams
@@ -318,7 +319,7 @@ object OverrideCompletions:
       val edits = editsAndImports._1 :+ edit
       val imports = completion.shortenedNames
         .sortBy(nme => nme.name)
-        .flatMap(name => autoImports.forSymbol(name.symbol))
+        .flatMap(name => autoImports.forShortName(name))
         .flatten
         .toSet ++ editsAndImports._2
       (edits, imports)
@@ -342,10 +343,12 @@ object OverrideCompletions:
       config: PresentationCompilerConfig,
       shouldAddOverrideKwd: Boolean
   )(using Context): CompletionValue.Override =
+    val renames = AutoImport.renameConfigMap(config)
     val printer = MetalsPrinter.standard(
       indexedContext,
       search,
-      includeDefaultParam = MetalsPrinter.IncludeDefaultParam.Never
+      includeDefaultParam = MetalsPrinter.IncludeDefaultParam.Never,
+      renames
     )
     val overrideKeyword: String =
       // if the overriding method is not an abstract member, add `override` keyword

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/DotcPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/DotcPrinter.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.pc.printer
 
 import scala.meta.internal.pc.IndexedContext
 import scala.meta.internal.pc.printer.DotcPrinter.ForInferredType
+import scala.meta.internal.pc.printer.ShortenedNames.PrettyType
 
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Flags.*
@@ -41,6 +42,22 @@ object DotcPrinter:
 
     def fullName(sym: Symbol): String =
       fullNameString(sym)
+
+    override def toText(tp: Type): Text =
+      // Override the behavior for `AppliedType` because
+      // `toText` in RefinedPrinter doesn't pretty print AppliedType
+      // if tycon is instance of PrettyType.
+      // For example, if we don't override `toText`,
+      // CompletionoverrideConfigSuite's `package` test will fail with
+      // completing `def function: Int <none> String = ${0:???}`
+      // instead of `def function: f.Function[Int, String] = ${0:???}`
+      tp match
+        case tp: AppliedType =>
+          tp.tycon match
+            case p: PrettyType =>
+              Str(p.toString) ~ "[" ~ toText(tp.args, ", ") ~ "]"
+            case other => super.toText(tp)
+        case other => super.toText(tp)
   end Std
 
   /**

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -4,10 +4,12 @@ import scala.collection.mutable
 
 import scala.meta.internal.jdk.CollectionConverters.*
 import scala.meta.internal.mtags.MtagsEnrichments.*
+import scala.meta.internal.pc.AutoImports.AutoImport
 import scala.meta.internal.pc.AutoImports.AutoImportsGenerator
 import scala.meta.internal.pc.IndexedContext
 import scala.meta.internal.pc.Params
 import scala.meta.internal.pc.printer.ShortenedNames.ShortName
+import scala.meta.pc.PresentationCompilerConfig
 import scala.meta.pc.SymbolSearch
 
 import dotty.tools.dotc.core.Contexts.Context
@@ -398,11 +400,12 @@ object MetalsPrinter:
   def standard(
       indexed: IndexedContext,
       symbolSearch: SymbolSearch,
-      includeDefaultParam: IncludeDefaultParam
+      includeDefaultParam: IncludeDefaultParam,
+      renames: Map[Symbol, String] = Map.empty
   ): MetalsPrinter =
     import indexed.ctx
     MetalsPrinter(
-      new ShortenedNames(indexed),
+      new ShortenedNames(indexed, renames),
       DotcPrinter.Std(),
       symbolSearch,
       includeDefaultParam

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/ShortenedNames.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/ShortenedNames.scala
@@ -136,18 +136,17 @@ class ShortenedNames(
                       (rename :: prev.map(_.name)).mkString(".")
                     )
                   case None =>
-                    renames.get(h) match
-                      case Some(rename) =>
-                        val short = ShortName(Names.termName(rename), h)
-                        if tryShortenName(short) then
-                          PrettyType(
-                            (rename :: prev.map(_.name)).mkString(".")
-                          )
-                        else processOwners(sym, h :: prev, tl)
-                      case None =>
-                        processOwners(sym, h :: prev, tl)
+                    processOwners(sym, h :: prev, tl)
 
-          processOwners(sym, Nil, sym.ownersIterator.toList)
+          lazy val shortened =
+            processOwners(sym, Nil, sym.ownersIterator.toList)
+          renames.get(sym.owner) match
+            case Some(rename) =>
+              val short = ShortName(Names.termName(rename), sym.owner)
+              if tryShortenName(short) then
+                PrettyType(s"$rename.${sym.name.show}")
+              else shortened
+            case _ => shortened
 
         case TermRef(prefix, designator) =>
           val sym =

--- a/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
@@ -308,24 +308,7 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
        |
        |  }
        |}
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|abstract class Mutable {
-           |  def foo: scala.collection.mutable.Set[Int]
-           |  def bar: scala.collection.immutable.Set[Int]
-           |}
-           |object Main {
-           |  new Mutable {
-           |
-           |    override def foo: collection.mutable.Set[Int] = ???
-           |
-           |    override def bar: Set[Int] = ???
-           |
-           |  }
-           |}
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   checkEdit(
@@ -376,19 +359,7 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
        |  override def foo: ju.List[Int] = ???
        |
        |}
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|abstract class JUtil {
-           |  def foo: java.util.List[Int]
-           |}
-           |class Main extends JUtil {
-           |
-           |  override def foo: java.util.List[Int] = ???
-           |
-           |}
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   checkEdit(
@@ -414,21 +385,7 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
        |
        |  val java = 42
        |}
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|package jutil
-           |abstract class JUtil {
-           |  def foo: java.util.List[Int]
-           |}
-           |class Main extends JUtil {
-           |
-           |  override def foo: java.util.List[Int] = ???
-           |
-           |  val java = 42
-           |}
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   checkEdit(

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -272,11 +272,11 @@ class CompletionIssueSuite extends BaseCompletionSuite {
     filter = (str) => str.contains("createProgress"),
     compat = Map(
       "3" -> """|import org.eclipse.lsp4j.services.LanguageClient
-                |import java.util.concurrent.CompletableFuture
                 |import org.eclipse.lsp4j.WorkDoneProgressCreateParams
+                |import java.{util => ju}
                 |
                 |trait Client extends LanguageClient{
-                |  override def createProgress(x$0: WorkDoneProgressCreateParams): CompletableFuture[Void] = ${0:???}
+                |  override def createProgress(x$0: WorkDoneProgressCreateParams): ju.concurrent.CompletableFuture[Void] = ${0:???}
                 |}
                 |""".stripMargin
     )

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -271,14 +271,15 @@ class CompletionIssueSuite extends BaseCompletionSuite {
        |""".stripMargin,
     filter = (str) => str.contains("createProgress"),
     compat = Map(
-      "3" -> """|import org.eclipse.lsp4j.services.LanguageClient
-                |import org.eclipse.lsp4j.WorkDoneProgressCreateParams
-                |import java.{util => ju}
-                |
-                |trait Client extends LanguageClient{
-                |  override def createProgress(x$0: WorkDoneProgressCreateParams): ju.concurrent.CompletableFuture[Void] = ${0:???}
-                |}
-                |""".stripMargin
+      "3" ->
+        """|import org.eclipse.lsp4j.services.LanguageClient
+           |import java.util.concurrent.CompletableFuture
+           |import org.eclipse.lsp4j.WorkDoneProgressCreateParams
+           |
+           |trait Client extends LanguageClient{
+           |  override def createProgress(x$0: WorkDoneProgressCreateParams): CompletableFuture[Void] = ${0:???}
+           |}
+           |""".stripMargin
     )
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
@@ -8,8 +8,6 @@ import tests.BaseCompletionSuite
 
 class CompletionOverrideConfigSuite extends BaseCompletionSuite {
 
-  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
-    Some(IgnoreScala3)
   override def config: PresentationCompilerConfig =
     PresentationCompilerConfigImpl().copy(
       _symbolPrefixes = Map(
@@ -66,7 +64,20 @@ class CompletionOverrideConfigSuite extends BaseCompletionSuite {
        |class Main extends Package {
        |  def function: f.Function[Int,String] = ${0:???}
        |}
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3" -> // space between Int, String
+        """|package b
+           |
+           |import java.util.{function => f}
+           |class Package {
+           |  def function: java.util.function.Function[Int, String]
+           |}
+           |class Main extends Package {
+           |  def function: f.Function[Int, String] = ${0:???}
+           |}
+           |""".stripMargin
+    )
   )
 
   check(
@@ -82,6 +93,12 @@ class CompletionOverrideConfigSuite extends BaseCompletionSuite {
        |""".stripMargin,
     """🔼 numberAbstract: Intdef numberAbstract: Int
       |⏫ number: Intoverride def number: Int
-      |""".stripMargin
+      |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|⏫ def numberAbstract: Int
+           |⏫ def number: Int
+           |""".stripMargin
+    )
   )
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -362,19 +362,7 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
        |    def foo: mutable.Set[Int] = ${0:???}
        |  }
        |}
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|abstract class Mutable {
-           |  def foo: scala.collection.mutable.Set[Int]
-           |}
-           |object Main {
-           |  new Mutable {
-           |    def foo: collection.mutable.Set[Int] = ${0:???}
-           |  }
-           |}
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   checkEditLine(
@@ -413,17 +401,7 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
        |class Main extends JUtil {
        |  def foo: ju.List[Int] = ${0:???}
        |}
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|abstract class JUtil {
-           |  def foo: java.util.List[Int]
-           |}
-           |class Main extends JUtil {
-           |  def foo: java.util.List[Int] = ${0:???}
-           |}
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   checkEdit(
@@ -448,19 +426,7 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
        |  val java = 42
        |  def foo: ju.List[Int] = ${0:???}
        |}
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|package jutil
-           |abstract class JUtil {
-           |  def foo: java.util.List[Int]
-           |}
-           |class Main extends JUtil {
-           |  val java = 42
-           |  def foo: java.util.List[Int] = ${0:???}
-           |}
-           |""".stripMargin
-    )
+       |""".stripMargin
   )
 
   checkEditLine(


### PR DESCRIPTION
https://github.com/scalameta/metals/issues/3928

This PR enables OverrideCompletions and implement-all abstract members' code action for Scala3 to import using preset renames like `java.util => ju`.

```scala
abstract class JUtil {
  def foo: java.util.List[Int]
}
class Main extends JUtil {
  def foo@@
}
```

completes

```scala
import java.{util => ju}
abstract class JUtil {
  def foo: java.util.List[Int]
}
class Main extends JUtil {
  def foo: ju.List[Int] = ${0:???}
}
```

