### PR TITLE
Scala2 - deduplicate NamedArgParams with Def params

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -297,10 +297,13 @@ class CompletionProvider(
           head match {
             case o: OverrideDefMember =>
               o.label
+            case named: NamedArgMember =>
+              s"named-${semanticdbSymbol(named.sym)}"
             case _ =>
               semanticdbSymbol(head.sym)
           }
         }
+
       def isIgnoredWorkspace: Boolean =
         head.isInstanceOf[WorkspaceMember] &&
           (isIgnored(head.sym) || isIgnored(head.sym.companion))

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -23,14 +23,14 @@ class CompletionArgSuite extends BaseCompletionSuite {
   check(
     "arg-newline",
     s"""|object Main {
-        |  def foo(banana: String, apple: String) = ???
+        |  def foo(banana: String, tomato: String) = ???
         |  foo(
         |    @@
         |  )
         |}
         |""".stripMargin,
-    """|apple = : String
-       |banana = : String
+    """|banana = : String
+       |tomato = : String
        |""".stripMargin,
     topLines = Option(2),
   )
@@ -695,6 +695,29 @@ class CompletionArgSuite extends BaseCompletionSuite {
            |foo = a : Int
            |fooBar = : Int
            |fooBar = a : Int
+           |""".stripMargin
+    ),
+    topLines = Some(4),
+  )
+
+  check(
+    "recursive",
+    """|
+       |object Main {
+       |   def foo(value: Int): Int = {
+       |     foo(valu@@)
+       |   }
+       |}
+       |""".stripMargin,
+    """|value: Int
+       |value = : Int
+       |value = value : Int
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|value = : Int
+           |value = value : Int
+           |value: Int
            |""".stripMargin
     ),
     topLines = Some(4),


### PR DESCRIPTION
NamedArgParam is based on actual symbol, in the following case the valid symbol `param` and correspoding NamedArgParam(`param`) were clashing
```
def foo(param: Int): Int = {
  foo(para@@)
}
```