### PR TITLE
bugfix: Don't show preparing PC message

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -65,9 +65,7 @@ final class Embedded(
   ): PresentationCompiler = {
     val classloader = presentationCompilers.getOrElseUpdate(
       ScalaVersions.dropVendorSuffix(mtags.scalaVersion),
-      statusBar.trackSlowTask("Preparing presentation compiler") {
-        newPresentationCompilerClassLoader(mtags, classpath)
-      },
+      newPresentationCompilerClassLoader(mtags, classpath),
     )
     serviceLoader(
       classOf[PresentationCompiler],

--- a/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/DefinitionCrossLspSuite.scala
@@ -84,9 +84,26 @@ class DefinitionCrossLspSuite
       _ <- server.didOpen("a/src/main/scala/a/Main.scala")
       _ = server.workspaceDefinitions // trigger definition
       _ <- server.didOpen("scala/Predef.scala")
-      _ = assertNoDiff(
-        client.workspaceMessageRequests,
-        "Preparing presentation compiler",
+      _ <- server.assertHover(
+        "a/src/main/scala/a/Main.scala",
+        """
+          |object Main {
+          |  prin@@tln("hello!")
+          |}""".stripMargin,
+        if (scalaVersion.startsWith("2.12"))
+          """|```scala
+             |def println(x: Any): Unit
+             |```
+             |Prints out an object to the default output, followed by a newline character.
+             |
+             |
+             |**Parameters**
+             |- `x`: the object to print.
+             |""".stripMargin
+        else """|```scala
+               |def println(x: Any): Unit
+               |```
+               |""".stripMargin,
       )
       _ = assertNoDiff(client.workspaceDiagnostics, "")
     } yield ()


### PR DESCRIPTION
Previously, we would show "Preparing presentation compiler" message, but since it seems to be on a critical path, it sometimes popped up and would not stop. Also the current place this is in is not actually downloading anything. Now, I decided after multiple iterations to just not show the message. If anything breaks we will show a proper message, but otherwise the message didn't add anything and might cause issues for the users.