### PR TITLE
fix: don't forward -1 as the diagnostic code

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -267,7 +267,10 @@ final class Diagnostics(
         d.getSeverity,
         d.getSource,
       )
-      if (d.getCode() != null) ld.setCode(d.getCode())
+      // Scala 3 sets the diagnostic code to -1 for NoExplanation Messages. Ideally
+      // this will change and we won't need this check in the future, but for now
+      // let's not forward them.
+      if (d.getCode() != null && d.getCode() != "-1") ld.setCode(d.getCode())
       ld.setData(d.getData)
       ld
     }


### PR DESCRIPTION
Since this code means nothing, we should ensure that it's not forwarded
to the client. I did upstream a change for this as well in
https://github.com/lampepfl/dotty/pull/16495, but I think we should
still filter this out now since it is happening.
