### PR TITLE
fix: make ivy completion tests more stable

### DIFF
--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -771,7 +771,7 @@ abstract class BaseWorksheetLspSuite(
            |/a/src/main/scala/foo/Main.worksheet.sc
            |import $$ivy.`io.cir`
            |import $$dep.`io.circe::circe-ref`
-           |import $$dep.`io.circe::circe-yaml:0.14`
+           |import $$dep.`io.circe::circe-yaml:0.13`
            |""".stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
@@ -802,10 +802,10 @@ abstract class BaseWorksheetLspSuite(
       )
       _ = assertNoDiff(artefactCompletionList, artefactExpectedCompletionList)
 
-      versionExpectedCompletionList = List("0.14.2", "0.14.1", "0.14.0")
+      versionExpectedCompletionList = List("0.13.1", "0.13.0")
       response <- server.completionList(
         "a/src/main/scala/foo/Main.worksheet.sc",
-        "import $dep.`io.circe::circe-yaml:0.14@@`",
+        "import $dep.`io.circe::circe-yaml:0.13@@`",
       )
       versionCompletionList = response
         .getItems()
@@ -815,7 +815,7 @@ abstract class BaseWorksheetLspSuite(
       _ = assertEquals(versionCompletionList, versionExpectedCompletionList)
       noCompletions <- server.completion(
         "a/src/main/scala/foo/Main.worksheet.sc",
-        "import $dep.`io.circe::circe-yaml:0.14`@@",
+        "import $dep.`io.circe::circe-yaml:0.13`@@",
       )
       _ = assertNoDiff(noCompletions, "")
     } yield ()


### PR DESCRIPTION
Right now these are failing since a new circe-yaml was released. In the
tests we are trying to completion the 0.14.x series, but that series is
still ongoing, meaning that every new release will break tests. Instead
this change just looks at the 0.13.x series, which is finished. This
will make these tests a bit more stable now and in the future.
