### PR TITLE
bugfix [Scala 3]: Don't show named argument completions on infix methods

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -508,4 +508,14 @@ class CompletionArgSuite extends BaseCompletionSuite {
     ),
   )
 
+  check(
+    "infix",
+    s"""|object Main{
+        |  val lst: List[Int] = List(1, 2, 3)
+        |  lst.map(x => x * x@@ )
+        |}
+        |""".stripMargin,
+    """|x: Int
+       |""".stripMargin,
+  )
 }


### PR DESCRIPTION
Reported in https://github.com/scalacenter/scastie/issues/711