### PR TITLE
chore: Choose object when using symbol search as fallback

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -10,6 +10,7 @@ import scala.meta.internal.mtags.GlobalSymbolIndex
 import scala.meta.internal.pc.InterruptException
 import scala.meta.internal.semanticdb.SymbolInformation.Kind
 import scala.meta.io.AbsolutePath
+import scala.meta.pc.CancelToken
 import scala.meta.pc.SymbolSearch
 import scala.meta.pc.SymbolSearchVisitor
 
@@ -51,6 +52,25 @@ final class WorkspaceSymbolProvider(
       case InterruptException() =>
         Nil
     }
+  }
+
+  def searchExactFrom(
+      queryString: String,
+      path: AbsolutePath,
+      token: CancelToken,
+  ): Seq[l.SymbolInformation] = {
+    val query = WorkspaceSymbolQuery.exact(queryString)
+    val visistor =
+      new WorkspaceSearchVisitor(
+        workspace,
+        query,
+        token,
+        index,
+        saveClassFileToDisk,
+      )
+    val targetId = buildTargets.inverseSources(path)
+    search(query, visistor, targetId)
+    visistor.allResults().filter(_.getName() == queryString)
   }
 
   def search(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -238,7 +238,7 @@ case class ScalaPresentationCompiler(
       params: OffsetParams
   ): CompletableFuture[jm.Either[String, ju.List[l.TextEdit]]] =
     val empty: jm.Either[String, ju.List[l.TextEdit]] =
-      jm.Either.forRight(ju.List.of())
+      jm.Either.forRight(ju.Collections.emptyList())
     compilerAccess.withInterruptableCompiler(empty, params.token) { pc =>
       new InlineValueProvider(
         new PcValReferenceProviderImpl(pc.compiler(), params)


### PR DESCRIPTION
Previously, we would suggest both object and class even if it clearly could not be a class. Now, we add some heuristics to minimize false positives.