### PR TITLE
docs: Move FAQ section to the toplevel to sidebar

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,43 +1,45 @@
 {
-  "docs": {
-    "Text Editors": [
-      "editors/overview",
-      "editors/vscode",
-      "editors/vim",
-      "editors/sublime",
-      "editors/emacs",
-      "editors/online-ides",
-      "editors/user-configuration"
-    ],
-    "Code Actions": [
-      "codeactions/codeactions"
-    ],
-    "Build Tools": [
-      "build-tools/overview",
-      "build-tools/bloop",
-      "build-tools/gradle",
-      "build-tools/maven",
-      "build-tools/mill",
-      "build-tools/sbt"
-    ],
-    "Contributing": [
-      "contributors/project-goals",
-      "contributors/getting-started",
-      "contributors/updating-website",
-      "contributors/releasing"
-    ],
-    "Integrating with Metals": [
-      "integrations/remote-language-server",
-      "integrations/new-build-tool",
-      "integrations/new-editor",
-      "integrations/test-explorer",
-      "integrations/tree-view-protocol",
-      "integrations/decoration-protocol",
-      "integrations/debug-adapter-protocol"
-    ],
-    "Troubleshooting": [
-      "troubleshooting/proxy",
-      "troubleshooting/faq"
-    ]
-  }
+  "docs": [
+    {
+      "Text Editors": [
+        "editors/overview",
+        "editors/vscode",
+        "editors/vim",
+        "editors/sublime",
+        "editors/emacs",
+        "editors/online-ides",
+        "editors/user-configuration"
+      ],
+      "Code Actions": ["codeactions/codeactions"],
+      "Build Tools": [
+        "build-tools/overview",
+        "build-tools/bloop",
+        "build-tools/gradle",
+        "build-tools/maven",
+        "build-tools/mill",
+        "build-tools/sbt"
+      ],
+      "Contributing": [
+        "contributors/project-goals",
+        "contributors/getting-started",
+        "contributors/updating-website",
+        "contributors/releasing"
+      ],
+      "Integrating with Metals": [
+        "integrations/remote-language-server",
+        "integrations/new-build-tool",
+        "integrations/new-editor",
+        "integrations/test-explorer",
+        "integrations/tree-view-protocol",
+        "integrations/decoration-protocol",
+        "integrations/debug-adapter-protocol"
+      ],
+      "Troubleshooting": ["troubleshooting/proxy"]
+    },
+    {
+      "id": "troubleshooting/faq",
+      "type": "doc",
+      "label": "FAQ"
+    }
+  ]
 }


### PR DESCRIPTION
This PR just moved the link to `Frequently Asked Question` in the sidebar to the top level.
I believe the link to the FAQ shouldn't be hidden under the drop-down menu (`TroubleShooting`).

What do you think about it?


### before

<img width="342" alt="Screen Shot 2022-08-09 at 17 39 25" src="https://user-images.githubusercontent.com/9353584/183604825-d302b924-d182-4d51-a392-b81695b3133f.png">


### after

<img width="306" alt="Screen Shot 2022-08-09 at 17 38 16" src="https://user-images.githubusercontent.com/9353584/183604783-32615d1a-eb2c-4b5c-859e-bb1513ebfc81.png">

## Context
I saw @vzmerr think about writing a troubleshooting guide (I think it's a good idea 👍 )
https://github.com/scalameta/metals/issues/4194#issuecomment-1204146318

However, I wonder how many users notice a FAQ section in the doc because it's default hidden in the `TroubleShooting` section. (Not sure because we didn't do any access analysis using GA or something).
