### PR TITLE
feat: include anon classes (val x = new Trait {}) in 'find all implementations'

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -333,8 +333,12 @@ final class ImplementationProvider(
         classContext.getLocations(symbol).filterNot { loc =>
           // we are not interested in local symbols from outside the workspace
           (loc.symbol.isLocal && loc.file.isEmpty) ||
-          // local symbols inheritance should only be picked up in the same file
-          (loc.symbol.isLocal && loc.file != currentPath)
+          // for local symbols, inheritance should only be picked up in the same file
+          // otherwise there can be a name collision between files
+          // local1' is from file A, local2 extends local1''
+          // but both local2 and local1'' are from file B
+          // clearly, local2 shouldn't be considered for local1'
+          (symbol.isLocal && loc.symbol.isLocal && loc.file != currentPath)
         }
       directImplementations ++ directImplementations
         .flatMap { loc => loop(loc.symbol, loc.file) }

--- a/tests/unit/src/test/scala/tests/ImplementationLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ImplementationLspSuite.scala
@@ -31,6 +31,11 @@ class ImplementationLspSuite extends BaseRangesSuite("implementation") {
        |/a/src/main/scala/a/Cat.scala
        |package a
        |class <<Cat>> extends Animal
+       |/a/src/main/scala/a/Human.scala
+       |package a
+       |object Human {
+       |  val person = new <<>>LivingBeing {}
+       |}
        |""".stripMargin,
   )
 


### PR DESCRIPTION
closes https://github.com/scalameta/metals-feature-requests/issues/289

It's a one liner and because of that it needs many lines of description ;)

---

### Why previous check is important? (case 1)
```
// local symbols inheritance should only be picked up in the same file
(loc.symbol.isLocal && loc.file != currentPath)
```
Let's consider following example (from `ImplementationLspSuite`)
```
/a/src/main/scala/a/Main.scala
package a
trait Ap@@p
object outer{
  abstract class <<State>> extends App
  val app = new <<>>State{}. // local0
}
/a/src/main/scala/a/Other.scala
package a
object Other{
  def main(){
    trait Inner // local0
    object InnerImpl extends Inner // local1 which extends local0
  }
}
```
App is extended by `outer.State`, which is extended by `local0` in `Main.scala`. This is important because https://github.com/scalameta/metals/blob/c328f0925e9692b493aba395492ae03fd36da424/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala#L331-L341 is recursive - in order to find implementations of `App` we will search implementations of `outer.State`, in order to find implemenatations of `outer.State` we need to find impls of `local0` and etc.

However, in `Other.scala` there is a trait Inner which has symbol `local0`, thus `InnerImpl` (local1) extends `local0`. Because https://github.com/scalameta/metals/blob/c328f0925e9692b493aba395492ae03fd36da424/metals/src/main/scala/scala/meta/internal/implementation/InheritanceContext.scala#L9-L12 accepts only symbol name, there's no doubt that there will be collisions for local symbols. Mentioned condition (`loc.symbol.isLocal && loc.file != currentPath`) allows to filter out such symbols.

---

### Why it isn't enough (case 2)

Because that 'same file check' discards such cases:
```
/a/src/main/scala/a/Main.scala
package a
trait Ap@@p
/a/src/main/scala/a/Other.scala
package a
object Other {
  val foo = new App {}
}
```
---

### What changed
Extend check with `symbol.isLocal` to `symbol.isLocal && loc.symbol.isLocal && loc.file != currentPath`. This condition covers both cases 1 and 2:
- take local inheritance into account only when both symbols are local (local1 extends local0) - case 1
- allows local inheritance when symbol for which we're looking for implementation isn't local (can I say it's global one then?) - case 2