### PR TITLE
refactor: improve reporting on Semanticdb from Mill for Java Modules

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -137,10 +137,11 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
 
 object MillBuildTool {
   val name: String = "mill-bsp"
-  // Starting with 0.10.6 when using mill-bsp as a build server it automatically emits SemanticDB
-  // even though it's not detected in the scalacOptions. So in this situation we don't want to warn
-  // about it and trust Mill to do its job.
-  val emitsSemanticDbByDefault = "0.10.6"
+  // Mill emits semanticDB in a different way where it's not actually detected in the javac/scalac
+  // options like other tools. Therefore for these versions we ensure we don't warn the user that
+  // semanticdb isn't being produced and we instead trust Mill to do the job.
+  val scalaSemanticDbSupport = "0.10.6"
+  val javaSemanticDbSupport = "0.11.0-M2"
 
   def isMillRelatedPath(
       path: AbsolutePath

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -200,7 +200,10 @@ final case class Indexer(
           importedBuild.scalacOptions,
           bspSession().map(_.mainConnection),
         )
-        data.addJavacOptions(importedBuild.javacOptions)
+        data.addJavacOptions(
+          importedBuild.javacOptions,
+          bspSession().map(_.mainConnection),
+        )
 
         // For "wrapped sources", we create dedicated TargetData.MappedSource instances,
         // able to convert back and forth positions from the user-facing file to

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
@@ -2,7 +2,9 @@ package scala.meta.internal.metals
 
 import java.nio.file.Path
 
+import scala.meta.internal.builds.MillBuildTool
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTarget
@@ -12,6 +14,7 @@ import ch.epfl.scala.bsp4j.JavacOptionsItem
 case class JavaTarget(
     info: BuildTarget,
     javac: JavacOptionsItem,
+    bspConnection: Option[BuildServerConnection],
 ) {
   def displayName: String = info.getDisplayName()
 
@@ -27,7 +30,8 @@ case class JavaTarget(
 
   def options: List[String] = javac.getOptions().asScala.toList
 
-  def isSemanticdbEnabled: Boolean = javac.isSemanticdbEnabled
+  def isSemanticdbEnabled: Boolean =
+    javac.isSemanticdbEnabled || semanticDbEnabledAlternatively
 
   def isSourcerootDeclared: Boolean = javac.isSourcerootDeclared
 
@@ -44,4 +48,22 @@ case class JavaTarget(
   def sourceVersion: Option[String] = javac.sourceVersion
 
   def targetroot: AbsolutePath = javac.targetroot
+
+  /**
+   * Typically to verify that SemanticDB is enabled correctly we check the javacOptions to ensure
+   * that both we see that it's enabled and that things like the sourceroot are set correctly.
+   * There are servers that configure SemanticDB in a non-traditional way. For those situations
+   * our check isn't as robust, but for the initial check here we just mark them as OK since
+   * we know and trust that for that given version and build server it should be configured.
+   *
+   * This is the case for mill-bsp >= 0.11.0-M2 for Java targets
+   */
+  private def semanticDbEnabledAlternatively = bspConnection.exists {
+    buildServer =>
+      buildServer.name == MillBuildTool.name &&
+      SemVer.isCompatibleVersion(
+        MillBuildTool.javaSemanticDbSupport,
+        buildServer.version,
+      )
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -69,7 +69,7 @@ case class ScalaTarget(
     buildServer =>
       buildServer.name == MillBuildTool.name &&
       SemVer.isCompatibleVersion(
-        MillBuildTool.emitsSemanticDbByDefault,
+        MillBuildTool.scalaSemanticDbSupport,
         buildServer.version,
       )
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/TargetData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/TargetData.scala
@@ -263,10 +263,13 @@ final class TargetData {
     }
   }
 
-  def addJavacOptions(result: JavacOptionsResult): Unit = {
+  def addJavacOptions(
+      result: JavacOptionsResult,
+      bspSession: Option[BuildServerConnection],
+  ): Unit = {
     result.getItems.asScala.foreach { javac =>
       info(javac.getTarget()).foreach { info =>
-        javaTargetInfo(javac.getTarget) = JavaTarget(info, javac)
+        javaTargetInfo(javac.getTarget) = JavaTarget(info, javac, bspSession)
       }
     }
   }


### PR DESCRIPTION
This is a follow-up to the work that I've done in
https://github.com/scalameta/metals/pull/4295. At that time I only
applied the changes to Scala Targets since Semanticdb was only produced
there when using Mill as your build server. Now that https://github.com/com-lihaoyi/mill/pull/2227
is merged Java Targets and mixed targets will now also produce
semanticdb. We now add the extra check for Mill and its version when we
check for semanticdb java support. This will ensure that users won't get
the error in the Doctor about lacking support.

CC @lefou