### PR TITLE
chore(ci): migrate to actions/java to use built-in sbt caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,23 +24,18 @@ jobs:
         shard: [1, 2]
         include:
           - os: ubuntu-latest
-            java: "adopt@1.8"
+            java: "8"
             shard: 1
           - os: ubuntu-latest
-            java: "adopt@1.8"
+            java: "8"
             shard: 2
-          - os: ubuntu-latest
-            CACHE_PATH: ~/.cache/coursier/v1
-          - os: macOS-latest
-            CACHE_PATH: ~/Library/Caches/Coursier/v1
-          - os: windows-latest
-            CACHE_PATH: ~\AppData\Local\Coursier\Cache\v1
     steps:
       - uses: actions/checkout@v3
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: coursier/cache-action@v6.3
+          cache: 'sbt'
       - name: Run unit tests
         run: |
           bin/test.sh unit/test
@@ -116,10 +111,11 @@ jobs:
             os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: "17"
-      - uses: coursier/cache-action@v6.3
+          cache: 'sbt'
       - name: ${{ matrix.command }}
         run: ${{ matrix.command }}
         env:

--- a/.github/workflows/mtags-auto-release.yml
+++ b/.github/workflows/mtags-auto-release.yml
@@ -25,10 +25,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.metals_ref }}
           token: ${{ secrets.GH_TOKEN }}
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/setup-java@v3
         with:
-          java-version: adopt@1.11
-      - uses: coursier/cache-action@v6.3
+          distribution: 'temurin'
+          java-version: 11
+          cache: 'sbt'
       - name: "Test and push tag"
         run: |
           sbt 'test-mtags-dyn ${{ github.event.inputs.scala_version }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: olafurpg/setup-scala@v13
-      - uses: olafurpg/setup-gpg@v3
-      - uses: coursier/cache-action@v6.3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
       - name: Publish
         run: |
           LOCKED=true

--- a/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
+++ b/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
@@ -67,7 +67,7 @@ class FindTextInDependencyJarsSuite
       assertLocations(
         jdkLocations, {
           val line =
-            if (isJavaAtLeast17) 1444
+            if (isJavaAtLeast17) 1447
             else if (isJavaAtLeast9) 626
             else 578
 

--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -322,21 +322,38 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
       _ <- server.didOpen("a/src/main/scala/a/Before.scala")
       _ = assertNoDiff(
         server.workspaceSymbol("Future"),
-        """|scala.concurrent.Future
-           |scala.concurrent.Future
-           |java.util.concurrent.Future
-           |scala.sys.process.ProcessImpl#Future
-           |scala.jdk.FutureConverters.FutureOps
-           |java.util.concurrent.FutureTask
-           |java.io.ObjectStreamClass#EntryFuture
-           |java.util.concurrent.RunnableFuture
-           |java.util.concurrent.ExecutorCompletionService#QueueingFuture
-           |java.util.concurrent.ScheduledFuture
-           |scala.jdk.FutureConverters
-           |scala.jdk.javaapi.FutureConverters
-           |java.util.concurrent.CompletableFuture
-           |java.util.concurrent.ScheduledThreadPoolExecutor#ScheduledFutureTask
-           |""".stripMargin,
+        if (isJava17) {
+          """|scala.concurrent.Future
+             |scala.concurrent.Future
+             |java.util.concurrent.Future
+             |scala.sys.process.ProcessImpl#Future
+             |scala.jdk.FutureConverters.FutureOps
+             |java.util.concurrent.FutureTask
+             |java.util.concurrent.RunnableFuture
+             |java.util.concurrent.ExecutorCompletionService#QueueingFuture
+             |java.util.concurrent.ScheduledFuture
+             |scala.jdk.FutureConverters
+             |scala.jdk.javaapi.FutureConverters
+             |java.util.concurrent.CompletableFuture
+             |java.util.concurrent.ScheduledThreadPoolExecutor#ScheduledFutureTask
+             |scala.concurrent.impl.FutureConvertersImpl
+             |""".stripMargin
+        } else {
+          """|scala.concurrent.Future
+             |scala.concurrent.Future
+             |java.util.concurrent.Future
+             |scala.sys.process.ProcessImpl#Future
+             |scala.jdk.FutureConverters.FutureOps
+             |java.util.concurrent.FutureTask
+             |java.io.ObjectStreamClass#EntryFuture
+             |java.util.concurrent.RunnableFuture
+             |java.util.concurrent.ExecutorCompletionService#QueueingFuture
+             |java.util.concurrent.ScheduledFuture
+             |scala.jdk.FutureConverters
+             |scala.jdk.javaapi.FutureConverters
+             |java.util.concurrent.CompletableFuture
+             |java.util.concurrent.ScheduledThreadPoolExecutor#ScheduledFutureTask""".stripMargin
+        },
       )
       _ <- server.didChangeConfiguration(
         """|{
@@ -348,15 +365,25 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
       )
       _ = assertNoDiff(
         server.workspaceSymbol("Future"),
-        """|scala.concurrent.Future
-           |scala.concurrent.Future
-           |scala.sys.process.ProcessImpl#Future
-           |scala.jdk.FutureConverters.FutureOps
-           |java.io.ObjectStreamClass#EntryFuture
-           |scala.jdk.FutureConverters
-           |scala.jdk.javaapi.FutureConverters
-           |scala.concurrent.impl.FutureConvertersImpl
-           |""".stripMargin,
+        if (isJava17)
+          """|scala.concurrent.Future
+             |scala.concurrent.Future
+             |scala.sys.process.ProcessImpl#Future
+             |scala.jdk.FutureConverters.FutureOps
+             |scala.jdk.FutureConverters
+             |scala.jdk.javaapi.FutureConverters
+             |scala.concurrent.impl.FutureConvertersImpl
+             |""".stripMargin
+        else
+          """|scala.concurrent.Future
+             |scala.concurrent.Future
+             |scala.sys.process.ProcessImpl#Future
+             |scala.jdk.FutureConverters.FutureOps
+             |java.io.ObjectStreamClass#EntryFuture
+             |scala.jdk.FutureConverters
+             |scala.jdk.javaapi.FutureConverters
+             |scala.concurrent.impl.FutureConvertersImpl
+             |""".stripMargin,
       )
     } yield ()
   }


### PR DESCRIPTION
I'd like to see if this works. There were a couple coversations a while back about
using setup-scala vs setup-java and it seems that many repos have migrated to just
using setup-java since it does offer sbt support, has a ton of users, and also
built-in sbt caching which simplifies a few things in our actions.

If you're rather just leave it as is since it is working fine, no
worries, I just really like that the setup-java offers built-in caching
for sbt.