### PR TITLE
add showing semanticdb for sbt files and worksheets

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -299,9 +299,10 @@ trait CommonMtagsEnrichments {
   protected def filenameToLanguage(filename: String): Language = {
     if (filename.endsWith(".java")) Language.JAVA
     else if (
-      filename.endsWith(".scala") || (filename.endsWith(".sc") && !filename
-        .endsWith(".worksheet.sc"))
-    ) Language.SCALA
+      filename.endsWith(".scala") || filename.endsWith(".sc")
+      || filename.endsWith(".sbt")
+    )
+      Language.SCALA
     else Language.UNKNOWN_LANGUAGE
   }
 


### PR DESCRIPTION
fixes https://github.com/scalameta/metals/issues/3597
connected to https://github.com/scalameta/metals-vscode/pull/1216

Edit: The tests are ok, so this change shouldn't break anything