### PR TITLE
fix: show references for renamed import

### DIFF
--- a/tests/mtest/src/main/scala/tests/RangeReplace.scala
+++ b/tests/mtest/src/main/scala/tests/RangeReplace.scala
@@ -12,9 +12,17 @@ trait RangeReplace {
       code: String,
       highlights: List[DocumentHighlight],
   ): String = {
-    highlights.foldLeft(code) { (base, highlight) =>
-      replaceInRange(base, highlight.getRange)
-    }
+    highlights
+      .foldLeft((code, List.empty[(Int, Int)])) {
+        case ((base, alreadyAddedMarkings), location) =>
+          replaceInRangeWithAdjustmens(
+            code,
+            base,
+            location.getRange,
+            alreadyAddedMarkings,
+          )
+      }
+      ._1
   }
 
   protected def replaceInRange(
@@ -22,20 +30,43 @@ trait RangeReplace {
       range: Range,
       prefix: String = "<<",
       suffix: String = ">>",
-  ): String = {
-    val input = Input.String(base)
+  ): String =
+    replaceInRangeWithAdjustmens(base, base, range, List(), prefix, suffix)._1
+
+  protected def replaceInRangeWithAdjustmens(
+      code: String,
+      currentBase: String,
+      range: Range,
+      alreadyAddedMarkings: List[(Int, Int)],
+      prefix: String = "<<",
+      suffix: String = ">>",
+  ): (String, List[(Int, Int)]) = {
+    val input = Input.String(code)
     val pos = range
       .toMeta(input)
       .getOrElse(
         throw new RuntimeException(s"$range was not contained in file")
       )
-    new java.lang.StringBuilder()
-      .append(base, 0, pos.start)
-      .append(prefix)
-      .append(base, pos.start, pos.end)
-      .append(suffix)
-      .append(base, pos.end, base.length)
-      .toString
+    def adjustPosition(pos: Int) =
+      alreadyAddedMarkings
+        .filter { case (i, _) => i <= pos }
+        .map(_._2)
+        .fold(0)(_ + _) + pos
+    val posStart = adjustPosition(pos.start)
+    val posEnd = adjustPosition(pos.end)
+    (
+      new java.lang.StringBuilder()
+        .append(currentBase, 0, posStart)
+        .append(prefix)
+        .append(currentBase, posStart, posEnd)
+        .append(suffix)
+        .append(currentBase, posEnd, currentBase.length)
+        .toString,
+      (pos.start, prefix.length) :: (
+        pos.end,
+        suffix.length,
+      ) :: alreadyAddedMarkings,
+    )
   }
 
 }

--- a/tests/slow/src/test/scala/tests/feature/CrossReferenceSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CrossReferenceSuite.scala
@@ -40,6 +40,36 @@ class CrossReferenceSuite extends BaseRangesSuite("cross-reference-suite") {
     scalaVersion = Some(V.scala3),
   )
 
+  check(
+    "import-rename",
+    """|/Main.scala
+       |package a
+       |
+       |import a.sample.{<<X1>> as X2}
+       |
+       |object sample:
+       |  class <<X@@1>>
+       |
+       |def f: <<X2>> = new <<X2>>
+       |""".stripMargin,
+    scalaVersion = Some(V.scala3),
+  )
+
+  check(
+    "import-rename2",
+    """|/Main.scala
+       |package a
+       |
+       |import sample.{<<X1>> as X@@2}
+       |
+       |object sample:
+       |  class <<X1>>
+       |
+       |def f: <<X2>> = ???
+       |""".stripMargin,
+    scalaVersion = Some(V.scala3),
+  )
+
   override def assertCheck(
       filename: String,
       edit: String,

--- a/tests/unit/src/main/scala/tests/TestRanges.scala
+++ b/tests/unit/src/main/scala/tests/TestRanges.scala
@@ -17,9 +17,17 @@ object TestRanges extends RangeReplace {
     val resolved = for {
       (file, code) <- sourceFiles.toSeq
       validLocations = locations.filter(_.getUri().contains(file))
-    } yield file -> validLocations.foldLeft(code) { (base, location) =>
-      replaceInRange(base, location.getRange)
-    }
+    } yield file -> validLocations
+      .foldLeft((code, List.empty[(Int, Int)])) {
+        case ((base, alreadyAddedMarkings), location) =>
+          replaceInRangeWithAdjustmens(
+            code,
+            base,
+            location.getRange,
+            alreadyAddedMarkings,
+          )
+      }
+      ._1
     resolved.toMap
   }
 


### PR DESCRIPTION
Previously:
for `import p.{A as B}` for B would not show any references.
Now: finds all the references same as for A.

The PR contains also a fix for adding ranges markings in tests. Previously it would apply the second range marking in the same line without the necessary adjustment (shift).

resolves https://github.com/scalameta/metals/issues/4562