### PR TITLE
fix: index inline extension methods in ScalaToplevelMtags

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
@@ -134,15 +134,22 @@ class ScalaToplevelMtags(
           val nextOwner =
             if (
               dialect.allowToplevelStatements &&
-              needEmitFileOwner(currRegion)
+              currRegion.produceSourceToplevel
             ) {
-              sourceTopLevelAdded = true
-              val pos = newPosition
               val srcName = input.filename.stripSuffix(".scala")
               val name = s"$srcName$$package"
-              withOwner(currRegion.owner) {
-                term(name, pos, Kind.OBJECT, 0)
+              val owner = withOwner(currRegion.owner) {
+                symbol(Descriptor.Term(name))
               }
+
+              if (needEmitFileOwner(currRegion)) {
+                sourceTopLevelAdded = true
+                val pos = newPosition
+                withOwner(currRegion.owner) {
+                  term(name, pos, Kind.OBJECT, 0)
+                }
+              }
+              owner
             } else currentOwner
           scanner.nextToken()
           loop(
@@ -155,13 +162,29 @@ class ScalaToplevelMtags(
           emitMember(false, currRegion.owner)
           loop(indent, isAfterNewline = false, currRegion, newExpectTemplate)
         // also covers extension methods because of `def` inside
-        case DEF if dialect.allowExtensionMethods && currRegion.isExtension =>
+        case DEF
+            // extension group
+            if (dialect.allowExtensionMethods && currRegion.isExtension) =>
           acceptTrivia()
           val name = newIdentifier
           withOwner(currRegion.owner) {
             term(name.name, name.pos, Kind.OBJECT, 0)
           }
           loop(indent, isAfterNewline = false, region, newExpectIgnoreBody)
+        // inline extension method `extension (...) def foo = ...`
+        case DEF if expectTemplate.map(needToParseExtension).getOrElse(false) =>
+          expectTemplate match {
+            case None => fail("never happens")
+            case Some(expect) =>
+              val next =
+                expect.startIndentedRegion(currRegion, expect.isExtension)
+              acceptTrivia()
+              val name = newIdentifier
+              withOwner(next.owner) {
+                term(name.name, name.pos, Kind.OBJECT, 0)
+              }
+              loop(indent, isAfterNewline = false, region, None)
+          }
         case DEF | VAL | VAR | GIVEN | TYPE
             if dialect.allowToplevelStatements &&
               needEmitFileOwner(currRegion) =>

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
@@ -174,13 +174,14 @@ class ScalaToplevelMtags(
         // inline extension method `extension (...) def foo = ...`
         case DEF if expectTemplate.map(needToParseExtension).getOrElse(false) =>
           expectTemplate match {
-            case None => fail("never happens")
+            case None =>
+              fail(
+                "failed while reading 'def' in 'extension (...) def ...', expectTemplate should be set by reading 'extension'."
+              )
             case Some(expect) =>
-              val next =
-                expect.startIndentedRegion(currRegion, expect.isExtension)
               acceptTrivia()
               val name = newIdentifier
-              withOwner(next.owner) {
+              withOwner(expect.owner) {
                 term(name.name, name.pos, Kind.OBJECT, 0)
               }
               loop(indent, isAfterNewline = false, region, None)

--- a/tests/cross/src/test/scala/tests/pc/AutoImportExtensionMethodsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportExtensionMethodsSuite.scala
@@ -1,0 +1,34 @@
+package tests.pc
+
+import tests.BaseAutoImportsSuite
+
+class AutoImportExtensionMethodsSuite extends BaseAutoImportsSuite {
+
+  override def ignoreScalaVersion = Some(IgnoreScala2)
+
+  check(
+    "basic",
+    """|object A:
+       |  extension (num: Int) def incr = ???
+       |
+       |def main = 1.<<incr>>
+       |""".stripMargin,
+    """|A
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "basic-edit",
+    """|object A:
+       |  extension (num: Int) def incr = ???
+       |
+       |def main = 1.<<incr>>
+       |""".stripMargin,
+    """|import A.incr
+       |object A:
+       |  extension (num: Int) def incr = ???
+       |
+       |def main = 1.incr
+       |""".stripMargin,
+  )
+}

--- a/tests/cross/src/test/scala/tests/pc/AutoImportExtensionMethodsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportExtensionMethodsSuite.scala
@@ -4,7 +4,7 @@ import tests.BaseAutoImportsSuite
 
 class AutoImportExtensionMethodsSuite extends BaseAutoImportsSuite {
 
-  override def ignoreScalaVersion = Some(IgnoreScala2)
+  override def ignoreScalaVersion: Some[IgnoreScalaVersion] = Some(IgnoreScala2)
 
   check(
     "basic",

--- a/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
@@ -292,6 +292,23 @@ class ScalaToplevelSuite extends BaseSuite {
     dialect = dialects.Scala3,
   )
 
+  check(
+    "inline-extension",
+    """|package a
+       |
+       |extension (s: String) def foo: Int = ???
+       |extension (i: Int) def bar: Int = ???
+       |extension (l: Long)
+       |  def baz: Long = ???
+       |""".stripMargin,
+    List(
+      "a/", "a/Test$package.", "a/Test$package.foo.", "a/Test$package.bar.",
+      "a/Test$package.baz.",
+    ),
+    all = true,
+    dialect = dialects.Scala3,
+  )
+
   def check(
       options: TestOptions,
       code: String,


### PR DESCRIPTION
Previously, ScalaToplevelMtags didn't parse inline extension methods

```scala
extension (num: Int) def incr = ???
```

As a result, we couldn't auto-import those extension methods that are
written in inline style.

This commit fixes to parse those extension methods, and also, added some
pc tests for auto-import extension methods.