### PR TITLE
bugfix: Properly cancel all current compilations

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BatchedFunction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BatchedFunction.scala
@@ -57,9 +57,11 @@ final class BatchedFunction[A, B](
     unlock()
   }
 
-  def cancelCurrentRequest(): Unit = {
-    current.get().cancelable.cancel()
+  def cancelAll(): Unit = {
+    queue.clear()
+    unlock()
   }
+
   def currentFuture(): Future[B] = {
     current.get().future
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -113,8 +113,17 @@ final class Compilations(
     } yield ()
 
   def cancel(): Unit = {
-    compileBatch.cancelCurrentRequest()
-    cascadeBatch.cancelCurrentRequest()
+    cascadeBatch.cancelAll()
+    compileBatch.cancelAll()
+    buildTargets.all
+      .flatMap { target =>
+        buildTargets.buildServerOf(target.getId())
+      }
+      .distinct
+      .foreach { conn =>
+        conn.cancelCompilations()
+      }
+
   }
 
   def recompileAll(): Future[Unit] = {

--- a/tests/unit/src/test/scala/tests/CancelCompileLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CancelCompileLspSuite.scala
@@ -1,13 +1,12 @@
 package tests
 
-import java.util.concurrent.CancellationException
-
 import scala.meta.internal.metals.ServerCommands
+
+import ch.epfl.scala.bsp4j.StatusCode
 
 class CancelCompileLspSuite extends BaseLspSuite("compile-cancel") {
 
-  // https://github.com/scalameta/metals/issues/3801
-  test("basic".flaky) {
+  test("basic") {
     cleanWorkspace()
     for {
       _ <- initialize(
@@ -19,33 +18,56 @@ class CancelCompileLspSuite extends BaseLspSuite("compile-cancel") {
           |}
           |/a/src/main/scala/a/A.scala
           |package a
-          |object A { val x = 1 }
+          |
+          |import scala.reflect.macros.blackbox.Context
+          |import scala.language.experimental.macros
+          |
+          |object A {
+          |  val x = 123
+          |  def sleep(): Unit = macro sleepImpl
+          |  def sleepImpl(c: Context)(): c.Expr[Unit] = {
+          |    import c.universe._
+          |    // Sleep for 3 seconds
+          |    Thread.sleep(3000)
+          |    reify { () }
+          |  }
+          |}
+          |
           |/b/src/main/scala/b/B.scala
           |package b
-          |object B { val x = a.A.x }
+          |object B { 
+          |  a.A.sleep()
+          |  val x = a.A.x 
+          |}
           |/c/src/main/scala/c/C.scala
           |package c
           |object C { val x: String = b.B.x }
           |""".stripMargin
       )
       _ <- server.server.buildServerPromise.future
-      compile = server.server.compilations.compileFile(
+      (compileReport, _) <- server.server.compilations
+        .compileFile(
+          workspace.resolve("c/src/main/scala/c/C.scala")
+        )
+        .zip {
+          // wait until the compilation start
+          Thread.sleep(1000)
+          server.executeCommand(ServerCommands.CancelCompile)
+        }
+      _ = assertNoDiff(client.workspaceDiagnostics, "")
+      _ = assertEquals(compileReport.getStatusCode(), StatusCode.CANCELLED)
+      _ <- server.server.compilations.compileFile(
         workspace.resolve("c/src/main/scala/c/C.scala")
       )
-      _ <- server.executeCommand(ServerCommands.CancelCompile)
-      _ = assertNoDiff(client.workspaceDiagnostics, "")
-      isCancelled <- compile.map(_ => false).recover {
-        case _: CancellationException => true
-      }
-      _ = Predef.assert(
-        isCancelled,
-        // NOTE(olafur): I don't know if this test is flaky, I suspect it might be but want to first give it a
-        // try before we come up with a way to test cancellation more robustly.
-        "expected didOpen future to fail with Cancellation Exception. " +
-          "If this happens frequently for unrelated changes, then this may be a flaky test that needs refactoring. " +
-          "If this assertion is flaky, feel free to remove it until it's refactored.",
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|c/src/main/scala/c/C.scala:2:28: error: type mismatch;
+           | found   : Int
+           | required: String
+           |object C { val x: String = b.B.x }
+           |                           ^^^^^
+           |""".stripMargin,
       )
-      _ <- server.executeCommand(ServerCommands.CascadeCompile)
     } yield ()
   }
 }


### PR DESCRIPTION
Previously, cancel would not be propagated through all the future trnasformations. Now, instead we have a separate queue of ongoing requests, which can be cancelled explicitely all at once. This approach is a bit more simple and doesn't require figuring out all the possible Future chains coming from compile.

Fix https://github.com/scalameta/metals/issues/3801 

Fix https://github.com/scalameta/metals/issues/3754