### PR TITLE
bugfix: Fix wrong namePos on package objects

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -669,8 +669,11 @@ class MetalsGlobal(
      * Returns the position of the name/identifier of this definition.
      */
     def namePos: Position = {
+      val name =
+        if (defn.symbol.isPackageObject) defn.symbol.enclosingPackageClass.name
+        else defn.name
       val start = defn.pos.point
-      val end = start + defn.name.dropLocal.decoded.length()
+      val end = start + name.dropLocal.decoded.length()
       Position.range(defn.pos.source, start, start, end)
     }
 

--- a/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
@@ -655,4 +655,18 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite {
        |}""".stripMargin,
   )
 
+  check(
+    // Scala 2.12.x has a bug where the namePos points at `object`
+    // working around would it involve a lot of additional logic
+    "package-object".tag(IgnoreScala212),
+    """|package example
+       |
+       |package object <<nes@@ted>> {
+       |
+       |  class PackageObjectNestedClass
+       |
+       |}
+       |""".stripMargin,
+  )
+
 }


### PR DESCRIPTION
Previously we would be using .name on package object and we would get `package`, which is not the correct name. Now, we look for the actual name of the package that this package object is accompanying.