### PR TITLE
Show @main lenses with scala cli scripts

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -831,10 +831,10 @@ object DebugProvider {
       case GlobalSymbol(
             GlobalSymbol(
               owner,
-              Descriptor.Term(sourceOwner),
+              Descriptor.Term(_),
             ),
             Descriptor.Method(name, _),
-          ) if sourceOwner.endsWith("$package") =>
+          ) =>
         val converted = GlobalSymbol(owner, Descriptor.Term(name))
         Some(converted.value)
       case _ =>

--- a/tests/slow/src/test/scala/tests/feature/CrossCodeLensLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CrossCodeLensLspSuite.scala
@@ -3,6 +3,7 @@ package tests.feature
 import scala.meta.internal.metals.{BuildInfo => V}
 
 import tests.BaseCodeLensLspSuite
+import tests.ScalaCliBuildLayout
 
 class CrossCodeLensLspSuite extends BaseCodeLensLspSuite("cross-code-lens") {
 
@@ -117,4 +118,32 @@ class CrossCodeLensLspSuite extends BaseCodeLensLspSuite("cross-code-lens") {
     } yield ()
   }
 
+  test("run-main-annotation-with-script") {
+    cleanWorkspace()
+    val path = "main.sc"
+    for {
+      _ <- initialize(
+        ScalaCliBuildLayout(
+          s"""|/$path
+              |val x = 3
+              |
+              |@main def main() = {
+              |  println("annotation")
+              |}""".stripMargin,
+          V.scala3,
+        )
+      )
+      _ <- server.didOpen(path)
+      _ <- assertCodeLenses(
+        path,
+        """|<<run>><<debug>>
+           |val x = 3
+           |
+           |<<run>><<debug>>
+           |@main def main() = {
+           |  println("annotation")
+           |}""".stripMargin,
+      )
+    } yield ()
+  }
 }

--- a/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
@@ -3,7 +3,6 @@ package tests
 import scala.meta.internal.builds.ShellRunner
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.UserConfiguration
-import scala.meta.internal.metals.{BuildInfo => V}
 
 import ch.epfl.scala.bsp4j.DebugSessionParams
 import com.google.gson.JsonObject
@@ -208,59 +207,6 @@ class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
         """|<<run>><<debug>>
            |print("oranges are nice")
            |""".stripMargin,
-      )
-    } yield ()
-  }
-
-  test("run-main-annotation-with-script") {
-    cleanWorkspace()
-    val path = "main.sc"
-    for {
-      _ <- initialize(
-        ScalaCliBuildLayout(
-          s"""|/$path
-              |val x = 3
-              |
-              |@main def main() = {
-              |  println("annotation")
-              |}""".stripMargin,
-          V.scala3,
-        )
-      )
-      _ <- server.didOpen(path)
-      _ <- assertCodeLenses(
-        path,
-        """|<<run>><<debug>>
-           |val x = 3
-           |
-           |<<run>><<debug>>
-           |@main def main() = {
-           |  println("annotation")
-           |}""".stripMargin,
-      )
-    } yield ()
-  }
-
-  test("run-main-annotation-with-scala-file") {
-    cleanWorkspace()
-    val path = "main.scala"
-    for {
-      _ <- initialize(
-        ScalaCliBuildLayout(
-          s"""|/$path
-              |@main def main() = {
-              |  println("annotation")
-              |}""".stripMargin,
-          V.scala3,
-        )
-      )
-      _ <- server.didOpen(path)
-      _ <- assertCodeLenses(
-        path,
-        """|<<run>><<debug>>
-           |@main def main() = {
-           |  println("annotation")
-           |}""".stripMargin,
       )
     } yield ()
   }


### PR DESCRIPTION
Hi!  This PR makes it so that `@main` lenses with scala cli scripts (e.g. files ending in `sc`) are shown.  They appeared previously only for scala cli files with the `.scala` extension, so the second added test would pass already, but the first wouldn't (though I'm unsure whether to put the new tests in `CodeLensLspSuite` or `CrossCodeLensLspSuite`).

I think this happened because the main (toplevel) function symbols for `sc` files typically have the form `_empty_/main.main().`, whereas `.scala` files would have the corresponding form `_empty_/main$package.main().`, and only the second form was accepted by `DebugProvider.dropSourceFromToplevelSymbol`.

Thanks
