### PR TITLE
Add Command for Running Specified Scalafix Rules

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -211,6 +211,35 @@ object ServerCommands {
        |""".stripMargin,
   )
 
+  val ScalafixRunOnly = new ParametrizedCommand[RunScalafixRulesParams](
+    "scalafix-run-only",
+    "Run a set of Scalafix Rules",
+    """|Run a set of Scalafix rules in your codebase.
+       |
+       |If no rules are specified, this command will prompt the user to select one from a list
+       |of their project's enabled rules.
+       |
+       |If you want to run all rules, use the `scalafix-run` command instead.
+       |""".stripMargin,
+    """|RunScalafixRulesParams object
+       |Example:
+       |```json
+       |{
+       |  "textDocumentPositionParams": {
+       |    "textDocument": {
+       |      "uri": "path/to/file.scala"
+       |    },
+       |    "position": {
+       |      "line": 70,
+       |      "character": 33
+       |    }
+       |  },
+       |  "rules": ["ExplicitResultTypes"]
+       |}
+       |```
+       |""".stripMargin,
+  )
+
   val CascadeCompile = new Command(
     "compile-cascade",
     "Cascade compile",
@@ -731,6 +760,7 @@ object ServerCommands {
       RestartBuildServer,
       RunDoctor,
       RunScalafix,
+      ScalafixRunOnly,
       DecodeFile,
       DisconnectBuildServer,
       ListBuildTargets,
@@ -801,4 +831,9 @@ case class DebugDiscoveryParams(
     @Nullable jvmOptions: java.util.List[String] = null,
     @Nullable env: java.util.Map[String, String] = null,
     @Nullable envFile: String = null,
+)
+
+case class RunScalafixRulesParams(
+    textDocumentPositionParams: TextDocumentPositionParams,
+    @Nullable rules: java.util.List[String] = null,
 )

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -679,6 +679,11 @@ class WorkspaceLspService(
       case ServerCommands.RunScalafix(params) =>
         val uri = params.getTextDocument().getUri()
         getServiceFor(uri).runScalafix(uri).asJavaObject
+      case ServerCommands.ScalafixRunOnly(params) =>
+        val uri = params.textDocumentPositionParams.getTextDocument().getUri()
+        val rules =
+          Option(params.rules).fold(List.empty[String])(_.asScala.toList)
+        getServiceFor(uri).runScalafixRules(uri, rules).asJavaObject
       case ServerCommands.ChooseClass(params) =>
         val uri = params.textDocument.getUri()
         val searchGranularity =

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -107,7 +107,8 @@ object TestGroups {
       "tests.codeactions.MillifyDependencyLspSuite",
       "tests.RenameFilesLspSuite", "tests.codeactions.ExtractMethodLspSuite",
       "tests.SemanticTokensExpectSuite",
-      "tests.debug.DebugProtocolCancelationSuite", "tests.RemovedScalaLspSuite"),
+      "tests.debug.DebugProtocolCancelationSuite", "tests.RemovedScalaLspSuite",
+      "tests.scalafix.ScalafixRunOnlyLspSuite"),
   )
 
 }

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -21,11 +21,13 @@ import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.TextEdits
 import scala.meta.internal.metals.clients.language.MetalsInputBoxParams
+import scala.meta.internal.metals.clients.language.MetalsQuickPickParams
 import scala.meta.internal.metals.clients.language.MetalsSlowTaskParams
 import scala.meta.internal.metals.clients.language.MetalsSlowTaskResult
 import scala.meta.internal.metals.clients.language.MetalsStatusParams
 import scala.meta.internal.metals.clients.language.NoopLanguageClient
 import scala.meta.internal.metals.clients.language.RawMetalsInputBoxResult
+import scala.meta.internal.metals.clients.language.RawMetalsQuickPickResult
 import scala.meta.internal.tvp.TreeViewDidChangeParams
 import scala.meta.io.AbsolutePath
 
@@ -105,6 +107,9 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
   }
   var inputBoxHandler: MetalsInputBoxParams => RawMetalsInputBoxResult = {
     _: MetalsInputBoxParams => RawMetalsInputBoxResult(cancelled = true)
+  }
+  var quickPickHandler: MetalsQuickPickParams => RawMetalsQuickPickResult = {
+    _: MetalsQuickPickParams => RawMetalsQuickPickResult(cancelled = true)
   }
 
   private val refreshCount = new AtomicInteger
@@ -353,6 +358,15 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
     CompletableFuture.completedFuture {
       messageRequests.addLast(params.prompt)
       inputBoxHandler(params)
+    }
+  }
+
+  override def rawMetalsQuickPick(
+      params: MetalsQuickPickParams
+  ): CompletableFuture[RawMetalsQuickPickResult] = {
+    CompletableFuture.completedFuture {
+      messageRequests.addLast(params.placeHolder)
+      quickPickHandler(params)
     }
   }
 

--- a/tests/unit/src/test/scala/tests/scalafix/ScalafixRunOnlyLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/scalafix/ScalafixRunOnlyLspSuite.scala
@@ -1,0 +1,116 @@
+package tests.scalafix
+
+import scala.jdk.CollectionConverters._
+
+import scala.meta.internal.metals.InitializationOptions
+import scala.meta.internal.metals.RunScalafixRulesParams
+import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.metals.clients.language.RawMetalsQuickPickResult
+
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextDocumentPositionParams
+import tests.BaseLspSuite
+
+class ScalafixRunOnlyLspSuite extends BaseLspSuite("run-scalafix-rules") {
+
+  override protected def initializationOptions: Option[InitializationOptions] =
+    Some(
+      InitializationOptions.Default.copy(
+        quickPickProvider = Some(true)
+      )
+    )
+
+  private def params(file: String, rules: List[String]) =
+    RunScalafixRulesParams(
+      new TextDocumentPositionParams(
+        new TextDocumentIdentifier(
+          workspace.resolve(file).toURI.toString()
+        ),
+        new Position(0, 0),
+      ),
+      if (rules.isEmpty) null else rules.asJava,
+    )
+
+  private val mainFile = "a/src/main/scala/Main.scala"
+
+  private val scalafixConf: String =
+    """|/.scalafix.conf
+       |rules = [
+       |  ExplicitResultTypes,
+       |  RemoveUnused
+       |]
+       |
+       |ExplicitResultTypes.rewriteStructuralTypesToNamedSubclass = false
+       |
+       |RemoveUnused.imports = false
+       |""".stripMargin
+
+  private val workspaceOutlay: String =
+    s"""/metals.json
+       |{"a":{"scalacOptions": ["-Wunused"] }}
+       |$scalafixConf
+       |/$mainFile
+       |// unused import
+       |import java.io.File
+       |class A
+       |object Main{
+       |  def debug { println("debug") } // ProcedureSyntax rule is not defined, should not be changed
+       |  val addTypeHere = new A{}
+       |  private val notUsed = 123 
+       |}
+       |""".stripMargin
+
+  test("single rule") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(workspaceOutlay)
+      _ <- server.didOpen(mainFile)
+      _ <- server.executeCommand(
+        ServerCommands.ScalafixRunOnly,
+        params(mainFile, List("ExplicitResultTypes")),
+      )
+      contents = server.bufferContents(mainFile)
+      _ = assertNoDiff(
+        contents,
+        """|// unused import
+           |import java.io.File
+           |class A
+           |object Main{
+           |  def debug { println("debug") } // ProcedureSyntax rule is not defined, should not be changed
+           |  val addTypeHere: A = new A{}
+           |  private val notUsed = 123 
+           |}
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("no rule prompts user") {
+    cleanWorkspace()
+    server.client.quickPickHandler =
+      _ => RawMetalsQuickPickResult("RemoveUnused", cancelled = false)
+
+    for {
+      _ <- initialize(workspaceOutlay)
+      _ <- server.didOpen(mainFile)
+      _ <- server.executeCommand(
+        ServerCommands.ScalafixRunOnly,
+        params(mainFile, List.empty[String]),
+      )
+      contents = server.bufferContents(mainFile)
+      _ = assertNoDiff(
+        contents,
+        """|// unused import
+           |import java.io.File
+           |class A
+           |object Main{
+           |  def debug { println("debug") } // ProcedureSyntax rule is not defined, should not be changed
+           |  val addTypeHere = new A{}
+           |   
+           |}
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+}


### PR DESCRIPTION
Hi!  This PR implements a new command `scalafix-run-only` which can be used to run a subset of your project's scalafix rules.  You may either specify the rules in the command input, else the command prompts the user from a list of rules.

The command is similar to `scalafix-run`, though I was unsure on how that command could be modified in a backward compatible way and keep the behaviour where no rules specified = prompt user.

Anyway, let me know what you think!



