### PR TITLE
feature: create single http server and doctor result

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -41,11 +41,24 @@ object ClientCommands {
         |   */
         |  version: String;
         |  /**
-        |   * Contains decisions that were made about what build tool or build server
-        |   * the user has chosen. There is also other brief information about understanding
+        |   * Contains metals version and jdk info and a brief information about understanding
         |   * the Doctor placed in here as well. (since version 3 (replaces headerText))
         |   */
         |   header: DoctorHeader;
+        |   /**
+        |   * Troubleshooting help for each workspace folder.
+        |   */
+        |   folders: DoctorFolderResult[];
+        |}
+        |
+        |```
+        |```json
+        |export interface DoctorFolderResult {
+        |   /**
+        |   * Contains decisions that were made about what build tool or build server
+        |   * the user has chosen.
+        |   */
+        |   header: DoctorFolderHeader
         |   /**
         |    * If build targets are detected in your workspace, they will be listed here with
         |    * the status of related functionality of Metals for each build target.
@@ -56,10 +69,19 @@ object ClientCommands {
         |   /** Explanations for the various statuses present in the doctor */
         |   explanations?: DoctorExplanation[];
         |}
-        |
         |```
         |```json
         |export interface DoctorHeader {
+        |  /** java version and location information */
+        |  jdkInfo?: string;
+        |  /** the version of the server that is being used */
+        |  serverInfo: string;
+        |  /** small description on what a build target is */
+        |  buildTargetDescription: string;
+        |}
+        |```
+        |```json
+        |export interface DoctorFolderHeader {
         |  /** if Metals detected multiple build tools, this specifies the one the user has chosen */
         |  buildTool?: string;
         |  /** the build server that is being used */
@@ -68,12 +90,6 @@ object ClientCommands {
         |   *  how to get it back.
         |   */
         |  importBuildStatus?: string;
-        |  /** java version and location information */
-        |  jdkInfo?: string;
-        |  /** the version of the server that is being used */
-        |  serverInfo: string;
-        |  /** small description on what a build target is */
-        |  buildTargetDescription: string;
         |}
         |```
         |```json

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -27,7 +27,6 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.clients.language.DelegatingLanguageClient
 import scala.meta.internal.metals.clients.language.ForwardingMetalsBuildClient
 import scala.meta.internal.metals.debug.BuildTargetClasses
-import scala.meta.internal.metals.doctor.Doctor
 import scala.meta.internal.metals.watcher.FileWatcher
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.semanticdb.Scala._
@@ -47,7 +46,7 @@ import org.eclipse.lsp4j.Position
  */
 final case class Indexer(
     workspaceReload: () => WorkspaceReload,
-    doctor: () => Doctor,
+    doctorCheck: () => Unit,
     languageClient: DelegatingLanguageClient,
     bspSession: () => Option[BspSession],
     executionContext: ExecutionContextExecutorService,
@@ -97,7 +96,7 @@ final case class Indexer(
         .flatMap(_ => importBuild(session))
         .map { _ =>
           scribe.info("Correctly reloaded workspace")
-          profiledIndexWorkspace(() => doctor().check())
+          profiledIndexWorkspace(doctorCheck)
           workspaceReload().persistChecksumStatus(Status.Installed, buildTool)
           BuildChange.Reloaded
         }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -52,7 +52,7 @@ import scala.meta.internal.metals.codelenses.WorksheetCodeLens
 import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.metals.debug.DebugProvider
 import scala.meta.internal.metals.doctor.Doctor
-import scala.meta.internal.metals.doctor.DoctorVisibilityDidChangeParams
+import scala.meta.internal.metals.doctor.HeadDoctor
 import scala.meta.internal.metals.findfiles._
 import scala.meta.internal.metals.formatting.OnTypeFormattingProvider
 import scala.meta.internal.metals.formatting.RangeFormattingProvider
@@ -85,7 +85,6 @@ import scala.meta.tokenizers.TokenizeException
 
 import ch.epfl.scala.bsp4j.CompileReport
 import ch.epfl.scala.{bsp4j => b}
-import io.undertow.server.HttpServerExchange
 import org.eclipse.lsp4j.ExecuteCommandParams
 import org.eclipse.lsp4j._
 import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
@@ -127,6 +126,7 @@ class MetalsLspService(
     initTreeView: () => Unit,
     val folder: AbsolutePath,
     folderVisibleName: Option[String],
+    headDoctor: HeadDoctor,
 ) extends Cancelable
     with TextDocumentService {
   import serverInputs._
@@ -235,7 +235,7 @@ class MetalsLspService(
     () => testProvider.refreshTestSuites(),
     () => {
       if (clientConfig.isDoctorVisibilityProvider())
-        doctor.executeRefreshDoctor()
+        headDoctor.executeRefreshDoctor()
       else ()
     },
     buildTarget => focusedDocumentBuildTarget.get() == buildTarget,
@@ -692,19 +692,19 @@ class MetalsLspService(
     languageClient,
   )
 
-  private val doctor: Doctor = new Doctor(
+  val doctor: Doctor = new Doctor(
     folder,
     buildTargets,
     diagnostics,
     languageClient,
     () => bspSession,
     () => bspConnector.resolve(),
-    () => httpServer,
     tables,
     clientConfig,
     mtagsResolver,
     () => userConfig().javaHome,
     maybeJdkVersion,
+    getVisibleName,
   )
 
   val gitHubIssueFolderInfo = new GitHubIssueFolderInfo(
@@ -742,8 +742,6 @@ class MetalsLspService(
 
   def loadedPresentationCompilerCount(): Int =
     compilers.loadedPresentationCompilerCount()
-
-  var httpServer: Option[MetalsHttpServer] = None
 
   val treeView =
     new FolderTreeViewProvider(
@@ -787,7 +785,7 @@ class MetalsLspService(
     folder,
     tables,
     languageClient,
-    doctor,
+    headDoctor.executeRefreshDoctor,
     () => slowConnectToBuildServer(forceImport = true),
     bspConnector,
     () => quickConnectToBuildServer(),
@@ -876,55 +874,17 @@ class MetalsLspService(
     }
   }
 
-  private def startHttpServer(workspaceLspServer: WorkspaceLspService): Unit = {
-    if (clientConfig.isHttpEnabled) {
-      val host = "localhost"
-      val port = 5031
-      var url = s"http://$host:$port"
-      var render: () => String = () => ""
-      var completeCommand: HttpServerExchange => Unit = (_) => ()
-      val server = register(
-        MetalsHttpServer(
-          host,
-          port,
-          () => render(),
-          e => completeCommand(e),
-          () => doctor.problemsHtmlPage(url),
-          (uri) => fileDecoderProvider.getTastyForURI(uri),
-          workspaceLspServer,
-        )
-      )
-      httpServer = Some(server)
-      val newClient = new MetalsHttpClient(
-        folder,
-        () => url,
-        languageClient.underlying,
-        () => server.reload(),
-        clientConfig.icons,
-        time,
-        sh,
-        clientConfig,
-      )
-      render = () => newClient.renderHtml
-      completeCommand = e => newClient.completeCommand(e)
-      languageClient.underlying = newClient
-      server.start()
-      url = server.address
-    }
-  }
-
   val isInitialized = new AtomicBoolean(false)
 
   def connectTables(): Connection = tables.connect()
 
-  def initialized(server: WorkspaceLspService): Future[Unit] =
+  def initialized(): Future[Unit] =
     Future
       .sequence(
         List[Future[Unit]](
           quickConnectToBuildServer().ignoreValue,
           slowConnectToBuildServer(forceImport = false).ignoreValue,
           Future(workspaceSymbols.indexClasspath()),
-          Future(startHttpServer(server)),
           Future(formattingProvider.load()),
         )
       )
@@ -1671,12 +1631,6 @@ class MetalsLspService(
 
   def restartCompiler(): Future[Unit] = Future { compilers.restartAll() }
 
-  def runDoctor(): Future[Unit] =
-    Future {
-      doctor.onVisibilityDidChange(true)
-      doctor.executeRunDoctor()
-    }
-
   def getLocationForSymbol(symbol: String): Option[Location] =
     definitionProvider
       .fromSymbol(symbol, focusedDocument())
@@ -1817,13 +1771,6 @@ class MetalsLspService(
       newPath: AbsolutePath,
   ): Future[WorkspaceEdit] =
     packageProvider.willMovePath(oldPath, newPath)
-
-  def doctorVisibilityDidChange(
-      params: DoctorVisibilityDidChangeParams
-  ): Future[Unit] =
-    Future {
-      doctor.onVisibilityDidChange(params.visible)
-    }
 
   def findTextInDependencyJars(
       params: FindTextInDependencyJarsRequest
@@ -2136,7 +2083,7 @@ class MetalsLspService(
     bspSession = Some(session)
     for {
       _ <- importBuild(session)
-      _ <- indexer.profiledIndexWorkspace(() => doctor.check())
+      _ <- indexer.profiledIndexWorkspace(runDoctorCheck)
       _ = if (session.main.isBloop) checkRunningBloopVersion(session.version)
     } yield {
       BuildChange.Reconnected
@@ -2163,7 +2110,7 @@ class MetalsLspService(
 
   private val indexer = Indexer(
     () => workspaceReload,
-    () => doctor,
+    runDoctorCheck,
     languageClient,
     () => bspSession,
     executionContext,
@@ -2552,4 +2499,10 @@ class MetalsLspService(
       }
       .flatMap(_ => autoConnectToBuildServer().map(_ => ()))
   }
+
+  def getTastyForURI(uri: URI): Future[Either[String, String]] =
+    fileDecoderProvider.getTastyForURI(uri)
+
+  def runDoctorCheck(): Unit = doctor.check(headDoctor)
+
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/PopupChoiceReset.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/PopupChoiceReset.scala
@@ -7,7 +7,6 @@ import scala.meta.internal.bsp.BspConnector
 import scala.meta.internal.bsp.BuildChange
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
-import scala.meta.internal.metals.doctor.Doctor
 import scala.meta.io.AbsolutePath
 
 import org.eclipse.lsp4j.MessageActionItem
@@ -18,7 +17,7 @@ class PopupChoiceReset(
     workspace: AbsolutePath,
     tables: Tables,
     languageClient: MetalsLanguageClient,
-    doctor: Doctor,
+    executeRefreshDoctor: () => Unit,
     slowConnect: () => Future[BuildChange],
     bspConnector: BspConnector,
     quickConnect: () => Future[BuildChange],
@@ -45,7 +44,7 @@ class PopupChoiceReset(
     } else {
       Future.successful(())
     }
-    result.foreach(_ => doctor.executeRefreshDoctor())
+    result.foreach(_ => executeRefreshDoctor())
     result
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals
 
+import java.net.URI
 import java.nio.file.ProviderMismatchException
 import java.util.concurrent.CompletableFuture
 import java.{util => ju}
@@ -25,6 +26,7 @@ import scala.meta.internal.metals.debug.BuildTargetNotFoundException
 import scala.meta.internal.metals.debug.BuildTargetUndefinedException
 import scala.meta.internal.metals.debug.DebugProvider
 import scala.meta.internal.metals.doctor.DoctorVisibilityDidChangeParams
+import scala.meta.internal.metals.doctor.HeadDoctor
 import scala.meta.internal.metals.findfiles.FindTextInDependencyJarsRequest
 import scala.meta.internal.metals.logging.LanguageClientLogger
 import scala.meta.internal.parsing.ClassFinderGranularity
@@ -48,6 +50,7 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
+import io.undertow.server.HttpServerExchange
 import org.eclipse.lsp4j
 import org.eclipse.lsp4j.CallHierarchyIncomingCall
 import org.eclipse.lsp4j.CallHierarchyIncomingCallsParams
@@ -106,6 +109,7 @@ class WorkspaceLspService(
   implicit val ex: ExecutionContextExecutorService = ec
   implicit val rc: ReportContext = LoggerReportContext
   private val cancelables = new MutableCancelable()
+  var httpServer: Option[MetalsHttpServer] = None
 
   private val clientConfig =
     ClientConfiguration(
@@ -141,6 +145,14 @@ class WorkspaceLspService(
 
   private val timerProvider: TimerProvider = new TimerProvider(time)
 
+  val doctor: HeadDoctor =
+    new HeadDoctor(
+      () => folderServices.map(_.doctor),
+      () => httpServer,
+      clientConfig,
+      languageClient,
+    )
+
   def createService(folder: Folder): MetalsLspService =
     folder match {
       case Folder(uri, name) =>
@@ -159,6 +171,7 @@ class WorkspaceLspService(
           initTreeView,
           uri,
           name,
+          doctor,
         )
     }
 
@@ -166,7 +179,7 @@ class WorkspaceLspService(
     new WorkspaceFolders(
       folders,
       createService,
-      _.initialized(this),
+      _.initialized(),
       () => shutdown().asScala,
       redirectSystemOut,
     )
@@ -565,20 +578,12 @@ class WorkspaceLspService(
   ): CompletableFuture[ju.List[Location]] =
     collectSeq(_.findTextInDependencyJars(params))(_.flatten.asJava).asJava
 
-  override def doctorVisibilityDidChange(
+  def doctorVisibilityDidChange(
       params: DoctorVisibilityDidChangeParams
-  ): CompletableFuture[Unit] = {
-    focusedDocument
-      .flatMap(getServiceForOpt)
-      .map(_.doctorVisibilityDidChange(params))
-      .getOrElse(
-        /* If we can't find the focused document, we still want to notify all the services.
-         * If a doctor is not visible this will have no effect.
-         */
-        Future.sequence(folderServices.map(_.doctorVisibilityDidChange(params)))
-      )
-      .asJavaUnit
-  }
+  ): CompletableFuture[Unit] =
+    Future {
+      doctor.onVisibilityDidChange(params.visible)
+    }.asJava
 
   override def didFocus(
       params: AnyRef
@@ -695,7 +700,9 @@ class WorkspaceLspService(
           else ClassFinderGranularity.Tasty
         getServiceFor(uri).chooseClass(uri, searchGranularity).asJavaObject
       case ServerCommands.RunDoctor() =>
-        onCurrentFolder(_.runDoctor(), "run doctor").asJavaObject
+        Future {
+          doctor.executeRunDoctor()
+        }.asJavaObject
       case ServerCommands.ZipReports() =>
         Future {
           val zip =
@@ -1096,10 +1103,49 @@ class WorkspaceLspService(
       service.connectTables()
     }
     syncUserconfiguration().flatMap { _ =>
-      Future // TODO:: change to single http server (https://github.com/scalameta/metals/issues/5129)
-        //                       and remove this ---v
-        .sequence(folderServices.map(_.initialized(this)))
+      Future
+        .sequence(folderServices.map(_.initialized()))
+        .flatMap(_ => Future(startHttpServer()))
         .ignoreValue
+    }
+  }
+
+  private def startHttpServer(): Unit = {
+    if (clientConfig.isHttpEnabled) {
+      val host = "localhost"
+      val port = 5031
+      var url = s"http://$host:$port"
+      var render: () => String = () => ""
+      var completeCommand: HttpServerExchange => Unit = (_) => ()
+      def getTestyForURI(uri: URI) =
+        getServiceFor(uri.toAbsolutePath).getTastyForURI(uri)
+      val server = register(
+        MetalsHttpServer(
+          host,
+          port,
+          () => render(),
+          e => completeCommand(e),
+          () => doctor.problemsHtmlPage(url),
+          getTestyForURI,
+          this,
+        )
+      )
+      httpServer = Some(server)
+      val newClient = new MetalsHttpClient(
+        folders.map(_.path),
+        () => url,
+        languageClient.underlying,
+        () => server.reload(),
+        clientConfig.icons,
+        time,
+        sh,
+        clientConfig,
+      )
+      render = () => newClient.renderHtml
+      completeCommand = e => newClient.completeCommand(e)
+      languageClient.underlying = newClient
+      server.start()
+      url = server.address
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsHttpClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsHttpClient.scala
@@ -48,7 +48,7 @@ import org.eclipse.lsp4j.ShowMessageRequestParams
  * and respond to UI dialogues through their browser instead.
  */
 final class MetalsHttpClient(
-    workspace: AbsolutePath,
+    folders: List[AbsolutePath],
     url: () => String,
     initial: MetalsLanguageClient,
     triggerReload: () => Unit,
@@ -252,14 +252,18 @@ final class MetalsHttpClient(
         .section("window/showMessage", showMessagesFormatted)
         .section(
           "window/logMessage",
-          _.text("Path: ")
-            .path(workspace.resolve(Directories.log).toNIO)
-            .element("section", "class='container is-dark'")(
-              _.element(
-                "pre",
-                "style='overflow:auto;max-height:400px;min-height:100px;color:white;'",
-              )(logsFormatted)
-            ),
+          builder =>
+            builder
+              .text("Paths: ")
+              .unorderedList(folders)(folder =>
+                builder.path(folder.resolve(Directories.log).toNIO)
+              )
+              .element("section", "class='container is-dark'")(
+                _.element(
+                  "pre",
+                  "style='overflow:auto;max-height:400px;min-height:100px;color:white;'",
+                )(logsFormatted)
+              ),
         )
         .section(
           "Log files",

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/HeadDoctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/HeadDoctor.scala
@@ -1,0 +1,157 @@
+package scala.meta.internal.metals.doctor
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.ClientCommands
+import scala.meta.internal.metals.ClientConfiguration
+import scala.meta.internal.metals.HtmlBuilder
+import scala.meta.internal.metals.MetalsHttpServer
+import scala.meta.internal.metals.ParametrizedCommand
+import scala.meta.internal.metals.Urls
+import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.config.DoctorFormat
+
+class HeadDoctor(
+    doctors: () => List[Doctor],
+    httpServer: () => Option[MetalsHttpServer],
+    clientConfig: ClientConfiguration,
+    languageClient: MetalsLanguageClient,
+) {
+  private val isVisible = new AtomicBoolean(false)
+
+  def onVisibilityDidChange(newState: Boolean): Unit = {
+    isVisible.set(newState)
+  }
+
+  /**
+   * Returns a full HTML page for the HTTP client.
+   */
+  def problemsHtmlPage(url: String): String = {
+    val livereload = Urls.livereload(url)
+    HtmlBuilder()
+      .page(
+        doctorTitle,
+        List(livereload, HtmlBuilder.htmlCSS),
+        HtmlBuilder.bodyStyle,
+      ) { html =>
+        html.section("Build targets", buildTargetsTable)
+      }
+      .render
+  }
+
+  /**
+   * Executes the "Run doctor" server command.
+   */
+  def executeRunDoctor(): Unit = {
+    onVisibilityDidChange(true)
+    executeDoctor(
+      clientCommand = ClientCommands.RunDoctor,
+      onServer = server => {
+        Urls.openBrowser(server.address + "/doctor")
+      },
+    )
+  }
+
+  def executeRefreshDoctor(): Unit =
+    executeDoctor(
+      clientCommand = ClientCommands.ReloadDoctor,
+      onServer = server => {
+        server.reload()
+      },
+    )
+
+  /**
+   * @param clientCommand RunDoctor or ReloadDoctor
+   * @param onServer piece of logic that will be executed when http server is enabled
+   */
+  private def executeDoctor(
+      clientCommand: ParametrizedCommand[String],
+      onServer: MetalsHttpServer => Unit,
+  ): Unit = {
+    val isVisibilityProvider = clientConfig.isDoctorVisibilityProvider()
+    val shouldDisplay = isVisibilityProvider && isVisible.get()
+    if (shouldDisplay || !isVisibilityProvider) {
+      if (
+        clientConfig.isExecuteClientCommandProvider && !clientConfig.isHttpEnabled
+      ) {
+        val output = clientConfig.doctorFormat match {
+          case DoctorFormat.Json => buildTargetsJson()
+          case DoctorFormat.Html => buildTargetsHtml()
+        }
+        val params = clientCommand.toExecuteCommandParams(output)
+        languageClient.metalsExecuteClientCommand(params)
+      } else {
+        httpServer() match {
+          case Some(server) =>
+            onServer(server)
+          case None =>
+            scribe.warn(
+              "Unable to run doctor. Make sure `isHttpEnabled` is set to `true`."
+            )
+        }
+      }
+    }
+  }
+
+  private def buildTargetsHtml(): String =
+    new HtmlBuilder()
+      .element("h1")(_.text(doctorTitle))
+      .call(buildTargetsTable)
+      .render
+
+  private def buildTargetsTable(html: HtmlBuilder): Unit = {
+    val jdkInfo = getJdkInfo()
+
+    jdkInfo.foreach { jdkMsg =>
+      html.element("p") { builder =>
+        builder.bold(jdkVersionTitle)
+        builder.text(jdkMsg)
+      }
+    }
+
+    html.element("p") { builder =>
+      builder.bold(serverVersionTitle)
+      builder.text(BuildInfo.metalsVersion)
+    }
+
+    html.element("p") {
+      _.text(buildTargetDescription)
+    }
+    val includeWorkspaceFolderName = areMultipleWorkspaceFolders
+    doctors().foreach(_.buildTargetsTable(html, includeWorkspaceFolderName))
+  }
+
+  private def buildTargetsJson(): String = {
+    val results = doctors().map(_.buildTargetsJson())
+    val jdkInfo = getJdkInfo().map(info => s"$jdkVersionTitle$info")
+    val serverInfo = s"$serverVersionTitle${BuildInfo.metalsVersion}"
+    val header = DoctorHeader(jdkInfo, serverInfo, buildTargetDescription)
+    val result =
+      DoctorResults(
+        doctorTitle,
+        header,
+        results,
+      ).toJson
+    ujson.write(result)
+  }
+
+  private def getJdkInfo(): Option[String] =
+    for {
+      version <- Option(System.getProperty("java.version"))
+      vendor <- Option(System.getProperty("java.vendor"))
+      home <- Option(System.getProperty("java.home"))
+    } yield s"$version from $vendor located at $home"
+
+  private def areMultipleWorkspaceFolders = doctors().length > 1
+
+  private val doctorTitle = "Metals Doctor"
+  private val jdkVersionTitle = "Metals Java: "
+  private val serverVersionTitle = "Metals Server version: "
+  private def buildTargetDescription =
+    "Below are listed the build targets " +
+      (if (areMultipleWorkspaceFolders) "for each workspace folder. "
+       else "for this workspace. ") +
+      "One build target corresponds to one classpath. For example, normally one sbt project maps to " +
+      "two build targets: main and test."
+}


### PR DESCRIPTION
Previously: For each workspace folder a separate http server was created and a separate doctor result was produced.
Now: Only a single http server is created and information from doctors is collected into a single doctor result.

resolves: https://github.com/scalameta/metals/issues/5129