### PR TITLE
fix: Make ResetWorkspace more stable

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BloopDir.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopDir.scala
@@ -1,0 +1,26 @@
+package scala.meta.internal.metals
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+
+object BloopDir {
+  def clear(workspace: AbsolutePath): Unit = {
+    val bloopDir = workspace.resolve(".bloop")
+    bloopDir.list.foreach { f =>
+      if (f.exists && f.isDirectory) f.deleteRecursively()
+    }
+    val remainingDirs =
+      bloopDir.list.filter(f => f.exists && f.isDirectory).toList
+    if (remainingDirs.isEmpty) {
+      scribe.info(
+        "Deleted directories inside .bloop"
+      )
+    } else {
+      val str = remainingDirs.mkString(", ")
+      scribe.error(
+        s"Couldn't delete directories inside .bloop, remaining: $str"
+      )
+    }
+
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -888,6 +888,26 @@ object Messages {
     }
   }
 
+  object ResetWorkspace {
+    val message: String =
+      "Are you sure you want to clear all caches and compiled artifacts and reset workspace?"
+    val resetWorkspace: String = "Reset workspace"
+    val cancel: String = "Cancel"
+    def params(): ShowMessageRequestParams = {
+      val params = new ShowMessageRequestParams(
+        List(
+          resetWorkspace,
+          cancel,
+        )
+          .map(new MessageActionItem(_))
+          .asJava
+      )
+      params.setMessage(message)
+      params.setType(MessageType.Warning)
+      params
+    }
+  }
+
   object NewScalaProject {
     def selectTheTemplate: String = "Select the template to use"
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -2576,29 +2576,12 @@ class MetalsLspService(
   }
 
   private def clearBloopDir(): Unit = {
-    try {
-      val bloopDir = folder.resolve(".bloop")
-      bloopDir.list.foreach { f =>
-        if (f.exists && f.isDirectory) f.deleteRecursively()
-      }
-      val remainingDirs =
-        bloopDir.list.filter(f => f.exists && f.isDirectory).toList
-      if (remainingDirs.isEmpty) {
-        scribe.info(
-          "Deleted directories inside .bloop"
-        )
-      } else {
-        val str = remainingDirs.mkString(", ")
-        scribe.error(
-          s"Couldn't delete directories inside .bloop, remaining: $str"
-        )
-      }
-    } catch {
+    try BloopDir.clear(folder)
+    catch {
       case e: Throwable =>
         languageClient.showMessage(Messages.ResetWorkspaceFailed)
         scribe.error("Error while deleting directories inside .bloop", e)
     }
-
   }
 
   def resetWorkspace(): Future[Unit] = {

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -81,6 +81,7 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
       actions.find(_.getTitle == "a.Main").get
   }
   var importScalaCliScript = new MessageActionItem(ImportScalaScript.dismiss)
+  var resetWorkspace = new MessageActionItem(ResetWorkspace.cancel)
 
   val resources = new ResourceOperations(buffers)
   val diagnostics: TrieMap[AbsolutePath, Seq[Diagnostic]] =
@@ -339,6 +340,8 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
           switchBuildTool
         } else if (ImportScalaScript.params() == params) {
           importScalaCliScript
+        } else if (ResetWorkspace.params() == params) {
+          resetWorkspace
         } else {
           throw new IllegalArgumentException(params.toString)
         }

--- a/tests/unit/src/test/scala/tests/ResetWorkspaceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ResetWorkspaceLspSuite.scala
@@ -1,10 +1,19 @@
 package tests
 
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ServerCommands
+
+import org.eclipse.lsp4j.MessageActionItem
 
 class ResetWorkspaceLspSuite extends BaseLspSuite(s"reset-workspace") {
 
   test("basic") {
+    def bloopDir = server.workspace.resolve(".bloop")
+    def classFileExists = bloopDir.exists && bloopDir.listRecursive.exists(f =>
+      f.isFile && !f.filename.endsWith(".json")
+    )
+    cleanWorkspace()
     for {
       _ <- initialize(
         """
@@ -16,8 +25,12 @@ class ResetWorkspaceLspSuite extends BaseLspSuite(s"reset-workspace") {
           |/a/src/main/scala/a/A.scala
           |package a
           |import scala.util.Success
+          |import b.B
+          |
           |object A {
-          |  val x: String = 42
+          |  case class Foo(x: Int)
+          |  case class Bar(y: String)
+          |  val foo = Foo(B.x)
           |}
           |/a/src/main/scala/b/B.scala
           |package b
@@ -27,23 +40,31 @@ class ResetWorkspaceLspSuite extends BaseLspSuite(s"reset-workspace") {
           |}
         """.stripMargin
       )
-
       _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        "",
+      )
+      _ = assert(classFileExists)
+      _ = client.resetWorkspace =
+        new MessageActionItem(Messages.ResetWorkspace.resetWorkspace)
       _ <- server.executeCommand(ServerCommands.ResetWorkspace)
       _ = assertNoDiff(
         client.workspaceShowMessages,
         "",
       )
+      _ <- server.didSave("a/src/main/scala/b/B.scala")(
+        _.replaceAll("val x: Int = 42", "val x: String = 42")
+      )
       _ = assertNoDiff(
         client.workspaceDiagnostics,
-        """|a/src/main/scala/a/A.scala:4:19: error: type mismatch;
+        """|a/src/main/scala/b/B.scala:4:19: error: type mismatch;
            | found   : Int(42)
            | required: String
            |  val x: String = 42
            |                  ^^
            |""".stripMargin,
       )
-
     } yield ()
   }
 }


### PR DESCRIPTION
Now user is asked for confirmation before clearing .bloop directory. 
Adds additional checks for non-existing files, since it used to fail both on `.toList` and `delete`. 
Also, the `ResetWorkspaceLspSuite` was flaky before, now it should work correctly