### PR TITLE
improvement: Allow compiler rename in lambdas

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
@@ -18,8 +18,8 @@ class PcRenameProvider(
     (!sym.isMethod || !forbiddenMethods(sym.decodedName)) &&
     (sym.ownersIterator
       .drop(1)
-      .exists(
-        _.isMethod
+      .exists(owner =>
+        owner.isMethod || owner.isAnonymousFunction
       )) // this also works for worksheets, since they are wrapped in `method main`
 
   }

--- a/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
@@ -19,6 +19,18 @@ class PcRenameSuite extends BasePcRenameSuite {
   )
 
   check(
+    "apply",
+    """|object A{
+       |  List(1, 2, 3).map{ _ =>
+       |    val <<a>> = 123
+       |    <<@@a>> + 1
+       |  }
+       |}  
+       |""".stripMargin,
+    wrap = false,
+  )
+
+  check(
     "generics",
     """|trait S1[X] { def <<torename>>(p: X): String = "" }
        |trait T1[Z] extends S1[Z] { override def <<torename>>(p: Z): String = super.<<torename>>(p) }


### PR DESCRIPTION
Previously, rename would not work using the presentation compiler inside lambdas, which should not require semanticdb for rename. Now, we also check if one of the owners of the renamed symbol is an anonymous function, since that symbol will be local.

For Scala 3 this seems to work correctly already since `ow.is(Method)` is true for lambdas.