### PR TITLE
chore: use value class to for new semanticDB path type

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -21,6 +21,7 @@ import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metap.PrinterSymtab
 import scala.meta.internal.mtags.Md5Fingerprints
+import scala.meta.internal.mtags.SemanticdbPath
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.parsing.TokenEditDistance
 import scala.meta.internal.parsing.Trees
@@ -78,7 +79,7 @@ final class SyntheticsDecorationProvider(
     }
   }
 
-  override def onDelete(path: AbsolutePath): Unit = ()
+  override def onDelete(path: SemanticdbPath): Unit = ()
   override def reset(): Unit = ()
 
   override def onChange(

--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -17,6 +17,7 @@ import scala.meta.internal.metals.ScalaVersionSelector
 import scala.meta.internal.metals.SemanticdbFeatureProvider
 import scala.meta.internal.mtags.GlobalSymbolIndex
 import scala.meta.internal.mtags.Mtags
+import scala.meta.internal.mtags.SemanticdbPath
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.mtags.SymbolDefinition
 import scala.meta.internal.mtags.{Symbol => MSymbol}
@@ -57,7 +58,7 @@ final class ImplementationProvider(
     implementationsInPath.clear()
   }
 
-  override def onDelete(path: AbsolutePath): Unit = {
+  override def onDelete(path: SemanticdbPath): Unit = {
     implementationsInPath.remove(path.toNIO)
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1455,14 +1455,15 @@ class MetalsLspService(
       }
       onChange(List(path)).asJava
     } else if (path.isSemanticdb) {
+      val semanticdbPath = SemanticdbPath(path)
       Future {
         event.eventType match {
           case EventType.Delete =>
-            semanticDBIndexer.onDelete(event.path)
+            semanticDBIndexer.onDelete(semanticdbPath)
           case EventType.CreateOrModify =>
-            semanticDBIndexer.onChange(event.path)
+            semanticDBIndexer.onChange(semanticdbPath)
           case EventType.Overflow =>
-            semanticDBIndexer.onOverflow(event.path)
+            semanticDBIndexer.onOverflow(semanticdbPath)
         }
       }.asJava
     } else if (path.isBuild) {

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -12,6 +12,7 @@ import scala.meta.Importee
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ResolvedSymbolOccurrence
 import scala.meta.internal.mtags.DefinitionAlternatives.GlobalSymbol
+import scala.meta.internal.mtags.SemanticdbPath
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.mtags.Symbol
 import scala.meta.internal.parsing.TokenEditDistance
@@ -54,7 +55,7 @@ final class ReferenceProvider(
     index.clear()
   }
 
-  override def onDelete(file: AbsolutePath): Unit = {
+  override def onDelete(file: SemanticdbPath): Unit = {
     index.remove(file.toNIO)
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
@@ -7,6 +7,7 @@ import java.nio.file.Path
 import scala.util.control.NonFatal
 
 import scala.meta.internal.mtags.SemanticdbClasspath
+import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.mtags.SemanticdbPath
 import scala.meta.internal.semanticdb.TextDocument
 import scala.meta.internal.semanticdb.TextDocuments
@@ -64,7 +65,11 @@ class SemanticdbIndexer(
     if (Files.isDirectory(dir)) {
       val stream = Files.walk(dir)
       try {
-        // stream.forEach(onChange(_))
+        stream.forEach {
+          case path if path.isSemanticdb =>
+            SemanticdbPath(AbsolutePath(path))
+          case _ => ()
+        }
       } finally {
         stream.close()
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
@@ -6,8 +6,8 @@ import java.nio.file.Path
 
 import scala.util.control.NonFatal
 
-import scala.meta.internal.mtags.SemanticdbClasspath
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.mtags.SemanticdbClasspath
 import scala.meta.internal.mtags.SemanticdbPath
 import scala.meta.internal.semanticdb.TextDocument
 import scala.meta.internal.semanticdb.TextDocuments

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -31,6 +31,7 @@ import scala.meta.internal.metals.testProvider.frameworks.MunitTestFinder
 import scala.meta.internal.metals.testProvider.frameworks.ScalatestTestFinder
 import scala.meta.internal.mtags
 import scala.meta.internal.mtags.GlobalSymbolIndex
+import scala.meta.internal.mtags.SemanticdbPath
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.parsing.Trees
 import scala.meta.internal.semanticdb
@@ -95,7 +96,10 @@ final class TestSuitesProvider(
       case _ => ()
     }
 
-  override def onDelete(file: AbsolutePath): Unit = {
+  override def onDelete(file: SemanticdbPath): Unit = ()
+  override def reset(): Unit = ()
+
+  def onFileDelete(file: AbsolutePath): Unit = {
     val removed = index.remove(file)
     if (isExplorerEnabled) {
       val removeEvents = removed
@@ -111,8 +115,6 @@ final class TestSuitesProvider(
       updateClientIfNonEmpty(removeEvents)
     }
   }
-
-  override def reset(): Unit = ()
 
   override def codeLenses(
       textDocumentWithPath: TextDocumentWithPath

--- a/mtags/src/main/scala/scala/meta/internal/mtags/SemanticdbClasspath.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/SemanticdbClasspath.scala
@@ -46,22 +46,19 @@ final case class SemanticdbClasspath(
 object SemanticdbClasspath {
   def toScala(
       workspace: AbsolutePath,
-      semanticdb: AbsolutePath
+      semanticdb: SemanticdbPath
   ): Option[AbsolutePath] = {
-    require(
-      semanticdb.toNIO.getFileName.toString.endsWith(".semanticdb"),
-      semanticdb
-    )
     semanticdb.toNIO.semanticdbRoot.map { root =>
       workspace
         .resolve(
-          semanticdb
+          semanticdb.absolutePath
             .resolveSibling(_.stripSuffix(".semanticdb"))
             .toRelative(AbsolutePath(root))
         )
         .dealias
     }
   }
+
   def fromScalaOrJava(path: RelativePath): RelativePath = {
     require(path.isScalaOrJavaFilename, path.toString)
     val semanticdbSibling = path.resolveSibling(_ + ".semanticdb")

--- a/mtags/src/main/scala/scala/meta/internal/mtags/SemanticdbPath.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/SemanticdbPath.scala
@@ -5,6 +5,9 @@ import java.nio.file.Path
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.io.AbsolutePath
 
+/**
+ * Wrapper over a path which is semanticDB file.
+ */
 final case class SemanticdbPath(val absolutePath: AbsolutePath) extends AnyVal {
   def semanticdbRoot: Option[Path] = absolutePath.toNIO.semanticdbRoot
   def toNIO: Path = absolutePath.toNIO

--- a/mtags/src/main/scala/scala/meta/internal/mtags/SemanticdbPath.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/SemanticdbPath.scala
@@ -1,0 +1,11 @@
+package scala.meta.internal.mtags
+
+import java.nio.file.Path
+
+import scala.meta.internal.mtags.MtagsEnrichments._
+import scala.meta.io.AbsolutePath
+
+final case class SemanticdbPath(val absolutePath: AbsolutePath) extends AnyVal {
+  def semanticdbRoot: Option[Path] = absolutePath.toNIO.semanticdbRoot
+  def toNIO: Path = absolutePath.toNIO
+}


### PR DESCRIPTION
I was really annoyed when I found that https://github.com/scalameta/metals/pull/5042 is not working as expected because Test Explorer onDelete was called only with semanticDB files..

Value classes ftw!