### PR TITLE
bugfix: Fix document highlight in for comprehensions

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcDocumentHighlightProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcDocumentHighlightProvider.scala
@@ -159,7 +159,7 @@ final class PcDocumentHighlightProvider(
         lazy val soughtNames: Set[Name] = sought.map(_.name)
 
         /*
-         * For comprehsnions have two owners, one for the enumerators and one for
+         * For comprehensions have two owners, one for the enumerators and one for
          * yield. This is a heuristic to find that out.
          */
         def isForComprehensionOwner(named: NameTree) =

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcDocumentHighlightProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcDocumentHighlightProvider.scala
@@ -155,7 +155,7 @@ object PcDocumentHighlightProvider:
         lazy val soughtNames: Set[Name] = sought.map(_.name)
 
         /*
-         * For comprehsnions have two owners, one for the enumerators and one for
+         * For comprehensions have two owners, one for the enumerators and one for
          * yield. This is a heuristic to find that out.
          */
         def isForComprehensionOwner(named: NameTree) =

--- a/tests/cross/src/test/scala/tests/highlight/SyntheticsDocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/SyntheticsDocumentHighlightSuite.scala
@@ -1,0 +1,77 @@
+package tests.highlight
+
+import tests.BaseDocumentHighlightSuite
+
+class SyntheticsDocumentHighlightSuite extends BaseDocumentHighlightSuite {
+
+  check(
+    "advanced1",
+    """
+      |object Main {
+      |  for { 
+      |    abc <- Option(1) 
+      |    one = 1
+      |    <<a@@dd>> = one + abc
+      |} yield { 
+      |   <<add>>.toString.toList.map(_.toChar)
+      |  }
+      |}""".stripMargin,
+  )
+
+  check(
+    "advanced2",
+    """
+      |object Main {
+      |  for { 
+      |    abc <- Option(1) 
+      |    one = 1
+      |    <<add>> = one + abc
+      |} yield { 
+      |   <<ad@@d>>.toString.toList.map(_.toChar)
+      |  }
+      |}""".stripMargin,
+  )
+
+  check(
+    "advanced3",
+    """
+      |object Main {
+      |  for { 
+      |    <<a@@bc>> <- Option(1) 
+      |    one = 1
+      |    add = one + <<abc>>
+      |} yield { 
+      |   <<abc>>.toString.toList.map(_.toChar)
+      |  }
+      |}""".stripMargin,
+  )
+
+  check(
+    "advanced4",
+    """
+      |object Main {
+      |  for { 
+      |    <<abc>> <- Option(1) 
+      |    one = 1
+      |    add = one + <<a@@bc>>
+      |} yield { 
+      |   <<abc>>.toString.toList.map(_.toChar)
+      |  }
+      |}""".stripMargin,
+  )
+
+  check(
+    "advanced5",
+    """
+      |object Main {
+      |  for { 
+      |    <<abc>> <- Option(1) 
+      |    one = 1
+      |    add = one + <<abc>>
+      |} yield { 
+      |   <<ab@@c>>.toString.toList.map(_.toChar)
+      |  }
+      |}""".stripMargin,
+  )
+
+}


### PR DESCRIPTION
Previously, document highlight in for comprehensions would not highlight both the definition and the usages in yield. This was caused by the fact that these two are really just separate symbols in separate anonymous functions. Now, we try to relate the two owner functions based on their point position, which seems to work correctly.

It's a bit different in case of Scala 3, since there seem to be more trees with the particular symbol generated, but still path will point us to different symbol than the one being used.