### PR TITLE
[Scala 3] Revert type completions feature

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -21,12 +21,9 @@ final class AutoImportsProvider(
       filename = params.uri().toString(),
       cursor = Some(params.offset())
     )
-    typeCheck(unit)
-
     val pos = unit.position(params.offset)
     // make sure the compilation unit is loaded
     typedTreeAt(pos)
-
     val importPosition = autoImportPosition(pos, params.text())
     val context = doLocateImportContext(pos)
     val isSeen = mutable.Set.empty[String]

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -516,8 +516,6 @@ class Completions(
               val include =
                 !isUninterestingSymbol(sym) &&
                   isNotLocalForwardReference(sym)
-                  // to not duplicate with package itself
-                  && isNotPackageObject(sym)
                   && isNotAModuleOrModuleIsValidForPos(sym)
                   && isNotAMethodOrMethodIsValidForPos(sym)
                   && isNotClassOrTraitOrTheyAreValidForPos(sym)
@@ -547,9 +545,6 @@ class Completions(
 
     end filterInteresting
 
-    private def isNotPackageObject(sym: Symbol) =
-      !sym.isPackageObject
-
     private def isNotAModuleOrModuleIsValidForPos(sym: Symbol) =
       !sym.info.typeSymbol.is(
         Flags.Module
@@ -561,9 +556,10 @@ class Completions(
       ) // !sym.info.typeSymbol.is(Flags.Method) does not detect Java methods
 
     private def isNotClassOrTraitOrTheyAreValidForPos(sym: Symbol) =
-      cursorPositionCondition.isClassOrTraitValidForPos ||
-        sym.is(Flags.Method) || sym.is(Package) ||
-        !sym.isClass && !sym.info.typeSymbol.is(Trait)
+      cursorPositionCondition.isClassOrTraitValidForPos || sym.is(
+        Flags.Method
+      ) || (!sym.isClass && !sym.info.typeSymbol
+        .is(Trait))
 
   end extension
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -515,14 +515,13 @@ class Completions(
 
               val include =
                 !isUninterestingSymbol(sym) &&
-                  isNotLocalForwardReference(sym) && (
-                    // to not duplicate with package itself
-                    sym.is(Package) ||
-                      isNotPackageObject(sym)
-                      && isNotAModuleOrModuleIsValidForPos(sym)
-                      && isNotAMethodOrMethodIsValidForPos(sym)
-                      && isNotClassOrTraitOrTheyAreValidForPos(sym)
-                  )
+                  isNotLocalForwardReference(sym)
+                  // to not duplicate with package itself
+                  && isNotPackageObject(sym)
+                  && isNotAModuleOrModuleIsValidForPos(sym)
+                  && isNotAMethodOrMethodIsValidForPos(sym)
+                  && isNotClassOrTraitOrTheyAreValidForPos(sym)
+
               (id, include)
             case kw: CompletionValue.Keyword => (kw.label, true)
             case namedArg: CompletionValue.NamedArg =>
@@ -563,7 +562,7 @@ class Completions(
 
     private def isNotClassOrTraitOrTheyAreValidForPos(sym: Symbol) =
       cursorPositionCondition.isClassOrTraitValidForPos ||
-        sym.is(Flags.Method) ||
+        sym.is(Flags.Method) || sym.is(Package) ||
         !sym.isClass && !sym.info.typeSymbol.is(Trait)
 
   end extension

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -32,7 +32,6 @@ import dotty.tools.dotc.util.NameTransformer
 import dotty.tools.dotc.util.NoSourcePosition
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.util.Spans
-import dotty.tools.dotc.util.Spans.Span
 import dotty.tools.dotc.util.SrcPos
 
 class Completions(
@@ -63,102 +62,6 @@ class Completions(
     case _ :: (_: Import) :: _ => false
     case (_: Ident) :: (_: SeqLiteral) :: _ => false
     case _ => true
-
-  /**
-   * It shows the conditions of the code in the cursor position, with
-   * respect to assessing
-   *  1. whether it makes semantic sense to complete
-   *  the position with symbols that are `class`, `trait`,
-   *  `abstract`, `object`, or method
-   *  1. whether it would make syntactic sense to add `[]` `()` or `{}`
-   *  suffixes to the symbols suggested for completion.
-   *
-   *  Note: In the comments `@@` represents the cursor position.
-   *
-   * @param isTypePosition if this is the position for defining a type such as
-   *                       `val a: In@@` or `def i: scala.IndexedSe@@`
-   * @param isNewPosition if it is the position for instantiation after
-   *                      the new keword, as in `new Fil@@`
-   * @param isInstantiationOrMethodCallPos if it is the position for method call or
-   *                                       instantiation as in `object A{ MyCaseClas@@ }`
-   * @param noSquareBracketExists if there is already a square bracket in the position as in
-   *                              `val a: IndexedMa@@[]`
-   */
-  private case class CursorPositionCondition(
-      isTypePosition: Boolean,
-      isNewPosition: Boolean,
-      isInstantiationOrMethodCallPos: Boolean,
-      noSquareBracketExists: Boolean,
-  ):
-
-    def isObjectValidForPos = (!isTypePosition && !isNewPosition)
-
-    /**
-     * classes and traits are type symbols. They are not suitable for
-     *        instantiation or method call positions. Only apply methods and objects
-     *        can be used in such positions.
-     */
-    def isClassOrTraitValidForPos = !isInstantiationOrMethodCallPos
-    def isMethodValidForPos = !isTypePosition
-
-    def isParanethesisValidForPos = !isTypePosition
-    def isSquareBracketsValidForPos = noSquareBracketExists
-      && (isTypePosition || isNewPosition || isInstantiationOrMethodCallPos)
-
-    /**
-     * as in ```new MyTrait@@```
-     */
-    def isCurlyBracesValidForPos = isNewPosition
-  end CursorPositionCondition
-
-  private lazy val cursorPositionCondition =
-    calculateTypeInstanceAndNewPositions(path)
-
-  private def calculateTypeInstanceAndNewPositions(
-      path: List[Tree]
-  ): CursorPositionCondition =
-    path match
-      case (head: (Select | Ident)) :: tail =>
-        // https://github.com/lampepfl/dotty/issues/15750
-        // due to this issue in dotty, because of which trees after typer lose information,
-        // we have to calculate hasNoSquareBracket manually:
-        val hasNoSquareBracket =
-          val span: Span = head.srcPos.span
-          if span.exists then
-            var i = span.end
-            while i < (text.length() - 1) && text(i).isWhitespace do i = i + 1
-
-            if (i < text.length()) then text(i) != '['
-            else true
-          else false
-        tail match
-          case (v: ValOrDefDef) :: _ =>
-            if v.tpt.sourcePos.contains(pos) then
-              CursorPositionCondition(true, false, false, hasNoSquareBracket)
-            else
-              CursorPositionCondition(false, false, false, hasNoSquareBracket)
-          case New(selectOrIdent: (Select | Ident)) :: _ =>
-            if selectOrIdent.sourcePos.contains(pos) then
-              CursorPositionCondition(false, true, false, hasNoSquareBracket)
-            else
-              CursorPositionCondition(false, false, false, hasNoSquareBracket)
-          case (a @ AppliedTypeTree(_, args)) :: _ =>
-            if args.exists(_.sourcePos.contains(pos)) then
-              CursorPositionCondition(true, false, false, hasNoSquareBracket)
-            else CursorPositionCondition(false, false, false, false)
-          case (_: Import) :: _ =>
-            CursorPositionCondition(false, false, false, hasNoSquareBracket)
-          case _ =>
-            CursorPositionCondition(false, false, true, hasNoSquareBracket)
-        end match
-
-      case (_: TypeTree) :: TypeApply(Select(newQualifier: New, _), _) :: _
-          if newQualifier.sourcePos.contains(pos) =>
-        CursorPositionCondition(false, true, false, true)
-
-      case _ => CursorPositionCondition(false, false, false, true)
-    end match
-  end calculateTypeInstanceAndNewPositions
 
   def completions(): (List[CompletionValue], SymbolSearch.Result) =
     val (advanced, exclusive) = advancedCompletions(path, pos, completionPos)
@@ -206,80 +109,33 @@ class Completions(
   inline private def undoBacktick(label: String): String =
     label.stripPrefix("`").stripSuffix("`")
 
-  private def getParams(symbol: Symbol) =
-    lazy val extensionParam = symbol.extensionParam
-    if symbol.is(Flags.Extension) then
-      symbol.paramSymss.filterNot(
-        _.contains(extensionParam)
-      )
-    else symbol.paramSymss
+  private def findSuffix(methodSymbol: Symbol): Option[String] =
+    if shouldAddSnippet && methodSymbol.is(Flags.Method) then
+      lazy val extensionParam = methodSymbol.extensionParam
 
-  private def isAbstractType(symbol: Symbol) =
-    (symbol.info.typeSymbol.is(Trait) // trait A{ def doSomething: Int}
-    // object B{ new A@@}
-    // Note: I realised that the value of Flag.Trait is flaky and
-    // leads to the failure of one of the DocSuite tests
-      || symbol.info.typeSymbol.isAllOf(
-        Flags.JavaInterface // in Java:  interface A {}
-        // in Scala 3: object B { new A@@}
-      ) || symbol.info.typeSymbol.isAllOf(
-        Flags.PureInterface // in Java: abstract class Shape { abstract void draw();}
-        // Shape has only abstract members, so can be represented by a Java interface
-        // in Scala 3: object B{ new Shap@@ }
-      ) || (symbol.info.typeSymbol.is(Flags.Abstract) &&
-        symbol.isClass) // so as to exclude abstract methods
-    // abstract class A(i: Int){ def doSomething: Int}
-    // object B{ new A@@}
-    )
-  end isAbstractType
+      val paramss =
+        if methodSymbol.is(Flags.Extension) then
+          methodSymbol.paramSymss.filter(
+            !_.contains(extensionParam)
+          )
+        else methodSymbol.paramSymss
 
-  private def findSuffix(symbol: Symbol): Option[String] =
-
-    val bracketSuffix =
-      if shouldAddSnippet && cursorPositionCondition.isSquareBracketsValidForPos
-        && (symbol.info.typeParams.nonEmpty
-          || (symbol.isAllOf(
-            Flags.JavaModule
-          ) && symbol.companionClass.typeParams.nonEmpty))
-      then "[$0]"
-      else ""
-
-    val bracesSuffix =
-      if shouldAddSnippet && symbol.is(
-          Flags.Method
-        ) && cursorPositionCondition.isParanethesisValidForPos
-      then
-        val paramss = getParams(symbol)
-        paramss match
-          case Nil => ""
-          case List(Nil) => "()"
-          case _ if config.isCompletionSnippetsEnabled =>
-            val onlyParameterless = paramss.forall(_.isEmpty)
-            lazy val onlyImplicitOrTypeParams = paramss.forall(
-              _.exists { sym =>
-                sym.isType || sym.is(Implicit) || sym.is(Given)
-              }
-            )
-            if onlyParameterless then "()" * paramss.length
-            else if onlyImplicitOrTypeParams then ""
-            else if bracketSuffix == "[$0]" then "()"
-            else "($0)"
-          case _ => ""
-        end match
-      else ""
-
-    val templateSuffix =
-      if shouldAddSnippet && cursorPositionCondition.isCurlyBracesValidForPos
-        && isAbstractType(symbol)
-      then
-        if bracketSuffix.nonEmpty || bracesSuffix.contains("$0") then " {}"
-        else " {$0}"
-      else ""
-
-    val concludedSuffix = bracketSuffix + bracesSuffix + templateSuffix
-    if concludedSuffix.nonEmpty then Some(concludedSuffix) else None
-
-  end findSuffix
+      paramss match
+        case Nil => None
+        case List(Nil) => Some("()")
+        case _ if config.isCompletionSnippetsEnabled =>
+          val onlyParameterless = paramss.forall(_.isEmpty)
+          lazy val onlyImplicitOrTypeParams = paramss.forall(
+            _.exists { sym =>
+              sym.isType || sym.is(Implicit) || sym.is(Given)
+            }
+          )
+          if onlyParameterless then Some("()" * paramss.length)
+          else if onlyImplicitOrTypeParams then None
+          else Some("($0)")
+        case _ => None
+      end match
+    else None
 
   def completionsWithSuffix(
       sym: Symbol,
@@ -395,18 +251,15 @@ class Completions(
         val values = FilenameCompletions.contribute(filename, td)
         (values, true)
       case (lit @ Literal(Constant(_: String))) :: _ =>
-        val completions = InterpolatorCompletions
-          .contribute(
-            pos,
-            completionPos,
-            indexedContext,
-            lit,
-            path,
-            this,
-            config.isCompletionSnippetsEnabled(),
-          )
-          .filterInteresting(enrich = false)
-          ._1
+        val completions = InterpolatorCompletions.contribute(
+          pos,
+          completionPos,
+          indexedContext,
+          lit,
+          path,
+          this,
+          config.isCompletionSnippetsEnabled(),
+        )
         (completions, true)
       // From Scala 3.1.3-RC3 (as far as I know), path contains
       // `Literal(Constant(null))` on head for an incomplete program, in this case, just ignore the head.
@@ -492,8 +345,7 @@ class Completions(
 
   extension (l: List[CompletionValue])
     def filterInteresting(
-        qualType: Type = ctx.definitions.AnyType,
-        enrich: Boolean = true,
+        qualType: Type = ctx.definitions.AnyType
     ): (List[CompletionValue], SymbolSearch.Result) =
 
       val isSeen = mutable.Set.empty[String]
@@ -506,7 +358,6 @@ class Completions(
             case symOnly: CompletionValue.Symbolic =>
               val sym = symOnly.symbol
               val name = SemanticdbSymbols.symbolName(sym)
-              val suffix = symOnly.snippetSuffix.getOrElse("")
               val id =
                 if sym.isClass || sym.is(Module) then
                   // drop #|. at the end to avoid duplication
@@ -516,9 +367,6 @@ class Completions(
               val include =
                 !isUninterestingSymbol(sym) &&
                   isNotLocalForwardReference(sym)
-                  && isNotAModuleOrModuleIsValidForPos(sym)
-                  && isNotAMethodOrMethodIsValidForPos(sym)
-                  && isNotClassOrTraitOrTheyAreValidForPos(sym)
 
               (id, include)
             case kw: CompletionValue.Keyword => (kw.label, true)
@@ -534,34 +382,11 @@ class Completions(
       end visit
 
       l.foreach(visit)
-
-      if enrich then
-        val searchResult =
-          enrichWithSymbolSearch(visit, qualType).getOrElse(
-            SymbolSearch.Result.COMPLETE
-          )
-        (buf.result, searchResult)
-      else (buf.result, SymbolSearch.Result.COMPLETE)
-
-    end filterInteresting
-
-    private def isNotAModuleOrModuleIsValidForPos(sym: Symbol) =
-      !sym.info.typeSymbol.is(
-        Flags.Module
-      ) || cursorPositionCondition.isObjectValidForPos
-
-    private def isNotAMethodOrMethodIsValidForPos(sym: Symbol) =
-      cursorPositionCondition.isMethodValidForPos || !sym.is(
-        Flags.Method
-      ) // !sym.info.typeSymbol.is(Flags.Method) does not detect Java methods
-
-    private def isNotClassOrTraitOrTheyAreValidForPos(sym: Symbol) =
-      cursorPositionCondition.isClassOrTraitValidForPos || sym.is(
-        Flags.Method
-      ) || (!sym.isClass && !sym.info.typeSymbol
-        .is(Trait))
-
-  end extension
+      val searchResult =
+        enrichWithSymbolSearch(visit, qualType).getOrElse(
+          SymbolSearch.Result.COMPLETE
+        )
+      (buf.result, searchResult)
 
   private lazy val isUninterestingSymbol: Set[Symbol] = Set[Symbol](
     defn.Any_==,

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -673,22 +673,7 @@ class CompletionDocSuite extends BaseCompletionSuite {
     includeDocs = true,
     compat = Map(
       "2.13" -> post212CatchDocs,
-      "3" ->
-        """|> A container class for catch/finally logic.
-           |
-           | Pass a different value for rethrow if you want to probably
-           | unwisely allow catching control exceptions and other throwables
-           | which the rest of the world may expect to get through.
-           |
-           |**Type Parameters**
-           |- `T`: result type of bodies used in try and catch blocks
-           |
-           |**Parameters**
-           |- `fin`: Finally logic which if defined will be invoked after catch logic
-           |- `rethrow`: Predicate on throwables determining when to rethrow a caught [Throwable](Throwable)
-           |- `pf`: Partial function used when applying catch logic to determine result value
-           |Catch - scala.util.control.Exception
-           |""".stripMargin,
+      "3" -> s"${post212CatchDocs}Catch[T](pf: Catcher[T], fin: Option[Finally], rethrow: Throwable => Boolean): Catch[T]",
     ),
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -355,12 +355,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
   )
 
   check(
-    "member-label".tag(
-      IgnoreScalaVersion.forRangeUntil(
-        "3.2.0-RC1",
-        "3.2.1",
-      )
-    ),
+    "member-label".tag(IgnoreScala3),
     """|object Main {
        |  
        |  s"Hello $List.e@@ "
@@ -373,11 +368,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
       "2.12" ->
         """|empty[A]: List[A]
            |equals(x$1: Any): Boolean
-           |""".stripMargin,
-      "3" ->
-        """|empty[A]: List[A]
-           |equals(x$0: Any): Boolean
-           |""".stripMargin,
+           |""".stripMargin
     ),
     topLines = Some(6),
     includeDetail = false,

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -92,10 +92,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
   )
 
   checkSnippet(
-    // Dotty does not currently support fuzzy completions. Please take a look at
-    // https://github.com/lampepfl/dotty-feature-requests/issues/314
-    "type-empty"
-      .tag(IgnoreScala3),
+    // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
+    "type-empty".tag(IgnoreScala3),
     """
       |object Main {
       |  type MyType = List[Int]
@@ -107,10 +105,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
   )
 
   checkSnippet(
-    // Dotty does not currently support fuzzy completions. Please take a look at
-    // https://github.com/lampepfl/dotty-feature-requests/issues/314
-    "type-new-empty"
-      .tag(IgnoreScala3),
+    // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
+    "type-new-empty".tag(IgnoreScala3),
     """
       |object Main {
       |  class Gen[T]
@@ -135,26 +131,15 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
        |""".stripMargin,
     compat = Map(
       "3" ->
-        """|IndexedSeq[$0]
+        // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
+        """|IndexedSeq
+           |IndexedSeq
            |""".stripMargin
     ),
   )
 
   checkSnippet(
-    "empty-params-with-implicit",
-    s"""|object Main {
-        |  def doSomething()(implicit x: Int) = x
-        |  val bar = doSomethi@@
-        |}
-        |""".stripMargin,
-    "doSomething($0)",
-  )
-
-  checkSnippet(
-    // handling this in Scala 3 requires covering CompletionKind.Member in enrichWithSymbols
-    // and filtering out the non-member items.
-    "type2"
-      .tag(IgnoreScala3),
+    "type2".tag(IgnoreScala3),
     s"""|object Main {
         |  new scala.IndexedSeq@@
         |}
@@ -178,10 +163,12 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |ArrayDeque
            |ArrayDequeOps
            |""".stripMargin,
-      "3" -> // ArrayDeque upper is for java, the lower for scala
-        """|ArrayDeque[$0]
-           |ArrayDeque[$0]
-           |ArrayDequeOps[$0]
+      // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
+      "3" ->
+        """|ArrayDeque($0)
+           |ArrayDeque
+           |ArrayDeque
+           |ArrayDequeOps
            |""".stripMargin,
     ),
   )
@@ -194,6 +181,12 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|SimpleFileVisitor[$0]
        |""".stripMargin,
+    compat = Map(
+      // scala 3 new completions not implemented, so no way to distinguish if we are at a type position
+      "3" ->
+        """|SimpleFileVisitor
+           |""".stripMargin
+    ),
   )
 
   checkSnippet(
@@ -212,8 +205,10 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |IterableOnce[$0] {}
            |""".stripMargin,
       "3" ->
-        """|Iterable[$0] {}
-           |IterableOnce[$0] {}
+        // scala 3 new completions not implemented, so no way to distinguish if we are at a type position
+        """|Iterable
+           |Iterable
+           |IterableOnce
            |""".stripMargin,
     ),
   )
@@ -234,8 +229,10 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |IterableOnce[$0]
            |""".stripMargin,
       "3" ->
-        """|Iterable[$0]
-           |IterableOnce[$0]
+        // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
+        """|Iterable
+           |Iterable
+           |IterableOnce
            |""".stripMargin,
     ),
   )
@@ -255,9 +252,11 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |Iterable[$0]
            |IterableOnce[$0]
            |""".stripMargin,
+      // scala 3 type completions not implemented, so no way to distinguish if we are at a type position
       "3" ->
-        """|Iterable[$0]
-           |IterableOnce[$0]
+        """|Iterable
+           |Iterable
+           |IterableOnce
            |""".stripMargin,
     ),
   )
@@ -374,11 +373,12 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
        |""".stripMargin,
     // additional completion when apply method is present
     compat = Map(
-      // Note: the class and trait items in here are invalid. So
-      // they are filtered out.
       "3" ->
         """|Try
            |Try($0)
+           |TryBlock
+           |TryModule
+           |TryMethods
            |TryMethods
            |""".stripMargin
     ),

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1480,7 +1480,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "pkg".tag(IgnoreScalaVersion.for3LessThan("3.1.3")),
+    "pkg",
     s"""|object Foo {
         |  scala.coll@@
         |}
@@ -1489,25 +1489,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "pkg-typed".tag(IgnoreScalaVersion.for3LessThan("3.1.3")),
-    s"""|object Foo {
-        |  val a : scala.coll@@
-        |}
-        |""".stripMargin,
-    "collection scala",
-  )
-
-  check(
-    "pkg-new".tag(IgnoreScalaVersion.for3LessThan("3.1.3")),
-    s"""|object Foo {
-        |  new scala.coll@@
-        |}
-        |""".stripMargin,
-    "collection scala",
-  )
-
-  check(
-    "pkg-scala".tag(IgnoreScalaVersion.for3LessThan("3.1.3")),
+    "pkg-scala",
     s"""|object Foo {
         |  scala@@
         |}

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1479,29 +1479,4 @@ class CompletionSuite extends BaseCompletionSuite {
     "",
   )
 
-  check(
-    "pkg",
-    s"""|object Foo {
-        |  scala.coll@@
-        |}
-        |""".stripMargin,
-    "collection scala",
-  )
-
-  check(
-    "pkg-scala",
-    s"""|object Foo {
-        |  scala@@
-        |}
-        |""".stripMargin,
-    """|scala <root>
-       |""".stripMargin,
-    compat = Map(
-      "2" ->
-        """|scala _root_
-           |`package` - scala
-           |""".stripMargin
-    ),
-  )
-
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -353,26 +353,13 @@ class CompletionSuite extends BaseCompletionSuite {
        |ProcessBuilder - scala.sys.process
        |CertPathBuilder - java.security.cert
        |CertPathBuilderSpi - java.security.cert
+       |ProcessBuilderImpl - scala.sys.process
        |CertPathBuilderResult - java.security.cert
        |PKIXBuilderParameters - java.security.cert
        |PooledConnectionBuilder - javax.sql
        |CertPathBuilderException - java.security.cert
        |PKIXCertPathBuilderResult - java.security.cert
        |""".stripMargin,
-    compat = Map(
-      "2" ->
-        """|ProcessBuilder java.lang
-           |ProcessBuilder - scala.sys.process
-           |CertPathBuilder - java.security.cert
-           |CertPathBuilderSpi - java.security.cert
-           |ProcessBuilderImpl - scala.sys.process
-           |CertPathBuilderResult - java.security.cert
-           |PKIXBuilderParameters - java.security.cert
-           |PooledConnectionBuilder - javax.sql
-           |CertPathBuilderException - java.security.cert
-           |PKIXCertPathBuilderResult - java.security.cert
-           |""".stripMargin
-    ),
   )
 
   check(
@@ -397,6 +384,7 @@ class CompletionSuite extends BaseCompletionSuite {
       "3" ->
         """|TrieMap scala.collection.concurrent
            |TrieMap[K, V](elems: (K, V)*): CC[K, V]
+           |TrieMapSerializationEnd - scala.collection.concurrent
            |""".stripMargin,
     ),
   )
@@ -681,6 +669,9 @@ class CompletionSuite extends BaseCompletionSuite {
     """.stripMargin,
     """|concat[T: ClassTag](xss: Array[T]*): Array[T]
        |""".stripMargin,
+    compat = Map(
+      "3" -> "concat[T: ClassTag](xss: Array[T]*): Array[T]"
+    ),
   )
 
   check(
@@ -904,6 +895,9 @@ class CompletionSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|selectDynamic(field: String): Foo
        |""".stripMargin,
+    compat = Map(
+      "3" -> "selectDynamic(field: String): Foo"
+    ),
   )
 
   check(
@@ -914,6 +908,12 @@ class CompletionSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|ListBuffer - scala.collection.mutable
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|ListBuffer[A](elems: A*): CC[A]
+           |ListBuffer - scala.collection.mutable
+           |""".stripMargin
+    ),
   )
 
   check(
@@ -924,14 +924,16 @@ class CompletionSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|ListBuffer - scala.collection.mutable
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|ListBuffer[A](elems: A*): CC[A]
+           |ListBuffer - scala.collection.mutable
+           |""".stripMargin
+    ),
   )
 
   check(
-    "type2"
-      // covering it for Scala 3 has to do with covering the
-      // CompletionKind.Member case in enrichWithSymbolSearch.
-      // The non-members have to get filtered out.
-      .tag(IgnoreScala3),
+    "type2".tag(IgnoreScala3),
     s"""|object Main {
         |  new scala.Iterable@@
         |}
@@ -963,6 +965,8 @@ class CompletionSuite extends BaseCompletionSuite {
            |Some[A](value: A): Some[A]
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
            |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
+           |SomeToExpr - scala.quoted.ToExpr
+           |SomeFromExpr - scala.quoted.FromExpr
            |""".stripMargin,
       "3" ->
         """|Some scala
@@ -990,6 +994,8 @@ class CompletionSuite extends BaseCompletionSuite {
            |Some[A](value: A): Some[A]
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
            |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
+           |SomeToExpr - scala.quoted.ToExpr
+           |SomeFromExpr - scala.quoted.FromExpr
            |""".stripMargin,
       "3" ->
         """|Some scala

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -111,19 +111,10 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """|package `import-conflict3`
        |import java.util.concurrent.Future
        |case class Foo(
-       |  name: scala.concurrent.Future[$0]
+       |  name: scala.concurrent.Future
        |)
        |""".stripMargin,
     filter = _ == "Future - scala.concurrent",
-    compat = Map(
-      "2" ->
-        """|package `import-conflict3`
-           |import java.util.concurrent.Future
-           |case class Foo(
-           |  name: scala.concurrent.Future
-           |)
-           |""".stripMargin
-    ),
   )
 
   checkEdit(
@@ -137,19 +128,10 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """|package `import-conflict4`
        |import java.util.concurrent._
        |case class Foo(
-       |  name: scala.concurrent.Future[$0]
+       |  name: scala.concurrent.Future
        |)
        |""".stripMargin,
     filter = _ == "Future - scala.concurrent",
-    compat = Map(
-      "2" ->
-        """|package `import-conflict4`
-           |import java.util.concurrent._
-           |case class Foo(
-           |  name: scala.concurrent.Future
-           |)
-           |""".stripMargin
-    ),
   )
 
   checkEdit(
@@ -164,20 +146,10 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |import java.util.concurrent.{Future => _, _}
        |import scala.concurrent.Future
        |case class Foo(
-       |  name: Future[$0]
+       |  name: Future
        |)
        |""".stripMargin,
     filter = _ == "Future - scala.concurrent",
-    compat = Map(
-      "2" ->
-        """|package `import-no-conflict`
-           |import java.util.concurrent.{Future => _, _}
-           |import scala.concurrent.Future
-           |case class Foo(
-           |  name: Future
-           |)
-           |""".stripMargin
-    ),
   )
 
   checkEdit(
@@ -206,16 +178,8 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """package pkg
       |
       |import java.util.concurrent.CompletableFuture
-      |object Main extends CompletableFuture[$0]
+      |object Main extends CompletableFuture
       |""".stripMargin,
-    compat = Map(
-      "2" ->
-        """package pkg
-          |
-          |import java.util.concurrent.CompletableFuture
-          |object Main extends CompletableFuture
-          |""".stripMargin
-    ),
   )
 
   checkEdit(
@@ -226,16 +190,8 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """package pkg
       |
       |import java.util.concurrent.CompletableFuture
-      |object Main extends CompletableFuture[$0]
+      |object Main extends CompletableFuture
       |""".stripMargin,
-    compat = Map(
-      "2" ->
-        """package pkg
-          |
-          |import java.util.concurrent.CompletableFuture
-          |object Main extends CompletableFuture
-          |""".stripMargin
-    ),
   )
 
   checkEdit(
@@ -344,21 +300,11 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """|import java.util.ArrayDeque
        |object Main {
        |  def foo(): Unit = null match {
-       |    case x: ArrayDeque[$0] =>
+       |    case x: ArrayDeque =>
        |  }
        |}
        |""".stripMargin,
     filter = _.contains("java.util"),
-    compat = Map(
-      "2" ->
-        """|import java.util.ArrayDeque
-           |object Main {
-           |  def foo(): Unit = null match {
-           |    case x: ArrayDeque =>
-           |  }
-           |}
-           |""".stripMargin
-    ),
   )
 
   checkEdit(
@@ -372,21 +318,11 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     """|import scala.util.Failure
        |object Main {
        |  def foo(): Unit = {
-       |    val x: Failure[$0]
+       |    val x: Failure
        |  }
        |}
        |""".stripMargin,
     filter = _.contains("scala.util"),
-    compat = Map(
-      "2" ->
-        """|import scala.util.Failure
-           |object Main {
-           |  def foo(): Unit = {
-           |    val x: Failure
-           |  }
-           |}
-           |""".stripMargin
-    ),
   )
 
   checkEdit(
@@ -509,18 +445,18 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "annotation-def-with-middle-space",
+    "annotation-def",
     """|
        |object Main {
        |  @noinline
-       |  def foo: ArrayBuffer@@ [Int] = ???
+       |  def foo: ArrayBuffer@@[Int] = ???
        |}
        |""".stripMargin,
     """|import scala.collection.mutable.ArrayBuffer
        |
        |object Main {
        |  @noinline
-       |  def foo: ArrayBuffer [Int] = ???
+       |  def foo: ArrayBuffer[Int] = ???
        |}
        |""".stripMargin,
     filter = _ == "ArrayBuffer - scala.collection.mutable",
@@ -645,7 +581,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "parent-object",
+    "parent-object-scala2".tag(IgnoreScala3),
     """|object Main {
        |  Implicits@@
        |}
@@ -656,14 +592,6 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     filter = _ == "Implicits - scala.concurrent.ExecutionContext",
-    compat = Map {
-      "3" ->
-        """|import scala.concurrent.ExecutionContext.Implicits
-           |object Main {
-           |  Implicits
-           |}
-           |""".stripMargin
-    },
   )
 
   // this test was intended to check that import is rendered correctly - without `$` symbol
@@ -754,6 +682,12 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |Future - java.util.concurrent
        |""".stripMargin,
     topLines = Some(2),
+    compat = Map(
+      "3" ->
+        """|Future scala.concurrent
+           |Future[T](body: => T)(implicit executor: ExecutionContext): Future[T]
+           |""".stripMargin
+    ),
   )
 
   check(
@@ -769,5 +703,11 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |Future - scala.concurrent
        |""".stripMargin,
     topLines = Some(2),
+    compat = Map(
+      "3" ->
+        """|Future java.util.concurrent
+           |Future[T](body: => T)(implicit executor: ExecutionContext): scala.concurrent.Future[T]
+           |""".stripMargin
+    ),
   )
 }

--- a/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
@@ -164,6 +164,7 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
                  |""".stripMargin,
             "3" ->
               """|TrieMap - scala.collection.concurrent
+                 |TrieMapSerializationEnd - scala.collection.concurrent
                  |TrieMap[K, V](elems: (K, V)*): CC[K, V]
                  |""".stripMargin,
           ),


### PR DESCRIPTION
This PR reverts the following changes.

- https://github.com/scalameta/metals/pull/4174
- https://github.com/scalameta/metals/pull/4223

Context: https://github.com/scalameta/metals/pull/4234#issuecomment-1208922560 we encounter some regressions related to the type completions feature. We revert those changes because we're going to release a new version of Metals, and it would be safer not to include those features in the new release https://github.com/scalameta/metals/pull/4214