### PR TITLE
ci(Mergify): Don't check the number of check-success

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,6 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=1"
       - author=scalameta-bot
-      - "#check-success=21"
       - label=semver-spec-patch
       - label=library-update
       - check-success=windows-latest jdk-17 unit tests 1 / 2


### PR DESCRIPTION
This change has been made by @tanishiking from https://mergify.com config editor.

mergify was double checking

- listed checks passed
- the number of check-success=21

but, https://github.com/scalameta/metals/pull/4424 didn't merge because now we have one more additional check (by mergify), and the `#check-success>=22` is required.

It looks like `#check-success=21` seems fragile. Therefore this PR removes the condition, it should be fine as we still have conditions for required checks.

**ref**

> There is no such thing as "every status check" in GitHub.
> ...
> Those three facts make it mandatory to write explicitly the checks that are expected for your condition to be valid. Therefore you must list explicitly every status check that is expected,

https://docs.mergify.com/conditions/#validating-all-status-checks