### PR TITLE
improvement: Don't use cache when querying for Scala nightlies

### DIFF
--- a/.github/workflows/check_scala3_nightly.yml
+++ b/.github/workflows/check_scala3_nightly.yml
@@ -12,7 +12,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "17"
-          cache: "sbt"
       - name: "Query maven-central"
         run: |
           sbt 'save-non-published-nightlies versions'


### PR DESCRIPTION
This might cause the nightlies to be discovered much later.