### PR TITLE
bugfix: Correctly index semanticdb when reconnecting

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -55,7 +55,7 @@ final case class Indexer(
     statusBar: () => StatusBar,
     timerProvider: TimerProvider,
     scalafixProvider: () => ScalafixProvider,
-    indexingPromise: Promise[Unit],
+    indexingPromise: () => Promise[Unit],
     buildData: () => Seq[Indexer.BuildTool],
     clientConfig: ClientConfiguration,
     definitionIndex: OnDemandSymbolIndex,
@@ -147,7 +147,7 @@ final case class Indexer(
           try indexWorkspace(check)
           finally {
             Future(scalafixProvider().load())
-            indexingPromise.trySuccess(())
+            indexingPromise().trySuccess(())
           }
         }
       },

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -253,7 +253,7 @@ class MetalsLspService(
       },
     )
   )
-  val indexingPromise: Promise[Unit] = Promise[Unit]()
+  var indexingPromise: Promise[Unit] = Promise[Unit]()
   var buildServerPromise: Promise[Unit] = Promise[Unit]()
   val parseTrees = new BatchedFunction[AbsolutePath, Unit](paths =>
     CancelableFuture(
@@ -2165,7 +2165,7 @@ class MetalsLspService(
     () => statusBar,
     timerProvider,
     () => scalafixProvider,
-    indexingPromise,
+    () => indexingPromise,
     () =>
       Seq(
         Indexer.BuildTool(

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -305,7 +305,6 @@ final class ReferenceProvider(
                 findRealRange,
                 includeSynthetics,
                 sourcePath.isJava,
-                source,
               )
             } catch {
               case NonFatal(e) =>
@@ -368,7 +367,6 @@ final class ReferenceProvider(
           findRealRange,
           includeSynthetics,
           source.isJava,
-          source,
         )
       else Seq.empty
 
@@ -396,7 +394,6 @@ final class ReferenceProvider(
       findRealRange: AdjustRange,
       includeSynthetics: Synthetic => Boolean,
       isJava: Boolean,
-      source: AbsolutePath,
   ): Seq[Location] = {
     val buf = Seq.newBuilder[Location]
     def add(range: s.Range): Unit = {

--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
@@ -67,7 +67,7 @@ class SemanticdbIndexer(
       try {
         stream.forEach {
           case path if path.isSemanticdb =>
-            SemanticdbPath(AbsolutePath(path))
+            onChange(SemanticdbPath(AbsolutePath(path)))
           case _ => ()
         }
       } finally {


### PR DESCRIPTION
Previously, when reconnecting we wouldn't actually reindex semanticdb, which could cause refrences to stop working. This wasn't an issue in Bloop since it copies a lot and we would be notified by those semanticdb files again. Now, we correctly index semanticdb files on connection.

Might be connected to https://github.com/scalameta/metals/issues/5176