### PR TITLE
bugfix: Support scala command as BSP server for debug

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -96,7 +96,7 @@ class BuildServerConnection private (
       "1.4.10",
       version,
     )
-    isSbt || isScalaCLI || (isBloop && supportNewDebugAdapter)
+    !isBloop || (isBloop && supportNewDebugAdapter)
   }
 
   def workspaceDirectory: AbsolutePath = workspace


### PR DESCRIPTION
Previously, we would check for specific build servers and versions if they support scala-debug-adapter with the new version. However, this might lead to disallowing using debugger if the name just mismatched. Now, we only ban older bloop server versions instead. Anything new supporting DAP will most likely use newest DAP.

Fixes https://github.com/VirtusLab/scala-cli/issues/1831