### PR TITLE
bugfix: Properly reindex build after reloading sbt

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -85,12 +85,14 @@ final case class Indexer(
       forceRefresh: Boolean,
       buildTool: BuildTool,
       checksum: String,
+      importBuild: BspSession => Future[Unit],
   ): Future[BuildChange] = {
     def reloadAndIndex(session: BspSession): Future[BuildChange] = {
       workspaceReload().persistChecksumStatus(Status.Started, buildTool)
 
       session
         .workspaceReload()
+        .flatMap(_ => importBuild(session))
         .map { _ =>
           scribe.info("Correctly reloaded workspace")
           profiledIndexWorkspace(() => doctor().check())


### PR DESCRIPTION
Previously, we would not refresh any build targets after reloading sbt, which meant no new libraries or scala versions would available. Now, we properly reindex the new build configuration.

Fixes https://github.com/scalameta/metals/issues/2328