### PR TITLE
Auto spawn/connect to bazel-bsp if it's installed

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -36,7 +36,7 @@ final class BuildTools(
   // Bloop since Metals thinks it's in state that's auto-connectable before the
   // user is even prompted.
   def isAutoConnectable: Boolean = {
-    isBloop || (isBsp && all.isEmpty) || (isBsp && explicitChoiceMade())
+    isBloop || (isBsp && all.isEmpty) || (isBsp && explicitChoiceMade()) || (isBsp && isBazel)
   }
   def isBloop: Boolean = {
     hasJsonFile(workspace.resolve(".bloop"))


### PR DESCRIPTION
While we can generate `.bsp/bazelbsp.json` by
`cs launch org.jetbrains.bsp;bazel-bsp:2.6.1 -M org.jetbrains.bsp.bazel.instal.Install` https://github.com/JetBrains/bazel-bsp#easy-way-coursier

Metals couldn't connect to the bazel-bsp because it wan't autoConnectable. This change enable Metals to see bazel-bsp as autoConnectable, and Metals will spawn and connct to bazel bsp if there's `.bsp/bazelbsp.json`.

As @kpodsiad did in
https://github.com/scalameta/metals/pull/3233
we should

- reindex if the build configuration changed
  - I'm wondering we should check all *.bzl files and WORKSPACE and BUILD / BUILD.bazel files. And maybe we should honor the project view settings.
- Auto install bazel-bsp when we see `WORKSPACE` file.

https://github.com/scalameta/metals/issues/5138
partially fix for https://github.com/scalameta/metals/issues/5064