### PR TITLE
improvement: Allow manual cancel of starting debug session

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -174,9 +174,13 @@ class BuildServerConnection private (
     register(server => server.buildTargetScalaTestClasses(params)).asScala
   }
 
-  def startDebugSession(params: DebugSessionParams): Future[URI] = {
-    register(server => server.debugSessionStart(params)).asScala
-      .map(address => URI.create(address.getUri))
+  def startDebugSession(
+      params: DebugSessionParams,
+      cancelPromise: Promise[Unit],
+  ): Future[URI] = {
+    val completableFuture = register(server => server.debugSessionStart(params))
+    cancelPromise.future.foreach(_ => completableFuture.cancel(true))
+    completableFuture.asScala.map(address => URI.create(address.getUri))
   }
 
   def jvmRunEnvironment(

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
@@ -68,25 +68,10 @@ final class StatusBar(
     }
   }
 
-  def trackSlowFuture[T](message: String, thunk: Future[T]): Unit = {
-    if (!clientConfig.slowTaskIsOn)
-      trackFuture(message, thunk)
-    else {
-      val task = client.metalsSlowTask(MetalsSlowTaskParams(message))
-      thunk.onComplete {
-        case Failure(exception) =>
-          slowTaskFailed(message, exception)
-          task.cancel(true)
-        case Success(_) =>
-          task.cancel(true)
-      }
-    }
-  }
-
-  def trackSlowFutureCancellable[T](
+  def trackSlowFuture[T](
       message: String,
       thunk: Future[T],
-      onCancel: () => Unit,
+      onCancel: () => Unit = () => (),
   ): Future[T] = {
     if (!clientConfig.slowTaskIsOn)
       trackFuture(message, thunk)
@@ -99,10 +84,9 @@ final class StatusBar(
         case Failure(exception) =>
           slowTaskFailed(message, exception)
           task.cancel(true)
-        case _: Success[T] =>
+        case Success(_) =>
           task.cancel(true)
       }
-
       thunk
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
@@ -17,7 +17,6 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.clients.language.MetalsSlowTaskParams
 import scala.meta.internal.metals.clients.language.MetalsStatusParams
-import scala.meta.internal.metals.config.StatusBarState
 
 import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.MessageType
@@ -53,7 +52,7 @@ final class StatusBar(
   }
 
   def trackSlowTask[T](message: String)(thunk: => T): T = {
-    if (clientConfig.statusBarState == StatusBarState.Off)
+    if (!clientConfig.slowTaskIsOn)
       trackBlockingTask(message)(thunk)
     else {
       val task = client.metalsSlowTask(MetalsSlowTaskParams(message))
@@ -70,7 +69,7 @@ final class StatusBar(
   }
 
   def trackSlowFuture[T](message: String, thunk: Future[T]): Unit = {
-    if (clientConfig.statusBarState == StatusBarState.Off)
+    if (!clientConfig.slowTaskIsOn)
       trackFuture(message, thunk)
     else {
       val task = client.metalsSlowTask(MetalsSlowTaskParams(message))
@@ -89,7 +88,7 @@ final class StatusBar(
       thunk: Future[T],
       onCancel: () => Unit,
   ): Future[T] = {
-    if (clientConfig.statusBarState == StatusBarState.Off)
+    if (!clientConfig.slowTaskIsOn)
       trackFuture(message, thunk)
     else {
       val task = client.metalsSlowTask(MetalsSlowTaskParams(message))

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -386,7 +386,7 @@ class DebugProvider(
   )(implicit ec: ExecutionContext): Future[DebugSession] = {
     val cancelPromise = Promise[Unit]()
     for {
-      server <- statusBar.trackSlowFutureCancellable(
+      server <- statusBar.trackSlowFuture(
         "Starting debug server",
         start(debugParams, cancelPromise),
         () => cancelPromise.trySuccess(()),

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -155,7 +155,7 @@ class DebugProvider(
         connWithTimeout
           .recover { case exception =>
             connectedToServer.tryFailure(exception)
-            cancelPromise.tryFailure(exception)
+            cancelPromise.trySuccess(())
             throw exception
           }
       }

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -106,7 +106,8 @@ object TestGroups {
       "tests.codeactions.ActionableDiagnosticsSuite",
       "tests.codeactions.MillifyDependencyLspSuite",
       "tests.RenameFilesLspSuite", "tests.codeactions.ExtractMethodLspSuite",
-      "tests.SemanticTokensExpectSuite"),
+      "tests.SemanticTokensExpectSuite",
+      "tests.debug.DebugProtocolCancelationSuite"),
   )
 
 }

--- a/tests/unit/src/test/scala/tests/FormattingLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/FormattingLspSuite.scala
@@ -316,7 +316,8 @@ class FormattingLspSuite extends BaseLspSuite("formatting") {
       _ = {
         assertNoDiff(
           client.workspaceMessageRequests,
-          MissingScalafmtVersion.messageRequestMessage,
+          s"""|${MissingScalafmtVersion.messageRequestMessage}
+              |Loading Scalafmt""".stripMargin,
         )
         assertNoDiff(
           client.workspaceShowMessages,

--- a/tests/unit/src/test/scala/tests/debug/DebugProtocolCancelationSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/DebugProtocolCancelationSuite.scala
@@ -1,5 +1,7 @@
 package tests.debug
 
+import java.util.concurrent.CancellationException
+
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.clients.language.MetalsSlowTaskResult
 
@@ -8,7 +10,6 @@ import ch.epfl.scala.bsp4j.ScalaMainClass
 import tests.BaseDapSuite
 import tests.QuickBuildInitializer
 import tests.QuickBuildLayout
-import java.util.concurrent.CancellationException
 
 // note(@tgodzik) all test have `System.exit(0)` added to avoid occasional issue due to:
 // https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment

--- a/tests/unit/src/test/scala/tests/debug/DebugProtocolCancelationSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/DebugProtocolCancelationSuite.scala
@@ -1,0 +1,66 @@
+package tests.debug
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.clients.language.MetalsSlowTaskResult
+
+import ch.epfl.scala.bsp4j.DebugSessionParamsDataKind
+import ch.epfl.scala.bsp4j.ScalaMainClass
+import tests.BaseDapSuite
+import tests.QuickBuildInitializer
+import tests.QuickBuildLayout
+import java.util.concurrent.CancellationException
+
+// note(@tgodzik) all test have `System.exit(0)` added to avoid occasional issue due to:
+// https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment
+class DebugProtocolCancelationSuite
+    extends BaseDapSuite(
+      "debug-protocol",
+      QuickBuildInitializer,
+      QuickBuildLayout,
+    ) {
+
+  test("start") {
+    client.slowTaskHandler = { _ =>
+      Some(MetalsSlowTaskResult(cancel = true))
+    }
+    val mainClass = new ScalaMainClass(
+      "a.Main",
+      List("Bar").asJava,
+      List("-Dproperty=Foo").asJava,
+    )
+    mainClass.setEnvironmentVariables(List("HELLO=Foo").asJava)
+    for {
+      _ <- initialize(
+        s"""/metals.json
+           |{
+           |  "a": {}
+           |}
+           |/a/src/main/scala/a/Main.scala
+           |package a
+           |object Main {
+           |  def main(args: Array[String]) = {
+           |    val foo = sys.props.getOrElse("property", "")
+           |    val bar = args(0)
+           |    val env = sys.env.get("HELLO")
+           |    print(foo + bar)
+           |    env.foreach(print)
+           |    System.exit(0)
+           |  }
+           |}
+           |""".stripMargin
+      )
+      expectedMsg = "The task has been cancelled"
+      debuggerMsg <- server
+        .startDebugging(
+          "a",
+          DebugSessionParamsDataKind.SCALA_MAIN_CLASS,
+          mainClass,
+        )
+        .map(_ => "Debugger has been started")
+        .recover { case _: CancellationException =>
+          expectedMsg
+        }
+    } yield assertNoDiff(debuggerMsg, expectedMsg)
+  }
+
+}


### PR DESCRIPTION
Previously, users would need to wait until the session times out, which would mean that it might be too long for some users and too little for some other. Now, we offer to cancel the session within a slow task.

This gives the control to the user instead of arbitrary timeout.

Fixes https://github.com/scalameta/metals/issues/4864