### PR TITLE
fix: Fix semantic tokens for multiline comments

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
@@ -42,7 +42,7 @@ object SemanticTokensProvider {
     if (tokenType != -1 && text.length() > 0) {
       val lines = text.split("\n", -1).toList
       lines.foreach { l =>
-        if (l.length() > 0)
+        if (l.length() > 0) {
           buffer.addAll(
             List(
               delta.number,
@@ -52,7 +52,10 @@ object SemanticTokensProvider {
               tokenModifier,
             )
           )
-        delta = Line(1, 0)
+          delta = Line(1, 0)
+        } else {
+          delta = delta.moveLine(1)
+        }
       }
       delta = Line(0, lines.last.length())
     } else {

--- a/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
@@ -62,6 +62,19 @@ class SemanticTokensLspSuite extends BaseLspSuite("SemanticTokens") {
   )
 
   check(
+    "multiline-comment-with-whitespace",
+    """| <</** This is >>/*comment*/
+       |<<*  a multiline>>/*comment*/
+       |
+       |<<*  comment>>/*comment*/
+       |
+       |<<*/>>/*comment*/
+       |
+       |<<object>>/*keyword*/ <<A>>/*class*/ {}
+       |""".stripMargin,
+  )
+
+  check(
     "using-directive",
     """|<<//>>>/*comment*/ <<using>>/*keyword*/ <<lib>>/*variable,readonly*/ <<"abc::abc:123">>/*string*/
        |<<//>>>/*comment*/ <<using>>/*keyword*/ <<scala>>/*variable,readonly*/ <<"3.1.1">>/*string*/


### PR DESCRIPTION
Previously semantic tokens were incorrect for multiline comments with empty lines