### PR TITLE
bugfix: Fix infinite loop when searching for munit test cases

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/MunitTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/MunitTestFinder.scala
@@ -188,7 +188,7 @@ class MunitTestFinder(
       case head :: tail =>
         head match {
           case lit: Lit.String => Some(lit)
-          case _ => extractLiteralName(head.children ::: tail ::: acc)
+          case _ => extractLiteralName(head.children ::: tail)
         }
       case immutable.Nil => None
     }
@@ -204,7 +204,7 @@ class MunitTestFinder(
                 Some((term, lit))
               case None => loop(tail)
             }
-          case _ => loop(head.children ::: tail ::: acc)
+          case _ => loop(head.children ::: tail)
         }
       case immutable.Nil => None
     }

--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -257,6 +257,17 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
         |
         |  List("") // negative case - apply without test call
         |
+        |  val numbers = List(1, 2, 3)
+        |  numbers.foreach{
+        |    n =>
+        |     test(n.toShort.toString) {
+        |         if (true) {
+        |           val input = 123
+        |           assert(input.toString.contains(n.toString))
+        |         }
+        |     }
+        |  }
+        |
         |  def check(name: String, n1: Int, n2: Int = 1) = {
         |    test(name) {
         |      assertEquals(n1, n2)


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/5001