### PR TITLE
chore: Deprecate and remove more Scala versions

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -65,13 +65,14 @@ object V {
   // Scala 2
   def deprecatedScala2Versions = Seq(
     scala211,
-    "2.12.9",
     "2.12.10",
     "2.12.11",
-    "2.13.1",
-    "2.13.2",
+    "2.12.12",
+    "2.12.13",
     "2.13.3",
     "2.13.4",
+    "2.13.5",
+    "2.13.6",
   )
 
   def nonDeprecatedScala2Versions = Seq(
@@ -80,10 +81,6 @@ object V {
     "2.12.16",
     "2.12.15",
     "2.12.14",
-    "2.12.13",
-    "2.12.12",
-    "2.13.5",
-    "2.13.6",
     "2.13.7",
     "2.13.8",
     "2.13.9",
@@ -96,9 +93,9 @@ object V {
 
   // Scala 3
   def nonDeprecatedScala3Versions =
-    Seq(nextScala3RC, scala3, "3.2.0", "3.1.3", "3.1.2", "3.1.1")
+    Seq(nextScala3RC, scala3, "3.2.0", "3.1.3")
   def deprecatedScala3Versions =
-    Seq("3.2.2-RC1", "3.1.0", "3.0.2", "3.0.1", "3.0.0")
+    Seq("3.2.2-RC1", "3.1.2", "3.1.1", "3.1.0", "3.0.2")
   def scala3Versions = nonDeprecatedScala3Versions ++ deprecatedScala3Versions
 
   lazy val nightlyScala3DottyVersions = {

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -72,7 +72,7 @@ class ProblemResolverSuite extends FunSuite {
 
   checkRecommendation(
     "deprecated-sbt-version",
-    scalaVersion = "2.12.9",
+    scalaVersion = "2.12.10",
     DeprecatedSbtVersion.message,
     sbtVersion = Some("1.3.0"),
   )


### PR DESCRIPTION
This should reduce the cross test times a bit and it's fine to deprecate and remove some older versions.