### PR TITLE
fix: correctly insert type annotation in tuples lambda args

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/InferredTypeProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/InferredTypeProvider.scala
@@ -147,9 +147,14 @@ final class InferredTypeProvider(
        * `.map((a: Int) => a + a)`
        */
       case Some(vl @ ValDef(sym, tpt, rhs)) =>
-        val isParam = path.tail.headOption.exists(_.symbol.isAnonymousFunction)
+        val isParam = path match
+          case head :: next :: _ if next.symbol.isAnonymousFunction => true
+          case head :: (b @ Block(stats, expr)) :: next :: _
+              if next.symbol.isAnonymousFunction =>
+            true
+          case _ => false
         def baseEdit(withParens: Boolean): TextEdit =
-          val keywordOffset = if vl.symbol.is(Flags.Param) then 0 else 4
+          val keywordOffset = if isParam then 0 else 4
           val endPos =
             findNamePos(params.text, vl, keywordOffset).endPos.toLsp
           adjustOpt.foreach(adjust => endPos.setEnd(adjust.adjustedEndPos))

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -281,6 +281,16 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
+    "lambda-tuple".tag(IgnoreScala2),
+    """|object A{
+       |  val toStringList = List((1, 2)).map((int, <<n>>) => n)
+       |}""".stripMargin,
+    """|object A{
+       |  val toStringList = List((1, 2)).map((int, n: Int) => n)
+       |}""".stripMargin,
+  )
+
+  checkEdit(
     "pattern-match-paren",
     """|object A{
        |  val list = List(1, 2, 3) match {
@@ -747,6 +757,7 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |}
        |""".stripMargin,
   )
+
   def checkEdit(
       name: TestOptions,
       original: String,


### PR DESCRIPTION
Previously
```scala
List((1,2)).map((<<a>>,b) => a)
// would insert type here
List((1,2)).map((a,b) => a: Int)
```
This happened because tuple argument symbols don't have `Param` flag (probably connected to https://github.com/lampepfl/dotty/issues/16110) Now we have different way to check if we are on parameter