### PR TITLE
bugfix: Include method signature in the label

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -259,12 +259,13 @@ final class Diagnostics(
       )
     }
     if (result.isEmpty) {
-      val pos = d.getRange.toMeta(snapshot)
-      val message = pos.formatMessage(
-        s"stale ${d.getSource} ${d.getSeverity.toString.toLowerCase()}",
-        d.getMessage,
-      )
-      scribe.info(message)
+      d.getRange.toMeta(snapshot).foreach { pos =>
+        val message = pos.formatMessage(
+          s"stale ${d.getSource} ${d.getSeverity.toString.toLowerCase()}",
+          d.getMessage,
+        )
+        scribe.info(message)
+      }
     }
     result
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaFormattingProvider.scala
@@ -121,7 +121,13 @@ final class JavaFormattingProvider(
     val range = params.getRange
     val path = params.getTextDocument.getUri.toAbsolutePath
     val input = path.toInputFromBuffers(buffers)
-    runFormat(path, input, options, range.toMeta(input)).asJava
+    range.toMeta(input) match {
+      case Some(rng) =>
+        runFormat(path, input, options, rng).asJava
+      case None =>
+        scribe.debug(s"range $range was not found in $path")
+        Nil.asJava
+    }
   }
 
   def format(): util.List[l.TextEdit] = java.util.Collections.emptyList()

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -719,25 +719,29 @@ object MetalsEnrichments
         None
     }
 
-    def toMeta(input: m.Input): m.Position =
-      m.Position.Range(
-        input,
-        range.startLine,
-        range.startCharacter,
-        range.endLine,
-        range.endCharacter,
-      )
+    def toMeta(input: m.Input): Option[m.Position] =
+      Try(
+        m.Position.Range(
+          input,
+          range.startLine,
+          range.startCharacter,
+          range.endLine,
+          range.endCharacter,
+        )
+      ).toOption
   }
 
   implicit class XtensionRangeBsp(range: b.Range) {
-    def toMeta(input: m.Input): m.Position =
-      m.Position.Range(
-        input,
-        range.getStart.getLine,
-        range.getStart.getCharacter,
-        range.getEnd.getLine,
-        range.getEnd.getCharacter,
-      )
+    def toMeta(input: m.Input): Option[m.Position] =
+      Try(
+        m.Position.Range(
+          input,
+          range.getStart.getLine,
+          range.getStart.getCharacter,
+          range.getEnd.getLine,
+          range.getEnd.getCharacter,
+        )
+      ).toOption
 
     def toLSP: l.Range =
       new l.Range(range.getStart.toLSP, range.getEnd.toLSP)

--- a/metals/src/main/scala/scala/meta/internal/parsing/ClassFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/ClassFinder.scala
@@ -83,14 +83,15 @@ class ClassFinder(trees: Trees) {
       path: AbsolutePath,
       pos: l.Position,
       checkInnerClasses: Boolean,
-  ): Option[String] = trees
-    .get(path)
-    .map { tree =>
-      val input = tree.pos.input
-      val metaPos = pos.toMeta(input)
-      findClassForOffset(tree, metaPos, path.filename, checkInnerClasses)
-    }
-    .filter(_.nonEmpty)
+  ): Option[String] = {
+    for {
+      tree <- trees.get(path)
+      input = tree.pos.input
+      metaPos <- pos.toMeta(input)
+      cls = findClassForOffset(tree, metaPos, path.filename, checkInnerClasses)
+      if cls.nonEmpty
+    } yield cls
+  }
 
   private def findClassForOffset(
       tree: Tree,

--- a/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
@@ -73,10 +73,11 @@ final class Trees(
       }
     }
 
-    get(source).flatMap { tree =>
-      val pos = lspPos.toMeta(tree.pos.input)
-      loop(tree, pos)
-    }
+    for {
+      tree <- get(source)
+      pos <- lspPos.toMeta(tree.pos.input)
+      lastEnc <- loop(tree, pos)
+    } yield lastEnc
 
   }
 

--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -156,28 +156,28 @@ trait MtagsEnrichments extends CommonMtagsEnrichments {
   }
 
   implicit class XtensionRangeLspInverse(range: l.Range) {
-    def toMeta(input: m.Input): m.Position = {
-      m.Position.Range(
-        input,
-        range.getStart.getLine,
-        range.getStart.getCharacter,
-        range.getEnd.getLine,
-        range.getEnd.getCharacter
-      )
-    }
-
     def toLocation(uri: URI): l.Location = new l.Location(uri.toString(), range)
   }
 
   implicit class XtensionPositionLspInverse(pos: l.Position) {
-    def toMeta(input: m.Input): m.Position = {
-      m.Position.Range(
-        input,
-        pos.getLine,
-        pos.getCharacter,
-        pos.getLine,
-        pos.getCharacter
-      )
+
+    /**
+     * LSP position translated to scalameta position. Might return None if
+     * pos is not contained in input
+     *
+     * @param input file input the position relates to
+     * @return scalameta position with offset if the pos is contained in the file
+     */
+    def toMeta(input: m.Input): Option[m.Position] = {
+      Try(
+        m.Position.Range(
+          input,
+          pos.getLine,
+          pos.getCharacter,
+          pos.getLine,
+          pos.getCharacter
+        )
+      ).toOption
     }
   }
 }

--- a/mtags/src/main/scala/scala/meta/internal/metals/TextEdits.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/TextEdits.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals
 
