### PR TITLE
fix: Don't backting soft keywords in Select

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -113,7 +113,11 @@ object MtagsEnrichments extends ScalametaCommonEnrichments:
       pos.offset() <= other.start && pos.endOffset() >= other.end
 
   extension (sym: Symbol)(using Context)
-    def fullNameBackticked: String = fullNameBackticked(Set.empty)
+    def fullNameBackticked: String = fullNameBackticked(Set.empty[String])
+
+    def fullNameBackticked(backtickSoftKeyword: Boolean = true): String =
+      if backtickSoftKeyword then fullNameBackticked(Set.empty[String])
+      else fullNameBackticked(KeywordWrapper.Scala3SoftKeywords)
 
     def fullNameBackticked(exclusions: Set[String]): String =
       @tailrec
@@ -130,7 +134,11 @@ object MtagsEnrichments extends ScalametaCommonEnrichments:
     def companion: Symbol =
       if sym.is(Module) then sym.companionClass else sym.companionModule
 
-    def nameBackticked: String = nameBackticked(Set.empty)
+    def nameBackticked: String = nameBackticked(Set.empty[String])
+
+    def nameBackticked(backtickSoftKeyword: Boolean = true): String =
+      if backtickSoftKeyword then nameBackticked(Set.empty[String])
+      else nameBackticked(KeywordWrapper.Scala3SoftKeywords)
 
     def nameBackticked(exclusions: Set[String]): String =
       KeywordWrapper.Scala3.backtickWrap(sym.decodedName, exclusions)
@@ -168,8 +176,12 @@ object MtagsEnrichments extends ScalametaCommonEnrichments:
     def decoded: String = name.stripModuleClassSuffix.show
 
   extension (s: String)
-    def backticked: String =
-      KeywordWrapper.Scala3.backtickWrap(s)
+    def backticked: String = s.backticked()
+
+    def backticked(backtickSoftKeyword: Boolean = true): String =
+      if backtickSoftKeyword then KeywordWrapper.Scala3.backtickWrap(s)
+      else
+        KeywordWrapper.Scala3.backtickWrap(s, KeywordWrapper.Scala3SoftKeywords)
 
     def stripBackticks: String = s.stripPrefix("`").stripSuffix("`")
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
@@ -17,7 +17,7 @@ import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.util.Spans
 import org.eclipse.{lsp4j as l}
 
-object AutoImports extends AutoImportsBackticks:
+object AutoImports:
 
   object AutoImport:
     def renameConfigMap(config: PresentationCompilerConfig)(using
@@ -196,7 +196,7 @@ object AutoImports extends AutoImportsBackticks:
               (
                 SymbolIdent.Select(
                   ownerImport.ident,
-                  symbol.nameBacktickedImport,
+                  symbol.nameBackticked(false),
                 ),
                 ownerImport.importSel,
               )
@@ -230,7 +230,7 @@ object AutoImports extends AutoImportsBackticks:
                 symbol,
                 SymbolIdent.Select(
                   SymbolIdent.direct(rename),
-                  symbol.nameBacktickedImport,
+                  symbol.nameBackticked(false),
                 ),
                 importSel,
               )
@@ -269,7 +269,7 @@ object AutoImports extends AutoImportsBackticks:
           .map {
             case ImportSel.Direct(sym) => importName(sym)
             case ImportSel.Rename(sym, rename) =>
-              s"${importName(sym.owner)}.{${sym.nameBacktickedImport} => $rename}"
+              s"${importName(sym.owner)}.{${sym.nameBackticked(false)} => $rename}"
           }
           .map(sel => s"${indent}import $sel")
           .mkString(topPadding, "\n", "\n")
@@ -280,8 +280,8 @@ object AutoImports extends AutoImportsBackticks:
 
     private def importName(sym: Symbol): String =
       if indexedContext.importContext.toplevelClashes(sym) then
