### PR TITLE
bugfix[Scala 3]: Fix issues when shortened type is used in type bounds

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ExtractMethodProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ExtractMethodProvider.scala
@@ -4,6 +4,7 @@ import java.nio.file.Paths
 
 import scala.meta as m
 
+import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.mtags.MtagsEnrichments.*
 import scala.meta.internal.pc.MetalsInteractive.*
 import scala.meta.internal.pc.printer.MetalsPrinter
@@ -33,7 +34,8 @@ final class ExtractMethodProvider(
     driver: InteractiveDriver,
     search: SymbolSearch,
     noIndent: Boolean,
-) extends ExtractMethodUtils:
+)(using ReportContext)
+    extends ExtractMethodUtils:
 
   def extractMethod(): List[TextEdit] =
     val text = range.text()

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/InferredTypeProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/InferredTypeProvider.scala
@@ -5,6 +5,7 @@ import java.nio.file.Paths
 import scala.annotation.tailrec
 import scala.meta as m
 
+import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.mtags.MtagsEnrichments.*
 import scala.meta.internal.pc.printer.MetalsPrinter
 import scala.meta.internal.pc.printer.ShortenedNames
@@ -50,7 +51,7 @@ final class InferredTypeProvider(
     driver: InteractiveDriver,
     config: PresentationCompilerConfig,
     symbolSearch: SymbolSearch,
-):
+)(using ReportContext):
 
   case class AdjustTypeOpts(
       text: String,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -5,6 +5,7 @@ import java.{util as ju}
 
 import scala.collection.JavaConverters.*
 
+import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.mtags.MtagsEnrichments.*
 import scala.meta.internal.pc.AutoImports.AutoImport
 import scala.meta.internal.pc.AutoImports.AutoImportsGenerator
@@ -52,7 +53,7 @@ object OverrideCompletions:
       config: PresentationCompilerConfig,
       autoImportsGen: AutoImportsGenerator,
       fallbackName: Option[String],
-  ): List[CompletionValue] =
+  )(using ReportContext): List[CompletionValue] =
     import indexedContext.ctx
     val clazz = td.symbol.asClass
     val syntheticCoreMethods: Set[Name] =
@@ -133,7 +134,7 @@ object OverrideCompletions:
       driver: InteractiveDriver,
       search: SymbolSearch,
       config: PresentationCompilerConfig,
-  ): ju.List[l.TextEdit] =
+  )(using ReportContext): ju.List[l.TextEdit] =
     object FindTypeDef:
       def unapply(path: List[Tree])(using Context): Option[TypeDef] = path match
         // class <<Foo>> extends ... {}
@@ -224,7 +225,7 @@ object OverrideCompletions:
       config: PresentationCompilerConfig,
   )(
       defn: TargetDef
-  )(using Context): List[l.TextEdit] =
+  )(using Context, ReportContext): List[l.TextEdit] =
     def calcIndent(
         defn: TargetDef,
         decls: List[Symbol],
@@ -392,7 +393,7 @@ object OverrideCompletions:
       config: PresentationCompilerConfig,
       autoImportsGen: AutoImportsGenerator,
       shouldAddOverrideKwd: Boolean,
-  )(using Context): CompletionValue.Override =
+  )(using Context, ReportContext): CompletionValue.Override =
     val renames = AutoImport.renameConfigMap(config)
     val printer = MetalsPrinter.standard(
       indexedContext,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/ShortenedNames.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/ShortenedNames.scala
@@ -220,7 +220,7 @@ object ShortenedNames:
     def apply(sym: Symbol)(using ctx: Context): ShortName =
       ShortName(sym.name, sym)
 
-  case class PrettyType(name: String) extends Type:
+  case class PrettyType(name: String) extends TermType:
     def hash: Int = 0
     def computeHash(bind: Binders) = hash
     override def toString = name

--- a/tests/cross/src/test/scala/tests/pc/CompletionTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionTypeSuite.scala
@@ -1,0 +1,28 @@
+package tests.pc
+
+import tests.BaseCompletionSuite
+
+class CompletionTypeSuite extends BaseCompletionSuite {
+
+  check(
+    "type-bound",
+    s"""|import java.nio.file.{FileSystem => FS}
+        |
+        |object O {
+        |  class Foo[T] {
+        |    def method[T <: FS](a: T) = ???
+        |  }
+        |  val foo = new Foo
+        |  foo.met@@
+        |}
+        |""".stripMargin,
+    s"""|method[T <: FS](a: T): Nothing
+        |""".stripMargin,
+    compat = Map(
+      "2" ->
+        """|method[T <: FileSystem](a: T): Nothing
+           |""".stripMargin
+    ),
+  )
+
+}


### PR DESCRIPTION
Previously, if we would try to show shorter type without packages in type bounds we would get an exception since type bounds require TermType.

Now, I switched TermType to be used for Pretty type and changed to default to long name in case of errors. I haven't seen issues related to TypeType, so we should be fine there, but we will get a nice error reprot if this happens.

Fixes https://github.com/scalameta/metals/issues/5225

CC @rochala 