### PR TITLE
fix: [Scala3] Don't compute docs on textDocument/completion

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -180,7 +180,7 @@ class MetalsPrinter(
                 param,
                 implicitEvidencesByTypeParam,
                 index,
-                paramsDocs,
+                if !onlyMethodParams then paramsDocs else Seq.empty,
                 nameToInfo,
               ) :: Nil
           index += 1

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -310,9 +310,11 @@ class CompletionSuite extends BaseCompletionSuite {
            |synchronized[X0](x$0: X0): X0
            |toString(): String
            |wait(): Unit
-           |wait(timeoutMillis: Long): Unit
-           |wait(timeoutMillis: Long, nanos: Int): Unit
+           |wait(x$0: Long): Unit
+           |wait(x$0: Long, x$1: Int): Unit
            |""".stripMargin,
+      // wait(x$0: Long) won't be replaced with timeoutMills here
+      // but it will be replaced in `completionItem/resolve`
     ),
   )
 


### PR DESCRIPTION
Previously, Metals compute docstrings of the method using `symbolSearch.symbolDocumentation` from `defaultMethodSignatures`.

This is for two reasons:
- replace java parameters such as `x$1` with the one from the document
- to print default parameters

However, it will be covered by `documentItem/resolve` so we don't need to compute them on `textDocument/completion`.
Also, I profiled Metals and realized `symbolSearch.symbolDocumentation` takes much of the time of code completion. This change may significantly improve the response time of `textDocument/completion`, especially in the large repositories.

---

(sorry for the large screen shot of `async-profiler`)

![Screen Shot 2022-09-19 at 10 06 40](https://user-images.githubusercontent.com/9353584/190976026-254741f0-bfdc-4e44-88ee-d1b7e9834215.png)

paramsDocs part will disappear