### PR TITLE
Add lsp-keep-workspace-alive to emacs config

### DIFF
--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -74,6 +74,8 @@ To use Metals in Emacs, place this snippet in your Emacs configuration (for exam
   ;; (setq lsp-log-io nil)
   ;; (setq lsp-completion-provider :capf)
   (setq lsp-prefer-flymake nil)
+  ;; Makes LSP shutdown the metals server when all buffers in the project are closed.
+  ;; https://emacs-lsp.github.io/lsp-mode/page/settings/mode/#lsp-keep-workspace-alive
   (setq lsp-keep-workspace-alive nil))
 
 ;; Add metals backend for lsp-mode

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -73,7 +73,8 @@ To use Metals in Emacs, place this snippet in your Emacs configuration (for exam
   ;; (setq lsp-idle-delay 0.500)
   ;; (setq lsp-log-io nil)
   ;; (setq lsp-completion-provider :capf)
-  (setq lsp-prefer-flymake nil))
+  (setq lsp-prefer-flymake nil)
+  (setq lsp-keep-workspace-alive nil))
 
 ;; Add metals backend for lsp-mode
 (use-package lsp-metals)


### PR DESCRIPTION
I think the suggested default configuration for Emacs should include `(setq lsp-keep-workspace-alive nil)` because that's the behavior I would expect by default from LSP: shutting down the metals server when I close all buffers of a project. For me, without anything special in my Emacs configuration, the variable was set to true by default.