### PR TITLE
fix: InverseSemanticdbSymbols for symbolic names

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -507,7 +507,11 @@ class MetalsGlobal(
       else if (s.isEmptyPackage) rootMirror.EmptyPackage :: Nil
       else if (s.isPackage) {
         try {
-          rootMirror.staticPackage(s.stripSuffix("/").replace("/", ".")) :: Nil
+          val pkg = s
+            .split("/")
+            .map(n => TermName(n.stripBackticks).encoded)
+            .mkString(".")
+          rootMirror.staticPackage(pkg) :: Nil
         } catch {
           case NonFatal(_) =>
             Nil
@@ -525,20 +529,25 @@ class MetalsGlobal(
                 case Descriptor.None =>
                   Nil
                 case Descriptor.Type(value) =>
-                  val member = owner.info.decl(TypeName(value)) :: Nil
-                  if (sym.isJava) owner.info.decl(TermName(value)) :: member
+                  val member = owner.info.decl(TypeName(value).encode) :: Nil
+                  if (sym.isJava)
+                    owner.info.decl(TermName(value).encode) :: member
                   else member
                 case Descriptor.Term(value) =>
-                  owner.info.decl(TermName(value)) :: Nil
+                  owner.info.decl(TermName(value).encode) :: Nil
                 case Descriptor.Package(value) =>
-                  owner.info.decl(TermName(value)) :: Nil
+                  owner.info.decl(TermName(value).encode) :: Nil
                 case Descriptor.Parameter(value) =>
-                  owner.paramss.flatten.filter(_.name.containsName(value))
+                  owner.paramss.flatten.filter(
+                    _.name.decodedName.containsName(value)
+                  )
                 case Descriptor.TypeParameter(value) =>
-                  owner.typeParams.filter(_.name.containsName(value))
+                  owner.typeParams.filter(
+                    _.name.decodedName.containsName(value)
+                  )
                 case Descriptor.Method(value, _) =>
                   owner.info
-                    .decl(TermName(value))
+                    .decl(TermName(value).encode)
                     .alternatives
                     .iterator
                     .filter(sym => semanticdbSymbol(sym) == s)

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1306,6 +1306,12 @@ final case class TestingServer(
     }
   }
 
+  def completionItemResolve(
+      item: l.CompletionItem
+  ): Future[l.CompletionItem] = {
+    fullServer.completionItemResolve(item).asScala
+  }
+
   def codeAction(
       filename: String,
       query: String,


### PR DESCRIPTION
Symbols in compiler have encoded names (eg. `$at$at` instead of `@@`) so we need to encode semanticdb symbols before matching on name.

Fixes https://github.com/scalameta/metals/issues/5469 and https://github.com/scalameta/metals/issues/5065