### PR TITLE
bugfix: Handle null being sent in the user configuration

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -2725,7 +2725,7 @@ class MetalsLanguageServer(
         .configuration(params)
         .asScala
         .flatMap { items =>
-          items.asScala.headOption match {
+          items.asScala.headOption.flatMap(Option.apply) match {
             case Some(item) =>
               val json = item.asInstanceOf[JsonElement].getAsJsonObject()
               updateConfiguration(json)


### PR DESCRIPTION
Previously, configuration items could return a null and we would invoke getAsJsonObject() on it. Now, we first check if it's a null.

Fixes https://github.com/scalameta/metals/issues/4577