### PR TITLE
bugfix: [Scala 2] Automatically import types in string interpolations

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -82,6 +82,13 @@ class CompletionProvider(
         case t: TextEditMember if t.detail.isDefined => t.detail.get
         case _ => detailString(member, history)
       }
+
+      def labelWithSig =
+        if (member.sym.isMethod || member.sym.isValue) {
+          ident + detail
+        } else {
+          ident
+        }
       val label = member match {
         case _: NamedArgMember =>
           val escaped = if (isSnippet) ident.replace("$", "$$") else ident
@@ -89,15 +96,10 @@ class CompletionProvider(
         case o: OverrideDefMember =>
           o.label
         case o: TextEditMember =>
-          o.label.getOrElse(ident)
+          o.label.getOrElse(labelWithSig)
         case o: WorkspaceMember =>
           s"$ident - ${o.sym.owner.fullName}"
-        case _ =>
-          if (member.sym.isMethod || member.sym.isValue) {
-            ident + detail
-          } else {
-            ident
-          }
+        case _ => labelWithSig
       }
       val item = new CompletionItem(label)
       if (metalsConfig.isCompletionItemDetailEnabled && !detail.isEmpty()) {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -156,6 +156,38 @@ class MetalsGlobal(
     }
   }
 
+  def workspaceSymbolListMembers(
+      query: String,
+      pos: Position,
+      visit: Member => Boolean
+  ): SymbolSearch.Result = {
+    if (query.isEmpty) SymbolSearch.Result.INCOMPLETE
+    else {
+      val context = doLocateContext(pos)
+      val visitor = new CompilerSearchVisitor(
+        context,
+        sym => visit(new WorkspaceMember(sym))
+      )
+      search.search(query, buildTargetIdentifier, visitor)
+    }
+  }
+
+  def workspaceSymbolListMembers(
+      query: String,
+      pos: Position
+  ): List[Member] = {
+    val buffer = mutable.ListBuffer.empty[Member]
+    workspaceSymbolListMembers(
+      query,
+      pos,
+      mem => {
+        buffer.append(mem)
+        true
+      }
+    )
+    buffer.toList
+  }
+
   def symbolDocumentation(symbol: Symbol): Option[SymbolDocumentation] = {
     def toSemanticdbSymbol(sym: Symbol) = compiler.semanticdbSymbol(
       if (!sym.isJava && sym.isPrimaryConstructor) sym.owner

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -30,7 +30,20 @@ trait Completions { this: MetalsGlobal =>
    * A member for symbols on the classpath that are not in scope, produced via workspace/symbol.
    */
   class WorkspaceMember(sym: Symbol)
-      extends ScopeMember(sym, NoType, true, EmptyTree)
+      extends ScopeMember(sym, NoType, true, EmptyTree) {
+    def additionalTextEdits: List[l.TextEdit] = Nil
+
+    def wrap: String => String = identity
+
+    def editRange: Option[l.Range] = None
+  }
+
+  class WorkspaceInterpolationMember(
+      sym: Symbol,
+      override val additionalTextEdits: List[l.TextEdit],
+      override val wrap: String => String,
+      override val editRange: Option[l.Range]
+  ) extends WorkspaceMember(sym)
 
   class NamedArgMember(sym: Symbol)
       extends ScopeMember(sym, NoType, true, EmptyTree)

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -132,6 +132,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       filter: String => Boolean = _ => true,
       command: Option[String] = None,
       compat: Map[String, String] = Map.empty,
+      itemIndex: Int = 0,
   )(implicit loc: Location): Unit = {
     test(name) {
       val items = getItems(original).filter(item => filter(item.getLabel))
@@ -141,7 +142,8 @@ abstract class BaseCompletionSuite extends BasePCSuite {
           s"expected single completion item, obtained ${items.length} items.\n${items}"
         )
       }
-      val item = items.head
+      if (items.size <= itemIndex) fail("Not enough completion items")
+      val item = items(itemIndex)
       val (code, _) = params(original)
       val obtained = TextEdits.applyEdits(code, item)
       assertNoDiff(

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -354,6 +354,26 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |""".stripMargin,
   )
 
+  check(
+    "member-label".tag(IgnoreScala3),
+    """|object Main {
+       |  
+       |  s"Hello $List.e@@ "
+       |}
+       |""".stripMargin,
+    """|empty[A]: List[A]
+       |equals(x$1: Object): Boolean
+       |""".stripMargin,
+    compat = Map(
+      "2.12" ->
+        """|empty[A]: List[A]
+           |equals(x$1: Any): Boolean
+           |""".stripMargin
+    ),
+    topLines = Some(6),
+    includeDetail = false,
+  )
+
   checkEdit(
     "member1",
     """|object Main {
@@ -656,6 +676,6 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |  s"this is an interesting ${file.Paths}"
        |}
        |""".stripMargin,
-    assertSingleItem = false
+    assertSingleItem = false,
   )
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -640,4 +640,22 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
     assertSingleItem = false,
     itemIndex = 1,
   )
+
+  checkEdit(
+    "auto-imports-prefix-with-interpolator".tag(IgnoreScala3),
+    """|
+       |class Paths
+       |object Main {
+       |  s"this is an interesting $Paths@@"
+       |}
+       |""".stripMargin,
+    """|import java.nio.file
+       |
+       |class Paths
+       |object Main {
+       |  s"this is an interesting ${file.Paths}"
+       |}
+       |""".stripMargin,
+    assertSingleItem = false
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -608,4 +608,36 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |""".stripMargin,
     filterText = "hello world",
   )
+
+  checkEdit(
+    "auto-imports".tag(IgnoreScala3),
+    """|object Main {
+       |  "this is an interesting $Paths@@"
+       |}
+       |""".stripMargin,
+    """|import java.nio.file.Paths
+       |object Main {
+       |  s"this is an interesting $Paths$0"
+       |}
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "auto-imports-prefix".tag(IgnoreScala3),
+    """|
+       |class Paths
+       |object Main {
+       |  "this is an interesting $Paths@@"
+       |}
+       |""".stripMargin,
+    """|import java.nio.file
+       |
+       |class Paths
+       |object Main {
+       |  s"this is an interesting ${file.Paths$0}"
+       |}
+       |""".stripMargin,
+    assertSingleItem = false,
+    itemIndex = 1,
+  )
 }


### PR DESCRIPTION
Previously, when trying to provide inside a string we would not get completions from the workspace. Now, we properly add them.

Related to https://github.com/scalameta/metals/issues/2105 but it still needs a fix for Scala 3