### PR TITLE
fix: fix implement-all members for anonymous class

### DIFF
--- a/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
@@ -406,6 +406,38 @@ class Scala3CodeActionLspSuite
   )
 
   check(
+    "implement-anonymous-class",
+    """|package anonymous
+       |
+       |trait Foo:
+       |  def foo(x: Int): Int
+       |  def bar(x: String): String
+       |
+       |def main =
+       |  <<new>> Foo {}
+       |
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |""".stripMargin,
+    """|package anonymous
+       |
+       |trait Foo:
+       |  def foo(x: Int): Int
+       |  def bar(x: String): String
+       |
+       |def main =
+       |  new Foo {
+       |
+       |    override def foo(x: Int): Int = ???
+       |
+       |    override def bar(x: String): String = ???
+       |
+       |  }
+       |""".stripMargin,
+    expectNoDiagnostics = false,
+  )
+
+  check(
     "wrong-type",
     """|package a
        |


### PR DESCRIPTION
fix: https://github.com/scalameta/metals/issues/4232

We had a pc test
    https://github.com/scalameta/metals/blob/ae5c4650aefb6e6228ad77991c5813c299e860ed/tests/cross/src/test/scala/tests/pc/AutoImplementAbstractMembersSuite.scala#L220-L236

but the error position is different in Scala.
`<<new>> Foo` instead of `new <<Foo>>`

This PR fixes the issue, and added a LSP test.
