### PR TITLE
fix: release 8 for mtag-interfaces

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -176,7 +176,16 @@ def lintingOptions(scalaVersion: String) = {
   )
 }
 
-val sharedSettings = List(
+val sharedJavacOptions = List(
+  Compile / javacOptions ++= {
+    if (sys.props("java.version").startsWith("1.8"))
+      Nil
+    else
+      Seq("--release", "8")
+  }
+)
+
+val sharedSettings = sharedJavacOptions ++ List(
   libraryDependencies ++= crossSetting(
     scalaVersion.value,
     if2 = List(
@@ -199,18 +208,13 @@ val sharedSettings = List(
     if3 = List("-Yrangepos", "-target:jvm-1.8"),
   ),
   scalacOptions ++= lintingOptions(scalaVersion.value),
-  Compile / javacOptions ++= {
-    if (sys.props("java.version").startsWith("1.8"))
-      Nil
-    else
-      Seq("--release", "8")
-  },
 )
 
 publish / skip := true
 
 lazy val interfaces = project
   .in(file("mtags-interfaces"))
+  .settings(sharedJavacOptions)
   .settings(
     moduleName := "mtags-interfaces",
     autoScalaLibrary := false,


### PR DESCRIPTION
Follow up to #4267

I haven't properly checked it - interfaces doesn't use `sharedSettings`