### PR TITLE
bugfix: Fix issues when renaming variables

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -518,24 +518,36 @@ final class RenameProvider(
       symbol: String,
   ): Option[s.Range] = {
     val name = range.inString(text)
-    val symbolName = symbol.desc.name
+    val nameString = symbol.desc.name.toString()
+    val isExplicitVarSetter =
+      name.exists(nm => nm.endsWith("_=") || nm.endsWith("_=`"))
     val isBackticked = name.exists(_.isBackticked)
+
+    val symbolName =
+      if (!isExplicitVarSetter) nameString.stripSuffix("_=")
+      else nameString
     val realName =
       if (isBackticked)
         name.map(_.stripBackticks)
       else name
-    if (symbol.isLocal || realName.contains(symbolName.toString)) {
+
+    if (symbol.isLocal || realName.contains(symbolName)) {
       /* We don't want to remove anything that is backticked, as we don't
        * know whether it's actuall needed (could be a pattern match). Here
        * we make sure that the backticks are not added twice.
        */
-      val realRange = if (isBackticked && !newName.isBackticked) {
+      val withoutBacktick = if (isBackticked && !newName.isBackticked) {
         range
           .withStartCharacter(range.startCharacter + 1)
           .withEndCharacter(range.endCharacter - 1)
       } else {
         range
       }
+
+      val realRange =
+        if (isExplicitVarSetter && !newName.endsWith("_="))
+          withoutBacktick.withEndCharacter(withoutBacktick.endCharacter - 2)
+        else withoutBacktick
       Some(realRange)
     } else {
       scribe.warn(s"Name doesn't match for $symbolName at $range")

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -812,6 +812,55 @@ class RenameLspSuite extends BaseRenameLspSuite(s"rename") {
        |""".stripMargin,
     newName = "NewSymbol",
   )
+
+  renamed(
+    "variable",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main {
+       |  var <<v@@5>> = false
+       |
+       |  def f5: Boolean = {
+       |    <<v5>> = true
+       |    <<v5>> == true
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "NewSymbol",
+  )
+
+  renamed(
+    "variable-explicit1",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main {
+       |  var <<v@@5>> = false
+       |
+       |  def f5: Boolean = {
+       |    <<v5>>_=(true)
+       |    <<v5>> == true
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "NewSymbol",
+  )
+
+  renamed(
+    "variable-explicit2",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main {
+       |  var <<v5>> = false
+       |
+       |  def f5: Boolean = {
+       |    `<<v@@5>>_=`(true)
+       |    <<v5>> == true
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "NewSymbol",
+  )
+
   override protected def libraryDependencies: List[String] =
     List("org.scalatest::scalatest:3.2.12", "io.circe::circe-generic:0.14.1")
 


### PR DESCRIPTION
Previously, when renaming variables we would check if the existing name would correspond to symbol name to make sure that we are not renaming soemthing by mistake. Now, we also take into account that the symbol might have the additional `_=`.

Fixes https://github.com/scalameta/metals/issues/4467