### PR TITLE
improvement: if no build tool fallback to scala-cli

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals
 
+import java.io.File
 import java.io.IOException
 import java.net.URI
 import java.nio.charset.StandardCharsets
@@ -293,6 +294,16 @@ object MetalsEnrichments
   }
 
   implicit class XtensionAbsolutePathBuffers(path: AbsolutePath) {
+
+    def hasScalaFiles: Boolean = {
+      def isScalaDir(file: File): Boolean = {
+        file.listFiles().exists { file =>
+          if (file.isDirectory()) isScalaDir(file)
+          else file.getName().endsWith(".scala")
+        }
+      }
+      path.isDirectory && isScalaDir(path.toFile)
+    }
 
     def scalaSourcerootOption: String = s""""-P:semanticdb:sourceroot:$path""""
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -881,17 +881,20 @@ class MetalsLspService(
   def connectTables(): Connection = tables.connect()
 
   def initialized(): Future[Unit] =
-    Future
-      .sequence(
-        List[Future[Unit]](
-          Future(buildTools.initialize()),
-          quickConnectToBuildServer().ignoreValue,
-          slowConnectToBuildServer(forceImport = false).ignoreValue,
-          Future(workspaceSymbols.indexClasspath()),
-          Future(formattingProvider.load()),
-        )
-      )
-      .ignoreValue
+    for {
+      _ <- maybeSetupScalaCli()
+      _ <-
+        Future
+          .sequence(
+            List[Future[Unit]](
+              Future(buildTools.initialize()),
+              quickConnectToBuildServer().ignoreValue,
+              slowConnectToBuildServer(forceImport = false).ignoreValue,
+              Future(workspaceSymbols.indexClasspath()),
+              Future(formattingProvider.load()),
+            )
+          )
+    } yield ()
 
   def onShutdown(): Unit = {
     tables.fingerprints.save(fingerprints.getAllFingerprints())
@@ -1904,7 +1907,16 @@ class MetalsLspService(
               tables.buildServers.chooseServer(ScalaCliBuildTool.name)
               quickConnectToBuildServer()
             case Some(digest) if isBloopOrEmpty =>
-              slowConnectToBloopServer(forceImport, buildTool, digest)
+              for {
+                _ <-
+                  if (scalaCli.loaded(folder)) scalaCli.stop()
+                  else Future.successful(())
+                buildChange <- slowConnectToBloopServer(
+                  forceImport,
+                  buildTool,
+                  digest,
+                )
+              } yield buildChange
             case Some(digest) =>
               indexer.reloadWorkspaceAndIndex(
                 forceImport,
@@ -1917,6 +1929,20 @@ class MetalsLspService(
           Future.successful(BuildChange.None)
       }
     } yield buildChange
+
+  /**
+   * If there is no auto-connectable build server and no supported build tool is found
+   * we assume it's a scala-cli project.
+   */
+  def maybeSetupScalaCli(): Future[Unit] = {
+    if (
+      !buildTools.isAutoConnectable
+      && buildTools.loadSupported.isEmpty
+      && folder.hasScalaFiles
+    ) {
+      scalaCli.setupIDE(folder)
+    } else Future.successful(())
+  }
 
   private def slowConnectToBloopServer(
       forceImport: Boolean,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1907,16 +1907,7 @@ class MetalsLspService(
               tables.buildServers.chooseServer(ScalaCliBuildTool.name)
               quickConnectToBuildServer()
             case Some(digest) if isBloopOrEmpty =>
-              for {
-                _ <-
-                  if (scalaCli.loaded(folder)) scalaCli.stop()
-                  else Future.successful(())
-                buildChange <- slowConnectToBloopServer(
-                  forceImport,
-                  buildTool,
-                  digest,
-                )
-              } yield buildChange
+              slowConnectToBloopServer(forceImport, buildTool, digest)
             case Some(digest) =>
               indexer.reloadWorkspaceAndIndex(
                 forceImport,
@@ -2046,6 +2037,8 @@ class MetalsLspService(
       case other => Future.successful(other)
     }
 
+    val scalaCliPath = scalaCli.path
+
     (for {
       _ <- disconnectOldBuildServer()
       maybeSession <- timerProvider.timed("Connected to build server", true) {
@@ -2064,6 +2057,12 @@ class MetalsLspService(
         case None =>
           Future.successful(BuildChange.None)
       }
+      _ <- scalaCliPath
+        .collectFirst {
+          case path if (!conflictsWithMainBsp(path.toNIO)) =>
+            scalaCli.start(path)
+        }
+        .getOrElse(Future.successful(()))
       _ = initTreeView()
     } yield result)
       .recover { case NonFatal(e) =>
@@ -2086,13 +2085,16 @@ class MetalsLspService(
       scribe.info(s"Disconnecting from ${connection.main.name} session...")
     )
 
-    bspSession match {
-      case None => Future.successful(())
-      case Some(session) =>
-        bspSession = None
-        mainBuildTargetsData.resetConnections(List.empty)
-        session.shutdown()
-    }
+    for {
+      _ <- scalaCli.stop()
+      _ <- bspSession match {
+        case None => Future.successful(())
+        case Some(session) =>
+          bspSession = None
+          mainBuildTargetsData.resetConnections(List.empty)
+          session.shutdown()
+      }
+    } yield ()
   }
 
   private def importBuild(session: BspSession) = {
@@ -2421,14 +2423,14 @@ class MetalsLspService(
   private def scalaCliDirOrFile(path: AbsolutePath): AbsolutePath = {
     val dir = path.parent
     val nioDir = dir.toNIO
-    val conflictsWithMainBsp =
-      buildTargets.sourceItems.filter(_.exists).exists { item =>
-        val nioItem = item.toNIO
-        nioDir.startsWith(nioItem) || nioItem.startsWith(nioDir)
-      }
-
-    if (conflictsWithMainBsp) path else dir
+    if (conflictsWithMainBsp(nioDir)) path else dir
   }
+
+  private def conflictsWithMainBsp(nioDir: Path) =
+    buildTargets.sourceItems.filter(_.exists).exists { item =>
+      val nioItem = item.toNIO
+      nioDir.startsWith(nioItem) || nioItem.startsWith(nioDir)
+    }
 
   def maybeImportScript(path: AbsolutePath): Option[Future[Unit]] = {
     val scalaCliPath = scalaCliDirOrFile(path)

--- a/tests/slow/src/test/scala/tests/feature/SyntaxErrorLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/SyntaxErrorLspSuite.scala
@@ -161,7 +161,7 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
     } yield ()
   }
 
-  test("no-build-tool") {
+  test("no-build-tool") { // we fallback to scala-cli
     for {
       _ <- initialize(
         """
@@ -173,7 +173,10 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
       _ <- server.didOpen("A.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
-        """|A.scala:1:20: error: illegal start of simple expression
+        """|A.scala:1:20: error: expression expected but '}' found
+           |object A { val x = }
+           |                   ^
+           |A.scala:1:20: error: illegal start of simple expression
            |object A { val x = }
            |                   ^
            |""".stripMargin,

--- a/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
+++ b/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
@@ -184,6 +184,23 @@ class ScalaCliSuite extends BaseScalaCliSuite(V.scala3) {
     } yield ()
   }
 
+
+  test("connecting-scalacli-as-fallback") {
+     cleanWorkspace()
+     FileLayout.fromString(simpleFileLayout, workspace)
+     for {
+       _ <- server.initialize()
+       _ <- server.initialized()
+       _ <- server.server.indexingPromise.future
+       _ <- server.didOpen("MyTests.scala")
+       _ <- assertDefinitionAtLocation(
+         "MyTests.scala",
+         "new Fo@@o",
+         "foo.sc",
+       )
+     } yield ()
+  }
+
   test("relative-semanticdb-root") {
     for {
       _ <- scalaCliInitialize(useBsp = false)(

--- a/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
+++ b/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
@@ -184,21 +184,20 @@ class ScalaCliSuite extends BaseScalaCliSuite(V.scala3) {
     } yield ()
   }
 
-
   test("connecting-scalacli-as-fallback") {
-     cleanWorkspace()
-     FileLayout.fromString(simpleFileLayout, workspace)
-     for {
-       _ <- server.initialize()
-       _ <- server.initialized()
-       _ <- server.server.indexingPromise.future
-       _ <- server.didOpen("MyTests.scala")
-       _ <- assertDefinitionAtLocation(
-         "MyTests.scala",
-         "new Fo@@o",
-         "foo.sc",
-       )
-     } yield ()
+    cleanWorkspace()
+    FileLayout.fromString(simpleFileLayout, workspace)
+    for {
+      _ <- server.initialize()
+      _ <- server.initialized()
+      _ <- server.server.indexingPromise.future
+      _ <- server.didOpen("MyTests.scala")
+      _ <- assertDefinitionAtLocation(
+        "MyTests.scala",
+        "new Fo@@o",
+        "foo.sc",
+      )
+    } yield ()
   }
 
   test("relative-semanticdb-root") {


### PR DESCRIPTION
Previously: If no bsp configuration and no build tool detected metals would not work.
Now:
We fallback to:
 1. generating `scala-cli` configuration if the user `scala-cli` installed (or scala in correct version).
 2. otherwise we use a jvm-based `scala-cli` to start a  bsp server w/o producing a configuration. 
