### PR TITLE
chore(ci): remove coc-metals from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,7 +41,6 @@ body:
       options:
         - VS Code
         - Sublime
-        - Nvim/Vim (coc-metals)
         - Nvim (nvim-metals)
         - Nvim/Vim (other)
         - Emacs (lsp-metals)


### PR DESCRIPTION
It's been archived for a while now so we can remove this.
