### PR TITLE
improvement: Cancel all in BspSession

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspSession.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspSession.scala
@@ -34,7 +34,9 @@ case class BspSession(
   def cancel(): Unit = connections.foreach(_.cancel())
 
   def shutdown(): Future[Unit] =
-    Future.sequence(connections.map(_.shutdown())).map(_ => ())
+    Future
+      .sequence(connections.map(_.shutdown()))
+      .map(_ => ())
 
   def mainConnection: BuildServerConnection = main
 

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -110,7 +110,8 @@ class BuildServerConnection private (
   /**
    * Run build/shutdown procedure
    */
-  def shutdown(): Future[Unit] =
+  def shutdown(): Future[Unit] = {
+    cancel()
     connection.map { conn =>
       try {
         if (isShuttingDown.compareAndSet(false, true)) {
@@ -133,6 +134,7 @@ class BuildServerConnection private (
           )
       }
     }
+  }
 
   def compile(params: CompileParams): CompletableFuture[CompileResult] = {
     register(

--- a/metals/src/main/scala/scala/meta/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/metals/MetalsLanguageServer.scala
@@ -15,7 +15,6 @@ import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsLspService
 import scala.meta.internal.metals.MetalsServerInputs
-import scala.meta.internal.metals.MutableCancelable
 import scala.meta.internal.metals.ThreadPools
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.clients.language.NoopLanguageClient
@@ -58,7 +57,6 @@ class MetalsLanguageServer(
   private val languageClient =
     new AtomicReference[MetalsLanguageClient](NoopLanguageClient)
 
-  private val cancelables = new MutableCancelable()
   private val isCancelled = new AtomicBoolean(false)
   private val isLanguageClientConnected = new AtomicBoolean(false)
 
@@ -87,7 +85,6 @@ class MetalsLanguageServer(
    */
   def cancel(): Unit = {
     if (isCancelled.compareAndSet(false, true)) {
-      cancelables.cancel()
       serverState.get match {
         case ServerState.Initialized(service) => service.cancel()
         case ShuttingDown(service) => service.cancel()


### PR DESCRIPTION
Previously, we would only invoke shutdown on the build server session and that would not stop the ongoing requests. Now, we also cancel all the request.

I saw a couple of situations where Metals server would stay up unable to shutdown. Not sure if this was the reason, but it should not cause any issues.