### PR TITLE
fix: Wrong semantic token for renamed imported classes

### DIFF
--- a/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
+++ b/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
@@ -168,6 +168,20 @@ class SemanticTokensSuite extends BasePCSuite {
         |}""".stripMargin,
   )
 
+  check(
+    "import-rename",
+    s"""|<<package>>/*keyword*/ <<example>>/*namespace*/
+        |
+        |<<import>>/*keyword*/ <<util>>/*namespace*/.{<<Failure>>/*class*/ <<=>>>/*operator*/ <<NoBad>>/*class*/}
+        |<<import>>/*keyword*/ <<math>>/*namespace*/.{<<floor>>/*method*/ <<=>>>/*operator*/ <<_>>/*variable*/, <<_>>/*variable*/}
+        |
+        |<<class>>/*keyword*/ <<Imports>>/*class*/ {
+        |  <<// rename reference>>/*comment*/
+        |  <<NoBad>>/*class*/(<<null>>/*keyword*/)
+        |  <<max>>/*method*/(<<1>>/*number*/, <<2>>/*number*/)
+        |}""".stripMargin,
+  )
+
   def check(
       name: TestOptions,
       expected: String,


### PR DESCRIPTION
```scala
package example

import util.{Failure => NoBad}
import math.{floor => _, _}

class Imports {
  // rename reference
  NoBad(null) // we have two symbols here: `Failure` class and `apply` method
  max(1, 2)
}
```
From two symbols on `NoBad`, we were first trying to pick the one with name matching text, but the name is `Failure`, not `NoBad`. This issue only appeared when imported name was the same length as `apply` (5 letters)