### PR TITLE
feat: Auto complete (missing) extension methods

### DIFF
--- a/metals-bench/src/main/scala/bench/ClasspathOnlySymbolSearch.scala
+++ b/metals-bench/src/main/scala/bench/ClasspathOnlySymbolSearch.scala
@@ -42,4 +42,12 @@ class ClasspathOnlySymbolSearch(classpath: ClasspathSearch)
   ): SymbolSearch.Result = {
     classpath.search(WorkspaceSymbolQuery.exact(query), visitor)
   }
+
+  override def searchMethods(
+      query: String,
+      buildTargetIdentifier: String,
+      visitor: SymbolSearchVisitor,
+  ): SymbolSearch.Result = {
+    SymbolSearch.Result.COMPLETE
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -30,6 +30,7 @@ import scala.meta.internal.metals.doctor.Doctor
 import scala.meta.internal.metals.watcher.FileWatcher
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.semanticdb.Scala._
+import scala.meta.internal.semanticdb.SymbolInformation.Kind
 import scala.meta.internal.tvp.TreeViewProvider
 import scala.meta.internal.worksheets.WorksheetProvider
 import scala.meta.io.AbsolutePath
@@ -430,11 +431,34 @@ final case class Indexer(
         val reluri = source.toIdeallyRelativeURI(sourceItem)
         val input = sourceToIndex0.toInput
         val symbols = ArrayBuffer.empty[WorkspaceSymbolInformation]
+        val methodSymbols = ArrayBuffer.empty[WorkspaceSymbolInformation]
         SemanticdbDefinition.foreach(input, dialect) {
           case SemanticdbDefinition(info, occ, owner) =>
-            if (WorkspaceSymbolProvider.isRelevantKind(info.kind)) {
+            // TODO: Do not index (extension) METHOD, they will be indexed later
+            // we index methods for auto-import missing extension methods feature for now
+            // but those feature should use methodSymbols
+            if (
+              WorkspaceSymbolProvider.isRelevantKind(
+                info.kind
+              ) || info.kind == Kind.METHOD
+            ) {
               occ.range.foreach { range =>
                 symbols += WorkspaceSymbolInformation(
+                  info.symbol,
+                  info.kind,
+                  range.toLSP,
+                )
+              }
+            }
+            // what we really want to index are "extension" methods
+            // However, we filter by `Kind.Method` because semanticdb doesn't have properties
+            // that represents "extension".
+            // Knowing `SemanticdbDefinition.foreach` uses `ScalaToplevelMtags` and it puts
+            // `Kind.Method` only to extension methods, we can safely filter extension methods
+            // by `info.kind == Kind.Method`. (TODO: add exntension properties to semanticdb schema).
+            if (info.kind == Kind.METHOD) {
+              occ.range.foreach { range =>
+                methodSymbols += WorkspaceSymbolInformation(
                   info.symbol,
                   info.kind,
                   range.toLSP,
@@ -454,7 +478,7 @@ final case class Indexer(
               )
             }
         }
-        workspaceSymbols().didChange(source, symbols.toSeq)
+        workspaceSymbols().didChange(source, symbols.toSeq, methodSymbols.toSeq)
 
         // Since the `symbols` here are toplevel symbols,
         // we cannot use `symbols` for expiring the cache for all symbols in the source.

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -437,6 +437,7 @@ final case class Indexer(
             // TODO: Do not index (extension) METHOD, they will be indexed later
             // we index methods for auto-import missing extension methods feature for now
             // but those feature should use methodSymbols
+            // see: https://github.com/scalameta/metals/issues/4212
             if (
               WorkspaceSymbolProvider.isRelevantKind(
                 info.kind

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsSymbolSearch.scala
@@ -99,4 +99,16 @@ class MetalsSymbolSearch(
       Some(new BuildTargetIdentifier(buildTargetIdentifier)),
     )
   }
+
+  override def searchMethods(
+      query: String,
+      buildTargetIdentifier: String,
+      visitor: SymbolSearchVisitor,
+  ): SymbolSearch.Result = {
+    wsp.searchMethods(
+      query,
+      visitor,
+      Some(new BuildTargetIdentifier(buildTargetIdentifier)),
+    )
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -105,6 +105,16 @@ class StandaloneSymbolSearch(
       .map(_.search(query, buildTargetIdentifier, visitor))
       .getOrElse(res)
   }
+
+  def searchMethods(
+      query: String,
+      buildTargetIdentifier: String,
+      visitor: SymbolSearchVisitor,
+  ): Result = {
+    workspaceFallback
+      .map(_.searchMethods(query, buildTargetIdentifier, visitor))
+      .getOrElse(Result.COMPLETE)
+  }
 }
 
 object StandaloneSymbolSearch {

--- a/mtags-interfaces/src/main/java/scala/meta/pc/SymbolSearch.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/SymbolSearch.java
@@ -43,6 +43,9 @@ public interface SymbolSearch {
     Result search(String query,
                   String buildTargetIdentifier,
                   SymbolSearchVisitor visitor);
+    Result searchMethods(String query,
+                  String buildTargetIdentifier,
+                  SymbolSearchVisitor visitor);
     enum Result {
         COMPLETE,
         INCOMPLETE

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -298,6 +298,19 @@ class Completions(
                 ).forall(visit),
         )
         Some(search.search(query, buildTargetIdentifier, visitor))
+      case CompletionKind.Members if query.nonEmpty =>
+        val visitor = new CompilerSearchVisitor(
+          query,
+          sym =>
+            if sym.is(ExtensionMethod) then
+              completionsWithSuffix(
+                sym,
+                sym.decodedName,
+                CompletionValue.Workspace(_, _, _),
+              ).forall(visit)
+            else false,
+        )
+        Some(search.search(query, buildTargetIdentifier, visitor))
       case _ => None
     end match
   end enrichWithSymbolSearch

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -74,12 +74,19 @@ class Completions(
             (advanced, SymbolSearch.Result.COMPLETE)
           case Select(qual, _) :: _ if qual.tpe.isErroneous =>
             (advanced, SymbolSearch.Result.COMPLETE)
+          case Select(qual, _) :: _ =>
+            val (_, compilerCompletions) = Completion.completions(pos)
+            val (compiler, result) = compilerCompletions
+              .flatMap(toCompletionValues)
+              .filterInteresting(qual.typeOpt.widenDealias)
+            (advanced ++ compiler, result)
           case _ =>
             val (_, compilerCompletions) = Completion.completions(pos)
             val (compiler, result) = compilerCompletions
               .flatMap(toCompletionValues)
               .filterInteresting()
             (advanced ++ compiler, result)
+        end match
 
     val application = CompletionApplication.fromPath(path)
     val ordering = completionOrdering(application)
@@ -271,7 +278,8 @@ class Completions(
     else sym.info.widenTermRefExpr.show
 
   private def enrichWithSymbolSearch(
-      visit: CompletionValue => Boolean
+      visit: CompletionValue => Boolean,
+      qualType: Type = ctx.definitions.AnyType,
   ): Option[SymbolSearch.Result] =
     val query = completionPos.query
     completionPos.kind match
@@ -302,7 +310,9 @@ class Completions(
         val visitor = new CompilerSearchVisitor(
           query,
           sym =>
-            if sym.is(ExtensionMethod) then
+            if sym.is(ExtensionMethod) &&
+              qualType.widenDealias <:< sym.extensionParam.info.widenDealias
+            then
               completionsWithSuffix(
                 sym,
                 sym.decodedName,
@@ -333,7 +343,9 @@ class Completions(
       else sym.fullName.stripModuleClassSuffix.show
 
   extension (l: List[CompletionValue])
-    def filterInteresting(): (List[CompletionValue], SymbolSearch.Result) =
+    def filterInteresting(
+        qualType: Type = ctx.definitions.AnyType
+    ): (List[CompletionValue], SymbolSearch.Result) =
 
       val isSeen = mutable.Set.empty[String]
       val buf = List.newBuilder[CompletionValue]
@@ -370,7 +382,9 @@ class Completions(
 
       l.foreach(visit)
       val searchResult =
-        enrichWithSymbolSearch(visit).getOrElse(SymbolSearch.Result.COMPLETE)
+        enrichWithSymbolSearch(visit, qualType).getOrElse(
+          SymbolSearch.Result.COMPLETE
+        )
       (buf.result, searchResult)
 
   private lazy val isUninterestingSymbol: Set[Symbol] = Set[Symbol](

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -316,7 +316,7 @@ class Completions(
               completionsWithSuffix(
                 sym,
                 sym.decodedName,
-                CompletionValue.Workspace(_, _, _),
+                CompletionValue.Extension(_, _, _),
               ).forall(visit)
             else false,
         )

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -320,8 +320,9 @@ class Completions(
               ).forall(visit)
             else false,
         )
-        Some(search.search(query, buildTargetIdentifier, visitor))
-      case _ => None
+        Some(search.searchMethods(query, buildTargetIdentifier, visitor))
+      case CompletionKind.Members => // query.isEmpry
+        Some(SymbolSearch.Result.INCOMPLETE)
     end match
   end enrichWithSymbolSearch
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
@@ -252,7 +252,10 @@ class CompletionsProvider(
 
     val completionTextSuffix = completion.snippetSuffix.getOrElse("")
     completion match
-      case CompletionValue.Workspace(label, sym, suffix) =>
+      case v: (CompletionValue.Workspace | CompletionValue.Extension) =>
+        val label = v.label
+        val sym = v.symbol
+        val suffix = v.snippetSuffix
         path match
           case (_: Ident) :: (_: Import) :: _ =>
             mkWorkspaceItem(
@@ -287,6 +290,7 @@ class CompletionsProvider(
                       ident,
                       sym.fullNameBackticked + completionTextSuffix,
                     )
+        end match
       case CompletionValue.Override(
             label,
             value,

--- a/mtags/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolQuery.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolQuery.scala
@@ -29,6 +29,12 @@ case class WorkspaceSymbolQuery(
     WorkspaceSymbolQuery.isRelevantKind(info.kind) &&
     this.matches(info.symbol)
   }
+
+  def matches(info: SymbolInformation, additionalKinds: Kind): Boolean = {
+    (WorkspaceSymbolQuery.isRelevantKind(info.kind)
+      || info.kind == additionalKinds) &&
+    this.matches(info.symbol)
+  }
 }
 
 object WorkspaceSymbolQuery {

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
@@ -159,7 +159,15 @@ class ScalaToplevelMtags(
           acceptTrivia()
           val name = newIdentifier
           withOwner(currRegion.owner) {
-            term(name.name, name.pos, Kind.OBJECT, 0)
+            term(
+              name.name,
+              name.pos,
+              // hack: (exclusively) making symbol kind of extension methods to Kind.Method
+              // so that we can tell it's an extension method in Indexer.scala
+              // TODO: add properties that represents "extension" method to semanticdb schema
+              Kind.METHOD,
+              0
+            )
           }
           loop(indent, isAfterNewline = false, region, newExpectIgnoreBody)
         case DEF | VAL | VAR | GIVEN | TYPE

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
@@ -165,6 +165,7 @@ class ScalaToplevelMtags(
               // hack: (exclusively) making symbol kind of extension methods to Kind.Method
               // so that we can tell it's an extension method in Indexer.scala
               // TODO: add properties that represents "extension" method to semanticdb schema
+              // see: https://github.com/scalameta/scalameta/issues/2799
               Kind.METHOD,
               0
             )

--- a/mtags/src/main/scala/scala/meta/internal/pc/EmptySymbolSearch.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/EmptySymbolSearch.scala
@@ -20,6 +20,14 @@ object EmptySymbolSearch extends SymbolSearch {
     SymbolSearch.Result.COMPLETE
   }
 
+  override def searchMethods(
+      query: String,
+      buildTargetIdentifier: String,
+      visitor: SymbolSearchVisitor
+  ): SymbolSearch.Result = {
+    SymbolSearch.Result.COMPLETE
+  }
+
   def definition(symbol: String, source: URI): ju.List[Location] = {
     ju.Collections.emptyList()
   }

--- a/tests/cross/src/test/scala/tests/pc/CompletionExtensionMethodSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionExtensionMethodSuite.scala
@@ -1,0 +1,118 @@
+package tests.pc
+
+import tests.BaseCompletionSuite
+
+class CompletionExtensionMethodSuite extends BaseCompletionSuite {
+
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala2)
+
+  check(
+    "simple",
+    """|package example
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def incr: Int = num + 1
+       |
+       |def main = 100.inc@@
+       |""".stripMargin,
+    """|incr: Int (extension)
+       |""".stripMargin,
+  )
+
+  check(
+    "simple2",
+    """|package example
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def incr: Int = num + 1
+       |
+       |def main = 100.i@@
+       |""".stripMargin,
+    """|incr: Int (extension)
+       |""".stripMargin,
+    filter = _.contains("(extension)"),
+  )
+
+  check(
+    "filter-by-type",
+    """|package example
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def incr: Int = num + 1
+       |  extension (str: String)
+       |    def identity: String = str
+       |
+       |def main = "foo".i@@
+       |""".stripMargin,
+    """|identity: String (extension)
+       |""".stripMargin, // incr won't be available
+    filter = _.contains("(extension)"),
+  )
+
+  check(
+    "filter-by-type-subtype",
+    """|package example
+       |
+       |class A
+       |class B extends A
+       |
+       |object enrichments:
+       |  extension (a: A)
+       |    def doSomething: A = a
+       |
+       |def main = (new B).do@@
+       |""".stripMargin,
+    """|doSomething: A (extension)
+       |""".stripMargin,
+    filter = _.contains("(extension)"),
+  )
+
+  checkEdit(
+    "simple-edit",
+    """|package example
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def incr: Int = num + 1
+       |
+       |def main = 100.inc@@
+       |""".stripMargin,
+    """|package example
+       |
+       |import example.enrichments.incr
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def incr: Int = num + 1
+       |
+       |def main = 100.incr
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "simple-edit-suffix",
+    """|package example
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def plus(other: Int): Int = num + other
+       |
+       |def main = 100.pl@@
+       |""".stripMargin,
+    """|package example
+       |
+       |import example.enrichments.plus
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def plus(other: Int): Int = num + other
+       |
+       |def main = 100.plus($0)
+       |""".stripMargin,
+  )
+
+}

--- a/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
+++ b/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
@@ -8,11 +8,13 @@ import java.{util => ju}
 import scala.meta.inputs.Input
 import scala.meta.internal.metals.ClasspathSearch
 import scala.meta.internal.metals.Docstrings
+import scala.meta.internal.metals.WorkspaceSymbolInformation
 import scala.meta.internal.metals.WorkspaceSymbolQuery
 import scala.meta.internal.mtags.GlobalSymbolIndex
 import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.mtags.Symbol
+import scala.meta.internal.{semanticdb => s}
 import scala.meta.pc.ParentSymbols
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
@@ -83,5 +85,21 @@ class TestingSymbolSearch(
     val query = WorkspaceSymbolQuery.exact(textQuery)
     workspace.search(query, visitor)
     classpath.search(query, visitor)
+  }
+
+  override def searchMethods(
+      textQuery: String,
+      buildTargetIdentifier: String,
+      visitor: SymbolSearchVisitor,
+  ): SymbolSearch.Result = {
+    val query = WorkspaceSymbolQuery.exact(textQuery)
+    workspace.search(
+      query,
+      visitor,
+      (info: WorkspaceSymbolInformation) => {
+        info.sematicdbKind == s.SymbolInformation.Kind.METHOD
+      },
+    )
+    SymbolSearch.Result.COMPLETE
   }
 }

--- a/tests/mtest/src/main/scala/tests/TestingWorkspaceSearch.scala
+++ b/tests/mtest/src/main/scala/tests/TestingWorkspaceSearch.scala
@@ -7,7 +7,9 @@ import scala.collection.mutable
 import scala.meta.Dialect
 import scala.meta.inputs.Input
 import scala.meta.internal.metals.SemanticdbDefinition
+import scala.meta.internal.metals.WorkspaceSymbolInformation
 import scala.meta.internal.metals.WorkspaceSymbolQuery
+import scala.meta.internal.{semanticdb => s}
 import scala.meta.pc.SymbolSearchVisitor
 
 object TestingWorkspaceSearch {
@@ -17,20 +19,26 @@ object TestingWorkspaceSearch {
 class TestingWorkspaceSearch {
   val inputs: mutable.Map[String, (String, Dialect)] =
     mutable.Map.empty[String, (String, Dialect)]
-  def search(query: WorkspaceSymbolQuery, visitor: SymbolSearchVisitor): Unit =
+  def search(
+      query: WorkspaceSymbolQuery,
+      visitor: SymbolSearchVisitor,
+      filter: WorkspaceSymbolInformation => Boolean = _ => true,
+  ): Unit =
     for {
       (path, (text, dialect)) <- inputs
     } {
       SemanticdbDefinition.foreach(Input.VirtualFile(path, text), dialect) {
         defn =>
-          if (query.matches(defn.info)) {
+          if (query.matches(defn.info, s.SymbolInformation.Kind.METHOD)) {
             val c = defn.toCached
-            visitor.visitWorkspaceSymbol(
-              Paths.get(path),
-              c.symbol,
-              c.kind,
-              c.range,
-            )
+            if (filter(c)) {
+              visitor.visitWorkspaceSymbol(
+                Paths.get(path),
+                c.symbol,
+                c.kind,
+                c.range,
+              )
+            }
           }
       }
     }

--- a/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
@@ -93,6 +93,12 @@ class CompletionCrossLspSuite
         filter = _.contains("plus"),
       )
       _ <- assertCompletion(
+        "1.plu@@",
+        """|plus(other: Int): Int (extension)
+           |""".stripMargin,
+        filter = _.contains("plus"),
+      )
+      _ <- assertCompletion(
         "\"plus is not available for string\".plu@@",
         "",
         filter = _.contains("plus"),

--- a/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
@@ -92,6 +92,11 @@ class CompletionCrossLspSuite
            |""".stripMargin,
         filter = _.contains("plus"),
       )
+      _ <- assertCompletion(
+        "\"plus is not available for string\".plu@@",
+        "",
+        filter = _.contains("plus"),
+      )
     } yield ()
   }
 }

--- a/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
@@ -81,7 +81,7 @@ class CompletionCrossLspSuite
       _ <- server.didOpen("a/src/main/scala/a/B.scala")
       _ = assertNoDiagnostics()
       _ <- assertCompletionEdit(
-        "1.plu@@",
+        "1.p@@",
         """|package a
            |
            |import b.plus
@@ -93,7 +93,7 @@ class CompletionCrossLspSuite
         filter = _.contains("plus"),
       )
       _ <- assertCompletion(
-        "1.plu@@",
+        "1.pl@@",
         """|plus(other: Int): Int (extension)
            |""".stripMargin,
         filter = _.contains("plus"),

--- a/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
+++ b/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
@@ -59,13 +59,17 @@ object MetalsTestEnrichments {
       } {
         val input = source.toInput
         val symbols = ArrayBuffer.empty[WorkspaceSymbolInformation]
+        val methodSymbols = ArrayBuffer.empty[WorkspaceSymbolInformation]
         SemanticdbDefinition.foreach(input, dialect) {
           case defn @ SemanticdbDefinition(info, _, _) =>
             if (WorkspaceSymbolProvider.isRelevantKind(info.kind)) {
               symbols += defn.toCached
             }
+            if (info.kind == s.SymbolInformation.Kind.METHOD) {
+              methodSymbols += defn.toCached
+            }
         }
-        wsp.didChange(source, symbols.toSeq)
+        wsp.didChange(source, symbols.toSeq, methodSymbols.toSeq)
       }
     }
     def indexLibraries(libraries: Seq[Library]): Unit = {


### PR DESCRIPTION
https://github.com/scalameta/metals-feature-requests/issues/282

![auto-complete-extension2](https://user-images.githubusercontent.com/9353584/181419832-6c0362b8-e3a5-4a06-b24e-bd2f76365b08.gif)

<details>
<summary>outdated screen record</summary>

![auto-complete-extension](https://user-images.githubusercontent.com/9353584/180706517-66b36887-21f8-461e-8a4a-f832dbd234b0.gif)

</details>

## Overall architecture
### Index extension methods
Thanks to https://github.com/scalameta/metals/pull/4141, now extension methods are indexed by `MetalsSymbolSearch.`
This PR enables Metals to enrich completions by `enrichWithSymbolSearch,` which includes the extension methods found by symbol search.

Note that, we index extension methods in `val inWorkspaceMethods: TrieMap[Path, Seq[WorkspaceSymbolInformation]]` which is newly created in this PR.

see more details: https://github.com/scalameta/metals/pull/4183#issuecomment-1197614724

### enrichWithSymbolSearch
When `completion.kind == Method`, now Metals search for the extension methods from by `SymbolSearch#searchMethods`.

In `MetalsSymbolSearch`, it implements `searchMethods` to search for extension methods from `inWorkspaceMethods` by `Fuzzy.matches`.

### Filter found extension methods by qualifier's type 

We filter out the extension methods whose extension parameter type doesn't match with the qualifier on the cursor. 

For example

```scala
// A.scala
extension (num: Int)
  def incr = num + 1

// B.scala
def main = "b".inc@@ // we shouldn't suggest `incr` because the types don't match
```

## Tricky part2
~As you can see from the screen record above, Metals can't suggest the extension method `offsetToPos` until we type `off`  or `offsetTo` (it depends... on what...?)~
~This is probably because we index the workspace symbols by trigram in bloom filters, and therefore we can't match the extension method until we type at least `off` 🤔 ~

~Actually, by commenting out 
https://github.com/scalameta/metals/blob/a6299f3a2845d4a751f46d76c90c54b712d66f05/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala#L116 (which we shouldn't do this actually) we could find those symbols by typing `o` or `of`.~

~I believe we can go with the current change as it's still an improvement, but I'm wondering how we can find the extension methods by typing one or two prefixes of the methods without causing the performance deterioration (such as removing the bloom filter check), in the future.~
