### PR TITLE
feature: Add support for type definition

### DIFF
--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -61,6 +61,13 @@ functionality.
     <td align="center">✅</td>
   </tr>
   <tr>
+    <td>Goto type definition</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+  </tr>
+  <tr>
     <td>Completions</td>
     <td align="center">✅</td>
     <td align="center">✅*</td>

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -491,10 +491,29 @@ class Compilers(
   def definition(
       params: TextDocumentPositionParams,
       token: CancelToken,
+  ): Future[DefinitionResult] = {
+    definition(params = params, token = token, findTypeDef = false)
+  }
+
+  def typeDefinition(
+      params: TextDocumentPositionParams,
+      token: CancelToken,
+  ): Future[DefinitionResult] = {
+    definition(params = params, token = token, findTypeDef = true)
+  }
+
+  private def definition(
+      params: TextDocumentPositionParams,
+      token: CancelToken,
+      findTypeDef: Boolean,
   ): Future[DefinitionResult] =
     withPCAndAdjustLsp(params) { (pc, pos, adjust) =>
-      pc.definition(CompilerOffsetParams.fromPos(pos, token))
-        .asScala
+      val params = CompilerOffsetParams.fromPos(pos, token)
+      val defResult =
+        if (findTypeDef) pc.typeDefinition(params)
+        else
+          pc.definition(CompilerOffsetParams.fromPos(pos, token))
+      defResult.asScala
         .map { c =>
           adjust.adjustLocations(c.locations())
           val definitionPaths = c

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1499,14 +1499,12 @@ class MetalsLanguageServer(
       definitionOrReferences(position, token).map(_.locations)
     }
 
-  @nowarn("msg=parameter value position")
   @JsonRequest("textDocument/typeDefinition")
   def typeDefinition(
       position: TextDocumentPositionParams
   ): CompletableFuture[util.List[Location]] =
-    CancelTokens { _ =>
-      scribe.warn("textDocument/typeDefinition is not supported.")
-      null
+    CancelTokens.future { token =>
+      compilers.typeDefinition(position, token).map(_.locations)
     }
 
   @JsonRequest("textDocument/implementation")

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -875,6 +875,7 @@ class MetalsLanguageServer(
         capabilities.setSelectionRangeProvider(true)
         capabilities.setCodeLensProvider(new CodeLensOptions(false))
         capabilities.setDefinitionProvider(true)
+        capabilities.setTypeDefinitionProvider(true)
         capabilities.setImplementationProvider(true)
         capabilities.setHoverProvider(true)
         capabilities.setReferencesProvider(true)

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -75,9 +75,15 @@ public abstract class PresentationCompiler {
      */
     public abstract CompletableFuture<DefinitionResult> definition(OffsetParams params);
 
+
     /**
-	 * Returns the occurrences of the symbol under the current position in the entire file.
-	 */
+     * Returns location of the expression's type definition at the given position.
+     */
+     public abstract CompletableFuture<DefinitionResult> typeDefinition(OffsetParams params);
+
+    /**
+    * Returns the occurrences of the symbol under the current position in the entire file.
+     */
     public abstract CompletableFuture<java.util.List<DocumentHighlight>> documentHighlight(OffsetParams params);
 
     /**

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -880,6 +880,62 @@ class MetalsGlobal(
     else memberType
   }
 
+  /**
+   * Traverses up the parent tree nodes to the largest enclosing application node.
+   *
+   * Example: {{{
+   *   original = println(List(1).map(_.toString))
+   *   pos      = List(1).map
+   *   expanded = List(1).map(_.toString)
+   * }}}
+   */
+  def expandRangeToEnclosingApply(pos: Position): Tree = {
+    def tryTail(enclosing: List[Tree]): Option[Tree] =
+      enclosing match {
+        case Nil => None
+        case head :: tail =>
+          head match {
+            case TreeApply(qual, _) if qual.pos.includes(pos) =>
+              tryTail(tail).orElse(Some(head))
+            case New(_) =>
+              tail match {
+                case Nil => None
+                case Select(_, _) :: next =>
+                  tryTail(next)
+                case _ =>
+                  None
+              }
+            case _ =>
+              None
+          }
+      }
+    lastVisitedParentTrees match {
+      case head :: tail =>
+        tryTail(tail).getOrElse(head)
+      case _ =>
+        EmptyTree
+    }
+  }
+
+  def seenFromType(tree0: Tree, symbol: Symbol): Type = {
+    def qual(t: Tree): Tree =
+      t match {
+        case TreeApply(q, _) => qual(q)
+        case Select(q, _) => q
+        case Import(q, _) => q
+        case t => t
+      }
+    try {
+      val tree = qual(tree0)
+      val pre = stabilizedType(tree)
+      val memberType = pre.memberType(symbol)
+      if (memberType.isErroneous) symbol.info
+      else memberType
+    } catch {
+      case NonFatal(_) => symbol.info
+    }
+  }
+
   // Extractor for both term and type applications like `foo(1)` and foo[T]`
   object TreeApply {
     def unapply(tree: Tree): Option[(Tree, List[Tree])] =

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -11,7 +11,33 @@ import org.eclipse.lsp4j.Location
 
 class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
   import compiler._
-  def definition(): DefinitionResult = {
+
+  def definition(): DefinitionResult =
+    definition(findTypeDef = false)
+
+  def typeDefinition(): DefinitionResult =
+    definition(findTypeDef = true)
+
+  private def typeSymbol(tree: Tree, pos: Position) = {
+    val expanded = expandRangeToEnclosingApply(pos)
+    if (!tree.isEmpty && expanded.symbol != null) {
+      val tpe =
+        if (expanded.tpe != NoType && expanded.tpe != null) expanded.tpe
+        else expanded.symbol.tpe
+      val tpeSym = tpe.widen.finalResultType.typeSymbol
+      if (tpeSym.isTypeParameter)
+        seenFromType(expanded, tpeSym).typeSymbol
+      else if (tpeSym != NoSymbol) tpeSym
+      else tree.symbol
+    } else
+      expanded match {
+        case _: Literal => expanded.tpe.widen.typeSymbol
+        case _ => tree.symbol
+      }
+
+  }
+
+  private def definition(findTypeDef: Boolean): DefinitionResult = {
     if (params.isWhitespace || params.isDelimiter || params.offset() == 0) {
       DefinitionResultImpl.empty
     } else {
@@ -23,31 +49,33 @@ class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
       typeCheck(unit)
       val pos = unit.position(params.offset())
       val tree = definitionTypedTreeAt(pos)
+      val symbol =
+        if (findTypeDef) typeSymbol(tree, pos) else tree.symbol
       if (
-        tree.symbol == null ||
-        tree.symbol == NoSymbol ||
-        tree.symbol.isErroneous
+        symbol == null ||
+        symbol == NoSymbol ||
+        symbol.isErroneous
       ) {
         DefinitionResultImpl.empty
-      } else if (tree.symbol.hasPackageFlag) {
+      } else if (symbol.hasPackageFlag) {
         DefinitionResultImpl(
-          semanticdbSymbol(tree.symbol),
+          semanticdbSymbol(symbol),
           ju.Collections.emptyList()
         )
       } else if (
-        tree.symbol.pos != null &&
-        tree.symbol.pos.isDefined &&
-        tree.symbol.pos.source.eq(unit.source)
+        symbol.pos != null &&
+        symbol.pos.isDefined &&
+        symbol.pos.source.eq(unit.source)
       ) {
         DefinitionResultImpl(
-          semanticdbSymbol(tree.symbol),
+          semanticdbSymbol(symbol),
           ju.Collections.singletonList(
-            new Location(params.uri().toString(), tree.symbol.pos.focus.toLsp)
+            new Location(params.uri().toString(), symbol.pos.focus.toLsp)
           )
         )
       } else {
         val res = new ju.ArrayList[Location]()
-        tree.symbol.alternatives
+        symbol.alternatives
           .map(semanticdbSymbol)
           .sorted
           .foreach { sym =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -231,6 +231,15 @@ case class ScalaPresentationCompiler(
     ) { pc => new PcDefinitionProvider(pc.compiler(), params).definition() }
   }
 
+  override def typeDefinition(
+      params: OffsetParams
+  ): CompletableFuture[DefinitionResult] = {
+    compilerAccess.withNonInterruptableCompiler(
+      DefinitionResultImpl.empty,
+      params.token
+    ) { pc => new PcDefinitionProvider(pc.compiler(), params).typeDefinition() }
+  }
+
   override def documentHighlight(
       params: OffsetParams
   ): CompletableFuture[util.List[DocumentHighlight]] =

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -688,6 +688,9 @@ trait Completions { this: MetalsGlobal =>
         t match {
           // new User(age = 42, name = "") becomes transparent, which doesn't happen with normal methods
           case Apply(Select(_: New, _), _) => true
+          // for named args apply becomes transparent but fun doesn't
+          case Apply(fun, args) =>
+            !fun.pos.isTransparent && args.forall(_.pos.isOffset)
           case _ => false
         }
       }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -191,14 +191,9 @@ object MetalsInteractive:
           val sym = funSym.owner.info.member(name).symbol
           List((sym, sym.info))
         else
-          val classTree = funSym.topLevelClass.asClass.rootTree
           val paramSymbol =
-            for
-              case DefDef(_, paramss, _, _) <- tpd
-                .defPath(funSym, classTree)
-                .lastOption
-              param <- paramss.flatten.find(_.name == name)
-            yield param.symbol
+            for param <- funSym.paramSymss.flatten.find(_.name == name)
+            yield param
           val sym = paramSymbol.getOrElse(fn.symbol)
           List((sym, sym.info))
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -66,7 +66,7 @@ class PcDefinitionProvider(
       driver: InteractiveDriver,
       indexed: IndexedContext,
   ): DefinitionResult =
-    given ctx: Context = indexed.ctx
+    import indexed.ctx
     definitionsForSymbol(
       MetalsInteractive.enclosingSymbols(path, pos, indexed),
       pos,
@@ -80,7 +80,7 @@ class PcDefinitionProvider(
       driver: InteractiveDriver,
       indexed: IndexedContext,
   ): DefinitionResult =
-    given ctx: Context = indexed.ctx
+    import indexed.ctx
     val enclosing = path.expandRangeToEnclosingApply(pos)
     val typeSymbols = MetalsInteractive
       .enclosingSymbolsWithExpressionType(enclosing, pos, indexed)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -118,6 +118,17 @@ case class ScalaPresentationCompiler(
       PcDefinitionProvider(driver, params, search).definitions()
     }
 
+  override def typeDefinition(
+      params: OffsetParams
+  ): CompletableFuture[DefinitionResult] =
+    compilerAccess.withNonInterruptableCompiler(
+      DefinitionResultImpl.empty,
+      params.token,
+    ) { access =>
+      val driver = access.compiler()
+      PcDefinitionProvider(driver, params, search).typeDefinitions()
+    }
+
   def documentHighlight(
       params: OffsetParams
   ): CompletableFuture[ju.List[DocumentHighlight]] =

--- a/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BasePcDefinitionSuite.scala
@@ -2,10 +2,10 @@ package tests.pc
 
 import java.net.URI
 
-import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.CompilerOffsetParams
 import scala.meta.internal.metals.TextEdits
 import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.pc.OffsetParams
 
 import munit.Location
 import munit.TestOptions
@@ -15,6 +15,8 @@ import tests.BasePCSuite
 import tests.pc.CrossTestEnrichments._
 
 abstract class BasePcDefinitionSuite extends BasePCSuite {
+
+  def definitions(offsetParams: OffsetParams): List[l.Location]
 
   def check(
       options: TestOptions,
@@ -33,10 +35,9 @@ abstract class BasePcDefinitionSuite extends BasePCSuite {
       import scala.meta.inputs.Input
       val offsetRange =
         Position.Range(Input.String(cleanedCode), offset, offset).toLsp
-      val defn = presentationCompiler
-        .definition(CompilerOffsetParams(URI.create(uri), cleanedCode, offset))
-        .get()
-      val edits = defn.locations().asScala.toList.flatMap { location =>
+      val locs =
+        definitions(CompilerOffsetParams(URI.create(uri), cleanedCode, offset))
+      val edits = locs.flatMap { location =>
         if (location.getUri() == uri) {
           List(
             new TextEdit(

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -59,9 +59,6 @@ class HoverTermSuite extends BaseHoverSuite {
       |""".stripMargin,
     """|def apply(name: String): Person
        |""".stripMargin.hover,
-    compat = Map(
-      "3" -> "case class Person: Person".hover
-    ),
   )
 
   check(
@@ -506,4 +503,5 @@ class HoverTermSuite extends BaseHoverSuite {
     "val second: Boolean".hover,
     automaticPackage = false,
   )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -236,7 +236,7 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
     "named-arg-local",
     """|
        |object Main {
-       |  def <<>>foo(arg: Int): Unit = ()
+       |  def foo(<<>>arg: Int): Unit = ()
        |
        |  foo(a@@rg = 42)
        |}
@@ -254,21 +254,53 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
   )
 
   check(
+    "named-arg-multiple",
+    """|object Main {
+       |  def tst(par1: Int, par2: String, <<>>par3: Boolean): Unit = {}
+       |
+       |  tst(1, p@@ar3 = true, par2 = "")
+       |}""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|object Main {
+           |  def tst(par1: Int, par2: String, <<par3>>: Boolean): Unit = {}
+           |
+           |  tst(1, p@@ar3 = true, par2 = "")
+           |}""".stripMargin
+    ),
+  )
+
+  check(
+    "named-arg-reversed",
+    """|object Main {
+       |  def tst(par1: Int, <<>>par2: String): Unit = {}
+       |
+       |  tst(pa@@r2 = "foo", par1 = 1)
+       |}
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|object Main {
+           |  def tst(par1: Int, <<par2>>: String): Unit = {}
+           |
+           |  tst(par2 = "foo", par1 = 1)
+           |}
+           |""".stripMargin
+    ),
+  )
+
+  check(
     "named-arg-global",
-    // NOTE(olafur) ideally we should navigate to the parameter symbol instead of the
-    // enclosing method symbol, but I can live with this behavior.
-    """|
-       |object Main {
-       |  assert(/*scala/Predef.assert(). Predef.scala*/@@assertion = true)
+    """|object Main {
+       |  assert(/*scala/Predef.assert().(assertion) Predef.scala*/@@assertion = true)
        |}
        |""".stripMargin,
     compat = Map(
       // in 3.0 here we obtain patched assert
       // see: https://github.com/scalameta/metals/issues/2918
       "3" ->
-        """|
-           |object Main {
-           |  assert(/*scala/Predef.assert(+1). Predef.scala*/@@assertion = true)
+        """|object Main {
+           |  assert(/*scala/Predef.assert(+1).(assertion) Predef.scala*/assertion = true)
            |}
            |""".stripMargin
     ),
@@ -359,23 +391,41 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
   )
 
   check(
-    "case-class-apply".tag(IgnoreScala2),
+    "case-class-apply",
     """|
-       |case class Foo(<<a>>: Int, b: String)
+       |case class Foo(<<>>a: Int, b: String)
        |class Main {
        |  Foo(@@a = 3, b = "42")
        |}
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|
+           |case class Foo(<<a>>: Int, b: String)
+           |class Main {
+           |  Foo(@@a = 3, b = "42")
+           |}
+           |""".stripMargin
+    ),
   )
 
   check(
-    "case-class-copy".tag(IgnoreScala2),
+    "case-class-copy",
     """|
-       |case class Foo(<<a>>: Int, b: String)
+       |case class Foo(<<>>a: Int, b: String)
        |class Main {
        |  Foo(2, "4").copy(@@a = 3, b = "42")
        |}
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|
+           |case class Foo(<<a>>: Int, b: String)
+           |class Main {
+           |  Foo(2, "4").copy(@@a = 3, b = "42")
+           |}
+           |""".stripMargin
+    ),
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -1,10 +1,23 @@
 package tests.pc
 
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.pc.OffsetParams
+
+import org.eclipse.lsp4j.Location
+
 class PcDefinitionSuite extends BasePcDefinitionSuite {
 
   override def requiresJdkSources: Boolean = true
 
   override def requiresScalaLibrarySources: Boolean = true
+
+  override def definitions(offsetParams: OffsetParams): List[Location] =
+    presentationCompiler
+      .definition(offsetParams)
+      .get()
+      .locations()
+      .asScala
+      .toList
 
   check(
     "basic",

--- a/tests/cross/src/test/scala/tests/typedef/TypeDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/typedef/TypeDefinitionSuite.scala
@@ -141,38 +141,43 @@ class TypeDefinitionSuite extends BasePcDefinitionSuite {
   )
 
   check(
-    // We don't jump directly to named parameter for scala 2
+    "named-arg-multiple",
+    """|object Main {
+       |  def tst(par1: Int, par2: String, par3: Boolean): Unit = {}
+       |
+       |  tst(1, p/*scala/Boolean# Boolean.scala*/@@ar3 = true, par2 = "")
+       |}""".stripMargin,
+  )
+
+  check(
+    "named-arg-reversed",
+    """|object Main {
+       |  def tst(par1: Int, par2: String): Unit = {}
+       |
+       |  tst(p/*scala/Predef.String# Predef.scala*/@@ar2 = "foo", par1 = 1)
+       |}""".stripMargin,
+  )
+
+  check(
     "named-arg-local",
     """|object Main {
        |  def foo(arg: Int): Unit = ()
        |
-       |  foo(a/*scala/Unit# Unit.scala*/@@rg = 42)
+       |  foo(a/*scala/Int# Int.scala*/@@rg = 42)
        |}
        |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|object Main {
-           |  def foo(arg: Int): Unit = ()
-           |
-           |  foo(a/*scala/Int# Int.scala*/rg = 42)
-           |}
-           |""".stripMargin
-    ),
   )
 
   check(
     "named-arg-global",
-    // We don't jump directly to named parameter for scala 2
     """|object Main {
-       |  assert(a/*scala/Unit# Unit.scala*/@@ssertion = true)
+       |  assert(a/*scala/Boolean# Boolean.scala*/@@ssertion = true)
        |}
        |""".stripMargin,
     compat = Map(
       "3" ->
         """|object Main {
-           |  def foo(/*scala/Int# Int.scala*/arg: Int): Unit = ()
-           |
-           |  foo(arg = 42)
+           |  assert(a/*scala/Boolean# Boolean.scala*/@@ssertion = true)
            |}
            |""".stripMargin
     ),
@@ -442,4 +447,5 @@ class TypeDefinitionSuite extends BasePcDefinitionSuite {
            |""".stripMargin
     ),
   )
+
 }

--- a/tests/cross/src/test/scala/tests/typedef/TypeDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/typedef/TypeDefinitionSuite.scala
@@ -1,0 +1,445 @@
+package tests.typedef
+
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.pc.OffsetParams
+
+import org.eclipse.lsp4j.Location
+import tests.pc.BasePcDefinitionSuite
+
+class TypeDefinitionSuite extends BasePcDefinitionSuite {
+
+  override def requiresJdkSources: Boolean = true
+
+  override def requiresScalaLibrarySources: Boolean = true
+
+  override def definitions(offsetParams: OffsetParams): List[Location] =
+    presentationCompiler
+      .typeDefinition(offsetParams)
+      .get()
+      .locations
+      .asScala
+      .toList
+
+  check(
+    "val",
+    """|class <<TClass>>(i: Int)
+       |
+       |object Main {
+       |  val ts@@t = new TClass(2)
+       |}""".stripMargin,
+    compat = Map(
+      "2" ->
+        """|class <<>>TClass(i: Int)
+           |
+           |object Main {
+           |  val tst = new TClass(2)
+           |}""".stripMargin
+    ),
+  )
+
+  check(
+    "for",
+    """|
+       |object Main {
+       |  for {
+       |    x <- List(1)
+       |    y <- 1.to(x)
+       |    z = y + x
+       |    if y < /*scala/Int# Int.scala*/@@x
+       |  } yield y
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "for-flatMap",
+    """|
+       |object Main {
+       |  for {
+       |    x /*scala/Option# Option.scala*/@@<- Option(1)
+       |    y <- Option(x)
+       |  } yield y
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "for-map",
+    """|
+       |object Main {
+       |  for {
+       |    x <- Option(1)
+       |    y /*scala/Option# Option.scala*/@@<- Option(x)
+       |  } yield y
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "for-withFilter",
+    """|
+       |object Main {
+       |  for {
+       |    x <- Option(1)
+       |    y <- Option(x)
+       |    /*scala/Option#WithFilter# Option.scala*/@@if y > 2
+       |  } yield y
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "constructor",
+    """
+      |class <<TClass>>(i: Int) {}
+      |
+      |object Main {
+      | def tst(m: TClass): Unit = {}
+      |
+      |  tst(new T@@Class(2))
+      |}""".stripMargin,
+    compat = Map(
+      "2" ->
+        """|class <<>>TClass(i: Int) {}
+           |
+           |object Main {
+           | def tst(m: TClass): Unit = {}
+           |
+           |  tst(new TClass(2))
+           |}
+           |""".stripMargin
+    ),
+  )
+
+  check(
+    "function",
+    """|
+       |object Main {
+       |  val increment: Int => Int = _ + 2
+       |  incre/*scala/Int# Int.scala*/@@ment(1)
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "tuple",
+    // assert we don't go to `Tuple2.scala`
+    """|
+       |object Main {
+       |  @@(1, 2)
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "method",
+    """|object Main {
+       |  def tst(): Unit = {}
+       |
+       |  ts@@/*scala/Unit# Unit.scala*/t()
+       |}""".stripMargin,
+  )
+
+  check(
+    // We don't jump directly to named parameter for scala 2
+    "named-arg-local",
+    """|object Main {
+       |  def foo(arg: Int): Unit = ()
+       |
+       |  foo(a/*scala/Unit# Unit.scala*/@@rg = 42)
+       |}
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|object Main {
+           |  def foo(arg: Int): Unit = ()
+           |
+           |  foo(a/*scala/Int# Int.scala*/rg = 42)
+           |}
+           |""".stripMargin
+    ),
+  )
+
+  check(
+    "named-arg-global",
+    // We don't jump directly to named parameter for scala 2
+    """|object Main {
+       |  assert(a/*scala/Unit# Unit.scala*/@@ssertion = true)
+       |}
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|object Main {
+           |  def foo(/*scala/Int# Int.scala*/arg: Int): Unit = ()
+           |
+           |  foo(arg = 42)
+           |}
+           |""".stripMargin
+    ),
+  )
+
+  check(
+    "list",
+    """|object Main {
+       | List(1).hea/*scala/Int# Int.scala*/@@d
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "class",
+    """|object Main {
+       | class <<F@@oo>>(val x: Int)
+       |}
+       |""".stripMargin,
+    compat = Map(
+      "2" ->
+        """|object Main {
+           | class <<>>Foo(val x: Int)
+           |}
+           |""".stripMargin
+    ),
+  )
+
+  check(
+    "val-keyword",
+    """|object Main {
+       | va@@l x = 42
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "literal",
+    """|object Main {
+       | val x = 4/*scala/Int# Int.scala*/@@2
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "if",
+    """|object Main {
+       | for {
+       |   x <- List(1)
+       |   i/*scala/collection/WithFilter# WithFilter.scala*/@@f x > 1
+       | } println(x)
+       |}
+       |""".stripMargin,
+    compat = Map(
+      "2.12" ->
+        """|object Main {
+           | for {
+           |   x <- List(1)
+           |   i/*scala/collection/generic/FilterMonadic# FilterMonadic.scala*/f x > 1
+           | } println(x)
+           |}
+           |""".stripMargin
+    ),
+  )
+
+  check(
+    "string",
+    """|object Main {
+       | "".stripS/*java/lang/String# String.java*/@@uffix("foo")
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "method-generic",
+    """|object Main {
+       | def foo[<<T>>](param: T): T = para@@m
+       |}
+       |""".stripMargin,
+    compat = Map(
+      "2" ->
+        """|object Main {
+           | def foo[<<>>T](param: T): T = param
+           |}
+           |""".stripMargin
+    ),
+  )
+
+  check(
+    "method-generic-result",
+    """|object A {
+       | def foo[T](param: T): T = param
+       |}
+       |object Main {
+       | println(A.fo/*scala/Int# Int.scala*/@@o(2))
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "apply",
+    """|
+       |object Main {
+       |  /*scala/collection/immutable/List# List.scala*/@@List(1)
+       |}
+       |""".stripMargin,
+    compat = Map(
+      "2.13" ->
+        """|
+           |object Main {
+           |  /*scala/collection/immutable/List# List.scala*/List(1)
+           |}
+           |""".stripMargin,
+      "3" ->
+        """|
+           |object Main {
+           |  /*scala/collection/immutable/List# List.scala*/List(1)
+           |}
+           |""".stripMargin,
+    ),
+  )
+
+  check(
+    "new",
+    """|
+       |object Main {
+       |  ne@@w java.io.File("")
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "extends",
+    """|
+       |object Main ex@@tends java.io.Serializable {
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "import1",
+    """|
+       |import scala.concurrent./*scala/concurrent/Future. Future.scala*/@@Future
+       |object Main {
+       |}
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|
+           |import scala.concurrent./*scala/concurrent/Future# Future.scala*//*scala/concurrent/Future. Future.scala*/@@Future
+           |object Main {
+           |}
+           |""".stripMargin
+    ),
+  )
+
+  check(
+    "import2",
+    """|
+       |imp@@ort scala.concurrent.Future
+       |object Main {
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "import3",
+    """|
+       |import scala.co@@ncurrent.Future
+       |object Main {
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "symbolic-infix",
+    """|
+       |object Main {
+       |  val lst = 1 /*scala/collection/immutable/List# List.scala*/@@:: Nil
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "package",
+    """|
+       |object Main {
+       |  val n = ma@@th.max(1, 2)
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "eta",
+    """|
+       |object Main {
+       |  List(1).map(/*scala/Int# Int.scala*/@@_ + 2)
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "eta-2",
+    """|
+       |object Main {
+       |  List(1).foldLeft(0)(_ + /*scala/Int# Int.scala*/@@_)
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "result-type",
+    """|
+       |object Main {
+       |  def x: /*scala/Int# Int.scala*/@@Int = 42
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "do-not-point-at ::",
+    """|
+       |class Main {
+       |  val all = Option(42)./*scala/Int# Int.scala*/@@get :: List("1", "2")
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "synthetic-definition-case-class",
+    """|
+       |class Main {
+       |  case class <<>>User(name: String, age: Int)
+       |  def hello(u: User): Unit = ()
+       |  hello(Us@@er())
+       |}
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|
+           |class Main {
+           |  case class <<User>>(name: String, age: Int)
+           |  def hello(u: User): Unit = ()
+           |  hello(User())
+           |}
+           |""".stripMargin
+    ),
+  )
+
+  check(
+    "synthetic-definition-class-constructor",
+    """|
+       |class Main {
+       |  class <<>>User(name: String, age: Int)
+       |  def hello(u: User): Unit = ()
+       |  hello(new Us@@er())
+       |}
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|
+           |class Main {
+           |  class <<User>>(name: String, age: Int)
+           |  def hello(u: User): Unit = ()
+           |  hello(new Us@@er())
+           |}
+           |""".stripMargin
+    ),
+  )
+}


### PR DESCRIPTION
This approach uses is a slight modification of definition provider, where we try to additionally find the type symbol of the definition symbol. It seems to work ok and doesn't require too many changes.

In some cases it might not be clear where to go for the type definition, but I think most cases covered by tests make sense. For example the type definition for type is the same as definition.

There is a small bug for named parameters in Scala 2, but that is unrelated to this PR and can be fixed later.

Fixes https://github.com/scalameta/metals/issues/4510
