### PR TITLE
Sort versions in reverse for coursier completions

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/CoursierComplete.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CoursierComplete.scala
@@ -7,6 +7,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.matching.Regex
 
+import scala.meta.internal.semver.SemVer.Version
 import scala.meta.internal.tokenizers.Chars
 
 import coursierapi.Complete
@@ -38,8 +39,14 @@ object CoursierComplete {
       if (dependency.endsWith(":") && dependency.count(_ == ':') == 1)
         completions(dependency + ":").map(":" + _)
       else List.empty
-    scalaCompletions ++ javaCompletions
+
+    val allCompletions = scalaCompletions ++ javaCompletions
+    // Attempt to sort versions in reverse order
+    if (dependency.replaceAll(":+", ":").count(_ == ':') == 2)
+      allCompletions.sortWith(Version.fromString(_) >= Version.fromString(_))
+    else allCompletions
   }
+
   def inferEditRange(point: Int, text: String): (Int, Int) = {
     def isArtifactPart(c: Char): Boolean =
       Chars.isIdentifierPart(c) || c == '.' || c == '-'

--- a/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
@@ -1,5 +1,6 @@
 package tests.feature
 
+import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.{BuildInfo => V}
 
@@ -44,15 +45,17 @@ class Ammonite213Suite extends tests.BaseAmmoniteSuite(V.ammonite213) {
       )
       _ = assertNoDiff(artefactCompletionList, artefactExpectedCompletionList)
 
-      versionExpectedCompletionList =
-        """
-          |0.14.0
-          |0.14.1""".stripMargin
-      versionCompletionList <- server.completion(
+      versionExpectedCompletionList = List("0.14.1", "0.14.0")
+      response <- server.completionList(
         "main.sc",
         "import $ivy.`io.circe::circe-yaml:0.14@@`",
       )
-      _ = assertNoDiff(versionCompletionList, versionExpectedCompletionList)
+      versionCompletionList = response
+        .getItems()
+        .asScala
+        .map(_.getLabel())
+        .toList
+      _ = assertEquals(versionCompletionList, versionExpectedCompletionList)
     } yield ()
   }
 }


### PR DESCRIPTION
Hi, I thought it would be more helpful if more up to date versions are shown first for version completions:
![dep-completions-sort](https://user-images.githubusercontent.com/17688577/196023524-cfa9b7a2-a306-4a48-ab6d-87c57ce28d6b.png)
So this PR reverses the sort when the completion items are versions.

Thanks!