### PR TITLE
feat: extends keyword completion

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
@@ -50,6 +50,7 @@ trait Keywords { this: MetalsGlobal =>
         val isTemplate = this.isTemplate(latestEnclosing)
         val isPackage = this.isPackage(latestEnclosing)
         val isParam = this.isParam(latestEnclosing)
+        val isSelect = this.isSelect(latestEnclosing)
         Keyword.all.collect {
           case kw
               if kw.matchesPosition(
@@ -62,6 +63,7 @@ trait Keywords { this: MetalsGlobal =>
                 isPackage = isPackage,
                 isParam = isParam,
                 isScala3 = false,
+                isSelect = isSelect,
                 allowToplevel = isAmmoniteScript,
                 leadingReverseTokens = reverseTokens
               ) =>
@@ -179,6 +181,13 @@ trait Keywords { this: MetalsGlobal =>
       case Ident(_) :: Template(_, _, _) :: _ => true
       case Ident(_) :: ValOrDefDef(_, _, _, _) :: _ => true
       case Ident(_) :: (_: TermTreeApi) :: _ => true
+      case _ => false
+    }
+
+  private def isSelect(enclosing: List[Tree]): Boolean =
+    enclosing match {
+      case (_: Ident) :: (_: Select) :: _ => true
+      case (_: Apply) :: (_: Select) :: _ => true
       case _ => false
     }
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
@@ -20,11 +20,16 @@ trait Keywords { this: MetalsGlobal =>
 
     lazy val notInComment = checkIfNotInComment(pos, text, latestEnclosing)
 
-    lazy val reverseTokens: Iterator[Token] =
-      text.substring(0, pos.start).tokenize.toOption match {
+    lazy val reverseTokens: Iterator[Token] = {
+      // Try not to tokenize the whole file
+      // Maybe we should re-use the tokenize result with `notInComment`
+      val lineStart =
+        if (pos.line > 0) pos.source.lineToOffset(pos.line - 1) else 0
+      text.substring(lineStart, pos.start).tokenize.toOption match {
         case Some(toks) => toks.tokens.reverseIterator
         case None => Iterator.empty
       }
+    }
 
     getIdentifierName(latestEnclosing, pos) match {
       case None =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.pc
 
 import scala.tools.nsc.reporters.StoreReporter
 
+import scala.meta._
 import scala.meta.internal.mtags.MtagsEnrichments._
 
 import org.eclipse.{lsp4j => l}
@@ -18,6 +19,12 @@ trait Keywords { this: MetalsGlobal =>
   ): List[Member] = {
 
     lazy val notInComment = checkIfNotInComment(pos, text, latestEnclosing)
+
+    lazy val reverseTokens: Iterator[Token] =
+      text.substring(0, pos.start).tokenize.toOption match {
+        case Some(toks) => toks.tokens.reverseIterator
+        case None => Iterator.empty
+      }
 
     getIdentifierName(latestEnclosing, pos) match {
       case None =>
@@ -55,7 +62,8 @@ trait Keywords { this: MetalsGlobal =>
                 isPackage = isPackage,
                 isParam = isParam,
                 isScala3 = false,
-                allowToplevel = isAmmoniteScript
+                allowToplevel = isAmmoniteScript,
+                leadingReverseTokens = reverseTokens
               ) =>
             mkTextEditMember(kw, editRange)
         }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
@@ -33,6 +33,7 @@ object KeywordsCompletions:
         val isTemplate = this.isTemplate(path)
         val isPackage = this.isPackage(path)
         val isParam = this.isParam(path)
+        val isSelect = this.isSelect(path)
         lazy val text = completionPos.cursorPos.source.content.mkString
         lazy val reverseTokens: Iterator[Token] =
           text
@@ -53,6 +54,7 @@ object KeywordsCompletions:
                 isPackage = isPackage,
                 isParam = isParam,
                 isScala3 = true,
+                isSelect = isSelect,
                 allowToplevel = true,
                 leadingReverseTokens = reverseTokens,
               ) && notInComment =>
@@ -95,6 +97,12 @@ object KeywordsCompletions:
   private def isMethodBody(enclosing: List[Tree]): Boolean =
     enclosing match
       case Ident(_) :: (_: DefDef) :: _ => true
+      case _ => false
+
+  private def isSelect(enclosing: List[Tree]): Boolean =
+    enclosing match
+      case (_: Apply) :: (_: Select) :: _ => true
+      case (_: Select) :: _ => true
       case _ => false
 
   private def isDefinition(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
@@ -44,6 +44,7 @@ object KeywordsCompletions:
                 isParam = isParam,
                 isScala3 = true,
                 allowToplevel = true,
+                leadingReverseTokens = Iterator.empty, // TODO
               ) && notInComment =>
             CompletionValue.keyword(kw.name, kw.insertText)
         }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
@@ -36,12 +36,21 @@ object KeywordsCompletions:
         val isSelect = this.isSelect(path)
         lazy val text = completionPos.cursorPos.source.content.mkString
         lazy val reverseTokens: Iterator[Token] =
+          // Try not to tokenize the whole file
+          // Maybe we should re-use the tokenize result with `notInComment`
+          val lineStart =
+            if completionPos.cursorPos.line > 0 then
+              completionPos.sourcePos.source.lineToOffset(
+                completionPos.cursorPos.line - 1
+              )
+            else 0
           text
-            .substring(0, completionPos.cursorPos.start)
+            .substring(lineStart, completionPos.cursorPos.start)
             .tokenize
             .toOption match
             case Some(toks) => toks.tokens.reverseIterator
             case None => Iterator.empty
+        end reverseTokens
         Keyword.all.collect {
           case kw
               if kw.matchesPosition(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
@@ -8,7 +8,7 @@ import scala.meta.tokens.Token
 import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.util.SourcePosition
-import org.eclipse.{lsp4j as l} // for tokenize
+import org.eclipse.{lsp4j as l}
 
 object KeywordsCompletions:
 

--- a/mtags/src/main/scala/scala/meta/internal/pc/Keyword.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Keyword.scala
@@ -4,27 +4,29 @@ import scala.meta.XtensionClassifiable
 import scala.meta.tokens.Token // for token.is
 // scalafmt: { maxColumn = 120 }
 
+/**
+ * @param isExpression Can this keyword appear in expression position?
+ * @param isBlock Can this keyword appear in a block statement position?
+ * @param isTemplate Can this keyword appear in a template statement position?
+ * @param isPackage Can this keyword appear in a package statement position?
+ * @param isMethodBody Can this keyword appear in a def block statement position?
+ * @param isDefinition Does this keyword define a symbol? For example "def" or "class"
+ * @param isParam Is located in param definition
+ * @param isScala3 Is this keyword only in Scala 3?
+ * @param commitCharacter Optional character to select this completion item, for example "."
+ * @param leadingReverseTokens The (reverse) tokens that should appear before the given position (removing whitespace and EOF)
+ */
 case class Keyword(
     name: String,
-    // Can this keyword appear in expression position?
     isExpression: Boolean = false,
-    // Can this keyword appear in a block statement position?
     isBlock: Boolean = false,
-    // Can this keyword appear in a template statement position?
     isTemplate: Boolean = false,
-    // Can this keyword appear in a package statement position?
     isPackage: Boolean = false,
-    // Can this keyword appear in a def block statement position?
     isMethodBody: Boolean = false,
-    // Does this keyword define a symbol? For example "def" or "class"
     isDefinition: Boolean = false,
-    // Is located in param definition
     isParam: Boolean = false,
-    // Is this keyword only in Scala 3?
     isScala3: Boolean = false,
-    // Optional character to select this completion item, for example "."
     commitCharacter: Option[String] = None,
-    // The (reverse) tokens that should appear before the given position (removing whitespace and EOF)
     leadingReverseTokens: Option[Iterator[Token] => Boolean] = None
 ) {
 

--- a/mtags/src/main/scala/scala/meta/internal/pc/Keyword.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Keyword.scala
@@ -50,11 +50,14 @@ case class Keyword(
       isPackage: Boolean,
       isParam: Boolean,
       isScala3: Boolean,
+      isSelect: Boolean,
       allowToplevel: Boolean,
       leadingReverseTokens: => Iterator[Token]
   ): Boolean = {
     val isAllowedInThisScalaVersion = (this.isScala3 && isScala3) || !this.isScala3
-    this.name.startsWith(name) && isAllowedInThisScalaVersion && {
+    this.name.startsWith(name) && isAllowedInThisScalaVersion &&
+    // don't complete keywords if it's in `xxx.key@@`
+    !isSelect && {
       (this.isExpression && isExpression) ||
       (this.isBlock && isBlock) ||
       (this.isDefinition && isDefinition) ||
@@ -128,6 +131,8 @@ object Keyword {
       case (_: Token.Ident) :: (_: Token.Ident) :: kw :: Nil =>
         if (kw.is[Token.KwClass] || kw.is[Token.KwTrait] || kw.is[Token.KwObject]) true
         else false
+      // ... classname() ext@@
+      case (_: Token.Ident) :: (_: Token.RightParen) :: _ => true
       case _ => false
     }
   }

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -523,9 +523,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
   )
 
   check(
-    "extends-class".tag(
-      IgnoreScala3
-    ), // extends keyword is not yet supported in Scala3
+    "extends-class",
     """
       |package foo
       |
@@ -533,12 +531,16 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     """.stripMargin,
     """|extends
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|extension
+           |extends
+           |""".stripMargin
+    ),
   )
 
   check(
-    "extends-obj".tag(
-      IgnoreScala3
-    ),
+    "extends-obj",
     """
       |package foo
       |
@@ -546,12 +548,16 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     """.stripMargin,
     """|extends
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|extension
+           |extends
+           |""".stripMargin
+    ),
   )
 
   check(
-    "extends-trait".tag(
-      IgnoreScala3
-    ),
+    "extends-trait",
     """
       |package foo
       |
@@ -559,12 +565,16 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     """.stripMargin,
     """|extends
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|extension
+           |extends
+           |""".stripMargin
+    ),
   )
 
   check(
-    "no-extends".tag(
-      IgnoreScala3
-    ),
+    "no-extends",
     """
       |package foo
       |

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -522,4 +522,57 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     "",
   )
 
+  check(
+    "extends-class".tag(
+      IgnoreScala3
+    ), // extends keyword is not yet supported in Scala3
+    """
+      |package foo
+      |
+      |class Foo ext@@
+    """.stripMargin,
+    """|extends
+       |""".stripMargin,
+  )
+
+  check(
+    "extends-obj".tag(
+      IgnoreScala3
+    ),
+    """
+      |package foo
+      |
+      |object Foo ext@@
+    """.stripMargin,
+    """|extends
+       |""".stripMargin,
+  )
+
+  check(
+    "extends-trait".tag(
+      IgnoreScala3
+    ),
+    """
+      |package foo
+      |
+      |trait Foo ext@@ {}
+    """.stripMargin,
+    """|extends
+       |""".stripMargin,
+  )
+
+  check(
+    "no-extends".tag(
+      IgnoreScala3
+    ),
+    """
+      |package foo
+      |
+      |def main = {
+      |  foo.ext@@
+      |}
+    """.stripMargin,
+    "",
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -574,12 +574,45 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
   )
 
   check(
+    "extends-with-constructor",
+    """
+      |package foo
+      |
+      |class Foo(x: Int) ext@@
+    """.stripMargin,
+    """|extends
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|extension
+           |extends
+           |""".stripMargin
+    ),
+  )
+
+  check(
     "no-extends",
     """
       |package foo
       |
-      |def main = {
-      |  foo.ext@@
+      |object Main {
+      |  def main = {
+      |    foo.ext@@
+      |  }
+      |}
+    """.stripMargin,
+    "",
+  )
+
+  check(
+    "no-extends-paren",
+    """
+      |package foo
+      |
+      |object Main {
+      |  def main = {
+      |    foo(i) ex@@
+      |  }
       |}
     """.stripMargin,
     "",

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -618,4 +618,24 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     "",
   )
 
+  check(
+    "extends-limitation",
+    """
+      |package foo
+      |
+      |// can't provide extends keyword completion if there's newline between class
+      |// because the completion engine tokenize only the line 
+      |class Main
+      |  exten@@
+    """.stripMargin,
+    "",
+    compat =
+      Map( // it works in Scala3 because `completionPos.cursorPos` gives us a `class Main\n exten`
+        "3" ->
+          """|extension
+             |extends
+             |""".stripMargin
+      ),
+  )
+
 }


### PR DESCRIPTION
https://github.com/scalameta/metals-feature-requests/issues/68
related: https://github.com/scalameta/metals/pull/4193

This commit implements `extends` keyword completion.
The `extends` keyword will be completed only if the leading tokens are
like
`(class|trait|object) <identifier> ext@@`

We check the scalameta tokens because we get nothing from the AST
when we type `class Foo ext@@` which is an incomplete class declaration
statement.

---

~we can implement for Scala3 in the same way.~ Scala3 is also supported