### PR TITLE
Scala 3 type completion

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -64,7 +64,7 @@ class Completions(
     case (_: Ident) :: (_: SeqLiteral) :: _ => false
     case _ => true
 
-  private def calculateTypeInstanceAndNewPositions =
+  private def calculateTypeInstanceAndNewPositions() =
 
     path match
       case head :: tail
@@ -439,7 +439,6 @@ class Completions(
                 if sym.isClass || sym.is(Module) then
                   // drop #|. at the end to avoid duplication
                   name.substring(0, name.length - 1)
-                  // + sym.toString
                 else name
 
               val include =

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -405,7 +405,7 @@ class Completions(
             this,
             config.isCompletionSnippetsEnabled(),
           )
-          .filterInteresting(false)
+          .filterInteresting(enrich = false)
           ._1
         (completions, true)
       // From Scala 3.1.3-RC3 (as far as I know), path contains
@@ -537,7 +537,9 @@ class Completions(
 
       if enrich then
         val searchResult =
-          enrichWithSymbolSearch(visit, qualType).getOrElse(SymbolSearch.Result.COMPLETE)
+          enrichWithSymbolSearch(visit, qualType).getOrElse(
+            SymbolSearch.Result.COMPLETE
+          )
         (buf.result, searchResult)
       else (buf.result, SymbolSearch.Result.COMPLETE)
 
@@ -554,7 +556,9 @@ class Completions(
       ) // !sym.info.typeSymbol.is(Flags.Method) does not detect Java methods
 
     private def isNotClassOrTraitOrTheyAreValidForPos(sym: Symbol) =
-      cursorPositionCondition.isClassOrTraitValidForPos || (!sym.isClass && !sym.info.typeSymbol
+      cursorPositionCondition.isClassOrTraitValidForPos || sym.is(
+        Flags.Method
+      ) || (!sym.isClass && !sym.info.typeSymbol
         .is(Trait))
 
   end extension

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -119,6 +119,10 @@ class Completions(
   ): CursorPositionCondition =
     path match
       case (head: (Select | Ident)) :: tail =>
+        // this method of calculating hasNoSquareBracket instead of using the
+        // path for the purpose is due to the issue that trees after typer
+        // lose information in dotty:
+        // https://github.com/lampepfl/dotty/issues/15750
         val hasNoSquareBracket =
           val span: Span = head.srcPos.span
           if span.exists then

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -654,7 +654,22 @@ class CompletionDocSuite extends BaseCompletionSuite {
     includeDocs = true,
     compat = Map(
       "2.13" -> post212CatchDocs,
-      "3" -> s"${post212CatchDocs}Catch[T](pf: Catcher[T], fin: Option[Finally], rethrow: Throwable => Boolean): Catch[T]",
+      "3" ->
+        """|> A container class for catch/finally logic.
+           |
+           | Pass a different value for rethrow if you want to probably
+           | unwisely allow catching control exceptions and other throwables
+           | which the rest of the world may expect to get through.
+           |
+           |**Type Parameters**
+           |- `T`: result type of bodies used in try and catch blocks
+           |
+           |**Parameters**
+           |- `fin`: Finally logic which if defined will be invoked after catch logic
+           |- `rethrow`: Predicate on throwables determining when to rethrow a caught [Throwable](Throwable)
+           |- `pf`: Partial function used when applying catch logic to determine result value
+           |Catch - scala.util.control.Exception
+           |""".stripMargin,
     ),
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -398,12 +398,13 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "member2".tag(
-      IgnoreScalaVersion.forRangeUntil(
-        "3.2.0-RC1",
-        "3.2.1",
-      )
-    ),
+    "member2"
+      .tag(
+        IgnoreScalaVersion.forRangeUntil(
+          "3.2.0-RC1",
+          "3.2.1",
+        )
+      ),
     """|object Main {
        |  s"Hello $Main.toStr@@!"
        |}

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -355,7 +355,12 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
   )
 
   check(
-    "member-label",
+    "member-label".tag(
+      IgnoreScalaVersion.forRangeUntil(
+        "3.2.0-RC1",
+        "3.2.1",
+      )
+    ),
     """|object Main {
        |  
        |  s"Hello $List.e@@ "
@@ -394,13 +399,12 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "member2",
-    // .tag(
-    //   IgnoreScalaVersion.forRangeUntil(
-    //     "3.2.0-RC1",
-    //     "3.2.1",
-    //   )
-    // ),
+    "member2".tag(
+      IgnoreScalaVersion.forRangeUntil(
+        "3.2.0-RC1",
+        "3.2.1",
+      )
+    ),
     """|object Main {
        |  s"Hello $Main.toStr@@!"
        |}

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -376,7 +376,6 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
            |""".stripMargin,
       "3" ->
         """|empty[A]: List[A]
-           |eq(x$0: Object): Boolean
            |equals(x$0: Any): Boolean
            |""".stripMargin,
     ),

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -355,7 +355,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
   )
 
   check(
-    "member-label".tag(IgnoreScala3),
+    "member-label",
     """|object Main {
        |  
        |  s"Hello $List.e@@ "
@@ -368,7 +368,12 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
       "2.12" ->
         """|empty[A]: List[A]
            |equals(x$1: Any): Boolean
-           |""".stripMargin
+           |""".stripMargin,
+      "3" ->
+        """|empty[A]: List[A]
+           |eq(x$0: Object): Boolean
+           |equals(x$0: Any): Boolean
+           |""".stripMargin,
     ),
     topLines = Some(6),
     includeDetail = false,
@@ -389,13 +394,13 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "member2"
-      .tag(
-        IgnoreScalaVersion.forRangeUntil(
-          "3.2.0-RC1",
-          "3.2.1",
-        )
-      ),
+    "member2",
+    // .tag(
+    //   IgnoreScalaVersion.forRangeUntil(
+    //     "3.2.0-RC1",
+    //     "3.2.1",
+    //   )
+    // ),
     """|object Main {
        |  s"Hello $Main.toStr@@!"
        |}

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -93,7 +93,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
 
   checkSnippet(
     // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
-    "type-empty".tag(IgnoreScala3),
+    "type-empty"
+      .tag(IgnoreScala3),
     """
       |object Main {
       |  type MyType = List[Int]
@@ -106,7 +107,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
 
   checkSnippet(
     // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
-    "type-new-empty".tag(IgnoreScala3),
+    "type-new-empty"
+      .tag(IgnoreScala3),
     """
       |object Main {
       |  class Gen[T]
@@ -132,14 +134,14 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
     compat = Map(
       "3" ->
         // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
-        """|IndexedSeq
-           |IndexedSeq
+        """|IndexedSeq[$0]
            |""".stripMargin
     ),
   )
 
   checkSnippet(
-    "type2".tag(IgnoreScala3),
+    "type2"
+      .tag(IgnoreScala3),
     s"""|object Main {
         |  new scala.IndexedSeq@@
         |}
@@ -164,11 +166,10 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |ArrayDequeOps
            |""".stripMargin,
       // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
-      "3" ->
-        """|ArrayDeque($0)
-           |ArrayDeque
-           |ArrayDeque
-           |ArrayDequeOps
+      "3" -> // ArrayDeque upper is for java, the lower for scala
+        """|ArrayDeque[$0]
+           |ArrayDeque[$0]
+           |ArrayDequeOps[$0]
            |""".stripMargin,
     ),
   )
@@ -181,12 +182,12 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|SimpleFileVisitor[$0]
        |""".stripMargin,
-    compat = Map(
-      // scala 3 new completions not implemented, so no way to distinguish if we are at a type position
-      "3" ->
-        """|SimpleFileVisitor
-           |""".stripMargin
-    ),
+    // compat = Map(
+    //   // scala 3 new completions not implemented, so no way to distinguish if we are at a type position
+    //   "3" ->
+    //     """|SimpleFileVisitor
+    //        |""".stripMargin
+    // ),
   )
 
   checkSnippet(
@@ -207,8 +208,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
       "3" ->
         // scala 3 new completions not implemented, so no way to distinguish if we are at a type position
         """|Iterable
-           |Iterable
-           |IterableOnce
+           |Iterable[$0] {}
+           |IterableOnce[$0] {}
            |""".stripMargin,
     ),
   )
@@ -230,9 +231,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |""".stripMargin,
       "3" ->
         // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
-        """|Iterable
-           |Iterable
-           |IterableOnce
+        """|Iterable[$0]
+           |IterableOnce[$0]
            |""".stripMargin,
     ),
   )
@@ -254,9 +254,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |""".stripMargin,
       // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
       "3" ->
-        """|Iterable
-           |Iterable
-           |IterableOnce
+        """|Iterable[$0]
+           |IterableOnce[$0]
            |""".stripMargin,
     ),
   )
