### PR TITLE
improvement: Dependency version completions for scala native 

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/semver/SemVer.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/semver/SemVer.scala
@@ -49,12 +49,12 @@ object SemVer {
     def fromString(version: String): Version = {
       val parts = version.split("\\.|-")
       val Array(major, minor, patch) =
-        parts.take(3).map(part => Try { part.toInt }.getOrElse(0))
+        parts.take(3).map(tryToInt)
       val (rc, milestone) = parts
         .lift(3)
         .map { v =>
-          if (v.startsWith("RC")) (Some(v.stripPrefix("RC").toInt), None)
-          else if (v.startsWith("M")) (None, Some(v.stripPrefix("M").toInt))
+          if (v.startsWith("RC")) (Some(tryToInt(v.stripPrefix("RC"))), None)
+          else if (v.startsWith("M")) (None, Some(tryToInt(v.stripPrefix("M"))))
           else (None, None)
         }
         .getOrElse((None, None))
@@ -67,6 +67,8 @@ object SemVer {
     }
 
   }
+
+  private def tryToInt(s: String): Int = Try { s.toInt }.toOption.getOrElse(0)
 
   def isCompatibleVersion(minimumVersion: String, version: String): Boolean = {
     Version.fromString(version) >= Version.fromString(minimumVersion)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MillIvyCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MillIvyCompletions.scala
@@ -31,7 +31,12 @@ trait MillIvyCompletions {
   ) extends DependencyCompletion {
     override def contribute: List[Member] = {
       val completions =
-        coursierComplete.complete(dependency.replace(CURSOR, ""))
+        coursierComplete.complete(
+          dependency.replace(CURSOR, ""),
+          // NOTE: module has to extend ScalaNativeModule or ScalaJSModule to support `::` before version
+          // so we can't use `::` before version by default
+          supportNonJvm = false
+        )
       val (editStart, editEnd) =
         CoursierComplete.inferEditRange(pos.point, text)
       val editRange = pos.withStart(editStart).withEnd(editEnd).toLsp

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/SbtLibCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/SbtLibCompletions.scala
@@ -67,7 +67,8 @@ trait SbtLibCompletions {
       val completions =
         coursierComplete.complete(
           dependency.replace(CURSOR, ""),
-          includeScala = false
+          includeScala = false,
+          supportNonJvm = false
         )
       val editRange =
         pos.withStart(pos.start + 1).withEnd(pos.end - 1 - cursorLen).toLsp

--- a/tests/cross/src/test/scala/tests/pc/CompletionMillIvySuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMillIvySuite.scala
@@ -27,6 +27,16 @@ class CompletionMillIvySuite extends BaseCompletionSuite {
     filename = "build.sc",
   )
 
+  checkEdit(
+    "scala-completions-edit",
+    """|val dependency = ivy"io.circe:@@"
+       |""".stripMargin,
+    """|val dependency = ivy"io.circe::circe-config"
+       |""".stripMargin,
+    filename = "build.sc",
+    filter = _ == "circe-config",
+  )
+
   check(
     "scala-completions",
     """|val dependency = ivy"io.circe::circe-core@@"
@@ -48,4 +58,51 @@ class CompletionMillIvySuite extends BaseCompletionSuite {
        |""".stripMargin,
     filename = "build.sc",
   )
+
+  check(
+    "version-double-colon",
+    """|val dependency = ivy"org.typelevel:cats-core_2.11::@@"
+       |""".stripMargin,
+    """|1.0.1
+       |1.0.0
+       |1.0.0-RC2
+       |1.0.0-RC1
+       |1.0.0-MF
+       |""".stripMargin,
+    filter = _.startsWith("1.0"),
+    filename = "build.sc",
+  )
+
+  checkEdit(
+    "version-no-double-colon-edit",
+    """|val dependency = ivy"org.typelevel:cats-core_2.11:@@"
+       |""".stripMargin,
+    """|val dependency = ivy"org.typelevel:cats-core_2.11:1.0.1"
+       |""".stripMargin,
+    filter = _ == "1.0.1",
+    filename = "build.sc",
+  )
+
+  check(
+    "version-double-colon2",
+    """|val dependency = ivy"org.typelevel:cats-core_2.11::1.0.@@"
+       |""".stripMargin,
+    """|1.0.1
+       |1.0.0
+       |1.0.0-RC2
+       |1.0.0-RC1
+       |1.0.0-MF
+       |""".stripMargin,
+    filename = "build.sc",
+  )
+
+  checkEdit(
+    "version-double-colon-edit",
+    """|val dependency = ivy"org.typelevel:cats-core_2.11::1.0.1@@"
+       |""".stripMargin,
+    """|val dependency = ivy"org.typelevel:cats-core_2.11::1.0.1"
+       |""".stripMargin,
+    filename = "build.sc",
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionScalaCliSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScalaCliSuite.scala
@@ -46,6 +46,17 @@ class CompletionScalaCliSuite extends BaseCompletionSuite {
     "0.14.1",
   )
 
+  // We don't to add `::` before version if `sjs1` is specified
+  checkEdit(
+    "version-edit",
+    """|//> using lib "io.circe::circe-core_sjs1:0.14.1@@"
+       |package A
+       |""".stripMargin,
+    """|//> using lib "io.circe::circe-core_sjs1:0.14.1"
+       |package A
+       |""".stripMargin,
+  )
+
   check(
     "multiple-libs",
     """|//> using lib "io.circe::circe-core:0.14.0", "io.circe::circe-core_na@@"
@@ -110,7 +121,7 @@ class CompletionScalaCliSuite extends BaseCompletionSuite {
     """|//> using lib "co.fs2::fs2-core:@@"
        |package A
        |""".stripMargin,
-    """|//> using lib "co.fs2::fs2-core:3.4.0"
+    """|//> using lib "co.fs2::fs2-core::3.4.0"
        |package A
        |""".stripMargin,
     filter = _.startsWith("3.4"),
@@ -142,6 +153,49 @@ class CompletionScalaCliSuite extends BaseCompletionSuite {
        |0.7.1
        |0.7.0
        |""".stripMargin,
+  )
+
+  check(
+    "version-double-colon",
+    """|//> using lib "com.outr::scribe-cats::@@"
+       |package A
+       |""".stripMargin,
+    """|3.7.1
+       |3.7.0
+       |""".stripMargin,
+    filter = _.startsWith("3.7"),
+  )
+
+  checkEdit(
+    "version-double-colon-edit",
+    """|//> using lib "com.outr::scribe-cats::@@"
+       |package A
+       |""".stripMargin,
+    """|//> using lib "com.outr::scribe-cats::3.7.1"
+       |package A
+       |""".stripMargin,
+    filter = _.startsWith("3.7.1"),
+  )
+
+  check(
+    "version-double-colon2",
+    """|//> using lib "com.outr::scribe-cats::3.7@@"
+       |package A
+       |""".stripMargin,
+    """|3.7.1
+       |3.7.0
+       |""".stripMargin,
+  )
+
+  checkEdit(
+    "version-double-colon-edit2",
+    """|//> using lib "com.outr::scribe-cats::3.7@@"
+       |package A
+       |""".stripMargin,
+    """|//> using lib "com.outr::scribe-cats::3.7.1"
+       |package A
+       |""".stripMargin,
+    filter = _.startsWith("3.7.1"),
   )
 
   private def scriptWrapper(code: String, filename: String): String =

--- a/tests/slow/src/test/scala/tests/scalacli/ScalaCliActionsSuite.scala
+++ b/tests/slow/src/test/scala/tests/scalacli/ScalaCliActionsSuite.scala
@@ -16,6 +16,7 @@ class ScalaCliActionsSuite
   val newestOsLib: String = coursierComplete
     .complete("com.lihaoyi::os-lib:")
     .headOption
+    .map(_.stripPrefix(":"))
     .getOrElse("0.8.1")
 
   checkScalaCLI(


### PR DESCRIPTION

Scala CLI and mill support syntax <org>::<name>::<version> for scala native and scala js dependencies. We can default to it in Scala CLI and maybe in mill too?

Also fixes version sorting for  `cats-core` , since there was a version `1.0.0-MF`, which was causing an exception