### PR TITLE
Limit running multiple import build

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -112,6 +112,10 @@ object Messages {
     MessageType.Error,
     "Import project failed, no functionality will work. See the logs for more details",
   )
+  val ImportAlreadyRunning = new MessageParams(
+    MessageType.Warning,
+    s"Import already running. \nPlease cancel the current import to run a new one.",
+  )
   val ImportProjectPartiallyFailed = new MessageParams(
     MessageType.Warning,
     "Import project partially failed, limited functionality may work in some parts of the workspace. " +

--- a/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
@@ -118,6 +118,43 @@ class SbtBloopLspSuite
       )
     } yield ()
   }
+  test("force-command-multiple") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/project/build.properties
+            |sbt.version=$sbtVersion
+            |/build.sbt
+            |scalaVersion := "${V.scala213}"
+            |""".stripMargin
+      )
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          // Project has no .bloop directory so user is asked to "import via bloop"
+          importBuildMessage,
+          progressMessage,
+        ).mkString("\n"),
+      )
+      _ = client.messageRequests.clear() // restart
+      _ <- server
+        .executeCommand(ServerCommands.ImportBuild)
+        .zip(server.executeCommand(ServerCommands.ImportBuild))
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        List(
+          progressMessage
+        ).mkString("\n"),
+      )
+      _ = assertNoDiff(
+        client.workspaceShowMessages,
+        List(
+          ImportAlreadyRunning.getMessage()
+        ).mkString("\n"),
+      )
+
+    } yield ()
+  }
 
   test("new-dependency") {
     cleanWorkspace()


### PR DESCRIPTION
Connected to https://github.com/scalameta/metals/issues/2151

Now we can't force multiple build import using `Import Build` command