### PR TITLE
bugfix: Use classpath jar for defining run classpath

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -497,6 +497,7 @@ class MetalsLspService(
         clientConfig,
         () => userConfig,
         trees,
+        workspace,
       )
     val goSuperLensProvider = new SuperMethodCodeLens(
       buffers,

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -48,6 +48,7 @@ final class RunTestCodeLens(
     clientConfig: ClientConfiguration,
     userConfig: () => UserConfiguration,
     trees: Trees,
+    workspace: AbsolutePath,
 ) extends CodeLens {
 
   override def isEnabled: Boolean = clientConfig.isDebuggingProvider()
@@ -273,7 +274,7 @@ final class RunTestCodeLens(
       case None =>
         main.toJson
       case Some((env, javaHome)) =>
-        ExtendedScalaMainClass(main, env, javaHome).toJson
+        ExtendedScalaMainClass(main, env, javaHome, workspace).toJson
     }
     val params = {
       val dataKind = b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS


### PR DESCRIPTION
Previously, we would use the classpath as string which might be too long on some systems for example on Windows. Now, we define it using jar with the classpath defined inside its manifest. This also benefits other system since it makes the path shorter.

The jar will only be created once per classpath change and deleted on exit.

Fixes https://github.com/scalameta/metals/issues/4827