### PR TITLE
fix: Fix highlight and rename for unapply in for-comp

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcDocumentHighlightProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcDocumentHighlightProvider.scala
@@ -18,6 +18,8 @@ final class PcDocumentHighlightProvider(
     tree match {
       case _: MemberDef =>
         new DocumentHighlight(pos.toLsp, DocumentHighlightKind.Write)
+      case _: Bind =>
+        new DocumentHighlight(pos.toLsp, DocumentHighlightKind.Write)
       case _ =>
         new DocumentHighlight(pos.toLsp, DocumentHighlightKind.Read)
     }

--- a/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
@@ -737,4 +737,21 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite {
       |  )
       |}""".stripMargin,
   )
+
+  check(
+    "for-comp-bind",
+    """
+      |object Main {
+      |  case class Bar(fooBar: Int, goo: Int)
+      |  val abc = for {
+      |    foo <- List(1)
+      |    _ = Option(1)
+      |    Bar(<<fooBar>>, goo) <- List(Bar(foo, 123))
+      |    baz = <<fooBar>> + goo
+      |  } yield {
+      |    val x = foo + <<foo@@Bar>> + baz
+      |    x
+      |  }
+      |}""".stripMargin,
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
@@ -451,4 +451,19 @@ class PcRenameSuite extends BasePcRenameSuite {
        |""".stripMargin,
     newName = "`other-rename`",
   )
+
+  check(
+    "for-comp-bind",
+    """
+      |case class Bar(fooBar: Int, goo: Int)
+      |val abc = for {
+      |  foo <- List(1)
+      |  _ = Option(1)
+      |  Bar(<<fooBar>>, goo) <- List(Bar(foo, 123))
+      |  baz = <<fooBar>> + goo
+      |} yield {
+      |  val x = foo + <<foo@@Bar>> + baz
+      |  x
+      |}""".stripMargin,
+  )
 }


### PR DESCRIPTION
Previously, if for-comprehension contained lines with `=`, highlight and rename haven't always seen symbols in unapply (eg. (a,b) <- List((1,2)))