### PR TITLE
Add message not null checks

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ForwardingMetalsBuildClient.scala
@@ -119,7 +119,9 @@ final class ForwardingMetalsBuildClient(
   def buildTaskStart(params: TaskStartParams): Unit = {
     params.getDataKind match {
       case TaskDataKind.COMPILE_TASK =>
-        if (params.getMessage.startsWith("Compiling")) {
+        if (
+          params.getMessage != null && params.getMessage.startsWith("Compiling")
+        ) {
           scribe.info(params.getMessage.toLowerCase())
         }
         for {
@@ -133,7 +135,10 @@ final class ForwardingMetalsBuildClient(
 
           val name = info.getDisplayName
           val promise = Promise[CompileReport]()
-          val isNoOp = params.getMessage.startsWith("Start no-op compilation")
+          val isNoOp =
+            params.getMessage != null && params.getMessage.startsWith(
+              "Start no-op compilation"
+            )
           val compilation = Compilation(new Timer(time), promise, isNoOp)
           compilations(task.getTarget) = compilation
 


### PR DESCRIPTION
Stumbled across an exception when the `message` in `build/taskStart` notification is `null` and according to [BPS specs](https://build-server-protocol.github.io/docs/specification/#task-started) it may be a valid case.