### PR TITLE
bugfix: Highlight transparent inline usages correctly

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcDocumentHighlightProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcDocumentHighlightProvider.scala
@@ -269,9 +269,15 @@ object PcDocumentHighlightProvider:
                 }
                 .flatten
                 .toSet ++ highlights
+            case inl: Inlined =>
+              val traverser =
+                new DeepFolder[Set[DocumentHighlight]](collectNames)
+              val trees = inl.call :: inl.expansion :: inl.bindings
+              trees.foldLeft(highlights) { case (set, tree) =>
+                traverser(set, tree)
+              }
             case o =>
               highlights
-
         val traverser = new DeepFolder[Set[DocumentHighlight]](collectNames)
         val all = traverser(Set.empty[DocumentHighlight], unit.tpdTree)
 

--- a/tests/cross/src/test/scala/tests/highlight/Scala3DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/Scala3DocumentHighlightSuite.scala
@@ -1,0 +1,54 @@
+package tests.highlight
+
+import tests.BaseDocumentHighlightSuite
+
+class Scala3DocumentHighlightSuite extends BaseDocumentHighlightSuite {
+
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreScala2)
+
+  check(
+    "transparent1",
+    """|trait Foo
+       |class Bar extends Foo
+       |
+       |transparent inline def <<foo>>(i: Int): Foo = new Bar
+       |val iii = 123
+       |val bar = <<f@@oo>>(iii)
+       |""".stripMargin,
+  )
+
+  check(
+    "transparent2",
+    """|trait Foo
+       |class Bar extends Foo
+       |
+       |transparent inline def <<f@@oo>>(i: Int): Foo = new Bar
+       |val iii = 123
+       |val bar = <<foo>>(iii)
+       |""".stripMargin,
+  )
+
+  check(
+    "transparent3",
+    """|trait Foo
+       |class Bar extends Foo
+       |
+       |transparent inline def foo(i: Int): Foo = new Bar
+       |val <<ii@@i>> = 123
+       |val bar = foo(<<iii>>)
+       |""".stripMargin,
+  )
+
+  check(
+    "transparent4",
+    """|trait Foo
+       |class Bar extends Foo
+       |
+       |transparent inline def foo(i: Int): Foo = new Bar
+       |val <<iii>> = 123
+       |val bar = foo(<<i@@ii>>)
+       |""".stripMargin,
+  )
+
+}


### PR DESCRIPTION
I will see if we can change the DeepFolder upstream