### PR TITLE
fix: ensure when we go from quickpick to showMessageRequest we include type

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
@@ -143,6 +143,7 @@ final class ConfiguredLanguageClient(
     val result = new ShowMessageRequestParams()
     result.setMessage(params.placeHolder)
     result.setActions(params.items.map(item => new MessageActionItem(item.id)))
+    result.setType(MessageType.Info)
     result
   }
 


### PR DESCRIPTION
Previously when we'd go from the quickpick params to a
showMessageRequest we wouldn't set the type. All of the usecases were
Info, so it was easy to add this in.

Fixes #4839
