### PR TITLE
improvement: Always specify enum owner

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -270,10 +270,18 @@ object CaseKeywordCompletion:
 
     val sortedSubclasses = subclassesForType(tpe)
     sortedSubclasses.foreach { case sym =>
-      val autoImport = autoImportsGen.forSymbol(sym)
+      val (autoImport, name) =
+        // We don't want to import cases
+        if sym.isAllOf(Flags.EnumCase) then
+          (
+            autoImportsGen.forSymbol(sym.owner),
+            s"${sym.owner.nameBackticked}.${sym.nameBackticked}",
+          )
+        else (autoImportsGen.forSymbol(sym), sym.decodedName)
+
       val completionOption = completionGenerator.toCompletionValue(
         sym,
-        sym.decodedName,
+        name,
         autoImport.getOrElse(Nil),
       )
       completionOption.foreach(result += _)

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -317,12 +317,6 @@ class CompletionMatchSuite extends BaseCompletionSuite {
       |  x match@@
       |}""".stripMargin,
     s"""|package example
-        |
-        |import example.Color.Red
-        |
-        |import example.Color.Blue
-        |
-        |import example.Color.Green
         |enum Color(rank: Int):
         |  case Red extends Color(1)
         |  case Blue extends Color(2)
@@ -331,9 +325,9 @@ class CompletionMatchSuite extends BaseCompletionSuite {
         |object Main {
         |  val x: Color = ???
         |  x match
-        |\tcase Red => $$0
-        |\tcase Blue =>
-        |\tcase Green =>
+        |\tcase Color.Red => $$0
+        |\tcase Color.Blue =>
+        |\tcase Color.Green =>
         |
         |}
         |""".stripMargin,


### PR DESCRIPTION
Previously, we would import all cases, which is not the usual way of dealing with enums. Now, we always specify the owner enum.