### PR TITLE
bugfix: Update all GH_TOKEN refs to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/mtags-auto-release.yml
+++ b/.github/workflows/mtags-auto-release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.metals_ref }}
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,4 +55,4 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It seems we had two palces where we used the custom token and it's not recommended to set one yourself.