### PR TITLE
docs: remove old resolver in docs

### DIFF
--- a/metals-docs/src/main/scala/docs/BootstrapModifier.scala
+++ b/metals-docs/src/main/scala/docs/BootstrapModifier.scala
@@ -29,7 +29,6 @@ class BootstrapModifier extends StringModifier {
            |  --java-opt -Xms100m \\
            |  --java-opt -Dmetals.client=$client \\
            |  org.scalameta:metals_2.13:${Docs.release.version} \\
-           |  -r bintray:scalacenter/releases \\
            |  -r sonatype:snapshots \\
            |  -o /usr/local/bin/$binary -f
            |```


### PR DESCRIPTION
This is no longer used and doesn't need to be listed
in the bootstrap instructions
