### PR TITLE
bugfix: Set terminated to true when timeout

### DIFF
--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/TestDebugger.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/TestDebugger.scala
@@ -105,6 +105,7 @@ final class TestDebugger(
     for {
       _ <- terminated.future.withTimeout(60, TimeUnit.SECONDS).recoverWith {
         case _: TimeoutException =>
+          terminated.trySuccess(())
           scribe.warn("We never got the terminate message")
           Future.unit
       }


### PR DESCRIPTION
Previously, if the debugee process closed before sending the terminate message, we would still wait to get all output for terminated promise in tests. Now, when timed out on terminated we fullfill the promise, so that anything waiting on it (for example allOutput) can proceed.