### PR TITLE
fix: use proper semanticdb document for `.sc` in scala-cli

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -147,6 +147,7 @@ class Compilers(
                   trees,
                   buildTargets,
                   saveSymbolFileToDisk = !config.isVirtualDocumentSupported(),
+                  sourceMapper,
                 )
               ).getOrElse(EmptySymbolSearch),
               "default",
@@ -593,6 +594,7 @@ class Compilers(
             trees,
             buildTargets,
             saveSymbolFileToDisk = !config.isVirtualDocumentSupported(),
+            sourceMapper,
             workspaceFallback = Some(search),
           )
           newCompiler(
@@ -624,6 +626,7 @@ class Compilers(
               trees,
               buildTargets,
               saveSymbolFileToDisk = !config.isVirtualDocumentSupported(),
+              sourceMapper,
             ),
             path.toString(),
             path,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -531,6 +531,7 @@ class MetalsLanguageServer(
           buildTargets,
           scalaVersionSelector,
           saveDefFileToDisk = !clientConfig.isVirtualDocumentSupported(),
+          sourceMapper,
         )
         formattingProvider = new FormattingProvider(
           workspace,

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -28,6 +28,7 @@ class StandaloneSymbolSearch(
     trees: Trees,
     buildTargets: BuildTargets,
     saveSymbolFileToDisk: Boolean,
+    sourceMapper: SourceMapper,
     workspaceFallback: Option[SymbolSearch] = None,
 ) extends SymbolSearch {
 
@@ -56,6 +57,7 @@ class StandaloneSymbolSearch(
       trees,
       buildTargets,
       saveSymbolFileToDisk,
+      sourceMapper,
     )
 
   def documentation(
@@ -128,6 +130,7 @@ object StandaloneSymbolSearch {
       trees: Trees,
       buildTargets: BuildTargets,
       saveSymbolFileToDisk: Boolean,
+      sourceMapper: SourceMapper,
   ): StandaloneSymbolSearch = {
     val (sourcesWithExtras, classpathWithExtras) =
       addScalaAndJava(
@@ -146,6 +149,7 @@ object StandaloneSymbolSearch {
       trees,
       buildTargets,
       saveSymbolFileToDisk,
+      sourceMapper,
     )
   }
   def apply(
@@ -157,6 +161,7 @@ object StandaloneSymbolSearch {
       trees: Trees,
       buildTargets: BuildTargets,
       saveSymbolFileToDisk: Boolean,
+      sourceMapper: SourceMapper,
   ): StandaloneSymbolSearch = {
     val (sourcesWithExtras, classpathWithExtras) =
       addScalaAndJava(scalaVersion, Nil, Nil, userConfig().javaHome)
@@ -170,6 +175,7 @@ object StandaloneSymbolSearch {
       trees,
       buildTargets,
       saveSymbolFileToDisk,
+      sourceMapper,
     )
   }
 

--- a/tests/unit/src/main/scala/tests/ScriptsAssertions.scala
+++ b/tests/unit/src/main/scala/tests/ScriptsAssertions.scala
@@ -52,7 +52,7 @@ trait ScriptsAssertions { self: BaseLspSuite =>
       definitionAt: String,
       expectedLocation: String,
       expectedLine: java.lang.Integer = null,
-  ): Future[Unit] = {
+  )(implicit l: munit.Location): Future[Unit] = {
 
     definitionsAt(file, definitionAt)
       .map { locations =>


### PR DESCRIPTION
Found this issue by running locally `tests.ScaCliSuite` - in my case a test with `.sc` file was flaky.

The problem is that scalaCli provides a semanticdb db for generated file from `.sc` that has a different positions (includes generated code) that then will be indexed by metals and break go-to-definition.