-        s"_root_.${sym.fullNameBacktickedImport}"
-      else sym.fullNameBacktickedImport
+        s"_root_.${sym.fullNameBackticked(false)}"
+      else sym.fullNameBackticked(false)
   end AutoImportsGenerator
 
   private def autoImportPosition(
@@ -376,11 +376,3 @@ object AutoImports extends AutoImportsBackticks:
   end autoImportPosition
 
 end AutoImports
-
-trait AutoImportsBackticks:
-  // Avoids backticketing import parts that match soft keywords
-  extension (sym: Symbol)(using Context)
-    def fullNameBacktickedImport: String =
-      sym.fullNameBackticked(KeywordWrapper.Scala3SoftKeywords)
-    def nameBacktickedImport: String =
-      sym.nameBackticked(KeywordWrapper.Scala3SoftKeywords)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
@@ -215,6 +215,10 @@ class CompletionProvider(
         case _ =>
           false
 
+    lazy val backtickSoftKeyword = path match
+      case (_: Select) :: _ => false
+      case _ => true
+
     def mkItemWithImports(
         v: CompletionValue.Workspace | CompletionValue.Extension |
           CompletionValue.Interpolator
@@ -222,7 +226,7 @@ class CompletionProvider(
       val sym = v.symbol
       path match
         case (_: Ident) :: (_: Import) :: _ =>
-          mkItem(sym.fullNameBackticked)
+          mkItem(sym.fullNameBackticked(backtickSoftKeyword = false))
         case _ =>
           autoImports.editsForSymbol(v.importSymbol) match
             case Some(edits) =>
@@ -236,7 +240,9 @@ class CompletionProvider(
                 case _ =>
                   mkItem(
                     v.insertText.getOrElse(
-                      ident.backticked + completionTextSuffix
+                      ident.backticked(
+                        backtickSoftKeyword
+                      ) + completionTextSuffix
                     ),
                     edits.edits,
                     range = v.range,
@@ -246,14 +252,18 @@ class CompletionProvider(
               r match
                 case IndexedContext.Result.InScope =>
                   mkItem(
-                    ident.backticked + completionTextSuffix
+                    ident.backticked(backtickSoftKeyword) + completionTextSuffix
                   )
                 case _ if isInStringInterpolation =>
                   mkItem(
                     "{" + sym.fullNameBackticked + completionTextSuffix + "}"
                   )
                 case _ =>
-                  mkItem(sym.fullNameBackticked + completionTextSuffix)
+                  mkItem(
+                    sym.fullNameBackticked(
+                      backtickSoftKeyword
+                    ) + completionTextSuffix
+                  )
               end match
           end match
       end match
@@ -265,7 +275,8 @@ class CompletionProvider(
       case v: CompletionValue.Interpolator if v.isWorkspace || v.isExtension =>
         mkItemWithImports(v)
       case _ =>
-        val insert = completion.insertText.getOrElse(ident.backticked)
+        val insert =
+          completion.insertText.getOrElse(ident.backticked(backtickSoftKeyword))
         mkItem(
           insert + completionTextSuffix,
           range = completion.range,

--- a/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
@@ -127,4 +127,81 @@ class CompletionBacktickSuite extends BaseCompletionSuite {
       filter = _.contains("a: String"),
     )
 
+  checkEdit(
+    "soft-keyword-select",
+    """|object Main {
+       |  case class Pos(start: Int, end: Int)
+       |  val a = Pos(1,2)
+       |  val b = a.end@@
+       |}
+       |""".stripMargin,
+    """|object Main {
+       |  case class Pos(start: Int, end: Int)
+       |  val a = Pos(1,2)
+       |  val b = a.end
+       |}
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "soft-keyword-ident",
+    """|object Main {
+       |  case class Pos(start: Int, end: Int) {
+       |    val point = start - end@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|object Main {
+       |  case class Pos(start: Int, end: Int) {
+       |    val point = start - end
+       |  }
+       |}
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|object Main {
+           |  case class Pos(start: Int, end: Int) {
+           |    val point = start - `end`
+           |  }
+           |}
+           |""".stripMargin
+    ),
+  )
+
+  checkEdit(
+    "soft-keyword-extension".tag(IgnoreScala2),
+    """|object A {
+       |  extension (a: String) def end = a.last
+       |}
+       |object Main {
+       |  val a = "abc".end@@
+       |}
+       |""".stripMargin,
+    """|import A.end
+       |object A {
+       |  extension (a: String) def end = a.last
+       |}
+       |object Main {
+       |  val a = "abc".end
+       |}
+       |""".stripMargin,
+    filter = _.contains("end: Char"),
+  )
+
+  checkEdit(
+    "keyword-select",
+    """|object Main {
+       |  case class Pos(start: Int, `lazy`: Boolean)
+       |  val a = Pos(1,true)
+       |  val b = a.laz@@
+       |}
+       |""".stripMargin,
+    """|object Main {
+       |  case class Pos(start: Int, `lazy`: Boolean)
+       |  val a = Pos(1,true)
+       |  val b = a.`lazy`
+       |}
+       |""".stripMargin,
+  )
+
 }


### PR DESCRIPTION
In Scala 3, we don't have to backtick soft keywords in things like `a.end`