### PR TITLE
bugfix: Rename properly companion object in local scope

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -96,24 +96,60 @@ trait CommonMtagsEnrichments {
         new l.Position(pos.endLine, pos.endColumn)
       )
     }
+
     def encloses(other: m.Position): Boolean = {
       pos.start <= other.start && pos.end >= other.end
+    }
+
+    def encloses(other: s.Range): Boolean = {
+      isBefore(
+        pos.startLine,
+        pos.startColumn,
+        other.startLine,
+        other.startCharacter
+      ) && isAfter(
+        pos.endLine,
+        pos.endColumn,
+        other.endLine,
+        other.endCharacter
+      )
     }
 
     def encloses(other: l.Range): Boolean = {
       val start = other.getStart()
       val end = other.getEnd()
-      val isBefore =
-        pos.startLine < start.getLine ||
-          (pos.startLine == start.getLine && pos.startColumn <= start
-            .getCharacter())
-
-      val isAfter = pos.endLine > end.getLine() ||
-        (pos.endLine >= end.getLine() && pos.endColumn >= end.getCharacter())
-
-      isBefore && isAfter
+      isBefore(
+        pos.startLine,
+        pos.startColumn,
+        start.getLine,
+        start.getCharacter()
+      ) && isAfter(
+        pos.endLine,
+        pos.endColumn,
+        end.getLine(),
+        end.getCharacter()
+      )
     }
+
+    private def isBefore(
+        startLine: Int,
+        startChar: Int,
+        startLineOther: Int,
+        startCharOther: Int
+    ) =
+      startLine < startLineOther ||
+        (startLine == startLineOther && startChar <= startCharOther)
+
+    private def isAfter(
+        endLine: Int,
+        endChar: Int,
+        endLineOther: Int,
+        endCharOther: Int
+    ) =
+      endLine > endLineOther ||
+        (endLine >= endLineOther && endChar >= endCharOther)
   }
+
   implicit class XtensionRangeParams(params: RangeParams) {
 
     def trimWhitespaceInRange: Option[OffsetParams] = {

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -812,6 +812,50 @@ class RenameLspSuite extends BaseRenameLspSuite(s"rename") {
        |""".stripMargin,
     newName = "NewSymbol",
   )
+
+  renamed(
+    "hierarchy-inside-method-class2",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main {
+       |  final def bar(n: Int) = {
+       |    sealed trait Hierarchy
+       |    final case class Instance() extends Hierarchy
+       |    val bar: Hierarchy = Instance()
+       |    val bar2: Instance = Instance()
+       |  }
+       |  final def foo(n: Int) = {
+       |    sealed trait Hierarchy
+       |    final case class <<Instance>>() extends Hierarchy
+       |    val bar: Hierarchy = new <<Instance>>()
+       |    val bar2: <<In@@stance>> = <<Instance>>()
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "NewSymbol",
+  )
+
+  renamed(
+    "hierarchy-inside-method-class3",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main {
+       |  final def bar(n: Int) = {
+       |    sealed trait Hierarchy
+       |    final case class Instance() extends Hierarchy
+       |    val bar: Hierarchy = Instance()
+       |    val bar2: Instance = Instance()
+       |  }
+       |  final def foo(n: Int) = {
+       |    sealed trait Hierarchy
+       |    final case class <<Instance>>() extends Hierarchy
+       |    val bar: Hierarchy = new <<Instance>>()
+       |    val bar2: <<Instance>> = <<Ins@@tance>>()
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "NewSymbol",
+  )
   override protected def libraryDependencies: List[String] =
     List("org.scalatest::scalatest:3.2.12", "io.circe::circe-generic:0.14.1")
 


### PR DESCRIPTION
Previously, we would not correctly rename companion objects in local contexts due to the fact that it's needed to eactually search for the symbol. Now, we try to correctly identify the companion object in local context based on the current scope.

One situation this might not work when we have the same named case class in an inner scope:

```scala
def method = {
  case class Instance()
  val ins = Instance()
  def inner = {
     case class Instance()
     val ins = Instance()
  }
}
```

however this seems like a rare enough scenario to not overcomplicate things.

We would need to find all the possible same named case classes and establish boundries, which might be quite difficult.

Alternatively, if we manage to make some local renames working with presentation compiler, this will work correctly and might actually be an easier approach.

Fixes https://github.com/scalameta/metals/issues/1539