### PR TITLE
chore: Add support for Scala 2.12.17

### DIFF
--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -21,7 +21,6 @@ coursier fetch \
   org.scalameta:mtags_2.13.6:$version \
   org.scalameta:mtags_2.13.7:$version \
   org.scalameta:mtags_2.13.8:$version \
-  org.scalameta:mtags_2.12.8:$version \
   org.scalameta:mtags_2.12.9:$version \
   org.scalameta:mtags_2.12.10:$version \
   org.scalameta:mtags_2.12.11:$version \
@@ -30,4 +29,5 @@ coursier fetch \
   org.scalameta:mtags_2.12.14:$version \
   org.scalameta:mtags_2.12.15:$version \
   org.scalameta:mtags_2.12.16:$version \
+  org.scalameta:mtags_2.12.17:$version \
   org.scalameta:mtags_2.11.12:$version $suffix

--- a/project/V.scala
+++ b/project/V.scala
@@ -3,7 +3,7 @@ import sbt._
 object V {
   val scala210 = "2.10.7"
   val scala211 = "2.11.12"
-  val scala212 = "2.12.16"
+  val scala212 = "2.12.17"
   val scala213 = "2.13.8"
   val scala3 = "3.2.0"
   val nextScala3RC = "3.2.1-RC1"
@@ -65,9 +65,9 @@ object V {
   // Scala 2
   def deprecatedScala2Versions = Seq(
     scala211,
-    "2.12.8",
     "2.12.9",
     "2.12.10",
+    "2.12.11",
     "2.13.1",
     "2.13.2",
     "2.13.3",
@@ -77,11 +77,11 @@ object V {
   def nonDeprecatedScala2Versions = Seq(
     scala213,
     scala212,
+    "2.12.16",
     "2.12.15",
     "2.12.14",
     "2.12.13",
     "2.12.12",
-    "2.12.11",
     "2.13.5",
     "2.13.6",
     "2.13.7",

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -47,8 +47,8 @@ class ProblemResolverSuite extends FunSuite {
 
   checkRecommendation(
     "deprecated-scala-version",
-    scalaVersion = "2.12.8",
-    DeprecatedScalaVersion("2.12.8").message,
+    scalaVersion = "2.12.10",
+    DeprecatedScalaVersion("2.12.10").message,
   )
 
   checkRecommendation(
@@ -72,7 +72,7 @@ class ProblemResolverSuite extends FunSuite {
 
   checkRecommendation(
     "deprecated-sbt-version",
-    scalaVersion = "2.12.8",
+    scalaVersion = "2.12.9",
     DeprecatedSbtVersion.message,
     sbtVersion = Some("1.3.0"),
   )


### PR DESCRIPTION
Also, remove support for Scala 2.12.8 since that is 10 versions ago