### PR TITLE
Scala cli actionable diagnostic

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -261,12 +261,14 @@ final class Diagnostics(
       snapshot: Input,
   ): Option[Diagnostic] = {
     val result = edit.toRevised(d.getRange).map { range =>
-      new l.Diagnostic(
+      val ld = new l.Diagnostic(
         range,
         d.getMessage,
         d.getSeverity,
         d.getSource,
       )
+      ld.setData(d.getData)
+      ld
     }
     if (result.isEmpty) {
       d.getRange.toMeta(snapshot).foreach { pos =>

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -677,6 +677,9 @@ object MetalsEnrichments
       val severity = d.getSeverity.toString.toLowerCase()
       s"$severity:$hint $uri:${d.getRange.getStart.getLine} ${d.getMessage}"
     }
+    def asTextEdit: Option[l.TextEdit] = {
+      decodeJson(d.getData, classOf[l.TextEdit])
+    }
   }
 
   implicit class XtensionSeverityBsp(sev: b.DiagnosticSeverity) {
@@ -752,8 +755,8 @@ object MetalsEnrichments
   }
 
   implicit class XtensionDiagnosticBsp(diag: b.Diagnostic) {
-    def toLsp: l.Diagnostic =
-      new l.Diagnostic(
+    def toLsp: l.Diagnostic = {
+      val ld = new l.Diagnostic(
         diag.getRange.toLsp,
         fansi.Str(diag.getMessage, ErrorMode.Strip).plainText,
         diag.getSeverity.toLsp,
@@ -761,6 +764,9 @@ object MetalsEnrichments
         // We omit diag.getCode since Bloop's BSP implementation uses 'code' with different semantics
         // than LSP. See https://github.com/scalacenter/bloop/issues/1134 for details
       )
+      ld.setData(diag.getData)
+      ld
+    }
   }
 
   implicit class XtensionHttpExchange(exchange: HttpServerExchange) {

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
@@ -1,8 +1,14 @@
 package scala.meta.internal.metals
 
+import scala.meta.internal.metals.MetalsEnrichments._
+
 import org.eclipse.{lsp4j => l}
 
 object ScalacDiagnostic {
+
+  object ScalaAction {
+    def unapply(d: l.Diagnostic): Option[l.TextEdit] = d.asTextEdit
+  }
 
   object NotAMember {
     private val regex = """(?s)value (.+) is not a member of.*""".r

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ActionableDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ActionableDiagnostic.scala
@@ -1,0 +1,55 @@
+package scala.meta.internal.metals.codeactions
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals._
+import scala.meta.pc.CancelToken
+
+import org.eclipse.{lsp4j => l}
+
+class ActionableDiagnostic() extends CodeAction {
+  override def kind: String = l.CodeActionKind.QuickFix
+
+  override def contribute(
+      params: l.CodeActionParams,
+      token: CancelToken,
+  )(implicit ec: ExecutionContext): Future[Seq[l.CodeAction]] = {
+
+    def createActionableDiagnostic(
+        diagnostic: l.Diagnostic,
+        textEdit: l.TextEdit,
+    ): l.CodeAction = {
+      val diagMessage = diagnostic.getMessage
+      val uri = params.getTextDocument().getUri()
+
+      CodeActionBuilder.build(
+        title =
+          s"Apply suggestion: ${diagMessage.linesIterator.headOption.getOrElse(diagMessage)}",
+        kind = l.CodeActionKind.QuickFix,
+        changes = List(uri.toAbsolutePath -> Seq(textEdit)),
+        diagnostics = List(diagnostic),
+      )
+    }
+
+    val codeActions = params
+      .getContext()
+      .getDiagnostics()
+      .asScala
+      .groupBy {
+        case ScalacDiagnostic.ScalaAction(textEdit) =>
+          Some(textEdit)
+        case _ => None
+      }
+      .collect {
+        case (Some(textEdit), diags)
+            if params.getRange().overlapsWith(diags.head.getRange()) =>
+          createActionableDiagnostic(diags.head, textEdit)
+      }
+      .toList
+      .sorted
+
+    Future.successful(codeActions)
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
@@ -29,6 +29,7 @@ final class CodeActionProvider(
     new ImplementAbstractMembers(compilers),
     new ImportMissingSymbol(compilers, buildTargets),
     new CreateNewSymbol(),
+    new ActionableDiagnostic(),
     new StringActions(buffers),
     extractMemberAction,
     new SourceOrganizeImports(

--- a/tests/unit/src/main/scala/tests/BaseScalaCliSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseScalaCliSuite.scala
@@ -101,35 +101,12 @@ abstract class BaseScalaCliSuite(scalaVersion: String)
        |}
        |
        |""".stripMargin
-
-  private def escape(s: String): String =
-    s.replace("\\", "\\\\")
   private def bspLayout =
     s"""/.bsp/scala-cli.json
-       |{
-       |  "name": "scala-cli",
-       |  "argv": [
-       |    "${escape(ScalaCli.javaCommand)}",
-       |    "-cp",
-       |    "${escape(ScalaCli.scalaCliClassPath().mkString(File.pathSeparator))}",
-       |    "${ScalaCli.scalaCliMainClass}",
-       |    "bsp",
-       |    "."
-       |  ],
-       |  "version": "${BuildInfo.scalaCliVersion}",
-       |  "bspVersion": "2.0.0",
-       |  "languages": [
-       |    "scala",
-       |    "java"
-       |  ]
-       |}
+       |${BaseScalaCliSuite.scalaCliBspJsonContent()}
        |
        |/.scala-build/ide-inputs.json
-       |{
-       |  "args": [
-       |    "."
-       |  ]
-       |}
+       |${BaseScalaCliSuite.scalaCliIdeInputJson(".")}
        |
        |""".stripMargin
 
@@ -352,5 +329,33 @@ abstract class BaseScalaCliSuite(scalaVersion: String)
         0,
       )
     } yield ()
+  }
+}
+
+object BaseScalaCliSuite {
+  def scalaCliBspJsonContent(args: List[String] = Nil): String = {
+    val argv = List(
+      ScalaCli.javaCommand,
+      "-cp",
+      ScalaCli.scalaCliClassPath().mkString(File.pathSeparator),
+      ScalaCli.scalaCliMainClass,
+      "bsp",
+      ".",
+    ) ++ args
+    val bsjJson = ujson.Obj(
+      "name" -> "scala-cli",
+      "argv" -> argv,
+      "version" -> BuildInfo.scalaCliVersion,
+      "bspVersion" -> "2.0.0",
+      "languages" -> List("scala", "java"),
+    )
+    ujson.write(bsjJson)
+  }
+
+  def scalaCliIdeInputJson(args: String*): String = {
+    val ideInputJson = ujson.Obj(
+      "args" -> args
+    )
+    ujson.write(ideInputJson)
   }
 }

--- a/tests/unit/src/test/scala/tests/codeactions/ActionableDiagnosticsSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ActionableDiagnosticsSuite.scala
@@ -1,0 +1,36 @@
+package tests.codeactions
+
+import scala.meta.internal.mtags.CoursierComplete
+
+import coursier.version.Version
+
+class ActionableDiagnosticsSuite
+    extends BaseCodeActionLspSuite("actionableDiagnostic") {
+
+  val oldOsLibVersion: Version = Version("0.7.8")
+  val newestOsLib: String = CoursierComplete
+    .complete("com.lihaoyi::os-lib:")
+    .headOption
+    .getOrElse("0.8.1")
+
+  check(
+    "actionable-diagnostic-update",
+    s"""|//> <<>>using lib "com.lihaoyi::os-lib:${oldOsLibVersion.repr}"
+        |
+        |object Hello extends App {
+        |  println("Hello")
+        |}
+        |""".stripMargin,
+    s"Apply suggestion: com.lihaoyi::os-lib:0.7.8 is outdated, update to $newestOsLib",
+    s"""|//> using lib "com.lihaoyi::os-lib:$newestOsLib"
+        |
+        |object Hello extends App {
+        |  println("Hello")
+        |}
+        |""".stripMargin,
+    scalaCliOptions = List("--actions", "-S", scalaVersion),
+    expectNoDiagnostics = false,
+    scalaCliLayout = true,
+  )
+
+}


### PR DESCRIPTION
This PR adds support for actionable diagnostic from `scala-cli`. These are diagnostics that contain information that allows users to fix some configs/directives by `Quick Fix` actions in metals.

For now, in `scala-cli` there is only implemented actionable diagnostics for updating lib in using directives, and it works in this way with metals:

https://user-images.githubusercontent.com/46607934/186489738-71ed74df-2ed0-4ce3-8466-b21d4674c2c0.mov



I added `didSave` flag to `check` method, because when actionable diagnostics were applied in unit tests and saved content to the file, the `scala-cli` reload bsp server and at the same time metals expect to get `Compile Result` from server but fail, because bsp server is down. I attach error logs:

```
2022.08.23 14:48:03 INFO  Disconnecting from scala-cli session...
2022.08.23 14:48:02 INFO  Shut down connection with build server.
2022.08.23 14:48:03 INFO  Attempting to connect to the build server...
2022.08.23 14:48:03 INFO  Running BSP server [/Users/lwronski/projects/scala-cli/out/cli/standaloneLauncher.dest/launcher, bsp, ., --actions, -S, 2.13.8]
2022.08.23 14:48:02 INFO  tracing is disabled for protocol BSP, to enable tracing of incoming and outgoing JSON messages create an empty file at /Users/lwronski/projects/metals/tests/unit/target/e2e/actionableDiagnostic/empty-string-multiline/.metals/bsp.trace.json or /Users/lwronski/Library/Caches/org.scalameta.metals/bsp.trace.json
tests.codeactions.ActionableDiagnosticsSuite:
==> X tests.codeactions.ActionableDiagnosticsSuite.empty-string-multiline  11.177s scala.meta.internal.metals.MetalsBspException: BSP connection failed in the attempt to get: CompileResult
Caused by: java.util.concurrent.ExecutionException: Boxed Exception
Caused by: java.lang.InterruptedException
```

To fix it, I just skip saving updating files to disk, and in this way, I avoiding to reload of bsp. I don't find any better solution to fix it in my test `ActionableDiagnosticsSuite`.