### PR TITLE
refactor: include the companion object name in code action title

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateCompanionObjectCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateCompanionObjectCodeAction.scala
@@ -119,7 +119,9 @@ class CreateCompanionObjectCodeAction(
       bracelessOK: Boolean,
   ): l.CodeAction = {
     val codeAction = new l.CodeAction()
-    codeAction.setTitle(CreateCompanionObjectCodeAction.companionObjectCreation)
+    codeAction.setTitle(
+      CreateCompanionObjectCodeAction.companionObjectCreation(name)
+    )
     codeAction.setKind(this.kind)
     val range = new l.Range(pos, pos)
 
@@ -190,5 +192,6 @@ class CreateCompanionObjectCodeAction(
 }
 
 object CreateCompanionObjectCodeAction {
-  val companionObjectCreation = "Create companion object"
+  def companionObjectCreation(name: String): String =
+    s"Create companion object for ${name}"
 }

--- a/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
@@ -278,7 +278,7 @@ class Scala3CodeActionLspSuite
        |
        |  class Bar {}
        |""".stripMargin,
-    s"""|${CreateCompanionObjectCodeAction.companionObjectCreation}
+    s"""|${CreateCompanionObjectCodeAction.companionObjectCreation("Foo")}
         |""".stripMargin,
     """|object Baz:
        |  enum Foo:
@@ -299,7 +299,7 @@ class Scala3CodeActionLspSuite
     "insert-companion-object-of-braceless-case-class-file-end",
     """|case class F<<>>oo(a: Int):
        |  def b = a""".stripMargin,
-    s"""|${CreateCompanionObjectCodeAction.companionObjectCreation}
+    s"""|${CreateCompanionObjectCodeAction.companionObjectCreation("Foo")}
         |""".stripMargin,
     """|case class Foo(a: Int):
        |  def b = a

--- a/tests/unit/src/test/scala/tests/codeactions/CompanionObjectSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/CompanionObjectSuite.scala
@@ -16,7 +16,7 @@ class CompanionObjectSuite extends BaseCodeActionLspSuite("companionObject") {
        |}
        |""".stripMargin,
     s"""|${ExtractRenameMember.title("class", "Foo")}
-        |${CreateCompanionObjectCodeAction.companionObjectCreation}
+        |${CreateCompanionObjectCodeAction.companionObjectCreation("Foo")}
         |""".stripMargin,
     """|class Foo {
        |
@@ -37,7 +37,7 @@ class CompanionObjectSuite extends BaseCodeActionLspSuite("companionObject") {
     "bracefull-companion-object-insert-for-scala2-file-end",
     """|case class F<<>>oo()""".stripMargin,
     s"""|${ExtractRenameMember.renameFileAsClassTitle("A.scala", "Foo")}
-        |${CreateCompanionObjectCodeAction.companionObjectCreation}
+        |${CreateCompanionObjectCodeAction.companionObjectCreation("Foo")}
         |""".stripMargin,
     """|case class Foo()
        |
@@ -60,7 +60,7 @@ class CompanionObjectSuite extends BaseCodeActionLspSuite("companionObject") {
        |  }
        |}
        |""".stripMargin,
-    s"""|${CreateCompanionObjectCodeAction.companionObjectCreation}
+    s"""|${CreateCompanionObjectCodeAction.companionObjectCreation("Foo")}
         |""".stripMargin,
     """|object Baz {
        |  class Foo {
@@ -108,7 +108,7 @@ class CompanionObjectSuite extends BaseCodeActionLspSuite("companionObject") {
        |}
        |""".stripMargin,
     s"""|${ExtractRenameMember.title("trait", "Foo")}
-        |${CreateCompanionObjectCodeAction.companionObjectCreation}
+        |${CreateCompanionObjectCodeAction.companionObjectCreation("Foo")}
         |""".stripMargin,
     """|trait Foo {
        |


### PR DESCRIPTION
Currently when you're in a large file with possible nested classes and
you trigger a code action you just see the `Create companion object` as
the code action title, but you don't get an indication of what you'll be
creating the companion object for. We do have that information so this
small change just adds the name of the thing we'll be creating a
companion object for in the code action title.
