### PR TITLE
feature: Add semantic tokens for sbt and script files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -180,6 +180,16 @@ final class ClientConfiguration(
     } yield refreshSupport
     codeLenseRefreshSupport.getOrElse(false)
   }
+
+  def semanticTokensRefreshSupport(): Boolean = {
+    val semanticTokensRefreshSupport: Option[Boolean] = for {
+      capabilities <- clientCapabilities
+      workspace <- Option(capabilities.getWorkspace())
+      semanticTokens <- Option(workspace.getSemanticTokens())
+      refreshSupport <- Option(semanticTokens.getRefreshSupport())
+    } yield refreshSupport
+    semanticTokensRefreshSupport.getOrElse(false)
+  }
 }
 
 object ClientConfiguration {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -2584,6 +2584,10 @@ class MetalsLspService(
       .fold(Future.successful(()))(
         worksheetProvider.evaluateAndPublish(_, EmptyCancelToken)
       )
+      .flatMap { _ =>
+        // we need to refresh tokens for worksheets since dependencies could have been added
+        languageClient.refreshSemanticTokens().asScala.map(_ => ())
+      }
   }
 
   private def onBuildChangedUnbatched(

--- a/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
@@ -285,11 +285,7 @@ object Ammonite {
     val startIdx = scalaCode.indexOf(startTag)
     if (startIdx >= 0) {
       val linesBefore = scalaCode.lineAtIndex(startIdx + startTag.length)
-      pos =>
-        if (pos.getLine < linesBefore)
-          new Position(0, 0)
-        else
-          new Position(pos.getLine - linesBefore, pos.getCharacter)
+      pos => new Position(pos.getLine - linesBefore, pos.getCharacter)
     } else
       identity _
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
@@ -95,6 +95,12 @@ final class ConfiguredLanguageClient(
     } else CompletableFuture.completedFuture(())
   }
 
+  override def refreshSemanticTokens(): CompletableFuture[Void] = {
+    if (clientConfig.semanticTokensRefreshSupport()) {
+      underlying.refreshSemanticTokens()
+    } else CompletableFuture.allOf()
+  }
+
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams
   ): Unit =

--- a/tests/mtest/src/main/scala/tests/TestSemanticTokens.scala
+++ b/tests/mtest/src/main/scala/tests/TestSemanticTokens.scala
@@ -10,6 +10,11 @@ import org.eclipse.{lsp4j => l}
 
 object TestSemanticTokens {
 
+  def removeSemanticHighlightDecorations(contents: String): String =
+    contents
+      .replaceAll(raw"/\*[\w,]+\*/", "")
+      .replaceAll(raw"\<\<|\>\>", "")
+
   def semanticString(fileContent: String, obtainedTokens: List[Int]): String = {
 
     /**

--- a/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
@@ -20,6 +20,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import tests.BaseImportSuite
 import tests.ScriptsAssertions
+import tests.TestSemanticTokens
 
 class SbtBloopLspSuite
     extends BaseImportSuite("sbt-bloop-import")
@@ -707,4 +708,55 @@ class SbtBloopLspSuite
       )
     } yield ()
   }
+
+  test("semantic-highlight") {
+    val expected =
+      s"""|<<lazy>>/*modifier*/ <<val>>/*keyword*/ <<root>>/*variable,readonly*/ = (<<project>>/*class*/ <<in>>/*method*/ <<file>>/*method*/(<<".">>/*string*/))
+          |  .<<configs>>/*method*/(<<IntegrationTest>>/*variable,readonly*/)
+          |  .<<settings>>/*method*/(
+          |    <<Defaults>>/*class*/.<<itSettings>>/*variable,readonly*/,
+          |    <<inThisBuild>>/*method*/(
+          |      <<List>>/*namespace*/(
+          |        <<organization>>/*variable,readonly*/ <<:=>>/*method*/ <<"com.example">>/*string*/,
+          |        <<scalaVersion>>/*variable,readonly*/ <<:=>>/*method*/ <<"2.13.10">>/*string*/,
+          |        <<scalacOptions>>/*variable,readonly*/ <<:=>>/*method*/ <<List>>/*namespace*/(<<"-Xsource:3">>/*string*/, <<"-Xlint:adapted-args">>/*string*/),
+          |        <<javacOptions>>/*variable,readonly*/ <<:=>>/*method*/ <<List>>/*namespace*/(
+          |          <<"-Xlint:all">>/*string*/,
+          |          <<"-Xdoclint:accessibility,html,syntax">>/*string*/
+          |        )
+          |      )
+          |    ),
+          |    <<name>>/*variable,readonly*/ <<:=>>/*method*/ <<"bsp-tests-source-sets">>/*string*/
+          |  )
+          |
+          |<<resolvers>>/*variable,readonly*/ <<++=>>/*method*/ <<Resolver>>/*variable,readonly*/.<<sonatypeOssRepos>>/*method*/(<<"snapshot">>/*string*/)
+          |<<libraryDependencies>>/*variable,readonly*/ <<+=>>/*method*/ <<"org.scalatest">>/*string*/ <<%%>>/*method*/ <<"scalatest">>/*string*/ <<%>>/*method*/ <<"3.2.9">>/*string*/ <<%>>/*method*/ <<Test>>/*variable,readonly*/
+          |<<libraryDependencies>>/*variable,readonly*/ <<+=>>/*method*/ <<"org.scalameta">>/*string*/ <<%%>>/*method*/ <<"scalameta">>/*string*/ <<%>>/*method*/ <<"4.6.0">>/*string*/
+          |
+         """.stripMargin
+
+    val fileContent =
+      TestSemanticTokens.removeSemanticHighlightDecorations(expected)
+    for {
+      _ <- initialize(
+        s"""|/build.sbt
+            |$fileContent
+         """.stripMargin
+      )
+      _ <- server.didChangeConfiguration(
+        """{
+          |  "enable-semantic-highlighting": true
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didOpen("build.sbt")
+      _ <- server.didSave("build.sbt")(identity)
+      _ <- server.assertSemanticHighlight(
+        "build.sbt",
+        expected,
+        fileContent,
+      )
+    } yield ()
+  }
+
 }

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -821,4 +821,56 @@ abstract class BaseWorksheetLspSuite(
       _ = assertNoDiff(noCompletions, "")
     } yield ()
   }
