### PR TITLE
Force update of scala-debug-adapter by Scala Steward

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -651,6 +651,8 @@ lazy val metalsDependencies = project
   .in(file("target/.dependencies"))
   .settings(
     publish / skip := true,
+    // silent the intransitive dependency warning
+    publishMavenStyle := false,
     libraryDependencies ++= List(
       // The dependencies listed below are only listed so Scala Steward
       // will pick them up and update them. They aren't actually used.
@@ -662,6 +664,7 @@ lazy val metalsDependencies = project
       "ch.epfl.scala" % "bloop-maven-plugin" % V.mavenBloop,
       "ch.epfl.scala" %% "gradle-bloop" % V.gradleBloop,
       "com.sourcegraph" % "semanticdb-java" % V.javaSemanticdb,
+      "ch.epfl.scala" %% "scala-debug-adapter" % V.debugAdapter intransitive (),
     ),
   )
   .disablePlugins(ScalafixPlugin)

--- a/project/V.scala
+++ b/project/V.scala
@@ -19,7 +19,7 @@ object V {
   val bsp = "2.1.0-M4"
   val coursier = "2.1.0-RC6"
   val coursierInterfaces = "1.0.13"
-  val debugAdapter = "3.0.4"
+  val debugAdapter = "3.0.7"
   val genyVersion = "0.7.1"
   val gradleBloop = "1.6.0"
   val java8Compat = "1.0.2"


### PR DESCRIPTION
This is an attempt to force Scala Steward to update the scala-debug-adapter version in:
https://github.com/scalameta/metals/blob/34b3cc8f38792be4170344bb4bb685ba15dc3c2a/project/V.scala#L22

It used not to do it because this version was not used in any `libraryDependencies` setting. It was only used in the `buildInfoKeys`:
https://github.com/scalameta/metals/blob/34b3cc8f38792be4170344bb4bb685ba15dc3c2a/build.sbt#L462