### PR TITLE
bugfix: Filter out <local child> symbol for exhaustive matches

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -722,6 +722,7 @@ class MetalsGlobal(
             isVisited += unique
             if (child.name.containsName(CURSOR)) ()
             else if (child.isStale) ()
+            else if (child.name == tpnme.LOCAL_CHILD) ()
             else if (child.isSealed && (child.isAbstract || child.isTrait)) {
               loop(child)
             } else {

--- a/mtags/src/main/scala-3.1/scala/meta/internal/pc/MetalsSealedDesc.scala
+++ b/mtags/src/main/scala-3.1/scala/meta/internal/pc/MetalsSealedDesc.scala
@@ -2,11 +2,13 @@ package scala.meta.internal.pc
 
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Flags.*
+import dotty.tools.dotc.core.StdNames.*
 import dotty.tools.dotc.core.Symbols.Symbol
 
 object MetalsSealedDesc:
   def sealedStrictDescendants(sym: Symbol)(using Context): List[Symbol] =
     sym.sealedStrictDescendants.filter(child =>
       !(child.is(Sealed) && (child.is(Abstract) || child.is(Trait)))
-        && (child.isPublic || child.isAccessibleFrom(sym.info))
+        && (child.isPublic || child.isAccessibleFrom(sym.info)) &&
+        child.name != tpnme.LOCAL_CHILD
     )

--- a/mtags/src/main/scala-3.2/scala/meta/internal/pc/MetalsSealedDesc.scala
+++ b/mtags/src/main/scala-3.2/scala/meta/internal/pc/MetalsSealedDesc.scala
@@ -2,11 +2,13 @@ package scala.meta.internal.pc
 
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Flags.*
+import dotty.tools.dotc.core.StdNames.*
 import dotty.tools.dotc.core.Symbols.Symbol
 
 object MetalsSealedDesc:
   def sealedStrictDescendants(sym: Symbol)(using Context): List[Symbol] =
     sym.sealedStrictDescendants.filter(child =>
       !(child.is(Sealed) && (child.is(Abstract) || child.is(Trait)))
-        && (child.isPublic || child.isAccessibleFrom(sym.info))
+        && (child.isPublic || child.isAccessibleFrom(sym.info)) &&
+        child.name != tpnme.LOCAL_CHILD
     )

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -8,8 +8,13 @@ class CompletionIssueSuite extends BaseCompletionSuite {
   override protected def extraDependencies(
       scalaVersion: String
   ): Seq[Dependency] = {
-
-    Seq(Dependency.of("org.eclipse.lsp4j", "org.eclipse.lsp4j", "0.16.0"))
+    Seq(
+      Dependency.of("org.eclipse.lsp4j", "org.eclipse.lsp4j", "0.16.0"),
+      if (scalaVersion.startsWith("2.12"))
+        Dependency.of("org.scalameta", "scalameta_2.12", "4.6.0")
+      else
+        Dependency.of("org.scalameta", "scalameta_2.13", "4.6.0"),
+    )
   }
 
   check(
@@ -250,6 +255,20 @@ class CompletionIssueSuite extends BaseCompletionSuite {
       |  def method(arg: String): Unit = ()
       |}
       |import obj.method""".stripMargin,
+  )
+
+  // We shouldn't get exhaustive completions for AbsolutePath
+  // related to https://github.com/scala/scala/commit/14fa7bef120cbb996d042daba6095530167c49ed
+  check(
+    "absolute-path",
+    """|
+       |import scala.meta.io.AbsolutePath
+       |object obj {
+       |  val path: AbsolutePath = ???
+       |  path match@@
+       |}
+       |""".stripMargin,
+    "match",
   )
 
   // The tests shows `x$1` but it's because the dependency is not indexed


### PR DESCRIPTION
This only shows up if we don't have a specific implementing class within a library and only local variable exists.

Related to https://github.com/scala/scala/commit/14fa7bef120cbb996d042daba6095530167c49ed