### PR TITLE
bugfix: Suggest class constructors when importing symbols

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/CompletionScala3Suite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScala3Suite.scala
@@ -23,6 +23,34 @@ class CompletionScala3Suite extends BaseCompletionSuite {
     topLines = Some(3),
   )
 
+  check(
+    "constructor-empty",
+    """|package a
+       |
+       |class Testing
+       |
+       |def main =
+       |  Testin@@
+       |""".stripMargin,
+    """|Testing a
+       |Testing(): Testing
+       |""".stripMargin,
+  )
+
+  check(
+    "constructor-params",
+    """|package a
+       |
+       |class Testing(a: Int, b: String)
+       |
+       |def main =
+       |  Testin@@
+       |""".stripMargin,
+    """|Testing a
+       |Testing(a: Int, b: String): Testing
+       |""".stripMargin,
+  )
+
   // https://github.com/scalameta/metals/issues/2810
   check(
     "higher-kinded-match-type".tag(IgnoreScalaVersion.forLessThan("3.1.3-RC2")),

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -952,6 +952,7 @@ class CompletionSuite extends BaseCompletionSuite {
         """|Some(value) scala
            |Some scala
            |Some[A](value: A): Some[A]
+           |SomeToExpr(x: Some[T])(using Quotes): Expr[Some[T]]
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
            |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
            |""".stripMargin
@@ -971,6 +972,7 @@ class CompletionSuite extends BaseCompletionSuite {
       ">=3.1.0" ->
         """|Some scala
            |Some[A](value: A): Some[A]
+           |SomeToExpr(x: Some[T])(using Quotes): Expr[Some[T]]
            |SomeToExpr[T: Type: ToExpr]: SomeToExpr[T]
            |SomeFromExpr[T](using Type[T], FromExpr[T]): SomeFromExpr[T]
            |""".stripMargin,

--- a/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
@@ -105,4 +105,52 @@ class CompletionCrossLspSuite
       )
     } yield ()
   }
+
+  test("basic-scala3") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""/metals.json
+           |{
+           |  "a": { "scalaVersion": "${V.scala3}" }
+           |}
+           |/a/src/main/scala/Main.scala
+           |import scala.concurrent.Future
+           |
+           |@main
+           |def hello: Unit =
+           |  println("Hello world!")
+           |  println(msg)
+           |  // @@
+           |
+           |def msg = "I was compiled by Scala 3. :)"
+           |
+           |
+           |/a/src/main/scala/foo/MyClass.scala
+           |package foo
+           |
+           |class MyClass1:
+           |  def myMethod = 1
+           |
+           |case class MyClass2(name: String):
+           |  def myMethod = 1
+           |
+           |object MyClass3:
+           |  def apply(name: String) = ???
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      _ = assertNoDiagnostics()
+      _ <- assertCompletion(
+        "MyC@@",
+        """|MyClass1(): MyClass1
+           |MyClass2(name: String): MyClass2
+           |MyClass3 - foo
+           |MyClass3(name: String): Nothing
+           |""".stripMargin,
+        filename = Some("a/src/main/scala/Main.scala"),
+      )
+    } yield ()
+  }
+
 }


### PR DESCRIPTION
Previously, auto imports would only work with new + classname or with objects. Now, since Scala 3 allows omitting new, we also suggest classes that can be constructed without the new keyword.

Fixes https://github.com/scalameta/metals/issues/4988