### PR TITLE
fix: (scala3) insert correct position for implement-all code action on class with type parameters

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -132,7 +132,8 @@ class MetalsPrinter(
   def defaultMethodSignature(
       gsym: Symbol,
       gtpe: Type,
-      onlyMethodParams: Boolean = false
+      onlyMethodParams: Boolean = false,
+      additionalMods: List[String] = Nil
   ): String =
     val namess = gtpe.paramNamess
     val infoss = gtpe.paramInfoss
@@ -212,19 +213,23 @@ class MetalsPrinter(
           else ""
         flags.flagStrings(privateWithin).mkString(" ") + " "
       else ""
+    val mods =
+      if additionalMods.isEmpty then flagString
+      else additionalMods.mkString(" ") + " " + flagString
 
     if onlyMethodParams then paramssSignature
     else
       // For Scala2 compatibility, show "this" instead of <init> for constructor
       val name = if gsym.isConstructor then StdNames.nme.this_ else gsym.name
       extensionSignatureString +
-        s"${flagString}def $name" +
+        s"${mods}def $name" +
         paramssSignature
   end defaultMethodSignature
 
   def defaultValueSignature(
       gsym: Symbol,
-      gtpe: Type
+      gtpe: Type,
+      additionalMods: List[String] = Nil
   ): String =
     val flags = (gsym.flags & methodFlags)
     val flagString =
@@ -234,8 +239,11 @@ class MetalsPrinter(
           else ""
         flags.flagStrings(privateWithin).mkString(" ") + " "
       else ""
+    val mods =
+      if additionalMods.isEmpty then flagString
+      else additionalMods.mkString(" ") + " " + flagString
     val prefix = if gsym.is(Mutable) then "var" else "val"
-    s"${flagString}$prefix ${gsym.name.show}: ${tpe(gtpe)}"
+    s"${mods}$prefix ${gsym.name.show}: ${tpe(gtpe)}"
   end defaultValueSignature
 
   /*

--- a/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
@@ -45,6 +45,36 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
+    "classdef-tparam",
+    """|package a
+       |
+       |object A {
+       |  trait Base {
+       |    def foo(x: Int): Int
+       |    def bar(x: String): String
+       |  }
+       |  class <<Concrete>>[T] extends Base
+       |}
+       |""".stripMargin,
+    """|package a
+       |
+       |object A {
+       |  trait Base {
+       |    def foo(x: Int): Int
+       |    def bar(x: String): String
+       |  }
+       |  class Concrete[T] extends Base {
+       |
+       |    override def foo(x: Int): Int = ???
+       |
+       |    override def bar(x: String): String = ???
+       |
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
     "empty-lines-between-members",
     """|package a
        |
@@ -932,6 +962,62 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
        |
        |	def foo(x: Int): Int = x
        |
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "extension-methods".tag(IgnoreScala2),
+    """|package a
+       |
+       |trait Base:
+       |  extension (x: Int)
+       |    def foo: Int
+       |    def bar: String
+       |
+       |class <<Concrete>> extends Base
+       |""".stripMargin,
+    """|package a
+       |
+       |trait Base:
+       |  extension (x: Int)
+       |    def foo: Int
+       |    def bar: String
+       |
+       |class Concrete extends Base {
+       |
+       |  exntesion (x: T) def foo: Int = ???
+       |
+       |  extension (x: T) def bar: Int = ???
+       |
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "extension-methods-tparam".tag(IgnoreScala2),
+    """|package a
+       |
+       |trait Base[T]:
+       |  extension (x: T)
+       |    def foo: Int
+       |    def bar: String
+       |
+       |class <<Concrete>>[T] extends Base[Int]
+       |""".stripMargin,
+    """|package a
+       |
+       |trait Base[T]:
+       |  extension (x: T)
+       |    def foo: Int
+       |    def bar: String
+       |
+       |class Concrete[T] extends Base[Int] {
+       |
+       |  extension (x: Int) def foo: Int = ???
+       |
+       |  extension (x: Int) def bar: String = ???
+       |
+       |}
        |""".stripMargin
   )
 

--- a/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala
@@ -985,9 +985,9 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
        |
        |class Concrete extends Base {
        |
-       |  exntesion (x: T) def foo: Int = ???
+       |  extension (x: Int) override def foo: Int = ???
        |
-       |  extension (x: T) def bar: Int = ???
+       |  extension (x: Int) override def bar: String = ???
        |
        |}
        |""".stripMargin
@@ -1013,9 +1013,9 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite {
        |
        |class Concrete[T] extends Base[Int] {
        |
-       |  extension (x: Int) def foo: Int = ???
+       |  extension (x: Int) override def foo: Int = ???
        |
-       |  extension (x: Int) def bar: String = ???
+       |  extension (x: Int) override def bar: String = ???
        |
        |}
        |""".stripMargin

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideConfigSuite.scala
@@ -96,8 +96,8 @@ class CompletionOverrideConfigSuite extends BaseCompletionSuite {
       |""".stripMargin,
     compat = Map(
       "3" ->
-        """|⏫ def numberAbstract: Int
-           |⏫ def number: Int
+        """|🔼 def numberAbstract: Int
+           |⏫ override def number: Int
            |""".stripMargin
     )
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -1088,4 +1088,49 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
     filter = (str) => str.contains("def")
   )
 
+  checkEdit(
+    "extension-override".tag(IgnoreScala2),
+    """|package a
+       |
+       |trait Base:
+       |  extension (x: Int)
+       |    def foo: Int
+       |
+       |class Concrete extends Base:
+       |  over@@
+       |""".stripMargin,
+    """|package a
+       |
+       |trait Base:
+       |  extension (x: Int)
+       |    def foo: Int
+       |
+       |class Concrete extends Base:
+       |  extension (x: Int) override def foo: Int = ${0:???}
+       |""".stripMargin,
+    filter = (str) => str.contains("foo")
+  )
+
+  checkEdit(
+    "extension".tag(IgnoreScala2),
+    """|package a
+       |
+       |trait Base:
+       |  extension (x: Int)
+       |    def foo: Int
+       |
+       |class Concrete extends Base:
+       |  def fo@@
+       |""".stripMargin,
+    """|package a
+       |
+       |trait Base:
+       |  extension (x: Int)
+       |    def foo: Int
+       |
+       |class Concrete extends Base:
+       |  extension (x: Int) def foo: Int = ${0:???}
+       |""".stripMargin
+  )
+
 }


### PR DESCRIPTION
fix https://github.com/scalameta/metals/issues/4062

Implement-all code action for Scala3 infers the insert position based on the existing members if there are no braces.

### fix1
Previously, Metals infer the insert position based on the class's constructor parameters and type parameters.
For example,

```scala
class Concrete[T] extends Base
```

Metals had been inferring the position based on `T` and we end up
inserting stub implementation in the wrong positions.

This commit excludes type params from the "existing declaration".

### fix2
Extension methods shouldn't have an `override` keyword. For example, the following code will be invalid.

```scala
class Concrete extends Base:
  override extension (x: Int) def foo: Int = ???
```

This commit excludes the `override` keyword if the completing method is an extension method.
It's ideal for adding `override` before `def` like 

```scala
class Concrete extends Base:
  extension (x: Int) override def foo: Int = ???
```

But it's a bit tricky to insert the keyword there because the `extension (x: Int) def ...` part is generated by MetalsPrinter.

---

The code action in Scala3 still has a problem with higher kind types, for example

```scala
trait NodeDb[F[_]]:
  type N

  extension (node: N)
    def parent: F[Option[N]]

private final class InMemoryNodeDb[F[_]] extends NodeDb[F]
```

will be 

```scala
trait NodeDb[F[_]]:
  type N

  extension (node: N)
    def parent: F[Option[N]]

private final class InMemoryNodeDb[F[_]] extends NodeDb[F] {
  extension (node: NodeDb.this.N) def parent: Any = ???
}
```

that doesn't compile. But let's work on this issue in another PR :)