### PR TITLE
feat: ScaladocCompletion for Scala3

### DIFF
--- a/mtags/src/main/scala-3.2/scala/meta/internal/pc/MetalsSignatures.scala
+++ b/mtags/src/main/scala-3.2/scala/meta/internal/pc/MetalsSignatures.scala
@@ -1,14 +1,15 @@
 package scala.meta.internal.pc
 
-import dotty.tools.dotc.ast.tpd
-import dotty.tools.dotc.util.SourcePosition
-import dotty.tools.dotc.core.Contexts.*
-import dotty.tools.dotc.util.Signatures
-import dotty.tools.dotc.util.Signatures.Signature
 import scala.meta.internal.mtags.MtagsEnrichments.*
 import scala.meta.pc.SymbolSearch
-import dotty.tools.dotc.core.Flags
+
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Denotations.*
+import dotty.tools.dotc.core.Flags
+import dotty.tools.dotc.util.Signatures
+import dotty.tools.dotc.util.Signatures.Signature
+import dotty.tools.dotc.util.SourcePosition
 
 object MetalsSignatures:
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionPos.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionPos.scala
@@ -56,6 +56,28 @@ object CompletionPos:
   end infer
 
   /**
+   * Infer the indentation by counting the number of spaces in the given line.
+   *
+   * @param lineOffset the offset position of the beginning of the line
+   */
+  private[completions] def inferIndent(
+      lineOffset: Int,
+      text: String
+  ): (Int, Boolean) =
+    var i = 0
+    var tabIndented = false
+    while lineOffset + i < text.length && {
+        val char = text.charAt(lineOffset + i)
+        if char == '\t' then
+          tabIndented = true
+          true
+        else char == ' '
+      }
+    do i += 1
+    (i, tabIndented)
+  end inferIndent
+
+  /**
    * Returns the start offset of the identifier starting as the given offset position.
    */
   private def inferIdentStart(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -36,6 +36,7 @@ import dotty.tools.dotc.util.SrcPos
 
 class Completions(
     pos: SourcePosition,
+    text: String,
     ctx: Context,
     search: SymbolSearch,
     buildTargetIdentifier: String,
@@ -175,6 +176,9 @@ class Completions(
       .stripSuffix(".scala")
 
     path match
+      case _ if ScaladocCompletions.isScaladocCompletion(pos, text) =>
+        val values = ScaladocCompletions.contribute(pos, text, config)
+        (values, true)
       // class FooImpl extends Foo:
       //   def x|
       case (dd: (DefDef | ValDef)) :: (t: Template) :: (td: TypeDef) :: _
@@ -322,6 +326,7 @@ class Completions(
       def visit(head: CompletionValue): Boolean =
         val (id, include) =
           head match
+            case doc: CompletionValue.Document => (doc.label, true)
             case over: CompletionValue.Override => (over.label, true)
             case symOnly: CompletionValue.Symbolic =>
               val sym = symOnly.symbol

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -206,7 +206,7 @@ object OverrideCompletions:
       // |  class FooImpl extends Foo {
       // |  }
       // ```
-      val (necessaryIndent, tabIndented) = inferIndent(
+      val (necessaryIndent, tabIndented) = CompletionPos.inferIndent(
         source.lineToOffset(td.sourcePos.line),
         text
       )
@@ -223,7 +223,10 @@ object OverrideCompletions:
       val (numIndent, shouldTabIndent) =
         decls.headOption
           .map { decl =>
-            inferIndent(source.lineToOffset(decl.sourcePos.line), text)
+            CompletionPos.inferIndent(
+              source.lineToOffset(decl.sourcePos.line),
+              text
+            )
           }
           .getOrElse({
             val default = defaultIndent(tabIndented)
@@ -440,24 +443,5 @@ object OverrideCompletions:
       else text.indexOf("{", start)
     if offset > 0 && offset < td.span.end then Some(offset)
     else None
-
-  /**
-   * Infer the indentation by counting the number of spaces in the given line.
-   *
-   * @param lineOffset the offset position of the beginning of the line
-   */
-  private def inferIndent(lineOffset: Int, text: String): (Int, Boolean) =
-    var i = 0
-    var tabIndented = false
-    while lineOffset + i < text.length && {
-        val char = text.charAt(lineOffset + i)
-        if char == '\t' then
-          tabIndented = true
-          true
-        else char == ' '
-      }
-    do i += 1
-    (i, tabIndented)
-  end inferIndent
 
 end OverrideCompletions

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/ScaladocCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/ScaladocCompletions.scala
@@ -1,0 +1,131 @@
+package scala.meta.internal.pc.completions
+
+import scala.meta.pc.PresentationCompilerConfig
+
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Flags.Method
+import dotty.tools.dotc.core.Flags.*
+import dotty.tools.dotc.core.NameKinds.*
+import dotty.tools.dotc.core.Symbols.NoSymbol
+import dotty.tools.dotc.core.Types.ExprType
+import dotty.tools.dotc.core.Types.MethodOrPoly
+import dotty.tools.dotc.util.SourcePosition
+
+object ScaladocCompletions:
+  // The indent for gutter asterisks aligned in column three.
+  // |/**
+  // |  *
+  private val scaladocIndent = "  "
+
+  def contribute(
+      pos: SourcePosition,
+      text: String,
+      config: PresentationCompilerConfig
+  )(using Context): List[CompletionValue] =
+    def buildText(
+        params: List[String],
+        hasReturnValue: Boolean,
+        indent: String
+    ): String =
+      val builder = new StringBuilder()
+      builder.append("\n")
+      builder.append(s"${indent}*")
+      if config.isCompletionSnippetsEnabled then builder.append(" $0\n")
+      else builder.append("\n")
+
+      if params.nonEmpty || hasReturnValue then builder.append(s"$indent*\n")
+
+      params.foreach(param => builder.append(s"$indent* @param $param\n"))
+      if hasReturnValue then builder.append(s"$indent* @return\n")
+      builder.append(s"$indent*/")
+
+      builder.toString()
+    end buildText
+
+    val ctx = summon[Context]
+    val (numIndent, shouldTabIndent) = CompletionPos.inferIndent(
+      ctx.source.lineToOffset(pos.line),
+      text
+    )
+    val indentChar = if shouldTabIndent then "\t" else " "
+    val necessaryIndent = indentChar * numIndent
+    val indent = necessaryIndent + scaladocIndent
+
+    val finder = new AssociatedMemberDefFinder(pos)
+    val root = ctx.compilationUnit.tpdTree
+    finder.findAssociatedDef(root) match
+      case None =>
+        val newText = buildText(Nil, false, indent)
+        List(CompletionValue.document("/** */", newText, "Scaladoc Comment"))
+      case Some(defn) =>
+        val params = defn.getParamss
+
+        val hasReturnValue = defn.symbol.info match
+          case tpe: (MethodOrPoly | ExprType) =>
+            if defn.symbol.isConstructor then false
+            else !(tpe.finalResultType =:= ctx.definitions.UnitType)
+          case _ => false
+
+        val newText = buildText(params, hasReturnValue, indent)
+        List(CompletionValue.document("/** */", newText, "Scaladoc Comment"))
+    end match
+
+  end contribute
+
+  def isScaladocCompletion(pos: SourcePosition, text: String): Boolean =
+    pos.point >= 3 &&
+      text.charAt(pos.point - 3) == '/' &&
+      text.charAt(pos.point - 2) == '*' &&
+      text.charAt(pos.point - 1) == '*'
+
+  class AssociatedMemberDefFinder(pos: SourcePosition) extends TreeTraverser:
+    private var associatedDef: Option[MemberDef] = None
+
+    override def traverse(tree: Tree)(using Context): Unit = tree match
+      case d: (TypeDef | DefDef | ValDef)
+          if d.sourcePos.exists && d.sourcePos.span.isSourceDerived &&
+            pos.startLine + 1 == d.sourcePos.startLine &&
+            !d.symbol.is(Synthetic) =>
+        val isCandidate = associatedDef match
+          case Some(current) =>
+            d.sourcePos.start <= current.sourcePos.start
+          case None => true
+        if isCandidate then associatedDef = Some(d)
+      case _ => traverseChildren(tree)
+
+    def findAssociatedDef(root: Tree)(using Context): Option[MemberDef] =
+      associatedDef = None
+      traverse(root)
+      associatedDef
+    end findAssociatedDef
+  end AssociatedMemberDefFinder
+
+  extension (defn: MemberDef)
+    private def getParamss(using ctx: Context): List[String] =
+      defn match
+        case defdef: DefDef =>
+          val extensionParam =
+            if defdef.symbol.isAllOf(ExtensionMethod) then
+              defdef.symbol.extensionParam
+            else NoSymbol
+          defdef.trailingParamss.flatten.collect {
+            case param
+                if !param.symbol.isOneOf(Synthetic) &&
+                  !param.name.is(EvidenceParamName) &&
+                  param.symbol != extensionParam =>
+              param.name.show
+          }
+        case clazz: TypeDef =>
+          clazz.symbol.primaryConstructor.rawParamss.flatten.collect {
+            case param
+                if !param.is(Synthetic) &&
+                  !param.isTypeParam &&
+                  !param.name.is(EvidenceParamName) =>
+              param.name.show
+          }
+        case other =>
+          Nil
+
+end ScaladocCompletions

--- a/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScaladocSuite.scala
@@ -4,8 +4,6 @@ import tests.BaseCompletionSuite
 
 class CompletionScaladocSuite extends BaseCompletionSuite {
 
-  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
-    Some(IgnoreScala3)
   check(
     "methoddef-label",
     """
@@ -316,6 +314,54 @@ class CompletionScaladocSuite extends BaseCompletionSuite {
        |    * $0
        |    */
        |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "extension".tag(IgnoreScala2),
+    """|extension (str: String)
+       |  /**@@
+       |  def foo(param1: Int): Int = ???
+       |""".stripMargin,
+    """|extension (str: String)
+       |  /**
+       |    * $0
+       |    *
+       |    * @param param1
+       |    * @return
+       |    */
+       |  def foo(param1: Int): Int = ???
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "anonymous-given".tag(IgnoreScala2),
+    """|/**@@
+       |def foo(param1: Int)(using String): Int = ???
+       |""".stripMargin,
+    """|/**
+       |  * $0
+       |  *
+       |  * @param param1
+       |  * @return
+       |  */
+       |def foo(param1: Int)(using String): Int = ???
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "named-given".tag(IgnoreScala2),
+    """|/**@@
+       |def foo(param1: Int)(using s: String): Int = ???
+       |""".stripMargin,
+    """|/**
+       |  * $0
+       |  *
+       |  * @param param1
+       |  * @param s
+       |  * @return
+       |  */
+       |def foo(param1: Int)(using s: String): Int = ???
        |""".stripMargin
   )
 }


### PR DESCRIPTION
close https://github.com/scalameta/metals/issues/3955

![scaladoc](https://user-images.githubusercontent.com/9353584/176735285-74e4a7fc-37c7-46c0-84a4-d6915e4573f2.gif)

Overview, basically the same with Scala2 implementation:

- if the cursor follows `/**`, insert `*/` on the cursor and compile it using `InteractiveDriver`
  - We need to close the multiline comment, otherwise, the following code will be commented out, and we can't retrieve the tree of the code under `/**`.
- Find the class/method definition we're documenting
  - the class/method that defined just below the cursor
    - (I simplified the algorithm than Scala2 one. In Scala2, we try to find the class/method that is defined closest to the cursor)
- Extract the method or class constructor parameters, and construct the text.