### PR TITLE
fix: do not fail when stripping ansi codes

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -46,6 +46,7 @@ import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
 
 import ch.epfl.scala.{bsp4j => b}
+import fansi.ErrorMode
 import io.undertow.server.HttpServerExchange
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.{lsp4j => l}
@@ -751,7 +752,7 @@ object MetalsEnrichments
     def toLSP: l.Diagnostic =
       new l.Diagnostic(
         diag.getRange.toLSP,
-        fansi.Str(diag.getMessage).plainText,
+        fansi.Str(diag.getMessage, ErrorMode.Strip).plainText,
         diag.getSeverity.toLSP,
         if (diag.getSource == null) "scalac" else diag.getSource
         // We omit diag.getCode since Bloop's BSP implementation uses 'code' with different semantics


### PR DESCRIPTION
Explained pretty well in https://github.com/com-lihaoyi/fansi/issues/46.

Full stacktrace of exception which was previously thrown:
```scala
java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
        at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$null$0(GenericEndpoint.java:67)
        at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.notify(GenericEndpoint.java:152)
        at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleNotification(RemoteEndpoint.java:220)
        at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:187)
        at org.eclipse.lsp4j.jsonrpc.TracingMessageConsumer.consume(TracingMessageConsumer.java:114)
        at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:194)
        at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:94)
        at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:113)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.reflect.InvocationTargetException
        at jdk.internal.reflect.GeneratedMethodAccessor2.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$null$0(GenericEndpoint.java:65)
        ... 12 more
Caused by: java.lang.IllegalArgumentException: Unknown ansi-escape [2m at index 206 inside string cannot be parsed into an fansi.Str
        at fansi.ErrorMode$Throw$.handle(Fansi.scala:440)
        at fansi.ErrorMode$Throw$.handle(Fansi.scala:428)
        at fansi.Str$.apply(Fansi.scala:280)
        at scala.meta.internal.metals.MetalsEnrichments$XtensionDiagnosticBsp.toLSP(MetalsEnrichments.scala:754)
        at scala.meta.internal.metals.Diagnostics.$anonfun$onBuildPublishDiagnostics$2(Diagnostics.scala:140)
        at scala.collection.StrictOptimizedIterableOps.map(StrictOptimizedIterableOps.scala:100)
        at scala.collection.StrictOptimizedIterableOps.map$(StrictOptimizedIterableOps.scala:87)
        at scala.collection.convert.JavaCollectionWrappers$JListWrapper.map(JavaCollectionWrappers.scala:103)
        at scala.meta.internal.metals.Diagnostics.onBuildPublishDiagnostics(Diagnostics.scala:140)
        at scala.meta.internal.metals.clients.language.ForwardingMetalsBuildClient.onBuildPublishDiagnostics(ForwardingMetalsBuildClient.scala:109)
        ... 16 more
```
cc: @LeonardMeyer