### PR TITLE
bugfix: backup log files instead of truncating

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/LoggerContext.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/LoggerContext.scala
@@ -2,6 +2,8 @@ package scala.meta.internal.metals
 
 import java.nio.file.Path
 
+import scala.meta.internal.metals.utils.TimestampedFile
+
 object LoggerReporter extends Reporter {
 
   override def create(report: => Report, ifVerbose: Boolean): Option[Path] = {
@@ -9,10 +11,10 @@ object LoggerReporter extends Reporter {
     None
   }
 
-  override def cleanUpOldReports(maxReportsNumber: Int): List[ReportFile] =
+  override def cleanUpOldReports(maxReportsNumber: Int): List[TimestampedFile] =
     List()
 
-  override def getReports(): List[ReportFile] = List()
+  override def getReports(): List[TimestampedFile] = List()
 
   override def deleteAll(): Unit = {}
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -38,6 +38,8 @@ import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
  *                                       supports a small subset of this, so it may be problematic
  *                                       for certain clients.
  * @param macOsMaxWatchRoots The maximum number of root directories to watch on MacOS.
+ * @param maxLogFileSize The maximum size of the log file before it gets backed up and truncated.
+ * @param maxLogBackups The maximum number of backup log files.
  */
 final case class MetalsServerConfig(
     globSyntax: GlobSyntaxConfig = GlobSyntaxConfig.default,
@@ -92,6 +94,14 @@ final case class MetalsServerConfig(
         .getOrElse(32),
     loglevel: String =
       sys.props.get("metals.loglevel").map(_.toLowerCase()).getOrElse("info"),
+    maxLogFileSize: Long = Option(System.getProperty("metals.max-logfile-size"))
+      .withFilter(_.forall(Character.isDigit(_)))
+      .map(_.toLong)
+      .getOrElse(3 << 20),
+    maxLogBackups: Int = Option(System.getProperty("metals.max-log-backups"))
+      .withFilter(_.forall(Character.isDigit(_)))
+      .map(_.toInt)
+      .getOrElse(10),
 ) {
   override def toString: String =
     List[String](
@@ -110,6 +120,8 @@ final case class MetalsServerConfig(
       s"bloop-port=${bloopPort.map(_.toString()).getOrElse("default")}",
       s"macos-max-watch-roots=${macOsMaxWatchRoots}",
       s"loglevel=${loglevel}",
+      s"max-logfile-size=${maxLogFileSize}",
+      s"max-log-backup=${maxLogBackups}",
     ).mkString("MetalsServerConfig(\n  ", ",\n  ", "\n)")
 }
 object MetalsServerConfig {

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceFolders.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceFolders.scala
@@ -13,6 +13,7 @@ class WorkspaceFolders(
     onInitialize: MetalsLspService => Future[Unit],
     shoutdownMetals: () => Future[Unit],
     redirectSystemOut: Boolean,
+    initialServerConfig: MetalsServerConfig,
 )(implicit ec: ExecutionContext) {
 
   private val folderServices: AtomicReference[List[MetalsLspService]] =
@@ -50,6 +51,7 @@ class WorkspaceFolders(
       MetalsLogger.setupLspLogger(
         folderServices.get().map(_.folder),
         redirectSystemOut,
+        initialServerConfig,
       )
       for {
         _ <- Future.sequence(

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -182,6 +182,7 @@ class WorkspaceLspService(
       _.initialized(),
       () => shutdown().asScala,
       redirectSystemOut,
+      serverInputs.initialServerConfig,
     )
 
   def folderServices = workspaceFolders.getFolderServices

--- a/metals/src/main/scala/scala/meta/internal/metals/utils/LimitedFilesManager.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/utils/LimitedFilesManager.scala
@@ -1,0 +1,41 @@
+package scala.meta.internal.metals.utils
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+class LimitedFilesManager(
+    directory: Path,
+    fileLimit: Int,
+    prefixPattern: String,
+) {
+  private val fileNameRegex = s"${prefixPattern}([-+]?[0-9]+)".r
+
+  def getAllFiles(): List[TimestampedFile] = {
+    if (Files.exists(directory) && Files.isDirectory(directory)) {
+      directory.toFile.listFiles().flatMap(timestampedFile).toList
+    } else List()
+  }
+
+  def deleteOld(): List[TimestampedFile] = {
+    val files = getAllFiles()
+    if (files.length > fileLimit) {
+      val filesToDelete = files
+        .sortBy(_.timestamp)
+        .slice(0, files.length - fileLimit)
+      filesToDelete.foreach { f => Files.delete(f.toPath) }
+      filesToDelete
+    } else List()
+  }
+
+  private def timestampedFile(file: File): Option[TimestampedFile] = {
+    file.getName() match {
+      case fileNameRegex(time) => Some(TimestampedFile(file, time.toLong))
+      case _: String => None
+    }
+  }
+}
+
+case class TimestampedFile(file: File, timestamp: Long) {
+  def toPath: Path = file.toPath()
+}

--- a/metals/src/main/scala/scala/meta/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/metals/MetalsLanguageServer.scala
@@ -163,7 +163,11 @@ class MetalsLanguageServer(
           val folderPaths = folders.map(_.path)
 
           setupJna()
-          MetalsLogger.setupLspLogger(folderPaths, redirectSystemOut)
+          MetalsLogger.setupLspLogger(
+            folderPaths,
+            redirectSystemOut,
+            serverInputs.initialServerConfig,
+          )
 
           val clientInfo = Option(params.getClientInfo()).fold("") { info =>
             s"for client ${info.getName()} ${Option(info.getVersion).getOrElse("")}"

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/utils/LimitedFilesManager.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/utils/LimitedFilesManager.scala
@@ -7,7 +7,7 @@ import java.nio.file.Path
 class LimitedFilesManager(
     directory: Path,
     fileLimit: Int,
-    prefixPattern: String,
+    prefixPattern: String
 ) {
   private val fileNameRegex = s"${prefixPattern}([-+]?[0-9]+)".r
 
@@ -17,12 +17,12 @@ class LimitedFilesManager(
     } else List()
   }
 
-  def deleteOld(): List[TimestampedFile] = {
+  def deleteOld(limit: Int = fileLimit): List[TimestampedFile] = {
     val files = getAllFiles()
-    if (files.length > fileLimit) {
+    if (files.length > limit) {
       val filesToDelete = files
         .sortBy(_.timestamp)
-        .slice(0, files.length - fileLimit)
+        .slice(0, files.length - limit)
       filesToDelete.foreach { f => Files.delete(f.toPath) }
       filesToDelete
     } else List()
@@ -38,4 +38,5 @@ class LimitedFilesManager(
 
 case class TimestampedFile(file: File, timestamp: Long) {
   def toPath: Path = file.toPath()
+  def name: String = file.getName()
 }

--- a/tests/unit/src/test/scala/tests/LogBackupSuite.scala
+++ b/tests/unit/src/test/scala/tests/LogBackupSuite.scala
@@ -1,0 +1,93 @@
+package tests
+
+import java.nio.file.Files
+
+import scala.util.control.NonFatal
+
+import scala.meta.internal.io.PathIO
+import scala.meta.internal.metals.Directories
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.RecursivelyDelete
+import scala.meta.internal.metals.logging.MetalsLogger
+import scala.meta.internal.metals.utils.LimitedFilesManager
+import scala.meta.io.AbsolutePath
+
+class LogBackupSuite extends BaseSuite {
+  val maxLogBackups = 2
+  val serverConfig: MetalsServerConfig =
+    MetalsServerConfig.default.copy(maxLogFileSize = 100, maxLogBackups = 2)
+  var workspace: AbsolutePath = _
+  def log: AbsolutePath = workspace.resolve(Directories.log)
+  def backupDir: AbsolutePath =
+    workspace.resolve(".metals").resolve(".backup_logs")
+  def limitedFilesManager = new LimitedFilesManager(
+    backupDir.toNIO,
+    maxLogBackups,
+    "log_",
+  )
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    workspace = createWorkspace(context.test.name)
+    cleanWorkspace()
+  }
+
+  test("too-small-for-backup") {
+    log.writeText(".")
+    MetalsLogger.backUpOldLogFileIfTooBig(workspace, serverConfig)
+    assert(!backupDir.exists)
+  }
+
+  test("backup") {
+    log.writeText(List.range(1, 100).mkString)
+    MetalsLogger.backUpOldLogFileIfTooBig(workspace, serverConfig)
+    assert(backupDir.exists)
+    assert(limitedFilesManager.getAllFiles().size == 1)
+    assert(!log.exists)
+  }
+
+  test("backup-and-delete-overflow") {
+    def createBackupLog(text: String) =
+      backupDir.resolve(s"log_${System.currentTimeMillis()}").writeText(text)
+    val logdata = List.range(1, 100).mkString
+    log.writeText(logdata)
+    createBackupLog("1")
+    Thread.sleep(2)
+    createBackupLog("2")
+    Thread.sleep(2)
+    MetalsLogger.backUpOldLogFileIfTooBig(workspace, serverConfig)
+    assertNoDiff(
+      limitedFilesManager
+        .getAllFiles()
+        .sortBy(_.timestamp)
+        .flatMap(file => Files.readAllLines(file.toPath).asScala)
+        .mkString("\n"),
+      s"""|2
+          |${logdata}""".stripMargin,
+    )
+    assert(!log.exists)
+  }
+
+  def cleanWorkspace(): Unit =
+    if (workspace.isDirectory) {
+      try {
+        RecursivelyDelete(workspace)
+        Files.createDirectories(workspace.toNIO)
+      } catch {
+        case NonFatal(_) =>
+          scribe.warn(s"Unable to delete workspace $workspace")
+      }
+    }
+
+  protected def createWorkspace(name: String): AbsolutePath = {
+    val pathToSuite = PathIO.workingDirectory
+      .resolve("target")
+      .resolve("e2e")
+      .resolve("log-backup")
+
+    val path = pathToSuite.resolve(name)
+
+    Files.createDirectories(path.toNIO)
+    path
+  }
+}

--- a/tests/unit/src/test/scala/tests/ReportsSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReportsSuite.scala
@@ -7,7 +7,6 @@ import java.nio.file.Paths
 import scala.meta.internal.metals.FolderReportsZippper
 import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.Report
-import scala.meta.internal.metals.ReportFile
 import scala.meta.internal.metals.StdReportContext
 import scala.meta.internal.metals.ZipReportsProvider
 import scala.meta.io.AbsolutePath
@@ -25,7 +24,7 @@ class ReportsSuite extends BaseSuite {
     )
 
   def exampleText(workspaceStr: String = workspace.toString()): String =
-    s"""|An error happend in the file:
+    s"""|An error occurred in the file:
         |${workspaceStr}/WrongFile.scala
         |""".stripMargin
 
@@ -40,7 +39,7 @@ class ReportsSuite extends BaseSuite {
     val obtained =
       new String(Files.readAllBytes(path.get), StandardCharsets.UTF_8)
     assertNoDiff(exampleText(StdReportContext.WORKSPACE_STR), obtained)
-    assert(ReportFile.fromFile(path.get.toFile).nonEmpty)
+    assert(reportsProvider.incognito.getReports().length == 1)
   }
 
   test("delete-old-reports") {


### PR DESCRIPTION
When log file bigger than 3MG backup the log file.
resolves: https://github.com/scalameta/metals/issues/5395