### PR TITLE
Enable enum completions in pattern matching

### DIFF
--- a/mtags/src/main/scala-3.2/scala/meta/internal/pc/MetalsSealedDesc.scala
+++ b/mtags/src/main/scala-3.2/scala/meta/internal/pc/MetalsSealedDesc.scala
@@ -1,8 +1,8 @@
 package scala.meta.internal.pc
 
 import dotty.tools.dotc.core.Contexts.Context
-import dotty.tools.dotc.core.Symbols.Symbol
 import dotty.tools.dotc.core.Flags.*
+import dotty.tools.dotc.core.Symbols.Symbol
 
 object MetalsSealedDesc:
   def sealedStrictDescendants(sym: Symbol)(using Context): List[Symbol] =

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -147,9 +147,11 @@ object CaseKeywordCompletion:
         && (sym.is(Case) || sym.is(Flags.Module) || sym.isClass)
         && parents.isSubClass(sym, false)
       indexedContext.scopeSymbols
-        .map(_.info.dealias.typeSymbol)
-        .filter(isValid(_))
-        .foreach(s => visit(s, s.decodedName, Nil))
+        .foreach(s => {
+          val ts  = s.info.dealias.typeSymbol
+          if (isValid(ts))
+            visit(ts, ts.decodedName, Nil)
+         )}
 
       // Step 2: walk through known subclasses of sealed types.
       MetalsSealedDesc.sealedStrictDescendants(selectorSym).foreach { sym =>

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -147,11 +147,10 @@ object CaseKeywordCompletion:
         && (sym.is(Case) || sym.is(Flags.Module) || sym.isClass)
         && parents.isSubClass(sym, false)
       indexedContext.scopeSymbols
-        .foreach(s => {
-          val ts  = s.info.dealias.typeSymbol
-          if (isValid(ts))
-            visit(ts, ts.decodedName, Nil)
-         )}
+        .foreach(s =>
+          val ts = s.info.dealias.typeSymbol
+          if (isValid(ts)) then visit(ts, ts.decodedName, Nil)
+        )
 
       // Step 2: walk through known subclasses of sealed types.
       MetalsSealedDesc.sealedStrictDescendants(selectorSym).foreach { sym =>

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -471,5 +471,22 @@ class CompletionCaseSuite extends BaseCompletionSuite {
     // Assert we don't use infix syntax because `::` resolves to conflicting symbol in scope.
     "case Outer.::(a, b) => $0",
   )
+  check(
+    "scala-enum".tag(IgnoreScala2),
+    """
+      |package example
+      |enum Color:
+      |  case Red, Blue, Green
+      |
+      |object Main {
+      |  val x: Color = ???
+      |  x match
+      |    case@@
+      |}""".stripMargin,
+    """|case Blue =>Color
+       |case Green =>Color
+       |case Red =>Color
+       |""".stripMargin,
+  )
 
 }


### PR DESCRIPTION
By refactoring `visit` method we enable completions with `enum` cases. 