### PR TITLE
refactor: avoid newlines in json doctor output

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/DoctorExplanation.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/DoctorExplanation.scala
@@ -99,7 +99,7 @@ sealed trait DoctorExplanation {
   ): Obj = {
     val explanations =
       if (show)
-        List(correctMessage, incorrectMessage)
+        List(correctMessage) ++ incorrectMessage.split("\n")
       else
         List(correctMessage)
 
@@ -172,7 +172,7 @@ object DoctorExplanation {
     val correctMessage: String =
       s"${Icons.unicode.check} - working non-interactive features (references, rename etc.)"
     val incorrectMessage: String =
-      s"""|${Icons.unicode.error} - missing semanticdb plugin, might not be added automatically by the build server (work for Bloop only)
+      s"""|${Icons.unicode.error} - missing semanticdb plugin, might not be added automatically by the build server (which is only done when using Bloop)
           |${Icons.unicode.info} - build target doesn't support Java files""".stripMargin
 
     def show(allTargetsInfo: Seq[DoctorTargetInfo]): Boolean =


### PR DESCRIPTION
Super small change that I'm currently hitting on in Neovim. When
consuming the json output for the doctor there used to not be any
newlines in the output. Once we added the Java problems we have one
value that has multiple lines. Not all clients will be able to handle
new lines here, so this small change instead just splits on the newline
and gives them back as two items in the array. Again, this only happens
when using the json output.
