### PR TITLE
fix: do not start debug session for test explorer if projects contains errors

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1860,7 +1860,9 @@ class MetalsLanguageServer(
         val debugSessionParams: Future[b.DebugSessionParams] = args match {
           case Seq(debugSessionParamsParser.Jsonized(params))
               if params.getData != null =>
-            debugProvider.ensureNoWorkspaceErrors(params)
+            debugProvider
+              .ensureNoWorkspaceErrors(params.getTargets.asScala.toSeq)
+              .map(_ => params)
 
           case Seq(mainClassParamsParser.Jsonized(params))
               if params.mainClass != null =>


### PR DESCRIPTION
Previously, when project has errors and user clicked run test button they was spinning due to debug session not started. Now errors are checked and in case of any errors debug session is not started.
Plays well with https://github.com/scalameta/metals-vscode/pull/1053

Demo:

![sbt-playground-1657200325163](https://user-images.githubusercontent.com/37124721/177784704-33a17eab-31ae-4f7a-b3e5-6c10ea40787d.gif)