### PR TITLE
fix: request configuration before connecting to build server

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -290,8 +290,6 @@ object UserConfiguration {
       properties: Properties = System.getProperties,
   ): Either[List[String], UserConfiguration] = {
     val errors = ListBuffer.empty[String]
-    val base: JsonObject =
-      Option(json.getAsJsonObject("metals")).getOrElse(new JsonObject)
 
     def getKey[A](
         key: String,
@@ -311,7 +309,7 @@ object UserConfiguration {
     def getSubKey(key: String): Option[JsonObject] =
       getKey(
         key,
-        base,
+        json,
         { value =>
           Try(value.getAsJsonObject())
             .fold(
@@ -324,7 +322,7 @@ object UserConfiguration {
         },
       )
     def getStringKey(key: String): Option[String] =
-      getStringKeyOnObj(key, base)
+      getStringKeyOnObj(key, json)
 
     def getStringKeyOnObj(
         key: String,
@@ -349,7 +347,7 @@ object UserConfiguration {
     def getBooleanKey(key: String): Option[Boolean] =
       getKey(
         key,
-        base,
+        json,
         { value =>
           Try(value.getAsBoolean())
             .fold(
@@ -375,7 +373,7 @@ object UserConfiguration {
     def getStringListKey(key: String): Option[List[String]] =
       getKey[List[String]](
         key,
-        base,
+        json,
         { elem =>
           if (elem.isJsonArray()) {
             val parsed = elem.getAsJsonArray().asScala.flatMap { value =>
@@ -398,7 +396,7 @@ object UserConfiguration {
     def getStringMap(key: String): Option[Map[String, String]] =
       getKey(
         key,
-        base,
+        json,
         { value =>
           Try {
             for {
@@ -532,7 +530,7 @@ object UserConfiguration {
 
   def parse(config: String): JsonObject = {
     import JsonParser._
-    s"""{"metals": $config}""".parseJson.getAsJsonObject
+    config.parseJson.getAsJsonObject
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/DelegatingLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/DelegatingLanguageClient.scala
@@ -1,12 +1,14 @@
 package scala.meta.internal.metals.clients.language
 
 import java.util.concurrent.CompletableFuture
+import java.{util => ju}
 
 import scala.meta.internal.decorations.PublishDecorationsParams
 import scala.meta.internal.tvp._
 
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams
 import org.eclipse.lsp4j.ApplyWorkspaceEditResponse
+import org.eclipse.lsp4j.ConfigurationParams
 import org.eclipse.lsp4j.ExecuteCommandParams
 import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
@@ -106,4 +108,9 @@ class DelegatingLanguageClient(var underlying: MetalsLanguageClient)
 
   override def refreshModel(): CompletableFuture[Unit] =
     underlying.refreshModel()
+
+  override def configuration(
+      configurationParams: ConfigurationParams
+  ): CompletableFuture[ju.List[Object]] =
+    underlying.configuration(configurationParams)
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -71,6 +71,7 @@ import scala.meta.io.RelativePath
 import _root_.org.eclipse.lsp4j.DocumentSymbolCapabilities
 import ch.epfl.scala.{bsp4j => b}
 import com.google.gson.JsonElement
+import com.google.gson.JsonObject
 import munit.Tag
 import org.eclipse.lsp4j.ClientCapabilities
 import org.eclipse.lsp4j.CodeActionContext
@@ -705,7 +706,12 @@ final case class TestingServer(
 
   def didChangeConfiguration(config: String): Future[Unit] = {
     val json = UserConfiguration.parse(config)
-    val params = new DidChangeConfigurationParams(json)
+
+    // lsp -didChangeConfiguration method should be called with a wrapped object
+    val didChangeJson = new JsonObject()
+    didChangeJson.add("metals", json)
+
+    val params = new DidChangeConfigurationParams(didChangeJson)
     server.didChangeConfiguration(params).asScala
   }
 


### PR DESCRIPTION
Use `workspace/configuration` call to the client to sync userConfiguration before starting an actual server
initialization.

`didChangeConfiguration` notification call happens after `initialized`
that leads that server uses a default config during connecting to the
build server and doesn't use the actual value of `bloopVersion` setting