### PR TITLE
bugfix: Allow completions in multiline expressions when debugging

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -324,7 +324,7 @@ class Compilers(
         val offsetParams = CompilerOffsetParams(
           path.toURI,
           modified,
-          lineStart + expressionOffset(expressionText, indentation),
+          lineStart + expressionOffset(expressionText, indentation) + 1,
           token,
         )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -277,6 +277,27 @@ class Compilers(
       expression: d.CompletionsArguments,
   ): Future[Seq[d.CompletionItem]] = {
 
+    /**
+     * Find the offset of the cursor inside the modified expression.
+     * We need it to give the compiler the right offset.
+     *
+     * @param modified modified expression with indentation inserted
+     * @param indentation indentation of the current breakpoint
+     * @return offset where the compiler should insert completions
+     */
+    def expressionOffset(modified: String, indentation: String) = {
+      val line = expression.getLine()
+      val column = expression.getColumn()
+      modified.split("\n").zipWithIndex.take(line).foldLeft(0) {
+        case (offset, (lineText, index)) =>
+          if (index + 1 == line) {
+            if (line > 1)
+              offset + column + indentation.size - 1
+            else
+              offset + column - 1
+          } else offset + lineText.size + 1
+      }
+    }
     loadCompiler(path)
       .map { compiler =>
         val input = path.toInputFromBuffers(buffers)
@@ -287,18 +308,43 @@ class Compilers(
           metaPos.start + 1,
         )
 
-        val indentation = lineStart - metaPos.start
+        val indentationSize = lineStart - metaPos.start
+        val indentationChar =
+          if (oldText.lift(lineStart - 1).exists(_ == '\t')) '\t' else ' '
+        val indentation = indentationChar.toString * indentationSize
+
+        val expressionText =
+          expression.getText().replace("\n", s"\n$indentation")
+
+        val prev = oldText.substring(0, lineStart)
+        val succ = oldText.substring(lineStart)
         // insert expression at the start of breakpoint's line and move the lines one down
-        val modified =
-          s"${oldText.substring(0, lineStart)};${expression
-              .getText()}\n${" " * indentation}${oldText.substring(lineStart)}"
+        val modified = s"$prev;$expressionText\n$indentation$succ"
 
         val offsetParams = CompilerOffsetParams(
           path.toURI,
           modified,
-          lineStart + expression.getColumn(),
+          lineStart + expressionOffset(expressionText, indentation),
           token,
         )
+
+        val previousLines = expression
+          .getText()
+          .split("\n")
+
+        // we need to adjust start to point at the start of the replacement in the expression
+        val adjustStart =
+          /* For multiple line we need to insert at the correct offset and
+           * then adjust column by indentation that was added to the expression
+           */
+          if (previousLines.size > 1)
+            previousLines
+              .take(expression.getLine() - 1)
+              .map(_.size + 1)
+              .sum - indentationSize
+          // for one line we only need to adjust column with indentation + ; that was added to the expression
+          else -(1 + indentationSize)
+
         compiler
           .complete(offsetParams)
           .asScala
@@ -307,7 +353,7 @@ class Compilers(
               .map(
                 toDebugCompletionItem(
                   _,
-                  indentation + 1,
+                  adjustStart,
                 )
               )
           )
@@ -771,7 +817,7 @@ class Compilers(
 
   private def toDebugCompletionItem(
       item: CompletionItem,
-      indentation: Int,
+      adjustStart: Int,
   ): d.CompletionItem = {
     val debugItem = new d.CompletionItem()
     debugItem.setLabel(item.getLabel())
@@ -781,10 +827,9 @@ class Compilers(
       case Right(insertReplace) =>
         (insertReplace.getNewText, insertReplace.getReplace)
     }
-    val start = range.getStart().getCharacter() - indentation
-    val end = range.getEnd().getCharacter() - indentation
+    val start = range.getStart().getCharacter + adjustStart
 
-    val length = end - start
+    val length = range.getEnd().getCharacter() - range.getStart().getCharacter()
     debugItem.setLength(length)
 
     // remove snippets, since they are not supported in DAP

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Completer.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Completer.scala
@@ -11,13 +11,20 @@ final class Completer(expression: String) extends Stoppage.Handler {
 
   override def apply(stoppage: Stoppage): DebugStep = {
     val frameId = stoppage.frame.info.getId
-    val column = expression.indexOf("@@")
+    val cursorOffset = expression.indexOf("@@")
+    val column = cursorOffset - expression
+      .substring(0, cursorOffset)
+      .lastIndexWhere(_ == '\n')
+    val line =
+      expression.substring(0, expression.indexOf("@@")).count(_ == '\n') + 1
     require(column >= 0, "Expression needs @@ for testing completions")
-    require(
-      !expression.contains('\n'),
-      "Only single line expression are supported currently",
+    Complete(
+      expression.replace("@@", ""),
+      frameId,
+      response = _,
+      line,
+      column + 1,
     )
-    Complete(expression.replace("@@", ""), frameId, response = _, 1, column + 1)
   }
 
   override def shutdown: Future[Unit] = Future.successful(())

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Completer.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Completer.scala
@@ -23,7 +23,7 @@ final class Completer(expression: String) extends Stoppage.Handler {
       frameId,
       response = _,
       line,
-      column + 1,
+      column,
     )
   }
 

--- a/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
@@ -117,6 +117,69 @@ class CompletionDapSuite
        |""".stripMargin
   )
 
+  assertCompletion(
+    "multiline",
+    expression = """|val a = 123
+                    |a.toStri@@""".stripMargin,
+    expectedCompletions = """|toBinaryString: String
+                             |toHexString: String
+                             |toOctalString: String
+                             |toString(): String
+                             |""".stripMargin,
+    expectedEdit = """|val a = 123
+                      |a.toBinaryString""".stripMargin,
+    topLines = Some(4),
+  )(
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |
+       |object Main {
+       |  case class Preceding(num: Int)
+       |
+       |  def main(args: Array[String]): Unit = {
+       |>>  println()
+       |    System.exit(0)
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  assertCompletion(
+    "multiline-longer",
+    expression = """|val a = 123
+                    |val b = 111
+                    |val c = 111
+                    |val d = 111
+                    |a.toStri@@
+                    |1 + 234""".stripMargin,
+    expectedCompletions = """|toBinaryString: String
+                             |toHexString: String
+                             |toOctalString: String
+                             |toString(): String
+                             |""".stripMargin,
+    expectedEdit = """|val a = 123
+                      |val b = 111
+                      |val c = 111
+                      |val d = 111
+                      |a.toBinaryString
+                      |1 + 234
+                      |""".stripMargin,
+    topLines = Some(4),
+  )(
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |
+       |object Main {
+       |  case class Preceding(num: Int)
+       |
+       |  def main(args: Array[String]): Unit = {
+       |>>  println()
+       |    System.exit(0)
+       |  }
+       |}
+       |""".stripMargin
+  )
+
   def assertCompletion(
       name: TestOptions,
       expression: String,

--- a/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
@@ -180,6 +180,32 @@ class CompletionDapSuite
        |""".stripMargin
   )
 
+  assertCompletion(
+    "single-dot",
+    expression = "Main.@@",
+    expectedCompletions = """|name: Option[String]
+                             |args: Array[String]
+                             |executionStart: Long
+                             |main(args: Array[String]): Unit
+                             |""".stripMargin,
+    expectedEdit = "Main.name",
+    topLines = Some(4),
+  )(
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |
+       |object Main extends App{
+       |
+       |  val name: Option[String] = Option("Tom")
+       |>>println(name)
+       |
+       |
+       |  System.exit(0)
+       |}
+       |
+       |""".stripMargin
+  )
+
   def assertCompletion(
       name: TestOptions,
       expression: String,


### PR DESCRIPTION
Previously, I assumed that only single line is allowed when using expression evaluator, which turned out to be false. Now, we should provide proper completions even if the expression is multiline.

Unfortunately the logic is not as clear as I would like it to be, but making it work was not fun. The API for those completions is much worse than the normal one.