### PR TITLE
bugfix: Fix Scala CLI script for release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,9 @@ website/.cache-loader
 project/metals.sbt
 coursier
 
+# Scala CLI
+
+.scala-build/
+
 # Sourcegraph specific
 index.scip

--- a/bin/merged_prs.scala
+++ b/bin/merged_prs.scala
@@ -1,27 +1,24 @@
 //> using scala "3.2.2"
 //> using dep "org.kohsuke:github-api:1.314"
 //> using dep "com.lihaoyi::os-lib:0.9.1"
-//> using dep "com.lihaoyi::mainargs:0.4.0"
 //> using options "-Wunused:all", "-deprecation"
 
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
-import mainargs.main
 import org.kohsuke.github.GitHubBuilder
 
 import java.text.SimpleDateFormat
 import java.util.Date
 
-val defaultToken = sys.env.get("GITHUB_TOKEN")
 val codename = "Aluminium"
 
 @main
 def main(
     firstTag: String,
     lastTag: String,
-    githubToken: Seq[String] = defaultToken.toSeq,
+    githubToken: String,
 ) = {
   val author = os.proc(List("git", "config", "user.name")).call().out.trim()
   val commits = os
@@ -51,14 +48,10 @@ def main(
     "--pretty=format:%H",
   )
 
-  val token = githubToken.headOption.getOrElse {
-    throw new Exception("No github API token was specified")
-  }
-
   val output = os.proc(command).call().out.trim()
 
   val gh = new GitHubBuilder()
-    .withOAuthToken(token)
+    .withOAuthToken(githubToken)
     .build()
 
   val foundPRs = mutable.Set.empty[Int]

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -19,8 +19,8 @@ title: Making a release
   - The tag must be called `vx.y.z`, e.g. `v3.0.0`.
   - `git tag -a vx.y.z -m "vx.y.z"`
 
-  You will need the tag to fill in some information in the release notes.
-  It can always be deleted and tagged again if you want to include more commits.
+  You will need the tag to fill in some information in the release notes. It can
+  always be deleted and tagged again if you want to include more commits.
   `git tag -d vx.y.z`
 
   Please wait with pushing the tag until the release notes are accepted.
@@ -31,26 +31,28 @@ You might use the `./bin/merged_prs.sc` script to generate merged PRs list
 between two last release tags. It can be run using scala-cli:
 
 ```
-cs install scala-cli 
-scala-cli ./bin/merged_prs.sc -- <tag1> <tag2> "<github_api_token>"
+cs install scala-cli
+scala-cli ./bin/merged_prs.scala -- <tag1> <tag2> "<github_api_token>"
 ```
 
-It will need a [basic github API token](https://github.com/settings/tokens) (don't need any additional scopes) to run, which may be specified via
-environment variable `GITHUB_TOKEN` or via the last argument.
+It will need a [basic github API token](https://github.com/settings/tokens)
+(don't need any additional scopes) to run, which may be specified via the last
+argument.
 
 The script will generate a new markdown file in `website/blog` filled with a
 basic release template.
 
-You can fill in the number of closed issues from the last milestone, though
-you will need to make sure everything is included there.
+You can fill in the number of closed issues from the last milestone, though you
+will need to make sure everything is included there.
 
 ### Update Metals version
 
 - `build.sbt` - update `localSnapshotVersion` and `mimaPreviousArtifacts`
 - `.github/ISSUE_TEMPLATE/bug_report.yml` - update `Version of Metals`
-- `./bin/test-release.sh` - remove any unsupported Scala versions and
-  add newly supported ones. This will be needed later to test the new release.
-- `.github/workflows/mtags-auto-release.yml` - update `metals_version` and `metals_ref`
+- `./bin/test-release.sh` - remove any unsupported Scala versions and add newly
+  supported ones. This will be needed later to test the new release.
+- `.github/workflows/mtags-auto-release.yml` - update `metals_version` and
+  `metals_ref`
 
 ### Open a PR with release notes
 
@@ -59,9 +61,9 @@ Open the PR to the repo https://github.com/scalameta/metals/releases/new.
 ### Start the release process:
 
 - `git push upstream --tags` will trigger release workflow
-- Do not create a release on GitHub just yet. Creating a release on GitHub
-  sends out a notification to repository watchers, and the release isn't ready
-  for that yet.
+- Do not create a release on GitHub just yet. Creating a release on GitHub sends
+  out a notification to repository watchers, and the release isn't ready for
+  that yet.
 
 - Wait for
   [the Github Actions job](https://github.com/scalameta/metals/actions?query=workflow%3ARelease)
@@ -97,10 +99,13 @@ Open the PR to the repo https://github.com/scalameta/metals/releases/new.
 
   - https://github.com/scalameta/metals-vscode:
     - generate metals website with `sbt docs/run`
-    - open `website/target/docs/editors/vscode.md` and copy everything from "Requirements" over to the scalameta/metals-vscode README
-      - remove "Using latest SNAPSHOT" section, this table is only up-to-date on the website
-    - check or update `enum` values of `fallbackScalaVersion` property in `package.json`.
-      They should be the same as `V.supportedScalaVersions` in `build.sbt`
+    - open `website/target/docs/editors/vscode.md` and copy everything from
+      "Requirements" over to the scalameta/metals-vscode README
+      - remove "Using latest SNAPSHOT" section, this table is only up-to-date on
+        the website
+    - check or update `enum` values of `fallbackScalaVersion` property in
+      `package.json`. They should be the same as `V.supportedScalaVersions` in
+      `build.sbt`
     - open a PR, feel free to merge after CI is green
     - open the last generated release draft, tag with a new version and publish
       the release. This will start github actions job and publish the extension
@@ -139,9 +144,11 @@ Open the PR to the repo https://github.com/scalameta/metals/releases/new.
   - In scalameta project:
     - checkout on the tag for this version
     - apply required changes for supporting new Scala2 compiler
-    - create and push tag with the following name: `semanticdb_v${existing-scalameta-version}_${scala-version}`
-      Notice this tag should include [these changes in `release.yml`](https://github.com/scalameta/scalameta/pull/2562/commits/1dfc99677659f5a9919c0dc9166547a0b332d35c)
+    - create and push tag with the following name:
+      `semanticdb_v${existing-scalameta-version}_${scala-version}` Notice this
+      tag should include
+      [these changes in `release.yml`](https://github.com/scalameta/scalameta/pull/2562/commits/1dfc99677659f5a9919c0dc9166547a0b332d35c)
 
-- Release mtags artifact.
-  Open [`Mtags auto release` action page](https://github.com/scalameta/metals/actions/workflows/mtags-auto-release.yml),
+- Release mtags artifact. Open
+  [`Mtags auto release` action page](https://github.com/scalameta/metals/actions/workflows/mtags-auto-release.yml),
   click `Run Workflow`, specify Scala version and confirm.


### PR DESCRIPTION
Previously, I only quickly switched the Ammonite script to Scala CLI, but I might have not actually tested it out properly. Now, I was able to generate release notes. I switched to a normal Scala file since this allows us to have sensible arguments