### PR TITLE
docs[skip ci]: Don't suggest updating mima

### DIFF
--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -120,10 +120,6 @@ Open the PR to the repo https://github.com/scalameta/metals/releases/new.
 - Announce the new release with the link to the release notes:
   - on [Discord](https://discord.com/invite/RFpSVth)
 
-### Update MiMa
-
-- Update `mimaPreviousArtifacts` in interfaces to the new released version
-
 ## Sanity check
 
 - [ ] draft release notes and create with PR with them


### PR DESCRIPTION
Actually, we should never need to update previous artifacts, since they should stay supported as long as possible.