### PR TITLE
bugfix: Fix coursier completions in ScalaCli scripts

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
@@ -14,9 +14,14 @@ trait ScalaCliCompletions {
           CoursierComplete.isScalaCliDep(
             pos.lineContent.replace(CURSOR, "").take(pos.column - 1)
           )
-        case (_: PackageDef) :: Nil if pos.source.file.path.endsWith(".sc") =>
+        // generated script file will end with .sc.scala
+        case (_: Template) :: (_: ModuleDef) :: _
+            if pos.source.file.path.endsWith(".sc.scala") =>
           CoursierComplete.isScalaCliDep(
-            pos.lineContent.replace(CURSOR, "").take(pos.column - 1)
+            pos.lineContent
+              .stripPrefix("/*<script>*/")
+              .replace(CURSOR, "")
+              .take(pos.column - 1)
           )
         case _ => None
       }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
@@ -7,10 +7,15 @@ import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.util.SourcePosition
 class ScalaCliCompletions(pos: SourcePosition, text: String):
   def unapply(path: List[Tree]) =
+    def scalaCliDep = CoursierComplete.isScalaCliDep(
+      pos.lineContent.take(pos.column).stripPrefix("/*<script>*/")
+    )
     path match
+      case Nil => scalaCliDep
+      // generated script file will end with .sc.scala
+      case (_: TypeDef) :: Nil if pos.source.file.path.endsWith(".sc.scala") =>
+        scalaCliDep
       case head :: next => None
-      case Nil =>
-        CoursierComplete.isScalaCliDep(pos.lineContent.take(pos.column))
 
   def contribute(dependency: String) =
     val completions = CoursierComplete.complete(dependency)

--- a/tests/cross/src/test/scala/tests/pc/CompletionScalaCliSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScalaCliSuite.scala
@@ -56,14 +56,18 @@ class CompletionScalaCliSuite extends BaseCompletionSuite {
 
   check(
     "script",
-    """|//> using lib "io.circe:circe-core_na@@
-       |package A
-       |""".stripMargin,
+    scriptWrapper(
+      """|//> using lib "io.circe:circe-core_na@@
+         |
+         |""".stripMargin,
+      "script.sc.scala",
+    ),
     """|circe-core_native0.4_2.12
        |circe-core_native0.4_2.13
        |circe-core_native0.4_3
        |""".stripMargin,
-    filename = "script.sc",
+    filename = "script.sc.scala",
+    enablePackageWrap = false,
   )
 
   check(
@@ -100,5 +104,14 @@ class CompletionScalaCliSuite extends BaseCompletionSuite {
        |""".stripMargin,
     "better-tostring",
   )
+
+  private def scriptWrapper(code: String, filename: String): String =
+    // Vaguely looks like a scala file that ScalaCLI generates
+    // from a sc file.
+    s"""|
+        |object ${filename.stripSuffix(".sc.scala")} {
+        |/*<script>*/${code}
+        |}
+        |""".stripMargin
 
 }


### PR DESCRIPTION
Previously, we were asuming that the file we are operating on will be empty, but that was not true (or it changed) and it's actually a converted script file. Now, we properly handle it when the extension is .sc.scala.