### PR TITLE
bugfix: Fix span for extension methods

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
@@ -76,9 +76,18 @@ abstract class PcCollector[T](
   )(tree: Tree, pos: SourcePosition, symbol: Option[Symbol]): T
 
   def adjust(
-      pos0: SourcePosition,
+      pos1: SourcePosition,
       forRename: Boolean = false,
   ): (SourcePosition, Boolean) =
+    val pos0 =
+      val span = pos1.span
+      if span.exists && span.point > span.end then
+        pos1.withSpan(
+          span
+            .withStart(span.point)
+            .withEnd(span.point + (span.end - span.start))
+        )
+      else pos1
 
     val pos =
       if sourceText(pos0.`end` - 1) == ',' then pos0.withEnd(pos0.`end` - 1)
@@ -392,7 +401,9 @@ abstract class PcCollector[T](
               arg,
               pos
                 .withSpan(
-                  arg.span.withEnd(arg.span.start + realName.length)
+                  arg.span
+                    .withEnd(arg.span.start + realName.length)
+                    .withPoint(arg.span.start)
                 ),
               sym,
             )

--- a/tests/cross/src/test/scala/tests/highlight/Scala3DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/Scala3DocumentHighlightSuite.scala
@@ -126,6 +126,17 @@ class Scala3DocumentHighlightSuite extends BaseDocumentHighlightSuite {
   )
 
   check(
+    "extension-with-type",
+    """|object Mincase:
+       |  extension [X](x: X)
+       |    def <<foobar>>(): Unit = ???
+       |
+       |  val x = 1.<<foo@@bar>>()
+       |  val y = (1: Int).<<foobar>>()
+       |""".stripMargin,
+  )
+
+  check(
     "extension-complex",
     """|object Extensions:
        |


### PR DESCRIPTION
Fixes span for extension methods with specified argument type i.e. 
`(1: Int).foo()` resulted in highlighting `<<(1:>> Int).foo()`

Connected to https://github.com/scalameta/metals/issues/5026