### PR TITLE
Import enum owner in case comp and in java enum match

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -173,12 +173,20 @@ object CaseKeywordCompletion:
       // Step 2: walk through known subclasses of sealed types.
       val sealedDescs = MetalsSealedDesc.sealedStrictDescendants(selectorSym)
       sealedDescs.foreach { sym =>
-        val autoImport = autoImportsGen.forSymbol(sym)
-        autoImport match
-          case Some(value) =>
-            visit(sym, sym.decodedName, value)
-          case scala.None =>
-            visit(sym, sym.showFullName, Nil)
+        // We don't want to import cases
+        if sym.isAllOf(Flags.EnumCase) || sym.isAllOf(Flags.EnumVal) then
+          visit(
+            sym,
+            s"${sym.owner.nameBackticked}.${sym.nameBackticked}",
+            autoImportsGen.forSymbol(sym.owner).getOrElse(Nil),
+          )
+        else
+          val autoImport = autoImportsGen.forSymbol(sym)
+          autoImport match
+            case Some(value) =>
+              visit(sym, sym.decodedName, value)
+            case scala.None =>
+              visit(sym, sym.showFullName, Nil)
       }
       val res = result.result()
 
@@ -272,7 +280,7 @@ object CaseKeywordCompletion:
     sortedSubclasses.foreach { case sym =>
       val (autoImport, name) =
         // We don't want to import cases
-        if sym.isAllOf(Flags.EnumCase) then
+        if sym.isAllOf(Flags.EnumCase) || sym.isAllOf(Flags.EnumVal) then
           (
             autoImportsGen.forSymbol(sym.owner),
             s"${sym.owner.nameBackticked}.${sym.nameBackticked}",

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -508,29 +508,41 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |  x match
       |    case@@
       |}""".stripMargin,
-    """|case Blue =>Color
-       |case Green =>Color
-       |case Red =>Color
+    """|case Color.Blue =>Color
+       |case Color.Green =>Color
+       |case Color.Red =>Color
        |""".stripMargin,
   )
 
-  check(
+  checkEdit(
     "scala-enum-with-param".tag(IgnoreScala2),
     """
-      |package example
+      |package withenum {
       |enum Foo:
       |  case Bla, Bar
       |  case Buzz(arg1: Int, arg2: Int)
-      |
+      |}
+      |package example
       |object Main {
-      |  val x: Foo = ???
+      |  val x: withenum.Foo = ???
       |  x match
       |    case@@
       |}""".stripMargin,
-    """|case Bar =>Foo
-       |case Bla =>Foo
-       |case Buzz(arg1, arg2) => example.Foo
-       |""".stripMargin,
+    """
+      |import withenum.Foo
+      |
+      |package withenum {
+      |enum Foo:
+      |  case Bla, Bar
+      |  case Buzz(arg1: Int, arg2: Int)
+      |}
+      |package example
+      |object Main {
+      |  val x: withenum.Foo = ???
+      |  x match
+      |    case Foo.Buzz(arg1, arg2) => $0
+      |}""".stripMargin,
+    filter = _.contains("Buzz"),
   )
 
   check(
@@ -572,8 +584,8 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |    a match
       |      cas@@
       |}""".stripMargin,
-    """|case B =>A
-       |case C =>A""".stripMargin,
+    """|case A.B =>A
+       |case A.C =>A""".stripMargin,
   )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -289,15 +289,12 @@ class CompletionMatchSuite extends BaseCompletionSuite {
                 |package example
                 |
                 |import java.nio.file.AccessMode
-                |import java.nio.file.AccessMode.READ
-                |import java.nio.file.AccessMode.WRITE
-                |import java.nio.file.AccessMode.EXECUTE
                 |
                 |object Main {
                 |  (null: AccessMode) match
-                |\tcase READ => $$0
-                |\tcase WRITE =>
-                |\tcase EXECUTE =>
+                |\tcase AccessMode.READ => $$0
+                |\tcase AccessMode.WRITE =>
+                |\tcase AccessMode.EXECUTE =>
                 |
                 |}""".stripMargin
     ),


### PR DESCRIPTION
Continuation of https://github.com/scalameta/metals/pull/4475
Now we import enum owner also in single case completions.
Also, apply the same import logic to java enums