### PR TITLE
improvement: Add date and time to reports and backup log files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/logging/MetalsLogger.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/logging/MetalsLogger.scala
@@ -10,6 +10,7 @@ import scala.util.control.NonFatal
 
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.TimeFormatter
 import scala.meta.internal.metals.utils.LimitedFilesManager
 import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
@@ -139,9 +140,7 @@ object MetalsLogger {
           logFilePath.toNIO
         ) > config.maxLogFileSize
       ) {
-        val backedUpLogFile = backupLogsDir(workspaceFolder).resolve(
-          s"log_${System.currentTimeMillis()}"
-        )
+        val backedUpLogFile = backupLogPath(workspaceFolder)
         backedUpLogFile.parent.createDirectories()
         Files.move(
           logFilePath.toNIO,
@@ -158,6 +157,12 @@ object MetalsLogger {
                         |""".stripMargin)
     }
     logFilePath
+  }
+
+  private def backupLogPath(wokspaceFolder: AbsolutePath): AbsolutePath = {
+    val now = TimeFormatter.getTime()
+    val filename = s"log_${now}"
+    backupLogsDir(wokspaceFolder).resolve(filename)
   }
 
   private def limitKeptBackupLogs(workspaceFolder: AbsolutePath, limit: Int) = {

--- a/metals/src/main/scala/scala/meta/internal/metals/logging/MetalsLogger.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/logging/MetalsLogger.scala
@@ -160,9 +160,10 @@ object MetalsLogger {
   }
 
   private def backupLogPath(wokspaceFolder: AbsolutePath): AbsolutePath = {
-    val now = TimeFormatter.getTime()
-    val filename = s"log_${now}"
-    backupLogsDir(wokspaceFolder).resolve(filename)
+    val date = TimeFormatter.getDate()
+    val time = TimeFormatter.getTime()
+    val filename = s"log_${time}"
+    backupLogsDir(wokspaceFolder).resolve(date).resolve(filename)
   }
 
   private def limitKeptBackupLogs(workspaceFolder: AbsolutePath, limit: Int) = {

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/ReportContext.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/ReportContext.scala
@@ -107,8 +107,7 @@ class StdReporter(workspace: Path, pathToReports: Path, level: ReportLevel)
       val sanitizedId = report.id.map(sanitize)
       if (sanitizedId.isDefined && reported.contains(sanitizedId.get)) None
       else {
-        val path =
-          reportsDir.resolve(s"r_${report.name}_${System.currentTimeMillis()}")
+        val path = reportPath(report.name)
         sanitizedId.foreach(reported += _)
         val idString = sanitizedId.map(id => s"$idPrefix$id\n").getOrElse("")
         path.writeText(s"$idString${sanitize(report.fullText)}")
@@ -122,6 +121,12 @@ class StdReporter(workspace: Path, pathToReports: Path, level: ReportLevel)
     userHome
       .map(textAfterWokspaceReplace.replace(_, StdReportContext.HOME_STR))
       .getOrElse(textAfterWokspaceReplace)
+  }
+
+  private def reportPath(name: String): Path = {
+    val now = TimeFormatter.getTime()
+    val filename = s"r_${name}_${now}"
+    reportsDir.resolve(filename)
   }
 
   override def cleanUpOldReports(

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/TimeFormatter.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/TimeFormatter.scala
@@ -6,8 +6,14 @@ import java.util.Calendar
 import scala.util.Try
 
 object TimeFormatter {
-  private val format = new SimpleDateFormat("dd-MM-yyyy--HH-mm-ss-SSS")
-  def getTime(): String = format.format(Calendar.getInstance().getTime())
-  def parse(date: String): Option[Long] =
-    Try { format.parse(date).getTime() }.toOption
+  private val timeFormat = new SimpleDateFormat("HH-mm-ss-SSS")
+  private val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
+  private val fullFormat = new SimpleDateFormat("yyyy-MM-dd--HH-mm-ss-SSS")
+  def getTime(): String = timeFormat.format(Calendar.getInstance().getTime())
+  def getDate(): String = dateFormat.format(Calendar.getInstance().getTime())
+  def parse(time: String, date: String): Option[Long] =
+    Try { fullFormat.parse(date + "--" + time).getTime() }.toOption
+  def hasDateName(str: String): Boolean = Try {
+    dateFormat.parse(str)
+  }.isSuccess
 }

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/TimeFormatter.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/TimeFormatter.scala
@@ -1,0 +1,13 @@
+package scala.meta.internal.metals
+
+import java.text.SimpleDateFormat
+import java.util.Calendar
+
+import scala.util.Try
+
+object TimeFormatter {
+  private val format = new SimpleDateFormat("dd-MM-yyyy--HH-mm-ss-SSS")
+  def getTime(): String = format.format(Calendar.getInstance().getTime())
+  def parse(date: String): Option[Long] =
+    Try { format.parse(date).getTime() }.toOption
+}

--- a/tests/unit/src/test/scala/tests/LogBackupSuite.scala
+++ b/tests/unit/src/test/scala/tests/LogBackupSuite.scala
@@ -9,6 +9,7 @@ import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.RecursivelyDelete
+import scala.meta.internal.metals.TimeFormatter
 import scala.meta.internal.metals.logging.MetalsLogger
 import scala.meta.internal.metals.utils.LimitedFilesManager
 import scala.meta.io.AbsolutePath
@@ -44,6 +45,13 @@ class LogBackupSuite extends BaseSuite {
     assert(backupDir.exists)
     assert(limitedFilesManager.getAllFiles().size == 1)
     assert(!log.exists)
+    val dirsWithDate = backupDir.toFile.listFiles()
+    assert(dirsWithDate.length == 1)
+    assert(
+      dirsWithDate.forall(d =>
+        d.isDirectory() && TimeFormatter.hasDateName(d.getName())
+      )
+    )
   }
 
   test("backup-and-delete-overflow") {

--- a/tests/unit/src/test/scala/tests/ReportsSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReportsSuite.scala
@@ -8,6 +8,7 @@ import scala.meta.internal.metals.FolderReportsZippper
 import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.Report
 import scala.meta.internal.metals.StdReportContext
+import scala.meta.internal.metals.TimeFormatter
 import scala.meta.internal.metals.ZipReportsProvider
 import scala.meta.io.AbsolutePath
 
@@ -40,6 +41,14 @@ class ReportsSuite extends BaseSuite {
       new String(Files.readAllBytes(path.get), StandardCharsets.UTF_8)
     assertNoDiff(exampleText(StdReportContext.WORKSPACE_STR), obtained)
     assert(reportsProvider.incognito.getReports().length == 1)
+    val dirsWithDate =
+      reportsProvider.reportsDir.resolve("metals").toFile().listFiles()
+    assert(dirsWithDate.length == 1)
+    assert(
+      dirsWithDate.forall(d =>
+        d.isDirectory() && TimeFormatter.hasDateName(d.getName())
+      )
+    )
   }
 
   test("delete-old-reports") {


### PR DESCRIPTION
Previously, reports have had only timestamp in milliseconds, which didn't tell the user anything about when the report was created.