### PR TITLE
Bump swoval version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -390,7 +390,7 @@ lazy val metals = project
       // for measuring memory footprint
       "org.openjdk.jol" % "jol-core" % "0.17",
       // for file watching
-      "com.swoval" % "file-tree-views" % "2.1.9",
+      "com.swoval" % "file-tree-views" % "2.1.10",
       // for http client
       "io.undertow" % "undertow-core" % "2.2.20.Final",
       "org.jboss.xnio" % "xnio-nio" % "3.8.9.Final",


### PR DESCRIPTION
A user reported very poor performance for directory/file registration on Windows (https://github.com/swoval/swoval/issues/161). This new version potentially addresses the cause of a performance regression that may have been introduced in v2.1.8.