### PR TITLE
chore: Fix expected line in FindTextInDependencyJarsSuite

### DIFF
--- a/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
+++ b/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
@@ -67,8 +67,7 @@ class FindTextInDependencyJarsSuite
       assertLocations(
         jdkLocations, {
           val line =
-            if (isJavaAtLeast17 && isWindows) 1445
-            else if (isJavaAtLeast17) 1447
+            if (isJavaAtLeast17) 1445
             else if (isJavaAtLeast9) 626
             else 578
 


### PR DESCRIPTION
This looks like JDK being slowly updated on different machines, so this started failing only after some time on all sytems.