### PR TITLE
feature: Add the possibility to discover the main class to run

### DIFF
--- a/docs/integrations/debug-adapter-protocol.md
+++ b/docs/integrations/debug-adapter-protocol.md
@@ -33,8 +33,8 @@ command.
 Starting a Debug Adapter Protocol session might take some time, since it needs
 to set up all the neccesary utilities for debugging. Metals also provides a
 `shellCommand` field, which will be present in the command attached to the run
-main methods code lenses. This field can be used to simply run the process quickly
-without the debugging capabilities.
+main methods code lenses. This field can be used to simply run the process
+quickly without the debugging capabilities.
 
 If you can't or won't support DAP, you can use the `runProvider` instead of
 `debugProvider `option in the initialization options sent from the editor to the
@@ -118,10 +118,33 @@ keys that can be sent as well with the same format as above.
 
 ```json
 {
-  "path": "file:///path/to/my/file.scala"
+  "path": "file:///path/to/my/file.scala",
   "runType": "testTarget"
 }
 ```
+
+Instead of `debug-adapter-start` if you only want to get data about the command
+to run you can use `discover-jvm-run-command`, which takes the same json as
+above, but instead of starting the DAP session it will return the
+`DebugSessionParams` object containing targets that this main class can be run
+for along with the data about the main class which will take form of:
+
+```json
+{
+  "targets": ["id1"],
+  "dataKind": "scala-main-class",
+  "data": {
+    "class": "Foo",
+    "arguments": [],
+    "jvmOptions": [],
+    "environmentVariables": [],
+    "shellCommand": "java ..."
+  }
+}
+```
+
+where `shellCommand` will be the exact command to run if you want to run it on
+your own without DAP.
 
 ### Wiring it all together
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -676,6 +676,7 @@ class MetalsLspService(
       compilers,
       statusBar,
       sourceMapper,
+      () => userConfig,
     )
   )
 
@@ -1825,6 +1826,10 @@ class MetalsLspService(
             Option(params.uri).map(_.toAbsolutePath)
           )
         }.asJavaObject
+      case ServerCommands.DiscoverMainClasses(unresolvedParams) =>
+        debugProvider
+          .runCommandDiscovery(unresolvedParams)
+          .asJavaObject
       case ServerCommands.RunScalafix(params) =>
         val uri = params.getTextDocument().getUri()
         scalafixProvider

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -132,6 +132,21 @@ object ServerCommands {
        |    "runType": "run"
        |}
        |```
+       |
+       |Response:
+       |```json
+       |{
+       |  "targets": ["id1"],
+       |  "dataKind": "scala-main-class",
+       |  "data": {
+       |    "class": "Foo",
+       |    "arguments": [],
+       |    "jvmOptions": [],
+       |    "environmentVariables": [],
+       |    "shellCommand": "java ..."
+       |  }
+       |}
+       |```
        |""".stripMargin,
   )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -118,6 +118,23 @@ object ServerCommands {
        |""".stripMargin,
   )
 
+  val DiscoverMainClasses = new ParametrizedCommand[DebugDiscoveryParams](
+    "discover-jvm-run-command",
+    "Discover main classes to run and return the object",
+    """|Gets the DebugSession object that also contains a command to run in shell based 
+       |on JVM environment including classpath, jvmOptions and environment parameters.
+       |""".stripMargin,
+    """|DebugUnresolvedTestClassParams object
+       |Example:
+       |```json
+       |{
+       |    "path": "path/to/file.scala",
+       |    "runType": "run"
+       |}
+       |```
+       |""".stripMargin,
+  )
+
   /** If uri is null discover all test suites, otherwise discover testcases in file */
   final case class DiscoverTestParams(
       @Nullable uri: String = null
@@ -666,6 +683,7 @@ object ServerCommands {
       CleanCompile,
       ConvertToNamedArguments,
       CopyWorksheetOutput,
+      DiscoverMainClasses,
       DiscoverTestSuites,
       ExtractMemberDefinition,
       GenerateBspConfig,

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -41,6 +41,7 @@ import scala.meta.internal.metals.ScalaTestSuitesDebugRequest
 import scala.meta.internal.metals.SourceMapper
 import scala.meta.internal.metals.StacktraceAnalyzer
 import scala.meta.internal.metals.StatusBar
+import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.clients.language.MetalsQuickPickItem
 import scala.meta.internal.metals.clients.language.MetalsQuickPickParams
@@ -64,7 +65,6 @@ import com.google.common.net.InetAddresses
 import com.google.gson.JsonElement
 import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.MessageType
-import scala.meta.internal.metals.UserConfiguration
 
 /**
  * @param supportsTestSelection test selection hasn't been defined in BSP spec yet.


### PR DESCRIPTION
Previously, the only possibility to discover the main class to run was to try and run it. Now, we can also ask for it so that client editor can use that shell command.

Needed for https://github.com/scalameta/metals-vscode/pull/1298