### PR TITLE
chore: Use repository scoped token for pushing tags

### DIFF
--- a/.github/workflows/mtags-auto-release.yml
+++ b/.github/workflows/mtags-auto-release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.metals_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PUSH_TAG_GH_TOKEN }}
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'


### PR DESCRIPTION
The default github tokens will not be able to invoke another workflow, which is an intended limitation. Instead I specified a fine grained token to use for that purpose.