### PR TITLE
chore: Update warnings list after Scala version bump

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,28 +159,25 @@ commands ++= Seq(
 // https://github.com/scala/bug/issues/10448
 def lintingOptions(scalaVersion: String) = {
   val unused213 = "-Wunused"
-  // Can't use due to issues with Scala 3 https://github.com/lampepfl/dotty/issues/16650
   val unused3 = "-Wunused:all"
   val common = List(
     // desugaring of for yield caused pattern var to complain
     // https://github.com/scala/bug/issues/10287
-    "-Wconf:msg=parameter value .+ in anonymous function:silent",
-    // silence unused parameters in mtags
-    "-Wconf:src=*.ScaladocParser.scala&msg=parameter value (pos|message) in method reportError:silent",
-    "-Wconf:src=*.Completions.scala&msg=parameter value (member|m) in method (isCandidate|isPrioritized):silent",
-    "-Wconf:src=*.JavaMtags.scala&msg=parameter value (ctor|method) in method (visitConstructor|visitMethod):silent",
-    "-Wconf:src=*.MtagsIndexer.scala&msg=parameter value owner in method visitOccurrence:silent",
+    "-Wconf:msg=in anonymous function is never used:silent",
+    // silence unused parameters in mtags in abstract methods
+    "-Wconf:src=*.BasePCSuite.scala&msg=parameter (scalaVersion|classpath) in method (extraDependencies|scalacOptions):silent",
+    "-Wconf:src=*.CodeLens.scala&msg=parameter (textDocumentWithPath|path) in method codeLenses is never used:silent",
+    "-Wconf:src=*.Completions.scala&msg=parameter (member|m) in method (isCandidate|isPrioritized):silent",
+    "-Wconf:src=*.JavaMtags.scala&msg=parameter (ctor|method) in method (visitConstructor|visitMethod):silent",
+    "-Wconf:src=*.MtagsIndexer.scala&msg=parameter owner in method visitOccurrence:silent",
+    "-Wconf:src=*.ScaladocParser.scala&msg=parameter (pos|message) in method reportError:silent",
+    "-Wconf:src=*.TreeViewProvider.scala&msg=parameter params in method (children|parent) is never used:silent",
     // silence "The outer reference in this type test cannot be checked at run time."
     "-Wconf:src=.*(CompletionProvider|ArgCompletions|Completions|Keywords|IndentOnPaste).scala&msg=The outer reference:silent",
-    "-Wconf:src=*.BasePCSuite.scala&msg=parameter value (scalaVersion|classpath) in method (extraDependencies|scalacOptions):silent",
   )
-  // -Wconf is available only from 2.13.2
-  val commonFiltered =
-    if (scalaVersion == "2.13.1") common.filterNot(_.startsWith("-Wconf"))
-    else common
   crossSetting(
     scalaVersion,
-    if213 = unused213 :: commonFiltered,
+    if213 = unused213 :: common,
     if3 = unused3 :: Nil,
     if211 = List("-Ywarn-unused-import"),
   )

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -148,7 +148,7 @@ final class Compilations(
       for {
         cleanResult <- cleaned
         if cleanResult.getCleaned() == true
-        compiled <- compile(targetIds).future
+        _ <- compile(targetIds).future
       } yield ()
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/CodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/CodeLens.scala
@@ -1,7 +1,5 @@
 package scala.meta.internal.metals.codelenses
 
-import scala.annotation.nowarn
-
 import scala.meta.internal.implementation.TextDocumentWithPath
 import scala.meta.io.AbsolutePath
 
@@ -10,12 +8,8 @@ import org.eclipse.{lsp4j => l}
 trait CodeLens {
   def isEnabled: Boolean
 
-  @nowarn(
-    "msg=parameter textDocumentWithPath in method codeLenses is never used"
-  )
   def codeLenses(textDocumentWithPath: TextDocumentWithPath): Seq[l.CodeLens] =
     Seq.empty
 
-  @nowarn("msg=parameter path in method codeLenses is never used")
   def codeLenses(path: AbsolutePath): Seq[l.CodeLens] = Seq.empty
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
@@ -406,7 +406,7 @@ final class Doctor(
       else
         (
           DoctorStatus.alert,
-          problemResolver.recommendation(javaTarget, scalaTarget = None),
+          problemResolver.recommendation(javaTarget),
         )
 
     val canRun = javaTarget.info.getCapabilities().getCanRun()
@@ -451,9 +451,7 @@ final class Doctor(
     val recommendedFix = problemResolver
       .recommendation(scalaTarget)
       .orElse {
-        javaTarget.flatMap(target =>
-          problemResolver.recommendation(target, Some(scalaTarget))
-        )
+        javaTarget.flatMap(target => problemResolver.recommendation(target))
       }
     val (targetType, diagnosticsStatus) =
       scalaTarget.sbtVersion match {
@@ -471,7 +469,7 @@ final class Doctor(
       case Some(target) =>
         (
           DoctorStatus.alert,
-          problemResolver.recommendation(target, Some(scalaTarget)),
+          problemResolver.recommendation(target),
         )
       case None if scalaTarget.isAmmonite => (DoctorStatus.info, None)
       case None => (DoctorStatus.alert, None)

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
@@ -38,11 +38,8 @@ class ProblemResolver(
     }
   }
 
-  def recommendation(
-      java: JavaTarget,
-      scalaTarget: Option[ScalaTarget],
-  ): Option[String] = {
-    findProblem(java, scalaTarget).map(_.message)
+  def recommendation(java: JavaTarget): Option[String] = {
+    findProblem(java).map(_.message)
   }
 
   def recommendation(scala: ScalaTarget): Option[String] = {
@@ -86,10 +83,7 @@ class ProblemResolver(
     }
     for {
       target <- javaTargets
-      issue <- findProblem(
-        target,
-        scalaTargets.find(_.info.getId() == target.info.getId()),
-      )
+      issue <- findProblem(target)
     } yield {
       issue match {
         case _: JavaSemanticDBDisabled => misconfiguredProjects += 1
@@ -314,8 +308,7 @@ class ProblemResolver(
   }
 
   private def findProblem(
-      javaTarget: JavaTarget,
-      scalaTarget: Option[ScalaTarget],
+      javaTarget: JavaTarget
   ): Option[JavaProblem] = {
     if (!javaTarget.isSemanticdbEnabled)
       Some(
@@ -332,23 +325,14 @@ class ProblemResolver(
           "-Xplugin:semanticdb -targetroot:javac-classes-directory"
         )
       )
-    else isWrongJavaRelease(javaTarget, scalaTarget)
+    else isWrongJavaRelease(javaTarget)
   }
 
   private def isWrongJavaRelease(
-      javaTarget: JavaTarget,
-      scalaTarget: Option[ScalaTarget],
+      javaTarget: JavaTarget
   ): Option[JavaProblem] = {
-    def buildJavaVersion =
-      for {
-        target <- scalaTarget
-        javaHome <- target.jvmHome
-        version <-
-          maybeJDKVersion
-      } yield version
-
     val releaseVersion = javaTarget.releaseVersion.flatMap(JdkVersion.parse)
-    releaseVersion.zip(buildJavaVersion) match {
+    releaseVersion.zip(maybeJDKVersion) match {
       case Some((releaseVersion, jvmHomeVersion))
           if jvmHomeVersion.major < releaseVersion.major =>
         Some(

--- a/metals/src/main/scala/scala/meta/internal/tvp/ClasspathSymbols.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/ClasspathSymbols.scala
@@ -195,8 +195,7 @@ class ClasspathSymbols(isStatisticsEnabled: Boolean = false) {
   ): Unit = {
     node.scalaSig match {
       case Some(scalaSig) =>
-        val ops = new ScalacpCopyPaste(scalaSig)
-        import ops._
+        import ScalacpCopyPaste._
         def infos(sym: SymbolInfoSymbol): List[SymbolInformation] = {
           if (sym.isSemanticdbLocal) return Nil
           if (sym.isUseless) return Nil

--- a/metals/src/main/scala/scala/meta/internal/tvp/ScalacpCopyPaste.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/ScalacpCopyPaste.scala
@@ -2,7 +2,6 @@ package scala.meta.internal.tvp
 
 import java.{util => ju}
 
-import scala.annotation.nowarn
 import scala.collection.mutable
 import scala.reflect.NameTransformer
 import scala.tools.scalap.scalax.rules.scalasig._
@@ -23,8 +22,7 @@ import scala.meta.internal.{semanticdb => s}
  * If the `Scalacp` class was not final then we could avoid this copy-pasting. Changes are
  * documented with "// scalacp deviation" comments.
  */
-@nowarn("msg=parameter value node")
-class ScalacpCopyPaste(node: ScalaSigNode) {
+object ScalacpCopyPaste {
   lazy val symbolCache = new ju.HashMap[Symbol, String]
   implicit class XtensionSymbolSSymbol(sym: Symbol) {
     def toSemantic: String = {

--- a/metals/src/main/scala/scala/meta/internal/tvp/TreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/TreeViewProvider.scala
@@ -1,13 +1,10 @@
 package scala.meta.internal.tvp
 
-import scala.annotation.nowarn
-
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import org.eclipse.{lsp4j => l}
 
-@nowarn("msg=parameter value")
 trait TreeViewProvider {
   val Project = TreeViewProvider.Project
   val Build = TreeViewProvider.Build


### PR DESCRIPTION
It seems that the new warnings were caused by two things:
- new false positive warnings in for comprehesnions (disabled altogether by `in anonymous function is never used`)
- changed messages for other  warnigns (updated)
- actual real unusused param in for comprehension (updated the code)