### PR TITLE
fix: correctly import companion object for apply method

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
@@ -243,7 +243,10 @@ class CompletionProvider(
         case (_: Ident) :: (_: Import) :: _ =>
           mkItem(sym.fullNameBackticked)
         case _ =>
-          autoImports.editsForSymbol(sym) match
+          val forImportSymbol = v match
+            case w: CompletionValue.Workspace => w.applyOwner
+            case _ => sym
+          autoImports.editsForSymbol(forImportSymbol) match
             case Some(edits) =>
               edits match
                 case AutoImportEdits(Some(nameEdit), other) =>
@@ -274,6 +277,7 @@ class CompletionProvider(
                 case _ =>
                   mkItem(sym.fullNameBackticked + completionTextSuffix)
               end match
+          end match
       end match
     end mkItemWithImports
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
@@ -243,10 +243,7 @@ class CompletionProvider(
         case (_: Ident) :: (_: Import) :: _ =>
           mkItem(sym.fullNameBackticked)
         case _ =>
-          val forImportSymbol = v match
-            case w: CompletionValue.Workspace => w.applyOwner
-            case _ => sym
-          autoImports.editsForSymbol(forImportSymbol) match
+          autoImports.editsForSymbol(v.importSymbol) match
             case Some(edits) =>
               edits match
                 case AutoImportEdits(Some(nameEdit), other) =>

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -98,8 +98,10 @@ object CompletionValue:
       label: String,
       symbol: Symbol,
       override val snippetSuffix: CompletionSuffix,
+      maybeApplyOwner: Option[Symbol] = None,
   ) extends Symbolic:
     override def isFromWorkspace: Boolean = true
+    val applyOwner: Symbol = maybeApplyOwner.getOrElse(symbol)
 
   /**
    * CompletionValue for extension methods via SymbolSearch

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -58,6 +58,7 @@ object CompletionValue:
           kind = completionItemDataKind,
         )
       )
+    def importSymbol: Symbol = symbol
 
     def completionItemKind(using Context): CompletionItemKind =
       val symbol = this.symbol
@@ -98,10 +99,9 @@ object CompletionValue:
       label: String,
       symbol: Symbol,
       override val snippetSuffix: CompletionSuffix,
-      maybeApplyOwner: Option[Symbol] = None,
+      override val importSymbol: Symbol,
   ) extends Symbolic:
     override def isFromWorkspace: Boolean = true
-    val applyOwner: Symbol = maybeApplyOwner.getOrElse(symbol)
 
   /**
    * CompletionValue for extension methods via SymbolSearch
@@ -195,12 +195,14 @@ object CompletionValue:
       override val additionalEdits: List[TextEdit],
       override val range: Option[Range],
       override val filterText: Option[String],
+      override val importSymbol: Symbol,
       isWorkspace: Boolean = false,
       isExtension: Boolean = false,
   ) extends Symbolic:
     override def description(printer: MetalsPrinter)(using Context): String =
       if isExtension then s"${printer.completionSymbol(symbol)} (extension)"
       else super.description(printer)
+  end Interpolator
 
   case class MatchCompletion(
       label: String,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -552,7 +552,7 @@ class Completions(
                 completionsWithSuffix(
                   sym,
                   sym.decodedName,
-                  CompletionValue.Workspace(_, _, _),
+                  CompletionValue.Workspace(_, _, _, Some(sym)),
                 ).forall(visit),
         )
         Some(search.search(query, buildTargetIdentifier, visitor))
@@ -733,7 +733,7 @@ class Completions(
         // show the abstract members first
         if !ov.symbol.is(Deferred) then penalty |= MemberOrdering.IsNotAbstract
         penalty
-      case CompletionValue.Workspace(_, sym, _) =>
+      case CompletionValue.Workspace(_, sym, _, _) =>
         symbolRelevance(sym) | (IsWorkspaceSymbol + sym.name.show.length)
       case sym: CompletionValue.Symbolic =>
         symbolRelevance(sym.symbol)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -552,7 +552,7 @@ class Completions(
                 completionsWithSuffix(
                   sym,
                   sym.decodedName,
-                  CompletionValue.Workspace(_, _, _, Some(sym)),
+                  CompletionValue.Workspace(_, _, _, sym),
                 ).forall(visit),
         )
         Some(search.search(query, buildTargetIdentifier, visitor))

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
@@ -171,15 +171,16 @@ object InterpolatorCompletions:
           completions.completionsWithSuffix(
             sym,
             label,
-            (name, sym, suffix) =>
+            (name, s, suffix) =>
               CompletionValue.Interpolator(
-                sym,
+                s,
                 label,
                 Some(newText(name, suffix.toEditOpt, identOrSelect)),
                 Nil,
                 Some(cursor.withStart(identOrSelect.span.start).toLsp),
                 // Needed for VS Code which will not show the completion otherwise
                 Some(identOrSelect.name.toString() + "." + label),
+                s,
                 isExtension = isExtension,
               ),
           )
@@ -304,14 +305,15 @@ object InterpolatorCompletions:
         completions.completionsWithSuffix(
           sym,
           label,
-          (name, sym, suffix) =>
+          (name, s, suffix) =>
             CompletionValue.Interpolator(
-              sym,
+              s,
               label,
               Some(newText(name, suffix.toEditOpt)),
               additionalEdits(),
               Some(nameRange),
               None,
+              sym,
               isWorkspace,
             ),
         )

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -779,4 +779,16 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite {
     filter = _.contains("(extension)"),
   )
 
+  checkEdit(
+    "apply-method".tag(IgnoreScala2),
+    """|object Main {
+       |  val a = "$ListBuf@@""
+       |}""".stripMargin,
+    """|import scala.collection.mutable.ListBuffer
+       |object Main {
+       |  val a = s"${ListBuffer($0)}""
+       |}""".stripMargin,
+    filter = _.contains("[A]"),
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -761,4 +761,16 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |""".stripMargin,
     topLines = Some(2),
   )
+
+  checkEdit(
+    "apply-method".tag(IgnoreScala2),
+    """|object Main {
+       |  val a = ListBuf@@
+       |}""".stripMargin,
+    """|import scala.collection.mutable.ListBuffer
+       |object Main {
+       |  val a = ListBuffer($0)
+       |}""".stripMargin,
+    filter = _.contains("[A]"),
+  )
 }


### PR DESCRIPTION
fixes https://github.com/scalameta/metals/issues/4066

Previously, when choosing apply method completion we would import incorrect symbol, now we import companion object.