### PR TITLE
improvement: Change string actions to RefactorRewrite

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/StringActions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/StringActions.scala
@@ -173,7 +173,7 @@ class StringActions(buffers: Buffers) extends CodeAction {
   ): l.CodeAction = {
     CodeActionBuilder.build(
       title = title,
-      kind = l.CodeActionKind.Refactor,
+      kind = l.CodeActionKind.RefactorRewrite,
       changes = List(uri.toAbsolutePath -> edits),
     )
   }


### PR DESCRIPTION
Previously, we would use generic `rewrite` type, but since recently VS Code started showing refactor types separately, so I think now would be a good time to change it to `rewrite.refactor`