### PR TITLE
refactor: account for new diagnosticData shape

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
@@ -1,13 +1,15 @@
 package scala.meta.internal.metals
 
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.codeactions.DiagnosticData
 
 import org.eclipse.{lsp4j => l}
 
 object ScalacDiagnostic {
 
-  object ScalaAction {
-    def unapply(d: l.Diagnostic): Option[l.TextEdit] = d.asTextEdit
+  object DiagnosticData {
+    def unapply(d: l.Diagnostic): Option[Either[l.TextEdit, DiagnosticData]] =
+      d.asDiagnosticData
   }
 
   object NotAMember {

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/DiagnosticData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/DiagnosticData.scala
@@ -1,0 +1,15 @@
+package scala.meta.internal.metals.codeactions
+
+import java.{util => ju}
+
+import org.eclipse.lsp4j.WorkspaceEdit
+
+/**
+ * Representation of what should be in the `data` field of a BSP diagnostic.
+ *
+ * NOTE: In the future there may be other keys besides `edits`, but we can
+ * probably just cross that bridge when we get there.
+ *
+ * @param edits The various edits that can be associated with a given Diagnostic.
+ */
+final case class DiagnosticData(edits: ju.List[WorkspaceEdit])

--- a/mtags-shared/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -31,16 +31,22 @@ trait CommonMtagsEnrichments {
   private def logger: Logger =
     Logger.getLogger(classOf[CommonMtagsEnrichments].getName)
 
-  protected def decodeJson[T](obj: AnyRef, cls: java.lang.Class[T]): Option[T] =
+  protected def decodeJson[T](
+      obj: AnyRef,
+      cls: java.lang.Class[T],
+      gson: Option[Gson] = None
+  ): Option[T] =
     for {
       data <- Option(obj)
       value <-
         try {
-          Some(
-            new Gson().fromJson[T](
-              data.asInstanceOf[JsonElement],
-              cls
-            )
+          Option(
+            gson
+              .getOrElse(new Gson())
+              .fromJson[T](
+                data.asInstanceOf[JsonElement],
+                cls
+              )
           )
         } catch {
           case NonFatal(e) =>


### PR DESCRIPTION
Previously in scala-cli the diagnostic `data` for actionable diagnostics
were `textEdit`s, whereas now they are nested under `edits` and are
`workspaceEdit`s. This change will ensure they still work for the old
format and also for the new.

This relates to the changes in https://github.com/VirtusLab/scala-cli/pull/1969.
