### PR TITLE
fix: add special case for autoimport inside Import tree

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
@@ -281,6 +281,22 @@ class AutoImportsSuite extends BaseAutoImportsSuite {
        |""".stripMargin,
   )
 
+  checkEdit(
+    "import-in-import",
+    """|package inimport
+       |
+       |object A {
+       |  import <<ExecutionContext>>.global
+       |}
+       |""".stripMargin,
+    """|package inimport
+       |
+       |object A {
+       |  import scala.concurrent.ExecutionContext.global
+       |}
+       |""".stripMargin,
+  )
+
   checkAmmoniteEdit(
     "first-auto-import-amm-script",
     ammoniteWrapper(


### PR DESCRIPTION
Previously, the behaviour for auto-import action wasn't specified for
`import <<$SYMBOL>>` case.
Now in imports the required symbol using specifying full name in case if it's missing in scope as we do that in completions