### PR TITLE
Add java completion

### DIFF
--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaCompletionProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaCompletionProvider.scala
@@ -1,0 +1,267 @@
+package scala.meta.internal.pc
+
+import javax.lang.model.`type`.ArrayType
+import javax.lang.model.`type`.DeclaredType
+import javax.lang.model.`type`.TypeVariable
+import javax.lang.model.element.Element
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.TypeElement
+import javax.lang.model.element.VariableElement
+
+import scala.annotation.tailrec
+import scala.jdk.CollectionConverters._
+
+import scala.meta.pc.OffsetParams
+
+import com.sun.source.tree.ClassTree
+import com.sun.source.tree.CompilationUnitTree
+import com.sun.source.tree.MemberSelectTree
+import com.sun.source.tree.MethodTree
+import com.sun.source.tree.Tree.Kind._
+import com.sun.source.util.JavacTask
+import com.sun.source.util.TreePath
+import com.sun.source.util.Trees
+import org.eclipse.lsp4j.CompletionItem
+import org.eclipse.lsp4j.CompletionItemKind
+import org.eclipse.lsp4j.CompletionList
+
+class JavaCompletionProvider(
+    compiler: JavaMetalsGlobal,
+    params: OffsetParams,
+    isCompletionSnippetsEnabled: Boolean
+) {
+
+  def completions(): CompletionList = {
+    val task: JavacTask = compiler.compilationTask(params.text(), params.uri())
+    val scanner = compiler.scanner(task)
+    val position =
+      CursorPosition(params.offset(), params.offset(), params.offset())
+    val node = compiler.compilerTreeNode(scanner, position)
+
+    node match {
+      case Some(n) =>
+        val list =
+          n.getLeaf.getKind match {
+            case MEMBER_SELECT => completeMemberSelect(task, n)
+            case IDENTIFIER => completeIdentifier(task, n)
+            case _ => new CompletionList()
+          }
+
+        val keywordsCompletion = keywords(n)
+        val resultList =
+          (list.getItems.asScala ++ keywordsCompletion.getItems.asScala).distinct
+            .sorted(ordering)
+            .asJava
+
+        new CompletionList(resultList)
+      case None => new CompletionList()
+    }
+  }
+
+  private def ordering: Ordering[CompletionItem] = {
+    val identifier = extractIdentifier.toLowerCase
+
+    new Ordering[CompletionItem] {
+      def score(item: CompletionItem): Int = {
+        val name = item.getLabel.toLowerCase
+
+        if (name.startsWith(identifier)) 0
+        else if (name.contains(identifier)) 1
+        else 2
+      }
+
+      override def compare(i1: CompletionItem, i2: CompletionItem): Int = {
+        java.lang.Integer.compare(score(i1), score(i2))
+      }
+    }
+
+  }
+
+  private def completeMemberSelect(
+      task: JavacTask,
+      path: TreePath
+  ): CompletionList = {
+    val typeAnalyzer = new JavaTypeAnalyzer(task)
+    val select = path.getLeaf.asInstanceOf[MemberSelectTree]
+    val newPath = new TreePath(path, select.getExpression)
+    val memberType = typeAnalyzer.typeMirror(newPath)
+
+    memberType match {
+      case dt: DeclaredType => completeDeclaredType(task, dt)
+      case at: ArrayType => completeArrayType(task, at)
+      case tv: TypeVariable => completeTypeVariable(task, tv)
+    }
+  }
+
+  private def completeIdentifier(
+      task: JavacTask,
+      path: TreePath
+  ): CompletionList =
+    new CompletionList(completeFromScope(task, path).asJava)
+
+  private def completeFromScope(
+      task: JavacTask,
+      path: TreePath
+  ): List[CompletionItem] = {
+    val trees = Trees.instance(task)
+    val scope = trees.getScope(path)
+
+    val scopeCompletion = JavaScopeVisitor.scopeMembers(task, scope)
+    val identifier = extractIdentifier
+
+    scopeCompletion
+      .map(completionItem)
+      .filter(item => CompletionFuzzy.matches(identifier, item.getLabel))
+  }
+
+  private def completeDeclaredType(
+      task: JavacTask,
+      declaredType: DeclaredType
+  ): CompletionList = {
+    val members = task.getElements
+      .getAllMembers(declaredType.asElement().asInstanceOf[TypeElement])
+      .asScala
+      .toList
+
+    val identifier = extractIdentifier
+
+    val completionItems = members
+      .filter(member =>
+        CompletionFuzzy.matches(identifier, member.getSimpleName.toString)
+      )
+      .map(completionItem)
+
+    new CompletionList(completionItems.asJava)
+  }
+
+  private def extractIdentifier: String = {
+    val start = inferIdentStart(params.offset(), params.text())
+    val end = params.offset()
+
+    params.text().substring(start, end)
+  }
+
+  private def keywords(path: TreePath): CompletionList = {
+    val identifier = extractIdentifier
+    val level = keywordLevel(path)
+
+    val completionItems =
+      JavaKeyword.all
+        .collect {
+          case keyword
+              if keyword.level == level && CompletionFuzzy.matches(
+                identifier,
+                keyword.name
+              ) =>
+            keyword.name
+        }
+        .map { keyword =>
+          val item = new CompletionItem(keyword)
+          item.setKind(CompletionItemKind.Keyword)
+
+          item
+        }
+
+    new CompletionList(completionItems.asJava)
+  }
+
+  @tailrec
+  private def keywordLevel(path: TreePath): JavaKeyword.Level = {
+    if (path == null) JavaKeyword.TopLevel
+    else {
+      path.getLeaf match {
+        case _: MethodTree => JavaKeyword.MethodLevel
+        case _: ClassTree => JavaKeyword.ClassLevel
+        case _: CompilationUnitTree => JavaKeyword.TopLevel
+        case _ => keywordLevel(path.getParentPath)
+      }
+    }
+  }
+
+  private def completeArrayType(
+      task: JavacTask,
+      arrayType: ArrayType
+  ): CompletionList = {
+    val identifier = extractIdentifier
+    if (CompletionFuzzy.matches(identifier, "length")) {
+      val item = new CompletionItem("length")
+      item.setKind(CompletionItemKind.Keyword)
+
+      new CompletionList(
+        List(item).asJava
+      )
+    } else {
+      new CompletionList()
+    }
+
+  }
+
+  @tailrec
+  private def completeTypeVariable(
+      task: JavacTask,
+      typeVariable: TypeVariable
+  ): CompletionList = {
+    typeVariable.getUpperBound match {
+      case dt: DeclaredType => completeDeclaredType(task, dt)
+      case tv: TypeVariable => completeTypeVariable(task, tv)
+      case _ => new CompletionList()
+    }
+  }
+
+  private def inferIdentStart(pos: Int, text: String): Int = {
+    var i = pos - 1
+    while (i >= 0 && Character.isJavaIdentifierPart(text.charAt(i))) {
+      i -= 1
+    }
+    i + 1
+  }
+
+  private def completionItem(element: Element): CompletionItem = {
+    val simpleName = element.getSimpleName.toString
+
+    val (label, insertText) = element match {
+      case e: ExecutableElement
+          if isCompletionSnippetsEnabled && e.getParameters.size() > 0 =>
+        (JavaLabels.executableLabel(e), s"$simpleName($$0)")
+      case e: ExecutableElement =>
+        (JavaLabels.executableLabel(e), s"$simpleName()")
+      case _ => (simpleName, simpleName)
+    }
+
+    val item = new CompletionItem(label)
+    item.setInsertText(insertText)
+
+    val kind = completionKind(element.getKind)
+    kind.foreach(item.setKind)
+
+    val detail = element match {
+      case v: VariableElement => JavaLabels.typeLabel(v.asType())
+      case e: ExecutableElement => JavaLabels.typeLabel(e.asType())
+      case t: TypeElement => JavaLabels.typeLabel(t.asType())
+      case _ => ""
+    }
+
+    item.setDetail(detail)
+
+    item
+  }
+
+  private def completionKind(k: ElementKind): Option[CompletionItemKind] =
+    k match {
+      case ElementKind.CLASS => Some(CompletionItemKind.Class)
+      case ElementKind.ENUM => Some(CompletionItemKind.Enum)
+      case ElementKind.ANNOTATION_TYPE => Some(CompletionItemKind.Interface)
+      case ElementKind.INTERFACE => Some(CompletionItemKind.Interface)
+      case ElementKind.CONSTRUCTOR => Some(CompletionItemKind.Constructor)
+      case ElementKind.TYPE_PARAMETER => Some(CompletionItemKind.TypeParameter)
+      case ElementKind.FIELD => Some(CompletionItemKind.Field)
+      case ElementKind.PACKAGE => Some(CompletionItemKind.Module)
+      case ElementKind.LOCAL_VARIABLE => Some(CompletionItemKind.Variable)
+      case ElementKind.RESOURCE_VARIABLE => Some(CompletionItemKind.Variable)
+      case ElementKind.PARAMETER => Some(CompletionItemKind.Property)
+      case ElementKind.METHOD => Some(CompletionItemKind.Method)
+      case _ => None
+    }
+
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaKeyword.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaKeyword.scala
@@ -1,0 +1,36 @@
+package scala.meta.internal.pc
+
+case class JavaKeyword(
+    name: String,
+    level: JavaKeyword.Level
+)
+
+object JavaKeyword {
+  sealed trait Level
+
+  case object TopLevel extends Level
+  case object ClassLevel extends Level
+  case object MethodLevel extends Level
+
+  val topLevelKeywords: List[JavaKeyword] = List(
+    "package", "import", "public", "private", "protected", "abstract", "class",
+    "interface"
+  ).map(JavaKeyword(_, TopLevel))
+
+  val classLevelKeywords: List[JavaKeyword] = List(
+    "public", "private", "protected", "static", "final", "native",
+    "synchronized", "abstract", "default", "class", "interface", "void",
+    "boolean", "int", "long", "float", "double", "extends", "implements",
+    "char", "byte", "short"
+  ).map(JavaKeyword(_, ClassLevel))
+
+  val methodLevelKeywords: List[JavaKeyword] = List(
+    "new", "assert", "try", "catch", "finally", "throw", "return", "break",
+    "case", "continue", "default", "do", "while", "for", "switch", "if", "else",
+    "instanceof", "var", "final", "class", "void", "boolean", "int", "long",
+    "float", "double", "char", "byte", "short"
+  ).map(JavaKeyword(_, MethodLevel))
+
+  val all: List[JavaKeyword] =
+    topLevelKeywords ++ classLevelKeywords ++ methodLevelKeywords
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaLabels.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaLabels.scala
@@ -1,0 +1,32 @@
+package scala.meta.internal.pc
+
+import javax.lang.model.`type`.TypeMirror
+import javax.lang.model.element.ElementKind.CONSTRUCTOR
+import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.VariableElement
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+object JavaLabels {
+  def typeLabel(t: TypeMirror): String =
+    t.accept(new JavaTypeVisitor(), null)
+
+  def argumentLabel(v: VariableElement): String = {
+    val argType = typeLabel(v.asType())
+    val argName = v.getSimpleName
+
+    s"$argType $argName"
+  }
+
+  def argumentsLabel(e: ExecutableElement): String =
+    e.getParameters.asScala.map(argumentLabel).mkString(", ")
+
+  def executableName(e: ExecutableElement): String =
+    (if (e.getKind == CONSTRUCTOR)
+       e.getEnclosingElement.getSimpleName
+     else e.getSimpleName).toString
+
+  def executableLabel(e: ExecutableElement): String =
+    s"${executableName(e)}(${argumentsLabel(e)})"
+
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaPresentationCompiler.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaPresentationCompiler.scala
@@ -49,7 +49,13 @@ case class JavaPresentationCompiler(
   override def complete(
       params: OffsetParams
   ): CompletableFuture[CompletionList] =
-    CompletableFuture.completedFuture(new CompletionList())
+    CompletableFuture.completedFuture(
+      new JavaCompletionProvider(
+        javaCompiler,
+        params,
+        config.isCompletionSnippetsEnabled
+      ).completions()
+    )
 
   override def completionItemResolve(
       item: CompletionItem,

--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaScopeVisitor.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaScopeVisitor.scala
@@ -1,0 +1,47 @@
+package scala.meta.internal.pc
+
+import javax.lang.model.element.Element
+import javax.lang.model.element.Modifier
+import javax.lang.model.util.Elements
+
+import scala.annotation.tailrec
+import scala.jdk.CollectionConverters.IterableHasAsScala
+
+import com.sun.source.tree.Scope
+import com.sun.source.util.JavacTask
+
+object JavaScopeVisitor {
+
+  @tailrec
+  private def unfurlScope(scope: Scope, acc: List[Scope]): List[Scope] = {
+    if (scope == null) acc.reverse
+    else unfurlScope(scope.getEnclosingScope, scope :: acc)
+  }
+
+  def scopeMembers(task: JavacTask, scope: Scope): List[Element] = {
+    val scopes = unfurlScope(scope, Nil)
+    val elements = task.getElements
+
+    (for {
+      curScope <- scopes
+      member <- curScope.getLocalElements.asScala
+      allClassMembers = classMembers(scope, elements)
+    } yield member :: allClassMembers).flatten
+  }
+
+  private def classMembers(scope: Scope, elements: Elements): List[Element] = {
+    if (scope.getEnclosingClass == null) Nil
+    else {
+      val typeElement = scope.getEnclosingClass
+
+      elements
+        .getAllMembers(typeElement)
+        .asScala
+        .filterNot(e =>
+          e.getModifiers.contains(Modifier.PRIVATE) || e.getModifiers
+            .contains(Modifier.PROTECTED)
+        )
+        .toList
+    }
+  }
+}

--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaTypeAnalyzer.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaTypeAnalyzer.scala
@@ -1,0 +1,12 @@
+package scala.meta.internal.pc
+
+import javax.lang.model.`type`.TypeMirror
+
+import com.sun.source.util.JavacTask
+import com.sun.source.util.TreePath
+import com.sun.source.util.Trees
+
+class JavaTypeAnalyzer(task: JavacTask) {
+  def typeMirror(path: TreePath): TypeMirror =
+    Trees.instance(task).getTypeMirror(path)
+}

--- a/tests/javapc/src/main/scala/tests/pc/BaseJavaCompletionSuite.scala
+++ b/tests/javapc/src/main/scala/tests/pc/BaseJavaCompletionSuite.scala
@@ -1,0 +1,54 @@
+package tests.pc
+
+import java.nio.file.Paths
+
+import scala.jdk.CollectionConverters._
+
+import scala.meta.internal.metals.CompilerOffsetParams
+import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.pc.CancelToken
+
+import munit.TestOptions
+import org.eclipse.lsp4j.CompletionItem
+
+class BaseJavaCompletionSuite extends BaseJavaPCSuite {
+  def check(
+      name: TestOptions,
+      original: String,
+      expected: String,
+      filename: String = "A.java",
+  ): Unit = {
+    test(name) {
+      val items = getItems(original, filename)
+
+      val out = new StringBuilder()
+
+      items.foreach { item =>
+        out.append(item.getLabel)
+        out.append("\n")
+      }
+
+      assertNoDiff(
+        out.toString(),
+        expected,
+      )
+    }
+  }
+
+  private def cancelToken: CancelToken = EmptyCancelToken
+
+  private def getItems(
+      original: String,
+      filename: String,
+  ): Seq[CompletionItem] = {
+    val (code, offset) = params(original)
+    val offsetParams = CompilerOffsetParams(
+      Paths.get(filename).toUri,
+      code,
+      offset,
+      cancelToken,
+    )
+
+    presentationCompiler.complete(offsetParams).get().getItems.asScala.toList
+  }
+}

--- a/tests/javapc/src/test/scala/pc/CompletionIdentifierSuite.scala
+++ b/tests/javapc/src/test/scala/pc/CompletionIdentifierSuite.scala
@@ -1,0 +1,142 @@
+package pc
+
+import tests.pc.BaseJavaCompletionSuite
+
+class CompletionIdentifierSuite extends BaseJavaCompletionSuite {
+  check(
+    "static value",
+    """
+      |
+      |class A {
+      |
+      |    public static int BAR = 42;
+      |
+      |    public static void foo() {
+      |         int x = BA@@
+      |    }
+      |
+      |}
+      |""".stripMargin,
+    """
+      |BAR
+      |""".stripMargin,
+  )
+
+  check(
+    "method",
+    """
+      |class A {
+      |
+      |    public void bar() {}
+      |
+      |    public static void foo(int bar) {
+      |         ba@@
+      |    }
+      |
+      |}
+      |""".stripMargin,
+    """
+      |bar
+      |bar()
+      |""".stripMargin,
+  )
+
+  check(
+    "argument",
+    """
+      |class A {
+      |
+      |    public static void foo(int bar) {
+      |         int x = ba@@;
+      |    }
+      |
+      |}
+      |""".stripMargin,
+    """
+      |bar
+      |""".stripMargin,
+  )
+
+  check(
+    "outer class",
+    """
+      |
+      |class OneMore {}
+      |
+      |class Main {
+      |
+      |    public static void foo(int bar) {
+      |         One@@
+      |    }
+      |
+      |}
+      |""".stripMargin,
+    """
+      |OneMore
+      |""".stripMargin,
+  )
+
+  check(
+    "import List",
+    """
+      |import java.util.List;
+      |
+      |class A {
+      |
+      |    public static void foo(int bar) {
+      |         Lis@@
+      |    }
+      |
+      |}
+      |""".stripMargin,
+    """
+      |List
+      |""".stripMargin,
+  )
+
+  check(
+    "import util",
+    """
+      |import java.util.*;
+      |
+      |class A {
+      |
+      |    public static void foo(int bar) {
+      |         Lis@@
+      |    }
+      |
+      |}
+      |""".stripMargin,
+    """
+      |ListResourceBundle
+      |ListIterator
+      |List
+      |TooManyListenersException
+      |LinkedList
+      |EventListenerProxy
+      |EventListener
+      |ArrayList
+      |AbstractSequentialList
+      |AbstractList
+      |""".stripMargin,
+  )
+
+  check(
+    "duplicate names",
+    """
+      |class A {
+      |
+      |   public static int duplicate = 42;
+      |
+      |    public static void duplicate(int bar) {
+      |         dup@@
+      |    }
+      |
+      |}
+      |""".stripMargin,
+    """
+      |duplicate
+      |duplicate(int bar)
+      |""".stripMargin,
+  )
+}

--- a/tests/javapc/src/test/scala/pc/CompletionKeywordSuite.scala
+++ b/tests/javapc/src/test/scala/pc/CompletionKeywordSuite.scala
@@ -1,0 +1,130 @@
+package pc
+
+import tests.pc.BaseJavaCompletionSuite
+
+class CompletionKeywordSuite extends BaseJavaCompletionSuite {
+  check(
+    "super",
+    """
+      |
+      |interface A {}
+      |
+      |class B implements A {
+      |
+      |    public static int foo() {
+      |         sup@@
+      |    }
+      |
+      |}
+      |""".stripMargin,
+    """
+      |super
+      |""".stripMargin,
+  )
+
+  check(
+    "this",
+    """
+      |
+      |interface A {}
+      |
+      |class B implements A {
+      |
+      |    public static int foo() {
+      |         thi@@
+      |    }
+      |
+      |}
+      |""".stripMargin,
+    """
+      |this
+      |""".stripMargin,
+  )
+
+  check(
+    "package",
+    """
+      |pac@@
+      |
+      |interface A {}
+      |""".stripMargin,
+    """
+      |package
+      |""".stripMargin,
+  )
+
+  check(
+    "extends",
+    """
+      |
+      |class A {}
+      |
+      |class B ext@@ A {}
+      |""".stripMargin,
+    """
+      |extends
+      |""".stripMargin,
+  )
+
+  check(
+    "no extends paren",
+    """
+      |
+      |class A {
+      |
+      |    public static int foo() {
+      |         return 42;
+      |    }
+      |
+      |    public static void main() {
+      |         foo() ext@@;
+      |    }
+      |
+      |}
+      |""".stripMargin,
+    "",
+  )
+
+  check(
+    "protected interface",
+    """
+      |
+      |protected inte@@ A {}
+      |""".stripMargin,
+    """
+      |interface
+      |""".stripMargin,
+  )
+
+  check(
+    "new",
+    """
+      |class A {
+      |
+      |    public static int foo() {
+      |         ne@@
+      |    }
+      |
+      |}
+      |""".stripMargin,
+    """
+      |new
+      |""".stripMargin,
+  )
+
+  check(
+    "return",
+    """
+      |class A {
+      |
+      |    public static int foo() {
+      |         ret@@
+      |    }
+      |
+      |}
+      |""".stripMargin,
+    """
+      |return
+      |""".stripMargin,
+  )
+}

--- a/tests/javapc/src/test/scala/pc/CompletionMemberSelectSuite.scala
+++ b/tests/javapc/src/test/scala/pc/CompletionMemberSelectSuite.scala
@@ -1,0 +1,51 @@
+package pc
+
+import tests.pc.BaseJavaCompletionSuite
+
+class CompletionMemberSelectSuite extends BaseJavaCompletionSuite {
+  check(
+    "static field member",
+    """
+      |class Simple{
+      |    public static int NUMBER = 42;
+      |
+      |    public static void main(String args[]){
+      |        new Simple().NU@@
+      |    }
+      |}
+      |""".stripMargin,
+    """
+      |NUMBER
+      |""".stripMargin,
+  )
+
+  check(
+    "array member",
+    """
+      |class Simple{
+      |    public static void main(String args[]){
+      |        new int[42].le@@
+      |    }
+      |}
+      |""".stripMargin,
+    """
+      |length
+      |""".stripMargin,
+  )
+
+  check(
+    "type variable",
+    """
+      |class Simple{
+      |    public static int NUMBER = 42;
+      |
+      |    public static void test<T extends Simple>() {
+      |        T.NUM@@
+      |    }
+      |}
+      |""".stripMargin,
+    """
+      |NUMBER
+      |""".stripMargin,
+  )
+}


### PR DESCRIPTION
Finally java completion feature is available for metals. It's based on Java Compiler API as [Java Hover](https://github.com/scalameta/metals/pull/5024) feature. 
![1](https://github.com/scalameta/metals/assets/37435137/e1c010db-cda9-41a8-b8c1-c8d993b640ae)
![2](https://github.com/scalameta/metals/assets/37435137/00748adc-5bba-4f26-b935-e5a12ca49aa1)
![3](https://github.com/scalameta/metals/assets/37435137/59a1b317-fd8d-4576-b632-d35841b05a30)
