### PR TITLE
improvement: Allow users to use older Scala support

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -226,11 +226,14 @@ object Embedded {
     }
   }
 
-  private def mtagsDependency(scalaVersion: String): Dependency =
+  private def mtagsDependency(
+      scalaVersion: String,
+      metalsVersion: String,
+  ): Dependency =
     Dependency.of(
       "org.scalameta",
       s"mtags_$scalaVersion",
-      BuildInfo.metalsVersion,
+      metalsVersion,
     )
 
   private def mdocDependency(
@@ -295,8 +298,11 @@ object Embedded {
     )
   }
 
-  def downloadMtags(scalaVersion: String): List[Path] =
-    downloadDependency(mtagsDependency(scalaVersion), Some(scalaVersion))
+  def downloadMtags(scalaVersion: String, metalsVersion: String): List[Path] =
+    downloadDependency(
+      mtagsDependency(scalaVersion, metalsVersion),
+      Some(scalaVersion),
+    )
 
   def downloadMdoc(
       scalaBinaryVersion: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -703,8 +703,8 @@ object Messages {
     ): String = {
       val using = "legacy " + usingString(usingNow)
       val recommended = recommendationString(usingNow)
-      s"You are using $using, which might stop being bugfixed in future versions of Metals. " +
-        s"Please upgrade to $recommended."
+      s"You are using $using, which might no longer be supported by Metals in the future. " +
+        s"To get the best support possible it's recommended to update to at least $recommended."
     }
   }
 
