### PR TITLE
bugfix: Fix compliation issues with 3.3.x

### DIFF
--- a/mtags/src/main/scala-3.0/scala/meta/internal/pc/printer/RefinedDotcPrinter.scala
+++ b/mtags/src/main/scala-3.0/scala/meta/internal/pc/printer/RefinedDotcPrinter.scala
@@ -1,0 +1,16 @@
+package scala.meta.internal.pc.printer
+
+import dotty.tools.dotc.printing.RefinedPrinter
+import dotty.tools.dotc.core.Types.*
+import dotty.tools.dotc.core.Contexts.Context
+
+abstract class RefinedDotcPrinter(_ctx: Context) extends RefinedPrinter(_ctx):
+
+  override protected def toTextRefinement(rt: RefinedType) =
+    val keyword = rt.refinedInfo match
+      case _: ExprType | _: MethodOrPoly => "def "
+      case _: TypeBounds => "type "
+      case _: TypeProxy => "val "
+      case _ => ""
+    (keyword ~ refinementNameString(rt) ~ toTextRHS(rt.refinedInfo)).close
+end RefinedDotcPrinter

--- a/mtags/src/main/scala-3.1/scala/meta/internal/pc/printer/RefinedDotcPrinter.scala
+++ b/mtags/src/main/scala-3.1/scala/meta/internal/pc/printer/RefinedDotcPrinter.scala
@@ -1,0 +1,16 @@
+package scala.meta.internal.pc.printer
+
+import dotty.tools.dotc.printing.RefinedPrinter
+import dotty.tools.dotc.core.Types.*
+import dotty.tools.dotc.core.Contexts.Context
+
+abstract class RefinedDotcPrinter(_ctx: Context) extends RefinedPrinter(_ctx):
+
+  override protected def toTextRefinement(rt: RefinedType) =
+    val keyword = rt.refinedInfo match
+      case _: ExprType | _: MethodOrPoly => "def "
+      case _: TypeBounds => "type "
+      case _: TypeProxy => "val "
+      case _ => ""
+    (keyword ~ refinementNameString(rt) ~ toTextRHS(rt.refinedInfo)).close
+end RefinedDotcPrinter

--- a/mtags/src/main/scala-3.2/scala/meta/internal/pc/printer/RefinedDotcPrinter.scala
+++ b/mtags/src/main/scala-3.2/scala/meta/internal/pc/printer/RefinedDotcPrinter.scala
@@ -1,0 +1,16 @@
+package scala.meta.internal.pc.printer
+
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Types.*
+import dotty.tools.dotc.printing.RefinedPrinter
+
+abstract class RefinedDotcPrinter(_ctx: Context) extends RefinedPrinter(_ctx):
+
+  override protected def toTextRefinement(rt: RefinedType) =
+    val keyword = rt.refinedInfo match
+      case _: ExprType | _: MethodOrPoly => "def "
+      case _: TypeBounds => "type "
+      case _: TypeProxy => "val "
+      case _ => ""
+    (keyword ~ refinementNameString(rt) ~ toTextRHS(rt.refinedInfo)).close
+end RefinedDotcPrinter

--- a/mtags/src/main/scala-3.3/scala/meta/internal/pc/printer/RefinedDotcPrinter.scala
+++ b/mtags/src/main/scala-3.3/scala/meta/internal/pc/printer/RefinedDotcPrinter.scala
@@ -1,0 +1,6 @@
+package scala.meta.internal.pc.printer
+
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.printing.RefinedPrinter
+
+abstract class RefinedDotcPrinter(_ctx: Context) extends RefinedPrinter(_ctx)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/DotcPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/DotcPrinter.scala
@@ -29,7 +29,9 @@ object DotcPrinter:
 
   private val defaultWidth = 1000
 
-  class Std(using ctx: Context) extends RefinedPrinter(ctx) with DotcPrinter:
+  class Std(using ctx: Context)
+      extends RefinedDotcPrinter(ctx)
+      with DotcPrinter:
 
     override def nameString(name: Name): String =
       super.nameString(name.stripModuleClassSuffix)
@@ -69,24 +71,6 @@ object DotcPrinter:
 
     def fullName(sym: Symbol): String =
       fullNameString(sym)
-
-    override protected def toTextRefinement(rt: RefinedType): Closed =
-      rt.refinedInfo match
-        case TypeBounds(lo, hi) if lo == hi =>
-          val tsym = rt.parent.member(rt.refinedName).symbol
-          if tsym.exists then
-            ("type " ~ simpleNameString(tsym) ~ " = " ~ toText(hi)).close
-          else super.toTextRefinement(rt)
-        case tp: TypeRef =>
-          ("val " ~ nameString(rt.refinedName) ~ ": " ~ toText(tp)).close
-        case tp: ExprType =>
-          ("def " ~ nameString(rt.refinedName) ~ ": " ~ toText(
-            tp.resType
-          )).close
-        case tp: MethodType =>
-          ("def " ~ nameString(rt.refinedName) ~ toText(tp)).close
-        case _ =>
-          super.toTextRefinement(rt)
 
     override def toText(tp: Type): Text =
       // Override the behavior for `AppliedType` because

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -646,6 +646,18 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |  val c: Foo{type T = Int; type G = Long} = new Foo { type T = Int; type G = Long}
        |}
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|object O{
+           |  trait Foo {
+           |    type T
+           |    type G
+           |  }
+           |
+           |  val c: Foo{type T >: Int <: Int; type G >: Long <: Long} = new Foo { type T = Int; type G = Long}
+           |}
+           |""".stripMargin
+    ),
   )
 
   checkEdit(
@@ -666,6 +678,17 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |  val d: Foo{type T = Int} = c
        |}
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|object O{
+           |  trait Foo {
+           |    type T
+           |  }
+           |  val c = new Foo { type T = Int }
+           |  val d: Foo{type T >: Int <: Int} = c
+           |}
+           |""".stripMargin
+    ),
   )
 
   checkEdit(
@@ -686,6 +709,17 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |  val c: Foo{type T = Int} = new Foo { type T = Int }
        |}
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|object O{
+           |  trait Foo {
+           |    type T
+           |  }
+           |
+           |  val c: Foo{type T >: Int <: Int} = new Foo { type T = Int }
+           |}
+           |""".stripMargin
+    ),
   )
 
   checkEdit(
@@ -705,7 +739,7 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |  type T
        |}
        |
-       |val c: Foo{type T = Int; val x: Int; def y: Int; val z: Int; def z_=(x$1: Int): Unit} = new Foo {
+       |val c: Foo{type T >: Int <: Int; val x: Int; def y: Int; val z: Int; def z_=(x$1: Int): Unit} = new Foo {
        |  type T = Int
        |  val x = 0
        |  def y = 0


### PR DESCRIPTION
Previously, toTextRefinement would return `Closed` type and now it returns `Text`, which is causing the compilation issues.

Now, since the printer prints the types for refinments correctly, we can avoid overriding the method altogether.

The type is printer a bit differently, but it does compile, so let's keep it in line with the compiler.