### PR TITLE
bugfix: print better constructors in synthetic decorator

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
@@ -156,7 +156,7 @@ class SemanticdbTreePrinter(
       isExplicitTuple: => Boolean = false,
   ): Option[String] =
     t match {
-      case s.Tree.Empty => None
+      case s.Tree.Empty => Some("...")
       case s.OriginalTree(_) => None
       case s.TypeApplyTree(function, typeArguments)
           // only print type parameters for tuple if it's not a tuple literal

--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -26,6 +26,7 @@ import scala.meta.internal.parsing.TokenEditDistance
 import scala.meta.internal.parsing.Trees
 import scala.meta.internal.pc.HoverMarkup
 import scala.meta.internal.semanticdb.MethodSignature
+import scala.meta.internal.semanticdb.Scala.Descriptor.Method
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.semanticdb.TextDocument
 import scala.meta.internal.semanticdb.TextDocuments
@@ -381,14 +382,20 @@ final class SyntheticsDecorationProvider(
 
   private def toDecorationString(
       textDoc: TextDocument
-  )(symbol: String): String = {
+  )(symbol: String): String =
     if (symbol.isLocal)
       textDoc.symbols
         .find(_.symbol == symbol)
         .map(_.displayName)
         .getOrElse("_")
-    else symbol.desc.name.value
-  }
+    else
+      symbol.desc match {
+        // for contructors we print the class name
+        case Method("<init>", disambiguator) =>
+          val classSymbol = symbol.stripSuffix("`<init>`" + disambiguator + ".")
+          "new " ++ classSymbol.desc.name.value
+        case symDesc => symDesc.name.value
+      }
 
   private def decorationOptions(
       lspRange: l.Range,


### PR DESCRIPTION
Previously: all method synthetic decorations were printed in the same manner.
Now: for constructors we print the class name instead on method name ("<init>").

Resolves: https://github.com/scalameta/metals/issues/4698