### PR TITLE
Don't run InteractiveDriver.run if the content didn't "change"

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsDriver.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsDriver.scala
@@ -23,7 +23,7 @@ import dotty.tools.dotc.util.SourceFile
  * the typed tree under the situation like developers
  * sequentially hover on the symbols in the same file without any changes.
  *
- * Note: we decided to cache only if the target URI only if the same as the previous run
+ * Note: we decided to cache only if the target URI is the same as in the previous run
  * because of `InteractiveDriver.currentCtx` that should return the context that
  * refers to the last compiled source file.
  * It would be ideal if we could update currentCtx even when we skip the compilation,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsDriver.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsDriver.scala
@@ -1,0 +1,35 @@
+package scala.meta.internal.pc
+
+import java.net.URI
+import java.{util as ju}
+
+import scala.collection.concurrent.TrieMap
+
+import scala.meta.internal.mtags.MD5
+
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.interactive.InteractiveDriver
+import dotty.tools.dotc.interactive.SourceTree
+import dotty.tools.dotc.reporting.Diagnostic
+import dotty.tools.dotc.util.SourceFile
+
+class MetalsDriver(
+    override val settings: List[String]
+) extends InteractiveDriver(settings):
+
+  private def alreadyCompiled(uri: URI, content: Array[Char]): Boolean =
+    compilationUnits.get(uri) match
+      case Some(unit) if ju.Arrays.equals(unit.source.content(), content) =>
+        true
+      case _ => false
+
+  override def run(uri: URI, source: SourceFile): List[Diagnostic] =
+    if alreadyCompiled(uri, source.content) then Nil
+    else super.run(uri, source)
+
+  override def run(uri: URI, sourceCode: String): List[Diagnostic] =
+    val contentHash = MD5.compute(sourceCode)
+    if alreadyCompiled(uri, sourceCode.toCharArray()) then Nil
+    else super.run(uri, sourceCode)
+
+end MetalsDriver

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsDriver.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsDriver.scala
@@ -13,23 +13,50 @@ import dotty.tools.dotc.interactive.SourceTree
 import dotty.tools.dotc.reporting.Diagnostic
 import dotty.tools.dotc.util.SourceFile
 
+/**
+ * MetalsDriver is a wrapper class that provides a compilation cache for InteractiveDriver.
+ * MetalsDriver skips running compilation if
+ * - the target URI of `run` is the same as the previous target URI
+ * - the content didn't change since the last compilation.
+ *
+ * This compilation cache enables Metals to skip compilation and re-use
+ * the typed tree under the situation like developers
+ * sequentially hover on the symbols in the same file without any changes.
+ *
+ * Note: we decided to cache only if the target URI only if the same as the previous run
+ * because of `InteractiveDriver.currentCtx` that should return the context that
+ * refers to the last compiled source file.
+ * It would be ideal if we could update currentCtx even when we skip the compilation,
+ * but we struggled to do that. See the discussion https://github.com/scalameta/metals/pull/4225#discussion_r941138403
+ * To avoid the complexity related to currentCtx,
+ * we decided to cache only when the target URI only if the same as the previous run.
+ */
 class MetalsDriver(
     override val settings: List[String]
 ) extends InteractiveDriver(settings):
 
+  @volatile private var lastCompiledURI: URI = _
+
   private def alreadyCompiled(uri: URI, content: Array[Char]): Boolean =
     compilationUnits.get(uri) match
-      case Some(unit) if ju.Arrays.equals(unit.source.content(), content) =>
+      case Some(unit)
+          if lastCompiledURI == uri &&
+            ju.Arrays.equals(unit.source.content(), content) =>
         true
       case _ => false
 
   override def run(uri: URI, source: SourceFile): List[Diagnostic] =
-    if alreadyCompiled(uri, source.content) then Nil
-    else super.run(uri, source)
+    val diags =
+      if alreadyCompiled(uri, source.content) then Nil
+      else super.run(uri, source)
+    lastCompiledURI = uri
+    diags
 
   override def run(uri: URI, sourceCode: String): List[Diagnostic] =
-    val contentHash = MD5.compute(sourceCode)
-    if alreadyCompiled(uri, sourceCode.toCharArray()) then Nil
-    else super.run(uri, sourceCode)
+    val diags =
+      if alreadyCompiled(uri, sourceCode.toCharArray()) then Nil
+      else super.run(uri, sourceCode)
+    lastCompiledURI = uri
+    diags
 
 end MetalsDriver

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsDriver.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsDriver.scala
@@ -5,11 +5,8 @@ import java.{util as ju}
 
 import scala.collection.concurrent.TrieMap
 
