### PR TITLE
fix: more accurate signature on error in override comp

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -396,7 +396,11 @@ object OverrideCompletions:
     val signature =
       // `iterator` method in `new Iterable[Int] { def iterato@@ }`
       // should be completed as `def iterator: Iterator[Int]` instead of `Iterator[A]`.
-      val seenFrom = defn.tpe.memberInfo(sym.symbol)
+      val seenFrom =
+        val memInfo = defn.tpe.memberInfo(sym.symbol)
+        if memInfo.isErroneous then sym.info
+        else memInfo
+
       if sym.is(Method) then
         printer.defaultMethodSignature(
           sym.symbol,
@@ -411,6 +415,7 @@ object OverrideCompletions:
           additionalMods =
             if overrideKeyword.nonEmpty then List(overrideKeyword) else Nil,
         )
+      end if
     end signature
 
     val label = s"$overrideDefLabel$signature"

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -233,16 +233,6 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
       |}
     """.stripMargin,
     filter = _.contains("iterat"),
-    compat = Map(
-      "3" -> // TODO: should s/Any/Iterator[A]/
-        """
-          |object Main {
-          |  new scala.Iterable[Unknown] {
-          |    def iterator: Iterator[Any] = ${0:???}
-          |  }
-          |}
-        """.stripMargin
-    ),
   )
 
   check(


### PR DESCRIPTION
Partially resolves https://github.com/scalameta/metals/issues/3928

I've noticed that `sym.info` works fine in `MetalsPrinter.completionSymbol`, so I used as a fallback if type is erroneous