### PR TITLE
Add Completions for ivy Imports (Ammonite)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -276,6 +276,8 @@ val mtagsSettings = List(
       // for token edit-distance used by goto definition
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "org.scalameta" % "semanticdb-scalac-core" % V.scalameta cross CrossVersion.full,
+      // for ivy completions
+      "io.get-coursier" % "interface" % V.coursierInterfaces,
     ),
     if3 = List(
       "org.scala-lang" %% "scala3-compiler" % scalaVersion.value,

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteCompletions.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.pc.completions
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
+import scala.meta.internal.mtags.BuildInfo
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.pc.CompletionFuzzy
 import scala.meta.internal.pc.MetalsGlobal
@@ -125,10 +126,14 @@ trait AmmoniteCompletions { this: MetalsGlobal =>
 
         query match {
           case Some(imp) =>
+            // TODO grab version from Ammonite file header if it exists
+            val scalaVersion = BuildInfo.scalaCompilerVersion
             val api = coursierapi.Complete
               .create()
-              .withScalaVersion("2.13.8")
-              .withScalaBinaryVersion("2.13")
+              .withScalaVersion(scalaVersion)
+              .withScalaBinaryVersion(
+                scalaVersion.split('.').take(2).mkString(".")
+              )
 
             def completions(s: String): List[String] =
               api.withInput(s).complete().getCompletions().asScala.toList

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteCompletions.scala
@@ -126,7 +126,6 @@ trait AmmoniteCompletions { this: MetalsGlobal =>
 
         query match {
           case Some(imp) =>
-            // TODO grab version from Ammonite file header if it exists
             val scalaVersion = BuildInfo.scalaCompilerVersion
             val api = coursierapi.Complete
               .create()

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -524,6 +524,9 @@ trait Completions { this: MetalsGlobal =>
       case (imp @ Import(select, selector)) :: _
           if isAmmoniteFileCompletionPosition(imp, pos) =>
         AmmoniteFileCompletions(select, selector, pos, editRange)
+      case (imp @ Import(select, selector)) :: _
+          if isAmmoniteIvyCompletionPosition(imp, pos) =>
+        AmmoniteIvyCompletions(select, selector, pos, editRange)
       case _ =>
         inferCompletionPosition(
           pos,
@@ -536,15 +539,25 @@ trait Completions { this: MetalsGlobal =>
     }
   }
 
-  def isAmmoniteFileCompletionPosition(tree: Tree, pos: Position): Boolean = {
+  private def isAmmoniteCompletionPosition(
+      magicImport: String,
+      tree: Tree,
+      pos: Position
+  ): Boolean = {
     tree match {
       case Import(select, _) =>
         pos.source.file.name.isAmmoniteGeneratedFile && select
           .toString()
-          .startsWith("$file")
+          .startsWith(magicImport)
       case _ => false
     }
   }
+
+  def isAmmoniteFileCompletionPosition(tree: Tree, pos: Position): Boolean =
+    isAmmoniteCompletionPosition("$file", tree, pos)
+
+  def isAmmoniteIvyCompletionPosition(tree: Tree, pos: Position): Boolean =
+    isAmmoniteCompletionPosition("$ivy", tree, pos)
 
   private def inferCompletionPosition(
       pos: Position,
@@ -808,13 +821,14 @@ trait Completions { this: MetalsGlobal =>
     result
   }
 
-  /**
-   * Returns the start offset of the identifier starting as the given offset position.
-   */
-  def inferIdentStart(pos: Position, text: String): Int = {
+  def inferStart(
+      pos: Position,
+      text: String,
+      charPred: Char => Boolean
+  ): Int = {
     def fallback: Int = {
       var i = pos.point - 1
-      while (i >= 0 && Chars.isIdentifierPart(text.charAt(i))) {
+      while (i >= 0 && charPred(text.charAt(i))) {
         i -= 1
       }
       i + 1
@@ -836,6 +850,12 @@ trait Completions { this: MetalsGlobal =>
       }
     loop(lastVisitedParentTrees)
   }
+
+  /**
+   * Returns the start offset of the identifier starting as the given offset position.
+   */
+  def inferIdentStart(pos: Position, text: String): Int =
+    inferStart(pos, text, Chars.isIdentifierPart)
 
   /**
    * Returns the end offset of the identifier starting as the given offset position.

--- a/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
@@ -3,7 +3,58 @@ package tests.feature
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.{BuildInfo => V}
 
-class Ammonite213Suite extends tests.BaseAmmoniteSuite(V.ammonite213)
+class Ammonite213Suite extends tests.BaseAmmoniteSuite(V.ammonite213) {
+
+  test("ivy-completion") {
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "${V.ammonite213}"
+           |  }
+           |}
+           |/main.sc
+           |import $$ivy.`io.cir`
+           |import $$ivy.`io.circe::circe-ref`
+           |import $$ivy.`io.circe::circe-yaml:0.14`
+           |""".stripMargin
+      )
+      _ <- server.didOpen("main.sc")
+      _ <- server.didSave("main.sc")(identity)
+      _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
+
+      groupExpectedCompletionList = "io.circe"
+      groupCompletionList <- server.completion(
+        "main.sc",
+        "import $ivy.`io.cir@@`",
+      )
+      _ = assertNoDiff(groupCompletionList, groupExpectedCompletionList)
+
+      artefactExpectedCompletionList =
+        """
+          |circe-refined
+          |circe-refined_sjs0.6
+          |circe-refined_sjs1""".stripMargin
+      artefactCompletionList <- server.completion(
+        "main.sc",
+        "import $ivy.`io.circe::circe-ref@@`",
+      )
+      _ = assertNoDiff(artefactCompletionList, artefactExpectedCompletionList)
+
+      versionExpectedCompletionList =
+        """
+          |0.14.0
+          |0.14.1""".stripMargin
+      versionCompletionList <- server.completion(
+        "main.sc",
+        "import $ivy.`io.circe::circe-yaml:0.14@@`",
+      )
+      _ = assertNoDiff(versionCompletionList, versionExpectedCompletionList)
+    } yield ()
+  }
+}
 
 class Ammonite3Suite extends tests.BaseAmmoniteSuite(V.ammonite3)
 


### PR DESCRIPTION
Hi, I've been playing around with Ammonite ivy import completions in metals (heavily inspired by https://github.com/com-lihaoyi/Ammonite/pull/957) using the awesome coursier api, demo:

https://user-images.githubusercontent.com/17688577/189854045-ea525c33-29a3-40d3-935f-56857652366f.mp4

It works very similarly to the existing completions for `$file`s, essentially we just ask `coursierapi.Complete` for completions.  Additionally, when we're at `import $ivy.|` we return a snippet to handle backticks, and when we're at `group:|` we make sure to get scala verion-specific (e.g. `%%`) completions also (hopefully these are both clear from the video).

There are a few TODOS/stuff I'm not 100% about:
- Scala 2 only atm
- ~the Scala version used by the coursier api is currently hard-coded (I'm unsure the best way to wire through the value for where I need it?) as opposed to deducing from file comments like `Ammonite.command` does,~ along with the repositories
- Often the number of completion items returned is a lot (1k+)
- not using `coursierapi.Cache` (but performance appears ok without it)

If you're all happy with this, I'd prefer to work incrementally on the above so as not to make one huge PR :slightly_smiling_face: .  Anyway, let me know what you think, thanks! 