### PR TITLE
refactor: a bit more details in logs about whether the java path exists

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
@@ -30,10 +30,10 @@ object JavaBinary {
       .flatMap(home =>
         List(binaryName, binaryName + ".exe").map(home.resolve("bin").resolve)
       )
-      .map { a =>
-        scribe.info(s"java binary path: $a ${a.exists}")
-        a
-
+      .map { path =>
+        scribe.debug(s"""java binary path: $path
+                        |path exists: ${path.exists}""".stripMargin)
+        path
       }
       .collectFirst {
         case path if path.exists => path


### PR DESCRIPTION
Super tiny change. I just saw this in the logs today and wasn't 100%
what the boolean value printed out was meaning until I looked at the
code. This just adds a tiny change to the logs to make it explicit that
the boolean being printed out refers to whether or not the path exists.
