### PR TITLE
dep: bump gradleBloop from 1.5.8.to 1.6.0

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -21,7 +21,7 @@ object V {
   val coursierInterfaces = "1.0.13"
   val debugAdapter = "3.0.4"
   val genyVersion = "0.7.1"
-  val gradleBloop = "1.5.8"
+  val gradleBloop = "1.6.0"
   val java8Compat = "1.0.2"
   val javaSemanticdb = "0.8.13"
   val jsoup = "1.15.3"


### PR DESCRIPTION
I wanted to quickly send this in to try and get it into the release. With this
new version Gradle 8 _should_ be supported which will be nice to have for Gradle
users
