### PR TITLE
Scala 2.13.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -308,6 +308,17 @@ val mtagsSettings = List(
   buildInfoKeys := Seq[BuildInfoKey](
     "scalaCompilerVersion" -> scalaVersion.value
   ),
+  Compile / unmanagedSourceDirectories := {
+    val current = (Compile / unmanagedSourceDirectories).value
+    val base = (Compile / sourceDirectory).value
+    val regex = "(\\d+)\\.(\\d+)\\.(\\d+).*".r
+    // For scala 2.13.9 we need to have a special Compat.scala
+    // For this case filter out `scala-2.13` directory that comes by default
+    if (scalaVersion.value == "2.13.9")
+      current.filter(f => f.getName() != "scala-2.13")
+    else
+      current
+  },
 )
 
 lazy val mtags3 = project

--- a/mtags/src/main/scala-2.11/scala/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.11/scala/meta/internal/pc/Compat.scala
@@ -15,4 +15,6 @@ trait Compat { this: MetalsGlobal =>
       case s: StoreReporter => Some(s)
       case _ => None
     }
+
+  def isAliasCompletion(m: Member): Boolean = false
 }

--- a/mtags/src/main/scala-2.12/scala/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.12/scala/meta/internal/pc/Compat.scala
@@ -12,4 +12,6 @@ trait Compat { this: MetalsGlobal =>
       case s: StoreReporter => Some(s)
       case _ => None
     }
+  
+  def isAliasCompletion(m: Member): Boolean = false
 }

--- a/mtags/src/main/scala-2.12/scala/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.12/scala/meta/internal/pc/Compat.scala
@@ -12,6 +12,6 @@ trait Compat { this: MetalsGlobal =>
       case s: StoreReporter => Some(s)
       case _ => None
     }
-  
+
   def isAliasCompletion(m: Member): Boolean = false
 }

--- a/mtags/src/main/scala-2.13.9/meta/internal/jdk/CollectionConverters.scala
+++ b/mtags/src/main/scala-2.13.9/meta/internal/jdk/CollectionConverters.scala
@@ -1,0 +1,5 @@
+package scala.meta.internal
+
+package object jdk {
+  val CollectionConverters = scala.jdk.CollectionConverters
+}

--- a/mtags/src/main/scala-2.13.9/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.13.9/meta/internal/pc/Compat.scala
@@ -14,6 +14,10 @@ trait Compat { this: MetalsGlobal =>
       case s: StoreReporter => Some(s)
       case _ => None
     }
-
-  def isAliasCompletion(m: Member): Boolean = false
+  
+  def isAliasCompletion(m: Member): Boolean = m match {
+    case tm: TypeMember => tm.aliasInfo.nonEmpty
+    case sm: ScopeMember => sm.aliasInfo.nonEmpty
+    case _ => false
+  }
 }

--- a/mtags/src/main/scala-2.13.9/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.13.9/meta/internal/pc/Compat.scala
@@ -14,7 +14,7 @@ trait Compat { this: MetalsGlobal =>
       case s: StoreReporter => Some(s)
       case _ => None
     }
