### PR TITLE
bugfix: Always change the correct comment when changing to mill syntax

### DIFF
--- a/tests/unit/src/test/scala/tests/codeactions/MillifyScalaCliDependencyCodeActionSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/MillifyScalaCliDependencyCodeActionSuite.scala
@@ -1,5 +1,7 @@
 package tests.codeactions
 
+import scala.meta.internal.metals.BuildInfo
+
 class MillifyScalaCliDependencyCodeActionSuite
     extends BaseCodeActionLspSuite("millifyScalaCliDependency") {
   val sbtStyleDependency =
@@ -41,6 +43,28 @@ class MillifyScalaCliDependencyCodeActionSuite
         |""".stripMargin,
     s"""Convert to $convertedDependency""",
     s"""|//> using lib $convertedDependency
+        |
+        |object Hello extends App {
+        |  println("Hello")
+        |}
+        |""".stripMargin,
+    scalaCliOptions = List("--actions", "-S", scalaVersion),
+    expectNoDiagnostics = false,
+    scalaCliLayout = true,
+  )
+
+  check(
+    "convert-dependency-multiple",
+    s"""|//> using scala "${BuildInfo.scala213}"
+        |//> <<>>using lib $sbtStyleDependencyMultiSpace
+        |
+        |object Hello extends App {
+        |  println("Hello")
+        |}
+        |""".stripMargin,
+    s"""Convert to $convertedDependency""",
+    s"""|//> using scala "${BuildInfo.scala213}"
+        |//> using lib $convertedDependency
         |
         |object Hello extends App {
         |  println("Hello")


### PR DESCRIPTION
Previously, we would always update the first line whe updating using directive, which was caused by wrong positions in the Comment token since we only tokenized the current line for efficiency sake. Now, we properly adjust the range with the line number at which the cursor is at.