### PR TITLE
bugfix: Only request build targets from a connection

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -81,11 +81,7 @@ final class BuildTargetClasses(
             .map(cacheTestClasses(classes, _))
 
           val jvmRunEnvironment = connection
-            .jvmRunEnvironment(
-              new b.JvmRunEnvironmentParams(
-                buildTargets.allBuildTargetIds.toList.asJava
-              )
-            )
+            .jvmRunEnvironment(new b.JvmRunEnvironmentParams(targetsList))
             .map(cacheJvmRunEnvironment)
 
           for {


### PR DESCRIPTION
Previously, we would always request jvmEnvironment for all build targets even if some of them were not available. Now, we properly only query the right targets.

Fixes https://github.com/scalameta/metals/issues/4824