### PR TITLE
feat: Import missing extension method

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
@@ -4,6 +4,15 @@ import org.eclipse.{lsp4j => l}
 
 object ScalacDiagnostic {
 
+  object NotAMember {
+    private val regex = """(?s)value (.+) is not a member of.*""".r
+    def unapply(d: l.Diagnostic): Option[String] =
+      d.getMessage() match {
+        case regex(name) => Some(name)
+        case _ => None
+      }
+  }
+
   object SymbolNotFound {
     private val regex = """(n|N)ot found: (value|type)?\s?(\w+)""".r
     def unapply(d: l.Diagnostic): Option[String] =

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
@@ -97,6 +97,9 @@ class ImportMissingSymbol(compilers: Compilers) extends CodeAction {
             case diag @ ScalacDiagnostic.SymbolNotFound(name)
                 if params.getRange().overlapsWith(diag.getRange()) =>
               importMissingSymbol(diag, name)
+            case d @ ScalacDiagnostic.NotAMember(name)
+                if params.getRange().overlapsWith(d.getRange()) =>
+              importMissingSymbol(d, name)
           }
       )
       .map { actions =>

--- a/mtags/src/main/scala/scala/meta/internal/mtags/MtagsIndexer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/MtagsIndexer.scala
@@ -64,18 +64,18 @@ trait MtagsIndexer {
         )
     }
   }
-  def term(name: String, pos: m.Position, kind: Kind, properties: Int): Unit =
+  def term(name: String, pos: m.Position, kind: Kind, properties: Int): String =
     addSignature(Descriptor.Term(name), pos, kind, properties)
-  def term(name: Term.Name, kind: Kind, properties: Int): Unit =
+  def term(name: Term.Name, kind: Kind, properties: Int): String =
     addSignature(Descriptor.Term(name.value), name.pos, kind, properties)
-  def tparam(name: Name, kind: Kind, properties: Int): Unit =
+  def tparam(name: Name, kind: Kind, properties: Int): String =
     addSignature(
       Descriptor.TypeParameter(name.value),
       name.pos,
       kind,
       properties
     )
