### PR TITLE
feature: Add support for running Native and JS

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -294,6 +294,17 @@ class BuildServerConnection private (
     }
   }
 
+  def buildTargetRun(
+      params: RunParams,
+      cancelPromise: Promise[Unit],
+  ): Future[RunResult] = {
+    val completableFuture = register(server => server.buildTargetRun(params))
+    cancelPromise.future.foreach { _ =>
+      completableFuture.cancel(true)
+    }
+    completableFuture.asScala
+  }
+
   def buildTargetScalacOptions(
       params: ScalacOptionsParams
   ): Future[ScalacOptionsResult] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -728,6 +728,7 @@ class MetalsLspService(
       testProvider,
     )
   )
+  buildClient.registerLogForwarder(debugProvider)
 
   private val scalafixProvider: ScalafixProvider = ScalafixProvider(
     buffers,

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -849,7 +849,8 @@ class WorkspaceLspService(
         folderServices.find(s =>
           targets.forall(s.supportsBuildTarget(_).isDefined)
         ) match {
-          case Some(service) => service.startDebugProvider(params).asJavaObject
+          case Some(service) =>
+            service.startDebugProvider(params).liftToLspError.asJavaObject
           case None =>
             failedRequest(
               s"Could not find folder for build targets: ${targets.mkString(",")}"

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
@@ -147,12 +147,12 @@ object DebugProtocol {
   object ConfigurationDone {
     def unapply(
         request: DebugRequestMessage
-    ): Option[Option[dap.ConfigurationDoneArguments]] = {
+    ): Option[dap.ConfigurationDoneArguments] = {
       if (request.getMethod != "configurationDone") None
-      else
-        Some(
-          parse[dap.ConfigurationDoneArguments](request.getParams).toOption
-        )
+      else if (request.getParams() == null)
+        Some(new dap.ConfigurationDoneArguments())
+      else parse[dap.ConfigurationDoneArguments](request.getParams).toOption
+
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
@@ -97,6 +97,15 @@ object DebugProtocol {
     response
   }
 
+  object EmptyResponse {
+    def apply(initialize: DebugRequestMessage): DebugResponseMessage = {
+      val response = new DebugResponseMessage
+      response.setId(initialize.getId())
+      response.setMethod(initialize.getMethod())
+      response
+    }
+  }
+
   object SyntheticMessage {
     def unapply(msg: IdentifiableMessage): Option[IdentifiableMessage] = {
       if (msg.getId == null) Some(msg)
@@ -135,6 +144,28 @@ object DebugProtocol {
     }
   }
 
+  object ConfigurationDone {
+    def unapply(
+        request: DebugRequestMessage
+    ): Option[Option[dap.ConfigurationDoneArguments]] = {
+      if (request.getMethod != "configurationDone") None
+      else
+        Some(
+          parse[dap.ConfigurationDoneArguments](request.getParams).toOption
+        )
+    }
+  }
+
+  object TerminateRequest {
+    def unapply(
+        request: DebugRequestMessage
+    ): Option[dap.TerminateArguments] = {
+      if (request.getMethod != "terminate") None
+      else
+        parse[dap.TerminateArguments](request.getParams).toOption
+    }
+  }
+
   object SetBreakpointRequest {
     def unapply(request: RequestMessage): Option[SetBreakpointsArguments] = {
       if (request.getMethod != "setBreakpoints") None
@@ -158,15 +189,14 @@ object DebugProtocol {
     }
   }
 
-  object RestartRequest {
-    def unapply(request: RequestMessage): Option[DisconnectArguments] = {
-      if (request.getMethod != "disconnect") None
+  object DisconnectRequest {
+    def unapply(request: DebugRequestMessage): Option[DisconnectArguments] = {
+      if (request.getMethod != DisconnectRequest.name) None
       else {
-        parse[DisconnectArguments](request.getParams)
-          .filter(_.getRestart)
-          .toOption
+        parse[DisconnectArguments](request.getParams).toOption
       }
     }
+    val name = "disconnect"
   }
 
   object OutputNotification {

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -42,6 +42,7 @@ import scala.meta.internal.metals.SourceMapper
 import scala.meta.internal.metals.StacktraceAnalyzer
 import scala.meta.internal.metals.StatusBar
 import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.clients.language.LogForwarder
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.clients.language.MetalsQuickPickItem
 import scala.meta.internal.metals.clients.language.MetalsQuickPickParams
@@ -87,13 +88,30 @@ class DebugProvider(
     sourceMapper: SourceMapper,
     userConfig: () => UserConfiguration,
     testProvider: TestSuitesProvider,
-) extends Cancelable {
+) extends Cancelable
+    with LogForwarder {
 
   import DebugProvider._
 
   private val debugSessions = new MutableCancelable()
 
-  override def cancel(): Unit = debugSessions.cancel()
+  private val currentRunner =
+    new ju.concurrent.atomic.AtomicReference[DebugRunner](null)
+
+  override def info(message: String): Unit = {
+    val runner = currentRunner.get()
+    if (runner != null) runner.stdout(message)
+  }
+
+  override def error(message: String): Unit = {
+    val runner = currentRunner.get()
+    if (runner != null) runner.error(message)
+  }
+
+  override def cancel(): Unit = {
+    Option(currentRunner.get()).foreach(_.cancel())
+    debugSessions.cancel()
+  }
 
   lazy val buildTargetClassesFinder = new BuildTargetClassesFinder(
     buildTargets,
@@ -102,9 +120,9 @@ class DebugProvider(
   )
 
   def start(
-      parameters: b.DebugSessionParams,
-      cancelPromise: Promise[Unit],
+      parameters: b.DebugSessionParams
   )(implicit ec: ExecutionContext): Future[DebugServer] = {
+    val cancelPromise = Promise[Unit]()
     for {
       sessionName <- Future.fromTry(parseSessionName(parameters))
       jvmOptionsTranslatedParams = translateJvmParams(parameters)
@@ -112,14 +130,78 @@ class DebugProvider(
         .fold[Future[BuildServerConnection]](BuildServerUnavailableError)(
           Future.successful
         )
-      debugServer <- start(
-        sessionName,
-        jvmOptionsTranslatedParams,
-        buildServer,
-        cancelPromise,
-      )
+      isJvm = parameters
+        .getTargets()
+        .asScala
+        .flatMap(buildTargets.scalaTarget)
+        .forall(
+          _.scalaInfo.getPlatform == b.ScalaPlatform.JVM
+        )
+      debugServer <-
+        if (isJvm)
+          statusBar.trackSlowFuture(
+            "Starting debug server",
+            start(
+              sessionName,
+              jvmOptionsTranslatedParams,
+              buildServer,
+              cancelPromise,
+            ),
+            () => cancelPromise.trySuccess(()),
+          )
+        else
+          runLocally(
+            sessionName,
+            jvmOptionsTranslatedParams,
+            buildServer,
+            cancelPromise,
+          )
     } yield debugServer
   }
+
+  private def runLocally(
+      sessionName: String,
+      parameters: b.DebugSessionParams,
+      buildServer: BuildServerConnection,
+      cancelPromise: Promise[Unit],
+  )(implicit ec: ExecutionContext): Future[DebugServer] = {
+    val proxyServer = new ServerSocket(0, 50, localAddress)
+    val host = InetAddresses.toUriString(proxyServer.getInetAddress)
+    val port = proxyServer.getLocalPort
+    proxyServer.setSoTimeout(10 * 1000)
+    val uri = URI.create(s"tcp://$host:$port")
+
+    val awaitClient = () => Future(proxyServer.accept())
+
+    DebugRunner
+      .open(
+        sessionName,
+        awaitClient,
+        stacktraceAnalyzer,
+        () => {
+          val runParams = new b.RunParams(parameters.getTargets().asScala.head)
+          buildServer.buildTargetRun(runParams, cancelPromise)
+        },
+        cancelPromise,
+      )
+      .flatMap { runner =>
+        currentRunner.set(runner)
+        runner.listen.map { code =>
+          currentRunner.set(null)
+          code
+        }
+      }
+
+    val server = new DebugServer(
+      sessionName,
+      uri,
+      () => Future.failed(new RuntimeException("No server connected")),
+    )
+
+    Future.successful(server)
+  }
+
+  private def localAddress: InetAddress = InetAddress.getByName("127.0.0.1")
 
   private def start(
       sessionName: String,
@@ -127,8 +209,7 @@ class DebugProvider(
       buildServer: BuildServerConnection,
       cancelPromise: Promise[Unit],
   )(implicit ec: ExecutionContext): Future[DebugServer] = {
-    val inetAddress = InetAddress.getByName("127.0.0.1")
-    val proxyServer = new ServerSocket(0, 50, inetAddress)
+    val proxyServer = new ServerSocket(0, 50, localAddress)
     val host = InetAddresses.toUriString(proxyServer.getInetAddress)
     val port = proxyServer.getLocalPort
     proxyServer.setSoTimeout(10 * 1000)
@@ -395,13 +476,8 @@ class DebugProvider(
   def asSession(
       debugParams: DebugSessionParams
   )(implicit ec: ExecutionContext): Future[DebugSession] = {
-    val cancelPromise = Promise[Unit]()
     for {
-      server <- statusBar.trackSlowFuture(
-        "Starting debug server",
-        start(debugParams, cancelPromise),
-        () => cancelPromise.trySuccess(()),
-      )
+      server <- start(debugParams),
     } yield {
       statusBar.addMessage("Started debug server!")
       DebugSession(server.sessionName, server.uri.toString)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -180,6 +180,13 @@ class DebugProvider(
         stacktraceAnalyzer,
         () => {
           val runParams = new b.RunParams(parameters.getTargets().asScala.head)
+          if (
+            parameters
+              .getDataKind() == b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS
+          ) {
+            runParams.setDataKind(parameters.getDataKind())
+            runParams.setData(parameters.getData())
+          }
           buildServer.buildTargetRun(runParams, cancelPromise)
         },
         cancelPromise,

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
@@ -19,11 +19,11 @@ import scala.meta.internal.metals.StacktraceAnalyzer
 import scala.meta.internal.metals.StatusBar
 import scala.meta.internal.metals.Trace
 import scala.meta.internal.metals.debug.DebugProtocol.CompletionRequest
+import scala.meta.internal.metals.debug.DebugProtocol.DisconnectRequest
 import scala.meta.internal.metals.debug.DebugProtocol.ErrorOutputNotification
 import scala.meta.internal.metals.debug.DebugProtocol.InitializeRequest
 import scala.meta.internal.metals.debug.DebugProtocol.LaunchRequest
 import scala.meta.internal.metals.debug.DebugProtocol.OutputNotification
-import scala.meta.internal.metals.debug.DebugProtocol.RestartRequest
 import scala.meta.internal.metals.debug.DebugProtocol.SetBreakpointRequest
 import scala.meta.internal.metals.debug.DebugProxy._
 import scala.meta.io.AbsolutePath
@@ -91,7 +91,7 @@ private[debug] final class DebugProxy(
     case request @ LaunchRequest(debugMode) =>
       this.debugMode = debugMode
       server.send(request)
-    case request @ RestartRequest(_) =>
+    case request @ DisconnectRequest(args) if args.getRestart() =>
       initialized.trySuccess(())
       // set the status first, since the server can kill the connection
       exitStatus.trySuccess(Restarted)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugRunner.scala
@@ -1,0 +1,179 @@
+package scala.meta.internal.metals.debug
+
+import java.net.Socket
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Try
+
+import scala.meta.internal.metals.Cancelable
+import scala.meta.internal.metals.StacktraceAnalyzer
+
+import ch.epfl.scala.bsp4j.RunResult
+import org.eclipse.lsp4j.debug.Capabilities
+import org.eclipse.lsp4j.debug.ExitedEventArguments
+import org.eclipse.lsp4j.debug.OutputEventArguments
+import org.eclipse.lsp4j.debug.OutputEventArgumentsCategory
+import org.eclipse.lsp4j.jsonrpc.MessageConsumer
+import org.eclipse.lsp4j.jsonrpc.debug.messages.DebugNotificationMessage
+import org.eclipse.lsp4j.jsonrpc.messages.IdentifiableMessage
+import org.eclipse.lsp4j.jsonrpc.messages.Message
+
+/**
+ * Runner used for basic DAP run requests without the overhead of
+ * debugging. This onlt runs the program and responds very basic messages and
+ * events to the DAP client.
+ */
+class DebugRunner(
+    sessionName: String,
+    client: RemoteEndpoint,
+    stackTraceAnalyzer: StacktraceAnalyzer,
+    runFuture: () => Future[RunResult],
+    cancelling: Promise[Unit],
+)(implicit ec: ExecutionContext) {
+
+  val lastId = new AtomicInteger(DebugProtocol.FirstMessageId)
+  private val clientReady: Promise[Unit] = Promise[Unit]()
+  private val exitStatus: Future[DebugProxy.ExitStatus] =
+    for {
+      _ <- clientReady.future
+      res <- runFuture()
+    } yield {
+      val exited = new DebugNotificationMessage
+      exited.setMethod("exited")
+      val exitedArgs = new ExitedEventArguments()
+      exitedArgs.setExitCode(res.getStatusCode().getValue())
+      exited.setParams(exitedArgs)
+      exited.setId(lastId.incrementAndGet())
+      client.consume(exited)
+
+      val terminated = new DebugNotificationMessage
+      terminated.setMethod("terminated")
+      terminated.setId(lastId.incrementAndGet())
+      client.consume(terminated)
+      DebugProxy.Terminated
+    }
+
+  private val cancelled = new AtomicBoolean()
+  private def listenToClient(): Unit = {
+    Future(client.listen(handleClientMessage)).andThen { case _ => cancel() }
+  }
+
+  lazy val listen: Future[DebugProxy.ExitStatus] = {
+    scribe.info(s"Starting debug runner for [$sessionName]")
+    listenToClient()
+    exitStatus.map { st =>
+      client.cancel()
+      st
+    }
+  }
+
+  private val handleClientMessage: MessageConsumer = { message =>
+    setIdFromMessage(message)
+    message match {
+      case null =>
+        () // ignore
+      case _ if cancelled.get() =>
+        () // ignore
+      case request @ DebugProtocol.InitializeRequest(_) =>
+        val response = DebugProtocol.EmptyResponse(request)
+        response.setResult(new Capabilities)
+        client.consume(response)
+
+      case request @ DebugProtocol.LaunchRequest(_) =>
+        val response = DebugProtocol.EmptyResponse(request)
+        clientReady.trySuccess(())
+        client.consume(response)
+
+      case request @ DebugProtocol.ConfigurationDone(_) =>
+        val response = DebugProtocol.EmptyResponse(request)
+        client.consume(response)
+
+      case request @ DebugProtocol.DisconnectRequest(_) =>
+        val response = DebugProtocol.EmptyResponse(request)
+        clientReady.trySuccess(())
+        client.consume(response)
+
+      case request @ DebugProtocol.TerminateRequest(_) =>
+        val response = DebugProtocol.EmptyResponse(request)
+        clientReady.trySuccess(())
+        cancelling.trySuccess(())
+        client.consume(response)
+
+      case message =>
+        scribe.debug("Message not handled:\n" + message)
+    }
+  }
+
+  def setIdFromMessage(msg: Message): Unit = {
+    msg match {
+      case message: IdentifiableMessage =>
+        Try(message.getId().toInt).foreach(lastId.set)
+      case _ =>
+    }
+  }
+
+  def stdout(message: String): Unit =
+    output(message, OutputEventArgumentsCategory.STDOUT)(_ => None)
+
+  def error(message: String): Unit = {
+    output(message, OutputEventArgumentsCategory.STDERR) { notification =>
+      stackTraceAnalyzer
+        .fileLocationFromLine(message)
+        .map(DebugProtocol.stacktraceOutputResponse(notification, _))
+
+    }
+  }
+
+  private def output(message: String, category: String)(
+      withDetails: OutputEventArguments => Option[DebugNotificationMessage]
+  ) = {
+    val output = new OutputEventArguments()
+    output.setCategory(category)
+    output.setOutput(message + "\n")
+
+    def default = {
+      val notification = new DebugNotificationMessage()
+      notification.setMethod("output")
+      notification.setParams(output)
+      notification
+    }
+
+    val notification = withDetails(output).getOrElse(default)
+    notification.setId(lastId.incrementAndGet())
+    client.consume(notification)
+  }
+
+  def cancel(): Unit = {
+    if (cancelled.compareAndSet(false, true)) {
+      scribe.info(s"Canceling run for [$sessionName]")
+      Cancelable.cancelAll(List(client))
+    }
+  }
+}
+
+object DebugRunner {
+
+  def open(
+      name: String,
+      awaitClient: () => Future[Socket],
+      stackTraceAnalyzer: StacktraceAnalyzer,
+      runFuture: () => Future[RunResult],
+      cancelling: Promise[Unit],
+  )(implicit ec: ExecutionContext): Future[DebugRunner] = {
+    for {
+      client <- awaitClient()
+        .map(new SocketEndpoint(_))
+        .map(new MessageIdAdapter(_))
+    } yield new DebugRunner(
+      name,
+      client,
+      stackTraceAnalyzer,
+      runFuture,
+      cancelling,
+    )
+  }
+}

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/RemoteServer.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/RemoteServer.scala
@@ -16,7 +16,7 @@ import scala.reflect.classTag
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.JsonParser._
 import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.internal.metals.debug.DebugProtocol.FirstMessageId
+import scala.meta.internal.metals.debug.DebugProtocol
 
 import com.google.gson.JsonElement
 import org.eclipse.lsp4j.debug.Capabilities
@@ -40,7 +40,7 @@ private[debug] final class RemoteServer(
 
   private val remote = new SocketEndpoint(socket)
   private val ongoing = new TrieMap[String, Response => Unit]()
-  private val id = new AtomicInteger(FirstMessageId)
+  private val id = new AtomicInteger(DebugProtocol.FirstMessageId)
   lazy val listening: Future[Unit] = Future(listen())
 
   override def initialize(
@@ -124,7 +124,7 @@ private[debug] final class RemoteServer(
   override def disconnect(
       args: DisconnectArguments
   ): CompletableFuture[Void] = {
-    sendRequest("disconnect", args)
+    sendRequest(DebugProtocol.DisconnectRequest.name, args)
   }
 
   private def listen(): Unit = {

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -17,6 +17,7 @@ import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.decorations.PublishDecorationsParams
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.ClientCommands
+import scala.meta.internal.metals.Debug
 import scala.meta.internal.metals.FileOutOfScalaCliBspScope
 import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.Messages._
@@ -131,6 +132,7 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
   override def metalsExecuteClientCommand(
       params: ExecuteCommandParams
   ): Unit = {
+    Debug.printEnclosing(params.getCommand())
     clientCommands.addLast(params)
     params.getCommand match {
       case ClientCommands.RefreshModel.id =>

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -20,6 +20,8 @@ import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Future
 import scala.concurrent.Promise
+import scala.util.Failure
+import scala.util.Success
 import scala.util.matching.Regex
 import scala.{meta => m}
 
@@ -635,6 +637,18 @@ final case class TestingServer(
     fullServer.executeCommand(command.toExecuteCommandParams()).asScala
   }
 
+  def listBuildTargets: Future[List[String]] = {
+    for {
+      targetsArray <- executeCommand(ServerCommands.ListBuildTargets)
+    } yield targetsArray.toJson.as[Array[String]] match {
+      case Failure(exception) =>
+        scribe.error("Could not read build targets", exception)
+        Nil
+      case Success(targets) =>
+        targets.toList
+    }
+  }
+
   /**
    * Operating on strings can be dangerous, but needed for running unknown commands
    * and for the StartDebugAdapter command, which doesn't have a stable argument.
@@ -1025,11 +1039,15 @@ final case class TestingServer(
     } yield classes
   }
 
-  def codeLensesText(filename: String, printCommand: Boolean = false)(
+  def codeLensesText(
+      filename: String,
+      printCommand: Boolean = false,
+      minExpectedLenses: Int = 1,
+  )(
       maxRetries: Int
   ): Future[String] = {
     for {
-      lenses <- codeLenses(filename, maxRetries)
+      lenses <- codeLenses(filename, maxRetries, minExpectedLenses)
       textEdits = CodeLensesTextEdits(lenses, printCommand)
     } yield TextEdits.applyEdits(textContents(filename), textEdits.toList)
   }
@@ -1037,6 +1055,7 @@ final case class TestingServer(
   def codeLenses(
       filename: String,
       maxRetries: Int = 4,
+      minExpectedLenses: Int = 1,
   ): Future[List[l.CodeLens]] = {
     Debug.printEnclosing(filename)
     val path = toPath(filename)
@@ -1052,21 +1071,24 @@ final case class TestingServer(
     // or fails if it could nat be achieved withing [[maxRetries]] number of tries
     var retries = maxRetries
     val codeLenses = Promise[List[l.CodeLens]]()
+    def getLenses = fullServer
+      .codeLens(params)
+      .asScala
+      .map(_.asScala)
+      .withTimeout(10, util.concurrent.TimeUnit.SECONDS)
+      .recover { _ =>
+        scribe.info(s"Timeout for fetching lenses reached for $filename")
+        Nil
+      }
+
     val handler = { refreshCount: Int =>
       scribe.info(s"Refreshing model for $filename")
       if (refreshCount > 0)
         for {
-          lenses <- fullServer
-            .codeLens(params)
-            .asScala
-            .map(_.asScala)
-            .withTimeout(10, util.concurrent.TimeUnit.SECONDS)
-            .recover { _ =>
-              scribe.info(s"Timeout for fetching lenses reached for $filename")
-              Nil
-            }
+          lenses <- getLenses
         } {
-          if (lenses.nonEmpty) codeLenses.trySuccess(lenses.toList)
+          if (lenses.size >= minExpectedLenses)
+            codeLenses.trySuccess(lenses.toList)
           else if (retries > 0) {
             retries -= 1
             server.compilations.compileFile(path)
@@ -1085,9 +1107,13 @@ final case class TestingServer(
       _ = client.refreshModelHandler = handler
       // first compilation, to trigger the handler
       _ <- server.compilations.compileFile(path)
-      lenses <- codeLenses.future
+      lenses <- getLenses
+        .flatMap { lenses =>
+          if (lenses.size >= minExpectedLenses) Future.successful(lenses)
+          else codeLenses.future
+        }
         .withTimeout(60, util.concurrent.TimeUnit.SECONDS)
-    } yield lenses
+    } yield lenses.toList
   }
 
   def formatCompletion(

--- a/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
@@ -53,6 +53,7 @@ class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
   checkTestCases(
     "test-suite-with-tests",
     library = Some("org.scalatest::scalatest:3.2.16"),
+    minExpectedLenses = 6,
   )(
     """|package foo.bar
        |<<test>><<debug test>>
@@ -69,7 +70,11 @@ class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
        |""".stripMargin
   )
 
-  check("test-suite-object", library = Some("com.lihaoyi::utest:0.7.3"))(
+  check(
+    "test-suite-object",
+    library = Some("com.lihaoyi::utest:0.7.3"),
+    minExpectedLenses = 3,
+  )(
     """|package foo.bar
        |<<test>><<debug test>>
        |object Foo extends utest.TestSuite {

--- a/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
@@ -10,7 +10,6 @@ import scala.util.Random
 import scala.meta.internal.metals.DebugUnresolvedMainClassParams
 import scala.meta.internal.metals.DebugUnresolvedTestClassParams
 import scala.meta.internal.metals.JsonParser._
-import scala.meta.internal.metals.MetalsBspException
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.debug.DebugProvider.WorkspaceErrorsException
 
@@ -92,7 +91,7 @@ class DebugProtocolSuite
            |""".stripMargin
       )
       failed = startDebugging()
-      debugger <- failed.recoverWith { case _: MetalsBspException =>
+      debugger <- failed.recoverWith { case _: ResponseErrorException =>
         server
           .didSave("a/src/main/scala/a/Main.scala") { text => text + "}" }
           .flatMap(_ => startDebugging())

--- a/tests/unit/src/test/scala/tests/debug/DebugProtocolCancelationSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/DebugProtocolCancelationSuite.scala
@@ -1,12 +1,11 @@
 package tests.debug
 
-import java.util.concurrent.CancellationException
-
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.clients.language.MetalsSlowTaskResult
 
 import ch.epfl.scala.bsp4j.DebugSessionParamsDataKind
 import ch.epfl.scala.bsp4j.ScalaMainClass
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 import tests.BaseDapSuite
 import tests.QuickBuildInitializer
 import tests.QuickBuildLayout
@@ -58,7 +57,7 @@ class DebugProtocolCancelationSuite
           mainClass,
         )
         .map(_ => "Debugger has been started")
-        .recover { case _: CancellationException =>
+        .recover { case _: ResponseErrorException =>
           expectedMsg
         }
     } yield assertNoDiff(debuggerMsg, expectedMsg)


### PR DESCRIPTION
This works by doing the bare minimum that DAP requires and forwarding the logs from the build server.

We can later use this minimal DAP server to also run quicker test instead of setting up the entire debugging session

Resolves https://github.com/scalameta/metals-feature-requests/issues/325