### PR TITLE
bugfix: Allow to add jvmopts and env variables when running tests

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -650,6 +650,9 @@ final case class ScalaTestSuiteSelection(
 case class DebugUnresolvedTestClassParams(
     testClass: String,
     @Nullable buildTarget: String = null,
+    @Nullable jvmOptions: java.util.List[String] = null,
+    @Nullable env: java.util.Map[String, String] = null,
+    @Nullable envFile: String = null,
 )
 
 case class DebugUnresolvedAttachRemoteParams(

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -231,6 +231,18 @@ class DebugProvider(
     buildTargets.buildServerOf(targetId).exists(_.supportsTestSelection)
   }
 
+  private def envFromFile(
+      envFile: Option[String]
+  )(implicit ec: ExecutionContext): Future[List[String]] =
+    envFile
+      .map { file =>
+        val path = AbsolutePath(file)(workspace)
+        DotEnvFileParser
+          .parse(path)
+          .map(_.map { case (key, value) => s"$key=$value" }.toList)
+      }
+      .getOrElse(Future.successful(List.empty))
+
   private def createMainParams(
       main: ScalaMainClass,
       target: BuildTargetIdentifier,
@@ -243,18 +255,7 @@ class DebugProvider(
     main.setJvmOptions(
       jvmOptions.getOrElse(ju.Collections.emptyList())
     )
-
-    val envFromFile: Future[List[String]] =
-      envFile
-        .map { file =>
-          val path = AbsolutePath(file)(workspace)
-          DotEnvFileParser
-            .parse(path)
-            .map(_.map { case (key, value) => s"$key=$value" }.toList)
-        }
-        .getOrElse(Future.successful(List.empty))
-
-    envFromFile.map { envFromFile =>
+    envFromFile(envFile).map { envFromFile =>
       main.setEnvironmentVariables((envFromFile ::: env).asJava)
       new b.DebugSessionParams(
         singletonList(target),
@@ -275,8 +276,7 @@ class DebugProvider(
       classes: List[ScalaMainClass],
       params: DebugDiscoveryParams,
   )(implicit ec: ExecutionContext): Future[DebugSessionParams] = {
-    val env =
-      if (params.env != null) createEnvList(params.env) else Nil
+    val env = Option(params.env).toList.flatMap(createEnvList)
 
     classes match {
       case Nil =>
@@ -476,7 +476,7 @@ class DebugProvider(
           )
         }
 
-        val env = if (params.env != null) createEnvList(params.env) else Nil
+        val env = Option(params.env).toList.flatMap(createEnvList)
         createMainParams(
           clazz,
           target.getId(),
@@ -515,13 +515,22 @@ class DebugProvider(
             "test",
           )
         }
-        Future.successful(
+        val env = Option(params.env).toList.flatMap(createEnvList)
+
+        envFromFile(Option(params.envFile)).map { envFromFile =>
+          val scalaTestSuite = new b.ScalaTestSuites(
+            List(
+              new b.ScalaTestSuiteSelection(params.testClass, Nil.asJava)
+            ).asJava,
+            Option(params.jvmOptions).getOrElse(Nil.asJava),
+            (envFromFile ::: env).asJava,
+          )
           new b.DebugSessionParams(
             singletonList(target.getId()),
-            b.DebugSessionParamsDataKind.SCALA_TEST_SUITES,
-            singletonList(clazz).toJson,
+            b.DebugSessionParamsDataKind.SCALA_TEST_SUITES_SELECTION,
+            scalaTestSuite.toJson,
           )
-        )
+        }
       // should not really happen due to
       // `findMainClassAndItsBuildTarget` succeeding with non-empty list
       case Nil => Future.failed(new ju.NoSuchElementException(params.testClass))


### PR DESCRIPTION
Previously, only the test suite name was sent via BSP. Now we also add env variables and jvmopts.

Fixes https://github.com/scalameta/metals/issues/4374