### PR TITLE
feature: Connect automatically when `.bsp` folder shows up

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -303,6 +303,7 @@ final case class Indexer(
       clientConfig.initialConfig.statistics.isIndex,
     ) {
       try {
+        fileWatcher.cancel()
         fileWatcher.start()
       } catch {
         // note(@tgodzik) This is needed in case of ammonite

--- a/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
@@ -50,6 +50,18 @@ final class FileWatcher(
     stopWatcher()
   }
 
+  def start(
+      files: Set[AbsolutePath]
+  ): Unit = {
+    stopWatcher = startWatch(
+      config,
+      workspaceDeferred().toNIO,
+      PathsToWatch(files.map(_.toNIO), Set.empty),
+      onFileWatchEvent,
+      watchFilter,
+    )
+  }
+
   def start(): Unit = {
     stopWatcher = startWatch(
       config,

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -483,6 +483,10 @@ trait CommonMtagsEnrichments {
       }
     def isBuild: Boolean =
       path.filename.startsWith("BUILD")
+
+    def isBsp: Boolean =
+      path.filename.startsWith(".bsp")
+
     def isScalaOrJava: Boolean = {
       toLanguage match {
         case Language.SCALA | Language.JAVA => true


### PR DESCRIPTION
Previously, if a user opened metals and then run .bsp generation they would need to restart metals or manually connect to build server. Now, we start watching for .bsp when no build tool exists and when it shows up we connect to the build server defined there.