### PR TITLE
refactor: Remove all warnings from the code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -532,7 +532,7 @@ lazy val input = project
     ),
     scalacOptions ++= Seq("-P:semanticdb:synthetics:on", "-Ymacro-annotations"),
     scalacOptions ~= { options =>
-      options.filter(_ != "-Wunused")
+      options.filter(!_.contains("-Wunused"))
     },
   )
   .disablePlugins(ScalafixPlugin)
@@ -550,6 +550,9 @@ lazy val input3 = project
     ),
     scalaVersion := V.scala3,
     publish / skip := true,
+    scalacOptions ~= { options =>
+      options.filter(!_.contains("-Wunused"))
+    },
   )
   .disablePlugins(ScalafixPlugin)
 

--- a/metals-bench/src/main/scala/bench/MetalsBench.scala
+++ b/metals-bench/src/main/scala/bench/MetalsBench.scala
@@ -32,7 +32,12 @@ class MetalsBench {
 
   MetalsLogger.updateDefaultFormat()
   val inputs: InputProperties = InputProperties.scala2()
-  val classpath = new SemanticdbClasspath(inputs.sourceroot, inputs.classpath)
+  val classpath =
+    new SemanticdbClasspath(
+      inputs.sourceroot,
+      inputs.classpath,
+      inputs.semanticdbTargets,
+    )
   val documents: List[(AbsolutePath, TextDocument)] =
     inputs.scalaFiles.map { input =>
       (input.file, classpath.textDocument(input.file).get)

--- a/mtags/src/main/scala-3.3/scala/meta/internal/pc/MetalsNavigateAST.scala
+++ b/mtags/src/main/scala-3.3/scala/meta/internal/pc/MetalsNavigateAST.scala
@@ -1,7 +1,6 @@
 package scala.meta.internal.pc
 
 import dotty.tools.dotc.ast.NavigateAST
-import dotty.tools.dotc.ast.Positioned
 import dotty.tools.dotc.ast.untpd.ExtMethods
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.util.Spans.Span

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
@@ -3,7 +3,6 @@ package scala.meta.internal.pc
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters.*
 
-import scala.meta.internal.mtags.KeywordWrapper
 import scala.meta.internal.mtags.MtagsEnrichments.*
 import scala.meta.internal.pc.printer.ShortenedNames.ShortName
 import scala.meta.pc.PresentationCompilerConfig

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
@@ -314,8 +314,8 @@ abstract class PcCollector[T](
       case _ => resultAllOccurences().toList
 
   def resultAllOccurences(): Set[T] =
-    def noTreeFilter = (tree: Tree) => true
-    def noSoughtFilter = (f: Symbol => Boolean) => true
+    def noTreeFilter = (_: Tree) => true
+    def noSoughtFilter = (_: Symbol => Boolean) => true
 
     traverseSought(noTreeFilter, noSoughtFilter)
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -10,7 +10,6 @@ import scala.meta.pc.DefinitionResult
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.SymbolSearch
 
-import dotty.tools.dotc.CompilationUnit
 import dotty.tools.dotc.ast.NavigateAST
 import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.ast.untpd
@@ -42,8 +41,6 @@ class PcDefinitionProvider(
       uri,
       SourceFile.virtual(filePath.toString, params.text),
     )
-    val unit = driver.currentCtx.run.units.head
-    val tree = unit.tpdTree
 
     val pos = driver.sourcePosition(params)
     val path =
@@ -55,7 +52,7 @@ class PcDefinitionProvider(
       if findTypeDef then findTypeDefinitions(path, pos, indexedContext)
       else findDefinitions(path, pos, indexedContext)
 
-    if result.locations().isEmpty() then fallbackToUntyped(unit, pos)(using ctx)
+    if result.locations().isEmpty() then fallbackToUntyped(pos)(using ctx)
     else result
   end definitions
 
@@ -71,9 +68,7 @@ class PcDefinitionProvider(
    * @param pos cursor position
    * @return definition result
    */
-  private def fallbackToUntyped(unit: CompilationUnit, pos: SourcePosition)(
-      using ctx: Context
-  ) =
+  private def fallbackToUntyped(pos: SourcePosition)(using Context) =
     lazy val untpdPath = NavigateAST
       .untypedPath(pos.span)
       .collect { case t: untpd.Tree => t }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SelectionRangeProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SelectionRangeProvider.scala
@@ -3,19 +3,17 @@ package scala.meta.internal.pc
 import java.nio.file.Paths
 import java.{util as ju}
 
-import scala.collection.JavaConverters.*
+import scala.jdk.CollectionConverters.*
 
 import scala.meta.inputs.Position
 import scala.meta.internal.mtags.MtagsEnrichments.*
 import scala.meta.internal.pc.SelectionRangeProvider.*
 import scala.meta.pc.OffsetParams
 import scala.meta.tokens.Token
-import scala.meta.tokens.Token.Trivia
 
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.interactive.Interactive
 import dotty.tools.dotc.interactive.InteractiveDriver
-import dotty.tools.dotc.semanticdb.Scala3
 import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.util.SourcePosition
 import org.eclipse.lsp4j

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/AmmoniteFileCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/AmmoniteFileCompletions.scala
@@ -4,8 +4,6 @@ package completions
 import java.nio.file.Files
 import java.nio.file.Path
 
-import scala.collection.JavaConverters.*
-
 import scala.meta.internal.mtags.MtagsEnrichments.*
 
 import dotty.tools.dotc.ast.tpd.Tree

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/AmmoniteIvyCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/AmmoniteIvyCompletions.scala
@@ -3,7 +3,6 @@ package scala.meta.internal.pc.completions
 import scala.meta.internal.mtags.CoursierComplete
 import scala.meta.internal.mtags.MtagsEnrichments.*
 
-import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.ast.untpd.ImportSelector
 import dotty.tools.dotc.core.Contexts.Context
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -239,7 +239,6 @@ object CaseKeywordCompletion:
       completionPos,
       clientSupportsSnippets,
     )
-    val result = ListBuffer.empty[CompletionValue]
     val tpe = selector.tpe.widen.bounds.hi match
       case tr @ TypeRef(_, _) => tr.underlying
       case t => t

--- a/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
@@ -28,7 +28,7 @@ import scala.meta.pc.SymbolDocumentation
  *
  * Handles both javadoc and scaladoc.
  */
-class Docstrings(index: GlobalSymbolIndex)(implicit rc: ReportContext) {
+class Docstrings(index: GlobalSymbolIndex) {
   val cache = new TrieMap[String, SymbolDocumentation]()
   private val logger = Logger.getLogger(classOf[Docstrings].getName)
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaToplevelMtags.scala
@@ -55,7 +55,7 @@ class JavaToplevelMtags(val input: Input.VirtualFile) extends MtagsIndexer {
   }
 
   @tailrec
-  private def skipMultilineComment(prevStar: Boolean = false): Unit = {
+  private def skipMultilineComment(prevStar: Boolean): Unit = {
     reader.nextChar()
     if (prevStar) {
       if (reader.ch == '/') reader.nextChar()

--- a/mtags/src/main/scala/scala/meta/internal/mtags/SemanticdbClasspath.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/SemanticdbClasspath.scala
@@ -2,22 +2,25 @@ package scala.meta.internal.mtags
 
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
+import java.nio.file.Path
 
 import scala.meta.AbsolutePath
-import scala.meta.Classpath
 import scala.meta.internal.mtags
 import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 import scala.meta.internal.mtags.Semanticdbs.FoundSemanticDbPath
+import scala.meta.io.Classpath
 import scala.meta.io.RelativePath
 
 final case class SemanticdbClasspath(
     sourceroot: AbsolutePath,
     classpath: Classpath = Classpath(Nil),
+    semanticdbTargets: List[Path] = Nil,
     charset: Charset = StandardCharsets.UTF_8,
     fingerprints: Md5Fingerprints = Md5Fingerprints.empty
 ) extends Semanticdbs {
   val loader = new OpenClassLoader()
   loader.addClasspath(classpath.entries.map(_.toNIO))
+  loader.addClasspath(semanticdbTargets)
 
   def getSemanticdbPath(scalaOrJavaPath: AbsolutePath): AbsolutePath = {
     semanticdbPath(scalaOrJavaPath).getOrElse(

--- a/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
@@ -14,7 +14,6 @@ import scala.meta.Dialect
 import scala.meta.inputs.Input
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.io.PathIO
-import scala.meta.internal.mtags.OpenClassLoader
 import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.{semanticdb => s}

--- a/project/InputProperties.scala
+++ b/project/InputProperties.scala
@@ -62,6 +62,13 @@ object InputProperties extends AutoPlugin {
           .map(_.data)
           .mkString(File.pathSeparator),
       )
+      props.put(
+        "semanticdbTargets",
+        List(
+          (input / Compile / semanticdbTargetRoot).value,
+          (input / Test / semanticdbTargetRoot).value,
+        ).mkString(File.pathSeparator),
+      )
       IO.write(props, "input", out)
       List(out)
     }

--- a/tests/input/src/main/scala-3/example/LocalDeclarations.scala
+++ b/tests/input/src/main/scala-3/example/LocalDeclarations.scala
@@ -15,7 +15,7 @@ object LocalDeclarations:
 
     val y = new Foo {}
 
-    y.y
+    val yy = y.y
 
     new LocalDeclarations with Foo:
       override def foo(): Unit = bar()

--- a/tests/unit/src/main/scala/tests/BaseExpectSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseExpectSuite.scala
@@ -28,7 +28,11 @@ abstract class BaseExpectSuite(val suiteName: String) extends BaseSuite {
   final lazy val sourceroot: AbsolutePath =
     AbsolutePath(BuildInfo.sourceroot)
   final lazy val classpath: SemanticdbClasspath = {
-    new SemanticdbClasspath(sourceroot, input.classpath)
+    new SemanticdbClasspath(
+      sourceroot,
+      input.classpath,
+      input.semanticdbTargets,
+    )
   }
   def saveExpect(): Unit
 }

--- a/tests/unit/src/main/scala/tests/InputProperties.scala
+++ b/tests/unit/src/main/scala/tests/InputProperties.scala
@@ -1,5 +1,7 @@
 package tests
 
+import java.nio.file.Path
+
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.io.PathIO
 import scala.meta.io.AbsolutePath
@@ -12,6 +14,7 @@ case class InputProperties(
     sourceDirectories: List[AbsolutePath],
     classpath: Classpath,
     dependencySources: Classpath,
+    semanticdbTargets: List[Path],
 ) {
 
   def scalaFiles: List[InputFile] = {
@@ -58,9 +61,17 @@ object InputProperties {
       sourceDirectories = Classpath(getKey("sourceDirectories")).entries,
       classpath = Classpath(getKey("classpath")),
       dependencySources = Classpath(getKey("dependencySources")),
+      semanticdbTargets =
+        Classpath(getKey("semanticdbTargets")).entries.map(_.toNIO),
     )
   }
 
   def fromDirectory(directory: AbsolutePath): InputProperties =
-    InputProperties(directory, List(directory), Classpath(Nil), Classpath(Nil))
+    InputProperties(
+      directory,
+      List(directory),
+      Classpath(Nil),
+      Classpath(Nil),
+      Nil,
+    )
 }

--- a/tests/unit/src/test/resources/definition-scala3/example/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/definition-scala3/example/LocalDeclarations.scala
@@ -15,7 +15,7 @@ object LocalDeclarations/*LocalDeclarations.scala*/:
 
     val y/*LocalDeclarations.semanticdb*/ = new Foo/*LocalDeclarations.scala*/ {}
 
-    y/*LocalDeclarations.semanticdb*/.y/*LocalDeclarations.scala*/
+    val yy/*LocalDeclarations.semanticdb*/ = y/*LocalDeclarations.semanticdb*/.y/*LocalDeclarations.scala*/
 
     new LocalDeclarations/*LocalDeclarations.scala*/ with Foo/*LocalDeclarations.scala*/:
       override def foo/*LocalDeclarations.semanticdb*/(): Unit/*Unit.scala*/ = bar/*LocalDeclarations.semanticdb*/()

--- a/tests/unit/src/test/resources/documentSymbol-scala3/example/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/documentSymbol-scala3/example/LocalDeclarations.scala
@@ -15,7 +15,7 @@
 
     /*example.nested.LocalDeclarations.create.y(Constant):16*/val y = new Foo {}
 
-    y.y
+    /*example.nested.LocalDeclarations.create.yy(Constant):18*/val yy = y.y
 
     /*example.nested.LocalDeclarations.create.new LocalDeclarations with Foo(Interface):21*/new LocalDeclarations with Foo:
       /*example.nested.LocalDeclarations.create.`new LocalDeclarations with Foo`#foo(Method):21*/override def foo(): Unit = bar()

--- a/tests/unit/src/test/resources/mtags-scala3/example/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/mtags-scala3/example/LocalDeclarations.scala
@@ -15,7 +15,7 @@ object LocalDeclarations/*example.nested.LocalDeclarations.*/:
 
     val y = new Foo {}
 
-    y.y
+    val yy = y.y
 
     new LocalDeclarations with Foo:
       override def foo(): Unit = bar()

--- a/tests/unit/src/test/resources/semanticTokens3/example/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/LocalDeclarations.scala
@@ -15,7 +15,7 @@
 
     <<val>>/*keyword*/ <<y>>/*variable,definition,readonly*/ = <<new>>/*keyword*/ <<Foo>>/*interface,abstract*/ {}
 
-    <<y>>/*variable,readonly*/.<<y>>/*variable,readonly*/
+    <<val>>/*keyword*/ <<yy>>/*variable,definition,readonly*/ = <<y>>/*variable,readonly*/.<<y>>/*variable,readonly*/
 
     <<new>>/*keyword*/ <<LocalDeclarations>>/*interface,abstract*/ <<with>>/*keyword*/ <<Foo>>/*interface,abstract*/:
       <<override>>/*modifier*/ <<def>>/*keyword*/ <<foo>>/*method,definition*/(): <<Unit>>/*class,abstract*/ = <<bar>>/*method*/()

--- a/tests/unit/src/test/resources/semanticdb-scala3/example/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/semanticdb-scala3/example/LocalDeclarations.scala
@@ -15,7 +15,7 @@ object LocalDeclarations/*example.nested.LocalDeclarations.*/:
 
     val y/*local7*/ = /*local5*/new Foo/*example.nested.Foo#*/ {}
 
-    y/*local7*/.y/*example.nested.Foo#y.*/
+    val yy/*local8*/ = y/*local7*/.y/*example.nested.Foo#y.*/
 
-    /*local9*/new LocalDeclarations/*example.nested.LocalDeclarations#*/ with Foo/*example.nested.Foo#*/:
-      override def foo/*local8*/(): Unit/*scala.Unit#*/ = bar/*local0*/()
+    /*local10*/new LocalDeclarations/*example.nested.LocalDeclarations#*/ with Foo/*example.nested.Foo#*/:
+      override def foo/*local9*/(): Unit/*scala.Unit#*/ = bar/*local0*/()


### PR DESCRIPTION
Since we now have unused warnings for Scala 3 I used this oportunity to clean up a bit. I also changed LocalDeclarations and turns out we broke the save-expect command, which I fixed right away.