### PR TITLE
improvement: add timeout to requests

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -141,6 +141,7 @@ final class BspServers(
       client,
       newConnection,
       tables.dismissedNotifications.ReconnectBsp,
+      tables.dismissedNotifications.RequestTimeout,
       config,
       details.getName(),
       bspStatusOpt,

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -94,6 +94,7 @@ final class BloopServers(
         () =>
           connectToLauncher(bloopVersion, config.bloopPort, userConfiguration),
         tables.dismissedNotifications.ReconnectBsp,
+        tables.dismissedNotifications.RequestTimeout,
         config,
         name,
         bspStatusOpt,

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -60,9 +60,9 @@ class BuildServerConnection private (
 )(implicit ec: ExecutionContextExecutorService)
     extends Cancelable {
 
-  private val defaultMinTimeout = FiniteDuration(3, TimeUnit.MINUTES)
-  private def defaultTimeout(name: String) =
-    Some(Timeout.default(name, defaultMinTimeout))
+  private val defaultTimeout = Some(
+    Timeout.default(FiniteDuration(3, TimeUnit.MINUTES))
+  )
 
   @volatile private var connection = Future.successful(initialConnection)
   initialConnection.setReconnect(() => reconnect().ignoreValue)
@@ -226,7 +226,7 @@ class BuildServerConnection private (
       register(
         server => server.buildTargetScalaMainClasses(params),
         onFail,
-        defaultTimeout("main classes"),
+        defaultTimeout,
       ).asScala
     } else Future.successful(resultOnUnsupported)
 
@@ -246,7 +246,7 @@ class BuildServerConnection private (
       register(
         server => server.buildTargetScalaTestClasses(params),
         onFail,
-        defaultTimeout("test classes"),
+        defaultTimeout,
       ).asScala
     } else Future.successful(resultOnUnsupported)
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/CancelableFuture.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CancelableFuture.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.metals
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.util.Try
 
 case class CancelableFuture[T](
     future: Future[T],
@@ -9,6 +10,10 @@ case class CancelableFuture[T](
 ) extends Cancelable {
   def map[U](f: T => U)(implicit ec: ExecutionContext): CancelableFuture[U] =
     CancelableFuture(future.map(f), cancelable)
+  def transform[U](f: Try[T] => Try[U])(implicit
+      ec: ExecutionContext
+  ): CancelableFuture[U] =
+    CancelableFuture(future.transform(f), cancelable)
   def cancel(): Unit = {
     cancelable.cancel()
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -31,8 +31,8 @@ final class Compilations(
     onStartCompilation: () => Unit,
 )(implicit ec: ExecutionContext) {
 
-  val cascadeCompileTimeout = Timeout.NoTimeout
-  val compileTimeout: Timeout.FlexTimeout =
+  private val cascadeCompileTimeout = Timeout.NoTimeout
+  private val compileTimeout: Timeout.FlexTimeout =
     Timeout.FlexTimeout("compile", Duration(10, TimeUnit.MINUTES))
   // we are maintaining a separate queue for cascade compilation since those must happen ASAP
   private val compileBatch =

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -32,6 +32,8 @@ final class Compilations(
 )(implicit ec: ExecutionContext) {
   private val compileTimeout: Timeout =
     Timeout("compile", Duration(10, TimeUnit.MINUTES))
+  private val cascadeTimeout: Timeout =
+    Timeout("cascade compile", Duration(15, TimeUnit.MINUTES))
   // we are maintaining a separate queue for cascade compilation since those must happen ASAP
   private val compileBatch =
     new BatchedFunction[
@@ -48,7 +50,7 @@ final class Compilations(
       b.BuildTargetIdentifier,
       Map[BuildTargetIdentifier, b.CompileResult],
     ](
-      compile(timeout = None),
+      compile(timeout = Some(cascadeTimeout)),
       "cascadeBatch",
       shouldLogQueue = true,
       Some(Map.empty),

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -39,12 +39,22 @@ final class Compilations(
     new BatchedFunction[
       b.BuildTargetIdentifier,
       Map[BuildTargetIdentifier, b.CompileResult],
-    ](compile(compileTimeout), "compileBatch", shouldLogQueue = true, Some(Map.empty))
+    ](
+      compile(compileTimeout),
+      "compileBatch",
+      shouldLogQueue = true,
+      Some(Map.empty),
+    )
   private val cascadeBatch =
     new BatchedFunction[
       b.BuildTargetIdentifier,
       Map[BuildTargetIdentifier, b.CompileResult],
-    ](compile(cascadeCompileTimeout), "cascadeBatch", shouldLogQueue = true, Some(Map.empty))
+    ](
+      compile(cascadeCompileTimeout),
+      "cascadeBatch",
+      shouldLogQueue = true,
+      Some(Map.empty),
+    )
   def pauseables: List[Pauseable] = List(compileBatch, cascadeBatch)
 
   private val isCompiling = TrieMap.empty[b.BuildTargetIdentifier, Boolean]

--- a/metals/src/main/scala/scala/meta/internal/metals/DismissedNotifications.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DismissedNotifications.scala
@@ -23,6 +23,7 @@ final class DismissedNotifications(conn: () => Connection, time: Time) {
   val ReconnectScalaCli = new Notification(13)
   val ScalaCliImportAuto = new Notification(14)
   val BspErrors = new Notification(15)
+  val RequestTimeout = new Notification(16)
 
   val all: List[Notification] = List(
     Only212Navigation,

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -1012,6 +1012,29 @@ object Messages {
     }
   }
 
+  object RequestTimeout {
+
+    val cancel = new MessageActionItem("Cancel")
+    val waitAction = new MessageActionItem("Wait")
+    val waitAlways = new MessageActionItem("WaitAlways")
+
+    def params(actionName: String, minutes: Int): ShowMessageRequestParams = {
+      val params = new ShowMessageRequestParams()
+      params.setMessage(
+        s"$actionName request is taking longer than expected (over $minutes minutes), do you want to cancel and rerun it?"
+      )
+      params.setType(MessageType.Info)
+      params.setActions(
+        List(
+          cancel,
+          waitAction,
+          waitAlways,
+        ).asJava
+      )
+      params
+    }
+  }
+
 }
 
 object FileOutOfScalaCliBspScope {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -233,7 +233,9 @@ object MetalsEnrichments
         ec: ExecutionContext
     ): Future[A] = withTimeout(FiniteDuration(length, unit))
 
-    def withTimeout(duration: FiniteDuration)(implicit ec: ExecutionContext): Future[A] = {
+    def withTimeout(
+        duration: FiniteDuration
+    )(implicit ec: ExecutionContext): Future[A] = {
       Future(Await.result(future, duration))
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -231,8 +231,10 @@ object MetalsEnrichments
 
     def withTimeout(length: Int, unit: TimeUnit)(implicit
         ec: ExecutionContext
-    ): Future[A] = {
-      Future(Await.result(future, FiniteDuration(length, unit)))
+    ): Future[A] = withTimeout(FiniteDuration(length, unit))
+
+    def withTimeout(duration: FiniteDuration)(implicit ec: ExecutionContext): Future[A] = {
+      Future(Await.result(future, duration))
     }
 
     def onTimeout(length: Int, unit: TimeUnit)(

--- a/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
@@ -255,6 +255,7 @@ final class Ammonite(
                 workspace(),
               ),
           tables.dismissedNotifications.ReconnectAmmonite,
+          tables.dismissedNotifications.RequestTimeout,
           config,
           "Ammonite",
         )

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -224,6 +224,7 @@ class ScalaCli(
         languageClient,
         () => ScalaCli.socketConn(command, connDir),
         tables.dismissedNotifications.ReconnectScalaCli,
+        tables.dismissedNotifications.RequestTimeout,
         config(),
         "Scala CLI",
         supportsWrappedSources = Some(true),

--- a/metals/src/main/scala/scala/meta/internal/metals/utils/FutureWithTimeout.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/utils/FutureWithTimeout.scala
@@ -1,20 +1,41 @@
 package scala.meta.internal.metals.utils
 
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
+import scala.util.Failure
+import scala.util.Try
+
+import scala.meta.internal.metals.Cancelable
+import scala.meta.internal.metals.CancelableFuture
+import scala.meta.internal.metals.MetalsEnrichments._
 
 object FutureWithTimeout {
   def apply[T](duration: Duration)(
-      future: Future[T],
-      timeBefore: Long = System.currentTimeMillis(),
-  )(implicit ex: ExecutionContext): Future[(T, Duration)] = Future {
-    val res = Await.result(future, duration)
-    val timeAfter = System.currentTimeMillis()
-    val execTime = timeAfter - timeBefore
-    (res, Duration(execTime, TimeUnit.MILLISECONDS))
+      future: () => CompletableFuture[T]
+  )(implicit ex: ExecutionContext): CancelableFuture[(T, Duration)] = {
+    val timeBefore: Long = System.currentTimeMillis()
+    val resultFuture = future()
+    val cancelable = Cancelable { () =>
+      Try(resultFuture.cancel(true))
+    }
+    val withTimeout =
+      Future {
+        val res = Await.result(resultFuture.asScala, duration)
+        val timeAfter = System.currentTimeMillis()
+        val execTime = timeAfter - timeBefore
+        (res, Duration(execTime, TimeUnit.MILLISECONDS))
+      }
+
+    withTimeout.onComplete {
+      case Failure(_: TimeoutException) => cancelable.cancel()
+      case _ =>
+    }
+    CancelableFuture(withTimeout, cancelable)
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/utils/FutureWithTimeout.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/utils/FutureWithTimeout.scala
@@ -8,12 +8,13 @@ import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 
 object FutureWithTimeout {
-  def apply[T](timeout: Long)(
-      future: => Future[T]
-  )(implicit ex: ExecutionContext): Future[(T, Long)] = Future {
-    val timeBefore = System.currentTimeMillis()
-    val res = Await.result(future, Duration(timeout, TimeUnit.MILLISECONDS))
+  def apply[T](duration: Duration)(
+      future: Future[T],
+      timeBefore: Long = System.currentTimeMillis(),
+  )(implicit ex: ExecutionContext): Future[(T, Duration)] = Future {
+    val res = Await.result(future, duration)
     val timeAfter = System.currentTimeMillis()
-    (res, timeAfter - timeBefore)
+    val execTime = timeAfter - timeBefore
+    (res, Duration(execTime, TimeUnit.MILLISECONDS))
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/utils/FutureWithTimeout.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/utils/FutureWithTimeout.scala
@@ -1,0 +1,19 @@
+package scala.meta.internal.metals.utils
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+
+object FutureWithTimeout {
+  def apply[T](timeout: Long)(
+      future: => Future[T]
+  )(implicit ex: ExecutionContext): Future[(T, Long)] = Future {
+    val timeBefore = System.currentTimeMillis()
+    val res = Await.result(future, Duration(timeout, TimeUnit.MILLISECONDS))
+    val timeAfter = System.currentTimeMillis()
+    (res, timeAfter - timeBefore)
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/utils/RequestRegistry.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/utils/RequestRegistry.scala
@@ -1,0 +1,81 @@
+package scala.meta.internal.metals.utils
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeoutException
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import scala.meta.internal.metals.Cancelable
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.MutableCancelable
+
+class RequestRegistry(
+    defaultMinTimeout: Duration,
+    initialCancellables: List[Cancelable],
+)(implicit
+    ex: ExecutionContext
+) {
+  private val timeouts: Timeouts = new Timeouts(defaultMinTimeout)
+  private val ongoingRequests =
+    new MutableCancelable().addAll(initialCancellables)
+  private val ongoingCompilations = new MutableCancelable()
+
+  def register[T](
+      action: () => CompletableFuture[T],
+      timeout: Timeout = Timeout.DefaultFlexTimeout,
+      isCompile: Boolean = false,
+  ): Future[T] = {
+    val timeBefore: Long = System.currentTimeMillis()
+    val resultFuture = action()
+    val cancelable = Cancelable { () =>
+      Try(resultFuture.cancel(true))
+    }
+
+    if (isCompile) ongoingCompilations.add(cancelable)
+    else ongoingRequests.add(cancelable)
+
+    val result = getTimeout(timeout) match {
+      case Some(timeoutValue) =>
+        FutureWithTimeout(timeoutValue)(resultFuture.asScala, timeBefore)
+          .transform {
+            case Success((res, time)) =>
+              timeouts.measured(timeout, time)
+              Success(res)
+            case Failure(e: TimeoutException) =>
+              timeouts.measured(timeout, timeoutValue)
+              Failure(e)
+            case Failure(e) => Failure(e)
+          }
+      case None => resultFuture.asScala
+    }
+    result.onComplete { _ =>
+      if (isCompile) ongoingCompilations.remove(cancelable)
+      else ongoingRequests.remove(cancelable)
+    }
+    result
+  }
+
+  def addOngoingRequest(values: Iterable[Cancelable]): MutableCancelable =
+    ongoingRequests.addAll(values)
+
+  def addOngoingCompilations(values: Iterable[Cancelable]): MutableCancelable =
+    ongoingCompilations.addAll(values)
+
+  def cancelCompilations(): Unit = {
+    ongoingCompilations.cancel()
+  }
+
+  def cancel(): Unit = {
+    ongoingCompilations.cancel()
+    ongoingRequests.cancel()
+  }
+
+  def getTimeout(timeout: Timeout): Option[Duration] =
+    timeouts.getTimeout(timeout)
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/utils/RequestRegistry.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/utils/RequestRegistry.scala
@@ -1,22 +1,32 @@
 package scala.meta.internal.metals.utils
 
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.CancelableFuture
+import scala.meta.internal.metals.DismissedNotifications
+import scala.meta.internal.metals.Messages.RequestTimeout
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MutableCancelable
 
+import org.eclipse.lsp4j.services.LanguageClient
+
 class RequestRegistry(
-    defaultMinTimeout: Duration,
+    defaultMinTimeout: FiniteDuration,
     initialCancellables: List[Cancelable],
+    languageClient: LanguageClient,
+    requestTimeOutNotification: Option[DismissedNotifications#Notification] =
+      None,
 )(implicit
     ex: ExecutionContext
 ) {
@@ -24,29 +34,49 @@ class RequestRegistry(
   private val ongoingRequests =
     new MutableCancelable().addAll(initialCancellables)
 
+  private def onTimeout(
+      actionName: String
+  )(duration: Duration): Future[FutureWithTimeout.OnTimeout] = {
+    languageClient
+      .showMessageRequest(
+        RequestTimeout.params(actionName, duration.toMinutes.toInt)
+      )
+      .asScala
+      .map {
+        case RequestTimeout.waitAction => FutureWithTimeout.Wait
+        case RequestTimeout.cancel => FutureWithTimeout.Cancel
+        case RequestTimeout.waitAlways =>
+          requestTimeOutNotification.foreach(_.dismiss(7, TimeUnit.DAYS))
+          FutureWithTimeout.Dismiss
+        case _ => FutureWithTimeout.Dismiss
+      }
+  }
+
   def register[T](
       action: () => CompletableFuture[T],
-      timeout: Timeout = Timeout.DefaultFlexTimeout,
+      timeout: Timeout,
   ): CancelableFuture[T] = {
-    val CancelableFuture(result, cancelable) = getTimeout(timeout) match {
-      case Some(timeoutValue) =>
-        FutureWithTimeout(timeoutValue)(action)
-          .transform {
-            case Success((res, time)) =>
-              timeouts.measured(timeout, time)
-              Success(res)
-            case Failure(e: TimeoutException) =>
-              timeouts.measured(timeout, timeoutValue)
-              Failure(e)
-            case Failure(e) => Failure(e)
+    val CancelableFuture(result, cancelable) =
+      timeouts.getNameAndTimeout(timeout) match {
+        case Some((actionName, timeoutValue))
+            if !requestTimeOutNotification.exists(_.isDismissed) =>
+          FutureWithTimeout(timeoutValue, onTimeout(actionName)(_))(action)
+            .transform {
+              case Success((res, time)) =>
+                timeouts.measured(timeout, time)
+                Success(res)
+              case Failure(e: TimeoutException) =>
+                timeouts.measured(timeout, timeoutValue)
+                Failure(e)
+              case Failure(e) => Failure(e)
+            }
+        case _ =>
+          val resultFuture = action()
+          val cancelable = Cancelable { () =>
+            Try(resultFuture.cancel(true))
           }
-      case None =>
-        val resultFuture = action()
-        val cancelable = Cancelable { () =>
-          Try(resultFuture.cancel(true))
-        }
-        CancelableFuture(resultFuture.asScala, cancelable)
-    }
+          CancelableFuture(resultFuture.asScala, cancelable)
+      }
 
     ongoingRequests.add(cancelable)
 

--- a/metals/src/main/scala/scala/meta/internal/metals/utils/Timeouts.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/utils/Timeouts.scala
@@ -1,36 +1,37 @@
 package scala.meta.internal.metals.utils
 
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.duration.Duration
 
 sealed trait Timeout
 object Timeout {
   case object NoTimeout extends Timeout
   case object DefaultFlexTimeout extends Timeout
-  case class FlexTimeout(id: String, minTimeout: Long) extends Timeout
+  case class FlexTimeout(id: String, minTimeout: Duration) extends Timeout
 }
 
-class Timeouts {
-  // 3 min
-  private val defaultMinTimeout: Long = 3 * 60 * 1000
+class Timeouts(defaultMinTimeout: Duration) {
   private val defaultFlexTimeout: AtomicReference[Option[AvgTime]] =
     new AtomicReference(None)
   private val timeouts: AtomicReference[Map[String, AvgTime]] =
     new AtomicReference(Map())
-  def measured(timeout: Timeout, time: Long): Any = {
+  def measured(timeout: Timeout, time: Duration): Any = {
     val addToOption: Option[AvgTime] => Option[AvgTime] = {
       case Some(avgTime) => Some(avgTime.add(time))
       case None => Some(AvgTime.of(time))
     }
     timeout match {
-      case Timeout.NoTimeout =>
       case Timeout.DefaultFlexTimeout =>
         defaultFlexTimeout.getAndUpdate(addToOption(_))
       case Timeout.FlexTimeout(id, _) =>
         timeouts.getAndUpdate(_.updatedWith(id)(addToOption))
+      case _ =>
     }
   }
 
-  def getTimeout(timeout: Timeout): Option[Long] = {
+  def getTimeout(timeout: Timeout): Option[Duration] = {
     timeout match {
       case Timeout.DefaultFlexTimeout =>
         Some(
@@ -43,7 +44,7 @@ class Timeouts {
           timeouts.get
             .get(id)
             .map(_.avgWithMin(minTimeout))
-            .getOrElse(defaultMinTimeout)
+            .getOrElse(minTimeout)
         )
       case Timeout.NoTimeout => None
     }
@@ -51,14 +52,16 @@ class Timeouts {
 }
 
 case class AvgTime(samples: Int, totalTime: Long) {
-  def add(time: Long): AvgTime = AvgTime(samples + 1, totalTime + time)
-  def avgWithMin(min: Long): Long = {
-    def max(l1: Long, l2: Long) = if (l1 > l2) l1 else l2
-    val avg = totalTime / samples
-    max(avg, min)
+  def add(time: Duration): AvgTime =
+    AvgTime(samples + 1, totalTime + time.toMillis)
+  def avgWithMin(min: Duration): Duration = {
+    def max(l1: Duration, l2: Duration) = if (l1 > l2) l1 else l2
+    val avg = (totalTime / samples)
+    val avg3 = Duration(avg * 3, TimeUnit.MILLISECONDS)
+    max(avg3, min)
   }
 }
 
 object AvgTime {
-  def of(time: Long): AvgTime = AvgTime(1, time)
+  def of(time: Duration): AvgTime = AvgTime(1, time.toMillis)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/utils/Timeouts.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/utils/Timeouts.scala
@@ -3,27 +3,27 @@ package scala.meta.internal.metals.utils
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 
 sealed trait Timeout
 object Timeout {
   case object NoTimeout extends Timeout
-  case object DefaultFlexTimeout extends Timeout
-  case class FlexTimeout(id: String, minTimeout: Duration) extends Timeout
+  case class DefaultFlexTimeout(id: String) extends Timeout
+  case class FlexTimeout(id: String, minTimeout: FiniteDuration) extends Timeout
 }
 
-class Timeouts(defaultMinTimeout: Duration) {
+class Timeouts(defaultMinTimeout: FiniteDuration) {
   private val defaultFlexTimeout: AtomicReference[Option[AvgTime]] =
     new AtomicReference(None)
   private val timeouts: AtomicReference[Map[String, AvgTime]] =
     new AtomicReference(Map())
-  def measured(timeout: Timeout, time: Duration): Any = {
+  def measured(timeout: Timeout, time: FiniteDuration): Any = {
     val addToOption: Option[AvgTime] => Option[AvgTime] = {
       case Some(avgTime) => Some(avgTime.add(time))
       case None => Some(AvgTime.of(time))
     }
     timeout match {
-      case Timeout.DefaultFlexTimeout =>
+      case Timeout.DefaultFlexTimeout(_) =>
         defaultFlexTimeout.getAndUpdate(addToOption(_))
       case Timeout.FlexTimeout(id, _) =>
         timeouts.getAndUpdate(_.updatedWith(id)(addToOption))
@@ -31,37 +31,40 @@ class Timeouts(defaultMinTimeout: Duration) {
     }
   }
 
-  def getTimeout(timeout: Timeout): Option[Duration] = {
+  def getNameAndTimeout(timeout: Timeout): Option[(String, FiniteDuration)] = {
     timeout match {
-      case Timeout.DefaultFlexTimeout =>
+      case Timeout.DefaultFlexTimeout(id) =>
         Some(
           defaultFlexTimeout.get
             .map(_.avgWithMin(defaultMinTimeout))
             .getOrElse(defaultMinTimeout)
-        )
+        ).map((id, _))
       case Timeout.FlexTimeout(id, minTimeout) =>
         Some(
           timeouts.get
             .get(id)
             .map(_.avgWithMin(minTimeout))
             .getOrElse(minTimeout)
-        )
+        ).map((id, _))
       case Timeout.NoTimeout => None
     }
   }
+
+  def getTimeout(timeout: Timeout): Option[FiniteDuration] =
+    getNameAndTimeout(timeout).map(_._2)
 }
 
 case class AvgTime(samples: Int, totalTime: Long) {
-  def add(time: Duration): AvgTime =
+  def add(time: FiniteDuration): AvgTime =
     AvgTime(samples + 1, totalTime + time.toMillis)
-  def avgWithMin(min: Duration): Duration = {
-    def max(l1: Duration, l2: Duration) = if (l1 > l2) l1 else l2
+  def avgWithMin(min: FiniteDuration): FiniteDuration = {
+    def max(l1: FiniteDuration, l2: FiniteDuration) = if (l1 > l2) l1 else l2
     val avg = (totalTime / samples)
-    val avg3 = Duration(avg * 3, TimeUnit.MILLISECONDS)
+    val avg3 = FiniteDuration(avg * 3, TimeUnit.MILLISECONDS)
     max(avg3, min)
   }
 }
 
 object AvgTime {
-  def of(time: Duration): AvgTime = AvgTime(1, time.toMillis)
+  def of(time: FiniteDuration): AvgTime = AvgTime(1, time.toMillis)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/utils/Timeouts.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/utils/Timeouts.scala
@@ -1,0 +1,64 @@
+package scala.meta.internal.metals.utils
+
+import java.util.concurrent.atomic.AtomicReference
+
+sealed trait Timeout
+object Timeout {
+  case object NoTimeout extends Timeout
+  case object DefaultFlexTimeout extends Timeout
+  case class FlexTimeout(id: String, minTimeout: Long) extends Timeout
+}
+
+class Timeouts {
+  // 3 min
+  private val defaultMinTimeout: Long = 3 * 60 * 1000
+  private val defaultFlexTimeout: AtomicReference[Option[AvgTime]] =
+    new AtomicReference(None)
+  private val timeouts: AtomicReference[Map[String, AvgTime]] =
+    new AtomicReference(Map())
+  def measured(timeout: Timeout, time: Long): Any = {
+    val addToOption: Option[AvgTime] => Option[AvgTime] = {
+      case Some(avgTime) => Some(avgTime.add(time))
+      case None => Some(AvgTime.of(time))
+    }
+    timeout match {
+      case Timeout.NoTimeout =>
+      case Timeout.DefaultFlexTimeout =>
+        defaultFlexTimeout.getAndUpdate(addToOption(_))
+      case Timeout.FlexTimeout(id, _) =>
+        timeouts.getAndUpdate(_.updatedWith(id)(addToOption))
+    }
+  }
+
+  def getTimeout(timeout: Timeout): Option[Long] = {
+    timeout match {
+      case Timeout.DefaultFlexTimeout =>
+        Some(
+          defaultFlexTimeout.get
+            .map(_.avgWithMin(defaultMinTimeout))
+            .getOrElse(defaultMinTimeout)
+        )
+      case Timeout.FlexTimeout(id, minTimeout) =>
+        Some(
+          timeouts.get
+            .get(id)
+            .map(_.avgWithMin(minTimeout))
+            .getOrElse(defaultMinTimeout)
+        )
+      case Timeout.NoTimeout => None
+    }
+  }
+}
+
+case class AvgTime(samples: Int, totalTime: Long) {
+  def add(time: Long): AvgTime = AvgTime(samples + 1, totalTime + time)
+  def avgWithMin(min: Long): Long = {
+    def max(l1: Long, l2: Long) = if (l1 > l2) l1 else l2
+    val avg = totalTime / samples
+    max(avg, min)
+  }
+}
+
+object AvgTime {
+  def of(time: Long): AvgTime = AvgTime(1, time)
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/utils/Timeouts.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/utils/Timeouts.scala
@@ -5,12 +5,12 @@ import java.util.concurrent.atomic.AtomicReference
 
 import scala.concurrent.duration.FiniteDuration
 
-case class Timeout(id: String, name: String, minTimeout: FiniteDuration)
+case class Timeout(id: String, name: Option[String], minTimeout: FiniteDuration)
 object Timeout {
   def apply(name: String, minTimeout: FiniteDuration): Timeout =
-    Timeout(name, name, minTimeout)
-  def default(name: String, minTimeout: FiniteDuration): Timeout =
-    Timeout("default", name, minTimeout)
+    Timeout(name, Some(name), minTimeout)
+  def default(minTimeout: FiniteDuration): Timeout =
+    Timeout("default", None, minTimeout)
 }
 
 class Timeouts() {

--- a/tests/unit/src/test/scala/tests/RequestRegistrySuite.scala
+++ b/tests/unit/src/test/scala/tests/RequestRegistrySuite.scala
@@ -1,0 +1,117 @@
+package tests
+
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+
+import scala.meta.internal.metals.utils.RequestRegistry
+import scala.meta.internal.metals.utils.Timeout
+
+import munit.FunSuite
+
+class RequestRegistrySuite extends FunSuite {
+  implicit val ex: ExecutionContextExecutor = ExecutionContext.global
+  val duration: FiniteDuration = Duration(1, TimeUnit.SECONDS)
+  def createRegistry() = new RequestRegistry(duration, List())
+
+  test("avg") {
+    val requestRegistry = createRegistry()
+    val doneTimeout = Timeout.FlexTimeout("done", duration)
+    for {
+      _ <- requestRegistry.register(
+        Examples.done,
+        doneTimeout,
+      )
+      _ <- requestRegistry.register(
+        Examples.done,
+        doneTimeout,
+      )
+      _ <- requestRegistry.register(
+        Examples.done,
+        doneTimeout,
+      )
+      _ <- requestRegistry.register(Examples.fast)
+      _ <- requestRegistry.register(Examples.fast)
+      _ <- requestRegistry.register(Examples.fast)
+      _ = assert(
+        requestRegistry.getTimeout(Timeout.DefaultFlexTimeout).get > duration
+      )
+      _ = assert(
+        requestRegistry
+          .getTimeout(Timeout.DefaultFlexTimeout)
+          .get < duration * 2
+      )
+      _ = assert(requestRegistry.getTimeout(doneTimeout).get == duration)
+    } yield ()
+  }
+
+  test("timeout") {
+    val requestRegistry = createRegistry()
+    for {
+      err <- requestRegistry
+        .register(Examples.infinite)
+        .failed
+      _ = assert(err.isInstanceOf[TimeoutException])
+      _ = assertEquals(
+        requestRegistry.getTimeout(Timeout.DefaultFlexTimeout).get,
+        duration * 3,
+      )
+      _ <- requestRegistry.register(Examples.fast)
+    } yield ()
+  }
+
+  test("cancel") {
+    val requestRegistry = createRegistry()
+    val f1 = requestRegistry.register(Examples.fast, isCompile = true)
+    val f2 = requestRegistry.register(Examples.fast)
+    requestRegistry.cancelCompilations()
+    for {
+      err <- f1.failed
+      _ = assert(err.isInstanceOf[CancellationException])
+      _ <- f2
+    } yield ()
+  }
+
+  test("cancel-all") {
+    val requestRegistry = createRegistry()
+    val f1 = requestRegistry.register(Examples.fast, isCompile = true)
+    val f2 = requestRegistry.register(Examples.fast)
+    requestRegistry.cancel()
+    for {
+      err <- f1.failed
+      _ = assert(err.isInstanceOf[CancellationException])
+      err <- f2.failed
+      _ = assert(err.isInstanceOf[CancellationException])
+    } yield ()
+  }
+
+}
+
+object RequestType extends Enumeration {
+  val Type1, Type2 = Value
+}
+
+object Examples {
+  def infinite: () => CompletableFuture[Void] = () =>
+    CompletableFuture.runAsync(
+      new Runnable {
+        def run() = while (0 == 0) { Thread.sleep(500) }
+      }
+    )
+
+  def fast: () => CompletableFuture[Void] = () =>
+    CompletableFuture.runAsync(
+      new Runnable {
+        def run() = Thread.sleep(500)
+      }
+    )
+
+  def done: () => CompletableFuture[Int] = () =>
+    CompletableFuture.completedFuture(2)
+}

--- a/tests/unit/src/test/scala/tests/RequestRegistrySuite.scala
+++ b/tests/unit/src/test/scala/tests/RequestRegistrySuite.scala
@@ -30,7 +30,8 @@ class RequestRegistrySuite extends FunSuite {
       onTimeout: () => MessageActionItem = () => Messages.RequestTimeout.cancel
   ) =
     new RequestRegistry(List(), new RequestRegistrySuite.Client(onTimeout))
-  val defaultTimeout: Some[Timeout] = Some(Timeout.default("request", duration))
+  val defaultTimeout: Some[Timeout] = Some(Timeout.default(duration))
+  val askIfCancelTimeout: Some[Timeout] = Some(Timeout("ask", duration))
 
   test("avg") {
     val requestRegistry = createRegistry()
@@ -122,7 +123,7 @@ class RequestRegistrySuite extends FunSuite {
       err <- requestRegistry
         .register(
           ExampleFutures.infinite(promise1),
-          defaultTimeout,
+          askIfCancelTimeout,
         )
         .future
         .failed

--- a/tests/unit/src/test/scala/tests/TimeoutSuite.scala
+++ b/tests/unit/src/test/scala/tests/TimeoutSuite.scala
@@ -23,10 +23,14 @@ class TimeoutSuite extends FunSuite {
   implicit val ex: ExecutionContextExecutorService =
     ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
   val duration: FiniteDuration = Duration(1, TimeUnit.SECONDS)
+  val onTimeout: Duration => Future[FutureWithTimeout.OnTimeout] = _ =>
+    Future.successful(FutureWithTimeout.Cancel)
 
   test("simple-timeout") {
     val promise = Promise[Unit]()
-    val f = FutureWithTimeout(duration)(ExampleFutures.infinite(promise)).future
+    val f = FutureWithTimeout(duration, onTimeout)(
+      ExampleFutures.infinite(promise)
+    ).future
     assert(!f.isCompleted)
 
     for {
@@ -42,7 +46,7 @@ class TimeoutSuite extends FunSuite {
   }
 
   test("no-timeout") {
-    FutureWithTimeout(duration)(ExampleFutures.fast).future.map {
+    FutureWithTimeout(duration, onTimeout)(ExampleFutures.fast).future.map {
       case (res, time) =>
         assert(time.toMillis >= ExampleFutures.timeStep)
         assertEquals(res, 1)
@@ -54,14 +58,20 @@ class TimeoutSuite extends FunSuite {
     val timeouts = new Timeouts(min(3))
     val flexTimeout = Timeout.FlexTimeout("flex", min(6))
     assertEquals(timeouts.getTimeout(Timeout.NoTimeout), None)
-    assertEquals(timeouts.getTimeout(Timeout.DefaultFlexTimeout), Some(min(3)))
+    assertEquals(
+      timeouts.getTimeout(Timeout.DefaultFlexTimeout("request")),
+      Some(min(3)),
+    )
     assertEquals(timeouts.getTimeout(flexTimeout), Some(min(6)))
-    timeouts.measured(Timeout.DefaultFlexTimeout, min(1))
-    timeouts.measured(Timeout.DefaultFlexTimeout, min(3))
+    timeouts.measured(Timeout.DefaultFlexTimeout("request"), min(1))
+    timeouts.measured(Timeout.DefaultFlexTimeout("request"), min(3))
     timeouts.measured(flexTimeout, min(1))
     timeouts.measured(flexTimeout, min(2))
     // avg * 3 > min
-    assertEquals(timeouts.getTimeout(Timeout.DefaultFlexTimeout), Some(min(6)))
+    assertEquals(
+      timeouts.getTimeout(Timeout.DefaultFlexTimeout("request")),
+      Some(min(6)),
+    )
     // avg * 3 < min
     assertEquals(timeouts.getTimeout(flexTimeout), Some(min(6)))
   }

--- a/tests/unit/src/test/scala/tests/TimeoutSuite.scala
+++ b/tests/unit/src/test/scala/tests/TimeoutSuite.scala
@@ -55,25 +55,25 @@ class TimeoutSuite extends FunSuite {
 
   test("timeouts") {
     def min(int: Int) = Duration(int, TimeUnit.MINUTES)
-    val timeouts = new Timeouts(min(3))
-    val flexTimeout = Timeout.FlexTimeout("flex", min(6))
-    assertEquals(timeouts.getTimeout(Timeout.NoTimeout), None)
+    val defaultTime = Timeout.default("request", min(3))
+    val timeouts = new Timeouts()
+    val flexTimeout = Timeout("flex", min(6))
     assertEquals(
-      timeouts.getTimeout(Timeout.DefaultFlexTimeout("request")),
-      Some(min(3)),
+      timeouts.getTimeout(defaultTime),
+      min(3),
     )
-    assertEquals(timeouts.getTimeout(flexTimeout), Some(min(6)))
-    timeouts.measured(Timeout.DefaultFlexTimeout("request"), min(1))
-    timeouts.measured(Timeout.DefaultFlexTimeout("request"), min(3))
+    assertEquals(timeouts.getTimeout(flexTimeout), min(6))
+    timeouts.measured(defaultTime, min(1))
+    timeouts.measured(defaultTime, min(3))
     timeouts.measured(flexTimeout, min(1))
     timeouts.measured(flexTimeout, min(2))
     // avg * 3 > min
     assertEquals(
-      timeouts.getTimeout(Timeout.DefaultFlexTimeout("request")),
-      Some(min(6)),
+      timeouts.getTimeout(defaultTime),
+      min(6),
     )
     // avg * 3 < min
-    assertEquals(timeouts.getTimeout(flexTimeout), Some(min(6)))
+    assertEquals(timeouts.getTimeout(flexTimeout), min(6))
   }
 }
 

--- a/tests/unit/src/test/scala/tests/TimeoutSuite.scala
+++ b/tests/unit/src/test/scala/tests/TimeoutSuite.scala
@@ -1,0 +1,72 @@
+package tests
+
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutorService
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+
+import scala.meta.internal.metals.utils.FutureWithTimeout
+import scala.meta.internal.metals.utils.Timeout
+import scala.meta.internal.metals.utils.Timeouts
+
+import munit.FunSuite
+
+class TimeoutSuite extends FunSuite {
+  implicit val ex: ExecutionContextExecutorService =
+    ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
+  val duration: FiniteDuration = Duration(1, TimeUnit.SECONDS)
+
+  test("simple-timeout") {
+    val f = FutureWithTimeout(duration)(ExampleFutures.infinite)
+    assert(!f.isCompleted)
+    f.failed.map {
+      case _: TimeoutException =>
+      case _ =>
+        throw new RuntimeException("future should have thrown TimeoutException")
+    }
+  }
+
+  test("no-timeout") {
+    val timeBefore = System.currentTimeMillis()
+    val future = ExampleFutures.fast
+    FutureWithTimeout(duration)(future, timeBefore).map { case (res, time) =>
+      assert(time.toMillis >= ExampleFutures.timeStep)
+      assertEquals(res, 1)
+    }
+  }
+
+  test("timeouts") {
+    def min(int: Int) = Duration(int, TimeUnit.MINUTES)
+    val timeouts = new Timeouts(min(3))
+    val flexTimeout = Timeout.FlexTimeout("flex", min(6))
+    assertEquals(timeouts.getTimeout(Timeout.NoTimeout), None)
+    assertEquals(timeouts.getTimeout(Timeout.DefaultFlexTimeout), Some(min(3)))
+    assertEquals(timeouts.getTimeout(flexTimeout), Some(min(6)))
+    timeouts.measured(Timeout.DefaultFlexTimeout, min(1))
+    timeouts.measured(Timeout.DefaultFlexTimeout, min(3))
+    timeouts.measured(flexTimeout, min(1))
+    timeouts.measured(flexTimeout, min(2))
+    // avg * 3 > min
+    assertEquals(timeouts.getTimeout(Timeout.DefaultFlexTimeout), Some(min(6)))
+    // avg * 3 < min
+    assertEquals(timeouts.getTimeout(flexTimeout), Some(min(6)))
+  }
+}
+
+object ExampleFutures {
+  val timeStep = 500 // 1/2 sec
+
+  def infinite(implicit ex: ExecutionContext): Future[Unit] = Future {
+    while (0 == 0) { Thread.sleep(timeStep) }
+  }
+
+  def fast(implicit ex: ExecutionContext): Future[Int] = Future {
+    Thread.sleep(timeStep)
+    1
+  }
+}

--- a/tests/unit/src/test/scala/tests/TimeoutSuite.scala
+++ b/tests/unit/src/test/scala/tests/TimeoutSuite.scala
@@ -55,7 +55,7 @@ class TimeoutSuite extends FunSuite {
 
   test("timeouts") {
     def min(int: Int) = Duration(int, TimeUnit.MINUTES)
-    val defaultTime = Timeout.default("request", min(3))
+    val defaultTime = Timeout.default(min(3))
     val timeouts = new Timeouts()
     val flexTimeout = Timeout("flex", min(6))
     assertEquals(


### PR DESCRIPTION
In some erroneous situations build server fails to respond, which in metals for e.g. compilation blocks the queue. This PR adds timeout to the requests, so in such situations we can recover.