### PR TITLE
bugfix: Don't throw exception if template ends at EOF

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/parsing/FoldingRangeExtractor.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/FoldingRangeExtractor.scala
@@ -245,8 +245,10 @@ final class FoldingRangeExtractor(
           val firstChar = block.pos.input.chars(block.pos.start)
           block.pos.startLine != block.pos.endLine && firstChar != '{'
         case temp: Template =>
-          val endChar = temp.pos.input.chars(temp.pos.end)
-          temp.pos.startLine != temp.pos.endLine && endChar != '}'
+          def endChar = temp.pos.input.chars(temp.pos.end)
+          def endsAtEndOfLine = temp.pos.end >= temp.pos.input.chars.size
+          temp.pos.startLine != temp.pos.endLine &&
+          (endsAtEndOfLine || endChar != '}')
         case _ => false
       }
     }

--- a/tests/unit/src/test/resources/foldingRange-scala3/expect/BlockWithNoBraces.scala
+++ b/tests/unit/src/test/resources/foldingRange-scala3/expect/BlockWithNoBraces.scala
@@ -15,3 +15,10 @@ def endmarker(): Unit =>>region>>
   ???
   ???<<region<<
 end endmarker
+
+object foo>>region>>:
+  println("")
+  println("")
+  println("")
+  println("")
+  println("")<<region<<

--- a/tests/unit/src/test/resources/foldingRange-scala3/input/BlockWithNoBraces.scala
+++ b/tests/unit/src/test/resources/foldingRange-scala3/input/BlockWithNoBraces.scala
@@ -15,3 +15,10 @@ def endmarker(): Unit =
   ???
   ???
 end endmarker
+
+object foo:
+  println("")
+  println("")
+  println("")
+  println("")
+  println("")


### PR DESCRIPTION
Previously, if a template was ended by EOF we would throw IndexOutOfBounds exception, however with optional braces it can end at EOF token, which doesn't correspond to any char. Now, we added a size check for that case.

Fixes https://github.com/scalameta/metals/issues/4243

We could try and adjust end pos to previous character, but that's also not that great since `)` doesn't really end a block