### PR TITLE
Fix Test Case Code Lenses Appearing with Test Explorer

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -67,13 +67,17 @@ final class TestSuitesProvider(
   private def isExplorerEnabled = clientConfig.isTestExplorerProvider() &&
     userConfig().testUserInterface == TestUserInterfaceKind.TestExplorer
 
-  override def isEnabled: Boolean = (clientConfig.isDebuggingProvider() &&
-    userConfig().testUserInterface == TestUserInterfaceKind.CodeLenses) ||
-    isExplorerEnabled
+  private def isCodeLensEnabled = clientConfig.isDebuggingProvider() &&
+    userConfig().testUserInterface == TestUserInterfaceKind.CodeLenses
+
+  private def isSuiteRefreshEnabled = isExplorerEnabled || isCodeLensEnabled
+
+  // Applies to code lenses only
+  override def isEnabled: Boolean = isCodeLensEnabled
 
   val refreshTestSuites: BatchedFunction[Unit, Unit] =
     BatchedFunction.fromFuture { _ =>
-      if (isEnabled) doRefreshTestSuites()
+      if (isSuiteRefreshEnabled) doRefreshTestSuites()
       else Future.unit
     }
 


### PR DESCRIPTION
Hi, this PR picks up on an oversight in https://github.com/scalameta/metals/pull/4569 (apologies), which resulted in test case code lenses showing in the event that `testUserInterface` was set to `test explorer`.