### PR TITLE
chore: update git-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,5 +1,6 @@
 
 # https://github.com/scalameta/metals/pull/4050
 # add 'trailingCommas = multiple' in scalafmt
+66a82f6279a3258842eb21472272f8d6f2df974d
 
 


### PR DESCRIPTION
Follow up of https://github.com/scalameta/metals/pull/4050. 

As you can see on e.g. [build.sbt on my branch](https://github.com/kpodsiad/metals/blame/94dfeaab7bbd522d61749e2e182c26f8cf2600f7/build.sbt) it works.
<img width="539" alt="Screenshot 2022-07-13 at 11 20 03" src="https://user-images.githubusercontent.com/37124721/178698965-7529fc74-85d7-440d-a46b-068091abfedf.png">