-  def param(name: Name, kind: Kind, properties: Int): Unit =
+  def param(name: Name, kind: Kind, properties: Int): String =
     addSignature(
       Descriptor.Parameter(name.value),
       name.pos,
@@ -86,7 +86,7 @@ trait MtagsIndexer {
       disambiguator: String,
       pos: m.Position,
       properties: Int
-  ): Unit =
+  ): String =
     addSignature(
       Descriptor.Method(Names.Constructor.value, disambiguator),
       pos,
@@ -98,7 +98,7 @@ trait MtagsIndexer {
       disambiguator: String,
       pos: m.Position,
       properties: Int
-  ): Unit =
+  ): String =
     addSignature(
       Descriptor.Method(name, disambiguator),
       pos,
@@ -110,7 +110,7 @@ trait MtagsIndexer {
       disambiguator: String,
       kind: Kind,
       properties: Int
-  ): Unit = {
+  ): String = {
     val methodName = name match {
       case Name.Anonymous() => Names.Constructor.value
       case _ => name.value
@@ -122,11 +122,11 @@ trait MtagsIndexer {
       properties
     )
   }
-  def tpe(name: String, pos: m.Position, kind: Kind, properties: Int): Unit =
+  def tpe(name: String, pos: m.Position, kind: Kind, properties: Int): String =
     addSignature(Descriptor.Type(name), pos, kind, properties)
-  def tpe(name: Name, kind: Kind, properties: Int): Unit =
+  def tpe(name: Name, kind: Kind, properties: Int): String =
     addSignature(Descriptor.Type(name.value), name.pos, kind, properties)
-  def pkg(name: String, pos: m.Position): Unit = {
+  def pkg(name: String, pos: m.Position): String = {
     addSignature(Descriptor.Package(name), pos, Kind.PACKAGE, 0)
   }
   def pkg(ref: Term): Unit =
@@ -142,7 +142,7 @@ trait MtagsIndexer {
       definition: m.Position,
       kind: s.SymbolInformation.Kind,
       properties: Int
-  ): Unit = {
+  ): String = {
     val previousOwner = currentOwner
     currentOwner = symbol(signature)
     myLastCurrentOwner = currentOwner
@@ -163,6 +163,7 @@ trait MtagsIndexer {
       displayName = signature.name.value
     )
     visitOccurrence(occ, info, previousOwner)
+    syntax
   }
   def symbol(signature: Descriptor): String =
     if (currentOwner.eq(Symbols.EmptyPackage) && signature.isPackage)

--- a/tests/slow/src/test/scala/tests/feature/ImportMissingSymbolCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/ImportMissingSymbolCrossLspSuite.scala
@@ -81,4 +81,46 @@ class ImportMissingSymbolCrossLspSuite
     } yield ()
   }
 
+  test("scala3-toplevel-extension-import-from-deps") {
+    val path = "b/src/main/scala/x/B.scala"
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a":{"scalaVersion" : "${V.scala3}"},
+            |  "b":{
+            |    "scalaVersion" : "${V.scala3}",
+            |    "dependsOn": ["a"]
+            |  }
+            |}
+            |/a/src/main/scala/example/A.scala
+            |package example
+            |
+            |extension (str: String)
+            |  def identity = str
+            |
+            |extension (num: Int)
+            |  def incr = num + 1
+            |
+            |/$path
+            |package x
+            |def main =
+            |  println(1.incr)
+            |""".stripMargin
+      )
+      _ <- server.didOpen(path)
+      _ <- server.assertCodeAction(
+        path,
+        s"""|package x
+            |def main =
+            |  println(1.<<incr>>)
+            |""".stripMargin,
+        s"""|${ImportMissingSymbol.title("incr", "example.A$package")}
+            |${ExtractValueCodeAction.title}
+            |""".stripMargin,
+        Nil,
+      )
+    } yield ()
+  }
+
 }

--- a/tests/slow/src/test/scala/tests/feature/ImportMissingSymbolCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/ImportMissingSymbolCrossLspSuite.scala
@@ -1,5 +1,6 @@
 package tests.feature
 
+import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
 import scala.meta.internal.metals.codeactions.CreateNewSymbol
 import scala.meta.internal.metals.codeactions.ExtractValueCodeAction
 import scala.meta.internal.metals.codeactions.ImportMissingSymbol
@@ -74,7 +75,8 @@ class ImportMissingSymbolCrossLspSuite
             |  println(1.<<incr>>)
             |""".stripMargin,
         s"""|${ImportMissingSymbol.title("incr", "example.IntEnrichment")}
-            |${ExtractValueCodeAction.title}
+            |${ExtractValueCodeAction.title("1.incr")}
+            |${ConvertToNamedArguments.title("println(...)")}
             |""".stripMargin,
         Nil,
       )
@@ -116,7 +118,8 @@ class ImportMissingSymbolCrossLspSuite
             |  println(1.<<incr>>)
             |""".stripMargin,
         s"""|${ImportMissingSymbol.title("incr", "example.A$package")}
-            |${ExtractValueCodeAction.title}
+            |${ExtractValueCodeAction.title("1.incr")}
+            |${ConvertToNamedArguments.title("println(...)")}
             |""".stripMargin,
         Nil,
       )

--- a/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -9,6 +9,7 @@ import munit.Location
 import munit.TestOptions
 import org.eclipse.lsp4j.CodeAction
 import tests.BaseLspSuite
+import tests.FileLayout
 
 abstract class BaseCodeActionLspSuite(
     suiteName: String
@@ -59,21 +60,64 @@ abstract class BaseCodeActionLspSuite(
         s""""scalacOptions": ["${scalacOptions.mkString("\",\"")}"],"""
       else ""
     val path = s"a/src/main/scala/a/$fileName"
