### PR TITLE
improvement: Remove check for stacktrace markers

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
@@ -66,25 +66,13 @@ class StacktraceAnalyzer(
     def findLocationForSymbol(s: String): Option[Location] =
       definitionProvider.fromSymbol(s, None).asScala.headOption
 
-    val cleanedLine = stripErrorSignifier(line)
-    if (cleanedLine.startsWith("at")) {
-      for {
-        symbol <- symbolFromLine(line)
-        location <- toToplevelSymbol(symbol)
-          .collectFirst(Function.unlift(findLocationForSymbol))
-      } yield trySetLineFromStacktrace(location, line)
-    } else {
-      None
-    }
-  }
+    for {
+      symbol <- symbolFromLine(line)
+      location <- toToplevelSymbol(symbol)
+        .collectFirst(Function.unlift(findLocationForSymbol))
+    } yield trySetLineFromStacktrace(location, line)
 
-  /**
-   * Strip out the `[E]` when the line is coming from bloop-cli.
-   * Or
-   * Strip out the `[error]` or `[info]` when the line is coming from sbt
-   */
-  private def stripErrorSignifier(line: String) =
-    line.replaceFirst("""(\[E\]|\[error\]|\[info\])""", "").trim
+  }
 
   private def makeGotoLocationCodeLens(
       location: l.Location,


### PR DESCRIPTION
There is no need to check for any specific markers, we should just try our best to find a symbol.

For example:
```
[T] java.nio.file.FileSystemException:/Users/kpodsiadlo/.../.bloop/common/bloop-bsp-clients-classes/classes-bloop-cli-vSjz_SG8RNKglt17I28D_A==/com/evolution/.../data/macros/WeightsMacros.class: Invalid argument
[T]     java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:100)
[T]     java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
[T]     java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
[T]     java.base/sun.nio.fs.UnixCopyFile.copyFile(UnixCopyFile.java:246)
[T]     java.base/sun.nio.fs.UnixCopyFile.copy(UnixCopyFile.java:603)
[T]     java.base/sun.nio.fs.UnixFileSystemProvider.copy(UnixFileSystemProvider.java:257)
[T]     java.base/java.nio.file.Files.copy(Files.java:1305)
[T]     bloop.io.ParallelOps$.copy$1(ParallelOps.scala:161)
[T]     bloop.io.ParallelOps$.$anonfun$copyDirectories$8(ParallelOps.scala:194)
[T]     scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[T]     monix.eval.internal.TaskRunLoop$.startFuture(TaskRunLoop.scala:494)
[T]     monix.eval.Task.runToFutureOpt(Task.scala:586)
[T]     monix.eval.internal.TaskDeprecated$Extensions.runSyncMaybeOptPrv(TaskDeprecated.scala:128)
[T]     monix.eval.internal.TaskDeprecated$Extensions.$anonfun$coeval$1(TaskDeprecated.scala:303)
[T]     monix.eval.Coeval$Always.apply(Coeval.scala:1451)
[T]     monix.eval.Coeval.value(Coeval.scala:258)
[T]     bloop.io.ParallelOps$.$anonfun$copyDirectories$7(ParallelOps.scala:220)
[T]     monix.reactive.internal.consumers.ForeachAsyncConsumer$$anon$1.onNext(ForeachAsyncConsumer.scala:44)
[T]     monix.reactive.internal.consumers.LoadBalanceConsumer$$anon$1.$anonfun$signalNext$1(LoadBalanceConsumer.scala:218)
[T]     monix.execution.internal.InterceptRunnable.run(InterceptRunnable.scala:27)
[T]     java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[T]     java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[T]     java.base/java.lang.Thread.run(Thread.java:833)
```
