### PR TITLE
fix: don't show incorrect `extension` keyword completion

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
@@ -20,14 +20,14 @@ trait Keywords { this: MetalsGlobal =>
 
     lazy val notInComment = checkIfNotInComment(pos, text, latestEnclosing)
 
-    lazy val reverseTokens: Iterator[Token] = {
+    lazy val reverseTokens: Array[Token] = {
       // Try not to tokenize the whole file
       // Maybe we should re-use the tokenize result with `notInComment`
       val lineStart =
         if (pos.line > 0) pos.source.lineToOffset(pos.line - 1) else 0
       text.substring(lineStart, pos.start).tokenize.toOption match {
-        case Some(toks) => toks.tokens.reverseIterator
-        case None => Iterator.empty
+        case Some(toks) => toks.tokens.reverse
+        case None => Array.empty[Token]
       }
     }
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
@@ -35,7 +35,7 @@ object KeywordsCompletions:
         val isParam = this.isParam(path)
         val isSelect = this.isSelect(path)
         lazy val text = completionPos.cursorPos.source.content.mkString
-        lazy val reverseTokens: Iterator[Token] =
+        lazy val reverseTokens: Array[Token] =
           // Try not to tokenize the whole file
           // Maybe we should re-use the tokenize result with `notInComment`
           val lineStart =
@@ -48,8 +48,8 @@ object KeywordsCompletions:
             .substring(lineStart, completionPos.cursorPos.start)
             .tokenize
             .toOption match
-            case Some(toks) => toks.tokens.reverseIterator
-            case None => Iterator.empty
+            case Some(toks) => toks.tokens.reverse
+            case None => Array.empty[Token]
         end reverseTokens
         Keyword.all.collect {
           case kw

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -531,12 +531,6 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     """.stripMargin,
     """|extends
        |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|extension
-           |extends
-           |""".stripMargin
-    ),
   )
 
   check(
@@ -548,12 +542,6 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     """.stripMargin,
     """|extends
        |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|extension
-           |extends
-           |""".stripMargin
-    ),
   )
 
   check(
@@ -565,12 +553,6 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     """.stripMargin,
     """|extends
        |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|extension
-           |extends
-           |""".stripMargin
-    ),
   )
 
   check(
@@ -582,12 +564,6 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     """.stripMargin,
     """|extends
        |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|extension
-           |extends
-           |""".stripMargin
-    ),
   )
 
   check(
@@ -632,8 +608,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     compat =
       Map( // it works in Scala3 because `completionPos.cursorPos` gives us a `class Main\n exten`
         "3" ->
-          """|extension
-             |extends
+          """|extends
              |""".stripMargin
       ),
   )


### PR DESCRIPTION
Maybe it would better to use something like `additionalFilter` instead of `reveresedTokensPredicate` for `extension`, but since there are only two keywords using that, it should be ok

fixes https://github.com/scalameta/metals/issues/4419