### PR TITLE
refactor: Change namePos to namePosition

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
@@ -127,8 +127,10 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams)(implicit
       // Def, val or val definition, example `val x: Int = 1`
       // Matches only if the cursor is over the definition name.
       case v: ValOrDefDef
-          if (v.namePos
-            .includes(pos) || pos.includes(v.namePos)) && v.symbol != null =>
+          if (v.namePosition
+            .includes(pos) || pos.includes(
+            v.namePosition
+          )) && v.symbol != null =>
         val symbol = (v.symbol.getter: Symbol) match {
           case NoSymbol => v.symbol
           case getter => getter

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/InferredTypeProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/InferredTypeProvider.scala
@@ -116,7 +116,7 @@ final class InferredTypeProvider(
           new TextEdit(nameEndPos, ": " + prettyType(tpt.tpe))
         // if type is defined and erronous try to replace it with the right one
         if (tpt.pos.isRange && retryType)
-          adjustType(rhs, tpt, vl.namePos.end)
+          adjustType(rhs, tpt, vl.namePosition.end)
         else typeNameEdit :: additionalImports
 
       /* `.map(a => a + a)`
@@ -167,7 +167,7 @@ final class InferredTypeProvider(
        * `def a[T](param : Int): Int = param`
        */
       case df @ DefDef(_, name, _, _, tpt, rhs) =>
-        val nameEnd = findNameEnd(df.namePos.start, name)
+        val nameEnd = findNameEnd(df.namePosition.start, name)
 
         // search for `)` or `]` or defaut to name's end to insert type
         val lastParamOffset =

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -699,7 +699,7 @@ class MetalsGlobal(
     /**
      * Returns the position of the name/identifier of this definition.
      */
-    def namePos: Position = {
+    def namePosition: Position = {
       val name =
         if (defn.symbol.isPackageObject) defn.symbol.enclosingPackageClass.name
         else defn.name
@@ -714,7 +714,7 @@ class MetalsGlobal(
     /**
      * Returns the position of the name/identifier of this select.
      */
-    def namePos: Position = {
+    def namePosition: Position = {
       val start = sel.pos.point
       val end = start + sel.name.getterName.decoded.trim.length()
       Position.range(sel.pos.source, start, start, end)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
@@ -169,8 +169,8 @@ abstract class PcCollector[T](
      * class Fo@@o = ???
      * etc.
      */
-    case (df: DefTree) if df.namePos.includes(pos) =>
-      Some(symbolAlternatives(df.symbol), df.namePos)
+    case (df: DefTree) if df.namePosition.includes(pos) =>
+      Some(symbolAlternatives(df.symbol), df.namePosition)
     /* Import selectors:
      * import scala.util.Tr@@y
      */
@@ -179,8 +179,8 @@ abstract class PcCollector[T](
     /* simple selector:
      * object.val@@ue
      */
-    case (sel: NameTree) if sel.namePos.includes(pos) =>
-      Some(symbolAlternatives(sel.symbol), sel.namePos)
+    case (sel: NameTree) if sel.namePosition.includes(pos) =>
+      Some(symbolAlternatives(sel.symbol), sel.namePosition)
 
     // needed for classOf[AB@@C]`
     case lit @ Literal(Constant(TypeRef(_, sym, _))) if lit.pos.includes(pos) =>
@@ -323,7 +323,7 @@ abstract class PcCollector[T](
           traverse(
             acc + collect(
               sel,
-              sel.namePos
+              sel.namePosition
             ),
             sel.qualifier
           )
@@ -336,7 +336,7 @@ abstract class PcCollector[T](
           (annotationChildren(df) ++ df.children).foldLeft({
             val t = collect(
               df,
-              df.namePos
+              df.namePosition
             )
             if (acc(t)) acc else acc + t
           })(traverse(_, _))
@@ -373,7 +373,7 @@ abstract class PcCollector[T](
           bind.children.foldLeft(
             acc + collect(
               bind,
-              bind.namePos
+              bind.namePosition
             )
           )(traverse(_, _))
 
@@ -444,7 +444,7 @@ abstract class PcCollector[T](
           tree.children.foldLeft(
             acc + collect(
               name,
-              name.namePos
+              name.namePosition
             )
           )(traverse(_, _))
 
@@ -486,7 +486,7 @@ abstract class PcCollector[T](
   private def typePos(tpe: TypeTree) = {
     tpe.original match {
       case AppliedTypeTree(tpt, _) => tpt.pos
-      case sel: NameTree => sel.namePos
+      case sel: NameTree => sel.namePosition
       case _ => tpe.pos
     }
   }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -172,7 +172,7 @@ class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
       case sel @ Select(_, name) if sel.tpe == ErrorType =>
         val symbols = tree.tpe.member(name)
         typedTree.setSymbol(symbols)
-      case defn: DefTree if !defn.namePos.metalsIncludes(pos) =>
+      case defn: DefTree if !defn.namePosition.metalsIncludes(pos) =>
         EmptyTree
       case _: Template =>
         EmptyTree

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -535,7 +535,8 @@ trait Completions { this: MetalsGlobal =>
           patternOnly = Some(name.stripSuffix("_CURSOR_")),
           hasBind = true
         )
-      case (c: DefTree) :: (p: PackageDef) :: _ if c.namePos.includes(pos) =>
+      case (c: DefTree) :: (p: PackageDef) :: _
+          if c.namePosition.includes(pos) =>
         FilenameCompletion(c, p, pos, editRange)
       case OverrideExtractor(name, template, start, isCandidate) =>
         OverrideCompletion(


### PR DESCRIPTION
connected to https://github.com/scalameta/metals/issues/5438
In Scala 2.13.12 `namePos` method is added for `NamedTree`, which shadowed our `namePos` extension method