### PR TITLE
bugfix: Revert undertow and ignore

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,6 +1,8 @@
 updates.ignore = [
   { groupId = "org.eclipse.jdt" },
   { groupId = "org.eclipse.platform" }
+  // https://github.com/undertow-io/undertow/pull/1310/commits/4521635d2f1d2eece5d6681d1e00be32bac95d0c
+  { groupId = "io.undertow" }
 ]
 commits.message = "build(deps): Update ${artifactName} from ${currentVersion} to ${nextVersion}"
 updates.limit = 5

--- a/build.sbt
+++ b/build.sbt
@@ -370,7 +370,7 @@ lazy val metals = project
       // for file watching
       "com.swoval" % "file-tree-views" % "2.1.9",
       // for http client
-      "io.undertow" % "undertow-core" % "2.3.0.Final",
+      "io.undertow" % "undertow-core" % "2.2.20.Final",
       "org.jboss.xnio" % "xnio-nio" % "3.8.8.Final",
       // for persistent data like "dismissed notification"
       "org.flywaydb" % "flyway-core" % "9.4.0",


### PR DESCRIPTION
It seems that undertow is now compiled with JDK 11, so we need to ignore it until we drop support for JDK 8.