### PR TITLE
bugfix: Check if the target can be compiled

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -202,6 +202,15 @@ final class BuildTargets() {
   ): Option[AbsolutePath] =
     buildServerOf(buildTarget).map(_.workspaceDirectory)
 
+  def canCompile(id: BuildTargetIdentifier): Boolean = {
+    targetData(id).exists { data =>
+      data.buildTargetInfo
+        .get(id)
+        .map[Boolean](_.getCapabilities().getCanCompile())
+        .getOrElse(true)
+    }
+  }
+
   /**
    * Returns the first build target containing this source file.
    */

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -189,8 +189,9 @@ final class Compilations(
         buildServer
       }
       .map { case (buildServer, targets) =>
-        val targets0 = targets.map { case (_, target) =>
-          target
+        val targets0 = targets.collect {
+          case (_, target) if buildTargets.canCompile(target) =>
+            target
         }
         (buildServer, targets0)
       }


### PR DESCRIPTION
Previously, we would not check if a build target can be compiled before sending a compile request. Now, we will not send the compile request if the build tool specifies a target as a one that can't be compiled.

Fixes https://github.com/scalameta/metals/issues/4254