+import scala.meta.Position
 import scala.meta.inputs.Input
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.mtags.MtagsEnrichments._
@@ -15,8 +16,11 @@ object TextEdits {
     if (edits.isEmpty) text
     else {
       val input = Input.String(text)
-      val positions = edits
-        .map(edit => edit -> edit.getRange.toMeta(input))
+      val positions: List[(TextEdit, Position)] = edits
+        .map(edit => (edit, edit.getRange.toMeta(input)))
+        .collect { case (edit, Some(pos)) =>
+          edit -> pos
+        }
         .sortBy(_._2.start)
       var curr = 0
       val out = new java.lang.StringBuilder()

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -239,17 +239,19 @@ trait CommonMtagsEnrichments {
       range.getStart().isNone &&
         range.getEnd().isNone
 
-    def toMeta(input: m.Input): m.Position =
+    def toMeta(input: m.Input): Option[m.Position] =
       if (range.isNone) {
-        m.Position.None
+        None
       } else {
-        m.Position.Range(
-          input,
-          range.getStart.getLine,
-          range.getStart.getCharacter,
-          range.getEnd.getLine,
-          range.getEnd.getCharacter
-        )
+        Try(
+          m.Position.Range(
+            input,
+            range.getStart.getLine,
+            range.getStart.getCharacter,
+            range.getEnd.getLine,
+            range.getEnd.getCharacter
+          )
+        ).toOption
       }
 
     def encloses(position: l.Position): Boolean = {

--- a/tests/cross/src/main/scala/tests/pc/BaseSelectionRangeSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BaseSelectionRangeSuite.scala
@@ -76,7 +76,14 @@ abstract class BaseSelectionRangeSuite extends BasePCSuite {
   ): String = {
     val input = Input.String(text)
 
-    val pos = selectionRange.getRange().toMeta(input)
+    val pos = selectionRange
+      .getRange()
+      .toMeta(input)
+      .getOrElse(
+        throw new RuntimeException(
+          s"Range ${selectionRange.getRange()} not contained in:\n$text"
+        )
+      )
     val out = new java.lang.StringBuilder()
     out.append(text, 0, pos.start)
     out.append(">>region>>")

--- a/tests/mtest/src/main/scala/tests/RangeReplace.scala
+++ b/tests/mtest/src/main/scala/tests/RangeReplace.scala
@@ -14,7 +14,11 @@ trait RangeReplace {
       suffix: String = ">>",
   ): String = {
     val input = Input.String(base)
-    val pos = range.toMeta(input)
+    val pos = range
+      .toMeta(input)
+      .getOrElse(
+        throw new RuntimeException(s"$range was not contained in file")
+      )
     new java.lang.StringBuilder()
       .append(base, 0, pos.start)
       .append(prefix)

--- a/tests/mtest/src/main/scala/tests/TestHovers.scala
+++ b/tests/mtest/src/main/scala/tests/TestHovers.scala
@@ -49,10 +49,17 @@ trait TestHovers {
     hover match {
       case Some(value) =>
         val types = value.getContents.getRight.getValue()
+
         val range = Option(value.getRange) match {
           case Some(value) if includeRange =>
+            val input = Input.String(code)
+            val pos = value
+              .toMeta(input)
+              .getOrElse(
+                throw new RuntimeException(s"$value was not contained in file")
+              )
             codeFence(
-              value.toMeta(Input.String(code)).text,
+              pos.text,
               "range",
             )
           case _ => ""

--- a/tests/unit/src/main/scala/bill/Bill.scala
+++ b/tests/unit/src/main/scala/bill/Bill.scala
@@ -512,12 +512,13 @@ object Bill {
         val path = params.getTextDocument.getUri.toAbsolutePath
         val input = path.toInput
         params.getDiagnostics.asScala.foreach { diag =>
-          val pos = diag.getRange.toMeta(input)
-          val message = pos.formatMessage(
-            diag.getSeverity.toString.toLowerCase(),
-            diag.getMessage,
-          )
-          println(message)
+          diag.getRange.toMeta(input).foreach { pos =>
+            val message = pos.formatMessage(
+              diag.getSeverity.toString.toLowerCase(),
+              diag.getMessage,
+            )
+            println(message)
+          }
         }
       }
       override def onBuildTargetDidChange(params: DidChangeBuildTarget): Unit =

--- a/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
+++ b/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
@@ -89,7 +89,7 @@ class FindTextInDependencyJarsSuite
       expected: String,
   ): Unit = {
     val rendered = locations
-      .map { loc =>
+      .flatMap { loc =>
         val uri = URI.create(loc.getUri())
         val input = if (uri.getScheme() == "jar") {
           val jarPath = uri.toAbsolutePath
@@ -107,8 +107,8 @@ class FindTextInDependencyJarsSuite
         loc
           .getRange()
           .toMeta(input)
-          .formatMessage("info", "result")
       }
+      .map(_.formatMessage("info", "result"))
       .mkString("\n")
     assertNoDiff(rendered, expected)
   }

--- a/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaDefinitionSuite.scala
@@ -186,6 +186,11 @@ class JavaDefinitionSuite extends BaseLspSuite("java-definition") {
     loc
       .getRange()
       .toMeta(input)
+      .getOrElse(
+        throw new RuntimeException(
+          s"Range ${loc.getRange()} is not available for ${loc.getUri()}"
+        )
+      )
       .formatMessage("info", "result", noPos = true)
   }
 }


### PR DESCRIPTION
Previously, we would be getting a lot of messages such as:

```
Caused by: java.lang.IllegalArgumentException: 76 is not a valid line number, allowed [0..72]
    at scala.meta.internal.inputs.InternalInput.lineToOffset(InternalInput.scala:37)
    at scala.meta.internal.inputs.InternalInput.lineToOffset$(InternalInput.scala:32)
```
which most likely are cause by the fact that input is not the same as the one used for position (most likely file changed and wasn't reparsed again)

Now, we explicitely handle any issues when the position is not available.