### PR TITLE
fix: soft-keyword-matching autoimports in Scala 3

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -123,13 +123,15 @@ object MtagsEnrichments extends CommonMtagsEnrichments:
       pos.offset() <= other.start && pos.endOffset() >= other.end
 
   extension (sym: Symbol)(using Context)
-    def fullNameBackticked: String =
+    def fullNameBackticked: String = fullNameBackticked(Set.empty)
+
+    def fullNameBackticked(exclusions: Set[String]): String =
       @tailrec
       def loop(acc: List[String], sym: Symbol): List[String] =
         if sym == NoSymbol || sym.isRoot || sym.isEmptyPackage then acc
         else if sym.isPackageObject then loop(acc, sym.owner)
         else
-          val v = KeywordWrapper.Scala3.backtickWrap(sym.decodedName)
+          val v = this.nameBackticked(sym)(exclusions)
           loop(v :: acc, sym.owner)
       loop(Nil, sym).mkString(".")
 
@@ -138,8 +140,10 @@ object MtagsEnrichments extends CommonMtagsEnrichments:
     def companion: Symbol =
       if sym.is(Module) then sym.companionClass else sym.companionModule
 
-    def nameBackticked: String =
-      KeywordWrapper.Scala3.backtickWrap(sym.decodedName)
+    def nameBackticked: String = nameBackticked(Set.empty)
+
+    def nameBackticked(exclusions: Set[String]): String =
+      KeywordWrapper.Scala3.backtickWrap(sym.decodedName, exclusions)
 
     def withUpdatedTpe(tpe: Type): Symbol =
       val upd = sym.copy(info = tpe)

--- a/mtags/src/main/scala/scala/meta/internal/mtags/KeywordWrapper.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/KeywordWrapper.scala
@@ -43,8 +43,12 @@ trait KeywordWrapper {
     !valid
   }
 
-  final def backtickWrap(s: String): String = {
-    if (s.isEmpty) "``"
+  final def backtickWrap(
+      s: String,
+      exclusions: Set[String] = Set.empty
+  ): String = {
+    if (exclusions.contains(s)) s
+    else if (s.isEmpty) "``"
     else if (s(0) == '`' && s.last == '`') s
     else if (needsBacktick(s)) "" + ('`') + s + '`'
     else s
@@ -63,15 +67,20 @@ object KeywordWrapper {
     "\u2190"
   )
 
-  val Scala3Keywords: Set[String] = Set(
+  // List of Scala 3 keywords
+  // https://dotty.epfl.ch/docs/internals/syntax.html#keywords
+  val Scala3HardKeywords: Set[String] = Set(
     "abstract", "case", "catch", "class", "def", "do", "else", "enum", "export",
     "extends", "false", "final", "finally", "for", "given", "if", "implicit",
     "import", "lazy", "match", "new", "null", "object", "override", "package",
     "private", "protected", "return", "sealed", "super", "then", "throw",
     "trait", "true", "try", "type", "val", "var", "while", "with", "yield", ":",
-    "=", "<-", "=>", "<:", ":>", "#", "@", "=>>", "?=>", "extension", "inline",
-    "|", "*", "+", "-"
+    "=", "<-", "=>", "<:", ":>", "#", "@", "=>>", "?=>"
   )
+
+  val Scala3SoftKeywords: Set[String] =
+    Set("as", "derives", "end", "extension", "infix", "inline", "opaque",
+      "open", "throws", "transparent", "using", "|", "*", "+", "-")
 
   class Scala2 extends KeywordWrapper {
     val keywords: Set[String] = Scala2Keywords
@@ -79,7 +88,7 @@ object KeywordWrapper {
   object Scala2 extends Scala2
 
   class Scala3 extends KeywordWrapper {
-    val keywords: Set[String] = Scala3Keywords
+    val keywords: Set[String] = Scala3HardKeywords ++ Scala3SoftKeywords
   }
   object Scala3 extends Scala3
 }

--- a/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
@@ -1,5 +1,6 @@
 package tests.pc
 
+import munit.Location
 import tests.BaseAutoImportsSuite
 
 class AutoImportsSuite extends BaseAutoImportsSuite {
@@ -366,5 +367,23 @@ class AutoImportsSuite extends BaseAutoImportsSuite {
         |$code
         |}
         |""".stripMargin
+
+  // https://dotty.epfl.ch/docs/internals/syntax.html#soft-keywords
+  List("infix", "inline", "opaque", "open", "transparent", "as", "derives",
+    "end", "extension", "throws", "using").foreach(softKeywordCheck)
+
+  private def softKeywordCheck(keyword: String)(implicit loc: Location) =
+    checkEdit(
+      s"'$keyword'-named-object".tag(IgnoreScala2),
+      s"""|
+          |object $keyword{ object ABC }
+          |object Main{ val obj = <<ABC>> }
+          |""".stripMargin,
+      s"""|import $keyword.ABC
+          |
+          |object $keyword{ object ABC }
+          |object Main{ val obj = ABC }
+          |""".stripMargin,
+    )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
@@ -1,16 +1,17 @@
 package tests.pc
 
+import munit.Location
 import tests.BaseCompletionSuite
 
 class CompletionBacktickSuite extends BaseCompletionSuite {
 
   check(
     "keyword",
-    s"""|object Main {
-        |  val `type` = 42
-        |  Main.typ@@
-        |}
-        |""".stripMargin,
+    """|object Main {
+       |  val `type` = 42
+       |  Main.typ@@
+       |}
+       |""".stripMargin,
     """|`type`: Int
        |""".stripMargin,
     filterText = "type",
@@ -21,11 +22,11 @@ class CompletionBacktickSuite extends BaseCompletionSuite {
 
   checkEdit(
     "keyword-edit",
-    s"""|object Main {
-        |  val `type` = 42
-        |  Main.typ@@
-        |}
-        |""".stripMargin,
+    """|object Main {
+       |  val `type` = 42
+       |  Main.typ@@
+       |}
+       |""".stripMargin,
     """|object Main {
        |  val `type` = 42
        |  Main.`type`
@@ -105,5 +106,25 @@ class CompletionBacktickSuite extends BaseCompletionSuite {
     "",
     filter = _.contains("`type`"),
   )
+
+  // https://dotty.epfl.ch/docs/internals/syntax.html#soft-keywords
+  List("infix", "inline", "opaque", "open", "transparent", "as", "derives",
+    "end", "extension", "throws", "using").foreach(softKeywordCheck)
+
+  private def softKeywordCheck(keyword: String)(implicit loc: Location) =
+    checkEdit(
+      s"'$keyword'-keyword-named-method-edit".tag(IgnoreScala2),
+      s"""|object Main {
+          |  def $keyword(a: String) = a
+          |  ${keyword}@@
+          |}
+          |""".stripMargin,
+      s"""|object Main {
+          |  def $keyword(a: String) = a
+          |  `$keyword`
+          |}
+          |""".stripMargin,
+      filter = _.contains("a: String"),
+    )
 
 }


### PR DESCRIPTION
Hello 🖖🏻 
This PR resolves https://github.com/scalameta/metals/issues/4348

I cannot think of any cases where soft keywords should be backticked, since these words are allowed to be identifiers as well.
Therefore removing soft keywords "inline" and "extension" from the list of keywords seemed to be the right thing to do

Please, let me know if that's not an appropriate solution
