### PR TITLE
chore: ensure semanticdb-java gets updated by Scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -650,6 +650,7 @@ lazy val metalsDependencies = project
       "org.virtuslab.scala-cli" % "cli_3" % V.scalaCli intransitive (),
       "ch.epfl.scala" % "bloop-maven-plugin" % V.mavenBloop,
       "ch.epfl.scala" %% "gradle-bloop" % V.gradleBloop,
+      "com.sourcegraph" % "semanticdb-java" % V.javaSemanticdb,
     ),
   )
   .disablePlugins(ScalafixPlugin)


### PR DESCRIPTION
This is just a follow-up to
https://github.com/scalameta/metals/pull/4812 to ensure that it will
always be updated by Steward.
