### PR TITLE
bugfix: Fix issues with jars containing + on windows

### DIFF
--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1353,6 +1353,19 @@ final case class TestingServer(
     }
   }
 
+  def definition(
+      filename: String,
+      query: String,
+      root: AbsolutePath,
+  ): Future[List[Location]] = {
+    for {
+      (text, params) <- offsetParams(filename, query, root)
+      definition <- server.definition(params).asScala
+    } yield {
+      definition.asScala.toList
+    }
+  }
+
   def highlight(
       filename: String,
       query: String,

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -1,5 +1,7 @@
 package tests
 
+import scala.concurrent.Future
+
 import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.StatisticsConfig
@@ -507,5 +509,66 @@ class DefinitionLspSuite extends BaseLspSuite("definition") {
       )
     } yield ()
   }
+
+  // The tested library is released with JDK 11
+  if (!isJava8)
+    test("jar-with-plus", withoutVirtualDocs = true) {
+      import scala.meta.internal.metals.MetalsEnrichments._
+      val testCase =
+        """|package a
+           |
+           |import com.thoughtworks.dsl.D@@sl
+           |class Main {
+           |  val foo = ""
+           |}""".stripMargin
+      val fileContents = testCase.replace("@@", "")
+      for {
+        _ <- initialize(
+          s"""
+             |/metals.json
+             |{
+             |  "a": { 
+             |    "libraryDependencies" : ["com.thoughtworks.dsl::dsl:2.0.0-M0+1-b691cde8"] 
+             |  }
+             |}
+             |/a/src/main/scala/example/MainA.scala
+             |$fileContents
+             |""".stripMargin
+        )
+        _ = server.didOpen("a/src/main/scala/example/MainA.scala")
+        _ = assertNoDiff(
+          server.workspaceDefinitions,
+          """|/a/src/main/scala/example/MainA.scala
+             |package a
+             |
+             |import com.thoughtworks.dsl.Dsl/*Dsl.scala*/
+             |class Main/*L3*/ {
+             |  val foo/*L4*/ = ""
+             |}
+             |""".stripMargin,
+        )
+        definition <- server.definition(
+          "a/src/main/scala/example/MainA.scala",
+          testCase,
+          workspace,
+        )
+        _ = assert(definition.nonEmpty, "Definition for Dsl class not found")
+        mainDefUri = definition.head.getUri()
+        contents <-
+          // jar is returned if virtual files are supported
+          if (mainDefUri.startsWith("jar"))
+            server.executeDecodeFileCommand(mainDefUri).map { result =>
+              assert(
+                result.value != null,
+                "No file contents returned for Dsl.scala",
+              )
+              result.value
+
+            }
+          else Future.successful(mainDefUri.toAbsolutePath.readText)
+      } yield {
+        assertContains(contents, "trait Dsl[-Keyword, Domain, +Value]")
+      }
+    }
 
 }


### PR DESCRIPTION
Previously, Metals would fail to read files from jars when they contained +. Now, we added a couple of fallbacks to make sure that works correctly.

Fixes https://github.com/scalameta/metals/issues/4896