### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,11 @@
+pull_request_rules:
+  - name: Automatic merge on approval
+    conditions:
+      - "#approved-reviews-by>=1"
+      - author=scalameta-bot
+      - "#check-success>=22"
+      - label=semver-spec-patch
+      - label=library-update
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
This change has been made by @tanishiking from https://mergify.com config editor.

close https://github.com/scalameta/metals/issues/4333

This PR enables mergify in `scalameta/metals` and will auto-merge the PRs that is

- created by `scalameta-bot`
- approved
  - will be auto-approved by GitHub actions: see: https://github.com/scalameta/metals/pull/4346
- all tests passed (currently checking the number of `check-success` instead of listing all the checks)
- has labels (both of them should be labeled by scala-steward (scalameta-bot)) see https://github.com/scalameta/metals/pull/4337
  - `semver-spec-patch`
  - `library-update`

Some conditions are duplicated with the auto-approve code action, but I think it's safer to check those conditions again in mergify side.