### PR TITLE
bugfix: Fix semantic highlight in sbt files

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -22,7 +22,6 @@ import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.mtags.BuildInfo
 import scala.meta.internal.mtags.MtagsEnrichments._
-import scala.meta.internal.pc.PcInlineValueProviderImpl
 import scala.meta.pc.AutoImportsResult
 import scala.meta.pc.DefinitionResult
 import scala.meta.pc.DisplayableException


### PR DESCRIPTION
Previously, semantic highlighting would be broken inside Metal's build.sbt file. This was caused by the fact that start/end is validated to always be `start <= end`, so we need to change it together instead one after another. Another issue was if we haven't find the literal name inside the source code we would get another exception.

Now, both cases are handled and this was tested manually for metals build file. This wasn't breaking in smaller test cases.

Also, when no semantic tokens are returned, we return an empty list not to interfere with the default highlighting.