### PR TITLE
fix: Fix reversed version order in dep completions in scala 2

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/mtags/CoursierComplete.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/mtags/CoursierComplete.scala
@@ -4,7 +4,6 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.Try
 import scala.util.matching.Regex
 
 import scala.meta.internal.jdk.CollectionConverters._
@@ -48,11 +47,7 @@ class CoursierComplete(scalaVersion: String) {
     val allCompletions = (scalaCompletions ++ javaCompletions).distinct
     // Attempt to sort versions in reverse order
     if (dependency.replaceAll(":+", ":").count(_ == ':') == 2)
-      Try {
-        allCompletions.sortWith(
-          Version.fromString(_) >= Version.fromString(_)
-        )
-      }.getOrElse(allCompletions.sortWith(_ >= _))
+      allCompletions.sortWith(Version.fromString(_) >= Version.fromString(_))
     else allCompletions
   }
 }

--- a/mtags-shared/src/main/scala/scala/meta/internal/semver/SemVer.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/semver/SemVer.scala
@@ -11,8 +11,8 @@ object SemVer {
       releaseCandidate: Option[Int] = None,
       milestone: Option[Int] = None,
       nightlyDate: Option[Int] = None
-  ) {
-    def >(that: Version): Boolean = {
+  ) extends Ordered[Version] {
+    override def >(that: Version): Boolean = {
       val diff = toList
         .zip(that.toList)
         .collectFirst {
@@ -21,9 +21,6 @@ object SemVer {
         .getOrElse(0)
       diff > 0
     }
-
-    def <(that: Version): Boolean =
-      that > this
 
     private def toList: List[Int] = {
       val rcMilestonePart =
@@ -36,11 +33,9 @@ object SemVer {
         List(nightlyDate.getOrElse(Int.MaxValue))
     }
 
-    def >=(that: Version): Boolean = this > that || this == that
-
     def compare(that: Version): Int =
       if (this > that) 1
-      else if (this < that) -1
+      else if (that > this) -1
       else 0
 
     override def toString: String =

--- a/mtags-shared/src/main/scala/scala/meta/internal/semver/SemVer.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/semver/SemVer.scala
@@ -38,6 +38,11 @@ object SemVer {
 
     def >=(that: Version): Boolean = this > that || this == that
 
+    def compare(that: Version): Int =
+      if (this > that) 1
+      else if (this < that) -1
+      else 0
+
     override def toString: String =
       List(
         Some(s"$major.$minor.$patch"),
@@ -51,7 +56,8 @@ object SemVer {
   object Version {
     def fromString(version: String): Version = {
       val parts = version.split("\\.|-")
-      val Array(major, minor, patch) = parts.take(3).map(_.toInt)
+      val Array(major, minor, patch) =
+        parts.take(3).map(part => Try { part.toInt }.getOrElse(0))
       val (rc, milestone) = parts
         .lift(3)
         .map { v =>

--- a/mtags-shared/src/main/scala/scala/meta/internal/semver/SemVer.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/semver/SemVer.scala
@@ -12,16 +12,6 @@ object SemVer {
       milestone: Option[Int] = None,
       nightlyDate: Option[Int] = None
   ) extends Ordered[Version] {
-    override def >(that: Version): Boolean = {
-      val diff = toList
-        .zip(that.toList)
-        .collectFirst {
-          case (a, b) if a - b != 0 => a - b
-        }
-        .getOrElse(0)
-      diff > 0
-    }
-
     private def toList: List[Int] = {
       val rcMilestonePart =
         releaseCandidate
@@ -33,10 +23,17 @@ object SemVer {
         List(nightlyDate.getOrElse(Int.MaxValue))
     }
 
-    def compare(that: Version): Int =
-      if (this > that) 1
-      else if (that > this) -1
-      else 0
+    def compare(that: Version): Int = {
+      val diff: Int = toList
+        .zip(that.toList)
+        .collectFirst {
+          case (a, b) if a - b != 0 => a - b
+        }
+        .getOrElse(0)
+      if (diff == 0) 0
+      else if (diff > 0) 1
+      else -1
+    }
 
     override def toString: String =
       List(

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -95,6 +95,8 @@ class CompletionProvider(
           s"$escaped = "
         case o: OverrideDefMember =>
           o.label
+        case d: DependecyMember =>
+          d.label
         case o: TextEditMember =>
           o.label.getOrElse(labelWithSig)
         case o: WorkspaceMember =>
@@ -125,6 +127,8 @@ class CompletionProvider(
           item.setFilterText(i.filterText)
         case i: OverrideDefMember =>
           item.setFilterText(i.filterText)
+        case i: DependecyMember =>
+          item.setFilterText(i.dependency)
         case _ =>
           // Explicitly set filter text because the label has method signature and
           // fully qualified name.
@@ -146,6 +150,8 @@ class CompletionProvider(
         case i: OverrideDefMember =>
           item.setTextEdit(i.edit)
           item.setAdditionalTextEdits(i.autoImports.asJava)
+        case d: DependecyMember =>
+          item.setTextEdit(d.edit)
         case w: WorkspaceMember =>
           def createTextEdit(identifier: String) =
             textEdit(w.wrap(identifier), w.editRange.getOrElse(editRange))

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -50,6 +50,7 @@ class MetalsGlobal(
     with completions.ScaladocCompletions
     with completions.TypeCompletions
     with completions.OverrideCompletions
+    with completions.DependencyCompletions
     with completions.ScalaCliCompletions
     with completions.MillIvyCompletions
     with completions.SbtLibCompletions

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -51,6 +51,18 @@ trait Completions { this: MetalsGlobal =>
   class NamedArgMember(sym: Symbol)
       extends ScopeMember(sym, NoType, true, EmptyTree)
 
+  class DependecyMember(val dependency: String, val edit: l.TextEdit)
+      extends ScopeMember(
+        completionsSymbol(dependency),
+        NoType,
+        true,
+        EmptyTree
+      ) {
+    val label: String = dependency.stripPrefix(":")
+    def isVersion: Boolean =
+      label.takeWhile(_ != '-').forall(c => c.isDigit || c == '.')
+  }
+
   class TextEditMember(
       val filterText: String,
       val edit: l.TextEdit,

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/DependencyCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/DependencyCompletions.scala
@@ -1,0 +1,34 @@
+package scala.meta.internal.pc.completions
+
+import scala.meta.internal.pc.MetalsGlobal
+import scala.meta.internal.semver.SemVer.Version
+
+import org.eclipse.{lsp4j => l}
+
+trait DependencyCompletions {
+  this: MetalsGlobal =>
+
+  abstract class DependencyCompletion extends CompletionPosition {
+    override def compare(o1: Member, o2: Member): Int =
+      (o1, o2) match {
+        case (c1: DependecyMember, c2: DependecyMember)
+            if c1.isVersion && c2.isVersion =>
+          // For version completions, we want to show the latest version first
+          Version.fromString(c2.label).compare(Version.fromString(c1.label))
+        case _ => super.compare(o1, o2)
+      }
+
+    def makeMembers(
+        completions: List[String],
+        editRange: l.Range
+    ): List[DependecyMember] =
+      completions
+        .map(insertText =>
+          new DependecyMember(
+            dependency = insertText,
+            edit = new l.TextEdit(editRange, insertText)
+          )
+        )
+  }
+
+}

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MillIvyCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MillIvyCompletions.scala
@@ -4,8 +4,6 @@ import scala.meta.internal.mtags.CoursierComplete
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.pc.MetalsGlobal
 
-import org.eclipse.{lsp4j => l}
-
 trait MillIvyCompletions {
   this: MetalsGlobal =>
   object MillIvyExtractor {
@@ -30,7 +28,7 @@ trait MillIvyCompletions {
       pos: Position,
       text: String,
       dependency: String
-  ) extends CompletionPosition {
+  ) extends DependencyCompletion {
     override def contribute: List[Member] = {
       val completions =
         coursierComplete.complete(dependency.replace(CURSOR, ""))
@@ -38,15 +36,8 @@ trait MillIvyCompletions {
         CoursierComplete.inferEditRange(pos.point, text)
       val editRange = pos.withStart(editStart).withEnd(editEnd).toLsp
 
-      completions
-        .map(insertText =>
-          new TextEditMember(
-            filterText = insertText,
-            edit = new l.TextEdit(editRange, insertText),
-            sym = completionsSymbol(insertText),
-            label = Some(insertText.stripPrefix(":"))
-          )
-        )
+      makeMembers(completions, editRange)
+
     }
   }
 }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/SbtLibCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/SbtLibCompletions.scala
@@ -3,8 +3,6 @@ package scala.meta.internal.pc.completions
 import scala.meta.internal.mtags.CoursierComplete
 import scala.meta.internal.pc.MetalsGlobal
 
-import org.eclipse.{lsp4j => l}
-
 trait SbtLibCompletions {
   this: MetalsGlobal =>
 
@@ -62,8 +60,9 @@ trait SbtLibCompletions {
       coursierComplete: CoursierComplete,
       pos: Position,
       dependency: String
-  ) extends CompletionPosition {
-    override def contribute: List[TextEditMember] = {
+  ) extends DependencyCompletion {
+
+    override def contribute: List[Member] = {
       val cursorLen = if (dependency.contains(CURSOR)) CURSOR.length() else 0
       val completions =
         coursierComplete.complete(
@@ -73,15 +72,8 @@ trait SbtLibCompletions {
       val editRange =
         pos.withStart(pos.start + 1).withEnd(pos.end - 1 - cursorLen).toLsp
 
-      completions
-        .map(insertText =>
-          new TextEditMember(
-            filterText = insertText,
-            edit = new l.TextEdit(editRange, insertText),
-            sym = completionsSymbol(insertText),
-            label = Some(insertText)
-          )
-        )
+      makeMembers(completions, editRange)
+
     }
   }
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.pc.completions
 
 import scala.meta.internal.mtags.CoursierComplete
 import scala.meta.internal.pc.MetalsGlobal
+import scala.meta.internal.semver.SemVer.Version
 
 import org.eclipse.{lsp4j => l}
 
@@ -39,7 +40,8 @@ trait ScalaCliCompletions {
         case (c1: TextEditMember, c2: TextEditMember) =>
           val (comp1, comp2) = (c1.edit.getNewText(), c2.edit.getNewText())
           // For version completions, we want to show the latest version first
-          if (comp1.headOption.exists(_.isDigit)) -comp1.compareTo(comp2)
+          if (comp1.headOption.exists(_.isDigit))
+            Version.fromString(comp2).compare(Version.fromString(comp1))
           else super.compare(o1, o2)
         case _ => super.compare(o1, o2)
       }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
@@ -34,6 +34,16 @@ trait ScalaCliCompletions {
       dependency: String
   ) extends CompletionPosition {
 
+    override def compare(o1: Member, o2: Member): Int =
+      (o1, o2) match {
+        case (c1: TextEditMember, c2: TextEditMember) =>
+          val (comp1, comp2) = (c1.edit.getNewText(), c2.edit.getNewText())
+          // For version completions, we want to show the latest version first
+          if (comp1.headOption.exists(_.isDigit)) -comp1.compareTo(comp2)
+          else super.compare(o1, o2)
+        case _ => super.compare(o1, o2)
+      }
+
     override def contribute: List[Member] = {
       val completions =
         coursierComplete.complete(dependency)

--- a/tests/cross/src/test/scala/tests/pc/CompletionScalaCliSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScalaCliSuite.scala
@@ -132,6 +132,18 @@ class CompletionScalaCliSuite extends BaseCompletionSuite {
     "circe-core_native0.4",
   )
 
+  check(
+    "version-sort",
+    """|//> using dep "com.lihaoyi::pprint:0.7@@"
+       |package A
+       |""".stripMargin,
+    """|0.7.3
+       |0.7.2
+       |0.7.1
+       |0.7.0
+       |""".stripMargin,
+  )
+
   private def scriptWrapper(code: String, filename: String): String =
     // Vaguely looks like a scala file that ScalaCLI generates
     // from a sc file.


### PR DESCRIPTION
In Scala 2 completions for dependencies where sorted in wrong order