### PR TITLE
chore: Change information about finding java home to debug

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
@@ -41,7 +41,6 @@ object JdkSources {
           )
           None
         case Success(value) =>
-          logger.info(s"Found java home path $value")
           Some(value)
       }
     }


### PR DESCRIPTION
Otherwise this gets printed many times and is not very useful.