### PR TITLE
fix: Scala3 properly inverse semanticdb type symbol

### DIFF
--- a/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCompletionLspSuite.scala
@@ -84,6 +84,11 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
            |object A {
            |  // @@
            |}
+           |/a/src/main/scala/a/inner/FooSample.scala
+           |package a.sample
+           |
+           |class FooSample
+           |object FooSample
            |""".stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/a/A.scala")
@@ -179,6 +184,13 @@ abstract class BaseCompletionLspSuite(name: String) extends BaseLspSuite(name) {
           |}
           |""".stripMargin,
         """|myLocalVariable: Array[String]
+           |""".stripMargin,
+      )
+      _ <- assertCompletion(
+        """
+          |val a: FooSa@@
+          |""".stripMargin,
+        """|FooSample - a.sample
            |""".stripMargin,
       )
     } yield ()


### PR DESCRIPTION
It was affecting woskpace completions: type symbol were converted into a term one and then filtered out.