### PR TITLE
docs: Point bootstrap commands to latest release version

### DIFF
--- a/docs/integrations/new-editor.md
+++ b/docs/integrations/new-editor.md
@@ -15,20 +15,8 @@ client over [JSON-RPC](https://www.jsonrpc.org/specification).
 Use [Coursier](https://github.com/coursier/coursier) to obtain the JVM classpath
 of Metals:
 
-```sh
-coursier bootstrap org.scalameta:metals_2.13:@VERSION@ -o metals -f
-```
+```scala mdoc:bootstrap
 
-(optional) It's recommended to enable JVM string de-duplication and provide a
-generous stack size and memory options.
-
-```sh
-coursier bootstrap \
-  --java-opt -XX:+UseG1GC \
-  --java-opt -XX:+UseStringDeduplication  \
-  --java-opt -Xss4m \
-  --java-opt -Xms100m \
-  org.scalameta:metals_2.13:@VERSION@ -o metals -f
 ```
 
 See [Metals server properties](#metals-server-properties) for additional system

--- a/metals-docs/src/main/scala/docs/BootstrapModifier.scala
+++ b/metals-docs/src/main/scala/docs/BootstrapModifier.scala
@@ -12,36 +12,21 @@ class BootstrapModifier extends StringModifier {
       code: Input,
       reporter: Reporter,
   ): String = {
-    info.split(" ") match {
-      case Array(binary, client) =>
-        s"""
-           |Next, build a `$binary` binary for the latest Metals release using the
-           |[Coursier](https://github.com/coursier/coursier) command-line interface.
-           |
-           |${Docs.releasesResolverTable}
-           |
-           |```sh
-           |# Make sure to use coursier v1.1.0-M9 or newer.
-           |curl -L -o coursier https://git.io/coursier-cli
-           |chmod +x coursier
-           |./coursier bootstrap \\
-           |  --java-opt -Xss4m \\
-           |  --java-opt -Xms100m \\
-           |  --java-opt -Dmetals.client=$client \\
-           |  org.scalameta:metals_2.13:${Docs.release.version} \\
-           |  -r sonatype:snapshots \\
-           |  -o /usr/local/bin/$binary -f
-           |```
-           |Make sure the generated `$binary` binary is available on your `$$PATH`.
-           |
-           |You can check version of your binary by executing `$binary -version`.
-           |
-           |Configure the system properties `-Dhttps.proxyHost=… -Dhttps.proxyPort=…`
-           |if you are behind an HTTP proxy.
-           |""".stripMargin
-      case _ =>
-        reporter.error(s"Invalid info '$info'. Expected '<binary> <client>'")
-        ""
-    }
+    s"""|```sh
+        |coursier bootstrap org.scalameta:metals_2.13:${Docs.release.version} -o metals -f
+        |```
+        |
+        |(optional) It's recommended to enable JVM string de-duplication and provide a
+        |generous stack size and memory options.
+        |
+        |```sh
+        |coursier bootstrap \\
+        |  --java-opt -XX:+UseG1GC \\
+        |  --java-opt -XX:+UseStringDeduplication  \\
+        |  --java-opt -Xss4m \\
+        |  --java-opt -Xms100m \\
+        |  org.scalameta:metals_2.13:${Docs.release.version} -o metals -f
+        |```""".stripMargin
+
   }
 }


### PR DESCRIPTION
Previously, it was pointing to the latest snapshot version, which meant that it was not possible to properly boostrap without adding a repo. Now, we point to latest release and the commands work.

Related to https://github.com/scalameta/metals/discussions/4670