### PR TITLE
chore: swap scalameta Mill g8 for com-lihaoyi one

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
@@ -340,8 +340,8 @@ object NewProjectProvider {
         description = "Simple http4s example",
       ),
       MetalsQuickPickItem(
-        id = "scalameta/mill-scala-seed.g8",
-        label = "scalameta/mill-scala-seed.g8",
+        id = "com-lihaoyi/mill-scala-hello.g8",
+        label = "com-lihaoyi/mill-scala-hello.g8",
         description = "A Scala template for the Mill build tool",
       ),
       MetalsQuickPickItem(


### PR DESCRIPTION
There is an official one now supported in the com-lihaoyi org. I think we
should switch out ours for this one. Then we can actually just archive
the one we have with a message to use the com-lihaoyi instead. Less
repos to maintain ha.
