### PR TITLE
fix: incorrect case completion position

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -504,8 +504,8 @@ trait Completions { this: MetalsGlobal =>
         )
       case (m @ Match(_, Nil)) :: parent :: _ =>
         CaseKeywordCompletion(m.selector, editRange, pos, text, parent)
-      case Ident(name) :: (_: CaseDef) :: (m: Match) :: parent :: _
-          if isCasePrefix(name) =>
+      case Ident(name) :: (cd: CaseDef) :: (m: Match) :: parent :: _
+          if isCasePrefix(name) && pos.line != cd.pos.line =>
         CaseKeywordCompletion(m.selector, editRange, pos, text, parent)
       case (ident @ Ident(name)) :: Block(
             _,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -331,8 +331,8 @@ class Completions(
       .stripSuffix(".scala")
     val MatchCaseExtractor = new MatchCaseExtractor(pos, text, completionPos)
     val ScalaCliCompletions = new ScalaCliCompletions(pos, text)
-    path match
 
+    path match
       case ScalaCliCompletions(dependency) =>
         (ScalaCliCompletions.contribute(dependency), true)
       case _ if ScaladocCompletions.isScaladocCompletion(pos, text) =>

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -498,7 +498,7 @@ class MatchCaseExtractor(
         case _ => None
   end MatchExtractor
   object CaseExtractor:
-    def unapply(path: List[Tree]): Option[(Tree, Tree)] =
+    def unapply(path: List[Tree])(using Context): Option[(Tree, Tree)] =
       path match
         // foo match
         // case None => ()
@@ -517,9 +517,10 @@ class MatchCaseExtractor(
         case (ident @ Ident(name)) :: Block(
               _,
               expr,
-            ) :: (_: CaseDef) :: (m: Match) :: parent :: _
+            ) :: (cd: CaseDef) :: (m: Match) :: parent :: _
             if ident == expr && "case"
-              .startsWith(name.toString()) =>
+              .startsWith(name.toString()) &&
+              cd.sourcePos.startLine != pos.startLine =>
           Some((m.selector, parent))
         // foo match
         //  ca@@

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -608,4 +608,15 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |case A.C =>""".stripMargin,
   )
 
+  check(
+    "same-line",
+    """
+      |object A {
+      |  Option(1) match {
+      |    case Some(a) => cas@@
+      |  }
+      |}""".stripMargin,
+    "",
+  )
+
 }


### PR DESCRIPTION
fixes https://github.com/scalameta/metals/issues/4515

Now we check if the next `case` will be in different line than the previous one