### PR TITLE
fix: Regions based on indent

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
@@ -14,12 +14,16 @@ object SemanticdbSymbols:
 
     val defns = ctx.definitions
     import defns.*
-
     def loop(s: String): List[Symbol] =
       if s.isNone || s.isRootPackage then RootPackage :: Nil
       else if s.isEmptyPackage then EmptyPackageVal :: Nil
       else if s.isPackage then
-        try requiredPackage(s.stripSuffix("/").replace("/", ".")) :: Nil
+        try
+          val pkg = requiredPackage(s.stripSuffix("/").replace("/", "."))
+          if pkg == NoSymbol then Nil
+          else
+            val moduleclasses = pkg.info.decls.filter(_.is(ModuleClass))
+            pkg :: moduleclasses.toList
         catch
           case NonFatal(_) =>
             Nil
@@ -64,7 +68,7 @@ object SemanticdbSymbols:
                     .alternatives
                     .iterator
                     .map(_.symbol)
-                    .filter(sym => symbolName(sym) == s)
+                    // .filter(sym => symbolName(sym) == s)
                     .toList
 
         parentSymbol.flatMap(tryMember)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
@@ -11,19 +11,13 @@ object SemanticdbSymbols:
 
   def inverseSemanticdbSymbol(sym: String)(using ctx: Context): List[Symbol] =
     import scala.meta.internal.semanticdb.Scala.*
-
     val defns = ctx.definitions
     import defns.*
     def loop(s: String): List[Symbol] =
       if s.isNone || s.isRootPackage then RootPackage :: Nil
       else if s.isEmptyPackage then EmptyPackageVal :: Nil
       else if s.isPackage then
-        try
-          val pkg = requiredPackage(s.stripSuffix("/").replace("/", "."))
-          if pkg == NoSymbol then Nil
-          else
-            val moduleclasses = pkg.info.decls.filter(_.is(ModuleClass))
-            pkg :: moduleclasses.toList
+        try requiredPackage(s.stripSuffix("/").replace("/", ".")) :: Nil
         catch
           case NonFatal(_) =>
             Nil
@@ -68,7 +62,7 @@ object SemanticdbSymbols:
                     .alternatives
                     .iterator
                     .map(_.symbol)
