### PR TITLE
improvement: Print information if compiler failed to infer edits for import

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -80,6 +80,15 @@ final class AutoImportsProvider(
             val nameEdit = new l.TextEdit(namePos, short)
             nameEdit :: edits
         }
+        if (edits.isEmpty) {
+          val trees = lastVisitedParentTrees
+            .take(5)
+            .map(_.getClass().getName())
+            .mkString(",")
+          logger.warning(
+            s"Could not infer edits for $pkg, tree around the position were $trees, auto import position was ${importPosition}"
+          )
+        }
         AutoImportsResultImpl(pkg, edits.asJava)
     }
   }


### PR DESCRIPTION
Helps with https://github.com/scalameta/metals/issues/4906

This shouldn't happen because auto import position is always defined except for when in imports, but we later have a condition that should deal with that.