### PR TITLE
Improve Behaviour of Initial ivy Completions (scala 2)

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -551,9 +551,9 @@ trait Completions { this: MetalsGlobal =>
   def isWorksheetIvyCompletionPosition(tree: Tree, pos: Position): Boolean =
     tree match {
       case Import(select, _) =>
-        pos.source.file.name.isWorksheet && (select
-          .toString() == "<$ivy: error>" || select
-          .toString() == "<$dep: error>")
+        pos.source.file.name.isWorksheet &&
+        (select.toString().startsWith("<$ivy: error>") ||
+          select.toString().startsWith("<$dep: error>"))
       case _ => false
     }
 

--- a/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
@@ -3,7 +3,34 @@ package tests.feature
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.{BuildInfo => V}
 
-class Ammonite213Suite extends tests.BaseAmmoniteSuite(V.ammonite213)
+class Ammonite213Suite extends tests.BaseAmmoniteSuite(V.ammonite213) {
+
+  test("ivy-completion-extended-initial-completion") {
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "${V.scala213}"
+           |  }
+           |}
+           |/main.sc
+           |import $$ivy.org.scalame
+           |""".stripMargin
+      )
+      _ <- server.didOpen("main.sc")
+      _ <- server.didSave("main.sc")(identity)
+      _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
+
+      groupCompletionList <- server.completion(
+        "main.sc",
+        "import $ivy.org.scalame@@",
+      )
+      _ = assertNoDiff(groupCompletionList, "org.scalameta")
+    } yield ()
+  }
+}
 
 class Ammonite3Suite extends tests.BaseAmmoniteSuite(V.ammonite3)
 

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -659,4 +659,30 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
       _ = assertNoDiff(noCompletions, "")
     } yield ()
   }
+
+  test("ivy-completion-extended-initial-completion") {
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "$scalaVersion"
+           |  }
+           |}
+           |/main.sc
+           |import $$ivy.org.scalame
+           |""".stripMargin
+      )
+      _ <- server.didOpen("main.sc")
+      _ <- server.didSave("main.sc")(identity)
+      _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
+
+      groupCompletionList <- server.completion(
+        "main.sc",
+        "import $ivy.org.scalame@@",
+      )
+      _ = assertNoDiff(groupCompletionList, "org.scalameta")
+    } yield ()
+  }
 }

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -659,30 +659,4 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
       _ = assertNoDiff(noCompletions, "")
     } yield ()
   }
-
-  test("ivy-completion-extended-initial-completion") {
-    for {
-      _ <- initialize(
-        s"""
-           |/metals.json
-           |{
-           |  "a": {
-           |    "scalaVersion": "$scalaVersion"
-           |  }
-           |}
-           |/main.sc
-           |import $$ivy.org.scalame
-           |""".stripMargin
-      )
-      _ <- server.didOpen("main.sc")
-      _ <- server.didSave("main.sc")(identity)
-      _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
-
-      groupCompletionList <- server.completion(
-        "main.sc",
-        "import $ivy.org.scalame@@",
-      )
-      _ = assertNoDiff(groupCompletionList, "org.scalameta")
-    } yield ()
-  }
 }


### PR DESCRIPTION
Hi! This PR improves ivy completions in some circumstances by returning completions on all parts of the group id without backtics being present, probably best explained by a snippet:

https://user-images.githubusercontent.com/17688577/201718881-1d251a70-356d-4f78-a637-11bf4b78d3ce.mp4

Previously, you would get no completion after `import $ivy.org.|`