### PR TITLE
fix:selection expansion in comments

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SelectionRangeProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SelectionRangeProvider.scala
@@ -5,23 +5,21 @@ import java.{util as ju}
 
 import scala.collection.JavaConverters.*
 
+import scala.meta.inputs.Position
 import scala.meta.internal.mtags.MtagsEnrichments.*
+import scala.meta.internal.pc.SelectionRangeProvider.*
 import scala.meta.pc.OffsetParams
+import scala.meta.tokens.Token
+import scala.meta.tokens.Token.Trivia
 
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.interactive.Interactive
 import dotty.tools.dotc.interactive.InteractiveDriver
-import dotty.tools.dotc.util.SourceFile
-import org.eclipse.lsp4j.SelectionRange
-
-import SelectionRangeProvider.*
 import dotty.tools.dotc.semanticdb.Scala3
-
-import scala.meta.tokens.Token
+import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.util.SourcePosition
-import scala.meta.inputs.Position
-import scala.meta.tokens.Token.Trivia
 import org.eclipse.lsp4j
+import org.eclipse.lsp4j.SelectionRange
 
 /**
  * Provides the functionality necessary for the `textDocument/selectionRange` request.

--- a/tests/cross/src/test/scala/tests/pc/SelectionRangeCommentSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SelectionRangeCommentSuite.scala
@@ -1,0 +1,34 @@
+package tests.pc
+
+class SelectionRangeCommentSuite extends BaseSelectionRangeSuite {
+
+// WIP! tests for selection expansion in comments not ready yet
+
+  check(
+    "match",
+    """|object Main extends App {
+       |  /*com@@ment*/
+       |  val total = for {
+       |    a <- Some(1)
+       |    b <- Some(2)
+       |  } yield a + b
+       |}""".stripMargin,
+    List(
+      """|object Main extends App {
+         |  /*>>region>>comment<<region<<*/
+         |  val total = for {
+         |    a <- Some(1)
+         |    b <- Some(2)
+         |  } yield a + b
+         |}""".stripMargin,
+      """|object Main extends App {
+         |  >>region>>/*comment*/<<region<<
+         |  val total = for {
+         |    a <- Some(1)
+         |    b <- Some(2)
+         |  } yield a + b
+         |}""".stripMargin,
+    ),
+  )
+
+}

--- a/tests/cross/src/test/scala/tests/pc/SelectionRangeCommentSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SelectionRangeCommentSuite.scala
@@ -1,8 +1,10 @@
 package tests.pc
 
 class SelectionRangeCommentSuite extends BaseSelectionRangeSuite {
-  
-  override def ignoreScalaVersion: Option[IgnoreScalaVersion] = Some(IgnoreScala2)
+
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] = Some(
+    IgnoreScala2
+  )
 
   check(
     "match",

--- a/tests/cross/src/test/scala/tests/pc/SelectionRangeCommentSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SelectionRangeCommentSuite.scala
@@ -1,8 +1,8 @@
 package tests.pc
 
 class SelectionRangeCommentSuite extends BaseSelectionRangeSuite {
-
-// WIP! tests for selection expansion in comments not ready yet
+  
+  override def ignoreScalaVersion: Option[IgnoreScalaVersion] = Some(IgnoreScala2)
 
   check(
     "match",
@@ -15,19 +15,20 @@ class SelectionRangeCommentSuite extends BaseSelectionRangeSuite {
        |}""".stripMargin,
     List(
       """|object Main extends App {
-         |  /*>>region>>comment<<region<<*/
-         |  val total = for {
-         |    a <- Some(1)
-         |    b <- Some(2)
-         |  } yield a + b
-         |}""".stripMargin,
-      """|object Main extends App {
          |  >>region>>/*comment*/<<region<<
          |  val total = for {
          |    a <- Some(1)
          |    b <- Some(2)
          |  } yield a + b
          |}""".stripMargin,
+      """|object Main extends >>region>>App {
+         |  /*comment*/
+         |  val total = for {
+         |    a <- Some(1)
+         |    b <- Some(2)
+         |  } yield a + b<<region<<
+         |}
+         |""".stripMargin,
     ),
   )
 


### PR DESCRIPTION
solves https://github.com/scalameta/metals/issues/3615
only works with pure scala 3 project,doesn't seem to work with worksheet 

There's redundancy in code but I'm not sure how to reduce it :
```scala
  val tkSrc = programStr.parse[Source].toOption.map(_.tokens)
    val tkExpr = programStr.parse[Stat].toOption.map(_.tokens)
    val tkType = programStr.parse[Type].toOption.map(_.tokens)

    val tokens = tkSrc orElse tkExpr orElse tkType
```