+
+    val layout =
+      s"""/metals.json
+         |{"a":{$scalacOptionsJson "scalaVersion" : "$scalaVersion"}}
+         |$scalafixConf
+         |/$path
+         |$input""".stripMargin
+
+    checkEdit(
+      name,
+      layout,
+      expectedActions,
+      expectedCode,
+      selectedActionIndex,
+      expectNoDiagnostics,
+      kind,
+      configuration,
+      renamePath,
+      extraOperations,
+      changeFile,
+      expectError,
+      filterAction,
+    )
+  }
+
+  def checkEdit(
+      name: TestOptions,
+      layout: String,
+      expectedActions: String,
+      expectedCode: String,
+      selectedActionIndex: Int = 0,
+      expectNoDiagnostics: Boolean = true,
+      kind: List[String] = Nil,
+      configuration: => Option[String] = None,
+      renamePath: Option[String] = None,
+      extraOperations: => Unit = (),
+      changeFile: String => String = identity,
+      expectError: Boolean = false,
+      filterAction: CodeAction => Boolean = _ => true,
+  )(implicit loc: Location): Unit = {
+    val files = FileLayout.mapFromString(layout)
+    val (path, input) = files
+      .find(f => f._2.contains("<<") && f._2.contains(">>"))
+      .getOrElse {
+        throw new IllegalArgumentException(
+          "No `<< >>` was defined that specifies cursor position"
+        )
+      }
     val newPath = renamePath.getOrElse(path)
-    val fileContent = input.replace("<<", "").replace(">>", "")
+    val fullInput = layout.replace("<<", "").replace(">>", "")
     val actualExpectedCode =
-      if (renamePath.nonEmpty) fileContent else expectedCode
+      if (renamePath.nonEmpty) input.replace("<<", "").replace(">>", "")
+      else expectedCode
 
     test(name) {
       cleanWorkspace()
       for {
-        _ <- initialize(
-          s"""/metals.json
-             |{"a":{$scalacOptionsJson "scalaVersion" : "$scalaVersion"}}
-             |$scalafixConf
-             |/$path
-             |$fileContent""".stripMargin
-        )
+        _ <- initialize(fullInput)
         _ <- server.didOpen(path)
         _ <- {
           configuration match {

--- a/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
@@ -249,6 +249,49 @@ class ScalaToplevelSuite extends BaseSuite {
     dialect = dialects.Scala213,
   )
 
+  check(
+    "extesion-methods",
+    """|package a
+       |
+       |object A:
+       |  extension (s: String)
+       |    def foo: Int = ???
+       |    def bar: String =
+       |      def hmm: Int = ???  // <- shouldn't be returned
+       |      ???
+       |
+       |""".stripMargin,
+    List(
+      "a/",
+      "a/A.",
+      "a/A.bar.",
+      "a/A.foo.",
+    ),
+    all = true,
+    dialect = dialects.Scala3,
+  )
+
+  check(
+    "toplevel-extesion",
+    """|package a
+       |
+       |extension (s: String)
+       |  def foo: Int = ???
+       |  def bar: String =
+       |    def hmm: Int = ???  // <- shouldn't be returned
+       |    ???
+       |
+       |""".stripMargin,
+    List(
+      "a/",
+      "a/Test$package.",
+      "a/Test$package.bar.",
+      "a/Test$package.foo.",
+    ),
+    all = true,
+    dialect = dialects.Scala3,
+  )
+
   def check(
       options: TestOptions,
       code: String,

--- a/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
@@ -250,7 +250,7 @@ class ScalaToplevelSuite extends BaseSuite {
   )
 
   check(
-    "extesion-methods",
+    "extension-methods",
     """|package a
        |
        |object A:
@@ -272,7 +272,7 @@ class ScalaToplevelSuite extends BaseSuite {
   )
 
   check(
-    "toplevel-extesion",
+    "toplevel-extension",
     """|package a
        |
        |extension (s: String)


### PR DESCRIPTION
refer https://github.com/scalameta/metals-feature-requests/issues/141

This PR enables Metals to auto-import missing extension method **from the workspace (it doesn't support import from third-party libraries).**

![extension-import](https://user-images.githubusercontent.com/9353584/178533047-b9140f6c-3c01-45e1-bff4-db952ca589d0.gif)

This is done by

- Index extension methods by `ScalaToplevelMtags`
- Show AutoImport code action for `value xxx is not a member of yyy`.

## What I didn't in this PR
- Auto import given instances
- Auto import implicit classes
- completion for extension method and auto-import
  - I'll open an feature-request-issue
