### PR TITLE
fix: add in a null check after calling `stabilizedType`

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -934,9 +934,11 @@ class MetalsGlobal(
         case t => t
       }
     val pre = stabilizedType(qual(tree))
-    val memberType = pre.memberType(symbol)
-    if (memberType.isErroneous) symbol.info
-    else memberType
+    if (pre != null) {
+      val memberType = pre.memberType(symbol)
+      if (memberType.isErroneous) symbol.info
+      else memberType
+    } else NoType
   }
 
   /**


### PR DESCRIPTION
I noticed this today while working on something in Metals that when trying to add another case into:

```scala
val codeActions = params
  .getContext()
  .getDiagnostics()
  .asScala
  .groupBy {
    c<_CURSOR_>
    case ScalacDiagnostic.ScalaAction(textEdit) =>
      Some(textEdit)
    case _ => None
  }
```

I was getting the following in the logs:

```
Jun 14, 2023 2:24:02 PM scala.meta.internal.pc.completions.Completions completionPosition
SEVERE: Cannot invoke "scala.reflect.internal.Types$Type.memberType(scala.reflect.internal.Symbols$Symbol)" because "pre" is null
java.lang.NullPointerException: Cannot invoke "scala.reflect.internal.Types$Type.memberType(scala.reflect.internal.Symbols$Symbol)" because "pre" is null
        at scala.meta.internal.pc.MetalsGlobal.metalsSeenFromType(MetalsGlobal.scala:946)
        at scala.meta.internal.pc.completions.MatchCaseCompletions$CaseKeywordCompletion.<init>(MatchCaseCompletions.scala:56)
        at scala.meta.internal.pc.completions.Completions.fromIdentApply$1(Completions.scala:458)
        at scala.meta.internal.pc.completions.Completions.completionPositionUnsafe(Completions.scala:485)
        at scala.meta.internal.pc.completions.Completions.completionPositionUnsafe$(Completions.scala:433)
        at scala.meta.internal.pc.MetalsGlobal.completionPositionUnsafe(MetalsGlobal.scala:33)
        at scala.meta.internal.pc.completions.Completions.completionPosition(Completions.scala:425)
        at scala.meta.internal.pc.completions.Completions.completionPosition$(Completions.scala:407)
        at scala.meta.internal.pc.MetalsGlobal.completionPosition(MetalsGlobal.scala:33)
        at scala.meta.internal.pc.CompletionProvider.safeCompletionsAt(CompletionProvider.scala:467)
        at scala.meta.internal.pc.CompletionProvider.completions(CompletionProvider.scala:58)
        at scala.meta.internal.pc.ScalaPresentationCompiler.$anonfun$complete$1(ScalaPresentationCompiler.scala:162)
        at scala.meta.internal.pc.CompilerAccess.withSharedCompiler(CompilerAccess.scala:137)
        at scala.meta.internal.pc.CompilerAccess.$anonfun$withInterruptableCompiler$1(CompilerAccess.scala:88)
        at scala.meta.internal.pc.CompilerAccess.$anonfun$onCompilerJobQueue$1(CompilerAccess.scala:197)
        at scala.meta.internal.pc.CompilerJobQueue$Job.run(CompilerJobQueue.scala:152)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

Digging into a bit the tree that ends up being passed in looks like:

```
Select(
  qualifier = Apply(
    fun = Select(
      qualifier = Apply(
        fun = Select(qualifier = Ident(name = params), name = getContext),
        args = List()
      ),
      name = getDiagnostics
    ),
    args = List()
  ),
  name = asScala
)
```

Which then `stabilizedType` returns a `null` for this causing a `NullPointerException` when we call `memberType` on it. I'm not 100% sure if maybe something else should actually be fixed here, but this just adds in a `null` check seeing that `stabilizedType` can return `null` in certain instances. If it does, we just return a `NoType`.