### PR TITLE
feat: update test suite location

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -209,6 +209,7 @@ object ClientCommands {
       |export type TestExplorerEvent =
       | RemoveTestSuite
       | AddTestSuite
+      | UpdateSuiteLocation
       | AddTestCases;
       |
       |export interface RemoveTestSuite {
@@ -224,6 +225,13 @@ object ClientCommands {
       |  symbol: string;
       |  location: Location;
       |  canResolveChildren: boolean;
+      |}
+      |
+      |export interface AddTestCases {
+      |  kind: "updateSuiteLocation";
+      |  fullyQualifiedClassName: FullyQualifiedClassName;
+      |  className: ClassName;
+      |  location: Location;
       |}
       |
       |export interface AddTestCases {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.metals
 
 import java.io.IOException
+import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
@@ -674,6 +675,9 @@ object MetalsEnrichments
         localOccurrence.symbol == symbol
       }
     }
+
+    def toLocation(uri: URI, symbol: String): Option[l.Location] =
+      toLocation(uri.toString, symbol)
 
     def toLocation(uri: String, symbol: String): Option[l.Location] = {
       textDocument.occurrences

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/BuildTargetUpdate.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/BuildTargetUpdate.scala
@@ -4,6 +4,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 
 import ch.epfl.scala.bsp4j.BuildTarget
 import org.eclipse.{lsp4j => l}
+
 final case class BuildTargetUpdate(
     targetName: String,
     targetUri: String,
@@ -43,6 +44,12 @@ object TestExplorerEvent {
     def asRemove: RemoveTestSuite =
       RemoveTestSuite(fullyQualifiedClassName, className)
   }
+
+  final case class UpdateSuiteLocation(
+      fullyQualifiedClassName: String,
+      className: String,
+      location: l.Location
+  ) extends TestExplorerEvent("updateSuiteLocation")
 
   final case class AddTestCases(
       fullyQualifiedClassName: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -32,6 +32,7 @@ import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTarget
 import ch.epfl.scala.bsp4j.ScalaPlatform
+import org.eclipse.{lsp4j => l}
 
 final class TestSuitesProvider(
     buildTargets: BuildTargets,
@@ -62,19 +63,31 @@ final class TestSuitesProvider(
     }
 
   /**
-   * Update test cases for given path.
-   * Only consider 'relevant' files which have had already discovered test suite.
+   * For test suites located in a given path,
+   * update their location (range) and their children (test cases).
+   *
+   * For children, only consider 'relevant' files which have already discovered children.
    * Metals have to update them because they can be visible to the user via:
    * 1. Test Explorer view can be opened and tree view is visible
    * 2. test suite's file can be opened and test cases are visible
    */
   override def onChange(docs: TextDocuments, file: AbsolutePath): Unit = {
-    if (isEnabled && index.hasTestCasesGranularity(file)) {
-      if (docs.documents.nonEmpty) {
-        val doc = docs.documents.headOption
-        val buildTargetUpdates = getTestCasesForPath(file, doc)
-        updateClientIfNonEmpty(buildTargetUpdates)
-      }
+    if (isEnabled && docs.documents.nonEmpty) {
+      val doc = docs.documents.headOption
+
+      val suiteLocationChanged =
+        if (index.contains(file))
+          doc.toList.flatMap { doc =>
+            getTestSuitesLocationUpdates(file, doc)
+          }
+        else Nil
+
+      val buildTargetUpdates =
+        if (index.hasTestCasesGranularity(file))
+          getTestCasesForPath(file, doc)
+        else Nil
+
+      updateClientIfNonEmpty(suiteLocationChanged ::: buildTargetUpdates)
     }
   }
 
@@ -123,6 +136,34 @@ final class TestSuitesProvider(
         ClientCommands.UpdateTestExplorer.toExecuteCommandParams(updates: _*)
       client.metalsExecuteClientCommand(params)
     }
+
+  private def getTestSuitesLocationUpdates(
+      path: AbsolutePath,
+      doc: TextDocument
+  ): List[BuildTargetUpdate] = {
+    val events = for {
+      metadata <- index.getMetadata(path).toList
+      entry <- metadata.entries
+      symbol <- doc.symbols.find(si =>
+        si.symbol == entry.suiteInfo.symbol.value
+      )
+      loc: l.Location <- doc.toLocation(path.toURI, symbol.symbol)
+      if loc != entry.testClass.location
+    } yield {
+      val event = UpdateSuiteLocation(
+        entry.suiteInfo.fullyQualifiedName.value,
+        entry.suiteInfo.className.value,
+        loc
+      )
+      (entry.buildTarget, event)
+    }
+    events.groupBy(_._1).toList.map { case (buildTarget, events) =>
+      BuildTargetUpdate(
+        buildTarget,
+        events.map(_._2)
+      )
+    }
+  }
 
   /**
    * Retrieves all cached test suites.
@@ -194,9 +235,9 @@ final class TestSuitesProvider(
           if (testCases.nonEmpty) {
             index.setHasTestCasesGranularity(path)
             val event = AddTestCases(
-              suite.fullyQualifiedName.value,
-              suite.className.value,
-              testCases.asJava
+              fullyQualifiedClassName = suite.fullyQualifiedName.value,
+              className = suite.className.value,
+              testCases = testCases.asJava
             )
             Some(event)
           } else None
@@ -236,6 +277,11 @@ final class TestSuitesProvider(
     val deletedSuites = removeStaleTestSuites(symbolsPerTarget)
     val addedEntries = getTestEntries(symbolsPerTarget)
 
+    // update cached suites with currently discovered
+    addedEntries.foreach { case (_, entries) =>
+      entries.foreach(index.put(_))
+    }
+
     val addedTestCases = addedEntries.mapValues {
       _.flatMap { entry =>
         val canResolve = entry.suiteInfo.framework.canResolveChildren
@@ -250,10 +296,6 @@ final class TestSuitesProvider(
     val buildTargetUpdates =
       getBuildTargetUpdates(deletedSuites, addedSuites, addedTestCases)
 
-    // update cached suites with currently discovered
-    addedEntries.foreach { case (_, entries) =>
-      entries.foreach(index.put(_))
-    }
     updateClientIfNonEmpty(buildTargetUpdates)
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/JunitTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/JunitTestFinder.scala
@@ -36,7 +36,7 @@ class JunitTestFinder {
       .collect {
         case symbol if isValid(symbol) =>
           doc
-            .toLocation(uri.toString, symbol.symbol)
+            .toLocation(uri, symbol.symbol)
             .map(location => TestCaseEntry(symbol.displayName, location))
       }
       .flatten

--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -521,7 +521,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
   )
 
   checkEvents(
-    "check-events",
+    "check-basic-events",
     s"""|/metals.json
         |{
         |  "app": {
@@ -537,8 +537,8 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
         |  def test1 = ()
         |}
         |""".stripMargin,
-    "app/src/main/scala/JunitTestSuite.scala",
-    () => {
+    file = "app/src/main/scala/JunitTestSuite.scala",
+    expected = () => {
       val fcqn = "JunitTestSuite"
       val className = "JunitTestSuite"
       val symbol = "_empty_/JunitTestSuite#"
@@ -571,6 +571,13 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
     }
   )
 
+  /**
+   * Discovers all tests in project or test cases in file
+   *
+   * @param files list of files for which compilation will be triggered. It's
+   * @param expected list of expected build target updates
+   * @param uri URI of file for which test cases should be discovered
+   */
   def testDiscover(
       name: TestOptions,
       layout: String,
@@ -591,6 +598,12 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
     }
   }
 
+  /**
+   * Check if Test Explorer returns particular events.
+   *
+   * @param file which should be compiled
+   * @param expected list of expected build target updates
+   */
   def checkEvents(
       name: TestOptions,
       layout: String,


### PR DESCRIPTION
needs https://github.com/scalameta/metals-vscode/pull/1043
VS Code updates range of test suite using their own heuristic but sometimes it yields wrong results. This should be handy also for potential non-vscode clients.

Todo: 
- [x] docs
- [ ] test
- [x] ~now I realized that VS Code doesn't need location, range is enough~ Actually, it doesn't matter that much.

I want to do some cleanup in Test Explorer, get rid of ballast code but this will happen on subsequent PRs.