### PR TITLE
improvement: Refactor type completions to provide both type symbol and object

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/MemberOrdering.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/MemberOrdering.scala
@@ -7,13 +7,14 @@ object MemberOrdering {
   val IsInherited: Int = 1 << 27
   val IsNotLocalByBlock: Int = 1 << 26
   val IsNotDefinedInFile: Int = 1 << 25
-  val IsNotGetter: Int = 1 << 24
-  val IsPackage: Int = 1 << 23
-  val IsNotCaseAccessor: Int = 1 << 22
-  val IsNotPublic: Int = 1 << 21
-  val IsSynthetic: Int = 1 << 20
-  val IsDeprecated: Int = 1 << 19
-  val IsEvilMethod: Int = 1 << 18 // example: clone() and finalize()
+  val IsNotTypeInTypePos: Int = 1 << 24
+  val IsNotGetter: Int = 1 << 23
+  val IsPackage: Int = 1 << 22
+  val IsNotCaseAccessor: Int = 1 << 21
+  val IsNotPublic: Int = 1 << 20
+  val IsSynthetic: Int = 1 << 19
+  val IsDeprecated: Int = 1 << 18
+  val IsEvilMethod: Int = 1 << 17 // example: clone() and finalize()
 
   // OverrideDefMember
   val IsNotAbstract: Int = 1 << 30
@@ -26,6 +27,7 @@ object MemberOrdering {
       (IsInherited, "inherited"),
       (IsNotLocalByBlock, "notLocalByBlock"),
       (IsNotDefinedInFile, "notDefinedInFile"),
+      (IsNotTypeInTypePos, "notTypeInTypePosition"),
       (IsNotGetter, "notGetter"),
       (IsPackage, "package"),
       (IsNotCaseAccessor, "notCaseAccessor"),

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionSuffix.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionSuffix.scala
@@ -1,48 +1,47 @@
 package scala.meta.internal.pc.completions
 
 /**
- * @param brace should we add "()" suffix?
- * @param bracket should we add "[]" suffix?
- * @param template should we add "{}" suffix?
+ * @param suffixes which we should insert
  * @param snippet which suffix should we insert the snippet $0
  */
 case class CompletionSuffix(
-    brace: Boolean,
-    bracket: Boolean,
-    template: Boolean,
+    suffixes: Set[SuffixKind],
     snippet: SuffixKind,
 ):
+  def labelSnippet =
+    suffixes.collectFirst {
+      case SuffixKind.Bracket(1) => "[T]"
+      case SuffixKind.Bracket(n) =>
+        (for (i <- 1 to n) yield s"T$i").mkString("[", ", ", "]")
+    }
   def hasSnippet = snippet != SuffixKind.NoSuffix
   def chain(copyFn: CompletionSuffix => CompletionSuffix) = copyFn(this)
+  def withNewSuffix(kind: SuffixKind) =
+    CompletionSuffix(suffixes + kind, snippet)
+  def withNewSuffixSnippet(kind: SuffixKind) =
+    CompletionSuffix(suffixes + kind, kind)
   def toEdit: String =
-    if !hasSuffix then ""
-    else
-      val braceSuffix =
-        if brace && snippet == SuffixKind.Brace then "($0)"
-        else if brace then "()"
-        else ""
-      val bracketSuffix =
-        if bracket && snippet == SuffixKind.Bracket then "[$0]"
-        else if bracket then "[]"
-        else ""
-      val templateSuffix =
-        if template && snippet == SuffixKind.Template then " {$0}"
-        else if template then " {}"
-        else ""
-      s"$bracketSuffix$braceSuffix$templateSuffix"
+    def loop(suffixes: List[SuffixKind]): String =
+      def cursor = if suffixes.head == snippet then "$0" else ""
+      suffixes match
+        case SuffixKind.Brace :: tail => s"($cursor)" + loop(tail)
+        case SuffixKind.Bracket(_) :: tail => s"[$cursor]" + loop(tail)
+        case SuffixKind.Template :: tail => s" {$cursor}" + loop(tail)
+        case _ => ""
+    loop(suffixes.toList)
   def toEditOpt: Option[String] =
     val edit = toEdit
     if edit.nonEmpty then Some(edit) else None
-  private def hasSuffix = brace || bracket || template
 end CompletionSuffix
 
 object CompletionSuffix:
   val empty = CompletionSuffix(
-    brace = false,
-    bracket = false,
-    template = false,
+    suffixes = Set.empty,
     snippet = SuffixKind.NoSuffix,
   )
 
 enum SuffixKind:
-  case Brace, Bracket, Template, NoSuffix
+  case Brace extends SuffixKind
+  case Bracket(typeParamsCount: Int) extends SuffixKind
+  case Template extends SuffixKind
+  case NoSuffix extends SuffixKind

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -33,7 +33,9 @@ sealed trait CompletionValue:
    * Label with potentially attached description.
    */
   def labelWithDescription(printer: MetalsPrinter)(using Context): String =
-    label
+    labelWithSuffix
+  def labelWithSuffix: String =
+    s"$label${snippetSuffix.labelSnippet.getOrElse("")}"
   def lspTags(using Context): List[CompletionItemTag] = Nil
 end CompletionValue
 
@@ -73,13 +75,14 @@ object CompletionValue:
     override def labelWithDescription(
         printer: MetalsPrinter
     )(using Context): String =
-      if symbol.is(Method) then s"${label}${description(printer)}"
-      else if symbol.isConstructor then label
-      else if symbol.is(Mutable) then s"${label}: ${description(printer)}"
+      if symbol.is(Method) then s"${labelWithSuffix}${description(printer)}"
+      else if symbol.isConstructor then labelWithSuffix
+      else if symbol.is(Mutable) then
+        s"${labelWithSuffix}: ${description(printer)}"
       else if symbol.is(Package) || symbol.is(Module) || symbol.isClass then
-        if isFromWorkspace then s"${label} -${description(printer)}"
-        else s"${label}${description(printer)}"
-      else s"${label}: ${description(printer)}"
+        if isFromWorkspace then s"${labelWithSuffix} -${description(printer)}"
+        else s"${labelWithSuffix}${description(printer)}"
+      else s"${labelWithSuffix}: ${description(printer)}"
 
     override def description(printer: MetalsPrinter)(using Context): String =
       printer.completionSymbol(symbol)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -94,23 +94,7 @@ class Completions(
       if generalExclude then false
       else
         this match
-          case Type(_, _) if sym.isType => true
-          case Type(_, _) if sym.isTerm =>
-            /* Type might be referenced by a path over an object:
-             * ```
-             * object sample:
-             *    class X
-             * val a: samp@@le.X = ???
-             * ```
-             * ignore objects that has companion class
-             *
-             * Also ignore objects that doesn't have any members.
-             * By some reason traits might have a fake companion object(example: scala.sys.process.ProcessBuilderImpl)
-             */
-            val allowModule =
-              sym.is(Module) &&
-                (sym.companionClass == NoSymbol && sym.info.allMembers.nonEmpty)
-            allowModule
+          case Type(_, _) => true
           case Term if isWildcardParam(sym) => false
           case Term if sym.isTerm || sym.is(Package) => true
           case Import => true
@@ -126,6 +110,11 @@ class Completions(
     def allowTemplateSuffix: Boolean =
       this match
         case Type(_, hasNewKw) => hasNewKw
+        case _ => false
+
+    def allowApplicationSuffix: Boolean =
+      this match
+        case Term => true
         case _ => false
 
   end CursorPos
@@ -211,7 +200,7 @@ class Completions(
         end match
 
     val application = CompletionApplication.fromPath(path)
-    val ordering = completionOrdering(application)
+    val ordering = completionOrdering(application, cursorPos)
     val values = application.postProcess(all.sorted(ordering))
     (values, result)
   end completions
@@ -263,7 +252,9 @@ class Completions(
       .chain { suffix => // for [] suffix
         if shouldAddSnippet &&
           cursorPos.allowBracketSuffix && symbol.info.typeParams.nonEmpty
-        then suffix.copy(bracket = true, snippet = SuffixKind.Bracket)
+        then
+          val typeParamsCount = symbol.info.typeParams.length
+          suffix.withNewSuffixSnippet(SuffixKind.Bracket(typeParamsCount))
         else suffix
       }
       .chain { suffix => // for () suffix
@@ -272,7 +263,7 @@ class Completions(
           val paramss = getParams(symbol)
           paramss match
             case Nil => suffix
-            case List(Nil) => suffix.copy(brace = true)
+            case List(Nil) => suffix.withNewSuffix(SuffixKind.Brace)
             case _ if config.isCompletionSnippetsEnabled =>
               val onlyParameterless = paramss.forall(_.isEmpty)
               lazy val onlyImplicitOrTypeParams = paramss.forall(
@@ -280,10 +271,11 @@ class Completions(
                   sym.isType || sym.is(Implicit) || sym.is(Given)
                 }
               )
-              if onlyParameterless then suffix.copy(brace = true)
+              if onlyParameterless then suffix.withNewSuffix(SuffixKind.Brace)
               else if onlyImplicitOrTypeParams then suffix
-              else if suffix.hasSnippet then suffix.copy(brace = true)
-              else suffix.copy(brace = true, snippet = SuffixKind.Brace)
+              else if suffix.hasSnippet then
+                suffix.withNewSuffix(SuffixKind.Brace)
+              else suffix.withNewSuffixSnippet(SuffixKind.Brace)
             case _ => suffix
           end match
         else suffix
@@ -292,8 +284,8 @@ class Completions(
         if shouldAddSnippet && cursorPos.allowTemplateSuffix
           && isAbstractType(symbol)
         then
-          if suffix.hasSnippet then suffix.copy(template = true)
-          else suffix.copy(template = true, snippet = SuffixKind.Template)
+          if suffix.hasSnippet then suffix.withNewSuffix(SuffixKind.Template)
+          else suffix.withNewSuffixSnippet(SuffixKind.Template)
         else suffix
       }
 
@@ -316,7 +308,7 @@ class Completions(
     val methodSymbols =
       if shouldAddSnippet &&
         (sym.is(Flags.Module) || sym.isClass && !sym.is(Flags.Trait)) &&
-        !isJavaDefined
+        !isJavaDefined && cursorPos.allowApplicationSuffix
       then
         val info =
           /* Companion will be added even for normal classes now,
@@ -636,11 +628,12 @@ class Completions(
             case symOnly: CompletionValue.Symbolic =>
               val sym = symOnly.symbol
               val name = SemanticdbSymbols.symbolName(sym)
-              val id =
+              val nameId =
                 if sym.isClass || sym.is(Module) then
                   // drop #|. at the end to avoid duplication
                   name.substring(0, name.length - 1)
                 else name
+              val id = nameId + symOnly.snippetSuffix.labelSnippet.getOrElse("")
               val include = cursorPos.include(sym)
               (id, include)
             case kw: CompletionValue.Keyword => (kw.label, true)
@@ -701,6 +694,7 @@ class Completions(
   private def computeRelevancePenalty(
       completion: CompletionValue,
       application: CompletionApplication,
+      cursorPos: CursorPos,
   ): Int =
     import scala.meta.internal.pc.MemberOrdering.*
 
@@ -746,7 +740,10 @@ class Completions(
         relevance |= IsSynthetic
       if sym.isDeprecated then relevance |= IsDeprecated
       if isEvilMethod(sym.name) then relevance |= IsEvilMethod
-
+      cursorPos match
+        case CursorPos.Type(_, _) if !sym.isType =>
+          relevance |= IsNotTypeInTypePos
+        case _ =>
       relevance
     end symbolRelevance
 
@@ -824,7 +821,8 @@ class Completions(
   end CompletionApplication
 
   private def completionOrdering(
-      application: CompletionApplication
+      application: CompletionApplication,
+      cursorPos: CursorPos,
   ): Ordering[CompletionValue] =
     new Ordering[CompletionValue]:
       val queryLower = completionPos.query.toLowerCase()
@@ -839,8 +837,8 @@ class Completions(
 
       def compareByRelevance(o1: CompletionValue, o2: CompletionValue): Int =
         Integer.compare(
-          computeRelevancePenalty(o1, application),
-          computeRelevancePenalty(o2, application),
+          computeRelevancePenalty(o1, application, cursorPos),
+          computeRelevancePenalty(o2, application, cursorPos),
         )
 
       def fuzzyScore(o: CompletionValue.Symbolic): Int =

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -703,9 +703,10 @@ class CompletionDocSuite extends BaseCompletionSuite {
            |- `fin`: Finally logic which if defined will be invoked after catch logic
            |- `rethrow`: Predicate on throwables determining when to rethrow a caught [Throwable](Throwable)
            |- `pf`: Partial function used when applying catch logic to determine result value
-           |Catch - scala.util.control.Exception
+           |Catch[T] - scala.util.control.Exception
            |""".stripMargin,
     ),
+    topLines = Some(1), // for Scala3, result contains `Catch[$0]` and `Catch`
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -136,6 +136,7 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
     compat = Map(
       "3" ->
         """|IndexedSeq[$0]
+           |IndexedSeq
            |""".stripMargin
     ),
   )
@@ -182,6 +183,9 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
         """|ArrayDeque[$0]
            |ArrayDeque[$0]
            |ArrayDequeOps[$0]
+           |ArrayDeque
+           |ArrayDeque
+           |ArrayDequeOps
            |""".stripMargin,
     ),
   )
@@ -194,6 +198,12 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|SimpleFileVisitor[$0]
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|SimpleFileVisitor[$0]
+           |SimpleFileVisitor
+           |""".stripMargin
+    ),
   )
 
   checkSnippet(
@@ -214,6 +224,7 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
       "3" ->
         """|Iterable[$0] {}
            |IterableOnce[$0] {}
+           |Iterable
            |""".stripMargin,
     ),
   )
@@ -236,6 +247,7 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
       "3" ->
         """|Iterable[$0]
            |IterableOnce[$0]
+           |Iterable
            |""".stripMargin,
     ),
   )
@@ -258,6 +270,7 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
       "3" ->
         """|Iterable[$0]
            |IterableOnce[$0]
+           |Iterable
            |""".stripMargin,
     ),
   )

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -320,6 +320,7 @@ class CompletionSuite extends BaseCompletionSuite {
        |ProcessBuilder - scala.sys.process
        |CertPathBuilder - java.security.cert
        |CertPathBuilderSpi - java.security.cert
+       |ProcessBuilderImpl - scala.sys.process
        |CertPathBuilderResult - java.security.cert
        |PKIXBuilderParameters - java.security.cert
        |PooledConnectionBuilder - javax.sql
@@ -904,6 +905,12 @@ class CompletionSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|ListBuffer - scala.collection.mutable
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|ListBuffer[T] - scala.collection.mutable
+           |ListBuffer - scala.collection.mutable
+           |""".stripMargin
+    ),
   )
 
   check(
@@ -914,6 +921,12 @@ class CompletionSuite extends BaseCompletionSuite {
         |""".stripMargin,
     """|ListBuffer - scala.collection.mutable
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|ListBuffer[T] - scala.collection.mutable
+           |ListBuffer - scala.collection.mutable
+           |""".stripMargin
+    ),
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -114,7 +114,9 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  name: scala.concurrent.Future[$0]
        |)
        |""".stripMargin,
-    filter = _ == "Future - scala.concurrent",
+    filter = elem =>
+      if (scalaVersion.startsWith("3")) elem == "Future[T] - scala.concurrent"
+      else elem == "Future - scala.concurrent",
     compat = Map(
       "2" ->
         """|package `import-conflict3`
@@ -140,7 +142,9 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  name: scala.concurrent.Future[$0]
        |)
        |""".stripMargin,
-    filter = _ == "Future - scala.concurrent",
+    filter = elem =>
+      if (scalaVersion.startsWith("3")) elem == "Future[T] - scala.concurrent"
+      else elem == "Future - scala.concurrent",
     compat = Map(
       "2" ->
         """|package `import-conflict4`
@@ -167,7 +171,9 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  name: Future[$0]
        |)
        |""".stripMargin,
-    filter = _ == "Future - scala.concurrent",
+    filter = elem =>
+      if (scalaVersion.startsWith("3")) elem == "Future[T] - scala.concurrent"
+      else elem == "Future - scala.concurrent",
     compat = Map(
       "2" ->
         """|package `import-no-conflict`
@@ -216,6 +222,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
           |object Main extends CompletableFuture
           |""".stripMargin
     ),
+    assertSingleItem = false,
   )
 
   checkEdit(
@@ -236,6 +243,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
           |object Main extends CompletableFuture
           |""".stripMargin
     ),
+    assertSingleItem = false,
   )
 
   checkEdit(
@@ -378,6 +386,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
            |}
            |""".stripMargin
     ),
+    assertSingleItem = false,
   )
 
   checkEdit(
@@ -511,28 +520,10 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |
        |object Main {
        |  @noinline
-       |  def foo: ArrayBuffer[$0] [Int] = ???
+       |  def foo: ArrayBuffer [Int] = ???
        |}
        |""".stripMargin,
     filter = _ == "ArrayBuffer - scala.collection.mutable",
-    compat = Map(
-      "2" ->
-        """|import scala.collection.mutable.ArrayBuffer
-           |
-           |object Main {
-           |  @noinline
-           |  def foo: ArrayBuffer [Int] = ???
-           |}
-           |""".stripMargin,
-      ">=3.2.1" ->
-        """|import scala.collection.mutable.ArrayBuffer
-           |
-           |object Main {
-           |  @noinline
-           |  def foo: ArrayBuffer [Int] = ???
-           |}
-           |""".stripMargin,
-    ),
   )
 
   checkEdit(
@@ -548,30 +539,10 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |import scala.collection.mutable.ArrayBuffer
        |object Main {
        |  @deprecated("", "")
-       |  class Foo extends ArrayBuffer[$0][Int]
+       |  class Foo extends ArrayBuffer[Int]
        |}
        |""".stripMargin,
     filter = _ == "ArrayBuffer - scala.collection.mutable",
-    compat = Map(
-      "2" ->
-        """|package annotationclass
-           |
-           |import scala.collection.mutable.ArrayBuffer
-           |object Main {
-           |  @deprecated("", "")
-           |  class Foo extends ArrayBuffer[Int]
-           |}
-           |""".stripMargin,
-      ">=3.2.1" ->
-        """|package annotationclass
-           |
-           |import scala.collection.mutable.ArrayBuffer
-           |object Main {
-           |  @deprecated("", "")
-           |  class Foo extends ArrayBuffer[Int]
-           |}
-           |""".stripMargin,
-    ),
   )
 
   checkEdit(
@@ -587,30 +558,10 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |import scala.collection.mutable.ArrayBuffer
        |object Main {
        |  @deprecated("", "")
-       |  trait Foo extends ArrayBuffer[$0][Int]
+       |  trait Foo extends ArrayBuffer[Int]
        |}
        |""".stripMargin,
     filter = _ == "ArrayBuffer - scala.collection.mutable",
-    compat = Map(
-      "2" ->
-        """|package annotationtrait
-           |
-           |import scala.collection.mutable.ArrayBuffer
-           |object Main {
-           |  @deprecated("", "")
-           |  trait Foo extends ArrayBuffer[Int]
-           |}
-           |""".stripMargin,
-      ">=3.2.1" ->
-        """|package annotationtrait
-           |
-           |import scala.collection.mutable.ArrayBuffer
-           |object Main {
-           |  @deprecated("", "")
-           |  trait Foo extends ArrayBuffer[Int]
-           |}
-           |""".stripMargin,
-    ),
   )
 
   checkEdit(
@@ -624,28 +575,10 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |
        |import scala.concurrent.Future
        |case class Foo(
-       |  name: Future[$0][String]
+       |  name: Future[String]
        |)
        |""".stripMargin,
     filter = _ == "Future - scala.concurrent",
-    compat = Map(
-      "2" ->
-        """|package classparam
-           |
-           |import scala.concurrent.Future
-           |case class Foo(
-           |  name: Future[String]
-           |)
-           |""".stripMargin,
-      ">=3.2.1" ->
-        """|package classparam
-           |
-           |import scala.concurrent.Future
-           |case class Foo(
-           |  name: Future[String]
-           |)
-           |""".stripMargin,
-    ),
   )
 
   checkEdit(
@@ -819,8 +752,21 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |""".stripMargin,
     """|Future scala.concurrent
        |Future - java.util.concurrent
+       |FutureTask - java.util.concurrent
        |""".stripMargin,
-    topLines = Some(2),
+    topLines = Some(3),
+    compat = Map(
+      "2.13" ->
+        """|Future scala.concurrent
+           |Future - java.util.concurrent
+           |FutureOps - scala.jdk.FutureConverters
+           |""".stripMargin,
+      "3" ->
+        """|Future[T] scala.concurrent
+           |Future scala.concurrent
+           |Future[T] - java.util.concurrent
+           |""".stripMargin,
+    ),
   )
 
   check(
@@ -834,8 +780,21 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |""".stripMargin,
     """|Future java.util.concurrent
        |Future - scala.concurrent
+       |FutureTask - java.util.concurrent
        |""".stripMargin,
-    topLines = Some(2),
+    topLines = Some(3),
+    compat = Map(
+      "2.13" ->
+        """|Future java.util.concurrent
+           |Future - scala.concurrent
+           |FutureOps - scala.jdk.FutureConverters
+           |""".stripMargin,
+      "3" ->
+        """|Future[T] java.util.concurrent
+           |Future java.util.concurrent
+           |Future[T] - scala.concurrent
+           |""".stripMargin,
+    ),
   )
 
   checkEdit(


### PR DESCRIPTION
As described in https://github.com/scalameta/metals/issues/4358.
Some details:
 1. I sort by adding a penalty for non-types on type position. I chose the penalty value to outweigh the `notGetter` penalty types get.

resolves: https://github.com/scalameta/metals/issues/4358