### PR TITLE
Use coursier completions to handle backpublished mtags

### DIFF
--- a/metals/src/main/scala/scala/meta/metals/Main.scala
+++ b/metals/src/main/scala/scala/meta/metals/Main.scala
@@ -4,6 +4,8 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.Executors
 
 import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters._
+import scala.util.Try
 import scala.util.control.NonFatal
 
 import scala.meta.internal.metals.BuildInfo
@@ -14,10 +16,8 @@ import scala.meta.internal.metals.Trace
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.logging.MetalsLogger
 
-import org.eclipse.lsp4j.jsonrpc.Launcher
 import coursierapi.Complete
-import scala.jdk.CollectionConverters._
-import scala.util.Try
+import org.eclipse.lsp4j.jsonrpc.Launcher
 
 object Main {
   def main(args: Array[String]): Unit = {

--- a/metals/src/main/scala/scala/meta/metals/Main.scala
+++ b/metals/src/main/scala/scala/meta/metals/Main.scala
@@ -15,12 +15,59 @@ import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.logging.MetalsLogger
 
 import org.eclipse.lsp4j.jsonrpc.Launcher
+import coursierapi.Complete
+import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 object Main {
   def main(args: Array[String]): Unit = {
     if (args.exists(Set("-v", "--version", "-version"))) {
+      val api: Complete = coursierapi.Complete
+        .create()
+        .withInput("org.scalameta:mtags")
+
+      val supported =
+        BuildInfo.supportedScalaVersions.toSet
+
+      import scala.collection.parallel._
+
+      val additional =
+        api
+          .complete()
+          .getCompletions()
+          .asScala
+          .toVector
+          .flatMap { case artif =>
+            Try {
+              val scalaVer = artif.stripPrefix("mtags_")
+              val List(epoch, major, rest) = scalaVer.split("\\.", 3).toList
+
+              if (epoch == "2" && major.toInt < 11) None // 2.10 and below
+              else if (rest.endsWith("-NIGHTLY")) None // dotty nightlies
+              else if (supported(scalaVer))
+                None // versions we already know about
+              else if (epoch == "0") None // old dotty versions
+              else if (scalaVer.contains("-M")) None // milestone versions
+              else Some(scalaVer)
+            }.toOption.flatten
+          }
+          .toParArray
+          .filter { scalaVer =>
+            val res = coursierapi.Complete
+              .create()
+              .withInput(
+                s"org.scalameta:mtags_$scalaVer:${BuildInfo.metalsVersion}"
+              )
+              .complete()
+
+            res.getCompletions().asScala.contains(BuildInfo.metalsVersion)
+          }
+          .toVector
+
       val supportedScala2Versions =
-        BuildInfo.supportedScala2Versions
+        (BuildInfo.supportedScala2Versions ++ additional.filter(
+          _.startsWith("2.")
+        )).distinct
           .groupBy(ScalaVersions.scalaBinaryVersionFromFullVersion)
           .toSeq
           .sortBy(_._1)
@@ -28,7 +75,9 @@ object Main {
           .mkString("\n#       ")
 
       val supportedScala3Versions =
-        BuildInfo.supportedScala3Versions.sorted.mkString(", ")
+        (BuildInfo.supportedScala3Versions ++ additional.filter(
+          _.startsWith("3.")
+        )).sorted.distinct.mkString(", ")
 
       println(
         s"""|metals ${BuildInfo.metalsVersion}


### PR DESCRIPTION
Users often refer to the output of `metals --version` (in vim/emacs and may be others) to ensure their version of Scala is supported.

With mtags being backpublished, that output is often out of date.

This PR is to start a conversation about may be detecting backpublished mtags and showing the user the full set of supported version?