### PR TITLE
adding AmmoniteFileCompletions for scala 3

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -103,6 +103,7 @@ case class ScalaPresentationCompiler(
         params,
         config,
         buildTargetIdentifier,
+        workspace,
       ).completions()
 
     }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/AmmoniteFileCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/AmmoniteFileCompletions.scala
@@ -1,0 +1,97 @@
+package scala.meta.internal.pc
+package completions
+
+import java.nio.file.Path
+import java.{util as ju}
+
+import scala.collection.JavaConverters.*
+
+import scala.meta.internal.mtags.MtagsEnrichments.*
+import scala.meta.internal.pc.AutoImports.AutoImport
+import scala.meta.io.AbsolutePath
+
+import dotty.tools.dotc.ast.tpd.Tree
+import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.ast.untpd.ImportSelector
+import org.eclipse.{lsp4j as l}
+
+object AmmoniteFileCompletions:
+
+  private def translateImportToPath(tree: Tree): String =
+    tree match
+      case Select(qual, name) =>
+        val pathPart = name.toString()
+        translateImportToPath(qual) + "/" + {
+          if pathPart == "$up" then ".."
+          else pathPart
+        }
+      case Ident(_) =>
+        ""
+      case _ => ""
+
+  def contribute(
+      select: Tree,
+      selector: List[ImportSelector],
+      editRange: l.Range,
+      rawPath: String,
+      workspace: Option[Path],
+      rawFileName: String,
+  ): List[CompletionValue] =
+
+    val fileName = rawFileName
+      .split("/")
+      .last
+      .stripSuffix(".amm.sc.scala")
+
+    val split = rawPath
+      .split("\\$file")
+      .toList
+
+    val query = selector.collectFirst { case sel: ImportSelector =>
+      sel.name.toString.replace(Cursor.value, "")
+
+    }
+
+    def parent =
+      val name = "^"
+
+      CompletionValue.FileSystemMember(
+        isDirectory = true,
+        name,
+        editRange,
+      )
+
+    (split, workspace) match
+      case (_ :: script :: Nil, Some(workspace)) =>
+        // drop / or \
+        val current = workspace.resolve(script.drop(1))
+        val importPath = translateImportToPath(select).drop(1)
+        val currentPath = AbsolutePath(
+          current.getParent.resolve(importPath)
+        )
+        val parentTextEdit =
+          if query
+              .exists(
+                _.isEmpty()
+              ) && currentPath.parentOpt.isDefined && currentPath.isDirectory
+          then List(parent)
+          else Nil
+        currentPath.list.toList
+          .filter(_.filename.stripSuffix(".sc") != fileName)
+          .collect {
+            case file
+                if (file.isDirectory || file.isAmmoniteScript) && query
+                  .exists(
+                    CompletionFuzzy.matches(_, file.filename)
+                  ) =>
+              CompletionValue.FileSystemMember(
+                isDirectory = file.isDirectory,
+                file.filename,
+                editRange,
+              )
+          } ++ parentTextEdit
+      case _ =>
+        Nil
+    end match
+  end contribute
+end AmmoniteFileCompletions

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -64,9 +64,7 @@ sealed trait CompletionValue:
       case CompletionValue.NamedArg(_, tpe) =>
         printer.tpe(tpe)
       case CompletionValue.Document(_, _, desc) => desc
-      case _: CompletionValue.Keyword => ""
-      case fileSysMem: CompletionValue.FileSystemMember =>
-        fileSysMem.fileName
+      case _ => ""
 
   private def forSymOnly[A](f: Symbol => A, orElse: => A): A =
     this match
@@ -124,16 +122,12 @@ object CompletionValue:
       extends CompletionValue
 
   case class FileSystemMember(
+      filename: String,
+      override val range: Option[Range],
       isDirectory: Boolean,
-      fileName: String,
-      editRange: Range,
   ) extends CompletionValue:
