### PR TITLE
refactor: use scala-cli for script instead of Ammonite

### DIFF
--- a/bin/merged_prs.sc
+++ b/bin/merged_prs.sc
@@ -1,9 +1,14 @@
-import $ivy.`org.kohsuke:github-api:1.114`
+//> using scala "3.2.2"
+//> using dep "org.kohsuke:github-api:1.314"
+//> using dep "com.lihaoyi::os-lib:0.9.1"
+//> using dep "com.lihaoyi::mainargs:0.4.0"
+//> using options "-Wunused:all", "-deprecation"
 
 import scala.collection.mutable.ListBuffer
-import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 
+import mainargs.main
 import org.kohsuke.github.GitHubBuilder
 
 import java.text.SimpleDateFormat

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -27,12 +27,12 @@ title: Making a release
 
 ### Draft the release notes
 
-You might use `./bin/merged_prs.sc` script to generate merged PRs list
-between two last release tags. It can be run using ammonite:
+You might use the `./bin/merged_prs.sc` script to generate merged PRs list
+between two last release tags. It can be run using scala-cli:
 
 ```
-cs install ammonite
-amm ./bin/merged_prs.sc <tag1> <tag2> "<github_api_token>"
+cs install scala-cli 
+scala-cli ./bin/merged_prs.sc -- <tag1> <tag2> "<github_api_token>"
 ```
 
 It will need a [basic github API token](https://github.com/settings/tokens) (don't need any additional scopes) to run, which may be specified via


### PR DESCRIPTION
This is mainly due to an error that I'm seeing in the Steward logs at https://github.com/scalameta/steward/actions/runs/4506533671/jobs/7933423154#step:4:516
so I figured I'd just update this.
