### PR TITLE
feature: Render wiki links as command links

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -69,6 +69,7 @@ class Compilers(
     trees: Trees,
     mtagsResolver: MtagsResolver,
     sourceMapper: SourceMapper,
+    convertTextToLink: String => String,
 )(implicit ec: ExecutionContextExecutorService)
     extends Cancelable {
   val plugins = new CompilerPlugins()
@@ -149,6 +150,7 @@ class Compilers(
                   buildTargets,
                   saveSymbolFileToDisk = !config.isVirtualDocumentSupported(),
                   sourceMapper,
+                  convertTextToLink,
                 )
               ).getOrElse(EmptySymbolSearch),
               "default",
@@ -644,6 +646,7 @@ class Compilers(
             buildTargets,
             saveSymbolFileToDisk = !config.isVirtualDocumentSupported(),
             sourceMapper,
+            convertTextToLink,
             workspaceFallback = Some(search),
           )
           newCompiler(
@@ -676,6 +679,7 @@ class Compilers(
               buildTargets,
               saveSymbolFileToDisk = !config.isVirtualDocumentSupported(),
               sourceMapper,
+              convertTextToLink,
             ),
             path.toString(),
             path,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLanguageServer.scala
@@ -165,7 +165,15 @@ class MetalsLanguageServer(
   private val focusedDocumentBuildTarget =
     new AtomicReference[b.BuildTargetIdentifier]()
   private val definitionIndex = newSymbolIndex()
-  private val symbolDocs = new Docstrings(definitionIndex)
+
+  def convertTextToLink(sym: String): String = {
+    clientConfig
+      .commandInHtmlFormat()
+      .map(format => ServerCommands.GotoSymbol.toCommandLink(sym, format))
+      .getOrElse(sym)
+
+  }
+  private val symbolDocs = new Docstrings(definitionIndex, convertTextToLink)
   var bspSession: Option[BspSession] =
     Option.empty[BspSession]
   private val savedFiles = new ActiveFiles(time)
@@ -704,6 +712,7 @@ class MetalsLanguageServer(
             trees,
             mtagsResolver,
             sourceMapper,
+            convertTextToLink,
           )
         )
         renameProvider = new RenameProvider(

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -29,6 +29,7 @@ class StandaloneSymbolSearch(
     buildTargets: BuildTargets,
     saveSymbolFileToDisk: Boolean,
     sourceMapper: SourceMapper,
+    convertTextToLink: String => String,
     workspaceFallback: Option[SymbolSearch] = None,
 ) extends SymbolSearch {
 
@@ -45,7 +46,7 @@ class StandaloneSymbolSearch(
     index.addSourceJar(s, ScalaVersions.dialectForDependencyJar(s.filename))
   )
 
-  private val docs = new Docstrings(index)
+  private val docs = new Docstrings(index, convertTextToLink)
   private val mtags = new Mtags()
   private val destinationProvider =
     new DestinationProvider(
@@ -131,6 +132,7 @@ object StandaloneSymbolSearch {
       buildTargets: BuildTargets,
       saveSymbolFileToDisk: Boolean,
       sourceMapper: SourceMapper,
+      convertTextToLink: String => String,
   ): StandaloneSymbolSearch = {
     val (sourcesWithExtras, classpathWithExtras) =
       addScalaAndJava(
@@ -150,6 +152,7 @@ object StandaloneSymbolSearch {
       buildTargets,
       saveSymbolFileToDisk,
       sourceMapper,
+      convertTextToLink,
     )
   }
   def apply(
@@ -162,6 +165,7 @@ object StandaloneSymbolSearch {
       buildTargets: BuildTargets,
       saveSymbolFileToDisk: Boolean,
       sourceMapper: SourceMapper,
+      convertTextToLink: String => String,
   ): StandaloneSymbolSearch = {
     val (sourcesWithExtras, classpathWithExtras) =
       addScalaAndJava(scalaVersion, Nil, Nil, userConfig().javaHome)
@@ -176,6 +180,7 @@ object StandaloneSymbolSearch {
       buildTargets,
       saveSymbolFileToDisk,
       sourceMapper,
+      convertTextToLink,
     )
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
@@ -28,7 +28,11 @@ import scala.meta.pc.SymbolDocumentation
  *
  * Handles both javadoc and scaladoc.
  */
-class Docstrings(index: GlobalSymbolIndex) {
+class Docstrings(
+    index: GlobalSymbolIndex,
+    convertTextToLink: String => String
+) {
+
   val cache = new TrieMap[String, SymbolDocumentation]()
   private val logger = Logger.getLogger(classOf[Docstrings].getName)
 
@@ -117,10 +121,12 @@ class Docstrings(index: GlobalSymbolIndex) {
     defn.path.toLanguage match {
       case Language.JAVA =>
         JavadocIndexer
-          .foreach(defn.path.toInput)(cacheSymbol)
+          .foreach(defn.path.toInput, convertTextToLink)(cacheSymbol)
       case Language.SCALA =>
         ScaladocIndexer
-          .foreach(defn.path.toInput, defn.dialect)(cacheSymbol)
+          .foreach(defn.path.toInput, defn.dialect, convertTextToLink)(
+            cacheSymbol
+          )
       case _ =>
     }
   }
@@ -141,5 +147,5 @@ class Docstrings(index: GlobalSymbolIndex) {
 }
 
 object Docstrings {
-  def empty: Docstrings = new Docstrings(OnDemandSymbolIndex.empty())
+  def empty: Docstrings = new Docstrings(OnDemandSymbolIndex.empty(), identity)
 }

--- a/mtags/src/main/scala/scala/meta/internal/metals/docstrings/MarkdownGenerator.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/docstrings/MarkdownGenerator.scala
@@ -20,14 +20,17 @@ object MarkdownGenerator {
   def toMarkdown(code: String): Seq[String] =
     Scala213(code).tokenize.get.collect {
       case c: Token.Comment if c.syntax.startsWith("/**") =>
-        fromDocstring(c.syntax, Map.empty)
+        fromDocstring(c.syntax, identity, Map.empty)
     }
 
   def fromDocstring(
       docstring: String,
+      scaladocLinkToCommand: String => String,
       defines: collection.Map[String, String]
   ): String = {
-    toMarkdown(ScaladocParser.parseComment(docstring, defines))
+    toMarkdown(
+      ScaladocParser.parseComment(docstring, scaladocLinkToCommand, defines)
+    )
   }
 
   def toMarkdown(b: Body): String = {

--- a/mtags/src/main/scala/scala/meta/internal/mtags/MtagsIndexer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/MtagsIndexer.scala
@@ -12,6 +12,25 @@ import scala.meta.internal.semanticdb.SymbolInformation.Kind
 import scala.meta.internal.{semanticdb => s}
 
 trait MtagsIndexer {
+  protected def convertWithContext(
+      owner: String,
+      convertTextToLink: String => String
+  )(text: String): String = {
+    if (text.contains('.')) {
+      val symbol = text.replace('.', '/') + "."
+      convertTextToLink(symbol)
+    } else {
+      /* If we only have name of the symbol we don't know what
+       * kind of symbol that is, so this is our best guess.
+       * We should be able to improve it when doing go to definition.
+       */
+      val ending =
+        if (text.endsWith("$")) "."
+        else if (text.head.isUpper) "#"
+        else "()."
+      convertTextToLink(owner + text + ending)
+    }
+  }
   def language: Language
   def indexRoot(): Unit
   def input: Input.VirtualFile

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -75,7 +75,7 @@ abstract class BasePCSuite extends BaseSuite {
     val search = new TestingSymbolSearch(
       ClasspathSearch
         .fromClasspath(myclasspath, ExcludedPackagesHandler.default),
-      new Docstrings(index),
+      new Docstrings(index, identity),
       workspace,
       index,
     )

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1240,11 +1240,12 @@ final case class TestingServer(
       query: String,
       expected: String,
       root: AbsolutePath = workspace,
+      modifyHover: String => String = identity,
   )(implicit loc: munit.Location): Future[Unit] = {
     for {
       hover <- hover(filename, query, root)
     } yield {
-      Assertions.assertNoDiff(hover, expected)
+      Assertions.assertNoDiff(modifyHover(hover), expected)
     }
   }
 

--- a/tests/unit/src/test/scala/tests/HoverLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/HoverLspSuite.scala
@@ -1,13 +1,19 @@
 package tests
 
+import scala.meta.internal.metals.CommandHTMLFormat
 import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.{BuildInfo => V}
+import scala.meta.internal.mtags.URIEncoderDecoder
 
 class HoverLspSuite extends BaseLspSuite("hover-") with TestHovers {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(TestingServer.TestDefault)
+    Some(
+      TestingServer.TestDefault.copy(
+        commandInHtmlFormat = Some(CommandHTMLFormat.VSCode)
+      )
+    )
 
   test("basic".tag(FlakyWindows)) {
     for {
@@ -33,6 +39,70 @@ class HoverLspSuite extends BaseLspSuite("hover-") with TestHovers {
            |**Throws**
            |- `NoSuchElementException`:
            |""".stripMargin.hover,
+      )
+    } yield ()
+  }
+
+  // Command links need to be encoded normally, but that is not great for readability in tests
+  private def decodeLinks(hover: String) =
+    // not everything will be decoded by URIEncoderDecoder since it's not needed
+    URIEncoderDecoder
+      .decode(hover)
+      .replace("%2F", "/")
+      .replace("%28", "(")
+      .replace("%29", ")")
+      .replace("%23", "#")
+
+  test("links") {
+    for {
+      _ <- initialize(
+        """/metals.json
+          |{"a":{}}
+        """.stripMargin
+      )
+      _ <- server.assertHover(
+        "a/src/main/scala/a/Main.scala",
+        """
+          |object Main {
+          |  val str : Str@@ing = ""
+          |}""".stripMargin,
+        """|```scala
+           |type String: String
+           |```
+           |The `String` type in Scala has all the methods of the underlying
+           | [java.lang.String](command:metals.goto?["java/lang/String."]), of which it is just an alias.
+           |
+           | In addition, extension methods in [scala.collection.StringOps](command:metals.goto?["scala/collection/StringOps."])
+           | are added implicitly through the conversion [augmentString](command:metals.goto?["scala/Predef.augmentString()."]).
+           |""".stripMargin.hover,
+        modifyHover = decodeLinks,
+      )
+    } yield ()
+  }
+
+  test("links-java") {
+    for {
+      _ <- initialize(
+        """/metals.json
+          |{"a":{}}
+        """.stripMargin
+      )
+      _ <- server.assertHover(
+        "a/src/main/scala/a/Main.scala",
+        """
+          |import java.net.URI
+          |import java.nio.file.Paths
+          |
+          |object Main {
+          |  val uri : URI = ???
+          |  Paths.g@@et(uri)
+          |}""".stripMargin,
+        """|```scala
+           |def get(uri: URI): Path
+           |```
+           |Converts the given URI to a [Path](command:metals.goto?["java/nio/file/Path#"]) object.
+           |""".stripMargin.hover,
+        modifyHover = decodeLinks,
       )
     } yield ()
   }


### PR DESCRIPTION
Previously, it was not possible to go to the links shown in Hover. Now, similar to decoration links it's possible to click on class/method links in Hover

There are a bit of heuristics here, so I wonder still if there is a better way for it.