### PR TITLE
improvement: Add semantic highlight for using directives

### DIFF
--- a/tests/unit/src/test/resources/semanticTokens/example/ImplicitConversions.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/ImplicitConversions.scala
@@ -20,7 +20,7 @@
   <<// interpolators>>/*comment*/
   <<s>>/*keyword*/<<">>/*string*/<<Hello >>/*string*/<<$>>/*keyword*/<<message>>/*variable,readonly*/<< >>/*string*/<<$>>/*keyword*/<<number>>/*variable,readonly*/<<">>/*string*/
   <<s>>/*keyword*/<<""">>/*string*/<<Hello>>/*string*/
-<<     |>>/*string*/<<$>>/*keyword*/<<message>>/*variable,readonly*/<<>>/*string*/
+<<     |>>/*string*/<<$>>/*keyword*/<<message>>/*variable,readonly*/
 <<     |>>/*string*/<<$>>/*keyword*/<<number>>/*variable,readonly*/<<""">>/*string*/.<<stripMargin>>/*method*/
 
   <<val>>/*keyword*/ <<a>>/*variable,readonly*/: <<Int>>/*class,abstract*/ = <<char>>/*variable,readonly*/

--- a/tests/unit/src/test/scala/tests/SemanticHighlightLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticHighlightLspSuite.scala
@@ -53,6 +53,39 @@ class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
         |""".stripMargin,
   )
 
+  check(
+    "multiline-comment",
+    """| <</** This is >>/*comment*/
+       |<<*  a multiline>>/*comment*/
+       |<<*  comment>>/*comment*/
+       |<<*/>>/*comment*/
+       |
+       |<<object>>/*keyword*/ <<A>>/*class*/ {}
+       |""".stripMargin,
+  )
+
+  check(
+    "using-directive",
+    """|<<//>>>/*comment*/ <<using>>/*keyword*/ <<lib>>/*variable*/ <<"abc::abc:123">>/*string*/
+       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<scala>>/*variable*/ <<"3.1.1">>/*string*/
+       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<options>>/*variable*/ <<"-Xasync">>/*string*/, <<"-Xfatal-warnings">>/*string*/
+       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<packaging>>/*variable*/.<<provided>>/*variable*/ <<"org.apache.spark::spark-sql">>/*string*/
+       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<target>>/*variable*/.<<platform>>/*variable*/ <<"scala-js">>/*string*/, <<"scala-native">>/*string*/
+       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<lib>>/*variable*/ <<"io.circe::circe-core:0.14.0">>/*string*/, <<"io.circe::circe-core_native::0.14.0">>/*string*/
+       |<<object>>/*keyword*/ <<A>>/*class*/ {}
+       |""".stripMargin,
+  )
+
+  check(
+    "simple",
+    """|<<package>>/*keyword*/ <<a>>/*namespace*/
+       |
+       |<<object>>/*keyword*/ <<A>>/*class*/ {
+       |  <<case>>/*keyword*/ <<class>>/*keyword*/ <<B>>/*class*/(<<c>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
+       |}
+       |""".stripMargin,
+  )
+
   def check(
       name: TestOptions,
       expected: String,

--- a/tests/unit/src/test/scala/tests/SemanticTokensExpectSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticTokensExpectSuite.scala
@@ -11,8 +11,6 @@ class SemanticTokensExpectSuite extends DirectoryExpectSuite("semanticTokens") {
   private val compiler = new ScalaPresentationCompiler(
     classpath = input.classpath.entries.map(_.toNIO)
   )
-  implicit val ec: scala.concurrent.ExecutionContext =
-    scala.concurrent.ExecutionContext.global
   override def testCases(): List[ExpectTestCase] = {
     input.scalaFiles.map { file =>
       ExpectTestCase(


### PR DESCRIPTION
In order to do that, we need to parse each using directive and add semantic tokens. For now, using directives can only appear before any scala code.

solves https://github.com/scalameta/metals/issues/5013