### PR TITLE
improvement: Fallback to symbol search as the last possibility for definition

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -441,6 +441,16 @@ class MetalsLspService(
     () => bspSession.map(_.mainConnection),
   )
 
+  private val workspaceSymbols: WorkspaceSymbolProvider =
+    new WorkspaceSymbolProvider(
+      workspace,
+      buildTargets,
+      definitionIndex,
+      saveClassFileToDisk = !clientConfig.isVirtualDocumentSupported(),
+      () => excludedPackageHandler,
+      classpathSearchIndexer = classpathSearchIndexer,
+    )
+
   private val definitionProvider: DefinitionProvider = new DefinitionProvider(
     workspace,
     mtags,
@@ -455,6 +465,7 @@ class MetalsLspService(
     scalaVersionSelector,
     saveDefFileToDisk = !clientConfig.isVirtualDocumentSupported(),
     sourceMapper,
+    workspaceSymbols,
   )
 
   val stacktraceAnalyzer: StacktraceAnalyzer = new StacktraceAnalyzer(
@@ -590,16 +601,6 @@ class MetalsLspService(
       trees,
       buildTargets,
       supermethods,
-    )
-
-  private val workspaceSymbols: WorkspaceSymbolProvider =
-    new WorkspaceSymbolProvider(
-      workspace,
-      buildTargets,
-      definitionIndex,
-      saveClassFileToDisk = !clientConfig.isVirtualDocumentSupported(),
-      () => excludedPackageHandler,
-      classpathSearchIndexer = classpathSearchIndexer,
     )
 
   private val javaHighlightProvider: JavaDocumentHighlightProvider =

--- a/tests/cross/src/main/scala/tests/BasePcRenameSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePcRenameSuite.scala
@@ -79,7 +79,7 @@ class BasePcRenameSuite extends BasePCSuite with RangeReplace {
         .get()
 
       val withRange =
-        if (range.isEmpty()) base else replaceInRange(base, range.get())
+        if (!range.isPresent()) base else replaceInRange(base, range.get())
       assertNoDiff(
         withRange,
         expected,


### PR DESCRIPTION
Previously, if the code never compiled, we would miss semanticdb and we often wouldn't be able to navigate to a symbol from outside the current file. Now, instead we will try to use the symbol search to find the symbol matching the current name.

This solution might cause some false positives with the same names, but I think overall this might help users a lot and avoid having broken metals in case of not compiling workspace.

This should also improve a lot with https://github.com/scalameta/metals/pull/4798