### PR TITLE
improvement: Add benchmarks for SemanticHighlight

### DIFF
--- a/metals-bench/src/main/scala/bench/PcBenchmark.scala
+++ b/metals-bench/src/main/scala/bench/PcBenchmark.scala
@@ -1,0 +1,60 @@
+package bench
+
+import java.nio.file.Path
+
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.ClasspathSearch
+import scala.meta.internal.metals.ExcludedPackagesHandler
+import scala.meta.internal.pc.ScalaPresentationCompiler
+import scala.meta.io.AbsolutePath
+import scala.meta.pc.PresentationCompiler
+import scala.meta.pc.SymbolSearch
+
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.TearDown
+import tests.Library
+import tests.TestingSymbolSearch
+
+abstract class PcBenchmark {
+
+  var pc: PresentationCompiler = _
+
+  def presentationCompiler(): PresentationCompiler = pc
+
+  def beforeAll(): Unit
+
+  def libraries: List[Library] = Library.jdk :: Library.allScala2
+
+  def classpath: List[Path] =
+    libraries.flatMap(_.classpath.entries.map(_.toNIO))
+
+  def sources: List[AbsolutePath] = libraries.flatMap(_.sources.entries)
+
+  def newSearch(): SymbolSearch = {
+    require(libraries.nonEmpty)
+    new TestingSymbolSearch(
+      ClasspathSearch.fromClasspath(
+        classpath,
+        ExcludedPackagesHandler.default,
+      )
+    )
+  }
+
+  def newPC(search: SymbolSearch = newSearch()): PresentationCompiler = {
+    new ScalaPresentationCompiler()
+      .withSearch(search)
+      .newInstance("", classpath.asJava, Nil.asJava)
+  }
+
+  @Setup
+  def setup(): Unit = {
+    beforeAll()
+    pc = newPC()
+  }
+
+  @TearDown
+  def tearDown(): Unit = {
+    presentationCompiler().shutdown()
+  }
+
+}

--- a/metals-bench/src/main/scala/bench/SemanticHighlightBench.scala
+++ b/metals-bench/src/main/scala/bench/SemanticHighlightBench.scala
@@ -1,0 +1,85 @@
+package bench
+
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+import java.{util => ju}
+
+import scala.meta.internal.io.FileIO
+import scala.meta.internal.metals.CompilerVirtualFileParams
+import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.io.AbsolutePath
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+
+@State(Scope.Benchmark)
+class SemanticHighlightBench extends PcBenchmark {
+  var highlightRequests: Map[String, String] = Map.empty
+
+  private def fromZipPath(zip: AbsolutePath, path: String) = {
+    FileIO.withJarFileSystem(zip, create = false, close = true)(root =>
+      FileIO.slurp(root.resolve(path), StandardCharsets.UTF_8)
+    )
+  }
+
+  def beforeAll(): Unit = {
+    val akka = Corpus.akka()
+    val replicator =
+      "akka-2.5.19/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala"
+    val scala = Corpus.scala()
+    val typers =
+      s"scala-${bench.BuildInfo.scalaVersion}/src/compiler/scala/tools/nsc/typechecker/Typers.scala"
+    val fastparse = Corpus.fastparse()
+    val exprs =
+      "fastparse-2.1.0/scalaparse/src/scalaparse/Exprs.scala"
+
+    highlightRequests = Map(
+      "A.scala" ->
+        """
+          |import Java
+          |import scala.collection.mutable
+          |        """.stripMargin,
+      "ClusterDaemon.scala" -> fromZipPath(
+        akka,
+        replicator,
+      ),
+      "Typers.scala" -> fromZipPath(
+        scala,
+        typers,
+      ),
+      "Exprs.scala" -> fromZipPath(
+        fastparse,
+        exprs,
+      ),
+    )
+  }
+
+  @Param(
+    Array("A.scala", "ClusterDaemon.scala", "Typers.scala", "Exprs.scala")
+  )
+  var currentHighlightRequest: String = _
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  def semanticHighlight(): ju.List[Integer] = {
+    val pc = presentationCompiler()
+    val text = currentHighlight
+    val vFile = CompilerVirtualFileParams(
+      URI.create(s"file://${currentHighlightRequest}"),
+      text,
+      EmptyCancelToken,
+    )
+
+    pc.semanticTokens(vFile).get()
+  }
+
+  def currentHighlight: String = highlightRequests(currentHighlightRequest)
+
+}

--- a/tests/unit/src/main/scala/bench/Corpus.scala
+++ b/tests/unit/src/main/scala/bench/Corpus.scala
@@ -11,7 +11,7 @@ object Corpus {
   def scala(): AbsolutePath = {
     download(
       "scala-sources.zip",
-      "https://github.com/scala/scala/archive/v2.12.10.zip",
+      s"https://github.com/scala/scala/archive/v${BuildInfo.scalaVersion}.zip",
     )
   }
   def fastparse(): AbsolutePath = {


### PR DESCRIPTION
They can be run using:

```
sbt bench/jmh:run -i 10 -wi 10 -f1 -t1 .*SemanticHighlightBench
```

I also reworked the CompletionBenchmark a bit since it needs a lot of the same elements.