### PR TITLE
feat(mill): also check default version in mill file

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -17,11 +17,19 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
   private def getMillVersion(workspace: AbsolutePath): String = {
     import scala.meta.internal.jdk.CollectionConverters._
     val millVersionPath = workspace.resolve(".mill-version")
+    lazy val millPath = workspace.resolve("mill")
     if (millVersionPath.isFile) {
       Files
         .readAllLines(millVersionPath.toNIO)
         .asScala
         .headOption
+        .getOrElse(version)
+    } else if (millPath.isFile) {
+      Files
+        .readAllLines(millPath.toNIO)
+        .asScala
+        .find(_.startsWith("DEFAULT_MILL_VERSION"))
+        .map(line => line.dropWhile(!_.isDigit).trim)
         .getOrElse(version)
     } else {
       version

--- a/tests/unit/src/test/scala/tests/MillVersionSuite.scala
+++ b/tests/unit/src/test/scala/tests/MillVersionSuite.scala
@@ -1,0 +1,48 @@
+package tests
+
+import scala.meta.internal.builds.MillBuildTool
+import scala.meta.internal.metals.UserConfiguration
+
+class MillVersionSuite extends BaseSuite {
+
+  def check(
+      layout: String,
+      expected: String
+  ): Unit = {
+    test(expected) {
+      val root = FileLayout.fromString(layout)
+      val obtained =
+        MillBuildTool(() => UserConfiguration()).bloopInstallArgs(root)
+      assert(obtained.contains(expected))
+    }
+  }
+
+  check(
+    """|.mill-version
+       |0.10.2
+       |""".stripMargin,
+    "0.10.2"
+  )
+
+  check(
+    """|mill
+       |#!/usr/bin/env sh
+       |
+       |# This is a wrapper script, that automatically download mill from GitHub release pages
+       |# You can give the required mill version with --mill-version parameter
+       |# If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
+       |#
+       |# Project page: https://github.com/lefou/millw
+       |# Script Version: 0.4.0
+       |#
+       |# If you want to improve this script, please also contribute your changes back!
+       |#
+       |# Licensed under the Apache License, Version 2.0
+       |
+       |
+       |DEFAULT_MILL_VERSION=0.9.12
+       |""".stripMargin,
+    "0.9.12"
+  )
+
+}


### PR DESCRIPTION
I just hit on this with https://github.com/com-lihaoyi/requests-scala
since they have a `mill` file which contains the default mill version
being used, but we only check for the version in the `.mill-version`
file. While most repos will have a `.mill-version` this adds an extra
fallback to check in the `mill` file to also grab it before we use the
default one we have. It can be the case that they are using an older
version of `mill` and our default version won't work to do the build
import. This guards against that.