### PR TITLE
Add LSP jar file system

### DIFF
--- a/docs/integrations/new-editor.md
+++ b/docs/integrations/new-editor.md
@@ -122,6 +122,7 @@ The currently available settings for `InitializationOptions` are listed below.
       icons?: "vscode" | "octicons" | "atom" | "unicode";
       inputBoxProvider?: boolean;
       isVirtualDocumentSupported?: boolean;
+      isLibraryFileSystemSupported?: boolean;
       isExitOnShutdown?: boolean;
       isHttpEnabled?: boolean;
       openFilesOnRenameProvider?: boolean;
@@ -326,6 +327,25 @@ Possible values:
 - `off` (default): the `metals/inputBox` request is not supported. In this case,
   Metals tries to fallback to `window/showMessageRequest` when possible.
 - `on`: the `metals/inputBox` request is fully supported.
+
+##### `isVirtualDocumentSupported`
+
+Possible values:
+
+- `off` (default): virtual documents are not supported. In this case, Metals
+  saves generated files to disk e.g. decompiled class files or source jar files.
+- `on`: virtual documents are supported and Metals sends the content of the file
+  to the client rather than a URI reference to it.
+  It's up to the client to display that content as though it were a file.
+
+##### `isLibraryFileSystemSupported`
+
+Possible values:
+
+- `off` (default): library file system is not supported.
+- `on`: library file system is supported.  Metals sends the
+  `metals-library-filesystem-ready` command when the libraries have been registered 
+  and the library filesystem is ready to navigate.
 
 ##### `isExitOnShutdown`
 

