### PR TITLE
chore[skip ci]: Switch nightly releases to branch with fixed test

### DIFF
--- a/.github/workflows/mtags-auto-release.yml
+++ b/.github/workflows/mtags-auto-release.yml
@@ -15,7 +15,7 @@ on:
         # If you update this line after release
         #   just put the tag name (`v*.*.*`) here as in `metals_version.value` above.
         # Don't be confused if this value contains `*.*.*_mtags_release`
-        default: "v0.11.11"
+        default: "0.11.11_mtags_release"
 jobs:
   test_and_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The current nightly release is failing.