### PR TITLE
fix: Fix select dynamic hover tests for 3.3.1-RC1

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -82,6 +82,9 @@ object HoverProvider:
       ) match
         case Nil =>
           fallbackToDynamics(path, printer)
+        case (symbol, tpe) :: _
+            if symbol.name == nme.selectDynamic || symbol.name == nme.applyDynamic =>
+          fallbackToDynamics(path, printer)
         case symbolTpes @ ((symbol, tpe) :: _) =>
           val exprTpw = tpe.widenTermRefExpr.metalsDealias
           val hoverString =
@@ -137,10 +140,7 @@ object HoverProvider:
       path: List[Tree],
       printer: MetalsPrinter,
   )(using Context): ju.Optional[HoverSignature] = path match
-    case Apply(
-          Select(sel, n),
-          List(Literal(Constant(name: String))),
-        ) :: _ if n == nme.selectDynamic || n == nme.applyDynamic =>
+    case SelectDynamicExtractor(sel, n, name) =>
       def findRefinement(tp: Type): ju.Optional[HoverSignature] =
         tp match
           case RefinedType(info, refName, tpe) if name == refName.toString() =>
@@ -162,3 +162,19 @@ object HoverProvider:
       ju.Optional.empty()
 
 end HoverProvider
+
+object SelectDynamicExtractor:
+  def unapply(path: List[Tree]) =
+    path match
+      case Apply(
+            Select(sel, n),
+            List(Literal(Constant(name: String))),
+          ) :: _ if n == nme.selectDynamic || n == nme.applyDynamic =>
+        Some(sel, n, name)
+      case Select(_, _) :: Apply(
+            Select(sel, n),
+            List(Literal(Constant(name: String))),
+          ) :: _ if n == nme.selectDynamic || n == nme.applyDynamic =>
+        Some(sel, n, name)
+      case _ => None
+end SelectDynamicExtractor


### PR DESCRIPTION
Path for selectDynamic changed, now it starts with Select(_, selectDynamic). We had to adjust `fallbackToDynamics` to match also new path. Also, now  `MetalsInteractive.enclosingSymbolsWithExpressionType` returns `selectDynamic` symbol.

Fixes nightly cross tests.