--- a/metals-bench/src/main/scala/bench/ServerInitializeBench.scala
+++ b/metals-bench/src/main/scala/bench/ServerInitializeBench.scala
@@ -52,7 +52,7 @@ class ServerInitializeBench {
   def run(): Unit = {
     val path = AbsolutePath(workspace)
     val buffers = Buffers()
-    val client = new TestingClient(path, buffers)
+    val client = new TestingClient(path, () => null, buffers)
     MetalsLogger.updateDefaultFormat()
     val ec = ExecutionContext.fromExecutorService(ex)
     val server = new MetalsLanguageServer(ec, sh = sh)

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals
 
+import java.nio.file.Files
 import java.nio.file.Path
 
 import scala.collection.mutable.ListBuffer
@@ -154,7 +155,7 @@ class BuildTargetInfo(buildTargets: BuildTargets) {
     val sourceJarName = jarName.replace(".jar", "-sources.jar")
     buildTargets
       .sourceJarFile(sourceJarName)
-      .exists(_.toFile.exists())
+      .exists(path => path.exists)
   }
 
   private def getSingleClassPathInfo(
@@ -164,7 +165,7 @@ class BuildTargetInfo(buildTargets: BuildTargets) {
   ): String = {
     val filename = shortPath.toString()
     val padding = " " * (maxFilenameSize - filename.size)
-    val status = if (path.toFile.exists) {
+    val status = if (Files.exists(path)) {
       val blankWarning = " " * 9
       if (path.toFile().isDirectory() || jarHasSource(filename))
         blankWarning

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -93,6 +93,9 @@ final class BuildTargets() {
   def allJava: Iterator[JavaTarget] =
     data.fromIterators(_.allJava)
 
+  def allJDKs: Iterator[String] =
+    data.fromIterators(_.allJDKs).distinct
+
   def info(id: BuildTargetIdentifier): Option[BuildTarget] =
     data.fromOptions(_.info(id))
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -249,6 +249,13 @@ object ClientCommands {
       |""".stripMargin,
   )
 
+  val LibraryFileSystemReady = new Command(
+    "metals-library-filesystem-ready",
+    "Library FS ready",
+    """|Notifies the client that the library filesystem is ready to be navigated.
+       |""".stripMargin,
+  )
+
   val RefreshModel = new Command(
     "metals-model-refresh",
     "Refresh model",
@@ -333,6 +340,7 @@ object ClientCommands {
       FocusDiagnostics,
       GotoLocation,
       EchoCommand,
+      LibraryFileSystemReady,
       RefreshModel,
       ShowStacktrace,
       CopyWorksheetOutput,

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -57,6 +57,9 @@ case class ClientConfiguration(initialConfig: MetalsServerConfig) {
   def isVirtualDocumentSupported(): Boolean =
     initializationOptions.isVirtualDocumentSupported.getOrElse(false)
 
+  def isLibraryFileSystemSupported(): Boolean =
+    initializationOptions.isLibraryFileSystemSupported.getOrElse(false)
+
   def icons(): Icons =
     initializationOptions.icons
       .map(Icons.fromString)

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -33,8 +33,10 @@ import org.eclipse.{lsp4j => l}
  * @param isExitOnShutdown whether the client needs Metals to shut down manually on exit.
  * @param isHttpEnabled whether the client needs Metals to start an HTTP client interface.
  * @param isVirtualDocumentSupported whether the client supports VirtualDocuments.
- *                                   For opening source jars in read-only
+ *                                   For showing decompiled class files, tasty files and
+ *                                   showing jar files
  * `*                    https://code.visualstudio.com/api/extension-guides/virtual-documents
+ * @param isLibraryFileSystemSupported whether client supports the library filesystem
  * @param openFilesOnRenameProvider whether or not the client supports opening files on rename.
  * @param quickPickProvider if the client implements `metals/quickPick`.
  * @param renameFileThreshold amount of files that should be opened during rename if client
@@ -65,6 +67,7 @@ final case class InitializationOptions(
     isHttpEnabled: Option[Boolean],
     commandInHtmlFormat: Option[CommandHTMLFormat],
     isVirtualDocumentSupported: Option[Boolean],
+    isLibraryFileSystemSupported: Option[Boolean],
     openFilesOnRenameProvider: Option[Boolean],
     quickPickProvider: Option[Boolean],
     renameFileThreshold: Option[Int],
@@ -89,6 +92,7 @@ object InitializationOptions {
 
   val Default: InitializationOptions = InitializationOptions(
     CompilerInitializationOptions.default,
+    None,
     None,
     None,
     None,
@@ -155,6 +159,8 @@ object InitializationOptions {
         .flatMap(CommandHTMLFormat.fromString),
       isVirtualDocumentSupported =
         jsonObj.getBooleanOption("isVirtualDocumentSupported"),
+      isLibraryFileSystemSupported =
+        jsonObj.getBooleanOption("isLibraryFileSystemSupported"),
       openFilesOnRenameProvider =
         jsonObj.getBooleanOption("openFilesOnRenameProvider"),
       quickPickProvider = jsonObj.getBooleanOption("quickPickProvider"),

--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -34,6 +34,7 @@ import org.eclipse.{lsp4j => l}
 final class InteractiveSemanticdbs(
     workspace: AbsolutePath,
     buildTargets: BuildTargets,
+    uriMapper: URIMapper,
     charset: Charset,
     client: MetalsLanguageClient,
     tables: Tables,
@@ -79,7 +80,8 @@ final class InteractiveSemanticdbs(
     }
 
     // anything aside from `*.scala`, `*.sbt`, `*.sc`, `*.java` file
-    def isExcludedFile = !source.isScalaFilename && !source.isJavaFilename
+    def isExcludedFile =
+      !source.isScalaFilename && !source.isJavaFilename && !source.isClassfile
 
     if (isExcludedFile || !shouldTryCalculateInteractiveSemanticdb) {
       TextDocumentLookup.NotFound(source)
@@ -87,18 +89,22 @@ final class InteractiveSemanticdbs(
       val result = textDocumentCache.compute(
         source,
         (path, existingDoc) => {
-          val text = unsavedContents.getOrElse(FileIO.slurp(source, charset))
-          val sha = MD5.compute(text)
-          if (existingDoc == null || existingDoc.md5 != sha) {
-            Try(compile(path, text)) match {
-              case Success(doc) if doc != null =>
-                if (!source.isDependencySource(workspace))
-                  semanticdbIndexer().onChange(source, doc)
-                doc
-              case _ => null
-            }
-          } else
+          if (existingDoc != null && source.isJarFileSystem)
             existingDoc
+          else {
+            val text = unsavedContents.getOrElse(FileIO.slurp(source, charset))
+            val sha = MD5.compute(text)
+            if (existingDoc == null || existingDoc.md5 != sha) {
+              Try(compile(path, text)) match {
+                case Success(doc) if doc != null =>
+                  if (!source.isDependencySource(workspace))
+                    semanticdbIndexer().onChange(source, doc)
+                  doc
+                case _ => null
+              }
+            } else
+              existingDoc
+          }
         },
       )
       TextDocumentLookup.fromOption(source, Option(result))
@@ -130,8 +136,9 @@ final class InteractiveSemanticdbs(
    */
   def didFocus(path: AbsolutePath): Unit = {
     activeDocument.get().foreach { uri =>
+      val metalsURI = uriMapper.convertToMetalsFS(uri)
       client.publishDiagnostics(
-        new PublishDiagnosticsParams(uri, Collections.emptyList())
+        new PublishDiagnosticsParams(metalsURI, Collections.emptyList())
       )
     }
     if (path.isDependencySource(workspace)) {
@@ -150,8 +157,9 @@ final class InteractiveSemanticdbs(
         }
         if (diagnostics.nonEmpty) {
           statusBar.addMessage(partialNavigation(clientConfig.icons))
+          val metalsURI = uriMapper.convertToMetalsFS(uri)
           client.publishDiagnostics(
-            new PublishDiagnosticsParams(uri, diagnostics.asJava)
+            new PublishDiagnosticsParams(metalsURI, diagnostics.asJava)
           )
         }
       }
@@ -161,7 +169,7 @@ final class InteractiveSemanticdbs(
   }
 
   private def compile(source: AbsolutePath, text: String): s.TextDocument = {
-    if (source.isJavaFilename)
+    if (source.isJavaFilename || source.isClassfile)
       javaInteractiveSemanticdb.fold(s.TextDocument())(
         _.textDocument(source, text)
       )

--- a/metals/src/main/scala/scala/meta/internal/metals/LSPFileSystemProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/LSPFileSystemProvider.scala
@@ -1,0 +1,249 @@
+package scala.meta.internal.metals
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.stream.Collectors
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+
+final case class FSReadDirectoryResponse(
+    name: String,
+    isFile: Boolean,
+)
+final case class FSReadDirectoriesResponse(
+    name: String,
+    directories: Array[FSReadDirectoryResponse],
+    error: String,
+)
+
+final case class FSReadFileResponse(
+    name: String,
+    value: String,
+    error: String,
+)
+
+final case class FSStatResponse(
+    name: String,
+    isFile: Boolean,
+    error: String,
+)
+
+final class LSPFileSystemProvider(
+    languageClient: MetalsLanguageClient,
+    uriMapper: URIMapper,
+    fileDecoderProvider: FileDecoderProvider,
+    clientConfig: ClientConfiguration,
+)(implicit ec: ExecutionContext) {
+
+  // cache the last few decompiled class files as they're repeatedly accessed by VSCode once opened or referenced
+  private val cache = LRUCache[Path, String](10)
+
+  def sendLibraryFileSystemReady(): Unit = {
+    if (clientConfig.isLibraryFileSystemSupported()) {
+      val params =
+        ClientCommands.LibraryFileSystemReady.toExecuteCommandParams()
+      languageClient.metalsExecuteClientCommand(params)
+    }
+  }
+
+  private def getLocalPathDirectory(
+      uri: String,
+      prefix: String,
+      mappingFunction: String => FileSystemInfo,
+  ): Array[FSReadDirectoryResponse] = {
+    val (name, remaining) = URIMapper.getURIParts(uri, prefix)
+    val fs = mappingFunction(name).fs
+    // assume all jar paths only have `/` as root
+    val path = fs.getPath(remaining.getOrElse("/"))
+    Files
+      .list(path)
+      .collect(Collectors.toList())
+      .asScala
+      .map(path =>
+        FSReadDirectoryResponse(
+          path.getFileName.toString,
+          Files.isRegularFile(path),
+        )
+      )
+      .toArray
+  }
+
+  private def getLocalSystemStat(
+      uri: String,
+      prefix: String,
+      mappingFunction: String => FileSystemInfo,
+  ): FSStatResponse = {
+    val (name, remaining) = URIMapper.getURIParts(uri, prefix)
+    try {
+      val fs = mappingFunction(name).fs
+      // assume all jar paths only have `/` as root
+      val path = fs.getPath(remaining.getOrElse("/"))
+      FSStatResponse(uri, Files.isRegularFile(path), null)
+    } catch {
+      case NonFatal(e) =>
+        scribe.error(s"getLocalSystemStat $uri $name $remaining", e)
+        throw e
+    }
+  }
+
+  private def getLocalFileContents(
+      uri: String,
+      prefix: String,
+      mappingFunction: String => FileSystemInfo,
+  ): FSReadFileResponse = {
+    val (name, remaining) = URIMapper.getURIParts(uri, prefix)
+    val fs = mappingFunction(name).fs
+    val path = fs.getPath(remaining.getOrElse("/"))
+    val contents =
+      if (path.isClassfile) {
+        val cacheResult = cache.get(path)
+        cacheResult.getOrElse({
+          val response =
+            fileDecoderProvider.decodeCFRAndWait(path.toUri.toAbsolutePath)
+          val success = Option(response.value)
+          success.foreach(content => cache += path -> content)
+          success.getOrElse(response.error)
+        })
+      } else
+        new String(Files.readAllBytes(path), StandardCharsets.UTF_8)
+    FSReadFileResponse(uri, contents, null)
+  }
+
+  def readDirectory(
+      uri: String
+  ): Future[FSReadDirectoriesResponse] = Future {
+    try {
+      val subPaths = uri match {
+        case URIMapper.parentURI =>
+          Array(
+            FSReadDirectoryResponse(URIMapper.jdkDir, false),
+            FSReadDirectoryResponse(URIMapper.workspaceJarDir, false),
+            FSReadDirectoryResponse(URIMapper.sourceJarDir, false),
+          )
+        case URIMapper.jdkURI =>
+          uriMapper.getJDKs
+            .map(jdk => FSReadDirectoryResponse(jdk, false))
+            .toArray
+        case URIMapper.workspaceJarURI =>
+          uriMapper.getWorkspaceJars
+            .map(jar => FSReadDirectoryResponse(jar, false))
+            .toArray
+        case URIMapper.sourceJarURI =>
+          uriMapper.getSourceJars
+            .map(jar => FSReadDirectoryResponse(jar, false))
+            .toArray
+        case jdk if jdk.startsWith(URIMapper.jdkURI) =>
+          getLocalPathDirectory(
+            jdk,
+            URIMapper.jdkURI,
+            uriMapper.getJDKFileSystem,
+          )
+        case workspaceJar
+            if workspaceJar.startsWith(URIMapper.workspaceJarURI) =>
+          getLocalPathDirectory(
+            workspaceJar,
+            URIMapper.workspaceJarURI,
+            uriMapper.getWorkspaceJarFileSystem,
+          )
+        case sourceJar if sourceJar.startsWith(URIMapper.sourceJarURI) =>
+          getLocalPathDirectory(
+            sourceJar,
+            URIMapper.sourceJarURI,
+            uriMapper.getSourceJarFileSystem,
+          )
+      }
+      FSReadDirectoriesResponse(uri, subPaths, null)
+    } catch {
+      case NonFatal(e) => FSReadDirectoriesResponse(uri, null, e.toString)
+    }
+  }
+
+  def readFile(uri: String): Future[FSReadFileResponse] = Future {
+    try {
+      uri match {
+        case jdk if jdk.startsWith(URIMapper.jdkURI) =>
+          getLocalFileContents(
+            jdk,
+            URIMapper.jdkURI,
+            uriMapper.getJDKFileSystem,
+          )
+        case workspaceJar
+            if workspaceJar.startsWith(URIMapper.workspaceJarURI) =>
+          getLocalFileContents(
+            workspaceJar,
+            URIMapper.workspaceJarURI,
+            uriMapper.getWorkspaceJarFileSystem,
+          )
+        case sourceJar if sourceJar.startsWith(URIMapper.sourceJarURI) =>
+          getLocalFileContents(
+            sourceJar,
+            URIMapper.sourceJarURI,
+            uriMapper.getSourceJarFileSystem,
+          )
+        // VSCODE (or other clients) may ask for non-existant files (e.g. .gitignore)
+        case _ => FSReadFileResponse(uri, null, "doesn't exist")
+      }
+    } catch {
+      case NonFatal(e) => FSReadFileResponse(uri, null, e.toString)
+    }
+  }
+
+  def getSystemStat(uri: String): Future[FSStatResponse] = Future {
+    try {
+      uri match {
+        case URIMapper.parentURI =>
+          FSStatResponse(URIMapper.rootDir, false, null)
+        case URIMapper.jdkURI => FSStatResponse(URIMapper.jdkDir, false, null)
+        case URIMapper.workspaceJarURI =>
+          FSStatResponse(URIMapper.workspaceJarDir, false, null)
+        case URIMapper.sourceJarURI =>
+          FSStatResponse(URIMapper.sourceJarDir, false, null)
+        case jdk if jdk.startsWith(URIMapper.jdkURI) =>
+          getLocalSystemStat(
+            jdk,
+            URIMapper.jdkURI,
+            uriMapper.getJDKFileSystem,
+          )
+        case workspaceJar
+            if workspaceJar.startsWith(URIMapper.workspaceJarURI) =>
+          getLocalSystemStat(
+            workspaceJar,
+            URIMapper.workspaceJarURI,
+            uriMapper.getWorkspaceJarFileSystem,
+          )
+        case sourceJar if sourceJar.startsWith(URIMapper.sourceJarURI) =>
+          getLocalSystemStat(
+            sourceJar,
+            URIMapper.sourceJarURI,
+            uriMapper.getSourceJarFileSystem,
+          )
+      }
+    } catch {
+      case NonFatal(e) =>
+        scribe.error(s"getSystemStat $uri", e)
+        FSStatResponse(uri, false, e.toString())
+    }
+  }
+}
+
+import scala.collection.mutable
+// TODO this is not thread safe - do we care?
+class LRUCache[K, V](maxEntries: Int)
+    extends java.util.LinkedHashMap[K, V](maxEntries, 1.0f, true) {
+
+  override def removeEldestEntry(eldest: java.util.Map.Entry[K, V]): Boolean =
+    size > maxEntries
+}
+
+object LRUCache {
+  def apply[K, V](maxEntries: Int): mutable.Map[K, V] = {
+    import scala.meta.internal.jdk.CollectionConverters._
+    new LRUCache[K, V](maxEntries).asScala
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MutableMd5Fingerprints.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MutableMd5Fingerprints.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.MetalsEnrichments.XtensionAbsolutePathBuffers
 import scala.meta.internal.mtags.MD5
 import scala.meta.internal.mtags.Md5Fingerprints
 import scala.meta.io.AbsolutePath
@@ -77,12 +78,17 @@ final class MutableMd5Fingerprints extends Md5Fingerprints {
       soughtMd5: String,
       charset: Charset,
   ): Option[String] = {
-    val text = FileIO.slurp(path, charset)
-    val md5 = MD5.compute(text)
-    if (soughtMd5 != md5) {
-      lookupText(path, soughtMd5)
-    } else {
-      Some(text)
+    val prints = fingerprints.get(path)
+    if (path.isJarFileSystem && prints != null && prints.size > 0)
+      Option(prints.peek()).map(_.text)
+    else {
+      val text = FileIO.slurp(path, charset)
+      val md5 = MD5.compute(text)
+      if (soughtMd5 != md5) {
+        lookupText(path, soughtMd5)
+      } else {
+        Some(text)
+      }
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -149,6 +149,42 @@ object ServerCommands {
        |""".stripMargin,
   )
 
+  val FileSystemStat = new ParametrizedCommand[String](
+    "filesystem-stat",
+    "Read Directory",
+    """|Return information about the uri. E.g. uri is a directory
+       |
+       |Virtual File Systems allow client to display filesystem data
+       |in the format that Metals dictates.
+       |e.g. jar library dependencies
+       |""".stripMargin,
+    "[uri], uri of the file or directory.",
+  )
+
+  val FileSystemReadDirectory = new ParametrizedCommand[String](
+    "filesystem-read-directory",
+    "Read Directory",
+    """|Return the contents of a virtual filesystem directory.
+       |
+       |Virtual File Systems allow client to display filesystem data
+       |in the format that Metals dictates.
+       |e.g. jar library dependencies
+       |""".stripMargin,
+    "[uri], uri of the directory.",
+  )
+
+  val FileSystemReadFile = new ParametrizedCommand[String](
+    "filesystem-read-file",
+    "Read File",
+    """|Return the contents of a virtual filesystem file.
+       |
+       |Virtual File Systems allow client to display filesystem data
+       |in the format that Metals dictates.
+       |e.g. jar library dependencies
+       |""".stripMargin,
+    "[uri], uri of the file.",
+  )
+
   val RunDoctor = new Command(
     "doctor-run",
     "Run doctor",

--- a/metals/src/main/scala/scala/meta/internal/metals/TargetData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/TargetData.scala
@@ -81,7 +81,8 @@ final class TargetData {
   }
   def all: Iterator[BuildTarget] =
     buildTargetInfo.values.toIterator
-
+  def allJDKs: Iterator[String] =
+    scalaTargetInfo.flatMap(_._2.jvmHome).iterator
   def allBuildTargetIds: Seq[BuildTargetIdentifier] =
     buildTargetInfo.keys.toSeq
   def allScala: Iterator[ScalaTarget] =

--- a/metals/src/main/scala/scala/meta/internal/metals/URIMapper.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/URIMapper.scala
@@ -1,0 +1,277 @@
+package scala.meta.internal.metals
+
+import java.net.URI
+import java.nio.file.FileSystem
+import java.nio.file.FileSystemNotFoundException
+import java.nio.file.FileSystems
+import java.nio.file.Path
+
+import scala.annotation.tailrec
+import scala.collection.concurrent.TrieMap
+import scala.util.Properties
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.mtags.URIEncoderDecoder
+import scala.meta.io.AbsolutePath
+
+import org.eclipse.lsp4j.CodeActionParams
+import org.eclipse.lsp4j.Location
+import org.eclipse.lsp4j.ReferenceParams
+import org.eclipse.lsp4j.SymbolInformation
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextDocumentPositionParams
+
+case class URIMapper() {
+
+  private lazy val isWindows: Boolean = Properties.isWin
+  private val metalsFSToLocalJDKs = TrieMap.empty[String, FileSystemInfo]
+  private val metalsFSToLocalWorkspaceJars =
+    TrieMap.empty[String, FileSystemInfo]
+  private val metalsFSToLocalSourceJars = TrieMap.empty[String, FileSystemInfo]
+  // full local URI path -> full metals URI path
+  private val localURIToMetalsURI = TrieMap.empty[String, String]
+
+  // in Windows the uri can be sent through in different case so lowercase all.
+  // e.g. file:///c:/coursier/somejar can be file:///C:/coursier/somejar in a stacktrace
+  private def changeCase(uri: String): String =
+    if (isWindows)
+      uri.toLowerCase()
+    else
+      uri
+
+  @tailrec
+  private def getDecentJDKName(path: Path): String =
+    if (
+      path.getParent == null || !List("lib", "src.zip").contains(path.filename)
+    )
+      path.filename
+    else
+      getDecentJDKName(path.getParent)
+
+  def addJDK(jdk: AbsolutePath): Unit = {
+    val name = getDecentJDKName(jdk.toNIO)
+    addJDK(name, jdk)
+  }
+
+  private def addJDK(name: String, sourcePath: AbsolutePath): Unit = {
+    val metalsURI = s"${URIMapper.jdkURI}/$name"
+    val localURI = sourcePath.toURI.toString
+    // AbsolutePath#toURI will partially encode the URI so decode it
+    val metalsEncodedURI = URIEncoderDecoder.decode(localURI)
+    localURIToMetalsURI.put(changeCase(metalsEncodedURI), metalsURI)
+    metalsFSToLocalJDKs.put(name, getFileSystem(sourcePath))
+  }
+
+  def addWorkspaceJar(jar: AbsolutePath): Unit = {
+    val metalsURI = s"${URIMapper.workspaceJarURI}/${jar.filename}"
+    val localURI = jar.toURI.toString
+    // AbsolutePath#toURI will partially encode the URI so decode it
+    val metalsEncodedURI = URIEncoderDecoder.decode(localURI)
+    localURIToMetalsURI.put(changeCase(metalsEncodedURI), metalsURI)
+    metalsFSToLocalWorkspaceJars.put(jar.filename, getFileSystem(jar))
+  }
+
+  def addSourceJar(jar: AbsolutePath): Unit = {
+    val metalsURI = s"${URIMapper.sourceJarURI}/${jar.filename}"
+    val localURI = jar.toURI.toString
+    // AbsolutePath#toURI will partially encode the URI so decode it
+    val metalsEncodedURI = URIEncoderDecoder.decode(localURI)
+    localURIToMetalsURI.put(changeCase(metalsEncodedURI), metalsURI)
+    metalsFSToLocalSourceJars.put(jar.filename, getFileSystem(jar))
+  }
+
+  def reset(): Unit = {
+    localURIToMetalsURI.clear()
+    metalsFSToLocalJDKs.clear()
+    metalsFSToLocalWorkspaceJars.clear()
+    metalsFSToLocalSourceJars.clear()
+  }
+
+  private def getFileSystem(localPath: AbsolutePath): FileSystemInfo = {
+    val fileUri = localPath.toNIO.toUri.toString.stripSuffix("/")
+    val localUri = s"jar:$fileUri"
+    val zipURI = URI.create(localUri)
+    val fs =
+      try {
+        FileSystems.getFileSystem(zipURI)
+      } catch {
+        case _: FileSystemNotFoundException =>
+          FileSystems.newFileSystem(zipURI, new java.util.HashMap[String, Any])
+      }
+    FileSystemInfo(fs, fileUri)
+  }
+
+  def getJDKs: Iterator[String] =
+    metalsFSToLocalJDKs.keySet.toIterator
+
+  def getSourceJars: Iterator[String] =
+    metalsFSToLocalSourceJars.keySet.toIterator
+
+  def getWorkspaceJars: Iterator[String] =
+    metalsFSToLocalWorkspaceJars.keySet.toIterator
+
+  def getJDKFileSystem(uri: String): FileSystemInfo =
+    metalsFSToLocalJDKs(uri)
+
+  def getWorkspaceJarFileSystem(uri: String): FileSystemInfo =
+    metalsFSToLocalWorkspaceJars(uri)
+
+  def getSourceJarFileSystem(uri: String): FileSystemInfo =
+    metalsFSToLocalSourceJars(uri)
+
+  private def getMetalsURIFromLocalURI(uri: String): String = {
+    if (localURIToMetalsURI.contains(changeCase(uri)))
+      localURIToMetalsURI(changeCase(uri))
+    else
+      uri
+  }
+
+  def encodeUri(uri: String): String = {
+    if (uri.startsWith("file://")) {
+      val path = uri.stripPrefix("file://")
+      new URI("file", "", path, null).toString
+    } else if (uri.startsWith("jar:")) {
+      val ssp = uri.stripPrefix("jar:")
+      new URI("jar", ssp, null).toString
+    } else if (uri.startsWith("metalsfs:")) {
+      // shouldn't need encoding.  Definitely don't encode using URI("metalsfs", "", path, null) as this will create triple slashes: metalsfs:///somejar
+      uri
+    } else
+      throw new IllegalStateException(s"Why here? $uri")
+  }
+
+  // transform the metalsfs URI into a local URI
+  def convertToLocal(uri: String): String = {
+    if (uri.startsWith(URIMapper.parentURI)) {
+      val (fs, fsPath) = URIEncoderDecoder.decode(uri) match {
+        case jdk if jdk.startsWith(URIMapper.jdkURI) =>
+          val (name, remaining) = URIMapper.getURIParts(jdk, URIMapper.jdkURI)
+          val fs = getJDKFileSystem(name)
+          (fs, remaining)
+        case workspaceJar
+            if workspaceJar.startsWith(URIMapper.workspaceJarURI) =>
+          val (name, remaining) =
+            URIMapper.getURIParts(workspaceJar, URIMapper.workspaceJarURI)
+          val fs = getWorkspaceJarFileSystem(name)
+          (fs, remaining)
+        case sourceJar if sourceJar.startsWith(URIMapper.sourceJarURI) =>
+          val (name, remaining) =
+            URIMapper.getURIParts(sourceJar, URIMapper.sourceJarURI)
+          val fs = getSourceJarFileSystem(name)
+          (fs, remaining)
+      }
+      // no path - return the original jar uri e.g. file:///somejar.jar
+      if (fsPath.isEmpty)
+        // uri already encoded in getFileSystem method
+        fs.fileUri
+      else
+        // path exists - return the jar path uri e.g. jar:file:///somejar.jar!/path
+        // the Path#toUri call will encode the URI so no need to encode it manually
+        fs.fs.getPath(fsPath.get).toUri.toString
+    } else uri
+  }
+
+  // transform the local URI into a metalsfs URI
+  def convertToMetalsFS(uri: String): String = {
+    val decodedURI = URIEncoderDecoder.decode(uri)
+    val metalsfsUri = if (uri.startsWith("jar:")) {
+      val path = decodedURI.stripPrefix("jar:")
+      val splitter = path.indexOf('!')
+      if (splitter == -1) getMetalsURIFromLocalURI(path)
+      else {
+        val remainder = path.substring(splitter + 1)
+        val localJarPath = path.substring(0, splitter)
+        val metalsJarPath = getMetalsURIFromLocalURI(localJarPath)
+        s"${metalsJarPath}${remainder}"
+      }
+    } else getMetalsURIFromLocalURI(decodedURI)
+    encodeUri(metalsfsUri)
+  }
+
+  def convertToMetalsFS(
+      symbolInformation: SymbolInformation
+  ): SymbolInformation = {
+    val symbolInfo = new SymbolInformation(
+      symbolInformation.getName,
+      symbolInformation.getKind,
+      convertToMetalsFS(symbolInformation.getLocation),
+      symbolInformation.getContainerName,
+    )
+    symbolInfo.setTags(symbolInformation.getTags)
+    symbolInfo
+  }
+
+  def convertToLocal(location: Location): Location =
+    new Location(convertToLocal(location.getUri), location.getRange)
+
+  def convertToMetalsFS(location: Location): Location =
+    new Location(convertToMetalsFS(location.getUri), location.getRange)
+
+  def convertToLocal(
+      params: ReferenceParams
+  ): ReferenceParams =
+    new ReferenceParams(
+      convertToLocal(params.getTextDocument),
+      params.getPosition,
+      params.getContext,
+    )
+
+  def convertToLocal(
+      params: TextDocumentPositionParams
+  ): TextDocumentPositionParams =
+    new TextDocumentPositionParams(
+      convertToLocal(params.getTextDocument),
+      params.getPosition,
+    )
+
+  def convertToLocal(
+      params: TextDocumentIdentifier
+  ): TextDocumentIdentifier =
+    new TextDocumentIdentifier(convertToLocal(params.getUri))
+
+  def convertToLocal(
+      params: HoverExtParams
+  ): HoverExtParams =
+    params.copy(textDocument = convertToLocal(params.textDocument))
+
+  def convertToLocal(
+      params: CodeActionParams
+  ): CodeActionParams =
+    new CodeActionParams(
+      convertToLocal(params.getTextDocument()),
+      params.getRange(),
+      params.getContext(),
+    )
+}
+case class FileSystemInfo(fs: FileSystem, fileUri: String)
+
+object URIMapper {
+  // various metals filesystem setup - change these to what we like
+  val rootDir: String = "metalsLibraries"
+  // vscode registers "metalsfs:///" as "metalsfs:/" so just stick to the single slash
+  val parentURI: String = s"metalsfs:/$rootDir"
+  val jdkDir: String = "jdk"
+  val workspaceJarDir: String = "jar"
+  val sourceJarDir: String = "source"
+  val jdkURI: String = s"${parentURI}/$jdkDir"
+  val workspaceJarURI: String = s"${parentURI}/$workspaceJarDir"
+  val sourceJarURI: String = s"${parentURI}/$sourceJarDir"
+
+  // transform the metalsfs URI into a local URI
+  // ("metalsfs:/XXX/YYY", "metalsfs:/XXX") => ("YYY", None)
+  // ("metalsfs:/XXX/YYY/somePackage/someClass", "metalsfs:/XXX") => ("YYY", Some("somePackage/someClass"))
+  def getURIParts(
+      uri: String,
+      prefix: String,
+  ): (String, Option[String]) = {
+    val basePart = uri.stripPrefix(s"${prefix}/")
+    val separatorIdx = basePart.indexOf('/')
+    if (separatorIdx == -1)
+      (basePart, None)
+    else {
+      val name = basePart.substring(0, separatorIdx)
+      val remaining = basePart.substring(separatorIdx + 1)
+      (name, Some(remaining))
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -40,6 +40,7 @@ import scala.meta.internal.metals.ScalaTestSuitesDebugRequest
 import scala.meta.internal.metals.ScalaVersionSelector
 import scala.meta.internal.metals.StacktraceAnalyzer
 import scala.meta.internal.metals.StatusBar
+import scala.meta.internal.metals.URIMapper
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.clients.language.MetalsQuickPickItem
 import scala.meta.internal.metals.clients.language.MetalsQuickPickParams
@@ -74,6 +75,7 @@ class DebugProvider(
     definitionProvider: DefinitionProvider,
     buildServerConnect: () => Option[BuildServerConnection],
     buildTargets: BuildTargets,
+    uriMapper: URIMapper,
     buildTargetClasses: BuildTargetClasses,
     compilations: Compilations,
     languageClient: MetalsLanguageClient,
@@ -162,6 +164,7 @@ class DebugProvider(
           MetalsDebugAdapter.`2.x`(
             buildTargets,
             targets,
+            uriMapper,
             supportVirtualDocuments = clientConfig.isVirtualDocumentSupported(),
           )
         } else {

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/SetBreakpointsRequestHandler.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/SetBreakpointsRequestHandler.scala
@@ -22,9 +22,10 @@ private[debug] final class SetBreakpointsRequestHandler(
     new TrieMap[AbsolutePath, Set[String]]
 
   def apply(
-      sourcePath: AbsolutePath,
+      sourceUri: String,
       request: SetBreakpointsArguments,
   ): Iterable[SetBreakpointsArguments] = {
+    val sourcePath = sourceUri.toAbsolutePath
     /* Get symbol for each breakpoint location to figure out the
      * class file that we need to register the breakpoint for.
      */

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
@@ -3,12 +3,11 @@ package scala.meta.internal.metals.debug
 import java.net.URI
 import java.nio.file.Paths
 
-import scala.util.Try
-
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.URIMapper
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
@@ -16,20 +15,22 @@ import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 private[debug] final class SourcePathAdapter(
     workspace: AbsolutePath,
     buildTargets: BuildTargets,
+    uriMapper: URIMapper,
     supportVirtualDocuments: Boolean,
 ) {
   // when virtual documents are supported there is no need to save jars on disk
   private val saveJarFileToDisk = !supportVirtualDocuments
   private val dependencies = workspace.resolve(Directories.dependencies)
 
-  def toDapURI(sourcePath: AbsolutePath): Option[URI] = {
-    if (
-      !supportVirtualDocuments && sourcePath.toNIO.startsWith(
-        dependencies.toNIO
-      )
-    ) {
+  def toDapURI(sourceUri: String): Option[URI] = {
+    val localUri =
+      if (sourceUri.startsWith(URIMapper.parentURI))
+        uriMapper.convertToLocal(sourceUri)
+      else sourceUri
+    val sourcePath = localUri.toAbsolutePath
+    if (saveJarFileToDisk && sourcePath.toNIO.startsWith(dependencies.toNIO)) {
       // if sourcePath is a dependency source file
-      // we retrieve the original source jar and we build the uri innside the source jar filesystem
+      // we retrieve the original source jar and we build the uri inside the source jar filesystem
       for {
         dependencySource <- sourcePath.toRelativeInside(dependencies)
         dependencyFolder <- dependencySource.toNIO.iterator.asScala.headOption
@@ -41,24 +42,25 @@ private[debug] final class SourcePathAdapter(
       } yield FileIO.withJarFileSystem(jarFile, create = false)(root =>
         root.resolve(relativePath.toString).toURI
       )
-    } else {
+    } else
       Some(sourcePath.toURI)
-    }
   }
 
-  def toMetalsPath(sourcePath: String): Option[AbsolutePath] = try {
-    val sourceUri =
-      Try(URI.create(sourcePath)).getOrElse(Paths.get(sourcePath).toUri())
-    sourceUri.getScheme match {
-      case "jar" =>
-        val path = sourceUri.toAbsolutePath
-        Some(if (saveJarFileToDisk) path.toFileOnDisk(workspace) else path)
-      case "file" => Some(AbsolutePath(Paths.get(sourceUri)))
-      case _ => None
-    }
+  def toMetalsPathOrUri(sourcePathOrUri: String): Option[String] = try {
+    val metalsUri = if (sourcePathOrUri.startsWith("jar:")) {
+      if (saveJarFileToDisk) {
+        val path = sourcePathOrUri.toAbsolutePath
+        path.toFileOnDisk(workspace).toURI.toString
+      } else
+        uriMapper.convertToMetalsFS(sourcePathOrUri)
+    } else if (sourcePathOrUri.startsWith("file:"))
+      sourcePathOrUri
+    else
+      Paths.get(sourcePathOrUri).toUri().toString
+    Some(metalsUri)
   } catch {
     case e: Throwable =>
-      scribe.error(s"Could not resolve $sourcePath", e)
+      scribe.error(s"Could not resolve $sourcePathOrUri", e)
       None
   }
 }
@@ -66,6 +68,7 @@ private[debug] final class SourcePathAdapter(
 private[debug] object SourcePathAdapter {
   def apply(
       buildTargets: BuildTargets,
+      uriMapper: URIMapper,
       targets: Seq[BuildTargetIdentifier],
       supportVirtualDocuments: Boolean,
   ): SourcePathAdapter = {
@@ -73,6 +76,7 @@ private[debug] object SourcePathAdapter {
     new SourcePathAdapter(
       workspace,
       buildTargets,
+      uriMapper,
       supportVirtualDocuments,
     )
   }

--- a/metals/src/main/scala/scala/meta/internal/parsing/FoldingRangeProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/FoldingRangeProvider.scala
@@ -47,7 +47,7 @@ final class FoldingRangeProvider(
   ): util.List[FoldingRange] = {
     val result = for {
       code <- buffers.get(filePath)
-      if filePath.isJava
+      if filePath.isJava || filePath.isClassfile
     } yield {
       val extractor =
         new JavaFoldingRangeExtractor(code, foldOnlyLines.get())

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -114,7 +114,7 @@ abstract class BaseLspSuite(
       .getOrElse(TestingServer.TestDefault)
       .copy(isVirtualDocumentSupported = Some(useVirtualDocs))
 
-    client = new TestingClient(workspace, buffers)
+    client = new TestingClient(workspace, () => server, buffers)
     server = new TestingServer(
       workspace,
       client,

--- a/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -94,7 +94,7 @@ abstract class BaseCodeActionLspSuite(
             .recover {
               case _: Throwable if expectError => Nil
             }
-        _ <- client.applyCodeAction(selectedActionIndex, codeActions, server)
+        _ <- client.applyCodeAction(selectedActionIndex, codeActions)
         _ <- server.didSave(newPath) { _ =>
           if (newPath != path)
             server.toPath(newPath).readText

--- a/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
+++ b/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
@@ -90,7 +90,8 @@ class FindTextInDependencyJarsSuite
   ): Unit = {
     val rendered = locations
       .map { loc =>
-        val uri = URI.create(loc.getUri())
+        val localURI = server.convertToLocal(loc.getUri())
+        val uri = URI.create(localURI)
         val input = if (uri.getScheme() == "jar") {
           val jarPath = uri.toAbsolutePath
           val relativePath =

--- a/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
@@ -153,7 +153,8 @@ class JavaDefinitionSuite extends BaseLspSuite("java-definition") {
     if (characterInc == -1) {
       throw new Exception("Query must contain @@")
     } else {
-      val path = AbsolutePath.fromAbsoluteUri(URI.create(uri))
+      val localUri = server.convertToLocal(uri)
+      val path = AbsolutePath.fromAbsoluteUri(URI.create(localUri))
       val raw = query.replaceAll("@@", "").trim()
       val result = FileIO
         .slurp(path, StandardCharsets.UTF_8)
@@ -173,7 +174,8 @@ class JavaDefinitionSuite extends BaseLspSuite("java-definition") {
   }
 
   private def renderLocation(loc: l.Location): String = {
-    val path = AbsolutePath.fromAbsoluteUri(URI.create(loc.getUri()))
+    val localURI = server.convertToLocal(loc.getUri())
+    val path = AbsolutePath.fromAbsoluteUri(URI.create(localURI))
     val relativePath =
       path.jarPath
         .map(jarPath => s"${jarPath.filename}${path}")

--- a/tests/unit/src/test/scala/tests/StatusBarSuite.scala
+++ b/tests/unit/src/test/scala/tests/StatusBarSuite.scala
@@ -11,7 +11,7 @@ import scala.meta.internal.metals.StatusBar
 
 class StatusBarSuite extends BaseSuite {
   val time = new FakeTime
-  val client = new TestingClient(PathIO.workingDirectory, Buffers())
+  val client = new TestingClient(PathIO.workingDirectory, () => null, Buffers())
   var status = new StatusBar(
     () => client,
     time,

--- a/tests/unit/src/test/scala/tests/URIMapperSuite.scala
+++ b/tests/unit/src/test/scala/tests/URIMapperSuite.scala
@@ -1,0 +1,65 @@
+package tests
+
+import scala.meta.internal.metals.JdkSources
+import scala.meta.internal.metals.URIMapper
+
+class URIMapperSuite extends BaseSuite {
+
+  test("convertToMetalsFS-file-windows-1") {
+    val entry = "file:///e%3A/Foo.scala"
+    val expected = "file:///e:/Foo.scala"
+
+    val uriMapper = new URIMapper()
+    val obtained = uriMapper.convertToMetalsFS(entry)
+    assertEquals(obtained, expected)
+  }
+
+  test("convertToMetalsFS-file-windows-2") {
+    val entry = "file:///e:/Foo.scala"
+    val expected = "file:///e:/Foo.scala"
+
+    val uriMapper = new URIMapper()
+    val obtained = uriMapper.convertToMetalsFS(entry)
+    assertEquals(obtained, expected)
+  }
+
+  test("convertToMetalsFS-file-unix") {
+    val entry = "file:///Foo.scala"
+    val expected = "file:///Foo.scala"
+
+    val uriMapper = new URIMapper()
+    val obtained = uriMapper.convertToMetalsFS(entry)
+    assertEquals(obtained, expected)
+  }
+
+  test("convertToMetalsFS-jdk") {
+    val uriMapper = new URIMapper()
+    val zip = JdkSources(None) match {
+      case Right(zip) => zip
+      case Left(_) => fail("No JDK defined")
+    }
+    val jdkUri = zip.toNIO.toUri().toString
+    uriMapper.addJDK(zip)
+    val metalsFSUri = uriMapper.convertToMetalsFS(jdkUri)
+    val localFSUri = uriMapper.convertToLocal(metalsFSUri)
+    assertEquals(localFSUri, jdkUri)
+    val backToMetalsFSUri = uriMapper.convertToMetalsFS(localFSUri)
+    assertEquals(backToMetalsFSUri, metalsFSUri)
+  }
+
+  test("convertToMetalsFS-jdk-class") {
+    val uriMapper = new URIMapper()
+    val zip = JdkSources(None) match {
+      case Right(zip) => zip
+      case Left(_) => fail("No JDK defined")
+    }
+    val jdkUri = zip.toNIO.toUri().toString
+    uriMapper.addJDK(zip)
+    val metalsFSUri = uriMapper.convertToMetalsFS(jdkUri)
+    val metalsClassUri = s"$metalsFSUri/javaClass.ext"
+    val localFSUri = uriMapper.convertToLocal(metalsClassUri)
+    assertEquals(localFSUri, s"jar:$jdkUri!/javaClass.ext")
+    val backToMetalsFSUri = uriMapper.convertToMetalsFS(localFSUri)
+    assertEquals(backToMetalsFSUri, metalsClassUri)
+  }
+}

--- a/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
@@ -110,7 +110,7 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
               None
             }
           }
-          client.applyCodeAction(selectedActionIndex, codeActions, server)
+          client.applyCodeAction(selectedActionIndex, codeActions)
         }
         _ <- server.didSave(path)(identity)
         _ = if (expectNoDiagnostics) assertNoDiagnostics() else ()


### PR DESCRIPTION

This is yet another way of implementing the FileSystemAPI.

I found with https://github.com/scalameta/metals/pull/3750 that it was getting too complicated and there were code paths in the MetalsURLConnection that I was unsure of.  There were also performance issues and I think it would have taken a lot of investigation to get the custom URLConnection and custom FileSystem on par with the built in Java ones.

So instead this PR simply maps `jar:` <-> `metalsfs:` uris whenever Metals communicates via LSP or via Debug Adaptor.  Bugs in this area should be easy to track down/fix as it's probably down to missing mapper code in one of the messages.

This PR shouldn't change any client that doesn't support `jar:` scheme in virtual documents.  As far as I know - that's only VSCode.  If there are others then they will need to change from handling `jar:` to handling `metalsfs:` scheme.  If they want they can also implement the LSP FileSystemAPI but they don't have to as virtual docs is separate from FileSystemAPI support.

By default - on VSCode - the user won't switch to a multi-workspace and display `Metals libraries` in the File Explorer but they have a command `Show libraries folder in file explorer` to do that.

I've tested this PR with navigation, debugging, searching jars, Metals Tree View and all seems ok.

This PR also auto-decompiles class files when they are missing source jars and allows navigation within that decompiled class file.  It also allows decoding of class and tasty files from within jars.  Currently it only does this from the file explorer. You can't run "goto definition" on a symbol that has no source jar.  Ideally this would jump to an auto-decompiled class file of the workspace jar.  I'm just not sure where this should be done.  It doesn't find the non-source jar because `SymbolIndexBucket#query0` only calls `loadFromSourceJars` - it doesn't try a `loadFromWorkspaceJars` equivalent.  Is that where the code should be changed?  Or should it be in `MetalsLanguageServer#definitionOrReferences` I don't want to cause issues (or performance issues) in other codepaths.

I've changed the MetalsDebugAdapter interfaces to use URI (as a String) instead of AbsolutePath.  Is this an issue - is it a public interface?  I see that there are 2 versions of the interface - do I need to create a 3rd?
The issue is that `metalsfs:` is not a valid path (which AbsolutePath wraps) and passing it as a URI fixes this.
I wonder if the uri mapping will also help VSCode notebook cells which I think have the scheme `vscode-notebook-cell:`

I've tried to test this without virtual docs enabled to mimic the behaviour of non-VSCode clients but it would be handy if someone double checked I've not caused any issues for those clients.

I've done nothing with handling `CompletionRequest ` in `DebugProxy` line:120->146.  I'm not sure if this should handle jar files - what does it actually do?
