### PR TITLE
fix(website): Make sure Markdown link is rendered correctly in Metals v0.11.10 announcement

### DIFF
--- a/website/blog/2023-01-02-aluminium.md
+++ b/website/blog/2023-01-02-aluminium.md
@@ -34,8 +34,8 @@ which will become the primary focus over the next releases.
 </tbody>
 </table>
 
-For full details: [https://github.com/scalameta/metals/milestone/54?closed=1]
-(https://github.com/scalameta/metals/milestone/54?closed=1)
+For full details:
+[https://github.com/scalameta/metals/milestone/54?closed=1](https://github.com/scalameta/metals/milestone/54?closed=1)
 
 Metals is a language server for Scala that works with VS Code, Vim, Emacs and
 Sublime Text. Metals is developed at the [Scala Center](https://scala.epfl.ch/)


### PR DESCRIPTION
A whitespace character between the square brackets and the parenthesis caused the link to not be rendered correctly.