### PR TITLE
Fix `exhaustive match` completion for type `TypeA with TypeB`

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -273,11 +273,14 @@ object CaseKeywordCompletion:
             loop(tp2)
           case t => parents += tpe.typeSymbol
       loop(tpe.widen.bounds.hi)
-      val subclasses = parents.toList.flatMap { parent =>
+      val subclasses = parents.toList.map { parent =>
         // There is an issue in Dotty, `sealedStrictDescendants` ends in an exception for java enums. https://github.com/lampepfl/dotty/issues/15908
         if parent.isAllOf(JavaEnumTrait) then parent.children
         else MetalsSealedDesc.sealedStrictDescendants(parent)
-      }
+      } match
+        case Nil => Nil
+        case subcls => subcls.reduce(_.intersect(_))
+
       sortSubclasses(tpe, subclasses, completionPos.sourceUri, search)
     end subclassesForType
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -432,7 +432,7 @@ class CompletionMatchSuite extends BaseCompletionSuite {
       |sealed trait TestB
       |case object Baz extends TestB
       |case object Goo extends TestB
-      |
+      |case object Both extends TestA with TestB
       |object Main {
       |  def testExhaustive[T <: TestA with TestB](test: T): Boolean =
       |    test m@@
@@ -446,14 +446,12 @@ class CompletionMatchSuite extends BaseCompletionSuite {
        |sealed trait TestB
        |case object Baz extends TestB
        |case object Goo extends TestB
-       |
+       |case object Both extends TestA with TestB
        |object Main {
        |  def testExhaustive[T <: TestA with TestB](test: T): Boolean =
        |    test match {
-       |\tcase Foo => $$0
-       |\tcase Bar =>
-       |\tcase Baz =>
-       |\tcase Goo =>
+       |\tcase Both => $$0
+       |\t
        |}
        |}""".stripMargin,
     filter = _.contains("exhaustive"),
@@ -467,14 +465,12 @@ class CompletionMatchSuite extends BaseCompletionSuite {
                 |sealed trait TestB
                 |case object Baz extends TestB
                 |case object Goo extends TestB
-                |
+                |case object Both extends TestA with TestB
                 |object Main {
                 |  def testExhaustive[T <: TestA with TestB](test: T): Boolean =
                 |    test match
-                |\tcase Foo => $$0
-                |\tcase Bar =>
-                |\tcase Baz =>
-                |\tcase Goo =>
+                |\tcase Both => $$0
+                |\t
                 |
                 |}""".stripMargin
     ),


### PR DESCRIPTION
Previously, in both Scala 2 and Scala 3 in code like 
```scala
sealed trait TestA
case object Foo extends TestA
case object Bar extends TestA
sealed trait TestB
case object Baz extends TestB
case object Goo extends TestB
object Main {
def testExhaustive[T <: TestA with TestB](test: T): Boolean =
  test ma@@
```
We would get  
```scala
test match {
    case Foo => 
    case Bar =>
    case Baz =>
    case Goo =>
  }
```
Which is incorrect, because these objects don't have type `TestA with TestB`.
Now, we show only only classes extending all "parent" types e.g.
```scala
case object Both extends TestA with TestB
```