### PR TITLE
Update bsp4j to 2.1.0-M3

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -16,7 +16,7 @@ object V {
   val betterMonadicFor = "0.3.1"
   val bloop = "1.5.4"
   val bloopNightly = bloop
-  val bsp = "2.1.0-M1"
+  val bsp = "2.1.0-M3"
   val coursier = "2.1.0-M7"
   val coursierInterfaces = "1.0.9"
   val debugAdapter = "2.2.0"

--- a/tests/unit/src/main/scala/bill/Bill.scala
+++ b/tests/unit/src/main/scala/bill/Bill.scala
@@ -220,6 +220,9 @@ object Bill {
     override def buildTargetInverseSources(
         params: InverseSourcesParams
     ): CompletableFuture[InverseSourcesResult] = ???
+    override def buildTargetOutputPaths(
+        params: OutputPathsParams
+    ): CompletableFuture[OutputPathsResult] = ???
     override def buildTargetDependencySources(
         params: DependencySourcesParams
     ): CompletableFuture[DependencySourcesResult] = {


### PR DESCRIPTION
In bsp4j `2.1.0-M2` was added function `buildTargetOutputPaths`  to exclude compilation artifacts from searchable files, more info you can find [here](https://github.com/build-server-protocol/build-server-protocol/issues/205).


By default, `metals` skip `output path` for build tools such as `sbt`, so if I'm right, `metals` don't have to add support for this function.