### PR TITLE
bugfix: handle backticks in inverse semanticdb path

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SemanticdbSymbols.scala
@@ -2,6 +2,8 @@ package scala.meta.internal.pc
 
 import scala.util.control.NonFatal
 
+import scala.meta.internal.mtags.MtagsEnrichments.stripBackticks
+
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.Names.*
@@ -17,7 +19,9 @@ object SemanticdbSymbols:
       if s.isNone || s.isRootPackage then RootPackage :: Nil
       else if s.isEmptyPackage then EmptyPackageVal :: Nil
       else if s.isPackage then
-        try requiredPackage(s.stripSuffix("/").replace("/", ".")) :: Nil
+        try
+          val pkg = s.split('/').map(_.stripBackticks).mkString(".")
+          requiredPackage(pkg) :: Nil
         catch
           case NonFatal(_) =>
             Nil
@@ -66,7 +70,9 @@ object SemanticdbSymbols:
                     .toList
 
         parentSymbol.flatMap(tryMember)
-    try loop(sym).filterNot(_ == NoSymbol)
+    try
+      val res = loop(sym)
+      res.filterNot(_ == NoSymbol)
     catch case NonFatal(e) => Nil
   end inverseSemanticdbSymbol
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -653,6 +653,14 @@ class CompletionArgSuite extends BaseCompletionSuite {
     """|foo = : Int
        |foo = a : Int
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|foo = : Int
+           |foo = a : Int
+           |foo: Int
+           |fooBar: Int
+           |""".stripMargin
+    ),
   )
 
   check(
@@ -672,6 +680,14 @@ class CompletionArgSuite extends BaseCompletionSuite {
     """|fooBar = : Int
        |fooBar = a : Int
        |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|fooBar = : Int
+           |fooBar = a : Int
+           |foo: Int
+           |fooBar: Int
+           |""".stripMargin
+    ),
   )
 
   check(


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/5341

The issue is was only present for package names, since `DescriptorParser` can deal with backticks.