### PR TITLE
improvement: Better exhaustive-case completion

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -442,6 +442,8 @@ trait Completions { this: MetalsGlobal =>
     ): CompletionPosition = {
       if (hasLeadingBrace(ident, text)) {
         if (isCasePrefix(ident.name)) {
+          val moveToNewLine = ident.pos.line == apply.pos.line
+          val addNewLineAfter = apply.pos.focusEnd.line == ident.pos.line
           CaseKeywordCompletion(
             EmptyTree,
             editRange,
@@ -449,7 +451,7 @@ trait Completions { this: MetalsGlobal =>
             text,
             source,
             apply,
-            includeExhaustive = true
+            includeExhaustive = Some((moveToNewLine, addNewLineAfter))
           )
         } else {
           NoneCompletion

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -451,7 +451,8 @@ trait Completions { this: MetalsGlobal =>
             text,
             source,
             apply,
-            includeExhaustive = Some((moveToNewLine, addNewLineAfter))
+            includeExhaustive =
+              Some(NewLineOptions(moveToNewLine, addNewLineAfter))
           )
         } else {
           NoneCompletion

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -407,7 +407,11 @@ class Completions(
           false,
         )
 
-      case MatchCaseExtractor.CaseExtractor(selector, parent) =>
+      case MatchCaseExtractor.CaseExtractor(
+            selector,
+            parent,
+            includeExhaustive,
+          ) =>
         (
           CaseKeywordCompletion.contribute(
             selector,
@@ -417,6 +421,7 @@ class Completions(
             search,
             parent,
             autoImports,
+            includeExhaustive = includeExhaustive,
           ),
           true,
         )

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -495,6 +495,63 @@ class CompletionMatchSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
+    "exhaustive-map-edit-2",
+    """|sealed trait B
+       |case class C(c: Int) extends B
+       |case class D(d: Int) extends B
+       |case class E(e: Int) extends B
+       |
+       |object A {
+       |  val b: B = ???
+       |  List(b).map{cas@@
+       |  }
+       |}""".stripMargin,
+    s"""|sealed trait B
+        |case class C(c: Int) extends B
+        |case class D(d: Int) extends B
+        |case class E(e: Int) extends B
+        |
+        |object A {
+        |  val b: B = ???
+        |  List(b).map{
+        |\tcase C(c) => $$0
+        |\tcase D(d) =>
+        |\tcase E(e) =>
+        |  }
+        |}""".stripMargin,
+    filter = _.contains("exhaustive"),
+  )
+
+  checkEdit(
+    "exhaustive-map-edit-3",
+    s"""|sealed trait B
+        |case class C(c: Int) extends B
+        |case class D(d: Int) extends B
+        |case class E(e: Int) extends B
+        |
+        |object A {
+        |  val b: B = ???
+        |  List(b).map{
+        |\tcas@@
+        |  }
+        |}""".stripMargin,
+    s"""|sealed trait B
+        |case class C(c: Int) extends B
+        |case class D(d: Int) extends B
+        |case class E(e: Int) extends B
+        |
+        |object A {
+        |  val b: B = ???
+        |  List(b).map{
+        |\tcase C(c) => $$0
+        |case D(d) =>
+        |case E(e) =>
+        |  }
+        |}""".stripMargin,
+    filter = _.contains("exhaustive"),
+  )
+
+  checkEdit(
     "exhaustive-rename".tag(IgnoreScala2),
     s"""|package b {
         |  enum Color: 


### PR DESCRIPTION
This pr consists of two changes:
1. Previously, exhaustive case completion in 
```scala
List(Option(1)).map{
  cas@@
} // resulted in
List(Option(1)).map{

    case Some(value) => 
    case None =>
      
}
// now results in 
List(Option(1)).map{
  case Some(value) => 
  case None =>
}
```
2. Previously cases in exhaustive-case completion in Scala 3 were not sorted, now we sort them the same way as for exhaustive match