### PR TITLE
fix: Semantic highlight on for-comp with `=` line

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/SemanticTokens.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/SemanticTokens.scala
@@ -48,15 +48,18 @@ object SemanticTokens {
   val getTypePriority: Map[Int, Int] = Map(
     // In .sbt on `List` are symbols `scala`, `collection`, `immutable`, `List`,
     // We want to pick `List`, so `namespace` has lower priority than `class`
-    TokenTypes.indexOf(SemanticTokenTypes.Namespace) -> 7,
+    TokenTypes.indexOf(SemanticTokenTypes.Namespace) -> 4,
     TokenTypes.indexOf(SemanticTokenTypes.Type) -> 10,
     TokenTypes.indexOf(SemanticTokenTypes.Class) -> 8,
     // On parametrized enums like enum Foo(bar: Int): ...
     // We have both `class` and `enum`, so enum has higher priority than class
     TokenTypes.indexOf(SemanticTokenTypes.Enum) -> 9,
-    TokenTypes.indexOf(SemanticTokenTypes.Interface) -> 6,
-    TokenTypes.indexOf(SemanticTokenTypes.TypeParameter) -> 5,
-    TokenTypes.indexOf(SemanticTokenTypes.Variable) -> 4,
+    TokenTypes.indexOf(SemanticTokenTypes.Interface) -> 7,
+    TokenTypes.indexOf(SemanticTokenTypes.TypeParameter) -> 6,
+    // In scala 2 for comprehensions including lines with `=`, we get `scala.x$1` symbols,
+    // we don't want to choose `scala` package`, so `variable` has higher priority than `namespace`
+    // See test `for-comprehension` in SemanticTokensSuite
+    TokenTypes.indexOf(SemanticTokenTypes.Variable) -> 5,
     TokenTypes.indexOf(SemanticTokenTypes.EnumMember) -> 3,
     TokenTypes.indexOf(SemanticTokenTypes.Method) -> 2,
     // In `case class A(a: Int)` we have class variable `a` and `apply` and `copy` parameter `a`

--- a/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
@@ -466,4 +466,13 @@ class PcRenameSuite extends BasePcRenameSuite {
       |  x
       |}""".stripMargin,
   )
+
+  check(
+    "for-comprehension",
+    """|val a = for {
+       |  <<ab@@c>> <- List("a", "b", "c")
+       |  _ = println("print!")
+       |} yield <<a@@bc>>
+       |""".stripMargin,
+  )
 }

--- a/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
+++ b/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
@@ -302,7 +302,7 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |
         |object <<B>>/*class*/ {
         |  val <<a>>/*variable,definition,readonly*/ = for {
-        |    <<foo>>/*parameter,declaration,readonly*/ <- <<List>>/*class*/("a", "b", "c")
+        |    <<foo>>/*variable,definition,readonly*/ <- <<List>>/*class*/("a", "b", "c")
         |    _ = <<println>>/*method*/("print!")
         |  } yield <<foo>>/*variable,readonly*/
         |}

--- a/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
+++ b/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
@@ -292,4 +292,33 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
         |}
         |""".stripMargin,
   )
+
+  // When for-comprehension includes line with `=`, we get `scala.x$1`, `scala.x$2` symbols on `foo`.
+  // Both `scala` and `x$#` have position on `foo`, and we don't want to highlight it as a `scala` package,
+  // so we need `namespace` to have lower priority than `variable`.
+  check(
+    "for-comprehension",
+    s"""|package <<example>>/*namespace*/
+        |
+        |object <<B>>/*class*/ {
+        |  val <<a>>/*variable,definition,readonly*/ = for {
+        |    <<foo>>/*parameter,declaration,readonly*/ <- <<List>>/*class*/("a", "b", "c")
+        |    _ = <<println>>/*method*/("print!")
+        |  } yield <<foo>>/*variable,readonly*/
+        |}
+        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|package <<example>>/*namespace*/
+           |
+           |object <<B>>/*class*/ {
+           |  val <<a>>/*variable,definition,readonly*/ = for {
+           |    <<foo>>/*variable,definition,readonly*/ <- <<List>>/*class*/("a", "b", "c")
+           |    <<_>>/*class,abstract*/ = <<println>>/*method*/("print!")
+           |  } yield <<foo>>/*variable,readonly*/
+           |}
+           |""".stripMargin
+    ),
+  )
+
 }


### PR DESCRIPTION
In Scala 2, when for-comprehension includes `=` line, we get `scala.x$#` symbols on variables.
We don't want to highlight them as a `scala` package, so `namespace` needs to have lower priority that `variable`.

I've noticed this when looking at https://github.com/scalameta/metals/issues/2679, which was solved when we started using presentation compiler for local renames. I've added a test so we can close it.