### PR TITLE
improvement: Add classpath to expect semantic tokens suite

### DIFF
--- a/tests/unit/src/test/resources/semanticTokens/example/Definitions.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/Definitions.scala
@@ -1,7 +1,7 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
-<<import>>/*keyword*/ <<io>>/*namespace*/.<<circe>>/*variable,readonly*/.<<derivation>>/*variable,readonly*/.<<deriveDecoder>>/*variable,readonly*/
-<<import>>/*keyword*/ <<io>>/*namespace*/.<<circe>>/*variable,readonly*/.<<derivation>>/*variable,readonly*/.<<deriveEncoder>>/*variable,readonly*/
+<<import>>/*keyword*/ <<io>>/*namespace*/.<<circe>>/*namespace*/.<<derivation>>/*namespace*/.<<deriveDecoder>>/*variable,readonly*/
+<<import>>/*keyword*/ <<io>>/*namespace*/.<<circe>>/*namespace*/.<<derivation>>/*namespace*/.<<deriveEncoder>>/*variable,readonly*/
 
 <<class>>/*keyword*/ <<Definitions>>/*class*/ {
   <<Predef>>/*class*/.<<any2stringadd>>/*method,deprecated*/(<<1>>/*number*/)
@@ -13,6 +13,6 @@
   ](
     <<elems>>/*parameter*/ = <<null>>/*keyword*/
   )
-  <<println>>/*method*/(<<deriveDecoder>>/*variable,readonly*/[<<MacroAnnotation>>/*class*/])
-  <<println>>/*method*/(<<deriveEncoder>>/*variable,readonly*/[<<MacroAnnotation>>/*class*/])
+  <<println>>/*method*/(<<deriveDecoder>>/*method*/[<<MacroAnnotation>>/*class*/])
+  <<println>>/*method*/(<<deriveEncoder>>/*method*/[<<MacroAnnotation>>/*class*/])
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/MacroAnnotation.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/MacroAnnotation.scala
@@ -1,6 +1,6 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
-<<import>>/*keyword*/ <<io>>/*namespace*/.<<circe>>/*variable,readonly*/.<<derivation>>/*variable,readonly*/.<<annotations>>/*variable,readonly*/.<<JsonCodec>>/*variable,readonly*/
+<<import>>/*keyword*/ <<io>>/*namespace*/.<<circe>>/*namespace*/.<<derivation>>/*namespace*/.<<annotations>>/*namespace*/.<<JsonCodec>>/*class*/
 
 <<@>>/*keyword*/<<JsonCodec>>/*class*/
 <<// FIXME: https://github.com/scalameta/scalameta/issues/1789>>/*comment*/

--- a/tests/unit/src/test/scala/tests/SemanticTokensExpectSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticTokensExpectSuite.scala
@@ -8,7 +8,9 @@ import scala.meta.internal.pc.ScalaPresentationCompiler
 class SemanticTokensExpectSuite extends DirectoryExpectSuite("semanticTokens") {
 
   override lazy val input: InputProperties = InputProperties.scala2()
-  private val compiler = new ScalaPresentationCompiler()
+  private val compiler = new ScalaPresentationCompiler(
+    classpath = input.classpath.entries.map(_.toNIO)
+  )
 
   override def testCases(): List[ExpectTestCase] = {
     input.scalaFiles.map { file =>


### PR DESCRIPTION
Previously, we didn't add classpath so some tokens were inferred wrong. Now, we use the input project classpath properly.