### PR TITLE
bugfix: Make sure that tokenizing doesn't hang

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
@@ -609,7 +609,9 @@ class ScalaToplevelMtags(
   def valIdentifiers: List[Identifier] = {
     var resultList: List[Identifier] = Nil
     var isUnapply = false
-    while (scanner.curr.token != EQUALS && scanner.curr.token != COLON) {
+    while (
+      scanner.curr.token != EQUALS && scanner.curr.token != COLON && scanner.curr.token != EOF
+    ) {
       scanner.curr.token match {
         case IDENTIFIER => {
           val pos = newPosition


### PR DESCRIPTION
Previously, it seems in some cases tokenization would hang at EOF judging from the stacktrace:

```
"pool-1-thread-57" #225 prio=5 os_prio=31 tid=0x00007f80a80f6800 nid=0x12107 runnable [0x0000700017937000]
   java.lang.Thread.State: RUNNABLE
    at scala.meta.internal.mtags.ScalaToplevelMtags.valIdentifiers(ScalaToplevelMtags.scala:622)
    at scala.meta.internal.mtags.ScalaToplevelMtags.emitTerm(ScalaToplevelMtags.scala:470)
    at scala.meta.internal.mtags.ScalaToplevelMtags.$anonfun$loop$10(ScalaToplevelMtags.scala:225)
    at scala.meta.internal.mtags.ScalaToplevelMtags$$Lambda$6359/1132081275.apply$mcV$sp(Unknown Source)
    at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
    at scala.meta.internal.mtags.MtagsIndexer.withOwner(MtagsIndexer.scala:48)
    at scala.meta.internal.mtags.MtagsIndexer.withOwner$(MtagsIndexer.scala:45)
    at scala.meta.internal.mtags.ScalaToplevelMtags.withOwner(ScalaToplevelMtags.scala:41)
    at scala.meta.internal.mtags.ScalaToplevelMtags.loop(ScalaToplevelMtags.scala:225)
    at scala.meta.internal.mtags.ScalaToplevelMtags.indexRoot(ScalaToplevelMtags.scala:53)
    at scala.meta.internal.metals.SemanticdbDefinition$.foreach(SemanticdbDefinition.scala:64)
    at scala.meta.internal.metals.Indexer.indexSourceFile(Indexer.scala:534)
    at scala.meta.internal.metals.Indexer.$anonfun$reindexWorkspaceSources$3(Indexer.scala:606)
    at scala.meta.internal.metals.Indexer.$anonfun$reindexWorkspaceSources$3$adapted(Indexer.scala:603)
    at scala.meta.internal.metals.Indexer$$Lambda$7696/1956632793.apply(Unknown Source)
    at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:575)
    at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:573)
    at scala.collection.AbstractIterator.foreach(Iterator.scala:1300)
    at scala.meta.internal.metals.Indexer.reindexWorkspaceSources(Indexer.scala:603)
    at scala.meta.internal.metals.MetalsLspService.$anonfun$onChange$2(MetalsLspService.scala:1482)
    at scala.meta.internal.metals.MetalsLspService$$Lambda$7690/361009775.apply$mcV$sp(Unknown Source)
    at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
    at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:678)
    at scala.concurrent.Future$$$Lambda$946/419852969.apply(Unknown Source)
    at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```

Now, we make sure that the loop ends when EOF is encountered.