### PR TITLE
chore: Only print debug compile queue if not empty

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -32,12 +32,12 @@ final class Compilations(
     new BatchedFunction[
       b.BuildTargetIdentifier,
       Map[BuildTargetIdentifier, b.CompileResult],
-    ](compile)
+    ](compile, "compileBatch", shouldLogQueue = true)
   private val cascadeBatch =
     new BatchedFunction[
       b.BuildTargetIdentifier,
       Map[BuildTargetIdentifier, b.CompileResult],
-    ](compile)
+    ](compile, "cascadeBatch", shouldLogQueue = true)
   def pauseables: List[Pauseable] = List(compileBatch, cascadeBatch)
 
   private val isCompiling = TrieMap.empty[b.BuildTargetIdentifier, Boolean]

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -256,18 +256,21 @@ class MetalsLspService(
   )
   var indexingPromise: Promise[Unit] = Promise[Unit]()
   var buildServerPromise: Promise[Unit] = Promise[Unit]()
-  val parseTrees = new BatchedFunction[AbsolutePath, Unit](paths =>
-    CancelableFuture(
-      buildServerPromise.future
-        .flatMap(_ => parseTreesAndPublishDiags(paths))
-        .ignoreValue,
-      Cancelable.empty,
-    )
+  val parseTrees = new BatchedFunction[AbsolutePath, Unit](
+    paths =>
+      CancelableFuture(
+        buildServerPromise.future
+          .flatMap(_ => parseTreesAndPublishDiags(paths))
+          .ignoreValue,
+        Cancelable.empty,
+      ),
+    "trees",
   )
 
   private val onBuildChanged =
     BatchedFunction.fromFuture[AbsolutePath, BuildChange](
-      onBuildChangedUnbatched
+      onBuildChangedUnbatched,
+      "onBuildChanged",
     )
 
   val pauseables: Pauseable = Pauseable.fromPausables(

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -24,7 +24,7 @@ final class BuildTargetClasses(
       : TrieMap[b.BuildTargetIdentifier, b.JvmEnvironmentItem] =
     TrieMap.empty[b.BuildTargetIdentifier, b.JvmEnvironmentItem]
   val rebuildIndex: BatchedFunction[b.BuildTargetIdentifier, Unit] =
-    BatchedFunction.fromFuture(fetchClasses)
+    BatchedFunction.fromFuture(fetchClasses, "buildTargetClasses")
 
   def classesOf(target: b.BuildTargetIdentifier): Classes = {
     index.getOrElse(target, new Classes)

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -79,18 +79,24 @@ final class TestSuitesProvider(
   override def isEnabled: Boolean = isCodeLensEnabled
 
   val refreshTestSuites: BatchedFunction[Unit, Unit] =
-    BatchedFunction.fromFuture { _ =>
-      if (isSuiteRefreshEnabled) doRefreshTestSuites()
-      else Future.unit
-    }
+    BatchedFunction.fromFuture(
+      { _ =>
+        if (isSuiteRefreshEnabled) doRefreshTestSuites()
+        else Future.unit
+      },
+      "refreshTestSuites",
+    )
 
   private val updateTestCases
       : BatchedFunction[(AbsolutePath, TextDocument), Unit] =
-    BatchedFunction.fromFuture { args =>
-      Future
-        .traverse(args) { case (path, doc) => refreshTestCases(path, doc) }
-        .map(_ => ())
-    }
+    BatchedFunction.fromFuture(
+      { args =>
+        Future
+          .traverse(args) { case (path, doc) => refreshTestCases(path, doc) }
+          .map(_ => ())
+      },
+      "updateTestCases",
+    )
 
   override def onChange(docs: TextDocuments, file: AbsolutePath): Unit =
     docs.documents.headOption.foreach {

--- a/tests/unit/src/test/scala/tests/BatchedFunctionSuite.scala
+++ b/tests/unit/src/test/scala/tests/BatchedFunctionSuite.scala
@@ -11,13 +11,16 @@ class BatchedFunctionSuite extends BaseSuite {
     implicit val ec = ExecutionContext.global
 
     val lock = new Object
-    val mkString = BatchedFunction.fromFuture[String, String]({ numbers =>
-      Future {
-        lock.synchronized {
-          numbers.mkString
+    val mkString = BatchedFunction.fromFuture[String, String](
+      { numbers =>
+        Future {
+          lock.synchronized {
+            numbers.mkString
+          }
         }
-      }
-    })
+      },
+      "exaample",
+    )
     val results = lock.synchronized {
       List(
         // First request instantly acquires lock and runs solo
@@ -46,11 +49,14 @@ class BatchedFunctionSuite extends BaseSuite {
   }
 
   def batchedExample(): BatchedFunction[String, String] =
-    BatchedFunction.fromFuture[String, String] { numbers =>
-      Future.successful {
-        numbers.mkString
-      }
-    }
+    BatchedFunction.fromFuture[String, String](
+      { numbers =>
+        Future.successful {
+          numbers.mkString
+        }
+      },
+      "example",
+    )
 
   test("pause") {
 


### PR DESCRIPTION
It was a bit much when printing every time, that would just be an empty string most of the time.