### PR TITLE
bugfix: Show lenses when BSP server is plain Scala

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -79,7 +79,7 @@ class BuildServerConnection private (
 
   def isMill: Boolean = name == MillBuildTool.name
 
-  def isScalaCLI: Boolean = name == ScalaCli.name
+  def isScalaCLI: Boolean = ScalaCli.names(name)
 
   def isAmmonite: Boolean = name == Ammonite.name
 

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -224,6 +224,7 @@ class ScalaCli(
       .map(Seq(_))
       .orElse {
         findInPath("scala-cli")
+          .orElse(findInPath("scala"))
           .filter(requireMinVersion(_, minVersion))
           .map(p => Seq(p.toString))
       }
@@ -321,7 +322,7 @@ object ScalaCli {
         finished.tryComplete(res)
       }
       SocketConnection(
-        ScalaCli.name,
+        ScalaCli.names.head,
         new ClosableOutputStream(proc.outputStream, "Scala CLI error stream"),
         proc.inputStream,
         List(Cancelable { () => proc.cancel }),
@@ -373,7 +374,7 @@ object ScalaCli {
   def scalaCliMainClass: String =
     "scala.cli.ScalaCli"
 
-  val name = "scala-cli"
+  val names: Set[String] = Set("scala-cli", "scala")
 
   sealed trait ConnectionState
   object ConnectionState {


### PR DESCRIPTION
Previously, we would only show lenses if the name of the Scala server was scala-cli. We now also support plain `scala`.

I also adjusted when searching for ScalaCLI on PATH to use plain `scala`

Fixes https://github.com/scalameta/metals/issues/5116