### PR TITLE
Auto-Import After Ammonite Headers

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
@@ -333,6 +333,23 @@ class AutoImportsSuite extends BaseAutoImportsSuite {
     ),
   )
 
+  checkAmmoniteEdit(
+    "first-auto-import-amm-script-with-header",
+    ammoniteWrapper(
+      """|// scala 2.13.1
+         |
+         |val p: <<Path>> = ???
+         |""".stripMargin
+    ),
+    ammoniteWrapper(
+      """|// scala 2.13.1
+         |import java.nio.file.Path
+         |
+         |val p: Path = ???
+         |""".stripMargin
+    ),
+  )
+
   private def ammoniteWrapper(code: String): String =
     // Vaguely looks like a scala file that Ammonite generates
     // from a sc file.


### PR DESCRIPTION
Hi!  This PR changes auto imports with Ammonite scripts so that if a script does not already contain an import, the first import is added after any [Ammonite headers](https://scalameta.org/metals/docs/troubleshooting/faq#how-do-i-use-scala-2xx-for-my-script), since these comments need to appear at the top of the file.

The implementation is otherwise similar to how `// using` comments are skipped in scala cli scripts.  Thanks!