### PR TITLE
feat: capture and forward `diagnosticCode`

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -267,6 +267,7 @@ final class Diagnostics(
         d.getSeverity,
         d.getSource,
       )
+      if (d.getCode() != null) ld.setCode(d.getCode())
       ld.setData(d.getData)
       ld
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -761,9 +761,10 @@ object MetalsEnrichments
         fansi.Str(diag.getMessage, ErrorMode.Strip).plainText,
         diag.getSeverity.toLsp,
         if (diag.getSource == null) "scalac" else diag.getSource,
-        // We omit diag.getCode since Bloop's BSP implementation uses 'code' with different semantics
-        // than LSP. See https://github.com/scalacenter/bloop/issues/1134 for details
       )
+      if (diag.getCode() != null) {
+        ld.setCode(diag.getCode())
+      }
       ld.setData(diag.getData)
       ld
     }


### PR DESCRIPTION
This relates to the grand plan of
https://github.com/lampepfl/dotty/issues/14904 and recently forwarding
the `diagnosticCode` has been merged in
https://github.com/lampepfl/dotty/pull/15565 and also backported so it
should show up in the 3.2.x series. While this pr isn't super exciting,
it's just making sure we capture the code and forward it, this should
unlock _much_ better ways to determine what code actions are available
for a given diagnostic. Meaning we don't have to do lovely things like
regex on the diagnostic message for Scala 3 diagnostics.

NOTE: that this does need some more changes in the build servers before
this is usable. So we can wait for those to be merged in if you'd like.

- [x] sbt - https://github.com/sbt/sbt/pull/6998
- [x] Bloop - https://github.com/scalacenter/bloop/pull/1750
- [x] Mill - https://github.com/com-lihaoyi/mill/pull/1912

Now if you look at the trace file for a diagnostic you'll see the
addition of the code:

```
  "diagnostics": [
    {
      "range": {
        "start": {
          "line": 9,
          "character": 15
        },
        "end": {
          "line": 9,
          "character": 19
        }
      },
      "severity": 1,
      "code": "7",
      "source": "sbt",
      "message": "Found:    (\u001b[32m\"hi\"\u001b[0m : String)\nRequired: Int\n\nThe following import might make progress towards fixing the problem:\n\n  import sourcecode.Text.generate\n\n"
    }
  ],
```

Refs: https://github.com/lampepfl/dotty/issues/14904