### PR TITLE
feat: Adding stub implementations for abstract given instances 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
@@ -39,4 +39,14 @@ object ScalacDiagnostic {
         case _ => None
       }
   }
+
+  object DeclarationOfGivenInstanceNotAllowed {
+    private val regex =
+      """Declaration of given instance given_.+ not allowed here.*""".r
+    def unapply(d: l.Diagnostic): Option[String] =
+      d.getMessage() match {
+        case regex() => Some(d.getMessage())
+        case _ => None
+      }
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImplementAbstractMembers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImplementAbstractMembers.scala
@@ -30,6 +30,9 @@ class ImplementAbstractMembers(compilers: Compilers) extends CodeAction {
           case d @ ScalacDiagnostic.MissingImplementation(_)
               if params.getRange().overlapsWith(d.getRange()) =>
             implementAbstractMembers(d, params, token)
+          case d @ ScalacDiagnostic.DeclarationOfGivenInstanceNotAllowed(_)
+              if (params.getRange().overlapsWith(d.getRange())) =>
+            implementAbstractMembers(d, params, token)
         }
     )
   }

--- a/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
@@ -1043,7 +1043,7 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
        |  override def bar(x: String): String = ???
        |
        |  def foo(x: Int): Int = x
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkEdit(
@@ -1064,12 +1064,36 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
        |
        |given Foo with {
        |
-       |  override def foo(x: Int): Int = x
+       |  override def foo(x: Int): Int = ???
        |
        |  override def bar(x: String): String = ???
        |
        |}
-       |""".stripMargin
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "given-object-with".tag(IgnoreScala2),
+    """|package given
+       |
+       |trait Foo:
+       |  def foo(x: Int): Int
+       |  def bar(x: String): String
+       |
+       |given <<Foo>>
+       |""".stripMargin,
+    """|package given
+       |
+       |trait Foo:
+       |  def foo(x: Int): Int
+       |  def bar(x: String): String
+       |
+       |given Foo with
+       |
+       |  override def foo(x: Int): Int = ???
+       |
+       |  override def bar(x: String): String = ???
+       |""".stripMargin,
   )
 
   def checkEdit(

--- a/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
@@ -1021,6 +1021,57 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
        |""".stripMargin,
   )
 
+  checkEdit(
+    "given-object-creation".tag(IgnoreScala2),
+    """|package given
+       |
+       |trait Foo:
+       |  def foo(x: Int): Int
+       |  def bar(x: String): String
+       |
+       |given <<Foo>> with
+       |  def foo(x: Int): Int = x
+       |""".stripMargin,
+    """|package given
+       |
+       |trait Foo:
+       |  def foo(x: Int): Int
+       |  def bar(x: String): String
+       |
+       |given Foo with
+       |
+       |  override def bar(x: String): String = ???
+       |
+       |  def foo(x: Int): Int = x
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "given-object-creation-braces".tag(IgnoreScala2),
+    """|package given
+       |
+       |trait Foo:
+       |  def foo(x: Int): Int
+       |  def bar(x: String): String
+       |
+       |given <<Foo>> with {}
+       |""".stripMargin,
+    """|package given
+       |
+       |trait Foo:
+       |  def foo(x: Int): Int
+       |  def bar(x: String): String
+       |
+       |given Foo with {
+       |
+       |  override def foo(x: Int): Int = x
+       |
+       |  override def bar(x: String): String = ???
+       |
+       |}
+       |""".stripMargin
+  )
+
   def checkEdit(
       name: TestOptions,
       original: String,

--- a/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
@@ -5,6 +5,7 @@ import scala.meta.internal.metals.codeactions.CreateCompanionObjectCodeAction
 import scala.meta.internal.metals.codeactions.ExtractRenameMember
 import scala.meta.internal.metals.codeactions.ExtractValueCodeAction
 import scala.meta.internal.metals.codeactions.FlatMapToForComprehensionCodeAction
+import scala.meta.internal.metals.codeactions.ImplementAbstractMembers
 import scala.meta.internal.metals.codeactions.InsertInferredType
 import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
 import scala.meta.internal.metals.codeactions.SourceOrganizeImports
@@ -325,6 +326,61 @@ class Scala3CodeActionLspSuite
        |  class Concrete extends Base:
        |""".stripMargin,
     expectError = true,
+    expectNoDiagnostics = false,
+  )
+
+  check(
+    "given-object-creation",
+    """|package a
+       |
+       |trait Foo:
+       |  def foo(x: Int): Int
+       |  def bar(x: String): String
+       |
+       |given <<Foo>> with {}
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |trait Foo:
+       |  def foo(x: Int): Int
+       |  def bar(x: String): String
+       |
+       |given Foo with {
+       |
+       |  override def foo(x: Int): Int = ???
+       |
+       |  override def bar(x: String): String = ???
+       |
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "given-object-with",
+    """|package given
+       |
+       |trait Foo:
+       |  def foo(x: Int): Int
+       |  def bar(x: String): String
+       |
+       |given <<Foo>>
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package given
+       |
+       |trait Foo:
+       |  def foo(x: Int): Int
+       |  def bar(x: String): String
+       |
+       |given Foo with
+       |
+       |  override def foo(x: Int): Int = ???
+       |
+       |  override def bar(x: String): String = ???
+       |""".stripMargin,
     expectNoDiagnostics = false,
   )
 


### PR DESCRIPTION
fix: https://github.com/scalameta/metals/issues/4052

Now, implement all abstract members code action is
available for given instance:
When we have

```scala
trait Foo:
  def bar: Int
  def baz: String

given Foo
```

the code action will implement the given instance like

```scala

given Foo with

  override def bar: Int = ???

  override def baz: String = ???
```
