### PR TITLE
bugfix: Properly restart worksheet presentation compiler

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -161,6 +161,7 @@ class Compilers(
     Cancelable.cancelEach(cache.values)(_.shutdown())
     Cancelable.cancelEach(worksheetsCache.values)(_.shutdown())
     cache.clear()
+    worksheetsCache.clear()
   }
 
   def restartAll(): Unit = {


### PR DESCRIPTION
Previously, we could get stale information in the worksheet, because we would not fully restart the worksheet presentation compilers. Now, we remove old compilers the same as with normal PC.