### PR TITLE
bugfix: Fix running when spaces are involved on windows

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/ExtendedScalaMainClass.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/ExtendedScalaMainClass.scala
@@ -2,6 +2,8 @@ package scala.meta.internal.metals.debug
 
 import java.io.File
 
+import scala.util.Properties
+
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
 
@@ -42,10 +44,21 @@ object ExtendedScalaMainClass {
       arguments: List[String],
       mainClass: String,
   ): String = {
-    val jvmOptsString = jvmOptions.mkString(" ")
+    val jvmOptsString =
+      if (jvmOptions.nonEmpty) jvmOptions.mkString("\"", "\" \"", "\"") else ""
     val classpathString = classpath.mkString(File.pathSeparator)
     val argumentsString = arguments.mkString(" ")
-    s"$javaHome $jvmOptsString -classpath $classpathString $mainClass $argumentsString"
+    // We need to add "" to account for whitespace and also escaped \ before "
+    val escapedJavaHome = javaHome.toNIO.getRoot().toString +
+      javaHome.toNIO
+        .iterator()
+        .asScala
+        .map(p => "\"" + p + "\"")
+        .mkString(File.separator)
+    val safeJavaHome =
+      if (Properties.isWin) escapedJavaHome.replace("""\"""", """\\"""")
+      else escapedJavaHome
+    s"$safeJavaHome $jvmOptsString -classpath \"$classpathString\" $mainClass $argumentsString"
   }
 
   def apply(

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/ExtendedScalaMainClass.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/ExtendedScalaMainClass.scala
@@ -53,7 +53,7 @@ object ExtendedScalaMainClass {
       javaHome.toNIO
         .iterator()
         .asScala
-        .map(p => "\"" + p + "\"")
+        .map(p => s""""$p"""")
         .mkString(File.separator)
     val safeJavaHome =
       if (Properties.isWin) escapedJavaHome.replace("""\"""", """\\"""")


### PR DESCRIPTION
Previously, we would not escape Java path, classpath or java properties, which meant that whenever spaces were involved things would not work on Windows (possibly on some other systems too). Now, we properly escape all those things.

I tested both by hand and added a test case, which proved to be a pain to write :/

Fixes https://github.com/scalameta/metals/issues/4801