### PR TITLE
bugfix:  `textDocument/documentSymbol` for scripts

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
@@ -123,7 +123,7 @@ final class DocumentSymbolProvider(
             addChild(s"new $name", SymbolKind.Interface, t.pos, selection, "")
             newOwner()
           } else continue()
-        case _: Source | _: Template =>
+        case _: Source | _: Template | _: MultiSource =>
           continue()
         case block: Term.Block =>
           if (owner.getName() == "try") {

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -80,6 +80,7 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
     actions =>
       actions.find(_.getTitle == "a.Main").get
   }
+  var importScalaCliScript = new MessageActionItem(ImportScalaScript.dismiss)
 
   val resources = new ResourceOperations(buffers)
   val diagnostics: TrieMap[AbsolutePath, Seq[Diagnostic]] =
@@ -336,6 +337,8 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
           chooseMainClass(params.getActions.asScala.toSeq)
         } else if (isNewBuildToolDetectedMessage()) {
           switchBuildTool
+        } else if (ImportScalaScript.params() == params) {
+          importScalaCliScript
         } else {
           throw new IllegalArgumentException(params.toString)
         }


### PR DESCRIPTION
Scripts are parsed into `MultiSource` tree, which was not handled when collecting documentSymbols.

resolves: https://github.com/scalameta/metals/issues/5411