### PR TITLE
improvement: restart sbt after java home change

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -14,12 +14,14 @@ import scala.meta.internal.io.FileIO
 import scala.meta.internal.metals.BuildServerConnection
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.ClosableOutputStream
+import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.metals.MetalsBuildClient
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.QuietInputStream
 import scala.meta.internal.metals.SocketConnection
 import scala.meta.internal.metals.Tables
+import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.mtags.MD5
 import scala.meta.internal.mtags.URIEncoderDecoder
@@ -43,6 +45,7 @@ final class BspServers(
     tables: Tables,
     bspGlobalInstallDirectories: List[AbsolutePath],
     config: MetalsServerConfig,
+    userConfig: () => UserConfiguration,
 )(implicit ec: ExecutionContextExecutorService) {
 
   def resolve(): BspResolvedResult = {
@@ -92,7 +95,10 @@ final class BspServers(
         args,
         projectDirectory,
         redirectErrorOutput = false,
-        Map(),
+        JdkSources
+          .defaultJavaHome(userConfig().javaHome)
+          .map("JAVA_HOME" -> _.toString())
+          .toMap,
         processOut = None,
         processErr = Some(l => scribe.info("BSP server: " + l)),
         discardInput = false,

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
@@ -39,4 +39,15 @@ object JavaBinary {
         case path if path.exists => path
       }
   }
+
+  def allPossibleJavaBinaries(
+      javaHome: Option[String]
+  ): List[AbsolutePath] = {
+    JdkSources
+      .defaultJavaHome(javaHome)
+      .flatMap(home => List(home.resolve("bin"), home.resolve("bin/jre")))
+      .flatMap(bin => List("java", "java.exe").map(bin.resolve))
+      .withFilter(_.exists)
+      .flatMap(binary => List(binary.dealias, binary))
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -965,4 +965,27 @@ object Messages {
     }
   }
 
+  object SbtServerJavaHomeUpdate {
+    val restart: MessageActionItem =
+      new MessageActionItem("Restart sbt server")
+
+    val notNow: MessageActionItem =
+      new MessageActionItem("Not now")
+
+    def params(): ShowMessageRequestParams = {
+      val params = new ShowMessageRequestParams()
+      params.setMessage(
+        s"Java home has been updated, do you want to restart the sbt BSP server? (the change will only be picked up after the restart)"
+      )
+      params.setType(MessageType.Info)
+      params.setActions(
+        List(
+          restart,
+          notNow,
+        ).asJava
+      )
+      params
+    }
+  }
+
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -411,6 +411,7 @@ class MetalsLspService(
     tables,
     bspGlobalDirectories,
     clientConfig.initialConfig,
+    userConfig,
   )
 
   private val bspConnector: BspConnector = new BspConnector(
@@ -2078,7 +2079,7 @@ class MetalsLspService(
     (for {
       _ <- disconnectOldBuildServer()
       maybeSession <- timerProvider.timed("Connected to build server", true) {
-        bspConnector.connect(folder, userConfig())
+        bspConnector.connect(folder, userConfig(), shellRunner)
       }
       result <- maybeSession match {
         case Some(session) =>


### PR DESCRIPTION
If `java_home` in `bsp/sbt.json` config is outdated restart sbt server on connect.

resolves: https://github.com/scalameta/metals/issues/5313