### PR TITLE
improvement: Show current compilation queue when debugging flag is on

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BatchedFunction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BatchedFunction.scala
@@ -40,6 +40,7 @@ final class BatchedFunction[A, B](
       callback: () => Unit,
   ): Future[B] = {
     val promise = Promise[B]()
+    scribe.debug(queue.toArray().mkString(","))
     queue.add(Request(arguments, promise, callback))
     runAcquire()
     promise.future


### PR DESCRIPTION
Seems I am having an issue from time to time, which I can't reproduce. The debug might help out here.