### PR TITLE
bugfix: Remove all cancallables on finish

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
@@ -116,9 +116,9 @@ class ShellRunner(
         ps.cancel
       }
     }
-    cancelables
-      .add(() => ps.cancel)
-      .add(() => taskResponse.cancel(false))
+    val newCancelables: List[Cancelable] =
+      List(() => ps.cancel, () => taskResponse.cancel(false))
+    newCancelables.foreach(cancelables.add)
 
     val processFuture = ps.complete
     statusBar.trackFuture(
@@ -131,6 +131,7 @@ class ShellRunner(
         scribe.info(s"time: ran '$commandRun' in $elapsed")
       result.trySuccess(code)
     }
+    result.future.onComplete(_ => newCancelables.foreach(cancelables.remove))
     result.future
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -133,8 +133,9 @@ class MetalsLanguageServer(
         case Some(session) => session.shutdown()
         case None => Future.successful(())
       }
-      try cancelables.cancel()
-      catch {
+      try {
+        cancelables.cancel()
+      } catch {
         case NonFatal(_) =>
       }
       try buildShutdown.asJava.get(100, TimeUnit.MILLISECONDS)
@@ -699,21 +700,23 @@ class MetalsLanguageServer(
             sourceMapper,
           )
         )
-        debugProvider = new DebugProvider(
-          workspace,
-          definitionProvider,
-          buildTargets,
-          buildTargetClasses,
-          compilations,
-          languageClient,
-          buildClient,
-          classFinder,
-          definitionIndex,
-          stacktraceAnalyzer,
-          clientConfig,
-          semanticdbs,
-          compilers,
-          statusBar,
+        debugProvider = register(
+          new DebugProvider(
+            workspace,
+            definitionProvider,
+            buildTargets,
+            buildTargetClasses,
+            compilations,
+            languageClient,
+            buildClient,
+            classFinder,
+            definitionIndex,
+            stacktraceAnalyzer,
+            clientConfig,
+            semanticdbs,
+            compilers,
+            statusBar,
+          )
         )
         scalafixProvider = ScalafixProvider(
           buffers,
@@ -1972,7 +1975,6 @@ class MetalsLanguageServer(
           )
         } yield {
           statusBar.addMessage("Started debug server!")
-          cancelables.add(server)
           DebugSession(server.sessionName, server.uri.toString)
         }
         session.asJavaObject


### PR DESCRIPTION
There were two remaining cases where cancllables were never removed from a queue:
- in shell runner
- debug sessions

Now, they are properly removed after finishing.

Follow up to https://github.com/scalameta/metals/pull/4421