### PR TITLE
Improve `rename` for local symbols and worksheets

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -489,6 +489,17 @@ class Compilers(
     }
   }.getOrElse(Future.successful(None))
 
+  def prepareRename(
+      params: TextDocumentPositionParams,
+      token: CancelToken,
+  ): Future[ju.Optional[LspRange]] = {
+    withPCAndAdjustLsp(params) { (pc, pos, adjust) =>
+      pc.prepareRename(
+        CompilerRangeParams.offsetOrRange(pos, token)
+      ).asScala
+    }
+  }.getOrElse(Future.successful(None.asJava))
+
   def rename(
       params: RenameParams,
       token: CancelToken,

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -497,6 +497,9 @@ class Compilers(
       pc.prepareRename(
         CompilerRangeParams.offsetOrRange(pos, token)
       ).asScala
+        .map { range =>
+          range.map(adjust.adjustRange(_))
+        }
     }
   }.getOrElse(Future.successful(None.asJava))
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1621,9 +1621,7 @@ class MetalsLanguageServer(
       params: TextDocumentPositionParams
   ): CompletableFuture[l.Range] =
     CancelTokens.future { token =>
-      val rm = renameProvider.prepareRename(params, token).map(_.orNull)
-      rm.onComplete(pprint.log(_))
-      rm
+      renameProvider.prepareRename(params, token).map(_.orNull)
     }
 
   @JsonRequest("textDocument/rename")

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1621,7 +1621,9 @@ class MetalsLanguageServer(
       params: TextDocumentPositionParams
   ): CompletableFuture[l.Range] =
     CancelTokens.future { token =>
-      renameProvider.prepareRename(params, token).map(_.orNull)
+      val rm = renameProvider.prepareRename(params, token).map(_.orNull)
+      rm.onComplete(pprint.log(_))
+      rm
     }
 
   @JsonRequest("textDocument/rename")

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -112,7 +112,6 @@ final class RenameProvider(
       token: CancelToken,
   ): Future[WorkspaceEdit] = {
     val source = params.getTextDocument.getUri.toAbsolutePath
-    pprint.log("tutaj wszedlem w ogole")
     val localRename = compilers
       .rename(params, token)
       .map(_.asScala.toList)

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -69,7 +69,6 @@ final class RenameProvider(
     val source = params.getTextDocument.getUri.toAbsolutePath
     val localPrepareRename =
       compilers.prepareRename(params, token).map(_.asScala)
-
     localPrepareRename
       .filter(_.nonEmpty)
       .fallbackTo(

--- a/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/rename/RenameProvider.scala
@@ -71,7 +71,7 @@ final class RenameProvider(
       compilers.prepareRename(params, token).map(_.asScala)
     localPrepareRename
       .filter(_.nonEmpty)
-      .fallbackTo(
+      .recoverWith { case _ =>
         compilations
           .compilationFinished(source)
           .flatMap { _ =>
@@ -104,7 +104,7 @@ final class RenameProvider(
                 } yield range.toLsp
             }
           }
-      )
+      }
   }
 
   def rename(
@@ -123,176 +123,179 @@ final class RenameProvider(
           documentEdits(Map(source -> edits)).asJava
         )
       )
-      .fallbackTo(compilations.compilationFinished(source).flatMap { _ =>
-        val defininionFuture = definitionProvider
-          .definition(source, params, token)
-        defininionFuture
-          .flatMap { definition =>
-            val textParams = new TextDocumentPositionParams(
-              params.getTextDocument(),
-              params.getPosition(),
-            )
+      .recoverWith { case _ =>
+        compilations.compilationFinished(source).flatMap { _ =>
+          val defininionFuture = definitionProvider
+            .definition(source, params, token)
+          defininionFuture
+            .flatMap { definition =>
+              val textParams = new TextDocumentPositionParams(
+                params.getTextDocument(),
+                params.getPosition(),
+              )
 
-            lazy val definitionTextParams =
-              definition.locations.asScala.map { l =>
-                new TextDocumentPositionParams(
-                  new TextDocumentIdentifier(l.getUri()),
-                  l.getRange().getStart(),
-                )
+              lazy val definitionTextParams =
+                definition.locations.asScala.map { l =>
+                  new TextDocumentPositionParams(
+                    new TextDocumentIdentifier(l.getUri()),
+                    l.getRange().getStart(),
+                  )
+                }
+
+              val symbolOccurrence =
+                definitionProvider
+                  .symbolOccurrence(source, textParams.getPosition)
+                  .orElse(
+                    findRenamedImportOccurrenceAtPosition(
+                      source,
+                      params.getPosition(),
+                    )
+                  )
+
+              val suggestedName = params.getNewName()
+              val withoutBackticks =
+                if (suggestedName.isBackticked)
+                  suggestedName.stripBackticks
+                else suggestedName
+              val newName = Identifier.backtickWrap(withoutBackticks)
+
+              def isNotRenamedSymbol(
+                  textDocument: TextDocument,
+                  occ: SymbolOccurrence,
+              ): Boolean = {
+                def realName = occ.symbol.desc.name.value
+                def foundName =
+                  occ.range
+                    .flatMap(rng => rng.inString(textDocument.text))
+                    .map(_.stripBackticks)
+                occ.symbol.isLocal ||
+                foundName.contains(realName)
               }
 
-            val symbolOccurrence =
-              definitionProvider
-                .symbolOccurrence(source, textParams.getPosition)
-                .orElse(
-                  findRenamedImportOccurrenceAtPosition(
-                    source,
-                    params.getPosition(),
-                  )
-                )
+              def shouldCheckImplementation(
+                  symbol: String,
+                  path: AbsolutePath,
+                  textDocument: TextDocument,
+              ) =
+                !symbol.desc.isType && !(symbol.isLocal && implementationProvider
+                  .defaultSymbolSearch(path, textDocument)(symbol)
+                  .exists(info => info.isTrait || info.isClass))
 
-            val suggestedName = params.getNewName()
-            val withoutBackticks =
-              if (suggestedName.isBackticked)
-                suggestedName.stripBackticks
-              else suggestedName
-            val newName = Identifier.backtickWrap(withoutBackticks)
-
-            def isNotRenamedSymbol(
-                textDocument: TextDocument,
-                occ: SymbolOccurrence,
-            ): Boolean = {
-              def realName = occ.symbol.desc.name.value
-              def foundName =
-                occ.range
-                  .flatMap(rng => rng.inString(textDocument.text))
-                  .map(_.stripBackticks)
-              occ.symbol.isLocal ||
-              foundName.contains(realName)
-            }
-
-            def shouldCheckImplementation(
-                symbol: String,
-                path: AbsolutePath,
-                textDocument: TextDocument,
-            ) =
-              !symbol.desc.isType && !(symbol.isLocal && implementationProvider
-                .defaultSymbolSearch(path, textDocument)(symbol)
-                .exists(info => info.isTrait || info.isClass))
-
-            val allReferences =
-              for {
-                (occurence, semanticDb) <- symbolOccurrence.toIterable
-                definitionLoc <-
-                  definition.locations.asScala.headOption.toIterable
-                definitionPath = definitionLoc.getUri().toAbsolutePath
-                defSemanticdb <- definition.semanticdb.toIterable
-                if canRenameSymbol(occurence.symbol, Option(newName)) &&
-                  isWorkspaceSymbol(occurence.symbol, definitionPath) &&
-                  isNotRenamedSymbol(semanticDb, occurence)
-                parentSymbols =
-                  implementationProvider
-                    .topMethodParents(occurence.symbol, defSemanticdb)
-                txtParams <- {
-                  if (parentSymbols.nonEmpty) parentSymbols.map(toTextParams)
-                  else if (definitionTextParams.nonEmpty) definitionTextParams
-                  else List(textParams)
-                }
-                isJava = definitionPath.isJava
-                currentReferences =
-                  referenceProvider
-                    .references(
-                      /**
-                       * isJava - in Java we can include declarations safely and we
-                       * also need to include contructors.
-                       */
-                      toReferenceParams(
-                        txtParams,
-                        includeDeclaration = isJava,
-                      ),
-                      findRealRange = findRealRange(newName),
-                      includeSynthetic,
-                    )
-                    .flatMap(_.locations)
-                definitionLocation = {
-                  if (parentSymbols.isEmpty)
-                    definition.locations.asScala
-                      .filter(_.getUri().isScalaOrJavaFilename)
-                  else parentSymbols
-                }
-                companionRefs = companionReferences(
-                  occurence.symbol,
-                  source,
-                  newName,
-                )
-                implReferences = implementations(
-                  txtParams,
-                  shouldCheckImplementation(
+              val allReferences =
+                for {
+                  (occurence, semanticDb) <- symbolOccurrence.toIterable
+                  definitionLoc <-
+                    definition.locations.asScala.headOption.toIterable
+                  definitionPath = definitionLoc.getUri().toAbsolutePath
+                  defSemanticdb <- definition.semanticdb.toIterable
+                  if canRenameSymbol(occurence.symbol, Option(newName)) &&
+                    isWorkspaceSymbol(occurence.symbol, definitionPath) &&
+                    isNotRenamedSymbol(semanticDb, occurence)
+                  parentSymbols =
+                    implementationProvider
+                      .topMethodParents(occurence.symbol, defSemanticdb)
+                  txtParams <- {
+                    if (parentSymbols.nonEmpty) parentSymbols.map(toTextParams)
+                    else if (definitionTextParams.nonEmpty) definitionTextParams
+                    else List(textParams)
+                  }
+                  isJava = definitionPath.isJava
+                  currentReferences =
+                    referenceProvider
+                      .references(
+                        /**
+                         * isJava - in Java we can include declarations safely and we
+                         * also need to include contructors.
+                         */
+                        toReferenceParams(
+                          txtParams,
+                          includeDeclaration = isJava,
+                        ),
+                        findRealRange = findRealRange(newName),
+                        includeSynthetic,
+                      )
+                      .flatMap(_.locations)
+                  definitionLocation = {
+                    if (parentSymbols.isEmpty)
+                      definition.locations.asScala
+                        .filter(_.getUri().isScalaOrJavaFilename)
+                    else parentSymbols
+                  }
+                  companionRefs = companionReferences(
                     occurence.symbol,
                     source,
-                    semanticDb,
-                  ),
-                  newName,
+                    newName,
+                  )
+                  implReferences = implementations(
+                    txtParams,
+                    shouldCheckImplementation(
+                      occurence.symbol,
+                      source,
+                      semanticDb,
+                    ),
+                    newName,
+                  )
+                } yield implReferences.map(implLocs =>
+                  currentReferences ++ implLocs ++ companionRefs ++ definitionLocation
                 )
-              } yield implReferences.map(implLocs =>
-                currentReferences ++ implLocs ++ companionRefs ++ definitionLocation
-              )
-            Future
-              .sequence(allReferences)
-              .map(locs =>
-                (locs.flatten, symbolOccurrence, definition, newName)
-              )
-          }
-          .map { case (allReferences, symbolOccurrence, definition, newName) =>
-            def isOccurrence(fn: String => Boolean): Boolean = {
-              symbolOccurrence.exists { case (occ, _) =>
-                fn(occ.symbol)
-              }
+              Future
+                .sequence(allReferences)
+                .map(locs =>
+                  (locs.flatten, symbolOccurrence, definition, newName)
+                )
             }
-
-            // If we didn't find any references then it might be a renamed symbol `import a.{ B => C }`
-            val fallbackOccurences =
-              if (allReferences.isEmpty)
-                renamedImportOccurrences(source, symbolOccurrence)
-              else allReferences
-
-            if (fallbackOccurences.isEmpty) {
-              scribe.debug(s"Symbol occurence was $symbolOccurrence")
-              scribe.debug(s"The definition found was $definition")
-            }
-
-            val allChanges = for {
-              (path, locs) <- fallbackOccurences.toList.distinct
-                .groupBy(_.getUri().toAbsolutePath)
-            } yield {
-              val textEdits = for (loc <- locs) yield {
-                textEdit(isOccurrence, loc, newName)
-              }
-              Seq(path -> textEdits.toList)
-            }
-            val fileChanges = allChanges.flatten.toMap
-            val shouldRenameInBackground =
-              !clientConfig.isOpenFilesOnRenameProvider || fileChanges.keySet.size >= clientConfig.renameFileThreshold
-            val (openedEdits, closedEdits) =
-              if (shouldRenameInBackground) {
-                if (clientConfig.isOpenFilesOnRenameProvider) {
-                  client.showMessage(fileThreshold(fileChanges.keySet.size))
+            .map {
+              case (allReferences, symbolOccurrence, definition, newName) =>
+                def isOccurrence(fn: String => Boolean): Boolean = {
+                  symbolOccurrence.exists { case (occ, _) =>
+                    fn(occ.symbol)
+                  }
                 }
-                fileChanges.partition { case (path, _) =>
-                  buffers.contains(path)
+
+                // If we didn't find any references then it might be a renamed symbol `import a.{ B => C }`
+                val fallbackOccurences =
+                  if (allReferences.isEmpty)
+                    renamedImportOccurrences(source, symbolOccurrence)
+                  else allReferences
+
+                if (fallbackOccurences.isEmpty) {
+                  scribe.debug(s"Symbol occurence was $symbolOccurrence")
+                  scribe.debug(s"The definition found was $definition")
                 }
-              } else {
-                (fileChanges, Map.empty[AbsolutePath, List[TextEdit]])
-              }
 
-            awaitingSave.add(() => changeClosedFiles(closedEdits))
+                val allChanges = for {
+                  (path, locs) <- fallbackOccurences.toList.distinct
+                    .groupBy(_.getUri().toAbsolutePath)
+                } yield {
+                  val textEdits = for (loc <- locs) yield {
+                    textEdit(isOccurrence, loc, newName)
+                  }
+                  Seq(path -> textEdits.toList)
+                }
+                val fileChanges = allChanges.flatten.toMap
+                val shouldRenameInBackground =
+                  !clientConfig.isOpenFilesOnRenameProvider || fileChanges.keySet.size >= clientConfig.renameFileThreshold
+                val (openedEdits, closedEdits) =
+                  if (shouldRenameInBackground) {
+                    if (clientConfig.isOpenFilesOnRenameProvider) {
+                      client.showMessage(fileThreshold(fileChanges.keySet.size))
+                    }
+                    fileChanges.partition { case (path, _) =>
+                      buffers.contains(path)
+                    }
+                  } else {
+                    (fileChanges, Map.empty[AbsolutePath, List[TextEdit]])
+                  }
 
-            val edits = documentEdits(openedEdits)
-            val renames =
-              fileRenames(isOccurrence, fileChanges.keySet, newName)
-            new WorkspaceEdit((edits ++ renames).asJava)
-          }
-      })
+                awaitingSave.add(() => changeClosedFiles(closedEdits))
+
+                val edits = documentEdits(openedEdits)
+                val renames =
+                  fileRenames(isOccurrence, fileChanges.keySet, newName)
+                new WorkspaceEdit((edits ++ renames).asJava)
+            }
+        }
+      }
   }
 
   def runSave(): Future[Unit] = {

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -6,12 +6,12 @@ import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.Range;
 
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
-import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.SelectionRange;
 
@@ -68,6 +68,12 @@ public abstract class PresentationCompiler {
      * Returns the type of the expression at the given position along with the symbol of the referenced symbol.
      */
     public abstract CompletableFuture<Optional<HoverSignature>> hover(OffsetParams params);
+
+    /**
+     * Renames the symbol at given position and all of its occurrences to `name`.
+     * @implNote use only on symbols defined inside a method
+    */
+    public abstract CompletableFuture<Optional<Range>> prepareRename(OffsetParams params);
 
     /**
      * Renames the symbol at given position and all of its occurrences to `name`.

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -15,7 +15,6 @@ import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.SelectionRange;
 
-
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
@@ -33,215 +32,240 @@ import java.util.concurrent.ScheduledExecutorService;
  */
 public abstract class PresentationCompiler {
 
-    // ==============================
-    // Language Server Protocol APIs.
-    // ==============================
+	// ==============================
+	// Language Server Protocol APIs.
+	// ==============================
 
-    /**
-     * Returns code completions for the given source position.
-     *
-     * The returned completion items are incomplete meaning they may not contain available
-     * information such as documentation or the detail signature may have `x$1` parameter
-     * names for Java methods. It's recommended to call
-     * {@link #completionItemResolve(CompletionItem, String)}
-     * before displaying the `detail` and `documentation` fields to the user.
-     *
-     * @implNote supports cancellation.
-     */
-    public abstract CompletableFuture<CompletionList> complete(OffsetParams params);
+	/**
+	 * Returns code completions for the given source position.
+	 *
+	 * The returned completion items are incomplete meaning they may not contain
+	 * available information such as documentation or the detail signature may have
+	 * `x$1` parameter names for Java methods. It's recommended to call
+	 * {@link #completionItemResolve(CompletionItem, String)} before displaying the
+	 * `detail` and `documentation` fields to the user.
+	 *
+	 * @implNote supports cancellation.
+	 */
+	public abstract CompletableFuture<CompletionList> complete(OffsetParams params);
 
-    /**
-     * Returns a fully resolved completion item with defined fields such as `documentation` and `details` populated.
-     *
-     * @implNote does not support cancellation.
-     */
-    public abstract CompletableFuture<CompletionItem> completionItemResolve(CompletionItem item, String symbol);
+	/**
+	 * Returns a fully resolved completion item with defined fields such as
+	 * `documentation` and `details` populated.
+	 *
+	 * @implNote does not support cancellation.
+	 */
+	public abstract CompletableFuture<CompletionItem> completionItemResolve(CompletionItem item, String symbol);
 
-    /**
-     * Returns the parameter hints at the given source position.
-     *
-     * @implNote supports cancellation.
-     */
-    public abstract CompletableFuture<SignatureHelp> signatureHelp(OffsetParams params);
+	/**
+	 * Returns the parameter hints at the given source position.
+	 *
+	 * @implNote supports cancellation.
+	 */
+	public abstract CompletableFuture<SignatureHelp> signatureHelp(OffsetParams params);
 
-    /**
-     * Returns the type of the expression at the given position along with the symbol of the referenced symbol.
-     */
-    public abstract CompletableFuture<Optional<HoverSignature>> hover(OffsetParams params);
+	/**
+	 * Returns the type of the expression at the given position along with the
+	 * symbol of the referenced symbol.
+	 */
+	public abstract CompletableFuture<Optional<HoverSignature>> hover(OffsetParams params);
 
-    /**
-     * Renames the symbol at given position and all of its occurrences to `name`.
-     * @implNote use only on symbols defined inside a method
-    */
-    public abstract CompletableFuture<Optional<Range>> prepareRename(OffsetParams params);
+	/**
+	 * Checks if the symbol at given position can be renamed using presentation
+	 * compiler. Returns Some(range) if symbol is defined inside a method or the
+	 * file is a worksheet, None otherwise
+	 */
+	public abstract CompletableFuture<Optional<Range>> prepareRename(OffsetParams params);
 
-    /**
-     * Renames the symbol at given position and all of its occurrences to `name`.
-     * @implNote use only on symbols defined inside a method
-    */
-    public abstract CompletableFuture<List<TextEdit>> rename(OffsetParams params, String name);
+	/**
+	 * Renames the symbol at given position and all of its occurrences to `name`. If
+	 * symbol can't be renamed using presentation compiler (prepareRename returns
+	 * None), returns empty list.
+	 */
+	public abstract CompletableFuture<List<TextEdit>> rename(OffsetParams params, String name);
 
-    /**
-     * Returns the definition of the symbol at the given position.
-     */
-    public abstract CompletableFuture<DefinitionResult> definition(OffsetParams params);
+	/**
+	 * Returns the definition of the symbol at the given position.
+	 */
+	public abstract CompletableFuture<DefinitionResult> definition(OffsetParams params);
 
+	/**
+	 * Returns location of the expression's type definition at the given position.
+	 */
+	public abstract CompletableFuture<DefinitionResult> typeDefinition(OffsetParams params);
 
-    /**
-     * Returns location of the expression's type definition at the given position.
-     */
-     public abstract CompletableFuture<DefinitionResult> typeDefinition(OffsetParams params);
+	/**
+	 * Returns the occurrences of the symbol under the current position in the
+	 * entire file.
+	 */
+	public abstract CompletableFuture<java.util.List<DocumentHighlight>> documentHighlight(OffsetParams params);
 
-    /**
-    * Returns the occurrences of the symbol under the current position in the entire file.
-     */
-    public abstract CompletableFuture<java.util.List<DocumentHighlight>> documentHighlight(OffsetParams params);
+	/**
+	 * Return decoded and pretty printed TASTy content for .scala or .tasty file.
+	 * 
+	 */
+	public abstract CompletableFuture<String> getTasty(URI targetUri, boolean isHttpEnabled);
 
-    /**
-     * Return decoded and pretty printed TASTy content for .scala or .tasty file.
+	/**
+	 * Return the necessary imports for a symbol at the given position.
+	 */
+	public abstract CompletableFuture<List<AutoImportsResult>> autoImports(String name, OffsetParams params,
+			Boolean isExtension);
 
-     */
-    public abstract CompletableFuture<String> getTasty(URI targetUri, boolean isHttpEnabled);
+	/**
+	 * Return the missing implements and imports for the symbol at the given
+	 * position.
+	 */
+	public abstract CompletableFuture<List<TextEdit>> implementAbstractMembers(OffsetParams params);
 
-    /**
-     * Return the necessary imports for a symbol at the given position.
-     */
-    public abstract CompletableFuture<List<AutoImportsResult>> autoImports(String name, OffsetParams params, Boolean isExtension);
+	/**
+	 * Return the missing implements and imports for the symbol at the given
+	 * position.
+	 */
+	public abstract CompletableFuture<List<TextEdit>> insertInferredType(OffsetParams params);
 
-    /**
-     * Return the missing implements and imports for the symbol at the given position.
-     */
-    public abstract CompletableFuture<List<TextEdit>> implementAbstractMembers(OffsetParams params);
+	/**
+	 * Extract method in selected range
+	 * 
+	 * @param range         range to extract from
+	 * @param extractionPos position in file to extract to
+	 */
+	public abstract CompletableFuture<List<TextEdit>> extractMethod(RangeParams range, OffsetParams extractionPos);
 
-    /**
-     * Return the missing implements and imports for the symbol at the given position.
-     */
-    public abstract CompletableFuture<List<TextEdit>> insertInferredType(OffsetParams params);
+	/**
+	 * Return named arguments for the apply method that encloses the given position.
+	 */
+	public abstract CompletableFuture<List<TextEdit>> convertToNamedArguments(OffsetParams params,
+			List<Integer> argIndices);
 
-    /**
-     * Extract method in selected range
-     * @param range range to extract from
-     * @param extractionPos position in file to extract to
-     */
-    public abstract CompletableFuture<List<TextEdit>> extractMethod(RangeParams range, OffsetParams extractionPos);
+	/**
+	 * The text contents of the fiven file changed.
+	 */
+	public abstract CompletableFuture<List<Diagnostic>> didChange(VirtualFileParams params);
 
-    /**
-     * Return named arguments for the apply method that encloses the given position.
-     */
-    public abstract CompletableFuture<List<TextEdit>> convertToNamedArguments(OffsetParams params, List<Integer> argIndices);
+	/**
+	 * File was closed.
+	 */
+	public abstract void didClose(URI uri);
 
-    /**
-     * The text contents of the fiven file changed.
-     */
-    public abstract CompletableFuture<List<Diagnostic>> didChange(VirtualFileParams params);
+	/**
+	 * Returns the Protobuf byte array representation of a SemanticDB
+	 * <code>TextDocument</code> for the given source.
+	 */
+	public abstract CompletableFuture<byte[]> semanticdbTextDocument(URI filename, String code);
 
-    /**
-     * File was closed.
-     */
-    public abstract void didClose(URI uri);
+	/**
+	 * Return the selections ranges for the given positions.
+	 */
+	public abstract CompletableFuture<List<SelectionRange>> selectionRange(List<OffsetParams> params);
 
-    /**
-     * Returns the Protobuf byte array representation of a SemanticDB <code>TextDocument</code> for the given source.
-     */
-    public abstract CompletableFuture<byte[]> semanticdbTextDocument(URI filename, String code);
+	// =================================
+	// Configuration and lifecycle APIs.
+	// =================================
 
-    /**
-     * Return the selections ranges for the given positions. 
-     */
-    public abstract CompletableFuture<List<SelectionRange>> selectionRange(List<OffsetParams> params);
+	/**
+	 * Clean up resources and shutdown the presentation compiler.
+	 *
+	 * It is necessary to call this method in order to for example stop the
+	 * presentation compiler thread. If this method is not called, then the JVM may
+	 * not shut exit cleanly.
+	 *
+	 * This presentation compiler instance should no longer be used after calling
+	 * this method.
+	 */
+	public abstract void shutdown();
 
-    // =================================
-    // Configuration and lifecycle APIs.
-    // =================================
+	/**
+	 * Clean the symbol table and other mutable state in the compiler.
+	 */
+	public abstract void restart();
 
-    /**
-     * Clean up resources and shutdown the presentation compiler.
-     *
-     * It is necessary to call this method in order to for example stop the presentation compiler thread.
-     * If this method is not called, then the JVM may not shut exit cleanly.
-     *
-     * This presentation compiler instance should no longer be used after calling this method.
-     */
-    public abstract void shutdown();
+	/**
+	 * Provide a SymbolSearch to extract docstrings, java parameter names and Scala
+	 * default parameter values.
+	 */
+	public abstract PresentationCompiler withSearch(SymbolSearch search);
 
-    /**
-     * Clean the symbol table and other mutable state in the compiler.
-     */
-    public abstract void restart();
+	/**
+	 * Provide a custom executor service to run asynchronous cancellation or
+	 * requests.
+	 */
+	public abstract PresentationCompiler withExecutorService(ExecutorService executorService);
 
-    /**
-     * Provide a SymbolSearch to extract docstrings, java parameter names and Scala default parameter values.
-     */
-    public abstract PresentationCompiler withSearch(SymbolSearch search);
+	/**
+	 * Provide a custom scheduled executor service to schedule `Thread.stop()` for
+	 * unresponsive compiler instances.
+	 */
+	public abstract PresentationCompiler withScheduledExecutorService(
+			ScheduledExecutorService scheduledExecutorService);
 
-    /**
-     * Provide a custom executor service to run asynchronous cancellation or requests.
-     */
-    public abstract PresentationCompiler withExecutorService(ExecutorService executorService);
+	/**
+	 * Provide custom configuration for features like signature help and
+	 * completions.
+	 */
+	public abstract PresentationCompiler withConfiguration(PresentationCompilerConfig config);
 
-    /**
-     * Provide a custom scheduled executor service to schedule `Thread.stop()` for unresponsive compiler instances.
-     */
-    public abstract PresentationCompiler withScheduledExecutorService(ScheduledExecutorService scheduledExecutorService);
+	/**
+	 * Provide workspace root for features like ammonite script $file completions.
+	 */
+	public abstract PresentationCompiler withWorkspace(Path workspace);
 
-    /**
-     * Provide custom configuration for features like signature help and completions.
-     */
-    public abstract PresentationCompiler withConfiguration(PresentationCompilerConfig config);
+	/**
+	 * Construct a new presentation compiler with the given parameters.
+	 *
+	 * @param buildTargetIdentifier the build target containing this source file.
+	 *                              This is needed for
+	 *                              {@link #completionItemResolve(CompletionItem, String)}.
+	 * @param classpath             the classpath of this build target.
+	 * @param options               the compiler flags for the new compiler.
+	 *                              Important, it is recommended to disable all
+	 *                              compiler plugins excluding
+	 *                              org.scalamacros:paradise, kind-projector and
+	 *                              better-monadic-for.
+	 */
+	public abstract PresentationCompiler newInstance(String buildTargetIdentifier, List<Path> classpath,
+			List<String> options);
 
-    /**
-     * Provide workspace root for features like ammonite script $file completions.
-     */
-    public abstract PresentationCompiler withWorkspace(Path workspace);
+	// =============================
+	// Intentionally missing methods
+	// =============================
 
+	// Metals uses diagnostics from the build. It is not on the roadmap to publish
+	// diagnostics
+	// from the presentation compiler because they are unreliable, especially for
+	// long-running
+	// compiler instances.
+	// def diagnostics(): List[Diagnostics]
 
-    /**
-     * Construct a new presentation compiler with the given parameters.
-     *
-     * @param buildTargetIdentifier the build target containing this source file. This is needed for
-     * {@link #completionItemResolve(CompletionItem, String)}.
-     * @param classpath the classpath of this build target.
-     * @param options the compiler flags for the new compiler. Important, it is recommended to disable
-     *                all compiler plugins excluding org.scalamacros:paradise, kind-projector and better-monadic-for.
-     */
-    public abstract PresentationCompiler newInstance(String buildTargetIdentifier, List<Path> classpath, List<String> options);
+	// The presentation compiler does not have enough information to implement it
+	// standalone.
+	// def definition(params: OffsetParams): List[Location]
 
+	// The presentation compiler does not have enough information to implement it
+	// standalone.
+	// def references(params: OffsetParams): List[Location]
 
-    // =============================
-    // Intentionally missing methods
-    // =============================
+	// ==============================================
+	// Internal methods - not intended for public use
+	// ==============================================
+	public abstract List<String> diagnosticsForDebuggingPurposes();
 
-    // Metals uses diagnostics from the build. It is not on the roadmap to publish diagnostics
-    // from the presentation compiler because they are unreliable, especially for long-running
-    // compiler instances.
-    // def diagnostics(): List[Diagnostics]
+	/**
+	 * Returns false if the presentation compiler has not been used since the last
+	 * reset.
+	 * 
+	 * NOTE(olafur) This method was added for testing purposes. It's critical that
+	 * we correctly reset the presentation compiler when build compilation complete
+	 * to prevent the presentatin compiler from returning stale results. It's
+	 * difficult to reliably test that a compiler is not returning stale results so
+	 * we test instead against the implementation detail that the compiler is `null`
+	 * when it has been reset.
+	 */
+	public abstract boolean isLoaded();
 
-    // The presentation compiler does not have enough information to implement it standalone.
-    // def definition(params: OffsetParams): List[Location]
-
-    // The presentation compiler does not have enough information to implement it standalone.
-    // def references(params: OffsetParams): List[Location]
-
-    // ==============================================
-    // Internal methods - not intended for public use
-    // ==============================================
-    public abstract List<String> diagnosticsForDebuggingPurposes();
-
-    /**
-     * Returns false if the presentation compiler has not been used since the last reset.
-     * 
-     * NOTE(olafur) This method was added for testing purposes. It's critical
-     * that we correctly reset the presentation compiler when build compilation
-     * complete to prevent the presentatin compiler from returning stale
-     * results. It's difficult to reliably test that a compiler is not
-     * returning stale results so we test instead against the implementation
-     * detail that the compiler is `null` when it has been reset.
-     */
-    public abstract boolean isLoaded();
-
-    /**
-     * Scala version for the current presentation compiler
-     */
-    public abstract String scalaVersion();
+	/**
+	 * Scala version for the current presentation compiler
+	 */
+	public abstract String scalaVersion();
 
 }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
@@ -95,7 +95,7 @@ abstract class PcCollector[T](
     else (pos, false)
   }
 
-  lazy val namedArgCache: Map[Int, NamedArg] = {
+  lazy val namedArgCache = {
     val parsedTree = parseTree(unit.source)
     parsedTree.collect { case arg @ AssignOrNamedArg(_, rhs) =>
       rhs.pos.start -> arg

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
@@ -110,6 +110,7 @@ abstract class PcCollector[T](
     }
   }
 
+  // First identify the symbol we are at, comments identify @@ as current cursor position
   lazy val soughtSymbols: Option[(Set[Symbol], Position)] = typedTree match {
     /* simple identifier:
      * val a = val@@ue + value
@@ -198,8 +199,6 @@ abstract class PcCollector[T](
   }
 
   def result(): List[T] = {
-
-    // First identify the symbol we are at, comments identify @@ as current cursor position
 
     // Now find all matching symbols in the document, comments identify <<>> as the symbol we are looking for
     soughtSymbols match {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
@@ -95,7 +95,7 @@ abstract class PcCollector[T](
     else (pos, false)
   }
 
-  lazy val namedArgCache = {
+  private lazy val namedArgCache = {
     val parsedTree = parseTree(unit.source)
     parsedTree.collect { case arg @ AssignOrNamedArg(_, rhs) =>
       rhs.pos.start -> arg

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
@@ -95,99 +95,100 @@ abstract class PcCollector[T](
     else (pos, false)
   }
 
+  lazy val namedArgCache: Map[Int, NamedArg] = {
+    val parsedTree = parseTree(unit.source)
+    parsedTree.collect { case arg @ AssignOrNamedArg(_, rhs) =>
+      rhs.pos.start -> arg
+    }.toMap
+  }
+  def fallbackSymbol(name: Name, pos: Position): Option[Symbol] = {
+    val context = doLocateImportContext(pos)
+    context.lookupSymbol(name, sym => sym.isType) match {
+      case LookupSucceeded(_, symbol) =>
+        Some(symbol)
+      case _ => None
+    }
+  }
+
+  val soughtSymbols: Option[Set[Symbol]] = typedTree match {
+    /* simple identifier:
+     * val a = val@@ue + value
+     */
+    case (id: Ident) =>
+      // might happen in type trees
+      // also this doesn't seem to be picked up by semanticdb
+      if (id.symbol == NoSymbol)
+        fallbackSymbol(id.name, pos).map(symbolAlternatives)
+      else {
+        Some(symbolAlternatives(id.symbol))
+      }
+    /* named argument, which is a bit complex:
+     * foo(nam@@e = "123")
+     */
+    case (apply: Apply) =>
+      apply.args
+        .flatMap { arg =>
+          namedArgCache.get(arg.pos.start)
+        }
+        .collectFirst {
+          case AssignOrNamedArg(id: Ident, _) if id.pos.includes(pos) =>
+            apply.symbol.paramss.flatten.find(_.name == id.name).map { s =>
+              // if it's a case class we need to look for parameters also
+              if (caseClassSynthetics(s.owner.name) && s.owner.isSynthetic) {
+                val applyOwner = s.owner.owner
+                val constructorOwner =
+                  if (applyOwner.isCaseClass) applyOwner
+                  else
+                    applyOwner.companion match {
+                      case NoSymbol =>
+                        localCompanion(applyOwner).getOrElse(NoSymbol)
+                      case comp => comp
+                    }
+                val info = constructorOwner.info
+                val constructorParams = info.members
+                  .filter(_.isConstructor)
+                  .flatMap(_.paramss)
+                  .flatten
+                  .toSet
+                (constructorParams ++ Set(
+                  s,
+                  info.member(s.getterName),
+                  info.member(s.setterName),
+                  info.member(s.localName)
+                )).filter(_ != NoSymbol)
+              } else Set(s)
+            }
+        }
+        .flatten
+    /* all definitions:
+     * def fo@@o = ???
+     * class Fo@@o = ???
+     * etc.
+     */
+    case (df: DefTree) if df.namePos.includes(pos) =>
+      Some(symbolAlternatives(df.symbol))
+    /* Import selectors:
+     * import scala.util.Tr@@y
+     */
+    case (imp: Import) if imp.pos.includes(pos) =>
+      imp.selector(pos).map(symbolAlternatives)
+    /* simple selector:
+     * object.val@@ue
+     */
+    case (sel: NameTree) if sel.namePos.includes(pos) =>
+      Some(symbolAlternatives(sel.symbol))
+
+    // needed for classOf[AB@@C]`
+    case lit @ Literal(Constant(TypeRef(_, sym, _))) if lit.pos.includes(pos) =>
+      Some(symbolAlternatives(sym))
+    case _ =>
+      None
+  }
+
   def result(): List[T] = {
 
-    lazy val namedArgCache = {
-      val parsedTree = parseTree(unit.source)
-      parsedTree.collect { case arg @ AssignOrNamedArg(_, rhs) =>
-        rhs.pos.start -> arg
-      }.toMap
-    }
-    def fallbackSymbol(name: Name, pos: Position) = {
-      val context = doLocateImportContext(pos)
-      context.lookupSymbol(name, sym => sym.isType) match {
-        case LookupSucceeded(_, symbol) =>
-          Some(symbol)
-        case _ => None
-      }
-    }
-
     // First identify the symbol we are at, comments identify @@ as current cursor position
-    val soughtSymbols: Option[Set[Symbol]] = typedTree match {
-      /* simple identifier:
-       * val a = val@@ue + value
-       */
-      case (id: Ident) =>
-        // might happen in type trees
-        // also this doesn't seem to be picked up by semanticdb
-        if (id.symbol == NoSymbol)
-          fallbackSymbol(id.name, pos).map(symbolAlternatives)
-        else {
-          Some(symbolAlternatives(id.symbol))
-        }
-      /* named argument, which is a bit complex:
-       * foo(nam@@e = "123")
-       */
-      case (apply: Apply) =>
-        apply.args
-          .flatMap { arg =>
-            namedArgCache.get(arg.pos.start)
-          }
-          .collectFirst {
-            case AssignOrNamedArg(id: Ident, _) if id.pos.includes(pos) =>
-              apply.symbol.paramss.flatten.find(_.name == id.name).map { s =>
-                // if it's a case class we need to look for parameters also
-                if (caseClassSynthetics(s.owner.name) && s.owner.isSynthetic) {
-                  val applyOwner = s.owner.owner
-                  val constructorOwner =
-                    if (applyOwner.isCaseClass) applyOwner
-                    else
-                      applyOwner.companion match {
-                        case NoSymbol =>
-                          localCompanion(applyOwner).getOrElse(NoSymbol)
-                        case comp => comp
-                      }
-                  val info = constructorOwner.info
-                  val constructorParams = info.members
-                    .filter(_.isConstructor)
-                    .flatMap(_.paramss)
-                    .flatten
-                    .toSet
-                  (constructorParams ++ Set(
-                    s,
-                    info.member(s.getterName),
-                    info.member(s.setterName),
-                    info.member(s.localName)
-                  )).filter(_ != NoSymbol)
-                } else Set(s)
-              }
-          }
-          .flatten
-      /* all definitions:
-       * def fo@@o = ???
-       * class Fo@@o = ???
-       * etc.
-       */
-      case (df: DefTree) if df.namePos.includes(pos) =>
-        Some(symbolAlternatives(df.symbol))
-      /* Import selectors:
-       * import scala.util.Tr@@y
-       */
-      case (imp: Import) if imp.pos.includes(pos) =>
-        imp.selector(pos).map(symbolAlternatives)
-      /* simple selector:
-       * object.val@@ue
-       */
-      case (sel: NameTree) if sel.namePos.includes(pos) =>
-        Some(symbolAlternatives(sel.symbol))
 
-      // needed for classOf[AB@@C]`
-      case lit @ Literal(Constant(TypeRef(_, sym, _)))
-          if lit.pos.includes(pos) =>
-        Some(symbolAlternatives(sym))
-      case _ =>
-        None
-    }
     // Now find all matching symbols in the document, comments identify <<>> as the symbol we are looking for
     soughtSymbols match {
       case Some(sought) =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
@@ -4,6 +4,14 @@ import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.OffsetParams
 
 import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j.Range
+
+object PcRenameProvider {
+  def prepareRename(
+      compiler: MetalsGlobal,
+      params: OffsetParams
+  ): Option[Range] = ???
+}
 
 class PcRenameProvider(
     override val compiler: MetalsGlobal,

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
@@ -3,14 +3,87 @@ package scala.meta.internal.pc
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.OffsetParams
 
-import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.TextEdit
 
 object PcRenameProvider {
+
   def prepareRename(
       compiler: MetalsGlobal,
       params: OffsetParams
-  ): Option[Range] = ???
+  ): Option[Range] = {
+    import compiler._
+
+    def canRenameSymbol(sym: Symbol): Boolean = {
+      pprint.log(sym.ownersIterator.map(s => (s, s.decodedName)).toList)
+      val forbiddenMethods =
+        Set("equals", "hashCode", "unapply", "unary_!", "!")
+      (!sym.isMethod || !forbiddenMethods(
+        sym.decodedName
+      )) && (sym.ownersIterator
+        .drop(1)
+        .exists(
+          _.isMethod
+        )) // this also works for worksheets, since they are wrapped in `method main`
+
+    }
+    val unit: RichCompilationUnit = addCompilationUnit(
+      code = params.text(),
+      filename = params.uri().toString(),
+      cursor = None
+    )
+    val pos: Position = unit.position(params.offset)
+    typeCheck(unit)
+    val typedTree: Tree = locateTree(pos) match {
+      // Check actual object if apply is synthetic
+      case sel @ Select(qual, name)
+          if name == nme.apply && qual.pos == sel.pos =>
+        qual
+      case Import(expr, _) if expr.pos.includes(pos) =>
+        // imports seem to be marked as transparent
+        locateTree(pos, expr, acceptTransparent = true)
+      case t => t
+    }
+    val s = typedTree match {
+      case (id: Ident) =>
+        Some((id.symbol, id.symbol.pos))
+      /* named argument, which is a bit complex:
+       * foo(nam@@e = "123")
+       */
+
+      /* all definitions:
+       * def fo@@o = ???
+       * class Fo@@o = ???
+       * etc.
+       */
+      case (df: DefTree) if df.namePos.includes(pos) =>
+        Some((df.symbol, df.namePos))
+      /* Import selectors:
+       * import scala.util.Tr@@y
+       */
+      case (imp: Import) if imp.pos.includes(pos) =>
+        imp.selector(pos).map(sym => (sym, sym.pos))
+      /* simple selector:
+       * object.val@@ue
+       */
+      case (sel: NameTree) if sel.namePos.includes(pos) =>
+        Some((sel.symbol, sel.symbol.pos))
+
+      // needed for classOf[AB@@C]`
+      case lit @ Literal(Constant(TypeRef(_, sym, _)))
+          if lit.pos.includes(pos) =>
+        Some((sym, sym.pos))
+      case _ =>
+        None
+    }
+    s.collect {
+      case (symbol, pos)
+          if canRenameSymbol(symbol) && symbol.allOverriddenSymbols.forall(
+            canRenameSymbol(_)
+          ) =>
+        pos.toLsp
+    }
+  }
 }
 
 class PcRenameProvider(
@@ -27,8 +100,19 @@ class PcRenameProvider(
       if (stripBackticks) newName.stripBackticks else newName
     )
   }
+  def canRenameSymbol(sym: Symbol): Boolean = {
+    val forbiddenMethods = Set("equals", "hashCode", "unapply", "unary_!", "!")
+    (!sym.isMethod || !forbiddenMethods(sym.decodedName)) && sym.ownersIterator
+      .drop(1)
+      .exists(_.isMethod)
 
-  def rename(): List[TextEdit] =
-    result()
+  }
+  def rename(): List[TextEdit] = {
+
+    val symbols = soughtSymbols.getOrElse(Set.empty)
+    if (symbols.nonEmpty && symbols.forall(canRenameSymbol(_)))
+      result()
+    else Nil
+  }
 
 }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
@@ -11,13 +11,12 @@ class PcRenameProvider(
     name: Option[String]
 ) extends PcCollector[l.TextEdit](compiler, params) {
   import compiler._
+  private val forbiddenMethods =
+    Set("equals", "hashCode", "unapply", "unary_!", "!")
 
   def canRenameSymbol(sym: Symbol): Boolean = {
-    val forbiddenMethods =
-      Set("equals", "hashCode", "unapply", "unary_!", "!")
-    (!sym.isMethod || !forbiddenMethods(
-      sym.decodedName
-    )) && (sym.ownersIterator
+    (!sym.isMethod || !forbiddenMethods(sym.decodedName)) &&
+    (sym.ownersIterator
       .drop(1)
       .exists(
         _.isMethod
@@ -26,7 +25,6 @@ class PcRenameProvider(
   }
   def prepareRename(
   ): Option[l.Range] = {
-
     soughtSymbols.flatMap { case (symbols, pos) =>
       if (symbols.forall(canRenameSymbol)) Some(pos.toLsp)
       else None
@@ -45,7 +43,6 @@ class PcRenameProvider(
   }
 
   def rename(): List[l.TextEdit] = {
-
     val symbols = soughtSymbols.map(_._1).getOrElse(Set.empty)
     if (symbols.nonEmpty && symbols.forall(canRenameSymbol(_)))
       result()

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
@@ -89,10 +89,10 @@ object PcRenameProvider {
 class PcRenameProvider(
     override val compiler: MetalsGlobal,
     params: OffsetParams,
-    name: String
+    name: Option[String]
 ) extends PcCollector[TextEdit](compiler, params) {
   import compiler._
-  val newName: String = Identifier.backtickWrap(name.stripBackticks)
+  val newName: String = name.map(name => Identifier.backtickWrap(name.stripBackticks)).getOrElse("newName")
   def collect(tree: Tree, toAdjust: Position): TextEdit = {
     val (pos, stripBackticks) = adjust(toAdjust)
     new TextEdit(

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
@@ -3,113 +3,50 @@ package scala.meta.internal.pc
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.OffsetParams
 
-import org.eclipse.lsp4j.Range
-import org.eclipse.lsp4j.TextEdit
-
-object PcRenameProvider {
-
-  def prepareRename(
-      compiler: MetalsGlobal,
-      params: OffsetParams
-  ): Option[Range] = {
-    import compiler._
-
-    def canRenameSymbol(sym: Symbol): Boolean = {
-      pprint.log(sym.ownersIterator.map(s => (s, s.decodedName)).toList)
-      val forbiddenMethods =
-        Set("equals", "hashCode", "unapply", "unary_!", "!")
-      (!sym.isMethod || !forbiddenMethods(
-        sym.decodedName
-      )) && (sym.ownersIterator
-        .drop(1)
-        .exists(
-          _.isMethod
-        )) // this also works for worksheets, since they are wrapped in `method main`
-
-    }
-    val unit: RichCompilationUnit = addCompilationUnit(
-      code = params.text(),
-      filename = params.uri().toString(),
-      cursor = None
-    )
-    val pos: Position = unit.position(params.offset)
-    typeCheck(unit)
-    val typedTree: Tree = locateTree(pos) match {
-      // Check actual object if apply is synthetic
-      case sel @ Select(qual, name)
-          if name == nme.apply && qual.pos == sel.pos =>
-        qual
-      case Import(expr, _) if expr.pos.includes(pos) =>
-        // imports seem to be marked as transparent
-        locateTree(pos, expr, acceptTransparent = true)
-      case t => t
-    }
-    val s = typedTree match {
-      case (id: Ident) =>
-        Some((id.symbol, id.symbol.pos))
-      /* named argument, which is a bit complex:
-       * foo(nam@@e = "123")
-       */
-
-      /* all definitions:
-       * def fo@@o = ???
-       * class Fo@@o = ???
-       * etc.
-       */
-      case (df: DefTree) if df.namePos.includes(pos) =>
-        Some((df.symbol, df.namePos))
-      /* Import selectors:
-       * import scala.util.Tr@@y
-       */
-      case (imp: Import) if imp.pos.includes(pos) =>
-        imp.selector(pos).map(sym => (sym, sym.pos))
-      /* simple selector:
-       * object.val@@ue
-       */
-      case (sel: NameTree) if sel.namePos.includes(pos) =>
-        Some((sel.symbol, sel.symbol.pos))
-
-      // needed for classOf[AB@@C]`
-      case lit @ Literal(Constant(TypeRef(_, sym, _)))
-          if lit.pos.includes(pos) =>
-        Some((sym, sym.pos))
-      case _ =>
-        None
-    }
-    s.collect {
-      case (symbol, pos)
-          if canRenameSymbol(symbol) && symbol.allOverriddenSymbols.forall(
-            canRenameSymbol(_)
-          ) =>
-        pos.toLsp
-    }
-  }
-}
+import org.eclipse.{lsp4j => l}
 
 class PcRenameProvider(
     override val compiler: MetalsGlobal,
     params: OffsetParams,
     name: Option[String]
-) extends PcCollector[TextEdit](compiler, params) {
+) extends PcCollector[l.TextEdit](compiler, params) {
   import compiler._
-  val newName: String = name.map(name => Identifier.backtickWrap(name.stripBackticks)).getOrElse("newName")
-  def collect(tree: Tree, toAdjust: Position): TextEdit = {
+
+  def canRenameSymbol(sym: Symbol): Boolean = {
+    val forbiddenMethods =
+      Set("equals", "hashCode", "unapply", "unary_!", "!")
+    (!sym.isMethod || !forbiddenMethods(
+      sym.decodedName
+    )) && (sym.ownersIterator
+      .drop(1)
+      .exists(
+        _.isMethod
+      )) // this also works for worksheets, since they are wrapped in `method main`
+
+  }
+  def prepareRename(
+  ): Option[l.Range] = {
+
+    soughtSymbols.flatMap { case (symbols, pos) =>
+      if (symbols.forall(canRenameSymbol)) Some(pos.toLsp)
+      else None
+    }
+  }
+
+  val newName: String = name
+    .map(name => Identifier.backtickWrap(name.stripBackticks))
+    .getOrElse("newName")
+  def collect(tree: Tree, toAdjust: Position): l.TextEdit = {
     val (pos, stripBackticks) = adjust(toAdjust)
-    new TextEdit(
+    new l.TextEdit(
       pos.toLsp,
       if (stripBackticks) newName.stripBackticks else newName
     )
   }
-  def canRenameSymbol(sym: Symbol): Boolean = {
-    val forbiddenMethods = Set("equals", "hashCode", "unapply", "unary_!", "!")
-    (!sym.isMethod || !forbiddenMethods(sym.decodedName)) && sym.ownersIterator
-      .drop(1)
-      .exists(_.isMethod)
 
-  }
-  def rename(): List[TextEdit] = {
+  def rename(): List[l.TextEdit] = {
 
-    val symbols = soughtSymbols.getOrElse(Set.empty)
+    val symbols = soughtSymbols.map(_._1).getOrElse(Set.empty)
     if (symbols.nonEmpty && symbols.forall(canRenameSymbol(_)))
       result()
     else Nil

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -21,6 +21,7 @@ import scala.tools.nsc.reporters.StoreReporter
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.mtags.BuildInfo
+import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.AutoImportsResult
 import scala.meta.pc.DefinitionResult
 import scala.meta.pc.HoverSignature
@@ -221,9 +222,7 @@ case class ScalaPresentationCompiler(
       Optional.empty[Range](),
       params.token
     ) { pc =>
-      Optional.ofNullable(
-        new PcRenameProvider(pc.compiler(), params, None).prepareRename().orNull
-      )
+      new PcRenameProvider(pc.compiler(), params, None).prepareRename().asJava
     }
 
   override def rename(

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -38,6 +38,7 @@ import org.eclipse.lsp4j.DocumentHighlight
 import org.eclipse.lsp4j.SelectionRange
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j
 
 case class ScalaPresentationCompiler(
     buildTargetIdentifier: String = "",
@@ -211,6 +212,18 @@ case class ScalaPresentationCompiler(
       new SignatureHelp(),
       params.token
     ) { pc => new SignatureHelpProvider(pc.compiler()).signatureHelp(params) }
+
+  override def prepareRename(
+      params: OffsetParams
+  ): CompletableFuture[ju.Optional[lsp4j.Range]] =
+    compilerAccess.withNonInterruptableCompiler(
+      Optional.empty[lsp4j.Range](),
+      params.token
+    ) { pc =>
+      Optional.ofNullable(
+        PcRenameProvider.prepareRename(pc.compiler(), params).orNull
+      )
+    }
 
   override def rename(
       params: OffsetParams,

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -36,7 +36,6 @@ import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DocumentHighlight
-import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.SelectionRange
 import org.eclipse.lsp4j.SignatureHelp

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -35,10 +35,11 @@ import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DocumentHighlight
+import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.SelectionRange
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.TextEdit
-import org.eclipse.lsp4j
+import org.eclipse.lsp4j.eclipse.lsp4j.Hover
 
 case class ScalaPresentationCompiler(
     buildTargetIdentifier: String = "",
@@ -215,9 +216,9 @@ case class ScalaPresentationCompiler(
 
   override def prepareRename(
       params: OffsetParams
-  ): CompletableFuture[ju.Optional[lsp4j.Range]] =
+  ): CompletableFuture[ju.Optional[Range]] =
     compilerAccess.withNonInterruptableCompiler(
-      Optional.empty[lsp4j.Range](),
+      Optional.empty[Range](),
       params.token
     ) { pc =>
       Optional.ofNullable(

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -39,7 +39,7 @@ import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.SelectionRange
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.TextEdit
-import org.eclipse.lsp4j.eclipse.lsp4j.Hover
+import org.eclipse.lsp4j.Hover
 
 case class ScalaPresentationCompiler(
     buildTargetIdentifier: String = "",
@@ -234,7 +234,7 @@ case class ScalaPresentationCompiler(
       List[TextEdit]().asJava,
       params.token
     ) { pc =>
-      new PcRenameProvider(pc.compiler(), params, name).rename().asJava
+      new PcRenameProvider(pc.compiler(), params, Some(name)).rename().asJava
     }
 
   override def hover(

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -35,11 +35,11 @@ import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DocumentHighlight
+import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.SelectionRange
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.TextEdit
-import org.eclipse.lsp4j.Hover
 
 case class ScalaPresentationCompiler(
     buildTargetIdentifier: String = "",
@@ -222,7 +222,7 @@ case class ScalaPresentationCompiler(
       params.token
     ) { pc =>
       Optional.ofNullable(
-        PcRenameProvider.prepareRename(pc.compiler(), params).orNull
+        new PcRenameProvider(pc.compiler(), params, None).prepareRename().orNull
       )
     }
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
@@ -34,6 +34,27 @@ abstract class PcCollector[T](driver: InteractiveDriver, params: OffsetParams):
   val uri = params.uri()
   val filePath = Paths.get(uri)
   val sourceText = params.text
+  val source =
+    SourceFile.virtual(filePath.toString, sourceText)
+  driver.run(uri, source)
+  given ctx: Context = driver.currentCtx
+  val unit = driver.currentCtx.run.units.head
+  val pos = driver.sourcePosition(params)
+  val rawPath =
+    Interactive
+      .pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
+      .dropWhile(t => // NamedArg anyway doesn't have symbol
+        t.symbol == NoSymbol && !t.isInstanceOf[NamedArg] ||
+          // same issue https://github.com/lampepfl/dotty/issues/15937 as below
+          t.isInstanceOf[TypeTree]
+      )
+
+  val path = rawPath match
+    // For type it will sometimes go into the wrong tree since TypeTree also contains the same span
+    // https://github.com/lampepfl/dotty/issues/15937
+    case TypeApply(sel: Select, _) :: tail if sel.span.contains(pos.span) =>
+      Interactive.pathTo(sel, pos.span) ::: rawPath
+    case _ => rawPath
 
   def collect(tree: Tree, pos: SourcePosition): T
 
@@ -55,153 +76,92 @@ abstract class PcCollector[T](driver: InteractiveDriver, params: OffsetParams):
     else (pos, false)
   end adjust
 
-  def result(): List[T] =
-    val source =
-      SourceFile.virtual(filePath.toString, sourceText)
-    driver.run(uri, source)
-    given ctx: Context = driver.currentCtx
-    val unit = driver.currentCtx.run.units.head
-    val pos = driver.sourcePosition(params)
-    val rawPath =
-      Interactive
-        .pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
-        .dropWhile(t => // NamedArg anyway doesn't have symbol
-          t.symbol == NoSymbol && !t.isInstanceOf[NamedArg] ||
-            // same issue https://github.com/lampepfl/dotty/issues/15937 as below
-            t.isInstanceOf[TypeTree]
-        )
+  def symbolAlternatives(sym: Symbol) =
+    val all =
+      if sym.is(Flags.ModuleClass) then
+        Set(sym, sym.companionModule, sym.companionModule.companion)
+      else if sym.isClass then
+        Set(sym, sym.companionModule, sym.companion.moduleClass)
+      else if sym.is(Flags.Module) then
+        Set(sym, sym.companionClass, sym.moduleClass)
+      else if sym.isTerm then
+        val info =
+          if sym.owner.isClass then sym.owner.info
+          else sym.owner.owner.info
+        Set(
+          sym,
+          info.member(sym.asTerm.name.setterName).symbol,
+          info.member(sym.asTerm.name.getterName).symbol,
+        ) ++ sym.allOverriddenSymbols.toSet
+      else Set(sym)
+    all.filter(s => s != NoSymbol && !s.isError)
+  end symbolAlternatives
 
-    val path = rawPath match
-      // For type it will sometimes go into the wrong tree since TypeTree also contains the same span
-      // https://github.com/lampepfl/dotty/issues/15937
-      case TypeApply(sel: Select, _) :: tail if sel.span.contains(pos.span) =>
-        Interactive.pathTo(sel, pos.span) ::: rawPath
-      case _ => rawPath
-
-    def symbolAlternatives(sym: Symbol) =
-      val all =
-        if sym.is(Flags.ModuleClass) then
-          Set(sym, sym.companionModule, sym.companionModule.companion)
-        else if sym.isClass then
-          Set(sym, sym.companionModule, sym.companion.moduleClass)
-        else if sym.is(Flags.Module) then
-          Set(sym, sym.companionClass, sym.moduleClass)
-        else if sym.isTerm then
-          val info =
-            if sym.owner.isClass then sym.owner.info
-            else sym.owner.owner.info
-          Set(
-            sym,
-            info.member(sym.asTerm.name.setterName).symbol,
-            info.member(sym.asTerm.name.getterName).symbol,
-          ) ++ sym.allOverriddenSymbols.toSet
-        else Set(sym)
-      all.filter(s => s != NoSymbol && !s.isError)
-    end symbolAlternatives
-
-    // First identify the symbol we are at, comments identify @@ as current cursor position
-    def soughtSymbols(path: List[Tree]): Option[Set[Symbol]] =
-      val sought = path match
-        /* simple identifier:
-         * val a = val@@ue + value
-         */
-        case (id: Ident) :: _ =>
-          Some(symbolAlternatives(id.symbol))
-        /* simple selector:
-         * object.val@@ue
-         */
-        case (sel: Select) :: _ if sel.nameSpan.contains(pos.span) =>
-          Some(symbolAlternatives(sel.symbol))
-        /* named argument:
-         * foo(nam@@e = "123")
-         */
-        case (arg: NamedArg) :: (appl: Apply) :: _ =>
-          val realName = arg.name.stripModuleClassSuffix.lastPart
-          if pos.span.start > arg.span.start && pos.span.end < arg.span.point + realName.length
+  // First identify the symbol we are at, comments identify @@ as current cursor position
+  def soughtSymbols(path: List[Tree]): Option[Set[Symbol]] = path match
+    /* simple identifier:
+     * val a = val@@ue + value
+     */
+    case (id: Ident) :: _ =>
+      Some(symbolAlternatives(id.symbol))
+    /* simple selector:
+     * object.val@@ue
+     */
+    case (sel: Select) :: _ if sel.nameSpan.contains(pos.span) =>
+      Some(symbolAlternatives(sel.symbol))
+    /* named argument:
+     * foo(nam@@e = "123")
+     */
+    case (arg: NamedArg) :: (appl: Apply) :: _ =>
+      val realName = arg.name.stripModuleClassSuffix.lastPart
+      if pos.span.start > arg.span.start && pos.span.end < arg.span.point + realName.length
+      then
+        appl.symbol.paramSymss.flatten.find(_.name == arg.name).map { s =>
+          // if it's a case class we need to look for parameters also
+          if caseClassSynthetics(s.owner.name) && s.owner.is(Flags.Synthetic)
           then
-            appl.symbol.paramSymss.flatten.find(_.name == arg.name).map { s =>
-              // if it's a case class we need to look for parameters also
-              if caseClassSynthetics(s.owner.name) && s.owner
-                  .is(Flags.Synthetic)
-              then
-                Set(
-                  s,
-                  s.owner.owner.companion.info.member(s.name).symbol,
-                  s.owner.owner.info.member(s.name).symbol,
-                )
-                  .filter(_ != NoSymbol)
-              else Set(s)
-            }
-          else None
-          end if
-        /* all definitions:
-         * def fo@@o = ???
-         * class Fo@@o = ???
-         * etc.
-         */
-        case (df: NamedDefTree) :: _ if df.nameSpan.contains(pos.span) =>
-          Some(symbolAlternatives(df.symbol))
-        /**
-         * For traversing annotations:
-         * @JsonNo@@tification("")
-         * def params() = ???
-         */
-        case (df: MemberDef) :: _ if df.span.contains(pos.span) =>
-          val annotTree = df.mods.annotations.find { t =>
-            t.span.contains(pos.span)
-          }
-          collectTrees(annotTree).flatMap { t =>
-            soughtSymbols(
-              Interactive.pathTo(t, pos.span)
+            Set(
+              s,
+              s.owner.owner.companion.info.member(s.name).symbol,
+              s.owner.owner.info.member(s.name).symbol,
             )
-          }.headOption
+              .filter(_ != NoSymbol)
+          else Set(s)
+        }
+      else None
+      end if
+    /* all definitions:
+     * def fo@@o = ???
+     * class Fo@@o = ???
+     * etc.
+     */
+    case (df: NamedDefTree) :: _ if df.nameSpan.contains(pos.span) =>
+      Some(symbolAlternatives(df.symbol))
+    /**
+     * For traversing annotations:
+     * @JsonNo@@tification("")
+     * def params() = ???
+     */
+    case (df: MemberDef) :: _ if df.span.contains(pos.span) =>
+      val annotTree = df.mods.annotations.find { t =>
+        t.span.contains(pos.span)
+      }
+      collectTrees(annotTree).flatMap { t =>
+        soughtSymbols(
+          Interactive.pathTo(t, pos.span)
+        )
+      }.headOption
 
-        /* Import selectors:
-         * import scala.util.Tr@@y
-         */
-        case (imp: Import) :: _ if imp.span.contains(pos.span) =>
-          imp.selector(pos.span).map(symbolAlternatives)
+    /* Import selectors:
+     * import scala.util.Tr@@y
+     */
+    case (imp: Import) :: _ if imp.span.contains(pos.span) =>
+      imp.selector(pos.span).map(symbolAlternatives)
 
-        case _ =>
-          None
+    case _ =>
+      None
 
-      sought match
-        case Some(value) => sought
-        case None =>
-          // Fallback check for extension method parameter
-          def collectExtMethods(
-              acc: Set[(Symbol, SourcePosition)],
-              tree: untpd.Tree,
-          ) =
-            tree match
-              case ExtMethods(paramss, _) =>
-                acc ++ paramss
-                  .flatMap(
-                    _.map(p =>
-                      (
-                        p.symbol,
-                        p.namePos,
-                      )
-                    )
-                  )
-                  .toSet
-              case _ => acc
-          val traverser =
-            new untpd.UntypedDeepFolder[Set[(Symbol, SourcePosition)]](
-              collectExtMethods
-            )
-          val extParams: Set[(Symbol, SourcePosition)] =
-            traverser(Set.empty[(Symbol, SourcePosition)], unit.untpdTree)
-          extParams.collectFirst {
-            case (sym, symPos)
-                if symPos.span.contains(
-                  pos.span
-                ) && sym != NoSymbol && !sym.isError =>
-              symbolAlternatives(sym)
-          }
-      end match
-    end soughtSymbols
-
+  def result(): List[T] =
     // Now find all matching symbols in the document, comments identify <<>> as the symbol we are looking for
     soughtSymbols(path) match
       case Some(sought) =>
@@ -361,7 +321,7 @@ abstract class PcCollector[T](driver: InteractiveDriver, params: OffsetParams):
   end result
 
   // @note (tgodzik) Not sure currently how to get rid of the warning, but looks to correctly
-  @nowarn
+  // @nowarn
   private def collectTrees(trees: Iterable[Positioned]): Iterable[Tree] =
     trees.collect { case t: Tree =>
       t

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcRenameProvider.scala
@@ -6,6 +6,13 @@ import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.util.SourcePosition
 import org.eclipse.{lsp4j as l}
+
+object PcRenameProvider:
+  def prepareRename(
+      driver: InteractiveDriver,
+      params: OffsetParams,
+  ): Option[l.Range] = ???
+
 final class PcRenameProvider(
     driver: InteractiveDriver,
     params: OffsetParams,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcRenameProvider.scala
@@ -6,12 +6,78 @@ import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.util.SourcePosition
 import org.eclipse.{lsp4j as l}
+import java.nio.file.Paths
+import dotty.tools.dotc.util.SourceFile
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.interactive.Interactive
+import dotty.tools.dotc.core.Symbols.NoSymbol
+import dotty.tools.dotc.core.Names.*
+import dotty.tools.dotc.core.StdNames.*
+import dotty.tools.dotc.core.Symbols.Symbol
+import dotty.tools.dotc.core.Flags.*
 
 object PcRenameProvider:
+
+  def canRenameSymbol(sym: Symbol)(using Context): Boolean =
+    pprint.log(sym.ownersIterator.toList.map(s => (s, s.name.decoded)))
+    val forbiddenMethods = Set("equals", "hashCode", "unapply", "unary_!", "!")
+    (!sym.is(Method) || !forbiddenMethods(sym.decodedName))
+    && sym.ownersIterator
+      .drop(1)
+      .exists(ow =>
+        ow.is(Method) || (ow.is(ModuleClass)) && ow.name.decoded == "worksheet"
+      )
+    && sym.isDefinedInCurrentRun
   def prepareRename(
       driver: InteractiveDriver,
       params: OffsetParams,
-  ): Option[l.Range] = ???
+  ): Option[l.Range] =
+    val uri = params.uri()
+    val filePath = Paths.get(uri)
+    val sourceText = params.text
+    val source =
+      SourceFile.virtual(filePath.toString, sourceText)
+    driver.run(uri, source)
+    given ctx: Context = driver.currentCtx
+    val unit = driver.currentCtx.run.units.head
+    val pos = driver.sourcePosition(params)
+    val rawPath =
+      Interactive
+        .pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
+        .dropWhile(t => // NamedArg anyway doesn't have symbol
+          t.symbol == NoSymbol && !t.isInstanceOf[NamedArg] ||
+            // same issue https://github.com/lampepfl/dotty/issues/15937 as below
+            t.isInstanceOf[TypeTree]
+        )
+    val path = rawPath match
+      case TypeApply(sel: Select, _) :: tail if sel.span.contains(pos.span) =>
+        Interactive.pathTo(sel, pos.span) ::: rawPath
+      case _ => rawPath
+    val caseClassSynthetics: Set[Name] = Set(nme.apply, nme.copy)
+
+    def findSymbol(path: List[Tree]): Option[(Symbol, SourcePosition)] =
+      path match
+        case (id: Ident) :: _ =>
+          Some(id.symbol, id.sourcePos)
+        case (sel: Select) :: _ if sel.nameSpan.contains(pos.span) =>
+          Some(sel.symbol, sel.sourcePos)
+        case (df: NamedDefTree) :: _ if df.nameSpan.contains(pos.span) =>
+          Some(df.symbol, df.namePos)
+        case (imp: Import) :: _ if imp.span.contains(pos.span) =>
+          imp.selector(pos.span).map(sym => (sym, sym.sourcePos))
+        case _ =>
+          None
+    val r = findSymbol(path).collect {
+      case (symbol, pos)
+          if canRenameSymbol(symbol) && symbol.allOverriddenSymbols.forall(
+            canRenameSymbol(_)
+          ) =>
+        pos.toLsp
+    }
+    pprint.log(r)
+    r
+  end prepareRename
+end PcRenameProvider
 
 final class PcRenameProvider(
     driver: InteractiveDriver,
@@ -30,6 +96,17 @@ final class PcRenameProvider(
 
   def rename(
   ): List[l.TextEdit] =
-    result()
+    pprint.log("wzsedlem")
+    val symbols = soughtSymbols(path).getOrElse(Set.empty)
+    pprint.log(symbols)
+    if symbols.nonEmpty && symbols.forall(PcRenameProvider.canRenameSymbol(_))
+    then
 
+      val res = result()
+      pprint.log(res)
+      res
+    else
+      pprint.log("dupa")
+      Nil
+  end rename
 end PcRenameProvider

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcRenameProvider.scala
@@ -18,73 +18,37 @@ import dotty.tools.dotc.core.Flags.*
 
 object PcRenameProvider:
 
-  def canRenameSymbol(sym: Symbol)(using Context): Boolean =
-    pprint.log(sym.ownersIterator.toList.map(s => (s, s.name.decoded)))
-    val forbiddenMethods = Set("equals", "hashCode", "unapply", "unary_!", "!")
-    (!sym.is(Method) || !forbiddenMethods(sym.decodedName))
-    && sym.ownersIterator
-      .drop(1)
-      .exists(ow =>
-        ow.is(Method) || (ow.is(ModuleClass)) && ow.name.decoded == "worksheet"
-      )
-    && sym.isDefinedInCurrentRun
-  def prepareRename(
-      driver: InteractiveDriver,
-      params: OffsetParams,
-  ): Option[l.Range] =
-    val uri = params.uri()
-    val filePath = Paths.get(uri)
-    val sourceText = params.text
-    val source =
-      SourceFile.virtual(filePath.toString, sourceText)
-    driver.run(uri, source)
-    given ctx: Context = driver.currentCtx
-    val unit = driver.currentCtx.run.units.head
-    val pos = driver.sourcePosition(params)
-    val rawPath =
-      Interactive
-        .pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
-        .dropWhile(t => // NamedArg anyway doesn't have symbol
-          t.symbol == NoSymbol && !t.isInstanceOf[NamedArg] ||
-            // same issue https://github.com/lampepfl/dotty/issues/15937 as below
-            t.isInstanceOf[TypeTree]
-        )
-    val path = rawPath match
-      case TypeApply(sel: Select, _) :: tail if sel.span.contains(pos.span) =>
-        Interactive.pathTo(sel, pos.span) ::: rawPath
-      case _ => rawPath
-    val caseClassSynthetics: Set[Name] = Set(nme.apply, nme.copy)
-
-    def findSymbol(path: List[Tree]): Option[(Symbol, SourcePosition)] =
-      path match
-        case (id: Ident) :: _ =>
-          Some(id.symbol, id.sourcePos)
-        case (sel: Select) :: _ if sel.nameSpan.contains(pos.span) =>
-          Some(sel.symbol, sel.sourcePos)
-        case (df: NamedDefTree) :: _ if df.nameSpan.contains(pos.span) =>
-          Some(df.symbol, df.namePos)
-        case (imp: Import) :: _ if imp.span.contains(pos.span) =>
-          imp.selector(pos.span).map(sym => (sym, sym.sourcePos))
-        case _ =>
-          None
-    val r = findSymbol(path).collect {
-      case (symbol, pos)
-          if canRenameSymbol(symbol) && symbol.allOverriddenSymbols.forall(
-            canRenameSymbol(_)
-          ) =>
-        pos.toLsp
-    }
-    pprint.log(r)
-    r
-  end prepareRename
+  
 end PcRenameProvider
 
 final class PcRenameProvider(
     driver: InteractiveDriver,
     params: OffsetParams,
-    name: String,
+    name: Option[String],
 ) extends PcCollector[l.TextEdit](driver, params):
-  val newName = name.stripBackticks.backticked
+
+  def canRenameSymbol(sym: Symbol)(using Context): Boolean =
+      pprint.log(sym.ownersIterator.toList.map(s => (s, s.name.decoded)))
+      val forbiddenMethods = Set("equals", "hashCode", "unapply", "unary_!", "!")
+      (!sym.is(Method) || !forbiddenMethods(sym.decodedName))
+      && sym.ownersIterator
+        .drop(1)
+        .exists(ow =>
+          ow.is(Method) || (ow.is(ModuleClass)) && ow.name.decoded == "worksheet"
+        )
+      && sym.isDefinedInCurrentRun
+
+
+  def prepareRename(): Option[l.Range] = {
+    soughtSymbols(path).flatMap(
+      (symbols, pos) =>
+        if symbols.forall(canRenameSymbol) then Some(pos.toLsp)
+        else None
+    )
+
+  }
+
+  val newName = name.map(_.stripBackticks.backticked).getOrElse("newName")
 
   def collect(tree: Tree, toAdjust: SourcePosition): l.TextEdit =
     val (pos, stripBackticks) = adjust(toAdjust)
@@ -96,17 +60,12 @@ final class PcRenameProvider(
 
   def rename(
   ): List[l.TextEdit] =
-    pprint.log("wzsedlem")
-    val symbols = soughtSymbols(path).getOrElse(Set.empty)
-    pprint.log(symbols)
-    if symbols.nonEmpty && symbols.forall(PcRenameProvider.canRenameSymbol(_))
+    val (symbols, _)  = soughtSymbols(path).getOrElse(Set.empty, pos)
+    if symbols.nonEmpty && symbols.forall(canRenameSymbol(_))
     then
-
       val res = result()
-      pprint.log(res)
       res
     else
-      pprint.log("dupa")
       Nil
   end rename
 end PcRenameProvider

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcRenameProvider.scala
@@ -18,7 +18,6 @@ import dotty.tools.dotc.core.Flags.*
 
 object PcRenameProvider:
 
-  
 end PcRenameProvider
 
 final class PcRenameProvider(
@@ -28,25 +27,21 @@ final class PcRenameProvider(
 ) extends PcCollector[l.TextEdit](driver, params):
 
   def canRenameSymbol(sym: Symbol)(using Context): Boolean =
-      pprint.log(sym.ownersIterator.toList.map(s => (s, s.name.decoded)))
-      val forbiddenMethods = Set("equals", "hashCode", "unapply", "unary_!", "!")
-      (!sym.is(Method) || !forbiddenMethods(sym.decodedName))
-      && sym.ownersIterator
-        .drop(1)
-        .exists(ow =>
-          ow.is(Method) || (ow.is(ModuleClass)) && ow.name.decoded == "worksheet"
-        )
-      && sym.isDefinedInCurrentRun
+    pprint.log(sym.ownersIterator.toList.map(s => (s, s.name.decoded)))
+    val forbiddenMethods = Set("equals", "hashCode", "unapply", "unary_!", "!")
+    (!sym.is(Method) || !forbiddenMethods(sym.decodedName))
+    && sym.ownersIterator
+      .drop(1)
+      .exists(ow =>
+        ow.is(Method) || (ow.is(ModuleClass)) && ow.name.decoded == "worksheet"
+      )
+    && sym.isDefinedInCurrentRun
 
-
-  def prepareRename(): Option[l.Range] = {
-    soughtSymbols(path).flatMap(
-      (symbols, pos) =>
-        if symbols.forall(canRenameSymbol) then Some(pos.toLsp)
-        else None
+  def prepareRename(): Option[l.Range] =
+    soughtSymbols(path).flatMap((symbols, pos) =>
+      if symbols.forall(canRenameSymbol) then Some(pos.toLsp)
+      else None
     )
-
-  }
 
   val newName = name.map(_.stripBackticks.backticked).getOrElse("newName")
 
@@ -60,12 +55,11 @@ final class PcRenameProvider(
 
   def rename(
   ): List[l.TextEdit] =
-    val (symbols, _)  = soughtSymbols(path).getOrElse(Set.empty, pos)
+    val (symbols, _) = soughtSymbols(path).getOrElse(Set.empty, pos)
     if symbols.nonEmpty && symbols.forall(canRenameSymbol(_))
     then
       val res = result()
       res
-    else
-      Nil
+    else Nil
   end rename
 end PcRenameProvider

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcRenameProvider.scala
@@ -17,10 +17,6 @@ import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.util.SourcePosition
 import org.eclipse.{lsp4j as l}
 
-object PcRenameProvider:
-
-end PcRenameProvider
-
 final class PcRenameProvider(
     driver: InteractiveDriver,
     params: OffsetParams,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -282,6 +282,19 @@ case class ScalaPresentationCompiler(
     }
   end hover
 
+  def prepareRename(
+      params: OffsetParams
+  ): CompletableFuture[ju.Optional[l.Range]] =
+    compilerAccess.withNonInterruptableCompiler(
+      Optional.empty[l.Range](),
+      params.token,
+    ) { access =>
+      val driver = access.compiler()
+      Optional.ofNullable(
+        PcRenameProvider.prepareRename(driver, params).orNull
+      )
+    }
+
   def rename(
       params: OffsetParams,
       name: String,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -291,7 +291,7 @@ case class ScalaPresentationCompiler(
     ) { access =>
       val driver = access.compiler()
       Optional.ofNullable(
-        PcRenameProvider.prepareRename(driver, params).orNull
+        PcRenameProvider(driver, params, None).prepareRename().orNull
       )
     }
 
@@ -304,7 +304,7 @@ case class ScalaPresentationCompiler(
       params.token,
     ) { access =>
       val driver = access.compiler()
-      PcRenameProvider(driver, params, name).rename().asJava
+      PcRenameProvider(driver, params, Some(name)).rename().asJava
     }
 
   def newInstance(

--- a/tests/cross/src/main/scala/tests/BasePcRenameSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePcRenameSuite.scala
@@ -20,6 +20,7 @@ class BasePcRenameSuite extends BasePCSuite with RangeReplace {
     test(name) {
       val original = s"""|object Main {
                          |def method() = {
+                         |List(1) + 2
                          |$methodBody
                          |}
                          |}

--- a/tests/cross/src/main/scala/tests/BasePcRenameSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePcRenameSuite.scala
@@ -6,10 +6,10 @@ import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.CompilerOffsetParams
 import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.metals.TextEdits
-import tests.RangeReplace
 
 import munit.Location
 import munit.TestOptions
+import tests.RangeReplace
 
 class BasePcRenameSuite extends BasePCSuite with RangeReplace {
 
@@ -55,7 +55,7 @@ class BasePcRenameSuite extends BasePCSuite with RangeReplace {
   def prepare(
       name: TestOptions,
       input: String,
-  ) = {
+  ): Unit = {
     test(name) {
       val edit = input.replaceAll("(<<|>>)", "")
       val expected =

--- a/tests/cross/src/test/scala/tests/pc/PcPrepareRenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcPrepareRenameSuite.scala
@@ -1,0 +1,612 @@
+package tests.pc
+
+import tests.BasePcRenameSuite
+
+class PcPrepareRenameSuite extends BasePcRenameSuite {
+
+  prepare(
+    "basic",
+    """package a
+      |object Main2{
+      |  val toRename = Main.preparetoR@@enameprepare
+      |}
+      |""".stripMargin,
+  )
+
+  prepare(
+    "prepare-import",
+    """|package a
+       |
+       |import java.util.{List => `J-List`}
+       |
+       |object Main{
+       |  val toRename: prepare`J-L@@ist`prepare[Int] = ???
+       |  val toRename2: `J-List`[Int] = ???
+       |  val toRename3: java.util.List[Int] = ???
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "prepare-import-local",
+    """|package a
+       |
+       |import a.{Main2 => prepareOt@@herMainprepare}
+       |
+       |object Main{
+       |  val toRename = OtherMain.toRename
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "prepare-import-object",
+    """|package a
+       |
+       |import scala.util.{Try => StdLibTry}
+       |
+       |object Renaming {
+       |  def foo(n: Int): prepareStdLib@@Tryprepare[Int] = 
+       |    prepareStdLibTryprepare(n)
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "case",
+    """|package a
+       |case class prepareUserprepare(name : String)
+       |object Main{
+       |  val user = prepareUserprepare.apply("James")
+       |  val user2 = prepareU@@serprepare(name = "Roger")
+       |  user.copy(name = "")
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "generics",
+    """|package a
+       |trait S1[X] { def preparetorenameprepare(p: X): String = "" }
+       |trait T1[Z] extends S1[Z] { override def preparetorenameprepare(p: Z): String = super.preparetorenameprepare(p) }
+       |trait T2[X] extends T1[X] { override def preparetorenameprepare(p: X): String = super.preparetorenameprepare(p) }
+       |trait T3[I, J] extends T2[I] { override def preparetorenameprepare(p: I): String = super.preparetorenameprepare(p) }
+       |trait T4[I, J] extends T3[J, I] { override def preparetorenameprepare(p: J): String = super.preparetorenameprepare(p) }
+       |trait T5[U] extends T4[U, U] { override def preparetore@@nameprepare(p: U): String = super.preparetorenameprepare(p) }
+       |""".stripMargin,
+  )
+
+  prepare(
+    "match-ret-type",
+    """|package a
+       |trait P
+       |trait PP extends P
+       |trait A { def preparetorenameprepare(a: String): P = ??? }
+       |trait B extends A { override def preparetore@@nameprepare(a: String): PP = ??? }
+       |
+       |""".stripMargin,
+  )
+
+  prepare(
+    "across-targets",
+    """|package a
+       |object Main{
+       |  val preparetoRenameprepare = 123
+       |}
+       |/b/src/main/scala/b/Main2.scala
+       |package b
+       |import a.Main
+       |object Main2{
+       |  val toRename = Main.preparetoR@@enameprepare
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "unapply",
+    """|object prepareF@@ooprepare {
+       |  def unapply(s: String): Option[String] = Some("")
+       |}
+       |
+       |object Main{
+       |  "foo" match {
+       |    case prepareFooprepare(s) => ()
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "unapply-param",
+    """|object Foo {
+       |  def unapply(<<preparenam@@eprepare>>: String): Option[String] = Some(preparenameprepare)
+       |}
+       |
+       |object Main{
+       |  "foo" match {
+       |    case Foo(name) => ()
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "local",
+    """|package a
+       |object Main{
+       |  def hello() = {
+       |    val <<preparetoRen@@ameprepare>> = 123
+       |    preparetoRenameprepare
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "method",
+    """|package a
+       |object Main{
+       |  def preparemet@@hodprepare(abc : String) = true
+       |
+       |  if(preparemethodprepare("")) println("Is true!")
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "self-type",
+    """|package a
+       |trait prepareA@@BCprepare
+       |trait Alphabet{
+       |  this: prepareABCprepare =>
+       |}
+       |object Main{
+       |  val a = new Alphabet with prepareABCprepare
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "method-inheritance",
+    """|package a
+       |trait Hello{
+       |  def preparemethodprepare(abc : String) : Boolean
+       |}
+       |
+       |class GoodMorning extends Hello {
+       |  def preparemet@@hodprepare(abc : String) = true
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "long-inheritance",
+    """|package a
+       |trait A[T, S] {
+       |  def preparemethodprepare(abc : T) : S
+       |}
+       |
+       |abstract class B[T] extends A[T, Boolean] {
+       |  def preparemethodprepare(abc : T) : Boolean
+       |}
+       |
+       |abstract class C extends B[String] {
+       |  def preparemeth@@odprepare(abc : String) : Boolean = false
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "multiple-inheritance",
+    """|package a
+       |trait A {
+       |  def preparemethodprepare(abc : String) : Boolean
+       |}
+       |
+       |trait B {
+       |  def preparemethodprepare(abc : String) : Boolean = true
+       |}
+       |
+       |abstract class C extends B with A {
+       |  override def preparemeth@@odprepare(abc : String) : Boolean = false
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "apply",
+    """|package a
+       |object User{
+       |  def prepareap@@plyprepare(name : String) = name
+       |  def apply(name : String, age: Int) = name
+       |}
+       |object Main{
+       |  val toRename = User##.##prepareprepare("abc")
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "colon-bad",
+    """|package a
+       |class User{
+       |  def prepare:@@:prepare(name : String) = name
+       |}
+       |object Main{
+       |  val user = new User()
+       |  "" prepare::prepare user
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "colon-good",
+    """|package a
+       |class User{
+       |  def prepare:@@:prepare(name : String) = name
+       |}
+       |object Main{
+       |  val user = new User()
+       |  "" prepare::prepare user
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "unary-bad",
+    """|package a
+       |class User{
+       |  def prepareunary_!prepare = false
+       |}
+       |object Main{
+       |  val user = new User()
+       |  prepare@@!prepareuser
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "unary-bad2",
+    """|package a
+       |class User{
+       |  def prepareu@@nary_!prepare = false
+       |}
+       |object Main{
+       |  val user = new User()
+       |  prepare!prepareuser
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "java-classes",
+    """|package a
+       |class MyException extends Exce@@ption
+       |class NewException extends RuntimeException
+       |class NewException2 extends RuntimeException
+       |""".stripMargin,
+  )
+
+  prepare(
+    "inheritance",
+    """|package a
+       |abstract class prepareAn@@imalprepare
+       |class Dog extends prepareAnimalprepare
+       |class Cat extends prepareAnimalprepare
+       |""".stripMargin,
+  )
+
+  prepare(
+    "companion",
+    """|package a
+       |class prepareMainprepare{}
+       |object prepareM@@ainprepare
+       |""".stripMargin,
+  )
+
+  prepare(
+    "companion2",
+    """|package a
+       |class prepareMa@@inprepare{}
+       |object prepareMainprepare
+       |""".stripMargin,
+  )
+
+  prepare(
+    "filename-exact-match",
+    """|package a
+       |object prepareMa@@inprepare
+       |object TheMain
+       |""".stripMargin,
+  )
+
+  prepare(
+    "filename-exact-match-2",
+    """|package a
+       |object Main
+       |object prepareThe@@Mainprepare
+       |""".stripMargin,
+  )
+
+
+  prepare(
+    "anon",
+    """|trait Methodable[T] {
+       |  def preparemethodprepare(asf: T): Int
+       |}
+       |
+       |trait Alphabet extends Methodable[String] {
+       |  def preparemethodprepare(adf: String) = 123
+       |}
+       |
+       |object Main {
+       |  val a = new Alphabet {
+       |    override def <<prepareme@@thodprepare>>(adf: String): Int = 321
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+
+
+  prepare(
+    "macro",
+    """|package a
+       |import io.circe.generic.JsonCodec
+       |trait LivingBeing
+       |@JsonCodec sealed trait prepareAn@@imalprepare extends LivingBeing
+       |object prepareAnimalprepare {
+       |  case object Dog extends prepareAnimalprepare
+       |  case object Cat extends prepareAnimalprepare
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "macro2",
+    """|package a
+       |import io.circe.generic.JsonCodec
+       |@JsonCodec
+       |final case class prepareMa@@in2prepare(name: String)
+       |""".stripMargin,
+  )
+
+
+
+  prepare(
+    "implicit-param",
+    """|package a
+       |object A {
+       |  implicit val preparesome@@Nameprepare: Int = 1
+       |  def m[A](implicit a: A): A = a
+       |  m[Int]
+       |}""".stripMargin,
+  )
+
+  prepare(
+    "nested-symbol",
+    """|package a
+       |object Foo {
+       |  object prepareMa@@inprepare
+       |}
+       |""".stripMargin,
+  )
+
+
+  prepare(
+    "backtick-old-and-new-name",
+    """|package a
+       |object Main{
+       |  val prepare`to-Rename`prepare = 123
+       |}
+       |object Main2{
+       |  val toRename = Main.prepare`to-R@@ename`prepare
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "backtick",
+    """|package a
+       |object Main{
+       |  val preparegreet@@ingprepare = "Hello"
+       |  "" match {
+       |    case `preparegreetingprepare` =>
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "double-backtick",
+    """|package a
+       |object Main{
+       |  val preparegreet@@ingprepare = "Hello"
+       |  "" match {
+       |    case prepare`greeting`prepare =>
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "backtick2",
+    """|package a
+       |object Main{
+       |  val preparegreetingprepare = "Hello"
+       |  "" match {
+       |    case `preparegre@@etingprepare` =>
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "backtick3",
+    """|package a
+       |object Main{
+       |  def local = {
+       |    val <<preparegreet@@ingprepare>> = "Hello"
+       |    "" match {
+       |      case `preparegreetingprepare` =>
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  // If renaming in VS Code, backticks are taken as part of the name
+  prepare(
+    "backtick4",
+    """|package a
+       |object Main{
+       |  def local = {
+       |    val greeting = "Hello"
+       |    "" match {
+       |      case <<`gre@@eting`>> =>
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "params",
+    """|case class Name(prepareva@@lueprepare: String)
+       |
+       |object Main {
+       |  val name1 = Name(preparevalueprepare = "42")
+       |   .copy(preparevalueprepare = "43")
+       |   .copy(preparevalueprepare = "43")
+       |   .preparevalueprepare
+       |  val name2 = Name(preparevalueprepare = "44")
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "constructor",
+    """|case class Name(prepareva@@lueprepare: String)
+       |
+       |object Main {
+       |  val name2 = new Name(preparevalueprepare = "44")
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "type-params",
+    """|package a
+       |trait prepareABCprepare
+       |class CBD[T <: prepareAB@@Cprepare]
+       |object Main{
+       |  val a = classOf[prepareABCprepare]
+       |  val b = new CBD[prepareABCprepare]
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "implicit-parameter",
+    """|trait A {
+       | implicit def preparefooprepare: Double
+       |}
+       |object A extends A {
+       |  implicit def preparefo@@oprepare: Double = 0.1
+       |  def bar(implicit x: Double): Double = x
+       |  val x = bar
+       |}
+       |""".stripMargin,
+  )
+
+
+  prepare(
+    "hierarchy-inside-method-trait",
+    """|package a
+       |object Main {
+       |  final def main(args: Array[String]) = {
+       |    sealed trait <<prepareSy@@mbolprepare>>
+       |    case class Method(name: String) extends prepareSymbolprepare
+       |    case class Variable(value: String) extends prepareSymbolprepare
+       |
+       |    val symbol2: prepareSymbolprepare = Method("method")
+       |    val symbol3: prepareSymbolprepare = Variable("value")
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "hierarchy-inside-method-class",
+    """|package a
+       |object Main {
+       |  final def main(args: Array[String]) = {
+       |    sealed abstract class <<prepareSy@@mbolprepare>>
+       |    case class Method(name: String) extends prepareSymbolprepare
+       |    case class Variable(value: String) extends prepareSymbolprepare
+       |
+       |    val symbol2: prepareSymbolprepare = Method("method")
+       |    val symbol3: prepareSymbolprepare = Variable("value")
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "variable",
+    """|package a
+       |object Main {
+       |  var preparev@@5prepare = false
+       |
+       |  def f5: Boolean = {
+       |    preparev5prepare = true
+       |    preparev5prepare == true
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "variable-explicit1",
+    """|package a
+       |object Main {
+       |  var preparev@@5prepare = false
+       |
+       |  def f5: Boolean = {
+       |    preparev5prepare_=(true)
+       |    preparev5prepare == true
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "variable-explicit2",
+    """|package a
+       |object Main {
+       |  var preparev5prepare = false
+       |
+       |  def f5: Boolean = {
+       |    <<`preparev@@5prepare_=`>>(true)
+       |    preparev5prepare == true
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  // NON COMPILING TESTS
+
+  prepare(
+    "not-compiling",
+    """|package a
+       |object Main {
+       |  def method() = {
+       |    List(1) + 2
+       |    val prepareabcprepare: Option[Int] = ???
+       |    <<prepareab@@cprepare>>.map(_ + 1)
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+}

--- a/tests/cross/src/test/scala/tests/pc/PcPrepareRenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcPrepareRenameSuite.scala
@@ -5,36 +5,17 @@ import tests.BasePcRenameSuite
 class PcPrepareRenameSuite extends BasePcRenameSuite {
 
   prepare(
-    "basic",
-    """package a
-      |object Main2{
-      |  val toRename = Main.preparetoR@@enameprepare
-      |}
-      |""".stripMargin,
-  )
-
-  prepare(
     "prepare-import",
     """|package a
        |
        |import java.util.{List => `J-List`}
        |
        |object Main{
-       |  val toRename: prepare`J-L@@ist`prepare[Int] = ???
-       |  val toRename2: `J-List`[Int] = ???
-       |  val toRename3: java.util.List[Int] = ???
-       |}
-       |""".stripMargin,
-  )
-
-  prepare(
-    "prepare-import-local",
-    """|package a
-       |
-       |import a.{Main2 => prepareOt@@herMainprepare}
-       |
-       |object Main{
-       |  val toRename = OtherMain.toRename
+       |  def m() = {
+       |    val toRename: <<`J-L@@ist`>>[Int] = ???
+       |    val toRename2: `J-List`[Int] = ???
+       |    val toRename3: java.util.List[Int] = ???
+       |  }
        |}
        |""".stripMargin,
   )
@@ -43,11 +24,13 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
     "prepare-import-object",
     """|package a
        |
-       |import scala.util.{Try => StdLibTry}
        |
        |object Renaming {
-       |  def foo(n: Int): prepareStdLib@@Tryprepare[Int] = 
-       |    prepareStdLibTryprepare(n)
+       |  def m() = {
+       |    import scala.util.{Try => StdLibTry}  
+       |    def foo(n: Int): <<StdLib@@Try>>[Int] = 
+       |      StdLibTryprepare(n)
+       |  }
        |}
        |""".stripMargin,
   )
@@ -55,11 +38,13 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
   prepare(
     "case",
     """|package a
-       |case class prepareUserprepare(name : String)
+       |case class Userprepare(name : String)
        |object Main{
-       |  val user = prepareUserprepare.apply("James")
-       |  val user2 = prepareU@@serprepare(name = "Roger")
-       |  user.copy(name = "")
+       |  def m() = {
+       |    val user = User.apply("James")
+       |    val user2 = U@@serprepare(name = "Roger")
+       |    user.copy(name = "")
+       |  }
        |}
        |""".stripMargin,
   )
@@ -67,12 +52,12 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
   prepare(
     "generics",
     """|package a
-       |trait S1[X] { def preparetorenameprepare(p: X): String = "" }
-       |trait T1[Z] extends S1[Z] { override def preparetorenameprepare(p: Z): String = super.preparetorenameprepare(p) }
-       |trait T2[X] extends T1[X] { override def preparetorenameprepare(p: X): String = super.preparetorenameprepare(p) }
-       |trait T3[I, J] extends T2[I] { override def preparetorenameprepare(p: I): String = super.preparetorenameprepare(p) }
-       |trait T4[I, J] extends T3[J, I] { override def preparetorenameprepare(p: J): String = super.preparetorenameprepare(p) }
-       |trait T5[U] extends T4[U, U] { override def preparetore@@nameprepare(p: U): String = super.preparetorenameprepare(p) }
+       |trait S1[X] { def torename(p: X): String = "" }
+       |trait T1[Z] extends S1[Z] { override def torename(p: Z): String = super.torename(p) }
+       |trait T2[X] extends T1[X] { override def torename(p: X): String = super.torename(p) }
+       |trait T3[I, J] extends T2[I] { override def torename(p: I): String = super.torename(p) }
+       |trait T4[I, J] extends T3[J, I] { override def torename(p: J): String = super.torename(p) }
+       |trait T5[U] extends T4[U, U] { override def tore@@name(p: U): String = super.torename(p) }
        |""".stripMargin,
   )
 
@@ -81,36 +66,23 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
     """|package a
        |trait P
        |trait PP extends P
-       |trait A { def preparetorenameprepare(a: String): P = ??? }
-       |trait B extends A { override def preparetore@@nameprepare(a: String): PP = ??? }
+       |trait A { def torename(a: String): P = ??? }
+       |trait B extends A { override def tore@@name(a: String): PP = ??? }
        |
-       |""".stripMargin,
-  )
-
-  prepare(
-    "across-targets",
-    """|package a
-       |object Main{
-       |  val preparetoRenameprepare = 123
-       |}
-       |/b/src/main/scala/b/Main2.scala
-       |package b
-       |import a.Main
-       |object Main2{
-       |  val toRename = Main.preparetoR@@enameprepare
-       |}
        |""".stripMargin,
   )
 
   prepare(
     "unapply",
-    """|object prepareF@@ooprepare {
+    """|object F@@oo {
        |  def unapply(s: String): Option[String] = Some("")
        |}
        |
        |object Main{
-       |  "foo" match {
-       |    case prepareFooprepare(s) => ()
+       |  def m() = {
+       |    "foo" match {
+       |      case Fooprepare(s) => ()
+       |    }
        |  }
        |}
        |""".stripMargin,
@@ -119,7 +91,7 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
   prepare(
     "unapply-param",
     """|object Foo {
-       |  def unapply(<<preparenam@@eprepare>>: String): Option[String] = Some(preparenameprepare)
+       |  def unapply(<<nam@@e>>: String): Option[String] = Some(name)
        |}
        |
        |object Main{
@@ -135,8 +107,8 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
     """|package a
        |object Main{
        |  def hello() = {
-       |    val <<preparetoRen@@ameprepare>> = 123
-       |    preparetoRenameprepare
+       |    val <<toRen@@ame>> = 123
+       |    toRename
        |  }
        |}
        |""".stripMargin,
@@ -146,9 +118,10 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
     "method",
     """|package a
        |object Main{
-       |  def preparemet@@hodprepare(abc : String) = true
-       |
-       |  if(preparemethodprepare("")) println("Is true!")
+       |  def m() = {
+       |    def <<met@@hodprepare>>(abc : String) = true
+       |    if(methodprepare("")) println("Is true!")
+       |  }
        |}
        |""".stripMargin,
   )
@@ -156,12 +129,15 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
   prepare(
     "self-type",
     """|package a
-       |trait prepareA@@BCprepare
-       |trait Alphabet{
-       |  this: prepareABCprepare =>
-       |}
+       |
        |object Main{
-       |  val a = new Alphabet with prepareABCprepare
+       |  def m() = {
+       |    trait <<A@@BC>>
+       |    trait Alphabet{
+       |      this: ABC =>
+       |    }
+       |    val a = new Alphabet with ABC
+       |  }
        |}
        |""".stripMargin,
   )
@@ -170,45 +146,11 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
     "method-inheritance",
     """|package a
        |trait Hello{
-       |  def preparemethodprepare(abc : String) : Boolean
+       |  def method(abc : String) : Boolean
        |}
        |
        |class GoodMorning extends Hello {
-       |  def preparemet@@hodprepare(abc : String) = true
-       |}
-       |""".stripMargin,
-  )
-
-  prepare(
-    "long-inheritance",
-    """|package a
-       |trait A[T, S] {
-       |  def preparemethodprepare(abc : T) : S
-       |}
-       |
-       |abstract class B[T] extends A[T, Boolean] {
-       |  def preparemethodprepare(abc : T) : Boolean
-       |}
-       |
-       |abstract class C extends B[String] {
-       |  def preparemeth@@odprepare(abc : String) : Boolean = false
-       |}
-       |""".stripMargin,
-  )
-
-  prepare(
-    "multiple-inheritance",
-    """|package a
-       |trait A {
-       |  def preparemethodprepare(abc : String) : Boolean
-       |}
-       |
-       |trait B {
-       |  def preparemethodprepare(abc : String) : Boolean = true
-       |}
-       |
-       |abstract class C extends B with A {
-       |  override def preparemeth@@odprepare(abc : String) : Boolean = false
+       |  def met@@hod(abc : String) = true
        |}
        |""".stripMargin,
   )
@@ -217,37 +159,26 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
     "apply",
     """|package a
        |object User{
-       |  def prepareap@@plyprepare(name : String) = name
+       |  def ap@@ply(name : String) = name
        |  def apply(name : String, age: Int) = name
        |}
        |object Main{
-       |  val toRename = User##.##prepareprepare("abc")
+       |  val toRename = User##.##("abc")
        |}
        |""".stripMargin,
   )
 
   prepare(
     "colon-bad",
-    """|package a
-       |class User{
-       |  def prepare:@@:prepare(name : String) = name
-       |}
+    """|package a  
        |object Main{
-       |  val user = new User()
-       |  "" prepare::prepare user
-       |}
-       |""".stripMargin,
-  )
-
-  prepare(
-    "colon-good",
-    """|package a
-       |class User{
-       |  def prepare:@@:prepare(name : String) = name
-       |}
-       |object Main{
-       |  val user = new User()
-       |  "" prepare::prepare user
+       |  def m() = {
+       |    class User{
+       |      def <<:@@:>>(name : String) = name
+       |    }
+       |    val user = new User()
+       |    "" :: user
+       |  }
        |}
        |""".stripMargin,
   )
@@ -255,25 +186,15 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
   prepare(
     "unary-bad",
     """|package a
-       |class User{
-       |  def prepareunary_!prepare = false
-       |}
+       |
        |object Main{
-       |  val user = new User()
-       |  prepare@@!prepareuser
-       |}
-       |""".stripMargin,
-  )
-
-  prepare(
-    "unary-bad2",
-    """|package a
-       |class User{
-       |  def prepareu@@nary_!prepare = false
-       |}
-       |object Main{
-       |  val user = new User()
-       |  prepare!prepareuser
+       |  def m() = {
+       |    class User{
+       |      def unary_! = false
+       |    }
+       |    val user = new User()
+       |    @@!user
+       |  }
        |}
        |""".stripMargin,
   )
@@ -288,76 +209,57 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
   )
 
   prepare(
-    "inheritance",
-    """|package a
-       |abstract class prepareAn@@imalprepare
-       |class Dog extends prepareAnimalprepare
-       |class Cat extends prepareAnimalprepare
-       |""".stripMargin,
-  )
-
-  prepare(
     "companion",
     """|package a
-       |class prepareMainprepare{}
-       |object prepareM@@ainprepare
+       |class Main{}
+       |object M@@ain
        |""".stripMargin,
   )
 
   prepare(
     "companion2",
     """|package a
-       |class prepareMa@@inprepare{}
-       |object prepareMainprepare
-       |""".stripMargin,
-  )
-
-  prepare(
-    "filename-exact-match",
-    """|package a
-       |object prepareMa@@inprepare
-       |object TheMain
-       |""".stripMargin,
-  )
-
-  prepare(
-    "filename-exact-match-2",
-    """|package a
-       |object Main
-       |object prepareThe@@Mainprepare
-       |""".stripMargin,
-  )
-
-
-  prepare(
-    "anon",
-    """|trait Methodable[T] {
-       |  def preparemethodprepare(asf: T): Int
-       |}
+       |object a {
+       |  def m() = {
+       |    class <<Ma@@in>>{}
+       |    object Main
        |
-       |trait Alphabet extends Methodable[String] {
-       |  def preparemethodprepare(adf: String) = 123
-       |}
-       |
-       |object Main {
-       |  val a = new Alphabet {
-       |    override def <<prepareme@@thodprepare>>(adf: String): Int = 321
        |  }
        |}
        |""".stripMargin,
   )
 
-
+  prepare(
+    "anon",
+    """|trait Methodable[T] {
+       |  def methodprepare(asf: T): Int
+       |}
+       |
+       |trait Alphabet extends Methodable[String] {
+       |  def methodprepare(adf: String) = 123
+       |}
+       |
+       |object Main {
+       |  val a = new Alphabet {
+       |    override def <<me@@thod>>(adf: String): Int = 321
+       |  }
+       |}
+       |""".stripMargin,
+  )
 
   prepare(
     "macro",
     """|package a
        |import io.circe.generic.JsonCodec
        |trait LivingBeing
-       |@JsonCodec sealed trait prepareAn@@imalprepare extends LivingBeing
-       |object prepareAnimalprepare {
-       |  case object Dog extends prepareAnimalprepare
-       |  case object Cat extends prepareAnimalprepare
+       |object Main {
+       |  def m() = {
+       |    @JsonCodec sealed trait <<An@@imal>> extends LivingBeing
+       |    object Animal {
+       |      case object Dog extends Animal
+       |      case object Cat extends Animal
+       |    }
+       |  }
        |}
        |""".stripMargin,
   )
@@ -367,75 +269,27 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
     """|package a
        |import io.circe.generic.JsonCodec
        |@JsonCodec
-       |final case class prepareMa@@in2prepare(name: String)
+       |final case class Ma@@in2(name: String)
        |""".stripMargin,
   )
-
-
 
   prepare(
     "implicit-param",
     """|package a
        |object A {
-       |  implicit val preparesome@@Nameprepare: Int = 1
+       |  implicit val some@@Name: Int = 1
        |  def m[A](implicit a: A): A = a
        |  m[Int]
        |}""".stripMargin,
   )
 
   prepare(
-    "nested-symbol",
-    """|package a
-       |object Foo {
-       |  object prepareMa@@inprepare
-       |}
-       |""".stripMargin,
-  )
-
-
-  prepare(
-    "backtick-old-and-new-name",
-    """|package a
-       |object Main{
-       |  val prepare`to-Rename`prepare = 123
-       |}
-       |object Main2{
-       |  val toRename = Main.prepare`to-R@@ename`prepare
-       |}
-       |""".stripMargin,
-  )
-
-  prepare(
-    "backtick",
-    """|package a
-       |object Main{
-       |  val preparegreet@@ingprepare = "Hello"
-       |  "" match {
-       |    case `preparegreetingprepare` =>
-       |  }
-       |}
-       |""".stripMargin,
-  )
-
-  prepare(
-    "double-backtick",
-    """|package a
-       |object Main{
-       |  val preparegreet@@ingprepare = "Hello"
-       |  "" match {
-       |    case prepare`greeting`prepare =>
-       |  }
-       |}
-       |""".stripMargin,
-  )
-
-  prepare(
     "backtick2",
     """|package a
        |object Main{
-       |  val preparegreetingprepare = "Hello"
+       |  val greeting = "Hello"
        |  "" match {
-       |    case `preparegre@@etingprepare` =>
+       |    case `gre@@eting` =>
        |  }
        |}
        |""".stripMargin,
@@ -446,9 +300,9 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
     """|package a
        |object Main{
        |  def local = {
-       |    val <<preparegreet@@ingprepare>> = "Hello"
+       |    val <<greet@@ing>> = "Hello"
        |    "" match {
-       |      case `preparegreetingprepare` =>
+       |      case `greeting` =>
        |    }
        |  }
        |}
@@ -472,24 +326,27 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
 
   prepare(
     "params",
-    """|case class Name(prepareva@@lueprepare: String)
+    """|
        |
        |object Main {
-       |  val name1 = Name(preparevalueprepare = "42")
-       |   .copy(preparevalueprepare = "43")
-       |   .copy(preparevalueprepare = "43")
-       |   .preparevalueprepare
-       |  val name2 = Name(preparevalueprepare = "44")
+       |  def m() = {
+       |    case class Name(<<va@@lue>>: String)
+       |    val name1 = Name(value = "42")
+       |      .copy(value = "43")
+       |      .copy(value = "43")
+       |      .value
+       |    val name2 = Name(value = "44")
+       |  }
        |}
        |""".stripMargin,
   )
 
   prepare(
     "constructor",
-    """|case class Name(prepareva@@lueprepare: String)
+    """|case class Name(va@@lue: String)
        |
        |object Main {
-       |  val name2 = new Name(preparevalueprepare = "44")
+       |  val name2 = new Name(value = "44")
        |}
        |""".stripMargin,
   )
@@ -497,40 +354,26 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
   prepare(
     "type-params",
     """|package a
-       |trait prepareABCprepare
-       |class CBD[T <: prepareAB@@Cprepare]
+       |trait ABC
+       |class CBD[T <: AB@@C]
        |object Main{
-       |  val a = classOf[prepareABCprepare]
-       |  val b = new CBD[prepareABCprepare]
+       |  val a = classOf[ABC]
+       |  val b = new CBD[ABC]
        |}
        |""".stripMargin,
   )
-
-  prepare(
-    "implicit-parameter",
-    """|trait A {
-       | implicit def preparefooprepare: Double
-       |}
-       |object A extends A {
-       |  implicit def preparefo@@oprepare: Double = 0.1
-       |  def bar(implicit x: Double): Double = x
-       |  val x = bar
-       |}
-       |""".stripMargin,
-  )
-
 
   prepare(
     "hierarchy-inside-method-trait",
     """|package a
        |object Main {
        |  final def main(args: Array[String]) = {
-       |    sealed trait <<prepareSy@@mbolprepare>>
-       |    case class Method(name: String) extends prepareSymbolprepare
-       |    case class Variable(value: String) extends prepareSymbolprepare
+       |    sealed trait <<Sy@@mbol>>
+       |    case class Method(name: String) extends Symbol
+       |    case class Variable(value: String) extends Symbol
        |
-       |    val symbol2: prepareSymbolprepare = Method("method")
-       |    val symbol3: prepareSymbolprepare = Variable("value")
+       |    val symbol2: Symbol = Method("method")
+       |    val symbol3: Symbol = Variable("value")
        |  }
        |}
        |""".stripMargin,
@@ -541,12 +384,12 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
     """|package a
        |object Main {
        |  final def main(args: Array[String]) = {
-       |    sealed abstract class <<prepareSy@@mbolprepare>>
-       |    case class Method(name: String) extends prepareSymbolprepare
-       |    case class Variable(value: String) extends prepareSymbolprepare
+       |    sealed abstract class <<Sy@@mbol>>
+       |    case class Method(name: String) extends Symbol
+       |    case class Variable(value: String) extends Symbol
        |
-       |    val symbol2: prepareSymbolprepare = Method("method")
-       |    val symbol3: prepareSymbolprepare = Variable("value")
+       |    val symbol2: Symbol = Method("method")
+       |    val symbol3: Symbol = Variable("value")
        |  }
        |}
        |""".stripMargin,
@@ -556,11 +399,11 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
     "variable",
     """|package a
        |object Main {
-       |  var preparev@@5prepare = false
+       |  var v@@5 = false
        |
        |  def f5: Boolean = {
-       |    preparev5prepare = true
-       |    preparev5prepare == true
+       |    v5 = true
+       |    v5 == true
        |  }
        |}
        |""".stripMargin,
@@ -570,11 +413,11 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
     "variable-explicit1",
     """|package a
        |object Main {
-       |  var preparev@@5prepare = false
+       |  var v@@5 = false
        |
        |  def f5: Boolean = {
-       |    preparev5prepare_=(true)
-       |    preparev5prepare == true
+       |    v5_=(true)
+       |    v5 == true
        |  }
        |}
        |""".stripMargin,
@@ -584,11 +427,11 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
     "variable-explicit2",
     """|package a
        |object Main {
-       |  var preparev5prepare = false
+       |  var v5 = false
        |
        |  def f5: Boolean = {
-       |    <<`preparev@@5prepare_=`>>(true)
-       |    preparev5prepare == true
+       |    <<`v@@5_=`>>(true)
+       |    v5 == true
        |  }
        |}
        |""".stripMargin,
@@ -602,8 +445,8 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
        |object Main {
        |  def method() = {
        |    List(1) + 2
-       |    val prepareabcprepare: Option[Int] = ???
-       |    <<prepareab@@cprepare>>.map(_ + 1)
+       |    val abc: Option[Int] = ???
+       |    <<ab@@c>>.map(_ + 1)
        |  }
        |}
        |""".stripMargin,

--- a/tests/cross/src/test/scala/tests/pc/PcPrepareRenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcPrepareRenameSuite.scala
@@ -469,4 +469,40 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
        |""".stripMargin,
   )
 
+  prepare(
+    "extension-param".tag(IgnoreScala2),
+    """|extension (<<sb@@d>>: String)
+       |  def double = sbd + sbd
+       |  def double2 = sbd + sbd
+       |end extension
+       |""".stripMargin,
+  )
+
+  prepare(
+    "extension-params-ref".tag(IgnoreScala2),
+    """|extension (sbd: String)
+       |  def double = <<sb@@d>> + sbd
+       |  def double2 = sbd + sbd
+       |end extension
+       |""".stripMargin,
+  )
+
+  prepare(
+    "extension-type-param".tag(IgnoreScala2),
+    """|extension [T](<<x@@s>>: List[T])
+       |  def double = xs ++ xs
+       |  def double2 = xs ++ xs
+       |end extension
+       |""".stripMargin,
+  )
+
+  prepare(
+    "extension-type-param-ref".tag(IgnoreScala2),
+    """|extension [T](xs: List[T])
+       |  def double = xs ++ xs
+       |  def double2 = xs ++ <<x@@s>>
+       |end extension
+       |""".stripMargin,
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/PcPrepareRenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcPrepareRenameSuite.scala
@@ -12,7 +12,7 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
        |
        |object Main{
        |  def m() = {
-       |    val toRename: <<`J-L@@ist`>>[Int] = ???
+       |    val toRename: `J-L@@ist`[Int] = ???
        |    val toRename2: `J-List`[Int] = ???
        |    val toRename3: java.util.List[Int] = ???
        |  }
@@ -20,15 +20,15 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
        |""".stripMargin,
   )
 
+  // currently we are not using presentation compiler in this case
   prepare(
     "prepare-import-object",
     """|package a
        |
-       |
        |object Renaming {
        |  def m() = {
        |    import scala.util.{Try => StdLibTry}  
-       |    def foo(n: Int): <<StdLib@@Try>>[Int] = 
+       |    def foo(n: Int): StdLib@@Try[Int] = 
        |      StdLibTryprepare(n)
        |  }
        |}
@@ -53,11 +53,7 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
     "generics",
     """|package a
        |trait S1[X] { def torename(p: X): String = "" }
-       |trait T1[Z] extends S1[Z] { override def torename(p: Z): String = super.torename(p) }
-       |trait T2[X] extends T1[X] { override def torename(p: X): String = super.torename(p) }
-       |trait T3[I, J] extends T2[I] { override def torename(p: I): String = super.torename(p) }
-       |trait T4[I, J] extends T3[J, I] { override def torename(p: J): String = super.torename(p) }
-       |trait T5[U] extends T4[U, U] { override def tore@@name(p: U): String = super.torename(p) }
+       |trait T1[Z] extends S1[Z] { override def tore@@name(p: Z): String = super.torename(p) }
        |""".stripMargin,
   )
 
@@ -241,7 +237,28 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
        |
        |object Main {
        |  val a = new Alphabet {
-       |    override def <<me@@thod>>(adf: String): Int = 321
+       |    override def me@@thod(adf: String): Int = 321
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
+  prepare(
+    "anon2",
+    """|object a {
+       |  def m() = {
+       |    trait Methodable[T] {
+       |      def methodprepare(asf: T): Int
+       |    }
+       |
+       |    trait Alphabet extends Methodable[String] {
+       |      def methodprepare(adf: String) = 123
+       |    }
+       |
+       |    object Main {
+       |      val a = new Alphabet {
+       |        override def <<me@@thod>>(adf: String): Int = 321
+       |    }
        |  }
        |}
        |""".stripMargin,
@@ -424,20 +441,20 @@ class PcPrepareRenameSuite extends BasePcRenameSuite {
   )
 
   prepare(
-    "variable-explicit2",
-    """|package a
-       |object Main {
-       |  var v5 = false
-       |
-       |  def f5: Boolean = {
-       |    <<`v@@5_=`>>(true)
-       |    v5 == true
-       |  }
-       |}
+    "worksheet-method",
+    """|trait S1[X] { def torename(p: X): String = "" }
+       |trait T1[Z] extends S1[Z] { override def <<tore@@name>>(p: Z): String = super.torename(p) }
        |""".stripMargin,
+    filename = "A.worksheet.sc",
   )
-
-  // NON COMPILING TESTS
+  prepare(
+    "worksheet-classes",
+    """|sealed abstract class <<Sy@@mbol>>
+       |case class Method(name: String) extends Symbol
+       |case class Variable(value: String) extends Symbol
+       |""".stripMargin,
+    filename = "A.worksheet.sc",
+  )
 
   prepare(
     "not-compiling",

--- a/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
@@ -371,4 +371,44 @@ class PcRenameSuite extends BasePcRenameSuite {
        |}
        |""".stripMargin,
   )
+
+  check(
+    "extension-param".tag(IgnoreScala2),
+    """|extension (<<sb@@d>>: String)
+       |  def double = <<sbd>> + <<sbd>>
+       |  def double2 = <<sbd>> + <<sbd>>
+       |end extension
+       |""".stripMargin,
+    newName = "greeting",
+  )
+
+  check(
+    "extension-params-ref".tag(IgnoreScala2),
+    """|extension (<<sbd>>: String)
+       |  def double = <<sb@@d>> + <<sbd>>
+       |  def double2 = <<sbd>> + <<sbd>>
+       |end extension
+       |""".stripMargin,
+    newName = "greeting",
+  )
+
+  check(
+    "extension-type-param".tag(IgnoreScala2),
+    """|extension [T](<<x@@s>>: List[T])
+       |  def double = <<xs>> ++ <<xs>>
+       |  def double2 = <<xs>> ++ <<xs>>
+       |end extension
+       |""".stripMargin,
+    newName = "ABC",
+  )
+
+  check(
+    "extension-type-param-ref".tag(IgnoreScala2),
+    """|extension [T](<<xs>>: List[T])
+       |  def double = <<xs>> ++ <<xs>>
+       |  def double2 = <<xs>> ++ <<x@@s>>
+       |end extension
+       |""".stripMargin,
+    newName = "ABC",
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
@@ -338,4 +338,37 @@ class PcRenameSuite extends BasePcRenameSuite {
        |  }
        |""".stripMargin,
   )
+
+  check(
+    "worksheet-method",
+    """|trait S1[X] { def <<torename>>(p: X): String = "" }
+       |trait T1[Z] extends S1[Z] { override def <<tore@@name>>(p: Z): String = super.<<torename>>(p) }
+       |""".stripMargin,
+    filename = "A.worksheet.sc",
+    wrap = false,
+  )
+
+  check(
+    "worksheet-classes",
+    """|sealed abstract class <<Sy@@mbol>>
+       |case class Method(name: String) extends <<Symbol>>
+       |case class Variable(value: String) extends <<Symbol>>
+       |""".stripMargin,
+    newName = "Tree",
+    filename = "A.worksheet.sc",
+    wrap = false,
+  )
+
+  check(
+    "not-compiling",
+    """|package a
+       |object Main {
+       |  def method() = {
+       |    List(1) + 2
+       |    val <<abc>>: Option[Int] = ???
+       |    <<ab@@c>>.map(_ + 1)
+       |  }
+       |}
+       |""".stripMargin,
+  )
 }

--- a/tests/unit/src/test/scala/tests/RenameLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameLspSuite.scala
@@ -876,6 +876,24 @@ class RenameLspSuite extends BaseRenameLspSuite(s"rename") {
     newName = "NewSymbol",
   )
 
+  // NON COMPILING TESTS
+
+  renamed(
+    "not-compiling",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main {
+       |  def method() = {
+       |    List(1) + 2
+       |    val <<abc>>: Option[Int] = ???
+       |    <<ab@@c>>.map(_ + 1)
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "NewSymbol",
+    expectedError = true,
+  )
+
   override protected def libraryDependencies: List[String] =
     List("org.scalatest::scalatest:3.2.12", "io.circe::circe-generic:0.14.1")
 


### PR DESCRIPTION
Connected to https://github.com/scalameta/metals/issues/4644

Previously (since https://github.com/scalameta/metals/pull/4542), we were using presentation compiler for renaming local symbols, but the project still had to compile, because both `prepare rename` and `rename` were using semantic db first. Now, in both we start by checking if the symbol can be renamed via presentation compiler (is defined inside a method or in a worksheet, maybe there are also other cases?) and use semantic db as a fallback.