### PR TITLE
bugfix: case pattern completions for bind

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -577,9 +577,9 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
     object CasePatternExtractor {
       def unapply(path: List[Tree]): Option[(Tree, Tree, String)] =
         path match {
-          // case @@ =>
-          case Bind(_, _) :: CaseDefMatch(selector, parent) =>
-            Some((selector, parent, ""))
+          // case abc@@ =>
+          case Bind(name, _) :: CaseDefMatch(selector, parent) =>
+            Some((selector, parent, name.decoded))
           // case Som@@ =>
           case Ident(
                 name

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -581,8 +581,11 @@ class MatchCaseExtractor(
         // case abc @ Som@@
         case Ident(name) :: Bind(_, _) :: CaseExtractor(selector, parent, _) =>
           Some((selector, parent, name.decoded))
+        // case abc@@
+        case Bind(name, Ident(_)) :: CaseExtractor(selector, parent, _) =>
+          Some((selector, parent, name.decoded))
         // case abc @ @@
-        case Bind(_, _) :: CaseExtractor(selector, parent, _) =>
+        case Bind(name, Literal(_)) :: CaseExtractor(selector, parent, _) =>
           Some((selector, parent, ""))
         case _ => None
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -405,11 +405,10 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |  }
       |}
     """.stripMargin,
-    """|head :: next scala.collection.immutable
-       |Nil scala.collection.immutable""".stripMargin,
+    "",
     compat = Map(
-      "2.12" ->
-        """|head :: tl scala.collection.immutable
+      "3" ->
+        """|head :: next scala.collection.immutable
            |Nil scala.collection.immutable
            |""".stripMargin
     ),

--- a/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
@@ -56,6 +56,17 @@ class CompletionPatternSuite extends BaseCompletionSuite {
     """
       |object A {
       |  Option(1) match {
+      |    case ma@@
+      |  }
+      |}""".stripMargin,
+    "",
+  )
+
+  check(
+    "bind2",
+    """
+      |object A {
+      |  Option(1) match {
       |    case abc @ @@ =>
       |  }
       |}""".stripMargin,
@@ -64,6 +75,7 @@ class CompletionPatternSuite extends BaseCompletionSuite {
        |""".stripMargin,
     topLines = Some(2),
   )
+
   check(
     "bind-ident",
     """


### PR DESCRIPTION
Previously:
```
case abc@@
```
created an empty pattern.
Now: it creates the desired pattern "abc".

Note: this is broken for keywords in Scala 3 (https://github.com/scalameta/metals/issues/4367).