### PR TITLE
bugfix: Case completions for tuple type

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -84,18 +84,20 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
 
       // Special handle case when selector is a tuple or `FunctionN`.
       if (definitions.isTupleType(parents.selector)) {
-        List(
-          new TextEditMember(
-            "case () =>",
-            new l.TextEdit(
-              editRange,
-              if (clientSupportsSnippets) "case ($0) =>" else "case () =>"
-            ),
-            selectorSym,
-            label = Some(s"case ${parents.selector} =>"),
-            command = metalsConfig.parameterHintsCommand().asScala
+        if (patternOnly.isEmpty)
+          List(
+            new TextEditMember(
+              "case () =>",
+              new l.TextEdit(
+                editRange,
+                if (clientSupportsSnippets) "case ($0) =>" else "case () =>"
+              ),
+              selectorSym,
+              label = Some(s"case ${parents.selector} =>"),
+              command = metalsConfig.parameterHintsCommand().asScala
+            )
           )
-        )
+        else Nil
       } else {
         val completionGenerator = new CompletionValueGenerator(
           editRange,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -86,8 +86,7 @@ object CaseKeywordCompletion:
           case _ =>
             new Parents(NoType, definitions)
       case sel =>
-        val selectorTpe = sel.tpe
-        new Parents(selectorTpe, definitions)
+        new Parents(sel.tpe, definitions)
 
     val selectorSym = parents.selector.widen.metalsDealias.typeSymbol
 
@@ -96,24 +95,19 @@ object CaseKeywordCompletion:
         selectorSym
       )
     then
-      val selectorTpe = parents.selector.show
-      val tpeLabel =
-        if !selectorTpe.contains("x$1") then selectorTpe
-        else selector.symbol.info.show
-      val label =
-        if patternOnly.isEmpty then s"case ${tpeLabel} =>"
-        else tpeLabel
-      if completionGenerator.fuzzyMatches(label) then
+      if patternOnly.isEmpty then
+        val selectorTpe = parents.selector.show
+        val tpeLabel =
+          if !selectorTpe.contains("x$1") then selectorTpe
+          else selector.symbol.info.show
+        val label = s"case ${tpeLabel} =>"
         List(
           CompletionValue.CaseKeyword(
             selectorSym,
             label,
             Some(
-              if patternOnly.isEmpty then
-                if config.isCompletionSnippetsEnabled() then "case ($0) =>"
-                else "case () =>"
-              else if config.isCompletionSnippetsEnabled() then "($0)"
-              else "()"
+              if config.isCompletionSnippetsEnabled() then "case ($0) =>"
+              else "case () =>"
             ),
             Nil,
             range = Some(completionPos.toEditRange),
@@ -121,7 +115,6 @@ object CaseKeywordCompletion:
           )
         )
       else Nil
-      end if
     else
       val result = ListBuffer.empty[SymbolImport]
       val isVisited = mutable.Set.empty[Symbol]

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -85,7 +85,9 @@ object CaseKeywordCompletion:
             new Parents(argTypes, definitions)
           case _ =>
             new Parents(NoType, definitions)
-      case sel => new Parents(sel.tpe, definitions)
+      case sel =>
+        val selectorTpe = sel.tpe
+        new Parents(selectorTpe, definitions)
 
     val selectorSym = parents.selector.widen.metalsDealias.typeSymbol
 
@@ -94,25 +96,32 @@ object CaseKeywordCompletion:
         selectorSym
       )
     then
+      val selectorTpe = parents.selector.show
+      val tpeLabel =
+        if !selectorTpe.contains("x$1") then selectorTpe
+        else selector.symbol.info.show
       val label =
-        if patternOnly.isEmpty then s"case ${parents.selector.show} =>"
-        else parents.selector.show
-      List(
-        CompletionValue.CaseKeyword(
-          selectorSym,
-          label,
-          Some(
-            if patternOnly.isEmpty then
-              if config.isCompletionSnippetsEnabled() then "case ($0) =>"
-              else "case () =>"
-            else if config.isCompletionSnippetsEnabled() then "($0)"
-            else "()"
-          ),
-          Nil,
-          range = Some(completionPos.toEditRange),
-          command = config.parameterHintsCommand().asScala,
+        if patternOnly.isEmpty then s"case ${tpeLabel} =>"
+        else tpeLabel
+      if completionGenerator.fuzzyMatches(label) then
+        List(
+          CompletionValue.CaseKeyword(
+            selectorSym,
+            label,
+            Some(
+              if patternOnly.isEmpty then
+                if config.isCompletionSnippetsEnabled() then "case ($0) =>"
+                else "case () =>"
+              else if config.isCompletionSnippetsEnabled() then "($0)"
+              else "()"
+            ),
+            Nil,
+            range = Some(completionPos.toEditRange),
+            command = config.parameterHintsCommand().asScala,
+          )
         )
-      )
+      else Nil
+      end if
     else
       val result = ListBuffer.empty[SymbolImport]
       val isVisited = mutable.Set.empty[Symbol]

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -740,4 +740,17 @@ class CompletionCaseSuite extends BaseCompletionSuite {
     ),
   )
 
+  check(
+    "for-comp",
+    """|object A {
+       |  val a = for {
+       |    foo <- List("a", "b", "c")
+       |    abc = println("Print!")
+       |  } yield bar@@
+       |
+       |}
+       |""".stripMargin,
+    "",
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -753,4 +753,16 @@ class CompletionCaseSuite extends BaseCompletionSuite {
     "",
   )
 
+  check(
+    "lambda-case-tuple",
+    """|object A {
+       |  val a = List((1,2)).foreach {
+       |    case (a,b) => println(a)
+       |    case@@
+       |  }
+       |}
+       |""".stripMargin,
+    "case (Int, Int) => scala",
+  )
+
 }


### PR DESCRIPTION
We shouldn't show case completions for tuple type if query doesn't match label. 
Also, sometimes label contained `x$1` symbol (eg. `(x$1: (Int, Int)) @unchecked scala`, which we don't want to show to the user.
I think the simplest way to detect it is just by looking if label contains `x$1`

connected to the issue found in https://github.com/scalameta/metals/pull/5196#discussion_r1203629508