### PR TITLE
Revert scalafmt update

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,6 +7,3 @@
 
 # Scala Steward: Reformat with scalafmt 3.5.9
 9b5fdfa91ba454f6311a50a9db8a773bb74c2c20
-
-# Scala Steward: Reformat with scalafmt 3.7.0
-938f56f84bdf239dde88aa27b9cb889012e1b708

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.7.0"
+version = "3.6.1"
 runner.dialect = scala213
 project.git = true
 align.preset = none

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ConvertToNamedArgumentsProvider.scala
@@ -59,10 +59,11 @@ final class ConvertToNamedArgumentsProvider(
         args.zipWithIndex
           .zip(paramss(fun))
           .collect {
-            case ((arg, index), param) if argIndices.contains(index) =>
+            case ((arg, index), param) if argIndices.contains(index) => {
               val position = arg.sourcePos.toLsp
               position.setEnd(position.getStart())
               new l.TextEdit(position, s"$param = ")
+            }
           }
 
       tree match

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
@@ -339,7 +339,7 @@ abstract class PcCollector[T](driver: InteractiveDriver, params: OffsetParams):
                   case sel if soughtNames(sel.name) =>
                     // Show both rename and main together
                     val spans =
-                      if !sel.renamed.isEmpty then
+                      if (!sel.renamed.isEmpty) then
                         Set(sel.renamed.span, sel.imported.span)
                       else Set(sel.imported.span)
                     spans.map { span =>

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
@@ -132,7 +132,7 @@ object SemanticdbSymbols:
         b.append('('); addName(sym.name); b.append(')')
       else if sym.isRoot then b.append(Symbols.RootPackage)
       else if sym.isEmptyPackage then b.append(Symbols.EmptyPackage)
-      else if sym.isScala2PackageObject then
+      else if (sym.isScala2PackageObject) then
         b.append(Symbols.PackageObjectDescriptor)
       else
         addName(sym.name)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -147,7 +147,7 @@ class Completions(
             var i = span.end
             while i < (text.length() - 1) && text(i).isWhitespace do i = i + 1
 
-            if i < text.length() then text(i) == '['
+            if (i < text.length()) then text(i) == '['
             else false
           else false
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -155,7 +155,7 @@ object CaseKeywordCompletion:
       indexedContext.scopeSymbols
         .foreach(s =>
           val ts = s.info.dealias.typeSymbol
-          if isValid(ts) then visit(autoImportsGen.inferSymbolImport(ts))
+          if (isValid(ts)) then visit(autoImportsGen.inferSymbolImport(ts))
         )
       // Step 2: walk through known subclasses of sealed types.
       val sealedDescs = MetalsSealedDesc.sealedStrictDescendants(selectorSym)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/NamedArgCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/NamedArgCompletions.scala
@@ -157,8 +157,9 @@ object NamedArgCompletions:
       then
         val editText = allParams.zipWithIndex
           .collect {
-            case (param, index) if !param.is(Flags.HasDefault) =>
+            case (param, index) if !param.is(Flags.HasDefault) => {
               s"${param.nameBackticked.replace("$", "$$")} = $${${index + 1}${findDefaultValue(param)}}"
+            }
           }
           .mkString(", ")
         List(

--- a/project/V.scala
+++ b/project/V.scala
@@ -36,7 +36,7 @@ object V {
   val sbtJdiTools = "1.1.1"
   val scalaCli = "0.1.19"
   val scalafix = "0.10.4"
-  val scalafmt = "3.7.0"
+  val scalafmt = "3.6.1"
   val scalameta = "4.7.1"
   val scribe = "3.10.6"
   val semanticdb = scalameta


### PR DESCRIPTION
It looks like the most recent scalafmt got released on JDK 11 which makes the tests for Scalafmt hang indefinetely.

