### PR TITLE
refactor: Show more debug messages

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -2018,7 +2018,11 @@ class MetalsLanguageServer(
               argIndices,
               token,
             )
-            if (!edits.isEmpty())
+            _ = if (edits.isEmpty())
+              scribe.info(
+                s"Could not find the correct names for arguments at $position with indices ${argIndices.asScala
+                    .mkString(",")}"
+              )
             workspaceEdit = new l.WorkspaceEdit(Map(uri -> edits).asJava)
             _ <- languageClient
               .applyEdit(new ApplyWorkspaceEditParams(workspaceEdit))

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -213,6 +213,11 @@ final class RenameProvider(
             renamedImportOccurrences(source, symbolOccurrence)
           else allReferences
 
+        if (fallbackOccurences.isEmpty) {
+          scribe.debug(s"Symbol occurence was $symbolOccurrence")
+          scribe.debug(s"The definition found was $definition")
+        }
+
         val allChanges = for {
           (path, locs) <- fallbackOccurences.toList.distinct
             .groupBy(_.getUri().toAbsolutePath)
@@ -415,7 +420,10 @@ final class RenameProvider(
     if (colonNotAllowed) {
       client.showMessage(forbiddenColonRename(name, newName))
     }
-    (!desc.isMethod || (!colonNotAllowed && !isForbidden))
+    val canRename = (!desc.isMethod || (!colonNotAllowed && !isForbidden))
+    if (!canRename)
+      scribe.debug(s"Cannot rename $symbol with new name $newName")
+    canRename
   }
 
   private def findRenamedImportOccurrenceAtPosition(


### PR DESCRIPTION
Added some more debug logs for:
- RenameProvider, since sometimes it fails without any messages and it's super hard to reproduce
- ConvertToNamedArguments command instead of Future.filter, which would throw an exception.