### PR TITLE
bugfix: Make sure that the Scala 3 compiler always retries properly

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaCompilerAccess.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaCompilerAccess.scala
@@ -47,7 +47,8 @@ class ScalaCompilerAccess(
     extends CompilerAccess[StoreReporter, MetalsGlobal](
       config,
       sh,
-      newCompiler
+      newCompiler,
+      shouldResetJobQueue = false
     ) {
 
   def newReporter = new StoreReporter

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
@@ -27,7 +27,11 @@ class Scala3CompilerAccess(
     extends CompilerAccess[StoreReporter, InteractiveDriver](
       config,
       sh,
-      newCompiler
+      newCompiler,
+      /* If running inside the executor, we need to reset the job queue
+       * Otherwise it will block indefinetely in case of infinite loops.
+       */
+      shouldResetJobQueue = true
     ):
 
   def newReporter = new StoreReporter(null)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
@@ -32,10 +32,14 @@ class Scala3CompilerAccess(
 
   def newReporter = new StoreReporter(null)
 
+  /**
+   * Handle the exception in order to make sure that
+   * we retry immediately. Otherwise, we will wait until
+   * the end of the timeout, which is 20s by default.
+   */
   protected def handleSharedCompilerException(
       t: Throwable
-  ): Option[String] =
-    throw t
+  ): Option[String] = None
 
   protected def ignoreException(t: Throwable): Boolean = false
 end Scala3CompilerAccess

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerWrapper.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerWrapper.scala
@@ -20,7 +20,7 @@ class Scala3CompilerWrapper(driver: InteractiveDriver)
     new ReporterAccess[StoreReporter]:
       def reporter = driver.currentCtx.reporter.asInstanceOf[StoreReporter]
 
-  override def askShutdown(): Unit = {}
+  override def askShutdown(): Unit = ()
 
   override def isAlive(): Boolean = false
 

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
@@ -23,7 +23,8 @@ import scala.meta.pc.PresentationCompilerConfig
 abstract class CompilerAccess[Reporter, Compiler](
     config: PresentationCompilerConfig,
     sh: Option[ScheduledExecutorService],
-    newCompiler: () => CompilerWrapper[Reporter, Compiler]
+    newCompiler: () => CompilerWrapper[Reporter, Compiler],
+    shouldResetJobQueue: Boolean
 )(implicit ec: ExecutionContextExecutor) {
   private val logger: Logger =
     Logger.getLogger(classOf[CompilerAccess[_, _]].getName)
@@ -214,14 +215,9 @@ abstract class CompilerAccess[Reporter, Compiler](
         { () =>
           if (!result.isDone()) {
             try {
-              val runsOnSameThread =
-                _compiler.presentationCompilerThread.isEmpty
+              if (shouldResetJobQueue) jobs.reset()
               result.cancel(false)
               shutdownCurrentCompiler()
-              /* If running inside the executor, we need to reset the job queue
-               * Otherwise it will block indefinetely in case of infinite loops.
-               */
-              if (runsOnSameThread) jobs.reset()
             } catch {
               case NonFatal(_) =>
               case other: Throwable =>

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
@@ -214,8 +214,14 @@ abstract class CompilerAccess[Reporter, Compiler](
         { () =>
           if (!result.isDone()) {
             try {
+              val runsOnSameThread =
+                _compiler.presentationCompilerThread.isEmpty
               result.cancel(false)
               shutdownCurrentCompiler()
+              /* If running inside the executor, we need to reset the job queue
+               * Otherwise it will block indefinetely in case of infinite loops.
+               */
+              if (runsOnSameThread) jobs.reset()
             } catch {
               case NonFatal(_) =>
               case other: Throwable =>

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerJobQueue.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerJobQueue.scala
@@ -85,6 +85,18 @@ class CompilerJobQueue(newExecutor: () => ThreadPoolExecutor) {
     }
   }
 
+  def reset(): Unit = {
+    state.get() match {
+      case curr @ State.Initialized(v) =>
+        if (state.compareAndSet(curr, State.Empty)) {
+          v.shutdown()
+        } else {
+          delay()
+        }
+      case _ =>
+    }
+  }
+
   private def delay(): Unit = Thread.sleep(50)
 
   override def toString(): String = s"CompilerJobQueue(${state.get})"

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerJobQueue.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerJobQueue.scala
@@ -92,6 +92,7 @@ class CompilerJobQueue(newExecutor: () => ThreadPoolExecutor) {
           v.shutdown()
         } else {
           delay()
+          reset()
         }
       case _ =>
     }

--- a/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
@@ -2,6 +2,7 @@ package tests.pc
 
 import java.lang
 import java.net.URI
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.atomic.AtomicBoolean
@@ -10,13 +11,21 @@ import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.CompilerOffsetParams
 import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.pc.InterruptException
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.pc.CancelToken
+import scala.meta.pc.PresentationCompilerConfig
 
 import munit.Location
 import munit.TestOptions
 import tests.BaseCompletionSuite
 
 class CancelCompletionSuite extends BaseCompletionSuite {
+
+  override protected def config: PresentationCompilerConfig =
+    PresentationCompilerConfigImpl().copy(
+      // to make "break-compilation" test faster
+      timeoutDelay = 5
+    )
 
   /**
    * A cancel token that cancels asynchronously on first `checkCancelled` call.
@@ -93,4 +102,54 @@ class CancelCompletionSuite extends BaseCompletionSuite {
        |""".stripMargin
   )
 
+  /**
+   * A cancel token to simulate infinite compilation
+   */
+  object FreezeCancelToken extends CancelToken {
+    val cancel = new CompletableFuture[lang.Boolean]()
+    var isCancelled = new AtomicBoolean(false)
+    override def onCancel(): CompletionStage[lang.Boolean] = cancel
+    override def checkCanceled(): Unit = {
+      var hello = true
+      var i = 0
+      while (hello) i += 1
+      hello = false
+    }
+
+  }
+
+  test("break-compilation".tag(IgnoreScala2)) {
+    val query = """
+                  |object A {
+                  |  val x = asser@@
+                  |}
+               """.stripMargin
+    val (code, offset) = params(query)
+    val uri = URI.create("file:///A.scala")
+    try {
+      presentationCompiler
+        .complete(
+          CompilerOffsetParams(
+            uri,
+            code,
+            offset,
+            FreezeCancelToken
+          )
+        )
+        .get()
+    } catch {
+      case _: CancellationException =>
+    }
+    val res = presentationCompiler
+      .complete(
+        CompilerOffsetParams(
+          uri,
+          code,
+          offset,
+          EmptyCancelToken
+        )
+      )
+      .get()
+    assert(res.getItems().asScala.nonEmpty)
+  }
 }


### PR DESCRIPTION
Previously, if the compiler was stuck in an infinite loop we would not be able to invoke any methods on the compiler. For Scala 2 we had a separate presentation compiler thread, which would get properly interupted stopped. Now, ~~we interrupt the thread the compiler is running~~ we need to reset the job queue and in the local testing this has helped. Unfortunately, I don't know how to reproduce the infinite loop and this should no longer be an issue for later Scala 3 versions

I also added handling of compiler exceptions, since there are currently none that I know of that should just we thrown and hnadled specifically.