### PR TITLE
chore: handle memory footprint errors on JDK17

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -147,37 +147,24 @@ final case class Indexer(
     )
     tracked.foreach { _ =>
       statusBar().addMessage(
-        s"${clientConfig.icons.rocket}Indexing complete!"
+        s"${clientConfig.icons.rocket} Indexing complete!"
       )
       if (clientConfig.initialConfig.statistics.isMemory) {
-        logMemory(
-          "definition index",
-          definitionIndex
-        )
-        logMemory(
-          "references index",
-          referencesProvider().index
-        )
-        logMemory(
-          "workspace symbol index",
-          workspaceSymbols().inWorkspace
-        )
-        logMemory(
-          "classpath symbol index",
-          workspaceSymbols().inDependencies.packages
-        )
-        logMemory(
-          "build targets",
-          buildTargets
+        Memory.logMemory(
+          List(
+            ("definition index", definitionIndex),
+            ("references index", referencesProvider().index),
+            ("workspace symbol index", workspaceSymbols().inWorkspace),
+            ("build targets", buildTargets),
+            (
+              "classpath symbol index",
+              workspaceSymbols().inDependencies.packages
+            )
+          )
         )
       }
     }
     tracked
-  }
-
-  private def logMemory(name: String, index: Object): Unit = {
-    val footprint = Memory.footprint(name, index)
-    scribe.info(s"memory: $footprint")
   }
 
   private def indexWorkspace(check: () => Unit): Unit = {


### PR DESCRIPTION
Previously, when Metals was run on JDK17 with `-Dstatistics=memory` one was getting multiple times:
```scala
java.lang.RuntimeException: Cannot get the field offset, try with -Djol.magicFieldOffset=true
        at org.openjdk.jol.vm.HotspotUnsafe.fieldOffset(HotspotUnsafe.java:461)
        at org.openjdk.jol.layouters.CurrentLayouter.layout(CurrentLayouter.java:70)
        at org.openjdk.jol.vm.HotspotUnsafe.sizeOf(HotspotUnsafe.java:207)
        at org.openjdk.jol.info.GraphWalker.walk(GraphWalker.java:97)
        at org.openjdk.jol.info.GraphLayout.parseInstance(GraphLayout.java:54)
        at scala.meta.internal.metals.Memory$.footprint(Memory.scala:31)
        at scala.meta.internal.metals.Indexer.logMemory(Indexer.scala:179)
        at scala.meta.internal.metals.Indexer.$anonfun$profiledIndexWorkspace$4(Indexer.scala:155)
        at scala.meta.internal.metals.Indexer.$anonfun$profiledIndexWorkspace$4$adapted(Indexer.scala:148)
        at scala.util.Success.foreach(Try.scala:260)
        at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:481)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.UnsupportedOperationException: can't get field offset on a hidden class: private final scala.meta.internal.metals.MetalsLanguageServer scala.meta.internal.metals.MetalsLanguageServer$$Lambda$90/0x0000000800d35488.arg$1
        at jdk.unsupported/sun.misc.Unsafe.objectFieldOffset(Unsafe.java:645)
        at org.openjdk.jol.vm.HotspotUnsafe.fieldOffset(HotspotUnsafe.java:454)
        ... 13 more
```

Now, catch this specific error and show user a less scary error message just once:
```
2022.06.25 09:41:58 ERROR org.openjdk.jol cannot compute memory footprint for build targets. Try to run Metals server with -Djol.magicFieldOffset=true property. See https://github.com/openjdk/jol/commit/5dafe85a1fca52342cb965e673513b76768ab945 for more details
```

According to commit linked below, setting `-Djol.magicFieldOffset=true` might be dangerous to use, hence this shouldn't be set as a default option.  

See https://github.com/openjdk/jol/commit/5dafe85a1fca52342cb965e673513b76768ab945 for more information about error. 