### PR TITLE
bugfix: Save fingerprints between restarts

### DIFF
--- a/metals/src/main/resources/db/migration/V4__Fingerprints.sql
+++ b/metals/src/main/resources/db/migration/V4__Fingerprints.sql
@@ -1,0 +1,7 @@
+-- Fingerprints saved between invocations
+create table fingerprints(
+  path varchar not null,
+  text varchar not null,
+  md5 varchar not null,
+  id int auto_increment unique
+);

--- a/metals/src/main/scala/scala/meta/internal/metals/Fingerprints.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Fingerprints.scala
@@ -1,0 +1,71 @@
+package scala.meta.internal.metals
+
+import java.nio.file.Paths
+import java.sql.Connection
+import java.sql.PreparedStatement
+
+import scala.meta.internal.metals.Fingerprint
+import scala.meta.internal.metals.JdbcEnrichments._
+import scala.meta.io.AbsolutePath
+
+/**
+ * Wrapper around the fingerprints sql table.
+ *
+ * It's needed to save the last known state of the workspace files to
+ * calculate differences between current state and semanticdb view of the file.
+ *
+ * We need to save it between restarts in case user reloaded a workspace with
+ * errors.
+ */
+final class Fingerprints(conn: () => Connection) {
+
+  private def clearAll(): Unit = {
+    val statement = conn().prepareStatement("truncate table fingerprints")
+    statement.execute()
+  }
+
+  def save(all: Map[AbsolutePath, List[Fingerprint]]): AnyVal = if (
+    all.nonEmpty
+  ) {
+    var symbolStmt: PreparedStatement = null
+    try {
+      symbolStmt = conn().prepareStatement(
+        s"insert into fingerprints (path, text, md5) values (?, ?, ?)"
+      )
+      all.foreach { case (path, fingerprints) =>
+        scribe.debug(s"Saving ${fingerprints.length} fingerprints for $path")
+        fingerprints.foreach { fingerprint =>
+          symbolStmt.setString(1, path.toString())
+          symbolStmt.setString(2, fingerprint.text)
+          symbolStmt.setString(3, fingerprint.md5)
+          symbolStmt.addBatch()
+        }
+      }
+      // Return number of rows inserted
+      symbolStmt.executeBatch().sum
+    } finally {
+      if (symbolStmt != null) symbolStmt.close()
+    }
+  }
+
+  def load(): Map[AbsolutePath, List[Fingerprint]] = {
+    val results = conn()
+      .query(
+        "select path, text, md5 from fingerprints;"
+      )(_ => ()) { rs =>
+        val path = rs.getString(1)
+        val text = rs.getString(2)
+        val md5 = rs.getString(3)
+        AbsolutePath(Paths.get(path)) -> Fingerprint(text, md5)
+      }
+      .groupBy { case (path, _) => path }
+      .map { case (path, fingerprints) =>
+        scribe.debug(s"Loading ${fingerprints.length} fingerprints for $path")
+        path -> fingerprints.map { case (_, finger) => finger }
+      }
+      .toMap
+    clearAll()
+    results
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -836,6 +836,9 @@ class MetalsLanguageServer(
         setupJna()
         initializeParams = Option(params)
         updateWorkspaceDirectory(params)
+
+        // load fingerprints from last execution
+        fingerprints.addAll(tables.fingerprints.load())
         val capabilities = new ServerCapabilities()
         capabilities.setExecuteCommandProvider(
           new ExecuteCommandOptions(
@@ -1006,6 +1009,7 @@ class MetalsLanguageServer(
     if (shutdownPromise.compareAndSet(null, promise)) {
       scribe.info("shutting down Metals")
       try {
+        tables.fingerprints.save(fingerprints.getAllFingerprints())
         cancel()
       } catch {
         case NonFatal(e) =>

--- a/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
@@ -32,6 +32,8 @@ final class Tables(
     new ChosenBuildServers(() => connection, time)
   val buildTool =
     new ChosenBuildTool(() => connection)
+  val fingerprints =
+    new Fingerprints(() => connection)
 
   def connect(): Unit = {
     this._connection =

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -123,7 +123,7 @@ import tests.MetalsTestEnrichments._
  * language server the same way from a real editor client like VS Code because JSON-RPC
  * notifications are `Any => Unit`, they cannot respond.
  */
-final class TestingServer(
+final case class TestingServer(
     workspace: AbsolutePath,
     val client: TestingClient,
     buffers: Buffers,
@@ -689,6 +689,10 @@ final class TestingServer(
           )
         )
     }
+  }
+
+  def shutdown(): Future[Unit] = {
+    server.shutdown().asScala
   }
 
   def didChangeConfiguration(config: String): Future[Unit] = {

--- a/tests/unit/src/test/scala/tests/FingerprintsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/FingerprintsLspSuite.scala
@@ -1,0 +1,132 @@
+package tests
+
+import scala.meta.internal.metals.ServerCommands
+
+class FingerprintsLspSuite extends BaseLspSuite("fingerprints") {
+  test("break") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """
+          |/metals.json
+          |{
+          |  "a": { }
+          |}
+          |/a/src/main/scala/a/Names.scala
+          |package a
+          |class Names {
+          |  val name = "John"
+          |  val surname = "Nowak"
+          |  override def toString() = name + " " + surname
+          |}
+          |/a/src/main/scala/a/Adresses.scala
+          |package a
+          |class Adresses {
+          |  val street = "Forbes"
+          |  val number = 123
+          |  override def toString() = street + " " + number
+          |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Names.scala")
+      _ <- server.didOpen("a/src/main/scala/a/Adresses.scala")
+      _ <- server.executeCommand(ServerCommands.CascadeCompile)
+      _ = assertNoDiff(client.workspaceDiagnostics, "")
+      _ = server.assertReferenceDefinitionBijection()
+      _ <- server.didSave("a/src/main/scala/a/Names.scala")(text =>
+        text.replace("+ surname", "+ surname2")
+      )
+      _ <- server.didSave("a/src/main/scala/a/Adresses.scala")(text =>
+        text.replace("+ number", "+ number2")
+      )
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|a/src/main/scala/a/Adresses.scala:5:44: error: not found: value number2
+           |  override def toString() = street + " " + number2
+           |                                           ^^^^^^^
+           |a/src/main/scala/a/Names.scala:5:42: error: not found: value surname2
+           |  override def toString() = name + " " + surname2
+           |                                         ^^^^^^^^
+           |""".stripMargin
+      )
+      _ <- server.didClose("a/src/main/scala/a/Adresses.scala")
+      _ <- server.shutdown()
+      newServer = server.copy()
+      _ <- newServer.initialize()
+      _ <- newServer.initialized()
+      _ <- newServer.didOpen("a/src/main/scala/a/Names.scala")
+      _ <- newServer.didOpen("a/src/main/scala/a/Adresses.scala")
+      _ <- newServer.executeCommand(ServerCommands.CascadeCompile)
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|a/src/main/scala/a/Adresses.scala:5:44: error: not found: value number2
+           |  override def toString() = street + " " + number2
+           |                                           ^^^^^^^
+           |a/src/main/scala/a/Names.scala:5:42: error: not found: value surname2
+           |  override def toString() = name + " " + surname2
+           |                                         ^^^^^^^^
+           |""".stripMargin
+      )
+      _ = assertNoDiff(
+        newServer.workspaceReferences().referencesFormat,
+        """|=============
+           |= a/Adresses#
+           |=============
+           |a/src/main/scala/a/Adresses.scala:2:7: a/Adresses#
+           |class Adresses {
+           |      ^^^^^^^^
+           |====================
+           |= a/Adresses#number.
+           |====================
+           |a/src/main/scala/a/Adresses.scala:4:7: a/Adresses#number.
+           |  val number = 123
+           |      ^^^^^^
+           |====================
+           |= a/Adresses#street.
+           |====================
+           |a/src/main/scala/a/Adresses.scala:3:7: a/Adresses#street.
+           |  val street = "Forbes"
+           |      ^^^^^^
+           |a/src/main/scala/a/Adresses.scala:5:29: a/Adresses#street.
+           |  override def toString() = street + " " + number2
+           |                            ^^^^^^
+           |========================
+           |= a/Adresses#toString().
+           |========================
+           |a/src/main/scala/a/Adresses.scala:5:16: a/Adresses#toString().
+           |  override def toString() = street + " " + number2
+           |               ^^^^^^^^
+           |==========
+           |= a/Names#
+           |==========
+           |a/src/main/scala/a/Names.scala:2:7: a/Names#
+           |class Names {
+           |      ^^^^^
+           |===============
+           |= a/Names#name.
+           |===============
+           |a/src/main/scala/a/Names.scala:3:7: a/Names#name.
+           |  val name = "John"
+           |      ^^^^
+           |a/src/main/scala/a/Names.scala:5:29: a/Names#name.
+           |  override def toString() = name + " " + surname2
+           |                            ^^^^
+           |==================
+           |= a/Names#surname.
+           |==================
+           |a/src/main/scala/a/Names.scala:4:7: a/Names#surname.
+           |  val surname = "Nowak"
+           |      ^^^^^^^
+           |=====================
+           |= a/Names#toString().
+           |=====================
+           |a/src/main/scala/a/Names.scala:5:16: a/Names#toString().
+           |  override def toString() = name + " " + surname2
+           |               ^^^^^^^^
+           |""".stripMargin
+      )
+      _ <- newServer.shutdown()
+    } yield ()
+
+  }
+}


### PR DESCRIPTION
Previously, if a user reloaded a broken workspace they would keep getting the dreaded "Could not load snapshot text for". Now, we save the fingerprints between restarts to improve the probability of finding the correct text, which corresponds to a semanicdb document.

It shouldn't save too much, since fingerprints are only updated for open files and we clean it after each reload.