### PR TITLE
Expose Test Cases as Separate Lenses

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -621,8 +621,24 @@ class MetalsLanguageServer(
           clientConfig.commandInHtmlFormat(),
         )
         val worksheetCodeLens = new WorksheetCodeLens(clientConfig)
+        testProvider = new TestSuitesProvider(
+          buildTargets,
+          buildTargetClasses,
+          trees,
+          definitionIndex,
+          semanticdbs,
+          buffers,
+          clientConfig,
+          () => userConfig,
+          languageClient,
+        )
         codeLensProvider = new CodeLensProvider(
-          List(runTestLensProvider, goSuperLensProvider, worksheetCodeLens),
+          List(
+            runTestLensProvider,
+            goSuperLensProvider,
+            worksheetCodeLens,
+            testProvider,
+          ),
           semanticdbs,
           stacktraceAnalyzer,
         )
@@ -648,17 +664,6 @@ class MetalsLanguageServer(
           clientConfig,
           () => userConfig,
           trees,
-        )
-        testProvider = new TestSuitesProvider(
-          buildTargets,
-          buildTargetClasses,
-          trees,
-          definitionIndex,
-          semanticdbs,
-          buffers,
-          clientConfig,
-          () => userConfig,
-          languageClient,
         )
         semanticDBIndexer = new SemanticdbIndexer(
           List(

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -130,8 +130,8 @@ final class TestSuitesProvider(
             null,
           )
           List(
-            lens("test", ClientCommands.StartRunSession),
-            lens("debug test", ClientCommands.StartDebugSession),
+            lens("test case", ClientCommands.StartRunSession),
+            lens("debug test case", ClientCommands.StartDebugSession),
           )
         }
       }.flatten

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -63,7 +63,8 @@ final class TestSuitesProvider(
     new MunitTestFinder(trees, symbolIndex, semanticdbs)
   private val scalatestTestFinder =
     new ScalatestTestFinder(trees, symbolIndex, semanticdbs)
-  private val isExplorerEnabled = clientConfig.isTestExplorerProvider() &&
+
+  private def isExplorerEnabled = clientConfig.isTestExplorerProvider() &&
     userConfig().testUserInterface == TestUserInterfaceKind.TestExplorer
 
   override def isEnabled: Boolean = (clientConfig.isDebuggingProvider() &&

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -116,7 +116,10 @@ final class TestSuitesProvider(
     val path = textDocumentWithPath.filePath
     for {
       target <- buildTargets.inverseSources(path).toList
-      cases <- getTestCasesForPath(path, None)
+      cases <- getTestCasesForPath(
+        path,
+        Some(textDocumentWithPath.textDocument),
+      )
       lens <- cases.events.asScala.collect { case AddTestCases(fqn, _, cases) =>
         cases.asScala.flatMap { entry =>
           val c = ScalaTestSuiteSelection(fqn, List(entry.name).asJava)

--- a/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
@@ -55,11 +55,11 @@ class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
     """|package foo.bar
        |<<test>><<debug test>>
        |class Foo extends org.scalatest.funsuite.AnyFunSuite {
-       |<<test>><<debug test>>
+       |<<test case>><<debug test case>>
        |  test("foo") {
        |    assert(1 == 1)
        |  }
-       |<<test>><<debug test>>
+       |<<test case>><<debug test case>>
        |  test("bar") {
        |    assert(1 == 1)
        |  }

--- a/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
@@ -44,7 +44,25 @@ class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
     """|package foo.bar
        |<<test>><<debug test>>
        |class Foo extends org.scalatest.funsuite.AnyFunSuite {
-       |  test("foo") {}
+       |}
+       |""".stripMargin
+  )
+
+  checkTestCases(
+    "test-suite-with-tests",
+    library = Some("org.scalatest::scalatest:3.2.4"),
+  )(
+    """|package foo.bar
+       |<<test>><<debug test>>
+       |class Foo extends org.scalatest.funsuite.AnyFunSuite {
+       |<<test>><<debug test>>
+       |  test("foo") {
+       |    assert(1 == 1)
+       |  }
+       |<<test>><<debug test>>
+       |  test("bar") {
+       |    assert(1 == 1)
+       |  }
        |}
        |""".stripMargin
   )


### PR DESCRIPTION
Hi, this PR makes individual test cases runnable by exposing them as lenses.  This is (mainly) done by making `TestSuitesProvider` implement `CodeLens`, related is https://github.com/scalameta/metals-feature-requests/issues/216.

If a user has their `testUserInterface` configuration option set to `code lenses` then these new lenses should show up on test cases, otherwise if the option is set to `test explorer` then the existing behaviour remains, 

![lenses](https://user-images.githubusercontent.com/17688577/197730117-2df26c6f-e998-4583-a374-2c7625944f03.png)

Thanks!