### PR TITLE
Proposal: New Code Action for Converting sbt Style to mill style Deps

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
@@ -50,6 +50,7 @@ final class CodeActionProvider(
     new ExtractMethodCodeAction(trees, compilers, languageClient),
     new ConvertToNamedArguments(trees, compilers, languageClient),
     new FlatMapToForComprehensionCodeAction(trees, buffers),
+    new MillifyDependencyCodeAction(buffers),
   )
 
   def codeActions(

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyDependencyCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyDependencyCodeAction.scala
@@ -1,0 +1,73 @@
+package scala.meta.internal.metals.codeactions
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.internal.metals.Buffers
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.codeactions.CodeAction
+import scala.meta.internal.parsing.Trees
+import scala.meta.pc.CancelToken
+import scala.meta.tokens.Token._
+
+import org.eclipse.{lsp4j => l}
+
+class MillifyDependencyCodeAction(buffers: Buffers) extends CodeAction {
+  override def kind: String = l.CodeActionKind.RefactorRewrite
+
+  override def contribute(params: l.CodeActionParams, token: CancelToken)(
+      implicit ec: ExecutionContext
+  ): Future[Seq[l.CodeAction]] = Future {
+    val path = params.getTextDocument().getUri().toAbsolutePath
+    val range = params.getRange()
+
+    val tokenized =
+      if (path.isScalaScript && range.getStart == range.getEnd)
+        buffers
+          .get(path)
+          .flatMap(Trees.defaultTokenizerDialect(_).tokenize.toOption)
+      else None
+
+    tokenized
+      .flatMap { tokens =>
+        tokens
+          .filter(t =>
+            t.pos.startLine == range.getStart.getLine
+              && t.pos.endLine == range.getEnd.getLine
+          )
+          .sliding(9)
+          .collectFirst {
+            case Seq(
+                  start @ Constant.String(groupId),
+                  (_: Space),
+                  Ident(artifactExtra),
+                  (_: Space),
+                  Constant.String(artifactId),
+                  (_: Space),
+                  Ident("%"),
+                  (_: Space),
+                  end @ Constant.String(version),
+                ) if Set("%", "%%", "%%%")(artifactExtra) =>
+              val groupArtifactJoin = artifactExtra.replace('%', ':')
+              val replacementText =
+                s"$groupId$groupArtifactJoin$artifactId:$version"
+              val pos = start.pos.toLsp
+              pos.setEnd(end.pos.toLsp.getEnd)
+              def action(text: String) = CodeActionBuilder.build(
+                title = MillifyDependencyCodeAction.title(text),
+                kind = this.kind,
+                changes = List(path -> List(new l.TextEdit(pos, text))),
+              )
+              val millAction =
+                if (path.isMill) List(action(s"ivy\"$replacementText\""))
+                else List.empty
+              action(s"`$replacementText`") :: millAction
+          }
+      }
+      .getOrElse(List.empty)
+  }
+}
+
+object MillifyDependencyCodeAction {
+  def title(transformed: String): String = s"Convert to $transformed"
+}

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -501,8 +501,9 @@ trait CommonMtagsEnrichments {
     def isScalaScript: Boolean = {
       filename.endsWith(".sc")
     }
+    def isMill: Boolean = isScalaScript && filename == "build.sc"
     def isAmmoniteScript: Boolean =
-      isScalaScript && !isWorksheet && filename != "build.sc"
+      isScalaScript && !isWorksheet && !isMill
     def isWorksheet: Boolean = {
       filename.endsWith(".worksheet.sc")
     }

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -101,7 +101,8 @@ object TestGroups {
       "tests.MtagsScala3Suite",
       "tests.codeactions.ConvertToNamedArgumentsLspSuite",
       "tests.testProvider.TestSuitesProviderSuite", "tests.MillVersionSuite",
-      "tests.FingerprintsLspSuite", "tests.JdkVersionSuite"),
+      "tests.FingerprintsLspSuite", "tests.JdkVersionSuite",
+      "tests.MillifyDependencyLspSuite"),
   )
 
 }

