### PR TITLE
bugfix: NoPosition on Bind in semantic tokens for scala 2

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
@@ -381,7 +381,7 @@ abstract class PcCollector[T](
          * }
          * case <<bar>>: Bar =>
          */
-        case bind: Bind if filter(bind) =>
+        case bind: Bind if bind.pos.isDefined && filter(bind) =>
           bind.children.foldLeft(
             acc + collect(
               bind,


### PR DESCRIPTION
Not sure what case was causing this, but I noticed it in `MetalsLspService`