### PR TITLE
bugfix: Properly import extension methods in string interpolation

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
@@ -309,6 +309,7 @@ class CompletionProvider(
                     nameEdit,
                     isFromWorkspace = true,
                     v.additionalEdits ++ other.toList,
+                    filterText = v.filterText,
                   )
                 case _ =>
                   mkItem(
@@ -319,6 +320,7 @@ class CompletionProvider(
                     isFromWorkspace = true,
                     v.additionalEdits ++ edits.edits,
                     range = v.range,
+                    filterText = v.filterText,
                   )
             case None =>
               val r = indexedContext.lookupSym(sym)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
@@ -179,7 +179,7 @@ object InterpolatorCompletions:
                 Nil,
                 Some(cursor.withStart(identOrSelect.span.start).toLsp),
                 // Needed for VS Code which will not show the completion otherwise
-                Some(identOrSelect.show + "." + label),
+                Some(identOrSelect.name.toString() + "." + label),
                 isExtension = isExtension,
               ),
           )

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -732,6 +732,8 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |def aaa = 123
        |def main = s" ${aaa.incr$0}"
        |""".stripMargin,
+    // simulate issues with VS Code
+    filterText = "aaa.incr",
   )
 
   checkEdit(
@@ -756,6 +758,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
        |def aaa = 123
        |def main = s"  ${aaa.plus($0)}"
        |""".stripMargin,
+    filterText = "aaa.plus",
   )
 
   check(


### PR DESCRIPTION
Visual Studio code seems to have issue filtering text in string interpolations, which doesn't seem to be a problem in any other editors.