### PR TITLE
feature: Don't update readonly bloop.json and allow to dismiss notifications

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DismissedNotifications.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DismissedNotifications.scala
@@ -19,9 +19,37 @@ final class DismissedNotifications(conn: () => Connection, time: Time) {
   val AmmoniteImportAuto = new Notification(9)
   val ReconnectAmmonite = new Notification(10)
   val UpdateScalafmtConf = new Notification(11)
+  val UpdateBloopJson = new Notification(12)
+
+  val all: List[Notification] = List(
+    Only212Navigation,
+    IncompatibleSbt,
+    ImportChanges,
+    DoctorWarning,
+    IncompatibleBloop,
+    ReconnectBsp,
+    CreateScalafmtFile,
+    ChangeScalafmtVersion,
+    AmmoniteImportAuto,
+    ReconnectAmmonite,
+    UpdateScalafmtConf,
+    UpdateBloopJson
+  )
+
+  def resetAll(): Unit = {
+    all.foreach { notification =>
+      if (notification.isDismissed) {
+        scribe.info(
+          s"Resetting notifications for notification '${notification.notificationName}'"
+        )
+        notification.reset()
+      }
+    }
+  }
 
   class Notification(val id: Int)(implicit name: sourcecode.Name) {
     override def toString: String = s"Notification(${name.value}, $id)"
+    def notificationName: String = name.value
     def isDismissed: Boolean = {
       val now = new Timestamp(time.currentMillis())
       conn().query {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -474,6 +474,10 @@ object MetalsEnrichments
       filename.endsWith(".zip")
     }
 
+    def canWrite: Boolean = {
+      path.toNIO.toFile().canWrite()
+    }
+
     /**
      * Reads file contents from editor buffer with fallback to disk.
      */

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1939,6 +1939,11 @@ class MetalsLanguageServer(
             popupChoiceReset.interactiveReset()
         }).asJavaObject
 
+      case ServerCommands.ResetNotifications() =>
+        Future {
+          tables.dismissedNotifications.resetAll()
+        }.asJavaObject
+
       case ServerCommands.NewScalaFile(args) =>
         val directoryURI = args.lift(0).flatten.map(new URI(_))
         val name = args.lift(1).flatten

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -380,6 +380,15 @@ object ServerCommands {
     "[string?], where string is a choice value."
   )
 
+  val ResetNotifications = new Command(
+    "reset-notifications",
+    "Reset notifications",
+    """|ResetNotifications command allows you to reset all the dismissed notifications.
+       |E.g. If you choose to dismiss build import forever, this command will make the notification show up again.
+       |
+       |""".stripMargin
+  )
+
   val NewScalaFile = new ListParametrizedCommand[String](
     "new-scala-file",
     "Create new scala file",
@@ -565,6 +574,7 @@ object ServerCommands {
       NewScalaProject,
       PresentationCompilerRestart,
       ResetChoicePopup,
+      ResetNotifications,
       RestartBuildServer,
       RunDoctor,
       RunScalafix,

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -240,7 +240,12 @@ class MetalsTreeViewProvider(
               TreeViewNode.fromCommand(ServerCommands.CancelCompile, "cancel"),
               TreeViewNode.fromCommand(ServerCommands.CleanCompile, "clean"),
               TreeViewNode
-                .fromCommand(ServerCommands.RestartBuildServer, "debug-stop")
+                .fromCommand(ServerCommands.RestartBuildServer, "debug-stop"),
+              TreeViewNode
+                .fromCommand(
+                  ServerCommands.ResetNotifications,
+                  "notifications-clear"
+                )
             )
           case _ =>
             Array()


### PR DESCRIPTION
Previously, metals would suggest to update bloop.json file even if it was readonly and there would be no way to dismiss the notification forever. Now, we will not suggest to update the file if it's readonly and users can ignore the notification if they want to. It's also possible to later reset all the notification so that everything can pop up again.