### PR TITLE
bugfix: Include entire expression in filterText for member itnerpolat…

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
@@ -54,7 +54,8 @@ trait InterpolatorCompletions { this: MetalsGlobal =>
       metalsTypeMembers(ident.pos).collect {
         case m if CompletionFuzzy.matches(query, m.sym.name) =>
           val edit = new l.TextEdit(pos, newText(m.sym))
-          val filterText = m.sym.getterName.decoded
+          // for VS Code we need to include the entire `ident.member`
+          val filterText = ident.name.decoded + "." + m.sym.getterName.decoded
           new TextEditMember(filterText, edit, m.sym)
       }
     }


### PR DESCRIPTION
…ion completions

Previously, VS Code would filter out member completions when for example trying to complete `" $value.to@@"`. Now, we use the full `value.to` string in the filterText.

This should not break any other clients, since VS Code is weirdest about filtering here.

I already did the same for Scala 3

@ckipp01 could you check if this works with nvim ?