### PR TITLE
Improvement: adds details to github issue

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/GithubNewIssueUrlCreator.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/GithubNewIssueUrlCreator.scala
@@ -1,0 +1,98 @@
+package scala.meta.internal.metals
+
+import java.net.URLEncoder
+
+import scala.util.Properties
+
+import scala.meta.internal.bsp.BspResolvedResult
+import scala.meta.internal.bsp.BspSession
+import scala.meta.internal.bsp.ResolvedBloop
+import scala.meta.internal.bsp.ResolvedBspOne
+import scala.meta.internal.bsp.ResolvedMultiple
+import scala.meta.internal.bsp.ResolvedNone
+import scala.meta.internal.builds.BuildTools
+
+import org.eclipse.lsp4j.ClientInfo
+
+class GithubNewIssueUrlCreator(
+    tables: Tables,
+    buildTargets: BuildTargets,
+    currentBuildServer: () => Option[BspSession],
+    calculateNewBuildServer: () => BspResolvedResult,
+    clientInfo: ClientInfo,
+    buildTools: BuildTools,
+) {
+
+  def buildUrl(): String = {
+    val scalaVersions =
+      buildTargets.allScala.map(_.scalaVersion).toSet.mkString("; ")
+    val clientVersion =
+      Option(clientInfo.getVersion()).map(v => s" v$v").getOrElse("")
+    val body =
+      s"""|<!--
+          |        Describe the bug ...
+          |
+          |        Reproduction steps
+          |          1. Go to ...
+          |          2. Click on ...
+          |          3. Scroll down to ...
+          |          4. See error
+          |-->
+          |
+          |### Expected behaviour:
+          |
+          |<!-- A clear and concise description of what you expected to happen. -->
+          |
+          |**Operating system:**
+          |${Properties.osName}
+          |
+          |**Java version:**
+          |${Properties.javaVersion}
+          |
+          |**Editor/extension:**
+          |${clientInfo.getName()}$clientVersion
+          |
+          |**Metals version:**
+          |${BuildInfo.metalsVersion}
+          |
+          |### Extra context or search terms:
+          |<!--
+          |        - Any other context about the problem
+          |        - Search terms to help others discover this
+          |-->
+          |
+          |### Workspace information:
+          |
+          | - **Scala versions:** $scalaVersions$selectedBuildTool$selectedBuildServer
+          | - **All build tools in workspace:** ${buildTools.all.mkString("; ")}
+          |""".stripMargin
+    s"https://github.com/scalameta/metals/issues/new?body=${URLEncoder.encode(body)}"
+  }
+
+  private def selectedBuildTool(): String = {
+    tables.buildTool
+      .selectedBuildTool()
+      .map { value =>
+        s"""|
+            | - **Build tool:** ${value}""".stripMargin
+      }
+      .getOrElse("")
+  }
+
+  private def selectedBuildServer(): String = {
+    val buildServer = currentBuildServer()
+      .map(s => s"${s.main.name} v${s.main.version}")
+      .getOrElse {
+        calculateNewBuildServer() match {
+          case ResolvedBloop => "Disconnected: Bloop"
+          case ResolvedBspOne(details) => s"Disconnected: ${details.getName()}"
+          case ResolvedMultiple(_, details) =>
+            s"Disconnected: Multiple Found ${details.map(_.getName()).mkString("; ")}"
+          case ResolvedNone => s"Disconnected: None Found"
+        }
+      }
+
+    s"""|
+        | - **Build server:** $buildServer""".stripMargin
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -716,6 +716,15 @@ class MetalsLspService(
     maybeJdkVersion,
   )
 
+  private val githubNewIssueUrlCreator = new GithubNewIssueUrlCreator(
+    tables,
+    buildTargets,
+    () => bspSession,
+    () => bspConnector.resolve(),
+    initializeParams.getClientInfo(),
+    buildTools,
+  )
+
   private val fileDecoderProvider: FileDecoderProvider =
     new FileDecoderProvider(
       workspace,
@@ -1871,6 +1880,10 @@ class MetalsLspService(
             else Future.successful(())
           }
         } yield ()).asJavaObject
+      case ServerCommands.OpenIssue() =>
+        Future
+          .successful(Urls.openBrowser(githubNewIssueUrlCreator.buildUrl()))
+          .asJavaObject
       case OpenBrowserCommand(url) =>
         Future.successful(Urls.openBrowser(url)).asJavaObject
       case ServerCommands.CascadeCompile() =>

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -590,10 +590,16 @@ object ServerCommands {
     "Open the Metals logs to troubleshoot issues.",
   )
 
-  val OpenIssue = new OpenBrowserCommand(
-    "https://github.com/scalameta/metals/issues/new/choose",
-    "Open issue on GitHub",
-    "Open the Metals repository on GitHub to ask a question, report a bug or request a new feature.",
+  val OpenIssue = new Command(
+    "open-new-github-issue",
+    "Open an issue on GitHub",
+    "Open the Metals repository on GitHub to ask a question or report a bug.",
+  )
+
+  val OpenFeatureRequest = new OpenBrowserCommand(
+    "https://github.com/scalameta/metals-feature-requests/issues/new?template=feature-request.yml",
+    "Open a feature request",
+    "Open the Metals repository on GitHub to open a feature request.",
   )
 
   val MetalsGithub = new OpenBrowserCommand(
@@ -700,6 +706,8 @@ object ServerCommands {
       SuperMethodHierarchy,
       StartScalaCliServer,
       StopScalaCliServer,
+      OpenIssue,
+      OpenFeatureRequest,
     )
 
   val allIds: Set[String] = all.map(_.id).toSet

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -205,6 +205,7 @@ class MetalsTreeViewProvider(
           echoCommand(ServerCommands.ReadBloopDocumentation, "book"),
           echoCommand(ServerCommands.ChatOnDiscord, "discord"),
           echoCommand(ServerCommands.OpenIssue, "issue-opened"),
+          echoCommand(ServerCommands.OpenFeatureRequest, "github"),
           echoCommand(ServerCommands.MetalsGithub, "github"),
           echoCommand(ServerCommands.BloopGithub, "github"),
           echoCommand(ServerCommands.ScalametaTwitter, "twitter"),


### PR DESCRIPTION
An improvement to "create GitHub issue" command.
Previously: it just redirected to the GitHub new issue creator.
Now: redirects and fills in basic information (metals version, os, editor/extension, java version).
connected to: https://github.com/scalameta/metals/issues/4924
#### Github issue example url:
https://github.com/scalameta/metals/issues/new?body=%3C%21--%0A++++++++Describe+the+bug+...%0A%0A++++++++Reproduction+steps%0A++++++++++1.+Go+to+...%0A++++++++++2.+Click+on+...%0A++++++++++3.+Scroll+down+to+...%0A++++++++++4.+See+error%0A--%3E%0A%0A%23%23%23+Expected+behaviour%3A%0A%0A%3C%21--+A+clear+and+concise+description+of+what+you+expected+to+happen.+--%3E%0A%0A**Operating+system%3A**%0AMac+OS+X%0A%0A**Java+version%3A**%0A17.0.1%0A%0A**Editor%2Fextension%3A**%0AVisual+Studio+Code+v1.75.1%0A%0A**Metals+version%3A**%0A0.11.11-SNAPSHOT%0A%0A%23%23%23+Extra+context+or+search+terms%3A%0A%3C%21--%0A++++++++-+Any+other+context+about+the+problem%0A++++++++-+Search+terms+to+help+others+discover+this%0A--%3E%0A%0A%23%23%23+Workspace+information%3A%0A%0A**Scala+versions%3A**+2.12.17%3B+2.13.10%3B+3.2.2%0A**Build+server%3A**+Bloop+v1.5.6%0A**All+build+tools+in+workspace%3A**+Bloop%3B+sbt%0A