### PR TITLE
bugfix: Make mtags-shared published with full scala version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -251,7 +251,7 @@ lazy val mtagsShared = project
     crossScalaVersions := {
       V.supportedScalaVersions ++ V.nightlyScala3Versions
     },
-    crossVersion := CrossVersion.binary,
+    crossVersion := CrossVersion.full,
     Compile / packageSrc / publishArtifact := true,
     libraryDependencies ++= List(
       "org.lz4" % "lz4-java" % "1.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -355,6 +355,8 @@ lazy val mtags3 = project
     sharedSettings,
     mtagsSettings,
     Compile / unmanagedSourceDirectories += (ThisBuild / baseDirectory).value / "mtags" / "src" / "main" / "scala",
+    Compile / unmanagedSourceDirectories += (ThisBuild / baseDirectory).value / "mtags-shared" / "src" / "main" / "scala",
+    Compile / unmanagedSourceDirectories += (ThisBuild / baseDirectory).value / "mtags-shared" / "src" / "main" / "scala-3",
     moduleName := "mtags3",
     scalaVersion := V.scala3,
     target := (ThisBuild / baseDirectory).value / "mtags" / "target" / "target3",
@@ -363,7 +365,7 @@ lazy val mtags3 = project
       (ThisBuild / baseDirectory).value / ".scalafix3.conf"
     ),
   )
-  .dependsOn(mtagsShared)
+  .dependsOn(interfaces)
   .enablePlugins(BuildInfoPlugin)
 
 lazy val mtags = project

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -118,11 +118,7 @@ final class Embedded(
       case None => resolutionParams
       case Some(version) =>
         resolutionParams.forceVersions(
-          List(
-            Dependency.of("org.scala-lang", "scala3-library_3", version),
-            Dependency.of("org.scala-lang", "scala3-compiler_3", version),
-            Dependency.of("org.scala-lang", "tasty-core_3", version),
-          ).map(d => (d.getModule, d.getVersion)).toMap.asJava
+          Embedded.scala3CompilerDependencies(version)
         )
     }
     val jars =
@@ -180,6 +176,12 @@ object Embedded {
         ),
       )
 
+  private[Embedded] def scala3CompilerDependencies(version: String) = List(
+    Dependency.of("org.scala-lang", "scala3-library_3", version),
+    Dependency.of("org.scala-lang", "scala3-compiler_3", version),
+    Dependency.of("org.scala-lang", "tasty-core_3", version),
+  ).map(d => (d.getModule, d.getVersion)).toMap.asJava
+
   def fetchSettings(
       dep: Dependency,
       scalaVersion: Option[String],
@@ -196,6 +198,10 @@ object Embedded {
             Dependency.of("org.scala-lang", "scala-compiler", scalaVersion),
             Dependency.of("org.scala-lang", "scala-reflect", scalaVersion),
           ).map(d => (d.getModule, d.getVersion)).toMap.asJava
+        )
+      else
+        resolutionParams.forceVersions(
+          scala3CompilerDependencies(scalaVersion)
         )
     }
 


### PR DESCRIPTION
This seems to have caused the issues in https://github.com/scalameta/metals/issues/5293 by bringing in snapshot version of the scala 3 library

Fixes https://github.com/scalameta/metals/issues/5293