### PR TITLE
`PresentationCompiler` returns custom `Hover`

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
@@ -4,6 +4,7 @@ import java.{util => ju}
 
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.pc.AutoImportsResult
+import scala.meta.pc.HoverSignature
 
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.Diagnostic
@@ -63,6 +64,9 @@ trait AdjustLspData {
       newHover.setRange(newRange)
       newHover
     }
+
+  def adjustHoverResp(hover: HoverSignature): HoverSignature =
+    hover.getRange().map(hover.withRange(_)).orElse(hover)
 
   def adjustCompletionListInPlace(list: CompletionList): Unit = {
     for (item <- list.getItems.asScala) {

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -22,6 +22,7 @@ import scala.meta.internal.worksheets.WorksheetProvider
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.AutoImportsResult
 import scala.meta.pc.CancelToken
+import scala.meta.pc.HoverSignature
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.PresentationCompiler
 import scala.meta.pc.SymbolSearch
@@ -45,7 +46,6 @@ import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.{Position => LspPosition}
 import org.eclipse.lsp4j.{Range => LspRange}
 import org.eclipse.lsp4j.{debug => d}
-import scala.meta.pc.HoverSignature
 
 /**
  * Manages lifecycle for presentation compilers in all build targets.

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -34,7 +34,6 @@ import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.CompletionParams
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DocumentHighlight
-import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.RenameParams
 import org.eclipse.lsp4j.SelectionRange
@@ -46,6 +45,7 @@ import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.{Position => LspPosition}
 import org.eclipse.lsp4j.{Range => LspRange}
 import org.eclipse.lsp4j.{debug => d}
+import scala.meta.pc.HoverSignature
 
 /**
  * Manages lifecycle for presentation compilers in all build targets.
@@ -192,7 +192,7 @@ class Compilers(
                 "object Ma\n",
                 "object Ma".length(),
               )
-            )
+            ).thenApply(_.map(_.toLsp()))
           }
         }
       }
@@ -481,7 +481,7 @@ class Compilers(
   def hover(
       params: HoverExtParams,
       token: CancelToken,
-  ): Future[Option[Hover]] = {
+  ): Future[Option[HoverSignature]] = {
     withPCAndAdjustLsp(params) { (pc, pos, adjust) =>
       pc.hover(CompilerRangeParams.offsetOrRange(pos, token))
         .asScala

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -1527,7 +1527,7 @@ class MetalsLanguageServer(
       compilers
         .hover(params, token)
         .map { hover =>
-          syntheticsDecorator.addSyntheticsHover(params, hover)
+          syntheticsDecorator.addSyntheticsHover(params, hover.map(_.toLsp()))
         }
         .map(
           _.orElse {

--- a/mtags-interfaces/src/main/java/scala/meta/pc/HoverSignature.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/HoverSignature.java
@@ -1,0 +1,13 @@
+package scala.meta.pc;
+
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.Hover;
+
+import java.util.Optional;
+
+public interface HoverSignature {
+  Hover toLsp();
+  Optional<String> signature();
+  Optional<Range> getRange();
+  HoverSignature withRange(Range range);
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -4,7 +4,6 @@ import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.DocumentHighlight;
-import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.TextEdit;
 
@@ -68,7 +67,7 @@ public abstract class PresentationCompiler {
     /**
      * Returns the type of the expression at the given position along with the symbol of the referenced symbol.
      */
-    public abstract CompletableFuture<Optional<Hover>> hover(OffsetParams params);
+    public abstract CompletableFuture<Optional<HoverSignature>> hover(OffsetParams params);
 
     /**
      * Renames the symbol at given position and all of its occurrences to `name`.

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
@@ -150,12 +150,12 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
       )
       val prettyType = metalsToLongString(tpe.widen.finalResultType, history)
       val lspRange = if (range.isRange) Some(range.toLsp) else None
-      Some(new ScalaHover(Left(prettyType), lspRange))
+      Some(new ScalaHover(expressionType = Some(prettyType), range = lspRange))
     } else if (symbol == null || tpe.typeSymbol.isAnonymousClass) None
     else if (symbol.hasPackageFlag || symbol.hasModuleFlag) {
       Some(
         new ScalaHover(
-          Left(
+          expressionType = Some(
             s"${symbol.javaClassSymbol.keyString} ${symbol.fullName}"
           )
         )
@@ -193,14 +193,11 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
         }
       Some(
         ScalaHover(
-          Right(
-            ScalaHoverInfo(
-              prettyType,
-              prettySignature,
-              docstring,
-              pos.start != pos.end || !prettySignature.endsWith(prettyType)
-            )
-          ),
+          expressionType = Some(prettyType),
+          symbolSignature = Some(prettySignature),
+          docstring = Some(docstring),
+          forceExpressionType =
+            pos.start != pos.end || !prettySignature.endsWith(prettyType),
           range = if (range.isRange) Some(range.toLsp) else None
         )
       )

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
@@ -4,24 +4,21 @@ import scala.reflect.internal.util.Position
 import scala.reflect.internal.{Flags => gf}
 
 import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.pc.HoverSignature
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.RangeParams
-
-import org.eclipse.lsp4j.Hover
-import org.eclipse.lsp4j.MarkupContent
-import org.eclipse.lsp4j.MarkupKind
 
 class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
   import compiler._
 
-  def hover(): Option[Hover] = params match {
+  def hover(): Option[HoverSignature] = params match {
     case range: RangeParams =>
       range.trimWhitespaceInRange.flatMap(hoverOffset)
     case _ if params.isWhitespace => None
     case _ => hoverOffset(params)
   }
 
-  def hoverOffset(params: OffsetParams): Option[Hover] = {
+  def hoverOffset(params: OffsetParams): Option[HoverSignature] = {
     val unit = addCompilationUnit(
       code = params.text(),
       filename = params.uri().toString(),
@@ -131,7 +128,7 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
   def toHover(
       symbol: Symbol,
       pos: Position
-  ): Option[Hover] = {
+  ): Option[HoverSignature] = {
     toHover(symbol, symbol.keyString, symbol.info, symbol.info, pos, pos)
   }
 
@@ -142,7 +139,7 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
       tpe: Type,
       pos: Position,
       range: Position
-  ): Option[Hover] = {
+  ): Option[HoverSignature] = {
     if (tpe == null || tpe.isErroneous || tpe == NoType) None
     else if (
       pos.start != pos.end && (symbol == null || symbol == NoSymbol || symbol.isErroneous)
@@ -152,20 +149,14 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
         lookupSymbol = name => context.lookupSymbol(name, _ => true) :: Nil
       )
       val prettyType = metalsToLongString(tpe.widen.finalResultType, history)
-      val hover = new Hover(HoverMarkup(prettyType).toMarkupContent)
-      if (range.isRange) {
-        hover.setRange(range.toLsp)
-      }
-      Some(hover)
+      val lspRange = if (range.isRange) Some(range.toLsp) else None
+      Some(new ScalaHover(Left(prettyType), lspRange))
     } else if (symbol == null || tpe.typeSymbol.isAnonymousClass) None
     else if (symbol.hasPackageFlag || symbol.hasModuleFlag) {
       Some(
-        new Hover(
-          new MarkupContent(
-            MarkupKind.MARKDOWN,
-            HoverMarkup(
-              s"${symbol.javaClassSymbol.keyString} ${symbol.fullName}"
-            )
+        new ScalaHover(
+          Left(
+            s"${symbol.javaClassSymbol.keyString} ${symbol.fullName}"
           )
         )
       )
@@ -200,17 +191,19 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams) {
         } else {
           ""
         }
-      val markdown = HoverMarkup(
-        prettyType,
-        prettySignature,
-        docstring,
-        pos.start != pos.end || !prettySignature.endsWith(prettyType)
+      Some(
+        ScalaHover(
+          Right(
+            ScalaHoverInfo(
+              prettyType,
+              prettySignature,
+              docstring,
+              pos.start != pos.end || !prettySignature.endsWith(prettyType)
+            )
+          ),
+          range = if (range.isRange) Some(range.toLsp) else None
+        )
       )
-      val hover = new Hover(markdown.toMarkupContent)
-      if (range.isRange) {
-        hover.setRange(range.toLsp)
-      }
-      Some(hover)
     }
   }
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -23,6 +23,7 @@ import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.mtags.BuildInfo
 import scala.meta.pc.AutoImportsResult
 import scala.meta.pc.DefinitionResult
+import scala.meta.pc.HoverSignature
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.PresentationCompiler
 import scala.meta.pc.PresentationCompilerConfig
@@ -34,7 +35,6 @@ import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DocumentHighlight
-import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.SelectionRange
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.TextEdit
@@ -225,9 +225,9 @@ case class ScalaPresentationCompiler(
 
   override def hover(
       params: OffsetParams
-  ): CompletableFuture[Optional[Hover]] =
+  ): CompletableFuture[Optional[HoverSignature]] =
     compilerAccess.withNonInterruptableCompiler(
-      Optional.empty[Hover](),
+      Optional.empty[HoverSignature](),
       params.token
     ) { pc =>
       Optional.ofNullable(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -6,11 +6,11 @@ import scala.util.control.NonFatal
 
 import scala.meta.internal.mtags.MtagsEnrichments.*
 import scala.meta.internal.pc.printer.MetalsPrinter
+import scala.meta.pc.HoverSignature
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.ParentSymbols
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
-import scala.meta.pc.HoverSignature
 
 import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.Constants.*
@@ -117,11 +117,11 @@ object HoverProvider:
                     !symbol.flags.isAllOf(EnumCase)
                 )
               ju.Optional.of(
-                ScalaHover.fromInfo(
-                  expressionType,
-                  hoverString,
-                  docString,
-                  forceExpressionType,
+                new ScalaHover(
+                  expressionType = Some(expressionType),
+                  symbolSignature = Some(hoverString),
+                  docstring = Some(docString),
+                  forceExpressionType = forceExpressionType,
                 )
               )
             case _ =>
@@ -149,10 +149,9 @@ object HoverProvider:
               if n == nme.selectDynamic then s": ${printer.tpe(tpe.resultType)}"
               else printer.tpe(tpe)
             ju.Optional.of(
-              ScalaHover.fromInfo(
-                tpeString,
-                s"def $name$tpeString",
-                "",
+              new ScalaHover(
+                expressionType = Some(tpeString),
+                symbolSignature = Some(s"def $name$tpeString"),
               )
             )
           case RefinedType(info, _, _) =>

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -270,9 +270,9 @@ case class ScalaPresentationCompiler(
     }
   end selectionRange
 
-  def hover(params: OffsetParams): CompletableFuture[ju.Optional[l.Hover]] =
+  def hover(params: OffsetParams): CompletableFuture[ju.Optional[HoverSignature]] =
     compilerAccess.withNonInterruptableCompiler(
-      ju.Optional.empty[l.Hover](),
+      ju.Optional.empty[HoverSignature](),
       params.token,
     ) { access =>
       val driver = access.compiler()

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -270,7 +270,9 @@ case class ScalaPresentationCompiler(
     }
   end selectionRange
 
-  def hover(params: OffsetParams): CompletableFuture[ju.Optional[HoverSignature]] =
+  def hover(
+      params: OffsetParams
+  ): CompletableFuture[ju.Optional[HoverSignature]] =
     compilerAccess.withNonInterruptableCompiler(
       ju.Optional.empty[HoverSignature](),
       params.token,

--- a/mtags/src/main/scala/scala/meta/internal/pc/HoverMarkup.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/HoverMarkup.scala
@@ -12,24 +12,28 @@ object HoverMarkup {
    */
   def apply(
       expressionType: String,
-      symbolSignature: String,
+      optSymbolSignature: Option[String],
       docstring: String,
       forceExpressionType: Boolean = false
   ): String = {
     val markdown = new StringBuilder()
-    if (forceExpressionType) {
+    if (forceExpressionType || optSymbolSignature.isEmpty) {
       markdown
-        .append("**Expression type**:\n")
+        .append(
+          if (optSymbolSignature.isDefined) "**Expression type**:\n" else ""
+        )
         .append("```scala\n")
         .append(expressionType)
         .append("\n```\n")
     }
-    if (symbolSignature.nonEmpty) {
-      markdown
-        .append(if (forceExpressionType) "**Symbol signature**:\n" else "")
-        .append("```scala\n")
-        .append(symbolSignature)
-        .append("\n```")
+    optSymbolSignature.foreach { symbolSignature =>
+      if (symbolSignature.nonEmpty) {
+        markdown
+          .append(if (forceExpressionType) "**Symbol signature**:\n" else "")
+          .append("```scala\n")
+          .append(symbolSignature)
+          .append("\n```")
+      }
     }
     if (docstring.nonEmpty)
       markdown

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaHover.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaHover.scala
@@ -24,19 +24,15 @@ case class ScalaHover(
         docstring.getOrElse(""),
         forceExpressionType
       )
-    val hover = new lsp4j.Hover(markdown.toMarkupContent)
-
-    range.foreach(hover.setRange)
-
-    hover
+    new lsp4j.Hover(markdown.toMarkupContent, range.orNull)
   }
 
   def getRange(): Optional[lsp4j.Range] = range.asJava
 
   def withRange(range: lsp4j.Range): HoverSignature =
     ScalaHover(
-      symbolSignature,
       expressionType,
+      symbolSignature,
       docstring,
       forceExpressionType,
       Some(range)

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaHover.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaHover.scala
@@ -1,0 +1,72 @@
+package scala.meta.internal.pc
+
+import scala.meta.internal.mtags.MtagsEnrichments._
+
+import scala.meta.pc.HoverSignature
+
+import org.eclipse.lsp4j
+import java.util.Optional
+
+case class ScalaHoverInfo(
+    expressionType: String,
+    symbolSignature: String,
+    docstring: String,
+    forceExpressionType: Boolean = false
+)
+
+case class ScalaHover(
+    info: Either[String, ScalaHoverInfo],
+    range: Option[lsp4j.Range] = None
+) extends HoverSignature {
+
+  def toLsp(): lsp4j.Hover = {
+    val markdown =
+      info match {
+        case Left(str) => HoverMarkup(str)
+        case Right(info) =>
+          HoverMarkup(
+            info.expressionType,
+            info.symbolSignature,
+            info.docstring,
+            info.forceExpressionType
+          )
+      }
+    val hover = new lsp4j.Hover(markdown.toMarkupContent)
+
+    range.foreach(hover.setRange)
+
+    hover
+  }
+
+  def signature(): Optional[String] =
+    info match {
+      case Left(_) => Optional.empty()
+      case Right(info) => Optional.of(info.symbolSignature)
+    }
+
+  def getRange(): Optional[lsp4j.Range] = range.asJava
+
+  def withRange(range: lsp4j.Range): HoverSignature = ScalaHover(info, Some(range))
+
+}
+
+object ScalaHover {
+  def fromInfo(
+      expressionType: String,
+      symbolSignature: String,
+      docstring: String,
+      forceExpressionType: Boolean = false,
+      range: Option[lsp4j.Range] = None
+  ): ScalaHover =
+    ScalaHover(
+      Right(
+        ScalaHoverInfo(
+          expressionType,
+          symbolSignature,
+          docstring,
+          forceExpressionType
+        )
+      ),
+      range
+    )
+}

--- a/mtags/src/main/scala/scala/meta/internal/pc/ScalaHover.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/ScalaHover.scala
@@ -1,36 +1,29 @@
 package scala.meta.internal.pc
 
-import scala.meta.internal.mtags.MtagsEnrichments._
+import java.util.Optional
 
+import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.HoverSignature
 
 import org.eclipse.lsp4j
-import java.util.Optional
-
-case class ScalaHoverInfo(
-    expressionType: String,
-    symbolSignature: String,
-    docstring: String,
-    forceExpressionType: Boolean = false
-)
 
 case class ScalaHover(
-    info: Either[String, ScalaHoverInfo],
+    expressionType: Option[String] = None,
+    symbolSignature: Option[String] = None,
+    docstring: Option[String] = None,
+    forceExpressionType: Boolean = false,
     range: Option[lsp4j.Range] = None
 ) extends HoverSignature {
 
+  def signature(): Optional[String] = symbolSignature.asJava
   def toLsp(): lsp4j.Hover = {
     val markdown =
-      info match {
-        case Left(str) => HoverMarkup(str)
-        case Right(info) =>
-          HoverMarkup(
-            info.expressionType,
-            info.symbolSignature,
-            info.docstring,
-            info.forceExpressionType
-          )
-      }
+      HoverMarkup(
+        expressionType.getOrElse(""),
+        symbolSignature,
+        docstring.getOrElse(""),
+        forceExpressionType
+      )
     val hover = new lsp4j.Hover(markdown.toMarkupContent)
 
     range.foreach(hover.setRange)
@@ -38,35 +31,15 @@ case class ScalaHover(
     hover
   }
 
-  def signature(): Optional[String] =
-    info match {
-      case Left(_) => Optional.empty()
-      case Right(info) => Optional.of(info.symbolSignature)
-    }
-
   def getRange(): Optional[lsp4j.Range] = range.asJava
 
-  def withRange(range: lsp4j.Range): HoverSignature = ScalaHover(info, Some(range))
-
-}
-
-object ScalaHover {
-  def fromInfo(
-      expressionType: String,
-      symbolSignature: String,
-      docstring: String,
-      forceExpressionType: Boolean = false,
-      range: Option[lsp4j.Range] = None
-  ): ScalaHover =
+  def withRange(range: lsp4j.Range): HoverSignature =
     ScalaHover(
-      Right(
-        ScalaHoverInfo(
-          expressionType,
-          symbolSignature,
-          docstring,
-          forceExpressionType
-        )
-      ),
-      range
+      symbolSignature,
+      expressionType,
+      docstring,
+      forceExpressionType,
+      Some(range)
     )
+
 }

--- a/tests/cross/src/main/scala/tests/pc/BaseHoverSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BaseHoverSuite.scala
@@ -45,13 +45,15 @@ abstract class BaseHoverSuite
       val hover = presentationCompiler
         .hover(pcParams)
         .get()
-      val obtained: String = renderAsString(code, hover.asScala, includeRange)
+        .asScala
+        .map(_.toLsp())
+      val obtained: String = renderAsString(code, hover, includeRange)
       assertNoDiff(
         obtained,
         getExpected(expected, compat, scalaVersion),
       )
       for {
-        h <- hover.asScala
+        h <- hover
         range <- Option(h.getRange)
       } {
         val base =

--- a/tests/mtest/src/main/scala/tests/TestHovers.scala
+++ b/tests/mtest/src/main/scala/tests/TestHovers.scala
@@ -12,11 +12,11 @@ trait TestHovers {
     def hover: String = {
       string.trim.linesIterator.toList match {
         case List(symbolSignature) =>
-          HoverMarkup("", symbolSignature, "")
+          HoverMarkup("", Some(symbolSignature), "")
         case List(expressionType, symbolSignature) =>
           HoverMarkup(
             expressionType,
-            symbolSignature,
+            Some(symbolSignature),
             "",
             forceExpressionType = true,
           )
@@ -32,7 +32,7 @@ trait TestHovers {
         case List(expressionType, symbolSignature) =>
           HoverMarkup(
             expressionType,
-            symbolSignature,
+            Some(symbolSignature),
             "",
             forceExpressionType = true,
           )


### PR DESCRIPTION
Relates to: https://github.com/scalameta/metals/issues/4473
Change so `PresentationCompiler` returns a custom instance of Hover (instead of `org.eclipse.lsp4j.Hover`). Now the fields are accessible instead of being clumped into a markdown.