@@ -713,9 +713,10 @@ object Messages {
         usingNow: Set[String]
     ): String = {
       val using = "legacy " + usingString(usingNow)
+      val isAre = if (usingNow.size == 1) "is" else "are"
       val recommended = recommendationString(usingNow)
-      s"You are using $using, which doesn't have the newest Metals features and bugfixes. " +
-        s"Please upgrade to $recommended."
+      s"You are using $using, which $isAre no longer supported by Metals. " +
+        s"To get the best support possible it's recommended to update to at least $recommended."
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -714,7 +714,7 @@ object Messages {
     ): String = {
       val using = "legacy " + usingString(usingNow)
       val recommended = recommendationString(usingNow)
-      s"You are using $using, which doesn't use newest Metals fixes. " +
+      s"You are using $using, which doesn't have the newest Metals features and bugfixes. " +
         s"Please upgrade to $recommended."
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -703,7 +703,18 @@ object Messages {
     ): String = {
       val using = "legacy " + usingString(usingNow)
       val recommended = recommendationString(usingNow)
-      s"You are using $using, which might not be supported in future versions of Metals. " +
+      s"You are using $using, which might stop being bugfixed in future versions of Metals. " +
+        s"Please upgrade to $recommended."
+    }
+  }
+
+  object DeprecatedRemovedScalaVersion {
+    def message(
+        usingNow: Set[String]
+    ): String = {
+      val using = "legacy " + usingString(usingNow)
+      val recommended = recommendationString(usingNow)
+      s"You are using $using, which doesn't use newest Metals fixes. " +
         s"Please upgrade to $recommended."
     }
   }
@@ -756,7 +767,14 @@ object Messages {
 
   object DeprecatedSbtVersion {
     def message: String = {
-      s"You are using an old sbt version, navigation for which might not be supported in the future versions of Metals. " +
+      s"You are using an old sbt version, support for which might stop being bugfixed in the future versions of Metals. " +
+        s"Please upgrade to at least sbt ${BuildInfo.minimumSupportedSbtVersion}."
+    }
+  }
+
+  object DeprecatedRemovedSbtVersion {
+    def message: String = {
+      s"You are using an old sbt version, support for which is no longer being bugfixed. " +
         s"Please upgrade to at least sbt ${BuildInfo.minimumSupportedSbtVersion}."
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
@@ -13,9 +13,27 @@ import coursierapi.error.SimpleResolutionError
 import org.jsoup.Jsoup
 
 trait MtagsResolver {
+
+  /**
+   * Try and resolve mtags module for a given version of Scala.
+   * Can contain a bunch of fallbacks in case of non stable versions.
+   * @return information to use and load the presentation compiler implementation
+   */
   def resolve(scalaVersion: String): Option[MtagsBinaries]
+
+  /**
+   * Check if a given Scala version is supported in Metals.
+   *
+   * @param version Scala version to check
+   */
   def isSupportedScalaVersion(version: String): Boolean =
     resolve(version).isDefined
+
+  /**
+   * Check if this version of Scala is supported in a previous
+   * binary compatible Metals version. Needed for the doctor.
+   * @param version scala version to check
+   */
   def isSupportedInOlderVersion(version: String): Boolean
 }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
@@ -72,7 +72,7 @@ object MtagsResolver {
           )
           if (metalsVersion != BuildInfo.metalsVersion) {
             scribe.warn(
-              s"$scalaVersion is no longer supported in the current Metals versions, using last known supported version $metalsVersion"
+              s"$scalaVersion is no longer supported in the current Metals versions, using the last known supported version $metalsVersion"
             )
           }
           val jars = Embedded.downloadMtags(scalaVersion, metalsVersion)

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/ScalaProblem.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/ScalaProblem.scala
@@ -42,6 +42,12 @@ case class DeprecatedScalaVersion(version: String) extends ScalaProblem {
       s"please upgrade to Scala ${ScalaVersions.recommendedVersion(version)}."
 }
 
+case class DeprecatedRemovedScalaVersion(version: String) extends ScalaProblem {
+  override def message: String =
+    s"Scala $version is no longer being bugfixed, " +
+      s"please upgrade to Scala ${ScalaVersions.recommendedVersion(version)}."
+}
+
 case class FutureScalaVersion(version: String) extends ScalaProblem {
   override def message: String = s"Scala $version is not yet supported, " +
     s"please downgrade to Scala ${ScalaVersions.recommendedVersion(version)}."
@@ -80,6 +86,11 @@ case object UnsupportedSbtVersion extends ScalaProblem {
 case object DeprecatedSbtVersion extends ScalaProblem {
   override def message: String =
     "Code navigation might not be supported in the future for this sbt version, " +
+      s"please upgrade to at least ${BuildInfo.minimumSupportedSbtVersion} and reimport the build"
+}
+case object DeprecatedRemovedSbtVersion extends ScalaProblem {
+  override def message: String =
+    "Support for Scala is no longer being bugfixed for this sbt version, " +
       s"please upgrade to at least ${BuildInfo.minimumSupportedSbtVersion} and reimport the build"
 }
 case object FutureSbtVersion extends ScalaProblem {

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/ScalaProblem.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/ScalaProblem.scala
@@ -37,15 +37,17 @@ case class UnsupportedScalaVersion(version: String) extends ScalaProblem {
 }
 
 case class DeprecatedScalaVersion(version: String) extends ScalaProblem {
+  private def recommendedVersion = ScalaVersions.recommendedVersion(version)
   override def message: String =
-    s"Scala $version might not be supported in upcoming versions of Metals, " +
-      s"please upgrade to Scala ${ScalaVersions.recommendedVersion(version)}."
+    s"Scala $version might no longer be supported by Metals in the future, " +
+      s"to get the best support possible it's recommended to update to at least $recommendedVersion."
 }
 
 case class DeprecatedRemovedScalaVersion(version: String) extends ScalaProblem {
+  private def recommendedVersion = ScalaVersions.recommendedVersion(version)
   override def message: String =
-    s"Scala $version is no longer being bugfixed, " +
-      s"please upgrade to Scala ${ScalaVersions.recommendedVersion(version)}."
+    s"Scala $version is no longer supported by Metals, " +
+      s"to get the best support possible it's recommended to update to at least $recommendedVersion."
 }
 
 case class FutureScalaVersion(version: String) extends ScalaProblem {
@@ -83,15 +85,17 @@ case object UnsupportedSbtVersion extends ScalaProblem {
     "Code navigation is not supported for this sbt version, please " +
       s"upgrade to at least ${BuildInfo.minimumSupportedSbtVersion} and reimport the build"
 }
-case object DeprecatedSbtVersion extends ScalaProblem {
+case class DeprecatedSbtVersion(sbtVersion: String, scalaVersion: String)
+    extends ScalaProblem {
   override def message: String =
-    "Code navigation might not be supported in the future for this sbt version, " +
-      s"please upgrade to at least ${BuildInfo.minimumSupportedSbtVersion} and reimport the build"
+    s"sbt version $sbtVersion uses Scala $scalaVersion, which might no longer be supported by Metals in the future. "
+  s"To get the best support possible it's recommended to update to at least ${BuildInfo.minimumSupportedSbtVersion} and reimport the build."
 }
-case object DeprecatedRemovedSbtVersion extends ScalaProblem {
+case class DeprecatedRemovedSbtVersion(sbtVersion: String, scalaVersion: String)
+    extends ScalaProblem {
   override def message: String =
-    "Support for Scala is no longer being bugfixed for this sbt version, " +
-      s"please upgrade to at least ${BuildInfo.minimumSupportedSbtVersion} and reimport the build"
+    s"sbt version $sbtVersion uses Scala $scalaVersion, which is no longer supported by Metals. " +
+      s"To get the best support possible it's recommended to update at least ${BuildInfo.minimumSupportedSbtVersion} and reimport the build."
 }
 case object FutureSbtVersion extends ScalaProblem {
   override def message: String =

--- a/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
+++ b/metals/src/main/scala/scala/meta/metals/DownloadDependencies.scala
@@ -88,7 +88,7 @@ object DownloadDependencies {
   def downloadMtags(): Seq[Path] = {
     scribe.info("Downloading mtags")
     BuildInfo.supportedScalaVersions.flatMap { scalaVersion =>
-      Embedded.downloadMtags(scalaVersion)
+      Embedded.downloadMtags(scalaVersion, BuildInfo.metalsVersion)
     }
   }
 

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -107,7 +107,7 @@ object TestGroups {
       "tests.codeactions.MillifyDependencyLspSuite",
       "tests.RenameFilesLspSuite", "tests.codeactions.ExtractMethodLspSuite",
       "tests.SemanticTokensExpectSuite",
-      "tests.debug.DebugProtocolCancelationSuite"),
+      "tests.debug.DebugProtocolCancelationSuite", "tests.RemovedScalaLspSuite"),
   )
 
 }

--- a/project/V.scala
+++ b/project/V.scala
@@ -63,6 +63,7 @@ object V {
       .distinct
 
   // Scala 2
+  // whenever version is removed please add it to MtagsResolver under last supported Metals version
   def deprecatedScala2Versions = Seq(
     scala211,
     "2.12.10",
@@ -94,6 +95,7 @@ object V {
   // Scala 3
   def nonDeprecatedScala3Versions =
     Seq(scala3, "3.2.1", "3.2.0", "3.1.3") ++ scala3RC.toSeq
+  // whenever version is removed please add it to MtagsResolver under last supported Metals version
   def deprecatedScala3Versions =
     Seq("3.3.0-RC1", "3.2.2-RC2", "3.1.2", "3.1.1", "3.1.0", "3.0.2")
   // NOTE if you hadd a new Scala Version make sure it's contained in quickPublishScalaVersions

--- a/tests/unit/src/main/scala/tests/TestMtagsResolver.scala
+++ b/tests/unit/src/main/scala/tests/TestMtagsResolver.scala
@@ -27,4 +27,6 @@ class TestMtagsResolver extends MtagsResolver {
     ScalaVersions.isSupportedAtReleaseMomentScalaVersion(version)
   }
 
+  override def isSupportedInOlderVersion(version: String): Boolean =
+    default.isSupportedInOlderVersion(version)
 }

--- a/tests/unit/src/test/scala/tests/MessagesSuite.scala
+++ b/tests/unit/src/test/scala/tests/MessagesSuite.scala
@@ -8,7 +8,7 @@ class MessagesSuite extends BaseSuite {
   test("deprecated-single") {
     assertDiffEqual(
       Messages.DeprecatedScalaVersion.message(Set("2.11.12")),
-      "You are using legacy Scala version 2.11.12, which might not be supported in future versions of Metals." +
+      "You are using legacy Scala version 2.11.12, which might stop being bugfixed in future versions of Metals." +
         s" Please upgrade to Scala version ${V.scala212}.",
     )
   }

--- a/tests/unit/src/test/scala/tests/MessagesSuite.scala
+++ b/tests/unit/src/test/scala/tests/MessagesSuite.scala
@@ -8,8 +8,8 @@ class MessagesSuite extends BaseSuite {
   test("deprecated-single") {
     assertDiffEqual(
       Messages.DeprecatedScalaVersion.message(Set("2.11.12")),
-      "You are using legacy Scala version 2.11.12, which might stop being bugfixed in future versions of Metals." +
-        s" Please upgrade to Scala version ${V.scala212}.",
+      "You are using legacy Scala version 2.11.12, which might no longer be supported by Metals in the future. " +
+        s"To get the best support possible it's recommended to update to at least Scala version ${V.scala212}.",
     )
   }
 

--- a/tests/unit/src/test/scala/tests/RemovedScalaLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RemovedScalaLspSuite.scala
@@ -1,0 +1,62 @@
+package tests
+
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.MtagsResolver
+
+class RemovedScalaLspSuite extends BaseLspSuite("cascade") {
+
+  override protected def mtagsResolver: MtagsResolver = MtagsResolver.default()
+
+  test("check-support") {
+    cleanWorkspace()
+    val withDocumentHighlight =
+      """|package a
+         |object A {
+         |  val <<ag@@e>> = 42
+         |  <<age>> + 12
+         |}""".stripMargin
+    val fileContents =
+      withDocumentHighlight
+        .replace(">>", "")
+        .replace("<<", "")
+        .replace("@@", "")
+    val expected = withDocumentHighlight.replace("@@", "")
+    val edit = withDocumentHighlight.replace(">>", "").replace("<<", "")
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": { "scalaVersion" : "2.13.1" }
+           |}
+           |/a/src/main/scala/a/A.scala
+           |$fileContents
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ = assertNoDiff(client.workspaceDiagnostics, "")
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        Messages.DeprecatedRemovedScalaVersion.message(Set("2.13.1")),
+      )
+      // document highlight is available in 0.11.10 for 3.0.0
+      _ <- server.assertHighlight(
+        "a/src/main/scala/a/A.scala",
+        edit,
+        expected,
+      )
+      // semantic highlight was not available in 0.11.10
+      _ <- server.didChangeConfiguration(
+        """{
+          |  "enable-semantic-highlighting": true
+          |}
+          |""".stripMargin
+      )
+      _ <- server.assertSemanticHighlight(
+        "a/src/main/scala/a/A.scala",
+        "",
+        fileContents,
+      )
+    } yield ()
+  }
+}

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -10,6 +10,8 @@ import scala.meta.internal.metals.JdkVersion
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ScalaTarget
 import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.metals.doctor.DeprecatedRemovedSbtVersion
+import scala.meta.internal.metals.doctor.DeprecatedRemovedScalaVersion
 import scala.meta.internal.metals.doctor.DeprecatedSbtVersion
 import scala.meta.internal.metals.doctor.DeprecatedScalaVersion
 import scala.meta.internal.metals.doctor.FutureSbtVersion
@@ -52,6 +54,12 @@ class ProblemResolverSuite extends FunSuite {
   )
 
   checkRecommendation(
+    "deprecated-removed-scala-version",
+    scalaVersion = "2.12.9",
+    DeprecatedRemovedScalaVersion("2.12.9").message,
+  )
+
+  checkRecommendation(
     "future-scala-version",
     scalaVersion = "2.12.50",
     FutureScalaVersion("2.12.50").message,
@@ -73,7 +81,14 @@ class ProblemResolverSuite extends FunSuite {
   checkRecommendation(
     "deprecated-sbt-version",
     scalaVersion = "2.12.10",
-    DeprecatedSbtVersion.message,
+    DeprecatedSbtVersion("1.3.0", "2.12.10").message,
+    sbtVersion = Some("1.3.0"),
+  )
+
+  checkRecommendation(
+    "deprecated-removed-sbt-version",
+    scalaVersion = "2.12.9",
+    DeprecatedRemovedSbtVersion("1.3.0", "2.12.9").message,
     sbtVersion = Some("1.3.0"),
   )
 


### PR DESCRIPTION
Previously, whenever we would drop support for a particular Scala version we would no longet support it in any way (no hover etc.). Now, thanks to having MiMa, we can always point to the last supported version and allow users to use it at their own risk.

This also addresses issues when some courses might be outdated and users would loose their support in Metals, which would be really bad for language adoption.