### PR TITLE
Ivy Completions Dash Fix

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteCompletions.scala
@@ -126,13 +126,9 @@ trait AmmoniteCompletions { this: MetalsGlobal =>
 
         query match {
           case Some(imp) =>
-            val scalaVersion = BuildInfo.scalaCompilerVersion
             val api = coursierapi.Complete
               .create()
-              .withScalaVersion(scalaVersion)
-              .withScalaBinaryVersion(
-                scalaVersion.split('.').take(2).mkString(".")
-              )
+              .withScalaVersion(BuildInfo.scalaCompilerVersion)
 
             def completions(s: String): List[String] =
               api.withInput(s).complete().getCompletions().asScala.toList
@@ -151,7 +147,7 @@ trait AmmoniteCompletions { this: MetalsGlobal =>
                 val rangeStart = inferStart(
                   pos,
                   pos.source.content.mkString,
-                  c => Chars.isIdentifierPart(c) || c == '.'
+                  c => Chars.isIdentifierPart(c) || c == '.' || c == '-'
                 )
                 pos.withStart(rangeStart).withEnd(pos.point).toLsp
               }


### PR DESCRIPTION
Hi!  This is a small PR which fixes TextEdit ranges when `-` appears in a dependency used for ivy completions.  Previously for example, selecting `io.get-coursier` at `io.get-coursi|` would leave you with `io.get-io.get-coursier`.

I tried to find out if there were any other chars that potentially could appear in artefact ids, https://maven.apache.org/guides/mini/guide-naming-conventions.html is not overly specific: ` then you can choose whatever name you want with lowercase letters and no strange symbols` :laughing: 

Also snuck in: remove setting the Scala binary version when creating the coursier api which is no longer needed since https://github.com/scalameta/metals/pull/4390 (mentioned in previous PR).