-                    // .filter(sym => symbolName(sym) == s)
+                    .filter(sym => symbolName(sym) == s)
                     .toList
 
         parentSymbol.flatMap(tryMember)

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -38,7 +38,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       original: String,
       filename: String = "A.scala",
   ): Seq[CompletionItem] = {
-    val (code, offset) = params(original)
+    val (code, offset) = params(original, filename)
     val result = resolvedCompletions(
       CompilerOffsetParams(
         Paths.get(filename).toUri(),
@@ -144,7 +144,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       }
       if (items.size <= itemIndex) fail("Not enough completion items")
       val item = items(itemIndex)
-      val (code, _) = params(original)
+      val (code, _) = params(original, filename)
       val obtained = TextEdits.applyEdits(code, item)
       assertNoDiff(
         obtained,

--- a/tests/cross/src/main/scala/tests/BaseDocumentHighlightSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseDocumentHighlightSuite.scala
@@ -23,7 +23,7 @@ class BaseDocumentHighlightSuite extends BasePCSuite with RangeReplace {
       val expected = original.replaceAll("@@", "")
       val base = original.replaceAll("(<<|>>|@@)", "")
 
-      val (code, offset) = params(edit)
+      val (code, offset) = params(edit, "Highlight.scala")
       val highlights = presentationCompiler
         .documentHighlight(
           CompilerOffsetParams(

--- a/tests/cross/src/main/scala/tests/BasePcRenameSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePcRenameSuite.scala
@@ -34,7 +34,7 @@ class BasePcRenameSuite extends BasePCSuite with RangeReplace {
       val expected =
         original.replaceAll("@@", "").replaceAll("\\<\\<\\S*\\>\\>", newName)
       val base = original.replaceAll("(<<|>>|@@)", "")
-      val (code, offset) = params(edit)
+      val (code, offset) = params(edit,filename)
       val renames = presentationCompiler
         .rename(
           CompilerOffsetParams(
@@ -66,7 +66,7 @@ class BasePcRenameSuite extends BasePCSuite with RangeReplace {
       val expected =
         input.replaceAll("@@", "")
       val base = input.replaceAll("(<<|>>|@@)", "")
-      val (code, offset) = params(edit)
+      val (code, offset) = params(edit, filename)
       val range = presentationCompiler
         .prepareRename(
           CompilerOffsetParams(

--- a/tests/cross/src/main/scala/tests/BasePcRenameSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePcRenameSuite.scala
@@ -34,7 +34,7 @@ class BasePcRenameSuite extends BasePCSuite with RangeReplace {
       val expected =
         original.replaceAll("@@", "").replaceAll("\\<\\<\\S*\\>\\>", newName)
       val base = original.replaceAll("(<<|>>|@@)", "")
-      val (code, offset) = params(edit,filename)
+      val (code, offset) = params(edit, filename)
       val renames = presentationCompiler
         .rename(
           CompilerOffsetParams(

--- a/tests/cross/src/main/scala/tests/BaseSignatureHelpSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseSignatureHelpSuite.scala
@@ -28,7 +28,7 @@ abstract class BaseSignatureHelpSuite extends BasePCSuite {
   )(implicit loc: Location): Unit = {
     test(name) {
       val pkg = scala.meta.Term.Name(name.name).syntax
-      val (code, offset) = params(s"package $pkg\n" + original)
+      val (code, offset) = params(s"package $pkg\n" + original, "A.scala")
       val result =
         presentationCompiler
           .signatureHelp(

--- a/tests/cross/src/main/scala/tests/pc/BaseSelectionRangeSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BaseSelectionRangeSuite.scala
@@ -24,7 +24,7 @@ abstract class BaseSelectionRangeSuite extends BasePCSuite {
       compat: Map[String, List[String]] = Map.empty,
   ): Unit = {
     test(name) {
-      val (code, offset) = params(original)
+      val (code, offset) = params(original, "SelectionRange.scala")
       val offsetParams: ju.List[OffsetParams] = List[OffsetParams](
         CompilerOffsetParams(
           Paths.get("SelectionRange.scala").toUri(),

--- a/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
@@ -50,7 +50,7 @@ class CancelCompletionSuite extends BaseCompletionSuite {
       compat: Map[String, String] = Map.empty,
   )(implicit loc: Location): Unit = {
     test(name) {
-      val (code, offset) = params(query)
+      val (code, offset) = params(query, "A.scala")
       val token = new AlwaysCancelToken
       try {
         presentationCompiler
@@ -124,7 +124,7 @@ class CancelCompletionSuite extends BaseCompletionSuite {
                   |  val x = asser@@
                   |}
                """.stripMargin
-    val (code, offset) = params(query)
+    val (code, offset) = params(query, "A.scala")
     val uri = URI.create("file:///A.scala")
     try {
       presentationCompiler

--- a/tests/cross/src/test/scala/tests/pc/CompletionExtensionMethodSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionExtensionMethodSuite.scala
@@ -130,4 +130,50 @@ class CompletionExtensionMethodSuite extends BaseCompletionSuite {
        |""".stripMargin,
   )
 
+  check(
+    "directly-in-pkg1",
+    """|
+       |package example:
+       |  extension (num: Int)
+       |    def incr: Int = num + 1
+       |
+       |package example2: 
+       |  def main = 100.inc@@
+       |""".stripMargin,
+    """|incr: Int (extension)
+       |""".stripMargin,
+  )
+
+  check(
+    "directly-in-pkg2",
+    """|package example:
+       |  object X:
+       |    def fooBar(num: Int) = num + 1
+       |  extension (num: Int) def incr: Int = num + 1
+       |
+       |package example2: 
+       |  def main = 100.inc@@
+       |""".stripMargin,
+    """|incr: Int (extension)
+       |""".stripMargin,
+  )
+
+  check(
+    "nested-pkg",
+    """|package a:  // some comment
+       |  package c: 
+       |    extension (num: Int)
+       |        def increment2 = num + 2
+       |  extension (num: Int)
+       |    def increment = num + 1
+       |
+       |
+       |package b:
+       |  def main: Unit = 123.incre@@
+       |""".stripMargin,
+    """|increment: Int (extension)
+       |increment2: Int (extension)
+       |""".stripMargin,
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionExtensionMethodSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionExtensionMethodSuite.scala
@@ -130,8 +130,10 @@ class CompletionExtensionMethodSuite extends BaseCompletionSuite {
        |""".stripMargin,
   )
 
+  // NOTE: In 3.1.3, package object name includes the whole path to file
+  // eg. in 3.2.2 we get `A$package`, but in 3.1.3 `/some/path/to/file/A$package`
   check(
-    "directly-in-pkg1",
+    "directly-in-pkg1".tag(IgnoreScalaVersion.forLessThan("3.2.2")),
     """|
        |package example:
        |  extension (num: Int)
@@ -145,7 +147,7 @@ class CompletionExtensionMethodSuite extends BaseCompletionSuite {
   )
 
   check(
-    "directly-in-pkg2",
+    "directly-in-pkg2".tag(IgnoreScalaVersion.forLessThan("3.2.2")),
     """|package example:
        |  object X:
        |    def fooBar(num: Int) = num + 1
@@ -158,8 +160,25 @@ class CompletionExtensionMethodSuite extends BaseCompletionSuite {
        |""".stripMargin,
   )
 
+  checkEdit(
+    "directly-in-pkg3".tag(IgnoreScalaVersion.forLessThan("3.2.2")),
+    """|package example:
+       |  extension (num: Int) def incr: Int = num + 1
+       |
+       |package example2: 
+       |  def main = 100.inc@@
+       |""".stripMargin,
+    """|import example.incr
+       |package example:
+       |  extension (num: Int) def incr: Int = num + 1
+       |
+       |package example2: 
+       |  def main = 100.incr
+       |""".stripMargin,
+  )
+
   check(
-    "nested-pkg",
+    "nested-pkg".tag(IgnoreScalaVersion.forLessThan("3.2.2")),
     """|package a:  // some comment
        |  package c: 
        |    extension (num: Int)

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -899,7 +899,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "directly-in-pkg".tag(IgnoreScala2),
+    "directly-in-pkg".tag(IgnoreScalaVersion.forLessThan("3.2.2")),
     """|package a:
        |  object Y:
        |    val bar = 123
@@ -920,7 +920,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
   )
 
   check(
-    "nested-pkg".tag(IgnoreScala2),
+    "nested-pkg".tag(IgnoreScalaVersion.forLessThan("3.2.2")),
     """|package a:
        |  package c: // some comment
        |    def increment2 = 2
@@ -938,4 +938,26 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |increment2: Int
        |""".stripMargin,
   )
+
+  check(
+    "indent-method".tag(IgnoreScalaVersion.forLessThan("3.2.2")),
+    """|package a:
+       |  val y = 123
+       |  given intGiven: Int = 123
+       |  type Alpha = String
+       |  class Foo(x: Int)
+       |  object X:
+       |    val x = 123
+       |  def fooBar(x: Int) = x + 1
+       |  package b:
+       |    def fooBar(x: String) = x.length
+       |
+       |package c:
+       |  def main() = foo@@
+       |""".stripMargin,
+    """|fooBar(x: Int): Int
+       |fooBar(x: String): Int
+       |""".stripMargin,
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -897,4 +897,45 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
            |""".stripMargin
     ),
   )
+
+  checkEdit(
+    "directly-in-pkg".tag(IgnoreScala2),
+    """|package a:
+       |  object Y:
+       |    val bar = 123
+       |  val fooBar = 123
+       |
+       |package b:
+       |  def main() = fooB@@
+       |""".stripMargin,
+    """|import a.fooBar
+       |package a:
+       |  object Y:
+       |    val bar = 123
+       |  val fooBar = 123
+       |
+       |package b:
+       |  def main() = fooBar
+       |""".stripMargin,
+  )
+
+  check(
+    "nested-pkg".tag(IgnoreScala2),
+    """|package a:
+       |  package c: // some comment
+       |    def increment2 = 2
+       |  def increment = 1
+       |
+       |package d:
+       |  val increment3 = 3
+       |
+       |
+       |package b:
+       |  def main: Unit = incre@@
+       |""".stripMargin,
+    """|increment3: Int
+       |increment: Int
+       |increment2: Int
+       |""".stripMargin,
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/InterruptPresentationCompilerSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InterruptPresentationCompilerSuite.scala
@@ -52,7 +52,7 @@ class InterruptPresentationCompilerSuite extends BasePCSuite {
       act: (PresentationCompiler, OffsetParams) => CompletableFuture[_],
   )(implicit loc: Location): Unit = {
     test(name) {
-      val (code, offset) = this.params(original)
+      val (code, offset) = this.params(original, "A.scala")
       val interrupt = index.asInstanceOf[InterruptSymbolIndex]
       try {
         val result = act(

--- a/tests/mtest/src/main/scala/tests/PCSuite.scala
+++ b/tests/mtest/src/main/scala/tests/PCSuite.scala
@@ -87,8 +87,8 @@ trait PCSuite {
 
   private def addSourceToIndex(filename: String, code2: String): Unit = {
     val file = tmp.resolve(filename)
+    Files.createDirectories(file.toNIO.getParent)
     Files.write(file.toNIO, code2.getBytes(StandardCharsets.UTF_8))
-
     try index.addSourceFile(file, Some(tmp), dialect)
     catch {
       case NonFatal(e) =>


### PR DESCRIPTION
solves https://github.com/scalameta/metals/issues/5241
The problem was not connected to packages being in the same file, but to `extensions` being defined in package at the toplevel. This PR contains multiple fixes:

1. For `val/def/extension/...` defined inside `package`, their owner is `module class <filename>$package$`, not the package directly, so in `inverseSemanticdbSymbol`, we have to look inside `module class`es too.
2. Previously regions based on indent were working incorrectly if colon was not followed directly by a newline.
3. We were not always using correct region after escaping from indented region.