### PR TITLE
bugfix: Occurence highlight did not work for local vars

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DocumentHighlightProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DocumentHighlightProvider.scala
@@ -4,10 +4,10 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.mtags.DefinitionAlternatives.GlobalSymbol
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.mtags.Symbol
+import scala.meta.internal.semanticdb.ClassSignature
 import scala.meta.internal.semanticdb.Scala.Descriptor
 import scala.meta.internal.semanticdb.Scala.Symbols
 import scala.meta.internal.semanticdb.SymbolInformation
-import scala.meta.internal.semanticdb.ClassSignature
 import scala.meta.internal.semanticdb.SymbolOccurrence
 import scala.meta.internal.semanticdb.TextDocument
 
@@ -78,6 +78,9 @@ final class DocumentHighlightProvider(
     }
   }
 
+  /**
+   * Set of all local symbols declared in the same scope as `symbol`
+   */
   private def findLocalsInScope(
       symbol: String,
       doc: TextDocument
@@ -100,6 +103,9 @@ final class DocumentHighlightProvider(
     }
   }
 
+  /**
+   * Set of all alternatives symbols for local var `info` (var declared in local class)
+   */
   private def localVarAlternatives(
       info: SymbolInformation,
       doc: TextDocument
@@ -107,8 +113,8 @@ final class DocumentHighlightProvider(
     val setterSuffix = "_="
     val symbolName = info.displayName.stripSuffix(setterSuffix)
 
-    val locals: Set[String] = findLocalsInScope(info.symbol, doc)
-    val localAlternatives: Seq[String] = doc.symbols
+    val locals = findLocalsInScope(info.symbol, doc)
+    val localAlternatives = doc.symbols
       .filter(sym => locals.contains(sym.symbol))
       .filter(_.displayName.stripSuffix(setterSuffix) == symbolName)
       .map(_.symbol)

--- a/tests/unit/src/test/scala/tests/DocumentHighlightLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DocumentHighlightLspSuite.scala
@@ -99,6 +99,47 @@ class DocumentHighlightLspSuite extends BaseLspSuite("documentHighlight") {
       |}""".stripMargin
   )
 
+  check(
+    "local-var",
+    """
+      |object Test {
+      |  def met() = {
+      |    class T1(var <<abc>>: Int) {
+      |      <<ab@@c>> = 4
+      |      def m2: Int = <<abc>> + 2
+      |    }
+      |  }
+      |}""".stripMargin
+  )
+  check(
+    "local-assign",
+    """
+      |object Test {
+      |  def met() = {
+      |    class T1(var <<abc>>: Int) {
+      |      <<abc>> = 4
+      |      def m2: Int = <<ab@@c>> + 2
+      |    }
+      |  }
+      |}""".stripMargin
+  )
+  check(
+    "local-class",
+    """
+      |object Test {
+      |  def met() = {
+      |    class T1(var abc: Int) {
+      |       class T2(var <<ab@@c>>: Int) {
+      |          <<abc>> = 4
+      |          def m3: Int = <<abc>> + 2
+      |      }
+      |      abc = 4
+      |      def m2: Int = abc + 2
+      |    }
+      |  }
+      |}""".stripMargin
+  )
+
   def check(name: TestOptions, testCase: String)(implicit
       loc: Location
   ): Unit = {

--- a/tests/unit/src/test/scala/tests/DocumentHighlightLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DocumentHighlightLspSuite.scala
@@ -104,9 +104,13 @@ class DocumentHighlightLspSuite extends BaseLspSuite("documentHighlight") {
     """
       |object Test {
       |  def met() = {
-      |    class T1(var <<abc>>: Int) {
-      |      <<ab@@c>> = 4
-      |      def m2: Int = <<abc>> + 2
+      |    class T1(var abc: Int) {
+      |       class T2(var <<abc>>: Int) {
+      |          <<ab@@c>> = 4
+      |          def m3: Int = <<abc>> + 2
+      |      }
+      |      abc = 4
+      |      def m2: Int = abc + 2
       |    }
       |  }
       |}""".stripMargin
@@ -116,9 +120,13 @@ class DocumentHighlightLspSuite extends BaseLspSuite("documentHighlight") {
     """
       |object Test {
       |  def met() = {
-      |    class T1(var <<abc>>: Int) {
-      |      <<abc>> = 4
-      |      def m2: Int = <<ab@@c>> + 2
+      |    class T1(var abc: Int) {
+      |       class T2(var <<abc>>: Int) {
+      |          <<a@@bc>> = 4
+      |          def m3: Int = <<abc>> + 2
+      |      }
+      |      abc = 4
+      |      def m2: Int = abc + 2
       |    }
       |  }
       |}""".stripMargin


### PR DESCRIPTION
Previously occurrences of `var` in methods as reference and assignment were different, now we have separate logic for them, so that it highlights all occurrences properly

fixes https://github.com/scalameta/metals/issues/4093