### PR TITLE
improvement: Don't fail on refreshing semantic tokens

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -113,7 +113,8 @@ class WorkspaceLspService(
     )
 
   private val languageClient = {
-    val languageClient = new ConfiguredLanguageClient(client, clientConfig)
+    val languageClient =
+      new ConfiguredLanguageClient(client, clientConfig, () => userConfig)
     // Set the language client so that we can forward log messages to the client
     LanguageClientLogger.languageClient = Some(languageClient)
     cancelables.add(() => languageClient.shutdown())

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
@@ -9,6 +9,7 @@ import scala.meta.internal.decorations.PublishDecorationsParams
 import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.ClientConfiguration
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.config.StatusBarState
 
 import org.eclipse.lsp4j.ExecuteCommandParams
@@ -27,6 +28,7 @@ import org.eclipse.lsp4j.ShowMessageRequestParams
 final class ConfiguredLanguageClient(
     initial: MetalsLanguageClient,
     clientConfig: ClientConfiguration,
+    userConfig: () => UserConfiguration,
 )(implicit ec: ExecutionContext)
     extends DelegatingLanguageClient(initial) {
 
@@ -97,8 +99,13 @@ final class ConfiguredLanguageClient(
   }
 
   override def refreshSemanticTokens(): CompletableFuture[Void] = {
-    if (clientConfig.semanticTokensRefreshSupport()) {
-      underlying.refreshSemanticTokens()
+    if (
+      userConfig().enableSemanticHighlighting &&
+      clientConfig.semanticTokensRefreshSupport()
+    ) {
+      underlying
+        .refreshSemanticTokens()
+        .handle((msg, ex) => null)
     } else CompletableFuture.allOf()
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/NoopLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/NoopLanguageClient.scala
@@ -55,6 +55,13 @@ abstract class NoopLanguageClient extends MetalsLanguageClient {
 
   override def refreshModel(): CompletableFuture[Unit] =
     CompletableFuture.completedFuture(())
+
+  override def refreshCodeLenses(): CompletableFuture[Void] =
+    CompletableFuture.completedFuture(null)
+
+  override def refreshSemanticTokens(): CompletableFuture[Void] =
+    CompletableFuture.completedFuture(null)
+
 }
 
 object NoopLanguageClient extends NoopLanguageClient


### PR DESCRIPTION
Connected to https://github.com/scalameta/metals/issues/5193

1. We don't refresh tokens if they are not enabled
2. We ignore the exception in refreshSemanticTokens since it might cause the server not to init (not exactly sure which flow)