### PR TITLE
bugfix: Clean diagnostics after importing a script

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
@@ -52,6 +52,7 @@ final class Ammonite(
     focusedDocument: () => Option[AbsolutePath],
     config: MetalsServerConfig,
     scalaVersionSelector: ScalaVersionSelector,
+    parseTreesAndPublishDiags: Seq[AbsolutePath] => Future[Unit],
 )(implicit ec: ExecutionContextExecutorService)
     extends Cancelable {
 
@@ -136,6 +137,7 @@ final class Ammonite(
             compilations
               .cascadeCompileFiles(toCompile) ::
               compilers.load(toCompile) ::
+              parseTreesAndPublishDiags(toCompile) ::
               Nil
           )
         } yield ()

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -56,6 +56,7 @@ class ScalaCli(
     languageClient: LanguageClient,
     config: () => MetalsServerConfig,
     userConfig: () => UserConfiguration,
+    parseTreesAndPublishDiags: Seq[AbsolutePath] => Future[Unit],
 )(implicit ec: ExecutionContextExecutorService)
     extends Cancelable {
 
@@ -129,6 +130,7 @@ class ScalaCli(
                 compilations
                   .cascadeCompileFiles(toCompile) ::
                   compilers().load(toCompile) ::
+                  parseTreesAndPublishDiags(allSources0) ::
                   Nil
               )
             } yield ()


### PR DESCRIPTION
Previously, if there was a parsing issue reported by the default Scala version it would not be cleaned out after importing the script. Now, we reparse the file with the proper dialect after importing.

Fixes https://github.com/scalameta/metals/issues/4482