### PR TITLE
Fix mtags release

### DIFF
--- a/.github/workflows/mtags-auto-release.yml
+++ b/.github/workflows/mtags-auto-release.yml
@@ -15,7 +15,7 @@ on:
         # If you update this line after release
         #   just put the tag name (`v*.*.*`) here as in `metals_version.value` above.
         # Don't be confused if this value contains `*.*.*_mtags_release`
-        default: "v0.11.8"
+        default: "0.11.8_mtags_release"
 jobs:
   test_and_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             METALS_VERSION=$(echo $GITHUB_REF_NAME | cut -d "_" -f2 | cut -c2-)
             SCALA_VERSION=$(echo $GITHUB_REF_NAME | cut -d "_" -f3)
             if [ ! -z $METALS_VERSION ] && [ ! -z $SCALA_VERSION ]; then
-              export CI_RELEASE="++$SCALA_VERSION mtags/publishSigned"
+              export CI_RELEASE="++$SCALA_VERSION! mtags/publishSigned"
               UPDATE_DOCS=false
               COMMAND="; set ThisBuild/version :=\"$METALS_VERSION\"; $COMMAND"
             else


### PR DESCRIPTION
Starting from 1.7.0 version sbt has more strict checks for crossVersions.
If a specific version isn't defined in `crossScalaVersion ` it can be passed only with force sign - `!`