### PR TITLE
feat: account for `ScalaDiagnostic` in diagnostic data

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
@@ -2,12 +2,20 @@ package scala.meta.internal.metals
 
 import scala.meta.internal.metals.MetalsEnrichments._
 
+import ch.epfl.scala.bsp4j
 import org.eclipse.{lsp4j => l}
 
 object ScalacDiagnostic {
 
-  object ScalaAction {
+  object LegacyScalaAction {
     def unapply(d: l.Diagnostic): Option[l.TextEdit] = d.asTextEdit
+  }
+
+  object ScalaDiagnostic {
+    def unapply(
+        d: l.Diagnostic
+    ): Option[Either[l.TextEdit, bsp4j.ScalaDiagnostic]] =
+      d.asScalaDiagnostic
   }
 
   object NotAMember {

--- a/mtags-shared/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -35,16 +35,19 @@ trait CommonMtagsEnrichments {
   private def logger: Logger =
     Logger.getLogger(classOf[CommonMtagsEnrichments].getName)
 
-  protected def decodeJson[T](obj: AnyRef, cls: java.lang.Class[T]): Option[T] =
+  protected def decodeJson[T](
+      obj: AnyRef,
+      cls: java.lang.Class[T],
+      gson: Option[Gson] = None
+  ): Option[T] =
     for {
       data <- Option(obj)
       value <-
         try {
-          Some(
-            new Gson().fromJson[T](
-              data.asInstanceOf[JsonElement],
-              cls
-            )
+          Option(
+            gson
+              .getOrElse(new Gson())
+              .fromJson[T](data.asInstanceOf[JsonElement], cls)
           )
         } catch {
           case NonFatal(e) =>

--- a/project/V.scala
+++ b/project/V.scala
@@ -16,7 +16,7 @@ object V {
   val betterMonadicFor = "0.3.1"
   val bloop = "1.5.6"
   val bloopConfig = "1.5.5"
-  val bsp = "2.1.0-M4"
+  val bsp = "2.1.0-M5"
   val coursier = "2.1.5"
   val coursierInterfaces = "1.0.18"
   val debugAdapter = "3.1.3"


### PR DESCRIPTION
This pr bumps the version of BSP to the latest that includes the changes necessary for the new `ScalaDiagnostic` that is included in the `data` field of the Diagnostic coming over BSP. These include actions coming straight from the Scala 3 compiler.

Here are some examples using sbt 1.9.0 and the code changes in [here](https://github.com/lampepfl/dotty/pull/17561):

![2023-06-15 14 43 48](https://github.com/scalameta/metals/assets/13974112/c685d8e0-5aee-431f-9915-cbb38eb8f07f)
![2023-06-15 14 45 16](https://github.com/scalameta/metals/assets/13974112/83530a5e-b5a1-4a65-a8e0-d9e21e67ffc1)
![2023-06-15 14 45 58](https://github.com/scalameta/metals/assets/13974112/2b01f440-4b37-4ef1-ba66-2a8469d55f55)

Supersedes https://github.com/scalameta/metals/pull/5173 since the shape is a bit different now than originally planned. Since this is the shape already baked into BSP, I'll do a follow-up in scala-cli to also update the top level `TextEdit` that it uses to instead use `ScalaDiagnostic` in `data`. 