### PR TITLE
ci(Mergify): configuration update / use squash

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,4 +27,4 @@ pull_request_rules:
       - check-success=Mill integration
     actions:
       merge:
-        method: merge
+        method: squash


### PR DESCRIPTION
This change has been made by @tanishiking from https://mergify.com config editor.

> The repository configuration doesn't allow merge commits. The merge method configured in Mergify configuration must be allowed in the repository configuration settings.

https://github.com/scalameta/metals/pull/4400/checks?check_run_id=8431753248

I guess we need to use squash instead, sorry for messing up PRs 😅 