### PR TITLE
Fix #4532: catch ZipException when opening jar files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/JarTopLevels.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JarTopLevels.scala
@@ -6,6 +6,7 @@ import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.Statement
 import java.util.zip.ZipError
+import java.util.zip.ZipException
 
 import scala.meta.internal.io.PlatformFileIO
 import scala.meta.internal.metals.JdbcEnrichments._
@@ -56,7 +57,7 @@ final class JarTopLevels(conn: () => Connection) {
         .headOption
         .map(_ => toplevels.result)
     } catch {
-      case _: ZipError =>
+      case _: ZipError | _: ZipException =>
         None
     }
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.mtags
 
 import java.util.zip.ZipError
+import java.util.zip.ZipException
 
 import scala.collection.concurrent.TrieMap
 import scala.util.control.NonFatal
@@ -82,6 +83,9 @@ final class OnDemandSymbolIndex(
           getOrCreateBucket(dialect).addSourceJar(jar)
         } catch {
           case e: ZipError =>
+            onError(IndexingExceptions.InvalidJarException(jar, e))
+            List.empty
+          case e: ZipException =>
             onError(IndexingExceptions.InvalidJarException(jar, e))
             List.empty
         }


### PR DESCRIPTION
A `ZipException` can happen if the jar file is an empty file.