### PR TITLE
chore(site): bump docusaurus to 2.2.0

### DIFF
--- a/docs/features/scripts.md
+++ b/docs/features/scripts.md
@@ -49,4 +49,4 @@ Current limitations can be found:
 - [here for Ammonite](https://github.com/scalameta/metals/issues?q=is%3Aopen+is%3Aissue+label%3A%22ammonite+support%22)
 - [here for Scala CLI](https://github.com/scalameta/metals/issues?q=is%3Aopen+is%3Aissue+label%3Ascala-cli)
 
-For troubleshooting that a look at the [FAQ](/docs/troubleshooting/faq#ammonite-scripts)
+For troubleshooting take a look at the [FAQ](/docs/troubleshooting/faq#ammonite-scripts)

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -30,7 +30,7 @@ module.exports = {
           "blogSidebarTitle": "All Blog Posts",
         },
         "theme": {
-          "customCss": "../src/css/customTheme.css"
+          "customCss": "./src/css/customTheme.css"
         },
         "gtag": {
           "trackingID": "UA-140140828-1"
@@ -59,10 +59,7 @@ module.exports = {
       "additionalLanguages": ["lisp"],
     },
     "colorMode": {
-      "switchConfig": {
-        "darkIcon": "🌙",
-        "lightIcon": "☀️"
-      }
+      "respectPrefersColorScheme": true
     },
     "navbar": {
       "title": "Metals",
@@ -136,7 +133,8 @@ module.exports = {
       }
     },
     "algolia": {
-      "apiKey": "c865f6d974a3072a35d4b53d48ac2307",
+      "appId": "DZKJ3Z5JFX",
+      "apiKey": "e8f55852e303f6374dfa716be910cf08",
       "indexName": "metals"
     }
   }

--- a/website/package.json
+++ b/website/package.json
@@ -9,11 +9,11 @@
   },
   "devDependencies": {},
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.15",
-    "@docusaurus/preset-classic": "2.0.0-beta.15",
+    "@docusaurus/core": "2.2.0",
+    "@docusaurus/preset-classic": "2.2.0",
     "clsx": "^1.1.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "@docusaurus/plugin-client-redirects": "2.0.0-beta.15"
+    "@docusaurus/plugin-client-redirects": "2.2.0"
   }
 }


### PR DESCRIPTION
We were on a beta version before so I thought it would be a good idea
to bump up to an actual stable version. Not much changes at all in appearance.
The only notable difference is that you can no lnoger customize the light/dark
toggle without doing a 'swizzle', which is way more work and not worth it
in my opinion. I also needed to add the `appId` for algolia and it looks
like the `customCss` is calculated from a different root since it was erroring
out and not finding it without changing what we had.


![2023-01-03 16 13 49](https://user-images.githubusercontent.com/13974112/210387623-f8d34584-a576-4aef-9dfd-ac6c46d29382.gif)
