### PR TITLE
fix: Adjust position in PcCollector for trailing comma

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticTokenProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SemanticTokenProvider.scala
@@ -47,11 +47,12 @@ final class SemanticTokenProvider(
         pos: Position,
         sym: Option[compiler.Symbol]
     ): NodeInfo = {
+      val pos0 = adjust(pos)._1
       val symbol = sym.getOrElse(tree.symbol)
       if (symbol == null)
-        NodeInfo(compiler.NoSymbol, pos)
+        NodeInfo(compiler.NoSymbol, pos0)
       else
-        NodeInfo(symbol, pos)
+        NodeInfo(symbol, pos0)
     }
   }
 
@@ -207,20 +208,9 @@ final class SemanticTokenProvider(
       nodesIterator: List[NodeInfo]
   ): Option[(NodeInfo, List[NodeInfo])] = {
 
-    val adjustForBacktick: Int = {
-      var ret: Int = 0
-      val cName = tk.text.toCharArray()
-      if (cName.size >= 2) {
-        if (
-          cName(0) == '`'
-          && cName(cName.size - 1) == '`'
-        ) ret = 2
-      }
-      ret
-    }
     def isTarget(node: NodeInfo): Boolean =
       node.pos.start == tk.pos.start &&
-        node.pos.end + adjustForBacktick == tk.pos.end &&
+        node.pos.end == tk.pos.end &&
         node.sym != NoSymbol
 
     val candidates = nodesIterator.dropWhile(_.pos.start < tk.pos.start)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
@@ -60,16 +60,19 @@ abstract class PcCollector[T](driver: InteractiveDriver, params: OffsetParams):
   def collect(parent: Option[Tree])(tree: Tree, pos: SourcePosition): T
 
   def adjust(
-      pos: SourcePosition,
+      pos0: SourcePosition,
       forRename: Boolean = false,
   ): (SourcePosition, Boolean) =
+
+    val pos =
+      if sourceText(pos0.`end` - 1) == ',' then pos0.withEnd(pos0.`end` - 1)
+      else pos0
     val isBackticked =
       sourceText(pos.start) == '`' && sourceText(pos.end - 1) == '`'
     // when the old name contains backticks, the position is incorrect
     val isOldNameBackticked = sourceText(pos.start) != '`' &&
       sourceText(pos.start - 1) == '`' &&
       sourceText(pos.end) == '`'
-
     if isBackticked && forRename then
       (pos.withStart(pos.start + 1).withEnd(pos.`end` - 1), true)
     else if isOldNameBackticked then

--- a/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
@@ -712,4 +712,29 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite {
        |  val a = (1 + 2 + 3) <<:@@:>> Nil
        |}""".stripMargin,
   )
+
+  check(
+    "trailling-comma".tag(IgnoreScala2),
+    """
+      |object Main {
+      |  val a = 1
+      |  val <<b>> = 2
+      |  List(
+      |    a,
+      |    <<b@@>>,
+      |  )
+      |}""".stripMargin,
+  )
+  check(
+    "trailling-comma2".tag(IgnoreScala2),
+    """
+      |object Main {
+      |  val a = 1
+      |  val <<`ab`>> = 2
+      |  List(
+      |    a,
+      |    <<`ab@@`>>,
+      |  )
+      |}""".stripMargin,
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
@@ -435,4 +435,20 @@ class PcRenameSuite extends BasePcRenameSuite {
        |""".stripMargin,
     newName = "testing",
   )
+
+  check(
+    "trailling-comma",
+    """|object A{
+       |  val <<`to-Rename`>> = 123
+       |}
+       |object B{
+       |  val toRename = 
+       |    List(
+       |      A.<<`to-R@@ename`>>,
+       |      A.<<`to-Rename`>>,
+       |    )
+       |}
+       |""".stripMargin,
+    newName = "`other-rename`",
+  )
 }


### PR DESCRIPTION
In Scala3, in cases like
```scala
def m(
  a: Int,
  b: <<Int,>> // this gets highlighted with the comma
) = ???
```
It was an issue in semantic tokens support for scala3, when we need positions to be the same.
Also, now we use `PcCollector.adjust` in `SemanticTokenProvider`
