### PR TITLE
feature: Add a way to turn on debug logging and fix scalafix warmup

### DIFF
--- a/docs/troubleshooting/faq.md
+++ b/docs/troubleshooting/faq.md
@@ -9,6 +9,12 @@ either hard to explain in the context of the docs or there just isn't a good
 enough place to stick it. This is an attempt to document some of the most common
 questions that we see related to Metals.
 
+## How do I get more debugging information?
+
+If you are using VS Code add `-Dmetals.loglevel=debug` to the
+`metals.serverProperties` setting, otherwise just add that property as an
+additional parameter for starting Metals server.
+
 ## I'm using Scala 2.13.x but doctor shows me `*-build` and `*-build-build` at 2.12.x
 
 ![build-build-doctor](https://i.imgur.com/mgnRXse.png)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLogger.scala
@@ -19,6 +19,17 @@ import scribe.modify.LogModifier
 
 object MetalsLogger {
 
+  private val level =
+    MetalsServerConfig.default.loglevel match {
+      case "debug" => Level.Debug
+      case "info" => Level.Info
+      case "warn" => Level.Warn
+      case "error" => Level.Error
+      case "fatal" => Level.Fatal
+      case "trace" => Level.Trace
+      case _ => Level.Info
+    }
+
   private val workspaceLogPath: RelativePath =
     RelativePath(".metals").resolve("metals.log")
 
@@ -27,7 +38,7 @@ object MetalsLogger {
       .clearHandlers()
       .withHandler(
         formatter = defaultFormat,
-        minimumLevel = Some(scribe.Level.Info),
+        minimumLevel = Some(level),
         modifiers = List(MetalsFilter())
       )
       .replace()
@@ -53,13 +64,13 @@ object MetalsLogger {
       .withHandler(
         writer = newFileWriter(logfile),
         formatter = defaultFormat,
-        minimumLevel = Some(Level.Info),
+        minimumLevel = Some(level),
         modifiers = List(MetalsFilter())
       )
       .withHandler(
         writer = LanguageClientLogger,
         formatter = MetalsLogger.defaultFormat,
-        minimumLevel = Some(Level.Info),
+        minimumLevel = Some(level),
         modifiers = List(MetalsFilter())
       )
       .replace()

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -95,7 +95,9 @@ final case class MetalsServerConfig(
       Option(System.getProperty("metals.macos-max-watch-roots"))
         .filter(_.forall(Character.isDigit(_)))
         .map(_.toInt)
-        .getOrElse(32)
+        .getOrElse(32),
+    loglevel: String =
+      sys.props.get("metals.loglevel").map(_.toLowerCase()).getOrElse("info")
 ) {
   override def toString: String =
     List[String](
@@ -112,7 +114,8 @@ final case class MetalsServerConfig(
       s"icons=$icons",
       s"statistics=$statistics",
       s"bloop-port=${bloopPort.map(_.toString()).getOrElse("default")}",
-      s"macos-max-watch-roots=${macOsMaxWatchRoots}"
+      s"macos-max-watch-roots=${macOsMaxWatchRoots}",
+      s"loglevel=${loglevel}"
     ).mkString("MetalsServerConfig(\n  ", ",\n  ", "\n)")
 }
 object MetalsServerConfig {


### PR DESCRIPTION
Seems the main idea behind scribe is to make it easy to define in the code, so I decided to add an new metals property.

One issue is that Flyway debug logs still seem to end up in whichever handler is defined first, but this should not be an issue in most cases, since those logs are not super interesting.