+
+  if (!ScalaVersions.isScala3Version(scalaVersion))
+    test("semantic-highlighting") {
+
+      val expected =
+        if (scalaVersion == V.scala212)
+          """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
+             |<<val>>/*keyword*/ <<hi1>>/*variable,readonly*/ =
+             |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
+             |<<val>>/*keyword*/ <<hi2>>/*variable,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
+             |
+             |<<val>>/*keyword*/ <<hellos>>/*variable,readonly*/ = <<List>>/*namespace*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
+             |""".stripMargin
+        else
+          """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
+             |<<val>>/*keyword*/ <<hi1>>/*variable,readonly*/ =
+             |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
+             |<<val>>/*keyword*/ <<hi2>>/*variable,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
+             |
+             |<<val>>/*keyword*/ <<hellos>>/*variable,readonly*/ = <<List>>/*variable,readonly*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
+             |""".stripMargin
+
+      val fileContent =
+        TestSemanticTokens.removeSemanticHighlightDecorations(expected)
+      for {
+        _ <- initialize(
+          s"""
+             |/metals.json
+             |{
+             |  "a": {
+             |    "scalaVersion": "$scalaVersion"
+             |  }
+             |}
+             |/a/src/main/scala/foo/Main.worksheet.sc
+             |$fileContent
+             |""".stripMargin
+        )
+        _ <- server.didChangeConfiguration(
+          """{
+            |  "enable-semantic-highlighting": true
+            |}
+            |""".stripMargin
+        )
+        _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
+        _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
+        _ <- server.assertSemanticHighlight(
+          "a/src/main/scala/foo/Main.worksheet.sc",
+          expected,
+          fileContent,
+        )
+      } yield ()
+    }
 }

--- a/tests/unit/src/test/scala/tests/SemanticHighlightLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticHighlightLspSuite.scala
@@ -15,44 +15,6 @@ class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
   )
 
   check(
-    "invalid-extension",
-    s"""|
-        |
-        |package example
-        |
-        |import util.{Failure => NotGood}
-        |import math.{floor => _, _}
-        |
-        |class Imports {
-        |  // rename reference
-        |  NotGood(null)
-        |  max(1, 2)
-        |}
-        |
-        |""".stripMargin,
-    "build.sc",
-  )
-
-  check(
-    "invalid-extension-sbt",
-    s"""|
-        |
-        |package example
-        |
-        |import util.{Failure => NotGood}
-        |import math.{floor => _, _}
-        |
-        |class Imports {
-        |  // rename reference
-        |  NotGood(null)
-        |  max(1, 2)
-        |}
-        |
-        |""".stripMargin,
-    "build.sbt",
-  )
-
-  check(
     "comments",
     s"""|
         |<<object>>/*keyword*/ <<Main>>/*class*/{
@@ -97,7 +59,7 @@ class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
       fileName: String = "Main.scala",
   ): Unit = {
     val fileContent =
-      expected.replaceAll(raw"/\*[\w,]+\*/", "").replaceAll(raw"\<\<|\>\>", "")
+      TestSemanticTokens.removeSemanticHighlightDecorations(expected)
 
     val filePath = "a/src/main/scala/a/" + fileName
     val absFilePath = "/" + filePath


### PR DESCRIPTION
Previously, semantic tokens would not work for files ending with `.sc` or `.sbt`. Now they properly work with correct types inferred by the compiler.

Main parts were:
- discarding any tokens that were added to the file, this required making sure that adjust position would return lines < 0, so that we can recognize those tokens
- make sure that the first token had the correct deltas
- worksheets need to have semantic tokens refreshed after downloading all dependencies etc.
- added tests for all the possibilities including Ammonite scripts, worksheets, sbt files within sbt BSP and Bloop