### PR TITLE
fix: check for the left in diagnosticCode

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -270,7 +270,12 @@ final class Diagnostics(
       // Scala 3 sets the diagnostic code to -1 for NoExplanation Messages. Ideally
       // this will change and we won't need this check in the future, but for now
       // let's not forward them.
-      if (d.getCode() != null && d.getCode() != "-1") ld.setCode(d.getCode())
+      if (
+        d.getCode() != null && d
+          .getCode()
+          .isLeft() && d.getCode().getLeft() != "-1"
+      )
+        ld.setCode(d.getCode())
       ld.setData(d.getData)
       ld
     }


### PR DESCRIPTION
This was a mistake that I made earlier that I didn't think about.
This can be either a String or an Int and ours are always Strings
so I need to check left for '-1'. The check I had before didn't
make any sense as I was comparing against an either
