### PR TITLE
bugfix: Fix tests using circe for completions

### DIFF
--- a/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
@@ -35,6 +35,7 @@ class Ammonite213Suite extends tests.BaseAmmoniteSuite(V.ammonite213) {
       artefactExpectedCompletionList =
         """
           |circe-refined
+          |circe-refined_native0.4
           |circe-refined_sjs0.6
           |circe-refined_sjs1""".stripMargin
       artefactCompletionList <- server.completion(


### PR DESCRIPTION
PReviously, no circe native was avaialable. Now. circe being also being released for native, so we need to adjust the test.