### PR TITLE
bugfix: find correctly symbols for type companion objects

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -132,11 +132,11 @@ class MetalsPrinter(
     val typeSymbol = info.typeSymbol
 
     if sym.is(Flags.Package) || sym.isClass then
-      " " + dotcPrinter.fullName(sym.owner)
+      " " + dotcPrinter.fullName(sym.effectiveOwner)
     else if sym.is(Flags.Module) || typeSymbol.is(Flags.Module) then
       if typeSymbol != NoSymbol then
-        " " + dotcPrinter.fullName(typeSymbol.owner)
-      else " " + dotcPrinter.fullName(sym.owner)
+        " " + dotcPrinter.fullName(typeSymbol.effectiveOwner)
+      else " " + dotcPrinter.fullName(sym.effectiveOwner)
     else if sym.is(Flags.Method) then
       defaultMethodSignature(sym, info, onlyMethodParams = true)
     else tpe(info)

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -985,4 +985,36 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
     ),
   )
 
+  check(
+    "type-apply".tag(IgnoreScala2),
+    """|package demo
+       |
+       |package other:
+       |  type MyType = Long
+       |
+       |  object MyType:
+       |    def apply(m: Long): MyType = m
+       |
+       |val j = MyTy@@
+       |""".stripMargin,
+    """|MyType(m: Long): MyType
+       |MyType - demo.other""".stripMargin,
+  )
+
+  check(
+    "type-apply2".tag(IgnoreScala2),
+    """|package demo
+       |
+       |package other:
+       |  object MyType:
+       |    def apply(m: Long): MyType = m
+       |
+       |  type MyType = Long
+       |
+       |val j = MyTy@@
+       |""".stripMargin,
+    """|MyType(m: Long): MyType
+       |MyType - demo.other""".stripMargin,
+  )
+
 }

--- a/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
@@ -501,6 +501,27 @@ class ScalaToplevelSuite extends BaseSuite {
     all = true,
   )
 
+  check(
+    "companion-to-type",
+    """|package s
+       |type Cow = Long
+       |
+       |object Cow:
+       |  def apply(m: Long): Cow = m
+       |
+       |""".stripMargin,
+    // For `s/Cow.` and `s/Cow.apply().` the corresponding symbols created by the compiler
+    // will be respectively `s/Test$package/Cow.` and `s/Test$package/Cow.apply().`.
+    //
+    // It is easier to work around this inconstancy in `SemanticdbSymbols.inverseSemanticdbSymbol`
+    // than to change symbols emitted by `ScalaTopLevelMtags`,
+    // since the object could be placed before type definition.
+    List("s/", "s/Test$package.", "s/Test$package.Cow#", "s/Cow.",
+      "s/Cow.apply()."),
+    dialect = dialects.Scala3,
+    all = true,
+  )
+
   def check(
       options: TestOptions,
       code: String,


### PR DESCRIPTION
``` File.scala
//File.scala
package a
type Cow = Int
object Cow 
```
for object symbol we'd emit in `ScalaTopLevelMtags`:
`"a/Cow."`
which inconsistent w/ Scala 3, where the symbol is `"a/File$package/Cow."`

Previously:
`inverseSemanticdbSymbol` wasn't able to find the correct symbol

Now:
~fixed symbols emitted by `ScalaTopLevelMtags`~
added a fallback in `inverseSemanticdbSymbol` to also look for the symbol in the synthetic object ending w/ "$package".

resolves: https://github.com/scalameta/metals/issues/5366