### PR TITLE
bugfix: Make finding filename more reliant

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.mtags
 
-import java.io.File
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -345,7 +344,7 @@ trait CommonMtagsEnrichments {
           } match {
             case Failure(exception) =>
               logger.warning(exception.getMessage())
-              input.path.reverse.takeWhile(_ != File.separatorChar).reverse
+              input.path.reverse.takeWhile(c => c != '/' && c != '\\').reverse
             case Success(value) =>
               value
           }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.mtags
 
+import java.io.File
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -12,6 +13,8 @@ import java.{util => ju}
 
 import scala.annotation.tailrec
 import scala.collection.AbstractIterator
+import scala.util.Failure
+import scala.util.Success
 import scala.util.Try
 import scala.util.control.NonFatal
 import scala.{meta => m}
@@ -334,8 +337,20 @@ trait CommonMtagsEnrichments {
       Try {
         val uri = URI.create(input.path)
         Paths.get(uri).filename
-      }.getOrElse {
-        Paths.get(input.path).filename
+      } match {
+        case Failure(exception) =>
+          logger.warning(exception.getMessage())
+          Try {
+            Paths.get(input.path).filename
+          } match {
+            case Failure(exception) =>
+              logger.warning(exception.getMessage())
+              input.path.reverse.takeWhile(_ != File.separatorChar).reverse
+            case Success(value) =>
+              value
+          }
+        case Success(value) =>
+          value
       }
     }
   }

--- a/tests/unit/src/test/scala/tests/MtagsEnrichmentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/MtagsEnrichmentsSuite.scala
@@ -1,5 +1,6 @@
 package tests
 
+import scala.meta.inputs.Input
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.{semanticdb => s}
 
@@ -96,6 +97,21 @@ class MtagsEnrichmentsSuite extends BaseSuite {
     assert(r((2, 10), (5, 10)).encloses(p(2, 9)) == false)
     assert(r((2, 10), (5, 10)).encloses(p(1, 10)) == false)
     assert(r((2, 10), (5, 10)).encloses(p(5, 11)) == false)
+  }
+
+  test("filename") {
+
+    def assertFilename(input: String, expected: String) = {
+      val filename = Input.VirtualFile(input, "").filename
+      assertEquals(filename, expected)
+    }
+
+    assertFilename("file:///a/v/main.scala", "main.scala")
+    assertFilename("/a/v/main.scala", "main.scala")
+    assertFilename(
+      "jar:file:///C:/Users/A C/AppData/Local/Coursier/cache/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.2.0/scala3-library_3-3.2.0-sources.jar!/scala/Tuple.scala",
+      "Tuple.scala",
+    )
   }
 
 }

--- a/tests/unit/src/test/scala/tests/MtagsEnrichmentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/MtagsEnrichmentsSuite.scala
@@ -101,8 +101,8 @@ class MtagsEnrichmentsSuite extends BaseSuite {
 
   test("filename") {
 
-    def assertFilename(input: String, expected: String) = {
-      val filename = Input.VirtualFile(input, "").filename
+    def assertFilename(path: String, expected: String) = {
+      val filename = Input.VirtualFile(path, "").filename
       assertEquals(filename, expected)
     }
 


### PR DESCRIPTION
We should have a sensible default way of getting the name instead of relying always on Java API.

Connected to https://github.com/scalameta/metals/issues/4600

Possibly we will need something more to solve it.