### PR TITLE
Keyword completions reimplementation without `scala.meta`

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
@@ -80,6 +80,7 @@ class CompletionProvider(
             completionPos,
             indexedCtx,
             path,
+            tpdPath,
             config,
             workspace,
             autoImportsGen,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -47,6 +47,7 @@ class Completions(
     completionPos: CompletionPos,
     indexedContext: IndexedContext,
     path: List[Tree],
+    tpdPath: List[Tree],
     config: PresentationCompilerConfig,
     workspace: Option[Path],
     autoImports: AutoImportsGenerator,
@@ -190,7 +191,7 @@ class Completions(
     val (all, result) =
       if exclusive then (advanced, SymbolSearch.Result.COMPLETE)
       else
-        val keywords = KeywordsCompletions.contribute(path, completionPos)
+        val keywords = KeywordsCompletions.contribute(tpdPath, completionPos)
         val allAdvanced = advanced ++ keywords
         path match
           // should not show completions for toplevel

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -529,6 +529,45 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
   )
 
   check(
+    "extends-with-class".tag(IgnoreScala2),
+    """
+      |package foo
+      |
+      |class Foo extends Any wi@@
+    """.stripMargin,
+    """|with
+       |""".stripMargin,
+  )
+
+  check(
+    "extends-class-nested",
+    """
+      |package foo
+      |
+      |class Foo {
+      |  class Boo ext@@
+      |}
+    """.stripMargin,
+    """|extends
+       |""".stripMargin,
+  )
+
+  check(
+    "extends-class-nested-with-body",
+    """
+      |package foo
+      |
+      |class Foo {
+      |  class Boo ext@@ {
+      |    def test: Int = ???
+      |  }
+      |}
+    """.stripMargin,
+    """|extends
+       |""".stripMargin,
+  )
+
+  check(
     "extends-obj",
     """
       |package foo
@@ -606,7 +645,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |package foo
       |
       |// can't provide extends keyword completion if there's newline between class
-      |// because the completion engine tokenize only the line 
+      |// because the completion engine tokenize only the line
       |class Main
       |  exten@@
     """.stripMargin,
@@ -625,6 +664,18 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |package foo
       |
       |enum Foo(x: Int) ext@@
+        """.stripMargin,
+    """|extends
+       |""".stripMargin,
+  )
+
+  check(
+    "extends-enum-case".tag(IgnoreScala2),
+    """
+      |package foo
+      |
+      |enum Foo(x: Int)
+      |  case Test ext@@
         """.stripMargin,
     """|extends
        |""".stripMargin,


### PR DESCRIPTION
This PR makes implementation of `Keyword.scala` independent of `scala.meta` parser.
It is handled by the compiler, and is a requirement for Stable PC implementation.

I also added `with` keyword completions if there is an `extends` keyword used before.