### PR TITLE
improvement: Fail the build if supported sbt version wasn't updated

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -86,11 +86,18 @@ object V {
     "2.13.8",
     "2.13.9",
   )
-  def scala2Versions = nonDeprecatedScala2Versions ++ deprecatedScala2Versions
 
-  // The minimum sbt version that uses a non-deprecated Scala version.
-  // Currently uses Scala 2.12.12 - update upon deprecation.
-  def minimumSupportedSbtVersion = "1.4.0"
+  def minimumSupportedSbtVersion = {
+    // Update when deprecating a Scala version together with sbt version
+    val sbtScalaVersion = "2.12.14"
+    if (!nonDeprecatedScala2Versions.contains(sbtScalaVersion))
+      throw new RuntimeException(
+        "Please change minimalSupportedSbtVersion when removing support for a particular Scala version"
+      )
+    "1.5.3"
+  }
+
+  def scala2Versions = nonDeprecatedScala2Versions ++ deprecatedScala2Versions
 
   // Scala 3
   def nonDeprecatedScala3Versions =


### PR DESCRIPTION
Previously, since Metals only knows about minimum supported Scala version, we would basically guess the recomended sbt version to update to. Now, instead we clearly state that the support depends on the specific Scala version that sbt is using.