### PR TITLE
[WIP] fix: [scala3] type complete both symbol with and without snippet suffix

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -671,6 +671,7 @@ class CompletionDocSuite extends BaseCompletionSuite {
        |Catch - scala.util.control.Exception
        |""".stripMargin,
     includeDocs = true,
+    topLines = Some(1), // for Scala3, result contains `Catch` and `Catch[$0]`
     compat = Map(
       "2.13" -> post212CatchDocs,
       "3" ->

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -133,11 +133,6 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
     """|IndexedSeq
        |IndexedSeq[$0]
        |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|IndexedSeq[$0]
-           |""".stripMargin
-    ),
   )
 
   checkSnippet(
@@ -179,8 +174,11 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |ArrayDequeOps
            |""".stripMargin,
       "3" -> // ArrayDeque upper is for java, the lower for scala
-        """|ArrayDeque[$0]
+        """|ArrayDeque
            |ArrayDeque[$0]
+           |ArrayDeque
+           |ArrayDeque[$0]
+           |ArrayDequeOps
            |ArrayDequeOps[$0]
            |""".stripMargin,
     ),
@@ -194,6 +192,12 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|SimpleFileVisitor[$0]
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|SimpleFileVisitor
+           |SimpleFileVisitor[$0]
+           |""".stripMargin
+    ),
   )
 
   checkSnippet(
@@ -212,7 +216,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |IterableOnce[$0] {}
            |""".stripMargin,
       "3" ->
-        """|Iterable[$0] {}
+        """|Iterable
+           |Iterable[$0] {}
            |IterableOnce[$0] {}
            |""".stripMargin,
     ),
@@ -234,7 +239,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |IterableOnce[$0]
            |""".stripMargin,
       "3" ->
-        """|Iterable[$0]
+        """|Iterable
+           |Iterable[$0]
            |IterableOnce[$0]
            |""".stripMargin,
     ),
@@ -256,7 +262,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |IterableOnce[$0]
            |""".stripMargin,
       "3" ->
-        """|Iterable[$0]
+        """|Iterable
+           |Iterable[$0]
            |IterableOnce[$0]
            |""".stripMargin,
     ),
@@ -394,6 +401,9 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
       "3" ->
         """|Try
            |Try($0)
+           |TryBlock
+           |TryModule
+           |TryMethods
            |TryMethods
            |""".stripMargin
     ),

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -353,6 +353,7 @@ class CompletionSuite extends BaseCompletionSuite {
        |ProcessBuilder - scala.sys.process
        |CertPathBuilder - java.security.cert
        |CertPathBuilderSpi - java.security.cert
+       |ProcessBuilderImpl - scala.sys.process
        |CertPathBuilderResult - java.security.cert
        |PKIXBuilderParameters - java.security.cert
        |PooledConnectionBuilder - javax.sql
@@ -360,17 +361,17 @@ class CompletionSuite extends BaseCompletionSuite {
        |PKIXCertPathBuilderResult - java.security.cert
        |""".stripMargin,
     compat = Map(
-      "2" ->
+      "3" ->
         """|ProcessBuilder java.lang
+           |ProcessBuilder - scala.sys.process
            |ProcessBuilder - scala.sys.process
            |CertPathBuilder - java.security.cert
            |CertPathBuilderSpi - java.security.cert
+           |CertPathBuilderSpi - java.security.cert
            |ProcessBuilderImpl - scala.sys.process
            |CertPathBuilderResult - java.security.cert
+           |CertPathBuilderResult - java.security.cert
            |PKIXBuilderParameters - java.security.cert
-           |PooledConnectionBuilder - javax.sql
-           |CertPathBuilderException - java.security.cert
-           |PKIXCertPathBuilderResult - java.security.cert
            |""".stripMargin
     ),
   )
@@ -397,6 +398,7 @@ class CompletionSuite extends BaseCompletionSuite {
       "3" ->
         """|TrieMap scala.collection.concurrent
            |TrieMap[K, V](elems: (K, V)*): CC[K, V]
+           |TrieMapSerializationEnd - scala.collection.concurrent
            |""".stripMargin,
     ),
   )
@@ -923,6 +925,12 @@ class CompletionSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|ListBuffer - scala.collection.mutable
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|ListBuffer - scala.collection.mutable
+           |ListBuffer - scala.collection.mutable
+           |""".stripMargin
+    ),
   )
 
   check(
@@ -933,6 +941,12 @@ class CompletionSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|ListBuffer - scala.collection.mutable
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|ListBuffer - scala.collection.mutable
+           |ListBuffer - scala.collection.mutable
+           |""".stripMargin
+    ),
   )
 
   check(
@@ -973,6 +987,8 @@ class CompletionSuite extends BaseCompletionSuite {
            |Some[A](value: A): Some[A]
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
            |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
+           |SomeToExpr - scala.quoted.ToExpr
+           |SomeFromExpr - scala.quoted.FromExpr
            |""".stripMargin
     ),
   )
