### PR TITLE
bugfix: Build.sc was seen as Ammonite script

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -355,7 +355,7 @@ trait CommonMtagsEnrichments {
     def isAmmoniteGeneratedFile: Boolean =
       doc.endsWith(".amm.sc.scala")
     def isAmmoniteScript: Boolean =
-      isScalaScript && !isWorksheet
+      isScalaScript && !isWorksheet && !doc.endsWith("build.sc")
     def asSymbol: Symbol = Symbol(doc)
     def endsWithAt(value: String, offset: Int): Boolean = {
       val start = offset - value.length
@@ -500,7 +500,7 @@ trait CommonMtagsEnrichments {
       filename.endsWith(".sc")
     }
     def isAmmoniteScript: Boolean =
-      isScalaScript && !isWorksheet
+      isScalaScript && !isWorksheet && !filename.endsWith("build.sc")
     def isWorksheet: Boolean = {
       filename.endsWith(".worksheet.sc")
     }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -355,7 +355,7 @@ trait CommonMtagsEnrichments {
     def isAmmoniteGeneratedFile: Boolean =
       doc.endsWith(".amm.sc.scala")
     def isAmmoniteScript: Boolean =
-      isScalaScript && !isWorksheet && !doc.endsWith("build.sc")
+      isScalaScript && !isWorksheet && !doc.endsWith("/build.sc")
     def asSymbol: Symbol = Symbol(doc)
     def endsWithAt(value: String, offset: Int): Boolean = {
       val start = offset - value.length

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -500,7 +500,7 @@ trait CommonMtagsEnrichments {
       filename.endsWith(".sc")
     }
     def isAmmoniteScript: Boolean =
-      isScalaScript && !isWorksheet && !filename.endsWith("build.sc")
+      isScalaScript && !isWorksheet && filename != "build.sc"
     def isWorksheet: Boolean = {
       filename.endsWith(".worksheet.sc")
     }


### PR DESCRIPTION
Previously, metals saw mill build.sc as ammonite script, now we filter it out in isAmmoniteScript so that it's fixed

fixes https://github.com/scalameta/metals/issues/4035