### PR TITLE
Change adding space after case completions

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -353,10 +353,13 @@ class CompletionValueGenerator(
     val label =
       if patternOnly.isEmpty then s"case $pattern =>"
       else pattern
+    val cursorSuffix =
+      (if patternOnly.nonEmpty then "" else " ") +
+        (if clientSupportsSnippets then "$0" else "")
     CompletionValue.CaseKeyword(
       sym,
       label,
-      Some(label + (if clientSupportsSnippets then " $0" else "")),
+      Some(label + cursorSuffix),
       autoImports,
       // filterText = if !doFilterText then Some("") else None,
       range = Some(completionPos.toEditRange),


### PR DESCRIPTION
It moves the place where we add `space` at the end of completion.
It is mostly for pattern only completions
```scala
// while triggering completions here 
List(Option(1)).map{ case So@@ => }

//previously we got double space
List(Option(1)).map{ case Some(value) $0 => }

//now 
List(Option(1)).map{ case Some(value)$0 => }
```
It also adds `space` after every case in exhaustive pattern match, not only after the first one, although I'm not sure if its correct