### PR TITLE
bugfix: Auto comment shebang for scripts

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
@@ -129,7 +129,9 @@ final class Trees(
     for {
       text <- buffers.get(path).orElse(path.readTextOpt)
     } yield try {
-      val input = Input.VirtualFile(path.toURI.toString(), text)
+      val skipFistShebang =
+        if (text.startsWith("#!")) text.replaceFirst("#!", "//") else text
+      val input = Input.VirtualFile(path.toURI.toString(), skipFistShebang)
       if (path.isAmmoniteScript || path.isMill) {
         val ammoniteInput = Input.Ammonite(input)
         dialect(ammoniteInput).parse(Parse.parseAmmonite)


### PR DESCRIPTION
Previously, Metals would report issues when shebang is preset. Now, instead we comment the shabangs line, which should work correctly since we replace the exact same number of characters.

Potentially this could be fixed in scalameta, but I feel like like this might be much more work than needed here.

Fixes https://github.com/scalameta/metals/issues/5179