### PR TITLE
improvement: Add null check in SemanticTokenProvider

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcDocumentHighlightProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcDocumentHighlightProvider.scala
@@ -13,7 +13,7 @@ final class PcDocumentHighlightProvider(
 
   def collect(
       parent: Option[Tree]
-  )(tree: Tree, toAdjust: Position): DocumentHighlight = {
+  )(tree: Tree, toAdjust: Position, sym: Option[Symbol]): DocumentHighlight = {
     val (pos, _) = adjust(toAdjust)
     tree match {
       case _: MemberDef =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
@@ -36,7 +36,7 @@ class PcRenameProvider(
     .getOrElse("newName")
   def collect(
       parent: Option[Tree]
-  )(tree: Tree, toAdjust: Position): l.TextEdit = {
+  )(tree: Tree, toAdjust: Position, sym: Option[Symbol]): l.TextEdit = {
     val (pos, stripBackticks) = adjust(toAdjust, forRename = true)
     new l.TextEdit(
       pos.toLsp,

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcValReferenceProviderImpl.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcValReferenceProviderImpl.scala
@@ -18,7 +18,8 @@ final class PcValReferenceProviderImpl(
 
   override def collect(parent: Option[Tree])(
       tree: Tree,
-      pos: Position
+      pos: Position,
+      sym: Option[Symbol]
   ): Occurrence = {
     val (adjustedPos, _) = adjust(pos)
     tree match {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticTokenProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticTokenProvider.scala
@@ -42,8 +42,16 @@ final class SemanticTokenProvider(
 
     override def collect(
         parent: Option[compiler.Tree]
-    )(tree: compiler.Tree, pos: Position): NodeInfo = {
-      NodeInfo(tree.symbol, pos)
+    )(
+        tree: compiler.Tree,
+        pos: Position,
+        sym: Option[compiler.Symbol]
+    ): NodeInfo = {
+      val symbol = sym.getOrElse(tree.symbol)
+      if (symbol == null)
+        NodeInfo(compiler.NoSymbol, pos)
+      else
+        NodeInfo(symbol, pos)
     }
   }
 
@@ -212,7 +220,8 @@ final class SemanticTokenProvider(
     }
     def isTarget(node: NodeInfo): Boolean =
       node.pos.start == tk.pos.start &&
-        node.pos.end + adjustForBacktick == tk.pos.end
+        node.pos.end + adjustForBacktick == tk.pos.end &&
+        node.sym != NoSymbol
 
     val candidates = nodesIterator.dropWhile(_.pos.start < tk.pos.start)
     candidates


### PR DESCRIPTION
Benchmarks for semantic tokens were broken because of some null symbols, now we replace them with `NoSymbol`.
It happened in https://github.com/scalameta/metals/pull/4867#discussion_r1089739671 while dropping `Option`

Also, changes how we use `fallbackSymbol`. Instead of creating `Ident(sym)` tree, we add parameter to `collect`