### PR TITLE
refactor: update scala-steward configs (run more frequently and limit number of PRs)

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: '0 0 1,15 * *'
+    - cron: "0 0 * * 1, 5" # every Monday and Friday
   workflow_dispatch:
 
 name: Launch Scala Steward

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,3 +3,4 @@ updates.ignore = [
   { groupId = "org.eclipse.platform" }
 ]
 commits.message = "build(deps): Update ${artifactName} from ${currentVersion} to ${nextVersion}"
+updates.limit = 5


### PR DESCRIPTION
This commit makes Scala-steward to

- Run scala-steward more frequently (twice a week)
- Create only 5 PRs to scalameta/metals at a time

Previously, scala-steward runs only 1st and 15th of a month,
and steward creates a bunch of PRs (around 10~PRs at a time).
However, scalameta/metals CIs are heavy (it has 20 workflows and
each takes around 20-30 minutes), and as a result, CI stucks every
scala-steward days.

This commit makes scala-steward to run more frequently, and limit
the number of PRs steward creates at a time.
This change would limit the number of PRs steward creates and makes
CIs work smoothly for library updates.

---

What do you think about this update?