### PR TITLE
chore: rename CompletionProvider

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -20,7 +20,7 @@ import scala.meta.internal.mtags.MtagsEnrichments.*
 import scala.meta.internal.pc.AutoImports.*
 import scala.meta.internal.pc.CompilerAccess
 import scala.meta.internal.pc.DefinitionResultImpl
-import scala.meta.internal.pc.completions.CompletionsProvider
+import scala.meta.internal.pc.completions.CompletionProvider
 import scala.meta.internal.pc.completions.OverrideCompletions
 import scala.meta.internal.semver.SemVer
 import scala.meta.pc.*
@@ -98,7 +98,7 @@ case class ScalaPresentationCompiler(
       params.token,
     ) { access =>
       val driver = access.compiler()
-      new CompletionsProvider(
+      new CompletionProvider(
         search,
         driver,
         params,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
@@ -31,7 +31,7 @@ import org.eclipse.lsp4j.InsertTextMode
 import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.Range as LspRange
 
-class CompletionsProvider(
+class CompletionProvider(
     search: SymbolSearch,
     driver: InteractiveDriver,
     params: OffsetParams,
@@ -414,7 +414,7 @@ class CompletionsProvider(
         )
     end match
   end completionItems
-end CompletionsProvider
+end CompletionProvider
 
 case object Cursor:
   val value = "CURSOR"


### PR DESCRIPTION
Most of similar files in mtags2/3 have the same name. This additional `s` often annoys me when I do file search in VSCode