### PR TITLE
bugfix: Refresh decorations even if empty to clear them out

### DIFF
--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -227,6 +227,27 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
            |}
            |""".stripMargin
       )
+      // no decorations should show up with everything set to false
+      _ <- server.didChangeConfiguration(
+        """{
+          |  "show-implicit-arguments": false,
+          |  "show-implicit-conversions-and-classes": false,
+          |  "show-inferred-type": false
+          |}
+          |""".stripMargin
+      )
+      _ = assertNoDiff(
+        client.workspaceDecorations,
+        """|object Main{
+           |  def hello()(implicit name: String) = {
+           |    println(s"Hello $name!")
+           |  }
+           |  implicit val andy : String = "Andy"
+           |  hello()
+           |  ("1" + "2").map(c => c.toDouble)
+           |}
+           |""".stripMargin
+      )
     } yield ()
   }
 


### PR DESCRIPTION
Previously, we would not clean out decorations if all decorations where switched off, which would cause sticky decorations. Now, we properly send empty decorations when refreshing.

We will not be sending empty messages when the document changes with the additional `isSyntheticsEnabled` flag being checked.