### PR TITLE
bugfix: Filter out -Ycheck-reentrant

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -416,6 +416,8 @@ class WorksheetProvider(
         val scalacOptions = info.scalac.getOptions.asScala
           .filterNot(_.contains("semanticdb"))
           .filterNot(_.contains("-Wconf"))
+          // seems to break worksheet support
+          .filterNot(_.contains("Ycheck-reentrant"))
           .filterNot(_.contains("org.wartremover.warts.NonUnitStatements"))
           .asJava
         val mdoc = embedded

--- a/tests/slow/src/test/scala/tests/feature/WorksheetCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/WorksheetCrossLspSuite.scala
@@ -8,6 +8,10 @@ class Worksheet211LspSuite extends tests.BaseWorksheetLspSuite(V.scala211)
 class Worksheet3LspSuite extends tests.BaseWorksheetLspSuite(V.scala3) {
   override def versionSpecificCodeToValidate: String =
     """given str: String = """""
+
+  override def versionSpecificScalacOptionsToValidate: List[String] = List(
+    "-Ycheck-reentrant"
+  )
 }
 
 class LatestWorksheet3LspSuite

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -28,6 +28,11 @@ abstract class BaseWorksheetLspSuite(
 
   def versionSpecificCodeToValidate: String = ""
 
+  /**
+   * These options when provided should not break worksheets.
+   */
+  def versionSpecificScalacOptionsToValidate: List[String] = Nil
+
   // sourcecode is not yet published for Scala 3
   if (!ScalaVersions.isScala3Version(scalaVersion))
     test("completion") {
@@ -669,11 +674,15 @@ abstract class BaseWorksheetLspSuite(
   test("export") {
     assume(!isWindows, "This test is flaky on Windows")
     cleanWorkspace()
+
+    val opts = versionSpecificScalacOptionsToValidate
+      .map(opt => s"\"$opt\"")
+      .mkString(",")
     for {
       _ <- initialize(
         s"""
            |/metals.json
-           |{"a": {"scalaVersion": "${scalaVersion}"}}
+           |{"a": {"scalaVersion": "${scalaVersion}", "scalacOptions": [$opts]}}
            |/a/src/main/scala/foo/Main.worksheet.sc
            |case class Hi(a: Int, b: Int, c: Int)
            |val hi1 =


### PR DESCRIPTION
Previously, when Ycheck-reentrant was included the worksheets would not show any results. Now they do.

It seems this might be caused by the fact that an exception is thrown from the compiler instead of a diagnostic.

```
2023.03.16 16:04:12 ERROR possible data race involving globally reachable mvariable ma in mpackage mcom.rmet.scala3seedling: Int
  use -Ylog:checkReentrant+ to find out more about why the variable is reachable.
```