### PR TITLE
bugfix: Print local type aliases properly

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
@@ -31,8 +31,6 @@ class SemanticdbTreePrinter(
         val isFunction = symbol.startsWith("scala/Function")
         val sym =
           if (tuple || isFunction) ""
-          // don't print unnamed types
-          else if (symbol.startsWith("local")) "_"
           else printSymbol(symbol)
         val typeArgs = printTypeArgs(typeArguments, tuple, isFunction)
         s"${printPrefix(prefix)}${sym}${typeArgs}"

--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -386,7 +386,7 @@ final class SyntheticsDecorationProvider(
       textDoc.symbols
         .find(_.symbol == symbol)
         .map(_.displayName)
-        .getOrElse(symbol)
+        .getOrElse("_")
     else symbol.desc.name.value
   }
 


### PR DESCRIPTION
Previously, we would not print local type names properly and instead just print "_". Now we search for the display name of that local type alias and display it instead.

Fixes https://github.com/scalameta/metals/issues/4186