### PR TITLE
feature: Adjust type if mismatch

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
@@ -78,7 +78,7 @@ class InsertInferredType(trees: Trees) extends CodeAction {
       title <- inferTypeTitle(name)
     } yield insertInferTypeAction(title)
 
-    def adjustTypeTree(tree: Defn): Option[l.Range] = tree match {
+    def typedDefnTreePos(tree: Defn): Option[l.Range] = tree match {
       case Defn.Def(_, name, _, _, tpe, _) if tpe.isDefined =>
         Some(name.pos.toLSP)
       case Defn.GivenAlias(_, name, _, _, _, _) =>
@@ -110,7 +110,7 @@ class InsertInferredType(trees: Trees) extends CodeAction {
       (mismatchedType, diag) <- typeMismatch
       defn <-
         trees.findLastEnclosingAt[Defn](path, diag.getRange().getStart())
-      pos <- adjustTypeTree(defn)
+      pos <- typedDefnTreePos(defn)
     } yield adjustTypeAction(mismatchedType, pos)
 
     List(actions, adjustType).flatten

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
@@ -9,6 +9,7 @@ import scala.meta.Pat
 import scala.meta.Term
 import scala.meta.internal.metals.CodeAction
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ScalacDiagnostic
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.parsing.Trees
 import scala.meta.pc.CancelToken
@@ -24,6 +25,16 @@ class InsertInferredType(trees: Trees) extends CodeAction {
       params: l.CodeActionParams,
       token: CancelToken,
   )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = Future {
+
+    def typeMismatch: Option[(String, l.Diagnostic)] = {
+      params
+        .getContext()
+        .getDiagnostics()
+        .asScala
+        .collectFirst { case ScalacDiagnostic.TypeMismatch(typ, diag) =>
+          (typ, diag)
+        }
+    }
 
     def insertInferTypeAction(title: String): l.CodeAction = {
       val codeAction = new l.CodeAction()
@@ -67,11 +78,47 @@ class InsertInferredType(trees: Trees) extends CodeAction {
       title <- inferTypeTitle(name)
     } yield insertInferTypeAction(title)
 
-    actions.toList
+    def adjustTypeTree(tree: Defn): Option[l.Range] = tree match {
+      case Defn.Def(_, name, _, _, tpe, _) if tpe.isDefined =>
+        Some(name.pos.toLSP)
+      case Defn.GivenAlias(_, name, _, _, _, _) =>
+        Some(name.pos.toLSP)
+      case Defn.Val(_, List(Pat.Var(name)), tpe, _) if tpe.isDefined =>
+        Some(name.pos.toLSP)
+      case Defn.Var(_, List(Pat.Var(name)), tpe, _) if tpe.isDefined =>
+        Some(name.pos.toLSP)
+      case _ =>
+        None
+    }
+
+    def adjustTypeAction(typ: String, range: l.Range): l.CodeAction = {
+      val codeAction = new l.CodeAction()
+      codeAction.setTitle(InsertInferredType.adjustType(typ))
+      codeAction.setKind(l.CodeActionKind.QuickFix)
+      codeAction.setCommand(
+        ServerCommands.InsertInferredType.toLSP(
+          new l.TextDocumentPositionParams(
+            params.getTextDocument(),
+            range.getStart(),
+          )
+        )
+      )
+      codeAction
+    }
+
+    val adjustType = for {
+      (mismatchedType, diag) <- typeMismatch
+      defn <-
+        trees.findLastEnclosingAt[Defn](path, diag.getRange().getStart())
+      pos <- adjustTypeTree(defn)
+    } yield adjustTypeAction(mismatchedType, pos)
+
+    List(actions, adjustType).flatten
   }
 }
 
 object InsertInferredType {
   val insertType = "Insert type annotation"
+  def adjustType(typ: String): String = s"Adjust type to $typ"
   val insertTypeToPattern = "Insert type annotation into pattern definition"
 }

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -32,6 +32,77 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
+    "wrong-val",
+    """|object A{
+       |  val <<alpha>> :  String = 123
+       |}""".stripMargin,
+    """|object A{
+       |  val alpha: Int = 123
+       |}""".stripMargin,
+  )
+
+  checkEdit(
+    "wrong-val2",
+    """|object A{
+       |  val <<alpha>> :  String = List(1, 2, 3)
+       |}""".stripMargin,
+    """|object A{
+       |  val alpha: List[Int] = List(1, 2, 3)
+       |}""".stripMargin,
+  )
+
+  checkEdit(
+    "wrong-val3",
+    """|object A{
+       |  val <<alpha>> :  List[Int] = ""
+       |}""".stripMargin,
+    """|object A{
+       |  val alpha: String = ""
+       |}""".stripMargin,
+  )
+
+  checkEdit(
+    "wrong-def",
+    """|object A{
+       |  def <<alpha>> :  String = 123
+       |}""".stripMargin,
+    """|object A{
+       |  def alpha: Int = 123
+       |}""".stripMargin,
+  )
+
+  checkEdit(
+    "wrong-def2",
+    """|object A{
+       |  def <<alpha>> :  String = List(1, 2, 3)
+       |}""".stripMargin,
+    """|object A{
+       |  def alpha: List[Int] = List(1, 2, 3)
+       |}""".stripMargin,
+  )
+
+  checkEdit(
+    "wrong-def3",
+    """|object A{
+       |  def <<alpha>> :  List[Int] = ""
+       |}""".stripMargin,
+    """|object A{
+       |  def alpha: String = ""
+       |}""".stripMargin,
+  )
+
+  checkEdit(
+    "wrong-def-toplevel".tag(IgnoreScala2),
+    """|def hello =
+       |  val <<a>> :  List[Int] = ""
+       |""".stripMargin,
+    """|def hello =
+       |  val a: String = ""
+       |
+       |""".stripMargin,
+  )
+
+  checkEdit(
     "toplevel".tag(IgnoreScala2),
     """|def <<alpha>> = List("")
        |""".stripMargin,

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -72,6 +72,16 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
+    "wrong-val4",
+    """|object A{
+       |  val <<alpha>> :  List[Int] = s""
+       |}""".stripMargin,
+    """|object A{
+       |  val alpha: String = s""
+       |}""".stripMargin,
+  )
+
+  checkEdit(
     "wrong-def",
     """|object A{
        |  def <<alpha>> :  String = 123
@@ -98,6 +108,16 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |}""".stripMargin,
     """|object A{
        |  def alpha: String = ""
+       |}""".stripMargin,
+  )
+
+  checkEdit(
+    "wrong-def4",
+    """|object A{
+       |  def <<alpha>> :  List[Int] = s""
+       |}""".stripMargin,
+    """|object A{
+       |  def alpha: String = s""
        |}""".stripMargin,
   )
 

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -32,9 +32,19 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
+    "wrong-def-params",
+    """|object A{
+       |  def <<alpha>>(a: Int, b: String): String = 123
+       |}""".stripMargin,
+    """|object A{
+       |  def alpha(a: Int, b: String): Int = 123
+       |}""".stripMargin,
+  )
+
+  checkEdit(
     "wrong-val",
     """|object A{
-       |  val <<alpha>> :  String = 123
+       |  val <<alpha>>:  String = 123
        |}""".stripMargin,
     """|object A{
        |  val alpha: Int = 123

--- a/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
@@ -405,6 +405,26 @@ class Scala3CodeActionLspSuite
     expectNoDiagnostics = false,
   )
 
+  check(
+    "wrong-type",
+    """|package a
+       |
+       |object A:
+       |  val str = ""
+       |  val alpha:Int=s<<>>tr
+       |
+       |""".stripMargin,
+    s"""|${InsertInferredType.adjustType("(a.A.str : String)")}
+        |""".stripMargin,
+    """|package a
+       |
+       |object A:
+       |  val str = ""
+       |  val alpha: String=str
+       |
+       |""".stripMargin,
+  )
+
   def checkExtractedMember(
       name: TestOptions,
       input: String,

--- a/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
@@ -33,6 +33,24 @@ class InsertInferredTypeLspSuite
   )
 
   check(
+    "wrong-type",
+    """|package a
+       |
+       |object A {
+       |  val alpha:String= 1<<>>23
+       |}
+       |""".stripMargin,
+    s"""|${InsertInferredType.adjustType("Int(123)")}
+        |""".stripMargin,
+    """|package a
+       |
+       |object A {
+       |  val alpha: Int= 123
+       |}
+       |""".stripMargin,
+  )
+
+  check(
     "def",
     """|package a
        |

--- a/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/InsertInferredTypeLspSuite.scala
@@ -51,6 +51,24 @@ class InsertInferredTypeLspSuite
   )
 
   check(
+    "wrong-type2",
+    """|package a
+       |
+       |object A {
+       |  def alpha:String= 1<<>>23
+       |}
+       |""".stripMargin,
+    s"""|${InsertInferredType.adjustType("Int(123)")}
+        |""".stripMargin,
+    """|package a
+       |
+       |object A {
+       |  def alpha: Int= 123
+       |}
+       |""".stripMargin,
+  )
+
+  check(
     "def",
     """|package a
        |


### PR DESCRIPTION
Previously, if the type was wrong user would need to remove the type and invoke insert type code action again or just do it all manuall. Now, we suggest fixing the type whenever a type mismatch error is encountered.

Fixes https://github.com/scalameta/metals/issues/4217