### PR TITLE
bugfix: [Scala 3] Show correct param names in java methods

### DIFF
--- a/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
@@ -99,4 +99,19 @@ class HoverDocSuite extends BaseHoverSuite {
     ),
   )
 
+  check(
+    "java-method",
+    """|import java.nio.file.Paths
+       |
+       |object O{
+       |  <<Paths.g@@et("")>>
+       |}
+       |""".stripMargin,
+    """|```scala
+       |def get(first: String, more: String*): Path
+       |```
+       |Converts a path string, or a sequence of strings that when joined form
+       |a path string, to a `Path`.
+       |""".stripMargin,
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -310,8 +310,8 @@ class CompletionSuite extends BaseCompletionSuite {
            |synchronized[X0](x$0: X0): X0
            |toString(): String
            |wait(): Unit
-           |wait(x$0: Long): Unit
-           |wait(x$0: Long, x$1: Int): Unit
+           |wait(timeoutMillis: Long): Unit
+           |wait(timeoutMillis: Long, nanos: Int): Unit
            |""".stripMargin,
     ),
   )


### PR DESCRIPTION
Previously, we would show params in Java methods as $x0 etc. Now, we show the correct name based on the information cached in Metals.