### PR TITLE
Fixes for the extract value feature

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/MetalsNames.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/MetalsNames.scala
@@ -28,6 +28,7 @@ case class MetalsNames(tree: Tree, prefix: String) {
           fy
         case Some(f: Term.For) => f
         case Some(df: Defn.Def) => df
+        case Some(tf: Term.Function) => tf
         case Some(other) => loop(other)
         case None => t
       }

--- a/tests/unit/src/test/scala/tests/codeactions/ExtractValueLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ExtractValueLspSuite.scala
@@ -5,7 +5,6 @@ import scala.meta.internal.metals.codeactions.ExtractValueCodeAction
 
 class ExtractValueLspSuite
     extends BaseCodeActionLspSuite("extractValueRewrite") {
-
   check(
     "block",
     """|object Main {
@@ -148,8 +147,9 @@ class ExtractValueLspSuite
     """|object Main {
        |  def method2(i: Int) : Int = ???
        |  def method1(s: String): Unit = {
+       |    println("Hello!"); 
        |    val newValue = 1 + 2
-       |    println("Hello!"); method2(1 + method2(newValue))
+       |    method2(1 + method2(newValue))
        |  }
        |}
        |""".stripMargin,
@@ -236,7 +236,6 @@ class ExtractValueLspSuite
        |}
        |""".stripMargin,
   )
-
   check(
     "extract-match",
     """|object Main{
@@ -255,7 +254,6 @@ class ExtractValueLspSuite
        |}
        |""".stripMargin,
   )
-
   check(
     "extract-throw",
     """|object Main{
@@ -359,6 +357,100 @@ class ExtractValueLspSuite
        |  new Car(age = newValue)
        |}
        |""".stripMargin,
+  )
+  check(
+    "multiline-line-block-with-braces",
+    """|object Main{
+       |  val aa : List[Int] = ???
+       |  def m(i: Int) : Int = ???
+       |
+       |  val newValue =
+       |     aa.map(item => {
+       |        m(i<<t>>em + 1)
+       |     })
+       |}""".stripMargin,
+    s"""|${ExtractValueCodeAction.title("item + 1")}
+        |${ConvertToNamedArguments.title("m(...)")}
+        |""".stripMargin,
+    """|object Main{
+       |  val aa : List[Int] = ???
+       |  def m(i: Int) : Int = ???
+       |
+       |  val newValue =
+       |     aa.map(item => {
+       |        val newValue = item + 1
+       |        m(newValue)
+       |     })
+       |}""".stripMargin,
+  )
+  check(
+    "one-line-block-with-braces",
+    """|object Main{
+       |  val aa : List[Int] = ???
+       |  def m(i: Int) : Int = ???
+       |
+       |  val newValue = aa.map(item => {m(i<<t>>em + 1)})
+       |}""".stripMargin,
+    s"""|${ExtractValueCodeAction.title("item + 1")}
+        |${ConvertToNamedArguments.title("m(...)")}
+        |""".stripMargin,
+    """|object Main{
+       |  val aa : List[Int] = ???
+       |  def m(i: Int) : Int = ???
+       |
+       |  val newValue = aa.map(item => {
+       |    val newValue = item + 1
+       |    m(newValue)})
+       |}""".stripMargin,
+  )
+
+  check(
+    "one-line-block-no-braces",
+    """|object Main{
+       |  val aa : List[Int] = ???
+       |  def m(i: Int) : Int = ???
+       |
+       |  val newValue = aa.map(item => m(i<<t>>em + 1))
+       |}""".stripMargin,
+    s"""|${ExtractValueCodeAction.title("item + 1")}
+        |${ConvertToNamedArguments.title("m(...)")}
+        |""".stripMargin,
+    """|object Main{
+       |  val aa : List[Int] = ???
+       |  def m(i: Int) : Int = ???
+       |
+       |  val newValue = aa.map(item => {
+       |    val newValue = item + 1
+       |    m(newValue)
+       |  })
+       |}""".stripMargin,
+  )
+
+  check(
+    "multiline-line-block-no-braces",
+    """|object Main{
+       |val aa : List[Int] = ???
+       |def m(i: Int) : Int = ???
+       |
+       |val newValue =
+       |  aa.map(item =>
+       |    m(<<i>>tem + 1)
+       |  )
+       |}""".stripMargin,
+    s"""|${ExtractValueCodeAction.title("item + 1")}
+        |${ConvertToNamedArguments.title("m(...)")}
+        |""".stripMargin,
+    """|object Main{
+       |val aa : List[Int] = ???
+       |def m(i: Int) : Int = ???
+       |
+       |val newValue =
+       |  aa.map(item => {
+       |    val newValue = item + 1
+       |    m(newValue)
+       |  }
+       |  )
+       |}""".stripMargin,
   )
 
 }


### PR DESCRIPTION
In this PR connected two issues of extracting value code action are solved.
1. Previously, the `newValue` definition was inserted in the line above the one a user was making changes on. This was error prone. E.g. extracting `2 + a` from
```
def m(i : Int) : Int = ???
val a = 1; val m1 = m(2 + a)
```
results in:
```
def m(i : Int) : Int = ???
val newValue = 2 + a
val a = 1; val m1 = m(newValue)
```
2. Values in bodies of lambda functions were not handled properly. For a value in the body of  `Term.Function` the scope was found incorrectly and no necessary brackets were inserted. E.g. extracting `x+1` from
```
def m(i: Int): Int = ???
val newValue: List[Int] = ???
val m1 = newValue.map(x => m(x + 1))
```
results in:
```
 def m(i: Int): Int = ???
val newValue: List[Int] = ???
val newValue1 = x + 1
val m1 = newValue.map(x => m(newValue1))
```
 