### PR TITLE
fix: Fix scala-cli dep completions for scala-cli 1.0.1

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/ScalaCliCompletions.scala
@@ -20,6 +20,9 @@ class ScalaCliCompletions(
       // generated script file will end with .sc.scala
       case (_: TypeDef) :: Nil if pos.source.file.path.endsWith(".sc.scala") =>
         scalaCliDep
+      case (_: Template) :: (_: TypeDef) :: Nil
+          if pos.source.file.path.endsWith(".sc.scala") =>
+        scalaCliDep
       case head :: next => None
 
   def contribute(dependency: String) =

--- a/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
+++ b/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
@@ -46,6 +46,26 @@ class ScalaCliSuite extends BaseScalaCliSuite(V.scala3) {
         "utest/framework/Tree.scala",
       )
 
+      completion <- server.completion(
+        "MyTests.scala",
+        "//> using lib \"com.lihao@@yi::utest",
+      )
+
+      _ = assertNoDiff(completion, "com.lihaoyi")
+
+      completion <- server.completion(
+        "MyTests.scala",
+        "//> using lib com.lihaoyi::pprin@@t",
+      )
+
+      _ = assertNoDiff(
+        completion,
+        """|pprint
+           |pprint_native0.4
+           |pprint_sjs1
+           |""".stripMargin,
+      )
+
     } yield ()
 
   private def simpleScriptTest(useBsp: Boolean): Future[Unit] =
@@ -55,7 +75,7 @@ class ScalaCliSuite extends BaseScalaCliSuite(V.scala3) {
            |#!/usr/bin/env -S scala-cli shebang --java-opt -Xms256m --java-opt -XX:MaxRAMPercentage=80 
            |//> using scala "$scalaVersion"
            |//> using lib "com.lihaoyi::utest::0.7.10"
-           |//> using lib "com.lihaoyi::pprint::0.6.6"
+           |//> using lib com.lihaoyi::pprint::0.6.6
            |
            |import foo.Foo
            |import utest._
@@ -121,13 +141,33 @@ class ScalaCliSuite extends BaseScalaCliSuite(V.scala3) {
         s"Expected no scalameta errors, got: $parserDiagnostics",
       )
 
+      completion <- server.completion(
+        "MyTests.sc",
+        "//> using lib \"com.lihao@@yi::utest",
+      )
+
+      _ = assertNoDiff(completion, "com.lihaoyi")
+
+      completion <- server.completion(
+        "MyTests.sc",
+        "//> using lib com.lihaoyi::pprin@@t",
+      )
+
+      _ = assertNoDiff(
+        completion,
+        """|pprint
+           |pprint_native0.4
+           |pprint_sjs1
+           |""".stripMargin,
+      )
+
     } yield ()
 
   private val simpleFileLayout =
     s"""|/MyTests.scala
         |//> using scala "$scalaVersion"
         |//> using lib "com.lihaoyi::utest::0.7.10"
-        |//> using lib "com.lihaoyi::pprint::0.6.6"
+        |//> using lib com.lihaoyi::pprint::0.6.6
         |
         |import foo.Foo
         |import utest._
@@ -189,7 +229,7 @@ class ScalaCliSuite extends BaseScalaCliSuite(V.scala3) {
         s"""/scripts/MyTests.scala
            |//> using scala "$scalaVersion"
            |//> using lib "com.lihaoyi::utest::0.7.10"
-           |//> using lib "com.lihaoyi::pprint::0.6.6"
+           |//> using lib com.lihaoyi::pprint::0.6.6
            |
            |import foo.Foo
            |import utest._


### PR DESCRIPTION
In Scala-Cli 1.0.1 the top wrapper changed, so dep completions stopped working