### PR TITLE
Code action to convert dependencies from sbt to mill style

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
@@ -57,6 +57,7 @@ final class CodeActionProvider(
     new ConvertToNamedArguments(trees, compilers, languageClient),
     new FlatMapToForComprehensionCodeAction(trees, buffers),
     new MillifyDependencyCodeAction(buffers),
+    new MillifyScalaCliDependencyCodeAction(buffers),
   )
 
   def codeActions(

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
@@ -28,9 +28,14 @@ class MillifyScalaCliDependencyCodeAction(buffers: Buffers) extends CodeAction {
 
     val tokenized =
       if (couldBeScalaCli && range.getStart == range.getEnd)
-        buffers
-          .get(path)
-          .flatMap(Trees.defaultTokenizerDialect(_).tokenize.toOption)
+        for {
+          buffer <- buffers.get(path)
+          line = buffer.linesIterator
+            .drop(range.getStart.getLine)
+            .take(range.getEnd().getLine() - range.getStart().getLine() + 1)
+            .mkString("\n")
+          tree <- Trees.defaultTokenizerDialect(line).tokenize.toOption
+        } yield tree
       else None
 
     tokenized

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
@@ -74,8 +74,8 @@ object MillifyScalaCliDependencyCodeAction {
   def convertSbtToMillStyleIfPossible(
       sbtStyleDirective: String
   ): Option[String] =
-    sbtStyleDirective.split(" ").toSeq match {
-      case Seq(
+    sbtStyleDirective.split(" ") match {
+      case Array(
             "//>",
             "using",
             dependencyIdentifierLike,
@@ -85,8 +85,8 @@ object MillifyScalaCliDependencyCodeAction {
             "%",
             version,
           )
-          if isDependencyIdentifier(dependencyIdentifierLike) &&
-            isSbtDependencyDelimiter(groupDelimiter) =>
+          if dependencyIdentifiers(dependencyIdentifierLike) &&
+            sbtDependencyDelimiters(groupDelimiter) =>
         val groupArtifactJoin = groupDelimiter.replace('%', ':')
         val millStyleDependency =
           s"$groupId$groupArtifactJoin$artifactId:$version".replace("\"", "")
@@ -96,13 +96,8 @@ object MillifyScalaCliDependencyCodeAction {
       case _ => None
     }
 
-  // TODO I guess it should be a part of ScalaCli common module to ease the refactoring
-  // in case other identifiers are introduced
-  private def isDependencyIdentifier(identifier: String) =
-    Set("dep", "lib", "plugin")(identifier)
-
-  private def isSbtDependencyDelimiter(identifier: String) =
-    Set("%", "%%", "%%%")(identifier)
+  private val dependencyIdentifiers = Set("dep", "lib", "plugin")
+  private val sbtDependencyDelimiters = Set("%", "%%", "%%%")
 
   def isScalaCliUsingDirectiveComment(text: String) =
     text.startsWith("//> using")

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
@@ -98,7 +98,7 @@ object MillifyScalaCliDependencyCodeAction {
   private val dependencyIdentifiers = Set("dep", "lib", "plugin")
   private val sbtDependencyDelimiters = Set("%", "%%", "%%%")
 
-  def isScalaCliUsingDirectiveComment(text: String) =
+  def isScalaCliUsingDirectiveComment(text: String): Boolean =
     text.startsWith("//> using")
 
   private def actionTitle(transformed: String): String =

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
@@ -72,7 +72,7 @@ object MillifyScalaCliDependencyCodeAction {
   def convertSbtToMillStyleIfPossible(
       sbtStyleDirective: String
   ): Option[String] =
-    sbtStyleDirective.split(" ") match {
+    sbtStyleDirective.split(" ").filterNot(_.isEmpty) match {
       case Array(
             "//>",
             "using",

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
@@ -14,8 +14,6 @@ import scala.meta.tokens.Token._
 
 import org.eclipse.{lsp4j => l}
 
-// TODO prepare LSP spec if it works in manual tests
-// there are some similarities to MillifyDependencyCodeAction so maybe they can be extracted
 class MillifyScalaCliDependencyCodeAction(buffers: Buffers) extends CodeAction {
 
   override def kind: String = l.CodeActionKind.QuickFix

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
@@ -41,10 +41,6 @@ class MillifyScalaCliDependencyCodeAction(buffers: Buffers) extends CodeAction {
     tokenized
       .flatMap { tokens =>
         tokens
-          .filter(t =>
-            t.pos.startLine == range.getStart.getLine
-              && t.pos.endLine == range.getEnd.getLine
-          )
           .collectFirst {
             case comment: Comment
                 if isScalaCliUsingDirectiveComment(comment.toString()) =>
@@ -70,7 +66,7 @@ object MillifyScalaCliDependencyCodeAction {
         List(path -> List(new l.TextEdit(comment.pos.toLsp, replacementText))),
     )
 
-  def convertSbtToMillStyleIfPossible(
+  private def convertSbtToMillStyleIfPossible(
       sbtStyleDirective: String
   ): Option[String] =
     sbtStyleDirective.split(" ").filterNot(_.isEmpty) match {
@@ -98,8 +94,11 @@ object MillifyScalaCliDependencyCodeAction {
   private val dependencyIdentifiers = Set("dep", "lib", "plugin")
   private val sbtDependencyDelimiters = Set("%", "%%", "%%%")
 
-  def isScalaCliUsingDirectiveComment(text: String): Boolean =
-    text.startsWith("//> using")
+  private def isScalaCliUsingDirectiveComment(text: String): Boolean =
+    text.split(" ").filterNot(_.isEmpty).toList match {
+      case "//>" :: "using" :: _ => true
+      case _ => false
+    }
 
   private def actionTitle(transformed: String): String =
     s"Convert to $transformed"

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
@@ -45,16 +45,12 @@ class MillifyScalaCliDependencyCodeAction(buffers: Buffers) extends CodeAction {
             t.pos.startLine == range.getStart.getLine
               && t.pos.endLine == range.getEnd.getLine
           )
-          .collect {
+          .collectFirst {
             case comment: Comment
                 if isScalaCliUsingDirectiveComment(comment.toString()) =>
-              comment
-          }
-          .collectFirst { comment =>
-            convertSbtToMillStyleIfPossible(comment.toString())
-              .map(buildAction(comment, kind, path)(_))
-              .map(List(_))
-              .getOrElse(List.empty)
+              convertSbtToMillStyleIfPossible(comment.toString())
+                .map(buildAction(comment, kind, path)(_))
+                .toList
           }
       }
       .getOrElse(List.empty)

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
@@ -1,0 +1,113 @@
+package scala.meta.internal.metals.codeactions
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.internal.metals.Buffers
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.codeactions.CodeAction
+import scala.meta.internal.metals.codeactions.MillifyScalaCliDependencyCodeAction._
+import scala.meta.internal.parsing.Trees
+import scala.meta.io.AbsolutePath
+import scala.meta.pc.CancelToken
+import scala.meta.tokens.Token._
+
+import org.eclipse.{lsp4j => l}
+
+// TODO prepare LSP spec if it works in manual tests
+// there are some similarities to MillifyDependencyCodeAction so maybe they can be extracted
+class MillifyScalaCliDependencyCodeAction(buffers: Buffers) extends CodeAction {
+
+  override def kind: String = l.CodeActionKind.QuickFix
+
+  override def contribute(params: l.CodeActionParams, token: CancelToken)(
+      implicit ec: ExecutionContext
+  ): Future[Seq[l.CodeAction]] = Future {
+
+    val path = params.getTextDocument().getUri().toAbsolutePath
+    val range = params.getRange()
+    val couldBeScalaCli = path.isScalaScript || path.isScala
+
+    val tokenized =
+      if (couldBeScalaCli && range.getStart == range.getEnd)
+        buffers
+          .get(path)
+          .flatMap(Trees.defaultTokenizerDialect(_).tokenize.toOption)
+      else None
+
+    tokenized
+      .flatMap { tokens =>
+        tokens
+          .filter(t =>
+            t.pos.startLine == range.getStart.getLine
+              && t.pos.endLine == range.getEnd.getLine
+          )
+          .collect {
+            case comment: Comment
+                if isScalaCliUsingDirectiveComment(comment.toString()) =>
+              comment
+          }
+          .collectFirst { comment =>
+            convertSbtToMillStyleIfPossible(comment.toString())
+              .map(buildAction(comment, kind, path)(_))
+              .map(List(_))
+              .getOrElse(List.empty)
+          }
+      }
+      .getOrElse(List.empty)
+  }
+
+}
+
+object MillifyScalaCliDependencyCodeAction {
+
+  private def buildAction(comment: Comment, kind: String, path: AbsolutePath)(
+      replacementText: String
+  ) =
+    CodeActionBuilder.build(
+      title = actionTitle(replacementText),
+      kind = kind,
+      changes =
+        List(path -> List(new l.TextEdit(comment.pos.toLsp, replacementText))),
+    )
+
+  def convertSbtToMillStyleIfPossible(
+      sbtStyleDirective: String
+  ): Option[String] =
+    sbtStyleDirective.split(" ").toSeq match {
+      case Seq(
+            "//>",
+            "using",
+            dependencyIdentifierLike,
+            groupId,
+            groupDelimiter,
+            artifactId,
+            "%",
+            version,
+          )
+          if isDependencyIdentifier(dependencyIdentifierLike) &&
+            isSbtDependencyDelimiter(groupDelimiter) =>
+        val groupArtifactJoin = groupDelimiter.replace('%', ':')
+        val millStyleDependency =
+          s"$groupId$groupArtifactJoin$artifactId:$version".replace("\"", "")
+        val replacementText =
+          s"//> using $dependencyIdentifierLike \"$millStyleDependency\""
+        Some(replacementText)
+      case _ => None
+    }
+
+  // TODO I guess it should be a part of ScalaCli common module to ease the refactoring
+  // in case other identifiers are introduced
+  private def isDependencyIdentifier(identifier: String) =
+    Set("dep", "lib", "plugin")(identifier)
+
+  private def isSbtDependencyDelimiter(identifier: String) =
+    Set("%", "%%", "%%%")(identifier)
+
+  def isScalaCliUsingDirectiveComment(text: String) =
+    text.startsWith("//> using")
+
+  private def actionTitle(transformed: String): String =
+    s"Convert to $transformed"
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/MillifyScalaCliDependencyCodeAction.scala
@@ -30,10 +30,10 @@ class MillifyScalaCliDependencyCodeAction(buffers: Buffers) extends CodeAction {
       if (couldBeScalaCli && range.getStart == range.getEnd)
         for {
           buffer <- buffers.get(path)
-          line = buffer.linesIterator
+          line <- buffer.linesIterator
             .drop(range.getStart.getLine)
-            .take(range.getEnd().getLine() - range.getStart().getLine() + 1)
-            .mkString("\n")
+            .take(1)
+            .headOption
           tree <- Trees.defaultTokenizerDialect(line).tokenize.toOption
         } yield tree
       else None
@@ -110,7 +110,7 @@ object MillifyScalaCliDependencyCodeAction {
       dependencyIdentifier: String,
       millStyleDependency: String,
   ) {
-    val replacementText =
+    val replacementText: String =
       s"//> using $dependencyIdentifier \"$millStyleDependency\""
   }
 }

--- a/tests/unit/src/test/scala/tests/codeactions/MillifyScalaCliDependencyCodeActionSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/MillifyScalaCliDependencyCodeActionSuite.scala
@@ -6,7 +6,7 @@ class MillifyScalaCliDependencyCodeActionSuite
     """"org.scalameta" %% "munit" % "0.7.26""""
 
   val convertedDependency = """"org.scalameta::munit:0.7.26""""
-  val convertTo = s"""//> using lib $convertedDependency"""
+  val convertTo: String = s"""//> using lib $convertedDependency"""
 
   check(
     "convert-dependency",

--- a/tests/unit/src/test/scala/tests/codeactions/MillifyScalaCliDependencyCodeActionSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/MillifyScalaCliDependencyCodeActionSuite.scala
@@ -1,0 +1,31 @@
+package tests.codeactions
+
+class MillifyScalaCliDependencyCodeActionSuite
+    extends BaseCodeActionLspSuite("millifyScalaCliDependency") {
+  val sbtStyleDependency =
+    """"org.scalameta" %% "munit" % "0.7.26""""
+
+  val convertedDependency = """"org.scalameta::munit:0.7.26""""
+  val convertTo = s"""//> using lib $convertedDependency"""
+
+  check(
+    "convert-dependency",
+    s"""|//> <<>>using lib $sbtStyleDependency
+        |
+        |object Hello extends App {
+        |  println("Hello")
+        |}
+        |""".stripMargin,
+    s"""Convert to $convertTo""",
+    s"""|//> using lib $convertedDependency
+        |
+        |object Hello extends App {
+        |  println("Hello")
+        |}
+        |""".stripMargin,
+    scalaCliOptions = List("--actions", "-S", scalaVersion),
+    expectNoDiagnostics = false,
+    scalaCliLayout = true,
+  )
+
+}

--- a/tests/unit/src/test/scala/tests/codeactions/MillifyScalaCliDependencyCodeActionSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/MillifyScalaCliDependencyCodeActionSuite.scala
@@ -16,7 +16,7 @@ class MillifyScalaCliDependencyCodeActionSuite
         |  println("Hello")
         |}
         |""".stripMargin,
-    s"""Convert to $convertTo""",
+    s"""Convert to $convertedDependency""",
     s"""|//> using lib $convertedDependency
         |
         |object Hello extends App {
@@ -39,7 +39,7 @@ class MillifyScalaCliDependencyCodeActionSuite
         |  println("Hello")
         |}
         |""".stripMargin,
-    s"""Convert to $convertTo""",
+    s"""Convert to $convertedDependency""",
     s"""|//> using lib $convertedDependency
         |
         |object Hello extends App {

--- a/tests/unit/src/test/scala/tests/codeactions/MillifyScalaCliDependencyCodeActionSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/MillifyScalaCliDependencyCodeActionSuite.scala
@@ -28,4 +28,27 @@ class MillifyScalaCliDependencyCodeActionSuite
     scalaCliLayout = true,
   )
 
+  val sbtStyleDependencyMultiSpace =
+    """    "org.scalameta"     %% "munit"   % "0.7.26""""
+
+  check(
+    "convert-dependency-multiple-whitespace",
+    s"""|//> <<>>using lib $sbtStyleDependencyMultiSpace
+        |
+        |object Hello extends App {
+        |  println("Hello")
+        |}
+        |""".stripMargin,
+    s"""Convert to $convertTo""",
+    s"""|//> using lib $convertedDependency
+        |
+        |object Hello extends App {
+        |  println("Hello")
+        |}
+        |""".stripMargin,
+    scalaCliOptions = List("--actions", "-S", scalaVersion),
+    expectNoDiagnostics = false,
+    scalaCliLayout = true,
+  )
+
 }


### PR DESCRIPTION
This PR is somewhat complimentary to https://github.com/scalameta/metals/pull/4465

![metals fix sbt style dependency](https://user-images.githubusercontent.com/7260594/227626189-bf6db01a-dd3e-4d0f-b20d-66ee5abc0b21.gif)


It introduces the code action that would convert SBT style imports to Mill style in scala-cli `using (dep | lib | plugin)` directives. Dependencies in project readme docs usually are SBT style so I think it might be useful.

It's a draft, LSP tests are still in progress but since this is my first contribution please let me know if it's the right direction. 