### PR TITLE
Fix #5096: run doc on java target with semanticdb

### DIFF
--- a/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
+++ b/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
@@ -64,7 +64,13 @@ object MetalsPlugin extends AutoPlugin {
         case defined @ Some(_) => defined
       }
     },
-    javacOptions ++= {
+    Compile / compile / javacOptions ++= {
+      if (javaSemanticdbEnabled.value)
+        javaSemanticdbOptions.value
+      else
+        Nil
+    },
+    Test / compile / javacOptions ++= {
       if (javaSemanticdbEnabled.value)
         javaSemanticdbOptions.value
       else

--- a/sbt-metals/src/sbt-test/sbt-metals/java-semanticdb-test-srcs/src/main/java/foo/Foo.java
+++ b/sbt-metals/src/sbt-test/sbt-metals/java-semanticdb-test-srcs/src/main/java/foo/Foo.java
@@ -1,0 +1,5 @@
+package foo;
+
+public class Foo {
+
+}

--- a/sbt-metals/src/sbt-test/sbt-metals/java-semanticdb-test-srcs/src/test/java/foo/Bar.java
+++ b/sbt-metals/src/sbt-test/sbt-metals/java-semanticdb-test-srcs/src/test/java/foo/Bar.java
@@ -1,5 +1,5 @@
 package foo;
 
 class Bar {
-  
+
 }

--- a/sbt-metals/src/sbt-test/sbt-metals/java-semanticdb-test-srcs/test
+++ b/sbt-metals/src/sbt-test/sbt-metals/java-semanticdb-test-srcs/test
@@ -1,1 +1,2 @@
 > Test/compile
+> doc

--- a/sbt-metals/src/sbt-test/sbt-metals/semanticdb/build.sbt
+++ b/sbt-metals/src/sbt-test/sbt-metals/semanticdb/build.sbt
@@ -71,7 +71,7 @@ def assertSemanticdbForScala2 = Def.task {
   val sv = scalaVersion.value
   val project = thisProject.value
   val config = configuration.value
-  val jOptions = javacOptions.value
+  val jOptions = (compile / javacOptions).value
 
   assert(enabled, s"semanticdb is disabled in ${project.id}/${config.id}")
   assertPlugin(sOptions, s"semanticdb-scalac", sv, BuildInfo.semanticdbVersion)


### PR DESCRIPTION
The semanticdb options added by sbt-metals make the doc task fails with error:
```
[error] compiler message file broken: key=javadoc.err.msg arguments=javadoc, invalid flag: -Xplugin:semanticdb -sourceroot:/home/piquerez/github/scalameta/metals-java -targetroot:/home/piquerez/github/scalameta/metals-java/target/scala-2.12/meta -build-tool:sbt
```

To fix this we must scope the semanticdb options in `Compile / compile / javacOptions` and `Test / compile / javacOptions`.

Unfortunately all the custom configurations, like `IntegrationTest`, won't inherit the semanticdb options, but that a well known issue that we cannot really workaround.