### PR TITLE
[WIP] Import missing given instance

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
@@ -50,7 +50,10 @@ class ImportMissingSymbol(compilers: Compilers) extends CodeAction {
 
             val codeAction = new l.CodeAction()
 
-            codeAction.setTitle(ImportMissingSymbol.title(name, i.packageName))
+            val importName = i.name.asScala.getOrElse(name)
+            codeAction.setTitle(
+              ImportMissingSymbol.title(importName, i.packageName)
+            )
             codeAction.setKind(l.CodeActionKind.QuickFix)
             codeAction.setDiagnostics(List(diagnostic).asJava)
             codeAction.setEdit(edit)

--- a/mtags-interfaces/src/main/java/scala/meta/pc/AutoImportsResult.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/AutoImportsResult.java
@@ -1,9 +1,11 @@
 package scala.meta.pc;
 
 import java.util.List;
+import java.util.Optional;
 import org.eclipse.lsp4j.TextEdit;
 
 public interface AutoImportsResult {
   public String packageName();
   public List<TextEdit> edits();
+  public Optional<String> name();
 }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -69,7 +69,7 @@ final class AutoImportsProvider(
             val nameEdit = new TextEdit(namePos, short)
             nameEdit :: edits
         }
-        AutoImportsResultImpl(pkg, edits.asJava)
+        AutoImportsResultImpl(pkg, edits.asJava, java.util.Optional.empty())
     }
   }
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -83,10 +83,14 @@ final class AutoImportsProvider(
 
       for
         sym <- results
-        edits <- generator.forSymbol(sym)
+        importOwner = sym.owner.companionModule.is(Given)
+        impSym = if importOwner then sym.owner else sym
+        edits <- generator.forSymbol(impSym)
       yield AutoImportsResultImpl(
-        sym.owner.showFullName,
+        impSym.owner.showFullName,
         edits.asJava,
+        if importOwner then Some(impSym.name.show).asJava
+        else ju.Optional.empty(),
       )
     else List.empty
     end if

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
@@ -34,6 +34,7 @@ object SemanticdbSymbols:
       else
         val (desc, parent) = DescriptorParser(s)
         val parentSymbol = loop(parent)
+        // TODO: toplevel
 
         def tryMember(sym: Symbol): List[Symbol] =
           sym match

--- a/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsResultImpl.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/AutoImportsResultImpl.scala
@@ -6,5 +6,8 @@ import scala.meta.pc.AutoImportsResult
 
 import org.eclipse.lsp4j.TextEdit
 
-case class AutoImportsResultImpl(packageName: String, edits: ju.List[TextEdit])
-    extends AutoImportsResult
+case class AutoImportsResultImpl(
+    packageName: String,
+    edits: ju.List[TextEdit],
+    name: ju.Optional[String]
+) extends AutoImportsResult


### PR DESCRIPTION
refer to https://github.com/scalameta/metals-feature-requests/issues/141

This PR enables us to import missing given instance

![import-given](https://user-images.githubusercontent.com/9353584/180139443-81c32a8e-abc4-42c7-b9a9-ab6b12352afc.gif)

## TODO
- parse top-level given
- testing

## There're some limitations:

- we don't filter missing instances by type, so if there's `stringOrd: Ord[String]`, we will receive suggestions both for `intOrd` and `stringOrd`, I'm wondering can we filter it with a reasonable computation cost 🤔 
- if there's no explicit method definition under the given instances 
  - for example, we can't find `lt` and `gt` because they're not under given instances.

```scala
trait Ord[T]:
  def compare(x: T, y: T): Int
  extension (x: T) def lt (y: T): Boolean = compare(x, y) > 0
  extension (x: T) def gt (y: T): Boolean = compare(x, y) < 0

given intOrd: Ord[Int] with
  def compare(x: Int, y: Int): Int = if x < y then 1 else -1
```



