### PR TITLE
improvement: Also allow nonboostrapped to fall back to the last nightly

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
@@ -90,7 +90,9 @@ object MtagsResolver {
           case State.Success(v) => Some(v)
           // Try to download latest supported snapshot
           case _: State.Failure
-              if original.isEmpty && scalaVersion.contains("NIGHTLY") =>
+              if original.isEmpty &&
+                scalaVersion.contains("NIGHTLY") ||
+                scalaVersion.contains("nonbootstrapped") =>
             findLatestSnapshot(scalaVersion) match {
               case None => None
               case Some(latestSnapshot) =>


### PR DESCRIPTION
Nightly with the same RC version will have the same tasty version, so it will be able to work correctly.

Unfortunately, it seems currently Bloop doesn't compile the nonbootstrapped, since it's missing bridges. We might need to use PRs from Alex.