### PR TITLE
bugfix: Don't collect symbols from Inline expansion

### DIFF
--- a/tests/cross/src/test/scala/tests/highlight/Scala3DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/Scala3DocumentHighlightSuite.scala
@@ -68,6 +68,28 @@ class Scala3DocumentHighlightSuite extends BaseDocumentHighlightSuite {
   )
 
   check(
+    "recursive-inline1",
+    """|inline def <<po@@wer>>(x: Double, n: Int): Double =
+       |  if n == 0 then 1.0
+       |  else if n == 1 then x
+       |  else
+       |    val y = <<power>>(x, n / 2)
+       |    if n % 2 == 0 then y * y else y * y * x
+       |""".stripMargin,
+  )
+
+  check(
+    "recursive-inline2",
+    """|inline def <<power>>(x: Double, n: Int): Double =
+       |  if n == 0 then 1.0
+       |  else if n == 1 then x
+       |  else
+       |    val y = <<po@@wer>>(x, n / 2)
+       |    if n % 2 == 0 then y * y else y * y * x
+       |""".stripMargin,
+  )
+
+  check(
     "extension-params",
     """|extension (<<sb@@d>>: String)
        |  def double = <<sbd>> + <<sbd>>


### PR DESCRIPTION
Previously, Metals would have a hanging thread when for example in github.com:Atry/scalajs-all-in-one-template. Now, it doesn't end up in an infinite loop.

I haven't been able to find a proper test for it aside from the very complex example with macros, but we shouldn't need to traverse expansion as it's the tree that is not in the original code.

Fixes https://github.com/scalameta/metals/issues/4987