### PR TITLE
Add Ammonite Ivy completions for Scala 3

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -39,7 +39,8 @@ class MetalsGlobal(
     val workspace: Option[Path]
 ) extends Global(settings, reporter)
     with completions.Completions
-    with completions.AmmoniteCompletions
+    with completions.AmmoniteFileCompletions
+    with completions.AmmoniteIvyCompletions
     with completions.ArgCompletions
     with completions.FilenameCompletions
     with completions.InterpolatorCompletions

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteFileCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteFileCompletions.scala
@@ -1,19 +1,15 @@
 package scala.meta.internal.pc.completions
 
-import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
-import scala.meta.internal.mtags.BuildInfo
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.pc.CompletionFuzzy
 import scala.meta.internal.pc.MetalsGlobal
-import scala.meta.internal.semver.SemVer.Version
-import scala.meta.internal.tokenizers.Chars
 import scala.meta.io.AbsolutePath
 
 import org.eclipse.{lsp4j => l}
 
-trait AmmoniteCompletions { this: MetalsGlobal =>
+trait AmmoniteFileCompletions { this: MetalsGlobal =>
 
   class FileSystemMember(
       sym: Symbol,
@@ -27,7 +23,7 @@ trait AmmoniteCompletions { this: MetalsGlobal =>
         label = Some(fileName)
       )
 
-  case class AmmoniteFileCompletions(
+  case class AmmoniteFileCompletion(
       select: Tree,
       selector: List[ImportSelector],
       pos: Position,
@@ -102,77 +98,6 @@ trait AmmoniteCompletions { this: MetalsGlobal =>
               } ++ parentTextEdit
           case _ =>
             Nil
-        }
-      } catch {
-        case NonFatal(e) =>
-          e.printStackTrace()
-          Nil
-      }
-  }
-
-  case class AmmoniteIvyCompletions(
-      select: Tree,
-      selector: List[ImportSelector],
-      pos: Position,
-      editRange: l.Range
-  ) extends CompletionPosition {
-
-    override def contribute: List[Member] =
-      try {
-
-        val query = selector.collectFirst {
-          case sel: ImportSelector if sel.name.toString().contains(CURSOR) =>
-            sel.name.decode.replace(CURSOR, "")
-        }
-
-        query match {
-          case Some(imp) =>
-            val api = coursierapi.Complete
-              .create()
-              .withScalaVersion(BuildInfo.scalaCompilerVersion)
-
-            def completions(s: String): List[String] =
-              api.withInput(s).complete().getCompletions().asScala.toList
-            val javaCompletions = completions(imp)
-            val scalaCompletions =
-              if (imp.endsWith(":") && imp.count(_ == ':') == 1)
-                completions(imp + ":").map(":" + _)
-              else List.empty
-
-            val isInitialCompletion =
-              pos.lineContent.trim == s"import $$ivy.$CURSOR"
-            val ivyEditRange =
-              if (isInitialCompletion) editRange
-              else {
-                // We need the text edit to span the whole group/artefact/version
-                val rangeStart = inferStart(
-                  pos,
-                  pos.source.content.mkString,
-                  c => Chars.isIdentifierPart(c) || c == '.' || c == '-'
-                )
-                pos.withStart(rangeStart).withEnd(pos.point).toLsp
-              }
-            val allCompletions = scalaCompletions ++ javaCompletions
-            val sortedCompletions =
-              if (imp.replaceAll(":+", ":").count(_ == ':') == 2)
-                allCompletions.sortWith(
-                  Version.fromString(_) >= Version.fromString(_)
-                )
-              else allCompletions
-            sortedCompletions.zipWithIndex.map { case (c, index) =>
-              new TextEditMember(
-                filterText = c,
-                edit = new l.TextEdit(
-                  ivyEditRange,
-                  if (isInitialCompletion) s"`$c$$0`" else c
-                ),
-                sym = select.symbol
-                  .newErrorSymbol(TermName(s"artefact$index"))
-                  .setInfo(NoType),
-                label = Some(c.stripPrefix(":"))
-              )
-            }
-          case _ => List.empty
         }
       } catch {
         case NonFatal(e) =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteIvyCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteIvyCompletions.scala
@@ -1,7 +1,5 @@
 package scala.meta.internal.pc.completions
 
-import scala.collection.JavaConverters._
-
 import scala.meta.internal.mtags.CoursierComplete
 import scala.meta.internal.pc.MetalsGlobal
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteIvyCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteIvyCompletions.scala
@@ -1,14 +1,11 @@
 package scala.meta.internal.pc.completions
 
 import scala.collection.JavaConverters._
-import scala.util.control.NonFatal
 
-import scala.meta.internal.mtags.BuildInfo
+import scala.meta.internal.mtags.CoursierComplete
 import scala.meta.internal.pc.MetalsGlobal
-import scala.meta.internal.tokenizers.Chars
 
 import org.eclipse.{lsp4j => l}
-import scala.meta.internal.mtags.CoursierComplete
 
 trait AmmoniteIvyCompletions {
   this: MetalsGlobal =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteIvyCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/AmmoniteIvyCompletions.scala
@@ -1,0 +1,59 @@
+package scala.meta.internal.pc.completions
+
+import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
+
+import scala.meta.internal.mtags.BuildInfo
+import scala.meta.internal.pc.MetalsGlobal
+import scala.meta.internal.tokenizers.Chars
+
+import org.eclipse.{lsp4j => l}
+import scala.meta.internal.mtags.CoursierComplete
+
+trait AmmoniteIvyCompletions {
+  this: MetalsGlobal =>
+
+  case class AmmoniteIvyCompletion(
+      select: Tree,
+      selector: List[ImportSelector],
+      pos: Position,
+      editRange: l.Range,
+      text: String
+  ) extends CompletionPosition {
+
+    override def contribute: List[Member] = {
+      val query = selector.collectFirst {
+        case sel: ImportSelector if sel.name.toString().contains(CURSOR) =>
+          sel.name.decode.replace(CURSOR, "")
+      }
+      query match {
+        case Some(imp) =>
+          val completions = CoursierComplete.complete(imp)
+          val isInitialCompletion =
+            pos.lineContent.trim == s"import $$ivy.$CURSOR"
+          val ivyEditRange =
+            if (isInitialCompletion) editRange
+            else {
+              // We need the text edit to span the whole group/artefact/version
+              val (rangeStart, _) =
+                CoursierComplete.inferEditRange(pos.point, text)
+              pos.withStart(rangeStart).withEnd(pos.point).toLsp
+            }
+          completions.zipWithIndex.map { case (c, index) =>
+            new TextEditMember(
+              filterText = c,
+              edit = new l.TextEdit(
+                ivyEditRange,
+                if (isInitialCompletion) s"`$c$$0`" else c
+              ),
+              sym = select.symbol
+                .newErrorSymbol(TermName(s"artefact$index"))
+                .setInfo(NoType),
+              label = Some(c.stripPrefix(":"))
+            )
+          }
+        case _ => List.empty
+      }
+    }
+  }
+}

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -530,13 +530,13 @@ trait Completions { this: MetalsGlobal =>
         )
       case (imp @ Import(select, selector)) :: _
           if isAmmoniteFileCompletionPosition(imp, pos) =>
-        AmmoniteFileCompletions(select, selector, pos, editRange)
+        AmmoniteFileCompletion(select, selector, pos, editRange)
       case (imp @ Import(select, selector)) :: _
           if isAmmoniteIvyCompletionPosition(
             imp,
             pos
           ) || isWorksheetIvyCompletionPosition(imp, pos) =>
-        AmmoniteIvyCompletions(select, selector, pos, editRange)
+        AmmoniteIvyCompletion(select, selector, pos, editRange, text)
       case _ =>
         inferCompletionPosition(
           pos,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/AmmoniteIvyCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/AmmoniteIvyCompletions.scala
@@ -16,7 +16,8 @@ object AmmoniteIvyCompletions:
   )(using Context): List[CompletionValue] =
     val pos = completionPos.sourcePos
     val query = selector.collectFirst {
-      case sel: ImportSelector if sel.sourcePos.encloses(pos) =>
+      case sel: ImportSelector
+          if sel.sourcePos.encloses(pos) && sel.sourcePos.`end` > pos.`end` =>
         sel.name.decoded
     }
     query match

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/AmmoniteIvyCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/AmmoniteIvyCompletions.scala
@@ -1,0 +1,34 @@
+package scala.meta.internal.pc.completions
+
+import scala.meta.internal.mtags.CoursierComplete
+import scala.meta.internal.mtags.MtagsEnrichments.*
+
+import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.ast.untpd.ImportSelector
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.util.SourcePosition
+
+object AmmoniteIvyCompletions:
+  def contribute(
+      select: Tree,
+      selector: List[ImportSelector],
+      pos: SourcePosition,
+  )(using Context): List[CompletionValue] =
+
+    val query = selector.collectFirst {
+      case sel: ImportSelector if sel.sourcePos.encloses(pos) =>
+        sel.name.decoded
+    }
+    query match
+      case None => Nil
+      case Some(dependency) =>
+        val completions = CoursierComplete.complete(dependency)
+        completions
+          .map(insertText =>
+            CompletionValue.AmmoniteIvyImport(
+              insertText.stripPrefix(":"),
+              Some(insertText),
+            )
+          )
+  end contribute
+end AmmoniteIvyCompletions

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -163,6 +163,13 @@ object CompletionValue:
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Folder
 
+  case class AmmoniteIvyImport(
+      label: String,
+      override val insertText: Option[String],
+  ) extends CompletionValue:
+    override val filterText: Option[String] = insertText
+    override def completionItemKind(using Context): CompletionItemKind =
+          CompletionItemKind.Folder
   case class Interpolator(
       symbol: Symbol,
       label: String,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -154,7 +154,7 @@ object CompletionValue:
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.File
 
-  case class ScalaCLiImport(
+  case class IvyImport(
       label: String,
       override val insertText: Option[String],
       override val range: Option[Range],
@@ -163,13 +163,6 @@ object CompletionValue:
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Folder
 
-  case class AmmoniteIvyImport(
-      label: String,
-      override val insertText: Option[String],
-  ) extends CompletionValue:
-    override val filterText: Option[String] = insertText
-    override def completionItemKind(using Context): CompletionItemKind =
-      CompletionItemKind.Folder
   case class Interpolator(
       symbol: Symbol,
       label: String,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -169,7 +169,7 @@ object CompletionValue:
   ) extends CompletionValue:
     override val filterText: Option[String] = insertText
     override def completionItemKind(using Context): CompletionItemKind =
-          CompletionItemKind.Folder
+      CompletionItemKind.Folder
   case class Interpolator(
       symbol: Symbol,
       label: String,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
@@ -18,7 +18,7 @@ class ScalaCliCompletions(pos: SourcePosition, text: String):
     val editRange = pos.withStart(editStart).withEnd(editEnd).toLsp
     completions
       .map(insertText =>
-        CompletionValue.ScalaCLiImport(
+        CompletionValue.IvyImport(
           insertText.stripPrefix(":"),
           Some(insertText),
           Some(editRange),

--- a/project/V.scala
+++ b/project/V.scala
@@ -126,5 +126,6 @@ object V {
       ammonite213Version,
       scala3,
       ammonite3Version,
+      nextScala3RC,
     ).toList
 }

--- a/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
@@ -1,29 +1,11 @@
 package tests.feature
 
-import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.{BuildInfo => V}
 
-class Ammonite213Suite extends tests.BaseAmmoniteSuite(V.ammonite213) {
-  ivyCompletionsTest(
-    version = V.ammonite213,
-    artefactExpectedCompletionList = """
-                                       |circe-refined
-                                       |circe-refined_native0.4
-                                       |circe-refined_sjs0.6
-                                       |circe-refined_sjs1""".stripMargin,
-  )
-}
+class Ammonite213Suite extends tests.BaseAmmoniteSuite(V.ammonite213)
 
-class Ammonite3Suite extends tests.BaseAmmoniteSuite(V.ammonite3) {
-  ivyCompletionsTest(
-    version = V.ammonite3,
-    artefactExpectedCompletionList = """
-                                       |circe-refined
-                                       |circe-refined_native0.4
-                                       |circe-refined_sjs1""".stripMargin,
-  )
-}
+class Ammonite3Suite extends tests.BaseAmmoniteSuite(V.ammonite3)
 
 class Ammonite212Suite extends tests.BaseAmmoniteSuite(V.ammonite212) {
 

--- a/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
@@ -5,62 +5,25 @@ import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.{BuildInfo => V}
 
 class Ammonite213Suite extends tests.BaseAmmoniteSuite(V.ammonite213) {
-
-  test("ivy-completion") {
-    for {
-      _ <- initialize(
-        s"""
-           |/metals.json
-           |{
-           |  "a": {
-           |    "scalaVersion": "${V.ammonite213}"
-           |  }
-           |}
-           |/main.sc
-           |import $$ivy.`io.cir`
-           |import $$ivy.`io.circe::circe-ref`
-           |import $$ivy.`io.circe::circe-yaml:0.14`
-           |""".stripMargin
-      )
-      _ <- server.didOpen("main.sc")
-      _ <- server.didSave("main.sc")(identity)
-      _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
-
-      groupExpectedCompletionList = "io.circe"
-      groupCompletionList <- server.completion(
-        "main.sc",
-        "import $ivy.`io.cir@@`",
-      )
-      _ = assertNoDiff(groupCompletionList, groupExpectedCompletionList)
-
-      artefactExpectedCompletionList =
-        """
-          |circe-refined
-          |circe-refined_native0.4
-          |circe-refined_sjs0.6
-          |circe-refined_sjs1""".stripMargin
-      artefactCompletionList <- server.completion(
-        "main.sc",
-        "import $ivy.`io.circe::circe-ref@@`",
-      )
-      _ = assertNoDiff(artefactCompletionList, artefactExpectedCompletionList)
-
-      versionExpectedCompletionList = List("0.14.1", "0.14.0")
-      response <- server.completionList(
-        "main.sc",
-        "import $ivy.`io.circe::circe-yaml:0.14@@`",
-      )
-      versionCompletionList = response
-        .getItems()
-        .asScala
-        .map(_.getLabel())
-        .toList
-      _ = assertEquals(versionCompletionList, versionExpectedCompletionList)
-    } yield ()
-  }
+  ivyCompletionsTest(
+    version = V.ammonite213,
+    artefactExpectedCompletionList = """
+                                       |circe-refined
+                                       |circe-refined_native0.4
+                                       |circe-refined_sjs0.6
+                                       |circe-refined_sjs1""".stripMargin,
+  )
 }
 
-class Ammonite3Suite extends tests.BaseAmmoniteSuite(V.ammonite3)
+class Ammonite3Suite extends tests.BaseAmmoniteSuite(V.ammonite3) {
+  ivyCompletionsTest(
+    version = V.ammonite3,
+    artefactExpectedCompletionList = """
+                                       |circe-refined
+                                       |circe-refined_native0.4
+                                       |circe-refined_sjs1""".stripMargin,
+  )
+}
 
 class Ammonite212Suite extends tests.BaseAmmoniteSuite(V.ammonite212) {
 

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -585,53 +585,61 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
     } yield ()
   }
 
-  def ivyCompletionsTest(
-      version: String,
-      artefactExpectedCompletionList: String,
-  ): Unit = {
-    test("ivy-completion") {
-      for {
-        _ <- initialize(
-          s"""
-             |/metals.json
-             |{
-             |  "a": {
-             |    "scalaVersion": "${version}"
-             |  }
-             |}
-             |/main.sc
-             |import $$ivy.`io.cir`
-             |import $$ivy.`io.circe::circe-ref`
-             |import $$ivy.`io.circe::circe-yaml:0.14`
-             |""".stripMargin
-        )
-        _ <- server.didOpen("main.sc")
-        _ <- server.didSave("main.sc")(identity)
-        _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
+  test("ivy-completion") {
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "$scalaVersion"
+           |  }
+           |}
+           |/main.sc
+           |import $$ivy.`io.cir`
+           |import $$ivy.`io.circe::circe-ref`
+           |import $$ivy.`io.circe::circe-yaml:0.14`
+           |""".stripMargin
+      )
+      _ <- server.didOpen("main.sc")
+      _ <- server.didSave("main.sc")(identity)
+      _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
 
-        groupExpectedCompletionList = "io.circe"
-        groupCompletionList <- server.completion(
-          "main.sc",
-          "import $ivy.`io.cir@@`",
-        )
-        _ = assertNoDiff(groupCompletionList, groupExpectedCompletionList)
-        artefactCompletionList <- server.completion(
-          "main.sc",
-          "import $ivy.`io.circe::circe-ref@@`",
-        )
-        _ = assertNoDiff(artefactCompletionList, artefactExpectedCompletionList)
+      groupExpectedCompletionList = "io.circe"
+      groupCompletionList <- server.completion(
+        "main.sc",
+        "import $ivy.`io.cir@@`",
+      )
+      _ = assertNoDiff(groupCompletionList, groupExpectedCompletionList)
+      artefactCompletionList <- server.completion(
+        "main.sc",
+        "import $ivy.`io.circe::circe-ref@@`",
+      )
+      artefactExpectedCompletionList = getExpected(
+        """|circe-refined
+           |circe-refined_native0.4
+           |circe-refined_sjs0.6
+           |circe-refined_sjs1
+           |""".stripMargin,
+        Map(
+          "3" -> """|circe-refined
+                    |circe-refined_native0.4
+                    |circe-refined_sjs1
+                    |""".stripMargin
+        ),
+        scalaVersion,
+      )
+      _ = assertNoDiff(artefactCompletionList, artefactExpectedCompletionList)
 
-        versionExpectedCompletionList =
-          """
-            |0.14.1
-            |0.14.0""".stripMargin
-        versionCompletionList <- server.completion(
-          "main.sc",
-          "import $ivy.`io.circe::circe-yaml:0.14@@`",
-        )
-        _ = assertNoDiff(versionCompletionList, versionExpectedCompletionList)
-      } yield ()
-    }
+      versionExpectedCompletionList =
+        """
+          |0.14.1
+          |0.14.0""".stripMargin
+      versionCompletionList <- server.completion(
+        "main.sc",
+        "import $ivy.`io.circe::circe-yaml:0.14@@`",
+      )
+      _ = assertNoDiff(versionCompletionList, versionExpectedCompletionList)
+    } yield ()
   }
-
 }

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -585,4 +585,53 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
     } yield ()
   }
 
+  def ivyCompletionsTest(
+      version: String,
+      artefactExpectedCompletionList: String,
+  ): Unit = {
+    test("ivy-completion") {
+      for {
+        _ <- initialize(
+          s"""
+             |/metals.json
+             |{
+             |  "a": {
+             |    "scalaVersion": "${version}"
+             |  }
+             |}
+             |/main.sc
+             |import $$ivy.`io.cir`
+             |import $$ivy.`io.circe::circe-ref`
+             |import $$ivy.`io.circe::circe-yaml:0.14`
+             |""".stripMargin
+        )
+        _ <- server.didOpen("main.sc")
+        _ <- server.didSave("main.sc")(identity)
+        _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
+
+        groupExpectedCompletionList = "io.circe"
+        groupCompletionList <- server.completion(
+          "main.sc",
+          "import $ivy.`io.cir@@`",
+        )
+        _ = assertNoDiff(groupCompletionList, groupExpectedCompletionList)
+        artefactCompletionList <- server.completion(
+          "main.sc",
+          "import $ivy.`io.circe::circe-ref@@`",
+        )
+        _ = assertNoDiff(artefactCompletionList, artefactExpectedCompletionList)
+
+        versionExpectedCompletionList =
+          """
+            |0.14.1
+            |0.14.0""".stripMargin
+        versionCompletionList <- server.completion(
+          "main.sc",
+          "import $ivy.`io.circe::circe-yaml:0.14@@`",
+        )
+        _ = assertNoDiff(versionCompletionList, versionExpectedCompletionList)
+      } yield ()
+    }
+  }
+
 }

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -631,15 +631,22 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
       )
       _ = assertNoDiff(artefactCompletionList, artefactExpectedCompletionList)
 
-      versionExpectedCompletionList =
-        """
-          |0.14.1
-          |0.14.0""".stripMargin
-      versionCompletionList <- server.completion(
+      versionExpectedCompletionList = List("0.14.1", "0.14.0")
+      response <- server.completionList(
         "main.sc",
         "import $ivy.`io.circe::circe-yaml:0.14@@`",
       )
-      _ = assertNoDiff(versionCompletionList, versionExpectedCompletionList)
+      versionCompletionList = response
+        .getItems()
+        .asScala
+        .map(_.getLabel())
+        .toList
+      _ = assertEquals(versionCompletionList, versionExpectedCompletionList)
+      noCompletions <- server.completion(
+        "main.sc",
+        "import $ivy.`io.circe::circe-yaml:0.14`@@",
+      )
+      _ = assertNoDiff(noCompletions, "")
     } yield ()
   }
 }

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -3,6 +3,7 @@ package tests
 import scala.concurrent.Promise
 
 import scala.meta.internal.metals.InitializationOptions
+import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ScalaVersions
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.clients.language.MetalsSlowTaskResult
@@ -801,15 +802,22 @@ abstract class BaseWorksheetLspSuite(
       )
       _ = assertNoDiff(artefactCompletionList, artefactExpectedCompletionList)
 
-      versionExpectedCompletionList =
-        """
-          |0.14.0
-          |0.14.1""".stripMargin
-      versionCompletionList <- server.completion(
+      versionExpectedCompletionList = List("0.14.1", "0.14.0")
+      response <- server.completionList(
         "Main.worksheet.sc",
         "import $dep.`io.circe::circe-yaml:0.14@@`",
       )
-      _ = assertNoDiff(versionCompletionList, versionExpectedCompletionList)
+      versionCompletionList = response
+        .getItems()
+        .asScala
+        .map(_.getLabel())
+        .toList
+      _ = assertEquals(versionCompletionList, versionExpectedCompletionList)
+      noCompletions <- server.completion(
+        "Main.worksheet.sc",
+        "import $dep.`io.circe::circe-yaml:0.14`@@",
+      )
+      _ = assertNoDiff(noCompletions, "")
     } yield ()
   }
 }

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -768,16 +768,16 @@ abstract class BaseWorksheetLspSuite(
            |    "scalaVersion": "${scalaVersion}"
            |  }
            |}
-           |/Main.worksheet.sc
+           |/a/src/main/scala/foo/Main.worksheet.sc
            |import $$ivy.`io.cir`
            |import $$dep.`io.circe::circe-ref`
            |import $$dep.`io.circe::circe-yaml:0.14`
            |""".stripMargin
       )
-      _ <- server.didOpen("Main.worksheet.sc")
+      _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
       groupExpectedCompletionList = "io.circe"
       groupCompletionList <- server.completion(
-        "Main.worksheet.sc",
+        "a/src/main/scala/foo/Main.worksheet.sc",
         "import $ivy.`io.cir@@`",
       )
       _ = assertNoDiff(groupCompletionList, groupExpectedCompletionList)
@@ -797,14 +797,14 @@ abstract class BaseWorksheetLspSuite(
         scalaVersion,
       )
       artefactCompletionList <- server.completion(
-        "Main.worksheet.sc",
+        "a/src/main/scala/foo/Main.worksheet.sc",
         "import $dep.`io.circe::circe-ref@@`",
       )
       _ = assertNoDiff(artefactCompletionList, artefactExpectedCompletionList)
 
       versionExpectedCompletionList = List("0.14.1", "0.14.0")
       response <- server.completionList(
-        "Main.worksheet.sc",
+        "a/src/main/scala/foo/Main.worksheet.sc",
         "import $dep.`io.circe::circe-yaml:0.14@@`",
       )
       versionCompletionList = response
@@ -814,7 +814,7 @@ abstract class BaseWorksheetLspSuite(
         .toList
       _ = assertEquals(versionCompletionList, versionExpectedCompletionList)
       noCompletions <- server.completion(
-        "Main.worksheet.sc",
+        "a/src/main/scala/foo/Main.worksheet.sc",
         "import $dep.`io.circe::circe-yaml:0.14`@@",
       )
       _ = assertNoDiff(noCompletions, "")

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
@@ -171,54 +171,6 @@ class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala213) {
     } yield ()
   }
 
-  test("ivy-completion") {
-    for {
-      _ <- initialize(
-        s"""
-           |/metals.json
-           |{
-           |  "a": {
-           |    "scalaVersion": "${V.scala213}"
-           |  }
-           |}
-           |/Main.worksheet.sc
-           |import $$ivy.`io.cir`
-           |import $$dep.`io.circe::circe-ref`
-           |import $$dep.`io.circe::circe-yaml:0.14`
-           |""".stripMargin
-      )
-      _ <- server.didOpen("Main.worksheet.sc")
-      groupExpectedCompletionList = "io.circe"
-      groupCompletionList <- server.completion(
-        "Main.worksheet.sc",
-        "import $ivy.`io.cir@@`",
-      )
-      _ = assertNoDiff(groupCompletionList, groupExpectedCompletionList)
-
-      artefactExpectedCompletionList =
-        """|circe-refined
-           |circe-refined_native0.4
-           |circe-refined_sjs0.6
-           |circe-refined_sjs1
-           |""".stripMargin
-      artefactCompletionList <- server.completion(
-        "Main.worksheet.sc",
-        "import $dep.`io.circe::circe-ref@@`",
-      )
-      _ = assertNoDiff(artefactCompletionList, artefactExpectedCompletionList)
-
-      versionExpectedCompletionList =
-        """
-          |0.14.0
-          |0.14.1""".stripMargin
-      versionCompletionList <- server.completion(
-        "Main.worksheet.sc",
-        "import $dep.`io.circe::circe-yaml:0.14@@`",
-      )
-      _ = assertNoDiff(versionCompletionList, versionExpectedCompletionList)
-    } yield ()
-  }
-
   test("literals") {
     for {
       _ <- initialize(


### PR DESCRIPTION
Adds ammonite ivy imports completions for Scala 3.
Also refactors these completions for Scala 2 to use `CoursierComplete`.

Fixes https://github.com/scalameta/metals/issues/4551