### PR TITLE
bugfix: Bump scalatest to fix zip issue

### DIFF
--- a/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
@@ -613,7 +613,7 @@ class SbtBloopLspSuite
             |import sbt._
             |import Keys._
             |object Deps {
-            |  val scalatest = "org.scalatest" %% "scalatest" % "3.2.4"
+            |  val scalatest = "org.scalatest" %% "scalatest" % "3.2.16"
             |}
          """.stripMargin
       )
@@ -623,7 +623,7 @@ class SbtBloopLspSuite
            |val scalatest: ModuleID
            |```
            |```range
-           |val scalatest = "org.scalatest" %% "scalatest" % "3.2.4"
+           |val scalatest = "org.scalatest" %% "scalatest" % "3.2.16"
            |```
            |""".stripMargin
       _ = assertNoDiff(hoverRes, expectedHoverRes)

--- a/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
@@ -46,7 +46,7 @@ class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
        |""".stripMargin
   )
 
-  check("test-suite-class", library = Some("org.scalatest::scalatest:3.2.4"))(
+  check("test-suite-class", library = Some("org.scalatest::scalatest:3.2.16"))(
     """|package foo.bar
        |<<test>><<debug test>>
        |class Foo extends org.scalatest.funsuite.AnyFunSuite {
@@ -56,7 +56,7 @@ class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
 
   checkTestCases(
     "test-suite-with-tests",
-    library = Some("org.scalatest::scalatest:3.2.4"),
+    library = Some("org.scalatest::scalatest:3.2.16"),
   )(
     """|package foo.bar
        |<<test>><<debug test>>

--- a/tests/unit/src/test/scala/tests/DebugDiscoverySuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugDiscoverySuite.scala
@@ -97,7 +97,7 @@ class DebugDiscoverySuite
         s"""/metals.json
            |{
            |  "a": {
-           |    "libraryDependencies":["org.scalatest::scalatest:3.2.4"]
+           |    "libraryDependencies":["org.scalatest::scalatest:3.2.16"]
            |  }
            |}
            |/${fooPath}
@@ -337,7 +337,7 @@ class DebugDiscoverySuite
         s"""/metals.json
            |{
            |  "a": {
-           |    "libraryDependencies":["org.scalatest::scalatest:3.2.4"]
+           |    "libraryDependencies":["org.scalatest::scalatest:3.2.16"]
            |  }
            |}
            |/${fooPath}
@@ -370,7 +370,7 @@ class DebugDiscoverySuite
         s"""/metals.json
            |{
            |  "a": {
-           |    "libraryDependencies":["org.scalatest::scalatest:3.2.4"]
+           |    "libraryDependencies":["org.scalatest::scalatest:3.2.16"]
            |  }
            |}
            |/${fooPath}
@@ -439,7 +439,7 @@ class DebugDiscoverySuite
         s"""/metals.json
            |{
            |  "a": {
-           |    "libraryDependencies":["org.scalatest::scalatest:3.2.4"]
+           |    "libraryDependencies":["org.scalatest::scalatest:3.2.16"]
            |  }
            |}
            |/${fooPath}

--- a/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
@@ -286,7 +286,7 @@ class DebugProtocolSuite
         s"""/metals.json
            |{
            |  "a": {
-           |    "libraryDependencies":["org.scalatest::scalatest:3.2.4"]
+           |    "libraryDependencies":["org.scalatest::scalatest:3.2.16"]
            |  }
            |}
            |/a/src/main/scala/a/Foo.scala
@@ -427,7 +427,7 @@ class DebugProtocolSuite
         s"""/metals.json
            |{
            |  "a": {
-           |    "libraryDependencies":["org.scalatest::scalatest:3.2.4"]
+           |    "libraryDependencies":["org.scalatest::scalatest:3.2.16"]
            |  }
            |}
            |/a/src/main/scala/a/Foo.scala
@@ -458,7 +458,7 @@ class DebugProtocolSuite
         s"""/metals.json
            |{
            |  "a": {
-           |    "libraryDependencies":["org.scalatest::scalatest:3.2.4"]
+           |    "libraryDependencies":["org.scalatest::scalatest:3.2.16"]
            |  }
            |}
            |/a/src/main/scala/a/Foo.scala

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -26,7 +26,7 @@ class DefinitionLspSuite extends BaseLspSuite("definition") {
            |  "a": { },
            |  "b": {
            |    "libraryDependencies": [
-           |      "org.scalatest::scalatest:3.2.4"
+           |      "org.scalatest::scalatest:3.2.16"
            |    ],
            |    "dependsOn": [ "a" ]
            |  }

--- a/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
+++ b/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
@@ -67,7 +67,8 @@ class FindTextInDependencyJarsSuite
       assertLocations(
         jdkLocations, {
           val line =
-            if (isJavaAtLeast17) 1445
+            if (isJavaAtLeast17 && isWindows) 1449
+            else if (isJavaAtLeast17) 1445
             else if (isJavaAtLeast9) 626
             else 578
 

--- a/tests/unit/src/test/scala/tests/ImplementationLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ImplementationLspSuite.scala
@@ -572,7 +572,7 @@ class ImplementationLspSuite extends BaseRangesSuite("implementation") {
   )
 
   override protected def libraryDependencies: List[String] =
-    List("org.scalatest::scalatest:3.2.4", "io.circe::circe-generic:0.12.0")
+    List("org.scalatest::scalatest:3.2.16", "io.circe::circe-generic:0.12.0")
 
   override def assertCheck(
       filename: String,

--- a/tests/unit/src/test/scala/tests/NewProjectLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewProjectLspSuite.scala
@@ -40,7 +40,7 @@ class NewProjectLspSuite extends BaseLspSuite("new-project") {
         |    name := "scalatest-example"
         |  )
         |
-        |libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.4" % Test
+        |libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.16" % Test
         |
         |
         |/$name/project/build.properties

--- a/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
+++ b/tests/unit/src/test/scala/tests/QuickBuildSuite.scala
@@ -22,7 +22,7 @@ class QuickBuildSuite extends BaseLspSuite(s"quick-build") {
           |  "b": {
           |    "scalacOptions": [ "-Wunused" ],
           |    "libraryDependencies": [
-          |      "org.scalatest::scalatest:3.2.4"
+          |      "org.scalatest::scalatest:3.2.16"
           |    ],
           |    "dependsOn": [ "a" ]
           |  }


### PR DESCRIPTION
It seems with newer JDK version there is a special additional check that fails with the jar of scalactic at the previous version.

Let's see if updating it helps.

Related to https://github.com/openjdk/jdk/commit/fff7e1ad00be07810bf948b8a6f94e83c435fa1f