### PR TITLE
fix(worksheets): filter out NonUnitStatements wartremover in worksheets

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -434,9 +434,13 @@ class WorksheetProvider(
         }
         if isSupported
       } yield {
+        // We filter out NonUnitStatements from wartremover or you'll get an
+        // error about $doc.binder returning Unit from mdoc, which causes the
+        // worksheet not to be evaluated.
         val scalacOptions = info.scalac.getOptions.asScala
           .filterNot(_.contains("semanticdb"))
           .filterNot(_.contains("-Wconf"))
+          .filterNot(_.contains("org.wartremover.warts.NonUnitStatements"))
           .asJava
         val mdoc = embedded
           .mdoc(


### PR DESCRIPTION
I also hit on this during work and it annoys me. If you have a build
that is using wartremover and you are using the default set of
`Warts.unsafe` it includes the `NonUnitStatements` rule. When this rule
is part of your `scalacOptions` when you attempt to create a worksheet
next to your sources it will never work due to the binder in mdoc.
You'll get the following error at the top of your file and nothing will
evaluate:

```scala
val x = 3 // example piece of code in your worksheet
```
```
Diagnostics:
scala.worksheet.sc:9 (mdoc generated code) [wartremover:NonUnitStatements] Statements must return Unit
val x = 3; $doc.binder(x, 1, 4, 1, 5)
```

This change just strips out that rule so it doesn't get passed in during
evaluation so that your worksheet can actually evaluate.