### PR TITLE
feat: find companion object of AnyVal, implicit class in class finder

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -68,6 +68,7 @@ import scala.meta.internal.metals.watcher.FileWatcherEvent
 import scala.meta.internal.metals.watcher.FileWatcherEvent.EventType
 import scala.meta.internal.mtags._
 import scala.meta.internal.parsing.ClassFinder
+import scala.meta.internal.parsing.ClassFinderGranularity
 import scala.meta.internal.parsing.DocumentSymbolProvider
 import scala.meta.internal.parsing.FoldingRangeProvider
 import scala.meta.internal.parsing.TokenEditDistance
@@ -1856,10 +1857,13 @@ class MetalsLspService(
           }
           .asJavaObject
       case ServerCommands.ChooseClass(params) =>
+        val searchGranularity =
+          if (params.kind == "class") ClassFinderGranularity.ClassFiles
+          else ClassFinderGranularity.Tasty
         fileDecoderProvider
           .chooseClassFromFile(
             params.textDocument.getUri().toAbsolutePath,
-            params.kind == "class",
+            searchGranularity,
           )
           .asJavaObject
       case ServerCommands.RunDoctor() =>

--- a/metals/src/main/scala/scala/meta/internal/metals/data/ClassName.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/data/ClassName.scala
@@ -1,0 +1,3 @@
+package scala.meta.internal.metals.data
+
+final case class ClassName(value: String) extends AnyVal

--- a/metals/src/main/scala/scala/meta/internal/metals/data/FullyQualifiedName.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/data/FullyQualifiedName.scala
@@ -1,0 +1,3 @@
+package scala.meta.internal.metals.data
+
+final case class FullyQualifiedName(value: String) extends AnyVal

--- a/metals/src/main/scala/scala/meta/internal/parsing/finder/ClassKind.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/finder/ClassKind.scala
@@ -1,0 +1,10 @@
+package scala.meta.internal.parsing.finder
+
+sealed trait ClassKind
+object ClassKind {
+  case object Class extends ClassKind
+  case object Trait extends ClassKind
+  case object Object extends ClassKind
+  case object Enum extends ClassKind
+  case object ToplevelPackage extends ClassKind
+}

--- a/metals/src/main/scala/scala/meta/internal/parsing/finder/MangledClassName.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/finder/MangledClassName.scala
@@ -1,0 +1,15 @@
+package scala.meta.internal.parsing.finder
+
+/**
+ * Mangled class name, like BinarySearch$Smaller$ for objects or ClassFinder$ClassKind for classes or traits.
+ * a.Bar$Bar2$Bar3$VeryInnerTrait for a very nested trait.
+ */
+final case class MangledClassName(value: String) extends AnyVal {
+  def stripSuffix(suffix: String): MangledClassName =
+    MangledClassName(value.stripSuffix(suffix))
+}
+
+/**
+ * Just class name which is visible in code. Using examples provided in [[MangledClassName]]: Smaller, ClassKind, VeryInnerTrait
+ */
+final case class ShortClassName(value: String) extends AnyVal

--- a/tests/unit/src/main/scala/tests/BaseClassFinderSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseClassFinderSuite.scala
@@ -4,7 +4,6 @@ import scala.meta.internal.metals.Buffers
 import scala.meta.internal.parsing.ClassFinder
 
 import munit.FunSuite
