### PR TITLE
fix: Don't show completions with case class members

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompilerSearchVisitor.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompilerSearchVisitor.scala
@@ -21,7 +21,7 @@ class CompilerSearchVisitor(
   val logger: Logger = Logger.getLogger(classOf[CompilerSearchVisitor].getName)
 
   private def isAccessible(sym: Symbol): Boolean = try
-    sym != NoSymbol && sym.isPublic
+    sym != NoSymbol && sym.isPublic && sym.isStatic
   catch
     case NonFatal(e) =>
       reports.incognito.create(

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -653,14 +653,6 @@ class CompletionArgSuite extends BaseCompletionSuite {
     """|foo = : Int
        |foo = a : Int
        |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|foo = : Int
-           |foo = a : Int
-           |foo: Int
-           |fooBar: Int
-           |""".stripMargin
-    ),
   )
 
   check(
@@ -680,14 +672,6 @@ class CompletionArgSuite extends BaseCompletionSuite {
     """|fooBar = : Int
        |fooBar = a : Int
        |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|fooBar = : Int
-           |fooBar = a : Int
-           |foo: Int
-           |fooBar: Int
-           |""".stripMargin
-    ),
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -394,7 +394,6 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
       "3" ->
         """|Try
            |Try($0)
-           |TryMethods
            |""".stripMargin
     ),
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -960,4 +960,29 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |""".stripMargin,
   )
 
+  check(
+    "case_class_param",
+    """|case class Foo(fooBar: Int, gooBar: Int)
+       |class Bar(val fooBaz: Int, val fooBal: Int) {
+       |  val fooBar: Option[Int] = Some(1)
+       |}
+       |object A {
+       |  val fooBar: List[Int] = List(1)
+       |}
+       |
+       |object Main {
+       |  val fooBar = "Abc"
+       |  val x = fooBa@@
+       |}
+       |""".stripMargin,
+    """|fooBar: String
+       |fooBar: List[Int]
+       |""".stripMargin,
+    compat = Map(
+      "2" -> """|fooBar: String
+                |fooBar - case_class_param.A: List[Int]
+                |""".stripMargin
+    ),
+  )
+
 }


### PR DESCRIPTION
I can't think of any other case when we don't want to see case class members, so it was easier to change it directly in completions, instead of changing `includeMembers` in `ScalaToplevelMtags`

solves https://github.com/scalameta/metals/issues/5289