### PR TITLE
bugfix: skip package objects as completions & never `backtickify` package objects

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -329,7 +329,8 @@ class CompletionProvider(
         completion.isCandidate(head) &&
         !head.sym.name.containsName(CURSOR) &&
         isNotLocalForwardReference &&
-        !isAliasCompletion(head)
+        !isAliasCompletion(head) &&
+        !head.sym.isPackageObjectOrClass
       ) {
         isSeen += id
         buf += head

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -260,6 +260,7 @@ class MetalsGlobal(
     if (
       Identifier.needsBacktick(sym.name.decoded)
       && sym.owner != definitions.ScalaPackageClass
+      && !sym.isPackageObjectOrClass
     ) {
       val name0: sym.NameType = sym.rawname
       val name: Name = name0.newName(Identifier.backtickWrap(name0))

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -488,4 +488,24 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
     """.stripMargin,
   )
 
+  checkEdit(
+    "package-object-backticks".tag(IgnoreScala3),
+    s"""|package a
+        |package object `x-x` {
+        |  type AAA = Int
+        |}
+        |object O {
+        |  val f : `x-x`.A@@
+        |}
+        |""".stripMargin,
+    s"""|package a
+        |package object `x-x` {
+        |  type AAA = Int
+        |}
+        |object O {
+        |  val f : `x-x`.AAA
+        |}
+        |""".stripMargin,
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1496,7 +1496,6 @@ class CompletionSuite extends BaseCompletionSuite {
     compat = Map(
       "2" ->
         """|scala _root_
-           |`package` - scala
            |""".stripMargin
     ),
   )


### PR DESCRIPTION
Previously: for some completions we'd try to `backtickify` package object symbol type, which would in an error.
Now:
 1. We make sure to never `backtickify` package object symbol type (the name there is always `package`)
 2. We filer package object as a potential completion
 
fixes: https://github.com/scalameta/metals/issues/5250