### PR TITLE
Update debug adapter to 2.2.0 stable (dependency update)

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -19,7 +19,7 @@ object V {
   val bsp = "2.1.0-M1"
   val coursier = "2.1.0-M6"
   val coursierInterfaces = "1.0.8"
-  val debugAdapter = "2.2.0-M1"
+  val debugAdapter = "2.2.0"
   val genyVersion = "0.7.1"
   val gradleBloop = bloop
   val java8Compat = "1.0.2"


### PR DESCRIPTION
Bump dependency to latest stable (to not always override it in SBT dependencies).

Also, I see that metals is missing from the list of projects covered by new public instance of Scala Steward: https://github.com/VirtusLab/scala-steward-repos/blob/main/repos-github.md Should I create a PR there for it to be added. I can see steward config in the repo, and I guess it was using old instance (hosted by the creator of scala steward), which is now decommissioned.