### PR TITLE
fix: ensure a new `.metals/` dir isn't create when/where undesired

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Trace.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Trace.scala
@@ -29,8 +29,17 @@ object Trace {
       AbsolutePath(projectDirectories.cacheDir)
     }.toOption
 
-  val localDirectory: AbsolutePath = PathIO.workingDirectory.resolve(".metals/")
-  val metalsLog: AbsolutePath = localDirectory.resolve("metals.log")
+  private val localDirectory: AbsolutePath =
+    PathIO.workingDirectory.resolve(".metals/")
+
+  // We default to the global cache here mainly because it's not safe to assume
+  // that PathIO.workingDirectory is actually what we want to fallback to.
+  // In editors like VS Code that have a "workspace" concept this will
+  // normally be fine, but in others like nvim where "workspace" doesn't really
+  // exist, we can only rely on the rootUri that is passed in, but we don't have
+  // access to that yet when we use this.
+  val metalsLog: AbsolutePath =
+    globalDirectory.getOrElse(localDirectory).resolve("metals.log")
 
   def protocolTracePath(
       protocolName: String,
@@ -42,7 +51,8 @@ object Trace {
 
   /**
    * Setups trace printer for a given protocol name and workspace.
-   * Searches for trace file in provided workspace. If there is no such file in the workspace, fall backs to the global directory.
+   * Searches for trace file in provided workspace. If there is no such file in
+   * the workspace, fall backs to the global directory.
    */
   def setupTracePrinter(
       protocolName: String,


### PR DESCRIPTION
So this was a total oversight of mine that has sort of existing for quite some time since it looks like it was changed in https://github.com/scalameta/metals/commit/1559f52e0f78e027519272414a8dde05ac355ac4. I've randomly had people in nvim-metals mention that they sometimes get `.metals/` dirs created where they didn't expect, but never had a good reproduction to really dig into. However today when trying to reproduce https://github.com/scalameta/nvim-metals/issues/530 I realized that this was happening.

# The Issue

The issue is that in editors like VS Code you almost always have a "workspace" since you open a "workspace". In editors like nvim, this concept is artificial and we instead have to rely on the client sending in the correct `rootUri`. Relying on the `cwd` is unsafe since if you have a workspce like:

```
.
├── build.sc
├── minimal
│  ├── src
│  │  └── Main.scala
```

Opening `nvim Main.scala` is totally valid and will still correctly send in the root where the `build.sc` is found. However, currently with the fallback logic to `PathIO.workingDirectory` this creates another `.metals/` inside of `src` which isn't desired.

# The Solution

The solution isn't perfect since in reality the if you open `nvim Main.scala` then the `lsp.trace.json` file that _could_ be inside of `PathIO.workingDirectory` can't really be used so you'll have to use the global one. Either way, this fix ensures that the very initial logging that happens, mainly:

```
2023.01.24 19:33:44 INFO  tracing is enabled: /Users/ckipp/Library/Caches/org.scalameta.metals/lsp.trace.json
2023.01.24 19:33:45 INFO  logging to file /Users/ckipp/Documents/scala-workspace/minimal/.metals/metals.log
```

Happens in the global `metals.log` dir _before_ it starts going into the actual `metals.log` at the root of the workspace. Again this really only affects the first couple messages and mainly fixes the `metals.log` use-case. The `lsp.trace.json` one I'm unsure about since at the point where we create that file we don't actually have `workspace` yet, meaning in nvim we can't safely assume where that file should be.

refs: https://github.com/scalameta/nvim-metals/issues/530