### PR TITLE
chore: Fix issues with Bloop and new Java module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -204,9 +204,9 @@ val sharedScalacOptions = List(
             isScala212(partialVersion) && V.scala212 != scalaVersion.value =>
         List("-target:jvm-1.8", "-Yrangepos", "-Xexperimental")
       case partialVersion if isScala3(partialVersion) =>
-        List("-release", "8", "-language:implicitConversions", "-Xsemanticdb")
+        List("-Xtarget:8", "-language:implicitConversions", "-Xsemanticdb")
       case _ =>
-        List("-release", "8", "-Yrangepos")
+        List("-target:jvm-1.8", "-Yrangepos")
     }
   }
 )


### PR DESCRIPTION
It seems there is an issue where `-release` is set and using the additional compiler modules.

This essentially reverts https://github.com/scalameta/metals/pull/5177

Fixes https://github.com/scalameta/metals/issues/5280

Ideally once we run on a single Java version this is no longer needed.