### PR TITLE
bugfix: Try to fix flaky ScalaCLI test

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1410,7 +1410,8 @@ class MetalsLanguageServer(
    */
   private def fileWatchFilter(path: Path): Boolean = {
     val abs = AbsolutePath(path)
-    abs.isScalaOrJava || abs.isSemanticdb || abs.isBuild || abs.isBsp
+    abs.isScalaOrJava || abs.isSemanticdb || abs.isBuild ||
+    abs.isInBspDirectory(workspace)
   }
 
   /**
@@ -1428,7 +1429,9 @@ class MetalsLanguageServer(
     val isScalaOrJava = path.isScalaOrJava
 
     event.eventType match {
-      case EventType.CreateOrModify if path.isBsp =>
+      case EventType.CreateOrModify
+          if path.isInBspDirectory(workspace) && path.extension == "json" =>
+        scribe.info(s"Detected new build tool in $path")
         quickConnectToBuildServer()
       case _ =>
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/watcher/FileWatcher.scala
@@ -51,12 +51,13 @@ final class FileWatcher(
   }
 
   def start(
-      files: Set[AbsolutePath]
+      paths: Set[AbsolutePath]
   ): Unit = {
+    val (files, directories) = paths.partition(_.isFile)
     stopWatcher = startWatch(
       config,
       workspaceDeferred().toNIO,
-      PathsToWatch(files.map(_.toNIO), Set.empty),
+      PathsToWatch(files.map(_.toNIO), directories.map(_.toNIO)),
       onFileWatchEvent,
       watchFilter,
     )

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -486,8 +486,8 @@ trait CommonMtagsEnrichments {
     def isBuild: Boolean =
       path.filename.startsWith("BUILD")
 
-    def isBsp: Boolean =
-      path.filename.startsWith(".bsp")
+    def isInBspDirectory(workspace: AbsolutePath): Boolean =
+      path.toNIO.startsWith(workspace.resolve(".bsp").toNIO)
 
     def isScalaOrJava: Boolean = {
       toLanguage match {

--- a/tests/unit/src/main/scala/tests/BaseScalaCliSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseScalaCliSuite.scala
@@ -191,7 +191,7 @@ abstract class BaseScalaCliSuite(scalaVersion: String)
         |}
         |""".stripMargin
 
-  test("connecting-scalacli".flaky) {
+  test("connecting-scalacli") {
     cleanWorkspace()
     for {
       _ <- server.initialize()


### PR DESCRIPTION
It seems that there was a race condition between when `.bsp` directory was created and the actual json creation.

Now we wait until the json file is created