### PR TITLE
bugfix: Fix issues with spaces in workspace path

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -131,7 +131,7 @@ trait MtagsEnrichments extends CommonMtagsEnrichments {
       value.size > 1 && value.head == '`' && value.last == '`'
     def toAbsolutePath: AbsolutePath = toAbsolutePath(true)
     def toAbsolutePath(followSymlink: Boolean): AbsolutePath = {
-      // Windows treats % literally:
+      // Windows sometimes treats % literally:
       // https://learn.microsoft.com/en-us/troubleshoot/windows-client/networking/url-encoding-unc-paths-not-url-decoded
       def decoded =
         if (Properties.isWin) URIEncoderDecoder.decode(value) else value
@@ -152,9 +152,8 @@ trait MtagsEnrichments extends CommonMtagsEnrichments {
             URLDecoder.decode(value, "UTF-8").toAbsolutePath(followSymlink)
         }
       } else {
-        val percentEncoded =
-          if (Properties.isWin) decoded.stripPrefix("metals:")
-          else URIEncoderDecoder.encode(value.stripPrefix("metals:"))
+        val stripped = value.stripPrefix("metals:")
+        val percentEncoded = URIEncoderDecoder.encode(stripped)
         URI.create(percentEncoded).toAbsolutePath(followSymlink)
       }
     }

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -53,6 +53,7 @@ abstract class BaseLspSuite(
   protected def initializationOptions: Option[InitializationOptions] = None
 
   private var useVirtualDocs = false
+  protected val changeSpacesToDash = true
 
   protected def useVirtualDocuments = useVirtualDocs
 
@@ -156,11 +157,15 @@ abstract class BaseLspSuite(
   }
 
   protected def createWorkspace(name: String): AbsolutePath = {
-    val path = PathIO.workingDirectory
+    val pathToSuite = PathIO.workingDirectory
       .resolve("target")
       .resolve("e2e")
       .resolve(suiteName)
-      .resolve(name.replace(' ', '-'))
+
+    val path =
+      if (changeSpacesToDash)
+        pathToSuite.resolve(name.replace(' ', '-'))
+      else pathToSuite.resolve(name)
 
     Files.createDirectories(path.toNIO)
     path

--- a/tests/unit/src/test/scala/tests/BuildIssueLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BuildIssueLspSuite.scala
@@ -1,0 +1,41 @@
+package tests
+
+import scala.meta.internal.metals.InitializationOptions
+
+class BuildIssueLspSuite extends BaseLspSuite(s"quick-build") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(TestingServer.TestDefault)
+
+  override protected val changeSpacesToDash: Boolean = false
+
+  test("basic spaces", withoutVirtualDocs = true) {
+    for {
+      _ <- initialize(
+        """
+          |/metals.json
+          |{
+          |  "a": {}
+          |}
+          |/a/src/main/scala/a/A.scala
+          |package a
+          |import scala.util.Success
+          |object A {
+          |  val name: Int = "ABC"
+          |}
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ = assertNoDiff(
+        server.workspaceDefinitions,
+        """|/a/src/main/scala/a/A.scala
+           |package a
+           |import scala.util.Success/*Try.scala*/
+           |object A/*L2*/ {
+           |  val name/*L3*/: Int/*Int.scala*/ = "ABC"
+           |}
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+}


### PR DESCRIPTION
Previously, I tried fixing an issue when your jars were located under a path with spaces. I realized that we should not encode spaces etc. in these situation. Turns out that for normal paths we have to encode them.

Now, we go back to encoding normal paths.

Should fix https://github.com/scalameta/metals/issues/4801