-
 abstract class BaseClassFinderSuite extends FunSuite {
   def init(scalaVersion: String): (Buffers, ClassFinder) = {
     val (buffers, trees) = TreeUtils.getTrees(scalaVersion)

--- a/tests/unit/src/test/scala/tests/classFinder/ClassBreakpointSuite.scala
+++ b/tests/unit/src/test/scala/tests/classFinder/ClassBreakpointSuite.scala
@@ -178,6 +178,6 @@ class ClassBreakpointSuite extends BaseClassFinderSuite {
       buffers.put(path, sourceText)
       val sym = classFinder.findClass(path, pos.toLsp.getStart())
       assert(sym.isDefined)
-      assertNoDiff(sym.get, expected)
+      assertNoDiff(sym.get.value, expected)
     }
 }

--- a/tests/unit/src/test/scala/tests/classFinder/FindAllClassesSuite.scala
+++ b/tests/unit/src/test/scala/tests/classFinder/FindAllClassesSuite.scala
@@ -133,6 +133,19 @@ class FindAllClassesSuite extends BaseClassFinderSuite {
     searchGranularity = ClassFinderGranularity.ClassFiles,
   )
 
+  check(
+    "case-class-generated-companion",
+    """|package a
+       |case class Foo(x: Int)
+       |""".stripMargin,
+    Vector(
+      "Class Foo a.Foo.class",
+      "Object Foo a.Foo$.class",
+    ),
+    scalaVersion = V.scala213,
+    searchGranularity = ClassFinderGranularity.ClassFiles,
+  )
+
   def check(
       name: TestOptions,
       sourceText: String,

--- a/tests/unit/src/test/scala/tests/classFinder/FindAllClassesSuite.scala
+++ b/tests/unit/src/test/scala/tests/classFinder/FindAllClassesSuite.scala
@@ -4,6 +4,7 @@ package classFinder
 import java.nio.file.Paths
 
 import scala.meta.internal.metals.{BuildInfo => V}
+import scala.meta.internal.parsing.ClassFinderGranularity
 import scala.meta.io.AbsolutePath
 
 import munit.Location
@@ -26,12 +27,13 @@ class FindAllClassesSuite extends BaseClassFinderSuite {
        |def foo(): Unit = ()
        |def foo2(): Unit = ()
        |""".stripMargin,
-    List(
+    Vector(
       "Class Foo a.Foo.tasty",
       "Class Bar a.Bar.tasty",
       "Toplevel package a.Main$package.tasty",
     ),
     scalaVersion = V.scala3,
+    searchGranularity = ClassFinderGranularity.Tasty,
   )
 
   check(
@@ -50,13 +52,13 @@ class FindAllClassesSuite extends BaseClassFinderSuite {
        |def foo(): Unit = ()
        |def foo2(): Unit = ()
        |""".stripMargin,
-    List(
+    Vector(
       "Class Foo a.Foo.class", "Object Foo a.Foo$.class",
       "Class InnerClass a.Foo$InnerClass.class", "Class Bar a.Bar.class",
       "Class InnerClass a.Bar$InnerClass.class",
       "Toplevel package a.Main$package.class",
     ),
-    checkInnerClasses = true,
+    searchGranularity = ClassFinderGranularity.ClassFiles,
     scalaVersion = V.scala3,
   )
 
@@ -91,7 +93,7 @@ class FindAllClassesSuite extends BaseClassFinderSuite {
          |  }
          |}
          |""".stripMargin,
-      List(
+      Vector(
         "Class Foo a.Foo.class", "Class InnerClass a.Foo$InnerClass.class",
         "Trait InnerTrait a.Foo$InnerTrait.class",
         "Object InnerObject a.Foo$InnerObject$.class",
@@ -108,16 +110,34 @@ class FindAllClassesSuite extends BaseClassFinderSuite {
         "Trait VeryInnerTrait a.Bar$Bar2$Bar3$VeryInnerTrait.class",
         "Object VeryInnerObject a.Bar$Bar2$Bar3$VeryInnerObject$.class",
       ),
-      checkInnerClasses = true,
+      searchGranularity = ClassFinderGranularity.ClassFiles,
       scalaVersion = scalaVer,
     )
   }
 
+  check(
+    "implicit-class-anyval",
+    """|package a
+       |object Foo {
+       |  implicit class FooOps(private val x: Int) extends AnyVal {
+       |    def foo: Int = x
+       |  }
+       |}
+       |""".stripMargin,
+    Vector(
+      "Object Foo a.Foo$.class",
+      "Class FooOps a.Foo$FooOps.class",
+      "Object FooOps a.Foo$FooOps$.class",
+    ),
+    scalaVersion = V.scala213,
+    searchGranularity = ClassFinderGranularity.ClassFiles,
+  )
+
   def check(
       name: TestOptions,
       sourceText: String,
-      expected: List[String],
-      checkInnerClasses: Boolean = false,
+      expected: Vector[String],
+      searchGranularity: ClassFinderGranularity,
       filename: String = "Main.scala",
       scalaVersion: String = V.scala213,
   )(implicit loc: Location): Unit =
@@ -125,12 +145,12 @@ class FindAllClassesSuite extends BaseClassFinderSuite {
       val (buffers, classFinder) = init(scalaVersion)
       val path = AbsolutePath(Paths.get(filename))
       buffers.put(path, sourceText)
-      val classes = classFinder.findAllClasses(path, checkInnerClasses)
+      val classes = classFinder.findAllClasses(path, searchGranularity)
 
       assert(classes.isDefined)
       assertEquals(
         classes.get
-          .map(c => s"${c.friendlyName} ${c.description}"),
+          .map(c => s"${c.prettyName} ${c.resourceMangledName}"),
         expected,
       )
     }

--- a/tests/unit/src/test/scala/tests/classFinder/TastyNameResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/classFinder/TastyNameResolverSuite.scala
@@ -151,6 +151,6 @@ class ClassNameResolverSuite extends BaseClassFinderSuite {
         classFinder.findTasty(path, pos.toLsp.getStart())
 
       assert(tastyPath.isDefined)
-      assertNoDiff(tastyPath.get, expected)
+      assertNoDiff(tastyPath.get.value, expected)
     }
 }


### PR DESCRIPTION
classes like `implicit class FooOps(private val foo: Int) extends AnyVal` produces two class files: FooOps.class and FooOps$.class. This PR:
- does some refactor in ClassFinder
- thanks to modifications, it's easier to add companion object for implicit, anyval classes
- EDIT: case class companion object was missing too, added