### PR TITLE
Offer exhaustive completions for map and other methods

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -393,13 +393,6 @@ class Completions(
             indexedContext,
             config,
             parent,
-          ) ++ CaseKeywordCompletion.matchContribute(
-            selector,
-            completionPos,
-            indexedContext,
-            config,
-            parent,
-            casePrefix = true,
           ),
           true,
         )

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -348,6 +348,37 @@ class Completions(
           false,
         )
 
+      case MatchCaseExtractor.CaseExtractor(selector @ EmptyTree, parent) =>
+        (
+          CaseKeywordCompletion.contribute(
+            selector,
+            completionPos,
+            indexedContext,
+            config,
+            parent,
+          ) ++ CaseKeywordCompletion.matchContribute(
+            selector,
+            completionPos,
+            indexedContext,
+            config,
+            parent,
+            casePrefix = true,
+          ),
+          true,
+        )
+
+      case MatchCaseExtractor.CaseExtractor(selector, parent) =>
+        (
+          CaseKeywordCompletion.contribute(
+            selector,
+            completionPos,
+            indexedContext,
+            config,
+            parent,
+          ),
+          true,
+        )
+
       case MatchCaseExtractor.TypedCasePatternExtractor(
             selector,
             parent,
@@ -381,18 +412,6 @@ class Completions(
             patternOnly = Some(identName),
           ),
           false,
-        )
-
-      case MatchCaseExtractor.CaseExtractor(selector, parent) =>
-        (
-          CaseKeywordCompletion.contribute(
-            selector,
-            completionPos,
-            indexedContext,
-            config,
-            parent,
-          ),
-          true,
         )
 
       // class FooImpl extends Foo:

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -347,38 +347,6 @@ class Completions(
           ),
           false,
         )
