### PR TITLE
refactor: Add labels to scala-steward PRs

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -20,3 +20,4 @@ jobs:
           author-email: scalameta@gmail.com
           author-name: Scalameta Bot
           repos-file: .github/steward-repos.md
+          other-args: '--add-labels'


### PR DESCRIPTION
first step for https://github.com/scalameta/metals/issues/4333

Thit commit let scala-steward PRs put
Github labels such as `semver-spec-patch`, which will be
useful for mergify.

see:
https://github.com/scala-steward-org/scala-steward/pull/2523
https://github.com/scala-steward-org/scala-steward-action/pull/387