### PR TITLE
use relative uri for interactive java TextDocument

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
@@ -107,8 +107,19 @@ class JavaInteractiveSemanticdb(
       s.TextDocument()
     }
 
+    val documentSource = scala.util
+      .Try(workspace.toNIO.relativize(source.toNIO))
+      .toOption
+      .map { relativeUri =>
+        val relativeString =
+          if (Properties.isWin) relativeUri.toString().replace("\\", "/")
+          else relativeUri.toString()
+        relativeString
+      }
+      .getOrElse(source.toString())
+
     val out = doc.copy(
-      uri = source.toURI.toString(),
+      uri = documentSource,
       text = text,
       md5 = MD5.compute(text),
     )

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbTextDocumentProvider.scala
@@ -5,6 +5,8 @@ import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
 
+import scala.util.Properties
+
 import scala.meta.internal.mtags.MD5
 
 import dotty.tools.dotc.interactive.InteractiveDriver
@@ -39,7 +41,8 @@ class SemanticdbTextDocumentProvider(
         scala.util.Try(workspacePath.relativize(filePath)).toOption
       }
       .map { relativeUri =>
-        relativeUri.toString()
+        if Properties.isWin then relativeUri.toString().replace("\\", "/")
+        else relativeUri.toString()
       }
       .getOrElse(filePath.toString)
 


### PR DESCRIPTION
I get exceptions in https://github.com/scalameta/metals/blob/8283260dc275a82dea0261ad3aaec632892014b2/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala#L87

This is with Windows + Scala 3 + a Java file

I'm a bit confused about what `TextDocument.uri` should actually contain.  It's a `String` but various code usage suggests that it should contain ideally a workspace relative path or fallback to an absolute path.

`JavaInteractiveSemanticDB` returns it as a URI (e.g. `file:///c:/blah`) so any attempt to get the workspace relative location or this `TextDocument.uri` throws an exception.

So here I've changed `JavaInteractiveSemanticDB` to return a relative path.

Am I correct in what `TextDocument.uri` should contain?  If so then this PR should solve my issue (and seems to when I publish locally).

I guess ideally `TextDocument.uri` would be a java.nio.Path or equivalent instead of a `String`?

To relativise the path, I've copied the code from `scala-2/../SemanticdbTextDocumentProvider.scala` and so I've also changed `scala-3/../SemanticdbTextDocumentProvider.scala` to include the fix for Windows as it looks like it should be there.