### PR TITLE
Add scala-debug-adapter 2x support by Scala CLI

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -95,7 +95,7 @@ class BuildServerConnection private (
       "1.4.10",
       version,
     )
-    isSbt || (isBloop && supportNewDebugAdapter)
+    isSbt || isScalaCLI || (isBloop && supportNewDebugAdapter)
   }
 
   def workspaceDirectory: AbsolutePath = workspace

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -159,7 +159,7 @@ class DebugProvider(
           )
         } else {
           throw new IllegalArgumentException(
-            s"${buildServer.name} ${buildServer.version} does not support scala-debug-adpater 2.x"
+            s"${buildServer.name} ${buildServer.version} does not support scala-debug-adapter 2.x"
           )
         }
       DebugProxy.open(


### PR DESCRIPTION
Scala CLI supports scala-debug-adapter 2x so it should be possible to use.