### PR TITLE
bugfix [skip-ci]: Use concurrency label to limit concurrent release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     tags: ["*"]
 jobs:
   publish:
+    concurrency: releasing
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -17,19 +18,6 @@ jobs:
           cache: 'sbt'
       - name: Publish
         run: |
-          LOCKED=true
-          while [ $LOCKED = true ]; do
-            # if there are several release jobs at the same time
-            # allow to continue the one which id is less than others
-            FIRST_IN_PROGRESS=$(gh api /repos/scalameta/metals/actions/workflows/release.yml/runs?status=in_progress -q ".workflow_runs[].id" | sort | head -n 1)
-            if [ "$FIRST_IN_PROGRESS" == "$GITHUB_RUN_ID" ]; then
-              LOCKED=false
-            else
-              echo "Waiting the completion of other release job..."
-              sleep 20
-            fi
-          done
-
           COMMAND="ci-release"
           UPDATE_DOCS=true
           if [[ $GITHUB_REF == "refs/tags"* ]] && [[ $GITHUB_REF_NAME == "mtags_v"* ]]; then


### PR DESCRIPTION
It seems the current mechanism started failing and is probably flaky