### PR TITLE
Add cross tests for pattern only case completions, fix for typed case completions

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -359,8 +359,8 @@ class Completions(
             indexedContext,
             config,
             parent,
-            Some(identName),
-            true,
+            patternOnly = Some(identName),
+            hasBind = true,
           ),
           false,
         )
@@ -373,7 +373,7 @@ class Completions(
             indexedContext,
             config,
             parent,
-            Some(identName),
+            patternOnly = Some(identName),
           ),
           false,
         )

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -394,11 +394,18 @@ class Completions(
       // otherwise after accepting completion we would get `case case None =>`
       case (lt @ Literal(
             Constant(null)
-          )) :: (c: CaseDef) :: (m: Match) :: parent :: _ =>
-        advancedCompletions(
-          path.tail,
-          c.startPos,
-          CompletionPos.infer(c.startPos, text, path.tail),
+          )) :: (c: CaseDef) :: (m: Match) :: parent :: _
+          if text(lt.startPos.start) == ' ' =>
+        (
+          CaseKeywordCompletion.contribute(
+            m.selector,
+            completionPos,
+            indexedContext,
+            config,
+            parent,
+            Some(""),
+          ),
+          false,
         )
 
       // class FooImpl extends Foo:

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -347,6 +347,26 @@ class Completions(
           false,
         )
 
