### PR TITLE
feat: better mill-bsp semanticdb support

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -129,6 +129,10 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
 
 object MillBuildTool {
   val name: String = "mill-bsp"
+  // Starting with 0.10.6 when using mill-bsp as a build server it automatically emits SemanticDB
+  // even though it's not detected in the scalacOptions. So in this situation we don't want to warn
+  // about it and trust Mill to do its job.
+  val emitsSemanticDbByDefault = "0.10.6"
 
   def isMillRelatedPath(
       path: AbsolutePath

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -194,7 +194,10 @@ final case class Indexer(
         val importedBuild = buildTool.importedBuild
         data.reset()
         data.addWorkspaceBuildTargets(importedBuild.workspaceBuildTargets)
-        data.addScalacOptions(importedBuild.scalacOptions)
+        data.addScalacOptions(
+          importedBuild.scalacOptions,
+          bspSession().map(_.mainConnection),
+        )
         data.addJavacOptions(importedBuild.javacOptions)
 
         // For "wrapped sources", we create dedicated TargetData.MappedSource instances,

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -4,7 +4,9 @@ import java.nio.file.Path
 
 import scala.meta.Dialect
 import scala.meta.dialects._
+import scala.meta.internal.builds.MillBuildTool
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTarget
@@ -20,6 +22,7 @@ case class ScalaTarget(
     scalac: ScalacOptionsItem,
     autoImports: Option[Seq[String]],
     sbtVersion: Option[String],
+    bspConnection: Option[BuildServerConnection],
 ) {
 
   def isSbt = sbtVersion.isDefined
@@ -51,9 +54,29 @@ case class ScalaTarget(
   def fmtDialect: ScalafmtDialect =
     ScalaVersions.fmtDialectForScalaVersion(scalaVersion, containsSource3)
 
-  def isSemanticdbEnabled: Boolean = scalac.isSemanticdbEnabled(scalaVersion)
+  /**
+   * Typically to verify that SemanticDB is enabled correctly we check the scalacOptions to ensure
+   * that both we see that it's enabled and that things like the sourceroot are set correctly.
+   * There are server that configure SemanticDB in a non-traditional way. For those situations
+   * our check isn't as robust, but for the initial check here we just mark them as OK since
+   * we know and trust that for that given version and build server it should be configured.
+   *
+   * This is the case for mill-bsp >= 0.10.6
+   */
+  private def semanticDbEnabledAlternatively = bspConnection.exists {
+    buildServer =>
+      buildServer.name == MillBuildTool.name &&
+      SemVer.isCompatibleVersion(
+        MillBuildTool.emitsSemanticDbByDefault,
+        buildServer.version,
+      )
+  }
 
-  def isSourcerootDeclared: Boolean = scalac.isSourcerootDeclared(scalaVersion)
+  def isSemanticdbEnabled: Boolean =
+    scalac.isSemanticdbEnabled(scalaVersion) || semanticDbEnabledAlternatively
+
+  def isSourcerootDeclared: Boolean =
+    scalac.isSourcerootDeclared(scalaVersion) || semanticDbEnabledAlternatively
 
   def fullClasspath: List[Path] =
     scalac.classpath.map(_.toAbsolutePath).collect {

--- a/metals/src/main/scala/scala/meta/internal/metals/TargetData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/TargetData.scala
@@ -236,7 +236,10 @@ final class TargetData {
   def checkIfGeneratedDir(path: AbsolutePath): Boolean =
     buildTargetGeneratedDirs.contains(path)
 
-  def addScalacOptions(result: ScalacOptionsResult): Unit = {
+  def addScalacOptions(
+      result: ScalacOptionsResult,
+      bspConnectionName: Option[BuildServerConnection],
+  ): Unit = {
     result.getItems.asScala.foreach { scalac =>
       info(scalac.getTarget()).foreach { info =>
         info.asScalaBuildTarget.foreach { scalaBuildTarget =>
@@ -248,6 +251,7 @@ final class TargetData {
             scalac,
             autoImports,
             sbtTarget.map(_.getSbtVersion()),
+            bspConnectionName,
           )
         }
       }

--- a/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
+++ b/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
@@ -110,7 +110,8 @@ object MetalsTestEnrichments {
         "",
       )
       data0.addScalacOptions(
-        new ScalacOptionsResult(List(item).asJava)
+        new ScalacOptionsResult(List(item).asJava),
+        None,
       )
       wsp.buildTargets.addData(data0)
     }

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -282,6 +282,7 @@ class ProblemResolverSuite extends FunSuite {
       scalacOptionsItem,
       autoImports = None,
       sbtVersion,
+      None,
     )
   }
 }


### PR DESCRIPTION
In the last release of Mill they added better support for producing
SemanticDB for clients like Metals without needing any changes in your
build. However the way it's done is a bit different and unlike the other
build servers meaning that you can't detect it by looking at the
scalacOptions. This changes special-cases Mill for now when a user is
using mill-bsp in a version >= 0.10.6. Mainly this is so users don't see
a big red X mark next to semanticdb in the doctor. There still will be
one for Java support as currently there is no semanticdb being produced
for Java targets in Mill.
