### PR TITLE
feat: Hover on structural types in Scala 3

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -157,24 +157,44 @@ object HoverProvider:
             findRefinement(info)
           case _ => ju.Optional.empty()
 
-      findRefinement(sel.tpe.termSymbol.info)
+      findRefinement(sel.tpe.termSymbol.info.dealias)
     case _ =>
       ju.Optional.empty()
 
 end HoverProvider
 
 object SelectDynamicExtractor:
-  def unapply(path: List[Tree]) =
+  def unapply(path: List[Tree])(using Context) =
     path match
-      case Apply(
-            Select(sel, n),
+      // the same tests as below, since 3.3.1-RC1 path starts with Select
+      case Select(_, _) :: Apply(
+            Select(Apply(reflSel, List(sel)), n),
             List(Literal(Constant(name: String))),
-          ) :: _ if n == nme.selectDynamic || n == nme.applyDynamic =>
+          ) :: _
+          if (n == nme.selectDynamic || n == nme.applyDynamic) &&
+            nme.reflectiveSelectable == reflSel.symbol.name =>
         Some(sel, n, name)
+      // tests `structural-types` and `structural-types1` in HoverScala3TypeSuite
+      case Apply(
+            Select(Apply(reflSel, List(sel)), n),
+            List(Literal(Constant(name: String))),
+          ) :: _
+          if (n == nme.selectDynamic || n == nme.applyDynamic) &&
+            nme.reflectiveSelectable == reflSel.symbol.name =>
+        Some(sel, n, name)
+      // the same tests as below, since 3.3.1-RC1 path starts with Select
       case Select(_, _) :: Apply(
             Select(sel, n),
             List(Literal(Constant(name: String))),
           ) :: _ if n == nme.selectDynamic || n == nme.applyDynamic =>
         Some(sel, n, name)
+      // tests `selectable`,  `selectable2` and `selectable-full` in HoverScala3TypeSuite
+      case Apply(
+            Select(sel, n),
+            List(Literal(Constant(name: String))),
+          ) :: _ if n == nme.selectDynamic || n == nme.applyDynamic =>
+        Some(sel, n, name)
       case _ => None
+    end match
+  end unapply
 end SelectDynamicExtractor

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -234,4 +234,56 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
     """|def foo2: Int
        |""".stripMargin.hover,
   )
+
+  check(
+    "structural-types",
+    """|
+       |import reflect.Selectable.reflectiveSelectable
+       |
+       |object StructuralTypes:
+       |   type User = {
+       |   def name: String
+       |   def age: Int
+       |   }
+       |
+       |   val user = null.asInstanceOf[User]
+       |   user.name
+       |   user.ag@@e
+       |
+       |   val V: Object {
+       |   def scalameta: String
+       |   } = new:
+       |   def scalameta = "4.0"
+       |   V.scalameta
+       |end StructuralTypes
+       |""".stripMargin,
+    """|def age: Int
+       |""".stripMargin.hover,
+  )
+
+  check(
+    "structural-types1",
+    """|
+       |import reflect.Selectable.reflectiveSelectable
+       |
+       |object StructuralTypes:
+       |   type User = {
+       |   def name: String
+       |   def age: Int
+       |   }
+       |
+       |   val user = null.asInstanceOf[User]
+       |   user.name
+       |   user.age
+       |
+       |   val V: Object {
+       |   def scalameta: String
+       |   } = new:
+       |   def scalameta = "4.0"
+       |   V.scala@@meta
+       |end StructuralTypes
+       |""".stripMargin,
+    """|def scalameta: String
+       |""".stripMargin.hover,
+  )
 }


### PR DESCRIPTION
Previously hover didn't work on structural types in Scala 3, e.g. type User = { def name: String}, changing unapply method fixes it.