@@ -373,12 +372,9 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
        |""".stripMargin,
     // additional completion when apply method is present
     compat = Map(
-      "3" ->
+      "3" -> // TODO: please double check
         """|Try
            |Try($0)
-           |TryBlock
-           |TryModule
-           |TryMethods
            |TryMethods
            |""".stripMargin
     ),

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -141,7 +141,7 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
   )
 
   checkSnippet(
-    "empty-params-with-implicit".only,
+    "empty-params-with-implicit",
     s"""|object Main {
         |  def doSomething()(implicit x: Int) = x
         |  val bar = doSomethi@@

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -182,12 +182,6 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|SimpleFileVisitor[$0]
        |""".stripMargin,
-    // compat = Map(
-    //   // scala 3 new completions not implemented, so no way to distinguish if we are at a type position
-    //   "3" ->
-    //     """|SimpleFileVisitor
-    //        |""".stripMargin
-    // ),
   )
 
   checkSnippet(

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -92,7 +92,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
   )
 
   checkSnippet(
-    // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
+    // Dotty does not currently support fuzzy completions. Please take a look at
+    // https://github.com/lampepfl/dotty-feature-requests/issues/314
     "type-empty"
       .tag(IgnoreScala3),
     """
@@ -106,7 +107,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
   )
 
   checkSnippet(
-    // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
+    // Dotty does not currently support fuzzy completions. Please take a look at
+    // https://github.com/lampepfl/dotty-feature-requests/issues/314
     "type-new-empty"
       .tag(IgnoreScala3),
     """
@@ -133,13 +135,14 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
        |""".stripMargin,
     compat = Map(
       "3" ->
-        // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
         """|IndexedSeq[$0]
            |""".stripMargin
     ),
   )
 
   checkSnippet(
+    // handling this in Scala 3 requires covering CompletionKind.Member in enrichWithSymbols
+    // and filtering out the non-member items.
     "type2"
       .tag(IgnoreScala3),
     s"""|object Main {
@@ -165,7 +168,6 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |ArrayDeque
            |ArrayDequeOps
            |""".stripMargin,
-      // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
       "3" -> // ArrayDeque upper is for java, the lower for scala
         """|ArrayDeque[$0]
            |ArrayDeque[$0]
@@ -200,9 +202,7 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |IterableOnce[$0] {}
            |""".stripMargin,
       "3" ->
-        // scala 3 new completions not implemented, so no way to distinguish if we are at a type position
-        """|Iterable
-           |Iterable[$0] {}
+        """|Iterable[$0] {}
            |IterableOnce[$0] {}
            |""".stripMargin,
     ),
@@ -224,7 +224,6 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |IterableOnce[$0]
            |""".stripMargin,
       "3" ->
-        // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
         """|Iterable[$0]
            |IterableOnce[$0]
            |""".stripMargin,
@@ -246,7 +245,6 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |Iterable[$0]
            |IterableOnce[$0]
            |""".stripMargin,
-      // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
       "3" ->
         """|Iterable[$0]
            |IterableOnce[$0]
@@ -366,7 +364,9 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
        |""".stripMargin,
     // additional completion when apply method is present
     compat = Map(
-      "3" -> // TODO: please double check
+      // Note: the class and trait items in here are invalid. So
+      // they are filtered out.
+      "3" ->
         """|Try
            |Try($0)
            |TryMethods

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -141,6 +141,16 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
   )
 
   checkSnippet(
+    "empty-params-with-implicit".only,
+    s"""|object Main {
+        |  def doSomething()(implicit x: Int) = x
+        |  val bar = doSomethi@@
+        |}
+        |""".stripMargin,
+    "doSomething($0)",
+  )
+
+  checkSnippet(
     // handling this in Scala 3 requires covering CompletionKind.Member in enrichWithSymbols
     // and filtering out the non-member items.
     "type2"

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -359,6 +359,20 @@ class CompletionSuite extends BaseCompletionSuite {
        |CertPathBuilderException - java.security.cert
        |PKIXCertPathBuilderResult - java.security.cert
        |""".stripMargin,
+    compat = Map(
+      "2" ->
+        """|ProcessBuilder java.lang
+           |ProcessBuilder - scala.sys.process
+           |CertPathBuilder - java.security.cert
+           |CertPathBuilderSpi - java.security.cert
+           |ProcessBuilderImpl - scala.sys.process
+           |CertPathBuilderResult - java.security.cert
+           |PKIXBuilderParameters - java.security.cert
+           |PooledConnectionBuilder - javax.sql
+           |CertPathBuilderException - java.security.cert
+           |PKIXCertPathBuilderResult - java.security.cert
+           |""".stripMargin
+    ),
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -353,7 +353,6 @@ class CompletionSuite extends BaseCompletionSuite {
        |ProcessBuilder - scala.sys.process
        |CertPathBuilder - java.security.cert
        |CertPathBuilderSpi - java.security.cert
-       |ProcessBuilderImpl - scala.sys.process
        |CertPathBuilderResult - java.security.cert
        |PKIXBuilderParameters - java.security.cert
        |PooledConnectionBuilder - javax.sql
@@ -384,7 +383,6 @@ class CompletionSuite extends BaseCompletionSuite {
       "3" ->
         """|TrieMap scala.collection.concurrent
            |TrieMap[K, V](elems: (K, V)*): CC[K, V]
-           |TrieMapSerializationEnd - scala.collection.concurrent
            |""".stripMargin,
     ),
   )
@@ -910,9 +908,8 @@ class CompletionSuite extends BaseCompletionSuite {
        |""".stripMargin,
     compat = Map(
       "3" ->
-        """|ListBuffer[A](elems: A*): CC[A]
-           |ListBuffer - scala.collection.mutable
-           |""".stripMargin
+        """ListBuffer - scala.collection.mutable
+          |""".stripMargin
     ),
   )
 
@@ -926,8 +923,7 @@ class CompletionSuite extends BaseCompletionSuite {
        |""".stripMargin,
     compat = Map(
       "3" ->
-        """|ListBuffer[A](elems: A*): CC[A]
-           |ListBuffer - scala.collection.mutable
+        """|ListBuffer - scala.collection.mutable
            |""".stripMargin
     ),
   )
@@ -965,8 +961,6 @@ class CompletionSuite extends BaseCompletionSuite {
            |Some[A](value: A): Some[A]
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
            |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
-           |SomeToExpr - scala.quoted.ToExpr
-           |SomeFromExpr - scala.quoted.FromExpr
            |""".stripMargin,
       "3" ->
         """|Some scala
@@ -994,8 +988,6 @@ class CompletionSuite extends BaseCompletionSuite {
            |Some[A](value: A): Some[A]
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
            |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
-           |SomeToExpr - scala.quoted.ToExpr
-           |SomeFromExpr - scala.quoted.FromExpr
            |""".stripMargin,
       "3" ->
         """|Some scala

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -681,9 +681,6 @@ class CompletionSuite extends BaseCompletionSuite {
     """.stripMargin,
     """|concat[T: ClassTag](xss: Array[T]*): Array[T]
        |""".stripMargin,
-    compat = Map(
-      "3" -> "concat[T: ClassTag](xss: Array[T]*): Array[T]"
-    ),
   )
 
   check(
@@ -907,9 +904,6 @@ class CompletionSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|selectDynamic(field: String): Foo
        |""".stripMargin,
-    compat = Map(
-      "3" -> "selectDynamic(field: String): Foo"
-    ),
   )
 
   check(
@@ -920,11 +914,6 @@ class CompletionSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|ListBuffer - scala.collection.mutable
        |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """ListBuffer - scala.collection.mutable
-          |""".stripMargin
-    ),
   )
 
   check(
@@ -935,15 +924,14 @@ class CompletionSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|ListBuffer - scala.collection.mutable
        |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|ListBuffer - scala.collection.mutable
-           |""".stripMargin
-    ),
   )
 
   check(
-    "type2".tag(IgnoreScala3),
+    "type2"
+      // covering it for Scala 3 has to do with covering the
+      // CompletionKind.Member case in enrichWithSymbolSearch.
+      // The non-members have to get filtered out.
+      .tag(IgnoreScala3),
     s"""|object Main {
         |  new scala.Iterable@@
         |}

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -115,6 +115,15 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |)
        |""".stripMargin,
     filter = _ == "Future - scala.concurrent",
+    compat = Map(
+      "2" ->
+        """|package `import-conflict3`
+           |import java.util.concurrent.Future
+           |case class Foo(
+           |  name: scala.concurrent.Future
+           |)
+           |""".stripMargin
+    ),
   )
 
   checkEdit(
@@ -132,6 +141,15 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |)
        |""".stripMargin,
     filter = _ == "Future - scala.concurrent",
+    compat = Map(
+      "2" ->
+        """|package `import-conflict4`
+           |import java.util.concurrent._
+           |case class Foo(
+           |  name: scala.concurrent.Future
+           |)
+           |""".stripMargin
+    ),
   )
 
   checkEdit(
@@ -150,6 +168,16 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |)
        |""".stripMargin,
     filter = _ == "Future - scala.concurrent",
+    compat = Map(
+      "2" ->
+        """|package `import-no-conflict`
+           |import java.util.concurrent.{Future => _, _}
+           |import scala.concurrent.Future
+           |case class Foo(
+           |  name: Future
+           |)
+           |""".stripMargin
+    ),
   )
 
   checkEdit(
@@ -180,6 +208,14 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
       |import java.util.concurrent.CompletableFuture
       |object Main extends CompletableFuture[$0]
       |""".stripMargin,
+    compat = Map(
+      "2" ->
+        """package pkg
+          |
+          |import java.util.concurrent.CompletableFuture
+          |object Main extends CompletableFuture
+          |""".stripMargin
+    ),
   )
 
   checkEdit(
@@ -192,6 +228,14 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
       |import java.util.concurrent.CompletableFuture
       |object Main extends CompletableFuture[$0]
       |""".stripMargin,
+    compat = Map(
+      "2" ->
+        """package pkg
+          |
+          |import java.util.concurrent.CompletableFuture
+          |object Main extends CompletableFuture
+          |""".stripMargin
+    ),
   )
 
   checkEdit(
@@ -305,6 +349,16 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     filter = _.contains("java.util"),
+    compat = Map(
+      "2" ->
+        """|import java.util.ArrayDeque
+           |object Main {
+           |  def foo(): Unit = null match {
+           |    case x: ArrayDeque =>
+           |  }
+           |}
+           |""".stripMargin
+    ),
   )
 
   checkEdit(
@@ -323,6 +377,16 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     filter = _.contains("scala.util"),
+    compat = Map(
+      "2" ->
+        """|import scala.util.Failure
+           |object Main {
+           |  def foo(): Unit = {
+           |    val x: Failure
+           |  }
+           |}
+           |""".stripMargin
+    ),
   )
 
   checkEdit(

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -445,18 +445,18 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "annotation-def",
+    "annotation-def-with-middle-space",
     """|
        |object Main {
        |  @noinline
-       |  def foo: ArrayBuffer@@[Int] = ???
+       |  def foo: ArrayBuffer@@ [Int] = ???
        |}
        |""".stripMargin,
     """|import scala.collection.mutable.ArrayBuffer
        |
        |object Main {
        |  @noinline
-       |  def foo: ArrayBuffer[Int] = ???
+       |  def foo: ArrayBuffer [Int] = ???
        |}
        |""".stripMargin,
     filter = _ == "ArrayBuffer - scala.collection.mutable",
@@ -581,7 +581,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "parent-object-scala2".tag(IgnoreScala3),
+    "parent-object",
     """|object Main {
        |  Implicits@@
        |}
@@ -592,6 +592,14 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     filter = _ == "Implicits - scala.concurrent.ExecutionContext",
+    compat = Map {
+      "3" ->
+        """|import scala.concurrent.ExecutionContext.Implicits
+           |object Main {
+           |  Implicits
+           |}
+           |""".stripMargin
+    },
   )
 
   // this test was intended to check that import is rendered correctly - without `$` symbol

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -111,7 +111,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """|package `import-conflict3`
        |import java.util.concurrent.Future
        |case class Foo(
-       |  name: scala.concurrent.Future
+       |  name: scala.concurrent.Future[$0]
        |)
        |""".stripMargin,
     filter = _ == "Future - scala.concurrent",
@@ -128,7 +128,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """|package `import-conflict4`
        |import java.util.concurrent._
        |case class Foo(
-       |  name: scala.concurrent.Future
+       |  name: scala.concurrent.Future[$0]
        |)
        |""".stripMargin,
     filter = _ == "Future - scala.concurrent",
@@ -146,7 +146,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |import java.util.concurrent.{Future => _, _}
        |import scala.concurrent.Future
        |case class Foo(
-       |  name: Future
+       |  name: Future[$0]
        |)
        |""".stripMargin,
     filter = _ == "Future - scala.concurrent",
@@ -178,7 +178,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """package pkg
       |
       |import java.util.concurrent.CompletableFuture
-      |object Main extends CompletableFuture
+      |object Main extends CompletableFuture[$0]
       |""".stripMargin,
   )
 
@@ -190,7 +190,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """package pkg
       |
       |import java.util.concurrent.CompletableFuture
-      |object Main extends CompletableFuture
+      |object Main extends CompletableFuture[$0]
       |""".stripMargin,
   )
 
