### PR TITLE
Fix: add star to import completions in Scala 3

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Keywords.scala
@@ -56,6 +56,7 @@ trait Keywords { this: MetalsGlobal =>
         val isPackage = this.isPackage(latestEnclosing)
         val isParam = this.isParam(latestEnclosing)
         val isSelect = this.isSelect(latestEnclosing)
+        val isImport = this.isImport(latestEnclosing)
         Keyword.all.collect {
           case kw
               if kw.matchesPosition(
@@ -69,6 +70,7 @@ trait Keywords { this: MetalsGlobal =>
                 isParam = isParam,
                 isScala3 = false,
                 isSelect = isSelect,
+                isImport = isImport,
                 allowToplevel = isAmmoniteScript,
                 leadingReverseTokens = reverseTokens
               ) =>
@@ -193,6 +195,12 @@ trait Keywords { this: MetalsGlobal =>
     enclosing match {
       case (_: Ident) :: (_: Select) :: _ => true
       case (_: Apply) :: (_: Select) :: _ => true
+      case _ => false
+    }
+
+  private def isImport(enclosing: List[Tree]): Boolean =
+    enclosing match {
+      case (_: Import) :: _ => true
       case _ => false
     }
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionPos.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionPos.scala
@@ -8,6 +8,7 @@ import scala.meta.internal.tokenizers.Chars
 import scala.meta.pc.OffsetParams
 
 import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.ast.untpd.ImportSelector
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.StdNames.*
 import dotty.tools.dotc.util.SourcePosition
@@ -114,6 +115,14 @@ object CompletionPos:
                 if s.name.toTermName == nme.ERROR || pos.span.point < s.span.point
                 then fallback
                 else s.span.point
+              case Import(_, sel) =>
+                sel
+                  .collectFirst {
+                    case ImportSelector(imported, renamed, _)
+                        if imported.sourcePos.contains(pos) =>
+                      imported.sourcePos.point
+                  }
+                  .getOrElse(fallback)
               case _ => fallback
     loop(path)
   end inferIdentStart

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/KeywordsCompletions.scala
@@ -34,6 +34,7 @@ object KeywordsCompletions:
         val isPackage = this.isPackage(path)
         val isParam = this.isParam(path)
         val isSelect = this.isSelect(path)
+        val isImport = this.isImport(path)
         lazy val text = completionPos.cursorPos.source.content.mkString
         lazy val reverseTokens: Array[Token] =
           // Try not to tokenize the whole file
@@ -64,6 +65,7 @@ object KeywordsCompletions:
                 isParam = isParam,
                 isScala3 = true,
                 isSelect = isSelect,
+                isImport = isImport,
                 allowToplevel = true,
                 leadingReverseTokens = reverseTokens,
               ) && notInComment =>
@@ -112,6 +114,11 @@ object KeywordsCompletions:
     enclosing match
       case (_: Apply) :: (_: Select) :: _ => true
       case (_: Select) :: _ => true
+      case _ => false
+
+  private def isImport(enclosing: List[Tree]): Boolean =
+    enclosing match
+      case Import(_, _) :: _ => true
       case _ => false
 
   private def isDefinition(

--- a/mtags/src/main/scala/scala/meta/internal/pc/Keyword.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/Keyword.scala
@@ -26,6 +26,7 @@ case class Keyword(
     isDefinition: Boolean = false,
     isParam: Boolean = false,
     isScala3: Boolean = false,
+    isImport: Boolean = false,
     commitCharacter: Option[String] = None,
     reversedTokensPredicate: Option[Array[Token] => Boolean] = None
 ) {
@@ -51,6 +52,7 @@ case class Keyword(
       isParam: Boolean,
       isScala3: Boolean,
       isSelect: Boolean,
+      isImport: Boolean,
       allowToplevel: Boolean,
       leadingReverseTokens: => Array[Token]
   ): Boolean = {
@@ -67,6 +69,7 @@ case class Keyword(
       (this.isPackage && isPackage) ||
       (this.isMethodBody && isMethodBody) ||
       (this.isParam && isParam) ||
+      (this.isImport && isImport) ||
       (this.name == "extends" && predicate)
     } &&
     (this.name != "extension" || predicate)
@@ -132,7 +135,8 @@ object Keyword {
     Keyword("with"),
     Keyword("catch"),
     Keyword("finally"),
-    Keyword("then")
+    Keyword("then"),
+    Keyword("*", isImport = true, isScala3 = true)
   )
 
   private def extendsPred(leadingReverseTokens: Array[Token]): Boolean = {

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -378,6 +378,32 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
+    "import-star-basic",
+    """
+      |import scala.collection.immutable.List.*@@
+      |""".stripMargin,
+    "",
+    compat = Map(
+      "3" ->
+        """|*
+           |""".stripMargin
+    ),
+  )
+
+  check(
+    "import-star-multi-import",
+    """
+      |import scala.collection.immutable.List.{range => r, *@@}
+      |""".stripMargin,
+    "",
+    compat = Map(
+      "3" ->
+        """|*
+           |""".stripMargin
+    ),
+  )
+
+  check(
     "import",
     """
       |import JavaCon@@


### PR DESCRIPTION
resolves https://github.com/scalameta/metals/issues/3057

Added `*` as a completion suggestion in imports in Scala 3 (as a keyword)