### PR TITLE
refactor: Do not index extension methods in workspaceSymbolIndex

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CodeActionProvider.scala
@@ -25,7 +25,7 @@ final class CodeActionProvider(
 
   private val allActions: List[CodeAction] = List(
     new ImplementAbstractMembers(compilers),
-    new ImportMissingSymbol(compilers),
+    new ImportMissingSymbol(compilers, buildTargets),
     new CreateNewSymbol(),
     new StringActions(buffers),
     extractMemberAction,

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -385,11 +385,15 @@ class Compilers(
   def autoImports(
       params: TextDocumentPositionParams,
       name: String,
+      findExtensionMethods: Boolean,
       token: CancelToken,
   ): Future[ju.List[AutoImportsResult]] = {
     withPCAndAdjustLsp(params) { (pc, pos, adjust) =>
-      pc.autoImports(name, CompilerOffsetParams.fromPos(pos, token))
-        .asScala
+      pc.autoImports(
+        name,
+        CompilerOffsetParams.fromPos(pos, token),
+        findExtensionMethods,
+      ).asScala
         .map { list =>
           list.map(adjust.adjustImportResult)
           list

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -522,15 +522,7 @@ final case class Indexer(
         val methodSymbols = ArrayBuffer.empty[WorkspaceSymbolInformation]
         SemanticdbDefinition.foreach(input, dialect) {
           case SemanticdbDefinition(info, occ, owner) =>
-            // TODO: Do not index (extension) METHOD, they will be indexed later
-            // we index methods for auto-import missing extension methods feature for now
-            // but those feature should use methodSymbols
-            // see: https://github.com/scalameta/metals/issues/4212
-            if (
-              WorkspaceSymbolProvider.isRelevantKind(
-                info.kind
-              ) || info.kind == Kind.METHOD
-            ) {
+            if (WorkspaceSymbolProvider.isRelevantKind(info.kind)) {
               occ.range.foreach { range =>
                 symbols += WorkspaceSymbolInformation(
                   info.symbol,

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -83,7 +83,7 @@ public abstract class PresentationCompiler {
     /**
      * Return the necessary imports for a symbol at the given position.
      */
-    public abstract CompletableFuture<List<AutoImportsResult>> autoImports(String name, OffsetParams params);
+    public abstract CompletableFuture<List<AutoImportsResult>> autoImports(String name, OffsetParams params, Boolean isExtension);
 
     /**
      * Return the missing implements and imports for the symbol at the given position.

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -158,7 +158,8 @@ case class ScalaPresentationCompiler(
 
   override def autoImports(
       name: String,
-      params: OffsetParams
+      params: OffsetParams,
+      isExtension: java.lang.Boolean // ignore, because Scala2 doesn't support extension method
   ): CompletableFuture[ju.List[AutoImportsResult]] =
     compilerAccess.withInterruptableCompiler(
       List.empty[AutoImportsResult].asJava,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -33,7 +33,7 @@ final class AutoImportsProvider(
     buildTargetIdentifier: String,
 ):
 
-  def autoImports(): List[AutoImportsResult] =
+  def autoImports(isExtension: Boolean): List[AutoImportsResult] =
     val uri = params.uri
     val filePath = Paths.get(uri)
     driver.run(
@@ -67,7 +67,9 @@ final class AutoImportsProvider(
       sym.name.show == query
 
     val visitor = new CompilerSearchVisitor(name, visit)
-    search.search(name, buildTargetIdentifier, visitor)
+    if isExtension then
+      search.searchMethods(name, buildTargetIdentifier, visitor)
+    else search.search(name, buildTargetIdentifier, visitor)
     val results = symbols.result.filter(isExactMatch(_, name))
 
     if results.nonEmpty then

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -156,6 +156,7 @@ case class ScalaPresentationCompiler(
   def autoImports(
       name: String,
       params: scala.meta.pc.OffsetParams,
+      isExtension: java.lang.Boolean,
   ): CompletableFuture[
     ju.List[scala.meta.pc.AutoImportsResult]
   ] =
@@ -172,7 +173,7 @@ case class ScalaPresentationCompiler(
         config,
         buildTargetIdentifier,
       )
-        .autoImports()
+        .autoImports(isExtension)
         .asJava
     }
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
@@ -191,7 +191,7 @@ class ScalaToplevelMtags(
               acceptTrivia()
               val name = newIdentifier
               withOwner(expect.owner) {
-                term(name.name, name.pos, Kind.OBJECT, 0)
+                term(name.name, name.pos, Kind.METHOD, 0)
               }
               loop(indent, isAfterNewline = false, region, None)
           }

--- a/tests/cross/src/main/scala/tests/BaseAutoImportsSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseAutoImportsSuite.scala
@@ -12,6 +12,8 @@ import munit.TestOptions
 
 trait BaseAutoImportsSuite extends BaseCodeActionSuite {
 
+  val isExtensionMethods: Boolean = false
+
   def check(
       name: String,
       original: String,
@@ -88,6 +90,7 @@ trait BaseAutoImportsSuite extends BaseCodeActionSuite {
           offset,
           cancelToken,
         ),
+        isExtensionMethods,
       )
       .get()
     result.asScala.toList

--- a/tests/cross/src/test/scala/tests/pc/AutoImportExtensionMethodsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportExtensionMethodsSuite.scala
@@ -6,6 +6,8 @@ class AutoImportExtensionMethodsSuite extends BaseAutoImportsSuite {
 
   override def ignoreScalaVersion: Some[IgnoreScalaVersion] = Some(IgnoreScala2)
 
+  override val isExtensionMethods: Boolean = true
+
   check(
     "basic",
     """|object A:


### PR DESCRIPTION
close https://github.com/scalameta/metals/issues/4212

In https://github.com/scalameta/metals/pull/4141 we started indexing the
extension methods (for auto-import missing extension methods) in
`workspaceSymbolIndex` where we should index only top-level symbols.

Later in https://github.com/scalameta/metals/pull/4183 we decided to index
those extension method symbols in a separate index
(see more details around here: https://github.com/scalameta/metals/pull/4183#pullrequestreview-1050733868).

This PR refactor import missing extension method to use
the index only for extension method symbols.

This change slightly improve the performance of symbol search
and reduce the memory footprint for symbol index.