### PR TITLE
chore: Add tests for hover on annotation

### DIFF
--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -504,4 +504,19 @@ class HoverTermSuite extends BaseHoverSuite {
     automaticPackage = false,
   )
 
+  check(
+    "annot".tag(IgnoreScalaVersion.for3LessThan("3.2.2-RC1")),
+    """|import scala.annotation.tailrec
+       |
+       |object O {
+       |  @<<tail@@rec>>
+       |  def hello(n: Int): Int = {
+       |    if (i == 0) 0
+       |    else hello( n - 1)
+       |  }
+       |}
+       |""".stripMargin,
+    "def this(): tailrec".hover,
+  )
+
 }


### PR DESCRIPTION
This was fixed upstream in the Scala 3 compile.

Fixes https://github.com/scalameta/metals/issues/1693