### PR TITLE
bugfix: Always set changes or document changes

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionBuilder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionBuilder.scala
@@ -23,7 +23,7 @@ object CodeActionBuilder {
 
     logging.logErrorWhen(
       !(changes.nonEmpty && documentChanges.nonEmpty),
-      "Only document or documentChanges can be set in code action at the same time",
+      "Only changes or documentChanges can be set in code action at the same time",
     )
 
     val workspaceEdits = new l.WorkspaceEdit()


### PR DESCRIPTION
Previously, we would set both and a language client will choose only one of them, so if they are set and empty it will apply empty changes. Now, only one of those is set.