### PR TITLE
improvement: Don't fail on no shutdown message

### DIFF
--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/TestDebugger.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/TestDebugger.scala
@@ -109,7 +109,10 @@ final class TestDebugger(
           Future.unit
       }
       _ = scribe.info("TestingDebugger terminated")
-      _ <- debugger.shutdown(60)
+      _ <- debugger.shutdown(60).recoverWith { case _: TimeoutException =>
+        scribe.warn("The debugger is most likely already shut down.")
+        Future.unit
+      }
       _ = scribe.info("Remote server shutdown")
       _ <- onStoppage.shutdown
     } yield ()


### PR DESCRIPTION
It seems this is ignored in scala-debug-adapter tests and VS Code doesn't seem to have a problem like the tests do. I think it's safe to ignore those timeout for the sake of less flakiness.