### PR TITLE
Request import build after restart

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
@@ -110,10 +110,11 @@ final class BloopInstall(
   ): Future[WorkspaceLoadedStatus] =
     synchronized {
       oldInstallResult(digest) match {
-        case Some(result) =>
+        case Some(result)
+            if result != WorkspaceLoadedStatus.Duplicate(Status.Requested) =>
           scribe.info(s"skipping build import with status '${result.name}'")
           Future.successful(result)
-        case None =>
+        case _ =>
           for {
             userResponse <- requestImport(
               buildTools,


### PR DESCRIPTION
Connected to https://github.com/scalameta/metals/issues/2547

Previously, reloading editor while import build prompt was open resulted in prompt not reappearing. Now the prompt reappears, but only if it was not answered. If user closes it or chooses any option it works the same as before (closing dismisses it for 2 minutes).