### PR TITLE
bugfix: Don't encode paths on Windows

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -178,12 +178,16 @@ final class FileDecoderProvider(
   }
 
   private def convertJarStrToURI(uriAsStr: String): URI = {
+    // Windows treats % literally:
+    // https://learn.microsoft.com/en-us/troubleshoot/windows-client/networking/url-encoding-unc-paths-not-url-decoded
+    val decoded =
+      if (Properties.isWin) URIEncoderDecoder.decode(uriAsStr) else uriAsStr
 
     /**
      *  URI.create will decode the string, which means ZipFileSystemProvider will not work
      *  Related stack question: https://stackoverflow.com/questions/9873845/java-7-zip-file-system-provider-doesnt-seem-to-accept-spaces-in-uri
      */
-    new URI("jar", uriAsStr.stripPrefix("jar:"), null)
+    new URI("jar", decoded.stripPrefix("jar:"), null)
   }
 
   private def decodeJar(uri: URI): DecoderResponse = {

--- a/tests/unit/src/test/scala/tests/MetalsEnrichmentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/MetalsEnrichmentsSuite.scala
@@ -22,18 +22,21 @@ class MetalsEnrichmentsSuite extends BaseSuite {
     assertEquals(relativeCreated, expected)
   }
 
-  test("dont-decode-uri") {
-    val uri =
-      "file:///Users/happyMetalsUser/hello%20space%20world/src/main/scala/Main.scala"
-    val path = uri.toAbsolutePath
-    assert(path.toString().contains("hello space world"))
-  }
+  // windows doesn't %20 as escapes
+  if (!isWindows) {
+    test("dont-decode-uri") {
+      val uri =
+        "file:///Users/happyMetalsUser/hello%20space%20world/src/main/scala/Main.scala"
+      val path = uri.toAbsolutePath
+      assert(path.toString().contains("hello space world"))
+    }
 
-  test("encode-uri-space") {
-    val uri =
-      "file:///Users/happyMetalsUser/hello space+world/src/main/scala/Main.scala"
-    val path = uri.toAbsolutePath
-    assert(path.toString().contains("hello space+world"))
+    test("encode-uri-space") {
+      val uri =
+        "file:///Users/happyMetalsUser/hello space+world/src/main/scala/Main.scala"
+      val path = uri.toAbsolutePath
+      assert(path.toString().contains("hello space+world"))
+    }
   }
 
 }


### PR DESCRIPTION
Previously, we were encoding characters such as whitespaces or + when encountered in string, however it seems those escaped characters with % are treated literally by windows. Now, we specially decode % escaped characters to make sure windows can correctly read them.

Fixes https://github.com/scalameta/metals/issues/4747

Tested manually, not sure how to do a proper test for it since the windows images we test on seem fine.