### PR TITLE
bugfix: Show completions in parens after newline

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -145,7 +145,8 @@ object CompletionValue:
   case class NamedArg(
       label: String,
       tpe: Type,
-  ) extends CompletionValue:
+      symbol: Symbol,
+  ) extends Symbolic:
     override def insertText: Option[String] = Some(label.replace("$", "$$"))
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Field
@@ -155,6 +156,7 @@ object CompletionValue:
     override def labelWithDescription(printer: MetalsPrinter)(using
         Context
     ): String = label
+  end NamedArg
 
   case class Autofill(
       value: String
@@ -246,7 +248,7 @@ object CompletionValue:
   def namedArg(label: String, sym: Symbol)(using
       Context
   ): CompletionValue =
-    NamedArg(label, sym.info.widenTermRefExpr)
+    NamedArg(label, sym.info.widenTermRefExpr, sym)
 
   def keyword(label: String, insertText: String): CompletionValue =
     Keyword(label, Some(insertText))

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/NamedArgCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/NamedArgCompletions.scala
@@ -112,7 +112,7 @@ object NamedArgCompletions:
           ) // filter out synthesized param, like evidence
       )
 
-    val prefix = ident.map(_.name.toString).getOrElse("")
+    val prefix = ident.map(_.name.toString).getOrElse("").stripPrefix("CURSOR")
     val params: List[Symbol] =
       allParams.filter(param => param.name.startsWith(prefix))
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -118,8 +118,8 @@ class CompletionArgSuite extends BaseCompletionSuite {
            |Main arg4
            |""".stripMargin,
       "3.1" ->
-        """|age = : Int
-           |address = : String
+        """|address = : String
+           |age = : Int
            |followers = : Int
            |""".stripMargin,
     ),

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -21,6 +21,21 @@ class CompletionArgSuite extends BaseCompletionSuite {
   )
 
   check(
+    "arg-newline",
+    s"""|object Main {
+        |  def foo(banana: String, apple: String) = ???
+        |  foo(
+        |    @@
+        |  )
+        |}
+        |""".stripMargin,
+    """|apple = : String
+       |banana = : String
+       |""".stripMargin,
+    topLines = Option(2),
+  )
+
+  check(
     "arg1",
     s"""|object Main {
         |  assert(assertion = true, @@)
@@ -477,6 +492,20 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |argument2 = x : Int
        |""".stripMargin,
     topLines = Some(4),
+    compat = Map(
+      /* Minor implementation detail between Scala 2 and Scala 3
+       * which shouldn't cause any issue and making it work the same
+       * would require non trivial code. `argument1 = x ` is not a
+       * NamedArgument in Scala 2 but a simple TextEditMember, which means
+       * `argument1 = ` will be prioritized.
+       */
+      "3" ->
+        """|argument1 = : Int
+           |argument1 = x : Int
+           |argument2 = : Int
+           |argument2 = x : Int
+           |""".stripMargin
+    ),
   )
 
 }


### PR DESCRIPTION
Previously, we wouldn't show named argument completions after (\n due to CURSOR being added and not stripped. Now, we properly show those completions.

I additionally had to change the sorting a bit to make NamedArguments show first, which is the same logic as with Scala 2. Together with making those completions symbolic it seems we got almost the same sorting as with Scala 2.

Issue reported by @prolativ
