### PR TITLE
refactor: use the newly published bloop-maven-plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -647,6 +647,7 @@ lazy val metalsDependencies = project
       "com.olegpy" %% "better-monadic-for" % V.betterMonadicFor,
       "com.lihaoyi" % "mill-contrib-testng" % V.mill,
       "org.virtuslab.scala-cli" % "cli_3" % V.scalaCli intransitive (),
+      "ch.epfl.scala" % "bloop-maven-plugin" % V.mavenBloop,
     ),
   )
   .disablePlugins(ScalafixPlugin)

--- a/docs/build-tools/maven.md
+++ b/docs/build-tools/maven.md
@@ -17,7 +17,7 @@ implemented.
 
 Currently, all you need to run the manual installation is:
 
-`mvn ch.epfl.scala:maven-bloop_2.13:@BLOOP_VERSION@:bloopInstall -DdownloadSources=true`
+`mvn ch.epfl.scala:bloop-maven-plugin:@BLOOP_MAVEN_VERSION@:bloopInstall -DdownloadSources=true`
 
 If you choose this option though you should select "Don't show again" when
 Metals prompts to import the build.

--- a/metals-docs/src/main/scala/docs/Docs.scala
+++ b/metals-docs/src/main/scala/docs/Docs.scala
@@ -79,6 +79,7 @@ object Docs {
           "SNAPSHOT_DATE" -> snapshot.lastModified.toString,
           "LOCAL_VERSION" -> V.localSnapshotVersion,
           "BLOOP_VERSION" -> V.bloopVersion,
+          "BLOOP_MAVEN_VERSION" -> V.mavenBloopVersion,
           "SBT_BLOOP_VERSION" -> V.sbtBloopVersion,
           "SCALAMETA_VERSION" -> V.scalametaVersion,
           "SCALA211_VERSION" -> V.scala211,

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.builds
 
+import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.JavaBinary
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.UserConfiguration
@@ -19,16 +20,18 @@ case class MavenBuildTool(userConfig: () => UserConfiguration)
     AbsolutePath(out)
   }
 
+  private lazy val bloopMavenPluginVersion = BuildInfo.mavenBloopVersion
+
   def bloopInstallArgs(workspace: AbsolutePath): List[String] = {
-    def command(versionToUse: String) =
+    val command =
       List(
         "generate-sources",
-        s"ch.epfl.scala:maven-bloop_2.13:$versionToUse:bloopInstall",
+        s"ch.epfl.scala:bloop-maven-plugin:$bloopMavenPluginVersion:bloopInstall",
         "-DdownloadSources=true",
       )
     userConfig().mavenScript match {
       case Some(script) =>
-        script :: command(userConfig().currentBloopVersion)
+        script :: command
       case None =>
         writeProperties()
         val javaArgs = List[String](
@@ -46,7 +49,7 @@ case class MavenBuildTool(userConfig: () => UserConfiguration)
         List(
           javaArgs,
           jarArgs,
-          command(userConfig().currentBloopVersion),
+          command,
         ).flatten
     }
   }

--- a/project/V.scala
+++ b/project/V.scala
@@ -27,7 +27,7 @@ object V {
   val jsoup = "1.15.3"
   val kindProjector = "0.13.2"
   val lsp4jV = "0.19.0"
-  val mavenBloop = bloop
+  val mavenBloop = "2.0.0-RC4"
   val mill = "0.10.10"
   val mdoc = "2.3.6"
   val munit = "1.0.0-M7"


### PR DESCRIPTION
This replaces the usage of the old `maven-bloop_2.13` plugin with the
`bloop-maven-plugin`. All of the behavior should remain the same.
