### PR TITLE
Fix case completions for enum with params

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -381,7 +381,7 @@ class CompletionValueGenerator(
       isModuleLike: Boolean,
   )(using Context): String =
     val suffix =
-      if isModuleLike then ""
+      if isModuleLike && !(sym.isClass && sym.is(Enum)) then ""
       else
         sym.primaryConstructor.paramSymss match
           case Nil => "()"

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -500,6 +500,26 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |case Red =>Color
        |""".stripMargin,
   )
+
+  check(
+    "scala-enum-with-param".tag(IgnoreScala2),
+    """
+      |package example
+      |enum Foo:
+      |  case Bla, Bar
+      |  case Buzz(arg1: Int, arg2: Int)
+      |
+      |object Main {
+      |  val x: Foo = ???
+      |  x match
+      |    case@@
+      |}""".stripMargin,
+    """|case Bar =>Foo
+       |case Bla =>Foo
+       |case Buzz(arg1, arg2) => example.Foo
+       |""".stripMargin,
+  )
+
   check(
     "single-case-class".tag(IgnoreScala2),
     """

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -308,9 +308,9 @@ class CompletionMatchSuite extends BaseCompletionSuite {
     """
       |package example
       |enum Color(rank: Int):
-      |  case Red(1)
-      |  case Blue(2)
-      |  case Green(3)
+      |  case Red extends Color(1)
+      |  case Blue extends Color(2)
+      |  case Green extends Color(3)
       |
       |object Main {
       |  val x: Color = ???
@@ -324,9 +324,9 @@ class CompletionMatchSuite extends BaseCompletionSuite {
         |
         |import example.Color.Green
         |enum Color(rank: Int):
-        |  case Red(1)
-        |  case Blue(2)
-        |  case Green(3)
+        |  case Red extends Color(1)
+        |  case Blue extends Color(2)
+        |  case Green extends Color(3)
         |
         |object Main {
         |  val x: Color = ???


### PR DESCRIPTION
fixes https://github.com/scalameta/metals/issues/4352

Also, I haven't realised before that test for scala enum in exhaustive match was broken and it is fixed now