### PR TITLE
refactor(ci): shuffle around build to speed it up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           [
             gradle-mac,
             sbt,
+            sbt-metals,
             maven,
             gradle,
             mill,
@@ -62,6 +63,7 @@ jobs:
             cross,
             scalafmt,
             scalafix,
+            download
           ]
         include:
           - type: gradle-mac
@@ -69,12 +71,12 @@ jobs:
             name: Gradle MacOS integration
             os: macOS-latest
           - type: sbt
-            command: bin/test.sh 'sbt-metals/scripted; slow/testOnly -- tests.sbt.*'
-            name: Sbt integration
+            command: bin/test.sh 'slow/testOnly -- tests.sbt.*'
+            name: sbt integration
             os: ubuntu-latest
-          - type: sbt-metals jdk8
+          - type: sbt-metals
             command: bin/test.sh sbt-metals/scripted
-            name: Sbt-metals/scripted jdk8
+            name: sbt-metals/scripted jdk8
             os: ubuntu-latest
             java: "8"
           - type: maven
@@ -109,6 +111,10 @@ jobs:
             command: ./bin/scalafmt --test
             name: Formatting
             os: ubuntu-latest
+          - type: download
+            command: ./bin/test.sh downloadDependencies
+            name: Test download dependencies
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -121,6 +127,3 @@ jobs:
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
-      - name: "test download dependencies"
-        run: sbt downloadDependencies
-        if: matrix.type == 'cross'


### PR DESCRIPTION
Just curious if this helps because I noticed that the cross tests and the sbt tests are the two that take the longes. I think we can split out the scripted tests from the slow sbt tests to speed that one up and I think we can split out the download dependencies from cross to also speed that up. While it make sense to have the download with the cross, the cross still takes around 40 min and then another 10 for the download. So I'm curious if it's just faster doing this.