### PR TITLE
fix: return all inversed dependencies in `inverseDependenciesAll`

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -556,8 +556,8 @@ object BuildTargets {
                 // in Bloop to compile only `B` than `A+B`.
                 leaves += head
             }
-            loop(tail)
           }
+          loop(tail)
       }
     loop(root)
     InverseDependencies(isVisited, leaves)


### PR DESCRIPTION
Previously, when project contained module which was aggregating all other modules Metals might omit some build targets when computing `inverseDependenciesAll`.
In the following example, Metals were omitting build targets `D` and `E` (maybe not always as this might be non deterministic).
(note: this graph shows dependency relation between projects)
[![](https://mermaid.ink/img/pako:eNpNjkEOwiAQRa9C_rq9AAsTW3oCXRk2kzJaokCDsDBN7y6KJsxqXt5LZjbMwTAkbpHWRZyV9qLMUfT9QQwVhi9cWjNWGFtTQbUwVVA1QwfH0ZE15d72URppYccasqyG4l1D-710eTWUeDI2hQh5pceTO1BO4fTyM2SKmf-RslR-d79qfwO_1jrn)](https://mermaid.live/edit#pako:eNpNjkEOwiAQRa9C_rq9AAsTW3oCXRk2kzJaokCDsDBN7y6KJsxqXt5LZjbMwTAkbpHWRZyV9qLMUfT9QQwVhi9cWjNWGFtTQbUwVVA1QwfH0ZE15d72URppYccasqyG4l1D-710eTWUeDI2hQh5pceTO1BO4fTyM2SKmf-RslR-d79qfwO_1jrn)

Now, `inverseDependenciesAll` return all projects.

---

This bug was affecting all features which were using `inverseDependenciesAll`, in my case it was `find definitions` and `find all references`