### PR TITLE
fix: do not convert to named arguments for a Java class

### DIFF
--- a/mtags-interfaces/src/main/java/scala/meta/pc/DisplayableException.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/DisplayableException.java
@@ -1,0 +1,7 @@
+package scala.meta.pc;
+
+public class DisplayableException extends RuntimeException {
+  public DisplayableException(String message) {
+    super(message);
+  }
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/DisplayableException.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/DisplayableException.java
@@ -1,5 +1,9 @@
 package scala.meta.pc;
 
+/** An expection, which message is to be displayed to the user.
+ * Currently used when code action command cannot be executed
+ * but the appropriate condition could not be checked when creating the action.
+ */
 public class DisplayableException extends RuntimeException {
   public DisplayableException(String message) {
     super(message);

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -146,6 +146,7 @@ public abstract class PresentationCompiler {
 
 	/**
 	 * Return named arguments for the apply method that encloses the given position.
+	 * May fail with a DisplayableException.
 	 */
 	public abstract CompletableFuture<List<TextEdit>> convertToNamedArguments(OffsetParams params,
 			List<Integer> argIndices);

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
@@ -44,21 +44,23 @@ final class ConvertToNamedArgumentsProvider(
       }
     }
 
-    def handleWithJavaFilter(symbol: Symbol)(f: () => List[l.TextEdit]) = {
+    def handleWithJavaFilter(symbol: Symbol, edits: => List[l.TextEdit]) = {
       if (symbol.isJava)
         Left(CodeActionErrorMessages.ConvertToNamedArguments.IsJavaObject)
-      else Right(f())
+      else Right(edits)
     }
 
     typedTree match {
       case FromNewApply(fun, args) if fun.symbol != null =>
-        handleWithJavaFilter(fun.symbol) { () =>
+        handleWithJavaFilter(
+          fun.symbol,
           makeTextEdits(fun.tpe.paramss.flatten, args)
-        }
+        )
       case Apply(fun, args) if fun.symbol != null && !fun.symbol.isJava =>
-        handleWithJavaFilter(fun.symbol) { () =>
+        handleWithJavaFilter(
+          fun.symbol,
           makeTextEdits(fun.tpe.params, args)
-        }
+        )
       case _ => Right(Nil)
     }
   }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
@@ -12,7 +12,7 @@ final class ConvertToNamedArgumentsProvider(
 ) {
 
   import compiler._
-  def convertToNamedArguments: List[l.TextEdit] = {
+  def convertToNamedArguments: Either[String, List[l.TextEdit]] = {
     val unit = addCompilationUnit(
       code = params.text(),
       filename = params.uri().toString(),
@@ -44,12 +44,22 @@ final class ConvertToNamedArgumentsProvider(
       }
     }
 
+    def handleWithJavaFilter(symbol: Symbol)(f: () => List[l.TextEdit]) = {
+      if (symbol.isJava)
+        Left(CodeActionErrorMessages.ConvertToNamedArguments.IsJavaObject)
+      else Right(f())
+    }
+
     typedTree match {
-      case FromNewApply(fun, args) =>
-        makeTextEdits(fun.tpe.paramss.flatten, args)
-      case Apply(fun, args) =>
-        makeTextEdits(fun.tpe.params, args)
-      case _ => Nil
+      case FromNewApply(fun, args) if fun.symbol != null =>
+        handleWithJavaFilter(fun.symbol) { () =>
+          makeTextEdits(fun.tpe.paramss.flatten, args)
+        }
+      case Apply(fun, args) if fun.symbol != null && !fun.symbol.isJava =>
+        handleWithJavaFilter(fun.symbol) { () =>
+          makeTextEdits(fun.tpe.params, args)
+        }
+      case _ => Right(Nil)
     }
   }
 }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
@@ -9,6 +9,7 @@ import scala.meta.pc.PresentationCompilerConfig
 
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Types.MethodType
 import dotty.tools.dotc.interactive.Interactive
 import dotty.tools.dotc.interactive.InteractiveDriver
@@ -21,7 +22,7 @@ final class ConvertToNamedArgumentsProvider(
     argIndices: Set[Int],
 ):
 
-  def convertToNamedArguments: List[l.TextEdit] =
+  def convertToNamedArguments: Either[String, List[l.TextEdit]] =
     val uri = params.uri
     val filePath = Paths.get(uri)
     driver.run(
@@ -54,17 +55,24 @@ final class ConvertToNamedArgumentsProvider(
             Some(fun, argss ++ args)
           case _ => None
 
-    def edits(tree: Option[tpd.Tree])(using Context): List[l.TextEdit] =
+    def edits(tree: Option[tpd.Tree])(using
+        Context
+    ): Either[String, List[l.TextEdit]] =
       def makeTextEdits(fun: tpd.Tree, args: List[tpd.Tree]) =
-        args.zipWithIndex
-          .zip(paramss(fun))
-          .collect {
-            case ((arg, index), param) if argIndices.contains(index) => {
-              val position = arg.sourcePos.toLsp
-              position.setEnd(position.getStart())
-              new l.TextEdit(position, s"$param = ")
-            }
-          }
+        if fun.symbol.is(Flags.JavaDefined) then
+          Left(CodeActionErrorMessages.ConvertToNamedArguments.IsJavaObject)
+        else
+          Right(
+            args.zipWithIndex
+              .zip(paramss(fun))
+              .collect {
+                case ((arg, index), param) if argIndices.contains(index) => {
+                  val position = arg.sourcePos.toLsp
+                  position.setEnd(position.getStart())
+                  new l.TextEdit(position, s"$param = ")
+                }
+              }
+          )
 
       tree match
         case Some(t) =>
@@ -73,8 +81,8 @@ final class ConvertToNamedArgumentsProvider(
               makeTextEdits(fun, args)
             case tpd.Apply(fun, args) =>
               makeTextEdits(fun, args)
-            case _ => Nil
-        case _ => Nil
+            case _ => Right(Nil)
+        case _ => Right(Nil)
       end match
     end edits
     edits(tree)(using newctx)

--- a/mtags/src/main/scala/scala/meta/internal/pc/CodeActionError.scala
+++ b/mtags/src/main/scala/scala/meta/internal/pc/CodeActionError.scala
@@ -1,0 +1,7 @@
+package scala.meta.internal.pc
+
+object CodeActionErrorMessages {
+  object ConvertToNamedArguments {
+    val IsJavaObject = "Cannot convert to named arguments for a Java class."
+  }
+}


### PR DESCRIPTION
previously: it was possible to convert to named arguments for a Java defined class, which resulted in invalid code
now: upon choosing convert to named arguments on a Java defined class no text edits are performed and a message "Cannot convert to named arguments for a Java class." is displayed instead

resolves https://github.com/scalameta/metals/issues/4851