### PR TITLE
bugfix: Show document highlight with cursor on primary cosntructor

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
@@ -127,6 +127,9 @@ abstract class PcCollector[T](
           info.member(sym.asTerm.name.setterName).symbol,
           info.member(sym.asTerm.name.getterName).symbol,
         ) ++ sym.allOverriddenSymbols.toSet
+      // type used in primary constructor will not match the one used in the class
+      else if sym.isTypeParam && sym.owner.isPrimaryConstructor then
+        Set(sym, sym.owner.owner.info.member(sym.name).symbol)
       else Set(sym)
     all.filter(s => s != NoSymbol && !s.isError)
   end symbolAlternatives
@@ -330,7 +333,6 @@ abstract class PcCollector[T](
           symbol: Option[Symbol] = None,
       ) =
         this.collect(parent)(tree, pos, symbol)
-
       tree match
         /**
          * All indentifiers such as:

--- a/tests/cross/src/test/scala/tests/highlight/TypeDocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/TypeDocumentHighlightSuite.scala
@@ -173,4 +173,20 @@ class TypeDocumentHighlightSuite extends BaseDocumentHighlightSuite {
        |}""".stripMargin,
   )
 
+  check(
+    "trait-param1",
+    """|trait Zg[<<T@@T>>]{
+       |  def doZ: List[<<TT>>]
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "trait-param2",
+    """|trait Zg[<<TT>>]{
+       |  def doZ: List[<<T@@T>>]
+       |}
+       |""".stripMargin,
+  )
+
 }


### PR DESCRIPTION
Previously, when using document highlight on the type parameter in the primary constructor, we would only get that specific parameter highlighted. This is because those were treated as different symbols with one having constructor parent and the other trait param.

Now, we properly match them as the same symbol from the user perspective.

This seems to be handled the other way already.