### PR TITLE
Update sbt-dependency-graph

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yml
+++ b/.github/workflows/sbt-dependency-graph.yml
@@ -7,13 +7,8 @@ jobs:
   submit:
     name: Submit dependency graph
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ github.token }}
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: scalacenter/sbt-dependency-graph-action@v1
         with:
-          scala-versions: 2.13.8
-          projects: mtags-interfaces mtags mtags3 metals
+          scala-versions: 2.12.16 2.13.8 3.1.3


### PR DESCRIPTION
No need for GITHUB_TOKEN anymore:
It is an automatic input of the action

No need for write permission on content:
If `Workflow permissions` is `Read and write` in Settings > Actions > General

Should work on all projects:
even the benchmark or the tests could be vulnerable