### PR TITLE
Add sbt-dependency-graph workflow

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yml
+++ b/.github/workflows/sbt-dependency-graph.yml
@@ -1,0 +1,18 @@
+name: Sbt Dependency Graph
+on:
+  push:
+    branches:
+      - main
+jobs:
+  submit:
+    name: Submit dependency graph
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: scalacenter/sbt-dependency-graph-action@v1
+        with:
+          scala-versions: 2.11.12 2.12.16 2.13.8 3.1.3


### PR DESCRIPTION
Could be useful to submit the dependency graph of Metals to Github to find vulnerabilities.
But also I would like to test the sbt-dependency-graph-action on a project with many cross Scala versions.