### PR TITLE
Show Scala completions first in ScalaCli using directives

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
@@ -11,10 +11,12 @@ trait ScalaCliCompletions {
     def unapply(path: List[Tree]): Option[String] =
       path match {
         case Nil =>
-          CoursierComplete.isScalaCliDep(pos.lineContent.replace(CURSOR, ""))
+          CoursierComplete.isScalaCliDep(
+            pos.lineContent.replace(CURSOR, "").take(pos.column - 1)
+          )
         case (_: PackageDef) :: Nil if pos.source.file.path.endsWith(".sc") =>
           CoursierComplete.isScalaCliDep(
-            pos.lineContent.replace(CURSOR, "").take(pos.column)
+            pos.lineContent.replace(CURSOR, "").take(pos.column - 1)
           )
         case _ => None
       }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CoursierComplete.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CoursierComplete.scala
@@ -38,7 +38,7 @@ object CoursierComplete {
       if (dependency.endsWith(":") && dependency.count(_ == ':') == 1)
         completions(dependency + ":").map(":" + _)
       else List.empty
-    javaCompletions ++ scalaCompletions
+    scalaCompletions ++ javaCompletions
   }
   def inferEditRange(point: Int, text: String): (Int, Int) = {
     def isArtifactPart(c: Char): Boolean =
@@ -62,8 +62,9 @@ object CoursierComplete {
     line match {
       case reg(deps) =>
         val dep =
-          deps.split(",").last.trim().stripPrefix("\"").stripSuffix("\"")
-        Some(dep)
+          deps.split(",").last
+        if (dep.endsWith("\"") || dep.endsWith(" ")) None
+        else Some(dep.trim.stripPrefix("\""))
       case _ =>
         None
     }

--- a/tests/cross/src/test/scala/tests/pc/CompletionScalaCliSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScalaCliSuite.scala
@@ -66,4 +66,20 @@ class CompletionScalaCliSuite extends BaseCompletionSuite {
     filename = "script.sc",
   )
 
+  check(
+    "closing-quote",
+    """|//> using lib "io.circe::circe-core:0.14.0"@@
+       |package A
+       |""".stripMargin,
+    "",
+  )
+
+  check(
+    "whitespace",
+    """|//> using lib "io.circe::circe-co @@
+       |package A
+       |""".stripMargin,
+    "",
+  )
+
 }


### PR DESCRIPTION
Now in `//> using lib "io.circe:@@"` scala completions (with adding second `:`) will show before java completions.
Also, fixes some issues e.g. showing completions after closing `"`