### PR TITLE
bugfix: keep evaluated worksheets synced with dependencies in presentation compiler

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -618,6 +618,32 @@ class MetalsLspService(
     definitionProvider,
   )
 
+  val worksheetProvider: WorksheetProvider = {
+    val worksheetPublisher =
+      if (clientConfig.isDecorationProvider)
+        new DecorationWorksheetPublisher(
+          clientConfig.isInlineDecorationProvider()
+        )
+      else
+        new WorkspaceEditWorksheetPublisher(buffers, trees)
+
+    register(
+      new WorksheetProvider(
+        folder,
+        buffers,
+        buildTargets,
+        languageClient,
+        userConfig,
+        statusBar,
+        diagnostics,
+        embedded,
+        worksheetPublisher,
+        compilations,
+        scalaVersionSelector,
+      )
+    )
+  }
+
   private val compilers: Compilers = register(
     new Compilers(
       folder,
@@ -635,6 +661,7 @@ class MetalsLspService(
       trees,
       mtagsResolver,
       sourceMapper,
+      worksheetProvider,
     )
   )
 
@@ -755,33 +782,6 @@ class MetalsLspService(
       () => bspSession.map(_.mainConnectionIsBloop).getOrElse(false),
       clientConfig.initialConfig.statistics,
     )
-
-  val worksheetProvider: WorksheetProvider = {
-    val worksheetPublisher =
-      if (clientConfig.isDecorationProvider)
-        new DecorationWorksheetPublisher(
-          clientConfig.isInlineDecorationProvider()
-        )
-      else
-        new WorkspaceEditWorksheetPublisher(buffers, trees)
-
-    register(
-      new WorksheetProvider(
-        folder,
-        buffers,
-        buildTargets,
-        languageClient,
-        userConfig,
-        statusBar,
-        diagnostics,
-        embedded,
-        worksheetPublisher,
-        compilers,
-        compilations,
-        scalaVersionSelector,
-      )
-    )
-  }
 
   private val popupChoiceReset: PopupChoiceReset = new PopupChoiceReset(
     folder,


### PR DESCRIPTION
Previously:
If compilers were reloaded (e.g. when doing `import build`) `worksheetsDigests` would fall out of sync with dependencies in the presentation compiler.
Now: 
 1. Moved `worksheetsDigests` to compilers so it's reset with presentation compilers too.
 2. Still evaluated worksheets get out of sync w/ `pc`s, so if there is no `pc` for `worksheet` we ask `WorksheetProvider` to produce one if it has this worksheet evaluated in `cache`.

should fix: https://github.com/scalameta/metals/issues/5199