### PR TITLE
ci: fix check_scala3_nightly workflow

### DIFF
--- a/.github/workflows/check_scala3_nightly.yml
+++ b/.github/workflows/check_scala3_nightly.yml
@@ -17,7 +17,7 @@ jobs:
           echo "3.2.0-RC1-bin-20220307-6dc591a-NIGHTLY" > $BROKEN
           echo "3.2.0-RC1-bin-20220308-29073f1-NIGHTLY" >> $BROKEN
 
-          cs complete org.scala-lang:scala3-compiler_3: | grep NIGHTLY | grep -v -f $BROKEN | sort > all_nightly
+          cs complete-dep org.scala-lang:scala3-compiler_3: | grep NIGHTLY | grep -v -f $BROKEN | sort > all_nightly
           LAST_NIGHTLY_MTAG=$(cs complete org.scalameta:mtags_3 | grep NIGHTLY | grep -v -f $BROKEN | sort | tail -n 1 | cut -d "_" -f2)
           LAST_NIGHTLY_POS=$(grep -n $LAST_NIGHTLY_MTAG  all_nightly | cut -d ":" -f1)
           LAST_NIGHTLY_POS=$(($LAST_NIGHTLY_POS+1))


### PR DESCRIPTION
Now this worklofw fails with:
```
Usage: cs List(complete) format index ...args...
Usage: cs List(complete) format index ...args...
No new releases found
```

In the latest version of `cs` the command `complete` was renamed to `complete-dep`.