### PR TITLE
improvement: Make sure 'isAccessibleFrom' always succeeds

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/IndexedContext.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/IndexedContext.scala
@@ -138,17 +138,21 @@ object IndexedContext:
 
   private def extractNames(ctx: Context): Names =
 
+    def isAccessibleFromSafe(sym: Symbol, site: Type): Boolean =
+      try sym.isAccessibleFrom(site, superAccess = false)
+      catch
+        case NonFatal(e) =>
+          false
+
     def accessibleSymbols(site: Type, tpe: Type)(using
         Context
     ): List[Symbol] =
-      tpe.decls.toList.filter(sym =>
-        sym.isAccessibleFrom(site, superAccess = false)
-      )
+      tpe.decls.toList.filter(sym => isAccessibleFromSafe(sym, site))
 
     def accesibleMembers(site: Type)(using Context): List[Symbol] =
       site.allMembers
         .filter(denot =>
-          try denot.symbol.isAccessibleFrom(site, superAccess = false)
+          try isAccessibleFromSafe(denot.symbol, site)
           catch
             case NonFatal(e) =>
               false


### PR DESCRIPTION
Previously, everything would break is `isAccessibleFrom` threw an exception. Now, we default to false, which is the safer option.

Connected to https://github.com/scalameta/metals/issues/5268