### PR TITLE
feat: Improve match-case completions in Scala 2

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -340,8 +340,8 @@ class CompletionProvider(
         false
       }
     }
-    completions.foreach(visit)
     completion.contribute.foreach(visit)
+    completions.foreach(visit)
     buf ++= keywords(
       pos,
       editRange,

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -487,6 +487,25 @@ trait Completions { this: MetalsGlobal =>
           text,
           parent
         )
+      case CaseExtractors.CasePatternExtractor(selector, parent, name) =>
+        CaseKeywordCompletion(
+          selector,
+          editRange,
+          pos,
+          text,
+          parent,
+          patternOnly = Some(name.stripSuffix("_CURSOR_"))
+        )
+      case CaseExtractors.TypedCasePatternExtractor(selector, parent, name) =>
+        CaseKeywordCompletion(
+          selector,
+          editRange,
+          pos,
+          text,
+          parent,
+          patternOnly = Some(name.stripSuffix("_CURSOR_")),
+          hasBind = true
+        )
       case (c: DefTree) :: (p: PackageDef) :: _ if c.namePos.includes(pos) =>
         FilenameCompletion(c, p, pos, editRange)
       case OverrideExtractor(name, template, start, isCandidate) =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -442,7 +442,15 @@ trait Completions { this: MetalsGlobal =>
     ): CompletionPosition = {
       if (hasLeadingBrace(ident, text)) {
         if (isCasePrefix(ident.name)) {
-          CaseKeywordCompletion(EmptyTree, editRange, pos, text, apply)
+          CaseKeywordCompletion(
+            EmptyTree,
+            editRange,
+            pos,
+            text,
+            source,
+            apply,
+            includeExhaustive = true
+          )
         } else {
           NoneCompletion
         }
@@ -485,6 +493,7 @@ trait Completions { this: MetalsGlobal =>
           editRange,
           pos,
           text,
+          source,
           parent
         )
       case CaseExtractors.CasePatternExtractor(selector, parent, name) =>
@@ -493,6 +502,7 @@ trait Completions { this: MetalsGlobal =>
           editRange,
           pos,
           text,
+          source,
           parent,
           patternOnly = Some(name.stripSuffix("_CURSOR_"))
         )
@@ -502,6 +512,7 @@ trait Completions { this: MetalsGlobal =>
           editRange,
           pos,
           text,
+          source,
           parent,
           patternOnly = Some(name.stripSuffix("_CURSOR_")),
           hasBind = true

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -126,6 +126,20 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
           )
         )
       } else {
+
+        // Step 0: case for selector type, e.g.
+        // case class Foo(a: Int, b: Int)
+        // List(Foo(1,2)).map{ case F@@ }
+        selectorSym.info match {
+          case NoType => ()
+          case _ =>
+            if (
+              !(selectorSym.isSealed &&
+                (selectorSym.isAbstract || selectorSym.isTrait))
+            )
+              visit(selectorSym, Identifier(selectorSym.name), Nil)
+        }
+
         // Step 1: walk through scope members.
         metalsScopeMembers(pos).iterator
           .foreach { m =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -8,6 +8,7 @@ import scala.collection.mutable.ListBuffer
 
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.internal.pc.CompletionFuzzy
 import scala.meta.internal.pc.Identifier
 import scala.meta.internal.pc.MetalsGlobal
 
@@ -33,7 +34,9 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
       editRange: l.Range,
       pos: Position,
       text: String,
-      parent: Tree
+      parent: Tree,
+      patternOnly: Option[String] = None,
+      hasBind: Boolean = false
   ) extends CompletionPosition {
     val context: Context = doLocateContext(pos)
     val parents: Parents = selector match {
@@ -69,7 +72,16 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
     }
     override def isPrioritized(member: Member): Boolean =
       member.isInstanceOf[TextEditMember]
+
     override def contribute: List[Member] = {
+      val completionGenerator = new CompletionValueGenerator(
+        editRange,
+        context,
+        clientSupportsSnippets,
+        patternOnly,
+        hasBind
+      )
+      val selectorSym = parents.selector.typeSymbol
       val result = ListBuffer.empty[Member]
       val isVisited = mutable.Set.empty[Symbol]
       def visit(
@@ -78,13 +90,6 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
           autoImports: List[l.TextEdit]
       ): Unit = {
         val fsym = sym.dealiasedSingleType
-        val isValid = !isVisited(sym) &&
-          !isVisited(fsym) &&
-          !parents.isParent(fsym) &&
-          (fsym.isCase ||
-            fsym.hasModuleFlag ||
-            fsym.isInstanceOf[TypeSymbol]) &&
-          parents.isSubClass(fsym, includeReverse = false)
         def recordVisit(s: Symbol): Unit = {
           if (s != NoSymbol && !isVisited(s)) {
             isVisited += s
@@ -93,53 +98,69 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
             recordVisit(s.dealiased)
           }
         }
-        if (isValid) {
+        if (!isVisited(sym) && !isVisited(fsym)) {
           recordVisit(sym)
           recordVisit(fsym)
-          result += toCaseMember(
-            name,
-            sym,
-            fsym,
-            context,
-            editRange,
-            autoImports
-          )
+          if (fuzzyMatches(name))
+            result += completionGenerator.toCaseMember(
+              name,
+              sym,
+              fsym,
+              autoImports
+            )
         }
       }
 
-      // Step 1: walk through scope members.
-      metalsScopeMembers(pos).iterator
-        .foreach(m => visit(m.sym.dealiased, Identifier(m.sym.name), Nil))
-
-      // Step 2: walk through known direct subclasses of sealed types.
-      val autoImport = autoImportPosition(pos, text)
-      parents.selector.typeSymbol.foreachKnownDirectSubClass { sym =>
-        autoImport match {
-          case Some(value) =>
-            val (shortName, edits) =
-              ShortenedNames.synthesize(sym, pos, context, value)
-            visit(sym, shortName, edits)
-          case scala.None =>
-            visit(sym, sym.fullNameSyntax, Nil)
-        }
-      }
-
-      // Step 3: special handle case when selector is a tuple or `FunctionN`.
+      // Special handle case when selector is a tuple or `FunctionN`.
       if (definitions.isTupleType(parents.selector)) {
-        result += new TextEditMember(
-          "case () =>",
-          new l.TextEdit(
-            editRange,
-            if (clientSupportsSnippets) "case ($0) =>" else "case () =>"
-          ),
-          parents.selector.typeSymbol,
-          label = Some(s"case ${parents.selector} =>"),
-          command = metalsConfig.parameterHintsCommand().asScala
+        List(
+          new TextEditMember(
+            "case () =>",
+            new l.TextEdit(
+              editRange,
+              if (clientSupportsSnippets) "case ($0) =>" else "case () =>"
+            ),
+            selectorSym,
+            label = Some(s"case ${parents.selector} =>"),
+            command = metalsConfig.parameterHintsCommand().asScala
+          )
         )
-      }
+      } else {
+        // Step 1: walk through scope members.
+        metalsScopeMembers(pos).iterator
+          .foreach { m =>
+            val sym = m.sym.dealiased
+            val fsym = sym.dealiasedSingleType
+            val isValid = !parents.isParent(fsym) &&
+              (fsym.isCase ||
+                fsym.hasModuleFlag ||
+                fsym.isInstanceOf[TypeSymbol]) &&
+              parents.isSubClass(fsym, includeReverse = false)
+            if (isValid) visit(sym, Identifier(m.sym.name), Nil)
+          }
 
-      result.toList
+        // Step 2: walk through known direct subclasses of sealed types.
+        val autoImport = autoImportPosition(pos, text)
+        selectorSym.foreachKnownDirectSubClass { sym =>
+          autoImport match {
+            case Some(value) =>
+              val (shortName, edits) =
+                ShortenedNames.synthesize(sym, pos, context, value)
+              visit(sym, shortName, edits)
+            case scala.None =>
+              visit(sym, sym.fullNameSyntax, Nil)
+          }
+        }
+
+        result.toList
+      }
     }
+
+    def fuzzyMatches(name: String): Boolean =
+      patternOnly match {
+        case None => true
+        case Some(query) => CompletionFuzzy.matches(query, name)
+      }
   }
 
   /**
@@ -176,6 +197,11 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
       val members = ListBuffer.empty[TextEditMember]
       val importPos = autoImportPosition(pos, text)
       val context = doLocateImportContext(pos)
+      val completionGenerator = new CompletionValueGenerator(
+        editRange,
+        context,
+        clientSupportsSnippets
+      )
       val subclassesResult = subclassesForType(tpe)
 
       // sort subclasses by declaration order
@@ -213,14 +239,11 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
             case scala.None =>
               (sym.fullNameSyntax, Nil)
           }
-        members += toCaseMember(
+        members += completionGenerator.toCaseMember(
           shortName,
           sym,
           sym.dealiasedSingleType,
-          context,
-          editRange,
-          edits,
-          isSnippet = false
+          edits
         )
       }
       val basicMatch = new TextEditMember(
@@ -243,12 +266,12 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
           val newText = new l.TextEdit(
             editRange,
             tail
-              .map(_.edit.getNewText())
+              .map(_.label.getOrElse(""))
               .mkString(
                 if (clientSupportsSnippets) {
-                  s"match {\n\t${head.edit.getNewText} $$0\n\t"
+                  s"match {\n\t${head.label.getOrElse("")} $$0\n\t"
                 } else {
-                  s"match {\n\t${head.edit.getNewText}\n\t"
+                  s"match {\n\t${head.label.getOrElse("")}\n\t"
                 },
                 "\n\t",
                 "\n}"
@@ -267,35 +290,6 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
           List(exhaustiveMatch, basicMatch)
       }
       result
-    }
-  }
-
-  case class CasePatternCompletion(
-      isTyped: Boolean,
-      c: CaseDef,
-      m: Match
-  ) extends CompletionPosition {
-    override def contribute: List[Member] = Nil
-    override def isCandidate(member: Member): Boolean = {
-      // Can't complete regular def methods in pattern matching.
-      !member.sym.isMethod || !member.sym.isVal
-    }
-    val parents = new Parents(m.selector.pos)
-    override def isPrioritized(head: Member): Boolean = {
-      parents.isSubClass(head.sym, includeReverse = false) || {
-        def alternatives(unapply: Symbol): Boolean =
-          unapply.alternatives.exists { unapply =>
-            unapply.info
-            unapply.paramLists match {
-              case (param :: Nil) :: Nil =>
-                parents.isSubClass(param, includeReverse = true)
-              case _ =>
-                false
-            }
-          }
-        alternatives(head.sym.tpe.member(termNames.unapply)) ||
-        alternatives(head.sym.tpe.member(termNames.unapplySeq))
-      }
     }
   }
 
@@ -324,82 +318,110 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
     Set("c", "ca", "cas", "case").contains(prefix)
   }
 
-  private def toCaseMember(
-      name: String,
-      sym: Symbol,
-      fsym: Symbol,
-      context: Context,
+  class CompletionValueGenerator(
       editRange: l.Range,
-      autoImports: List[l.TextEdit],
-      isSnippet: Boolean = true
-  ): TextEditMember = {
-    sym.info // complete
-    val isModuleLike = fsym.hasModuleFlag || fsym.hasJavaEnumFlag
-    if (sym.isCase || isModuleLike) {
-      // Syntax for deconstructing the symbol as an infix operator, for example `case head :: tail =>`
-      val isInfixEligible =
-        context.symbolIsInScope(sym) ||
-          autoImports.nonEmpty
-      val infixPattern: Option[String] =
-        if (
-          isInfixEligible &&
-          sym.isCase &&
-          !Character.isUnicodeIdentifierStart(sym.decodedName.head)
-        ) {
-          sym.primaryConstructor.paramss match {
-            case (a :: b :: Nil) :: _ =>
-              Some(
-                s"${a.decodedName} ${sym.decodedName} ${b.decodedName}"
-              )
-            case _ => scala.None
-          }
-        } else {
-          scala.None
-        }
-      val pattern = infixPattern.getOrElse {
-        // Fallback to "apply syntax", example `case ::(head, tail) =>`
-        val suffix =
-          if (isModuleLike) ""
-          else {
-            sym.primaryConstructor.paramss match {
-              case Nil => "()"
-              case head :: _ =>
-                head
-                  .map(param => Identifier(param.name))
-                  .mkString("(", ", ", ")")
-            }
-          }
-        name + suffix
-      }
-      val label = s"case $pattern =>"
+      context: Context,
+      clientSupportsSnippets: Boolean,
+      patternOnly: Option[String] = None,
+      hasBind: Boolean = false
+  ) {
+
+    def toCaseMember(
+        name: String,
+        sym: Symbol,
+        fsym: Symbol,
+        autoImports: List[l.TextEdit]
+    ): TextEditMember = {
+      sym.info
+      val isModuleLike = fsym.hasModuleFlag || fsym.hasJavaEnumFlag
+      val pattern =
+        if ((sym.isCase || isModuleLike) && !hasBind) {
+          val isInfixEligible =
+            context.symbolIsInScope(sym) ||
+              autoImports.nonEmpty
+          if (
+            isInfixEligible &&
+            sym.isCase &&
+            !Character.isUnicodeIdentifierStart(sym.decodedName.head)
+          )
+            // Deconstructing the symbol as an infix operator, for example `case head :: tail =>`
+            tryInfixPattern(sym).getOrElse(
+              unapplyPattern(sym, name, isModuleLike)
+            )
+          else
+            unapplyPattern(
+              sym,
+              name,
+              isModuleLike
+            ) // Apply syntax, example `case ::(head, tail) =>`
+        } else
+          typePattern(
+            sym,
+            name
+          ) // Symbol is not a case class with unapply deconstructor so we use typed pattern, example `_: User`
+
+      val label =
+        if (patternOnly.isEmpty) s"case $pattern =>"
+        else pattern
+      val cursorSuffix = (if (patternOnly.nonEmpty) "" else " ") +
+        (if (clientSupportsSnippets) "$0" else "")
       new TextEditMember(
         filterText = label,
         edit = new l.TextEdit(
           editRange,
-          label + (if (isSnippet && clientSupportsSnippets) " $0" else "")
+          label + cursorSuffix
         ),
         sym = sym,
         label = Some(label),
         additionalTextEdits = autoImports
       )
-    } else {
-      // Symbol is not a case class with unapply deconstructor so we use typed pattern, example `_: User`
+    }
+
+    private def tryInfixPattern(sym: Symbol): Option[String] = {
+      sym.primaryConstructor.paramss match {
+        case (a :: b :: Nil) :: Nil =>
+          Some(
+            s"${a.decodedName} ${sym.decodedName} ${b.decodedName}"
+          )
+        case _ :: (a :: b :: Nil) :: _ =>
+          Some(
+            s"${a.decodedName} ${sym.decodedName} ${b.decodedName}"
+          )
+        case _ => None
+      }
+    }
+    private def unapplyPattern(
+        sym: Symbol,
+        name: String,
+        isModuleLike: Boolean
+    ): String = {
+      val suffix =
+        if (isModuleLike) ""
+        else
+          sym.primaryConstructor.paramss match {
+            case Nil => "()"
+            case _ :: params :: _ =>
+              params
+                .map(param => param.name)
+                .mkString("(", ", ", ")")
+            case head :: _ =>
+              head
+                .map(param => param.name)
+                .mkString("(", ", ", ")")
+          }
+      name + suffix
+    }
+
+    private def typePattern(
+        sym: Symbol,
+        name: String
+    ): String = {
       val suffix = sym.typeParams match {
         case Nil => ""
         case tparams => tparams.map(_ => "_").mkString("[", ", ", "]")
       }
-      new TextEditMember(
-        s"case _: $name",
-        new l.TextEdit(
-          editRange,
-          if (isSnippet && clientSupportsSnippets)
-            s"case $${0:_}: $name$suffix => "
-          else s"case _: $name$suffix =>"
-        ),
-        sym,
-        Some(s"case _: $name$suffix =>"),
-        additionalTextEdits = autoImports
-      )
+      val bind = if (hasBind) "" else "_: "
+      bind + name + suffix
     }
   }
 
@@ -466,6 +488,53 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
               if ident == expr && isCasePrefix(name) =>
             Some((selector, parent))
 
+          case _ => None
+        }
+    }
+    object CasePatternExtractor {
+      def unapply(path: List[Tree]): Option[(Tree, Tree, String)] =
+        path match {
+          // case @@ =>
+          case Bind(_, _) :: CaseDefMatch(selector, parent) =>
+            Some((selector, parent, ""))
+          // case Som@@ =>
+          case Ident(
+                name
+              ) :: CaseDefMatch(selector, parent) =>
+            Some((selector, parent, name.decoded))
+          // case abc @ @@ =>
+          case Bind(_, _) :: Bind(
+                _,
+                _
+              ) :: CaseDefMatch(selector, parent) =>
+            Some((selector, parent, ""))
+          // case abc @ Som@@ =>
+          case Ident(name) :: Bind(
+                _,
+                _
+              ) :: CaseDefMatch(selector, parent) =>
+            Some((selector, parent, name.decoded))
+          case _ => None
+        }
+    }
+
+    object TypedCasePatternExtractor {
+      def unapply(path: List[Tree]): Option[(Tree, Tree, String)] =
+        path match {
+          // case _: Som@@ =>
+          // case _: @@ =>
+          case Ident(name) :: Typed(
+                _,
+                _
+              ) :: CaseDefMatch(selector, parent) =>
+            Some((selector, parent, name.decoded))
+          // case ab: Som@@ =>
+          // case ab: @@ =>
+          case Ident(name) :: Typed(_, _) :: Bind(
+                _,
+                _
+              ) :: CaseDefMatch(selector, parent) =>
+            Some((selector, parent, name.decoded))
           case _ => None
         }
     }

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -54,7 +54,8 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |    @@
       |  }
       |}""".stripMargin,
-    """|case Bird(name) => pkg
+    """|case _: Animal => pkg
+       |case Bird(name) => pkg
        |case _: Cat => pkg
        |case _: Dog => pkg
        |case Elephant => pkg

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -285,6 +285,7 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """|case None => scala
        |case Some(value) => scala
+       |case (exhaustive) Option[A] (2 cases)
        |""".stripMargin,
     compat = Map("3" -> """|case None => scala
                            |case Some(value) => scala
@@ -330,6 +331,7 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """|case None => scala
        |case Some(value) => scala
+       |case (exhaustive) Option[A] (2 cases)
        |""".stripMargin,
     compat = Map("3" -> """|case None => scala
                            |case Some(value) => scala
@@ -347,6 +349,7 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """|case None => scala
        |case Some(value) => scala
+       |case (exhaustive) Option[A] (2 cases)
        |""".stripMargin,
     compat = Map("3" -> """|case None => scala
                            |case Some(value) => scala

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -405,14 +405,16 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |  }
       |}
     """.stripMargin,
-    "",
+    """|head :: next scala.collection.immutable
+       |Nil scala.collection.immutable""".stripMargin,
+    compat = Map(
+      "2.12" ->
+        """|head :: tl scala.collection.immutable
+           |Nil scala.collection.immutable
+           |""".stripMargin
+    ),
     // to avoid newMain annotation
     filter = str => !str.contains("newMain"),
-    compat = Map(
-      "3" ->
-        """|head :: next scala.collection.immutable
-           |Nil scala.collection.immutable""".stripMargin
-    ),
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -475,18 +475,23 @@ class CompletionMatchSuite extends BaseCompletionSuite {
     ),
   )
   check(
-    "exhaustive-map".tag(IgnoreScala2),
+    "exhaustive-map",
     """
       |object A {
       |  List(Option(1)).map{ ca@@ }
       |}""".stripMargin,
-    """|case (exhaustive) Option (2 cases)
+    """|case (exhaustive) Option[A] (2 cases)
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|case (exhaustive) Option (2 cases)
+           |""".stripMargin
+    ),
     filter = _.contains("exhaustive"),
   )
 
   checkEdit(
-    "exhaustive-map-edit".tag(IgnoreScala2),
+    "exhaustive-map-edit",
     """
       |object A {
       |  List(Option(1)).map{cas@@}

--- a/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
@@ -14,8 +14,12 @@ class CompletionPatternSuite extends BaseCompletionSuite {
       _parameterHintsCommand = paramHint
     )
 
-  override def ignoreScalaVersion: Option[IgnoreScalaVersion] =
-    Some(IgnoreScala2)
+  override val compatProcess: Map[String, String => String] = Map(
+    "3" -> { (s: String) =>
+      // In Scala3 wildcard type has been changed from [_] to [?]
+      s.replace("Some[_]", "Some[?]")
+    }
+  )
 
   checkEdit(
     "empty",
@@ -80,8 +84,13 @@ class CompletionPatternSuite extends BaseCompletionSuite {
       |    case _: @@ =>
       |  }
       |}""".stripMargin,
-    """|Some[?] scala
+    """|None scala
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|Some[?] scala
+           |""".stripMargin
+    ),
     topLines = Some(1),
   )
   check(
@@ -92,7 +101,7 @@ class CompletionPatternSuite extends BaseCompletionSuite {
       |    case _: S@@ =>
       |  }
       |}""".stripMargin,
-    """|Some[?] scala
+    """|Some[_] scala
        |""".stripMargin,
     topLines = Some(1),
   )
@@ -105,8 +114,13 @@ class CompletionPatternSuite extends BaseCompletionSuite {
       |    case ab: @@ =>
       |  }
       |}""".stripMargin,
-    """|Some[?] scala
+    """|None scala
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|Some[?] scala
+           |""".stripMargin
+    ),
     topLines = Some(1),
   )
 
@@ -118,7 +132,7 @@ class CompletionPatternSuite extends BaseCompletionSuite {
       |    case ab: S@@ =>
       |  }
       |}""".stripMargin,
-    """|Some[?] scala
+    """|Some[_] scala
        |""".stripMargin,
     topLines = Some(1),
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -934,7 +934,7 @@ class CompletionSuite extends BaseCompletionSuite {
         |    case Som@@
         |}
         |""".stripMargin,
-    """|Some scala
+    """|Some(value) scala
        |""".stripMargin,
     compat = Map(
       "3" ->
@@ -994,14 +994,14 @@ class CompletionSuite extends BaseCompletionSuite {
         |    case S@@
         |}
         |""".stripMargin,
-    """|Some scala
+    """|Some(value) scala
        |Seq scala.collection
        |Set scala.collection.immutable
        |""".stripMargin,
     topLines = Some(3),
     compat = Map(
       "2.13" ->
-        """|Some scala
+        """|Some(value) scala
            |Seq scala.collection.immutable
            |Set scala.collection.immutable
            |""".stripMargin,
@@ -1020,14 +1020,14 @@ class CompletionSuite extends BaseCompletionSuite {
         |    case _: S@@
         |}
         |""".stripMargin,
-    """|Some scala
+    """|Some[_] scala
        |Seq scala.collection
        |Set scala.collection.immutable
        |""".stripMargin,
     topLines = Some(3),
     compat = Map(
       "2.13" ->
-        """|Some scala
+        """|Some[_] scala
            |Seq scala.collection.immutable
            |Set scala.collection.immutable
            |""".stripMargin,
@@ -1053,8 +1053,8 @@ class CompletionSuite extends BaseCompletionSuite {
         |  }
         |}
         |""".stripMargin,
-    """|Number: Regex
-       |NotString: Int
+    """|NotString: Int
+       |Number: Regex
        |Nil scala.collection.immutable
        |""".stripMargin,
     topLines = Option(3),


### PR DESCRIPTION
Makes match-case completions in Scala 2 work like in Scala 3.
Improvements include:
- pattern only completions, i.e. completions in:
```scala
Option(1) match {
  case No@@
  case _: So@@
```
- completions like:
```scala
case class Foo(a: Int, b: Int)
List(Foo(1,2)).map{ case F@@ }
List(Foo(1,2)).map{ case Foo(a,b) => } // useful for single case classes
``` 
- exhaustive match completions in anonymous functions:
```scala
List(Option(1)).map { case@@ }
List(Option(1)).map {
  case Some(value) => 
  case None =>
}
```