### PR TITLE
Provide extension method code completions when typing `xxx.@@`

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -87,8 +87,7 @@ final class WorkspaceSymbolProvider(
       target: Option[BuildTargetIdentifier],
   ): SymbolSearch.Result = {
     workspaceMethodSearch(query, visitor, target)
-    if (query.isEmpty()) SymbolSearch.Result.INCOMPLETE
-    else SymbolSearch.Result.COMPLETE
+    SymbolSearch.Result.COMPLETE
   }
 
   def indexClasspath(): Unit = {

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -586,7 +586,7 @@ class Completions(
               ).map(visit).forall(_ == true),
         )
         Some(search.search(query, buildTargetIdentifier, visitor))
-      case CompletionKind.Members if query.nonEmpty =>
+      case CompletionKind.Members =>
         val visitor = new CompilerSearchVisitor(sym =>
           if sym.is(ExtensionMethod) &&
             qualType.widenDealias <:< sym.extensionParam.info.widenDealias
@@ -599,8 +599,6 @@ class Completions(
           else false,
         )
         Some(search.searchMethods(query, buildTargetIdentifier, visitor))
-      case CompletionKind.Members => // query.isEmpry
-        Some(SymbolSearch.Result.INCOMPLETE)
     end match
   end enrichWithSymbolSearch
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionExtensionMethodSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionExtensionMethodSuite.scala
@@ -37,6 +37,21 @@ class CompletionExtensionMethodSuite extends BaseCompletionSuite {
   )
 
   check(
+    "simple-empty",
+    """|package example
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def incr: Int = num + 1
+       |
+       |def main = 100.@@
+       |""".stripMargin,
+    """|incr: Int (extension)
+       |""".stripMargin,
+    filter = _.contains("(extension)"),
+  )
+
+  check(
     "filter-by-type",
     """|package example
        |


### PR DESCRIPTION
Closes #4215

Seems like just removing `if query.nonEmpty` works.
I couldn't find any places where [MetalsSymbolSearch.searchMethods](https://github.com/scalameta/metals/blob/main/metals/src/main/scala/scala/meta/internal/metals/MetalsSymbolSearch.scala#L103-L113) or any of the subsequent calls would fail on empty query.
Please correct me if I'm wrong.

#### a/A.scala
```scala
package a

extension (num: Int)
  def ++ = num + 1
```

#### b/B.scala
![Peek 2023-05-17 17-25](https://github.com/scalameta/metals/assets/30271846/76226332-e226-47bf-82c4-84f10a725382)