### PR TITLE
Refactor override completions, move auto import generator

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -484,28 +484,7 @@ trait Completions { this: MetalsGlobal =>
             isPossibleInterpolatorMember(lit, head, text, pos)
               .getOrElse(NoneCompletion)
         }
-      case (_: Ident) ::
-          Select(Ident(TermName("scala")), TypeName("Unit")) ::
-          (defdef: DefDef) ::
-          (t: Template) :: _ if defdef.name.endsWith(CURSOR) =>
-        OverrideCompletion(
-          defdef.name,
-          t,
-          pos,
-          text,
-          defdef.pos.start,
-          !_.isGetter
-        )
-      case (valdef @ ValDef(_, name, _, Literal(Constant(null)))) ::
-          (t: Template) :: _ if name.endsWith(CURSOR) =>
-        OverrideCompletion(
-          name,
-          t,
-          pos,
-          text,
-          valdef.pos.start,
-          _ => true
-        )
+
       case (m @ Match(_, Nil)) :: parent :: _ =>
         CaseKeywordCompletion(m.selector, editRange, pos, text, parent)
       case Ident(name) :: (cd: CaseDef) :: (m: Match) :: parent :: _
@@ -519,14 +498,14 @@ trait Completions { this: MetalsGlobal =>
         CaseKeywordCompletion(m.selector, editRange, pos, text, parent)
       case (c: DefTree) :: (p: PackageDef) :: _ if c.namePos.includes(pos) =>
         FilenameCompletion(c, p, pos, editRange)
-      case (ident: Ident) :: (t: Template) :: _ =>
+      case OverrideExtractor(name, template, start, isCandidate) =>
         OverrideCompletion(
-          ident.name,
-          t,
+          name,
+          template,
           pos,
           text,
-          ident.pos.start,
-          _ => true
+          start,
+          isCandidate
         )
       case (imp @ Import(select, selector)) :: _
           if isAmmoniteFileCompletionPosition(imp, pos) =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -516,4 +516,39 @@ trait OverrideCompletions { this: MetalsGlobal =>
     if (offset > 0 && offset < t.pos.end) Some(offset)
     else None
   }
+
+  object OverrideExtractor {
+    def unapply(
+        path: List[Tree]
+    ): Option[(Name, Template, Int, Symbol => Boolean)] = {
+      path match {
+        case (_: Ident) ::
+            Select(Ident(TermName("scala")), TypeName("Unit")) ::
+            (defdef: DefDef) ::
+            (t: Template) :: _ if defdef.name.endsWith(CURSOR) =>
+          Some(
+            defdef.name,
+            t,
+            defdef.pos.start,
+            !_.isGetter
+          )
+        case (valdef @ ValDef(_, name, _, Literal(Constant(null)))) ::
+            (t: Template) :: _ if name.endsWith(CURSOR) =>
+          Some(
+            name,
+            t,
+            valdef.pos.start,
+            _ => true
+          )
+        case (ident: Ident) :: (t: Template) :: _ =>
+          Some(
+            ident.name,
+            t,
+            ident.pos.start,
+            _ => true
+          )
+        case _ => None
+      }
+    }
+  }
 }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
@@ -142,7 +142,7 @@ object AutoImports extends AutoImportsBackticks:
    * @param renames A function that returns the name of the given symbol which is renamed on import statement.
    */
   class AutoImportsGenerator(
-      pos: SourcePosition,
+      val pos: SourcePosition,
       importPosition: AutoImportPosition,
       indexedContext: IndexedContext,
       renames: Symbol => Option[String],

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -126,10 +126,11 @@ object CompletionValue:
       label: String,
       value: String,
       symbol: Symbol,
-      shortenedNames: List[ShortName],
+      override val additionalEdits: List[TextEdit],
       override val filterText: Option[String],
-      start: Int,
+      override val range: Option[Range],
   ) extends Symbolic:
+    override def insertText: Option[String] = Some(value)
     override def completionItemDataKind: Integer =
       CompletionItemData.OverrideKind
     override def completionItemKind(using Context): CompletionItemKind =

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -60,22 +60,13 @@ object CaseKeywordCompletion:
       config: PresentationCompilerConfig,
       search: SymbolSearch,
       parent: Tree,
+      autoImportsGen: AutoImportsGenerator,
       patternOnly: Option[String] = None,
       hasBind: Boolean = false,
   ): List[CompletionValue] =
     import indexedContext.ctx
-    val pos = completionPos.sourcePos
-    val typedTree = indexedContext.ctx.compilationUnit.tpdTree
     val definitions = indexedContext.ctx.definitions
-    val text = pos.source.content().mkString
     val clientSupportsSnippets = config.isCompletionSnippetsEnabled()
-    lazy val autoImportsGen = AutoImports.generator(
-      pos,
-      text,
-      typedTree,
-      indexedContext,
-      config,
-    )
     val completionGenerator = CompletionValueGenerator(
       indexedContext,
       completionPos,
@@ -239,20 +230,11 @@ object CaseKeywordCompletion:
       indexedContext: IndexedContext,
       config: PresentationCompilerConfig,
       search: SymbolSearch,
+      autoImportsGen: AutoImportsGenerator,
   ): List[CompletionValue] =
     import indexedContext.ctx
-    val pos = completionPos.sourcePos
-    val typedTree = indexedContext.ctx.compilationUnit.tpdTree
-    val definitions = indexedContext.ctx.definitions
-    val text = pos.source.content().mkString
     val clientSupportsSnippets = config.isCompletionSnippetsEnabled()
-    lazy val autoImportsGen = AutoImports.generator(
-      pos,
-      text,
-      typedTree,
-      indexedContext,
-      config,
-    )
+
     val completionGenerator = CompletionValueGenerator(
       indexedContext,
       completionPos,


### PR DESCRIPTION
Mosty moving cases to `OverrideCompletions` to clean up in `Completions`. Also moves adding auto imports inside `OverrideCompletions`