### PR TITLE
bugfix: Make multistage Mill scripts work

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
@@ -122,7 +122,7 @@ final class Trees(
       text <- buffers.get(path).orElse(path.readTextOpt)
     } yield {
       val input = Input.VirtualFile(path.toURI.toString(), text)
-      if (path.isAmmoniteScript) {
+      if (path.isAmmoniteScript || path.isMill) {
         val ammoniteInput = Input.Ammonite(input)
         dialect(ammoniteInput).parse(Parse.parseAmmonite)
       } else {

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -114,11 +114,23 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
             |
             |val schema = Schema.loadFromString("{}")
             |println(schema.isSuccess)
+            |
+            |/build.sc
+            |
+            |// this part may contain some config
+            |@
+            |import mill._
+            |import mill.scalalib._
+            |object demo extends ScalaModule {
+            |  def scalaVersion: T[String] = T("2.13.10")
+            |}
             |""".stripMargin
       )
       _ <- server.didOpen("main.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
       _ <- server.didSave("main.sc")(identity)
+      _ = assertNoDiagnostics()
+      _ <- server.didOpen("build.sc")
       _ = assertNoDiagnostics()
     } yield ()
   }


### PR DESCRIPTION
Previously, we would only use Input.Ammonite for scripts, but not `build.sc`, which meant we were parsing Mill build files wrong. Now, we use Input.Ammonite for both.

Fixes https://github.com/scalameta/metals/issues/4682