### PR TITLE
Better title for `extract value` code action

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractValueCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractValueCodeAction.scala
@@ -314,7 +314,8 @@ class ExtractValueCodeAction(
 
 object ExtractValueCodeAction {
   def title(expr: String): String = {
-    if (expr.length <= 10) s"Extract `$expr` as value"
-    else s"Extract `${expr.take(10)}` ... as value"
+    val trimmed = expr.trim.stripPrefix("{").stripSuffix("}").trim()
+    if (trimmed.length <= 10) s"Extract `$trimmed` as value"
+    else s"Extract `${trimmed.take(10)}` ... as value"
   }
 }


### PR DESCRIPTION
When extracting from block apply, like `Future { ...@@ }` we have to extract as method, not as a value, to not change the logic. Also improves titles, from `{ \n <<code>>` to `code`.
Connected to https://github.com/scalameta/metals/issues/4207