### PR TITLE
improvement: Add definition and declaration properties

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcSemanticTokensProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcSemanticTokensProvider.scala
@@ -16,6 +16,32 @@ final class PcSemanticTokensProvider(
 ) {
   // Initialize Tree
   object Collector extends PcCollector[Option[Node]](cp, params) {
+
+    /**
+     * Declaration is set only for parameters, defs/vals/vars without rhs,
+     * type parameterss and inside pattern matches. In all those cases we don't
+     * have a specific value.
+     */
+    private def isDeclaration(tree: compiler.Tree) = tree match {
+      case _: compiler.Bind => true
+      case df: compiler.ValOrDefDef => df.rhs.isEmpty
+      case tdef: compiler.TypeDef =>
+        tdef.rhs.symbol == compiler.NoSymbol
+      case _ => false
+    }
+
+    /**
+     * Definition is set only for defs/vals/vars/type with rhs.
+     * We don;t want to set it for enum cases despite the fact
+     * that the compiler sees them as vals, as it's not clear
+     * if they should be declaration/definition at all.
+     */
+    private def isDefinition(tree: compiler.Tree) = tree match {
+      case df: compiler.ValOrDefDef => df.rhs.nonEmpty
+      case tdef: compiler.TypeDef => tdef.rhs.symbol != compiler.NoSymbol
+      case _ => false
+    }
+
     override def collect(
         parent: Option[compiler.Tree]
     )(
@@ -23,11 +49,19 @@ final class PcSemanticTokensProvider(
         pos: compiler.Position,
         symbol: Option[compiler.Symbol]
     ): Option[Node] = {
-      val sym = symbol.fold(tree.symbol)(s => s)
+      val sym = symbol.fold(tree.symbol)(identity)
       if (
         !pos.isDefined || sym == null || sym == compiler.NoSymbol || sym.isConstructor
       ) None
-      else Some(makeNode(sym, adjust(pos)._1))
+      else
+        Some(
+          makeNode(
+            sym = sym,
+            pos = adjust(pos)._1,
+            isDefinition = isDefinition(tree),
+            isDeclaration = isDeclaration(tree)
+          )
+        )
     }
   }
   def provide(): List[Node] =
@@ -41,7 +75,9 @@ final class PcSemanticTokensProvider(
 
   def makeNode(
       sym: Collector.compiler.Symbol,
-      pos: Collector.compiler.Position
+      pos: Collector.compiler.Position,
+      isDefinition: Boolean,
+      isDeclaration: Boolean
   ): Node = {
     var mod: Int = 0
     def addPwrToMod(tokenID: String) = {
@@ -88,6 +124,8 @@ final class PcSemanticTokensProvider(
     if (sym.isAbstract) addPwrToMod(SemanticTokenModifiers.Abstract)
     if (sym.isDeprecated) addPwrToMod(SemanticTokenModifiers.Deprecated)
     if (sym.owner.isModule) addPwrToMod(SemanticTokenModifiers.Static)
+    if (isDeclaration) addPwrToMod(SemanticTokenModifiers.Declaration)
+    if (isDefinition) addPwrToMod(SemanticTokenModifiers.Definition)
 
     TokenNode(pos.start, pos.end, typ, mod)
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcSemanticTokensProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcSemanticTokensProvider.scala
@@ -23,11 +23,12 @@ final class PcSemanticTokensProvider(
     driver: InteractiveDriver,
     params: VirtualFileParams,
 ):
-
   /**
-   * Declaration is set only for parameters, defs/vals/vars without rhs,
-   * type parameterss and inside pattern matches. In all those cases we don't
-   * have a specific value.
+   * Declaration is set for:
+   * 1. parameters,
+   * 2. defs/vals/vars without rhs,
+   * 3. type parameters,
+   * In all those cases we don't have a specific value for sure.
    */
   private def isDeclaration(tree: Tree) = tree match
     case df: ValOrDefDef => df.rhs.isEmpty
@@ -35,16 +36,19 @@ final class PcSemanticTokensProvider(
       df.rhs match
         case _: Template => false
         case _ => df.rhs.isEmpty
-    case df: Bind => true
     case _ => false
 
   /**
-   * Definition is set only for defs/vals/vars/type with rhs.
-   * We don;t want to set it for enum cases despite the fact
+   * Definition is set for:
+   * 1. defs/vals/vars/type with rhs.
+   * 2. pattern matches
+   *
+   * We don't want to set it for enum cases despite the fact
    * that the compiler sees them as vals, as it's not clear
    * if they should be declaration/definition at all.
    */
   private def isDefinition(tree: Tree) = tree match
+    case df: Bind => true
     case df: ValOrDefDef =>
       !df.rhs.isEmpty && !df.symbol.isAllOf(Flags.EnumCase)
     case df: TypeDef =>

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcSemanticTokensProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcSemanticTokensProvider.scala
@@ -23,13 +23,53 @@ final class PcSemanticTokensProvider(
     driver: InteractiveDriver,
     params: VirtualFileParams,
 ):
+
+  /**
+   * Declaration is set only for parameters, defs/vals/vars without rhs,
+   * type parameterss and inside pattern matches. In all those cases we don't
+   * have a specific value.
+   */
+  private def isDeclaration(tree: Tree) = tree match
+    case df: ValOrDefDef => df.rhs.isEmpty
+    case df: TypeDef =>
+      df.rhs match
+        case _: Template => false
+        case _ => df.rhs.isEmpty
+    case df: Bind => true
+    case _ => false
+
+  /**
+   * Definition is set only for defs/vals/vars/type with rhs.
+   * We don;t want to set it for enum cases despite the fact
+   * that the compiler sees them as vals, as it's not clear
+   * if they should be declaration/definition at all.
+   */
+  private def isDefinition(tree: Tree) = tree match
+    case df: ValOrDefDef =>
+      !df.rhs.isEmpty && !df.symbol.isAllOf(Flags.EnumCase)
+    case df: TypeDef =>
+      df.rhs match
+        case _: Template => false
+        case _ => !df.rhs.isEmpty
+    case _ => false
+
   object Collector extends PcCollector[Option[Node]](driver, params):
     override def collect(
         parent: Option[Tree]
     )(tree: Tree, pos: SourcePosition, symbol: Option[Symbol]): Option[Node] =
-      val sym = symbol.fold(tree.symbol)(s => s)
+      val sym = symbol.fold(tree.symbol)(identity)
       if !pos.exists || sym == null || sym == NoSymbol then None
-      else Some(makeNode(sym, adjust(pos)._1))
+      else
+        Some(
+          makeNode(
+            sym = sym,
+            pos = adjust(pos)._1,
+            isDefinition = isDefinition(tree),
+            isDeclaration = isDeclaration(tree),
+          )
+        )
+    end collect
+  end Collector
 
   given Context = Collector.ctx
 
@@ -45,6 +85,8 @@ final class PcSemanticTokensProvider(
   def makeNode(
       sym: Symbol,
       pos: SourcePosition,
+      isDefinition: Boolean,
+      isDeclaration: Boolean,
   ): Node =
 
     var mod: Int = 0
@@ -91,6 +133,9 @@ final class PcSemanticTokensProvider(
     then addPwrToMod(SemanticTokenModifiers.Abstract)
     if sym.annotations.exists(_.symbol.decodedName == "deprecated")
     then addPwrToMod(SemanticTokenModifiers.Deprecated)
+
+    if isDeclaration then addPwrToMod(SemanticTokenModifiers.Declaration)
+    if isDefinition then addPwrToMod(SemanticTokenModifiers.Definition)
 
     TokenNode(pos.start, pos.`end`, typ, mod)
   end makeNode

--- a/tests/cross/src/main/scala/tests/BaseSemanticTokensSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseSemanticTokensSuite.scala
@@ -7,8 +7,6 @@ import scala.meta.internal.metals.CompilerVirtualFileParams
 
 import munit.Location
 import munit.TestOptions
-import tests.BasePCSuite
-import tests.TestSemanticTokens
 
 class BaseSemanticTokensSuite extends BasePCSuite {
 

--- a/tests/cross/src/test/scala/tests/tokens/SemanticTokensScala3Suite.scala
+++ b/tests/cross/src/test/scala/tests/tokens/SemanticTokensScala3Suite.scala
@@ -35,7 +35,7 @@ class SemanticTokensScala3Suite extends BaseSemanticTokensSuite {
     "named-arguments",
     s"""|package <<example>>/*namespace*/
         |
-        |def <<m>>/*method,definition*/(<<xs>>/*parameter,readonly,declaration*/: <<Int>>/*class,abstract*/*) = <<xs>>/*parameter,readonly*/.<<map>>/*method*/(<<_>>/*parameter,readonly*/ <<+>>/*method*/ 1)
+        |def <<m>>/*method,definition*/(<<xs>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/*) = <<xs>>/*parameter,readonly*/.<<map>>/*method*/(<<_>>/*parameter,readonly*/ <<+>>/*method*/ 1)
         |val <<a>>/*variable,definition,readonly*/ = <<m>>/*method*/(xs = 1,2,3)
         |""".stripMargin,
   )
@@ -72,19 +72,19 @@ class SemanticTokensScala3Suite extends BaseSemanticTokensSuite {
             |import <<reflect>>/*namespace*/.<<Selectable>>/*class*/.<<reflectiveSelectable>>/*method*/
             |
             |object <<StructuralTypes>>/*class*/:
-            |  type <<User>>/*type*/ = {
-            |    def <<name>>/*method*/: <<String>>/*type*/
-            |    def <<age>>/*method*/: <<Int>>/*class,abstract*/
+            |  type <<User>>/*type,definition*/ = {
+            |    def <<name>>/*method,declaration*/: <<String>>/*type*/
+            |    def <<age>>/*method,declaration*/: <<Int>>/*class,abstract*/
             |  }
             |
-            |  val <<user>>/*variable,readonly*/ = null.<<asInstanceOf>>/*method*/[<<User>>/*type*/]
+            |  val <<user>>/*variable,definition,readonly*/ = null.<<asInstanceOf>>/*method*/[<<User>>/*type*/]
             |  <<user>>/*variable,readonly*/.<<name>>/*method*/
             |  <<user>>/*variable,readonly*/.<<age>>/*method*/
             |
-            |  val <<V>>/*variable,readonly*/: <<Object>>/*class*/ {
-            |    def <<scalameta>>/*method*/: <<String>>/*type*/
+            |  val <<V>>/*variable,definition,readonly*/: <<Object>>/*class*/ {
+            |    def <<scalameta>>/*method,declaration*/: <<String>>/*type*/
             |  } = new:
-            |    def <<scalameta>>/*method*/ = "4.0"
+            |    def <<scalameta>>/*method,definition*/ = "4.0"
             |  <<V>>/*variable,readonly*/.<<scalameta>>/*method*/
             |end StructuralTypes
             |""".stripMargin
@@ -107,19 +107,19 @@ class SemanticTokensScala3Suite extends BaseSemanticTokensSuite {
     "predef",
     """
       |object <<Main>>/*class*/ {
-      |  val <<a>>/*variable,readonly*/ = <<List>>/*class*/(1,2,3)
-      |  val <<y>>/*variable,readonly*/ = <<Vector>>/*class*/(1,2)
-      |  val <<z>>/*variable,readonly*/ = <<Set>>/*class*/(1,2,3)
-      |  val <<w>>/*variable,readonly*/ = <<Right>>/*class*/(1)
+      |  val <<a>>/*variable,definition,readonly*/ = <<List>>/*class*/(1,2,3)
+      |  val <<y>>/*variable,definition,readonly*/ = <<Vector>>/*class*/(1,2)
+      |  val <<z>>/*variable,definition,readonly*/ = <<Set>>/*class*/(1,2,3)
+      |  val <<w>>/*variable,definition,readonly*/ = <<Right>>/*class*/(1)
       |}""".stripMargin,
   )
 
   check(
     "case-class",
-    """|case class <<Foo>>/*class*/(<<i>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<j>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
+    """|case class <<Foo>>/*class*/(<<i>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<j>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
        |
        |object <<A>>/*class*/ {
-       |  val <<f>>/*variable,readonly*/ = <<Foo>>/*class*/(1,2)
+       |  val <<f>>/*variable,definition,readonly*/ = <<Foo>>/*class*/(1,2)
        |}
        |""".stripMargin,
   )

--- a/tests/cross/src/test/scala/tests/tokens/SemanticTokensScala3Suite.scala
+++ b/tests/cross/src/test/scala/tests/tokens/SemanticTokensScala3Suite.scala
@@ -9,23 +9,24 @@ class SemanticTokensScala3Suite extends BaseSemanticTokensSuite {
 
   check(
     "enum",
-    s"""|package <<example>>/*namespace*/
-        |
-        |enum <<FooEnum>>/*enum,abstract*/:
-        |  case <<Bar>>/*enum*/, <<Baz>>/*enum*/
-        |object <<FooEnum>>/*class*/
-        |""".stripMargin,
+    """|package <<example>>/*namespace*/
+       |
+       |enum <<FooEnum>>/*enum,abstract*/:
+       |  case <<Bar>>/*enum*/, <<Baz>>/*enum*/
+       |object <<FooEnum>>/*class*/
+       |""".stripMargin,
   )
 
   check(
     "enum1",
-    s"""|package <<example>>/*namespace*/
-        |
-        |enum <<FooEnum>>/*enum,abstract*/:
-        |  case <<A>>/*enum*/(<<a>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
-        |  case <<B>>/*enum*/(<<a>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
-        |  case <<C>>/*enum*/(<<a>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
-        |""".stripMargin,
+    """|package <<example>>/*namespace*/
+       |
+       |enum <<FooEnum>>/*enum,abstract*/:
+       |  case <<A>>/*enum*/(<<a>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
+       |  case <<B>>/*enum*/(<<a>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
+       |  case <<C>>/*enum*/(<<a>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
+       |
+       |""".stripMargin,
   )
 
   // Issue: Sequential parameters are not highlighted
@@ -34,8 +35,8 @@ class SemanticTokensScala3Suite extends BaseSemanticTokensSuite {
     "named-arguments",
     s"""|package <<example>>/*namespace*/
         |
-        |def <<m>>/*method*/(<<xs>>/*parameter,readonly*/: <<Int>>/*class,abstract*/*) = <<xs>>/*parameter,readonly*/.<<map>>/*method*/(<<_>>/*parameter,readonly*/ <<+>>/*method*/ 1)
-        |val <<a>>/*variable,readonly*/ = <<m>>/*method*/(xs = 1,2,3)
+        |def <<m>>/*method,definition*/(<<xs>>/*parameter,readonly,declaration*/: <<Int>>/*class,abstract*/*) = <<xs>>/*parameter,readonly*/.<<map>>/*method*/(<<_>>/*parameter,readonly*/ <<+>>/*method*/ 1)
+        |val <<a>>/*variable,definition,readonly*/ = <<m>>/*method*/(xs = 1,2,3)
         |""".stripMargin,
   )
 
@@ -48,19 +49,19 @@ class SemanticTokensScala3Suite extends BaseSemanticTokensSuite {
         |import <<reflect>>/*namespace*/.<<Selectable>>/*class*/.<<reflectiveSelectable>>/*method*/
         |
         |object <<StructuralTypes>>/*class*/:
-        |  type <<User>>/*type*/ = {
-        |    def <<name>>/*method*/: <<String>>/*type*/
-        |    def <<age>>/*method*/: <<Int>>/*class,abstract*/
+        |  type <<User>>/*type,definition*/ = {
+        |    def <<name>>/*method,declaration*/: <<String>>/*type*/
+        |    def <<age>>/*method,declaration*/: <<Int>>/*class,abstract*/
         |  }
         |
-        |  val <<user>>/*variable,readonly*/ = null.<<asInstanceOf>>/*method*/[<<User>>/*type*/]
+        |  val <<user>>/*variable,definition,readonly*/ = null.<<asInstanceOf>>/*method*/[<<User>>/*type*/]
         |  <<user>>/*variable,readonly*/.name
         |  <<user>>/*variable,readonly*/.age
         |
-        |  val <<V>>/*variable,readonly*/: <<Object>>/*class*/ {
-        |    def <<scalameta>>/*method*/: <<String>>/*type*/
+        |  val <<V>>/*variable,definition,readonly*/: <<Object>>/*class*/ {
+        |    def <<scalameta>>/*method,declaration*/: <<String>>/*type*/
         |  } = new:
-        |    def <<scalameta>>/*method*/ = "4.0"
+        |    def <<scalameta>>/*method,definition*/ = "4.0"
         |  <<V>>/*variable,readonly*/.scalameta
         |end StructuralTypes
         |""".stripMargin,
@@ -95,9 +96,9 @@ class SemanticTokensScala3Suite extends BaseSemanticTokensSuite {
     s"""|package <<example>>/*namespace*/
         |
         |object <<A>>/*class*/ {
-        |  val <<a>>/*variable,readonly*/ = 1
-        |  var <<b>>/*variable*/ = 2
-        |  val <<c>>/*variable,readonly*/ = <<List>>/*class*/(1,<<a>>/*variable,readonly*/,<<b>>/*variable*/)
+        |  val <<a>>/*variable,definition,readonly*/ = 1
+        |  var <<b>>/*variable,definition*/ = 2
+        |  val <<c>>/*variable,definition,readonly*/ = <<List>>/*class*/(1,<<a>>/*variable,readonly*/,<<b>>/*variable*/)
         |  <<b>>/*variable*/ = <<a>>/*variable,readonly*/
         |""".stripMargin,
   )

--- a/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
+++ b/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
@@ -10,13 +10,13 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |
         |class <<Test>>/*class*/{
         |
-        | var <<wkStr>>/*variable*/ = "Dog-"
-        | val <<nameStr>>/*variable,readonly*/ = "Jack"
+        | var <<wkStr>>/*variable,definition*/ = "Dog-"
+        | val <<nameStr>>/*variable,definition,readonly*/ = "Jack"
         |
-        | def <<Main>>/*method*/={
+        | def <<Main>>/*method,definition*/={
         |
-        |  val <<preStr>>/*variable,readonly*/= "I am "
-        |  var <<postStr>>/*variable*/= "in a house. "
+        |  val <<preStr>>/*variable,definition,readonly*/= "I am "
+        |  var <<postStr>>/*variable,definition*/= "in a house. "
         |  <<wkStr>>/*variable*/=<<nameStr>>/*variable,readonly*/ <<+>>/*method*/ "Cat-"
         |
         |  <<testC>>/*class*/.<<bc>>/*method*/(<<preStr>>/*variable,readonly*/
@@ -27,7 +27,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |
         |object <<testC>>/*class*/{
         |
-        | def <<bc>>/*method*/(<<msg>>/*parameter,readonly*/:<<String>>/*type*/)={
+        | def <<bc>>/*method,definition*/(<<msg>>/*parameter,readonly,declaration*/:<<String>>/*type*/)={
         |   <<println>>/*method*/(<<msg>>/*parameter,readonly*/)
         | }
         |}
@@ -42,9 +42,9 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |
         |   /**
         |   * Test of Comment Block
-        |   */  val <<x>>/*variable,readonly*/ = 1
+        |   */  val <<x>>/*variable,definition,readonly*/ = 1
         |
-        |  def <<add>>/*method*/(<<a>>/*parameter,readonly*/ : <<Int>>/*class,abstract*/) = {
+        |  def <<add>>/*method,definition*/(<<a>>/*parameter,readonly,declaration*/ : <<Int>>/*class,abstract*/) = {
         |    // Single Line Comment
         |    <<a>>/*parameter,readonly*/ <<+>>/*method,abstract*/ 1 // com = 1
         |   }
@@ -58,9 +58,9 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
             |
             |   /**
             |   * Test of Comment Block
-            |   */  val <<x>>/*variable,readonly*/ = 1
+            |   */  val <<x>>/*variable,definition,readonly*/ = 1
             |
-            |  def <<add>>/*method*/(<<a>>/*parameter,readonly*/ : <<Int>>/*class,abstract*/) = {
+            |  def <<add>>/*method,definition*/(<<a>>/*parameter,readonly,declaration*/ : <<Int>>/*class,abstract*/) = {
             |    // Single Line Comment
             |    <<a>>/*parameter,readonly*/ <<+>>/*method*/ 1 // com = 1
             |   }
@@ -74,14 +74,14 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
     s"""|package <<example>>/*namespace*/
         |
         |object <<ab>>/*class*/ {
-        |  var  <<iVar>>/*variable*/:<<Int>>/*class,abstract*/ = 1
-        |  val  <<iVal>>/*variable,readonly*/:<<Double>>/*class,abstract*/ = 4.94065645841246544e-324d
-        |  val  <<fVal>>/*variable,readonly*/:<<Float>>/*class,abstract*/ = 1.40129846432481707e-45
-        |  val  <<lVal>>/*variable,readonly*/:<<Long>>/*class,abstract*/ = 9223372036854775807L
+        |  var  <<iVar>>/*variable,definition*/:<<Int>>/*class,abstract*/ = 1
+        |  val  <<iVal>>/*variable,definition,readonly*/:<<Double>>/*class,abstract*/ = 4.94065645841246544e-324d
+        |  val  <<fVal>>/*variable,definition,readonly*/:<<Float>>/*class,abstract*/ = 1.40129846432481707e-45
+        |  val  <<lVal>>/*variable,definition,readonly*/:<<Long>>/*class,abstract*/ = 9223372036854775807L
         |}
         |
         |object <<sample10>>/*class*/ {
-        |  def <<main>>/*method*/(<<args>>/*parameter,readonly*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
+        |  def <<main>>/*method,definition*/(<<args>>/*parameter,readonly,declaration*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
         |    <<println>>/*method*/(
         |     (<<ab>>/*class*/.<<iVar>>/*variable*/ <<+>>/*method,abstract*/ <<ab>>/*class*/.<<iVal>>/*variable,readonly*/).<<toString>>/*method*/
         |    )
@@ -94,14 +94,14 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         s"""|package <<example>>/*namespace*/
             |
             |object <<ab>>/*class*/ {
-            |  var  <<iVar>>/*variable*/:<<Int>>/*class,abstract*/ = 1
-            |  val  <<iVal>>/*variable,readonly*/:<<Double>>/*class,abstract*/ = 4.94065645841246544e-324d
-            |  val  <<fVal>>/*variable,readonly*/:<<Float>>/*class,abstract*/ = 1.40129846432481707e-45
-            |  val  <<lVal>>/*variable,readonly*/:<<Long>>/*class,abstract*/ = 9223372036854775807L
+            |  var  <<iVar>>/*variable,definition*/:<<Int>>/*class,abstract*/ = 1
+            |  val  <<iVal>>/*variable,definition,readonly*/:<<Double>>/*class,abstract*/ = 4.94065645841246544e-324d
+            |  val  <<fVal>>/*variable,definition,readonly*/:<<Float>>/*class,abstract*/ = 1.40129846432481707e-45
+            |  val  <<lVal>>/*variable,definition,readonly*/:<<Long>>/*class,abstract*/ = 9223372036854775807L
             |}
             |
             |object <<sample10>>/*class*/ {
-            |  def <<main>>/*method*/(<<args>>/*parameter,readonly*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
+            |  def <<main>>/*method,definition*/(<<args>>/*parameter,readonly,declaration*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
             |    <<println>>/*method*/(
             |     (<<ab>>/*class*/.<<iVar>>/*variable*/ <<+>>/*method*/ <<ab>>/*class*/.<<iVal>>/*variable,readonly*/).<<toString>>/*method*/
             |    )
@@ -117,28 +117,29 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |package <<a>>/*namespace*/.<<b>>/*namespace*/
         |object <<Sample5>>/*class*/ {
         |
-        |  def <<main>>/*method*/(<<args>>/*parameter,readonly*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
-        |      val <<itr>>/*variable,readonly*/ = new <<IntIterator>>/*class*/(5)
-        |      var <<str>>/*variable*/ = <<itr>>/*variable,readonly*/.<<next>>/*method*/().<<toString>>/*method*/ <<+>>/*method*/ ","
+        |  type <<PP>>/*type,definition*/ = <<Int>>/*class,abstract*/
+        |  def <<main>>/*method,definition*/(<<args>>/*parameter,readonly,declaration*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
+        |      val <<itr>>/*variable,definition,readonly*/ = new <<IntIterator>>/*class*/(5)
+        |      var <<str>>/*variable,definition*/ = <<itr>>/*variable,readonly*/.<<next>>/*method*/().<<toString>>/*method*/ <<+>>/*method*/ ","
         |          <<str>>/*variable*/ += <<itr>>/*variable,readonly*/.<<next>>/*method*/().<<toString>>/*method*/
         |      <<println>>/*method*/("count:"<<+>>/*method*/<<str>>/*variable*/)
         |  }
         |
-        |  trait <<Iterator>>/*interface,abstract*/[<<A>>/*typeParameter,abstract*/] {
-        |    def <<next>>/*method,abstract*/(): <<A>>/*typeParameter,abstract*/
+        |  trait <<Iterator>>/*interface,abstract*/[<<A>>/*typeParameter,declaration,abstract*/] {
+        |    def <<next>>/*method,declaration,abstract*/(): <<A>>/*typeParameter,abstract*/
         |  }
         |
         |  abstract class <<hasLogger>>/*class,abstract*/ {
-        |    def <<log>>/*method*/(<<str>>/*parameter,readonly*/:<<String>>/*type*/) = {<<println>>/*method*/(<<str>>/*parameter,readonly*/)}
+        |    def <<log>>/*method,definition*/(<<str>>/*parameter,readonly,declaration*/:<<String>>/*type*/) = {<<println>>/*method*/(<<str>>/*parameter,readonly*/)}
         |  }
         |
-        |  class <<IntIterator>>/*class*/(<<to>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
+        |  class <<IntIterator>>/*class*/(<<to>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
         |  extends <<hasLogger>>/*class,abstract*/ with <<Iterator>>/*interface,abstract*/[<<Int>>/*class,abstract*/]  {
-        |    private var <<current>>/*variable*/ = 0
-        |    override def <<next>>/*method*/(): <<Int>>/*class,abstract*/ = {
+        |    private var <<current>>/*variable,definition*/ = 0
+        |    override def <<next>>/*method,definition*/(): <<Int>>/*class,abstract*/ = {
         |      if (<<current>>/*variable*/ <<<>>/*method,abstract*/ <<to>>/*variable,readonly*/) {
         |        <<log>>/*method*/("main")
-        |        val <<t>>/*variable,readonly*/ = <<current>>/*variable*/
+        |        val <<t>>/*variable,definition,readonly*/ = <<current>>/*variable*/
         |        <<current>>/*variable*/ = <<current>>/*variable*/ <<+>>/*method,abstract*/ 1
         |        <<t>>/*variable,readonly*/
         |      } else 0
@@ -155,28 +156,29 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
             |package <<a>>/*namespace*/.<<b>>/*namespace*/
             |object <<Sample5>>/*class*/ {
             |
-            |  def <<main>>/*method*/(<<args>>/*parameter,readonly*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
-            |      val <<itr>>/*variable,readonly*/ = new <<IntIterator>>/*class*/(5)
-            |      var <<str>>/*variable*/ = <<itr>>/*variable,readonly*/.<<next>>/*method*/().<<toString>>/*method*/ <<+>>/*method*/ ","
+            |  type <<PP>>/*type,definition*/ = <<Int>>/*class,abstract*/
+            |  def <<main>>/*method,definition*/(<<args>>/*parameter,readonly,declaration*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
+            |      val <<itr>>/*variable,definition,readonly*/ = new <<IntIterator>>/*class*/(5)
+            |      var <<str>>/*variable,definition*/ = <<itr>>/*variable,readonly*/.<<next>>/*method*/().<<toString>>/*method*/ <<+>>/*method*/ ","
             |          <<str>>/*variable*/ += <<itr>>/*variable,readonly*/.<<next>>/*method*/().<<toString>>/*method*/
             |      <<println>>/*method*/("count:"<<+>>/*method*/<<str>>/*variable*/)
             |  }
             |
-            |  trait <<Iterator>>/*interface,abstract*/[<<A>>/*typeParameter,abstract*/] {
-            |    def <<next>>/*method*/(): <<A>>/*typeParameter,abstract*/
+            |  trait <<Iterator>>/*interface,abstract*/[<<A>>/*typeParameter,definition,abstract*/] {
+            |    def <<next>>/*method,declaration*/(): <<A>>/*typeParameter,abstract*/
             |  }
             |
             |  abstract class <<hasLogger>>/*class,abstract*/ {
-            |    def <<log>>/*method*/(<<str>>/*parameter,readonly*/:<<String>>/*type*/) = {<<println>>/*method*/(<<str>>/*parameter,readonly*/)}
+            |    def <<log>>/*method,definition*/(<<str>>/*parameter,readonly,declaration*/:<<String>>/*type*/) = {<<println>>/*method*/(<<str>>/*parameter,readonly*/)}
             |  }
             |
-            |  class <<IntIterator>>/*class*/(<<to>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
+            |  class <<IntIterator>>/*class*/(<<to>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
             |  extends <<hasLogger>>/*class,abstract*/ with <<Iterator>>/*interface,abstract*/[<<Int>>/*class,abstract*/]  {
-            |    private var <<current>>/*variable*/ = 0
-            |    override def <<next>>/*method*/(): <<Int>>/*class,abstract*/ = {
+            |    private var <<current>>/*variable,definition*/ = 0
+            |    override def <<next>>/*method,definition*/(): <<Int>>/*class,abstract*/ = {
             |      if (<<current>>/*variable*/ <<<>>/*method*/ <<to>>/*variable,readonly*/) {
             |        <<log>>/*method*/("main")
-            |        val <<t>>/*variable,readonly*/ = <<current>>/*variable*/
+            |        val <<t>>/*variable,definition,readonly*/ = <<current>>/*variable*/
             |        <<current>>/*variable*/ = <<current>>/*variable*/ <<+>>/*method*/ 1
             |        <<t>>/*variable,readonly*/
             |      } else 0
@@ -194,10 +196,10 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
     s"""|package <<example>>/*namespace*/
         |object <<sample9>>/*class*/ {
         |  @<<deprecated>>/*class*/("this method will be removed", "FooLib 12.0")
-        |  def <<oldMethod>>/*method,deprecated*/(<<x>>/*parameter,readonly*/: <<Int>>/*class,abstract*/) = <<x>>/*parameter,readonly*/
+        |  def <<oldMethod>>/*method,definition,deprecated*/(<<x>>/*parameter,readonly,declaration*/: <<Int>>/*class,abstract*/) = <<x>>/*parameter,readonly*/
         |
-        |  def <<main>>/*method*/(<<args>>/*parameter,readonly*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
-        |    val <<str>>/*variable,readonly*/ = <<oldMethod>>/*method,deprecated*/(2).<<toString>>/*method*/
+        |  def <<main>>/*method,definition*/(<<args>>/*parameter,readonly,declaration*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
+        |    val <<str>>/*variable,definition,readonly*/ = <<oldMethod>>/*method,deprecated*/(2).<<toString>>/*method*/
         |     <<println>>/*method*/("Hello, world!"<<+>>/*method*/ <<str>>/*variable,readonly*/)
         |  }
         |}
@@ -211,7 +213,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |
         |object <<sample3>>/*class*/ {
         |
-        |  def <<sorted1>>/*method*/(<<x>>/*parameter,readonly*/: <<Int>>/*class,abstract*/)
+        |  def <<sorted1>>/*method,definition*/(<<x>>/*parameter,readonly,declaration*/: <<Int>>/*class,abstract*/)
         |     = <<SortedSet>>/*class*/(<<x>>/*parameter,readonly*/)
         |}
         |
@@ -222,30 +224,30 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
     "anonymous-class",
     s"""|package <<example>>/*namespace*/ 
         |object <<A>>/*class*/ {
-        |  trait <<Methodable>>/*interface,abstract*/[<<T>>/*typeParameter,abstract*/] {
-        |    def <<method>>/*method,abstract*/(<<asf>>/*parameter,readonly*/: <<T>>/*typeParameter,abstract*/): <<Int>>/*class,abstract*/
+        |  trait <<Methodable>>/*interface,abstract*/[<<T>>/*typeParameter,declaration,abstract*/] {
+        |    def <<method>>/*method,declaration,abstract*/(<<asf>>/*parameter,readonly,declaration*/: <<T>>/*typeParameter,abstract*/): <<Int>>/*class,abstract*/
         |  }
         |
-        |  abstract class <<Alp>>/*class,abstract*/(<<alp>>/*variable,readonly*/: <<Int>>/*class,abstract*/) extends <<Methodable>>/*interface,abstract*/[<<String>>/*type*/] {
-        |    def <<method>>/*method*/(<<adf>>/*parameter,readonly*/: <<String>>/*type*/) = 123
+        |  abstract class <<Alp>>/*class,abstract*/(<<alp>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/) extends <<Methodable>>/*interface,abstract*/[<<String>>/*type*/] {
+        |    def <<method>>/*method,definition*/(<<adf>>/*parameter,readonly,declaration*/: <<String>>/*type*/) = 123
         |  }
-        |  val <<a>>/*variable,readonly*/ = new <<Alp>>/*class,abstract*/(<<alp>>/*parameter,readonly*/ = 10) {
-        |    override def <<method>>/*method*/(<<adf>>/*parameter,readonly*/: <<String>>/*type*/): <<Int>>/*class,abstract*/ = 321
+        |  val <<a>>/*variable,definition,readonly*/ = new <<Alp>>/*class,abstract*/(<<alp>>/*parameter,readonly*/ = 10) {
+        |    override def <<method>>/*method,definition*/(<<adf>>/*parameter,readonly,declaration*/: <<String>>/*type*/): <<Int>>/*class,abstract*/ = 321
         |  }
         |}""".stripMargin,
     // In Scala 3 methods in `trait` are not abstract
     compat = Map(
       "3" -> s"""|package <<example>>/*namespace*/ 
                  |object <<A>>/*class*/ {
-                 |  trait <<Methodable>>/*interface,abstract*/[<<T>>/*typeParameter,abstract*/] {
-                 |    def <<method>>/*method*/(<<asf>>/*parameter,readonly*/: <<T>>/*typeParameter,abstract*/): <<Int>>/*class,abstract*/
+                 |  trait <<Methodable>>/*interface,abstract*/[<<T>>/*typeParameter,definition,abstract*/] {
+                 |    def <<method>>/*method,declaration*/(<<asf>>/*parameter,readonly,declaration*/: <<T>>/*typeParameter,abstract*/): <<Int>>/*class,abstract*/
                  |  }
                  |
-                 |  abstract class <<Alp>>/*class,abstract*/(<<alp>>/*variable,readonly*/: <<Int>>/*class,abstract*/) extends <<Methodable>>/*interface,abstract*/[<<String>>/*type*/] {
-                 |    def <<method>>/*method*/(<<adf>>/*parameter,readonly*/: <<String>>/*type*/) = 123
+                 |  abstract class <<Alp>>/*class,abstract*/(<<alp>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/) extends <<Methodable>>/*interface,abstract*/[<<String>>/*type*/] {
+                 |    def <<method>>/*method,definition*/(<<adf>>/*parameter,readonly,declaration*/: <<String>>/*type*/) = 123
                  |  }
-                 |  val <<a>>/*variable,readonly*/ = new <<Alp>>/*class,abstract*/(<<alp>>/*parameter,readonly*/ = 10) {
-                 |    override def <<method>>/*method*/(<<adf>>/*parameter,readonly*/: <<String>>/*type*/): <<Int>>/*class,abstract*/ = 321
+                 |  val <<a>>/*variable,definition,readonly*/ = new <<Alp>>/*class,abstract*/(<<alp>>/*parameter,readonly*/ = 10) {
+                 |    override def <<method>>/*method,definition*/(<<adf>>/*parameter,readonly,declaration*/: <<String>>/*type*/): <<Int>>/*class,abstract*/ = 321
                  |  }
                  |}""".stripMargin
     ),
@@ -261,6 +263,21 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |  // rename reference
         |  <<NoBad>>/*class*/(null)
         |}""".stripMargin,
+  )
+
+  check(
+    "pattern-match",
+    s"""|package <<example>>/*namespace*/
+        |
+        |class <<Imports>>/*class*/ {
+        |  
+        |  val <<a>>/*variable,definition,readonly*/ = <<Option>>/*class*/(<<Option>>/*class*/(""))
+        |  <<a>>/*variable,readonly*/ match {
+        |    case <<Some>>/*class*/(<<Some>>/*class*/(<<b>>/*variable,declaration,readonly*/)) => <<b>>/*variable,readonly*/
+        |    case <<Some>>/*class*/(<<b>>/*variable,declaration,readonly*/) => <<b>>/*variable,readonly*/
+        |    case <<other>>/*variable,declaration,readonly*/ => 
+        |  }
+}}""".stripMargin,
   )
 
 }

--- a/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
+++ b/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
@@ -273,11 +273,23 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |  
         |  val <<a>>/*variable,definition,readonly*/ = <<Option>>/*class*/(<<Option>>/*class*/(""))
         |  <<a>>/*variable,readonly*/ match {
-        |    case <<Some>>/*class*/(<<Some>>/*class*/(<<b>>/*variable,declaration,readonly*/)) => <<b>>/*variable,readonly*/
-        |    case <<Some>>/*class*/(<<b>>/*variable,declaration,readonly*/) => <<b>>/*variable,readonly*/
-        |    case <<other>>/*variable,declaration,readonly*/ => 
+        |    case <<Some>>/*class*/(<<Some>>/*class*/(<<b>>/*variable,definition,readonly*/)) => <<b>>/*variable,readonly*/
+        |    case <<Some>>/*class*/(<<b>>/*variable,definition,readonly*/) => <<b>>/*variable,readonly*/
+        |    case <<other>>/*variable,definition,readonly*/ => 
         |  }
-}}""".stripMargin,
+        |}""".stripMargin,
   )
 
+  check(
+    "pattern-match-value",
+    s"""|package <<example>>/*namespace*/
+        |
+        |object <<A>>/*class*/ {
+        |  val <<x>>/*variable,definition,readonly*/ = <<List>>/*variable,readonly*/(1,2,3)
+        |  val <<s>>/*variable,definition,readonly*/ = <<Some>>/*class*/(1)
+        |  val <<Some>>/*class*/(<<s1>>/*variable,definition,readonly*/) = <<s>>/*variable,readonly*/
+        |  val <<Some>>/*class*/(<<s2>>/*variable,definition,readonly*/) = <<s>>/*variable,readonly*/
+        |}
+        |""".stripMargin,
+  )
 }

--- a/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
+++ b/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
@@ -27,7 +27,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |
         |object <<testC>>/*class*/{
         |
-        | def <<bc>>/*method,definition*/(<<msg>>/*parameter,readonly,declaration*/:<<String>>/*type*/)={
+        | def <<bc>>/*method,definition*/(<<msg>>/*parameter,declaration,readonly*/:<<String>>/*type*/)={
         |   <<println>>/*method*/(<<msg>>/*parameter,readonly*/)
         | }
         |}
@@ -44,7 +44,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |   * Test of Comment Block
         |   */  val <<x>>/*variable,definition,readonly*/ = 1
         |
-        |  def <<add>>/*method,definition*/(<<a>>/*parameter,readonly,declaration*/ : <<Int>>/*class,abstract*/) = {
+        |  def <<add>>/*method,definition*/(<<a>>/*parameter,declaration,readonly*/ : <<Int>>/*class,abstract*/) = {
         |    // Single Line Comment
         |    <<a>>/*parameter,readonly*/ <<+>>/*method,abstract*/ 1 // com = 1
         |   }
@@ -60,7 +60,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
             |   * Test of Comment Block
             |   */  val <<x>>/*variable,definition,readonly*/ = 1
             |
-            |  def <<add>>/*method,definition*/(<<a>>/*parameter,readonly,declaration*/ : <<Int>>/*class,abstract*/) = {
+            |  def <<add>>/*method,definition*/(<<a>>/*parameter,declaration,readonly*/ : <<Int>>/*class,abstract*/) = {
             |    // Single Line Comment
             |    <<a>>/*parameter,readonly*/ <<+>>/*method*/ 1 // com = 1
             |   }
@@ -81,7 +81,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |}
         |
         |object <<sample10>>/*class*/ {
-        |  def <<main>>/*method,definition*/(<<args>>/*parameter,readonly,declaration*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
+        |  def <<main>>/*method,definition*/(<<args>>/*parameter,declaration,readonly*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
         |    <<println>>/*method*/(
         |     (<<ab>>/*class*/.<<iVar>>/*variable*/ <<+>>/*method,abstract*/ <<ab>>/*class*/.<<iVal>>/*variable,readonly*/).<<toString>>/*method*/
         |    )
@@ -101,7 +101,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
             |}
             |
             |object <<sample10>>/*class*/ {
-            |  def <<main>>/*method,definition*/(<<args>>/*parameter,readonly,declaration*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
+            |  def <<main>>/*method,definition*/(<<args>>/*parameter,declaration,readonly*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
             |    <<println>>/*method*/(
             |     (<<ab>>/*class*/.<<iVar>>/*variable*/ <<+>>/*method*/ <<ab>>/*class*/.<<iVal>>/*variable,readonly*/).<<toString>>/*method*/
             |    )
@@ -118,7 +118,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |object <<Sample5>>/*class*/ {
         |
         |  type <<PP>>/*type,definition*/ = <<Int>>/*class,abstract*/
-        |  def <<main>>/*method,definition*/(<<args>>/*parameter,readonly,declaration*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
+        |  def <<main>>/*method,definition*/(<<args>>/*parameter,declaration,readonly*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
         |      val <<itr>>/*variable,definition,readonly*/ = new <<IntIterator>>/*class*/(5)
         |      var <<str>>/*variable,definition*/ = <<itr>>/*variable,readonly*/.<<next>>/*method*/().<<toString>>/*method*/ <<+>>/*method*/ ","
         |          <<str>>/*variable*/ += <<itr>>/*variable,readonly*/.<<next>>/*method*/().<<toString>>/*method*/
@@ -130,7 +130,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |  }
         |
         |  abstract class <<hasLogger>>/*class,abstract*/ {
-        |    def <<log>>/*method,definition*/(<<str>>/*parameter,readonly,declaration*/:<<String>>/*type*/) = {<<println>>/*method*/(<<str>>/*parameter,readonly*/)}
+        |    def <<log>>/*method,definition*/(<<str>>/*parameter,declaration,readonly*/:<<String>>/*type*/) = {<<println>>/*method*/(<<str>>/*parameter,readonly*/)}
         |  }
         |
         |  class <<IntIterator>>/*class*/(<<to>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
@@ -157,7 +157,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
             |object <<Sample5>>/*class*/ {
             |
             |  type <<PP>>/*type,definition*/ = <<Int>>/*class,abstract*/
-            |  def <<main>>/*method,definition*/(<<args>>/*parameter,readonly,declaration*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
+            |  def <<main>>/*method,definition*/(<<args>>/*parameter,declaration,readonly*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
             |      val <<itr>>/*variable,definition,readonly*/ = new <<IntIterator>>/*class*/(5)
             |      var <<str>>/*variable,definition*/ = <<itr>>/*variable,readonly*/.<<next>>/*method*/().<<toString>>/*method*/ <<+>>/*method*/ ","
             |          <<str>>/*variable*/ += <<itr>>/*variable,readonly*/.<<next>>/*method*/().<<toString>>/*method*/
@@ -169,7 +169,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
             |  }
             |
             |  abstract class <<hasLogger>>/*class,abstract*/ {
-            |    def <<log>>/*method,definition*/(<<str>>/*parameter,readonly,declaration*/:<<String>>/*type*/) = {<<println>>/*method*/(<<str>>/*parameter,readonly*/)}
+            |    def <<log>>/*method,definition*/(<<str>>/*parameter,declaration,readonly*/:<<String>>/*type*/) = {<<println>>/*method*/(<<str>>/*parameter,readonly*/)}
             |  }
             |
             |  class <<IntIterator>>/*class*/(<<to>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
@@ -196,9 +196,9 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
     s"""|package <<example>>/*namespace*/
         |object <<sample9>>/*class*/ {
         |  @<<deprecated>>/*class*/("this method will be removed", "FooLib 12.0")
-        |  def <<oldMethod>>/*method,definition,deprecated*/(<<x>>/*parameter,readonly,declaration*/: <<Int>>/*class,abstract*/) = <<x>>/*parameter,readonly*/
+        |  def <<oldMethod>>/*method,definition,deprecated*/(<<x>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/) = <<x>>/*parameter,readonly*/
         |
-        |  def <<main>>/*method,definition*/(<<args>>/*parameter,readonly,declaration*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
+        |  def <<main>>/*method,definition*/(<<args>>/*parameter,declaration,readonly*/: <<Array>>/*class*/[<<String>>/*type*/]) ={
         |    val <<str>>/*variable,definition,readonly*/ = <<oldMethod>>/*method,deprecated*/(2).<<toString>>/*method*/
         |     <<println>>/*method*/("Hello, world!"<<+>>/*method*/ <<str>>/*variable,readonly*/)
         |  }
@@ -213,7 +213,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |
         |object <<sample3>>/*class*/ {
         |
-        |  def <<sorted1>>/*method,definition*/(<<x>>/*parameter,readonly,declaration*/: <<Int>>/*class,abstract*/)
+        |  def <<sorted1>>/*method,definition*/(<<x>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/)
         |     = <<SortedSet>>/*class*/(<<x>>/*parameter,readonly*/)
         |}
         |
@@ -225,14 +225,14 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
     s"""|package <<example>>/*namespace*/ 
         |object <<A>>/*class*/ {
         |  trait <<Methodable>>/*interface,abstract*/[<<T>>/*typeParameter,declaration,abstract*/] {
-        |    def <<method>>/*method,declaration,abstract*/(<<asf>>/*parameter,readonly,declaration*/: <<T>>/*typeParameter,abstract*/): <<Int>>/*class,abstract*/
+        |    def <<method>>/*method,declaration,abstract*/(<<asf>>/*parameter,declaration,readonly*/: <<T>>/*typeParameter,abstract*/): <<Int>>/*class,abstract*/
         |  }
         |
         |  abstract class <<Alp>>/*class,abstract*/(<<alp>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/) extends <<Methodable>>/*interface,abstract*/[<<String>>/*type*/] {
-        |    def <<method>>/*method,definition*/(<<adf>>/*parameter,readonly,declaration*/: <<String>>/*type*/) = 123
+        |    def <<method>>/*method,definition*/(<<adf>>/*parameter,declaration,readonly*/: <<String>>/*type*/) = 123
         |  }
         |  val <<a>>/*variable,definition,readonly*/ = new <<Alp>>/*class,abstract*/(<<alp>>/*parameter,readonly*/ = 10) {
-        |    override def <<method>>/*method,definition*/(<<adf>>/*parameter,readonly,declaration*/: <<String>>/*type*/): <<Int>>/*class,abstract*/ = 321
+        |    override def <<method>>/*method,definition*/(<<adf>>/*parameter,declaration,readonly*/: <<String>>/*type*/): <<Int>>/*class,abstract*/ = 321
         |  }
         |}""".stripMargin,
     // In Scala 3 methods in `trait` are not abstract
@@ -240,14 +240,14 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
       "3" -> s"""|package <<example>>/*namespace*/ 
                  |object <<A>>/*class*/ {
                  |  trait <<Methodable>>/*interface,abstract*/[<<T>>/*typeParameter,definition,abstract*/] {
-                 |    def <<method>>/*method,declaration*/(<<asf>>/*parameter,readonly,declaration*/: <<T>>/*typeParameter,abstract*/): <<Int>>/*class,abstract*/
+                 |    def <<method>>/*method,declaration*/(<<asf>>/*parameter,declaration,readonly*/: <<T>>/*typeParameter,abstract*/): <<Int>>/*class,abstract*/
                  |  }
                  |
                  |  abstract class <<Alp>>/*class,abstract*/(<<alp>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/) extends <<Methodable>>/*interface,abstract*/[<<String>>/*type*/] {
-                 |    def <<method>>/*method,definition*/(<<adf>>/*parameter,readonly,declaration*/: <<String>>/*type*/) = 123
+                 |    def <<method>>/*method,definition*/(<<adf>>/*parameter,declaration,readonly*/: <<String>>/*type*/) = 123
                  |  }
                  |  val <<a>>/*variable,definition,readonly*/ = new <<Alp>>/*class,abstract*/(<<alp>>/*parameter,readonly*/ = 10) {
-                 |    override def <<method>>/*method,definition*/(<<adf>>/*parameter,readonly,declaration*/: <<String>>/*type*/): <<Int>>/*class,abstract*/ = 321
+                 |    override def <<method>>/*method,definition*/(<<adf>>/*parameter,declaration,readonly*/: <<String>>/*type*/): <<Int>>/*class,abstract*/ = 321
                  |  }
                  |}""".stripMargin
     ),
@@ -285,7 +285,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
     s"""|package <<example>>/*namespace*/
         |
         |object <<A>>/*class*/ {
-        |  val <<x>>/*variable,definition,readonly*/ = <<List>>/*variable,readonly*/(1,2,3)
+        |  val <<x>>/*variable,definition,readonly*/ = <<List>>/*class*/(1,2,3)
         |  val <<s>>/*variable,definition,readonly*/ = <<Some>>/*class*/(1)
         |  val <<Some>>/*class*/(<<s1>>/*variable,definition,readonly*/) = <<s>>/*variable,readonly*/
         |  val <<Some>>/*class*/(<<s2>>/*variable,definition,readonly*/) = <<s>>/*variable,readonly*/

--- a/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
@@ -750,7 +750,7 @@ class SbtBloopLspSuite
 
   test("semantic-highlight") {
     val expected =
-      s"""|<<lazy>>/*modifier*/ <<val>>/*keyword*/ <<root>>/*variable,readonly*/ = (<<project>>/*class*/ <<in>>/*method*/ <<file>>/*method*/(<<".">>/*string*/))
+      s"""|<<lazy>>/*modifier*/ <<val>>/*keyword*/ <<root>>/*variable,definition,readonly*/ = (<<project>>/*class*/ <<in>>/*method*/ <<file>>/*method*/(<<".">>/*string*/))
           |  .<<configs>>/*method*/(<<IntegrationTest>>/*variable,readonly*/)
           |  .<<settings>>/*method*/(
           |    <<Defaults>>/*class*/.<<itSettings>>/*variable,readonly*/,

--- a/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
@@ -280,7 +280,7 @@ class SbtServerSuite
   test("semantic-highlight") {
     cleanWorkspace()
     val expected =
-      s"""|<<lazy>>/*modifier*/ <<val>>/*keyword*/ <<root>>/*variable,readonly*/ = (<<project>>/*class*/ <<in>>/*method*/ <<file>>/*method*/(<<".">>/*string*/))
+      s"""|<<lazy>>/*modifier*/ <<val>>/*keyword*/ <<root>>/*variable,definition,readonly*/ = (<<project>>/*class*/ <<in>>/*method*/ <<file>>/*method*/(<<".">>/*string*/))
           |  .<<configs>>/*method*/(<<IntegrationTest>>/*variable,readonly*/)
           |  .<<settings>>/*method*/(
           |    <<Defaults>>/*class*/.<<itSettings>>/*variable,readonly*/,

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -905,13 +905,22 @@ abstract class BaseWorksheetLspSuite(
   test("semantic-highlighting") {
 
     val expected =
-      """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
-         |<<val>>/*keyword*/ <<hi1>>/*variable,readonly*/ =
-         |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
-         |<<val>>/*keyword*/ <<hi2>>/*variable,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
-         |
-         |<<val>>/*keyword*/ <<hellos>>/*variable,readonly*/ = <<List>>/*class*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
-         |""".stripMargin
+      if (scalaVersion == V.scala212)
+        """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
+           |<<val>>/*keyword*/ <<hi1>>/*variable,definition,readonly*/ =
+           |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
+           |<<val>>/*keyword*/ <<hi2>>/*variable,definition,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
+           |
+           |<<val>>/*keyword*/ <<hellos>>/*variable,definition,readonly*/ = <<List>>/*class*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
+           |""".stripMargin
+      else
+        """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
+           |<<val>>/*keyword*/ <<hi1>>/*variable,definition,readonly*/ =
+           |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
+           |<<val>>/*keyword*/ <<hi2>>/*variable,definition,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
+           |
+           |<<val>>/*keyword*/ <<hellos>>/*variable,definition,readonly*/ = <<List>>/*class*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
+           |""".stripMargin
 
     val fileContent =
       TestSemanticTokens.removeSemanticHighlightDecorations(expected)

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1322,7 +1322,7 @@ final case class TestingServer(
       filePath: String,
       expected: String,
       fileContent: String,
-  ): Future[Unit] = {
+  )(implicit location: munit.Location): Future[Unit] = {
     val uri = toPath(filePath).toTextDocumentIdentifier
     val params = new org.eclipse.lsp4j.SemanticTokensParams(uri)
 

--- a/tests/unit/src/test/resources/semanticTokens/example/Comments.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/Comments.scala
@@ -3,7 +3,7 @@
 <<class>>/*keyword*/ <</* comment */>>/*comment*/ <<Comments>>/*class*/ {
   <<object>>/*keyword*/ <</* comment */>>/*comment*/ <<A>>/*class*/
   <<trait>>/*keyword*/ <</* comment */>>/*comment*/ <<A>>/*interface,abstract*/
-  <<val>>/*keyword*/ <</* comment */>>/*comment*/ <<a>>/*variable,readonly*/ = <<1>>/*number*/
-  <<def>>/*keyword*/ <</* comment */>>/*comment*/ <<b>>/*method*/ = <<1>>/*number*/
-  <<var>>/*keyword*/ <</* comment */>>/*comment*/ <<c>>/*variable*/ = <<1>>/*number*/
+  <<val>>/*keyword*/ <</* comment */>>/*comment*/ <<a>>/*variable,definition,readonly*/ = <<1>>/*number*/
+  <<def>>/*keyword*/ <</* comment */>>/*comment*/ <<b>>/*method,definition*/ = <<1>>/*number*/
+  <<var>>/*keyword*/ <</* comment */>>/*comment*/ <<c>>/*variable,definition*/ = <<1>>/*number*/
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/ForComprehensions.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/ForComprehensions.scala
@@ -2,15 +2,15 @@
 
 <<class>>/*keyword*/ <<ForComprehensions>>/*class*/ {
   <<for>>/*keyword*/ {
-    <<a>>/*parameter,readonly*/ <<<->>/*operator*/ <<List>>/*class*/(<<1>>/*number*/)
-    <<b>>/*parameter,readonly*/ <<<->>/*operator*/ <<List>>/*class*/(<<a>>/*parameter,readonly*/)
+    <<a>>/*parameter,declaration,readonly*/ <<<->>/*operator*/ <<List>>/*class*/(<<1>>/*number*/)
+    <<b>>/*parameter,declaration,readonly*/ <<<->>/*operator*/ <<List>>/*class*/(<<a>>/*parameter,readonly*/)
     <<if>>/*keyword*/ (
       <<a>>/*parameter,readonly*/,
       <<b>>/*parameter,readonly*/,
     ) <<==>>/*method*/ (<<1>>/*number*/, <<2>>/*number*/)
     (
-      <<c>>/*variable,readonly*/,
-      <<d>>/*variable,readonly*/,
+      <<c>>/*variable,declaration,readonly*/,
+      <<d>>/*variable,declaration,readonly*/,
     ) <<<->>/*operator*/ <<List>>/*class*/((<<a>>/*parameter,readonly*/, <<b>>/*parameter,readonly*/))
     <<if>>/*keyword*/ (
       <<a>>/*parameter,readonly*/,
@@ -18,14 +18,14 @@
       <<c>>/*variable,readonly*/,
       <<d>>/*variable,readonly*/,
     ) <<==>>/*method*/ (<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/, <<4>>/*number*/)
-    <<e>>/*variable,readonly*/ = (
+    <<e>>/*variable,definition,readonly*/ = (
       <<a>>/*parameter,readonly*/,
       <<b>>/*parameter,readonly*/,
       <<c>>/*variable,readonly*/,
       <<d>>/*variable,readonly*/,
     )
     <<if>>/*keyword*/ <<e>>/*variable,readonly*/ <<==>>/*method*/ (<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/, <<4>>/*number*/)
-    <<f>>/*parameter,readonly*/ <<<->>/*operator*/ <<List>>/*class*/(<<e>>/*variable,readonly*/)
+    <<f>>/*parameter,declaration,readonly*/ <<<->>/*operator*/ <<List>>/*class*/(<<e>>/*variable,readonly*/)
   } <<yield>>/*keyword*/ {
     (
       <<a>>/*parameter,readonly*/,

--- a/tests/unit/src/test/resources/semanticTokens/example/ForComprehensions.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/ForComprehensions.scala
@@ -9,8 +9,8 @@
       <<b>>/*parameter,readonly*/,
     ) <<==>>/*method*/ (<<1>>/*number*/, <<2>>/*number*/)
     (
-      <<c>>/*variable,declaration,readonly*/,
-      <<d>>/*variable,declaration,readonly*/,
+      <<c>>/*variable,definition,readonly*/,
+      <<d>>/*variable,definition,readonly*/,
     ) <<<->>/*operator*/ <<List>>/*class*/((<<a>>/*parameter,readonly*/, <<b>>/*parameter,readonly*/))
     <<if>>/*keyword*/ (
       <<a>>/*parameter,readonly*/,

--- a/tests/unit/src/test/resources/semanticTokens/example/ImplicitClasses.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/ImplicitClasses.scala
@@ -1,10 +1,10 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<object>>/*keyword*/ <<ImplicitClasses>>/*class*/ {
-  <<implicit>>/*modifier*/ <<class>>/*keyword*/ <<Xtension>>/*class*/(<<number>>/*variable,readonly*/: <<Int>>/*class,abstract*/) {
-    <<def>>/*keyword*/ <<increment>>/*method*/: <<Int>>/*class,abstract*/ = <<number>>/*variable,readonly*/ <<+>>/*method,abstract*/ <<1>>/*number*/
+  <<implicit>>/*modifier*/ <<class>>/*keyword*/ <<Xtension>>/*class*/(<<number>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/) {
+    <<def>>/*keyword*/ <<increment>>/*method,definition*/: <<Int>>/*class,abstract*/ = <<number>>/*variable,readonly*/ <<+>>/*method,abstract*/ <<1>>/*number*/
   }
-  <<implicit>>/*modifier*/ <<class>>/*keyword*/ <<XtensionAnyVal>>/*class*/(<<private>>/*modifier*/ <<val>>/*keyword*/ <<number>>/*variable,readonly*/: <<Int>>/*class,abstract*/) <<extends>>/*keyword*/ <<AnyVal>>/*class,abstract*/ {
-    <<def>>/*keyword*/ <<double>>/*method*/: <<Int>>/*class,abstract*/ = <<number>>/*variable,readonly*/ <<*>>/*method,abstract*/ <<2>>/*number*/
+  <<implicit>>/*modifier*/ <<class>>/*keyword*/ <<XtensionAnyVal>>/*class*/(<<private>>/*modifier*/ <<val>>/*keyword*/ <<number>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/) <<extends>>/*keyword*/ <<AnyVal>>/*class,abstract*/ {
+    <<def>>/*keyword*/ <<double>>/*method,definition*/: <<Int>>/*class,abstract*/ = <<number>>/*variable,readonly*/ <<*>>/*method,abstract*/ <<2>>/*number*/
   }
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/ImplicitConversions.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/ImplicitConversions.scala
@@ -1,13 +1,13 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<class>>/*keyword*/ <<ImplicitConversions>>/*class*/ {
-  <<implicit>>/*modifier*/ <<def>>/*keyword*/ <<string2Number>>/*method*/(
-      <<string>>/*parameter,readonly*/: <<String>>/*type*/
+  <<implicit>>/*modifier*/ <<def>>/*keyword*/ <<string2Number>>/*method,definition*/(
+      <<string>>/*parameter,declaration,readonly*/: <<String>>/*type*/
   ): <<Int>>/*class,abstract*/ = <<42>>/*number*/
-  <<val>>/*keyword*/ <<message>>/*variable,readonly*/ = <<"">>/*string*/
-  <<val>>/*keyword*/ <<number>>/*variable,readonly*/ = <<42>>/*number*/
-  <<val>>/*keyword*/ <<tuple>>/*variable,readonly*/ = (<<1>>/*number*/, <<2>>/*number*/)
-  <<val>>/*keyword*/ <<char>>/*variable,readonly*/: <<Char>>/*class,abstract*/ = <<'a'>>/*string*/
+  <<val>>/*keyword*/ <<message>>/*variable,definition,readonly*/ = <<"">>/*string*/
+  <<val>>/*keyword*/ <<number>>/*variable,definition,readonly*/ = <<42>>/*number*/
+  <<val>>/*keyword*/ <<tuple>>/*variable,definition,readonly*/ = (<<1>>/*number*/, <<2>>/*number*/)
+  <<val>>/*keyword*/ <<char>>/*variable,definition,readonly*/: <<Char>>/*class,abstract*/ = <<'a'>>/*string*/
 
   <<// extension methods>>/*comment*/
   <<message>>/*variable,readonly*/
@@ -15,7 +15,7 @@
   <<tuple>>/*variable,readonly*/ <<+>>/*method*/ <<"Hello">>/*string*/
 
   <<// implicit conversions>>/*comment*/
-  <<val>>/*keyword*/ <<x>>/*variable,readonly*/: <<Int>>/*class,abstract*/ = <<message>>/*variable,readonly*/
+  <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/: <<Int>>/*class,abstract*/ = <<message>>/*variable,readonly*/
 
   <<// interpolators>>/*comment*/
   <<s>>/*keyword*/<<">>/*string*/<<Hello >>/*string*/<<$>>/*keyword*/<<message>>/*variable,readonly*/<< >>/*string*/<<$>>/*keyword*/<<number>>/*variable,readonly*/<<">>/*string*/
@@ -23,6 +23,6 @@
 <<     |>>/*string*/<<$>>/*keyword*/<<message>>/*variable,readonly*/
 <<     |>>/*string*/<<$>>/*keyword*/<<number>>/*variable,readonly*/<<""">>/*string*/.<<stripMargin>>/*method*/
 
-  <<val>>/*keyword*/ <<a>>/*variable,readonly*/: <<Int>>/*class,abstract*/ = <<char>>/*variable,readonly*/
-  <<val>>/*keyword*/ <<b>>/*variable,readonly*/: <<Long>>/*class,abstract*/ = <<char>>/*variable,readonly*/
+  <<val>>/*keyword*/ <<a>>/*variable,definition,readonly*/: <<Int>>/*class,abstract*/ = <<char>>/*variable,readonly*/
+  <<val>>/*keyword*/ <<b>>/*variable,definition,readonly*/: <<Long>>/*class,abstract*/ = <<char>>/*variable,readonly*/
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/Locals.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/Locals.scala
@@ -2,7 +2,7 @@
 
 <<class>>/*keyword*/ <<Locals>>/*class*/ {
   {
-    <<val>>/*keyword*/ <<x>>/*variable,readonly*/ = <<2>>/*number*/
+    <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<2>>/*number*/
     <<x>>/*variable,readonly*/ <<+>>/*method,abstract*/ <<2>>/*number*/
   }
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/MacroAnnotation.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/MacroAnnotation.scala
@@ -5,21 +5,21 @@
 <<@>>/*keyword*/<<JsonCodec>>/*class*/
 <<// FIXME: https://github.com/scalameta/scalameta/issues/1789>>/*comment*/
 <<case>>/*keyword*/ <<class>>/*keyword*/ <<MacroAnnotation>>/*class*/(
-    <<name>>/*variable,readonly*/: <<String>>/*type*/
+    <<name>>/*variable,declaration,readonly*/: <<String>>/*type*/
 ) {
-  <<def>>/*keyword*/ <<method>>/*method*/ = <<42>>/*number*/
+  <<def>>/*keyword*/ <<method>>/*method,definition*/ = <<42>>/*number*/
 }
 
 <<object>>/*keyword*/ <<MacroAnnotations>>/*class*/ {
   <<import>>/*keyword*/ <<scala>>/*namespace*/.<<meta>>/*namespace*/.<<_>>/*variable*/
   <<// IntelliJ has never managed to goto definition for the inner classes from Trees.scala>>/*comment*/
   <<// due to the macro annotations.>>/*comment*/
-  <<val>>/*keyword*/ <<x>>/*variable,readonly*/: <<Defn>>/*class*/.<<Class>>/*interface,abstract*/ = <<Defn>>/*class*/.<<Class>>/*class*/(
+  <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/: <<Defn>>/*class*/.<<Class>>/*interface,abstract*/ = <<Defn>>/*class*/.<<Class>>/*class*/(
     <<Nil>>/*class*/,
     <<Type>>/*class*/.<<Name>>/*class*/(<<"test">>/*string*/),
     <<Nil>>/*class*/,
     <<Ctor>>/*class*/.<<Primary>>/*class*/(<<Nil>>/*class*/, <<Term>>/*class*/.<<Name>>/*class*/(<<"this">>/*string*/), <<Nil>>/*class*/),
     <<Template>>/*class*/(<<Nil>>/*class*/, <<Nil>>/*class*/, <<Self>>/*class*/(<<Name>>/*class*/.<<Anonymous>>/*class*/(), <<None>>/*class*/), <<Nil>>/*class*/),
   )
-  <<val>>/*keyword*/ <<y>>/*variable,readonly*/: <<Mod>>/*class*/.<<Final>>/*interface,abstract*/ = <<Mod>>/*class*/.<<Final>>/*class*/()
+  <<val>>/*keyword*/ <<y>>/*variable,definition,readonly*/: <<Mod>>/*class*/.<<Final>>/*interface,abstract*/ = <<Mod>>/*class*/.<<Final>>/*class*/()
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/MethodOverload.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/MethodOverload.scala
@@ -1,9 +1,9 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
-<<class>>/*keyword*/ <<MethodOverload>>/*class*/(<<b>>/*variable,readonly*/: <<String>>/*type*/) {
+<<class>>/*keyword*/ <<MethodOverload>>/*class*/(<<b>>/*variable,declaration,readonly*/: <<String>>/*type*/) {
   <<def>>/*keyword*/ <<this>>/*keyword*/() = <<this>>/*keyword*/(<<"">>/*string*/)
-  <<def>>/*keyword*/ <<this>>/*keyword*/(<<c>>/*parameter,readonly*/: <<Int>>/*class,abstract*/) = <<this>>/*keyword*/(<<"">>/*string*/)
-  <<val>>/*keyword*/ <<a>>/*variable,readonly*/ = <<2>>/*number*/
-  <<def>>/*keyword*/ <<a>>/*method*/(<<x>>/*parameter,readonly*/: <<Int>>/*class,abstract*/) = <<2>>/*number*/
-  <<def>>/*keyword*/ <<a>>/*method*/(<<x>>/*parameter,readonly*/: <<Int>>/*class,abstract*/, <<y>>/*parameter,readonly*/: <<Int>>/*class,abstract*/) = <<2>>/*number*/
+  <<def>>/*keyword*/ <<this>>/*keyword*/(<<c>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/) = <<this>>/*keyword*/(<<"">>/*string*/)
+  <<val>>/*keyword*/ <<a>>/*variable,definition,readonly*/ = <<2>>/*number*/
+  <<def>>/*keyword*/ <<a>>/*method,definition*/(<<x>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/) = <<2>>/*number*/
+  <<def>>/*keyword*/ <<a>>/*method,definition*/(<<x>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/, <<y>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/) = <<2>>/*number*/
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/Miscellaneous.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/Miscellaneous.scala
@@ -2,10 +2,10 @@
 
 <<class>>/*keyword*/ <<Miscellaneous>>/*class*/ {
   <<// backtick identifier>>/*comment*/
-  <<val>>/*keyword*/ <<`a b`>>/*variable,readonly*/ = <<42>>/*number*/
+  <<val>>/*keyword*/ <<`a b`>>/*variable,definition,readonly*/ = <<42>>/*number*/
 
   <<// block with only wildcard value>>/*comment*/
-  <<def>>/*keyword*/ <<apply>>/*method*/(): <<Unit>>/*class,abstract*/ = {
+  <<def>>/*keyword*/ <<apply>>/*method,definition*/(): <<Unit>>/*class,abstract*/ = {
     <<val>>/*keyword*/ <<_>>/*variable*/ = <<42>>/*number*/
   }
   <<// infix + inferred apply/implicits/tparams>>/*comment*/

--- a/tests/unit/src/test/resources/semanticTokens/example/NamedArguments.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/NamedArguments.scala
@@ -1,19 +1,19 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<case>>/*keyword*/ <<class>>/*keyword*/ <<User>>/*class*/(
-    <<name>>/*variable,readonly*/: <<String>>/*type*/ = {
+    <<name>>/*variable,declaration,readonly*/: <<String>>/*type*/ = {
       <<// assert default values have occurrences>>/*comment*/
       <<Map>>/*class*/.<<toString>>/*method*/
     }
 )
 <<object>>/*keyword*/ <<NamedArguments>>/*class*/ {
-  <<final>>/*modifier*/ <<val>>/*keyword*/ <<susan>>/*variable,readonly*/ = <<"Susan">>/*string*/
-  <<val>>/*keyword*/ <<user1>>/*variable,readonly*/ =
+  <<final>>/*modifier*/ <<val>>/*keyword*/ <<susan>>/*variable,definition,readonly*/ = <<"Susan">>/*string*/
+  <<val>>/*keyword*/ <<user1>>/*variable,definition,readonly*/ =
     <<User>>/*class*/
       .<<apply>>/*method*/(
         <<name>>/*parameter,readonly*/ = <<"John">>/*string*/
       )
-  <<val>>/*keyword*/ <<user2>>/*variable,readonly*/: <<User>>/*class*/ =
+  <<val>>/*keyword*/ <<user2>>/*variable,definition,readonly*/: <<User>>/*class*/ =
     <<User>>/*class*/(
       <<name>>/*parameter,readonly*/ = <<susan>>/*variable,readonly*/
     ).<<copy>>/*method*/(
@@ -24,7 +24,7 @@
   <<@>>/*keyword*/<<deprecated>>/*class*/(
     <<message>>/*parameter,readonly*/ = <<"a">>/*string*/,
     <<since>>/*parameter,readonly*/ = <<susan>>/*variable,readonly*/,
-  ) <<def>>/*keyword*/ <<b>>/*method,deprecated*/ = <<1>>/*number*/
+  ) <<def>>/*keyword*/ <<b>>/*method,definition,deprecated*/ = <<1>>/*number*/
 
   <<// vararg>>/*comment*/
   <<List>>/*class*/(

--- a/tests/unit/src/test/resources/semanticTokens/example/PatternMatching.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/PatternMatching.scala
@@ -3,7 +3,7 @@
 <<class>>/*keyword*/ <<PatternMatching>>/*class*/ {
   <<val>>/*keyword*/ <<some>>/*variable,definition,readonly*/ = <<Some>>/*class*/(<<1>>/*number*/)
   <<some>>/*variable,readonly*/ <<match>>/*keyword*/ {
-    <<case>>/*keyword*/ <<Some>>/*class*/(<<number>>/*variable,declaration,readonly*/) <<=>>>/*operator*/
+    <<case>>/*keyword*/ <<Some>>/*class*/(<<number>>/*variable,definition,readonly*/) <<=>>>/*operator*/
       <<number>>/*variable,readonly*/
   }
 
@@ -12,12 +12,12 @@
   (<<left>>/*variable,readonly*/, <<right>>/*variable,readonly*/)
 
   <<// val deconstruction>>/*comment*/
-  <<val>>/*keyword*/ <<Some>>/*class*/(<<number1>>/*variable,declaration,readonly*/) =
+  <<val>>/*keyword*/ <<Some>>/*class*/(<<number1>>/*variable,definition,readonly*/) =
     <<some>>/*variable,readonly*/
   <<println>>/*method*/(<<number1>>/*variable,readonly*/)
 
   <<def>>/*keyword*/ <<localDeconstruction>>/*method,definition*/ = {
-    <<val>>/*keyword*/ <<Some>>/*class*/(<<number2>>/*variable,declaration,readonly*/) =
+    <<val>>/*keyword*/ <<Some>>/*class*/(<<number2>>/*variable,definition,readonly*/) =
       <<some>>/*variable,readonly*/
     <<number2>>/*variable,readonly*/
   }

--- a/tests/unit/src/test/resources/semanticTokens/example/PatternMatching.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/PatternMatching.scala
@@ -1,23 +1,23 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<class>>/*keyword*/ <<PatternMatching>>/*class*/ {
-  <<val>>/*keyword*/ <<some>>/*variable,readonly*/ = <<Some>>/*class*/(<<1>>/*number*/)
+  <<val>>/*keyword*/ <<some>>/*variable,definition,readonly*/ = <<Some>>/*class*/(<<1>>/*number*/)
   <<some>>/*variable,readonly*/ <<match>>/*keyword*/ {
-    <<case>>/*keyword*/ <<Some>>/*class*/(<<number>>/*variable,readonly*/) <<=>>>/*operator*/
+    <<case>>/*keyword*/ <<Some>>/*class*/(<<number>>/*variable,declaration,readonly*/) <<=>>>/*operator*/
       <<number>>/*variable,readonly*/
   }
 
   <<// tuple deconstruction>>/*comment*/
-  <<val>>/*keyword*/ (<<left>>/*variable,readonly*/, <<right>>/*variable,readonly*/) = (<<1>>/*number*/, <<2>>/*number*/)
+  <<val>>/*keyword*/ (<<left>>/*variable,definition,readonly*/, <<right>>/*variable,definition,readonly*/) = (<<1>>/*number*/, <<2>>/*number*/)
   (<<left>>/*variable,readonly*/, <<right>>/*variable,readonly*/)
 
   <<// val deconstruction>>/*comment*/
-  <<val>>/*keyword*/ <<Some>>/*class*/(<<number1>>/*variable,readonly*/) =
+  <<val>>/*keyword*/ <<Some>>/*class*/(<<number1>>/*variable,declaration,readonly*/) =
     <<some>>/*variable,readonly*/
   <<println>>/*method*/(<<number1>>/*variable,readonly*/)
 
-  <<def>>/*keyword*/ <<localDeconstruction>>/*method*/ = {
-    <<val>>/*keyword*/ <<Some>>/*class*/(<<number2>>/*variable,readonly*/) =
+  <<def>>/*keyword*/ <<localDeconstruction>>/*method,definition*/ = {
+    <<val>>/*keyword*/ <<Some>>/*class*/(<<number2>>/*variable,declaration,readonly*/) =
       <<some>>/*variable,readonly*/
     <<number2>>/*variable,readonly*/
   }

--- a/tests/unit/src/test/resources/semanticTokens/example/ReflectiveInvocation.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/ReflectiveInvocation.scala
@@ -2,7 +2,7 @@
 
 <<class>>/*keyword*/ <<ReflectiveInvocation>>/*class*/ {
   <<new>>/*keyword*/ <<Serializable>>/*type*/ {
-    <<def>>/*keyword*/ <<message>>/*method*/ = <<"message">>/*string*/
+    <<def>>/*keyword*/ <<message>>/*method,definition*/ = <<"message">>/*string*/
     <<// reflective invocation>>/*comment*/
   }.<<message>>/*method*/
 

--- a/tests/unit/src/test/resources/semanticTokens/example/Scalalib.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/Scalalib.scala
@@ -1,8 +1,8 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<class>>/*keyword*/ <<Scalalib>>/*class*/ {
-  <<val>>/*keyword*/ <<nil>>/*variable,readonly*/ = <<List>>/*class*/()
-  <<val>>/*keyword*/ <<lst>>/*variable,readonly*/ = <<List>>/*class*/[
+  <<val>>/*keyword*/ <<nil>>/*variable,definition,readonly*/ = <<List>>/*class*/()
+  <<val>>/*keyword*/ <<lst>>/*variable,definition,readonly*/ = <<List>>/*class*/[
     (
         <<Nothing>>/*class,abstract*/,
         <<Null>>/*class,abstract*/,

--- a/tests/unit/src/test/resources/semanticTokens/example/StructuralTypes.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/StructuralTypes.scala
@@ -1,19 +1,19 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<object>>/*keyword*/ <<StructuralTypes>>/*class*/ {
-  <<type>>/*keyword*/ <<User>>/*type*/ = {
-    <<def>>/*keyword*/ <<name>>/*method,abstract*/: <<String>>/*type*/
-    <<def>>/*keyword*/ <<age>>/*method,abstract*/: <<Int>>/*class,abstract*/
+  <<type>>/*keyword*/ <<User>>/*type,definition*/ = {
+    <<def>>/*keyword*/ <<name>>/*method,declaration,abstract*/: <<String>>/*type*/
+    <<def>>/*keyword*/ <<age>>/*method,declaration,abstract*/: <<Int>>/*class,abstract*/
   }
 
-  <<val>>/*keyword*/ <<user>>/*variable,readonly*/ = <<null>>/*keyword*/.<<asInstanceOf>>/*method*/[<<User>>/*type*/]
+  <<val>>/*keyword*/ <<user>>/*variable,definition,readonly*/ = <<null>>/*keyword*/.<<asInstanceOf>>/*method*/[<<User>>/*type*/]
   <<user>>/*variable,readonly*/.<<name>>/*method,abstract*/
   <<user>>/*variable,readonly*/.<<age>>/*method,abstract*/
 
-  <<val>>/*keyword*/ <<V>>/*variable,readonly*/: <<Object>>/*class*/ {
-    <<def>>/*keyword*/ <<scalameta>>/*method,abstract*/: <<String>>/*type*/
+  <<val>>/*keyword*/ <<V>>/*variable,definition,readonly*/: <<Object>>/*class*/ {
+    <<def>>/*keyword*/ <<scalameta>>/*method,declaration,abstract*/: <<String>>/*type*/
   } = <<new>>/*keyword*/ {
-    <<def>>/*keyword*/ <<scalameta>>/*method*/ = <<"4.0">>/*string*/
+    <<def>>/*keyword*/ <<scalameta>>/*method,definition*/ = <<"4.0">>/*string*/
   }
   <<V>>/*variable,readonly*/.<<scalameta>>/*method,abstract*/
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/TryCatch.scala
@@ -5,7 +5,7 @@
     <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<2>>/*number*/
     <<x>>/*variable,readonly*/ <<+>>/*method,abstract*/ <<2>>/*number*/
   } <<catch>>/*keyword*/ {
-    <<case>>/*keyword*/ <<t>>/*variable,declaration,readonly*/: <<Throwable>>/*type*/ <<=>>>/*operator*/
+    <<case>>/*keyword*/ <<t>>/*variable,definition,readonly*/: <<Throwable>>/*type*/ <<=>>>/*operator*/
       <<t>>/*variable,readonly*/.<<printStackTrace>>/*method*/()
   } <<finally>>/*keyword*/ {
     <<val>>/*keyword*/ <<text>>/*variable,definition,readonly*/ = <<"">>/*string*/

--- a/tests/unit/src/test/resources/semanticTokens/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/TryCatch.scala
@@ -2,13 +2,13 @@
 
 <<class>>/*keyword*/ <<TryCatch>>/*class*/ {
   <<try>>/*keyword*/ {
-    <<val>>/*keyword*/ <<x>>/*variable,readonly*/ = <<2>>/*number*/
+    <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<2>>/*number*/
     <<x>>/*variable,readonly*/ <<+>>/*method,abstract*/ <<2>>/*number*/
   } <<catch>>/*keyword*/ {
-    <<case>>/*keyword*/ <<t>>/*variable,readonly*/: <<Throwable>>/*type*/ <<=>>>/*operator*/
+    <<case>>/*keyword*/ <<t>>/*variable,declaration,readonly*/: <<Throwable>>/*type*/ <<=>>>/*operator*/
       <<t>>/*variable,readonly*/.<<printStackTrace>>/*method*/()
   } <<finally>>/*keyword*/ {
-    <<val>>/*keyword*/ <<text>>/*variable,readonly*/ = <<"">>/*string*/
+    <<val>>/*keyword*/ <<text>>/*variable,definition,readonly*/ = <<"">>/*string*/
     <<text>>/*variable,readonly*/ <<+>>/*method*/ <<"">>/*string*/
   }
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/TypeParameters.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/TypeParameters.scala
@@ -1,8 +1,8 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
-<<class>>/*keyword*/ <<TypeParameters>>/*class*/[<<A>>/*typeParameter,abstract*/] {
-  <<def>>/*keyword*/ <<method>>/*method*/[<<B>>/*typeParameter,abstract*/] = <<42>>/*number*/
-  <<trait>>/*keyword*/ <<TraitParameter>>/*interface,abstract*/[<<C>>/*typeParameter,abstract*/]
-  <<type>>/*keyword*/ <<AbstractTypeAlias>>/*type,abstract*/[<<D>>/*typeParameter,abstract*/]
-  <<type>>/*keyword*/ <<TypeAlias>>/*type*/[<<E>>/*typeParameter,abstract*/] = <<List>>/*type*/[<<E>>/*typeParameter,abstract*/]
+<<class>>/*keyword*/ <<TypeParameters>>/*class*/[<<A>>/*typeParameter,declaration,abstract*/] {
+  <<def>>/*keyword*/ <<method>>/*method,definition*/[<<B>>/*typeParameter,declaration,abstract*/] = <<42>>/*number*/
+  <<trait>>/*keyword*/ <<TraitParameter>>/*interface,abstract*/[<<C>>/*typeParameter,declaration,abstract*/]
+  <<type>>/*keyword*/ <<AbstractTypeAlias>>/*type,declaration,abstract*/[<<D>>/*typeParameter,declaration,abstract*/]
+  <<type>>/*keyword*/ <<TypeAlias>>/*type,definition*/[<<E>>/*typeParameter,declaration,abstract*/] = <<List>>/*type*/[<<E>>/*typeParameter,abstract*/]
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/VarArgs.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/VarArgs.scala
@@ -1,6 +1,6 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<class>>/*keyword*/ <<VarArgs>>/*class*/ {
-  <<def>>/*keyword*/ <<add>>/*method*/(<<a>>/*parameter,readonly*/: <<Int>>/*class,abstract*/*) = <<a>>/*parameter,readonly*/
-  <<def>>/*keyword*/ <<add2>>/*method*/(<<a>>/*parameter,readonly*/: <<Seq>>/*type*/[<<Int>>/*class,abstract*/]*) = <<a>>/*parameter,readonly*/
+  <<def>>/*keyword*/ <<add>>/*method,definition*/(<<a>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/*) = <<a>>/*parameter,readonly*/
+  <<def>>/*keyword*/ <<add2>>/*method,definition*/(<<a>>/*parameter,declaration,readonly*/: <<Seq>>/*type*/[<<Int>>/*class,abstract*/]*) = <<a>>/*parameter,readonly*/
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/Vars.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/Vars.scala
@@ -1,7 +1,7 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<object>>/*keyword*/ <<Vars>>/*class*/ {
-  <<var>>/*keyword*/ <<a>>/*variable*/ = <<2>>/*number*/
+  <<var>>/*keyword*/ <<a>>/*variable,definition*/ = <<2>>/*number*/
 
   <<a>>/*variable*/ = <<2>>/*number*/
 

--- a/tests/unit/src/test/resources/semanticTokens/example/nested/LocalClass.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/nested/LocalClass.scala
@@ -1,7 +1,7 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/.<<nested>>/*namespace*/
 
 <<class>>/*keyword*/ <<LocalClass>>/*class*/ {
-  <<def>>/*keyword*/ <<foo>>/*method*/(): <<Unit>>/*class,abstract*/ = {
+  <<def>>/*keyword*/ <<foo>>/*method,definition*/(): <<Unit>>/*class,abstract*/ = {
     <<case>>/*keyword*/ <<class>>/*keyword*/ <<LocalClass>>/*class*/()
   }
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/nested/LocalDeclarations.scala
@@ -1,27 +1,27 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/.<<nested>>/*namespace*/
 
 <<trait>>/*keyword*/ <<LocalDeclarations>>/*interface,abstract*/ {
-  <<def>>/*keyword*/ <<foo>>/*method,abstract*/(): <<Unit>>/*class,abstract*/
+  <<def>>/*keyword*/ <<foo>>/*method,declaration,abstract*/(): <<Unit>>/*class,abstract*/
 }
 
 <<trait>>/*keyword*/ <<Foo>>/*interface,abstract*/ {
-  <<val>>/*keyword*/ <<y>>/*variable,readonly*/ = <<3>>/*number*/
+  <<val>>/*keyword*/ <<y>>/*variable,definition,readonly*/ = <<3>>/*number*/
 }
 
 <<object>>/*keyword*/ <<LocalDeclarations>>/*class*/ {
-  <<def>>/*keyword*/ <<create>>/*method*/(): <<LocalDeclarations>>/*interface,abstract*/ = {
-    <<def>>/*keyword*/ <<bar>>/*method*/(): <<Unit>>/*class,abstract*/ = ()
+  <<def>>/*keyword*/ <<create>>/*method,definition*/(): <<LocalDeclarations>>/*interface,abstract*/ = {
+    <<def>>/*keyword*/ <<bar>>/*method,definition*/(): <<Unit>>/*class,abstract*/ = ()
 
-    <<val>>/*keyword*/ <<x>>/*variable,readonly*/ = <<new>>/*keyword*/ {
-      <<val>>/*keyword*/ <<x>>/*variable,readonly*/ = <<2>>/*number*/
+    <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<new>>/*keyword*/ {
+      <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<2>>/*number*/
     }
 
-    <<val>>/*keyword*/ <<y>>/*variable,readonly*/ = <<new>>/*keyword*/ <<Foo>>/*interface,abstract*/ {}
+    <<val>>/*keyword*/ <<y>>/*variable,definition,readonly*/ = <<new>>/*keyword*/ <<Foo>>/*interface,abstract*/ {}
 
     <<x>>/*variable,readonly*/.<<x>>/*variable,readonly*/ <<+>>/*method,abstract*/ <<y>>/*variable,readonly*/.<<y>>/*variable,readonly*/
 
     <<new>>/*keyword*/ <<LocalDeclarations>>/*interface,abstract*/ <<with>>/*keyword*/ <<Foo>>/*interface,abstract*/ {
-      <<override>>/*modifier*/ <<def>>/*keyword*/ <<foo>>/*method*/(): <<Unit>>/*class,abstract*/ = <<bar>>/*method*/()
+      <<override>>/*modifier*/ <<def>>/*keyword*/ <<foo>>/*method,definition*/(): <<Unit>>/*class,abstract*/ = <<bar>>/*method*/()
     }
 
   }

--- a/tests/unit/src/test/resources/semanticTokens3/example/AbstractGiven.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/AbstractGiven.scala
@@ -1,4 +1,4 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<abstract>>/*modifier*/ <<class>>/*keyword*/ <<AbstractGiven>>/*class,abstract*/:
-  <<given>>/*keyword*/ <<int>>/*method*/: <<Int>>/*class,abstract*/
+  <<given>>/*keyword*/ <<int>>/*method,declaration*/: <<Int>>/*class,abstract*/

--- a/tests/unit/src/test/resources/semanticTokens3/example/AndOrType.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/AndOrType.scala
@@ -3,6 +3,6 @@
 <<trait>>/*keyword*/ <<Cancelable>>/*interface,abstract*/
 <<trait>>/*keyword*/ <<Movable>>/*interface,abstract*/
 
-<<type>>/*keyword*/ <<Y>>/*type*/ = (<<Cancelable>>/*interface,abstract*/ <<&>>/*type*/ <<Movable>>/*interface,abstract*/)
+<<type>>/*keyword*/ <<Y>>/*type,definition*/ = (<<Cancelable>>/*interface,abstract*/ <<&>>/*type*/ <<Movable>>/*interface,abstract*/)
 
-<<type>>/*keyword*/ <<X>>/*type*/ = <<String>>/*type*/ <<|>>/*type*/ <<Int>>/*class,abstract*/
+<<type>>/*keyword*/ <<X>>/*type,definition*/ = <<String>>/*type*/ <<|>>/*type*/ <<Int>>/*class,abstract*/

--- a/tests/unit/src/test/resources/semanticTokens3/example/ColorEnum.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/ColorEnum.scala
@@ -1,6 +1,6 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
-<<enum>>/*keyword*/ <<Color>>/*enum,abstract*/(<<val>>/*keyword*/ <<rgb>>/*variable,readonly*/: <<Int>>/*class,abstract*/):
+<<enum>>/*keyword*/ <<Color>>/*enum,abstract*/(<<val>>/*keyword*/ <<rgb>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/):
   <<case>>/*keyword*/ <<Red>>/*enum*/ <<extends>>/*keyword*/ <<Color>>/*enum,abstract*/(<<0xff0000>>/*number*/)
   <<case>>/*keyword*/ <<Green>>/*enum*/ <<extends>>/*keyword*/ <<Color>>/*enum,abstract*/(<<0x00ff00>>/*number*/)
   <<case>>/*keyword*/ <<Blue>>/*enum*/ <<extends>>/*keyword*/ <<Color>>/*enum,abstract*/(<<0x0000ff>>/*number*/)

--- a/tests/unit/src/test/resources/semanticTokens3/example/Comments.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/Comments.scala
@@ -3,7 +3,7 @@
 <<class>>/*keyword*/ <</* comment */>>/*comment*/ <<Comments>>/*class*/ {
   <<object>>/*keyword*/ <</* comment */>>/*comment*/ <<A>>/*class*/
   <<trait>>/*keyword*/ <</* comment */>>/*comment*/ <<A>>/*interface,abstract*/
-  <<val>>/*keyword*/ <</* comment */>>/*comment*/ <<a>>/*variable,readonly*/ = <<1>>/*number*/
-  <<def>>/*keyword*/ <</* comment */>>/*comment*/ <<b>>/*method*/ = <<1>>/*number*/
-  <<var>>/*keyword*/ <</* comment */>>/*comment*/ <<c>>/*variable*/ = <<1>>/*number*/
+  <<val>>/*keyword*/ <</* comment */>>/*comment*/ <<a>>/*variable,definition,readonly*/ = <<1>>/*number*/
+  <<def>>/*keyword*/ <</* comment */>>/*comment*/ <<b>>/*method,definition*/ = <<1>>/*number*/
+  <<var>>/*keyword*/ <</* comment */>>/*comment*/ <<c>>/*variable,definition*/ = <<1>>/*number*/
 }

--- a/tests/unit/src/test/resources/semanticTokens3/example/Extension.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/Extension.scala
@@ -1,11 +1,11 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
-<<extension>>/*keyword*/ (<<i>>/*parameter,readonly*/: <<Int>>/*class,abstract*/) <<def>>/*keyword*/ <<asString>>/*method*/: <<String>>/*type*/ = <<i>>/*parameter,readonly*/.<<toString>>/*method*/
+<<extension>>/*keyword*/ (<<i>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/) <<def>>/*keyword*/ <<asString>>/*method,definition*/: <<String>>/*type*/ = <<i>>/*parameter,readonly*/.<<toString>>/*method*/
 
-<<extension>>/*keyword*/ (<<s>>/*parameter,readonly*/: <<String>>/*type*/)
-  <<def>>/*keyword*/ <<asInt>>/*method*/: <<Int>>/*class,abstract*/ = <<s>>/*parameter,readonly*/.<<toInt>>/*method*/
-  <<def>>/*keyword*/ <<double>>/*method*/: <<String>>/*type*/ = <<s>>/*parameter,readonly*/ <<*>>/*method*/ <<2>>/*number*/
+<<extension>>/*keyword*/ (<<s>>/*parameter,declaration,readonly*/: <<String>>/*type*/)
+  <<def>>/*keyword*/ <<asInt>>/*method,definition*/: <<Int>>/*class,abstract*/ = <<s>>/*parameter,readonly*/.<<toInt>>/*method*/
+  <<def>>/*keyword*/ <<double>>/*method,definition*/: <<String>>/*type*/ = <<s>>/*parameter,readonly*/ <<*>>/*method*/ <<2>>/*number*/
 
 <<trait>>/*keyword*/ <<AbstractExtension>>/*interface,abstract*/:
-  <<extension>>/*keyword*/ (<<d>>/*parameter,readonly*/: <<Double>>/*class,abstract*/)
-    <<def>>/*keyword*/ <<abc>>/*method*/: <<String>>/*type*/
+  <<extension>>/*keyword*/ (<<d>>/*parameter,declaration,readonly*/: <<Double>>/*class,abstract*/)
+    <<def>>/*keyword*/ <<abc>>/*method,declaration*/: <<String>>/*type*/

--- a/tests/unit/src/test/resources/semanticTokens3/example/ForComprehensions.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/ForComprehensions.scala
@@ -9,8 +9,8 @@
       <<b>>/*parameter,readonly*/,
     ) <<==>>/*method*/ (<<1>>/*number*/, <<2>>/*number*/)
     (
-      <<c>>/*variable,declaration,readonly*/,
-      <<d>>/*variable,declaration,readonly*/,
+      <<c>>/*variable,definition,readonly*/,
+      <<d>>/*variable,definition,readonly*/,
     ) <<<->>/*operator*/ <<List>>/*class*/((<<a>>/*parameter,readonly*/, <<b>>/*parameter,readonly*/))
     <<if>>/*keyword*/ (
       <<a>>/*parameter,readonly*/,
@@ -18,7 +18,7 @@
       <<c>>/*variable,readonly*/,
       <<d>>/*variable,readonly*/,
     ) <<==>>/*method*/ (<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/, <<4>>/*number*/)
-    <<e>>/*variable,declaration,readonly*/ = (
+    <<e>>/*variable,definition,readonly*/ = (
       <<a>>/*parameter,readonly*/,
       <<b>>/*parameter,readonly*/,
       <<c>>/*variable,readonly*/,

--- a/tests/unit/src/test/resources/semanticTokens3/example/ForComprehensions.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/ForComprehensions.scala
@@ -2,15 +2,15 @@
 
 <<class>>/*keyword*/ <<ForComprehensions>>/*class*/ {
   <<for>>/*keyword*/ {
-    <<a>>/*parameter,readonly*/ <<<->>/*operator*/ <<List>>/*class*/(<<1>>/*number*/)
-    <<b>>/*parameter,readonly*/ <<<->>/*operator*/ <<List>>/*class*/(<<a>>/*parameter,readonly*/)
+    <<a>>/*parameter,declaration,readonly*/ <<<->>/*operator*/ <<List>>/*class*/(<<1>>/*number*/)
+    <<b>>/*parameter,declaration,readonly*/ <<<->>/*operator*/ <<List>>/*class*/(<<a>>/*parameter,readonly*/)
     <<if>>/*keyword*/ (
       <<a>>/*parameter,readonly*/,
       <<b>>/*parameter,readonly*/,
     ) <<==>>/*method*/ (<<1>>/*number*/, <<2>>/*number*/)
     (
-      <<c>>/*variable,readonly*/,
-      <<d>>/*variable,readonly*/,
+      <<c>>/*variable,declaration,readonly*/,
+      <<d>>/*variable,declaration,readonly*/,
     ) <<<->>/*operator*/ <<List>>/*class*/((<<a>>/*parameter,readonly*/, <<b>>/*parameter,readonly*/))
     <<if>>/*keyword*/ (
       <<a>>/*parameter,readonly*/,
@@ -18,14 +18,14 @@
       <<c>>/*variable,readonly*/,
       <<d>>/*variable,readonly*/,
     ) <<==>>/*method*/ (<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/, <<4>>/*number*/)
-    <<e>>/*variable,readonly*/ = (
+    <<e>>/*variable,declaration,readonly*/ = (
       <<a>>/*parameter,readonly*/,
       <<b>>/*parameter,readonly*/,
       <<c>>/*variable,readonly*/,
       <<d>>/*variable,readonly*/,
     )
     <<if>>/*keyword*/ <<e>>/*variable,readonly*/ <<==>>/*method*/ (<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/, <<4>>/*number*/)
-    <<f>>/*parameter,readonly*/ <<<->>/*operator*/ <<List>>/*class*/(<<e>>/*variable,readonly*/)
+    <<f>>/*parameter,declaration,readonly*/ <<<->>/*operator*/ <<List>>/*class*/(<<e>>/*variable,readonly*/)
   } <<yield>>/*keyword*/ {
     (
       <<a>>/*parameter,readonly*/,

--- a/tests/unit/src/test/resources/semanticTokens3/example/GivenAlias.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/GivenAlias.scala
@@ -2,11 +2,6 @@
 
 <<given>>/*keyword*/ <<intValue>>/*variable,definition,readonly*/: <<Int>>/*class,abstract*/ = <<4>>/*number*/
 <<given>>/*keyword*/ <<String>>/*type*/ = <<"str">>/*string*/
-<<given>>/*keyword*/ (<<using>>/*keyword*/ <<i>>/*parameter,readonly*/: <<Int>>/*class,abstract*/): <<Double>>/*class,abstract*/ = <<4.0>>/*number*/
-<<given>>/*keyword*/ [<<T>>/*typeParameter,abstract*/]: <<List>>/*type*/[<<T>>/*typeParameter,abstract*/] = <<Nil>>/*class*/
-<<given>>/*keyword*/ <<given_Char>>/*variable,readonly*/: <<Char>>/*class,abstract*/ = <<'?'>>/*string*/
-<<given>>/*keyword*/ <<`given_Float`>>/*variable,readonly*/: <<Float>>/*class,abstract*/ = <<3.0>>/*number*/
-<<given>>/*keyword*/ <<`* *`>>/*variable,readonly*/ : <<Long>>/*class,abstract*/ = <<5>>/*number*/
 <<given>>/*keyword*/ (<<using>>/*keyword*/ <<i>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/): <<Double>>/*class,abstract*/ = <<4.0>>/*number*/
 <<given>>/*keyword*/ [<<T>>/*typeParameter,definition,abstract*/]: <<List>>/*type*/[<<T>>/*typeParameter,abstract*/] = <<Nil>>/*class*/
 <<given>>/*keyword*/ <<given_Char>>/*variable,definition,readonly*/: <<Char>>/*class,abstract*/ = <<'?'>>/*string*/

--- a/tests/unit/src/test/resources/semanticTokens3/example/GivenAlias.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/GivenAlias.scala
@@ -1,47 +1,52 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
-<<given>>/*keyword*/ <<intValue>>/*variable,readonly*/: <<Int>>/*class,abstract*/ = <<4>>/*number*/
+<<given>>/*keyword*/ <<intValue>>/*variable,definition,readonly*/: <<Int>>/*class,abstract*/ = <<4>>/*number*/
 <<given>>/*keyword*/ <<String>>/*type*/ = <<"str">>/*string*/
 <<given>>/*keyword*/ (<<using>>/*keyword*/ <<i>>/*parameter,readonly*/: <<Int>>/*class,abstract*/): <<Double>>/*class,abstract*/ = <<4.0>>/*number*/
 <<given>>/*keyword*/ [<<T>>/*typeParameter,abstract*/]: <<List>>/*type*/[<<T>>/*typeParameter,abstract*/] = <<Nil>>/*class*/
 <<given>>/*keyword*/ <<given_Char>>/*variable,readonly*/: <<Char>>/*class,abstract*/ = <<'?'>>/*string*/
 <<given>>/*keyword*/ <<`given_Float`>>/*variable,readonly*/: <<Float>>/*class,abstract*/ = <<3.0>>/*number*/
 <<given>>/*keyword*/ <<`* *`>>/*variable,readonly*/ : <<Long>>/*class,abstract*/ = <<5>>/*number*/
+<<given>>/*keyword*/ (<<using>>/*keyword*/ <<i>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/): <<Double>>/*class,abstract*/ = <<4.0>>/*number*/
+<<given>>/*keyword*/ [<<T>>/*typeParameter,definition,abstract*/]: <<List>>/*type*/[<<T>>/*typeParameter,abstract*/] = <<Nil>>/*class*/
+<<given>>/*keyword*/ <<given_Char>>/*variable,definition,readonly*/: <<Char>>/*class,abstract*/ = <<'?'>>/*string*/
+<<given>>/*keyword*/ <<`given_Float`>>/*variable,definition,readonly*/: <<Float>>/*class,abstract*/ = <<3.0>>/*number*/
+<<given>>/*keyword*/ <<`* *`>>/*variable,definition,readonly*/ : <<Long>>/*class,abstract*/ = <<5>>/*number*/
 
-<<def>>/*keyword*/ <<method>>/*method*/(<<using>>/*keyword*/ <<Int>>/*class,abstract*/) = <<"">>/*string*/
+<<def>>/*keyword*/ <<method>>/*method,definition*/(<<using>>/*keyword*/ <<Int>>/*class,abstract*/) = <<"">>/*string*/
 
 <<object>>/*keyword*/ <<X>>/*class*/:
   <<given>>/*keyword*/ <<Double>>/*class,abstract*/ = <<4.0>>/*number*/
-  <<val>>/*keyword*/ <<double>>/*variable,readonly*/ = <<given_Double>>/*variable,readonly*/
+  <<val>>/*keyword*/ <<double>>/*variable,definition,readonly*/ = <<given_Double>>/*variable,readonly*/
 
-  <<given>>/*keyword*/ <<of>>/*method*/[<<A>>/*typeParameter,abstract*/]: <<Option>>/*class,abstract*/[<<A>>/*typeParameter,abstract*/] = <<???>>/*method*/
+  <<given>>/*keyword*/ <<of>>/*method,definition*/[<<A>>/*typeParameter,definition,abstract*/]: <<Option>>/*class,abstract*/[<<A>>/*typeParameter,abstract*/] = <<???>>/*method*/
 
 <<trait>>/*keyword*/ <<Xg>>/*interface,abstract*/:
-  <<def>>/*keyword*/ <<doX>>/*method*/: <<Int>>/*class,abstract*/
+  <<def>>/*keyword*/ <<doX>>/*method,declaration*/: <<Int>>/*class,abstract*/
 
 <<trait>>/*keyword*/ <<Yg>>/*interface,abstract*/:
-  <<def>>/*keyword*/ <<doY>>/*method*/: <<String>>/*type*/
+  <<def>>/*keyword*/ <<doY>>/*method,declaration*/: <<String>>/*type*/
 
-<<trait>>/*keyword*/ <<Zg>>/*interface,abstract*/[<<T>>/*typeParameter,abstract*/]:
-  <<def>>/*keyword*/ <<doZ>>/*method*/: <<List>>/*type*/[<<T>>/*typeParameter,abstract*/]
+<<trait>>/*keyword*/ <<Zg>>/*interface,abstract*/[<<T>>/*typeParameter,definition,abstract*/]:
+  <<def>>/*keyword*/ <<doZ>>/*method,declaration*/: <<List>>/*type*/[<<T>>/*typeParameter,abstract*/]
 
 <<given>>/*keyword*/ <<Xg>>/*interface,abstract*/ <<with>>/*keyword*/
-  <<def>>/*keyword*/ <<doX>>/*method*/ = <<7>>/*number*/
+  <<def>>/*keyword*/ <<doX>>/*method,definition*/ = <<7>>/*number*/
 
 <<given>>/*keyword*/ (<<using>>/*keyword*/ <<Xg>>/*interface,abstract*/): <<Yg>>/*interface,abstract*/ <<with>>/*keyword*/
-  <<def>>/*keyword*/ <<doY>>/*method*/ = <<"7">>/*string*/
+  <<def>>/*keyword*/ <<doY>>/*method,definition*/ = <<"7">>/*string*/
 
-<<given>>/*keyword*/ [<<T>>/*typeParameter,abstract*/]: <<Zg>>/*interface,abstract*/[<<T>>/*typeParameter,abstract*/] <<with>>/*keyword*/
-  <<def>>/*keyword*/ <<doZ>>/*method*/: <<List>>/*type*/[<<T>>/*typeParameter,abstract*/] = <<Nil>>/*class*/
+<<given>>/*keyword*/ [<<T>>/*typeParameter,definition,abstract*/]: <<Zg>>/*interface,abstract*/[<<T>>/*typeParameter,abstract*/] <<with>>/*keyword*/
+  <<def>>/*keyword*/ <<doZ>>/*method,definition*/: <<List>>/*type*/[<<T>>/*typeParameter,abstract*/] = <<Nil>>/*class*/
 
-<<val>>/*keyword*/ <<a>>/*variable,readonly*/ = <<intValue>>/*variable,readonly*/
-<<val>>/*keyword*/ <<b>>/*variable,readonly*/ = <<given_String>>/*variable,readonly*/
-<<val>>/*keyword*/ <<c>>/*variable,readonly*/ = <<X>>/*class*/.<<given_Double>>/*variable,readonly*/
-<<val>>/*keyword*/ <<d>>/*variable,readonly*/ = <<given_List_T>>/*method*/[<<Int>>/*class,abstract*/]
-<<val>>/*keyword*/ <<e>>/*variable,readonly*/ = <<given_Char>>/*variable,readonly*/
-<<val>>/*keyword*/ <<f>>/*variable,readonly*/ = <<given_Float>>/*variable,readonly*/
-<<val>>/*keyword*/ <<g>>/*variable,readonly*/ = <<`* *`>>/*variable,readonly*/
-<<val>>/*keyword*/ <<i>>/*variable,readonly*/ = <<X>>/*class*/.<<of>>/*method*/[<<Int>>/*class,abstract*/]
-<<val>>/*keyword*/ <<x>>/*variable,readonly*/ = <<given_Xg>>/*class*/
-<<val>>/*keyword*/ <<y>>/*variable,readonly*/ = <<given_Yg>>/*method*/
-<<val>>/*keyword*/ <<z>>/*variable,readonly*/ = <<given_Zg_T>>/*method*/[<<String>>/*type*/]
+<<val>>/*keyword*/ <<a>>/*variable,definition,readonly*/ = <<intValue>>/*variable,readonly*/
+<<val>>/*keyword*/ <<b>>/*variable,definition,readonly*/ = <<given_String>>/*variable,readonly*/
+<<val>>/*keyword*/ <<c>>/*variable,definition,readonly*/ = <<X>>/*class*/.<<given_Double>>/*variable,readonly*/
+<<val>>/*keyword*/ <<d>>/*variable,definition,readonly*/ = <<given_List_T>>/*method*/[<<Int>>/*class,abstract*/]
+<<val>>/*keyword*/ <<e>>/*variable,definition,readonly*/ = <<given_Char>>/*variable,readonly*/
+<<val>>/*keyword*/ <<f>>/*variable,definition,readonly*/ = <<given_Float>>/*variable,readonly*/
+<<val>>/*keyword*/ <<g>>/*variable,definition,readonly*/ = <<`* *`>>/*variable,readonly*/
+<<val>>/*keyword*/ <<i>>/*variable,definition,readonly*/ = <<X>>/*class*/.<<of>>/*method*/[<<Int>>/*class,abstract*/]
+<<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<given_Xg>>/*class*/
+<<val>>/*keyword*/ <<y>>/*variable,definition,readonly*/ = <<given_Yg>>/*method*/
+<<val>>/*keyword*/ <<z>>/*variable,definition,readonly*/ = <<given_Zg_T>>/*method*/[<<String>>/*type*/]

--- a/tests/unit/src/test/resources/semanticTokens3/example/ImplicitClasses.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/ImplicitClasses.scala
@@ -1,10 +1,10 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<object>>/*keyword*/ <<ImplicitClasses>>/*class*/ {
-  <<implicit>>/*modifier*/ <<class>>/*keyword*/ <<Xtension>>/*class*/(<<number>>/*variable,readonly*/: <<Int>>/*class,abstract*/) {
-    <<def>>/*keyword*/ <<increment>>/*method*/: <<Int>>/*class,abstract*/ = <<number>>/*variable,readonly*/ <<+>>/*method*/ <<1>>/*number*/
+  <<implicit>>/*modifier*/ <<class>>/*keyword*/ <<Xtension>>/*class*/(<<number>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/) {
+    <<def>>/*keyword*/ <<increment>>/*method,definition*/: <<Int>>/*class,abstract*/ = <<number>>/*variable,readonly*/ <<+>>/*method*/ <<1>>/*number*/
   }
-  <<implicit>>/*modifier*/ <<class>>/*keyword*/ <<XtensionAnyVal>>/*class*/(<<private>>/*modifier*/ <<val>>/*keyword*/ <<number>>/*variable,readonly*/: <<Int>>/*class,abstract*/) <<extends>>/*keyword*/ <<AnyVal>>/*class,abstract*/ {
-    <<def>>/*keyword*/ <<double>>/*method*/: <<Int>>/*class,abstract*/ = <<number>>/*variable,readonly*/ <<*>>/*method*/ <<2>>/*number*/
+  <<implicit>>/*modifier*/ <<class>>/*keyword*/ <<XtensionAnyVal>>/*class*/(<<private>>/*modifier*/ <<val>>/*keyword*/ <<number>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/) <<extends>>/*keyword*/ <<AnyVal>>/*class,abstract*/ {
+    <<def>>/*keyword*/ <<double>>/*method,definition*/: <<Int>>/*class,abstract*/ = <<number>>/*variable,readonly*/ <<*>>/*method*/ <<2>>/*number*/
   }
 }

--- a/tests/unit/src/test/resources/semanticTokens3/example/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/LocalDeclarations.scala
@@ -1,21 +1,21 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/.<<nested>>/*namespace*/
 
 <<trait>>/*keyword*/ <<LocalDeclarations>>/*interface,abstract*/:
-  <<def>>/*keyword*/ <<foo>>/*method*/(): <<Unit>>/*class,abstract*/
+  <<def>>/*keyword*/ <<foo>>/*method,declaration*/(): <<Unit>>/*class,abstract*/
 
 <<trait>>/*keyword*/ <<Foo>>/*interface,abstract*/:
-  <<val>>/*keyword*/ <<y>>/*variable,readonly*/ = <<3>>/*number*/
+  <<val>>/*keyword*/ <<y>>/*variable,definition,readonly*/ = <<3>>/*number*/
 
 <<object>>/*keyword*/ <<LocalDeclarations>>/*class*/:
-  <<def>>/*keyword*/ <<create>>/*method*/(): <<LocalDeclarations>>/*interface,abstract*/ =
-    <<def>>/*keyword*/ <<bar>>/*method*/(): <<Unit>>/*class,abstract*/ = ()
+  <<def>>/*keyword*/ <<create>>/*method,definition*/(): <<LocalDeclarations>>/*interface,abstract*/ =
+    <<def>>/*keyword*/ <<bar>>/*method,definition*/(): <<Unit>>/*class,abstract*/ = ()
 
-    <<val>>/*keyword*/ <<x>>/*variable,readonly*/ = <<new>>/*keyword*/:
-      <<val>>/*keyword*/ <<x>>/*variable,readonly*/ = <<2>>/*number*/
+    <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<new>>/*keyword*/:
+      <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<2>>/*number*/
 
-    <<val>>/*keyword*/ <<y>>/*variable,readonly*/ = <<new>>/*keyword*/ <<Foo>>/*interface,abstract*/ {}
+    <<val>>/*keyword*/ <<y>>/*variable,definition,readonly*/ = <<new>>/*keyword*/ <<Foo>>/*interface,abstract*/ {}
 
     <<y>>/*variable,readonly*/.<<y>>/*variable,readonly*/
 
     <<new>>/*keyword*/ <<LocalDeclarations>>/*interface,abstract*/ <<with>>/*keyword*/ <<Foo>>/*interface,abstract*/:
-      <<override>>/*modifier*/ <<def>>/*keyword*/ <<foo>>/*method*/(): <<Unit>>/*class,abstract*/ = <<bar>>/*method*/()
+      <<override>>/*modifier*/ <<def>>/*keyword*/ <<foo>>/*method,definition*/(): <<Unit>>/*class,abstract*/ = <<bar>>/*method*/()

--- a/tests/unit/src/test/resources/semanticTokens3/example/Locals.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/Locals.scala
@@ -2,7 +2,7 @@
 
 <<class>>/*keyword*/ <<Locals>>/*class*/ {
   {
-    <<val>>/*keyword*/ <<x>>/*variable,readonly*/ = <<2>>/*number*/
+    <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<2>>/*number*/
     <<x>>/*variable,readonly*/ <<+>>/*method*/ <<2>>/*number*/
   }
 }

--- a/tests/unit/src/test/resources/semanticTokens3/example/MethodOverload.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/MethodOverload.scala
@@ -1,9 +1,9 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
-<<class>>/*keyword*/ <<MethodOverload>>/*class*/(<<b>>/*variable,readonly*/: <<String>>/*type*/) {
+<<class>>/*keyword*/ <<MethodOverload>>/*class*/(<<b>>/*variable,declaration,readonly*/: <<String>>/*type*/) {
   <<def>>/*keyword*/ <<this>>/*keyword*/() = <<this>>/*keyword*/(<<"">>/*string*/)
-  <<def>>/*keyword*/ <<this>>/*keyword*/(<<c>>/*parameter,readonly*/: <<Int>>/*class,abstract*/) = <<this>>/*keyword*/(<<"">>/*string*/)
-  <<val>>/*keyword*/ <<a>>/*variable,readonly*/ = <<2>>/*number*/
-  <<def>>/*keyword*/ <<a>>/*method*/(<<x>>/*parameter,readonly*/: <<Int>>/*class,abstract*/) = <<2>>/*number*/
-  <<def>>/*keyword*/ <<a>>/*method*/(<<x>>/*parameter,readonly*/: <<Int>>/*class,abstract*/, <<y>>/*parameter,readonly*/: <<Int>>/*class,abstract*/) = <<2>>/*number*/
+  <<def>>/*keyword*/ <<this>>/*keyword*/(<<c>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/) = <<this>>/*keyword*/(<<"">>/*string*/)
+  <<val>>/*keyword*/ <<a>>/*variable,definition,readonly*/ = <<2>>/*number*/
+  <<def>>/*keyword*/ <<a>>/*method,definition*/(<<x>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/) = <<2>>/*number*/
+  <<def>>/*keyword*/ <<a>>/*method,definition*/(<<x>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/, <<y>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/) = <<2>>/*number*/
 }

--- a/tests/unit/src/test/resources/semanticTokens3/example/Miscellaneous.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/Miscellaneous.scala
@@ -2,10 +2,10 @@
 
 <<class>>/*keyword*/ <<Miscellaneous>>/*class*/ {
   <<// backtick identifier>>/*comment*/
-  <<val>>/*keyword*/ <<`a b`>>/*variable,readonly*/ = <<42>>/*number*/
+  <<val>>/*keyword*/ <<`a b`>>/*variable,definition,readonly*/ = <<42>>/*number*/
 
   <<// block with only wildcard value>>/*comment*/
-  <<def>>/*keyword*/ <<apply>>/*method*/(): <<Unit>>/*class,abstract*/ = {
+  <<def>>/*keyword*/ <<apply>>/*method,definition*/(): <<Unit>>/*class,abstract*/ = {
     <<val>>/*keyword*/ <<_>>/*variable*/ = <<42>>/*number*/
   }
   <<// infix + inferred apply/implicits/tparams>>/*comment*/

--- a/tests/unit/src/test/resources/semanticTokens3/example/NamedArguments.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/NamedArguments.scala
@@ -1,19 +1,19 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<case>>/*keyword*/ <<class>>/*keyword*/ <<User>>/*class*/(
-    <<name>>/*variable,readonly*/: <<String>>/*type*/ = {
+    <<name>>/*variable,declaration,readonly*/: <<String>>/*type*/ = {
       <<// assert default values have occurrences>>/*comment*/
       <<Map>>/*class*/.<<toString>>/*method*/
     }
 )
 <<object>>/*keyword*/ <<NamedArguments>>/*class*/ {
-  <<final>>/*modifier*/ <<val>>/*keyword*/ <<susan>>/*variable,readonly*/ = <<"Susan">>/*string*/
-  <<val>>/*keyword*/ <<user1>>/*variable,readonly*/ =
+  <<final>>/*modifier*/ <<val>>/*keyword*/ <<susan>>/*variable,definition,readonly*/ = <<"Susan">>/*string*/
+  <<val>>/*keyword*/ <<user1>>/*variable,definition,readonly*/ =
     <<User>>/*class*/
       .<<apply>>/*method*/(
         <<name>>/*parameter,readonly*/ = <<"John">>/*string*/
       )
-  <<val>>/*keyword*/ <<user2>>/*variable,readonly*/: <<User>>/*class*/ =
+  <<val>>/*keyword*/ <<user2>>/*variable,definition,readonly*/: <<User>>/*class*/ =
     <<User>>/*class*/(
       <<name>>/*parameter,readonly*/ = <<susan>>/*variable,readonly*/
     ).<<copy>>/*method*/(
@@ -24,7 +24,7 @@
   <<@>>/*keyword*/<<deprecated>>/*class*/(
     <<message>>/*parameter,readonly*/ = <<"a">>/*string*/,
     <<since>>/*parameter,readonly*/ = <<susan>>/*variable,readonly*/,
-  ) <<def>>/*keyword*/ <<b>>/*method,deprecated*/ = <<1>>/*number*/
+  ) <<def>>/*keyword*/ <<b>>/*method,definition,deprecated*/ = <<1>>/*number*/
 
   <<// vararg>>/*comment*/
   <<List>>/*class*/(

--- a/tests/unit/src/test/resources/semanticTokens3/example/Ord.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/Ord.scala
@@ -1,12 +1,12 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
-<<trait>>/*keyword*/ <<Ord>>/*interface,abstract*/[<<T>>/*typeParameter,abstract*/]:
-  <<def>>/*keyword*/ <<compare>>/*method*/(<<x>>/*parameter,readonly*/: <<T>>/*typeParameter,abstract*/, <<y>>/*parameter,readonly*/: <<T>>/*typeParameter,abstract*/): <<Int>>/*class,abstract*/
+<<trait>>/*keyword*/ <<Ord>>/*interface,abstract*/[<<T>>/*typeParameter,definition,abstract*/]:
+  <<def>>/*keyword*/ <<compare>>/*method,declaration*/(<<x>>/*parameter,declaration,readonly*/: <<T>>/*typeParameter,abstract*/, <<y>>/*parameter,declaration,readonly*/: <<T>>/*typeParameter,abstract*/): <<Int>>/*class,abstract*/
 
 <<given>>/*keyword*/ <<intOrd>>/*class*/: <<Ord>>/*interface,abstract*/[<<Int>>/*class,abstract*/] <<with>>/*keyword*/
-  <<def>>/*keyword*/ <<compare>>/*method*/(<<x>>/*parameter,readonly*/: <<Int>>/*class,abstract*/, <<y>>/*parameter,readonly*/: <<Int>>/*class,abstract*/) =
+  <<def>>/*keyword*/ <<compare>>/*method,definition*/(<<x>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/, <<y>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/) =
     <<if>>/*keyword*/ <<x>>/*parameter,readonly*/ <<<>>/*method*/ <<y>>/*parameter,readonly*/ <<then>>/*keyword*/ -<<1>>/*number*/ <<else>>/*keyword*/ <<if>>/*keyword*/ <<x>>/*parameter,readonly*/ <<>>>/*method*/ <<y>>/*parameter,readonly*/ <<then>>/*keyword*/ +<<1>>/*number*/ <<else>>/*keyword*/ <<0>>/*number*/
 
 <<given>>/*keyword*/ <<Ord>>/*interface,abstract*/[<<String>>/*type*/] <<with>>/*keyword*/
-  <<def>>/*keyword*/ <<compare>>/*method*/(<<x>>/*parameter,readonly*/: <<String>>/*type*/, <<y>>/*parameter,readonly*/: <<String>>/*type*/) =
+  <<def>>/*keyword*/ <<compare>>/*method,definition*/(<<x>>/*parameter,declaration,readonly*/: <<String>>/*type*/, <<y>>/*parameter,declaration,readonly*/: <<String>>/*type*/) =
     <<x>>/*parameter,readonly*/.<<compare>>/*method*/(<<y>>/*parameter,readonly*/)

--- a/tests/unit/src/test/resources/semanticTokens3/example/PatternMatching.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/PatternMatching.scala
@@ -1,23 +1,23 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<class>>/*keyword*/ <<PatternMatching>>/*class*/ {
-  <<val>>/*keyword*/ <<some>>/*variable,readonly*/ = <<Some>>/*class*/(<<1>>/*number*/)
+  <<val>>/*keyword*/ <<some>>/*variable,definition,readonly*/ = <<Some>>/*class*/(<<1>>/*number*/)
   <<some>>/*variable,readonly*/ <<match>>/*keyword*/ {
-    <<case>>/*keyword*/ <<Some>>/*class*/(<<number>>/*variable,readonly*/) <<=>>>/*operator*/
+    <<case>>/*keyword*/ <<Some>>/*class*/(<<number>>/*variable,declaration,readonly*/) <<=>>>/*operator*/
       <<number>>/*variable,readonly*/
   }
 
   <<// tuple deconstruction>>/*comment*/
-  <<val>>/*keyword*/ (<<left>>/*variable,readonly*/, <<right>>/*variable,readonly*/) = (<<1>>/*number*/, <<2>>/*number*/)
+  <<val>>/*keyword*/ (<<left>>/*variable,definition,readonly*/, <<right>>/*variable,definition,readonly*/) = (<<1>>/*number*/, <<2>>/*number*/)
   (<<left>>/*variable,readonly*/, <<right>>/*variable,readonly*/)
 
   <<// val deconstruction>>/*comment*/
-  <<val>>/*keyword*/ <<Some>>/*class*/(<<number1>>/*variable,readonly*/) =
+  <<val>>/*keyword*/ <<Some>>/*class*/(<<number1>>/*variable,definition,readonly*/) =
     <<some>>/*variable,readonly*/
   <<println>>/*method*/(<<number1>>/*variable,readonly*/)
 
-  <<def>>/*keyword*/ <<localDeconstruction>>/*method*/ = {
-    <<val>>/*keyword*/ <<Some>>/*class*/(<<number2>>/*variable,readonly*/) =
+  <<def>>/*keyword*/ <<localDeconstruction>>/*method,definition*/ = {
+    <<val>>/*keyword*/ <<Some>>/*class*/(<<number2>>/*variable,declaration,readonly*/) =
       <<some>>/*variable,readonly*/
     <<number2>>/*variable,readonly*/
   }

--- a/tests/unit/src/test/resources/semanticTokens3/example/PatternMatching.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/PatternMatching.scala
@@ -3,7 +3,7 @@
 <<class>>/*keyword*/ <<PatternMatching>>/*class*/ {
   <<val>>/*keyword*/ <<some>>/*variable,definition,readonly*/ = <<Some>>/*class*/(<<1>>/*number*/)
   <<some>>/*variable,readonly*/ <<match>>/*keyword*/ {
-    <<case>>/*keyword*/ <<Some>>/*class*/(<<number>>/*variable,declaration,readonly*/) <<=>>>/*operator*/
+    <<case>>/*keyword*/ <<Some>>/*class*/(<<number>>/*variable,definition,readonly*/) <<=>>>/*operator*/
       <<number>>/*variable,readonly*/
   }
 
@@ -17,7 +17,7 @@
   <<println>>/*method*/(<<number1>>/*variable,readonly*/)
 
   <<def>>/*keyword*/ <<localDeconstruction>>/*method,definition*/ = {
-    <<val>>/*keyword*/ <<Some>>/*class*/(<<number2>>/*variable,declaration,readonly*/) =
+    <<val>>/*keyword*/ <<Some>>/*class*/(<<number2>>/*variable,definition,readonly*/) =
       <<some>>/*variable,readonly*/
     <<number2>>/*variable,readonly*/
   }

--- a/tests/unit/src/test/resources/semanticTokens3/example/Scalalib.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/Scalalib.scala
@@ -1,8 +1,8 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<class>>/*keyword*/ <<Scalalib>>/*class*/ {
-  <<val>>/*keyword*/ <<nil>>/*variable,readonly*/ = <<List>>/*class*/()
-  <<val>>/*keyword*/ <<lst>>/*variable,readonly*/ = <<List>>/*class*/[
+  <<val>>/*keyword*/ <<nil>>/*variable,definition,readonly*/ = <<List>>/*class*/()
+  <<val>>/*keyword*/ <<lst>>/*variable,definition,readonly*/ = <<List>>/*class*/[
     (
         <<Nothing>>/*class,abstract*/,
         <<Null>>/*class,abstract*/,

--- a/tests/unit/src/test/resources/semanticTokens3/example/StructuralTypes.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/StructuralTypes.scala
@@ -3,18 +3,18 @@
 <<import>>/*keyword*/ <<reflect>>/*namespace*/.<<Selectable>>/*class*/.<<reflectiveSelectable>>/*method*/
 
 <<object>>/*keyword*/ <<StructuralTypes>>/*class*/:
-  <<type>>/*keyword*/ <<User>>/*type*/ = {
-    <<def>>/*keyword*/ <<name>>/*method*/: <<String>>/*type*/
-    <<def>>/*keyword*/ <<age>>/*method*/: <<Int>>/*class,abstract*/
+  <<type>>/*keyword*/ <<User>>/*type,definition*/ = {
+    <<def>>/*keyword*/ <<name>>/*method,declaration*/: <<String>>/*type*/
+    <<def>>/*keyword*/ <<age>>/*method,declaration*/: <<Int>>/*class,abstract*/
   }
 
-  <<val>>/*keyword*/ <<user>>/*variable,readonly*/ = <<null>>/*keyword*/.<<asInstanceOf>>/*method*/[<<User>>/*type*/]
+  <<val>>/*keyword*/ <<user>>/*variable,definition,readonly*/ = <<null>>/*keyword*/.<<asInstanceOf>>/*method*/[<<User>>/*type*/]
   <<user>>/*variable,readonly*/.<<name>>/*variable*/
   <<user>>/*variable,readonly*/.<<age>>/*variable*/
 
-  <<val>>/*keyword*/ <<V>>/*variable,readonly*/: <<Object>>/*class*/ {
-    <<def>>/*keyword*/ <<scalameta>>/*method*/: <<String>>/*type*/
+  <<val>>/*keyword*/ <<V>>/*variable,definition,readonly*/: <<Object>>/*class*/ {
+    <<def>>/*keyword*/ <<scalameta>>/*method,declaration*/: <<String>>/*type*/
   } = <<new>>/*keyword*/:
-    <<def>>/*keyword*/ <<scalameta>>/*method*/ = <<"4.0">>/*string*/
+    <<def>>/*keyword*/ <<scalameta>>/*method,definition*/ = <<"4.0">>/*string*/
   <<V>>/*variable,readonly*/.<<scalameta>>/*variable*/
 <<end>>/*keyword*/ <<StructuralTypes>>/*class*/

--- a/tests/unit/src/test/resources/semanticTokens3/example/ToplevelDefVal.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/ToplevelDefVal.scala
@@ -1,8 +1,8 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
-<<def>>/*keyword*/ <<foo>>/*method*/(): <<Int>>/*class,abstract*/ = <<42>>/*number*/
+<<def>>/*keyword*/ <<foo>>/*method,definition*/(): <<Int>>/*class,abstract*/ = <<42>>/*number*/
 
-<<val>>/*keyword*/ <<abc>>/*variable,readonly*/: <<String>>/*type*/ = <<"sds">>/*string*/
+<<val>>/*keyword*/ <<abc>>/*variable,definition,readonly*/: <<String>>/*type*/ = <<"sds">>/*string*/
 
 <<// tests jar's indexing on Windows>>/*comment*/
-<<type>>/*keyword*/ <<SourceToplevelTypeFromDepsRef>>/*type*/ = <<EmptyTuple>>/*type*/
+<<type>>/*keyword*/ <<SourceToplevelTypeFromDepsRef>>/*type,definition*/ = <<EmptyTuple>>/*type*/

--- a/tests/unit/src/test/resources/semanticTokens3/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/TryCatch.scala
@@ -2,13 +2,13 @@
 
 <<class>>/*keyword*/ <<TryCatch>>/*class*/ {
   <<try>>/*keyword*/ {
-    <<val>>/*keyword*/ <<x>>/*variable,readonly*/ = <<2>>/*number*/
+    <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<2>>/*number*/
     <<x>>/*variable,readonly*/ <<+>>/*method*/ <<2>>/*number*/
   } <<catch>>/*keyword*/ {
-    <<case>>/*keyword*/ <<t>>/*variable,readonly*/: <<Throwable>>/*type*/ <<=>>>/*operator*/
+    <<case>>/*keyword*/ <<t>>/*variable,declaration,readonly*/: <<Throwable>>/*type*/ <<=>>>/*operator*/
       <<t>>/*variable,readonly*/.<<printStackTrace>>/*method*/()
   } <<finally>>/*keyword*/ {
-    <<val>>/*keyword*/ <<text>>/*variable,readonly*/ = <<"">>/*string*/
+    <<val>>/*keyword*/ <<text>>/*variable,definition,readonly*/ = <<"">>/*string*/
     <<text>>/*variable,readonly*/ <<+>>/*method*/ <<"">>/*string*/
   }
 }

--- a/tests/unit/src/test/resources/semanticTokens3/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/TryCatch.scala
@@ -5,7 +5,7 @@
     <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<2>>/*number*/
     <<x>>/*variable,readonly*/ <<+>>/*method*/ <<2>>/*number*/
   } <<catch>>/*keyword*/ {
-    <<case>>/*keyword*/ <<t>>/*variable,declaration,readonly*/: <<Throwable>>/*type*/ <<=>>>/*operator*/
+    <<case>>/*keyword*/ <<t>>/*variable,definition,readonly*/: <<Throwable>>/*type*/ <<=>>>/*operator*/
       <<t>>/*variable,readonly*/.<<printStackTrace>>/*method*/()
   } <<finally>>/*keyword*/ {
     <<val>>/*keyword*/ <<text>>/*variable,definition,readonly*/ = <<"">>/*string*/

--- a/tests/unit/src/test/resources/semanticTokens3/example/TypeParameters.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/TypeParameters.scala
@@ -1,8 +1,8 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
-<<class>>/*keyword*/ <<TypeParameters>>/*class*/[<<A>>/*typeParameter,abstract*/] {
-  <<def>>/*keyword*/ <<method>>/*method*/[<<B>>/*typeParameter,abstract*/] = <<42>>/*number*/
-  <<trait>>/*keyword*/ <<TraitParameter>>/*interface,abstract*/[<<C>>/*typeParameter,abstract*/]
-  <<type>>/*keyword*/ <<AbstractTypeAlias>>/*type,abstract*/[<<D>>/*typeParameter,abstract*/]
-  <<type>>/*keyword*/ <<TypeAlias>>/*type*/[<<E>>/*typeParameter,abstract*/] = <<List>>/*type*/[<<E>>/*typeParameter,abstract*/]
+<<class>>/*keyword*/ <<TypeParameters>>/*class*/[<<A>>/*typeParameter,definition,abstract*/] {
+  <<def>>/*keyword*/ <<method>>/*method,definition*/[<<B>>/*typeParameter,definition,abstract*/] = <<42>>/*number*/
+  <<trait>>/*keyword*/ <<TraitParameter>>/*interface,abstract*/[<<C>>/*typeParameter,definition,abstract*/]
+  <<type>>/*keyword*/ <<AbstractTypeAlias>>/*type,definition,abstract*/[<<D>>/*typeParameter,definition,abstract*/]
+  <<type>>/*keyword*/ <<TypeAlias>>/*type,definition*/[<<E>>/*typeParameter,definition,abstract*/] = <<List>>/*type*/[<<E>>/*typeParameter,abstract*/]
 }

--- a/tests/unit/src/test/resources/semanticTokens3/example/VarArgs.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/VarArgs.scala
@@ -1,6 +1,6 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<class>>/*keyword*/ <<VarArgs>>/*class*/ {
-  <<def>>/*keyword*/ <<add>>/*method*/(<<a>>/*parameter,readonly*/: <<Int>>/*class,abstract*/*) = <<a>>/*parameter,readonly*/
-  <<def>>/*keyword*/ <<add2>>/*method*/(<<a>>/*parameter,readonly*/: <<Seq>>/*type*/[<<Int>>/*class,abstract*/]*) = <<a>>/*parameter,readonly*/
+  <<def>>/*keyword*/ <<add>>/*method,definition*/(<<a>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/*) = <<a>>/*parameter,readonly*/
+  <<def>>/*keyword*/ <<add2>>/*method,definition*/(<<a>>/*parameter,declaration,readonly*/: <<Seq>>/*type*/[<<Int>>/*class,abstract*/]*) = <<a>>/*parameter,readonly*/
 }

--- a/tests/unit/src/test/resources/semanticTokens3/example/Vars.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/Vars.scala
@@ -1,7 +1,7 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<object>>/*keyword*/ <<Vars>>/*class*/ {
-  <<var>>/*keyword*/ <<a>>/*variable*/ = <<2>>/*number*/
+  <<var>>/*keyword*/ <<a>>/*variable,definition*/ = <<2>>/*number*/
 
   <<a>>/*variable*/ = <<2>>/*number*/
 

--- a/tests/unit/src/test/resources/semanticTokens3/example/nested/LocalClass.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/nested/LocalClass.scala
@@ -1,7 +1,7 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/.<<nested>>/*namespace*/
 
 <<class>>/*keyword*/ <<LocalClass>>/*class*/ {
-  <<def>>/*keyword*/ <<foo>>/*method*/(): <<Unit>>/*class,abstract*/ = {
+  <<def>>/*keyword*/ <<foo>>/*method,definition*/(): <<Unit>>/*class,abstract*/ = {
     <<case>>/*keyword*/ <<class>>/*keyword*/ <<LocalClass>>/*class*/()
   }
 }

--- a/tests/unit/src/test/scala/tests/SemanticHighlightLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticHighlightLspSuite.scala
@@ -22,7 +22,7 @@ class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
        |<<   * Test of Comment Block>>/*comment*/
        |<<   */>>/*comment*/  <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<1>>/*number*/
        |
-       |  <<def>>/*keyword*/ <<add>>/*method,definition*/(<<a>>/*parameter,readonly,declaration*/ : <<Int>>/*class,abstract*/) = {
+       |  <<def>>/*keyword*/ <<add>>/*method,definition*/(<<a>>/*parameter,declaration,readonly*/ : <<Int>>/*class,abstract*/) = {
        |    <<// Single Line Comment>>/*comment*/
        |    <<a>>/*parameter,readonly*/ <<+>>/*method,abstract*/ <<1>>/*number*/ <<// com = 1>>/*comment*/
        |   }
@@ -86,24 +86,24 @@ class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
   check(
     "predef",
     """|<<object>>/*keyword*/ <<Main>>/*class*/ {
-       |  <<val>>/*keyword*/ <<x>>/*variable,readonly*/ = <<List>>/*class*/(<<1>>/*number*/,<<2>>/*number*/,<<3>>/*number*/)
-       |  <<val>>/*keyword*/ <<y>>/*variable,readonly*/ = <<a>>/*variable,readonly*/ <<match>>/*keyword*/ {
+       |  <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<List>>/*class*/(<<1>>/*number*/,<<2>>/*number*/,<<3>>/*number*/)
+       |  <<val>>/*keyword*/ <<y>>/*variable,definition,readonly*/ = <<a>>/*variable,readonly*/ <<match>>/*keyword*/ {
        |    <<case>>/*keyword*/ <<List>>/*class*/(<<a>>/*variable*/,<<b>>/*variable*/,<<c>>/*variable*/) <<=>>>/*operator*/ <<a>>/*variable,readonly*/
        |    <<case>>/*keyword*/ <<_>>/*variable*/ <<=>>>/*operator*/ <<0>>/*number*/
        |  }
-       |  <<val>>/*keyword*/ <<z>>/*variable,readonly*/ = <<Set>>/*class*/(<<1>>/*number*/,<<2>>/*number*/,<<3>>/*number*/)
-       |  <<val>>/*keyword*/ <<w>>/*variable,readonly*/ = <<Right>>/*class*/(<<1>>/*number*/)
+       |  <<val>>/*keyword*/ <<z>>/*variable,definition,readonly*/ = <<Set>>/*class*/(<<1>>/*number*/,<<2>>/*number*/,<<3>>/*number*/)
+       |  <<val>>/*keyword*/ <<w>>/*variable,definition,readonly*/ = <<Right>>/*class*/(<<1>>/*number*/)
        |}
        |""".stripMargin,
   )
 
   check(
     "case-class",
-    """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Foo>>/*class*/(<<i>>/*variable,readonly*/: <<Int>>/*class,abstract*/, <<j>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
+    """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Foo>>/*class*/(<<i>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<j>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
        |
        |
        |<<object>>/*keyword*/ <<A>>/*class*/ {
-       |  <<val>>/*keyword*/ <<f>>/*variable,readonly*/ = <<Foo>>/*class*/(<<1>>/*number*/,<<2>>/*number*/)
+       |  <<val>>/*keyword*/ <<f>>/*variable,definition,readonly*/ = <<Foo>>/*class*/(<<1>>/*number*/,<<2>>/*number*/)
        |}
        |""".stripMargin,
   )
@@ -113,13 +113,13 @@ class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
     """|<<package>>/*keyword*/ <<a>>/*namespace*/
        |
        |<<object>>/*keyword*/ <<A>>/*class*/ {
-       |  <<var>>/*keyword*/ <<abc>>/*variable*/ = <<123>>/*number*/
-       |  <<var>>/*keyword*/ <<edf>>/*variable*/ = <<abc>>/*variable*/ <<+>>/*method,abstract*/ <<2>>/*number*/
+       |  <<var>>/*keyword*/ <<abc>>/*variable,definition*/ = <<123>>/*number*/
+       |  <<var>>/*keyword*/ <<edf>>/*variable,definition*/ = <<abc>>/*variable*/ <<+>>/*method,abstract*/ <<2>>/*number*/
        |  <<abc>>/*variable*/ = <<edf>>/*variable*/ <<->>/*method,abstract*/ <<2>>/*number*/
        |  <<A>>/*class*/.<<edf>>/*variable*/ = <<A>>/*class*/.<<abc>>/*variable*/ 
        |
-       |  <<def>>/*keyword*/ <<m>>/*method*/() = {
-       |    <<var>>/*keyword*/ <<beta>>/*variable*/ = <<3>>/*number*/
+       |  <<def>>/*keyword*/ <<m>>/*method,definition*/() = {
+       |    <<var>>/*keyword*/ <<beta>>/*variable,definition*/ = <<3>>/*number*/
        |    <<beta>>/*variable*/ = <<beta>>/*variable*/ <<+>>/*method,abstract*/ <<1>>/*number*/
        |    <<beta>>/*variable*/
        |  }
@@ -131,7 +131,7 @@ class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
       name: TestOptions,
       expected: String,
       fileName: String = "Main.scala",
-  ): Unit = {
+  )(implicit loc: munit.Location): Unit = {
     val fileContent =
       TestSemanticTokens.removeSemanticHighlightDecorations(expected)
 

--- a/tests/unit/src/test/scala/tests/SemanticHighlightLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticHighlightLspSuite.scala
@@ -16,21 +16,18 @@ class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
 
   check(
     "comments",
-    s"""|
-        |<<object>>/*keyword*/ <<Main>>/*class*/{
-        |
-        |   <</**>>/*comment*/
-        |<<   * Test of Comment Block>>/*comment*/
-        |<<   */>>/*comment*/  <<val>>/*keyword*/ <<x>>/*variable,readonly*/ = <<1>>/*number*/
-        |
-        |  <<def>>/*keyword*/ <<add>>/*method*/(<<a>>/*parameter,readonly*/ : <<Int>>/*class,abstract*/) = {
-        |    <<// Single Line Comment>>/*comment*/
-        |    <<a>>/*parameter,readonly*/ <<+>>/*method,abstract*/ <<1>>/*number*/ <<// com = 1>>/*comment*/
-        |   }
-        |}
-        |
-        |
-        |""".stripMargin,
+    """|<<object>>/*keyword*/ <<Main>>/*class*/{
+       |
+       |   <</**>>/*comment*/
+       |<<   * Test of Comment Block>>/*comment*/
+       |<<   */>>/*comment*/  <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<1>>/*number*/
+       |
+       |  <<def>>/*keyword*/ <<add>>/*method,definition*/(<<a>>/*parameter,readonly,declaration*/ : <<Int>>/*class,abstract*/) = {
+       |    <<// Single Line Comment>>/*comment*/
+       |    <<a>>/*parameter,readonly*/ <<+>>/*method,abstract*/ <<1>>/*number*/ <<// com = 1>>/*comment*/
+       |   }
+       |}
+       |""".stripMargin,
   )
 
   check(
@@ -42,8 +39,8 @@ class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
         |<<import>>/*keyword*/ <<java>>/*namespace*/.<<nio>>/*namespace*/.<<file>>/*namespace*/.<<AccessMode>>/*enum*/.<<WRITE>>/*enumMember*/
         |<<import>>/*keyword*/ <<java>>/*namespace*/.<<nio>>/*namespace*/.<<file>>/*namespace*/.<<AccessMode>>/*enum*/.<<EXECUTE>>/*enumMember*/
         |<<object>>/*keyword*/ <<Main>>/*class*/ {
-        |  <<val>>/*keyword*/ <<vTrue>>/*variable,readonly*/ = <<true>>/*keyword*/
-        |  <<val>>/*keyword*/ <<vFalse>>/*variable,readonly*/ = <<false>>/*keyword*/
+        |  <<val>>/*keyword*/ <<vTrue>>/*variable,definition,readonly*/ = <<true>>/*keyword*/
+        |  <<val>>/*keyword*/ <<vFalse>>/*variable,definition,readonly*/ = <<false>>/*keyword*/
         |  (<<null>>/*keyword*/: <<AccessMode>>/*enumMember,abstract*/) <<match>>/*keyword*/ {
         |    <<case>>/*keyword*/ <<READ>>/*enumMember*/ <<=>>>/*operator*/ <<0>>/*number*/
         |    <<case>>/*keyword*/ <<WRITE>>/*enumMember*/ <<=>>>/*operator*/
@@ -81,7 +78,7 @@ class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
     """|<<package>>/*keyword*/ <<a>>/*namespace*/
        |
        |<<object>>/*keyword*/ <<A>>/*class*/ {
-       |  <<case>>/*keyword*/ <<class>>/*keyword*/ <<B>>/*class*/(<<c>>/*variable,readonly*/: <<Int>>/*class,abstract*/)
+       |  <<case>>/*keyword*/ <<class>>/*keyword*/ <<B>>/*class*/(<<c>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
        |}
        |""".stripMargin,
   )


### PR DESCRIPTION
Previously, semantic tokens would not include declaration and definition tokens. Now, we use the tree information to figure out if a tree is a definition tree (DefTree) and whether rhs is empty (in that case it's only a declaration).