### PR TITLE
bugfix: Fix go to definition and hover for TypeTest

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -243,6 +243,18 @@ object MetalsInteractive:
             target.sourcePos.contains(pos) =>
         List((target.symbol, target.typeOpt))
 
+      /* TypeTest class https://dotty.epfl.ch/docs/reference/other-new-features/type-test.html
+       * compiler automatically adds unapply if possible, we need to find the type symbol
+       */
+      case (head @ CaseDef(pat, _, _)) :: _
+          if defn.TypeTestClass == pat.symbol.owner =>
+        pat match
+          case UnApply(fun, _, pats) =>
+            val tpeSym = pats.head.typeOpt.typeSymbol
+            List((tpeSym, tpeSym.info))
+          case _ =>
+            Nil
+
       case path @ head :: tail =>
         if head.symbol.is(Synthetic) then
           enclosingSymbolsWithExpressionType(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -243,6 +243,21 @@ object MetalsInteractive:
             target.sourcePos.contains(pos) =>
         List((target.symbol, target.typeOpt))
 
+      /* In some cases type might be represented by TypeTree, however it's possible
+       * that the type tree will not be marked properly as synthetic even if it doesn't
+       * exist in the code.
+       *
+       * For example for `Li@@st(1)` we will get the type tree representing [Int]
+       * despite it not being in the code.
+       *
+       * To work around it we check if the current and parent spans match, if they match
+       * this most likely means that the type tree is synthetic, since it has efectively
+       * span of 0.
+       */
+      case (tpt: TypeTree) :: parent :: _
+          if tpt.span != parent.span && !tpt.symbol.is(Synthetic) =>
+        List((tpt.symbol, tpt.tpe))
+
       /* TypeTest class https://dotty.epfl.ch/docs/reference/other-new-features/type-test.html
        * compiler automatically adds unapply if possible, we need to find the type symbol
        */

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -284,6 +284,45 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |end StructuralTypes
        |""".stripMargin,
     """|def scalameta: String
+    """.stripMargin.hover,
+  )
+
+  check(
+    "macro",
+    """|
+       |import scala.quoted.*
+       |
+       |def myMacroImpl(using Quotes) =
+       |  import quotes.reflect.Ident
+       |  def foo = ??? match
+       |    case x: I@@dent => x
+       |
+       |  def bar: Ident = foo
+       |
+       |  ???
+       |
+       |""".stripMargin,
+    """|type Ident: Ident
+       |""".stripMargin.hover,
+  )
+
+  check(
+    "macro2",
+    """|
+       |
+       |import scala.quoted.*
+       |
+       |def myMacroImpl(using Quotes) =
+       |  import quotes.reflect.Ident
+       |  def foo = ??? match
+       |    case x: Ident => x
+       |
+       |  def bar: Ide@@nt = foo
+       |
+       |  ???
+       |
+       |""".stripMargin,
+    """|type Ident: Ident
        |""".stripMargin.hover,
   )
 }

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -531,4 +531,22 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |
        |""".stripMargin,
   )
+
+  check(
+    "macro".tag(IgnoreScala2),
+    """|
+       |
+       |import scala.quoted.*
+       |
+       |def myMacroImpl(using Quotes) =
+       |  import quotes.reflect.Ident
+       |  def foo = ??? match
+       |    case x: I/*scala/quoted/Quotes#reflectModule#Ident# Quotes.scala*/@@dent => x
+       |
+       |  def bar: Ident = foo
+       |
+       |  ???
+       |
+       |""".stripMargin,
+  )
 }


### PR DESCRIPTION
In some case [TypeTest](https://dotty.epfl.ch/docs/reference/other-new-features/type-test.html) will be used in pattern match and it actually changes the case to a new unapply. Previously, we wouldn't be able to figure out the initial type.

Now, we special case TypeTest and find the exact typeSymbol we need.

Fixes https://github.com/scalameta/metals/issues/5102

There are two connected fixes here in two commits.