### PR TITLE
bugfix: Correctly display statuses for Ammonite scripts in Doctor

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
@@ -14,7 +14,7 @@ import org.jsoup.Jsoup
 
 trait MtagsResolver {
   def resolve(scalaVersion: String): Option[MtagsBinaries]
-  final def isSupportedScalaVersion(version: String): Boolean =
+  def isSupportedScalaVersion(version: String): Boolean =
     resolve(version).isDefined
 }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -74,7 +74,7 @@ case class ScalaTarget(
       )
   }
 
-  def isAmmonite = displayName.endsWith(".sc")
+  def isAmmonite: Boolean = displayName.endsWith(".sc")
 
   def isSemanticdbEnabled: Boolean =
     scalac.isSemanticdbEnabled(scalaVersion) ||

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -74,8 +74,11 @@ case class ScalaTarget(
       )
   }
 
+  def isAmmonite = displayName.endsWith(".sc")
+
   def isSemanticdbEnabled: Boolean =
-    scalac.isSemanticdbEnabled(scalaVersion) || semanticDbEnabledAlternatively
+    scalac.isSemanticdbEnabled(scalaVersion) ||
+      semanticDbEnabledAlternatively || isAmmonite
 
   def isSourcerootDeclared: Boolean =
     scalac.isSourcerootDeclared(scalaVersion) || semanticDbEnabledAlternatively

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
@@ -575,6 +575,7 @@ final class Doctor(
           DoctorStatus.alert,
           problemResolver.recommendation(target, Some(scalaTarget)),
         )
+      case None if scalaTarget.isAmmonite => (DoctorStatus.info, None)
       case None => (DoctorStatus.alert, None)
     }
 
@@ -586,6 +587,8 @@ final class Doctor(
     val sbtRecommendation =
       if (scalaTarget.isSbt)
         Some("Diagnostics and debugging for sbt are not supported currently.")
+      else if (scalaTarget.isAmmonite)
+        Some("Debugging for Ammonite are not supported currently.")
       else None
     DoctorTargetInfo(
       scalaTarget.displayName,

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/DoctorExplanation.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/DoctorExplanation.scala
@@ -80,7 +80,9 @@ sealed trait DoctorExplanation {
       _.element("p")(_.text(title)).element("ul") { ul =>
         ul.element("li")(_.text(correctMessage))
         if (show)
-          ul.element("li")(_.text(incorrectMessage))
+          incorrectMessage.linesIterator.foreach { legend =>
+            ul.element("li")(_.text(legend))
+          }
       }
     )
 
@@ -170,7 +172,8 @@ object DoctorExplanation {
     val correctMessage: String =
       s"${Icons.unicode.check} - working non-interactive features (references, rename etc.)"
     val incorrectMessage: String =
-      s"${Icons.unicode.error} - missing semanticdb plugin, might not be added automatically by the build server (work for Bloop only)"
+      s"""|${Icons.unicode.error} - missing semanticdb plugin, might not be added automatically by the build server (work for Bloop only)
+          |${Icons.unicode.info} - build target doesn't support Java files""".stripMargin
 
     def show(allTargetsInfo: Seq[DoctorTargetInfo]): Boolean =
       allTargetsInfo.exists(_.javaStatus.isCorrect == false)

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/DoctorResults.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/DoctorResults.scala
@@ -44,6 +44,7 @@ object DoctorStatus {
   object check extends DoctorStatus(Icons.unicode.check, true)
   object alert extends DoctorStatus(Icons.unicode.alert, false)
   object error extends DoctorStatus(Icons.unicode.error, false)
+  object info extends DoctorStatus(Icons.unicode.info, false)
 }
 
 final case class DoctorTargetInfo(

--- a/tests/unit/src/main/scala/tests/TestMtagsResolver.scala
+++ b/tests/unit/src/main/scala/tests/TestMtagsResolver.scala
@@ -13,14 +13,18 @@ import scala.meta.internal.metals.ScalaVersions
 class TestMtagsResolver extends MtagsResolver {
 
   val default: MtagsResolver = MtagsResolver.default()
+
+  /**
+   * We don't need to check unsupported versions in tests and that makes the tests run longer.
+   */
   override def resolve(scalaVersion: String): Option[MtagsBinaries] = {
-    default.resolve(scalaVersion).orElse(fakeBinaries(scalaVersion))
+    if (ScalaVersions.isSupportedAtReleaseMomentScalaVersion(scalaVersion))
+      default.resolve(scalaVersion).orElse(Some(MtagsBinaries.BuildIn))
+    else None
   }
 
-  private def fakeBinaries(scalaVersion: String): Option[MtagsBinaries] = {
-    if (ScalaVersions.isSupportedAtReleaseMomentScalaVersion(scalaVersion))
-      Some(MtagsBinaries.BuildIn)
-    else
-      None
+  override def isSupportedScalaVersion(version: String): Boolean = {
+    ScalaVersions.isSupportedAtReleaseMomentScalaVersion(version)
   }
+
 }

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -199,6 +199,13 @@ class ProblemResolverSuite extends FunSuite {
     classpath = List("org/scalameta/munit_2.13/1.0.1/"),
   )
 
+  checkRecommendation(
+    "main.sc",
+    scalaVersion = BuildInfo.scala213,
+    "",
+    classpath = List("org/scalameta/munit_2.13/1.0.1/"),
+  )
+
   def checkRecommendation(
       name: TestOptions,
       scalaVersion: String,
@@ -261,6 +268,7 @@ class ProblemResolverSuite extends FunSuite {
         /* dependencies = */ Nil.asJava,
         /* capabilities = */ new BuildTargetCapabilities(true, true, true),
       )
+    buildTarget.setDisplayName(id)
     val scalaBuildTarget = new ScalaBuildTarget(
       "org.scala-lang",
       scalaVersion,


### PR DESCRIPTION
Previously, we would report issues with Java support and semanticdb, which isn't true, since semanticdb is generated and Java is not supported. Now, we correctly show that in the doctor.

Fixes https://github.com/scalameta/metals/issues/3305

![image](https://user-images.githubusercontent.com/3807253/200347574-774f51ad-a95c-452b-99d7-bb42fb4a2935.png)
