### PR TITLE
bugfix: Check if symbol exists before invoking .owner

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -118,7 +118,9 @@ class MetalsPrinter(
     if sym.is(Flags.Package) || sym.isClass then
       " " + dotcPrinter.fullName(sym.owner)
     else if sym.is(Flags.Module) || typeSymbol.is(Flags.Module) then
-      " " + dotcPrinter.fullName(typeSymbol.owner)
+      if typeSymbol != NoSymbol then
+        " " + dotcPrinter.fullName(typeSymbol.owner)
+      else " " + dotcPrinter.fullName(sym.owner)
     else if sym.is(Flags.Method) then
       defaultMethodSignature(sym, info, onlyMethodParams = true)
     else tpe(info)


### PR DESCRIPTION
Related to https://github.com/scalameta/metals/issues/4837