### PR TITLE
Refresh test case code lenses after discovery

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -357,6 +357,8 @@ final class TestSuitesProvider(
       entries.foreach(index.put(_))
     }
 
+    if (isCodeLensEnabled) client.refreshModel()
+
     if (isExplorerEnabled) {
       val addedTestCases = addedEntries.mapValues {
         _.flatMap { entry =>


### PR DESCRIPTION
Hi!  This is a PR attempts to address the issue in which test case code lenses may not initially appear for a file and you would need to re-open to obtain to obtain test case lenses (https://github.com/scalameta/metals/issues/5115).

The proposed fix is to call `client.refreshModel` after test discovery (`workspace/codeLens/refresh`).

Thanks!

