### PR TITLE
Auto approve PR by scalameta-bot

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,15 @@
+name: Auto approve patch updates
+
+on:
+  pull_request_target:
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@v2
+        if: contains(github.event.pull_request.labels.*.name, 'semver-spec-patch') && github.actor == 'scalameta-bot'
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
part of https://github.com/scalameta/metals/issues/4333

- Auto-approve the PRs that is created by `scalameta-bot` and has label `semver-spec-patch`.
- `scalameta-bot` will approve the PR

Added this auto-approve workflow because scalameta/metals
requires PRs to receive at least one approval from authorized users
(maintainers) to merge.
Therefore, until someone approve the PR, mergify cannot merge the PR.

This workflow will self-approve (by `scalameta-bot`) and enable mergify
to auto-merge the library update PRs.

---

- I didn't use mergify's auto-review functionality, because mergify
  cannot specify a user who approve the PR (with a free OSS plan)
  - https://docs.mergify.com/actions/review/
- This action doesn't depends on other workflows result, which means will auto-approve even if the CIs fail.
  - It's ideal approve only when CIs passed, but depending on other workflows' status in github actions are bit complicated (in comparison to mergify), let mergify check the CI statuses.
  - see: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow
- concerns
  - Can scalameta-bot self-approve?
  - Does scalameta-bot's approval unlock merging? (maybe we have to give
    scalameta-bot write right to this repo?)