### PR TITLE
bugfix: Catch StackOverflowException from the parser

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
@@ -8,6 +8,8 @@ object Directories {
     RelativePath(".metals").resolve("readonly")
   def tmp: RelativePath =
     RelativePath(".metals").resolve(".tmp")
+  def reports: RelativePath =
+    RelativePath(".metals").resolve(".reports")
   def dependencies: RelativePath =
     readonly.resolve(dependenciesName)
   def log: RelativePath =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -287,7 +287,7 @@ class MetalsLspService(
   )
 
   private val timerProvider: TimerProvider = new TimerProvider(time)
-  private val trees = new Trees(buffers, scalaVersionSelector)
+  private val trees = new Trees(buffers, scalaVersionSelector, workspace)
 
   private val documentSymbolProvider = new DocumentSymbolProvider(
     trees,

--- a/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
@@ -120,7 +120,7 @@ final class Trees(
   private def parse(
       path: AbsolutePath,
       dialect: Dialect,
-  ): Option[Parsed[Tree]] = {
+  ): Option[Parsed[Tree]] = try {
     for {
       text <- buffers.get(path).orElse(path.readTextOpt)
     } yield {
@@ -132,6 +132,11 @@ final class Trees(
         dialect(input).parse[Source]
       }
     }
+  } catch {
+    // if the parsers breaks we should not throw the exception further
+    case _: StackOverflowError =>
+      scribe.debug("Could not parse:\n" + path.readTextOpt.getOrElse(""))
+      None
   }
 }
 

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -168,6 +168,7 @@ final case class TestingServer(
       () => initialUserConfig,
       server.buildTargets,
     ),
+    workspace,
   )
 
   private val virtualDocSources = TrieMap.empty[String, AbsolutePath]

--- a/tests/unit/src/main/scala/tests/TreeUtils.scala
+++ b/tests/unit/src/main/scala/tests/TreeUtils.scala
@@ -1,10 +1,13 @@
 package tests
 
+import java.nio.file.Paths
+
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.ScalaVersionSelector
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.parsing.Trees
+import scala.meta.io.AbsolutePath
 
 object TreeUtils {
   def getTrees(scalaVersion: String): (Buffers, Trees) = getTrees(
@@ -18,7 +21,7 @@ object TreeUtils {
         () => UserConfiguration(fallbackScalaVersion = scalaVersion),
         buildTargets,
       )
-    val trees = new Trees(buffers, selector)
+    val trees = new Trees(buffers, selector, AbsolutePath(Paths.get(".")))
     (buffers, trees)
   }
 }


### PR DESCRIPTION
Previously, the exception could break anthing trying to use Trees and since it's an error in the parser we shouldn't break metals. Now, we catch the exception instead and print the code it failed on.

Related to https://github.com/scalameta/metals/issues/4837