### PR TITLE
bugfix: switch from scala-cli to a build tool

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
@@ -6,6 +6,7 @@ import java.nio.file.StandardCopyOption
 
 import scala.concurrent.Future
 
+import scala.meta.internal.metals.scalacli.ScalaCli
 import scala.meta.io.AbsolutePath
 
 trait BuildTool {
@@ -40,6 +41,12 @@ trait BuildTool {
 
   def executableName: String
 
+  def isBspCompatible(bsp: String): Boolean =
+    bsp match {
+      case SbtBuildTool.name => false
+      case MillBuildTool.name => false
+      case _ => !ScalaCli.names.contains(bsp)
+    }
 }
 
 object BuildTool {

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -6,6 +6,7 @@ import scala.util.Properties
 
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.scalacli.ScalaCli
 import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
 
@@ -144,6 +145,12 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
   }
 
   override val buildServerName: Option[String] = Some(MillBuildTool.name)
+
+  override def isBspCompatible(bsp: String): Boolean =
+    bsp match {
+      case SbtBuildTool.name => false
+      case _ => !ScalaCli.names.contains(bsp)
+    }
 }
 
 object MillBuildTool {

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -7,6 +7,7 @@ import java.util.Properties
 import scala.meta.inputs.Input
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals._
+import scala.meta.internal.metals.scalacli.ScalaCli
 import scala.meta.internal.semver.SemVer
 import scala.meta.internal.semver.SemVer.isCompatibleVersion
 import scala.meta.io.AbsolutePath
@@ -169,6 +170,12 @@ case class SbtBuildTool(
   override def toString: String = SbtBuildTool.name
 
   def executableName = SbtBuildTool.name
+
+  override def isBspCompatible(bsp: String): Boolean =
+    bsp match {
+      case MillBuildTool.name => false
+      case _ => !ScalaCli.names.contains(bsp)
+    }
 }
 
 object SbtBuildTool {

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -163,11 +163,12 @@ object Messages {
 
     def notNow: MessageActionItem = Messages.notNow
 
+    def newBuildTool(buildToolName: String): String =
+      s"New $buildToolName workspace detected, would you like to import the build?"
+
     def params(buildToolName: String): ShowMessageRequestParams = {
       val params = new ShowMessageRequestParams()
-      params.setMessage(
-        s"New $buildToolName workspace detected, would you like to import the build?"
-      )
+      params.setMessage(newBuildTool(buildToolName))
       params.setType(MessageType.Info)
       params.setActions(
         List(

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -247,6 +247,9 @@ class ScalaCli(
       st.path == path || path.toNIO.startsWith(st.path.toNIO)
     )(false)
 
+  def path: Option[AbsolutePath] =
+    ifConnectedOrElse(st => Option(st.path))(None)
+
   def start(path: AbsolutePath): Future[Unit] = {
     disconnectOldBuildServer().onComplete {
       case Failure(e) =>

--- a/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
@@ -800,5 +800,4 @@ class SbtBloopLspSuite
       )
     } yield ()
   }
-
 }

--- a/tests/slow/src/test/scala/tests/sbt/SwitchFromScalaCli.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SwitchFromScalaCli.scala
@@ -1,0 +1,116 @@
+package tests.sbt
+
+import java.io.File
+
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.Messages._
+import scala.meta.internal.metals.scalacli.ScalaCli
+import scala.meta.internal.metals.{BuildInfo => V}
+
+import tests.BaseLspSuite
+import tests.BloopImportInitializer
+
+class SwitchFromScalaCli
+    extends BaseLspSuite(
+      "switching-from-scalacli-to-sbt",
+      BloopImportInitializer,
+    ) {
+
+  test("switch-when-scala-cli-running") {
+    cleanWorkspace()
+    writeLayout(
+      """|/a/src/main/scala/A.scala
+         |
+         |object A{
+         |  val foo = 1
+         |  foo + foo
+         |}
+         |""".stripMargin
+    )
+    for {
+      _ <- server.initialize()
+      _ <- server.initialized()
+      _ <- server.server.scalaCli.start(server.server.folder)
+      _ = assert(server.server.scalaCli.path.contains(server.server.folder))
+      _ = writeLayout(
+        s"""|/project/build.properties
+            |sbt.version=${V.sbtVersion}
+            |/build.sbt
+            |ThisBuild / scalaVersion := "${V.scala213}"
+            |val a = project.in(file("a"))
+            |""".stripMargin
+      )
+      _ = client.importBuild = ImportBuild.yes
+      _ <- server.didOpen("build.sbt")
+      _ <- server.didSave("build.sbt")(identity)
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        s"""|${Messages.ImportBuild.newBuildTool("sbt")}
+            |${Messages.bloopInstallProgress("sbt").message}""".stripMargin,
+      )
+      _ = assert(server.server.bspSession.exists(_.main.isBloop))
+      _ = assert(server.server.scalaCli.path.isEmpty)
+    } yield ()
+  }
+
+  test("switch-when-scala-cli-explicitly-chosen") {
+    cleanWorkspace()
+    writeLayout(
+      s"""|/.bsp/scala-cli.json
+          |${ScalaCliBsp.scalaCliBspJsonContent()}
+          |/a/src/main/scala/A.scala
+          |
+          |object A{
+          |  val foo = 1
+          |  foo + foo
+          |}
+          |""".stripMargin
+    )
+    for {
+      _ <- server.initialize()
+      _ <- server.initialized()
+      // we explicitly choose scala-cli
+      _ = server.server.tables.buildServers.chooseServer("scala-cli")
+      _ = assert(server.server.bspSession.exists(_.main.isScalaCLI))
+      _ = writeLayout(
+        s"""|/project/build.properties
+            |sbt.version=${V.sbtVersion}
+            |/build.sbt
+            |ThisBuild / scalaVersion := "${V.scala213}"
+            |val a = project.in(file("a"))
+            |""".stripMargin
+      )
+      _ = client.importBuild = ImportBuild.yes
+      _ <- server.didOpen("build.sbt")
+      _ <- server.didSave("build.sbt")(identity)
+      _ = assertNoDiff(
+        client.workspaceMessageRequests,
+        s"""|${Messages.ImportBuild.newBuildTool("sbt")}
+            |${Messages.bloopInstallProgress("sbt").message}""".stripMargin,
+      )
+      _ = assert(server.server.bspSession.exists(_.main.isBloop))
+    } yield ()
+  }
+}
+
+object ScalaCliBsp {
+  def scalaCliBspJsonContent(): String = {
+    val argv = List(
+      ScalaCli.javaCommand,
+      "-cp",
+      ScalaCli.scalaCliClassPath().mkString(File.pathSeparator),
+      ScalaCli.scalaCliMainClass,
+      "bsp",
+      ".",
+    )
+    val bsjJson = ujson.Obj(
+      "name" -> "scala-cli",
+      "argv" -> argv,
+      "version" -> BuildInfo.scalaCliVersion,
+      "bspVersion" -> "2.0.0",
+      "languages" -> List("scala", "java"),
+    )
+    ujson.write(bsjJson)
+  }
+}


### PR DESCRIPTION
This PR contains two changes:
1. when auto-connecting to a build sever we stop scala-cli and try to restarted if it doesn't conflict w/ the main bsp
2. on build change if the selected build tool is incompatible w/ chosen bsp we suggest importing the build using bloop