### PR TITLE
fix: support tab indent in implement-all code action

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -748,12 +748,22 @@ trait Completions { this: MetalsGlobal =>
   // class Main {
   //   def foo<COMPLETE> // inferred indent is 2 spaces.
   // }
-  def inferIndent(lineStart: Int, text: String): Int = {
+  def inferIndent(lineStart: Int, text: String): (Int, Boolean) = {
     var i = 0
-    while (lineStart + i < text.length && text.charAt(lineStart + i) == ' ') {
+    var tabIndented = false
+    while (
+      lineStart + i < text.length && {
+        val char = text.charAt(lineStart + i)
+        if (char == '\t') {
+          tabIndented = true
+          true
+        } else
+          char == ' '
+      }
+    ) {
       i += 1
     }
-    i
+    (i, tabIndented)
   }
 
   // Returns the symbols that have been renamed in this scope.

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionPos.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionPos.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.pc
 package completions
 
+import scala.meta.internal.mtags.MtagsEnrichments.*
 import scala.meta.internal.tokenizers.Chars
 
 import dotty.tools.dotc.ast.tpd.*
@@ -24,13 +25,7 @@ case class CompletionPos(
   def sourcePos: SourcePosition = cursorPos.withSpan(Spans.Span(start, end))
 
   def toEditRange: l.Range =
-    def toPos(offset: Int): l.Position =
-      val lineStartOffest = cursorPos.source.startOfLine(offset)
-      val line = cursorPos.source.offsetToLine(lineStartOffest)
-      val column = offset - lineStartOffest
-      new l.Position(line, column)
-
-    new l.Range(toPos(start), toPos(end))
+    new l.Range(cursorPos.offsetToPos(start), cursorPos.offsetToPos(end))
   end toEditRange
 end CompletionPos
 

--- a/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
@@ -829,6 +829,67 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
+    "tab-indented1",
+    """|package a
+       |
+       |object A {
+       |	trait Base {
+       |		def foo(x: Int): Int
+       |		def bar(x: String): String
+       |	}
+       |	class <<Concrete>> extends Base {
+       |	}
+       |}
+       |""".stripMargin,
+    """|package a
+       |
+       |object A {
+       |	trait Base {
+       |		def foo(x: Int): Int
+       |		def bar(x: String): String
+       |	}
+       |	class Concrete extends Base {
+       |
+       |		override def foo(x: Int): Int = ???
+       |
+       |		override def bar(x: String): String = ???
+       |
+       |	}
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "tab-indented2",
+    """|package a
+       |
+       |object A {
+       |	trait Base {
+       |		def foo(x: Int): Int
+       |		def bar(x: String): String
+       |	}
+       |	class <<Concrete>> extends Base
+       |}
+       |""".stripMargin,
+    """|package a
+       |
+       |object A {
+       |	trait Base {
+       |		def foo(x: Int): Int
+       |		def bar(x: String): String
+       |	}
+       |	class Concrete extends Base {
+       |
+       |		override def foo(x: Int): Int = ???
+       |
+       |		override def bar(x: String): String = ???
+       |
+       |	}
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
     "braceless-basic".tag(IgnoreScala2),
     """|package a
        |
@@ -887,6 +948,32 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
        |    def foo(x: Int): Int = x
        |
        |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "tab-indented-braceless".tag(IgnoreScala2),
+    """|package a
+       |
+       |trait Base:
+       |	def foo(x: Int): Int
+       |	def bar(x: String): String
+       |
+       |class <<Concrete>> extends Base:
+       |	def foo(x: Int): Int = x
+       |""".stripMargin,
+    """|package a
+       |
+       |trait Base:
+       |	def foo(x: Int): Int
+       |	def bar(x: String): String
+       |
+       |class Concrete extends Base:
+       |
+       |	override def bar(x: String): String = ???
+       |
+       |	def foo(x: Int): Int = x
+       |
        |""".stripMargin
   )
 


### PR DESCRIPTION
fix https://github.com/scalameta/metals/issues/4027

Before this commit, the code action always add indent with spaces, now
Metals support tab indent in implement-all code action.

If the class / object to implement is indented with tabs,
Metals will use tabs for indents instead of spaces.

As a limitation, Metals cannot infer the indent from the whole file:
for example

```scala
package foo

abstract class Foo:
\tdef foo: Int

class FooImpl extends Foo
```

we should implement `FooImpl` with tabs, but we can't
because Metals infers the indent from the line of `FooImpl`.
In this case, there's no indent, and fallback to space indent.