### PR TITLE
bugfix: Always check if position is defined

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticTokenProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticTokenProvider.scala
@@ -294,7 +294,7 @@ final class SemanticTokenProvider(
          * statements such as:
          * val Some(<<a>>) = Some(2)
          */
-        case bnd: cp.Bind =>
+        case bnd: cp.Bind if bnd.pos.isRange =>
           bnd.children.foldLeft(nodes + NodeInfo(bnd, bnd.pos))(traverse(_, _))
 
         /* all definitions:
@@ -314,7 +314,7 @@ final class SemanticTokenProvider(
          * User(<<name>> = "abc")
          * etc.
          */
-        case appl: cp.Apply =>
+        case appl: cp.Apply if appl.pos.isRange =>
           val named = appl.args
             .flatMap { arg =>
               namedArgCache.get(arg.pos.start)
@@ -338,7 +338,7 @@ final class SemanticTokenProvider(
          * Some type trees don't have symbols attached such as:
          * type A = List[_ <: <<Iterable>>[Int]]
          */
-        case id: cp.Ident if id.symbol == cp.NoSymbol =>
+        case id: cp.Ident if id.symbol == cp.NoSymbol && id.pos.isRange =>
           fallbackSymbol(id.name, id.pos) match {
             case Some(_) => nodes + NodeInfo(id, id.pos)
             case _ => nodes


### PR DESCRIPTION
Previously, we could get an exception:

```
java.lang.UnsupportedOperationException: Position.start on NoPosition
	at scala.reflect.internal.util.Position.fail(Position.scala:24)
	at scala.reflect.internal.util.UndefinedPosition.start(Position.scala:101)
	at scala.reflect.internal.util.UndefinedPosition.start(Position.scala:97)
	at scala.meta.internal.pc.SemanticTokenProvider.$anonfun$ord$1(SemanticTokenProvider.scala:41)
	at scala.meta.internal.pc.SemanticTokenProvider.$anonfun$ord$1$adapted(SemanticTokenProvider.scala:40)
	at scala.math.Ordering$$anon$4.compare(Ordering.scala:316)
	at scala.collection.immutable.RedBlackTree$.upd(RedBlackTree.scala:415)
	at scala.collection.immutable.RedBlackTree$.update(RedBlackTree.scala:175)
	at scala.collection.immutable.TreeSet.incl(TreeSet.scala:163)
	at scala.collection.immutable.TreeSet.incl(TreeSet.scala:39)
	at scala.collection.immutable.SetOps.$plus(Set.scala:46)
	at scala.collection.immutable.SetOps.$plus$(Set.scala:46)
	at scala.collection.immutable.AbstractSet.$plus(Set.scala:348)
```

Now, this should not happen since we always check if pos is defined.