### PR TITLE
Fix sbt-dependency-graph workflow

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yml
+++ b/.github/workflows/sbt-dependency-graph.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: scalacenter/sbt-dependency-graph-action@v1
         with:
           scala-versions: 2.11.12 2.12.16 2.13.8 3.1.3
+          projects: mtags-interfaces mtags mtags3 metals


### PR DESCRIPTION
Exclude the test projects to avoid resolving the snapshot version of mtags