### PR TITLE
bugfix: Properly check symbol in classOf

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
@@ -357,7 +357,7 @@ abstract class PcCollector[T](
               )(traverse(_, _))
 
             // needed for `classOf[<<ABC>>]`
-            case lit @ Literal(Constant(TypeRef(_, sym, _))) =>
+            case lit @ Literal(Constant(TypeRef(_, sym, _))) if sought(sym) =>
               val posStart = text.indexOfSlice(sym.decodedName, lit.pos.start)
               acc + collect(
                 lit,

--- a/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
@@ -423,4 +423,16 @@ class PcRenameSuite extends BasePcRenameSuite {
        |""".stripMargin,
     newName = "ABC",
   )
+
+  check(
+    "class-of",
+    """|object Test {
+       |  classOf[String]
+       |  def test() = {
+       |    val <<tes@@tVal>> = "test"
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "testing",
+  )
 }


### PR DESCRIPTION
It seems we forgot to include a check whether classOf actually contains a symbol we are interested in.

Fixes https://github.com/scalameta/metals/issues/4844