### PR TITLE
bugfix: Fix issues with auto imports not showing up

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
@@ -1,7 +1,5 @@
 package scala.meta.internal.metals.codeactions
 
-import java.util.Collections
-
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -40,8 +38,9 @@ class ImportMissingSymbol(compilers: Compilers, buildTargets: BuildTargets)
       codeAction
         .getEdit()
         .getChanges()
-        .getOrDefault(uri, Collections.emptyList)
         .asScala
+        .values
+        .flatMap(_.asScala)
 
     def joinActionEdits(actions: Seq[l.CodeAction]) = {
       actions


### PR DESCRIPTION
Previously, we merging different auto imports into one, we would us uri to get the changes from the single action. That uri might have been encoded/decode which might be different from what there is in a map of changes.

Now, instead we just merge all the changes to avoid any issues with url decoding or encoding. Those changes cannot come from different files, so this will not be an issue.

Fixes https://github.com/scalameta/metals/issues/4906