--- a/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -22,6 +22,7 @@ abstract class BaseCodeActionLspSuite(
       input: String,
       scalafixConf: String = "",
       scalacOptions: List[String] = Nil,
+      fileName: String = "A.scala",
       filterAction: CodeAction => Boolean = _ => true,
   )(implicit loc: Location): Unit = {
     val fileContent = input.replace("<<", "").replace(">>", "")
@@ -32,6 +33,7 @@ abstract class BaseCodeActionLspSuite(
       fileContent,
       scalafixConf = scalafixConf,
       scalacOptions = scalacOptions,
+      fileName = fileName,
       filterAction = filterAction,
     )
   }

--- a/tests/unit/src/test/scala/tests/codeactions/MillifyDependencyLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/MillifyDependencyLspSuite.scala
@@ -1,0 +1,65 @@
+package tests.codeactions
+
+import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
+import scala.meta.internal.metals.codeactions.ExtractValueCodeAction
+import scala.meta.internal.metals.codeactions.MillifyDependencyCodeAction
+import scala.meta.internal.metals.codeactions.RewriteBracesParensCodeAction
+import scala.meta.internal.metals.codeactions.StringActions
+
+class MillifyDependencyLspSuite
+    extends BaseCodeActionLspSuite("millifyDependency") {
+
+  check(
+    "script-import",
+    "import $ivy.\"org.scalameta\" %%<<>> \"metals\" % \"1.0\"",
+    MillifyDependencyCodeAction.title("`org.scalameta::metals:1.0`"),
+    "import $ivy.`org.scalameta::metals:1.0`",
+    fileName = "script.sc",
+  )
+
+  check(
+    "script-import-cursor-after-import",
+    "import $ivy.\"org.scalameta\" %% \"metals\" % \"1.0\"<<>>",
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.interpolationTitle}
+        |${MillifyDependencyCodeAction.title("`org.scalameta::metals:1.0`")}""".stripMargin,
+    "import $ivy.`org.scalameta::metals:1.0`",
+    fileName = "script.sc",
+    selectedActionIndex = 2,
+  )
+
+  check(
+    "mill-ivy",
+    """|import mill._, scalalib._
+       |
+       |object MyModule extends ScalaModule {
+       |  def ivyDeps = Agg(
+       |    "org.scalameta" %% "metals" % "1.0"<<>>
+       |  )
+       |}""".stripMargin,
+    s"""|${StringActions.multilineTitle}
+        |${StringActions.interpolationTitle}
+        |${RewriteBracesParensCodeAction.toBraces("Agg")}
+        |${ExtractValueCodeAction.title("\"org.scala` ...")}
+        |${ConvertToNamedArguments.title("Agg(...)")}
+        |${MillifyDependencyCodeAction.title("`org.scalameta::metals:1.0`")}
+        |${MillifyDependencyCodeAction.title("ivy\"org.scalameta::metals:1.0\"")}""".stripMargin,
+    """|import mill._, scalalib._
+       |
+       |object MyModule extends ScalaModule {
+       |  def ivyDeps = Agg(
+       |    ivy"org.scalameta::metals:1.0"
+       |  )
+       |}""".stripMargin,
+    fileName = "build.sc",
+    selectedActionIndex = 6,
+  )
+
+  checkNoAction(
+    "sbt-no-action",
+    """|object Main {
+       |  "org.scalameta" %%<<>> "metals" % "1.0"
+       |}""".stripMargin,
+    fileName = "build.sbt",
+  )
+}


### PR DESCRIPTION
I often copy-paste dependencies in the form `"org.scalameta" %% "metals" % "1.0"` into mill build files and scripts, which I then have to change to `"org.scalameta::metals:1.0"`.  For those as lazy as me, this PR adds a new code action to do this for you when you're in a script or mill build file: 

https://user-images.githubusercontent.com/17688577/193214315-faea3cca-c162-4ecd-9803-5e0f87c24bf9.mp4

Originally the implementation used `Trees.findLastEnclosingAt`, but I switched to matching on tokens as this gives better behaviour (both examples in the vid would not be recognized due to parsing failures).

A few limitations are that pasting straight into a comment (e.g. for scala cli using directives) would not be picked up, and groupid, artifactid and version all need to be string literals (perhaps this could be extended by accepting an identifier for version and interpolating?).

wdyt?