### PR TITLE
bugfix: Make sure that correct extension param is highlighted

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
@@ -251,11 +251,13 @@ abstract class PcCollector[T](driver: InteractiveDriver, params: OffsetParams):
                   (soughtOrOverride(ident.symbol) ||
                     isForComprehensionOwner(ident) ||
                     (extensionParam && isExtensionParam(ident.symbol))) =>
-              ident.symbol.nameBackticked
-              occurences + collect(
-                ident,
-                ident.sourcePos,
-              )
+              // symbols will differ for params in different ext methods, but source pos will be the same
+              if sought.exists(_.sourcePos == ident.symbol.sourcePos) then
+                occurences + collect(
+                  ident,
+                  ident.sourcePos,
+                )
+              else occurences
             /**
              * All select statements such as:
              * val a = hello.<<b>>

--- a/tests/cross/src/test/scala/tests/highlight/Scala3DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/Scala3DocumentHighlightSuite.scala
@@ -87,4 +87,24 @@ class Scala3DocumentHighlightSuite extends BaseDocumentHighlightSuite {
        |""".stripMargin,
   )
 
+  check(
+    "extension-complex",
+    """|object Extensions:
+       |
+       |  extension [A, B](<<eit@@hers>>: Seq[Either[A, B]])
+       |    def sequence = <<eithers>>.partitionMap(identity) match
+       |      case (Nil, rights)       => Right(rights)
+       |      case (firstLeft :: _, _) => Left(firstLeft)
+       |    def sequence2 = <<eithers>>.partitionMap(identity) match
+       |      case (Nil, rights)       => Right(rights)
+       |      case (firstLeft :: _, _) => Left(firstLeft)
+       |
+       |  extension (map: Map[String, String])
+       |    def getOrLeft(key: String): Either[String, String] =
+       |      map.get(key) match
+       |        case None        => Left(s"Missing ${key} in }")
+       |        case Some(value) => Right(value)
+       |""".stripMargin,
+  )
+
 }


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/4848

Turns out that the symbols on different extension methods are different despite being in the same group and it's hard to find all those symbol, but their definition should be in the same exact place.