### PR TITLE
fix: complete already overridden symbols in scala 3

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -410,7 +410,7 @@ class Completions(
 
       // class FooImpl extends Foo:
       //   def x|
-      case OverrideExtractor(td, completing, start, exhaustive) =>
+      case OverrideExtractor(td, completing, start, exhaustive, fallbackName) =>
         (
           OverrideCompletions.contribute(
             td,
@@ -420,6 +420,7 @@ class Completions(
             search,
             config,
             autoImports,
+            fallbackName,
           ),
           exhaustive,
         )

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -55,6 +55,7 @@ object OverrideCompletions:
       search: SymbolSearch,
       config: PresentationCompilerConfig,
       autoImportsGen: AutoImportsGenerator,
+      fallbackName: Option[Name],
   ): List[CompletionValue] =
     import indexedContext.ctx
     val clazz = td.symbol.asClass
@@ -87,6 +88,7 @@ object OverrideCompletions:
     // because they are not method definitions (not starting from `def`).
     val flags = completing.map(_.flags & interestingFlags).getOrElse(EmptyFlags)
 
+    val name = completing.fold(fallbackName)(sym => Some(sym.name))
     // not using `td.tpe.abstractTermMembers` because those members includes
     // the abstract members in `td.tpe`. For example, when we type `def foo@@`,
     // `td.tpe.abstractTermMembers` contains `method foo: <error>` and it overrides the parent `foo` method.
@@ -100,8 +102,8 @@ object OverrideCompletions:
       .distinct
       .collect {
         case denot
-            if completing
-              .fold(true)(sym => denot.name.startsWith(sym.name.show)) &&
+            if name
+              .fold(true)(name => denot.name.startsWith(name.show)) &&
               !denot.symbol.isType =>
           denot.symbol
       }
@@ -491,19 +493,21 @@ object OverrideCompletions:
               completing,
               dd.sourcePos.start,
               true,
+              None,
             )
           )
 
         // class FooImpl extends Foo:
         //   ov|
         case (ident: Ident) :: (t: Template) :: (td: TypeDef) :: _
-            if t.parents.nonEmpty && ident.name.startsWith("o") =>
+            if t.parents.nonEmpty && "override".startsWith(ident.name.show) =>
           Some(
             (
               td,
               None,
               ident.sourcePos.start,
               false,
+              None,
             )
           )
 
@@ -516,6 +520,7 @@ object OverrideCompletions:
               None,
               t.sourcePos.start,
               true,
+              None,
             )
           )
 
@@ -529,8 +534,24 @@ object OverrideCompletions:
               Some(sel.symbol),
               sel.sourcePos.start,
               false,
+              None,
             )
           )
+
+        // class Main extends Val:
+        //    he@@ // incomplete symbol
+        case (id: Ident) :: (t: Template) :: (td: TypeDef) :: _
+            if t.parents.nonEmpty =>
+          Some(
+            (
+              td,
+              None,
+              id.sourcePos.start,
+              false,
+              Some(id.name),
+            )
+          )
+
         case _ => None
 
   end OverrideExtractor

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -205,16 +205,16 @@ class MetalsPrinter(
       .mkString("", "", s": ${returnType}")
 
     val flags = (gsym.flags & methodFlags)
-    val flagString =
+    val flagsSeq =
       if !flags.isEmpty then
         val privateWithin =
           if gsym.privateWithin != NoSymbol then gsym.privateWithin.name.show
           else ""
-        flags.flagStrings(privateWithin).mkString(" ") + " "
-      else ""
-    val mods =
-      if additionalMods.isEmpty then flagString
-      else additionalMods.mkString(" ") + " " + flagString
+        flags.flagStrings(privateWithin)
+      else Nil
+    val mods = (additionalMods ++ flagsSeq).distinct match
+      case Nil => ""
+      case xs => xs.mkString("", " ", " ")
 
     if onlyMethodParams then paramssSignature
     else

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -1063,7 +1063,33 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "overriden-twice".tag(IgnoreScala3), // empty
+    "overriden-twice",
+    """
+      |trait A {
+      |  def close: Unit
+      |}
+      |trait B extends A{
+      |  override def close : Unit = {}
+      |}
+      |class C extends B{
+      |  close@@
+      |}
+    """.stripMargin,
+    """|trait A {
+       |  def close: Unit
+       |}
+       |trait B extends A{
+       |  override def close : Unit = {}
+       |}
+       |class C extends B{
+       |  override def close: Unit = ${0:???}
+       |}
+       |""".stripMargin,
+    filter = (str) => str.contains("def"),
+  )
+
+  checkEdit(
+    "not-complete-ident".tag(IgnoreScala3),
     """
       |trait A {
       |  def close: Unit
@@ -1074,7 +1100,7 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
       |class C extends B{
       |  clos@@
       |}
-    """.stripMargin,
+      """.stripMargin,
     """|trait A {
        |  def close: Unit
        |}

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -1089,7 +1089,7 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "not-complete-ident".tag(IgnoreScala3),
+    "not-complete-ident",
     """
       |trait A {
       |  def close: Unit


### PR DESCRIPTION
Partially solves https://github.com/scalameta/metals/issues/3928

Previously 
```scala
trait A {
  def close: Unit
}
trait B extends A{
  override def close : Unit = {}
}
class C extends B{
  close@@
}
```
would result in 
```scala
override override def close: Unit = ???
```

Also fixes not showing completions on not completed method names like in
```scala

class C extends B{
  clos@@
}
```