### PR TITLE
bugfix: Retry starting Ammonite when file changed

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1127,13 +1127,6 @@ class MetalsLanguageServer(
       }
     } else {
       buildServerPromise.future.flatMap { _ =>
-        val triggeredImportOpt =
-          if (
-            path.isAmmoniteScript && buildTargets.inverseSources(path).isEmpty
-          )
-            maybeImportScript(path)
-          else
-            None
         def load(): Future[Unit] = {
           val compileAndLoad =
             Future.sequence(
@@ -1151,7 +1144,7 @@ class MetalsLanguageServer(
             )
             .ignoreValue
         }
-        triggeredImportOpt.getOrElse(load())
+        maybeImportScript(path).getOrElse(load())
       }.asJava
     }
   }
@@ -1281,7 +1274,10 @@ class MetalsLanguageServer(
           renameProvider.runSave(),
           parseTrees(path),
           onChange(List(path)),
-        )
+        ) ++ // if we fixed the script, we might need to retry connection
+          maybeImportScript(
+            path
+          )
       )
       .ignoreValue
       .asJava
@@ -2765,36 +2761,42 @@ class MetalsLanguageServer(
   def maybeImportScript(path: AbsolutePath): Option[Future[Unit]] = {
     val scalaCliPath = scalaCliDirOrFile(path)
     if (
-      ammonite.loaded(path) || scalaCli.loaded(scalaCliPath) || isMillBuildSc(
-        path
-      )
+      !path.isAmmoniteScript ||
+      !buildTargets.inverseSources(path).isEmpty ||
+      ammonite.loaded(path) ||
+      scalaCli.loaded(scalaCliPath) ||
+      isMillBuildSc(path)
     )
       None
     else {
-      def doImportScalaCli(): Unit =
-        scalaCli.start(scalaCliPath).onComplete {
-          case Failure(e) =>
+      def doImportScalaCli(): Future[Unit] =
+        scalaCli
+          .start(scalaCliPath)
+          .map { _ =>
+            languageClient.showMessage(
+              Messages.ImportScalaScript.ImportedScalaCli
+            )
+          }
+          .recover { e =>
             languageClient.showMessage(
               Messages.ImportScalaScript.ImportFailed(path.toString)
             )
             scribe.warn(s"Error importing Scala CLI project $scalaCliPath", e)
-          case Success(_) =>
+          }
+      def doImportAmmonite(): Future[Unit] =
+        ammonite
+          .start(Some(path))
+          .map { _ =>
             languageClient.showMessage(
-              Messages.ImportScalaScript.ImportedScalaCli
+              Messages.ImportScalaScript.ImportedAmmonite
             )
-        }
-      def doImportAmmonite(): Unit =
-        ammonite.start(Some(path)).onComplete {
-          case Failure(e) =>
+          }
+          .recover { e =>
             languageClient.showMessage(
               Messages.ImportScalaScript.ImportFailed(path.toString)
             )
             scribe.warn(s"Error importing Ammonite script $path", e)
-          case Success(_) =>
-            languageClient.showMessage(
-              Messages.ImportScalaScript.ImportedAmmonite
-            )
-        }
+          }
 
       val autoImportAmmonite =
         tables.dismissedNotifications.AmmoniteImportAuto.isDismissed
@@ -2821,35 +2823,34 @@ class MetalsLanguageServer(
       val futureRes =
         if (autoImportAmmonite) {
           doImportAmmonite()
-          Future.unit
         } else if (autoImportScalaCli) {
           doImportScalaCli()
-          Future.unit
         } else {
-          val futureResp = languageClient
+          languageClient
             .showMessageRequest(Messages.ImportScalaScript.params())
             .asScala
-          futureResp.onComplete {
-            case Failure(e) =>
-              scribe.warn("Error requesting Scala script import", e)
-            case Success(null) =>
-              scribe.debug("Scala script import cancelled by user")
-            case Success(resp) =>
-              resp.getTitle match {
-                case Messages.ImportScalaScript.doImportAmmonite =>
-                  doImportAmmonite()
-                  askAutoImport(
-                    tables.dismissedNotifications.AmmoniteImportAuto
-                  )
-                case Messages.ImportScalaScript.doImportScalaCli =>
-                  doImportScalaCli()
-                  askAutoImport(
-                    tables.dismissedNotifications.ScalaCliImportAuto
-                  )
-                case _ =>
+            .flatMap { response =>
+              if (response != null)
+                response.getTitle match {
+                  case Messages.ImportScalaScript.doImportAmmonite =>
+                    askAutoImport(
+                      tables.dismissedNotifications.AmmoniteImportAuto
+                    )
+                    doImportAmmonite()
+                  case Messages.ImportScalaScript.doImportScalaCli =>
+                    askAutoImport(
+                      tables.dismissedNotifications.ScalaCliImportAuto
+                    )
+                    doImportScalaCli()
+                  case _ => Future.unit
+                }
+              else {
+                Future.unit
               }
-          }
-          futureResp.ignoreValue
+            }
+            .recover { e =>
+              scribe.warn("Error requesting Scala script import", e)
+            }
         }
       Some(futureRes)
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
@@ -263,11 +263,6 @@ final class Ammonite(
           _ <- connectToNewBuildServer(conn)
         } yield ()
       }
-      .recoverWith {
-        case t @ (_: AmmoniteFetcherException | _: AmmoniteMetalsException) =>
-          languageClient.showMessage(Messages.errorFromThrowable(t))
-          Future(())
-      }
   }
 
   def stop(): CompletableFuture[Object] = {


### PR DESCRIPTION
Previously, we would only start Ammonite when the file was opened. If the start failed user would need to reopen the file. Now, if the file changed and no ammonite session was started we will attempt to run it again.

Fixes https://github.com/scalameta/metals/issues/4581