### PR TITLE
bugfix: Don't show string code actions when they are enclosed within range

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/StringActions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/StringActions.scala
@@ -41,7 +41,7 @@ class StringActions(buffers: Buffers) extends CodeAction {
               )
               .collect {
                 case token: Token.Constant.String
-                    if (token.pos.toLsp.overlapsWith(range)
+                    if (token.pos.toLsp.encloses(range)
                       && isNotTripleQuote(token)) =>
                   token
                 case start: Token.Interpolation.Start
@@ -71,7 +71,7 @@ class StringActions(buffers: Buffers) extends CodeAction {
 
             val interpolationActions = tokens.collect {
               case token: Token.Constant.String
-                  if token.pos.toLsp.overlapsWith(range) =>
+                  if token.pos.toLsp.encloses(range) =>
                 interpolateAction(uri, token)
             }.toList
 
@@ -80,9 +80,9 @@ class StringActions(buffers: Buffers) extends CodeAction {
                 case (start: Token.Interpolation.Start, i: Int)
                     if (i + 2 < tokens.length
                       && tokens(i + 2).is[Token.Interpolation.End]) =>
-                  def overlaps = List(start, tokens(i + 1), tokens(i + 2))
-                    .exists(_.pos.toLsp.overlapsWith(range))
-                  if (overlaps) {
+                  def encloses = List(start, tokens(i + 1), tokens(i + 2))
+                    .exists(_.pos.toLsp.encloses(range))
+                  if (encloses) {
                     val lspRange = start.pos.toLsp
                     val editRange =
                       new l.Range(lspRange.getStart, lspRange.getEnd)

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -142,6 +142,7 @@ class ImportMissingSymbolLspSuite
        |
        |object A {
        |  val f = <<Future.successful(Instant.now)
+       |  val a = "  " + "  " + "  "
        |  val b = ListBuffer.newBuilder[Int]>>
        |}
        |""".stripMargin,
@@ -162,6 +163,7 @@ class ImportMissingSymbolLspSuite
        |
        |object A {
        |  val f = Future.successful(Instant.now)
+       |  val a = "  " + "  " + "  "
        |  val b = ListBuffer.newBuilder[Int]
        |}
        |""".stripMargin,


### PR DESCRIPTION
Previously, string code actions would show up in force when for example selecting the entire file to import all symbols, which would cause a bit of spam on the screen. Now, we show add/remove interpolation code actions if cursor/range is within the string