### PR TITLE
fix: Remove additional indent for imports in worksheets

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
@@ -13,7 +13,7 @@ object ScalacDiagnostic {
   object NotAMember {
     private val regex = """(?s)value (.+) is not a member of.*""".r
     def unapply(d: l.Diagnostic): Option[String] =
-      d.getMessage() match {
+      d.getMessage().trim() match {
         case regex(name) => Some(name)
         case _ => None
       }
@@ -22,7 +22,7 @@ object ScalacDiagnostic {
   object SymbolNotFound {
     private val regex = """(n|N)ot found: (value|type)?\s?(\w+)""".r
     def unapply(d: l.Diagnostic): Option[String] =
-      d.getMessage() match {
+      d.getMessage().trim() match {
         case regex(_, _, name) => Some(name)
         case _ => None
       }
@@ -58,7 +58,7 @@ object ScalacDiagnostic {
     // https://github.com/scala/scala/blob/fd69ef805d4ba217f3495c106f9c698094682ae8/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala#L547
     private val regex = """(?s).*needs to be abstract.*""".r
     def unapply(d: l.Diagnostic): Option[String] =
-      d.getMessage() match {
+      d.getMessage().trim() match {
         case regex() => Some(d.getMessage())
         case _ => None
       }
@@ -67,7 +67,7 @@ object ScalacDiagnostic {
     // https://github.com/scala/scala/blob/4c0f49c7de6ba48f2b0ae59e64ea94fabd82b4a7/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala#L566
     private val regex = """(?s).*object creation impossible.*""".r
     def unapply(d: l.Diagnostic): Option[String] =
-      d.getMessage() match {
+      d.getMessage().trim() match {
         case regex() => Some(d.getMessage())
         case _ => None
       }
@@ -76,7 +76,7 @@ object ScalacDiagnostic {
   object UnusedImport {
     private val regex = """(?i)Unused import""".r
     def unapply(d: l.Diagnostic): Option[String] =
-      d.getMessage() match {
+      d.getMessage().trim() match {
         case regex() => Some(d.getMessage())
         case _ => None
       }
@@ -86,7 +86,7 @@ object ScalacDiagnostic {
     private val regex =
       """Declaration of given instance given_.+ not allowed here.*""".r
     def unapply(d: l.Diagnostic): Option[String] =
-      d.getMessage() match {
+      d.getMessage().trim() match {
         case regex() => Some(d.getMessage())
         case _ => None
       }


### PR DESCRIPTION
Previously, auto imports in worksheets would have unnecessary indent.
```scala
val a = SortedSet@@ 

//completion would result in

  import scala.collection.immutable.SortedSet
val a = SortedSet
```

Solves issue mentioned in https://github.com/scalameta/metals/issues/4793