### PR TITLE
`extends` keyword completion

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/Keyword.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Keyword.scala
@@ -106,10 +106,9 @@ object Keyword {
     Keyword("macro"), // in-frequently used language feature
     // The keywords below were left out in the first iteration of implementing keyword completions
     // since they appear in positions that are a bit more difficult to detect on the syntax tree.
-    Keyword("extends"),
     Keyword("with"),
     Keyword("catch"),
-    Keyword("extends"),
+    Keyword("extends", isPackage = true),
     Keyword("finally"),
     Keyword("then")
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -486,11 +486,28 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
   )
 
   check(
+    "extends",
+    """
+      |package foo
+      |
+      |class Foo ext@@{
+      |}
+    """.stripMargin,
+    """|extension
+       |extends
+       |""".stripMargin,
+    compat = Map(
+      "2" -> "extends"
+    ),
+  )
+
+  check(
     "topLevel",
     "@@",
     """|abstract class
        |case class
        |class
+       |extends
        |final
        |import
        |object
@@ -526,6 +543,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
                 |sealed abstract class
                 |sealed class
                 |implicit
+                |extends
                 |""".stripMargin
     ),
   )


### PR DESCRIPTION
Support for the completion of `extends` keyword.
It resolves [#68](https://github.com/scalameta/metals-feature-requests/issues/68)