### PR TITLE
chore: Switch to JDK 17 for most tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macOS-latest, ubuntu-latest]
-        java: ["adopt@1.11"]
+        java: ["17"]
         shard: [1, 2]
         include:
           - os: ubuntu-latest
@@ -28,12 +28,6 @@ jobs:
             shard: 1
           - os: ubuntu-latest
             java: "adopt@1.8"
-            shard: 2
-          - os: ubuntu-latest
-            java: "17"
-            shard: 1
-          - os: ubuntu-latest
-            java: "17"
             shard: 2
           - os: ubuntu-latest
             CACHE_PATH: ~/.cache/coursier/v1
@@ -83,11 +77,11 @@ jobs:
             command: bin/test.sh 'sbt-metals/scripted; slow/testOnly -- tests.sbt.*'
             name: Sbt integration
             os: ubuntu-latest
-          - type: sbt-metals jdk17
+          - type: sbt-metals jdk8
             command: bin/test.sh sbt-metals/scripted
-            name: Sbt-metals/scripted jdk17
+            name: Sbt-metals/scripted jdk8
             os: ubuntu-latest
-            java: "17"
+            java: "8"
           - type: maven
             command: bin/test.sh 'slow/testOnly -- tests.maven.*'
             name: Maven integration
@@ -124,7 +118,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: olafurpg/setup-scala@v13
         with:
-          java-version: "adopt@1.11"
+          java-version: "17"
       - uses: coursier/cache-action@v6.3
       - name: ${{ matrix.command }}
         run: ${{ matrix.command }}

--- a/metals/src/main/resources/gradle/wrapper/gradle-wrapper.properties
+++ b/metals/src/main/resources/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -95,7 +95,7 @@ case class GradleBuildTool(userConfig: () => UserConfiguration)
   // @tgodzik This this is the wrapper version we specify it as such,
   // since it's hard to determine which version will be used as gradle
   // doesn't save it in any settings
-  override def version: String = "5.3.1"
+  override def version: String = "7.5.0"
 
   override def minimumVersion: String = "4.3.0"
 

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -95,7 +95,7 @@ object UserConfiguration {
         """"/usr/local/bin/gradle"""",
         "Gradle script",
         """Optional absolute path to a `gradle` executable to use for running `gradle bloopInstall`.
-          |By default, Metals uses gradlew with 5.3.1 gradle version. Update this setting if your `gradle` script requires more customizations
+          |By default, Metals uses gradlew with 7.5.0 gradle version. Update this setting if your `gradle` script requires more customizations
           |like using environment variables.
           |""".stripMargin,
       ),

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -89,6 +89,25 @@ class CompletionDocSuite extends BaseCompletionSuite {
          |`OptionalInt` may have unpredictable results and should be avoided.
          |OptionalInt java.util
          |""".stripMargin
+    else if (isJava17)
+      """|> A container object which may or may not contain an `int` value.
+         |If a value is present, `isPresent()` returns `true`. If no
+         |value is present, the object is considered *empty* and
+         |`isPresent()` returns `false`.
+         |
+         |Additional methods that depend on the presence or absence of a contained
+         |value are provided, such as [orElse()](#orElse(int))
+         |(returns a default value if no value is present) and
+         |[ifPresent()](#ifPresent(IntConsumer)) (performs an
+         |action if a value is present).
+         |
+         |This is a [value-based]()
+         |class; programmers should treat instances that are
+         |[equal](#equals(Object)) as interchangeable and should not
+         |use instances for synchronization, or unpredictable behavior may
+         |occur. For example, in a future release, synchronization may fail.
+         |OptionalInt java.util
+         |""".stripMargin
     else
       """|> A container object which may or may not contain an `int` value.
          |If a value is present, `isPresent()` returns `true`. If no


### PR DESCRIPTION
It should be enough to mostly test on JDK 17 with a couple tests also running on JDK 8.