### PR TITLE
bugfix: Remove to check for Scala versions in worksheets

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -41,15 +41,6 @@ object Messages {
   )
 
   object Worksheets {
-    def unsupportedScalaVersion(
-        unsupportedVersion: String,
-        fallback: String,
-        recommended: String,
-    ) = new MessageParams(
-      MessageType.Warning,
-      s"Scala ${unsupportedVersion} is not supported in worksheets. Falling back to ${fallback} without your classpath.\n" +
-        s"Consider using ${recommended} instead to fix this.",
-    )
 
     val unableToExport = new MessageParams(
       MessageType.Warning,


### PR DESCRIPTION
Previously, worksheets would not work for backpublished versions. Now they should work correctly in their case.

The check is not needed since most binary versions should be supported until there is a breaking change.