-
-      case MatchCaseExtractor.CaseExtractor(selector @ EmptyTree, parent) =>
-        (
-          CaseKeywordCompletion.contribute(
-            selector,
-            completionPos,
-            indexedContext,
-            config,
-            parent,
-          ) ++ CaseKeywordCompletion.matchContribute(
-            selector,
-            completionPos,
-            indexedContext,
-            config,
-            parent,
-            casePrefix = true,
-          ),
-          true,
-        )
-
-      case MatchCaseExtractor.CaseExtractor(selector, parent) =>
-        (
-          CaseKeywordCompletion.contribute(
-            selector,
-            completionPos,
-            indexedContext,
-            config,
-            parent,
-          ),
-          true,
-        )
-
       case MatchCaseExtractor.TypedCasePatternExtractor(
             selector,
             parent,
@@ -412,6 +380,37 @@ class Completions(
             patternOnly = Some(identName),
           ),
           false,
+        )
+
+      case MatchCaseExtractor.CaseExtractor(selector @ EmptyTree, parent) =>
+        (
+          CaseKeywordCompletion.contribute(
+            selector,
+            completionPos,
+            indexedContext,
+            config,
+            parent,
+          ) ++ CaseKeywordCompletion.matchContribute(
+            selector,
+            completionPos,
+            indexedContext,
+            config,
+            parent,
+            casePrefix = true,
+          ),
+          true,
+        )
+
+      case MatchCaseExtractor.CaseExtractor(selector, parent) =>
+        (
+          CaseKeywordCompletion.contribute(
+            selector,
+            completionPos,
+            indexedContext,
+            config,
+            parent,
+          ),
+          true,
         )
 
       // class FooImpl extends Foo:

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -336,13 +336,14 @@ class Completions(
         val values = ScaladocCompletions.contribute(pos, text, config)
         (values, true)
 
-      case MatchCaseExtractor.MatchExtractor(selector) =>
+      case MatchCaseExtractor.MatchExtractor(selector, parent) =>
         (
           CaseKeywordCompletion.matchContribute(
             selector,
             completionPos,
             indexedContext,
             config,
+            parent,
           ),
           false,
         )

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -336,17 +336,17 @@ class Completions(
         val values = ScaladocCompletions.contribute(pos, text, config)
         (values, true)
 
-      case MatchCaseExtractor.MatchExtractor(selector, parent) =>
+      case MatchCaseExtractor.MatchExtractor(selector) =>
         (
           CaseKeywordCompletion.matchContribute(
             selector,
             completionPos,
             indexedContext,
             config,
-            parent,
           ),
-          true,
+          false,
         )
+
       case MatchCaseExtractor.TypedCasePatternExtractor(
             selector,
             parent,
@@ -380,21 +380,6 @@ class Completions(
             patternOnly = Some(identName),
           ),
           false,
-        )
-
-      // `List(foo).map{case@@}`
-      // This is a special case, because we want to show also the exhaustive match completion,
-      // which the user would normally see only after typing `List(foo).map{mat@@}`
-      case MatchCaseExtractor.CaseExtractor(selector @ EmptyTree, parent) =>
-        (
-          CaseKeywordCompletion.contribute(
-            selector,
-            completionPos,
-            indexedContext,
-            config,
-            parent,
-          ),
-          true,
         )
 
       case MatchCaseExtractor.CaseExtractor(selector, parent) =>

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -345,7 +345,7 @@ class Completions(
             config,
             parent,
           ),
-          false,
+          true,
         )
       case MatchCaseExtractor.TypedCasePatternExtractor(
             selector,
@@ -382,6 +382,9 @@ class Completions(
           false,
         )
 
+      // `List(foo).map{case@@}`
+      // This is a special case, because we want to show also the exhaustive match completion,
+      // which the user would normally see only after typing `List(foo).map{mat@@}`
       case MatchCaseExtractor.CaseExtractor(selector @ EmptyTree, parent) =>
         (
           CaseKeywordCompletion.contribute(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -174,6 +174,8 @@ object CaseKeywordCompletion:
       val res = result.result()
 
       selector match
+        // In `List(foo).map { cas@@} we want to provide also `case (exhaustive)` completion
+        // which works like exhaustive match.
         case EmptyTree =>
           val sealedMembers = res.filter(c => sealedDescs.contains(c.symbol))
           sealedMembers match

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -166,6 +166,11 @@ object CaseKeywordCompletion:
    * @param typedtree typed tree of the file, used for generating auto imports
    * @param indexedContext
    * @param config
+   * @param parent the parent tree node of the pattern match, for example `Apply(_, _)` when in
+   *               `List(1).foreach { cas@@ }`, used as fallback to compute the type of the selector when
+   *               it's `EmptyTree`.
+   * @param casePrefix when in `List(1).foreach { case@@ }` we want user to see `case (exhaustive) Option (2 cases)`,
+   *                   when false (default) we get `match (exhaustive) Option (2 cases)`
    */
   def matchContribute(
       selector: Tree,

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -290,6 +290,7 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """|case None => scala
        |case Some(value) => scala
+       |case (exhaustive) Option (2 cases)
        |""".stripMargin,
   )
 
@@ -331,6 +332,7 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """|case None => scala
        |case Some(value) => scala
+       |case (exhaustive) Option (2 cases)
        |""".stripMargin,
   )
 
@@ -344,6 +346,7 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """|case None => scala
        |case Some(value) => scala
+       |case (exhaustive) Option (2 cases)
        |""".stripMargin,
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -290,8 +290,11 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """|case None => scala
        |case Some(value) => scala
-       |case (exhaustive) Option (2 cases)
        |""".stripMargin,
+    compat = Map("3" -> """|case None => scala
+                           |case Some(value) => scala
+                           |case (exhaustive) Option (2 cases)
+                           |""".stripMargin),
   )
 
   check(
@@ -332,8 +335,11 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """|case None => scala
        |case Some(value) => scala
-       |case (exhaustive) Option (2 cases)
        |""".stripMargin,
+    compat = Map("3" -> """|case None => scala
+                           |case Some(value) => scala
+                           |case (exhaustive) Option (2 cases)
+                           |""".stripMargin),
   )
 
   check(
@@ -346,8 +352,11 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """|case None => scala
        |case Some(value) => scala
-       |case (exhaustive) Option (2 cases)
        |""".stripMargin,
+    compat = Map("3" -> """|case None => scala
+                           |case Some(value) => scala
+                           |case (exhaustive) Option (2 cases)
+                           |""".stripMargin),
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -501,8 +501,8 @@ class CompletionMatchSuite extends BaseCompletionSuite {
     s"""
        |object A {
        |  List(Option(1)).map{
-       |\tcase None => $$0
-       |\tcase Some(value) =>
+       |\tcase Some(value) => $$0
+       |\tcase None =>
        |}
        |}""".stripMargin,
     filter = _.contains("exhaustive"),

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -496,7 +496,7 @@ class CompletionMatchSuite extends BaseCompletionSuite {
     "exhaustive-map-edit".tag(IgnoreScala2),
     """
       |object A {
-      |  List(Option(1)).map{mat@@}
+      |  List(Option(1)).map{cas@@}
       |}""".stripMargin,
     s"""
        |object A {

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -481,4 +481,31 @@ class CompletionMatchSuite extends BaseCompletionSuite {
                 |}""".stripMargin
     ),
   )
+  check(
+    "exhaustive-map".tag(IgnoreScala2),
+    """
+      |object A {
+      |  List(Option(1)).map{ ca@@ }
+      |}""".stripMargin,
+    """|case (exhaustive) Option (2 cases)
+       |""".stripMargin,
+    filter = _.contains("exhaustive"),
+  )
+
+  checkEdit(
+    "exhaustive-map-edit".tag(IgnoreScala2),
+    """
+      |object A {
+      |  List(Option(1)).map{mat@@}
+      |}""".stripMargin,
+    s"""
+       |object A {
+       |  List(Option(1)).map{
+       |\tcase None => $$0
+       |\tcase Some(value) =>
+       |}
+       |}""".stripMargin,
+    filter = _.contains("exhaustive"),
+  )
+
 }


### PR DESCRIPTION
feature request https://github.com/scalameta/metals-feature-requests/issues/302

This adds exhaustive match completions for partial functions.
User can find this completion both by typing
```scala
List(Option(1)).map { match@@}
```
and 

```scala
List(Option(1)).map { case@@}
```
with result 
```scala
List(Option(1)).map { 
  case None =>
  case Some(value)
 }
```