### PR TITLE
refactor: Reduce the level when mtags was found to debug

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
@@ -185,7 +185,7 @@ object MtagsResolver {
               case ResolveType.Nightly =>
                 s"Resolved latest nightly mtags version: $scalaVersion"
             }
-            scribe.info(msg)
+            scribe.debug(msg)
             Some(v)
           // Fallback to Stable PC version
           case _: State.Failure


### PR DESCRIPTION
It seems currently it will span the users and it's not really useful information.