### PR TITLE
bugfix: Find correct definition of apply when using case classes

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionResult.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionResult.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.metals
 import java.util
 import java.util.Collections
 
+import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.semanticdb.Scala.Symbols
 import scala.meta.internal.semanticdb.TextDocument
 import scala.meta.io.AbsolutePath
@@ -16,6 +17,12 @@ case class DefinitionResult(
     semanticdb: Option[TextDocument],
 ) {
   def isEmpty: Boolean = locations.isEmpty()
+  def ++(other: DefinitionResult) = DefinitionResult(
+    (locations.asScala ++ other.locations.asScala).asJava,
+    symbol,
+    definition,
+    semanticdb,
+  )
 }
 
 object DefinitionResult {


### PR DESCRIPTION
Previously, DefinitionProvider would just look for the definition of object. Now, it also checks if the object is not a synthetic apply and in that case it tries to find that exact apply in addition to the object.

Fixes https://github.com/scalameta/metals/issues/1809