### PR TITLE
docs: fix release note metadata

### DIFF
--- a/website/blog/2022-08-10-aluminium.md
+++ b/website/blog/2022-08-10-aluminium.md
@@ -11,11 +11,11 @@ We're happy to announce the release of Metals v0.11.8, bringing a number of impr
 <tbody>
   <tr>
     <td>Commits since last release</td>
-    <td align="center">103</td>
+    <td align="center">84</td>
   </tr>
   <tr>
     <td>Merged PRs</td>
-    <td align="center">79</td>
+    <td align="center">80</td>
   </tr>
     <tr>
     <td>Contributors</td>
@@ -110,7 +110,7 @@ Big thanks to everybody who contributed to this release or reported an issue!
 ```
 $ git shortlog -sn --no-merges v0.11.7..v0.11.8
 33	Tomasz Godzik
-    30	Rikito Taniguchi
+    11	Rikito Taniguchi
      9	Scala Steward
      6	jkciesluk
      6	Kamil Podsiadło


### PR DESCRIPTION
I (@tanishiking) misplaced the v0.11.8 tag to
https://github.com/scalameta/metals/pull/4214/commits/51260e5415e2cf7304703c87c0eeb70f4865b588
and generated the release note.
However, that commit is squashed and the previous release note was
something wrong with its metadata such as

- contributors (my commit numbers was wiredly bigger than actual number)
- Commits since last release contained the number of commits in the
  release note PR

I re-tagged v0.11.8 to
https://github.com/scalameta/metals/commit/6bf55ab632a900331720fd5f04e916596a3311f6
and re-generated the release note.

