### PR TITLE
Fix show declaration type on outgoing calls request

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/callHierarchy/OutgoingCallsFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/callHierarchy/OutgoingCallsFinder.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.metals.callHierarchy
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import scala.meta.Decl
 import scala.meta.Member
 import scala.meta.Name
 import scala.meta.Pat
@@ -169,6 +170,7 @@ class OutgoingCallsFinder(
         Future
           .sequence(
             (definition match {
+              case _: Decl => Nil
               case member: Member =>
                 memberSearch(member)
               case other => List(search(other))

--- a/tests/unit/src/test/scala/tests/CallHierarchyLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CallHierarchyLspSuite.scala
@@ -532,4 +532,44 @@ class CallHierarchyLspSuite extends BaseCallHierarchySuite("call-hierarchy") {
     } yield ()
   }
 
+  test("decl-incoming-call") {
+    for {
+      _ <- assertIncomingCalls(
+        """|/a/src/main/scala/a/Demo.scala
+           |package a
+           |
+           |trait Service[R] {
+           |  def ge@@t(): R
+           |}
+           |
+           |object Demo {
+           |  val r: Service[String] = ???
+           |  def <<main>>/*1*/() = r.<?<get>?>/*1*/()
+           |}
+           |
+           |""".stripMargin
+      )
+    } yield ()
+  }
+
+  test("decl-outgoing-call") { // https://github.com/scalameta/metals/issues/4489
+    for {
+      _ <- assertOutgoingCalls(
+        """|/a/src/main/scala/a/Demo.scala
+           |package a
+           |
+           |trait Service[R] {
+           |  def ge@@t(): R
+           |}
+           |
+           |object Demo {
+           |  val r: Service[String] = ???
+           |  def main() = r.get()
+           |}
+           |
+           |""".stripMargin
+      )
+    } yield ()
+  }
+
 }


### PR DESCRIPTION
This will fix #4489 by simply don't search for outgoing calls in the case of declaration.