### PR TITLE
buigfix: given scala toplevel mtags

### DIFF
--- a/metals-bench/src/main/scala/bench/MetalsBench.scala
+++ b/metals-bench/src/main/scala/bench/MetalsBench.scala
@@ -6,6 +6,7 @@ import scala.tools.nsc.interactive.Global
 
 import scala.meta.dialects
 import scala.meta.interactive.InteractiveSemanticdb
+import scala.meta.internal.metals.EmptyReportContext
 import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.metals.logging.MetalsLogger
 import scala.meta.internal.mtags.Mtags
@@ -148,7 +149,7 @@ class MetalsBench {
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))
   def indexSources(): Unit = {
-    val index = OnDemandSymbolIndex.empty()
+    val index = OnDemandSymbolIndex.empty()(EmptyReportContext)
     fullClasspath.entries.foreach(entry =>
       index.addSourceJar(entry, dialects.Scala213)
     )

--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -13,6 +13,7 @@ import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.DefinitionProvider
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.metals.ScalaVersionSelector
 import scala.meta.internal.metals.SemanticdbFeatureProvider
 import scala.meta.internal.mtags.GlobalSymbolIndex
@@ -46,7 +47,7 @@ final class ImplementationProvider(
     definitionProvider: DefinitionProvider,
     trees: Trees,
     scalaVersionSelector: ScalaVersionSelector,
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, rc: ReportContext)
     extends SemanticdbFeatureProvider {
   import ImplementationProvider._
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -75,7 +75,7 @@ class Compilers(
     trees: Trees,
     mtagsResolver: MtagsResolver,
     sourceMapper: SourceMapper,
-)(implicit ec: ExecutionContextExecutorService)
+)(implicit ec: ExecutionContextExecutorService, rc: ReportContext)
     extends Cancelable {
   val plugins = new CompilerPlugins()
 

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -66,7 +66,7 @@ final class DefinitionProvider(
     saveDefFileToDisk: Boolean,
     sourceMapper: SourceMapper,
     workspaceSearch: WorkspaceSymbolProvider,
-)(implicit ec: ExecutionContext) {
+)(implicit ec: ExecutionContext, rc: ReportContext) {
 
   val destinationProvider = new DestinationProvider(
     index,

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -79,7 +79,7 @@ final case class Indexer(
     symbolDocs: Docstrings,
     scalaVersionSelector: ScalaVersionSelector,
     sourceMapper: SourceMapper,
-) {
+)(implicit rc: ReportContext) {
 
   private implicit def ec: ExecutionContextExecutorService = executionContext
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsSymbolSearch.scala
@@ -24,7 +24,8 @@ class MetalsSymbolSearch(
     docs: Docstrings,
     wsp: WorkspaceSymbolProvider,
     defn: DefinitionProvider,
-) extends SymbolSearch {
+)(implicit rc: ReportContext)
+    extends SymbolSearch {
   // A cache for definitionSourceToplevels.
   // The key is an absolute path to the dependency source file, and
   // the value is the list of symbols that the file contains.

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -30,7 +30,8 @@ class StandaloneSymbolSearch(
     saveSymbolFileToDisk: Boolean,
     sourceMapper: SourceMapper,
     workspaceFallback: Option[SymbolSearch] = None,
-) extends SymbolSearch {
+)(implicit rc: ReportContext)
+    extends SymbolSearch {
 
   private val dependencySourceCache =
     new TrieMap[AbsolutePath, ju.List[String]]()
@@ -131,7 +132,7 @@ object StandaloneSymbolSearch {
       buildTargets: BuildTargets,
       saveSymbolFileToDisk: Boolean,
       sourceMapper: SourceMapper,
-  ): StandaloneSymbolSearch = {
+  )(implicit rc: ReportContext): StandaloneSymbolSearch = {
     val (sourcesWithExtras, classpathWithExtras) =
       addScalaAndJava(
         scalaVersion,
@@ -162,7 +163,7 @@ object StandaloneSymbolSearch {
       buildTargets: BuildTargets,
       saveSymbolFileToDisk: Boolean,
       sourceMapper: SourceMapper,
-  ): StandaloneSymbolSearch = {
+  )(implicit rc: ReportContext): StandaloneSymbolSearch = {
     val (sourcesWithExtras, classpathWithExtras) =
       addScalaAndJava(scalaVersion, Nil, Nil, userConfig().javaHome)
 

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -104,6 +104,7 @@ class WorkspaceLspService(
 ) extends ScalaLspService {
   import serverInputs._
   implicit val ex: ExecutionContextExecutorService = ec
+  implicit val rc: ReportContext = LoggerReportContext
   private val cancelables = new MutableCancelable()
 
   private val clientConfig =

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSearchVisitor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSearchVisitor.scala
@@ -32,7 +32,8 @@ class WorkspaceSearchVisitor(
     token: CancelChecker,
     index: GlobalSymbolIndex,
     saveClassFileToDisk: Boolean,
-) extends SymbolSearchVisitor {
+)(implicit rc: ReportContext)
+    extends SymbolSearchVisitor {
   private val fromWorkspace = new ju.ArrayList[l.SymbolInformation]()
   private val fromClasspath = new ju.ArrayList[l.SymbolInformation]()
   private val bufferedClasspath = new ju.ArrayList[(String, String)]()

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -29,7 +29,7 @@ final class WorkspaceSymbolProvider(
     bucketSize: Int = CompressedPackageIndex.DefaultBucketSize,
     classpathSearchIndexer: ClasspathSearch.Indexer =
       ClasspathSearch.Indexer.default,
-) {
+)(implicit rc: ReportContext) {
   val inWorkspace: TrieMap[Path, WorkspaceSymbolsIndex] =
     TrieMap.empty[Path, WorkspaceSymbolsIndex]
 

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -26,7 +26,8 @@ class MetalsTreeViewProvider(
     getFolderTreeViewProviders: () => List[FolderTreeViewProvider],
     languageClient: MetalsLanguageClient,
     sh: ScheduledExecutorService,
-) extends TreeViewProvider {
+)(implicit rc: ReportContext)
+    extends TreeViewProvider {
   private val ticks =
     TrieMap.empty[String, ScheduledFuture[_]]
 

--- a/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
@@ -28,7 +28,7 @@ import scala.meta.pc.SymbolDocumentation
  *
  * Handles both javadoc and scaladoc.
  */
-class Docstrings(index: GlobalSymbolIndex) {
+class Docstrings(index: GlobalSymbolIndex)(implicit rc: ReportContext) {
   val cache = new TrieMap[String, SymbolDocumentation]()
   private val logger = Logger.getLogger(classOf[Docstrings].getName)
 
@@ -141,5 +141,7 @@ class Docstrings(index: GlobalSymbolIndex) {
 }
 
 object Docstrings {
-  def empty: Docstrings = new Docstrings(OnDemandSymbolIndex.empty())
+  def empty(implicit rc: ReportContext): Docstrings = new Docstrings(
+    OnDemandSymbolIndex.empty()
+  )
 }

--- a/mtags/src/main/scala/scala/meta/internal/metals/SemanticdbDefinition.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/SemanticdbDefinition.scala
@@ -44,7 +44,7 @@ object SemanticdbDefinition {
       includeMembers: Boolean
   )(
       fn: SemanticdbDefinition => Unit
-  ): Unit = {
+  )(implicit rc: ReportContext): Unit = {
     input.toLanguage match {
       case Language.SCALA =>
         val mtags = new ScalaToplevelMtags(

--- a/mtags/src/main/scala/scala/meta/internal/mtags/Mtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/Mtags.scala
@@ -3,12 +3,14 @@ package scala.meta.internal.mtags
 import scala.meta.Dialect
 import scala.meta.dialects
 import scala.meta.inputs.Input
+import scala.meta.internal.metals.EmptyReportContext
+import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 import scala.meta.internal.semanticdb.Language
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.semanticdb.TextDocument
 
-final class Mtags {
+final class Mtags(implicit rc: ReportContext) {
   def totalLinesOfCode: Long = javaLines + scalaLines
   def totalLinesOfScala: Long = scalaLines
   def totalLinesOfJava: Long = javaLines
@@ -73,7 +75,9 @@ final class Mtags {
   }
 }
 object Mtags {
-  def index(input: Input.VirtualFile, dialect: Dialect): TextDocument = {
+  def index(input: Input.VirtualFile, dialect: Dialect)(implicit
+      rc: ReportContext = EmptyReportContext
+  ): TextDocument = {
     new Mtags().index(input.toLanguage, input, dialect)
   }
 
@@ -90,7 +94,7 @@ object Mtags {
   def allToplevels(
       input: Input.VirtualFile,
       dialect: Dialect
-  ): TextDocument = {
+  )(implicit rc: ReportContext = EmptyReportContext): TextDocument = {
     input.toLanguage match {
       case Language.JAVA =>
         new JavaMtags(input, includeMembers = true).index()
@@ -105,7 +109,7 @@ object Mtags {
   def toplevels(
       input: Input.VirtualFile,
       dialect: Dialect = dialects.Scala213
-  ): List[String] = {
+  )(implicit rc: ReportContext = EmptyReportContext): List[String] = {
     new Mtags().toplevels(input, dialect)
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
@@ -9,6 +9,7 @@ import scala.util.control.NonFatal
 import scala.meta.Dialect
 import scala.meta.dialects
 import scala.meta.internal.io.{ListFiles => _}
+import scala.meta.internal.metals.ReportContext
 import scala.meta.io.AbsolutePath
 
 /**
@@ -28,7 +29,8 @@ final class OnDemandSymbolIndex(
     dialectBuckets: TrieMap[Dialect, SymbolIndexBucket],
     onError: PartialFunction[Throwable, Unit],
     toIndexSource: AbsolutePath => AbsolutePath
-) extends GlobalSymbolIndex {
+)(implicit rc: ReportContext)
+    extends GlobalSymbolIndex {
   val mtags = new Mtags
   var indexedSources = 0L
   def close(): Unit = {
@@ -150,7 +152,7 @@ object OnDemandSymbolIndex {
         throw e
       },
       toIndexSource: AbsolutePath => AbsolutePath = identity
-  ): OnDemandSymbolIndex = {
+  )(implicit rc: ReportContext): OnDemandSymbolIndex = {
     new OnDemandSymbolIndex(TrieMap.empty, onError, toIndexSource)
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
@@ -6,6 +6,8 @@ import scala.meta.Dialect
 import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import scala.meta.internal.inputs._
+import scala.meta.internal.metals.Report
+import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 import scala.meta.internal.semanticdb.Language
 import scala.meta.internal.semanticdb.Scala
@@ -43,7 +45,8 @@ class ScalaToplevelMtags(
     includeInnerClasses: Boolean,
     includeMembers: Boolean,
     dialect: Dialect
-) extends MtagsIndexer {
+)(implicit rc: ReportContext)
+    extends MtagsIndexer {
 
   import ScalaToplevelMtags._
 
@@ -181,23 +184,25 @@ class ScalaToplevelMtags(
             // extension group
             if (dialect.allowExtensionMethods && currRegion.isExtension) =>
           acceptTrivia()
-          val name = newIdentifier
-          withOwner(currRegion.owner) {
-            term(name.name, name.pos, Kind.METHOD, EXTENSION)
+          newIdentifier.foreach { name =>
+            withOwner(currRegion.owner) {
+              term(name.name, name.pos, Kind.METHOD, EXTENSION)
+            }
           }
           loop(indent, isAfterNewline = false, region, newExpectIgnoreBody)
         // inline extension method `extension (...) def foo = ...`
         case DEF if expectTemplate.map(needToParseExtension).getOrElse(false) =>
           expectTemplate match {
             case None =>
-              fail(
+              reportError(
                 "failed while reading 'def' in 'extension (...) def ...', expectTemplate should be set by reading 'extension'."
               )
             case Some(expect) =>
               acceptTrivia()
-              val name = newIdentifier
-              withOwner(expect.owner) {
-                term(name.name, name.pos, Kind.METHOD, EXTENSION)
+              newIdentifier.foreach { name =>
+                withOwner(expect.owner) {
+                  term(name.name, name.pos, Kind.METHOD, EXTENSION)
+                }
               }
               loop(indent, isAfterNewline = false, region, None)
           }
@@ -418,7 +423,7 @@ class ScalaToplevelMtags(
   def parsePath(): List[Identifier] = {
     val buf = List.newBuilder[Identifier]
     def loop(): Unit = {
-      buf += newIdentifier
+      newIdentifier.foreach(buf += _)
       acceptTrivia()
       scanner.curr.token match {
         case DOT =>
@@ -437,24 +442,26 @@ class ScalaToplevelMtags(
   def emitMember(isPackageObject: Boolean, owner: String): Unit = {
     val kind = scanner.curr.token
     acceptTrivia()
-    val name = newIdentifier
+    val maybeName = newIdentifier
     currentOwner = owner
-    kind match {
-      case CLASS =>
-        tpe(name.name, name.pos, Kind.CLASS, 0)
-      case TRAIT =>
-        tpe(name.name, name.pos, Kind.TRAIT, 0)
-      case ENUM =>
-        withOwner(owner) {
+    maybeName.foreach { name =>
+      kind match {
+        case CLASS =>
           tpe(name.name, name.pos, Kind.CLASS, 0)
-        }
-      case OBJECT =>
-        if (isPackageObject) {
-          currentOwner = symbol(Scala.Descriptor.Package(name.name))
-          term("package", name.pos, Kind.OBJECT, 0)
-        } else {
-          term(name.name, name.pos, Kind.OBJECT, 0)
-        }
+        case TRAIT =>
+          tpe(name.name, name.pos, Kind.TRAIT, 0)
+        case ENUM =>
+          withOwner(owner) {
+            tpe(name.name, name.pos, Kind.CLASS, 0)
+          }
+        case OBJECT =>
+          if (isPackageObject) {
+            currentOwner = symbol(Scala.Descriptor.Package(name.name))
+            term("package", name.pos, Kind.OBJECT, 0)
+          } else {
+            term(name.name, name.pos, Kind.OBJECT, 0)
+          }
+      }
     }
     scanner.nextToken()
   }
@@ -487,8 +494,9 @@ class ScalaToplevelMtags(
           resetRegion(region)
         })
       case TYPE =>
-        val name = newIdentifier
-        tpe(name.name, name.pos, Kind.TYPE, 0)
+        newIdentifier.foreach { name =>
+          tpe(name.name, name.pos, Kind.TYPE, 0)
+        }
       case DEF =>
         methodIdentifier.foreach(name =>
           method(
@@ -584,14 +592,17 @@ class ScalaToplevelMtags(
   /**
    * Returns a name and position for the current identifier token
    */
-  def newIdentifier: Identifier = {
+  def newIdentifier: Option[Identifier] = {
     scanner.curr.token match {
-      case IDENTIFIER => // OK
-      case _ => fail("identifier")
+      case IDENTIFIER =>
+        val pos = newPosition
+        val name = scanner.curr.name
+        Some(new Identifier(name, pos))
+      case _ =>
+        reportError("identifier")
+        None
     }
-    val pos = newPosition
-    val name = scanner.curr.name
-    new Identifier(name, pos)
+
   }
 
   /**
@@ -603,7 +614,9 @@ class ScalaToplevelMtags(
         Some(new Identifier(scanner.curr.name, newPosition))
       case THIS =>
         None
-      case _ => fail("identifier")
+      case _ =>
+        reportError("identifier")
+        None
     }
   }
 
@@ -627,7 +640,7 @@ class ScalaToplevelMtags(
         val identifier = newIdentifier
         consumeParams()
         scanner.curr.token match {
-          case COLON => Some(identifier)
+          case COLON => identifier
           case _ => None
         }
       case _ => None
@@ -662,8 +675,14 @@ class ScalaToplevelMtags(
         case _ => false
       })
 
-  def fail(expected: String): Nothing = {
-    throw new TokenizeException(newPosition, failMessage(expected))
+  def reportError(expected: String): Unit = {
+    rc.incognito.create(
+      Report(
+        "scala-toplevel-mtags",
+        failMessage(expected),
+        s"""${input.path}:${newPosition}"""
+      )
+    )
   }
 
   def failMessage(expected: String): String = {

--- a/tests/mtest/src/main/scala/tests/DelegatingGlobalSymbolIndex.scala
+++ b/tests/mtest/src/main/scala/tests/DelegatingGlobalSymbolIndex.scala
@@ -1,6 +1,7 @@
 package tests
 
 import scala.meta.Dialect
+import scala.meta.internal.metals.EmptyReportContext
 import scala.meta.internal.mtags
 import scala.meta.internal.mtags.GlobalSymbolIndex
 import scala.meta.internal.mtags.OnDemandSymbolIndex
@@ -11,7 +12,8 @@ import scala.meta.io.AbsolutePath
  * Symbol index that delegates all methods to an underlying implementation
  */
 class DelegatingGlobalSymbolIndex(
-    var underlying: GlobalSymbolIndex = OnDemandSymbolIndex.empty()
+    var underlying: GlobalSymbolIndex =
+      OnDemandSymbolIndex.empty()(EmptyReportContext)
 ) extends GlobalSymbolIndex {
 
   def definitions(symbol: mtags.Symbol): List[SymbolDefinition] =

--- a/tests/mtest/src/main/scala/tests/PCSuite.scala
+++ b/tests/mtest/src/main/scala/tests/PCSuite.scala
@@ -11,8 +11,10 @@ import scala.meta.dialects
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.ClasspathSearch
 import scala.meta.internal.metals.Docstrings
+import scala.meta.internal.metals.EmptyReportContext
 import scala.meta.internal.metals.ExcludedPackagesHandler
 import scala.meta.internal.metals.JdkSources
+import scala.meta.internal.metals.ReportContext
 import scala.meta.io.AbsolutePath
 
 import coursierapi.Fetch
@@ -44,7 +46,9 @@ trait PCSuite {
     .map(_.toPath())
     .toSeq
 
-  protected def search(myclasspath: Seq[Path]): TestingSymbolSearch = {
+  protected def search(
+      myclasspath: Seq[Path]
+  )(implicit rc: ReportContext = EmptyReportContext): TestingSymbolSearch = {
     new TestingSymbolSearch(
       ClasspathSearch
         .fromClasspath(myclasspath, ExcludedPackagesHandler.default),

--- a/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
+++ b/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
@@ -8,6 +8,8 @@ import java.{util => ju}
 import scala.meta.inputs.Input
 import scala.meta.internal.metals.ClasspathSearch
 import scala.meta.internal.metals.Docstrings
+import scala.meta.internal.metals.EmptyReportContext
+import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.metals.WorkspaceSymbolInformation
 import scala.meta.internal.metals.WorkspaceSymbolQuery
 import scala.meta.internal.mtags.GlobalSymbolIndex
@@ -29,10 +31,12 @@ import org.eclipse.lsp4j.Location
  */
 class TestingSymbolSearch(
     classpath: ClasspathSearch = ClasspathSearch.empty,
-    docs: Docstrings = Docstrings.empty,
-    workspace: TestingWorkspaceSearch = TestingWorkspaceSearch.empty,
-    index: GlobalSymbolIndex = OnDemandSymbolIndex.empty(),
-) extends SymbolSearch {
+    docs: Docstrings = Docstrings.empty(EmptyReportContext),
+    workspace: TestingWorkspaceSearch =
+      TestingWorkspaceSearch.empty(EmptyReportContext),
+    index: GlobalSymbolIndex = OnDemandSymbolIndex.empty()(EmptyReportContext),
+)(implicit rc: ReportContext = EmptyReportContext)
+    extends SymbolSearch {
   override def documentation(
       symbol: String,
       parents: ParentSymbols,

--- a/tests/mtest/src/main/scala/tests/TestingWorkspaceSearch.scala
+++ b/tests/mtest/src/main/scala/tests/TestingWorkspaceSearch.scala
@@ -6,6 +6,8 @@ import scala.collection.mutable
 
 import scala.meta.Dialect
 import scala.meta.inputs.Input
+import scala.meta.internal.metals.EmptyReportContext
+import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.metals.SemanticdbDefinition
 import scala.meta.internal.metals.WorkspaceSymbolInformation
 import scala.meta.internal.metals.WorkspaceSymbolQuery
@@ -13,10 +15,12 @@ import scala.meta.internal.mtags.ScalametaCommonEnrichments.XtensionWorkspaceSym
 import scala.meta.pc.SymbolSearchVisitor
 
 object TestingWorkspaceSearch {
-  def empty: TestingWorkspaceSearch = new TestingWorkspaceSearch
+  def empty(implicit
+      rc: ReportContext = EmptyReportContext
+  ): TestingWorkspaceSearch = new TestingWorkspaceSearch
 }
 
-class TestingWorkspaceSearch {
+class TestingWorkspaceSearch(implicit rc: ReportContext = EmptyReportContext) {
   val inputs: mutable.Map[String, (String, Dialect)] =
     mutable.Map.empty[String, (String, Dialect)]
   def search(

--- a/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
+++ b/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
@@ -71,7 +71,7 @@ object MetalsTestEnrichments {
                 symbols += defn.toCached
               }
             }
-        }
+        }(m.internal.metals.EmptyReportContext)
         wsp.didChange(source, symbols.toSeq, methodSymbols.toSeq)
       }
     }

--- a/tests/unit/src/main/scala/tests/TestingWorkspaceSymbolProvider.scala
+++ b/tests/unit/src/main/scala/tests/TestingWorkspaceSymbolProvider.scala
@@ -2,6 +2,7 @@ package tests
 
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.CompressedPackageIndex
+import scala.meta.internal.metals.EmptyReportContext
 import scala.meta.internal.metals.ExcludedPackagesHandler
 import scala.meta.internal.metals.WorkspaceSymbolProvider
 import scala.meta.internal.mtags.OnDemandSymbolIndex
@@ -11,7 +12,8 @@ object TestingWorkspaceSymbolProvider {
   def apply(
       workspace: AbsolutePath,
       saveClassFileToDisk: Boolean = true,
-      index: OnDemandSymbolIndex = OnDemandSymbolIndex.empty(),
+      index: OnDemandSymbolIndex =
+        OnDemandSymbolIndex.empty()(EmptyReportContext),
       bucketSize: Int = CompressedPackageIndex.DefaultBucketSize,
   ): WorkspaceSymbolProvider = {
     new WorkspaceSymbolProvider(
@@ -21,6 +23,6 @@ object TestingWorkspaceSymbolProvider {
       saveClassFileToDisk = saveClassFileToDisk,
       () => ExcludedPackagesHandler.default,
       bucketSize = bucketSize,
-    )
+    )(EmptyReportContext)
   }
 }

--- a/tests/unit/src/test/scala/tests/DefinitionDirectorySuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionDirectorySuite.scala
@@ -1,12 +1,13 @@
 package tests
 
 import scala.meta.dialects
+import scala.meta.internal.metals.EmptyReportContext
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.mtags.Symbol
 
 class DefinitionDirectorySuite extends BaseSuite {
   test("basicScala") {
-    val index = OnDemandSymbolIndex.empty()
+    val index = OnDemandSymbolIndex.empty()(EmptyReportContext)
     def assertDefinition(sym: String): Unit = {
       val definition = index.definition(Symbol(sym))
       if (definition.isEmpty) throw new NoSuchElementException(sym)
@@ -24,7 +25,7 @@ class DefinitionDirectorySuite extends BaseSuite {
     assertDefinition("com/foo/Bar.")
   }
   test("basicJava") {
-    val index = OnDemandSymbolIndex.empty()
+    val index = OnDemandSymbolIndex.empty()(EmptyReportContext)
     def assertDefinition(sym: String): Unit = {
       val definition = index.definition(Symbol(sym))
       if (definition.isEmpty) throw new NoSuchElementException(sym)

--- a/tests/unit/src/test/scala/tests/DefinitionSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionSuite.scala
@@ -2,6 +2,7 @@ package tests
 
 import scala.meta._
 import scala.meta.internal.inputs._
+import scala.meta.internal.metals.EmptyReportContext
 import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ScalaVersions
@@ -35,7 +36,7 @@ abstract class DefinitionSuiteBase(
   override lazy val input: InputProperties = inputProps
 
   override def testCases(): List[ExpectTestCase] = {
-    val index = OnDemandSymbolIndex.empty()
+    val index = OnDemandSymbolIndex.empty()(EmptyReportContext)
     // Step 1. Index project sources
     input.allFiles.foreach { source =>
       index.addSourceFile(source.file, Some(source.sourceDirectory), dialect)

--- a/tests/unit/src/test/scala/tests/JdkSourcesSuite.scala
+++ b/tests/unit/src/test/scala/tests/JdkSourcesSuite.scala
@@ -1,6 +1,7 @@
 package tests
 
 import scala.meta.dialects
+import scala.meta.internal.metals.EmptyReportContext
 import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.mtags.Symbol
@@ -12,7 +13,7 @@ class JdkSourcesSuite extends BaseSuite {
 
   test("index-src.zip") {
     val jdk = JdkSources().right.get
-    val symbolIndex = OnDemandSymbolIndex.empty()
+    val symbolIndex = OnDemandSymbolIndex.empty()(EmptyReportContext)
 
     symbolIndex.addSourceJar(jdk, dialects.Scala213)
 

--- a/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
@@ -428,6 +428,28 @@ class ScalaToplevelSuite extends BaseSuite {
     all = true,
   )
 
+  check(
+    "givens",
+    """|package a
+       |given intValue: Int = 4
+       |given String = "str"
+       |given (using i: Int): Double = 4.0
+       |given [T]: List[T] = Nil
+       |given given_Char: Char = '?'
+       |given `given_Float`: Float = 3.0
+       |given `* *` : Long = 5
+       |given [T]: List[T] =
+       |  val m = 3 
+       |  ???
+       |given listOrd[T](using ord: List[T]): List[List[T]] = ???
+       |""".stripMargin,
+    List("a/", "a/Test$package.", "a/Test$package.`* *`().",
+      "a/Test$package.given_Char().", "a/Test$package.given_Float().",
+      "a/Test$package.intValue().", "a/Test$package.listOrd()."),
+    dialect = dialects.Scala3,
+    all = true,
+  )
+
   def check(
       options: TestOptions,
       code: String,

--- a/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
@@ -429,7 +429,7 @@ class ScalaToplevelSuite extends BaseSuite {
   )
 
   check(
-    "givens",
+    "given-aliases",
     """|package a
        |given intValue: Int = 4
        |given String = "str"


### PR DESCRIPTION
Previously:
In ScalatopLevelMtags we expected an identifier after `given` keyword, so we would fail on `given [A]...`.
Now:
1. We check if it's an identifier and emit a term only if after the identifier there is a colon with only args and params in between.
2. We don't throw exceptions in `ScalatopLevelMtags` on an error, instead we create a report and keep indexing.
