### PR TITLE
bugfix: Cancel and create new server in test retry

### DIFF
--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -95,7 +95,10 @@ abstract class BaseLspSuite(
   )(implicit loc: Location): Unit = {
     def functionRetry(retry: Int): Future[Unit] = {
       fn.recoverWith {
-        case _ if retry > 0 => functionRetry(retry - 1)
+        case _ if retry > 0 =>
+          cancelServer()
+          newServer(testOpts.name)
+          functionRetry(retry - 1)
         case e => Future.failed(e)
       }
     }


### PR DESCRIPTION
Previously, when FileWatcher tests would be retried on MacOS (where it is most flaky) we would get an exception that the server is alreayd initialized. Now, we cancel the old server properly and create a new one for the retried tests.