### PR TITLE
chore: Remove old workaround

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -452,29 +452,8 @@ class CompletionProvider(
       val isTypeMember = kind == CompletionListKind.Type
       params.checkCanceled()
       val matchingResults = completions.matchingResults { entered => name =>
-        val decoded = entered.decoded
-
-        /**
-         * NOTE(tgodzik): presentation compiler bug https://github.com/scala/scala/pull/8193
-         *  should be removed once we drop support for 2.12.8 and 2.13.0
-         *  in case we have a comment presentation compiler will see it as the name
-         *  CompletionIssueSuite.issue-813 for more details
-         */
-        val realEntered =
-          if (decoded.startsWith("//") || decoded.startsWith("/*")) { // start of a comment
-            // we reverse the situation and look for the word from start of complition to either '.' or ' '
-            val reversedString = decoded.reverse
-            val lastSpace = reversedString.indexOfSlice(" ")
-            val lastDot = reversedString.indexOfSlice(".")
-            val startOfWord =
-              if (lastSpace < lastDot && lastSpace >= 0) lastSpace else lastDot
-            reversedString.slice(0, startOfWord).reverse
-          } else {
-            entered.toString
-          }
-        if (isTypeMember)
-          CompletionFuzzy.matchesSubCharacters(realEntered, name)
-        else CompletionFuzzy.matches(realEntered, name)
+        if (isTypeMember) CompletionFuzzy.matchesSubCharacters(entered, name)
+        else CompletionFuzzy.matches(entered, name)
       }
 
       val latestParentTrees = getLastVisitedParentTrees(pos)


### PR DESCRIPTION
The workaround was needed until 2.12.8 and 2.13.0, which are no longer supported.

I was waiting on this for 3 years :sweat_smile: 