### PR TITLE
fix: Fix PcCollector for `@@` symbol

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
@@ -224,7 +224,7 @@ object SemanticTokensProvider {
             _: Token.Interpolation.SpliceEnd | _: Token.Interpolation.End =>
           getTypeId(SemanticTokenTypes.String) // $ symbol
 
-        case _ if isScala3 && trySoftKeyword(tk) != -1 =>
+        case _ if isScala3 && !tk.isWhiteSpaceOrComment =>
           trySoftKeyword(tk)
         case _ => -1
       }
@@ -235,9 +235,11 @@ object SemanticTokensProvider {
           1 << getModifierId(SemanticTokenModifiers.Readonly)
         case _ => 0
       }
+
     if (tokenType != -1) (tokenType, tokenModifier)
-    else
+    else if (!tk.isWhiteSpaceOrComment) {
       tokenFallback(tk)
+    } else (-1, 0)
 
   }
   def tokenFallback(tk: scala.meta.tokens.Token): (Integer, Integer) = {
@@ -251,8 +253,8 @@ object SemanticTokensProvider {
     }
   }
 
+  private val SoftKeywordsUnapply = new SoftKeywords(scala.meta.dialects.Scala3)
   def trySoftKeyword(tk: Token): Integer = {
-    val SoftKeywordsUnapply = new SoftKeywords(scala.meta.dialects.Scala3)
     tk match {
       case SoftKeywordsUnapply.KwAs() => getTypeId(SemanticTokenTypes.Keyword)
       case SoftKeywordsUnapply.KwDerives() =>

--- a/tests/cross/src/test/scala/tests/highlight/TypeDocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/TypeDocumentHighlightSuite.scala
@@ -189,4 +189,13 @@ class TypeDocumentHighlightSuite extends BaseDocumentHighlightSuite {
        |""".stripMargin,
   )
 
+  check(
+    "symbolic-type",
+    """|object A {
+       |  type <<!!>>[+T, -U] = Int
+       |  def m(x: Int <<!@@!>> String) = ???
+       |}
+       |""".stripMargin,
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/tokens/SemanticTokensScala3Suite.scala
+++ b/tests/cross/src/test/scala/tests/tokens/SemanticTokensScala3Suite.scala
@@ -124,4 +124,20 @@ class SemanticTokensScala3Suite extends BaseSemanticTokensSuite {
        |""".stripMargin,
   )
 
+  check(
+    "import-selector",
+    """|package <<a>>/*namespace*/
+       |
+       |import <<a>>/*namespace*/.<<Tag>>/*class*/.<<@@>>/*type*/
+       |
+       |object <<A>>/*class*/ {
+       |  case class <<B>>/*class*/(<<c>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
+       |}
+       |
+       |object <<Tag>>/*class*/ {
+       |  type <<@@>>/*type,definition*/ = <<Int>>/*class,abstract*/
+       |}
+       |""".stripMargin,
+  )
+
 }

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -678,7 +678,7 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
     val expected =
       """|
          |
-         |<<import>>/*keyword*/ <<util>>/*namespace*/.{<<Failure>>/*class*/ <<=>>>/*operator*/ <<NotGood>>/*class*/}
+         |<<import>>/*keyword*/ <<scala>>/*namespace*/.<<util>>/*namespace*/.{<<Failure>>/*class*/ <<=>>>/*operator*/ <<NotGood>>/*class*/}
          |<<import>>/*keyword*/ <<math>>/*namespace*/.{<<floor>>/*method*/ <<=>>>/*operator*/ <<_>>/*variable,readonly*/, <<_>>/*variable,readonly*/}
          |
          |<<class>>/*keyword*/ <<Imports>>/*class*/ {

--- a/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
@@ -165,6 +165,21 @@ class SemanticTokensLspSuite extends BaseLspSuite("SemanticTokens") {
        |""".stripMargin,
   )
 
+  check(
+    "import-selector",
+    """|<<package>>/*keyword*/ <<a>>/*namespace*/
+       |
+       |<<import>>/*keyword*/ <<a>>/*namespace*/.<<Tag>>/*class*/.<<@@>>/*type*/
+       |
+       |<<object>>/*keyword*/ <<A>>/*class*/ {
+       |  <<case>>/*keyword*/ <<class>>/*keyword*/ <<B>>/*class*/(<<c>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
+       |}
+       |
+       |<<object>>/*keyword*/ <<Tag>>/*class*/ {
+       |  <<type>>/*keyword*/ <<@@>>/*type,definition*/ = <<Int>>/*class,abstract*/
+       |}""".stripMargin,
+  )
+
   def check(
       name: TestOptions,
       expected: String,


### PR DESCRIPTION
Touches https://github.com/scalameta/metals/issues/5065

I couldn't reproduce broken semantic highlights in the whole file, but this PR solves issue with no highlight/semantic highlight on `@@` (and other symbols containing `@`, `!` etc)

Name for `@@` is "$at@at", which doesn't match string "@@". Now we match on decoded name, which is "@@".
Also, changes `soughtFilter` to be easier to use