### PR TITLE
Add case completions for single case classes in Scala3

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -142,6 +142,11 @@ object CaseKeywordCompletion:
         command = config.parameterHintsCommand().asScala,
       )
     else
+      // Step 0: case for selector type
+      if !(selectorSym.is(Sealed) &&
+          (selectorSym.is(Abstract) || selectorSym.is(Trait)))
+      then visit(selectorSym, selectorSym.decodedName, Nil)
+
       // Step 1: walk through scope members.
       def isValid(sym: Symbol) = !parents.isParent(sym)
         && (sym.is(Case) || sym.is(Flags.Module) || sym.isClass)

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -63,6 +63,18 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |case HasWings(e) => pkg
        |case Seal => pkg
        |""".stripMargin,
+    compat = Map(
+      "3" -> """|case _: Animal => pkg
+                |case Bird(name) => pkg
+                |case _: Cat => pkg
+                |case _: Dog => pkg
+                |case Elephant => pkg
+                |case _: HasFeet[_, _] => pkg
+                |case _: HasMouth[_] => pkg
+                |case HasWings(e) => pkg
+                |case Seal => pkg
+                |""".stripMargin
+    ),
   )
 
   check(
@@ -486,6 +498,19 @@ class CompletionCaseSuite extends BaseCompletionSuite {
     """|case Blue =>Color
        |case Green =>Color
        |case Red =>Color
+       |""".stripMargin,
+  )
+  check(
+    "single-case-class".tag(IgnoreScala2),
+    """
+      |package example
+      |case class Foo(a: Int, b: Int)
+      |
+      |object A {
+      |  
+      |  List(Foo(1,2)).map{ cas@@ }
+      |}""".stripMargin,
+    """|case Foo(a, b) => example
        |""".stripMargin,
   )
 


### PR DESCRIPTION
This pr adds case completions for single case classes and not sealed traits.
It's mostly for 
```scala
case class Foo(a: Int, b: Int)
List(Foo(1,2)).map { case@@} 
```