### PR TITLE
fix: Detect pull_request label event for auto-approve

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,6 +2,7 @@ name: Auto approve patch updates
 
 on:
   pull_request_target:
+    types: [labeled]
 
 jobs:
   auto-approve:


### PR DESCRIPTION
part of https://github.com/scalameta/metals/issues/4333
Sorry for messing the actions so many times 😓 

---

Previously, the `auto-approve` code action tried to automatically approve PRs that is created by `scalameta-bot` and labeled with `semver-spec-patch` (on PR is created).
However, it didn't work in the following PR and github action

https://github.com/scalameta/metals/pull/4364
https://github.com/scalameta/metals/runs/8261788560?check_suite_focus=true

Because it seems like, there's no label information available on PR is created by `scalameta-bot`

It looks like scala-steward does

- create a pull request
- and then add labels to pull request
  - because [create pull request doesn't support label](https://docs.github.com/ja/rest/pulls/pulls#create-a-pull-request) I guess.
- That's why `github.event.pull_request.labels[*].name` will be empty.
  - Though we could label the PR when we create a PR from web UI

https://github.com/scala-steward-org/scala-steward/blob/67a1b0a182a5f1bf06de0372090231ce049644a9/modules/core/src/main/scala/org/scalasteward/core/nurture/NurtureAlg.scala#L190-L202

---

Alternatively, this commit change the code action to detect the `labeled` event. And it will auto-approve it if the label contains `semver-spec-patch` and the user who labeled was `scalameta-bot`.
(I believe `label-author` should be `scalameta-bot`. Otherwise, all the people will be able to approve any pull request via attaching `semver-spec-patch` label to any PRs).