### PR TITLE
feat: Refactor package definition when moving files between packages

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -1077,4 +1077,17 @@ object MetalsEnrichments
     def toLsp = new l.Position(breakpoint.getLine() - 1, breakpoint.getColumn())
   }
 
+  implicit class XtensionWorkspaceEdits(edits: Seq[l.WorkspaceEdit]) {
+    def mergeChanges: l.WorkspaceEdit = {
+      val changes = edits.view
+        .flatMap(e => Option(e.getChanges()).map(_.asScala))
+        .flatten
+        .groupMapReduce(_._1)(_._2.asScala) { _ ++ _ }
+        .mapValues(_.distinct.asJava) // deduplicate same changes
+        .toMap
+        .asJava
+      new l.WorkspaceEdit(changes)
+    }
+  }
+
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/PackageProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/PackageProvider.scala
@@ -1,40 +1,56 @@
 package scala.meta.internal.metals
 
-import java.nio.file.Path
+import scala.annotation.tailrec
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.{meta => m}
 
+import scala.meta._
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.newScalaFile.NewFileTemplate
+import scala.meta.internal.parsing.Trees
 import scala.meta.internal.pc.Identifier
 import scala.meta.io.AbsolutePath
 
+import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.ReferenceContext
+import org.eclipse.lsp4j.ReferenceParams
+import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.WorkspaceEdit
 
