### PR TITLE
fix: Shorten Dep Diagnostic Ranges for scala-cli

### DIFF
--- a/tests/slow/src/main/scala/tests/scalacli/BaseScalaCLIActionSuite.scala
+++ b/tests/slow/src/main/scala/tests/scalacli/BaseScalaCLIActionSuite.scala
@@ -8,6 +8,46 @@ import tests.codeactions.BaseCodeActionLspSuite
 class BaseScalaCLIActionSuite(name: String)
     extends BaseCodeActionLspSuite(name) {
 
+  def checkNoActionScalaCLI(
+      name: TestOptions,
+      input: String,
+      expectNoDiagnostics: Boolean = true,
+      kind: List[String] = Nil,
+      scalafixConf: String = "",
+      scalacOptions: List[String] = Nil,
+      scalaCliOptions: List[String] = Nil,
+      configuration: => Option[String] = None,
+      scalaVersion: String = scalaVersion,
+      renamePath: Option[String] = None,
+      extraOperations: => Unit = (),
+      fileName: String = "A.scala",
+      changeFile: String => String = identity,
+      expectError: Boolean = false,
+      filterAction: CodeAction => Boolean = _ => true,
+  ): Unit = {
+    val fileContent = input.replace("<<", "").replace(">>", "")
+
+    checkScalaCLI(
+      name = name,
+      input = input,
+      expectedActions = "",
+      expectedCode = fileContent,
+      expectNoDiagnostics = expectNoDiagnostics,
+      kind = kind,
+      scalaCliOptions = scalaCliOptions,
+      configuration = configuration,
+      scalaVersion = scalaVersion,
+      scalafixConf = scalafixConf,
+      scalacOptions = scalacOptions,
+      renamePath = renamePath,
+      extraOperations = extraOperations,
+      fileName = fileName,
+      changeFile = changeFile,
+      expectError = expectError,
+      filterAction = filterAction,
+    )
+  }
+
   def checkScalaCLI(
       name: TestOptions,
       input: String,

--- a/tests/slow/src/test/scala/tests/scalacli/ScalaCliActionsSuite.scala
+++ b/tests/slow/src/test/scala/tests/scalacli/ScalaCliActionsSuite.scala
@@ -20,7 +20,7 @@ class ScalaCliActionsSuite
 
   checkScalaCLI(
     "actionable-diagnostic-update",
-    s"""|//> <<>>using lib "com.lihaoyi::os-lib:${oldOsLibVersion.repr}"
+    s"""|//> using lib "<<>>com.lihaoyi::os-lib:${oldOsLibVersion.repr}"
         |
         |object Hello extends App {
         |  println("Hello")
@@ -28,6 +28,18 @@ class ScalaCliActionsSuite
         |""".stripMargin,
     s"""Apply suggestion: "os-lib is outdated, update to $newestOsLib"""",
     s"""|//> using lib "com.lihaoyi::os-lib:$newestOsLib"
+        |
+        |object Hello extends App {
+        |  println("Hello")
+        |}
+        |""".stripMargin,
+    scalaCliOptions = List("--actions", "-S", scalaVersion),
+    expectNoDiagnostics = false,
+  )
+
+  checkNoActionScalaCLI(
+    "actionable-diagnostic-out-of-range",
+    s"""|//> <<>>using lib "com.lihaoyi::os-lib:${oldOsLibVersion.repr}"
         |
         |object Hello extends App {
         |  println("Hello")


### PR DESCRIPTION
Hi!  This PR addresses the issue where ranges for scala-cli update dependency diagnostics span the whole line instead of the dependency in question. For example below:
![scala-cli-before](https://github.com/scalameta/metals/assets/17688577/18cb58fe-35ad-45a2-8cdf-86dc6b98386a)
Only the `os-lib` dep is out of date, but the range has been expanded to the whole line (and as a result is also out of sync with the code action range).

The proposed fix is to add a new parameter to `TokenEditDistance.toRevised`, which when true will attempt to adjust the new range to match the start/end offsets in the matching token (if applicable):

![scala-cli-import-after](https://github.com/scalameta/metals/assets/17688577/29c933c7-192f-463d-a82d-faa447624033)

Thanks!