### PR TITLE
bugfix: send folder name and uri with information about tests

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -203,6 +203,8 @@ object ClientCommands {
       |export interface BuildTargetUpdate {
       |  targetName: TargetName;
       |  targetUri: TargetUri;
+      |  folderName: FolderName;
+      |  folderUri: FolderUri;
       |  events: TestExplorerEvent[];
       |}
       |

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -469,6 +469,8 @@ class MetalsLspService(
     clientConfig,
     userConfig,
     languageClient,
+    getVisibleName,
+    folder,
   )
 
   private val codeLensProvider: CodeLensProvider = {

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/BuildTargetUpdate.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/BuildTargetUpdate.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.metals.testProvider
 
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTarget
 import org.eclipse.{lsp4j => l}
@@ -8,16 +9,22 @@ import org.eclipse.{lsp4j => l}
 final case class BuildTargetUpdate(
     targetName: String,
     targetUri: String,
+    folderName: String,
+    folderUri: String,
     events: java.util.List[TestExplorerEvent],
 )
 object BuildTargetUpdate {
   def apply(
       buildTarget: BuildTarget,
+      folderName: String,
+      folderUri: AbsolutePath,
       events: Seq[TestExplorerEvent],
   ): BuildTargetUpdate =
     BuildTargetUpdate(
       buildTarget.getDisplayName,
       buildTarget.getId.getUri,
+      folderName,
+      folderUri.toNIO.toString(),
       events.asJava,
     )
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -54,6 +54,8 @@ final class TestSuitesProvider(
     clientConfig: ClientConfiguration,
     userConfig: () => UserConfiguration,
     client: MetalsLanguageClient,
+    folderName: String,
+    folderUri: AbsolutePath,
 )(implicit ec: ExecutionContext)
     extends SemanticdbFeatureProvider
     with CodeLens {
@@ -105,7 +107,7 @@ final class TestSuitesProvider(
       val removeEvents = removed
         .groupBy(_.buildTarget)
         .map { case (buildTarget, entries) =>
-          BuildTargetUpdate(
+          buildTargetUpdate(
             buildTarget,
             entries.map(_.suiteDetails.asRemoveEvent),
           )
@@ -170,7 +172,7 @@ final class TestSuitesProvider(
       case Some(path0) => getTestCasesForPath(path0, None)
       case None =>
         index.allSuites.map { case (buildTarget, entries) =>
-          BuildTargetUpdate(
+          buildTargetUpdate(
             buildTarget,
             entries.map(_.suiteDetails.asAddEvent).toList,
           )
@@ -236,7 +238,7 @@ final class TestSuitesProvider(
     events
       .groupBy { case (target, _) => target }
       .map { case (buildTarget, events) =>
-        BuildTargetUpdate(
+        buildTargetUpdate(
           buildTarget,
           events.map { case (_, event) => event },
         )
@@ -267,7 +269,7 @@ final class TestSuitesProvider(
         }
         buildTarget <- metadata.entries.map(_.buildTarget).distinct
       } yield {
-        BuildTargetUpdate(buildTarget, events)
+        buildTargetUpdate(buildTarget, events)
       }
     buildTargetUpdates
   }
@@ -473,7 +475,7 @@ final class TestSuitesProvider(
         .filter { case (_, events) => events.nonEmpty }
 
     aggregated.map { case (target, events) =>
-      BuildTargetUpdate(target, events)
+      buildTargetUpdate(target, events)
     }.toList
   }
 
@@ -515,5 +517,16 @@ final class TestSuitesProvider(
       }
     entryOpt
   }
+
+  private def buildTargetUpdate(
+      buildTarget: BuildTarget,
+      events: Seq[TestExplorerEvent],
+  ): BuildTargetUpdate =
+    BuildTargetUpdate(
+      buildTarget,
+      folderName,
+      folderUri,
+      events,
+    )
 
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1001,7 +1001,11 @@ final case class TestingServer(
         }
     }
 
-    val compilations = paths.map(path => server.compilations.compileFile(path))
+    val compilations =
+      paths.map(path =>
+        fullServer.getServiceFor(path).compilations.compileFile(path)
+      )
+
     for {
       _ <- Future.sequence(compilations)
       _ <- waitFor(util.concurrent.TimeUnit.SECONDS.toMillis(1))

--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -47,7 +47,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
     ),
     () => {
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -83,7 +83,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
     List("app/src/main/scala/a/b/c/MunitTestSuite.scala"),
     () => {
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -146,7 +146,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
     ),
     () => {
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -210,7 +210,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
     List("app/src/main/scala/JunitTestSuite.scala"),
     () => {
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -290,7 +290,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
     List("app/src/main/scala/a/b/c/MunitTestSuite.scala"),
     () => {
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -383,7 +383,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
     List("app/src/main/scala/MunitTestSuite.scala"),
     () => {
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -440,7 +440,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
     List("app/src/main/scala/MunitTestSuite.scala"),
     () => {
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -511,7 +511,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       val symbol = "_empty_/JunitTestSuite#"
       val file = "app/src/main/scala/JunitTestSuite.scala"
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -560,7 +560,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       val symbol = "a/FunSuite#"
       val file = "app/src/main/scala/a/FunSuite.scala"
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -615,7 +615,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       val symbol = "a/b/WordSpec#"
       val file = "app/src/main/scala/a/b/WordSpec.scala"
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -676,7 +676,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       val symbol = "a/b/WordSpec#"
       val file = "app/src/main/scala/a/b/WordSpec.scala"
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -727,7 +727,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       val symbol = "_empty_/FlatSpec#"
       val file = "app/src/main/scala/FlatSpec.scala"
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -781,7 +781,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       val symbol = "_empty_/FunSpec#"
       val file = "app/src/main/scala/FunSpec.scala"
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -835,7 +835,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       val symbol = "_empty_/FreeSpec#"
       val file = "app/src/main/scala/FreeSpec.scala"
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -887,7 +887,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       val symbol = "_empty_/PropSpec#"
       val file = "app/src/main/scala/PropSpec.scala"
       List(
-        BuildTargetUpdate(
+        rootBuildTargetUpdate(
           "app",
           targetUri,
           List[TestExplorerEvent](
@@ -1009,4 +1009,16 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
   private def classUriFor(relativePath: String): String =
     workspace.resolve(relativePath).toURI.toString
 
+  private def rootBuildTargetUpdate(
+      targetName: String,
+      targetUri: String,
+      events: java.util.List[TestExplorerEvent],
+  ): BuildTargetUpdate =
+    BuildTargetUpdate(
+      targetName,
+      targetUri,
+      "root",
+      server.server.folder.toNIO.toString,
+      events,
+    )
 }


### PR DESCRIPTION
Previously: Test cases were identified by build target and fully-qualified identifier.
Now: They are also identified by folder information (name & uri).

resolves: https://github.com/scalameta/metals/issues/5189