### PR TITLE
chore: mention Scala CLi in new file provider

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -394,7 +394,7 @@ object ServerCommands {
     "Create new scala file",
     s"""|Create and open new Scala file.
         |
-        |The currently allowed Scala file types that ca be passed in are:
+        |The currently allowed Scala file types that can be passed in are:
         |
         | - ${NewFileTypes.ScalaFile.id} (${NewFileTypes.ScalaFile.label})
         | - ${NewFileTypes.Class.id} (${NewFileTypes.Class.label})
@@ -404,7 +404,7 @@ object ServerCommands {
         | - ${NewFileTypes.Trait.id} (${NewFileTypes.Trait.label})
         | - ${NewFileTypes.PackageObject.id} (${NewFileTypes.PackageObject.label})
         | - ${NewFileTypes.Worksheet.id} (${NewFileTypes.Worksheet.label})
-        | - ${NewFileTypes.AmmoniteScript.id} (${NewFileTypes.AmmoniteScript.label})
+        | - ${NewFileTypes.ScalaScript.id} (${NewFileTypes.ScalaScript.label})
         |
         |Note: requires 'metals/inputBox' capability from language client.
         |""".stripMargin,

--- a/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
@@ -101,8 +101,8 @@ class NewFileProvider(
           .mapOption(
             createEmptyFile(directory, _, ".worksheet.sc")
           )
-      case AmmoniteScript =>
-        getName(AmmoniteScript, name)
+      case ScalaScript =>
+        getName(ScalaScript, name)
           .mapOption(
             createEmptyFile(directory, _, ".sc")
           )
@@ -136,7 +136,7 @@ class NewFileProvider(
       Trait,
       PackageObject,
       Worksheet,
-      AmmoniteScript,
+      ScalaScript,
     )
     val withEnum =
       if (isScala3) allFileTypes :+ Enum else allFileTypes

--- a/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileTypes.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileTypes.scala
@@ -58,10 +58,10 @@ object NewFileTypes {
     override val label: String = "Worksheet"
   }
 
-  case object AmmoniteScript extends NewFileType {
-    override val id: String = "ammonite-script"
+  case object ScalaScript extends NewFileType {
+    override val id: String = "scala-script"
     override val syntax: Option[String] = None
-    override val label: String = "Ammonite Script"
+    override val label: String = "Scala Script(Ammonite or Scala CLI)"
   }
 
   case object JavaClass extends NewFileType {
@@ -98,7 +98,7 @@ object NewFileTypes {
       case ScalaFile.id => Some(ScalaFile)
       case PackageObject.id => Some(PackageObject)
       case Worksheet.id => Some(Worksheet)
-      case AmmoniteScript.id => Some(AmmoniteScript)
+      case ScalaScript.id => Some(ScalaScript)
       case JavaClass.id => Some(JavaClass)
       case JavaInterface.id => Some(JavaInterface)
       case JavaEnum.id => Some(JavaEnum)

--- a/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
@@ -49,17 +49,17 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
     expectedContent = "",
   )
 
-  checkScala("new-ammonite-script")(
+  checkScala("new-scala-script")(
     directory = Some("a/src/main/scala/"),
-    fileType = Right(AmmoniteScript),
+    fileType = Right(ScalaScript),
     fileName = Right("Foo"),
     expectedFilePath = "a/src/main/scala/Foo.sc",
     expectedContent = "",
   )
 
-  checkScala("new-ammonite-script-name-provided")(
+  checkScala("new-scala-script-name-provided")(
     directory = Some("a/src/main/scala/"),
-    fileType = Right(AmmoniteScript),
+    fileType = Right(ScalaScript),
     fileName = Left("Foo"),
     expectedFilePath = "a/src/main/scala/Foo.sc",
     expectedContent = "",
@@ -67,7 +67,7 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
 
   checkScala("new-ammonite-script-fully-provided")(
     directory = Some("a/src/main/scala/"),
-    fileType = Left(AmmoniteScript),
+    fileType = Left(ScalaScript),
     fileName = Left("Foo"),
     expectedFilePath = "a/src/main/scala/Foo.sc",
     expectedContent = "",


### PR DESCRIPTION
A script file might be either ammonite or scala-cli.
Changed name and label just to be more explicit +an additional promotion point for scala-cli