### PR TITLE
bugfix: Fix issues with go to definition in derived clauses

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -514,4 +514,21 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |}
        |""".stripMargin,
   )
+
+  check(
+    "derives-def".tag(IgnoreScala2),
+    """|
+       |import scala.deriving.Mirror
+       |
+       |trait <<Show>>[A]:
+       |  def show(a: A): String
+       |
+       |object Show:
+       |  inline def derived[T](using Mirror.Of[T]): Show[T] = new Show[T]:
+       |    override def show(a: T): String = a.toString
+       |
+       |case class Box[A](value: A) derives Sh@@ow
+       |
+       |""".stripMargin,
+  )
 }


### PR DESCRIPTION
Previously, when some nodes were absent from the typed tree we wouldn't be able to find the definition. Now, we try to find them in the untyped tree, which sometimes might have symbols already present, since the full typer phase was already done.

Fixes https://github.com/scalameta/metals/issues/4903