### PR TITLE
bugfix[skip ci] Remove lock mechanism since it stopped working

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,6 @@ jobs:
           cache: 'sbt'
       - name: Publish
         run: |
-          LOCKED=true
-          while [ $LOCKED = true ]; do
-            # if there are several release jobs at the same time
-            # allow to continue the one which id is less than others
-            FIRST_IN_PROGRESS=$(gh api /repos/scalameta/metals/actions/workflows/release.yml/runs?status=in_progress -q ".workflow_runs[].id" | sort | head -n 1)
-            if [ "$FIRST_IN_PROGRESS" == "$GITHUB_RUN_ID" ]; then
-              LOCKED=false
-            else
-              echo "Waiting the completion of other release job..."
-              sleep 20
-            fi
-          done
-
           COMMAND="ci-release"
           UPDATE_DOCS=true
           if [[ $GITHUB_REF == "refs/tags"* ]] && [[ $GITHUB_REF_NAME == "mtags_v"* ]]; then


### PR DESCRIPTION
It seems the API doesn't work with the additional filter and there is no way around it currently, so removing for now at least be able to release the release notes