### PR TITLE
feature: Add known scalafix rules' dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -595,6 +595,21 @@ def isInTestShard(name: String, logger: Logger): Boolean = {
   }
 }
 
+lazy val metalsDependencies = project
+  .in(file("target/.dependencies"))
+  .settings(
+    publish / skip := true,
+    libraryDependencies ++= List(
+      // The dependencies listed below are only listed so Scala Steward
+      // will pick them up and update them. They aren't actually used.
+      "com.lihaoyi" %% "ammonite-util" % V.ammonite,
+      "org.typelevel" % "kind-projector" % V.kindProjector cross CrossVersion.full,
+      "com.olegpy" %% "better-monadic-for" % V.betterMonadicFor,
+      "com.lihaoyi" % "mill-contrib-testng" % V.mill
+    )
+  )
+  .disablePlugins(ScalafixPlugin)
+
 lazy val unit = project
   .in(file("tests/unit"))
   .settings(
@@ -607,13 +622,7 @@ lazy val unit = project
     libraryDependencies ++= List(
       "io.get-coursier" %% "coursier" % V.coursier, // for jars
       "ch.epfl.scala" %% "bloop-config" % V.bloop,
-      "org.scalameta" %% "munit" % V.munit,
-      // The dependencies listed below are only listed so Scala Steward
-      // will pick them up and update them. They aren't actually used.
-      "com.lihaoyi" %% "ammonite-util" % V.ammonite intransitive (),
-      "org.typelevel" % "kind-projector" % V.kindProjector cross CrossVersion.full intransitive (),
-      "com.olegpy" %% "better-monadic-for" % V.betterMonadicFor intransitive (),
-      "com.lihaoyi" % "mill-contrib-testng" % V.mill intransitive ()
+      "org.scalameta" %% "munit" % V.munit
     ),
     buildInfoPackage := "tests",
     Compile / resourceGenerators += InputProperties

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -40,7 +40,10 @@ object TestGroups {
       "tests.classFinder.FindAllClassesSuite",
       "tests.codeactions.ExtractValueLspSuite", "tests.clients.CommandSuite",
       "tests.JavaInteractiveSemanticdbSuite", "tests.SemVerSuite",
-      "tests.codeactions.CompanionObjectSuite"),
+      "tests.codeactions.CompanionObjectSuite",
+      "tests.codeactions.FlatMapToForComprehensionSuite",
+      "tests.MtagsScala2Suite", "tests.UriEncoderDecoderSuite",
+      "tests.DidFocusWhileCompilingLspSuite"),
     Set("tests.AmmoniteSuite", "tests.debug.BreakpointDapSuite",
       "tests.OnTypeFormattingSuite", "tests.ReferenceLspSuite",
       "tests.SuperMethodLspSuite", "tests.SyntaxErrorLspSuite",
@@ -92,7 +95,10 @@ object TestGroups {
       "tests.classFinder.ClassBreakpointSuite",
       "tests.classFinder.ClassNameResolverSuite", "tests.JavaDefinitionSuite",
       "tests.IdentifierComparatorSuite", "tests.parsing.JavaEditDistanceSuite",
-      "tests.PathTrieSuite")
+      "tests.PathTrieSuite", "tests.scalafix.ScalafixProviderLspSuite",
+      "tests.MtagsScala3Suite",
+      "tests.codeactions.ConvertToNamedArgumentsLspSuite",
+      "tests.testProvider.TestSuitesProviderSuite", "tests.MillVersionSuite")
   )
 
 }


### PR DESCRIPTION
Previously, if a user used an unknown rule we would fail and make them add the dependency manually. Now, we added all known hygiene rules from https://scalacenter.github.io/scalafix/docs/rules/community-rules.html by default.

I was also considering code generation rules, but we can add it later if needed.

This is a stop gap measure until it's possible to define dependencies in `.scalafix.conf` https://github.com/scalacenter/scalafix/issues/1625