### PR TITLE
feature: Automatically add extension methods in string interpolation

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -60,6 +60,9 @@ sealed trait CompletionValue:
         "" // Override doesn't need description as it already has full signature in label
       case ext: CompletionValue.Extension =>
         s"${printer.completionSymbol(ext.symbol)} (extension)"
+      case interpolator: CompletionValue.Interpolator
+          if interpolator.isExtension =>
+        s"${printer.completionSymbol(interpolator.symbol)} (extension)"
       case so: CompletionValue.Symbolic =>
         printer.completionSymbol(so.symbol)
       case CompletionValue.NamedArg(label, tpe) =>
@@ -144,7 +147,8 @@ object CompletionValue:
       override val additionalEdits: List[TextEdit],
       override val range: Option[Range],
       override val filterText: Option[String],
-      isWorkspace: Boolean,
+      isWorkspace: Boolean = false,
+      isExtension: Boolean = false,
   ) extends Symbolic
 
   case class Document(label: String, doc: String, description: String)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionsProvider.scala
@@ -336,7 +336,7 @@ class CompletionsProvider(
     completion match
       case v: (CompletionValue.Workspace | CompletionValue.Extension) =>
         mkItemWithImports(v)
-      case v: CompletionValue.Interpolator if v.isWorkspace =>
+      case v: CompletionValue.Interpolator if v.isWorkspace || v.isExtension =>
         mkItemWithImports(v)
       case CompletionValue.Override(
             label,

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -711,4 +711,69 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
            |""".stripMargin
     ),
   )
+
+  checkEdit(
+    "extension".tag(IgnoreScala2),
+    """|package example
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def incr: Int = num + 1
+       |def aaa = 123
+       |def main = s" $aaa.inc@@"
+       |""".stripMargin,
+    """|package example
+       |
+       |import example.enrichments.incr
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def incr: Int = num + 1
+       |def aaa = 123
+       |def main = s" ${aaa.incr$0}"
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "extension2".tag(IgnoreScala2),
+    """|package example
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def plus(other: Int): Int = num + other
+       |
+       |def aaa = 123
+       |def main = s"  $aaa.pl@@"
+       |""".stripMargin,
+    """|package example
+       |
+       |import example.enrichments.plus
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def plus(other: Int): Int = num + other
+       |
+       |def aaa = 123
+       |def main = s"  ${aaa.plus($0)}"
+       |""".stripMargin,
+  )
+
+  check(
+    "filter-by-type".tag(IgnoreScala2),
+    """|package example
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def incr: Int = num + 1
+       |  extension (str: String)
+       |    def identity: String = str
+       |
+       |val foo = "foo"
+       |def main = s" $foo.i@@"
+       |""".stripMargin,
+    """|identity: String (extension)
+       |""".stripMargin, // incr won't be available
+    filter = _.contains("(extension)"),
+  )
+
 }


### PR DESCRIPTION
Previously, extension methods would only be available outside string itnerpolations. Now it's also available inside.

It would be probably be better to handle it together with normal extension methods, but since it's the two combined it might be difficult to do it sensibly.