### PR TITLE
Issue#4154: Add builder for lsp code actions

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -53,6 +53,7 @@ import scala.meta.internal.metals.clients.language.DelegatingLanguageClient
 import scala.meta.internal.metals.clients.language.ForwardingMetalsBuildClient
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.clients.language.NoopLanguageClient
+import scala.meta.internal.metals.codeactions.CodeActionProvider
 import scala.meta.internal.metals.codeactions.ExtractMemberDefinitionData
 import scala.meta.internal.metals.codelenses.RunTestCodeLens
 import scala.meta.internal.metals.codelenses.SuperMethodCodeLens

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeAction.scala
@@ -1,4 +1,4 @@
-package scala.meta.internal.metals
+package scala.meta.internal.metals.codeactions
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionBuilder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionBuilder.scala
@@ -1,0 +1,37 @@
+package scala.meta.internal.metals.codeactions
+
+import org.eclipse.{lsp4j => l}
+import scala.meta.io.AbsolutePath
+import scala.meta.internal.metals.MetalsEnrichments._
+
+object CodeActionBuilder {
+  def build(
+      title: String,
+      kind: String,
+      changes: Seq[(AbsolutePath, Seq[l.TextEdit])] = Nil,
+      documentChanges: List[Either[l.TextDocumentEdit, l.ResourceOperation]] =
+        Nil,
+      command: Option[l.Command] = None,
+      diagnostics: List[l.Diagnostic] = Nil,
+  ): l.CodeAction = {
+    val codeAction = new l.CodeAction()
+    codeAction.setTitle(title)
+    codeAction.setKind(kind)
+
+    val workspaceEdits = new l.WorkspaceEdit()
+    workspaceEdits.setChanges(
+      changes
+        .map { case (path, edits) =>
+          path.toURI.toString -> edits.asJava
+        }
+        .toMap
+        .asJava
+    )
+    workspaceEdits.setDocumentChanges(documentChanges.map(_.asJava).asJava)
+
+    codeAction.setEdit(workspaceEdits)
+    command.foreach(codeAction.setCommand)
+    codeAction.setDiagnostics(diagnostics.asJava)
+    codeAction
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionBuilder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionBuilder.scala
@@ -1,16 +1,18 @@
 package scala.meta.internal.metals.codeactions
 
-import org.eclipse.{lsp4j => l}
-import scala.meta.io.AbsolutePath
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+
+import org.eclipse.{lsp4j => l}
 
 object CodeActionBuilder {
+  type DocumentChange = Either[l.TextDocumentEdit, l.ResourceOperation]
+
   def build(
       title: String,
       kind: String,
       changes: Seq[(AbsolutePath, Seq[l.TextEdit])] = Nil,
-      documentChanges: List[Either[l.TextDocumentEdit, l.ResourceOperation]] =
-        Nil,
+      documentChanges: List[DocumentChange] = Nil,
       command: Option[l.Command] = None,
       diagnostics: List[l.Diagnostic] = Nil,
   ): l.CodeAction = {

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
@@ -1,11 +1,12 @@
-package scala.meta.internal.metals
+package scala.meta.internal.metals.codeactions
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import scala.meta.internal.metals._
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
-import scala.meta.internal.metals.codeactions._
+import scala.meta.internal.metals.codeactions.CodeAction
 import scala.meta.internal.parsing.Trees
 import scala.meta.pc.CancelToken
 

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateCompanionObjectCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateCompanionObjectCodeAction.scala
@@ -9,9 +9,10 @@ import scala.meta.Term
 import scala.meta.Tree
 import scala.meta.inputs.Position
 import scala.meta.internal.metals.Buffers
-import scala.meta.internal.metals.CodeAction
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.metals.codeactions.CodeAction
+import scala.meta.internal.metals.codeactions.CodeActionBuilder
 import scala.meta.internal.parsing.Trees
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.CancelToken
@@ -118,11 +119,6 @@ class CreateCompanionObjectCodeAction(
       hasBraces: Boolean,
       bracelessOK: Boolean,
   ): l.CodeAction = {
-    val codeAction = new l.CodeAction()
-    codeAction.setTitle(
-      CreateCompanionObjectCodeAction.companionObjectCreation(name)
-    )
-    codeAction.setKind(this.kind)
     val range = new l.Range(pos, pos)
 
     val braceFulCompanion =
@@ -145,18 +141,21 @@ class CreateCompanionObjectCodeAction(
     val companionObjectStartPosition = new l.Position()
     companionObjectStartPosition.setLine(pos.getLine + 3)
 
-    codeAction.setCommand(
+    val companionObjectCommand =
       buildCommandForNavigatingToCompanionObject(
         uri,
         companionObjectStartPosition,
       )
+
+    val edits =
+      List(path -> List(companionObjectTextEdit))
+
+    CodeActionBuilder.build(
+      title = CreateCompanionObjectCodeAction.companionObjectCreation(name),
+      kind = this.kind,
+      command = Some(companionObjectCommand),
+      changes = edits,
     )
-    codeAction.setEdit(
-      new l.WorkspaceEdit(
-        Map(path.toURI.toString -> List(companionObjectTextEdit).asJava).asJava
-      )
-    )
-    codeAction
   }
 
   private def buildCommandForNavigatingToCompanionObject(

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateNewSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CreateNewSymbol.scala
@@ -5,6 +5,7 @@ import scala.concurrent.Future
 
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals._
+import scala.meta.internal.metals.codeactions.CodeAction
 import scala.meta.pc.CancelToken
 
 import org.eclipse.{lsp4j => l}
@@ -24,14 +25,15 @@ class CreateNewSymbol() extends CodeAction {
         diagnostic: l.Diagnostic,
         name: String,
     ): l.CodeAction = {
-      val codeAction = new l.CodeAction()
-      codeAction.setTitle(CreateNewSymbol.title(name))
-      codeAction.setKind(l.CodeActionKind.QuickFix)
-      codeAction.setDiagnostics(List(diagnostic).asJava)
-      codeAction.setCommand(
+      val command =
         ServerCommands.NewScalaFile.toLSP(parentUri.toString(), name)
+
+      CodeActionBuilder.build(
+        title = CreateNewSymbol.title(name),
+        kind = l.CodeActionKind.QuickFix,
+        command = Some(command),
+        diagnostics = List(diagnostic),
       )
-      codeAction
     }
 
     val codeActions = params

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractValueCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractValueCodeAction.scala
@@ -11,8 +11,9 @@ import scala.meta.Term
 import scala.meta.Tree
 import scala.meta.inputs.Position
 import scala.meta.internal.metals.Buffers
-import scala.meta.internal.metals.CodeAction
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.codeactions.CodeAction
+import scala.meta.internal.metals.codeactions.CodeActionBuilder
 import scala.meta.internal.parsing.Trees
 import scala.meta.pc.CancelToken
 import scala.meta.tokens.Token
@@ -77,15 +78,11 @@ class ExtractValueCodeAction(
       }
 
     textEdits.map { case (edits, title) =>
-      val codeAction = new l.CodeAction()
-      codeAction.setTitle(ExtractValueCodeAction.title(title))
-      codeAction.setKind(this.kind)
-      codeAction.setEdit(
-        new l.WorkspaceEdit(
-          Map(path.toURI.toString -> edits.asJava).asJava
-        )
+      CodeActionBuilder.build(
+        title = ExtractValueCodeAction.title(title),
+        kind = this.kind,
+        changes = List(path -> edits),
       )
-      codeAction
     }
 
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/FlatMapToForComprehensionCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/FlatMapToForComprehensionCodeAction.scala
@@ -12,8 +12,9 @@ import scala.meta.Term
 import scala.meta.Tree
 import scala.meta.inputs.Position
 import scala.meta.internal.metals.Buffers
-import scala.meta.internal.metals.CodeAction
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.codeactions.CodeAction
+import scala.meta.internal.metals.codeactions.CodeActionBuilder
 import scala.meta.internal.parsing.Trees
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.CancelToken
@@ -102,22 +103,21 @@ class FlatMapToForComprehensionCodeAction(
                |$yieldTermIndentedString
                |$indentation}""".stripMargin
 
-    val codeAction = new l.CodeAction()
     val range =
       new l.Range(startPos, endPos)
-    codeAction.setTitle(
-      FlatMapToForComprehensionCodeAction.flatMapToForComprehension
-    )
-    codeAction.setKind(this.kind)
+
     val forComprehensionTextEdit = new l.TextEdit(range, forYieldString)
-    codeAction.setEdit(
-      new l.WorkspaceEdit(
-        Map(
-          path.toURI.toString -> List(forComprehensionTextEdit).asJava
-        ).asJava
+
+    val edits =
+      List(
+        path -> List(forComprehensionTextEdit)
       )
+
+    CodeActionBuilder.build(
+      title = FlatMapToForComprehensionCodeAction.flatMapToForComprehension,
+      kind = this.kind,
+      changes = edits,
     )
-    codeAction
   }
 
   /**

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImplementAbstractMembers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImplementAbstractMembers.scala
@@ -5,6 +5,7 @@ import scala.concurrent.Future
 
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals._
+import scala.meta.internal.metals.codeactions.CodeAction
 import scala.meta.pc.CancelToken
 
 import org.eclipse.{lsp4j => l}
@@ -50,16 +51,13 @@ class ImplementAbstractMembers(compilers: Compilers) extends CodeAction {
       .implementAbstractMembers(textDocumentPositionParams, token)
       .map { edits =>
         val uri = params.getTextDocument().getUri()
-        val edit = new l.WorkspaceEdit(Map(uri -> edits).asJava)
 
-        val codeAction = new l.CodeAction()
-
-        codeAction.setTitle(ImplementAbstractMembers.title)
-        codeAction.setKind(l.CodeActionKind.QuickFix)
-        codeAction.setDiagnostics(List(diagnostic).asJava)
-        codeAction.setEdit(edit)
-
-        codeAction
+        CodeActionBuilder.build(
+          title = ImplementAbstractMembers.title,
+          kind = l.CodeActionKind.QuickFix,
+          changes = List(uri.toAbsolutePath -> edits.asScala.toSeq),
+          diagnostics = List(diagnostic),
+        )
       }
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
@@ -7,10 +7,11 @@ import scala.meta.Defn
 import scala.meta.Enumerator
 import scala.meta.Pat
 import scala.meta.Term
-import scala.meta.internal.metals.CodeAction
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ScalacDiagnostic
 import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.metals.codeactions.CodeAction
+import scala.meta.internal.metals.codeactions.CodeActionBuilder
 import scala.meta.internal.parsing.Trees
 import scala.meta.pc.CancelToken
 
@@ -37,19 +38,20 @@ class InsertInferredType(trees: Trees) extends CodeAction {
     }
 
     def insertInferTypeAction(title: String): l.CodeAction = {
-      val codeAction = new l.CodeAction()
-      codeAction.setTitle(title)
-      codeAction.setKind(l.CodeActionKind.RefactorRewrite)
       val range = params.getRange().getStart()
-      codeAction.setCommand(
+      val commandTypeAction =
         ServerCommands.InsertInferredType.toLSP(
           new l.TextDocumentPositionParams(
             params.getTextDocument(),
             range,
           )
         )
+
+      CodeActionBuilder.build(
+        title = title,
+        kind = l.CodeActionKind.RefactorRewrite,
+        command = Some(commandTypeAction),
       )
-      codeAction
     }
 
     def inferTypeTitle(name: Term.Name): Option[String] = name.parent.flatMap {
@@ -92,18 +94,19 @@ class InsertInferredType(trees: Trees) extends CodeAction {
     }
 
     def adjustTypeAction(typ: String, range: l.Range): l.CodeAction = {
-      val codeAction = new l.CodeAction()
-      codeAction.setTitle(InsertInferredType.adjustType(typ))
-      codeAction.setKind(l.CodeActionKind.QuickFix)
-      codeAction.setCommand(
+      val commandTypeAction =
         ServerCommands.InsertInferredType.toLSP(
           new l.TextDocumentPositionParams(
             params.getTextDocument(),
             range.getStart(),
           )
         )
+
+      CodeActionBuilder.build(
+        title = InsertInferredType.adjustType(typ),
+        kind = l.CodeActionKind.QuickFix,
+        command = Some(commandTypeAction),
       )
-      codeAction
     }
 
     val adjustType = for {

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
@@ -4,7 +4,6 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import scala.meta.internal.metals.BuildTargets
-import scala.meta.internal.metals.CodeAction
 import scala.meta.internal.metals.Diagnostics
 import scala.meta.internal.metals.MetalsEnrichments.XtensionString
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -12,6 +11,8 @@ import scala.meta.internal.metals.ScalaTarget
 import scala.meta.internal.metals.ScalacDiagnostic
 import scala.meta.internal.metals.ScalafixProvider
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.codeactions.CodeAction
+import scala.meta.internal.metals.codeactions.CodeActionBuilder
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.CancelToken
 
@@ -55,15 +56,13 @@ sealed abstract class OrganizeImports(
     scalafixProvider
       .organizeImports(path, scalaVersion)
       .map { edits =>
-        val codeAction = new l.CodeAction()
-        codeAction.setTitle(this.title)
-        codeAction.setKind(this.kind)
-        codeAction.setEdit(
-          new l.WorkspaceEdit(
-            Map(path.toURI.toString -> edits.asJava).asJava
+        Seq(
+          CodeActionBuilder.build(
+            title = this.title,
+            kind = this.kind,
+            changes = List(path.toURI.toAbsolutePath -> edits),
           )
         )
-        Seq(codeAction)
       }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/PatternMatchRefactor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/PatternMatchRefactor.scala
@@ -4,8 +4,9 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import scala.meta.Term
-import scala.meta.internal.metals.CodeAction
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.codeactions.CodeAction
+import scala.meta.internal.metals.codeactions.CodeActionBuilder
 import scala.meta.internal.parsing.Trees
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.CancelToken
@@ -68,14 +69,14 @@ class PatternMatchRefactor(trees: Trees) extends CodeAction {
         }
 
       val edits = List(new l.TextEdit(range, text))
-      val codeAction = new l.CodeAction()
-      codeAction.setTitle(PatternMatchRefactor.convertPatternMatch)
-      codeAction.setKind(this.kind)
-      codeAction.setEdit(
-        new l.WorkspaceEdit(
-          Map(path.toURI.toString -> edits.asJava).asJava
+
+      val codeAction =
+        CodeActionBuilder.build(
+          title = PatternMatchRefactor.convertPatternMatch,
+          kind = this.kind,
+          changes = List(path -> edits),
         )
-      )
+
       Seq(codeAction)
     case _ => Seq.empty
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/RewriteBracesParensCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/RewriteBracesParensCodeAction.scala
@@ -5,8 +5,9 @@ import scala.concurrent.Future
 import scala.reflect.ClassTag
 
 import scala.meta.Term
-import scala.meta.internal.metals.CodeAction
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.codeactions.CodeAction
+import scala.meta.internal.metals.codeactions.CodeActionBuilder
 import scala.meta.internal.parsing.Trees
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.CancelToken
@@ -84,7 +85,6 @@ class RewriteBracesParensCodeAction(
               val newRight = if (isParens) "}" else ")"
               val start = new l.TextEdit(leftParen.pos.toLSP, newLeft)
               val end = new l.TextEdit(rightParen.pos.toLSP, newRight)
-              val codeAction = new l.CodeAction()
 
               val name = appl.fun match {
                 case Term.Name(value) => value
@@ -96,14 +96,11 @@ class RewriteBracesParensCodeAction(
                 if (isParens) RewriteBracesParensCodeAction.toBraces(name)
                 else RewriteBracesParensCodeAction.toParens(name)
 
-              codeAction.setTitle(title)
-              codeAction.setKind(this.kind)
-              codeAction.setEdit(
-                new l.WorkspaceEdit(
-                  Map(path.toURI.toString -> List(start, end).asJava).asJava
-                )
+              CodeActionBuilder.build(
+                title = title,
+                kind = this.kind,
+                changes = List(path -> List(start, end)),
               )
-              codeAction
           }
       }
       .flatten

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/StringActions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/StringActions.scala
@@ -4,8 +4,9 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import scala.meta.internal.metals.Buffers
-import scala.meta.internal.metals.CodeAction
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.codeactions.CodeAction
+import scala.meta.internal.metals.codeactions.CodeActionBuilder
 import scala.meta.internal.parsing.Trees
 import scala.meta.pc.CancelToken
 import scala.meta.tokens.Token
@@ -170,14 +171,11 @@ class StringActions(buffers: Buffers) extends CodeAction {
       uri: String,
       edits: List[l.TextEdit],
   ): l.CodeAction = {
-    val codeAction = new l.CodeAction()
-    codeAction.setTitle(title)
-    codeAction.setKind(l.CodeActionKind.Refactor)
-    codeAction.setEdit(
-      new l.WorkspaceEdit(Map(uri -> edits.asJava).asJava)
+    CodeActionBuilder.build(
+      title = title,
+      kind = l.CodeActionKind.Refactor,
+      changes = List(uri.toAbsolutePath -> edits),
     )
-
-    codeAction
   }
 }
 


### PR DESCRIPTION
Avoid repeating code when creating a lsp code action.

I've made a slight change to the code specified in the issue. Instead of passing a single `workspaceEdits` params in the `ActionCodeBuilder`, I have chosen to separate it in two parameter to handle the case where we can get an `Either` in the `ExtractRenameNumber` code action file without duplicating the `build` function.

Related to issue #4154