### PR TITLE
bugfix: Only log message if it's not null

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
@@ -106,8 +106,9 @@ final class ConfiguredLanguageClient(
       underlying
         .refreshSemanticTokens()
         .handle { (msg, ex) =>
-          scribe.warn(s"Error while refreshing semantic tokens: $msg", ex)
-          null
+          if (ex != null)
+            scribe.warn(s"Error while refreshing semantic tokens: $msg", ex)
+          msg
         }
     } else CompletableFuture.allOf()
   }


### PR DESCRIPTION
`handle` on CompletableFuture is invoked every time, so we should only log if an error is actually present.