### PR TITLE
bugfix: Properly extract multiline ranges

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -693,11 +693,16 @@ object MetalsEnrichments
     def inString(text: String): Option[String] = {
       var i = 0
       var max = 0
+      def isNewline = text.charAt(i) == '\n'
       while (max < range.startLine) {
-        if (text.charAt(i) == '\n') max += 1
+        if (isNewline) max += 1
         i += 1
       }
       val start = i + range.startCharacter
+      while (max < range.endLine) {
+        if (isNewline) max += 1
+        i += 1
+      }
       val end = i + range.endCharacter
       if (start < text.size && end <= text.size)
         Some(text.substring(start, end))


### PR DESCRIPTION
Previously, if we used `inString` with a range that spans multiple lines, we would get a wrong substring. Now, we correctly handle end offset.

Fixes https://github.com/scalameta/metals/issues/4487

Unfortunately, I don't have a test case for that.