### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,9 +3,28 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=1"
       - author=scalameta-bot
-      - "#check-success>=22"
+      - "#check-success=21"
       - label=semver-spec-patch
       - label=library-update
+      - check-success=windows-latest jdk-17 unit tests 1 / 2
+      - check-success=windows-latest jdk-17 unit tests 2 / 2
+      - check-success=macOS-latest jdk-17 unit tests 1 / 2
+      - check-success=macOS-latest jdk-17 unit tests 2 / 2
+      - check-success=ubuntu-latest jdk-17 unit tests 1 / 2
+      - check-success=ubuntu-latest jdk-17 unit tests 2 / 2
+      - check-success=ubuntu-latest jdk-8 unit tests 1 / 2
+      - check-success=ubuntu-latest jdk-8 unit tests 2 / 2
+      - check-success=Gradle MacOS integration
+      - check-success=Gradle integration
+      - check-success=Sbt integration
+      - check-success=Maven integration
+      - check-success=Scalafix and docs
+      - check-success=Formatting
+      - check-success=Scala cross tests
+      - check-success=Scala3 latest NIGHTLY cross test
+      - check-success=Sbt-metals/scripted jdk8
+      - check-success=LSP integration tests
+      - check-success=Mill integration
     actions:
       merge:
         method: merge


### PR DESCRIPTION
This change has been made by @tanishiking from https://mergify.com config editor.

Previously, we had `"#check-success>=22"` rules, but I realized the number of checks is `21` (not 22) 😅 

Now the mergify condition is the combination of "the number of check-success is exactly 21" and "listed checks". The combination of conditions protects us from unexpectedly merging PRs when, for example

- by checking the number of `check-success`
  - we can prevent unexpectedly merging PRs when some new checks are added (but some checks are failing)
- by checking the list of checks
  - a check is deleted and a new check is added (the total number of checks didn't change)