-    override def range = Some(editRange)
-    override def filterText = Some(fileName)
-    override def additionalEdits = List(
-      new TextEdit(editRange, fileName.stripSuffix(".sc"))
-    )
-    override def label = fileName
+    override def label: String = filename
+    override def insertText: Option[String] = Some(filename.stripSuffix(".sc"))
 
   case class Interpolator(
       symbol: Symbol,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -562,7 +562,7 @@ class Completions(
               val id = namedArg.label + "="
               (id, true)
             case fileSysMember: CompletionValue.FileSystemMember =>
-              (fileSysMember.fileName, true)
+              (fileSysMember.label, true)
 
         if !isSeen(id) && include then
           isSeen += id

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
@@ -1,6 +1,8 @@
 package scala.meta.internal.pc
 package completions
 
+import java.nio.file.Path
+
 import scala.annotation.tailrec
 import scala.collection.JavaConverters.*
 
@@ -32,6 +34,7 @@ class CompletionsProvider(
     params: OffsetParams,
     config: PresentationCompilerConfig,
     buildTargetIdentifier: String,
+    workspace: Option[Path],
 ):
   def completions(): CompletionList =
     val uri = params.uri
@@ -68,6 +71,7 @@ class CompletionsProvider(
             indexedCtx,
             path,
             config,
+            workspace,
           ).completions()
         val autoImportsGen = AutoImports.generator(
           completionPos.sourcePos,
@@ -142,7 +146,9 @@ class CompletionsProvider(
       // Insert potentially missing `*/` to avoid comment out all codes after the "/**".
       text.substring(0, offset) + "*/" + text.substring(offset)
     else if isEmptyLine(offset, offset) || isDollar then
-      text.substring(0, offset) + "CURSOR" + text.substring(offset)
+      text.substring(0, offset) + Cursor.value + text.substring(
+        offset
+      )
     else text
   end applyCompletionCursor
 
@@ -330,3 +336,6 @@ class CompletionsProvider(
     end match
   end completionItems
 end CompletionsProvider
+
+case object Cursor:
+  val value = "CURSOR"

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -220,97 +220,95 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
     } yield ()
   }
 
-  if (scalaVersion != V.ammonite3)
-    test("file-completion") {
-      for {
-        _ <- initialize(
-          s"""
-             |/metals.json
-             |{
-             |  "a": {
-             |    "scalaVersion": "$scalaVersion"
-             |  }
-             |}
-             |/b/otherMain.sc
-             | // scala $scalaVersion
-             |import $$file.other
-             |
-             |/b/otherScript.sc
-             | // scala $scalaVersion
-             |val a = ""
-             |           
-             |/b/other.sc
-             | // scala $scalaVersion
-             |val a = ""
-             |
-             |/b/others/Script.sc
-             | // scala $scalaVersion
-             |val a = ""
-             |
-             |/b/notThis.sc
-             | // scala $scalaVersion
-             |val a = ""
-             |
-             |""".stripMargin
-        )
-        _ <- server.didOpen("b/otherMain.sc")
-        _ <- server.didOpen("b/other.sc")
-        _ <- server.didOpen("b/otherScript.sc")
-        _ <- server.didOpen("b/others/Script.sc")
-        _ <- server.didOpen("b/notThis.sc")
-        _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
-        _ <- server.didSave("b/otherMain.sc")(identity)
-        _ <- server.didSave("b/other.sc")(identity)
-        _ <- server.didSave("b/otherScript.sc")(identity)
-        _ <- server.didSave("b/others/Script.sc")(identity)
-        _ <- server.didSave("b/notThis.sc")(identity)
-        expectedCompletionList = """|other.sc
-                                    |otherScript.sc
-                                    |others""".stripMargin
-        completionList <- server.completion(
-          "b/otherMain.sc",
-          "import $file.other@@",
-        )
-        _ = assertNoDiff(completionList, expectedCompletionList)
+  test("file-completion") {
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "$scalaVersion"
+           |  }
+           |}
+           |/b/otherMain.sc
+           | // scala $scalaVersion
+           |import $$file.other
+           |
+           |/b/otherScript.sc
+           | // scala $scalaVersion
+           |val a = ""
+           |           
+           |/b/other.sc
+           | // scala $scalaVersion
+           |val a = ""
+           |
+           |/b/others/Script.sc
+           | // scala $scalaVersion
+           |val a = ""
+           |
+           |/b/notThis.sc
+           | // scala $scalaVersion
+           |val a = ""
+           |
+           |""".stripMargin
+      )
+      _ <- server.didOpen("b/otherMain.sc")
+      _ <- server.didOpen("b/other.sc")
+      _ <- server.didOpen("b/otherScript.sc")
+      _ <- server.didOpen("b/others/Script.sc")
+      _ <- server.didOpen("b/notThis.sc")
+      _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
+      _ <- server.didSave("b/otherMain.sc")(identity)
+      _ <- server.didSave("b/other.sc")(identity)
+      _ <- server.didSave("b/otherScript.sc")(identity)
+      _ <- server.didSave("b/others/Script.sc")(identity)
+      _ <- server.didSave("b/notThis.sc")(identity)
+      expectedCompletionList = """|other.sc
+                                  |otherScript.sc
+                                  |others""".stripMargin
+      completionList <- server.completion(
+        "b/otherMain.sc",
+        "import $file.other@@",
+      )
+      _ = assertNoDiff(completionList, expectedCompletionList)
 
-      } yield ()
-    }
+    } yield ()
+  }
 
-  if (scalaVersion != V.ammonite3)
-    test("file-completion-path") {
-      for {
-        _ <- initialize(
-          s"""
-             |/metals.json
-             |{
-             |  "a": {
-             |    "scalaVersion": "$scalaVersion"
-             |  }
-             |}
-             |/foos/Script.sc
-             | // scala $scalaVersion
-             |val a = ""
-             |
-             |/foo.sc
-             | // scala $scalaVersion
-             |import $$file.foos.Script
-             |""".stripMargin
-        )
-        _ <- server.didOpen("foo.sc")
-        _ <- server.didOpen("foos/Script.sc")
-        _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
-        _ <- server.didSave("foo.sc")(identity)
-        _ <- server.didSave("foos/Script.sc")(identity)
+  test("file-completion-path") {
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "$scalaVersion"
+           |  }
+           |}
+           |/foos/Script.sc
+           | // scala $scalaVersion
+           |val a = ""
+           |
+           |/foo.sc
+           | // scala $scalaVersion
+           |import $$file.foos.Script
+           |""".stripMargin
+      )
+      _ <- server.didOpen("foo.sc")
+      _ <- server.didOpen("foos/Script.sc")
+      _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
+      _ <- server.didSave("foo.sc")(identity)
+      _ <- server.didSave("foos/Script.sc")(identity)
 
-        expectedCompletionList = "Script.sc"
-        completionList <- server.completion(
-          "foo.sc",
-          "import $file.foos.Script@@",
-        )
-        _ = assertNoDiff(completionList, expectedCompletionList)
+      expectedCompletionList = "Script.sc"
+      completionList <- server.completion(
+        "foo.sc",
+        "import $file.foos.Script@@",
+      )
+      _ = assertNoDiff(completionList, expectedCompletionList)
 
-      } yield ()
-    }
+    } yield ()
+  }
 
   test("completion") {
     for {


### PR DESCRIPTION
It resolves #4201 

- It takes the workspace path of the `ScalaPresentationCompiler` and provides it to` CompletionsProvider` and ultimately the `AmmoniteFileCompletions`

- It utilises the same logic and code as in Scala 2 AmmoniteCompletions with the goal of making the tests for `Ammonite3Suite` pass

