### PR TITLE
fix: fix name shadowing in pc collector

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
@@ -44,7 +44,7 @@ abstract class PcCollector[T](
       } else if (sym.isModuleOrModuleClass) {
         if (sym.owner.isMethod) Set(sym) ++ localCompanion(sym)
         else Set(sym, sym.companionClass, sym.moduleClass)
-      } else if (sym.isTerm) {
+      } else if (sym.isTerm && (sym.owner.isClass || sym.owner.isConstructor)) {
         val info =
           if (sym.owner.isClass) sym.owner.info
           else sym.owner.owner.info

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
@@ -84,10 +84,10 @@ abstract class PcCollector[T](driver: InteractiveDriver, params: OffsetParams):
         Set(sym, sym.companionModule, sym.companion.moduleClass)
       else if sym.is(Flags.Module) then
         Set(sym, sym.companionClass, sym.moduleClass)
-      else if sym.isTerm then
+      else if sym.isTerm && (sym.owner.isClass || sym.owner.isConstructor)
+      then
         val info =
-          if sym.owner.isClass then sym.owner.info
-          else sym.owner.owner.info
+          if sym.owner.isClass then sym.owner.info else sym.owner.owner.info
         Set(
           sym,
           info.member(sym.asTerm.name.setterName).symbol,

--- a/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
@@ -688,4 +688,15 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite {
        |}""".stripMargin,
   )
 
+  check(
+    "shadowing",
+    """|object Main {
+       |  val abc = {
+       |    val <<abc>> = 1
+       |    <<a@@bc>> + 1
+       |  }
+       |  val d = abc + 1
+       |}""".stripMargin,
+  )
+
 }


### PR DESCRIPTION
Previously highlight and other pc collector features in
```scala
object A {
  val a = {
    val a = 1
    @@a + 1
  }
  val b = a + 1
}
```
On inner `a` would highlight all occurences of both variables `a`