### PR TITLE
fix: scala-steward cron

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: "0 0 * * 1,5" # every Monday and Friday
+    - cron: '0 0 0 * 1,5' # every Monday and Friday
   workflow_dispatch:
 
 name: Launch Scala Steward


### PR DESCRIPTION
https://github.com/scalameta/metals/actions/runs/2978475788

- Use single-quote instead of double quote
- Previously we run scala-steward every hour on Monday and Friday