### PR TITLE
bugfix: Fix adjusting range for hovers

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
@@ -66,7 +66,7 @@ trait AdjustLspData {
     }
 
   def adjustHoverResp(hover: HoverSignature): HoverSignature =
-    hover.getRange().map(hover.withRange(_)).orElse(hover)
+    hover.getRange().map(rng => hover.withRange(adjustRange(rng))).orElse(hover)
 
   def adjustCompletionListInPlace(list: CompletionList): Unit = {
     for (item <- list.getItems.asScala) {


### PR DESCRIPTION
I haven't noticed that it caused tests to fail. We should always adjust position of anything coming from the compiler as it might been wrapped with additional code such as in case of sbt with additional imports.