### PR TITLE
fix: Fix semantic tokens for worksheets in Scala 3

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -6,6 +6,7 @@ import java.util.Collections
 import java.util.concurrent.ScheduledExecutorService
 import java.{util => ju}
 
+import scala.annotation.tailrec
 import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Future
 import scala.util.Try
@@ -399,6 +400,7 @@ class Compilers(
            * @param remaining the rest of the tokens to analyze
            * @return the first found that should be contained with the rest
            */
+          @tailrec
           def findCorrectStart(
               line: Integer,
               character: Integer,
@@ -431,9 +433,34 @@ class Compilers(
             }
           }
 
+          @tailrec
+          def adjustForScala3Worksheet(
+              remaining: List[Integer],
+              acc: List[List[Integer]] = List.empty,
+          ): List[Integer] = {
+            remaining match {
+              case Nil => acc.reverse.flatten
+              case deltaLine :: deltaColumn :: next if deltaLine != 0 =>
+                // we need to remove additional indent
+                val adjustedColumn: Integer = (Math.max(0, deltaColumn - 2))
+                val adjusted: List[Integer] =
+                  List(deltaLine, adjustedColumn) ++ next.take(3)
+                adjustForScala3Worksheet(
+                  next.drop(3),
+                  adjusted :: acc,
+                )
+              case _ =>
+                adjustForScala3Worksheet(
+                  remaining.drop(5),
+                  remaining.take(5) :: acc,
+                )
+            }
+          }
+
           val vFile =
             CompilerVirtualFileParams(path.toNIO.toUri(), input.text, token)
           val isScala3 = ScalaVersions.isScala3Version(compiler.scalaVersion())
+
           compiler
             .semanticTokens(vFile)
             .asScala
@@ -444,9 +471,13 @@ class Compilers(
                 isScala3,
               )
 
-              new SemanticTokens(
-                findCorrectStart(0, 0, plist.asScala.toList).asJava
-              )
+              val tokens =
+                findCorrectStart(0, 0, plist.asScala.toList)
+              if (isScala3 && path.isWorksheet) {
+                new SemanticTokens(adjustForScala3Worksheet(tokens).asJava)
+              } else {
+                new SemanticTokens(tokens.asJava)
+              }
             }
         }
         .getOrElse(Future.successful(new SemanticTokens(emptyTokens)))

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -872,55 +872,54 @@ abstract class BaseWorksheetLspSuite(
       } yield ()
     }
 
-  if (!ScalaVersions.isScala3Version(scalaVersion))
-    test("semantic-highlighting") {
+  test("semantic-highlighting") {
 
-      val expected =
-        if (scalaVersion == V.scala212)
-          """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
-             |<<val>>/*keyword*/ <<hi1>>/*variable,readonly*/ =
-             |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
-             |<<val>>/*keyword*/ <<hi2>>/*variable,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
-             |
-             |<<val>>/*keyword*/ <<hellos>>/*variable,readonly*/ = <<List>>/*class*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
-             |""".stripMargin
-        else
-          """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
-             |<<val>>/*keyword*/ <<hi1>>/*variable,readonly*/ =
-             |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
-             |<<val>>/*keyword*/ <<hi2>>/*variable,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
-             |
-             |<<val>>/*keyword*/ <<hellos>>/*variable,readonly*/ = <<List>>/*variable,readonly*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
-             |""".stripMargin
+    val expected =
+      if (scalaVersion == V.scala212)
+        """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
+           |<<val>>/*keyword*/ <<hi1>>/*variable,readonly*/ =
+           |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
+           |<<val>>/*keyword*/ <<hi2>>/*variable,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
+           |
+           |<<val>>/*keyword*/ <<hellos>>/*variable,readonly*/ = <<List>>/*class*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
+           |""".stripMargin
+      else
+        """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
+           |<<val>>/*keyword*/ <<hi1>>/*variable,readonly*/ =
+           |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
+           |<<val>>/*keyword*/ <<hi2>>/*variable,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
+           |
+           |<<val>>/*keyword*/ <<hellos>>/*variable,readonly*/ = <<List>>/*variable,readonly*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
+           |""".stripMargin
 
-      val fileContent =
-        TestSemanticTokens.removeSemanticHighlightDecorations(expected)
-      for {
-        _ <- initialize(
-          s"""
-             |/metals.json
-             |{
-             |  "a": {
-             |    "scalaVersion": "$scalaVersion"
-             |  }
-             |}
-             |/a/src/main/scala/foo/Main.worksheet.sc
-             |$fileContent
-             |""".stripMargin
-        )
-        _ <- server.didChangeConfiguration(
-          """{
-            |  "enable-semantic-highlighting": true
-            |}
-            |""".stripMargin
-        )
-        _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
-        _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
-        _ <- server.assertSemanticHighlight(
-          "a/src/main/scala/foo/Main.worksheet.sc",
-          expected,
-          fileContent,
-        )
-      } yield ()
-    }
+    val fileContent =
+      TestSemanticTokens.removeSemanticHighlightDecorations(expected)
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "$scalaVersion"
+           |  }
+           |}
+           |/a/src/main/scala/foo/Main.worksheet.sc
+           |$fileContent
+           |""".stripMargin
+      )
+      _ <- server.didChangeConfiguration(
+        """{
+          |  "enable-semantic-highlighting": true
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
+      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
+      _ <- server.assertSemanticHighlight(
+        "a/src/main/scala/foo/Main.worksheet.sc",
+        expected,
+        fileContent,
+      )
+    } yield ()
+  }
 }


### PR DESCRIPTION
Previously tokens were alligned incorrectly, because of additional indent.