### PR TITLE
Improvement: compiler access error reporting

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/ReportContext.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/ReportContext.scala
@@ -182,9 +182,11 @@ case class Report(
   def fullText: String =
     error match {
       case Some(error) =>
-        s"""|$text
-            |Error message: ${error.getMessage()}
-            |Error: $error
+        s"""|$error
+            |$text
+            |
+            |error stacktrace:
+            |${error.getStackTrace().mkString("\n\t")}
             |""".stripMargin
       case None => text
     }

--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/CompilerThrowable.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/CompilerThrowable.scala
@@ -16,9 +16,14 @@ object CompilerThrowable {
     )
     @tailrec def loop(ex: Throwable): Unit = {
       isVisited.add(ex)
-      val stacktrace = ex.getStackTrace.takeWhile(
-        !_.getClassName.contains("ScalaPresentationCompiler")
-      )
+      val fullStacktrace = ex.getStackTrace
+      val stacktrace = {
+        val i = fullStacktrace.indexWhere(
+          _.getClassName.contains("ScalaPresentationCompiler")
+        )
+        val hi = if (i < 0) fullStacktrace.length else i + 1
+        fullStacktrace.slice(0, hi)
+      }
       ex.setStackTrace(stacktrace)
       // avoid infinite loop when traversing exceptions cyclic dependencies between causes.
       if (e.getCause != null && !isVisited.contains(e.getCause)) {


### PR DESCRIPTION
1. added printing stacktrace
2. added offset/range markers to printed text
3. make` trimStacktrace` include a line from `ScalaPresentationCompiler`