### PR TITLE
bugfix: perform `substituteTypeVars` also for methods with no args

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -809,7 +809,7 @@ class Completions(
         def postProcess(items: List[CompletionValue]): List[CompletionValue] =
           items.map {
             case CompletionValue.Compiler(label, sym, suffix)
-                if sym.info.paramNamess.nonEmpty && isMember(sym) =>
+                if isMember(sym) =>
               CompletionValue.Compiler(
                 label,
                 substituteTypeVars(sym),

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -266,7 +266,7 @@ class CompletionSuite extends BaseCompletionSuite {
            |toFactory(from: From): Factory[A, C]
            |formatted(fmtstr: String): String
            |→[B](y: B): (A, B)
-           |iterableFactory[A]: Factory[A, CC[A]]
+           |iterableFactory[A]: Factory[A, List[A]]
            |asInstanceOf[X0]: X0
            |equals(x$0: Any): Boolean
            |getClass[X0 >: List.type](): Class[? <: X0]
@@ -1550,6 +1550,16 @@ class CompletionSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     "",
     filter = _.startsWith("_"),
+  )
+
+  check(
+    "no-params-method",
+    """|object O {
+       |  Some(1).get@@
+       |}
+       |""".stripMargin,
+    "get: Int",
+    topLines = Some(1),
   )
 
 }


### PR DESCRIPTION
Previously: we'd perform `substituteTypeVars` for select only if the member had any ages lists.
Now: we check if it's a method, to make this work for methods with no args lists.

connected to: https://github.com/scalameta/metals/issues/3030