### PR TITLE
feat: make sure we capture `.config/mill-version` for Mill builds

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -17,13 +17,21 @@ case class MillBuildTool(userConfig: () => UserConfiguration)
   private def getMillVersion(workspace: AbsolutePath): String = {
     import scala.meta.internal.jdk.CollectionConverters._
     val millVersionPath = workspace.resolve(".mill-version")
+    lazy val altMillVersionPath =
+      workspace.resolve(".config").resolve("mill-version")
     lazy val millPath = workspace.resolve("mill")
-    if (millVersionPath.isFile) {
+
+    def readMillVersion(path: AbsolutePath) =
       Files
-        .readAllLines(millVersionPath.toNIO)
+        .readAllLines(path.toNIO)
         .asScala
         .headOption
         .getOrElse(version)
+
+    if (millVersionPath.isFile) {
+      readMillVersion(millVersionPath)
+    } else if (altMillVersionPath.isFile) {
+      readMillVersion(altMillVersionPath)
     } else if (millPath.isFile) {
       Files
         .readAllLines(millPath.toNIO)

--- a/tests/unit/src/test/scala/tests/MillVersionSuite.scala
+++ b/tests/unit/src/test/scala/tests/MillVersionSuite.scala
@@ -25,6 +25,13 @@ class MillVersionSuite extends BaseSuite {
   )
 
   check(
+    """|.config/mill-version
+       |0.11.1
+       |""".stripMargin,
+    "0.11.1",
+  )
+
+  check(
     """|mill
        |#!/usr/bin/env sh
        |


### PR DESCRIPTION
With the new version of Mill it's also a possibility to define your
version in `.config/mill-version`. This changes makes sure that we also
double-check there to pull the mill version of a project.
