### PR TITLE
refactor: Don't log "navigation doesn't work" if fallback to compiler based navigation

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -2637,9 +2637,6 @@ class MetalsLanguageServer(
             definitionResult(positionParams, token)
           }
         case None =>
-          if (semanticDBDoc.isEmpty) {
-            warnings.noSemanticdb(source)
-          }
           // Even if it failed to retrieve the symbol occurrence from semanticdb,
           // try to find its definitions from presentation compiler.
           definitionResult(positionParams, token)


### PR DESCRIPTION
related https://github.com/scalameta/metals/issues/2376

Previously, Metals says
"code navigation does not work for the file ... because the SemanticbDB file ... doesn't exist. There can be many reasons for this error."

When users try to go to definition and the target file doesn't have SemanticDB. This log message is a bit misleading.

- code navigation should work even if there's no semanticdb file
  - because Metals fall back to presentation-compiler-based navigation
  - https://github.com/scalameta/metals/blob/f48987e43d3b36c530da396ba94290d25e3332f9/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala#L96-L99
- if the code navigation actually doesn't work, it's PCDefinitionProvider's issue.
  - SemanticDB not found is also an issue though

As a result, even if it might be a `PCDefinitionProider` issue, users will report it as a SemanticDB issue.

This commit changed not to log "code navigation does not work ..." when Metals fall back to compiler-based code navigation. Metals still log "code navigation does not work ..." if it doesn't fall back to compiler-based code navigation https://github.com/scalameta/metals/blob/f48987e43d3b36c530da396ba94290d25e3332f9/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala#L100-L102

What do you think?