### PR TITLE
bugfix: [Scala 3] Properly prepend package to toplevel methods

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaMtags.scala
@@ -32,7 +32,7 @@ class ScalaMtags(val input: Input.VirtualFile, dialect: Dialect)
   }
 
   private var _toplevelSourceRef: Option[(String, OverloadDisambiguator)] = None
-  private def topleveSourceData: (String, OverloadDisambiguator) = {
+  private def toplevelSourceData: (String, OverloadDisambiguator) = {
     _toplevelSourceRef match {
       case Some(v) => v
       case None =>
@@ -47,8 +47,8 @@ class ScalaMtags(val input: Input.VirtualFile, dialect: Dialect)
         value
     }
   }
-  private def toplevelSourceOwner: String = topleveSourceData._1
-  private def toplevelOverloads: OverloadDisambiguator = topleveSourceData._2
+  private def toplevelSourceOwner: String = toplevelSourceData._1
+  private def toplevelOverloads: OverloadDisambiguator = toplevelSourceData._2
 
   def currentTree: Tree = myCurrentTree
   private var myCurrentTree: Tree = Source(Nil)
@@ -297,14 +297,14 @@ class ScalaMtags(val input: Input.VirtualFile, dialect: Dialect)
           // see: https://github.com/scalameta/scalameta/issues/2443
           //      https://github.com/lampepfl/dotty/issues/11690
           val extensionParamss = t.paramss
-          val (owner, overloads) =
+          val overloads =
             if (isPackageOwner)
-              topleveSourceData
+              toplevelOverloads
             else
-              (currentOwner, new OverloadDisambiguator())
+              new OverloadDisambiguator()
 
           def addDefnDef(t: Defn.Def): Unit =
-            withOwner(owner) {
+            withOwner(fileOwner) {
               disambiguatedMethod(
                 t,
                 t.name,
@@ -315,7 +315,7 @@ class ScalaMtags(val input: Input.VirtualFile, dialect: Dialect)
               )
             }
           def addDeclDef(t: Decl.Def): Unit =
-            withOwner(owner) {
+            withOwner(fileOwner) {
               disambiguatedMethod(
                 t,
                 t.name,

--- a/tests/unit/src/test/resources/definition-scala3/example/Extension.scala
+++ b/tests/unit/src/test/resources/definition-scala3/example/Extension.scala
@@ -1,11 +1,11 @@
 package example
 
-extension/*<no symbol>*/ (i/*Extension.scala fallback to example.Extension$package.*/: Int/*Int.scala*/)
-  def asString/*Extension.scala fallback to example.Extension$package.*/: String/*Predef.scala*/ = i/*Extension.scala fallback to example.Extension$package.*/.toString
+extension/*<no symbol>*/ (i/*Extension.scala*/: Int/*Int.scala*/)
+  def asString/*Extension.scala*/: String/*Predef.scala*/ = i/*Extension.scala*/.toString
 
-extension/*<no symbol>*/ (s/*Extension.scala fallback to example.Extension$package.*/: String/*Predef.scala*/) {
-  def asInt/*Extension.scala fallback to example.Extension$package.*/: Int/*Int.scala*/ = s/*Extension.scala fallback to example.Extension$package.*/.toInt/*StringOps.scala*/
-  def double/*Extension.scala fallback to example.Extension$package.*/: String/*Predef.scala*/ = s/*Extension.scala fallback to example.Extension$package.*/ */*StringOps.scala*/ 2
+extension/*<no symbol>*/ (s/*Extension.scala*/: String/*Predef.scala*/) {
+  def asInt/*Extension.scala*/: Int/*Int.scala*/ = s/*Extension.scala*/.toInt/*StringOps.scala*/
+  def double/*Extension.scala*/: String/*Predef.scala*/ = s/*Extension.scala*/ */*StringOps.scala*/ 2
 }
 
 trait AbstractExtension/*Extension.scala*/ {

--- a/tests/unit/src/test/resources/mtags-scala3/example/Extension.scala
+++ b/tests/unit/src/test/resources/mtags-scala3/example/Extension.scala
@@ -1,11 +1,11 @@
 /*example.Extension$package.*/package example
 
-extension (i/*Extension$package.asString().(i)*/: Int)
-  def asString/*Extension$package.asString().*/: String = i.toString
+extension (i/*example.Extension$package.asString().(i)*/: Int)
+  def asString/*example.Extension$package.asString().*/: String = i.toString
 
-extension (s/*Extension$package.asInt().(s)*//*Extension$package.double().(s)*/: String) {
-  def asInt/*Extension$package.asInt().*/: Int = s.toInt
-  def double/*Extension$package.double().*/: String = s * 2
+extension (s/*example.Extension$package.asInt().(s)*//*example.Extension$package.double().(s)*/: String) {
+  def asInt/*example.Extension$package.asInt().*/: Int = s.toInt
+  def double/*example.Extension$package.double().*/: String = s * 2
 }
 
 trait AbstractExtension/*example.AbstractExtension#*/ {


### PR DESCRIPTION
Previously, when indexing Scala files we would not add the package part for toplevel methods, which would make it impossible to find them. Even without package you need `_empty_/`. Now, we propely append them.

Fixes https://github.com/scalameta/metals/issues/4531