### PR TITLE
fix(ci): don't run scripted tests twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             name: Gradle MacOS integration
             os: macOS-latest
           - type: sbt
-            command: bin/test.sh 'sbt-metals/scripted; slow/testOnly -- tests.sbt.*'
+            command: bin/test.sh 'slow/testOnly -- tests.sbt.*'
             name: Sbt integration
             os: ubuntu-latest
           - type: sbt-metals jdk8


### PR DESCRIPTION
It looks like we're currently running out scripted tests twice when we
don't need to. We're running it in the sbt integration job and also in
the sbt-metals/scripted job. This remotes the scripted stuff from the
sbt integration job and just relies on it running in the scripted one.
