### PR TITLE
fix: Add bloop package for bloop command

### DIFF
--- a/docs/build-tools/mill.md
+++ b/docs/build-tools/mill.md
@@ -24,7 +24,7 @@ Using Mill with Bloop is the current preferred way by Metals.
 
 Metals requires the Bloop config files, which you can generate with the following command:
 
-``mill --import "ivy:com.lihaoyi::mill-contrib-bloop::" mill.contrib.Bloop/install``
+``mill --import "ivy:com.lihaoyi::mill-contrib-bloop::" mill.contrib.bloop.Bloop/install``
 
 Afterwards, you can just open Metals and start working on your code.
 

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -82,12 +82,12 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
       "--import" :: "ivy:com.lihaoyi::mill-contrib-bloop:" :: Nil
     else "--predef" :: predefScriptPath.toString :: Nil
   }
-        
+
   private def bloopCmd(millVersion: String) = {
     // Bloop was moved to the bloop package in 0.9.3
     // https://github.com/com-lihaoyi/mill/pull/992
     val useBloopPackage = SemVer.isCompatibleVersion("0.9.3", millVersion)
-      
+
     if (useBloopPackage)
       "mill.contrib.bloop.Bloop/install"
     else "mill.contrib.Bloop/install"
@@ -95,7 +95,7 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
 
   override def bloopInstallArgs(workspace: AbsolutePath): List[String] = {
     val millVersion = getMillVersion(workspace)
-      
+
     val cmd =
       bloopImportArgs(millVersion) ::: bloopCmd(millVersion) :: Nil
     putTogetherArgs(cmd, millVersion, workspace)

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -82,11 +82,22 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
       "--import" :: "ivy:com.lihaoyi::mill-contrib-bloop:" :: Nil
     else "--predef" :: predefScriptPath.toString :: Nil
   }
+        
+  private def bloopCmd(millVersion: String) = {
+    // Bloop was moved to the bloop package in 0.9.3
+    // https://github.com/com-lihaoyi/mill/pull/992
+    val useBloopPackage = SemVer.isCompatibleVersion("0.9.3", millVersion)
+      
+    if (useBloopPackage)
+      "mill.contrib.bloop.Bloop/install"
+    else "mill.contrib.Bloop/install"
+  }
 
   override def bloopInstallArgs(workspace: AbsolutePath): List[String] = {
     val millVersion = getMillVersion(workspace)
+      
     val cmd =
-      bloopImportArgs(millVersion) ::: "mill.contrib.Bloop/install" :: Nil
+      bloopImportArgs(millVersion) ::: bloopCmd(millVersion) :: Nil
     putTogetherArgs(cmd, millVersion, workspace)
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -123,7 +123,7 @@ object UserConfiguration {
         """empty string `""`.""",
         """"/usr/local/bin/mill"""",
         "Mill script",
-        """Optional absolute path to a `mill` executable to use for running `mill mill.contrib.Bloop/install`.
+        """Optional absolute path to a `mill` executable to use for running `mill mill.contrib.bloop.Bloop/install`.
           |By default, Metals uses mill wrapper script with 0.5.0 mill version. Update this setting if your `mill` script requires more customizations
           |like using environment variables.
           |""".stripMargin,


### PR DESCRIPTION
The bloop contrib module was moved to the bloop package as part of 0.9.3. 

Without adding the bloop package, the bloop install command doesn't work on the latest milestone releases.

Ref: https://github.com/com-lihaoyi/mill/pull/992