### PR TITLE
bugfix: handle delete file events notifications

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -497,8 +497,7 @@ class WorkspaceLspService(
           .iterator
           .toList
           .map(event => {
-            val uri = event.getUri()
-            (uri.toAbsolutePath, getServiceFor(uri))
+            (event, getServiceFor(event.getUri()))
           })
           .groupBy(_._2)
           .map { case (service, paths) =>


### PR DESCRIPTION
Previously: we did not handle properly `deletions`, which caused metals to try and read an non-existing file.
Now: we also handle `deletion` in `didChangeWatchedFiles`.