### PR TITLE
improvement: offer amend to handle single file scala-cli config on new file

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
@@ -8,6 +8,7 @@ import scala.meta.internal.builds.BuildServerProvider
 import scala.meta.internal.builds.ShellRunner
 import scala.meta.internal.metals.Messages.BspProvider
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.StatusBar
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.io.AbsolutePath
 
@@ -20,6 +21,7 @@ final class BspConfigGenerator(
     workspace: AbsolutePath,
     languageClient: MetalsLanguageClient,
     shellRunner: ShellRunner,
+    statusBar: StatusBar,
 )(implicit ec: ExecutionContext) {
   def runUnconditionally(
       buildTool: BuildServerProvider,
@@ -46,6 +48,7 @@ final class BspConfigGenerator(
       status <- buildTool.generateBspConfig(
         workspace,
         args => runUnconditionally(buildTool, args),
+        statusBar,
       )
     } yield (buildTool, status)
   }

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -296,7 +296,9 @@ class BspConnector(
               buildTool
                 .generateBspConfig(
                   workspace,
-                  args => bspConfigGenerator.runUnconditionally(buildTool, args),
+                  args =>
+                    bspConfigGenerator.runUnconditionally(buildTool, args),
+                  statusBar,
                 )
                 .map(status => handleGenerationStatus(buildTool, status))
             case Right(details) if details.getName == BloopServers.name =>
@@ -329,6 +331,7 @@ class BspConnector(
               .generateBspConfig(
                 workspace,
                 args => bspConfigGenerator.runUnconditionally(buildTool, args),
+                statusBar,
               )
               .map(status => handleGenerationStatus(buildTool, status))
           case Right(connectionDetails) =>

--- a/metals/src/main/scala/scala/meta/internal/bsp/ScalaCliBspScope.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/ScalaCliBspScope.scala
@@ -1,0 +1,37 @@
+package scala.meta.internal.bsp
+
+import scala.util.Try
+
+import scala.meta.internal.builds.ScalaCliBuildTool
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+
+object ScalaCliBspScope {
+  def inScope(root: AbsolutePath, file: AbsolutePath): Boolean = {
+    val roots = scalaCliBspRoot(root)
+    roots.isEmpty || roots.exists(bspRoot =>
+      file.toNIO.startsWith(bspRoot.toNIO)
+    )
+  }
+
+  private def scalaCliBspRoot(root: AbsolutePath): List[AbsolutePath] =
+    for {
+      path <- ScalaCliBuildTool.pathsToScalaCliBsp(root)
+      text <- path.readTextOpt.toList
+      json = ujson.read(text)
+      args <- json("argv").arrOpt.toList
+      tailArgs = args.toList.flatMap(_.strOpt).dropWhile(_ != "bsp")
+      rootArg <- tailArgs match {
+        case "bsp" :: tail => dropOptions(tail).takeWhile(!_.startsWith("-"))
+        case _ => Nil
+      }
+      rootPath <- Try(AbsolutePath(rootArg).dealias).toOption
+      if rootPath.exists
+    } yield rootPath
+
+  private def dropOptions(args: List[String]): List[String] =
+    args match {
+      case s"--$_" :: _ :: tail => dropOptions(tail)
+      case rest => rest
+    }
+}

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildServerProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildServerProvider.scala
@@ -4,6 +4,7 @@ import scala.concurrent.Future
 
 import scala.meta.internal.bsp.BspConfigGenerationStatus._
 import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.StatusBar
 import scala.meta.io.AbsolutePath
 
 /**
@@ -18,6 +19,7 @@ trait BuildServerProvider extends BuildTool {
   def generateBspConfig(
       workspace: AbsolutePath,
       systemProcess: List[String] => Future[BspConfigGenerationStatus],
+      statusBar: StatusBar,
   ): Future[BspConfigGenerationStatus] =
     createBspFileArgs(workspace).map(systemProcess).getOrElse {
       Future.successful(

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -115,7 +115,8 @@ final class BuildTools(
     if (isGradle) buf += GradleBuildTool(userConfig)
     if (isMaven) buf += MavenBuildTool(userConfig)
     if (isMill) buf += MillBuildTool(userConfig)
-    if (isScalaCli) buf += ScalaCliBuildTool(workspace, userConfig)
+    if (isScalaCli)
+      buf += ScalaCliBuildTool(workspace, userConfig)
 
     buf.result()
   }

--- a/metals/src/main/scala/scala/meta/internal/builds/ScalaCliBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ScalaCliBuildTool.scala
@@ -7,6 +7,7 @@ import scala.concurrent.Future
 import scala.meta.internal.bsp.BspConfigGenerationStatus._
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.StatusBar
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.scalacli.ScalaCli
 import scala.meta.io.AbsolutePath
@@ -23,21 +24,25 @@ class ScalaCliBuildTool(
   override def generateBspConfig(
       workspace: AbsolutePath,
       systemProcess: List[String] => Future[BspConfigGenerationStatus],
+      statusBar: StatusBar,
   ): Future[BspConfigGenerationStatus] =
     createBspFileArgs(workspace).map(systemProcess).getOrElse {
       // fallback to creating `.bsp/scala-cli.json` that starts JVM launcher
       val bspConfig = workspace.resolve(".bsp").resolve("scala-cli.json")
-      bspConfig.writeText(ScalaCli.scalaCliBspJsonContent())
+      statusBar.addMessage("scala-cli bspConfig")
+      bspConfig
+        .writeText(ScalaCli.scalaCliBspJsonContent(root = workspace.toString()))
       Future.successful(Generated)
     }
 
   def createBspConfigIfNone(
       workspace: AbsolutePath,
       systemProcess: List[String] => Future[BspConfigGenerationStatus],
+      statusBar: StatusBar,
   ): Future[BspConfigGenerationStatus] = {
     if (ScalaCliBuildTool.pathsToScalaCliBsp(workspace).exists(_.isFile))
       Future.successful(Generated)
-    else generateBspConfig(workspace, systemProcess)
+    else generateBspConfig(workspace, systemProcess, statusBar)
   }
 
   override def createBspFileArgs(
@@ -89,7 +94,10 @@ object ScalaCliBuildTool {
         json = ujson.read(text)
         version <- json("version").strOpt
       } yield version
-    new ScalaCliBuildTool(workspaceFolderVersions.headOption, userConfig)
+    new ScalaCliBuildTool(
+      workspaceFolderVersions.headOption,
+      userConfig,
+    )
   }
 }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -1,5 +1,7 @@
 package scala.meta.internal.metals
 
+import java.nio.file.Path
+
 import scala.collection.mutable
 
 import scala.meta.internal.builds.BuildTool
@@ -1008,4 +1010,25 @@ object Messages {
     }
   }
 
+}
+
+object FileOutOfScalaCliBspScope {
+  val regenerateAndRestart = new MessageActionItem("Yes")
+  val ignore = new MessageActionItem("No")
+  def askToRegenerateConfigAndRestartBspMsg(file: String): String =
+    s"""|$file is outside of scala-cli build server scope.
+        |Would you like to fix this by regenerating bsp configuration and restarting the build sever?""".stripMargin
+  def askToRegenerateConfigAndRestartBsp(
+      file: Path
+  ): ShowMessageRequestParams = {
+    val params = new ShowMessageRequestParams()
+    params.setMessage(
+      askToRegenerateConfigAndRestartBspMsg(
+        s"File: ${file.getFileName().toString()}"
+      )
+    )
+    params.setType(MessageType.Warning)
+    params.setActions(List(regenerateAndRestart, ignore).asJava)
+    params
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -421,14 +421,17 @@ object ScalaCli {
 
   val scalaCliBspVersion = "2.1.0-M4"
 
-  def scalaCliBspJsonContent(args: List[String] = Nil): String = {
+  def scalaCliBspJsonContent(
+      args: List[String] = Nil,
+      root: String = ".",
+  ): String = {
     val argv = List(
       ScalaCli.javaCommand,
       "-cp",
       ScalaCli.scalaCliClassPath().mkString(File.pathSeparator),
       ScalaCli.scalaCliMainClass,
       "bsp",
-      ".",
+      root,
     ) ++ args
     val bsjJson = ujson.Obj(
       "name" -> "scala-cli",

--- a/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
+++ b/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
@@ -2,13 +2,24 @@ package tests.scalacli
 
 import scala.concurrent.Future
 
+import scala.meta.internal.metals.FileOutOfScalaCliBspScope
 import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.metals.SlowTaskConfig
+import scala.meta.internal.metals.StatusBarConfig
+import scala.meta.internal.metals.scalacli.ScalaCli
 import scala.meta.internal.metals.{BuildInfo => V}
 
 import tests.FileLayout
 
 class ScalaCliSuite extends BaseScalaCliSuite(V.scala3) {
+  override def serverConfig: MetalsServerConfig =
+    MetalsServerConfig.default.copy(
+      slowTask = SlowTaskConfig.on,
+      statusBar = StatusBarConfig.showMessage,
+    )
 
   private def simpleFileTest(useBsp: Boolean): Future[Unit] =
     for {
@@ -358,6 +369,67 @@ class ScalaCliSuite extends BaseScalaCliSuite(V.scala3) {
         "test/MyTests.scala",
         "val tests = Test@@s",
         "utest/Tests.scala",
+      )
+    } yield ()
+  }
+
+  test("single-file-config") {
+    cleanWorkspace()
+    val msg = FileOutOfScalaCliBspScope.askToRegenerateConfigAndRestartBspMsg(
+      "File: SomeFile.scala"
+    )
+    def workspaceMsgs =
+      (server.client.messageRequests.asScala ++ server.client.showMessages.asScala
+        .map(_.getMessage()))
+        .collect {
+          case `msg` => msg
+          case msg @ "scala-cli bspConfig" => msg
+        }
+        .mkString("\n")
+    def hasBuildTarget(fileName: String) = server.server.buildTargets
+      .inverseSources(workspace.resolve(fileName))
+      .isDefined
+    for {
+      _ <- scalaCliInitialize(useBsp = false)(
+        s"""/src/Main.scala
+           |object Main:
+           |  def foo = 3
+           |  val m = foo
+           |/SomeFile.scala
+           |object Other:
+           |  def foo = 3
+           |  val m = foo
+           |/.bsp/scala-cli.json
+           |${ScalaCli.scalaCliBspJsonContent(root = workspace.resolve("src/Main.scala").toString())}
+           |/.scala-build/ide-inputs.json
+           |${BaseScalaCliSuite.scalaCliIdeInputJson(".")}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("src/Main.scala")
+      _ = assertNoDiff(workspaceMsgs, "")
+      _ = assert(hasBuildTarget("src/Main.scala"))
+      _ = assert(!hasBuildTarget("SomeFile.scala"))
+
+      _ <- server.didOpen("SomeFile.scala")
+      _ <- server.server.buildServerPromise.future
+      _ = assertNoDiff(workspaceMsgs, msg)
+      _ = assert(!hasBuildTarget("SomeFile.scala"))
+
+      _ = server.client.regenerateAndRestartScalaCliBuildSever =
+        FileOutOfScalaCliBspScope.regenerateAndRestart
+      _ <- server.didOpen("SomeFile.scala")
+      _ <- server.server.buildServerPromise.future
+      _ = assertNoDiff(
+        workspaceMsgs,
+        List(msg, msg, "scala-cli bspConfig").mkString("\n"),
+      )
+      _ = assert(hasBuildTarget("src/Main.scala"))
+      _ = assert(hasBuildTarget("SomeFile.scala"))
+
+      _ <- server.didOpen("SomeFile.scala")
+      _ = assertNoDiff(
+        workspaceMsgs,
+        List(msg, msg, "scala-cli bspConfig").mkString("\n"),
       )
     } yield ()
   }

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -17,6 +17,7 @@ import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.decorations.PublishDecorationsParams
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.ClientCommands
+import scala.meta.internal.metals.FileOutOfScalaCliBspScope
 import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ServerLivenessMonitor
@@ -85,6 +86,7 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
   var resetWorkspace = new MessageActionItem(ResetWorkspace.cancel)
   var buildServerNotResponding =
     ServerLivenessMonitor.ServerNotResponding.dismiss
+  var regenerateAndRestartScalaCliBuildSever = FileOutOfScalaCliBspScope.ignore
 
   val resources = new ResourceOperations(buffers)
   val diagnostics: TrieMap[AbsolutePath, Seq[Diagnostic]] =
@@ -349,6 +351,15 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
           params.getMessage == ServerLivenessTestData.serverNotRespondingMessage
         ) {
           buildServerNotResponding
+        } else if (
+          params
+            .getMessage()
+            .endsWith(
+              FileOutOfScalaCliBspScope
+                .askToRegenerateConfigAndRestartBspMsg("")
+            )
+        ) {
+          regenerateAndRestartScalaCliBuildSever
         } else {
           throw new IllegalArgumentException(params.toString)
         }


### PR DESCRIPTION
Sometimes users compile a single file using `scala-cli`, which as a side effect creates a `bsp` config for a single file.

Now when the user opens a file, that is not in the `scala-cli` build server scope (according to config) we asks the user if the want to amend that configuration and restart build server.

connected to: https://github.com/scalameta/metals/issues/4741