### PR TITLE
create java semanticdb info using JDK instead of javac CLI

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -75,9 +75,11 @@ case class GradleBuildTool(userConfig: () => UserConfiguration)
 
   override def bloopInstallArgs(workspace: AbsolutePath): List[String] = {
     val cmd = {
-      if (isBloopConfigured(workspace)) List("--console=plain", "bloopInstall")
+      if (isBloopConfigured(workspace))
+        List("--stacktrace", "--console=plain", "bloopInstall")
       else {
         List(
+          "--stacktrace",
           "--console=plain",
           "--init-script",
           initScriptPath.toString,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -337,18 +337,9 @@ class MetalsLspService(
     )
 
   private val interactiveSemanticdbs: InteractiveSemanticdbs = {
-    val javaInteractiveSemanticdb =
-      for {
-        javaHome <- optJavaHome
-        jdkVersion <- maybeJdkVersion
-        javaSemanticDb <- JavaInteractiveSemanticdb.create(
-          javaHome,
-          folder,
-          buildTargets,
-          jdkVersion,
-        )
-      } yield javaSemanticDb
-
+    val javaInteractiveSemanticdb = maybeJdkVersion.map(jdkVersion =>
+      JavaInteractiveSemanticdb.create(folder, buildTargets, jdkVersion)
+    )
     register(
       new InteractiveSemanticdbs(
         folder,

--- a/metals/src/main/scala/scala/meta/internal/parsing/JavaFoldingRangeExtractor.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/JavaFoldingRangeExtractor.scala
@@ -122,8 +122,7 @@ final object JavaFoldingRangeExtractor {
       text: String,
       path: AbsolutePath,
   ): Option[(Trees, CompilationUnitTree)] = {
-    val javaGlobal = new JavaMetalsGlobal(null, null)
-    val javacTask = javaGlobal.compilationTask(text, path.toURI)
+    val javacTask = JavaMetalsGlobal.compilationTask(text, path.toURI)
     val elems = javacTask.parse()
     javacTask.analyze()
     val trees = Trees.instance(javacTask)

--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaCompletionProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaCompletionProvider.scala
@@ -44,8 +44,8 @@ class JavaCompletionProvider(
           params.text().substring(params.offset())
       else params.text()
     val task: JavacTask =
-      compiler.compilationTask(textWithSemicolon, params.uri())
-    val scanner = compiler.scanner(task)
+      JavaMetalsGlobal.compilationTask(textWithSemicolon, params.uri())
+    val scanner = JavaMetalsGlobal.scanner(task)
     val position =
       CursorPosition(params.offset(), params.offset(), params.offset())
     val node = compiler.compilerTreeNode(scanner, position)

--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaHoverProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaHoverProvider.scala
@@ -49,8 +49,9 @@ class JavaHoverProvider(
   }
 
   def hoverOffset(params: OffsetParams): Option[HoverSignature] = {
-    val task: JavacTask = compiler.compilationTask(params.text(), params.uri())
-    val scanner = compiler.scanner(task)
+    val task: JavacTask =
+      JavaMetalsGlobal.compilationTask(params.text(), params.uri())
+    val scanner = JavaMetalsGlobal.scanner(task)
     val types = task.getTypes()
     val elements = task.getElements()
     val position = params match {

--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaMetalsGlobal.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaMetalsGlobal.scala
@@ -1,5 +1,7 @@
 package scala.meta.internal.pc
 
+import java.io.File
+import java.io.Writer
 import java.net.URI
 import javax.tools.Diagnostic
 import javax.tools.DiagnosticListener
@@ -19,40 +21,7 @@ class JavaMetalsGlobal(
     val search: SymbolSearch,
     val metalsConfig: PresentationCompilerConfig
 ) {
-
-  private val COMPILER: JavaCompiler = ToolProvider.getSystemJavaCompiler()
-
-  private val noopDiagnosticListener = new DiagnosticListener[JavaFileObject] {
-
-    // ignore errors since presentation compiler will have a lot of transient ones
-    override def report(diagnostic: Diagnostic[_ <: JavaFileObject]): Unit = ()
-
-  }
-
-  def compilationTask(sourceCode: String, uri: URI): JavacTask = {
-    val javaFileObject = SourceJavaFileObject.make(sourceCode, uri)
-
-    COMPILER
-      .getTask(
-        null,
-        null,
-        noopDiagnosticListener,
-        null,
-        null,
-        List(javaFileObject).asJava
-      )
-      .asInstanceOf[JavacTask]
-  }
-
   var lastVisitedParentTrees: List[TreePath] = Nil
-
-  def scanner(task: JavacTask): JavaTreeScanner = {
-    val elems = task.parse()
-    task.analyze()
-    val root = elems.iterator().next()
-
-    new JavaTreeScanner(task, root)
-  }
 
   def compilerTreeNode(
       scanner: JavaTreeScanner,
@@ -60,7 +29,53 @@ class JavaMetalsGlobal(
   ): Option[TreePath] = {
     scanner.scan(scanner.root, position)
     lastVisitedParentTrees = scanner.lastVisitedParentTrees
-
     lastVisitedParentTrees.headOption
+  }
+}
+
+object JavaMetalsGlobal {
+
+  private val COMPILER: JavaCompiler = ToolProvider.getSystemJavaCompiler()
+
+  private val noopDiagnosticListener = new DiagnosticListener[JavaFileObject] {
+
+    // ignore errors since presentation compiler will have a lot of transient ones
+    override def report(diagnostic: Diagnostic[_ <: JavaFileObject]): Unit = ()
+  }
+
+  def makeFileObject(file: File): JavaFileObject = {
+    val fileManager = COMPILER.getStandardFileManager(null, null, null)
+    val files = fileManager.getJavaFileObjectsFromFiles(List(file).asJava)
+    files.iterator().next()
+  }
+
+  def compilationTask(sourceCode: String, uri: URI): JavacTask = {
+    val javaFileObject = SourceJavaFileObject.make(sourceCode, uri)
+    compilationTask(javaFileObject, None, Nil)
+  }
+
+  def compilationTask(
+      javaFileObject: JavaFileObject,
+      out: Option[Writer],
+      allOptions: List[String]
+  ): JavacTask = {
+    COMPILER
+      .getTask(
+        out.orNull,
+        null,
+        noopDiagnosticListener,
+        allOptions.asJava,
+        null,
+        List(javaFileObject).asJava
+      )
+      .asInstanceOf[JavacTask]
+  }
+
+  def scanner(task: JavacTask): JavaTreeScanner = {
+    val elems = task.parse()
+    task.analyze()
+    val root = elems.iterator().next()
+
+    new JavaTreeScanner(task, root)
   }
 }

--- a/tests/unit/src/test/scala/tests/JavaInteractiveSemanticdbSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaInteractiveSemanticdbSuite.scala
@@ -1,15 +1,122 @@
 package tests
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import scala.concurrent.ExecutionContext
+import scala.util.Properties
+
+import scala.meta.internal.io.FileIO
+import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.JavaInteractiveSemanticdb
+import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.metals.JdkVersion
+import scala.meta.internal.mtags.MtagsEnrichments.XtensionStringMtags
+import scala.meta.io.AbsolutePath
 
 import munit.FunSuite
 
 class JavaInteractiveSemanticdbSuite extends FunSuite {
+
+  private val javaBasePrefix: String =
+    if (Properties.isJavaAtLeast("9")) "java.base/" else ""
+
+  private val optJavaHome = JdkSources.defaultJavaHome(None).headOption
+  private implicit val ctx: ExecutionContext = this.munitExecutionContext
+  private val maybeJdkVersion: Option[JdkVersion] =
+    JdkVersion.maybeJdkVersionFromJavaHome(optJavaHome)
 
   test("parse jdk-version") {
     assertEquals(JdkVersion.parse("17-ea"), Some(JdkVersion(17)))
     assertEquals(JdkVersion.parse("9"), Some(JdkVersion(9)))
     assertEquals(JdkVersion.parse("1.8.0_312"), Some(JdkVersion(8)))
     assertEquals(JdkVersion.parse("11.0.13"), Some(JdkVersion(11)))
+  }
+
+  test("compile jdk-class") {
+    JdkSources(None) match {
+      case Left(_) => fail("No JDK")
+      case Right(jdkSource) =>
+        val workspace = Files.createTempDirectory("metals")
+        workspace.toFile().deleteOnExit()
+        val buildTargets = BuildTargets.empty
+        maybeJdkVersion match {
+          case None => fail("No JDK Version")
+          case Some(jdkVersion) =>
+            val javaCompile = JavaInteractiveSemanticdb.create(
+              AbsolutePath(workspace),
+              buildTargets,
+              jdkVersion,
+            )
+            val fileToCompile =
+              s"jar:${jdkSource.toURI}!/${javaBasePrefix}java/nio/file/Path.java"
+            val file = fileToCompile.toAbsolutePath
+            val contents = FileIO.slurp(file, StandardCharsets.UTF_8)
+            val output = javaCompile.textDocument(file, contents)
+            // size varies per JDK version
+            assert(output.symbols.nonEmpty)
+            assert(output.occurrences.nonEmpty)
+        }
+    }
+  }
+
+  test("compile source") {
+    val workspace = Files.createTempDirectory("metals")
+    workspace.toFile().deleteOnExit()
+    val buildTargets = BuildTargets.empty
+    maybeJdkVersion match {
+      case None => fail("No JDK Version")
+      case Some(jdkVersion) =>
+        val javaCompile = JavaInteractiveSemanticdb.create(
+          AbsolutePath(workspace),
+          buildTargets,
+          jdkVersion,
+        )
+        val path = workspace.resolve("foo/bar/Main.java")
+        Files.createDirectories(path.getParent)
+        val contents = """package foo.bar;
+                         |
+                         |public class Main {
+                         |  void hello()
+                         |  {
+                         |    System.out.println("Hello!");
+                         |  }
+                         |}""".stripMargin
+        Files.write(path, contents.getBytes(StandardCharsets.UTF_8))
+        val output = javaCompile.textDocument(AbsolutePath(path), contents)
+        assertEquals(output.symbols.size, 3)
+        // size varies per JDK version
+        assert(output.occurrences.nonEmpty)
+    }
+  }
+
+  test("compile source-with-error") {
+    val workspace = Files.createTempDirectory("metals")
+    workspace.toFile().deleteOnExit()
+    val buildTargets = BuildTargets.empty
+    maybeJdkVersion match {
+      case None => fail("No JDK Version")
+      case Some(jdkVersion) =>
+        val javaCompile = JavaInteractiveSemanticdb.create(
+          AbsolutePath(workspace),
+          buildTargets,
+          jdkVersion,
+        )
+        val path = workspace.resolve("foo/bar/Main.java")
+        Files.createDirectories(path.getParent)
+        val contents = """package foo.bar;
+                         |
+                         |public class Main {
+                         |  void hello()
+                         |  {
+                         |    System.out.println(foo);
+                         |  }
+                         |}""".stripMargin
+        Files.write(path, contents.getBytes(StandardCharsets.UTF_8))
+        val output = javaCompile.textDocument(AbsolutePath(path), contents)
+        assertEquals(output.symbols.size, 3)
+        // size varies per JDK version
+        assert(output.occurrences.nonEmpty)
+    }
   }
 }


### PR DESCRIPTION
Should be faster and easier to test/debug and brings it into line with using same JDK compiler as other Java handling code.

Because this runs in process (instead of running an external javac process), Metals needs to start with the same options as the SCIP plugin so even more `-add-exports`...

Currently has...
```
--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
```
needs also...
```
--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
```

Is there a process for notifying the client maintainers?  Or shall I just raise a PR in vscode-metals and assume they will check there?

Also - why are these `--add-opens` instead of `--add-exports`.  Isn't `-add-opens` only required when accessing private code using reflection?