### PR TITLE
add isStale filter in IndexedContext

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -144,6 +144,18 @@ object MtagsEnrichments extends CommonMtagsEnrichments:
       upd.rawParamss = paramsWithFlags
       upd
     end withUpdatedTpe
+
+    // Returns true if this symbol is locally defined from an old version of the source file.
+    def isStale: Boolean =
+      sym.sourcePos.span.exists && {
+        val source = ctx.source
+        if source ne sym.source then
+          !source.content.startsWith(
+            sym.decodedName.toString(),
+            sym.sourcePos.span.point,
+          )
+        else false
+      }
   end extension
 
   extension (name: Name)(using Context)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/IndexedContext.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/IndexedContext.scala
@@ -31,9 +31,12 @@ sealed trait IndexedContext:
         Result.InScope
       case Some(symbols) if symbols.exists(isTypeAliasOf(_, sym)) =>
         Result.InScope
-      case Some(_) =>
-        Result.Conflict
+      // when all the conflicting symbols came from an old version of the file
+      case Some(symbols) if symbols.nonEmpty && symbols.forall(_.isStale) =>
+        Result.Missing
+      case Some(_) => Result.Conflict
       case None => Result.Missing
+  end lookupSym
 
   final def hasRename(sym: Symbol, as: String): Boolean =
     rename(sym) match


### PR DESCRIPTION
Sometimes `indexedContext.scopeSymbols` gave us symbols from an old version of the file, which was a problem in some tests, like here https://github.com/scalameta/metals/blob/cf2e8c0f977b6eb34aa95b9fd0cf3176be41ba17/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala#L56-L59

Works the same as for scala2
https://github.com/scalameta/metals/blob/cf2e8c0f977b6eb34aa95b9fd0cf3176be41ba17/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala#L689-L692