-import scala.meta.internal.mtags.MD5
-
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.interactive.InteractiveDriver
-import dotty.tools.dotc.interactive.SourceTree
 import dotty.tools.dotc.reporting.Diagnostic
 import dotty.tools.dotc.util.SourceFile
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
@@ -24,7 +24,7 @@ class Scala3CompilerAccess(
     sh: Option[ScheduledExecutorService],
     newCompiler: () => Scala3CompilerWrapper,
 )(using ec: ExecutionContextExecutor)
-    extends CompilerAccess[StoreReporter, InteractiveDriver](
+    extends CompilerAccess[StoreReporter, MetalsDriver](
       config,
       sh,
       newCompiler,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerWrapper.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerWrapper.scala
@@ -7,10 +7,10 @@ import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.reporting.StoreReporter
 
-class Scala3CompilerWrapper(driver: InteractiveDriver)
-    extends CompilerWrapper[StoreReporter, InteractiveDriver]:
+class Scala3CompilerWrapper(driver: MetalsDriver)
+    extends CompilerWrapper[StoreReporter, MetalsDriver]:
 
-  override def compiler(): InteractiveDriver = driver
+  override def compiler(): MetalsDriver = driver
 
   override def resetReporter(): Unit =
     val ctx = driver.currentCtx

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -54,7 +54,7 @@ case class ScalaPresentationCompiler(
   private val forbiddenOptions = Set("-print-lines", "-print-tasty")
   private val forbiddenDoubleOptions = Set("-release")
 
-  val compilerAccess: CompilerAccess[StoreReporter, InteractiveDriver] =
+  val compilerAccess: CompilerAccess[StoreReporter, MetalsDriver] =
     Scala3CompilerAccess(
       config,
       sh,
@@ -70,7 +70,7 @@ case class ScalaPresentationCompiler(
       case head :: tail => head :: removeDoubleOptions(tail)
       case Nil => options
 
-  def newDriver: InteractiveDriver =
+  def newDriver: MetalsDriver =
     val implicitSuggestionTimeout = List("-Ximport-suggestion-timeout", "0")
     val defaultFlags = List("-color:never")
     val filteredOptions = removeDoubleOptions(
@@ -81,7 +81,7 @@ case class ScalaPresentationCompiler(
         .mkString(
           File.pathSeparator
         ) :: Nil
-    new InteractiveDriver(settings)
+    new MetalsDriver(settings)
 
   override def getTasty(
       targetUri: URI,


### PR DESCRIPTION
If the content didn't change since the last `driver.run`, do not compile
because the compilation unit should have the up to date typed tree.
Skip compilation saves up much of CPU usage when users are reading
source code (and hover on symbols) without modifying the source code.

---

What happens if we change in a file affect another file's type
information?

For example, when we have the following source files, if we hover on
`B.foo` in `A.scala`, Metals shows the symbol's type is `Int`.

```scala
// A.scala
def main = println(B.foo)

// B.scala
object B:
  def foo: Int = ???
```

When we modify `B.scala` to `def foo: String = ???`, what happens to
`A.scala`?
You may think that, Metals keep using the old compilation
unit that shows `B.foo` as `Int` instead of `String` because Metals
invalidates the compilation cache based on its content hash.

That's not true, `alreadyCompiled("A.scala", <content hash>)` will be
`false`, and Metals will run `driver.run` on `A.scala` and show `String`
for `B.foo` in `A.scala`.

Why? Because Metals will recreate a new `MetalsDriver` and `lastCompiled`
cache will be cleared up.

- When a file has changed, Metals call [Compilers.restart](https://github.com/scalameta/metals/blob/c6e0f30febeff67e970e463d79862e27e45ada3f/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala#L247).
- The restart method calls `shutdownCurrentCompiler` that [set `_compiler` to `null`.](https://github.com/scalameta/metals/blob/c6e0f30febeff67e970e463d79862e27e45ada3f/mtags/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala#L57-L74).

This is basically the same way to cache compilation as Scala2
See my explanation on how Scala2 + Metals compilation cache works
https://contributors.scala-lang.org/t/how-does-scala2-compiler-cache-invalidate-the-typechecking-result-for-the-given-tree/5858/4?u=tanishiking