### PR TITLE
fix: ensure name for scala-cli is correct

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -371,7 +371,7 @@ object ScalaCli {
   def scalaCliMainClass: String =
     "scala.cli.ScalaCli"
 
-  val name = "ScalaCli"
+  val name = "scala-cli"
 
   sealed trait ConnectionState
   object ConnectionState {


### PR DESCRIPTION
This is a follow-up to https://github.com/scalameta/metals/pull/4649 since it didn't actually fix the issue since `isScalaCli` was looking for the connection name to be `ScalaCli`, however it's actually `scala-cli` when you look at the value of `name` when that check is done. You can also see this in the `build/initialize`.

```
[Trace - 11:38:07 am] Received response 'build/initialize - (1)' in 615ms
Result: {
  "displayName": "scala-cli",
  "version": "0.1.17",
  ...
```

CC @lwronski 