### PR TITLE
chore: Ignore failing tests on Java 8

### DIFF
--- a/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
@@ -100,7 +100,7 @@ class HoverDocSuite extends BaseHoverSuite {
   )
 
   check(
-    "java-method",
+    "java-method".tag(IgnoreScalaVersion(_ => isJava8)),
     """|import java.nio.file.Paths
        |
        |object O{

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -314,7 +314,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "fuzzy1",
+    "fuzzy1".tag(IgnoreScalaVersion(_ => isJava8)),
     """
       |object A {
       |  new PBuil@@
@@ -439,7 +439,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "import3",
+    "import3".tag(IgnoreScalaVersion(_ => isJava8)),
     """
       |import Path@@
       |""".stripMargin,


### PR DESCRIPTION
We no longer run cross tests on JDK 8 so it's safe and clearer to ignore failing tests explicitely

Fixes https://github.com/scalameta/metals/issues/4585