### PR TITLE
feat: implement basic Text Explorer support for scalatest

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -161,12 +161,14 @@ object TestFramework {
     .map {
       case "JUnit" => JUnit4
       case "munit" => MUnit
+      case "ScalaTest" => Scalatest
       case _ => Unknown
     }
     .getOrElse(Unknown)
 }
 case object JUnit4 extends TestFramework(true)
 case object MUnit extends TestFramework(true)
+case object Scalatest extends TestFramework(true)
 case object Unknown extends TestFramework(false)
 
 object BuildTargetClasses {

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/MunitTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/MunitTestFinder.scala
@@ -6,14 +6,13 @@ import scala.collection.mutable
 
 import scala.meta.Defn
 import scala.meta.Lit
-import scala.meta.Pkg
 import scala.meta.Template
 import scala.meta.Term
 import scala.meta.Tree
-import scala.meta.Type
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.testProvider.FullyQualifiedName
 import scala.meta.internal.metals.testProvider.TestCaseEntry
+import scala.meta.internal.metals.testProvider.frameworks.TreeUtils._
 import scala.meta.internal.mtags
 import scala.meta.internal.mtags.GlobalSymbolIndex
 import scala.meta.internal.mtags.Semanticdbs
@@ -162,65 +161,6 @@ class MunitTestFinder(
       .toVector
 
   /**
-   * Class definition is valid when package + class name is equal to one we are looking for
-   */
-  private def isValid(
-      name: Type.Name,
-      currentPackage: Vector[String],
-      searched: String,
-  ): Boolean = {
-    val fullyQualifiedName = currentPackage.appended(name.value).mkString(".")
-    fullyQualifiedName == searched
-  }
-
-  /**
-   * Extract class/trait template from the given Tree.
-   * @param tree Tree which may contain Template
-   * @param fullyQualifiedName fully qualified class name of class/trait
-   * @return Template of a given class if present
-   */
-  private def extractTemplateFrom(
-      tree: Tree,
-      fullyQualifiedName: String,
-  ): Option[Template] = {
-
-    /**
-     * Search loop with short circuiting when first matching result is obtained.
-     */
-    def loop(
-        t: Tree,
-        currentPackage: Vector[String],
-    ): Option[Template] = {
-      t match {
-        case cls: Defn.Class
-            if isValid(cls.name, currentPackage, fullyQualifiedName) =>
-          Some(cls.templ)
-        case trt: Defn.Trait
-            if isValid(trt.name, currentPackage, fullyQualifiedName) =>
-          Some(trt.templ)
-        // short-circuit to not go deeper into unuseful defns
-        case _: Defn => None
-        case Pkg(ref, children) =>
-          val pkg = extractPackageName(ref)
-          val newPackage = currentPackage ++ pkg
-          LazyList
-            .from(children)
-            .map(loop(_, newPackage))
-            .find(_.isDefined)
-            .flatten
-        case _ =>
-          LazyList
-            .from(t.children)
-            .map(loop(_, currentPackage))
-            .find(_.isDefined)
-            .flatten
-      }
-    }
-
-    loop(tree, Vector.empty)
-  }
-
-  /**
    * Find test call (Term.Name("test")) and test name (Lit.String(...)) in a given tree.
    *
    * e.g.
@@ -316,22 +256,4 @@ class MunitTestFinder(
 
     loop(tree.children)
   }
-
-  /**
-   * Extract package name from given Term
-   *
-   * package a => Term.Name(a)
-   * package a.b.c => Term.Select(Term.Select(a, b), c) (Term.Name are omitted)
-   */
-  @tailrec
-  private def extractPackageName(
-      term: Term,
-      acc: List[String] = Nil,
-  ): Vector[String] =
-    term match {
-      case Term.Name(value) => (value :: acc).toVector
-      case Term.Select(qual, Term.Name(value)) =>
-        extractPackageName(qual, value :: acc)
-      case _ => Vector.empty
-    }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
@@ -1,0 +1,294 @@
+package scala.meta.internal.metals.testProvider.frameworks
+
+import scala.meta.Lit
+import scala.meta.Stat
+import scala.meta.Template
+import scala.meta.Term
+import scala.meta.Tree
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.testProvider.FullyQualifiedName
+import scala.meta.internal.metals.testProvider.TestCaseEntry
+import scala.meta.internal.metals.testProvider.frameworks.ScalatestStyle._
+import scala.meta.internal.metals.testProvider.frameworks.ScalatestTestFinder._
+import scala.meta.internal.metals.testProvider.frameworks.TreeUtils
+import scala.meta.internal.mtags
+import scala.meta.internal.parsing.Trees
+import scala.meta.internal.semanticdb.ClassSignature
+import scala.meta.internal.semanticdb.SymbolInformation
+import scala.meta.internal.semanticdb.TextDocument
+import scala.meta.internal.semanticdb.TypeRef
+import scala.meta.io.AbsolutePath
+
+/**
+ * Scalatest finder searches for tests based solely on trees.
+ */
+class ScalatestTestFinder(
+    trees: Trees,
+    symbolIndex: mtags.GlobalSymbolIndex,
+    semanticdbs: mtags.Semanticdbs,
+) {
+
+  def findTests(
+      doc: TextDocument,
+      path: AbsolutePath,
+      suiteName: FullyQualifiedName,
+      symbol: mtags.Symbol,
+  ): Seq[TestCaseEntry] = {
+    val result = for {
+      tree <- trees.get(path)
+      style <- inferScalatestStyle(doc, symbol)
+    } yield findTestLocations(path, style, tree, suiteName)
+
+    result.getOrElse(Vector.empty)
+  }
+
+  /**
+   * Infer first matching scalatest style for test class.
+   * Implementation searches in direct parents and if it's not successful it performs lazy dfs search.
+   *
+   * @param doc semanticDB of file in which test class is located
+   * @param classSymbol symbol of class for which method should infer style
+   */
+  private def inferScalatestStyle(
+      doc: TextDocument,
+      classSymbol: mtags.Symbol,
+  ): Option[ScalatestStyle] = {
+    val parents = doc.symbols.collect {
+        // format: off
+        case SymbolInformation(symbolValue, _, _, _, _, sig: ClassSignature, _, _, _, _) if symbolValue == classSymbol.value =>
+        // format: on
+        sig.parents
+          .collect { case TypeRef(_, parentSymbol, _) => parentSymbol }
+    }.flatten
+
+    def lazySearch = LazyList.from(parents).collect {
+      case parentSymbol if !ScalatestStyle.baseSymbols.contains(parentSymbol) =>
+        for {
+          definition <- symbolIndex.definition(mtags.Symbol(parentSymbol))
+          tree <- trees.get(definition.path)
+          doc <- semanticdbs
+            .textDocument(definition.path)
+            .documentIncludingStale
+          style <- inferScalatestStyle(doc, mtags.Symbol(parentSymbol))
+        } yield style
+    }
+
+    parents
+      .collectFirst { case ScalatestStyle(style) =>
+        style
+      }
+      .orElse(lazySearch.find(_.isDefined).flatten)
+  }
+}
+
+object ScalatestTestFinder {
+  def findTestLocations(
+      path: AbsolutePath,
+      style: ScalatestStyle,
+      tree: Tree,
+      suiteName: FullyQualifiedName,
+  ): Seq[TestCaseEntry] =
+    TreeUtils.extractTemplateFrom(tree, suiteName.value) match {
+      case Some(template) =>
+        style match {
+          case AnyFunSuite | AnyPropSpec =>
+            findAnyFunSuiteTests(path, template, style)
+
+          case AnyWordSpec | AnyFreeSpec =>
+            findAnyWordSpecTests(path, template, style)
+
+          case AnyFlatSpec =>
+            findAnyFlatSpecTests(path, template)
+
+          case AnyFunSpec =>
+            findAnyFunSpecTests(path, template)
+        }
+      case None =>
+        Nil
+    }
+
+  private def findAnyFunSuiteTests(
+      path: AbsolutePath,
+      template: Template,
+      style: ScalatestStyle,
+  ): List[TestCaseEntry] = {
+    // collect all entries like test("testname") { ... }
+    template.stats.collect {
+          // format: off
+          case Term.Apply(appl @ Term.Apply(Term.Name(funName), Lit.String(testname) :: _), _) 
+              if style.leafMethods.contains(funName) =>
+          // format: on
+        TestCaseEntry(testname, appl.pos.toLSP.toLocation(path.toURI))
+    }
+  }
+
+  /**
+   * AnyWordSpec can contain multiple "descriptions" like "A Set" when { "empty" should { "real test" in { ... } } }
+   */
+  private def findAnyWordSpecTests(
+      path: AbsolutePath,
+      template: Template,
+      style: ScalatestStyle,
+  ): List[TestCaseEntry] = {
+
+    def loop(
+        stats: List[Stat],
+        namePrefix: List[String],
+        acc: List[TestCaseEntry],
+    ): List[TestCaseEntry] =
+      stats.flatMap {
+        // format: off
+        // gather intermediate name parts
+        case Term.ApplyInfix(Lit.String(lhs), Term.Name(infixOp), _, List(Term.Block(stats))) 
+          if style.intermediateMethods.contains(infixOp) =>
+        // format: on
+          val newNamePrefix =
+            if (infixOp != "-") namePrefix :+ lhs :+ infixOp
+            else namePrefix :+ lhs
+          loop(stats, newNamePrefix, acc)
+
+        // format: off
+        // gather leaf name part and collect test entry
+        case Term.ApplyInfix(lhs: Lit.String, Term.Name(infixOp), _, _) 
+          if style.leafMethods.contains(infixOp) => 
+        // format: on
+          val testname = namePrefix.appended(lhs.value).mkString(" ")
+          TestCaseEntry(testname, lhs.pos.toLSP.toLocation(path.toURI)) :: acc
+
+        case _ =>
+          acc
+      }
+
+    loop(template.stats, Nil, Nil)
+  }
+
+  /**
+   * AnyFlatSpec can start with optional name prefix which will be substituted for all subsequent "it" calls.
+   */
+  private def findAnyFlatSpecTests(
+      path: AbsolutePath,
+      template: Template,
+  ): List[TestCaseEntry] = {
+    val (result, _) = template.stats.foldLeft(
+      (List.empty[TestCaseEntry], Option.empty[String])
+    ) { case ((acc, namePrefix), stat) =>
+      stat match {
+        // format: off
+        // "An empty Set" should "have size 0" in { ... }
+        case Term.ApplyInfix(appl @ Term.ApplyInfix(Lit.String(newPrefix), Term.Name(infixOp), _, List(Lit.String(right))), _: Term.Name, _, _) => 
+        // format: on
+          val testname = s"$newPrefix $infixOp $right"
+          val test =
+            TestCaseEntry(testname, appl.pos.toLSP.toLocation(path.toURI))
+          (test :: acc, Some(newPrefix))
+
+        // format: off
+        // it should "have size 0" in { ... } - replace it with encountered name or leave empty
+        case Term.ApplyInfix(appl @ Term.ApplyInfix(Term.Name("it"), Term.Name(infixOp), _, List(Lit.String(right))), _: Term.Name, _, _) => 
+        // format: on
+          val prefix = namePrefix.fold("")(_ + " ")
+          val testname = s"$prefix$infixOp $right"
+          val test =
+            TestCaseEntry(testname, appl.pos.toLSP.toLocation(path.toURI))
+          (test :: acc, namePrefix)
+        case _ => (acc, namePrefix)
+      }
+    }
+    result
+  }
+
+  /**
+   * Similar to the AnyWordSpec, but it's not a infix style
+   * describe("A Set") { describe("when empty") { it("should have size 0") { ... } } }
+   */
+  private def findAnyFunSpecTests(
+      path: AbsolutePath,
+      template: Template,
+  ): List[TestCaseEntry] = {
+
+    def loop(
+        stats: List[Stat],
+        sharedPrefix: List[String],
+        acc: List[TestCaseEntry],
+    ): List[TestCaseEntry] = {
+      lazy val prefix = sharedPrefix.mkString(" ")
+      stats.flatMap {
+        // format: off
+        // gather name part from describe
+        case Term.Apply(Term.Apply(Term.Name("describe"), (prefix: Lit.String) :: Nil), (block: Term.Block) :: Nil) => 
+        // format: on
+          (acc, sharedPrefix :+ prefix.value)
+          loop(block.stats, sharedPrefix :+ prefix.value, acc)
+
+        // format: off
+        // collect test entry from it
+        case Term.Apply(appl @ Term.Apply(Term.Name("it"), (name: Lit.String) :: Nil), _) => 
+        // format: on
+          val testname = s"$prefix ${name.value}"
+          val test =
+            TestCaseEntry(testname, appl.pos.toLSP.toLocation(path.toURI))
+          test :: acc
+
+        case _ =>
+          acc
+      }
+    }
+    loop(template.stats, Nil, Nil)
+  }
+
+}
+
+sealed trait ScalatestStyle {
+  def symbols: Set[String]
+  def intermediateMethods: Set[String] = Set.empty
+  def leafMethods: Set[String] = Set.empty
+}
+
+object ScalatestStyle {
+  private val styles =
+    Vector(
+      AnyFunSuite,
+      AnyPropSpec,
+      AnyFlatSpec,
+      AnyFunSpec,
+      AnyWordSpec,
+      AnyFreeSpec,
+    )
+
+  val baseSymbols: Set[String] = styles.flatMap(_.symbols).toSet
+
+  def unapply(symbol: String): Option[ScalatestStyle] =
+    styles.find(_.symbols.contains(symbol))
+
+  case object AnyFunSuite extends ScalatestStyle {
+    val symbols: Set[String] = Set("org/scalatest/funsuite/AnyFunSuite#")
+    override val leafMethods: Set[String] = Set("test")
+  }
+
+  case object AnyPropSpec extends ScalatestStyle {
+    val symbols: Set[String] = Set("org/scalatest/propspec/AnyPropSpec#")
+    override val leafMethods: Set[String] = Set("property")
+  }
+
+  case object AnyFlatSpec extends ScalatestStyle {
+    val symbols: Set[String] = Set("org/scalatest/flatspec/AnyFlatSpec#")
+  }
+
+  case object AnyFunSpec extends ScalatestStyle {
+    val symbols: Set[String] = Set("org/scalatest/funspec/AnyFunSpec#")
+  }
+
+  case object AnyWordSpec extends ScalatestStyle {
+    val symbols: Set[String] = Set("org/scalatest/wordspec/AnyWordSpec#")
+    override val intermediateMethods: Set[String] =
+      Set("when", "should", "must", "can", "which")
+    override val leafMethods: Set[String] = Set("in")
+  }
+
+  case object AnyFreeSpec extends ScalatestStyle {
+    val symbols: Set[String] = Set("org/scalatest/freespec/AnyFreeSpec#")
+    override val intermediateMethods: Set[String] = Set("-")
+    override val leafMethods: Set[String] = Set("in")
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/TreeUtils.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/TreeUtils.scala
@@ -1,0 +1,90 @@
+package scala.meta.internal.metals.testProvider.frameworks
+
+import scala.annotation.tailrec
+
+import scala.meta.Defn
+import scala.meta.Pkg
+import scala.meta.Template
+import scala.meta.Term
+import scala.meta.Tree
+import scala.meta.Type
+
+private[frameworks] object TreeUtils {
+
+  /**
+   * Extract class/trait template from the given Tree.
+   * @param tree Tree which may contain Template
+   * @param fullyQualifiedName fully qualified class name of class/trait
+   * @return Template of a given class if present
+   */
+  def extractTemplateFrom(
+      tree: Tree,
+      fullyQualifiedName: String,
+  ): Option[Template] = {
+
+    /**
+     * Search loop with short circuiting when first matching result is obtained.
+     */
+    def loop(
+        t: Tree,
+        currentPackage: Vector[String],
+    ): Option[Template] = {
+      t match {
+        case cls: Defn.Class
+            if isValid(cls.name, currentPackage, fullyQualifiedName) =>
+          Some(cls.templ)
+        case trt: Defn.Trait
+            if isValid(trt.name, currentPackage, fullyQualifiedName) =>
+          Some(trt.templ)
+        // short-circuit to not go deeper into unuseful defns
+        case _: Defn => None
+        case Pkg(ref, children) =>
+          val pkg = extractPackageName(ref)
+          val newPackage = currentPackage ++ pkg
+          LazyList
+            .from(children)
+            .map(loop(_, newPackage))
+            .find(_.isDefined)
+            .flatten
+        case _ =>
+          LazyList
+            .from(t.children)
+            .map(loop(_, currentPackage))
+            .find(_.isDefined)
+            .flatten
+      }
+    }
+
+    loop(tree, Vector.empty)
+  }
+
+  /**
+   * Class definition is valid when package + class name is equal to one we are looking for
+   */
+  private def isValid(
+      name: Type.Name,
+      currentPackage: Vector[String],
+      searched: String,
+  ): Boolean = {
+    val fullyQualifiedName = currentPackage.appended(name.value).mkString(".")
+    fullyQualifiedName == searched
+  }
+
+  /**
+   * Extract package name from given Term
+   *
+   * package a => Term.Name(a)
+   * package a.b.c => Term.Select(Term.Select(a, b), c) (Term.Name are omitted)
+   */
+  @tailrec
+  private def extractPackageName(
+      term: Term,
+      acc: List[String] = Nil,
+  ): Vector[String] =
+    term match {
+      case Term.Name(value) => (value :: acc).toVector
+      case Term.Select(qual, Term.Name(value)) =>
+        extractPackageName(qual, value :: acc)
+      case _ => Vector.empty
+    }
+}

--- a/tests/unit/src/main/scala/tests/QuickLocation.scala
+++ b/tests/unit/src/main/scala/tests/QuickLocation.scala
@@ -8,9 +8,15 @@ final case class QuickLocation(
 ) {
   def toLsp: l.Location = new l.Location(
     uri,
-    new l.Range(
-      new l.Position(range._1, range._2),
-      new l.Position(range._3, range._4),
-    ),
+    QuickRange(range).toLsp,
+  )
+}
+
+final case class QuickRange(
+    range: (Int, Int, Int, Int)
+) {
+  def toLsp: l.Range = new l.Range(
+    new l.Position(range._1, range._2),
+    new l.Position(range._3, range._4),
   )
 }

--- a/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
@@ -1,0 +1,227 @@
+package tests.testProvider
+
+import java.nio.file.Paths
+
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.testProvider.FullyQualifiedName
+import scala.meta.internal.metals.testProvider.frameworks.ScalatestStyle
+import scala.meta.internal.metals.testProvider.frameworks.ScalatestTestFinder
+import scala.meta.io.AbsolutePath
+
+import munit.FunSuite
+import munit.Location
+import munit.TestOptions
+import tests.QuickRange
+import tests.TreeUtils
+
+class ScalatestFinderSuite extends FunSuite {
+
+  check(
+    "any-fun-suite",
+    """|import org.scalatest.funsuite.AnyFunSuite
+       |import org.scalatest.Tag
+       |
+       |class SetSuite extends AnyFunSuite {
+       |
+       |  test("An empty Set should have size 0", Tag.apply("customTag")) {
+       |    assert(Set.empty.size == 0)
+       |  }
+       |
+       |  test("Invoking head on an empty Set should produce NoSuchElementException") {
+       |    assertThrows[NoSuchElementException] {
+       |      Set.empty.head
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+    FullyQualifiedName("SetSuite"),
+    Vector(
+      ("An empty Set should have size 0", QuickRange(5, 2, 5, 65)),
+      (
+        "Invoking head on an empty Set should produce NoSuchElementException",
+        QuickRange(9, 2, 9, 77),
+      ),
+    ),
+    ScalatestStyle.AnyFunSuite,
+  )
+
+  check(
+    "any-word-spec",
+    """|class SetSpec extends AnyWordSpec {
+       |
+       |  "A Set" when {
+       |    "empty" should {
+       |      "have size 0" in {
+       |        assert(Set.empty.size == 0)
+       |      }
+       |
+       |      "produce NoSuchElementException when head is invoked" in {
+       |        assertThrows[NoSuchElementException] {
+       |          Set.empty.head
+       |        }
+       |      }
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+    FullyQualifiedName("SetSpec"),
+    Vector(
+      ("A Set when empty should have size 0", QuickRange(4, 6, 4, 19)),
+      (
+        "A Set when empty should produce NoSuchElementException when head is invoked",
+        QuickRange(8, 6, 8, 59),
+      ),
+    ),
+    ScalatestStyle.AnyWordSpec,
+  )
+
+  check(
+    "any-flat-spec",
+    """|import org.scalatest.flatspec.AnyFlatSpec
+       |
+       |class FlatSpec extends AnyFlatSpec {
+       |
+       |  "An empty Set" should "have size 0" in {
+       |    assert(Set.empty.size == 0)
+       |  }
+       |
+       |  it should "produce NoSuchElementException when head is invoked" in {
+       |    assertThrows[NoSuchElementException] {
+       |      Set.empty.head
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+    FullyQualifiedName("FlatSpec"),
+    Vector(
+      (
+        "An empty Set should produce NoSuchElementException when head is invoked",
+        QuickRange(8, 2, 8, 65),
+      ),
+      ("An empty Set should have size 0", QuickRange(4, 2, 4, 37)),
+    ),
+    ScalatestStyle.AnyFlatSpec,
+  )
+
+  check(
+    "any-fun-spec",
+    """|import org.scalatest.funspec.AnyFunSpec
+       |
+       |class FunSpec extends AnyFunSpec {
+       |
+       |  describe("A Set") {
+       |    describe("when empty") {
+       |      it("should have size 0") {
+       |        assert(Set.empty.size == 0)
+       |      }
+       |
+       |      it("should produce NoSuchElementException when head is invoked") {
+       |        assertThrows[NoSuchElementException] {
+       |          Set.empty.head
+       |        }
+       |      }
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+    FullyQualifiedName("FunSpec"),
+    Vector(
+      ("A Set when empty should have size 0", QuickRange(6, 6, 6, 30)),
+      (
+        "A Set when empty should produce NoSuchElementException when head is invoked",
+        QuickRange(10, 6, 10, 70),
+      ),
+    ),
+    ScalatestStyle.AnyFunSpec,
+  )
+
+  check(
+    "any-free-spec",
+    """|import org.scalatest.freespec.AnyFreeSpec
+       |
+       |class FreeSpec extends AnyFreeSpec {
+       |
+       |  "A Set" - {
+       |    "when empty" - {
+       |      "should have size 0" in {
+       |        assert(Set.empty.size == 0)
+       |      }
+       |
+       |      "should produce NoSuchElementException when head is invoked" in {
+       |        assertThrows[NoSuchElementException] {
+       |          Set.empty.head
+       |        }
+       |      }
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+    FullyQualifiedName("FreeSpec"),
+    Vector(
+      ("A Set when empty should have size 0", QuickRange(6, 6, 6, 26)),
+      (
+        "A Set when empty should produce NoSuchElementException when head is invoked",
+        QuickRange(10, 6, 10, 66),
+      ),
+    ),
+    ScalatestStyle.AnyFreeSpec,
+  )
+
+  check(
+    "any-prop-spec",
+    """|import org.scalatest.propspec.AnyPropSpec
+       |
+       |class PropSpec extends AnyPropSpec {
+       |
+       |  property("an empty Set should have size 0") {
+       |    assert(Set.empty.size == 0)
+       |  }
+       |
+       |  property(
+       |    "invoking head on an empty set should produce NoSuchElementException"
+       |  ) {
+       |    assertThrows[NoSuchElementException] {
+       |      Set.empty.head
+       |    }
+       |  }
+       |}
+       |
+       |""".stripMargin,
+    FullyQualifiedName("PropSpec"),
+    Vector(
+      ("an empty Set should have size 0", QuickRange(4, 2, 4, 45)),
+      (
+        "invoking head on an empty set should produce NoSuchElementException",
+        QuickRange(8, 2, 10, 3),
+      ),
+    ),
+    ScalatestStyle.AnyPropSpec,
+  )
+
+  def check(
+      name: TestOptions,
+      sourceText: String,
+      suite: FullyQualifiedName,
+      expected: Vector[(String, QuickRange)],
+      style: ScalatestStyle,
+      scalaVersion: String = BuildInfo.scala213,
+  )(implicit loc: Location): Unit =
+    test(name) {
+      val filename = "TestFile.scala"
+      val path = AbsolutePath(Paths.get(filename))
+
+      val (buffers, trees) = TreeUtils.getTrees(scalaVersion)
+      buffers.put(path, sourceText)
+
+      val result = for {
+        tree <- trees.get(path)
+      } yield ScalatestTestFinder.findTestLocations(path, style, tree, suite)
+
+      val expected0 = expected.map { case (name, range) => (name, range.toLsp) }
+      val obtained =
+        result.getOrElse(Vector.empty).map(t => (t.name, t.location.getRange))
+
+      assertEquals(obtained, expected0)
+    }
+
+}

--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -32,15 +32,9 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
     new GsonBuilder().setPrettyPrinting.disableHtmlEscaping().create()
 
   testDiscover(
-    "discover-single-junit",
-    s"""|/metals.json
-        |{
-        |  "app": {
-        |    "libraryDependencies" : [ "junit:junit:4.13.2", "com.github.sbt:junit-interface:0.13.3" ],
-        |    "scalaVersion": "${BuildInfo.scalaVersion}"
-        |  }
-        |}
-        |
+    "single-junit",
+    List("junit:junit:4.13.2", "com.github.sbt:junit-interface:0.13.3"),
+    s"""|
         |/app/src/main/scala/NoPackage.scala
         |import org.junit.Test
         |class NoPackage {
@@ -74,15 +68,9 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
   )
 
   testDiscover(
-    "discover-single-munit",
-    s"""|/metals.json
-        |{
-        |  "app": {
-        |    "libraryDependencies" : [ "org.scalameta::munit:0.7.29" ],
-        |    "scalaVersion": "${BuildInfo.scalaVersion}"
-        |  }
-        |}
-        |
+    "single-munit",
+    List("org.scalameta::munit:0.7.29"),
+    s"""|
         |/app/src/main/scala/a/b/c/MunitTestSuite.scala
         |package a.b
         |package c
@@ -116,15 +104,13 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
   )
 
   testDiscover(
-    "discover-multiple-suites",
-    s"""|/metals.json
-        |{
-        |  "app": {
-        |    "libraryDependencies" : [ "org.scalameta::munit:0.7.29", "junit:junit:4.13.2", "com.github.sbt:junit-interface:0.13.3"],
-        |    "scalaVersion": "${BuildInfo.scalaVersion}"
-        |  }
-        |}
-        |
+    "multiple-suites",
+    List(
+      "org.scalameta::munit:0.7.29",
+      "junit:junit:4.13.2",
+      "com.github.sbt:junit-interface:0.13.3",
+    ),
+    s"""|
         |/app/src/main/scala/NoPackage.scala
         |class NoPackage extends munit.FunSuite {
         |  test("noPackage") {}
@@ -211,15 +197,9 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
   )
 
   testDiscover(
-    "discover-test-cases-junit",
-    s"""|/metals.json
-        |{
-        |  "app": {
-        |    "libraryDependencies" : [ "junit:junit:4.13.2", "com.github.sbt:junit-interface:0.13.3" ],
-        |    "scalaVersion": "${BuildInfo.scalaVersion}"
-        |  }
-        |}
-        |
+    "test-cases-junit",
+    List("junit:junit:4.13.2", "com.github.sbt:junit-interface:0.13.3"),
+    s"""|
         |/app/src/main/scala/JunitTestSuite.scala
         |import org.junit.Test
         |class JunitTestSuite {
@@ -255,15 +235,9 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
   )
 
   testDiscover(
-    "discover-test-cases-munit",
-    s"""|/metals.json
-        |{
-        |  "app": {
-        |    "libraryDependencies" : ["org.scalameta::munit:1.0.0-M4" ],
-        |    "scalaVersion": "${BuildInfo.scalaVersion}"
-        |  }
-        |}
-        |
+    "test-cases-munit",
+    List("org.scalameta::munit:1.0.0-M4"),
+    s"""|
         |/app/src/main/scala/a/b/c/MunitTestSuite.scala
         |package a.b
         |package c
@@ -387,14 +361,8 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
 
   testDiscover(
     "munit-no-package",
-    s"""|/metals.json
-        |{
-        |  "app": {
-        |    "libraryDependencies" : ["org.scalameta::munit:1.0.0-M4" ],
-        |    "scalaVersion": "${BuildInfo.scalaVersion}"
-        |  }
-        |}
-        |
+    List("org.scalameta::munit:1.0.0-M4"),
+    s"""|
         |/app/src/main/scala/MunitTestSuite.scala
         |
         |class MunitTestSuite extends munit.FunSuite {
@@ -432,14 +400,8 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
 
   testDiscover(
     "munit-from-parent",
-    s"""|/metals.json
-        |{
-        |  "app": {
-        |    "libraryDependencies" : ["org.scalameta::munit:1.0.0-M4" ],
-        |    "scalaVersion": "${BuildInfo.scalaVersion}"
-        |  }
-        |}
-        |
+    List("org.scalameta::munit:1.0.0-M4"),
+    s"""|
         |/app/src/main/scala/a/BaseMunitSuite.scala
         |package a
         |trait BaseMunitSuite extends munit.FunSuite {
@@ -522,14 +484,8 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
 
   checkEvents(
     "check-basic-events",
-    s"""|/metals.json
-        |{
-        |  "app": {
-        |    "libraryDependencies" : [ "junit:junit:4.13.2", "com.github.sbt:junit-interface:0.13.3" ],
-        |    "scalaVersion": "${BuildInfo.scalaVersion}"
-        |  }
-        |}
-        |
+    List("junit:junit:4.13.2", "com.github.sbt:junit-interface:0.13.3"),
+    s"""|
         |/app/src/main/scala/JunitTestSuite.scala
         |import org.junit.Test
         |class JunitTestSuite {
@@ -571,15 +527,335 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
     },
   )
 
+  checkEvents(
+    "scalatest-any-fun-suite",
+    List("org.scalatest::scalatest:3.2.13"),
+    s"""|
+        |/app/src/main/scala/a/FunSuite.scala
+        |package a
+        |import org.scalatest.funsuite.AnyFunSuite
+        |import org.scalatest.Tag
+        |
+        |class FunSuite extends AnyFunSuite {
+        |  test("An empty Set should have size 0", Tag.apply("tag")) {
+        |    assert(Set.empty.size == 0)
+        |  }
+        |}
+        |""".stripMargin,
+    file = "app/src/main/scala/a/FunSuite.scala",
+    expected = () => {
+      val fcqn = "a.FunSuite"
+      val className = "FunSuite"
+      val symbol = "a/FunSuite#"
+      val file = "app/src/main/scala/a/FunSuite.scala"
+      List(
+        BuildTargetUpdate(
+          "app",
+          targetUri,
+          List[TestExplorerEvent](
+            AddTestSuite(
+              fcqn,
+              className,
+              symbol,
+              QuickLocation(
+                classUriFor(file),
+                (4, 6, 4, 14),
+              ).toLsp,
+              canResolveChildren = true,
+            ),
+            AddTestCases(
+              fcqn,
+              className,
+              List(
+                TestCaseEntry(
+                  "An empty Set should have size 0",
+                  QuickLocation(classUriFor(file), (5, 2, 5, 59)).toLsp,
+                )
+              ).asJava,
+            ),
+          ).asJava,
+        )
+      )
+    },
+  )
+
+  checkEvents(
+    "scalatest-any-word-spec",
+    List("org.scalatest::scalatest:3.2.13"),
+    s"""|
+        |/app/src/main/scala/a/b/WordSpec.scala
+        |package a.b
+        |import org.scalatest.wordspec.AnyWordSpec
+        |
+        |class WordSpec extends AnyWordSpec {
+        |  "A Set" when {
+        |    "empty" should {
+        |      "have size 0" in {
+        |        assert(Set.empty.size == 0)
+        |      }
+        |    }
+        |  }
+        |}
+        |""".stripMargin,
+    file = "app/src/main/scala/a/b/WordSpec.scala",
+    expected = () => {
+      val fcqn = "a.b.WordSpec"
+      val className = "WordSpec"
+      val symbol = "a/b/WordSpec#"
+      val file = "app/src/main/scala/a/b/WordSpec.scala"
+      List(
+        BuildTargetUpdate(
+          "app",
+          targetUri,
+          List[TestExplorerEvent](
+            AddTestSuite(
+              fcqn,
+              className,
+              symbol,
+              QuickLocation(
+                classUriFor(file),
+                (3, 6, 3, 14),
+              ).toLsp,
+              canResolveChildren = true,
+            ),
+            AddTestCases(
+              fcqn,
+              className,
+              List(
+                TestCaseEntry(
+                  "A Set when empty should have size 0",
+                  QuickLocation(classUriFor(file), (6, 6, 6, 19)).toLsp,
+                )
+              ).asJava,
+            ),
+          ).asJava,
+        )
+      )
+    },
+  )
+
+  checkEvents(
+    "scalatest-any-flat-spec",
+    List("org.scalatest::scalatest:3.2.13"),
+    s"""|
+        |/app/src/main/scala/FlatSpec.scala
+        |import org.scalatest.flatspec.AnyFlatSpec
+        |
+        |class FlatSpec extends AnyFlatSpec {
+        |
+        |  "An empty Set" should "have size 0" in {
+        |    assert(Set.empty.size == 0)
+        |  }
+        |}
+        |""".stripMargin,
+    file = "app/src/main/scala/FlatSpec.scala",
+    expected = () => {
+      val fcqn = "FlatSpec"
+      val className = "FlatSpec"
+      val symbol = "_empty_/FlatSpec#"
+      val file = "app/src/main/scala/FlatSpec.scala"
+      List(
+        BuildTargetUpdate(
+          "app",
+          targetUri,
+          List[TestExplorerEvent](
+            AddTestSuite(
+              fcqn,
+              className,
+              symbol,
+              QuickLocation(
+                classUriFor(file),
+                (2, 6, 2, 14),
+              ).toLsp,
+              canResolveChildren = true,
+            ),
+            AddTestCases(
+              fcqn,
+              className,
+              List(
+                TestCaseEntry(
+                  "An empty Set should have size 0",
+                  QuickLocation(classUriFor(file), (4, 2, 4, 37)).toLsp,
+                )
+              ).asJava,
+            ),
+          ).asJava,
+        )
+      )
+    },
+  )
+
+  checkEvents(
+    "scalatest-any-fun-spec",
+    List("org.scalatest::scalatest:3.2.13"),
+    s"""|
+        |/app/src/main/scala/FunSpec.scala
+        |import org.scalatest.funspec.AnyFunSpec
+        |
+        |class FunSpec extends AnyFunSpec {
+        |  describe("A Set") {
+        |    describe("when empty") {
+        |      it("should have size 0") {
+        |        assert(Set.empty.size == 0)
+        |      }
+        |    }
+        |  }
+        |}
+        |""".stripMargin,
+    file = "app/src/main/scala/FunSpec.scala",
+    expected = () => {
+      val fcqn = "FunSpec"
+      val className = "FunSpec"
+      val symbol = "_empty_/FunSpec#"
+      val file = "app/src/main/scala/FunSpec.scala"
+      List(
+        BuildTargetUpdate(
+          "app",
+          targetUri,
+          List[TestExplorerEvent](
+            AddTestSuite(
+              fcqn,
+              className,
+              symbol,
+              QuickLocation(
+                classUriFor(file),
+                (2, 6, 2, 13),
+              ).toLsp,
+              canResolveChildren = true,
+            ),
+            AddTestCases(
+              fcqn,
+              className,
+              List(
+                TestCaseEntry(
+                  "A Set when empty should have size 0",
+                  QuickLocation(classUriFor(file), (5, 6, 5, 30)).toLsp,
+                )
+              ).asJava,
+            ),
+          ).asJava,
+        )
+      )
+    },
+  )
+
+  checkEvents(
+    "scalatest-any-free-spec",
+    List("org.scalatest::scalatest:3.2.13"),
+    s"""|
+        |/app/src/main/scala/FreeSpec.scala
+        |import org.scalatest.freespec.AnyFreeSpec
+        |
+        |class FreeSpec extends AnyFreeSpec {
+        |  "A Set" - {
+        |    "when empty" - {
+        |      "should have size 0" in {
+        |        assert(Set.empty.size == 0)
+        |      }
+        |    }
+        |  }
+        |}
+        |""".stripMargin,
+    file = "app/src/main/scala/FreeSpec.scala",
+    expected = () => {
+      val fcqn = "FreeSpec"
+      val className = "FreeSpec"
+      val symbol = "_empty_/FreeSpec#"
+      val file = "app/src/main/scala/FreeSpec.scala"
+      List(
+        BuildTargetUpdate(
+          "app",
+          targetUri,
+          List[TestExplorerEvent](
+            AddTestSuite(
+              fcqn,
+              className,
+              symbol,
+              QuickLocation(
+                classUriFor(file),
+                (2, 6, 2, 14),
+              ).toLsp,
+              canResolveChildren = true,
+            ),
+            AddTestCases(
+              fcqn,
+              className,
+              List(
+                TestCaseEntry(
+                  "A Set when empty should have size 0",
+                  QuickLocation(classUriFor(file), (5, 6, 5, 26)).toLsp,
+                )
+              ).asJava,
+            ),
+          ).asJava,
+        )
+      )
+    },
+  )
+
+  checkEvents(
+    "scalatest-any-prop-spec",
+    List("org.scalatest::scalatest:3.2.13"),
+    s"""|
+        |/app/src/main/scala/PropSpec.scala
+        |import org.scalatest.propspec.AnyPropSpec
+        |
+        |class PropSpec extends AnyPropSpec {
+        |
+        |  property("an empty Set should have size 0") {
+        |    assert(Set.empty.size == 0)
+        |  }
+        |}
+        |
+        |""".stripMargin,
+    file = "app/src/main/scala/PropSpec.scala",
+    expected = () => {
+      val fcqn = "PropSpec"
+      val className = "PropSpec"
+      val symbol = "_empty_/PropSpec#"
+      val file = "app/src/main/scala/PropSpec.scala"
+      List(
+        BuildTargetUpdate(
+          "app",
+          targetUri,
+          List[TestExplorerEvent](
+            AddTestSuite(
+              fcqn,
+              className,
+              symbol,
+              QuickLocation(
+                classUriFor(file),
+                (2, 6, 2, 14),
+              ).toLsp,
+              canResolveChildren = true,
+            ),
+            AddTestCases(
+              fcqn,
+              className,
+              List(
+                TestCaseEntry(
+                  "an empty Set should have size 0",
+                  QuickLocation(classUriFor(file), (4, 2, 4, 45)).toLsp,
+                )
+              ).asJava,
+            ),
+          ).asJava,
+        )
+      )
+    },
+  )
+
   /**
    * Discovers all tests in project or test cases in file
    *
+   * @param dependencies list of dependencies, e.g. "org.scalameta::munit:0.7.29"
    * @param files list of files for which compilation will be triggered. It's
    * @param expected list of expected build target updates
    * @param uri URI of file for which test cases should be discovered
    */
   def testDiscover(
       name: TestOptions,
+      dependencies: List[String],
       layout: String,
       files: List[String],
       expected: () => List[BuildTargetUpdate],
@@ -587,10 +863,20 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
   )(implicit
       loc: munit.Location
   ): Unit = {
+    val layoutWithDependencies =
+      s"""|/metals.json
+          |{
+          |  "app": {
+          |    "libraryDependencies" : ${getDependenciesArray(dependencies)},
+          |    "scalaVersion": "${BuildInfo.scalaVersion}"
+          |  }
+          |}
+          |$layout
+          |""".stripMargin
     test(name) {
       for {
         _ <- Future.successful(cleanWorkspace())
-        _ <- initialize(layout)
+        _ <- initialize(layoutWithDependencies)
         discovered <- server.discoverTestSuites(files, uri())
       } yield {
         assertEquals(discovered, expected())
@@ -601,21 +887,33 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
   /**
    * Check if Test Explorer returns particular events.
    *
+   * @param dependencies list of dependencies, e.g. "org.scalameta::munit:0.7.29"
    * @param file which should be compiled
    * @param expected list of expected build target updates
    */
   def checkEvents(
       name: TestOptions,
+      dependencies: List[String],
       layout: String,
       file: String,
       expected: () => List[BuildTargetUpdate],
   )(implicit
       loc: munit.Location
   ): Unit = {
+    val layoutWithDependencies =
+      s"""|/metals.json
+          |{
+          |  "app": {
+          |    "libraryDependencies" : ${getDependenciesArray(dependencies)},
+          |    "scalaVersion": "${BuildInfo.scalaVersion}"
+          |  }
+          |}
+          |$layout
+          |""".stripMargin
     test(name) {
       for {
         _ <- Future.successful(cleanWorkspace())
-        _ <- initialize(layout)
+        _ <- initialize(layoutWithDependencies)
         _ <- server.didOpen(file)
         _ <- server.executeCommand(ServerCommands.CascadeCompile)
         jsonObjects <- server.client.testExplorerUpdates.future
@@ -626,6 +924,11 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
         assertEquals(prettyPrinted, prettyPrintedExpected)
       }
     }
+  }
+
+  private def getDependenciesArray(dependencies: List[String]): String = {
+    val commaSeparated = dependencies.map(d => s"\"$d\"").mkString(", ")
+    s"[ $commaSeparated ]"
   }
 
   private def targetUri: String =


### PR DESCRIPTION
needs https://github.com/scalameta/metals-vscode/pull/1117

Supports:
- `AnyFunSuite`
- `AnyPropSpec`
- `AnyFlatSpec`
- `AnyFunSpec`
- `AnyWordSpec`
- `AnyFreeSpec`

Example:
<img width="765" alt="Screenshot 2022-08-20 at 08 09 39" src="https://user-images.githubusercontent.com/37124721/185733308-8cc6b0df-8803-47d8-9b9e-d72b4ed34349.png">