@@ -300,7 +300,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """|import java.util.ArrayDeque
        |object Main {
        |  def foo(): Unit = null match {
-       |    case x: ArrayDeque =>
+       |    case x: ArrayDeque[$0] =>
        |  }
        |}
        |""".stripMargin,
@@ -318,7 +318,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """|import scala.util.Failure
        |object Main {
        |  def foo(): Unit = {
-       |    val x: Failure
+       |    val x: Failure[$0]
        |  }
        |}
        |""".stripMargin,
@@ -682,12 +682,6 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |Future - java.util.concurrent
        |""".stripMargin,
     topLines = Some(2),
-    compat = Map(
-      "3" ->
-        """|Future scala.concurrent
-           |Future[T](body: => T)(implicit executor: ExecutionContext): Future[T]
-           |""".stripMargin
-    ),
   )
 
   check(
@@ -703,11 +697,5 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |Future - scala.concurrent
        |""".stripMargin,
     topLines = Some(2),
-    compat = Map(
-      "3" ->
-        """|Future java.util.concurrent
-           |Future[T](body: => T)(implicit executor: ExecutionContext): scala.concurrent.Future[T]
-           |""".stripMargin
-    ),
   )
 }

--- a/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
@@ -164,7 +164,6 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
                  |""".stripMargin,
             "3" ->
               """|TrieMap - scala.collection.concurrent
-                 |TrieMapSerializationEnd - scala.collection.concurrent
                  |TrieMap[K, V](elems: (K, V)*): CC[K, V]
                  |""".stripMargin,
           ),


### PR DESCRIPTION
it **partially** resolves #3954 
it **partially** resolves #3956
-  **filtering out invalid trait, object, class, import, or apply method completions** according to position for scala 3.
-  adding **square bracket suffix** where relevant for type, new, and instantiation completions, for scala 3.
-  adding **curly brace suffix** in new completions of trait, abstract, java interface types for scala 3.
-  applying **filtering** without enriching with symbols on the **interpolate completions**

**Not covered in the PR:**

https://github.com/scalameta/metals-feature-requests/issues/292

- member completion for Scala 3 as in:
 ```
object A {
   new scala.Iterable@@
}
```
Covering it requires covering the case for `CompletionKind.Members` in `enrichWithSymbolSearch` and **filtering out the non-members,** in a similar way to the `postProcess` method in `CompletionApplication`.

