### PR TITLE
bugfix: use GITHUB_TOKEN instead, which is the default env variable

### DIFF
--- a/.github/workflows/check_scala3_nightly.yml
+++ b/.github/workflows/check_scala3_nightly.yml
@@ -20,4 +20,4 @@ jobs:
             gh workflow run mtags-auto-release.yml -f scala_version=$version
           done <versions
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
More info for example here: https://dev.to/github/the-githubtoken-in-github-actions-how-it-works-change-permissions-customizations-3cgp