### PR TITLE
fix: Dialect should be scala21xSource3 for `-Xsource:3.x.x`

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -69,7 +69,8 @@ case class ScalaTarget(
 
   def scalaBinaryVersion: String = scalaInfo.getScalaBinaryVersion()
 
-  private def containsSource3 = scalac.getOptions().contains("-Xsource:3")
+  private def containsSource3 =
+    scalac.getOptions().asScala.exists(opt => opt.startsWith("-Xsource:3"))
 
   def targetroot: AbsolutePath = scalac.targetroot(scalaVersion)
 

--- a/tests/slow/src/test/scala/tests/feature/FoldingCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/FoldingCrossLspSuite.scala
@@ -48,7 +48,7 @@ class FoldingCrossLspSuite extends BaseLspSuite("foldingRange-cross") {
         s"""|
             |/metals.json
             |{
-            |  "a": { "scalaVersion" : "${V.scala213}", "scalacOptions" : ["-Xsource:3"] }
+            |  "a": { "scalaVersion" : "${V.scala213}", "scalacOptions" : ["-Xsource:3.0"] }
             |}
             |/a/src/main/scala/a/Main.scala
             |package b
@@ -59,6 +59,8 @@ class FoldingCrossLspSuite extends BaseLspSuite("foldingRange-cross") {
             |    println("")
             |    println("")
             |    println("")
+            |    true &&
+            |    false
             |  }
             |  val args = List.empty[String]
             |  func(args*) 
@@ -77,6 +79,8 @@ class FoldingCrossLspSuite extends BaseLspSuite("foldingRange-cross") {
            |    println("")
            |    println("")
            |    println("")
+           |    true &&
+           |    false
            |  }<<region<<
            |  val args = List.empty[String]
            |  func(args*) 


### PR DESCRIPTION
fix https://github.com/scalameta/metals/issues/4133

Previously, Metals recognise only `-Xsource:3`, but it doesn't for
`-Xsource:3.0` (`-Xsource:3.x.x`) even though it is valid in Scala2
compiler.
see: https://github.com/scala/scala/blob/d23424cd3aa17f7ad95b81018c70ceed2566962b/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala#L105

This commit change Metals to understand `-Xsource:3.x.x` in addition to
`-Xsource:3` scalacOption.