### PR TITLE
fix: Try to download semanticdb even if it might not be supported

### DIFF
--- a/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
+++ b/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
@@ -89,10 +89,7 @@ object MetalsPlugin extends AutoPlugin {
   private def processJavaHome: File = file(System.getProperty("java.home"))
 
   def requiresSemanticdb: Def.Initialize[Boolean] = Def.setting {
-    bspEnabled.value &&
-    (isScala3.value || BuildInfo.supportedScala2Versions.contains(
-      scalaVersion.value
-    ))
+    bspEnabled.value
   }
 
   def isScala3: Def.Initialize[Boolean] = Def.setting {

--- a/sbt-metals/src/sbt-test/sbt-metals/semanticdb/build.sbt
+++ b/sbt-metals/src/sbt-test/sbt-metals/semanticdb/build.sbt
@@ -26,13 +26,18 @@ lazy val b = project
     inConfig(Test) { checkSemanticdb := assertSemanticdbForScala3.value },
   )
 
-// not supported scala version
+// old scala version
 lazy val c = project
   .in(file("c"))
   .settings(
-    scalaVersion := "2.12.7",
-    inConfig(Compile) { checkSemanticdb := assertSemanticdbDisabled.value },
-    inConfig(Compile) { checkSemanticdb := assertSemanticdbDisabled.value },
+    scalaVersion := "2.12.8", // latest scalameta doesn't publish for ~2.12.7
+    inConfig(Compile) {
+      checkSemanticdb := {
+        assertSemanticdbForScala2.value
+        compile.value
+      }
+    },
+    inConfig(Test) { checkSemanticdb := assertSemanticdbForScala2.value },
   )
 
 // bsp disabled


### PR DESCRIPTION
https://github.com/scalameta/metals/issues/4449

Previously, requiresSemanticdb will be false if the given scala version is not yet listed in the `supportedScalaVersion` which comes from the BuildInfo of Metals.
This means, we have to wait for the next release (or using the snapshot build) for downloading the semanticdb-plugin for the latest scala compiler.
(For example, in order to use 2.13.9, we had to wait for the build that supports scalac 2.13.9).

With this change, Metals try to download the semanticdb-plugin anyway, and users won't need to wait for the next build for using the latest scala compiler.