### PR TITLE
feature: Add Ammonite completions to worksheets

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteCompletions.scala
@@ -152,18 +152,19 @@ trait AmmoniteCompletions { this: MetalsGlobal =>
                 pos.withStart(rangeStart).withEnd(pos.point).toLsp
               }
 
-            (javaCompletions ++ scalaCompletions).map { c =>
-              new TextEditMember(
-                filterText = c,
-                edit = new l.TextEdit(
-                  ivyEditRange,
-                  if (isInitialCompletion) s"`$c$$0`" else c
-                ),
-                sym = select.symbol
-                  .newErrorSymbol(TermName("artefact"))
-                  .setInfo(NoType),
-                label = Some(c.stripPrefix(":"))
-              )
+            (javaCompletions ++ scalaCompletions).zipWithIndex.map {
+              case (c, index) =>
+                new TextEditMember(
+                  filterText = c,
+                  edit = new l.TextEdit(
+                    ivyEditRange,
+                    if (isInitialCompletion) s"`$c$$0`" else c
+                  ),
+                  sym = select.symbol
+                    .newErrorSymbol(TermName(s"artefact$index"))
+                    .setInfo(NoType),
+                  label = Some(c.stripPrefix(":"))
+                )
             }
           case _ => List.empty
         }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -525,7 +525,10 @@ trait Completions { this: MetalsGlobal =>
           if isAmmoniteFileCompletionPosition(imp, pos) =>
         AmmoniteFileCompletions(select, selector, pos, editRange)
       case (imp @ Import(select, selector)) :: _
-          if isAmmoniteIvyCompletionPosition(imp, pos) =>
+          if isAmmoniteIvyCompletionPosition(
+            imp,
+            pos
+          ) || isWorksheetIvyCompletionPosition(imp, pos) =>
         AmmoniteIvyCompletions(select, selector, pos, editRange)
       case _ =>
         inferCompletionPosition(
@@ -558,6 +561,15 @@ trait Completions { this: MetalsGlobal =>
 
   def isAmmoniteIvyCompletionPosition(tree: Tree, pos: Position): Boolean =
     isAmmoniteCompletionPosition("$ivy", tree, pos)
+
+  def isWorksheetIvyCompletionPosition(tree: Tree, pos: Position): Boolean =
+    tree match {
+      case Import(select, _) =>
+        pos.source.file.name.isWorksheet && (select
+          .toString() == "<$ivy: error>" || select
+          .toString() == "<$dep: error>")
+      case _ => false
+    }
 
   private def inferCompletionPosition(
       pos: Position,

--- a/tests/slow/src/test/scala/tests/feature/WorksheetCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/WorksheetCrossLspSuite.scala
@@ -21,22 +21,4 @@ class LatestWorksheet3LspSuite
     """given str: String = """""
 }
 
-class Worksheet213LspSuite extends tests.BaseWorksheetLspSuite(V.scala213) {
-
-  test("literals") {
-    for {
-      _ <- initialize(
-        s"""
-           |/metals.json
-           |{"a": {"scalaVersion": "${V.scala213}"}}
-           |/a/src/main/scala/foo/Main.worksheet.sc
-           |val literal: 42 = 42
-           |""".stripMargin
-      )
-      _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
-      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
-      _ = assertNoDiagnostics()
-    } yield ()
-  }
-
-}
+class Worksheet212LspSuite extends tests.BaseWorksheetLspSuite(V.scala212)

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
@@ -170,4 +170,68 @@ class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala213) {
       )
     } yield ()
   }
+
+  test("ivy-completion") {
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "${V.scala213}"
+           |  }
+           |}
+           |/Main.worksheet.sc
+           |import $$ivy.`io.cir`
+           |import $$dep.`io.circe::circe-ref`
+           |import $$dep.`io.circe::circe-yaml:0.14`
+           |""".stripMargin
+      )
+      _ <- server.didOpen("Main.worksheet.sc")
+      groupExpectedCompletionList = "io.circe"
+      groupCompletionList <- server.completion(
+        "Main.worksheet.sc",
+        "import $ivy.`io.cir@@`",
+      )
+      _ = assertNoDiff(groupCompletionList, groupExpectedCompletionList)
+
+      artefactExpectedCompletionList =
+        """|circe-refined
+           |circe-refined_native0.4
+           |circe-refined_sjs0.6
+           |circe-refined_sjs1
+           |""".stripMargin
+      artefactCompletionList <- server.completion(
+        "Main.worksheet.sc",
+        "import $dep.`io.circe::circe-ref@@`",
+      )
+      _ = assertNoDiff(artefactCompletionList, artefactExpectedCompletionList)
+
+      versionExpectedCompletionList =
+        """
+          |0.14.0
+          |0.14.1""".stripMargin
+      versionCompletionList <- server.completion(
+        "Main.worksheet.sc",
+        "import $dep.`io.circe::circe-yaml:0.14@@`",
+      )
+      _ = assertNoDiff(versionCompletionList, versionExpectedCompletionList)
+    } yield ()
+  }
+
+  test("literals") {
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {"scalaVersion": "${V.scala213}"}}
+           |/a/src/main/scala/foo/Main.worksheet.sc
+           |val literal: 42 = 42
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
+      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
+      _ = assertNoDiagnostics()
+    } yield ()
+  }
 }


### PR DESCRIPTION
Futher refactor is being done in https://github.com/scalameta/metals/pull/4417 so I will hold off for now, but the IvyCompletions could be taken out of AmmoniteCompletions trait.