### PR TITLE
bugfix: navigation for apply function in a companion object

### DIFF
--- a/tests/unit/src/test/scala/tests/ScalaToplevelLibrarySuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaToplevelLibrarySuite.scala
@@ -62,8 +62,8 @@ class ScalaToplevelLibrarySuite extends BaseSuite {
       input: Input.VirtualFile,
   ): Unit = {
     assertNoDiff(
-      obtained.mkString("\n"),
-      expected.mkString("\n"),
+      obtained.sorted.mkString("\n"),
+      expected.sorted.mkString("\n"),
       s"${input.path}",
     )
   }


### PR DESCRIPTION
Previously: ScalaMtags indexer would not take notice of the automatically created apply function that is produced in a companion object for a case class. This lead to the disambiguator counter to be off by one and goto pointing to the wrong reference.
Now: we make sure that classes are indexed before objects and record found case class to fix the disambiguator counter for apply.

resolves https://github.com/scalameta/metals/issues/4769