### PR TITLE
bugfix: Allow to run/debug in ScalaCli when started from Metals

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -23,6 +23,7 @@ import scala.util.Try
 import scala.meta.internal.builds.MillBuildTool
 import scala.meta.internal.builds.SbtBuildTool
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.scalacli.ScalaCli
 import scala.meta.internal.pc.InterruptException
 import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
@@ -74,10 +75,12 @@ class BuildServerConnection private (
 
   def isMill: Boolean = name == MillBuildTool.name
 
-  // although hasDebug is already available in BSP capabilities
-  // see https://github.com/build-server-protocol/build-server-protocol/pull/161
-  // most of the bsp servers such as bloop and sbt don't support it.
-  def isBloopOrSbt: Boolean = isBloop || isSbt
+  def isScalaCLI: Boolean = name == ScalaCli.name
+
+  /* Currently only Bloop and sbt support running single test cases
+   * and ScalaCLI uses Bloop underneath.
+   */
+  def supportsTestSelection: Boolean = isBloop || isSbt || isScalaCLI
 
   /* Some users may still use an old version of Bloop that relies on scala-debug-adapter 1.x.
    * This method is used to do the switch between MetalsDebugAdapter1x and MetalsDebugAdapter2x.

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -588,7 +588,6 @@ class MetalsLanguageServer(
             buildTargets,
             clientConfig,
             () => userConfig,
-            () => bspSession.exists(_.main.isBloopOrSbt),
             trees,
           )
 
@@ -695,7 +694,6 @@ class MetalsLanguageServer(
         debugProvider = new DebugProvider(
           workspace,
           definitionProvider,
-          () => bspSession.map(_.mainConnection),
           buildTargets,
           buildTargetClasses,
           compilations,
@@ -707,7 +705,6 @@ class MetalsLanguageServer(
           clientConfig,
           semanticdbs,
           compilers,
-          () => bspSession.exists(_.main.isBloopOrSbt),
           statusBar,
         )
         scalafixProvider = ScalafixProvider(

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -360,4 +360,6 @@ object ScalaCli {
   def scalaCliMainClass: String =
     "scala.cli.ScalaCli"
 
+  val name = "ScalaCli"
+
 }


### PR DESCRIPTION
Previously, if ScalaCLI was not started from `.bsp` it would not be possible to run or debug. Now, we also check if we can run using built in ScalaCLI