### PR TITLE
fix: Highlight for named arguments in Scala 2

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
@@ -149,6 +149,7 @@ abstract class PcCollector[T](
                   .filter(_.isConstructor)
                   .flatMap(_.paramss)
                   .flatten
+                  .filter(_.name == id.name)
                   .toSet
                 (
                   (constructorParams ++ Set(

--- a/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
@@ -52,6 +52,34 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite {
   )
 
   check(
+    "named-arg",
+    """
+      |case class Foo(foo: Int, <<bar>>: Int)
+      |object Main {
+      |  val x = Foo(
+      |    foo = 123,
+      |    <<ba@@r>> = 456
+      |  ) 
+      |
+      |}""".stripMargin,
+  )
+
+  check(
+    "named-arg1",
+    """
+      |case class Foo(<<foo>>: Int, bar: Int)
+      |object Main {
+      |  val x = Foo(
+      |    <<fo@@o>> = 123,
+      |    bar = 456
+      |  )
+      |  val y = x.<<foo>>
+      |  
+      |
+      |}""".stripMargin,
+  )
+
+  check(
     "scopes",
     """
       |object Main {


### PR DESCRIPTION
Previously, we were incorrectly highlighting all named arguments for case class