### PR TITLE
bugfix: arguments name completions for constructors

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -35,9 +35,12 @@ trait ArgCompletions { this: MetalsGlobal =>
           case _ => Nil
         }
       } else {
-        method.tpe.paramss.headOption
-          .getOrElse(methodSym.paramss.flatten)
+        if (methodSym.isClass) methodSym.constrParamAccessors
+        else
+          method.tpe.paramss.headOption
+            .getOrElse(methodSym.paramss.flatten)
       }
+
     lazy val isNamed: Set[Name] = apply.args.iterator
       .filterNot(_ == ident)
       .zip(baseParams.iterator)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/NamedArgCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/NamedArgCompletions.scala
@@ -46,7 +46,9 @@ object NamedArgCompletions:
 
   private def isInfix(pos: SourcePosition, apply: Apply)(using ctx: Context) =
     apply.fun match
-      // is a select statement without a dot `qual.name` and is not a synthetic apply etc.
+      case Select(New(_), _) => false
+      case Select(_, name) if name.decoded == "apply" => false
+      // is a select statement without a dot `qual.name`
       case sel @ Select(qual, _) if !sel.symbol.is(Flags.Synthetic) =>
         !(qual.span.end until sel.nameSpan.start)
           .map(pos.source.apply)

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -509,4 +509,31 @@ class CompletionArgSuite extends BaseCompletionSuite {
     """|x: Int
        |""".stripMargin,
   )
+
+  check(
+    "contructor-param",
+    """|class Foo (xxx: Int)
+       |
+       |object Main {
+       |  val foo = new Foo(x@@)
+       |}
+       |""".stripMargin,
+    """|xxx = : Int
+       |""".stripMargin,
+  )
+
+  check(
+    "contructor-param2",
+    """|class Foo ()
+       |
+       |object Foo {
+       |  def apply(xxx: Int): Foo = ???
+       |}
+       |object Main {
+       |  val foo = Foo(x@@)
+       |}
+       |""".stripMargin,
+    """|xxx = : Int
+       |""".stripMargin,
+  )
 }


### PR DESCRIPTION
Previously: no arguments name completions should be provided inside of a contractor invocation both for Scala 2 and 3
Now: name completions are correctly provided
resolves: https://github.com/scalameta/metals/issues/5168