### PR TITLE
Fix ArgCompletions for nested apply

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -467,4 +467,19 @@ class CompletionArgSuite extends BaseCompletionSuite {
     "f(a = ${1|???,str1,str|}, b = ${2|???,str1,str|}, `type` = ${3|???,str1,str|})",
   )
 
+  check(
+    "nested-apply".tag(IgnoreScala3),
+    s"""|object Main{
+        |  def foo(argument1: Int, argument2: Int): Int = arg1 + arg2
+        |  val x: Int = 3
+        |  foo(foo(@@), )
+        |}
+        |""".stripMargin,
+    """|argument1 = : Int
+       |argument2 = : Int
+       |argument1 = x : Int
+       |argument2 = x : Int
+       |""".stripMargin,
+    topLines = Some(4),
+  )
 }


### PR DESCRIPTION
Sometimes typedTreeAt can't insert type correctly, now as a fallback we search for the symbol in metalsScopeMembers.
Fixes https://github.com/scalameta/metals/issues/4244