### PR TITLE
fix: correctly sort dependency completions

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/CoursierComplete.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/CoursierComplete.scala
@@ -5,6 +5,7 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.util.Try
 import scala.util.matching.Regex
 
 import scala.meta.internal.semver.SemVer.Version
@@ -49,7 +50,11 @@ object CoursierComplete {
     val allCompletions = (scalaCompletions ++ javaCompletions).distinct
     // Attempt to sort versions in reverse order
     if (dependency.replaceAll(":+", ":").count(_ == ':') == 2)
-      allCompletions.sortWith(Version.fromString(_) >= Version.fromString(_))
+      Try {
+        allCompletions.sortWith(
+          Version.fromString(_) >= Version.fromString(_)
+        )
+      }.getOrElse(allCompletions.sortWith(_ >= _))
     else allCompletions
   }
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionScalaCliSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScalaCliSuite.scala
@@ -105,6 +105,17 @@ class CompletionScalaCliSuite extends BaseCompletionSuite {
     "better-tostring",
   )
 
+  checkEdit(
+    "alternative-sorting",
+    """|//> using lib "co.fs2::fs2-core:@@"
+       |package A
+       |""".stripMargin,
+    """|//> using lib "co.fs2::fs2-core:3.4.0"
+       |package A
+       |""".stripMargin,
+    filter = _.startsWith("3.4"),
+  )
+
   private def scriptWrapper(code: String, filename: String): String =
     // Vaguely looks like a scala file that ScalaCLI generates
     // from a sc file.


### PR DESCRIPTION
Not all dependencies have version names in the same format, so previous way of sorting was causing exceptions. Now we use basic sorting on String as a fallback

fixes https://github.com/scalameta/metals/issues/4799