### PR TITLE
chore: use sonatypeOssRepos instead of sonatypeRepo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,8 +54,8 @@ inThisBuild(
     homepage := Some(url("https://github.com/scalameta/metals")),
     developers := metalsDevs,
     testFrameworks := List(),
-    resolvers += Resolver.sonatypeRepo("public"),
-    resolvers += Resolver.sonatypeRepo("snapshot"),
+    resolvers ++= Resolver.sonatypeOssRepos("public"),
+    resolvers ++= Resolver.sonatypeOssRepos("snapshot"),
     dependencyOverrides += V.guava,
     // faster publishLocal:
     packageDoc / publishArtifact := sys.env.contains("CI"),


### PR DESCRIPTION
After updating sbt to 1.7.0, we started to get the following warnings
on startup of sbt.

```
/Users/tanishiking/src/github.com/tanishiking/metals/build.sbt:57: warning: method sonatypeRepo in class ResolverFunctions is deprecated (since 1.7.0): Use sonatypeOssRepos instead
    resolvers += Resolver.sonatypeRepo("public"),
                          ^
/Users/tanishiking/src/github.com/tanishiking/metals/build.sbt:58: warning: method sonatypeRepo in class ResolverFunctions is deprecated (since 1.7.0): Use sonatypeOssRepos instead
    resolvers += Resolver.sonatypeRepo("snapshot"),
                          ^
```

As the original PR to sbt/librarymanagement says, `sonatyOssRepos` add
`https://s01.oss.sonatype.org` in addition to
`https://oss.sonatype.org`.
https://github.com/sbt/librarymanagement/pull/393

for more information: https://central.sonatype.org/news/20210223_new-users-on-s01/