### PR TITLE
improvement: Try to download mtags for latest supported nightly Scala…

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
@@ -5,7 +5,12 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.semver.SemVer
+
 import coursierapi.error.SimpleResolutionError
+import org.jsoup.Jsoup
 
 trait MtagsResolver {
   def resolve(scalaVersion: String): Option[MtagsBinaries]
@@ -23,6 +28,13 @@ object MtagsResolver {
       new ConcurrentHashMap[String, State]()
 
     def resolve(scalaVersion: String): Option[MtagsBinaries] = {
+      resolve(scalaVersion, original = None)
+    }
+
+    private def resolve(
+        scalaVersion: String,
+        original: Option[String],
+    ): Option[MtagsBinaries] = {
       def logError(e: Throwable): Unit = {
         val msg = s"Failed to fetch mtags for ${scalaVersion}"
         e match {
@@ -59,7 +71,7 @@ object MtagsResolver {
         Some(MtagsBinaries.BuildIn)
       } else {
         val computed = states.compute(
-          scalaVersion,
+          original.getOrElse(scalaVersion),
           (_, value) => {
             value match {
               case null => fetch()
@@ -76,9 +88,77 @@ object MtagsResolver {
         )
         computed match {
           case State.Success(v) => Some(v)
-          case _: State.Failure => None
+          // Try to download latest supported snapshot
+          case _: State.Failure
+              if original.isEmpty && scalaVersion.contains("NIGHTLY") =>
+            findLatestSnapshot(scalaVersion) match {
+              case None => None
+              case Some(latestSnapshot) =>
+                scribe.warn(s"Using latest stable version $latestSnapshot")
+                resolve(
+                  latestSnapshot,
+                  Some(scalaVersion),
+                )
+            }
+          case _ =>
+            None
         }
       }
+    }
+
+    /**
+     * Nightlies version are able to work with artifacts compiled within the
+     * same RC version.
+     *
+     * For example 3.2.2-RC1-bin-20221009-2052fc2-NIGHTLY presentation compiler
+     * will work with classfiles compiled with 3.2.2-RC1-bin-20220910-ac6cd1c-NIGHTLY
+     *
+     * @param exactVersion version we failed to find and looking for an alternative for
+     * @return latest supported nightly version by thise version of metals
+     */
+    private def findLatestSnapshot(exactVersion: String): Option[String] = try {
+
+      val metalsVersion = BuildInfo.metalsVersion
+
+      // strip timestamp to get only 3.2.2-RC1
+      val rcVersion = SemVer.Version
+        .fromString(exactVersion)
+        .copy(nightlyDate = None)
+        .toString()
+
+      val url =
+        s"https://oss.sonatype.org/content/repositories/snapshots/org/scalameta/"
+
+      val allScalametaArtifacts = Jsoup.connect(url).get
+
+      // find all the nightlies for current RC
+      val lastNightlies = allScalametaArtifacts
+        .select("a")
+        .asScala
+        .filter { a =>
+          val name = a.text()
+          name.contains("NIGHTLY") && name.contains(rcVersion)
+        }
+
+      // find last supported Scala version for this metals version
+      lastNightlies.reverseIterator
+        .find { nightlyLink =>
+          val link = nightlyLink.attr("href")
+
+          val mtagsPage = Jsoup.connect(link).get
+
+          mtagsPage
+            .select("a")
+            .asScala
+            .find(_.text() == metalsVersion + "/")
+            .isDefined
+        }
+        .map(_.text().stripPrefix("mtags_").stripSuffix("/"))
+
+    } catch {
+      case NonFatal(t) =>
+        scribe.error("Could not check latest nightlies", t)
+        None
     }
 
     sealed trait State


### PR DESCRIPTION
… version

Sometimes, a nigthly version might be released late or use might use an older snapshot of Metals, in which case it will not be possible to use Metals for that nightly. Thanks to this PR, we will find the latest supported nightly version and use it instead. This should work correctly because each nightly can work with classfiles compiled with the same RC.

Unfortunately, this is not possible to test automatically since any version available locally will not be available in snapshots.

Reported by @kordyjan 