### PR TITLE
Fix: Remove multiple enum owner imports

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -313,7 +313,7 @@ object CaseKeywordCompletion:
         val exhaustive = CompletionValue.MatchCompletion(
           "match (exhaustive)",
           insertText,
-          members.flatMap(_.additionalEdits),
+          members.flatMap(_.additionalEdits).distinct,
           s" ${tpe.typeSymbol.decodedName} (${members.length} cases)",
         )
         List(basicMatch, exhaustive)

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -306,24 +306,32 @@ class CompletionMatchSuite extends BaseCompletionSuite {
   checkEdit(
     "exhaustive-scala-enum".tag(IgnoreScala2),
     """
-      |package example
+      |package withenum {
       |enum Color(rank: Int):
       |  case Red extends Color(1)
       |  case Blue extends Color(2)
       |  case Green extends Color(3)
+      |}
+      |
+      |package example
       |
       |object Main {
-      |  val x: Color = ???
+      |  val x: withenum.Color = ???
       |  x match@@
       |}""".stripMargin,
-    s"""|package example
+    s"""|import withenum.Color
+        |
+        |package withenum {
         |enum Color(rank: Int):
         |  case Red extends Color(1)
         |  case Blue extends Color(2)
         |  case Green extends Color(3)
+        |}
+        |
+        |package example
         |
         |object Main {
-        |  val x: Color = ???
+        |  val x: withenum.Color = ???
         |  x match
         |\tcase Color.Red => $$0
         |\tcase Color.Blue =>


### PR DESCRIPTION
Previously exhaustive match completion on enum created multiple imports of enum owner
```scala
package withenum {
enum Color(rank: Int):
  case Red extends Color(1)
  case Blue extends Color(2)
  case Green extends Color(3)
}

package example
object Main {
  val x: withenum.Color = ???
  x match@@
}
```
Resulted in 
```scala
import withenum.Color
import withenum.Color
import withenum.Color

package withenum {
enum Color(rank: Int):
  case Red extends Color(1)
  case Blue extends Color(2)
  case Green extends Color(3)
}

package example
object Main {
  val x: withenum.Color = ???
  x match@@
}
```

Now, we do `distinct` on additional edits so duplicates will be removed