### PR TITLE
ci: fix check_scala3_nightly

### DIFF
--- a/.github/workflows/check_scala3_nightly.yml
+++ b/.github/workflows/check_scala3_nightly.yml
@@ -20,4 +20,4 @@ jobs:
             gh workflow run mtags-auto-release.yml -f scala_version=$version
           done <versions
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
It seems that `gh` command now requires `GH_TOKEN` This should fix this workflow failure - https://github.com/scalameta/metals/actions/runs/3737671059