+      // in `case @@` we have to change completionPos to `case` pos,
+      // otherwise after accepting completion we would get `case case None =>`
+      case (c @ CaseDef(
+            Literal((Constant(null))),
+            _,
+            _,
+          )) :: (m: Match) :: parent :: _
+          if pos.start - c.sourcePos.start > 4 =>
+        (
+          CaseKeywordCompletion.contribute(
+            m.selector,
+            completionPos,
+            indexedContext,
+            config,
+            parent,
+            Some(""),
+          ),
+          false,
+        )
+
       case CaseExtractors.CaseExtractor(selector, parent) =>
         (
           CaseKeywordCompletion.contribute(
@@ -386,24 +406,6 @@ class Completions(
             config,
             parent,
             Some(identName),
-          ),
-          false,
-        )
-
-      // in `case @@` we have to change completionPos to `case` pos,
-      // otherwise after accepting completion we would get `case case None =>`
-      case (lt @ Literal(
-            Constant(null)
-          )) :: (c: CaseDef) :: (m: Match) :: parent :: _
-          if text(lt.startPos.start) == ' ' =>
-        (
-          CaseKeywordCompletion.contribute(
-            m.selector,
-            completionPos,
-            indexedContext,
-            config,
-            parent,
-            Some(""),
           ),
           false,
         )

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -330,13 +330,13 @@ class Completions(
       .toString()
     lazy val filename = rawFileName
       .stripSuffix(".scala")
-    val CaseExtractor = new CaseExtractor(pos, text, completionPos)
+    val MatchCaseExtractor = new MatchCaseExtractor(pos, text, completionPos)
     path match
       case _ if ScaladocCompletions.isScaladocCompletion(pos, text) =>
         val values = ScaladocCompletions.contribute(pos, text, config)
         (values, true)
 
-      case CaseExtractor.MatchExtractor(selector) =>
+      case MatchCaseExtractor.MatchExtractor(selector) =>
         (
           CaseKeywordCompletion.matchContribute(
             selector,
@@ -347,7 +347,7 @@ class Completions(
           false,
         )
 
-      case CaseExtractor.TypedCasePatternExtractor(
+      case MatchCaseExtractor.TypedCasePatternExtractor(
             selector,
             parent,
             identName,
@@ -365,7 +365,11 @@ class Completions(
           false,
         )
 
-      case CaseExtractor.CasePatternExtractor(selector, parent, identName) =>
+      case MatchCaseExtractor.CasePatternExtractor(
+            selector,
+            parent,
+            identName,
+          ) =>
         (
           CaseKeywordCompletion.contribute(
             selector,
@@ -378,7 +382,7 @@ class Completions(
           false,
         )
 
-      case CaseExtractor.CaseExtractor(selector, parent) =>
+      case MatchCaseExtractor.CaseExtractor(selector, parent) =>
         (
           CaseKeywordCompletion.contribute(
             selector,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -311,6 +311,7 @@ class CompletionValueGenerator(
   def fuzzyMatches(name: String) =
     patternOnly match
       case None => true
+      case Some("") => true
       case Some(query) => CompletionFuzzy.matches(query, name)
 
   def toCompletionValue(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -408,7 +408,7 @@ class CompletionValueGenerator(
   )(using Context): String =
     val suffix = sym.typeParams match
       case Nil => ""
-      case tparams => tparams.map(_ => "_").mkString("[", ", ", "]")
+      case tparams => tparams.map(_ => "?").mkString("[", ", ", "]")
     val bind = if hasBind then "" else "_: "
     bind + name + suffix
 end CompletionValueGenerator

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -361,8 +361,8 @@ class CompletionValueGenerator(
         if patternOnly.isEmpty then s"case $pattern =>"
         else pattern
       val cursorSuffix =
-            (if patternOnly.nonEmpty then "" else " ") +
-              (if clientSupportsSnippets then "$0" else "")
+        (if patternOnly.nonEmpty then "" else " ") +
+          (if clientSupportsSnippets then "$0" else "")
       Some(
         CompletionValue.CaseKeyword(
           sym,
@@ -419,7 +419,7 @@ class CompletionValueGenerator(
     bind + name + suffix
 end CompletionValueGenerator
 
-class CaseExtractor(
+class MatchCaseExtractor(
     pos: SourcePosition,
     text: String,
     completionPos: CompletionPos,
@@ -530,4 +530,4 @@ class CaseExtractor(
           Some((selector, parent, name.decoded))
         case _ => None
   end TypedCasePatternExtractor
-end CaseExtractor
+end MatchCaseExtractor

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -323,7 +323,6 @@ class CompletionValueGenerator(
       name: String,
       autoImports: List[l.TextEdit],
   )(using Context): Option[CompletionValue.CaseKeyword] =
-    sym.info
     val isModuleLike =
       sym.is(Flags.Module) || sym.isOneOf(JavaEnumTrait) || sym.isOneOf(
         JavaEnumValue

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -69,8 +69,8 @@ class CompletionCaseSuite extends BaseCompletionSuite {
                 |case _: Cat => pkg
                 |case _: Dog => pkg
                 |case Elephant => pkg
-                |case _: HasFeet[_, _] => pkg
-                |case _: HasMouth[_] => pkg
+                |case _: HasFeet[?, ?] => pkg
+                |case _: HasMouth[?] => pkg
                 |case HasWings(e) => pkg
                 |case Seal => pkg
                 |""".stripMargin

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -170,6 +170,7 @@ class CompletionCaseSuite extends BaseCompletionSuite {
   )
 
   // TODO: `Left` has conflicting name in Scope, we should fix it so the result is the same as for scala 2
+  // Issue: https://github.com/scalameta/metals/issues/4368
   check(
     "sealed-conflict",
     """

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -393,6 +393,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
   )
   // TODO: Should provide empty completions
   // The issue is that the tree looks the same as for `case @@` (it doesn't see `new`)
+  // Issue: https://github.com/scalameta/metals/issues/4367
   check(
     "new-pattern",
     """

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -409,8 +409,8 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     filter = str => !str.contains("newMain"),
     compat = Map(
       "3" ->
-        """|case head :: next => scala.collection.immutable
-           |case Nil => scala.collection.immutable""".stripMargin
+        """|head :: next scala.collection.immutable
+           |Nil scala.collection.immutable""".stripMargin
     ),
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
@@ -80,20 +80,19 @@ class CompletionPatternSuite extends BaseCompletionSuite {
       |    case _: @@ =>
       |  }
       |}""".stripMargin,
-    """|None scala
-       |Some[_] scala
+    """|Some[?] scala
        |""".stripMargin,
-    topLines = Some(2),
+    topLines = Some(1),
   )
   check(
     "wildcard-ident",
     """
       |object A {
       |  Option(1) match {
-      |    case _: N@@ =>
+      |    case _: S@@ =>
       |  }
       |}""".stripMargin,
-    """|None scala
+    """|Some[?] scala
        |""".stripMargin,
     topLines = Some(1),
   )
@@ -106,10 +105,9 @@ class CompletionPatternSuite extends BaseCompletionSuite {
       |    case ab: @@ =>
       |  }
       |}""".stripMargin,
-    """|None scala
-       |Some[_] scala
+    """|Some[?] scala
        |""".stripMargin,
-    topLines = Some(2),
+    topLines = Some(1),
   )
 
   check(
@@ -120,7 +118,7 @@ class CompletionPatternSuite extends BaseCompletionSuite {
       |    case ab: S@@ =>
       |  }
       |}""".stripMargin,
-    """|Some[_] scala
+    """|Some[?] scala
        |""".stripMargin,
     topLines = Some(1),
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
@@ -1,0 +1,127 @@
+package tests.pc
+
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
+import scala.meta.pc.PresentationCompilerConfig
+
+import tests.BaseCompletionSuite
+
+class CompletionPatternSuite extends BaseCompletionSuite {
+
+  def paramHint: Option[String] = Some("param-hint")
+
+  override def config: PresentationCompilerConfig =
+    PresentationCompilerConfigImpl().copy(
+      _parameterHintsCommand = paramHint
+    )
+  
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+      Some(IgnoreScala2)
+
+  checkEdit(
+    "empty",
+    """
+      |object A {
+      |  Option(1) match {
+      |    case @@ =>
+      |  }
+      |}""".stripMargin,
+   """
+     |object A {
+     |  Option(1) match {
+     |    case Some(value) $0 =>
+     |  }
+     |}""".stripMargin,
+     filter = _.contains("Some(value)")
+  )
+
+  check(
+    "ident",
+    """
+      |object A {
+      |  Option(1) match {
+      |    case S@@ =>
+      |  }
+      |}""".stripMargin,
+    """|Some(value) scala
+       |""".stripMargin,
+    topLines = Some(1),
+  )
+
+  check(
+    "bind",
+    """
+      |object A {
+      |  Option(1) match {
+      |    case abc @ @@ =>
+      |  }
+      |}""".stripMargin,
+    """|None scala
+       |Some(value) scala
+       |""".stripMargin,
+    topLines = Some(2),
+  )
+  check(
+    "bind-ident",
+    """
+      |object A {
+      |  Option(1) match {
+      |    case abc @ S@@ =>
+      |  }
+      |}""".stripMargin,
+    """|Some(value) scala
+       |""".stripMargin,
+    topLines = Some(1),
+  )
+  check(
+    "wildcard1",
+    """
+      |object A {
+      |  Option(1) match {
+      |    case _: @@ =>
+      |  }
+      |}""".stripMargin,
+    """|None scala
+       |Some[_] scala
+       |""".stripMargin,
+    topLines = Some(2),
+  )
+  check(
+    "wildcard-ident",
+    """
+      |object A {
+      |  Option(1) match {
+      |    case _: N@@ =>
+      |  }
+      |}""".stripMargin,
+    """|None scala
+       |""".stripMargin,
+    topLines = Some(1),
+  )
+
+  check(
+    "typed-bind",
+    """
+      |object A {
+      |  Option(1) match {
+      |    case ab: @@ =>
+      |  }
+      |}""".stripMargin,
+    """|None scala
+       |Some[_] scala
+       |""".stripMargin,
+    topLines = Some(2),
+  )
+
+  check(
+    "typed-bind-ident",
+    """
+      |object A {
+      |  Option(1) match {
+      |    case ab: S@@ =>
+      |  }
+      |}""".stripMargin,
+    """|Some[_] scala
+       |""".stripMargin,
+    topLines = Some(1),
+  )
+}

--- a/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
@@ -13,9 +13,9 @@ class CompletionPatternSuite extends BaseCompletionSuite {
     PresentationCompilerConfigImpl().copy(
       _parameterHintsCommand = paramHint
     )
-  
+
   override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
-      Some(IgnoreScala2)
+    Some(IgnoreScala2)
 
   checkEdit(
     "empty",
@@ -25,13 +25,13 @@ class CompletionPatternSuite extends BaseCompletionSuite {
       |    case @@ =>
       |  }
       |}""".stripMargin,
-   """
-     |object A {
-     |  Option(1) match {
-     |    case Some(value) $0 =>
-     |  }
-     |}""".stripMargin,
-     filter = _.contains("Some(value)")
+    """
+      |object A {
+      |  Option(1) match {
+      |    case Some(value) $0 =>
+      |  }
+      |}""".stripMargin,
+    filter = _.contains("Some(value)"),
   )
 
   check(
@@ -73,7 +73,7 @@ class CompletionPatternSuite extends BaseCompletionSuite {
     topLines = Some(1),
   )
   check(
-    "wildcard1",
+    "wildcard",
     """
       |object A {
       |  Option(1) match {

--- a/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
@@ -28,7 +28,7 @@ class CompletionPatternSuite extends BaseCompletionSuite {
     """
       |object A {
       |  Option(1) match {
-      |    case Some(value) $0 =>
+      |    case Some(value)$0 =>
       |  }
       |}""".stripMargin,
     filter = _.contains("Some(value)"),

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1053,7 +1053,7 @@ class CompletionSuite extends BaseCompletionSuite {
            |Set scala.collection.immutable
            |""".stripMargin,
       "3" ->
-        """|Some[_] scala
+        """|Some[?] scala
            |Seq scala.collection.immutable
            |Set scala.collection.immutable
            |""".stripMargin,


### PR DESCRIPTION
Adds a cross tests suite to check if we cover all cases like `case _: @@`, `case xxx @ So@@` etc.
Also fixes sorting completions when `CaseKeywordCompletions` are not exclusive. 

Edit: I moved all extractors to one place 