### PR TITLE
improvement: Add Mima for mtags Java interfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,10 @@ jobs:
             command: ./bin/scalafmt --test
             name: Formatting
             os: ubuntu-latest
+          - type: MiMa
+            command: sbt interfaces/mimaReportBinaryIssues
+            name: MiMa
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/build.sbt
+++ b/build.sbt
@@ -229,6 +229,9 @@ lazy val interfaces = project
   .settings(
     moduleName := "mtags-interfaces",
     autoScalaLibrary := false,
+    mimaPreviousArtifacts := Set(
+      "org.scalameta" % "mtags-interfaces" % "0.11.10"
+    ),
     crossPaths := false,
     libraryDependencies ++= List(
       V.lsp4j

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -120,6 +120,10 @@ Open the PR to the repo https://github.com/scalameta/metals/releases/new.
 - Announce the new release with the link to the release notes:
   - on [Discord](https://discord.com/invite/RFpSVth)
 
+### Update MiMa
+
+- Update `mimaPreviousArtifacts` in interfaces to the new released version
+
 ## Sanity check
 
 - [ ] draft release notes and create with PR with them

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -18,6 +18,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.List;
 import java.util.LinkedList;
@@ -37,11 +38,13 @@ public abstract class PresentationCompiler {
 	// Language Server Protocol APIs.
 	// ==============================
 
-     /**
-     * Returns token informations from presentation compiler.
-     *
-     */
-    public abstract CompletableFuture<List<Integer>> semanticTokens(VirtualFileParams params);
+	/**
+	 * Returns token informations from presentation compiler.
+	 *
+	 */
+	public CompletableFuture<List<Integer>> semanticTokens(VirtualFileParams params) {
+		return CompletableFuture.completedFuture(Collections.emptyList());
+	}
 
 	/**
 	 * Returns code completions for the given source position.
@@ -134,7 +137,11 @@ public abstract class PresentationCompiler {
 	/**
 	 * Return the text edits for inlining a value.
 	 */
-	public abstract CompletableFuture<List<TextEdit>> inlineValue(OffsetParams params);
+	public CompletableFuture<List<TextEdit>> inlineValue(OffsetParams params) {
+		return CompletableFuture.supplyAsync(() -> {
+			throw new DisplayableException("Inline value is not available in this version of Scala");
+		});
+	}
 
 	/**
 	 * Extract method in selected range

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,9 @@ addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.6")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.2.2")
 
+// Mima used for mtags-interfaces
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")
+
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
 resolvers ++= Resolver.sonatypeOssRepos("public")


### PR DESCRIPTION
Previously, we would change the presentation compiler interfaces whenever needed, but because of that we wouldn't be able to for example load an older mtags version or  move parts of Scala 3 mtags to the compiler.

Now, we add Mima and we will require some basic implementation, which enables us to
- whenever we depracate Scala version we can hardcode the last supported mtags
- allow the Scala 3 compiler to use the same interfaces