### PR TITLE
docs: Switch from algolia to easyops-cn/docusaurus-search-local

### DIFF
--- a/docs/contributors/updating-website.md
+++ b/docs/contributors/updating-website.md
@@ -36,6 +36,10 @@ You can now build and launch the website using these commands:
 cd website
 yarn install # only the first time, to install the dependencies
 yarn start
+
+# To test search feature in local development
+yarn build
+yarn serve
 ```
 
 Now visit [localhost:3000](http://localhost:3000) and you should see a local version of the

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -52,7 +52,8 @@ module.exports = {
           }
         ]
       }
-    ]
+    ],
+    require.resolve("@easyops-cn/docusaurus-search-local"),
   ],
   "themeConfig": {
     "prism": {
@@ -131,11 +132,6 @@ module.exports = {
       "logo": {
         "src": "img/scalameta-logo.png"
       }
-    },
-    "algolia": {
-      "appId": "DZKJ3Z5JFX",
-      "apiKey": "e8f55852e303f6374dfa716be910cf08",
-      "indexName": "metals"
     }
   }
 }

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -53,7 +53,7 @@ module.exports = {
         ]
       }
     ],
-    require.resolve("@easyops-cn/docusaurus-search-local"),
+    "@easyops-cn/docusaurus-search-local",
   ],
   "themeConfig": {
     "prism": {

--- a/website/package.json
+++ b/website/package.json
@@ -10,10 +10,11 @@
   "devDependencies": {},
   "dependencies": {
     "@docusaurus/core": "2.3.1",
+    "@docusaurus/plugin-client-redirects": "2.3.1",
     "@docusaurus/preset-classic": "2.3.1",
+    "@easyops-cn/docusaurus-search-local": "^0.35.0",
     "clsx": "^1.1.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "@docusaurus/plugin-client-redirects": "2.3.1"
+    "react-dom": "^18.2.0"
   }
 }


### PR DESCRIPTION
![search-local-2](https://user-images.githubusercontent.com/9353584/226149069-42751ea3-7d34-46dc-9466-833d6f0e7173.gif)

We've been working on updating the algolia index for scalameta sites. However, there's been a lot of trouble keeping the algolia keys up to date, and the search function sometimes goes down.
see:
https://github.com/scalacenter/scalafix/issues/1514 https://github.com/scalameta/metals/pull/3604
https://github.com/scalameta/scalameta/pull/2569

This commit switches the search function from algolia to one of the
local search indexes
https://github.com/easyops-cn/docusaurus-search-local
chosen from
https://docusaurus.io/community/resources#search

I picked easyops-cn/docusaurus-search-local because

- it seems to be well maintained
- it works without server setup (unlike typesense)
- looks prettier than cmfcmf/docusaurus-search-local (original one)

but, other suggestions are welcome :)

---

screen-record for https://github.com/cmfcmf/docusaurus-search-local for comparison

![search-local](https://user-images.githubusercontent.com/9353584/226148269-a5c31de6-a17a-4b8c-ab32-f792c14b23b2.gif)
