### PR TITLE
improvement: Check if possible java home is a correct path 

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals
 
+import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
 
 object JavaBinary {
@@ -15,10 +16,27 @@ object JavaBinary {
    * Returns absolute path to the `binaryName` binary of the configured Java Home directory.
    */
   def apply(javaHome: Option[String], binaryName: String): String = {
-    javaHome
-      .orElse(JdkSources.defaultJavaHome)
-      .map(AbsolutePath(_).resolve("bin").resolve(binaryName).toString())
+    path(javaHome, binaryName)
+      .map(_.toString())
       .getOrElse(binaryName)
   }
 
+  def path(
+      javaHome: Option[String],
+      binaryName: String = "java",
+  ): Option[AbsolutePath] = {
+    JdkSources
+      .defaultJavaHome(javaHome)
+      .flatMap(home =>
+        List(binaryName, binaryName + ".exe").map(home.resolve("bin").resolve)
+      )
+      .map { a =>
+        scribe.info(s"java binary path: $a ${a.exists}")
+        a
+
+      }
+      .collectFirst {
+        case path if path.exists => path
+      }
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -183,8 +183,7 @@ class MetalsLspService(
   )
 
   private val optJavaHome =
-    (userConfig().javaHome orElse JdkSources.defaultJavaHome)
-      .map(AbsolutePath(_))
+    JdkSources.defaultJavaHome(userConfig().javaHome).headOption
   private val maybeJdkVersion: Option[JdkVersion] =
     JdkVersion.maybeJdkVersionFromJavaHome(optJavaHome)
 

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.metals
 
-import java.nio.file.Paths
 import java.util.Properties
 
 import scala.collection.mutable.ListBuffer
@@ -60,13 +59,7 @@ case class UserConfiguration(
   def currentBloopVersion: String =
     bloopVersion.getOrElse(BuildInfo.bloopVersion)
 
-  def usedJavaBinary(): Option[AbsolutePath] = {
-    javaHome
-      .orElse(
-        JdkSources.defaultJavaHome
-      )
-      .map(home => AbsolutePath(Paths.get(home).resolve("bin/java")))
-  }
+  def usedJavaBinary(): Option[AbsolutePath] = JavaBinary.path(javaHome)
 }
 
 object UserConfiguration {

--- a/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
@@ -1,8 +1,13 @@
 package scala.meta.internal.metals
 
 import java.nio.file.Paths
+import java.util.logging.Logger
 
-import scala.meta.internal.mtags.ScalametaCommonEnrichments._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
 
@@ -14,6 +19,9 @@ object JdkSources {
   private val sources = RelativePath(Paths.get(zipFileName))
   private val libSources = RelativePath(Paths.get("lib")).resolve(sources)
 
+  private val logger: Logger =
+    Logger.getLogger(JdkSources.getClass().getName)
+
   def apply(
       userJavaHome: Option[String] = None
   ): Either[NoSourcesAvailable, AbsolutePath] = {
@@ -24,10 +32,25 @@ object JdkSources {
     }
   }
 
-  def defaultJavaHome: Option[String] = {
-    Option(System.getenv("JAVA_HOME")).orElse(
-      Option(System.getProperty("java.home"))
-    )
+  private def fromString(path: String): Option[AbsolutePath] = {
+    Option(path).flatMap { str =>
+      Try(AbsolutePath(str)) match {
+        case Failure(exception) =>
+          logger.warning(
+            s"Failed to parse java home path $str: ${exception.getMessage}"
+          )
+          None
+        case Success(value) =>
+          logger.info(s"Found java home path $value")
+          Some(value)
+      }
+    }
+  }
+
+  def defaultJavaHome(userJavaHome: Option[String]): List[AbsolutePath] = {
+    userJavaHome.flatMap(fromString).toList ++
+      fromString(System.getenv("JAVA_HOME")).toList ++
+      fromString(System.getProperty("java.home")).toList
   }
 
   private def candidates(userJavaHome: Option[String]): List[AbsolutePath] = {
@@ -41,8 +64,7 @@ object JdkSources {
     }
 
     for {
-      javaHomeString <- userJavaHome.orElse(defaultJavaHome).toList
-      javaHome = AbsolutePath(javaHomeString)
+      javaHome <- defaultJavaHome(userJavaHome)
       jdkHome = {
         if (isJdkCandidate(javaHome)) {
           Nil

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -1,7 +1,6 @@
 package tests.troubleshoot
 
 import java.nio.file.Files
-import java.nio.file.Paths
 
 import scala.concurrent.ExecutionContext
 
@@ -16,7 +15,6 @@ import scala.meta.internal.metals.doctor.DeprecatedSbtVersion
 import scala.meta.internal.metals.doctor.DeprecatedScalaVersion
 import scala.meta.internal.metals.doctor.FutureSbtVersion
 import scala.meta.internal.metals.doctor.FutureScalaVersion
-import scala.meta.internal.metals.doctor.MissingJdkSources
 import scala.meta.internal.metals.doctor.MissingSourceRoot
 import scala.meta.internal.metals.doctor.OutdatedJunitInterfaceVersion
 import scala.meta.internal.metals.doctor.OutdatedMunitInterfaceVersion
@@ -122,21 +120,6 @@ class ProblemResolverSuite extends FunSuite {
     scalaVersion = BuildInfo.scala212,
     MissingSourceRoot("\"-P:semanticdb:sourceroot:$workspace\"").message,
     scalacOpts = List("-Xplugin:/semanticdb-scalac_2.12.12-4.4.2.jar"),
-  )
-
-  checkRecommendation(
-    "missing-jdk-sources",
-    scalaVersion = BuildInfo.scala212,
-    MissingJdkSources(
-      List(
-        "/some/invalid/src.zip",
-        "/some/invalid/lib/src.zip",
-        "/some/invalid/path/src.zip",
-        "/some/invalid/path/lib/src.zip",
-      ).map(path => AbsolutePath(Paths.get(path)))
-    ).message,
-    sbtVersion = Some("1.6.0"),
-    invalidJavaHome = true,
   )
 
   checkRecommendation(


### PR DESCRIPTION
Previously, we would just use the Java Home string as is, which might have been set wrong by the user.

It would fail if the java home was incorrect, which would make it impossible to use metals.

Now, we check if the potential java home can actually be used.

Should fix https://github.com/scalameta/metals/issues/5230