### PR TITLE
improvement: Add the possibility to only support running the code

### DIFF
--- a/docs/integrations/debug-adapter-protocol.md
+++ b/docs/integrations/debug-adapter-protocol.md
@@ -1,20 +1,23 @@
 ---
 id: debug-adapter-protocol
-sidebar_label: Debug Adapter Protocol
-title: Debug Adapter Protocol
+sidebar_label: Running and debugging
+title: Running and debugging
 ---
 
 Metals implements the Debug Adapter Protocol, which can be used by the editor to
-communicate with JVM to run and debug code.
+communicate with JVM to run and debug code. Alternatively, Metals is also able
+to provide editors with all the information needed to run the code (this is
+currently supported in run code lenses for main classes).
 
-## How to add support for debugging in my editor?
+## How to add support for debugging or running in my editor?
 
 There are two main ways to add support for debugging depending on the
 capabilities exposed by the client.
 
 ### Via code lenses
 
-The editor needs to handle two commands in its language client extension:
+If you want to use DAP the editor needs to handle two commands in its language
+client extension:
 [`metals-run-session-start`](https://github.com/scalameta/metals/blob/main/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala)
 and
 [`metals-debug-session-start`](https://github.com/scalameta/metals/blob/main/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala).
@@ -26,6 +29,17 @@ starting the run/debug session is as follows:
 Then we can request the debug adapter URI from the metals server using the
 [`debug-adapter-start`](https://github.com/scalameta/metals/blob/master/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala)
 command.
+
+Starting a Debug Adapter Protocol session might take some time, since it needs
+to set up all the neccesary utilities for debugging. Metals also provides a
+`shellCommand` field, which will be present in the command attached to the run
+main methods code lenses. This field can be used to simply run the process quickly
+without the debugging capabilities.
+
+If you can't or won't support DAP, you can use the `runProvider` instead of
+`debugProvider `option in the initialization options sent from the editor to the
+Metals server. This will make sure that only the `run` code lense show up with
+the needed `shellCommand` field.
 
 ### Via explicit main or test commands
 
@@ -121,6 +135,7 @@ and how it is
 ## Supported Testing Frameworks
 
 ```scala mdoc:test-frameworks
+
 ```
 
 ## Debugging the connection

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -132,6 +132,9 @@ final class ClientConfiguration(
       false,
     )
 
+  def isRunProvider(): Boolean =
+    initializationOptions.runProvider.getOrElse(false)
+
   def isDecorationProvider(): Boolean =
     extract(
       initializationOptions.decorationProvider,

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -53,6 +53,7 @@ import org.eclipse.{lsp4j => l}
 final case class InitializationOptions(
     compilerOptions: CompilerInitializationOptions,
     debuggingProvider: Option[Boolean],
+    runProvider: Option[Boolean],
     decorationProvider: Option[Boolean],
     inlineDecorationProvider: Option[Boolean],
     didFocusProvider: Option[Boolean],
@@ -113,6 +114,7 @@ object InitializationOptions {
     None,
     None,
     None,
+    None,
   )
 
   def from(
@@ -138,6 +140,7 @@ object InitializationOptions {
     InitializationOptions(
       compilerOptions = extractCompilerOptions(jsonObj),
       debuggingProvider = jsonObj.getBooleanOption("debuggingProvider"),
+      runProvider = jsonObj.getBooleanOption("runProvider"),
       decorationProvider = jsonObj.getBooleanOption("decorationProvider"),
       inlineDecorationProvider =
         jsonObj.getBooleanOption("inlineDecorationProvider"),

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
@@ -88,7 +88,8 @@ final class ConfiguredLanguageClient(
     if (clientConfig.codeLenseRefreshSupport)
       underlying.refreshCodeLenses.thenApply(_ => ())
     else if (
-      clientConfig.isExecuteClientCommandProvider && clientConfig.isDebuggingProvider
+      clientConfig.isExecuteClientCommandProvider &&
+      (clientConfig.isDebuggingProvider || clientConfig.isRunProvider())
     ) {
       val params = ClientCommands.RefreshModel.toExecuteCommandParams()
       CompletableFuture.completedFuture(metalsExecuteClientCommand(params))

--- a/tests/unit/src/main/scala/tests/BaseWorkspaceSymbolSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorkspaceSymbolSuite.scala
@@ -6,7 +6,6 @@ import scala.meta.internal.metals.WorkspaceSymbolProvider
 import scala.meta.io.AbsolutePath
 
 import munit.Location
-import org.eclipse.lsp4j.SymbolInformation
 import tests.MetalsTestEnrichments._
 
 abstract class BaseWorkspaceSymbolSuite extends BaseSuite {

--- a/tests/unit/src/test/scala/tests/RunProviderLensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RunProviderLensLspSuite.scala
@@ -1,0 +1,22 @@
+package tests
+
+import scala.meta.internal.metals.InitializationOptions
+
+class RunProviderLensLspSuite extends BaseCodeLensLspSuite("runCodeLenses") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(
+      TestingServer.TestDefault
+        .copy(debuggingProvider = Option(false), runProvider = Option(true))
+    )
+
+  check("main")(
+    """|package foo
+       |<<run>>
+       |object Main {
+       |  def main(args: Array[String]): Unit = {}
+       |}
+       |""".stripMargin
+  )
+
+}


### PR DESCRIPTION
Previously, to run the code clients would need to support DAP, which is quite heavywight and not needed at all times. Now, we add `runProvider` that can be used to indicate that the editor only wants to support `run` lenses. The editor can later use the `shellCommand` field to run the code. This was suggested a while ago by @ayoub-benali and could possibly be used for sublime (and not only).