### PR TITLE
[docs] Update Maven integration launcher to 2.13

### DIFF
--- a/docs/build-tools/maven.md
+++ b/docs/build-tools/maven.md
@@ -17,7 +17,7 @@ implemented.
 
 Currently, all you need to run the manual installation is:
 
-`mvn ch.epfl.scala:maven-bloop_2.12:@BLOOP_VERSION@:bloopInstall -DdownloadSources=true`
+`mvn ch.epfl.scala:maven-bloop_2.13:@BLOOP_VERSION@:bloopInstall -DdownloadSources=true`
 
 If you choose this option though you should select "Don't show again" when
 Metals prompts to import the build.


### PR DESCRIPTION
I was confused why the command from the docs wasn't working at all

What complicated things is that `maven-bloop` is somehow impossible to find on https://mvnrepository.com, even though it's indexed on https://index.scala-lang.org/scalacenter/bloop/artifacts/maven-bloop/1.5.2