### PR TITLE
fix: Don't show completions ending with CURSOR

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -71,17 +71,24 @@ class Completions(
       case _ :: (_: Import) :: _ => false
       case (_: Ident) :: (_: SeqLiteral) :: _ => false
       case _ => true
-
   enum CursorPos:
     case Type(hasTypeParams: Boolean, hasNewKw: Boolean)
     case Term
     case Import
 
     def include(sym: Symbol)(using Context): Boolean =
+      def hasSyntheticCursorSuffix: Boolean =
+        if !sym.name.endsWith(Cursor.value) then false
+        else
+          val realNameLength = sym.decodedName.length - Cursor.value.length
+          sym.source == pos.source &&
+          sym.span.start + realNameLength == pos.span.end
+
       val generalExclude =
         isUninterestingSymbol(sym) ||
           !isNotLocalForwardReference(sym) ||
-          sym.isPackageObject
+          sym.isPackageObject ||
+          hasSyntheticCursorSuffix
 
       def isWildcardParam(sym: Symbol) =
         if sym.isTerm && sym.owner.isAnonymousFunction then

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1623,4 +1623,30 @@ class CompletionSuite extends BaseCompletionSuite {
     topLines = Some(1),
   )
 
+  // In Scala 3 we get: (x$1 : (String, Unit)) @unchecked scala
+  // should be solved by https://github.com/scalameta/metals/pull/5292
+  check(
+    "for-comprehension".tag(IgnoreScala3),
+    """|object B {
+       |  val a = for {
+       |    foo <- List("a", "b", "c")
+       |    abc@@ = println("Print!")
+       |  } yield abc
+       |}
+       |""".stripMargin,
+    "",
+  )
+
+  check(
+    "for-comprehension2".tag(IgnoreScala3),
+    """|object B {
+       |  val a = for {
+       |    foo <- List("a", "b", "c")
+       |    abcCURSORde = println("Print!")
+       |  } yield abc@@
+       |}
+       |""".stripMargin,
+    "abcCURSORde: Unit",
+  )
+
 }


### PR DESCRIPTION
Connected to https://github.com/scalameta/metals/issues/5182

Completions with `CURSOR` could be seen not only in `for-comprehension` with `=` lines, but also is more random places and issues with them are hard to reproduce. I think it's better to not show them at all