### PR TITLE
Keep exception cause in some mtags exceptions

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -2360,9 +2360,9 @@ class MetalsLspService(
         case e @ (_: ParseException | _: TokenizeException) =>
           scribe.error(e.toString)
         case e: IndexingExceptions.InvalidJarException =>
-          scribe.warn(s"invalid jar: ${e.path}", e.underlying)
+          scribe.warn(s"invalid jar: ${e.path}", e.getCause)
         case e: IndexingExceptions.PathIndexingException =>
-          scribe.error(s"issues while parsing: ${e.path}", e.underlying)
+          scribe.error(s"issues while parsing: ${e.path}", e.getCause)
         case e: IndexingExceptions.InvalidSymbolException =>
           reports.incognito.create(
             Report(
@@ -2371,7 +2371,7 @@ class MetalsLspService(
               e,
             )
           )
-          scribe.error(s"searching for `${e.symbol}` failed", e.underlying)
+          scribe.error(s"searching for `${e.symbol}` failed", e.getCause)
         case _: NoSuchFileException =>
         // only comes for badly configured jar with `/Users` path added.
         case NonFatal(e) =>

--- a/mtags/src/main/scala/scala/meta/internal/mtags/IndexingExceptions.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/IndexingExceptions.scala
@@ -3,12 +3,12 @@ package scala.meta.internal.mtags
 import scala.meta.io.AbsolutePath
 
 object IndexingExceptions {
-  case class InvalidJarException(path: AbsolutePath, underlying: Throwable)
-      extends Exception(path.toString)
+  class InvalidJarException(val path: AbsolutePath, underlying: Throwable)
+      extends Exception(path.toString, underlying)
 
-  case class InvalidSymbolException(symbol: String, underlying: Throwable)
-      extends Exception(symbol)
+  class InvalidSymbolException(val symbol: String, underlying: Throwable)
+      extends Exception(symbol, underlying)
 
-  case class PathIndexingException(path: AbsolutePath, underlying: Throwable)
-      extends Exception(path.toString())
+  class PathIndexingException(val path: AbsolutePath, underlying: Throwable)
+      extends Exception(path.toString(), underlying)
 }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
@@ -47,7 +47,7 @@ final class OnDemandSymbolIndex(
     catch {
       case NonFatal(e) =>
         onErrorOption(
-          IndexingExceptions.InvalidSymbolException(symbol.value, e)
+          new IndexingExceptions.InvalidSymbolException(symbol.value, e)
         )
     }
   }
@@ -56,7 +56,7 @@ final class OnDemandSymbolIndex(
     try findSymbolDefinition(symbol)
     catch {
       case NonFatal(e) =>
-        onError(IndexingExceptions.InvalidSymbolException(symbol.value, e))
+        onError(new IndexingExceptions.InvalidSymbolException(symbol.value, e))
         List.empty
     }
 
@@ -83,10 +83,10 @@ final class OnDemandSymbolIndex(
           getOrCreateBucket(dialect).addSourceJar(jar)
         } catch {
           case e: ZipError =>
-            onError(IndexingExceptions.InvalidJarException(jar, e))
+            onError(new IndexingExceptions.InvalidJarException(jar, e))
             List.empty
           case e: ZipException =>
-            onError(IndexingExceptions.InvalidJarException(jar, e))
+            onError(new IndexingExceptions.InvalidJarException(jar, e))
             List.empty
         }
       }
@@ -128,7 +128,7 @@ final class OnDemandSymbolIndex(
     try thunk
     catch {
       case NonFatal(e) =>
-        onError(IndexingExceptions.PathIndexingException(path, e))
+        onError(new IndexingExceptions.PathIndexingException(path, e))
         fallback
     }
 


### PR DESCRIPTION
Passing the cause exception to the `Exception` contructor makes it easier for users to know what's going on: the JVM or the `printStackTrace` method will print the current exception and its cause (and the cause's cause, etc.). That way, we know in more detail what the underlying cause of the exception is.