### PR TITLE
bugfix: Show package completions

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -21,9 +21,12 @@ final class AutoImportsProvider(
       filename = params.uri().toString(),
       cursor = Some(params.offset())
     )
+    typeCheck(unit)
+
     val pos = unit.position(params.offset)
     // make sure the compilation unit is loaded
     typedTreeAt(pos)
+
     val importPosition = autoImportPosition(pos, params.text())
     val context = doLocateImportContext(pos)
     val isSeen = mutable.Set.empty[String]

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -516,6 +516,8 @@ class Completions(
               val include =
                 !isUninterestingSymbol(sym) &&
                   isNotLocalForwardReference(sym)
+                  // to not duplicate with package itself
+                  && isNotPackageObject(sym)
                   && isNotAModuleOrModuleIsValidForPos(sym)
                   && isNotAMethodOrMethodIsValidForPos(sym)
                   && isNotClassOrTraitOrTheyAreValidForPos(sym)
@@ -545,6 +547,9 @@ class Completions(
 
     end filterInteresting
 
+    private def isNotPackageObject(sym: Symbol) =
+      !sym.isPackageObject
+
     private def isNotAModuleOrModuleIsValidForPos(sym: Symbol) =
       !sym.info.typeSymbol.is(
         Flags.Module
@@ -556,10 +561,9 @@ class Completions(
       ) // !sym.info.typeSymbol.is(Flags.Method) does not detect Java methods
 
     private def isNotClassOrTraitOrTheyAreValidForPos(sym: Symbol) =
-      cursorPositionCondition.isClassOrTraitValidForPos || sym.is(
-        Flags.Method
-      ) || (!sym.isClass && !sym.info.typeSymbol
-        .is(Trait))
+      cursorPositionCondition.isClassOrTraitValidForPos ||
+        sym.is(Flags.Method) || sym.is(Package) ||
+        !sym.isClass && !sym.info.typeSymbol.is(Trait)
 
   end extension
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -515,13 +515,14 @@ class Completions(
 
               val include =
                 !isUninterestingSymbol(sym) &&
-                  isNotLocalForwardReference(sym)
-                  // to not duplicate with package itself
-                  && isNotPackageObject(sym)
-                  && isNotAModuleOrModuleIsValidForPos(sym)
-                  && isNotAMethodOrMethodIsValidForPos(sym)
-                  && isNotClassOrTraitOrTheyAreValidForPos(sym)
-
+                  isNotLocalForwardReference(sym) && (
+                    // to not duplicate with package itself
+                    sym.is(Package) ||
+                      isNotPackageObject(sym)
+                      && isNotAModuleOrModuleIsValidForPos(sym)
+                      && isNotAMethodOrMethodIsValidForPos(sym)
+                      && isNotClassOrTraitOrTheyAreValidForPos(sym)
+                  )
               (id, include)
             case kw: CompletionValue.Keyword => (kw.label, true)
             case namedArg: CompletionValue.NamedArg =>
@@ -562,7 +563,7 @@ class Completions(
 
     private def isNotClassOrTraitOrTheyAreValidForPos(sym: Symbol) =
       cursorPositionCondition.isClassOrTraitValidForPos ||
-        sym.is(Flags.Method) || sym.is(Package) ||
+        sym.is(Flags.Method) ||
         !sym.isClass && !sym.info.typeSymbol.is(Trait)
 
   end extension

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1479,4 +1479,29 @@ class CompletionSuite extends BaseCompletionSuite {
     "",
   )
 
+  check(
+    "pkg",
+    s"""|object Foo {
+        |  scala.coll@@
+        |}
+        |""".stripMargin,
+    "collection scala",
+  )
+
+  check(
+    "pkg-scala",
+    s"""|object Foo {
+        |  scala@@
+        |}
+        |""".stripMargin,
+    """|scala <root>
+       |""".stripMargin,
+    compat = Map(
+      "2" ->
+        """|scala _root_
+           |`package` - scala
+           |""".stripMargin
+    ),
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1480,7 +1480,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "pkg",
+    "pkg".tag(IgnoreScalaVersion.for3LessThan("3.1.3")),
     s"""|object Foo {
         |  scala.coll@@
         |}
@@ -1489,7 +1489,25 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "pkg-scala",
+    "pkg-typed".tag(IgnoreScalaVersion.for3LessThan("3.1.3")),
+    s"""|object Foo {
+        |  val a : scala.coll@@
+        |}
+        |""".stripMargin,
+    "collection scala",
+  )
+
+  check(
+    "pkg-new".tag(IgnoreScalaVersion.for3LessThan("3.1.3")),
+    s"""|object Foo {
+        |  new scala.coll@@
+        |}
+        |""".stripMargin,
+    "collection scala",
+  )
+
+  check(
+    "pkg-scala".tag(IgnoreScalaVersion.for3LessThan("3.1.3")),
     s"""|object Foo {
         |  scala@@
         |}


### PR DESCRIPTION
Previously we would not show package completions in a number of places, which is useful when using for example pprint. Now we properly show them in probably all the situations.

Looks like we didn't have tests for these.

Scala 2 tests have an additional completion, but that seems to be ignored by VS Code, though I wonder if this is an issue for other editors :thinking: 

@tanishiking Let's merge it before the release.