### PR TITLE
bugfix: Print correct method signature for Selectable

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -12,11 +12,13 @@ import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 
 import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.core.Constants.*
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.NameKinds.*
 import dotty.tools.dotc.core.NameOps.*
 import dotty.tools.dotc.core.Names.*
+import dotty.tools.dotc.core.StdNames.*
 import dotty.tools.dotc.core.SymDenotations.*
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Types.*
@@ -58,6 +60,19 @@ object HoverProvider:
     else
       val skipCheckOnName =
         !pos.isPoint // don't check isHoveringOnName for RangeHover
+
+      val printerContext =
+        driver.compilationUnits.get(uri) match
+          case Some(unit) =>
+            val newctx =
+              ctx.fresh.setCompilationUnit(unit)
+            MetalsInteractive.contextOfPath(enclosing)(using newctx)
+          case None => ctx
+      val printer = MetalsPrinter.standard(
+        IndexedContext(printerContext),
+        search,
+        includeDefaultParam = MetalsPrinter.IncludeDefaultParam.Include,
+      )
       MetalsInteractive.enclosingSymbolsWithExpressionType(
         enclosing,
         pos,
@@ -65,21 +80,9 @@ object HoverProvider:
         skipCheckOnName,
       ) match
         case Nil =>
-          ju.Optional.empty()
+          fallbackToDynamics(path, printer)
         case symbolTpes @ ((symbol, tpe) :: _) =>
           val exprTpw = tpe.widenTermRefExpr.dealias
-          val printerContext =
-            driver.compilationUnits.get(uri) match
-              case Some(unit) =>
-                val newctx =
-                  ctx.fresh.setCompilationUnit(unit)
-                MetalsInteractive.contextOfPath(enclosing)(using newctx)
-              case None => ctx
-          val printer = MetalsPrinter.standard(
-            IndexedContext(printerContext),
-            search,
-            includeDefaultParam = MetalsPrinter.IncludeDefaultParam.Include,
-          )
 
           val hoverString =
             tpw match
@@ -128,6 +131,35 @@ object HoverProvider:
 
   extension (pos: SourcePosition)
     private def isPoint: Boolean = pos.start == pos.end
+
+  private def fallbackToDynamics(
+      path: List[Tree],
+      printer: MetalsPrinter,
+  )(using Context): ju.Optional[Hover] = path match
+    case Apply(
+          Select(sel, n),
+          List(Literal(Constant(name: String))),
+        ) :: _ if n == nme.selectDynamic || n == nme.applyDynamic =>
+      def findRefinement(tp: Type): ju.Optional[Hover] =
+        tp match
+          case RefinedType(info, refName, tpe) if name == refName.toString() =>
+            val tpeString =
+              if n == nme.selectDynamic then s": ${printer.tpe(tpe.resultType)}"
+              else printer.tpe(tpe)
+            val content = HoverMarkup(
+              tpeString,
+              s"def $name$tpeString",
+              "",
+            )
+            ju.Optional.of(new Hover(content.toMarkupContent))
+
+          case RefinedType(info, _, _) =>
+            findRefinement(info)
+          case _ => ju.Optional.empty()
+
+      findRefinement(sel.tpe.termSymbol.info)
+    case _ =>
+      ju.Optional.empty()
 
   private def expandRangeToEnclosingApply(
       path: List[Tree],

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -197,4 +197,41 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |def apply[A, B](value: A): Left[A, B]
        |""".stripMargin.hover,
   )
+
+  check(
+    "selectable",
+    """|trait Sel extends Selectable:
+       |  def selectDynamic(name: String): Any = ???
+       |  def applyDynamic(name: String)(args: Any*): Any = ???
+       |val sel = (new Sel {}).asInstanceOf[Sel { def foo2: Int}]
+       |val foo2 = sel.fo@@o2
+       |""".stripMargin,
+    """|def foo2: Int
+       |""".stripMargin.hover,
+  )
+
+  check(
+    "selectable2",
+    """|trait Sel extends Selectable:
+       |  def selectDynamic(name: String): Any = ???
+       |  def applyDynamic(name: String)(args: Any*): Any = ???
+       |val sel = (new Sel {}).asInstanceOf[Sel { def bar2(x: Int): Int }]
+       |val bar2 = sel.ba@@r2(3)
+       |""".stripMargin,
+    """|def bar2(x: Int): Int
+       |""".stripMargin.hover,
+  )
+  check(
+    "selectable-full",
+    """|trait Sel extends Selectable:
+       |  def foo1: Int = ???
+       |  def bar1(x: Int): Int = ???
+       |  def selectDynamic(name: String): Any = ???
+       |  def applyDynamic(name: String)(args: Any*): Any = ???
+       |val sel = (new Sel {}).asInstanceOf[Sel { def foo2: Int; def bar2(x: Int): Int }]
+       |val bar2 = sel.fo@@o2
+       |""".stripMargin,
+    """|def foo2: Int
+       |""".stripMargin.hover,
+  )
 }


### PR DESCRIPTION
Previously, we would not show anything when selectDynamic or applyDynamic methods were used. Now, we look up the refinement to get the proper signatures.

Fixes https://github.com/scalameta/metals/issues/4192