-class PackageProvider(private val buildTargets: BuildTargets) {
+class PackageProvider(
+    buildTargets: BuildTargets,
+    trees: Trees,
+    refProvider: ReferenceProvider,
+) {
+  import PackageProvider._
+  def willMovePath(
+      oldPath: AbsolutePath,
+      newPath: AbsolutePath,
+  )(implicit ec: ExecutionContext): Future[WorkspaceEdit] =
+    if (oldPath.isDirectory) willMoveDir(oldPath, newPath)
+    else willMoveFile(oldPath, newPath)
 
-  def workspaceEdit(path: AbsolutePath): Option[WorkspaceEdit] = {
+  def workspaceEdit(path: AbsolutePath): Option[WorkspaceEdit] =
     packageStatement(path).map(template =>
       workspaceEdit(path, template.fileContent)
     )
-  }
 
   def packageStatement(path: AbsolutePath): Option[NewFileTemplate] = {
 
     def packageObjectStatement(
-        path: Iterator[Path]
+        packageParts: Vector[String]
     ): Option[NewFileTemplate] = {
-      val pathList = path.toList
       val packageDeclaration =
-        if (pathList.size > 1)
-          s"package ${pathList.dropRight(1).map(p => wrap(p.toString())).mkString(".")}\n\n"
+        if (packageParts.size > 1)
+          s"package ${packageParts.dropRight(1).map(p => wrap(p)).mkString(".")}\n\n"
         else ""
-      pathList.lastOption.map { packageObjectName =>
+      packageParts.lastOption.map { packageObjectName =>
         val indent = "  "
-        val backtickedName = wrap(
-          packageObjectName.toString()
-        )
+        val backtickedName = wrap(packageObjectName)
         NewFileTemplate(
           s"""|${packageDeclaration}package object $backtickedName {
               |${indent}@@
@@ -44,47 +60,425 @@ class PackageProvider(private val buildTargets: BuildTargets) {
       }
     }
 
-    if (
-      path.isScalaOrJava && !path.isScalaScript && !path.isJarFileSystem &&
-      path.toFile.length() == 0
-    ) {
-      buildTargets
-        .inverseSourceItem(path)
-        .map(path.toRelative)
-        .flatMap(relativePath => Option(relativePath.toNIO.getParent))
-        .flatMap { parent =>
-          val pathIterator = parent.iterator().asScala
-          if (path.filename == "package.scala") {
-            packageObjectStatement(pathIterator)
-          } else {
-            val packageName = parent
-              .iterator()
-              .asScala
-              .map(p => wrap(p.toString()))
-              .mkString(".")
-            val text =
-              if (path.isScala) s"package $packageName\n\n@@"
-              else s"package $packageName;\n\n@@"
-            Some(NewFileTemplate(text))
-          }
+    for {
+      packageParts <- Option.when(
+        path.isScalaOrJava && !path.isJarFileSystem &&
+          !path.isScalaScript && path.toFile.length() == 0
+      )(deducePkgParts(path))
+      if packageParts.size > 0
+      newFileTemplate <-
+        if (path.filename == "package.scala")
+          packageObjectStatement(packageParts)
+        else {
+          val packageName = packageParts.mkString(".")
+          val text =
+            if (path.isScala) s"package $packageName\n\n@@"
+            else s"package $packageName;\n\n@@"
+          Some(NewFileTemplate(text))
         }
-    } else {
-      None
-    }
+    } yield newFileTemplate
   }
 
-  private def wrap(str: String) = Identifier.backtickWrap(str)
+  private def willMoveDir(
+      oldDirPath: AbsolutePath,
+      newDirPath: AbsolutePath,
+  )(implicit ec: ExecutionContext): Future[WorkspaceEdit] = {
+    val oldPkg = calcPathToSourceRoot(oldDirPath)
+    val newPkg = calcPathToSourceRoot(newDirPath)
+
+    val files = oldDirPath.listRecursive
+      .filter(_.isScalaFilename)
+      .map(oldFilePath =>
+        oldFilePath -> newDirPath.resolve(oldFilePath.toRelative(oldDirPath))
+      )
+      .toList
+
+    Future
+      .traverse(files) { case (oldFilePath, newFilePath) =>
+        willMoveFile(
+          oldFilePath,
+          newFilePath,
+          Some(DirChange(oldPkg, newPkg)),
+        )
+      }
+      .map(_.mergeChanges)
+  }
+
+  private def willMoveFile(
+      oldPath: AbsolutePath,
+      newPath: AbsolutePath,
+      optDirChange: Option[DirChange] = None,
+  )(implicit ec: ExecutionContext): Future[WorkspaceEdit] = Future {
+    val edit = trees
+      .get(oldPath)
+      .map(tree => {
+        val oldPkgParts = deducePkgParts(oldPath)
+        val newPkgParts = deducePkgParts(newPath)
+        val fileEdits = calcMovedFileEdits(tree, oldPath, newPkgParts)
+        val refsEdits = calcRefsEdits(
+          tree,
+          oldPath,
+          oldPkgParts,
+          newPkgParts,
+          optDirChange,
+        )
+        List(fileEdits, refsEdits).mergeChanges
+      })
+
+    edit.getOrElse(new WorkspaceEdit())
+  }
+
+  private def calcMovedFileEdits(
+      tree: Tree,
+      oldPath: AbsolutePath,
+      newPkgParts: Vector[String],
+  ): WorkspaceEdit = {
+    val pkgs = findPkgs(tree)
+
+    val oldPkgSplit: Vector[Vector[String]] =
+      pkgs.map(p => extractNames(p.ref))
+
+    val optPkgObj = tree.collect { case p: Pkg.Object => p }.headOption
+
+    // edit of package stament
+    val pkgStmtParts =
+      if (optPkgObj.isDefined) newPkgParts.dropRight(1) else newPkgParts
+    val pkgEdit = calcPkgEdit(oldPkgSplit, pkgStmtParts, oldPath, pkgs)
+
+    // edit of package object name if it exists in the file
+    val pkgObjEdit = for {
+      pkgObjStmt <- optPkgObj
+      lastPkg <- newPkgParts.lastOption
+      edit = workspaceEdit(oldPath, lastPkg, pkgObjStmt.name.pos.toLsp)
+      if pkgObjStmt.name.value != lastPkg
+    } yield edit
+
+    (List(pkgEdit) ++ pkgObjEdit).mergeChanges
+  }
+
+  private def calcRefsEdits(
+      movedTree: Tree,
+      oldPath: AbsolutePath,
+      oldPkgParts: Vector[String],
+      newPkgParts: Vector[String],
+      optDirChange: Option[DirChange],
+  ): WorkspaceEdit = {
+    val newPkgName = newPkgParts.mkString(".")
+    val decls = findTopLevelDecls(movedTree)
+    val oldUri = oldPath.toURI.toString
+    val edits = decls.view
+      .flatMap(decl => findRefs(decl, oldUri).map((decl, _)))
+      .view
+      .groupMap { case (_, location) =>
+        location.getUri()
+      } { case (decl, _) =>
+        decl
+      }
+      .map { case (fileUri, refs) =>
+        val filePath = fileUri.toAbsolutePath
+        val refPkgParts = deducePkgParts(fileUri.toAbsolutePath)
+        val optTree = trees.get(filePath)
+        val refsNames = refs.map(_.value).toSet
+
+        val importersAndParts = optTree
+          .fold(Vector.empty[Importer])(findImporters)
+          .map(i => (i, extractNames(i.ref)))
+
+        val changes = optDirChange match {
+          case Some(DirChange(oldPkg, newPkg)) =>
+            val refsInImportsEdits = importersAndParts.flatMap {
+              case (importer, importParts) =>
+                calcImportEditsForDirMove(importer, importParts, oldPkg, newPkg)
+            }
+            val shouldAddImports = fileUri != oldUri &&
+              !refPkgParts.startsWith(oldPkg) && refsInImportsEdits.isEmpty
+            val newImports = Option.when(shouldAddImports)(
+              calcNewImports(optTree, refsNames, newPkgName)
+            )
+            newImports ++ refsInImportsEdits
+          case None =>
+            val refsInImportsEdits = importersAndParts.flatMap {
+              case (importer, importParts) =>
+                calcImportEditsForFileMove(
+                  importer,
+                  importParts,
+                  oldPkgParts,
+                  refsNames,
+                  newPkgName,
+                )
+            }
+            val shouldAddImports =
+              fileUri != oldUri && refsInImportsEdits.isEmpty
+            val newImports = Option.when(shouldAddImports) {
+              calcNewImports(optTree, refsNames, newPkgName)
+            }
+            refsInImportsEdits ++ newImports
+        }
+
+        new WorkspaceEdit(
+          Map(filePath.toURI.toString -> changes.toList.asJava).asJava
+        )
+      }
+    edits.toSeq.mergeChanges
+  }
+
+  private def calcImportEditsForDirMove(
+      importer: Importer,
+      importParts: Vector[String],
+      oldPkgPrefix: Vector[String],
+      newPkgPrefix: Vector[String],
+  ): List[TextEdit] = if (importParts.startsWith(oldPkgPrefix)) {
+    val newImport = newPkgPrefix ++ importParts.drop(oldPkgPrefix.size)
+    List(new TextEdit(importer.ref.pos.toLsp, newImport.mkString(".")))
+  } else List.empty
+
+  private def calcNewImports(
+      optTree: Option[Tree],
+      refsNames: Set[String],
+      newPkgName: String,
+  ): TextEdit = {
+    val importees = mkImportees(refsNames.toList)
+    val importString = s"\nimport $newPkgName.$importees"
+
+    val optLastPkg = for {
+      tree <- optTree
+      lastPkg <- findPkgs(tree).lastOption
+    } yield lastPkg
+
+    val optLastImport = for {
+      lastPkg <- optLastPkg
+      lastImport <- lastPkg.stats.collect { case i: Import => i }.lastOption
+    } yield lastImport
+
+    val optNewImportRange = optLastImport
+      .map(_.pos)
+      .orElse(optLastPkg.map(_.ref.pos))
+      .map(posNextToEndOf(_))
+
+    val range = optNewImportRange.getOrElse(
+      new Range(new Position(0, 0), new Position(0, 0))
+    )
+    new TextEdit(range, importString)
+  }
+
+  private def calcImportEditsForFileMove(
+      importer: Importer,
+      importParts: Vector[String],
+      oldPkgParts: Vector[String],
+      refsNames: Set[String],
+      newPkgName: String,
+  ): List[TextEdit] =
+    if (importParts == oldPkgParts) {
+      val importees = importer.importees
+      def isReferenced(importee: Importee) = importee match {
+        case Importee.Name(name) => refsNames.contains(name.value)
+        case Importee.Rename(from, _) => refsNames.contains(from.value)
+        case Importee.Unimport(name) => refsNames.contains(name.value)
+        case _ => false
+      }
+      val (refsImportees, refsIndices) = importees.zipWithIndex.filter {
+        case (i, _) =>
+          isReferenced(i)
+      }.unzip
+      if (refsImportees.length == 0) {
+        List.empty
+      } else {
+        val importeeStr = mkImportees(refsImportees.collect {
+          case Importee.Name(name) => name.value
+          case Importee.Rename(from, to) =>
+            s"${from.value} => ${to.value}"
+          case Importee.Unimport(name) => name.value
+        })
+        val newImportStr = {
+          val bracedImporteeStr = refsImportees match {
+            case List(Importee.Rename(_, _)) => s"{$importeeStr}"
+            case _ => importeeStr
+          }
+          s"$newPkgName.$bracedImporteeStr"
+        }
+        if (refsImportees.length == importer.importees.length) {
+          List(new TextEdit(importer.pos.toLsp, newImportStr))
+        } else {
+          // In this branch some importees should be removed from the import, but not all.
+          // Trying to remove them with commas
+          val indSet = refsIndices.toSet
+          val oldImportEdits =
+            importees.zip(importees.drop(1)).zipWithIndex.flatMap {
+              case ((i1, i2), ind) =>
+                val pos =
+                  if (indSet.contains(ind))
+                    Some(
+                      i1.pos.toLsp.copy(
+                        endLine = i2.pos.startLine,
+                        endCharacter = i2.pos.startColumn,
+                      )
+                    )
+                  else if (
+                    indSet.contains(ind + 1) && importees.length == ind + 2
+                  ) // cases like "import foo.{A, B, C}" when C is moved
+                    Some(
+                      i2.pos.toLsp.copy(
+                        startLine = i1.pos.endLine,
+                        startCharacter = i1.pos.endColumn,
+                      )
+                    )
+                  else None
+                pos.map(new TextEdit(_, ""))
+            }
+          val newImportPos = posNextToEndOf(importer.pos)
+          val newImportEdit =
+            new TextEdit(newImportPos, s"import $newImportStr")
+          newImportEdit :: oldImportEdits
+        }
+      }
+    } else List.empty
+
+  private def findImporters(tree: Tree): Vector[Importer] = {
+    def go(tree: Tree): LazyList[Importer] = tree match {
+      case i: Import => LazyList.from(i.importers)
+      case t => LazyList.from(t.children).flatMap(go)
+    }
+    go(tree).toVector
+  }
+
+  private def findTopLevelDecls(tree: Tree): List[Name] = {
+    def go(tree: Tree): LazyList[Name] = tree match {
+      case d: Defn with Member => LazyList(d.name)
+      case t => LazyList.from(t.children).flatMap(go)
+    }
+    go(tree).toList
+  }
+
+  private def findRefs(
+      name: Name,
+      uri: String,
+  ): List[Location] = {
+    val params = new ReferenceParams(
+      new TextDocumentIdentifier(uri),
+      new Position(name.pos.startLine, name.pos.startColumn),
+      new ReferenceContext(false), // do not include declaration
+    )
+    refProvider.references(params).flatMap(_.locations)
+  }
+
+  private def calcPkgEdit(
+      oldPackageSplit: Vector[Vector[String]],
+      newPackageParts: Vector[String],
+      oldPath: AbsolutePath,
+      packages: Vector[Pkg],
+  ): WorkspaceEdit =
+    packages match {
+      case firstPkg +: otherPkgs =>
+        val lastPkg = otherPkgs.lastOption.getOrElse(firstPkg).ref.pos
+        val range = firstPkg.ref.pos.toLsp.copy(
+          startCharacter = 0,
+          endLine = lastPkg.endLine,
+          endCharacter = lastPkg.endColumn,
+        )
+        val newSplit = splitPackageStatements(oldPackageSplit, newPackageParts)
+        val pkgStatement =
+          newSplit.map(ps => s"package ${ps.mkString(".")}").mkString("\n")
+        if (oldPackageSplit != newSplit)
+          workspaceEdit(oldPath, pkgStatement, range)
+        else new WorkspaceEdit()
+      case _ => new WorkspaceEdit()
+    }
+
+  private def findPkgs(tree: Tree): Vector[Pkg] =
+    tree.collect { case p: Pkg => p }.toVector
+
+  private def wrap(str: String): String = Identifier.backtickWrap(str)
 
   private def workspaceEdit(
       path: AbsolutePath,
-      packageStatement: String,
+      replacement: String,
+      range: Range = new Range(new Position(0, 0), new Position(0, 0)),
   ): WorkspaceEdit = {
-    val textEdit = new TextEdit(
-      new Range(new Position(0, 0), new Position(0, 0)),
-      packageStatement,
-    )
+    val textEdit = new TextEdit(range, replacement)
     val textEdits = List(textEdit).asJava
     val changes = Map(path.toURI.toString -> textEdits).asJava
     new WorkspaceEdit(changes)
   }
+
+  private def deducePkgParts(path: AbsolutePath): Vector[String] =
+    calcPathToSourceRoot(path).dropRight(1)
+
+  private def calcPathToSourceRoot(
+      path: AbsolutePath
+  ): Vector[String] =
+    buildTargets
+      .inverseSourceItem(path)
+      .map(path.toRelative(_).toNIO)
+      .map { _.iterator().asScala.map(p => wrap(p.toString())).toVector }
+      .getOrElse(Vector.empty)
+
+  /**
+   * Splits package declaration into statements
+   * Desired property - not to break old visibility regions
+   * @param oldPackageSplit: content of package statements before refactoring
+   * @param newPkgs: list of package parts that should be present after refactoring
+   * @return split of `newPkgs` into package statements with respect to the `oldPackageSplit`
+   */
+  private def splitPackageStatements(
+      oldPackageSplit: Vector[Vector[String]],
+      newPkgs: Vector[String],
+  ): Vector[Vector[String]] = {
+    val oldPackageSplitSet = oldPackageSplit.toSet
+    val oldEndPkgs =
+      oldPackageSplit.flatMap(_.lastOption).reverse.zipWithIndex.toMap
+
+    var consideredEndPkg = 0
+    var pkgStmts: Vector[Vector[String]] = Vector.empty
+    var pkgStmt: Vector[String] = Vector.empty
+
+    newPkgs.reverse.foreach { newPkg =>
+      val foundEndPkg =
+        oldEndPkgs.get(newPkg).filter { _ >= consideredEndPkg }
+      foundEndPkg match {
+        case Some(endPkgInd) => {
+          if (endPkgInd == 0) pkgStmt = newPkg +: pkgStmt
+          else {
+            if (pkgStmt.nonEmpty) pkgStmts = pkgStmt +: pkgStmts
+            pkgStmt = Vector(newPkg)
+          }
+          consideredEndPkg = endPkgInd + 1
+        }
+        case None =>
+          if (oldPackageSplitSet.contains(pkgStmt)) {
+            pkgStmts = pkgStmt +: pkgStmts
+            pkgStmt = Vector.empty
+          }
+          pkgStmt = newPkg +: pkgStmt
+      }
+    }
+    if (pkgStmt.nonEmpty) pkgStmts = pkgStmt +: pkgStmts
+    pkgStmts
+  }
+
+  @tailrec
+  private def extractNames(
+      t: Term,
+      acc: Vector[String] = Vector.empty,
+  ): Vector[String] = {
+    t match {
+      case n: Term.Name => n.value +: acc
+      case s: Term.Select => extractNames(s.qual, s.name.value +: acc)
+    }
+  }
+
+  private def mkImportees(names: List[String]): String =
+    names match {
+      case List(single) => single
+      case list => list.mkString("{", ", ", "}")
+    }
+
+  private def posNextToEndOf(pos: m.Position): Range = {
+    val start = pos.end + 1
+    m.Position.Range(pos.input, start, start).toLsp
+  }
+
+}
+
+object PackageProvider {
+  final case class DirChange(oldPkg: Vector[String], newPkg: Vector[String])
 }

--- a/tests/unit/src/main/scala/tests/BaseRenameFilesLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseRenameFilesLspSuite.scala
@@ -1,0 +1,76 @@
+package tests
+
+import scala.concurrent.Future
+
+import munit.Location
+import munit.TestOptions
+
+abstract class BaseRenameFilesLspSuite(name: String)
+    extends BaseLspSuite(name) {
+
+  def renamed(
+      name: TestOptions,
+      layoutWithMarkers: String,
+      fileRenames: Map[String, String],
+      expectedRenames: Map[String, String],
+      sourcesAreCompiled: Boolean = false,
+  )(implicit loc: Location): Unit = {
+    test(name) {
+      cleanWorkspace()
+      val layout = layoutWithMarkers.replaceAll("(<<|>>)", "")
+      for {
+        _ <- initialize(
+          s"""/metals.json
+             |${defaultMetalsJson()}
+             |$layout""".stripMargin
+        )
+        expectedSources = calcExpectedSources(
+          layoutWithMarkers,
+          expectedRenames,
+        )
+        _ <-
+          if (sourcesAreCompiled)
+            Future.traverse(expectedSources.keySet)(server.didOpen)
+          else Future.unit
+        renamedSources <- server.willRenameFiles(
+          expectedSources.keySet,
+          fileRenames,
+        )
+        _ = assertEquals(renamedSources, expectedSources)
+      } yield ()
+    }
+  }
+
+  private def defaultMetalsJson(scalaVersion: Option[String] = None): String = {
+    val actualScalaVersion = scalaVersion.getOrElse(BuildInfo.scalaVersion)
+    s"""|{
+        |  "a" : {
+        |    "scalaVersion": "$actualScalaVersion"
+        |  }
+        |}""".stripMargin
+  }
+
+  private def calcExpectedSources(
+      layoutWithMarkers: String,
+      expectedRenames: Map[String, String],
+  ) = {
+    val renameRex = """<<([ a-zA-Z0-9_.,-/=>;]+)>>""".r
+    FileLayout
+      .mapFromString(layoutWithMarkers)
+      .view
+      .mapValues { source =>
+        renameRex.replaceAllIn(
+          source,
+          m => {
+            val toRename = m.group(1)
+            assert(
+              expectedRenames.contains(toRename),
+              s"`expectedRenames` did not contain key `$toRename`",
+            )
+            expectedRenames(toRename)
+          },
+        )
+      }
+      .toMap
+  }
+}

--- a/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
@@ -651,9 +651,7 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
              |$existingFiles
           """.stripMargin
         )
-        _ <-
-          server
-            .executeCommand(command, args: _*)
+        _ <- server.executeCommand(command, args: _*)
         _ = {
           assertNoDiff(
             client.workspaceMessageRequests,

--- a/tests/unit/src/test/scala/tests/RenameFilesLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameFilesLspSuite.scala
@@ -1,0 +1,348 @@
+package tests
+
+class RenameFilesLspSuite extends BaseRenameFilesLspSuite("rename_files") {
+  private val prefix = "a/src/main/scala"
+
+  /* Unchanged semantics */
+  renamed(
+    "identity",
+    s"""|/$prefix/A/Sun.scala
+        |package A
+        |object Sun 
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/Sun.scala" -> s"$prefix/A/Sun.scala"),
+    expectedRenames = Map.empty,
+  )
+
+  renamed(
+    "no-package",
+    s"""|/$prefix/A/Sun.scala
+        |object Sun 
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/Sun.scala" -> s"$prefix/A/Sun.scala"),
+    expectedRenames = Map.empty,
+  )
+
+  /* Single-package semantics */
+  renamed(
+    "single-package",
+    s"""|/$prefix/A/Sun.scala
+        |package <<A>>
+        |object Sun 
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/Sun.scala" -> s"$prefix/A/B/Sun.scala"),
+    expectedRenames = Map("A" -> "A.B"),
+  )
+
+  renamed(
+    "single-package-non-matching-structure",
+    s"""|/$prefix/A/B/Sun.scala
+        |package <<A>>
+        |object Sun 
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/B/Sun.scala" -> s"$prefix/A/C/Sun.scala"),
+    expectedRenames = Map("A" -> "A.C"),
+  )
+
+  /* Multi-package-semantics */
+
+  // Changes in all package parts mean that a file was moved to a completely
+  // different scope and we can merge packages into one
+  renamed(
+    "multi-package-rename-all",
+    s"""|/$prefix/A/B/Sun.scala
+        |<<package A; package B>>
+        |object Sun 
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/B/Sun.scala" -> s"$prefix/C/D/Sun.scala"),
+    expectedRenames = Map("package A; package B" -> "package C.D"),
+  )
+
+  renamed(
+    "multi-package-rename-last",
+    s"""|/$prefix/A/B/Sun.scala
+        |package A
+        |package <<B>>
+        |object Sun 
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/B/Sun.scala" -> s"$prefix/A/C/Sun.scala"),
+    expectedRenames = Map("B" -> "C"),
+  )
+
+  renamed(
+    "multi-package-rename-first-end",
+    s"""|/$prefix/A/B/C/D/Sun.scala
+        |package A.<<B>>
+        |package C.D
+        |object Sun 
+        |""".stripMargin,
+    fileRenames =
+      Map(s"$prefix/A/B/C/D/Sun.scala" -> s"$prefix/A/E/C/D/Sun.scala"),
+    expectedRenames = Map("B" -> "E"),
+  )
+
+  renamed(
+    "multi-package-add-between",
+    s"""|/$prefix/A/B/Sun.scala
+        |package A
+        |<<package B>>
+        |object Sun 
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/B/Sun.scala" -> s"$prefix/A/C/B/Sun.scala"),
+    expectedRenames = Map("package B" -> "package C\npackage B"),
+  )
+
+  renamed(
+    "multi-package-add-to-last",
+    s"""|/$prefix/A/B/Sun.scala
+        |package A
+        |package <<B>>
+        |object Sun 
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/B/Sun.scala" -> s"$prefix/A/B/C/Sun.scala"),
+    expectedRenames = Map("B" -> "B.C"),
+  )
+
+  renamed(
+    "multi-package-dir-to-more-nested",
+    s"""|/$prefix/A/Sun.scala
+        |package <<A>>
+        |object Sun
+        |/$prefix/A/Moon.scala
+        |package <<A>>
+        |object Sun
+        |""".stripMargin,
+    fileRenames = Map(
+      s"$prefix/A" -> s"$prefix/A/B"
+    ),
+    expectedRenames = Map("A" -> "A.B"),
+  )
+
+  renamed(
+    "multi-package-dir-to-less-nested",
+    s"""|/$prefix/A/B/Sun.scala
+        |package <<A.B>>
+        |object Sun 
+        |/$prefix/A/B/Moon.scala
+        |package <<A.B>>
+        |object Moon 
+        |""".stripMargin,
+    fileRenames = Map(
+      s"$prefix/A/B" -> s"$prefix/A"
+    ),
+    expectedRenames = Map("A.B" -> "A"),
+  )
+
+  renamed(
+    "multi-package-dir-to-another-file-tree",
+    s"""|/$prefix/A/B/Sun.scala
+        |package <<A.B>>
+        |object Sun
+        |/$prefix/A/B/Moon.scala
+        |package <<A.B>>
+        |object Moon
+        |""".stripMargin,
+    fileRenames = Map(
+      s"$prefix/A/B" -> s"$prefix/C/D/E"
+    ),
+    expectedRenames = Map("A.B" -> "C.D.E"),
+  )
+
+  /* Package object semantics */
+
+  renamed(
+    "package-object",
+    s"""|/$prefix/A/B/packageFile.scala
+        |package <<A>>
+        |package object <<B>> 
+        |""".stripMargin,
+    fileRenames = Map(
+      s"$prefix/A/B" -> s"$prefix/C/D"
+    ),
+    expectedRenames = Map("A" -> "C", "B" -> "D"),
+  )
+
+  /* References semantics */
+
+  renamed(
+    "references-simple-file-move",
+    s"""|/$prefix/A/Sun.scala
+        |package <<A>>
+        |object Sun 
+        |/$prefix/B/Moon.scala
+        |package B
+        |import <<A>>.Sun
+        |object Moon 
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/Sun.scala" -> s"$prefix/C/Sun.scala"),
+    expectedRenames = Map("A" -> "C"),
+    sourcesAreCompiled = true,
+  )
+
+  renamed(
+    "references-wildcard-imports",
+    s"""|/$prefix/A/B/Sun.scala
+        |package <<A>>.B
+        |object Sun 
+        |/$prefix/B/Moon.scala
+        |package B
+        |import <<A>>.B._
+        |import <<A>>.B.{Sun, _}
+        |object Moon 
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/B" -> s"$prefix/C/B"),
+    expectedRenames = Map("A" -> "C"),
+    sourcesAreCompiled = true,
+  )
+
+  renamed(
+    "references-package-object",
+    s"""|/$prefix/A/B/package.scala
+        |package <<A>>
+        |package object <<B>> {
+        | trait Sun
+        |}
+        |/$prefix/X/Moon.scala
+        |package X
+        |import <<A>>.<<B>>.Sun
+        |object Moon 
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/B" -> s"$prefix/C/D"),
+    expectedRenames = Map("A" -> "C", "B" -> "D"),
+    sourcesAreCompiled = true,
+  )
+
+  renamed(
+    "references-same-package-no-imports",
+    s"""|/$prefix/A/Mars.scala
+        |package <<A>>
+        |object Phobos 
+        |object Deimos
+        |/$prefix/A/Earth.scala
+        |package A
+        |<<//>>
+        |object Sun {
+        |  println(Phobos)
+        |  println(Deimos)
+        |  println(Phobos)
+        |}
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/Mars.scala" -> s"$prefix/B/Mars.scala"),
+    expectedRenames = Map("A" -> "B", "//" -> "\nimport B.{Phobos, Deimos}//"),
+    sourcesAreCompiled = true,
+  )
+
+  renamed(
+    "references-package-imports",
+    s"""|/$prefix/A/B/Sun.scala
+        |package <<A>>.B
+        |object Sun { }
+        |/$prefix/B/Moon.scala
+        |package B
+        |import <<A>>.{B => BB}
+        |import <<A>>._ 
+        |object Moon {
+        |  println(BB.Sun)
+        |}
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A" -> s"$prefix/C"),
+    expectedRenames = Map("A" -> "C"),
+    sourcesAreCompiled = true,
+  )
+
+  renamed(
+    "references-dir-rename-no-new-imports",
+    s"""|/$prefix/A/B/Sun.scala
+        |package <<A>>.B
+        |object Sun
+        |/$prefix/A/B/Moon.scala
+        |package <<A>>.B
+        |object Moon {
+        |  println(Sun)
+        |}
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A" -> s"$prefix/C"),
+    expectedRenames = Map("A" -> "C"),
+    sourcesAreCompiled = true,
+  )
+
+  renamed(
+    "references-multi-package-new-imports",
+    s"""|/$prefix/A/B/Sun.scala
+        |package A.<<B>>
+        |object Sun
+        |/$prefix/A/B/Moon.scala
+        |package A
+        |package B
+        |import scala.util.Try
+        |<<//>>
+        |object Moon {
+        |  println(Try(Sun))
+        |}
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/B/Sun.scala" -> s"$prefix/A/B/C/Sun.scala"),
+    expectedRenames = Map("B" -> "B.C", "//" -> "\nimport A.B.C.Sun//"),
+    sourcesAreCompiled = true,
+  )
+
+  renamed(
+    "references-mixed-import",
+    s"""|/$prefix/A/Mars.scala
+        |package <<A>>
+        |object Phobos
+        |object Deimos
+        |/$prefix/A/Pluto.scala
+        |package A
+        |object Pluto
+        |/$prefix/B/Solar.scala
+        |package B
+        |import A.{<<Phobos => P, >>Pluto<<, Deimos>>}
+        |<<//>>
+        |object Mars
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/Mars.scala" -> s"$prefix/C/Mars.scala"),
+    expectedRenames = Map(
+      "A" -> "C",
+      "Phobos => P, " -> "",
+      ", Deimos" -> "",
+      "//" -> "import C.{Phobos => P, Deimos}//",
+    ),
+    sourcesAreCompiled = true,
+  )
+
+  /* Cases that are not yet supported */
+  renamed(
+    "unsupported-qualified-refs",
+    s"""|/$prefix/A/B/Sun.scala
+        |package <<A>>.B
+        |object Sun 
+        |/$prefix/X/Moon.scala
+        |package X
+        |<<//>>should not import anything
+        |object Moon {
+        |  A.B.Sun // should be refactored
+        |}
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A" -> s"$prefix/C"),
+    expectedRenames = Map("A" -> "C", "//" -> "\nimport C.B.Sun//"),
+    sourcesAreCompiled = true,
+  )
+
+  renamed(
+    "unsupported-package-renames",
+    s"""|/$prefix/A/B/Sun.scala
+        |package A.<<B>>
+        |object Sun 
+        |/$prefix/X/Moon.scala
+        |package X
+        |import A.{B => BB}
+        |<<//>>should not import anything
+        |object Moon {
+        |  println(BB.Sun)
+        |}
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/A/B" -> s"$prefix/A/C"),
+    expectedRenames = Map("B" -> "C", "//" -> "\nimport A.C.Sun//"),
+    sourcesAreCompiled = true,
+  )
+}


### PR DESCRIPTION
### Summary
This PR implements https://github.com/scalameta/metals/issues/4664 by adding support for [workspace/willRenameFiles](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_willRenameFiles) LSP request. 

Feature is developed with an eye on VS Code as it has support for `willRenameFiles` request. The request is sent before files/directories are renamed/drag-and-dropped. As a response to this intent a language server proposes corresponding file edits.

Semantics of the feature is reflected in the test suite.

Implementation tries to provide as much refactorings as possible: 
- single/multi-package statements
- package objects
- various kinds of imports: single/multiple/wildcard/rename
- new imports when definitions are moved out of scope, etc.

However, lots of corner-cases might be unconsidered yet. Please let me know if you find any

### Performance
I have no idea how to make any representative benchmarks here.  
However, operations on large packages can give an overall feeling of latency.  
E.g. renaming `cats` package to `dogs` on [cats-core](https://github.com/typelevel/cats/tree/main/core/src/main) module resulted in ~500 changed files and took 9 seconds to complete on my laptop.

### Teasers
- multi-package refactoring

https://user-images.githubusercontent.com/15569000/202900506-7c89bc90-6236-4081-ae0d-140d756fadca.mp4

- directory rename

https://user-images.githubusercontent.com/15569000/202900772-767620aa-f12b-4611-9074-9c4df71a6181.mp4

- package-object refactoring

https://user-images.githubusercontent.com/15569000/202900824-6a31a8c5-5697-4c90-ab6c-df2b9f160897.mp4


- new imports

https://user-images.githubusercontent.com/15569000/202900837-e424c11f-a6af-4723-ad04-3d0c9f8aca9f.mp4


