### PR TITLE
bugfix: Fix `select.nameSpan` for expressions in parentheses

### DIFF
--- a/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
@@ -699,4 +699,17 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite {
        |}""".stripMargin,
   )
 
+  check(
+    "select-parentheses",
+    """|object Main {
+       |  val a = (1 + 2 + 3).<<toStr@@ing>>
+       |}""".stripMargin,
+  )
+
+  check(
+    "select-parentheses2".tag(IgnoreScala2),
+    """|object Main {
+       |  val a = (1 + 2 + 3) <<:@@:>> Nil
+       |}""".stripMargin,
+  )
 }


### PR DESCRIPTION
For expressions like (1 + 2).toString, span was incorrect, because they were treated as right associative infix operators.