### PR TITLE
fix extract value for `new` keyword

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractValueCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractValueCodeAction.scala
@@ -121,6 +121,10 @@ class ExtractValueCodeAction(
         Some(expr)
       case Term.Do(_, expr) =>
         Some(expr)
+      case Term.New(init) =>
+        init.argss.flatten
+          .find { arg => arg.pos.encloses(range) }
+          .map(applyArgument(_))
       case _ => None
     }
   }
@@ -147,6 +151,8 @@ class ExtractValueCodeAction(
         expr.pos.encloses(range)
       case Term.Do(_, expr) =>
         expr.pos.encloses(range)
+      case Term.New(init) =>
+        init.argss.flatten.exists { arg => arg.pos.encloses(range) }
       case _ => false
     }
   }

--- a/tests/unit/src/test/scala/tests/codeactions/ExtractValueLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ExtractValueLspSuite.scala
@@ -342,4 +342,22 @@ class ExtractValueLspSuite
        |}
        |""".stripMargin,
   )
+
+  check(
+    "extract-new",
+    """|class Car(age: Int)
+       |object Main{
+       |  new Car(age = <<1>>)
+       |}
+       |""".stripMargin,
+    s"""|${ExtractValueCodeAction.title("1")}
+        |""".stripMargin,
+    """|class Car(age: Int)
+       |object Main{
+       |  val newValue = 1
+       |  new Car(age = newValue)
+       |}
+       |""".stripMargin,
+  )
+
 }


### PR DESCRIPTION
Previously we couldn’t extract value from
```scala
new Car(<<"red">>)
```
This pr enables it