-  
+
   def isAliasCompletion(m: Member): Boolean = m match {
     case tm: TypeMember => tm.aliasInfo.nonEmpty
     case sm: ScopeMember => sm.aliasInfo.nonEmpty

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -328,7 +328,8 @@ class CompletionProvider(
         !isFileAmmoniteCompletion() &&
         completion.isCandidate(head) &&
         !head.sym.name.containsName(CURSOR) &&
-        isNotLocalForwardReference
+        isNotLocalForwardReference &&
+        !isAliasCompletion(head)
       ) {
         isSeen += id
         buf += head

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -85,11 +85,11 @@ trait Completions { this: MetalsGlobal =>
    */
   def relevancePenalty(m: Member): Int =
     m match {
-      case TypeMember(sym, _, true, isInherited, _) =>
+      case tm: TypeMember if tm.accessible =>
         computeRelevancePenalty(
-          sym,
+          tm.sym,
           m.implicitlyAdded,
-          isInherited
+          tm.inherited
         )
       case w: WorkspaceMember =>
         MemberOrdering.IsWorkspaceSymbol + w.sym.name.length()
@@ -101,9 +101,9 @@ trait Completions { this: MetalsGlobal =>
         ) >>> 15
         if (!w.sym.isAbstract) penalty |= MemberOrdering.IsNotAbstract
         penalty
-      case ScopeMember(sym, _, true, _) =>
+      case sm: ScopeMember if sm.accessible =>
         computeRelevancePenalty(
-          sym,
+          sm.sym,
           m.implicitlyAdded,
           isInherited = false
         )

--- a/project/V.scala
+++ b/project/V.scala
@@ -4,7 +4,7 @@ object V {
   val scala210 = "2.10.7"
   val scala211 = "2.11.12"
   val scala212 = "2.12.17"
-  val scala213 = "2.13.8"
+  val scala213 = "2.13.9"
   val scala3 = "3.2.0"
   val nextScala3RC = "3.2.1-RC2"
   val sbtScala = "2.12.14"
@@ -85,6 +85,7 @@ object V {
     "2.13.5",
     "2.13.6",
     "2.13.7",
+    "2.13.8",
   )
   def scala2Versions = nonDeprecatedScala2Versions ++ deprecatedScala2Versions
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -236,6 +236,7 @@ class CompletionSuite extends BaseCompletionSuite {
     compat = Map(
       "2.13.7" -> dot2137,
       "2.13.8" -> dot2137,
+      "2.13.9" -> dot2137,
       "2.13" -> dot213,
       "2.11" ->
         """|apply[A](xs: A*): List[A]

--- a/tests/mtest/src/main/scala/tests/Compat.scala
+++ b/tests/mtest/src/main/scala/tests/Compat.scala
@@ -16,8 +16,14 @@ object Compat {
     val (startsWith, gt) =
       cases.partition { case (v, _) => !v.startsWith(">=") }
 
-    val fromStartWith = startsWith.collectFirst {
-      case (v, a) if scalaVersion.startsWith(v) => a
+    val fromStartWith = {
+      val filtered = startsWith
+        .filter { case (v, _) => scalaVersion.startsWith(v) }
+      if (filtered.nonEmpty) {
+        val out = filtered.maxBy { case (v, _) => v.length() }._2
+        Some(out)
+      } else
+        None
     }
 
     matchesGte(scalaVersion, gt).orElse(fromStartWith)

--- a/tests/unit/src/test/resources/definition/example/Scalalib.scala
+++ b/tests/unit/src/test/resources/definition/example/Scalalib.scala
@@ -1,7 +1,7 @@
 package example
 
 class Scalalib/*Scalalib.scala*/ {
-  val nil/*Scalalib.scala*/ = List/*package.scala*/()
+  val nil/*Scalalib.scala*/ = List/*List.scala*/()
   val lst/*Scalalib.scala*/ = List/*package.scala*/[
     (
         Nothing,

--- a/tests/unit/src/test/resources/semanticdb/example/Scalalib.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/Scalalib.scala
@@ -1,7 +1,7 @@
 package example
 
 class Scalalib/*example.Scalalib#*/ {
-  val nil/*example.Scalalib#nil.*/ = List/*scala.package.List.*/()
+  val nil/*example.Scalalib#nil.*/ = List/*scala.collection.immutable.Nil.*/()
   val lst/*example.Scalalib#lst.*/ = List/*scala.package.List.*/[
     (
         Nothing/*scala.Nothing#*/,

--- a/tests/unit/src/test/scala/tests/DiagnosticsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DiagnosticsLspSuite.scala
@@ -149,8 +149,10 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
       _ <- server.didOpen("a/src/main/scala/a/Post.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
-        """|a/src/main/scala/a/Post.scala:5:1: error: object creation impossible. Missing implementation for:
-           |  def post: Int // inherited from trait Post
+        """|a/src/main/scala/a/Post.scala:5:1: error: object creation impossible.
+           |Missing implementation for member of trait Post:
+           |  def post: Int = ???
+           |
            |object Post extends Post
            |^^^^^^^^^^^^^^^^^^^^^^^^
            |""".stripMargin,


### PR DESCRIPTION
Due to https://github.com/scala/scala/pull/9754 it was required to add additional compat method to filter out non relevant type completions.

