### PR TITLE
refactor: [scala3] findSuffix to return a data structure so we can tell what kinds of suffix will be added to the edit.

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
@@ -270,7 +270,7 @@ class CompletionProvider(
 
     val ident = completion.label
 
-    val completionTextSuffix = completion.snippetSuffix.getOrElse("")
+    val completionTextSuffix = completion.snippetSuffix.toEdit
 
     lazy val isInStringInterpolation =
       path match

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionSuffix.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionSuffix.scala
@@ -13,7 +13,7 @@ case class CompletionSuffix(
     snippet: SuffixKind,
 ):
   def hasSnippet = snippet != SuffixKind.NoSuffix
-  def map(copyFn: CompletionSuffix => CompletionSuffix) = copyFn(this)
+  def chain(copyFn: CompletionSuffix => CompletionSuffix) = copyFn(this)
   def toEdit: String =
     if !hasSuffix then ""
     else

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionSuffix.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionSuffix.scala
@@ -1,0 +1,48 @@
+package scala.meta.internal.pc.completions
+
+/**
+ * @param brace should we add "()" suffix?
+ * @param bracket should we add "[]" suffix?
+ * @param template should we add "{}" suffix?
+ * @param snippet which suffix should we insert the snippet $0
+ */
+case class CompletionSuffix(
+    brace: Boolean,
+    bracket: Boolean,
+    template: Boolean,
+    snippet: SuffixKind,
+):
+  def hasSnippet = snippet != SuffixKind.NoSuffix
+  def map(copyFn: CompletionSuffix => CompletionSuffix) = copyFn(this)
+  def toEdit: String =
+    if !hasSuffix then ""
+    else
+      val braceSuffix =
+        if brace && snippet == SuffixKind.Brace then "($0)"
+        else if brace then "()"
+        else ""
+      val bracketSuffix =
+        if bracket && snippet == SuffixKind.Bracket then "[$0]"
+        else if bracket then "[]"
+        else ""
+      val templateSuffix =
+        if template && snippet == SuffixKind.Template then " {$0}"
+        else if template then " {}"
+        else ""
+      s"$bracketSuffix$braceSuffix$templateSuffix"
+  def toEditOpt: Option[String] =
+    val edit = toEdit
+    if edit.nonEmpty then Some(edit) else None
+  private def hasSuffix = brace || bracket || template
+end CompletionSuffix
+
+object CompletionSuffix:
+  val empty = CompletionSuffix(
+    brace = false,
+    bracket = false,
+    template = false,
+    snippet = SuffixKind.NoSuffix,
+  )
+
+enum SuffixKind:
+  case Brace, Bracket, Template, NoSuffix

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -20,7 +20,7 @@ import org.eclipse.lsp4j.TextEdit
 sealed trait CompletionValue:
   def label: String
   def insertText: Option[String] = None
-  def snippetSuffix: Option[String] = None
+  def snippetSuffix: CompletionSuffix = CompletionSuffix.empty
   def additionalEdits: List[TextEdit] = Nil
   def range: Option[Range] = None
   def filterText: Option[String] = None
@@ -88,13 +88,13 @@ object CompletionValue:
   case class Compiler(
       label: String,
       symbol: Symbol,
-      override val snippetSuffix: Option[String],
+      override val snippetSuffix: CompletionSuffix,
   ) extends Symbolic
   case class Scope(label: String, symbol: Symbol) extends Symbolic
   case class Workspace(
       label: String,
       symbol: Symbol,
-      override val snippetSuffix: Option[String],
+      override val snippetSuffix: CompletionSuffix,
   ) extends Symbolic
 
   /**
@@ -103,7 +103,7 @@ object CompletionValue:
   case class Extension(
       label: String,
       symbol: Symbol,
-      override val snippetSuffix: Option[String],
+      override val snippetSuffix: CompletionSuffix,
   ) extends Symbolic
 
   /**

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -243,13 +243,13 @@ class Completions(
 
   private def findSuffix(symbol: Symbol): CompletionSuffix =
     CompletionSuffix.empty
-      .map { suffix => // for [] suffix
+      .chain { suffix => // for [] suffix
         if shouldAddSnippet &&
           cursorPos.allowBracketSuffix && symbol.info.typeParams.nonEmpty
         then suffix.copy(bracket = true, snippet = SuffixKind.Bracket)
         else suffix
       }
-      .map { suffix => // for () suffix
+      .chain { suffix => // for () suffix
         if shouldAddSnippet && symbol.is(Flags.Method)
         then
           val paramss = getParams(symbol)
@@ -271,7 +271,7 @@ class Completions(
           end match
         else suffix
       }
-      .map { suffix => // for {} suffix
+      .chain { suffix => // for {} suffix
         if shouldAddSnippet && cursorPos.allowTemplateSuffix
           && isAbstractType(symbol)
         then

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
@@ -175,7 +175,7 @@ object InterpolatorCompletions:
               CompletionValue.Interpolator(
                 sym,
                 label,
-                Some(newText(name, suffix, identOrSelect)),
+                Some(newText(name, suffix.toEditOpt, identOrSelect)),
                 Nil,
                 Some(cursor.withStart(identOrSelect.span.start).toLsp),
                 // Needed for VS Code which will not show the completion otherwise
@@ -308,7 +308,7 @@ object InterpolatorCompletions:
             CompletionValue.Interpolator(
               sym,
               label,
-              Some(newText(name, suffix)),
+              Some(newText(name, suffix.toEditOpt)),
               additionalEdits(),
               Some(nameRange),
               None,

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -488,21 +488,4 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
     """.stripMargin,
   )
 
-  // https://github.com/scalameta/metals/issues/4004
-  checkEdit(
-    "extension-param3".tag(IgnoreScala2),
-    s"""|package a
-        |object Foo:
-        |  extension (s: String)
-        |    def bar()() = 0
-        |  val bar = "abc".ba@@
-    """.stripMargin,
-    s"""|package a
-        |object Foo:
-        |  extension (s: String)
-        |    def bar()() = 0
-        |  val bar = "abc".bar()()
-    """.stripMargin,
-  )
-
 }


### PR DESCRIPTION


related to https://github.com/scalameta/metals/issues/4358

This commit refactors `findSuffix` to return `CompletionSuffix` that has information about what kind of completion suffix will be added: does compeltion suffix contains `()`, `[]`, or `{}`? where are we gonna move the cursor to?

This refactoring is required for improving the completion (with suffix)'s label.
see: https://github.com/scalameta/metals/pull/4369