### PR TITLE
refactor: Remove worksheet adjustments, which are no longer needed

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/SourceMapper.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SourceMapper.scala
@@ -3,7 +3,6 @@ package scala.meta.internal.metals
 import scala.meta.inputs.Input
 import scala.meta.internal.builds.SbtBuildTool
 import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.internal.worksheets.WorksheetProvider
 import scala.meta.io.AbsolutePath
 
 import org.eclipse.{lsp4j => l}
@@ -44,10 +43,6 @@ final case class SourceMapper(
           .map(
             SbtBuildTool.sbtInputPosAdjustment(input, _)
           )
-      } else if (
-        path.isWorksheet && ScalaVersions.isScala3Version(scalaVersion)
-      ) {
-        WorksheetProvider.worksheetScala3Adjustments(input)
       } else None
 
     forScripts.getOrElse(default)

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -12,10 +12,7 @@ import scala.collection.concurrent.TrieMap
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-import scala.meta._
 import scala.meta.inputs.Input.VirtualFile
-import scala.meta.internal.metals.AdjustLspData
-import scala.meta.internal.metals.AdjustedLspData
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.Cancelable
@@ -448,34 +445,4 @@ object WorksheetProvider {
   }
   final case class MdocRef(scalaVersion: String, value: Mdoc)
 
-  def worksheetScala3AdjustmentsForPC(
-      originInput: Input.VirtualFile
-  ): Option[(Input.VirtualFile, AdjustLspData)] = {
-    val ident = "  "
-    val withOuter = s"""|object worksheet{
-                        |$ident${originInput.value.replace("\n", "\n" + ident)}
-                        |}""".stripMargin
-    val modifiedInput =
-      originInput.copy(value = withOuter)
-    val adjustLspData = AdjustedLspData.create(
-      pos => {
-        new Position(pos.getLine() - 1, pos.getCharacter() - ident.size)
-      },
-      filterOutLocations = { loc => !loc.getUri().isWorksheet },
-    )
-    Some((modifiedInput, adjustLspData))
-  }
-
-  def worksheetScala3Adjustments(
-      originInput: Input.VirtualFile
-  ): Option[(Input.VirtualFile, Position => Position, AdjustLspData)] = {
-    worksheetScala3AdjustmentsForPC(originInput).map { case (input, adjust) =>
-      def adjustRequest(position: Position) = new Position(
-        position.getLine() + 1,
-        position.getCharacter() + 2,
-      )
-      (input, adjustRequest, adjust)
-
-    }
-  }
 }


### PR DESCRIPTION
Previously, we needed to pack the worksheet input into a wrapper object, but it seems this is now supported in the compiler.