### PR TITLE
bugfix: [Scala 3] Improve constant and refined types printing

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/ShortenedNames.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/ShortenedNames.scala
@@ -184,6 +184,8 @@ class ShortenedNames(
           AppliedType(loop(tycon, None), args.map(a => loop(a, None)))
         case TypeBounds(lo, hi) =>
           TypeBounds(loop(lo, None), loop(hi, None))
+        case RefinedType(parent, names, infos) =>
+          RefinedType(loop(parent, None), names, loop(infos, None))
         case ExprType(res) =>
           ExprType(loop(res, None))
         case AnnotatedType(parent, annot) =>

--- a/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
@@ -222,7 +222,7 @@ class HoverDefnSuite extends BaseHoverSuite {
     compat = Map(
       "2.12" -> "",
       "3" -> """|Int
-                |val x: (1 : Int)""".stripMargin.hover
+                |val x: 1""".stripMargin.hover
     )
   )
 
@@ -232,7 +232,7 @@ class HoverDefnSuite extends BaseHoverSuite {
       |  <<val @@x : 1 | 2 = 1>>
       |}
       |""".stripMargin,
-    "val x: (1 : Int) | (2 : Int)".hover
+    "val x: 1 | 2".hover
   )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -511,6 +511,107 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |""".stripMargin
   )
 
+  checkEdit(
+    "literal-types1".tag(IgnoreScalaVersion.forLessThan("2.13.0")),
+    """|object O {
+       |  val a: Some[1] = Some(1)
+       |  val <<b>> = a
+       |}
+       |""".stripMargin,
+    """|object O {
+       |  val a: Some[1] = Some(1)
+       |  val b: Some[1] = a
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "refined-types",
+    """|object O{
+       |  trait Foo {
+       |    type T
+       |    type G
+       |  }
+       |
+       |  val <<c>> = new Foo { type T = Int; type G = Long}
+       |}
+       |""".stripMargin,
+    """|object O{
+       |  trait Foo {
+       |    type T
+       |    type G
+       |  }
+       |
+       |  val c: Foo{type T = Int; type G = Long} = new Foo { type T = Int; type G = Long}
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "refined-types2",
+    """|object O{
+       |  trait Foo {
+       |    type T
+       |  }
+       |  val c = new Foo { type T = Int }
+       |  val <<d>> = c
+       |}
+       |""".stripMargin,
+    """|object O{
+       |  trait Foo {
+       |    type T
+       |  }
+       |  val c = new Foo { type T = Int }
+       |  val d: Foo{type T = Int} = c
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "refined-types3",
+    """|object O{
+       |  trait Foo {
+       |    type T
+       |  }
+       |
+       |  val <<c>> = new Foo { type T = Int }
+       |}
+       |""".stripMargin,
+    """|object O{
+       |  trait Foo {
+       |    type T
+       |  }
+       |
+       |  val c: Foo{type T = Int} = new Foo { type T = Int }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "refined-types4".tag(IgnoreScala2),
+    """|trait Foo extends Selectable {
+       |  type T
+       |}
+       |
+       |val <<c>> = new Foo {
+       |  type T = Int
+       |  val x = 0
+       |  def y = 0
+       |  var z = 0
+       |}
+       |""".stripMargin,
+    """|trait Foo extends Selectable {
+       |  type T
+       |}
+       |
+       |val c: Foo{type T = Int; val x: Int; def y: Int; val z: Int; def z_=(x$1: Int): Unit} = new Foo {
+       |  type T = Int
+       |  val x = 0
+       |  def y = 0
+       |  var z = 0
+       |}
+       |""".stripMargin
+  )
   def checkEdit(
       name: TestOptions,
       original: String,


### PR DESCRIPTION
Previously, we would print constant types as for example `1: Int` which is not correct Scala code. Now we simply print the literal type itself `1`

Also, we used to previously print refined types as `Foo{T = scala.Int}`, which is not correct Scala code. Now, we print it correctly as `Foo{type T = Int}`.

These two issues were predominatly popping up in Scala 3 inferred type provider.

Fixes https://github.com/scalameta/metals/issues/4113