### PR TITLE
improvement: Make fallback semantic tokens readonly

### DIFF
--- a/metals-bench/src/main/scala/bench/SemanticTokensBench.scala
+++ b/metals-bench/src/main/scala/bench/SemanticTokensBench.scala
@@ -22,7 +22,7 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 
 @State(Scope.Benchmark)
-class SemanticHighlightBench extends PcBenchmark {
+class SemanticTokensBench extends PcBenchmark {
   var highlightRequests: Map[String, String] = Map.empty
 
   private def fromZipPath(zip: AbsolutePath, path: String) = {

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -5,7 +5,6 @@ import scala.concurrent.Promise
 
 import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.internal.metals.ScalaVersions
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.{BuildInfo => V}
 
@@ -674,52 +673,51 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
     } yield ()
   }
 
-  if (!ScalaVersions.isScala3Version(scalaVersion))
-    test("semantic-highlighting") {
+  test("semantic-highlighting") {
 
-      val expected =
-        """|
-           |
-           |<<import>>/*keyword*/ <<util>>/*namespace*/.{<<Failure>>/*class*/ <<=>>>/*operator*/ <<NotGood>>/*class*/}
-           |<<import>>/*keyword*/ <<math>>/*namespace*/.{<<floor>>/*method*/ <<=>>>/*operator*/ <<_>>/*variable*/, <<_>>/*variable*/}
-           |
-           |<<class>>/*keyword*/ <<Imports>>/*class*/ {
-           |  <<// rename reference>>/*comment*/
-           |  <<NotGood>>/*class*/(<<null>>/*keyword*/)
-           |  <<max>>/*method*/(<<1>>/*number*/, <<2>>/*number*/)
+    val expected =
+      """|
+         |
+         |<<import>>/*keyword*/ <<util>>/*namespace*/.{<<Failure>>/*class*/ <<=>>>/*operator*/ <<NotGood>>/*class*/}
+         |<<import>>/*keyword*/ <<math>>/*namespace*/.{<<floor>>/*method*/ <<=>>>/*operator*/ <<_>>/*variable,readonly*/, <<_>>/*variable,readonly*/}
+         |
+         |<<class>>/*keyword*/ <<Imports>>/*class*/ {
+         |  <<// rename reference>>/*comment*/
+         |  <<NotGood>>/*class*/(<<null>>/*keyword*/)
+         |  <<max>>/*method*/(<<1>>/*number*/, <<2>>/*number*/)
+         |}
+         |""".stripMargin
+
+    val fileContent =
+      TestSemanticTokens.removeSemanticHighlightDecorations(expected)
+
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "scalaVersion": "$scalaVersion"
+           |  }
            |}
+           |/main.sc
+           |$fileContent
            |""".stripMargin
-
-      val fileContent =
-        TestSemanticTokens.removeSemanticHighlightDecorations(expected)
-
-      for {
-        _ <- initialize(
-          s"""
-             |/metals.json
-             |{
-             |  "a": {
-             |    "scalaVersion": "$scalaVersion"
-             |  }
-             |}
-             |/main.sc
-             |$fileContent
-             |""".stripMargin
-        )
-        _ <- server.didChangeConfiguration(
-          """{
-            |  "enable-semantic-highlighting": true
-            |}
-            |""".stripMargin
-        )
-        _ <- server.didOpen("main.sc")
-        _ <- server.didSave("main.sc")(identity)
-        _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
-        _ <- server.assertSemanticHighlight(
-          "main.sc",
-          expected,
-          fileContent,
-        )
-      } yield ()
-    }
+      )
+      _ <- server.didChangeConfiguration(
+        """{
+          |  "enable-semantic-highlighting": true
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didOpen("main.sc")
+      _ <- server.didSave("main.sc")(identity)
+      _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
+      _ <- server.assertSemanticHighlight(
+        "main.sc",
+        expected,
+        fileContent,
+      )
+    } yield ()
+  }
 }

--- a/tests/unit/src/test/resources/semanticTokens/example/Imports.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/Imports.scala
@@ -1,7 +1,7 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<import>>/*keyword*/ <<util>>/*namespace*/.{<<Failure>>/*class*/ <<=>>>/*operator*/ <<NotGood>>/*class*/}
-<<import>>/*keyword*/ <<math>>/*namespace*/.{<<floor>>/*method*/ <<=>>>/*operator*/ <<_>>/*variable*/, <<_>>/*variable*/}
+<<import>>/*keyword*/ <<math>>/*namespace*/.{<<floor>>/*method*/ <<=>>>/*operator*/ <<_>>/*variable,readonly*/, <<_>>/*variable,readonly*/}
 
 <<class>>/*keyword*/ <<Imports>>/*class*/ {
   <<// rename reference>>/*comment*/

--- a/tests/unit/src/test/resources/semanticTokens/example/MacroAnnotation.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/MacroAnnotation.scala
@@ -11,7 +11,7 @@
 }
 
 <<object>>/*keyword*/ <<MacroAnnotations>>/*class*/ {
-  <<import>>/*keyword*/ <<scala>>/*namespace*/.<<meta>>/*namespace*/.<<_>>/*variable*/
+  <<import>>/*keyword*/ <<scala>>/*namespace*/.<<meta>>/*namespace*/.<<_>>/*variable,readonly*/
   <<// IntelliJ has never managed to goto definition for the inner classes from Trees.scala>>/*comment*/
   <<// due to the macro annotations.>>/*comment*/
   <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/: <<Defn>>/*class*/.<<Class>>/*interface,abstract*/ = <<Defn>>/*class*/.<<Class>>/*class*/(

--- a/tests/unit/src/test/resources/semanticTokens/example/Miscellaneous.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/Miscellaneous.scala
@@ -6,11 +6,11 @@
 
   <<// block with only wildcard value>>/*comment*/
   <<def>>/*keyword*/ <<apply>>/*method,definition*/(): <<Unit>>/*class,abstract*/ = {
-    <<val>>/*keyword*/ <<_>>/*variable*/ = <<42>>/*number*/
+    <<val>>/*keyword*/ <<_>>/*variable,readonly*/ = <<42>>/*number*/
   }
   <<// infix + inferred apply/implicits/tparams>>/*comment*/
   (<<List>>/*class*/(<<1>>/*number*/)
-    .<<map>>/*method*/(<<_>>/*variable*/ <<+>>/*method,abstract*/ <<1>>/*number*/)
+    .<<map>>/*method*/(<<_>>/*variable,readonly*/ <<+>>/*method,abstract*/ <<1>>/*number*/)
     <<++>>/*method*/
       <<List>>/*class*/(<<3>>/*number*/))
 }

--- a/tests/unit/src/test/resources/semanticTokens3/example/Imports.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/Imports.scala
@@ -1,7 +1,7 @@
 <<package>>/*keyword*/ <<example>>/*namespace*/
 
 <<import>>/*keyword*/ <<util>>/*namespace*/.{<<Failure>>/*class*/ <<=>>>/*operator*/ <<NotGood>>/*class*/}
-<<import>>/*keyword*/ <<math>>/*namespace*/.{<<floor>>/*method*/ <<=>>>/*operator*/ <<_>>/*variable*/, <<_>>/*variable*/}
+<<import>>/*keyword*/ <<math>>/*namespace*/.{<<floor>>/*method*/ <<=>>>/*operator*/ <<_>>/*variable,readonly*/, <<_>>/*variable,readonly*/}
 
 <<class>>/*keyword*/ <<Imports>>/*class*/ {
   <<// rename reference>>/*comment*/

--- a/tests/unit/src/test/resources/semanticTokens3/example/Miscellaneous.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/Miscellaneous.scala
@@ -6,11 +6,11 @@
 
   <<// block with only wildcard value>>/*comment*/
   <<def>>/*keyword*/ <<apply>>/*method,definition*/(): <<Unit>>/*class,abstract*/ = {
-    <<val>>/*keyword*/ <<_>>/*variable*/ = <<42>>/*number*/
+    <<val>>/*keyword*/ <<_>>/*variable,readonly*/ = <<42>>/*number*/
   }
   <<// infix + inferred apply/implicits/tparams>>/*comment*/
   (<<List>>/*class*/(<<1>>/*number*/)
-    .<<map>>/*method*/(<<_>>/*variable*/ <<+>>/*method*/ <<1>>/*number*/)
+    .<<map>>/*method*/(<<_>>/*variable,readonly*/ <<+>>/*method*/ <<1>>/*number*/)
     <<++>>/*method*/
       <<List>>/*class*/(<<3>>/*number*/))
 }

--- a/tests/unit/src/test/resources/semanticTokens3/example/NamedArguments.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/NamedArguments.scala
@@ -28,7 +28,7 @@
 
   <<// vararg>>/*comment*/
   <<List>>/*class*/(
-    <<elems>>/*variable*/ = <<2>>/*number*/
+    <<elems>>/*variable,readonly*/ = <<2>>/*number*/
   )
 
 }

--- a/tests/unit/src/test/resources/semanticTokens3/example/StructuralTypes.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/StructuralTypes.scala
@@ -9,12 +9,12 @@
   }
 
   <<val>>/*keyword*/ <<user>>/*variable,definition,readonly*/ = <<null>>/*keyword*/.<<asInstanceOf>>/*method*/[<<User>>/*type*/]
-  <<user>>/*variable,readonly*/.<<name>>/*variable*/
-  <<user>>/*variable,readonly*/.<<age>>/*variable*/
+  <<user>>/*variable,readonly*/.<<name>>/*variable,readonly*/
+  <<user>>/*variable,readonly*/.<<age>>/*variable,readonly*/
 
   <<val>>/*keyword*/ <<V>>/*variable,definition,readonly*/: <<Object>>/*class*/ {
     <<def>>/*keyword*/ <<scalameta>>/*method,declaration*/: <<String>>/*type*/
   } = <<new>>/*keyword*/:
     <<def>>/*keyword*/ <<scalameta>>/*method,definition*/ = <<"4.0">>/*string*/
-  <<V>>/*variable,readonly*/.<<scalameta>>/*variable*/
+  <<V>>/*variable,readonly*/.<<scalameta>>/*variable,readonly*/
 <<end>>/*keyword*/ <<StructuralTypes>>/*class*/

--- a/tests/unit/src/test/scala/tests/RemovedScalaLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RemovedScalaLspSuite.scala
@@ -69,10 +69,10 @@ class RemovedScalaLspSuite extends BaseLspSuite("cascade") {
       _ <- server.assertSemanticHighlight(
         "a/src/main/scala/a/A.scala",
         // we get only semantic tokens for keywords, tokens for symbols are missing
-        """|<<package>>/*keyword*/ <<a>>/*variable*/
+        """|<<package>>/*keyword*/ <<a>>/*variable,readonly*/
            |<<object>>/*keyword*/ <<A>>/*class*/ {
-           |  <<val>>/*keyword*/ <<age>>/*variable*/ = <<42>>/*number*/
-           |  <<age>>/*variable*/ + <<12>>/*number*/
+           |  <<val>>/*keyword*/ <<age>>/*variable,readonly*/ = <<42>>/*number*/
+           |  <<age>>/*variable,readonly*/ + <<12>>/*number*/
            |}
            |""".stripMargin,
         fileContents,

--- a/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
@@ -6,7 +6,7 @@ import munit.TestOptions
  * Test for request "textDocument/semanticTokens/full"
  * https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens
  */
-class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
+class SemanticTokensLspSuite extends BaseLspSuite("SemanticTokens") {
 
   check(
     "empty-file",
@@ -63,12 +63,12 @@ class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
 
   check(
     "using-directive",
-    """|<<//>>>/*comment*/ <<using>>/*keyword*/ <<lib>>/*variable*/ <<"abc::abc:123">>/*string*/
-       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<scala>>/*variable*/ <<"3.1.1">>/*string*/
-       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<options>>/*variable*/ <<"-Xasync">>/*string*/, <<"-Xfatal-warnings">>/*string*/
-       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<packaging>>/*variable*/.<<provided>>/*variable*/ <<"org.apache.spark::spark-sql">>/*string*/
-       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<target>>/*variable*/.<<platform>>/*variable*/ <<"scala-js">>/*string*/, <<"scala-native">>/*string*/
-       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<lib>>/*variable*/ <<"io.circe::circe-core:0.14.0">>/*string*/, <<"io.circe::circe-core_native::0.14.0">>/*string*/
+    """|<<//>>>/*comment*/ <<using>>/*keyword*/ <<lib>>/*variable,readonly*/ <<"abc::abc:123">>/*string*/
+       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<scala>>/*variable,readonly*/ <<"3.1.1">>/*string*/
+       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<options>>/*variable,readonly*/ <<"-Xasync">>/*string*/, <<"-Xfatal-warnings">>/*string*/
+       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<packaging>>/*variable,readonly*/.<<provided>>/*variable,readonly*/ <<"org.apache.spark::spark-sql">>/*string*/
+       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<target>>/*variable,readonly*/.<<platform>>/*variable,readonly*/ <<"scala-js">>/*string*/, <<"scala-native">>/*string*/
+       |<<//>>>/*comment*/ <<using>>/*keyword*/ <<lib>>/*variable,readonly*/ <<"io.circe::circe-core:0.14.0">>/*string*/, <<"io.circe::circe-core_native::0.14.0">>/*string*/
        |<<object>>/*keyword*/ <<A>>/*class*/ {}
        |""".stripMargin,
   )
@@ -88,8 +88,8 @@ class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
     """|<<object>>/*keyword*/ <<Main>>/*class*/ {
        |  <<val>>/*keyword*/ <<x>>/*variable,definition,readonly*/ = <<List>>/*class*/(<<1>>/*number*/,<<2>>/*number*/,<<3>>/*number*/)
        |  <<val>>/*keyword*/ <<y>>/*variable,definition,readonly*/ = <<a>>/*variable,readonly*/ <<match>>/*keyword*/ {
-       |    <<case>>/*keyword*/ <<List>>/*class*/(<<a>>/*variable*/,<<b>>/*variable*/,<<c>>/*variable*/) <<=>>>/*operator*/ <<a>>/*variable,readonly*/
-       |    <<case>>/*keyword*/ <<_>>/*variable*/ <<=>>>/*operator*/ <<0>>/*number*/
+       |    <<case>>/*keyword*/ <<List>>/*class*/(<<a>>/*variable,readonly*/,<<b>>/*variable,readonly*/,<<c>>/*variable,readonly*/) <<=>>>/*operator*/ <<a>>/*variable,readonly*/
+       |    <<case>>/*keyword*/ <<_>>/*variable,readonly*/ <<=>>>/*operator*/ <<0>>/*number*/
        |  }
        |  <<val>>/*keyword*/ <<z>>/*variable,definition,readonly*/ = <<Set>>/*class*/(<<1>>/*number*/,<<2>>/*number*/,<<3>>/*number*/)
        |  <<val>>/*keyword*/ <<w>>/*variable,definition,readonly*/ = <<Right>>/*class*/(<<1>>/*number*/)
@@ -124,6 +124,44 @@ class SemanticHighlightLspSuite extends BaseLspSuite("SemanticHighlight") {
        |    <<beta>>/*variable*/
        |  }
        |}
+       |""".stripMargin,
+  )
+
+  check(
+    "self-type",
+    """|<<package>>/*keyword*/ <<a>>/*namespace*/
+       |
+       |<<object>>/*keyword*/ <<Abc>>/*class*/ { <<self>>/*variable,readonly*/: <<Any>>/*class*/ <<=>>>/*operator*/
+       |  <<val>>/*keyword*/ <<xyz>>/*variable,definition,readonly*/ = <<1>>/*number*/
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "self-type2",
+    """|<<package>>/*keyword*/ <<a>>/*namespace*/
+       |
+       |<<import>>/*keyword*/ <<scala>>/*namespace*/.<<util>>/*namespace*/.<<chaining>>/*class*/.<<_>>/*variable,readonly*/
+       |
+       |
+       |<<trait>>/*keyword*/ <<User>>/*interface,abstract*/ {
+       |  <<def>>/*keyword*/ <<username>>/*method,declaration,abstract*/: <<String>>/*type*/
+       |}
+       |
+       |<<trait>>/*keyword*/ <<Tweeter>>/*interface,abstract*/ {
+       |  <<self>>/*variable,readonly*/: <<User>>/*interface,abstract*/ <<=>>>/*operator*/  <<// reassign this>>/*comment*/
+       |  <<def>>/*keyword*/ <<tweet>>/*method,definition*/(<<tweetText>>/*parameter,declaration,readonly*/: <<String>>/*type*/) = <<println>>/*method*/(<<s>>/*keyword*/<<">>/*string*/<<$>>/*keyword*/<<username>>/*method,abstract*/<<: >>/*string*/<<$>>/*keyword*/<<tweetText>>/*parameter,readonly*/<<">>/*string*/)
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "wildcard-import",
+    """|<<package>>/*keyword*/ <<a>>/*namespace*/
+       |
+       |<<import>>/*keyword*/ <<scala>>/*namespace*/.<<util>>/*namespace*/.<<chaining>>/*class*/.<<_>>/*variable,readonly*/
+       |
+       |<<object>>/*keyword*/ <<A>>/*class*/ {}
        |""".stripMargin,
   )
 


### PR DESCRIPTION
When we can't match any node with scalameta ident token, we make it either `class` or `variable`, if it starts with upper or lower case. Now this `variable` will have `readonly` modifier, since it's rarely mutable (e.g. self types, wildcard imports).

Solves https://github.com/scalameta/metals/issues/5052