### PR TITLE
fix: Arg completions for case class in nested apply

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
@@ -47,10 +47,10 @@ abstract class PcCollector[T](
   def symbolAlternatives(sym: Symbol): Set[Symbol] = {
     val all =
       if (sym.isClass) {
-        if (sym.owner.isMethod) Set(sym) ++ localCompanion(sym)
+        if (sym.owner.isMethod) Set(sym) ++ sym.localCompanion(pos)
         else Set(sym, sym.companionModule, sym.companion.moduleClass)
       } else if (sym.isModuleOrModuleClass) {
-        if (sym.owner.isMethod) Set(sym) ++ localCompanion(sym)
+        if (sym.owner.isMethod) Set(sym) ++ sym.localCompanion(pos)
         else Set(sym, sym.companionClass, sym.moduleClass)
       } else if (sym.isTerm && (sym.owner.isClass || sym.owner.isConstructor)) {
         val info =
@@ -73,20 +73,7 @@ abstract class PcCollector[T](
    * @param sym symbol to find a companion for
    * @return companion if it exists
    */
-  def localCompanion(sym: Symbol): Option[Symbol] = {
-    val nameToLookFor =
-      if (sym.isModuleClass) sym.name.companionName.companionName
-      else sym.name.companionName
-    val context = doLocateImportContext(pos)
-    context.lookupSymbol(
-      nameToLookFor,
-      s => s.owner == sym.owner
-    ) match {
-      case LookupSucceeded(_, symbol) =>
-        Some(symbol)
-      case _ => None
-    }
-  }
+
   def adjust(
       pos: Position,
       forRename: Boolean = false
@@ -154,7 +141,7 @@ abstract class PcCollector[T](
                   else
                     applyOwner.companion match {
                       case NoSymbol =>
-                        localCompanion(applyOwner).getOrElse(NoSymbol)
+                        applyOwner.localCompanion(pos).getOrElse(NoSymbol)
                       case comp => comp
                     }
                 val info = constructorOwner.info

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -592,4 +592,111 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |""".stripMargin,
     topLines = Some(2),
   )
+
+  check(
+    "case-class-apply",
+    """|object Main {
+       |  def m() = {
+       |    case class A(foo: Int, fooBar: Int)
+       |    println(A(foo@@))
+       |  }
+       |}
+       |""".stripMargin,
+    """|foo = : Int
+       |fooBar = : Int
+       |""".stripMargin,
+    topLines = Some(2),
+  )
+
+  check(
+    "case-class-apply1",
+    """|object Main {
+       |  def m() = {
+       |    case class A(foo: Int, fooBar: Int)
+       |    object A { def apply(foo: Int) = new A(foo, 3) }
+       |    println(A(foo@@))
+       |  }
+       |}
+       |""".stripMargin,
+    """|foo = : Int
+       |""".stripMargin,
+  )
+
+  check(
+    "case-class-apply2",
+    """|object Main {
+       |  def m() = {
+       |    case class A(foo: Int, fooBar: Int)
+       |    object A { def apply(foo: Int) = new A(foo, 3) }
+       |    println(A(foo = 1, foo@@))
+       |  }
+       |}
+       |""".stripMargin,
+    """|fooBar = : Int
+       |""".stripMargin,
+  )
+
+  check(
+    "case-class-apply3",
+    """|case class A(val foo: Int, val fooBar: Int)
+       |object A {
+       |  def apply(foo: Int): A = new A(foo, 3)
+       |}
+       |
+       |object Main {
+       |  for {
+       |      a <- List(1, 2, 3)
+       |      x = A(foo@@)
+       |   }
+       |}
+       |""".stripMargin,
+    """|foo = : Int
+       |foo = a : Int
+       |""".stripMargin,
+  )
+
+  check(
+    "case-class-apply4",
+    """|case class A(val foo: Int, val fooBar: Int)
+       |object A {
+       |  def apply(foo: Int): A = new A(foo, 3)
+       |}
+       |
+       |object Main {
+       |  for {
+       |      a <- List(1, 2, 3)
+       |      x = A(foo = 1, foo@@)
+       |   }
+       |}
+       |""".stripMargin,
+    """|fooBar = : Int
+       |fooBar = a : Int
+       |""".stripMargin,
+  )
+
+  check(
+    "case-class-for-comp",
+    """|case class Abc(foo: Int, fooBar: Int)
+       |object Main {
+       |   for {
+       |      a <- List(1, 2, 3)
+       |      x = Abc(foo@@)
+       |   }
+       |}
+       |""".stripMargin,
+    """|foo = : Int
+       |fooBar = : Int
+       |foo = a : Int
+       |fooBar = a : Int
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|foo = : Int
+           |foo = a : Int
+           |fooBar = : Int
+           |fooBar = a : Int
+           |""".stripMargin
+    ),
+    topLines = Some(4),
+  )
 }


### PR DESCRIPTION
fixes https://github.com/scalameta/metals/issues/5156

Sometimes on nested apply we get `method.tpe == null`, for which we have fallback way to get parameters. The cases were in wrong order, since for classes (and now case classes) there is a simpler way. 