### PR TITLE
bugfix: Fix signature help when named params are present

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -491,6 +491,92 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
   )
 
   check(
+    "case-class",
+    """
+      |import java.{util => ju}
+      |import javax.annotation.Nullable
+      |
+      |
+      |case class TreeViewNode(
+      |    viewId: String,
+      |    @Nullable nodeUri: String,
+      |    label: String,
+      |    @Nullable command: String = null,
+      |    @Nullable icon: String = null,
+      |    @Nullable tooltip: String = null,
+      |    // One of "collapsed", "expanded" or "none"
+      |    @Nullable collapseState: String = null,
+      |)
+      |
+      |object O{
+      |  val viewId = ""
+      |  val rootUri = ""
+      |  val title = ""
+      |  def root: TreeViewNode =
+      |    TreeViewNode(
+      |      vi@@ewId,
+      |      rootUri,
+      |      title,
+      |      collapseState = "",
+      |    )
+      |}
+      |
+      |
+    """.stripMargin,
+    """|apply(viewId: String, nodeUri: String, label: String, command: String = ..., icon: String = ..., tooltip: String = ..., collapseState: String = ...): TreeViewNode
+       |      ^^^^^^^^^^^^^^
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|apply(viewId: String, nodeUri: String, label: String, command: String, icon: String, tooltip: String, collapseState: String): case-class.TreeViewNode
+           |      ^^^^^^^^^^^^^^
+           |""".stripMargin
+    ),
+  )
+
+  check(
+    "case-class2",
+    """
+      |import java.{util => ju}
+      |import javax.annotation.Nullable
+      |
+      |
+      |case class TreeViewNode(
+      |    viewId: String,
+      |    @Nullable nodeUri: String,
+      |    label: String,
+      |    @Nullable command: String = null,
+      |    // One of "collapsed", "expanded" or "none"
+      |    @Nullable collapseState: String = null,
+      |)
+      |
+      |object O{
+      |  def root: TreeViewNode =
+      |    val viewId = ""
+      |    val rootUri = ""
+      |    val title = ""
+      |    TreeViewNode(
+      |      vi@@ewId,
+      |      rootUri,
+      |      title,
+      |      collapseState = "",
+      |    )
+      |}
+      |
+      |
+    """.stripMargin,
+    """|apply(<viewId: String>, <nodeUri: String>, <label: String>, <collapseState: String = ...>, <command: String = ...>): TreeViewNode
+       |      ^^^^^^^^^^^^^^^^
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|apply(viewId: String, nodeUri: String, label: String, command: String, collapseState: String): case-class2.TreeViewNode
+           |      ^^^^^^^^^^^^^^
+           |""".stripMargin
+    ),
+  )
+
+  check(
     "named",
     """
       |case class User(name: String = "John", age: Int = 42)


### PR DESCRIPTION
Previously, we would show a wrong parameter, when named params were present, in two ways:
- use wrong position for checking current highlighted param - this is due to the fact that all the params are synthetic in such situation
- use wrong order of params for the parameters present in the correct place

Now, those two issue are handled properly by:
- first, correct position was already calculated, but not used
- second, by adjusting the sorting

Fixes https://github.com/scalameta/metals/issues/4249

I added more docs than code since the behaviour was a little unclear