### PR TITLE
improvement: dealias inferred types if not in scope

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -266,7 +266,7 @@ object MtagsEnrichments extends CommonMtagsEnrichments:
       tpe.dealias match
         case app @ AppliedType(tycon, params) =>
           // we dealias applied type params by hand, because `dealias` doesn't do it
-          AppliedType(tycon, params.map(_.dealias))
+          AppliedType(tycon, params.map(_.metalsDealias))
         case dealised => dealised
 
 end MtagsEnrichments

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -758,6 +758,96 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |""".stripMargin,
   )
 
+  checkEdit(
+    "dealias",
+    """|class Foo() {
+       |  type T = Int
+       |  def getT: T = 1
+       |}
+       |
+       |object O {
+       | val <<c>> = new Foo().getT
+       |}
+       |""".stripMargin,
+    """|class Foo() {
+       |  type T = Int
+       |  def getT: T = 1
+       |}
+       |
+       |object O {
+       | val c: Int = new Foo().getT
+       |}
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "dealias2",
+    """|object Foo {
+       |  type T = Int
+       |  def getT: T = 1
+       |  val <<c>> = getT
+       |}
+       |""".stripMargin,
+    """|object Foo {
+       |  type T = Int
+       |  def getT: T = 1
+       |  val c: T = getT
+       |}
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "dealias3".tag(IgnoreScala2),
+    """|object Foo:
+       |  opaque type T = Int
+       |  def getT: T = 1
+       |val <<c>> = Foo.getT
+       |""".stripMargin,
+    """|import Foo.T
+       |object Foo:
+       |  opaque type T = Int
+       |  def getT: T = 1
+       |val c: T = Foo.getT
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "dealias4".tag(IgnoreScala2),
+    """|object O:
+       | type M = Int
+       | type W = M => Int
+       | def get: W = ???
+       |
+       |val <<m>> = O.get
+       |""".stripMargin,
+    """|object O:
+       | type M = Int
+       | type W = M => Int
+       | def get: W = ???
+       |
+       |val m: Int => Int = O.get
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "dealias5".tag(IgnoreScala2),
+    """|object O:
+       | opaque type M = Int
+       | type W = M => Int
+       | def get: W = ???
+       |
+       |val <<m>> = O.get
+       |""".stripMargin,
+    """|import O.M
+       |object O:
+       | opaque type M = Int
+       | type W = M => Int
+       | def get: W = ???
+       |
+       |val m: M => Int = O.get
+       |""".stripMargin,
+  )
+
   def checkEdit(
       name: TestOptions,
       original: String,


### PR DESCRIPTION
Previously: the inferred type was not dealiased.
Now: if the inferred type is not in the scope we dealias (keeping opaque types).

Note 1: This is very binary, since we either don't dealias anything or dealias all (also stripping annotations) if any of the aliases is not in scope:
```
object M:
  type T1 = Int
  object R:
    type T2 = String
    def get: Either[T1, T2] = ???
  val m = R.get //inferred type: Either[Int, String]
  
```
We could strip only the ones not in scope instead.
Note 2: Alternatively we could present the user with options.

Resolves: https://github.com/scalameta/metals/issues/4858