### PR TITLE
improvement: Use PcCollector for SemanticTokenProvider

### DIFF
--- a/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
+++ b/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
@@ -152,6 +152,22 @@ class SemanticTokensSuite extends BasePCSuite {
         |""".stripMargin,
   )
 
+  check(
+    "anonymous-class",
+    s"""|<<object>>/*keyword*/ <<A>>/*class*/ {
+        |  <<trait>>/*keyword*/ <<Methodable>>/*interface,abstract*/[<<T>>/*typeParameter,abstract*/] {
+        |    <<def>>/*keyword*/ <<method>>/*method,abstract*/(<<asf>>/*parameter*/: <<T>>/*typeParameter,abstract*/): <<Int>>/*class,abstract*/
+        |  }
+        |
+        |  <<abstract>>/*modifier*/ <<class>>/*keyword*/ <<Alphabet>>/*class,abstract*/(<<alp>>/*variable,readonly*/: <<Int>>/*class,abstract*/) <<extends>>/*keyword*/ <<Methodable>>/*interface,abstract*/[<<String>>/*type*/] {
+        |    <<def>>/*keyword*/ <<method>>/*method*/(<<adf>>/*parameter*/: <<String>>/*type*/) = <<123>>/*number*/
+        |  }
+        |  <<val>>/*keyword*/ <<a>>/*variable,readonly*/ = <<new>>/*keyword*/ <<Alphabet>>/*class,abstract*/(<<alp>>/*parameter*/ = <<10>>/*number*/) {
+        |    <<override>>/*modifier*/ <<def>>/*keyword*/ <<method>>/*method*/(<<adf>>/*parameter*/: <<String>>/*type*/): <<Int>>/*class,abstract*/ = <<321>>/*number*/
+        |  }
+        |}""".stripMargin,
+  )
+
   def check(
       name: TestOptions,
       expected: String,

--- a/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
@@ -711,16 +711,16 @@ class SbtBloopLspSuite
 
   test("semantic-highlight") {
     val expected =
-      s"""|<<lazy>>/*modifier*/ <<val>>/*keyword*/ <<root>>/*variable,readonly*/ = (<<project>>/*class*/ <<in>>/*method*/ <<file>>/*method*/(<<".">>/*string*/))
+      s"""|<<lazy>>/*modifier*/ <<val>>/*keyword*/ <<root>>/*variable,readonly*/ = (<<project>>/*method*/ <<in>>/*method*/ <<file>>/*method*/(<<".">>/*string*/))
           |  .<<configs>>/*method*/(<<IntegrationTest>>/*variable,readonly*/)
           |  .<<settings>>/*method*/(
           |    <<Defaults>>/*class*/.<<itSettings>>/*variable,readonly*/,
           |    <<inThisBuild>>/*method*/(
-          |      <<List>>/*namespace*/(
+          |      <<List>>/*class*/(
           |        <<organization>>/*variable,readonly*/ <<:=>>/*method*/ <<"com.example">>/*string*/,
           |        <<scalaVersion>>/*variable,readonly*/ <<:=>>/*method*/ <<"2.13.10">>/*string*/,
-          |        <<scalacOptions>>/*variable,readonly*/ <<:=>>/*method*/ <<List>>/*namespace*/(<<"-Xsource:3">>/*string*/, <<"-Xlint:adapted-args">>/*string*/),
-          |        <<javacOptions>>/*variable,readonly*/ <<:=>>/*method*/ <<List>>/*namespace*/(
+          |        <<scalacOptions>>/*variable,readonly*/ <<:=>>/*method*/ <<List>>/*class*/(<<"-Xsource:3">>/*string*/, <<"-Xlint:adapted-args">>/*string*/),
+          |        <<javacOptions>>/*variable,readonly*/ <<:=>>/*method*/ <<List>>/*class*/(
           |          <<"-Xlint:all">>/*string*/,
           |          <<"-Xdoclint:accessibility,html,syntax">>/*string*/
           |        )

--- a/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
@@ -279,16 +279,16 @@ class SbtServerSuite
 
   test("semantic-highlight") {
     val expected =
-      s"""|<<lazy>>/*modifier*/ <<val>>/*keyword*/ <<root>>/*variable,readonly*/ = (<<project>>/*class*/ <<in>>/*method*/ <<file>>/*method*/(<<".">>/*string*/))
+      s"""|<<lazy>>/*modifier*/ <<val>>/*keyword*/ <<root>>/*variable,readonly*/ = (<<project>>/*method*/ <<in>>/*method*/ <<file>>/*method*/(<<".">>/*string*/))
           |  .<<configs>>/*method*/(<<IntegrationTest>>/*variable,readonly*/)
           |  .<<settings>>/*method*/(
           |    <<Defaults>>/*class*/.<<itSettings>>/*variable,readonly*/,
           |    <<inThisBuild>>/*method*/(
-          |      <<List>>/*namespace*/(
+          |      <<List>>/*class*/(
           |        <<organization>>/*variable,readonly*/ <<:=>>/*method*/ <<"com.example">>/*string*/,
           |        <<scalaVersion>>/*variable,readonly*/ <<:=>>/*method*/ <<"2.13.10">>/*string*/,
-          |        <<scalacOptions>>/*variable,readonly*/ <<:=>>/*method*/ <<List>>/*namespace*/(<<"-Xsource:3">>/*string*/, <<"-Xlint:adapted-args">>/*string*/),
-          |        <<javacOptions>>/*variable,readonly*/ <<:=>>/*method*/ <<List>>/*namespace*/(
+          |        <<scalacOptions>>/*variable,readonly*/ <<:=>>/*method*/ <<List>>/*class*/(<<"-Xsource:3">>/*string*/, <<"-Xlint:adapted-args">>/*string*/),
+          |        <<javacOptions>>/*variable,readonly*/ <<:=>>/*method*/ <<List>>/*class*/(
           |          <<"-Xlint:all">>/*string*/,
           |          <<"-Xdoclint:accessibility,html,syntax">>/*string*/
           |        )
@@ -301,7 +301,7 @@ class SbtServerSuite
           |<<libraryDependencies>>/*variable,readonly*/ <<+=>>/*method*/ <<"org.scalatest">>/*string*/ <<%%>>/*method*/ <<"scalatest">>/*string*/ <<%>>/*method*/ <<"3.2.9">>/*string*/ <<%>>/*method*/ <<Test>>/*variable,readonly*/
           |<<libraryDependencies>>/*variable,readonly*/ <<+=>>/*method*/ <<"org.scalameta">>/*string*/ <<%%>>/*method*/ <<"scalameta">>/*string*/ <<%>>/*method*/ <<"4.6.0">>/*string*/
           |
-         """.stripMargin
+             """.stripMargin
 
     val fileContent =
       TestSemanticTokens.removeSemanticHighlightDecorations(expected)

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -832,7 +832,7 @@ abstract class BaseWorksheetLspSuite(
              |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
              |<<val>>/*keyword*/ <<hi2>>/*variable,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
              |
-             |<<val>>/*keyword*/ <<hellos>>/*variable,readonly*/ = <<List>>/*namespace*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
+             |<<val>>/*keyword*/ <<hellos>>/*variable,readonly*/ = <<List>>/*class*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
              |""".stripMargin
         else
           """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,readonly*/: <<Int>>/*class,abstract*/)

--- a/tests/unit/src/test/resources/semanticTokens/example/MacroAnnotation.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/MacroAnnotation.scala
@@ -14,12 +14,12 @@
   <<import>>/*keyword*/ <<scala>>/*namespace*/.<<meta>>/*namespace*/.<<_>>/*variable*/
   <<// IntelliJ has never managed to goto definition for the inner classes from Trees.scala>>/*comment*/
   <<// due to the macro annotations.>>/*comment*/
-  <<val>>/*keyword*/ <<x>>/*variable,readonly*/: <<Defn>>/*class*/.<<Class>>/*interface,abstract*/ = <<Defn>>/*class*/.<<Class>>/*method,deprecated*/(
+  <<val>>/*keyword*/ <<x>>/*variable,readonly*/: <<Defn>>/*class*/.<<Class>>/*interface,abstract*/ = <<Defn>>/*class*/.<<Class>>/*class*/(
     <<Nil>>/*variable,readonly*/,
     <<Type>>/*class*/.<<Name>>/*class*/(<<"test">>/*string*/),
     <<Nil>>/*variable,readonly*/,
     <<Ctor>>/*class*/.<<Primary>>/*class*/(<<Nil>>/*variable,readonly*/, <<Term>>/*class*/.<<Name>>/*class*/(<<"this">>/*string*/), <<Nil>>/*variable,readonly*/),
     <<Template>>/*class*/(<<Nil>>/*variable,readonly*/, <<Nil>>/*variable,readonly*/, <<Self>>/*class*/(<<Name>>/*class*/.<<Anonymous>>/*class*/(), <<None>>/*class*/), <<Nil>>/*variable,readonly*/),
   )
-  <<val>>/*keyword*/ <<y>>/*variable,readonly*/: <<Mod>>/*class*/.<<Final>>/*interface,abstract*/ = <<Mod>>/*class*/.<<Final>>/*method*/()
+  <<val>>/*keyword*/ <<y>>/*variable,readonly*/: <<Mod>>/*class*/.<<Final>>/*interface,abstract*/ = <<Mod>>/*class*/.<<Final>>/*class*/()
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/TryCatch.scala
@@ -5,7 +5,7 @@
     <<val>>/*keyword*/ <<x>>/*variable,readonly*/ = <<2>>/*number*/
     <<x>>/*variable,readonly*/ <<+>>/*method,abstract*/ <<2>>/*number*/
   } <<catch>>/*keyword*/ {
-    <<case>>/*keyword*/ t: <<Throwable>>/*type*/ <<=>>>/*operator*/
+    <<case>>/*keyword*/ <<t>>/*variable,readonly*/: <<Throwable>>/*type*/ <<=>>>/*operator*/
       <<t>>/*variable,readonly*/.<<printStackTrace>>/*method*/()
   } <<finally>>/*keyword*/ {
     <<val>>/*keyword*/ <<text>>/*variable,readonly*/ = <<"">>/*string*/


### PR DESCRIPTION
Previously `SemanticTokenProvider` had its own tree traverser for collecting all symbol occurrences.
This PR changes it to use `PcCollector`, which should make optimisation and bugfixes easier. It should also simplify adding `SemanticTokens` for Scala 3