@@ -992,6 +1008,8 @@ class CompletionSuite extends BaseCompletionSuite {
            |Some[A](value: A): Some[A]
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
            |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
+           |SomeToExpr - scala.quoted.ToExpr
+           |SomeFromExpr - scala.quoted.FromExpr
            |""".stripMargin,
       "3" ->
         """|Some scala
@@ -1509,6 +1527,7 @@ class CompletionSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|scala <root>
+       |package - scala
        |""".stripMargin,
     compat = Map(
       "2" ->

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -114,6 +114,8 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  name: scala.concurrent.Future[$0]
        |)
        |""".stripMargin,
+    assertSingleItem = false,
+    itemIndex = if (scalaVersion.startsWith("3")) 1 else 0,
     filter = _ == "Future - scala.concurrent",
     compat = Map(
       "2" ->
@@ -140,6 +142,8 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  name: scala.concurrent.Future[$0]
        |)
        |""".stripMargin,
+    assertSingleItem = false,
+    itemIndex = if (scalaVersion.startsWith("3")) 1 else 0,
     filter = _ == "Future - scala.concurrent",
     compat = Map(
       "2" ->
@@ -168,6 +172,8 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |)
        |""".stripMargin,
     filter = _ == "Future - scala.concurrent",
+    assertSingleItem = false,
+    itemIndex = if (scalaVersion.startsWith("3")) 1 else 0,
     compat = Map(
       "2" ->
         """|package `import-no-conflict`
@@ -208,6 +214,8 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
       |import java.util.concurrent.CompletableFuture
       |object Main extends CompletableFuture[$0]
       |""".stripMargin,
+    assertSingleItem = false,
+    itemIndex = if (scalaVersion.startsWith("3")) 1 else 0,
     compat = Map(
       "2" ->
         """package pkg
@@ -228,6 +236,8 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
       |import java.util.concurrent.CompletableFuture
       |object Main extends CompletableFuture[$0]
       |""".stripMargin,
+    assertSingleItem = false,
+    itemIndex = if (scalaVersion.startsWith("3")) 1 else 0,
     compat = Map(
       "2" ->
         """package pkg
@@ -368,6 +378,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     filter = _.contains("scala.util"),
+    assertSingleItem = false,
     compat = Map(
       "2" ->
         """|import scala.util.Failure
@@ -742,13 +753,20 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|Future scala.concurrent
+       |Future scala.concurrent
        |Future - java.util.concurrent
        |""".stripMargin,
-    topLines = Some(2),
+    topLines = if (scalaVersion.startsWith("3")) Some(3) else Some(2),
+    compat = Map(
+      "2" ->
+        """|Future scala.concurrent
+           |Future - java.util.concurrent
+           |""".stripMargin
+    ),
   )
 
   check(
-    "ordering-2",
+    "ordering-3",
     """|import java.util.concurrent.Future
        |object Main {
        |  def foo(
@@ -757,8 +775,15 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|Future java.util.concurrent
+       |Future java.util.concurrent
        |Future - scala.concurrent
        |""".stripMargin,
-    topLines = Some(2),
+    topLines = if (scalaVersion.startsWith("3")) Some(3) else Some(2),
+    compat = Map(
+      "2" ->
+        """|Future java.util.concurrent
+           |Future - scala.concurrent
+           |""".stripMargin
+    ),
   )
 }

--- a/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
@@ -164,6 +164,7 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
                  |""".stripMargin,
             "3" ->
               """|TrieMap - scala.collection.concurrent
+                 |TrieMapSerializationEnd - scala.collection.concurrent
                  |TrieMap[K, V](elems: (K, V)*): CC[K, V]
                  |""".stripMargin,
           ),


### PR DESCRIPTION
part of https://github.com/scalameta/metals/issues/4358

- This PR changes type completion to complete both `IndexedSeq[$0]` and `IndexedSeq` for `val x: scala.IndexedSeq@@` in Scala3.
  - What do you think about this behavior? Should we complete only `IndexedSeq[$0]`?
- If we complete both items, how should we differentiate them by labels?

<img width="705" alt="Screen Shot 2022-09-09 at 21 36 07" src="https://user-images.githubusercontent.com/9353584/189353530-29160e81-4784-4408-9a6e-9d022245ada6.png">

↑ current implementation ↑
(former one: `ListBuffer`, and latter one is `ListBuffer[$0]`

---

Currently, type completion (in Scala3) filters out "non-compilable completions"

For example, for `val x: scala.IndexedSe@@`,
Scala3 complete `IndexedSeq[$0]` (for `type IndexedSeq[T]`), but doesn't return `IndexedSeq` (for `object IndexedSeq`).

https://github.com/scalameta/metals/blob/46cf3548176501e1d5b0880f6d4de8d165f76630/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala#L125-L141

This commit enables Metals (in Scala3) to complete both `IndexedSeq[$0]` and `IndexedSeq`.

**why we want this change?**
Scala3 type completion is done this by filtering out those symbols based on the completion position in
[CompletionPos.include](https://github.com/scalameta/metals/blob/46cf3548176501e1d5b0880f6d4de8d165f76630/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala#L74-L104)

However, we may want to stop filtering out those symbols for two reasons

- Filtering out based on completion position is error prone
  - All the filtering logic is based on our heuristics, and it's hard to cover all the cases correctly.
  - Actually, original type completion (for Scala3) caused a regression (and fixed in the `main` branch) https://github.com/scalameta/metals/pull/4234
- I believe `IndexedSeq` completion is still valuable (while `IndexedSeq[$]` is also good)
  - I think completions provide just some help to developers. They don't need to be "semantically correct".

**concern and plan**
- (concern) Differentiate labels of the symbols with and without snippet suffix
  - Currently, both completion `IndexedSeq` and `IndexedSeq[$0]` has the same label (completion kinds are different, though). It would be ideal if we could show different labels for them.
- (plan) Sort those symbols prioritizing the one with snippet suffix (or based on the cursor position).
