### PR TITLE
bugfix: Check position before invoking .pos.point

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
@@ -235,8 +235,8 @@ abstract class PcCollector[T](
          */
         def isForComprehensionOwner(named: NameTree) =
           soughtNames(named.name) &&
-            named.symbol.owner.isAnonymousFunction && owners.exists(
-              pos.isDefined && _.pos.point == named.symbol.owner.pos.point
+            named.symbol.owner.isAnonymousFunction && owners.exists(owner =>
+              pos.isDefined && owner.pos.isDefined && owner.pos.point == named.symbol.owner.pos.point
             )
 
         def soughtOrOverride(sym: Symbol) =


### PR DESCRIPTION
Discovered in https://github.com/scalameta/metals/issues/5176