### PR TITLE
chore: Add support for Scala 3.2.2-RC2

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -6,7 +6,7 @@ object V {
   val scala212 = "2.12.17"
   val scala213 = "2.13.10"
   val scala3 = "3.2.1"
-  val nextScala3RC = "3.2.2-RC1"
+  val nextScala3RC = "3.2.2-RC2"
   val sbtScala = "2.12.16"
   val ammonite212Version = "2.12.17"
   val ammonite213Version = "2.13.10"
@@ -98,7 +98,7 @@ object V {
   def nonDeprecatedScala3Versions =
     Seq(nextScala3RC, scala3, "3.2.0", "3.1.3", "3.1.2", "3.1.1")
   def deprecatedScala3Versions =
-    Seq("3.1.0", "3.0.2", "3.0.1", "3.0.0")
+    Seq("3.2.2-RC1", "3.1.0", "3.0.2", "3.0.1", "3.0.0")
   def scala3Versions = nonDeprecatedScala3Versions ++ deprecatedScala3Versions
 
   lazy val nightlyScala3DottyVersions = {


### PR DESCRIPTION
Backpublish for 0.11.9 is already running.