### PR TITLE
fix: Fix memory leak in tests

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -362,7 +362,8 @@ final case class Indexer(
       sh.schedule(
         new Runnable {
           override def run(): Unit = {
-            tables.jarSymbols.deleteNotUsedTopLevels(usedJars.toArray)
+            if (tables.databaseExists())
+              tables.jarSymbols.deleteNotUsedTopLevels(usedJars.toArray)
           }
         },
         2,

--- a/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Tables.scala
@@ -71,6 +71,9 @@ final class Tables(
     }
   }
 
+  def databaseExists(): Boolean =
+    databasePath.exists
+
   private def connection: Connection = connect()
 
   // The try/catch dodge-ball court in these methods is not glamorous, I'm sure it can be refactored for more


### PR DESCRIPTION
When running unit tests, connections with database were not correctly closed, which resulted in memory leak and not killing all threads. First, database connection was closed correctly, but Indexer shedules removal of unused jars from cache after 2 seconds, which was creating new database and never closing it.