### PR TITLE
refactor: Move some logic from CompletionProvider 

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -226,7 +226,7 @@ class CompletionProvider(
         case o: OverrideDefMember if o.sym.isJavaDefined =>
           CompletionItemData.OverrideKind
         case _ =>
-          null
+          CompletionItemData.None
       }
 
       val additionalSymbols = member match {

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -31,6 +31,7 @@ sealed trait CompletionValue:
   def completionData(
       buildTargetIdentifier: String
   )(using Context): Option[CompletionItemData] = None
+  def command: Option[String] = None
 
   /**
    * Label with potentially attached description.
@@ -142,6 +143,7 @@ object CompletionValue:
       label: String,
       tpe: Type,
   ) extends CompletionValue:
+    override def insertText: Option[String] = Some(label.replace("$", "$$"))
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Field
     override def description(printer: MetalsPrinter)(using Context): String =
@@ -156,6 +158,7 @@ object CompletionValue:
   ) extends CompletionValue:
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Enum
+    override def insertText: Option[String] = Some(value)
     override def label: String = "Autofill with default values"
 
   case class Keyword(label: String, override val insertText: Option[String])
@@ -213,7 +216,7 @@ object CompletionValue:
       override val insertText: Option[String],
       override val additionalEdits: List[TextEdit],
       override val range: Option[Range] = None,
-      val command: Option[String] = None,
+      override val command: Option[String] = None,
   ) extends Symbolic:
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Method
@@ -225,6 +228,9 @@ object CompletionValue:
 
   case class Document(label: String, doc: String, description: String)
       extends CompletionValue:
+    override def filterText: Option[String] = Some(description)
+
+    override def insertText: Option[String] = Some(doc)
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Snippet
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -418,13 +418,12 @@ object OverrideCompletions:
       if config.isCompletionSnippetsEnabled && shouldMoveCursor then "${0:???}"
       else "???"
     val value = s"$signature = $stub"
-    val filterText = signature
     CompletionValue.Override(
       label,
       value,
       sym.symbol,
       printer.shortenedNames,
-      Some(filterText),
+      Some(signature),
       start,
     )
   end toCompletionValue

--- a/mtags/src/main/scala/scala/meta/internal/pc/CompletionItemData.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CompletionItemData.scala
@@ -30,6 +30,7 @@ case class CompletionItemData(
 
 object CompletionItemData {
   def empty: CompletionItemData = CompletionItemData("", "")
+  val None: java.lang.Integer = 0
   // This is an `override def` completion item.
   val OverrideKind: java.lang.Integer = 1
   // This is a completion implementing all abstract members


### PR DESCRIPTION
Moving some of the logic from CompletionProvider to CompletionValue allows us to simplify the code a bit and have a single place dedicated to calculating all the elements of completions.

I want to further change that, but I don't want to do that allow at once.