### PR TITLE
bugfix: Don't use interrupt for the Scala 3 compiler

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
@@ -99,12 +99,11 @@ abstract class CompilerAccess[Reporter, Compiler](
             isFinished.compareAndSet(false, true) &&
             isDefined
           ) {
-            _compiler.presentationCompilerThread.foreach(_.interrupt())
-            if (
-              _compiler.presentationCompilerThread.isEmpty || !_compiler.presentationCompilerThread
-                .contains(thread)
-            ) {
-              thread.interrupt()
+            _compiler.presentationCompilerThread match {
+              case None => // don't interrupt if we don't have separate thread
+              case Some(pcThread) =>
+                pcThread.interrupt()
+                if (thread != pcThread) thread.interrupt()
             }
           }
         }


### PR DESCRIPTION
Scala 3 compiler doesn't operate on a separate thread the same way as Scala 2 does, so interrupt will cause it to close all the channels while not actually stopping any computation by the compiler.

Fixes https://github.com/scalameta/metals/issues/4196

I tried reopening, but that's not really possible, so best is to not interrupt the thread.