### PR TITLE
bufix: Properly write constant types in signatures

### DIFF
--- a/mtags/src/main/scala-2.11/scala/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.11/scala/meta/internal/pc/Compat.scala
@@ -17,4 +17,6 @@ trait Compat { this: MetalsGlobal =>
     }
 
   def isAliasCompletion(m: Member): Boolean = false
+
+  def constantType(c: ConstantType): ConstantType = c
 }

--- a/mtags/src/main/scala-2.12/scala/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.12/scala/meta/internal/pc/Compat.scala
@@ -14,4 +14,6 @@ trait Compat { this: MetalsGlobal =>
     }
 
   def isAliasCompletion(m: Member): Boolean = false
+
+  def constantType(c: ConstantType): ConstantType = c
 }

--- a/mtags/src/main/scala-2.13.9/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.13.9/meta/internal/pc/Compat.scala
@@ -20,4 +20,7 @@ trait Compat { this: MetalsGlobal =>
     case sm: ScopeMember => sm.aliasInfo.nonEmpty
     case _ => false
   }
+
+  def constantType(c: ConstantType): ConstantType =
+    if (c.value.isSuitableLiteralType) LiteralType(c.value) else c
 }

--- a/mtags/src/main/scala-2.13/scala/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.13/scala/meta/internal/pc/Compat.scala
@@ -16,4 +16,7 @@ trait Compat { this: MetalsGlobal =>
     }
 
   def isAliasCompletion(m: Member): Boolean = false
+
+  def constantType(c: ConstantType): ConstantType =
+    if (c.value.isSuitableLiteralType) LiteralType(c.value) else c
 }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Signatures.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Signatures.scala
@@ -290,9 +290,16 @@ trait Signatures { compiler: MetalsGlobal =>
     private val returnType =
       printType(shortType(gtpe.finalResultType, shortenedNames))
 
-    def printType(tpe: Type): String =
-      if (printLongType) tpe.toLongString
-      else tpe.toString()
+    def printType(tpe: Type): String = {
+      val tpeToPrint = tpe match {
+        case c: ConstantType =>
+          constantType(c)
+        case _ => tpe
+      }
+      if (printLongType) tpeToPrint.toLongString
+      else tpeToPrint.toString()
+    }
+
     def methodDocstring: String = {
       if (isDocs) info.fold("")(_.docstring())
       else ""


### PR DESCRIPTION
Previously, we would print constant types as `String("mode")`. Now, we print only the underlying `"mode"`.

Fixes https://github.com/scalameta/metals/issues/4411