### PR TITLE
improvement: print better bracket suffix in label, Scala 3 completions

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionSuffix.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionSuffix.scala
@@ -8,12 +8,7 @@ case class CompletionSuffix(
     suffixes: Set[SuffixKind],
     snippet: SuffixKind,
 ):
-  def labelSnippet =
-    suffixes.collectFirst {
-      case SuffixKind.Bracket(1) => "[T]"
-      case SuffixKind.Bracket(n) =>
-        (for (i <- 1 to n) yield s"T$i").mkString("[", ", ", "]")
-    }
+  def addLabelSnippet = suffixes.contains(SuffixKind.Bracket)
   def hasSnippet = snippet != SuffixKind.NoSuffix
   def chain(copyFn: CompletionSuffix => CompletionSuffix) = copyFn(this)
   def withNewSuffix(kind: SuffixKind) =
@@ -25,7 +20,7 @@ case class CompletionSuffix(
       def cursor = if suffixes.head == snippet then "$0" else ""
       suffixes match
         case SuffixKind.Brace :: tail => s"($cursor)" + loop(tail)
-        case SuffixKind.Bracket(_) :: tail => s"[$cursor]" + loop(tail)
+        case SuffixKind.Bracket :: tail => s"[$cursor]" + loop(tail)
         case SuffixKind.Template :: tail => s" {$cursor}" + loop(tail)
         case _ => ""
     loop(suffixes.toList)
@@ -41,7 +36,4 @@ object CompletionSuffix:
   )
 
 enum SuffixKind:
-  case Brace extends SuffixKind
-  case Bracket(typeParamsCount: Int) extends SuffixKind
-  case Template extends SuffixKind
-  case NoSuffix extends SuffixKind
+  case Brace, Bracket, Template, NoSuffix

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.pc
 package completions
 
+import scala.meta.internal.mtags.MtagsEnrichments.decoded
 import scala.meta.internal.pc.printer.MetalsPrinter
 
 import dotty.tools.dotc.core.Contexts.Context
@@ -33,9 +34,7 @@ sealed trait CompletionValue:
    * Label with potentially attached description.
    */
   def labelWithDescription(printer: MetalsPrinter)(using Context): String =
-    labelWithSuffix
-  def labelWithSuffix: String =
-    s"$label${snippetSuffix.labelSnippet.getOrElse("")}"
+    label
   def lspTags(using Context): List[CompletionItemTag] = Nil
 end CompletionValue
 
@@ -75,14 +74,24 @@ object CompletionValue:
     override def labelWithDescription(
         printer: MetalsPrinter
     )(using Context): String =
-      if symbol.is(Method) then s"${labelWithSuffix}${description(printer)}"
-      else if symbol.isConstructor then labelWithSuffix
-      else if symbol.is(Mutable) then
-        s"${labelWithSuffix}: ${description(printer)}"
+      if symbol.is(Method) then s"${label}${description(printer)}"
+      else if symbol.isConstructor then label
+      else if symbol.is(Mutable) then s"$label: ${description(printer)}"
       else if symbol.is(Package) || symbol.is(Module) || symbol.isClass then
-        if isFromWorkspace then s"${labelWithSuffix} -${description(printer)}"
-        else s"${labelWithSuffix}${description(printer)}"
-      else s"${labelWithSuffix}: ${description(printer)}"
+        if isFromWorkspace then
+          s"${labelWithSuffix(printer)} -${description(printer)}"
+        else s"${labelWithSuffix(printer)}${description(printer)}"
+      else if symbol.isType then s"$label${description(printer)}"
+      else s"$label: ${description(printer)}"
+
+    private def labelWithSuffix(printer: MetalsPrinter)(using Context): String =
+      if snippetSuffix.addLabelSnippet
+      then
+        val printedParams = symbol.info.typeParams.map(p =>
+          p.paramName.decoded ++ printer.tpe(p.paramInfo)
+        )
+        s"${label}${printedParams.mkString("[", ",", "]")}"
+      else label
 
     override def description(printer: MetalsPrinter)(using Context): String =
       printer.completionSymbol(symbol)
@@ -93,7 +102,11 @@ object CompletionValue:
       symbol: Symbol,
       override val snippetSuffix: CompletionSuffix,
   ) extends Symbolic
-  case class Scope(label: String, symbol: Symbol) extends Symbolic
+  case class Scope(
+      label: String,
+      symbol: Symbol,
+      override val snippetSuffix: CompletionSuffix,
+  ) extends Symbolic
   case class Workspace(
       label: String,
       symbol: Symbol,
@@ -259,6 +272,4 @@ object CompletionValue:
   ): CompletionValue =
     Document(label, insertText, description)
 
-  def scope(label: String, sym: Symbol): CompletionValue =
-    Scope(label, sym)
 end CompletionValue

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -81,7 +81,7 @@ object CompletionValue:
         if isFromWorkspace then
           s"${labelWithSuffix(printer)} -${description(printer)}"
         else s"${labelWithSuffix(printer)}${description(printer)}"
-      else if symbol.isType then s"$label${description(printer)}"
+      else if symbol.isType then labelWithSuffix(printer)
       else s"$label: ${description(printer)}"
 
     private def labelWithSuffix(printer: MetalsPrinter)(using Context): String =

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -139,6 +139,11 @@ class MetalsPrinter(
       else " " + dotcPrinter.fullName(sym.effectiveOwner)
     else if sym.is(Flags.Method) then
       defaultMethodSignature(sym, info, onlyMethodParams = true)
+    else if sym.isType
+    then
+      info match
+        case TypeAlias(t) => " = " + tpe(t.resultType)
+        case t => tpe(t.resultType)
     else tpe(info)
     end if
   end completionSymbol

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -140,6 +140,8 @@ class MetalsPrinter(
     else if sym.is(Flags.Method) then
       defaultMethodSignature(sym, info, onlyMethodParams = true)
     else tpe(info)
+    end if
+  end completionSymbol
 
   /**
    * Compute method signature for the given (method) symbol.

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -213,7 +213,12 @@ abstract class BasePCSuite extends BaseSuite with PCSuite {
   }
 
   case class IgnoreScalaVersion(ignored: String => Boolean)
-      extends Tag("NoScalaVersion")
+      extends Tag("NoScalaVersion") {
+    def and(other: IgnoreScalaVersion): IgnoreScalaVersion =
+      IgnoreScalaVersion { v =>
+        ignored(v) || other.ignored(v)
+      }
+  }
 
   object IgnoreScalaVersion {
     def apply(version: String): IgnoreScalaVersion = {
@@ -248,7 +253,7 @@ abstract class BasePCSuite extends BaseSuite with PCSuite {
       }
     }
 
-    def forLaterThan(version: String): IgnoreScalaVersion = {
+    def forLaterOrEqualTo(version: String): IgnoreScalaVersion = {
       val disableFrom = SemVer.Version.fromString(version)
       IgnoreScalaVersion { v =>
         val semver = SemVer.Version.fromString(v)
@@ -263,6 +268,9 @@ abstract class BasePCSuite extends BaseSuite with PCSuite {
   object IgnoreScala212 extends IgnoreScalaVersion(_.startsWith("2.12"))
 
   object IgnoreScala3 extends IgnoreScalaVersion(_.startsWith("3."))
+
+  val IgnoreForScala3CompilerPC: IgnoreScalaVersion =
+    IgnoreScalaVersion.forLaterOrEqualTo(BuildInfoVersions.firstScala3PCVersion)
 
   case class RunForScalaVersion(versions: Set[String])
       extends Tag("RunScalaVersion")

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1645,6 +1645,20 @@ class CompletionSuite extends BaseCompletionSuite {
         | val t: TT@@
         |}
         |""".stripMargin,
+    "TTT",
+    compat = Map(
+      "3" -> "TTT[A <: Int]"
+    ),
+    includeDetail = false,
+  )
+
+  check(
+    "type-with-params-with-detail",
+    s"""|object O {
+        | type TTT[A <: Int] = List[A]
+        | val t: TT@@
+        |}
+        |""".stripMargin,
     "TTT[A] = O.TTT",
     compat = Map(
       "3" -> "TTT[A <: Int] = List[A]"
@@ -1658,7 +1672,8 @@ class CompletionSuite extends BaseCompletionSuite {
         | val t: TT@@
         |}
         |""".stripMargin,
-    "TTT[A <: Int] = List[A]",
+    "TTT[A <: Int]",
+    includeDetail = false,
   )
 
   check(
@@ -1668,7 +1683,31 @@ class CompletionSuite extends BaseCompletionSuite {
         | val t: TT@@
         |}
         |""".stripMargin,
+    "TTT[K <: Int]",
+    includeDetail = false,
+  )
+
+  check(
+    "type-lambda2-with-detail".tag(IgnoreScala2),
+    s"""|object O {
+        | type TTT[K <: Int] = [V] =>> Map[K, V]
+        | val t: TT@@
+        |}
+        |""".stripMargin,
     "TTT[K <: Int] = [V] =>> Map[K, V]",
+  )
+
+  check(
+    "type-bound",
+    s"""|trait O {
+        | type TTT <: Int
+        | val t: TT@@
+        |}
+        |""".stripMargin,
+    "TTT<: O.TTT",
+    compat = Map(
+      "3" -> "TTT <: Int"
+    ),
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -908,7 +908,7 @@ class CompletionSuite extends BaseCompletionSuite {
        |""".stripMargin,
     compat = Map(
       "3" ->
-        """|ListBuffer[T] - scala.collection.mutable
+        """|ListBuffer[A] - scala.collection.mutable
            |ListBuffer - scala.collection.mutable
            |""".stripMargin
     ),
@@ -924,7 +924,7 @@ class CompletionSuite extends BaseCompletionSuite {
        |""".stripMargin,
     compat = Map(
       "3" ->
-        """|ListBuffer[T] - scala.collection.mutable
+        """|ListBuffer[A] - scala.collection.mutable
            |ListBuffer - scala.collection.mutable
            |""".stripMargin
     ),
@@ -1636,6 +1636,57 @@ class CompletionSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     "abcCURSORde: Unit",
+  )
+
+  check(
+    "type-with-params",
+    s"""|object O {
+        | type TTT[A <: Int] = List[A]
+        | val t: TT@@
+        |}
+        |""".stripMargin,
+    "TTT[A] = O.TTT",
+    compat = Map(
+      "3" -> "TTT[A <: Int] = List[A]"
+    ),
+  )
+
+  check(
+    "type-lambda".tag(IgnoreScala2),
+    s"""|object O {
+        | type TTT = [A <: Int] =>> List[A]
+        | val t: TT@@
+        |}
+        |""".stripMargin,
+    "TTT[A <: Int] = List[A]",
+  )
+
+  check(
+    "type-lambda2".tag(IgnoreScala2),
+    s"""|object O {
+        | type TTT[K <: Int] = [V] =>> Map[K, V]
+        | val t: TT@@
+        |}
+        |""".stripMargin,
+    "TTT[K <: Int] = [V] =>> Map[K, V]",
+  )
+
+  check(
+    "class-with-params",
+    s"""|object O {
+        | class AClass[A <: Int]
+        | object AClass
+        | val v: ACla@@
+        |}
+        |""".stripMargin,
+    "AClass `class-with-params`.O",
+    compat = Map(
+      "3" ->
+        """|AClass[A <: Int] class-with-params.O
+           |AClass class-with-params.O
+           |AbstractTypeClassManifest - scala.reflect.ClassManifestFactory
+           |""".stripMargin
+    ),
   )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -899,7 +899,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "type",
+    "type".tag(IgnoreForScala3CompilerPC),
     s"""|object Main {
         |  val foo: ListBuffe@@
         |}
@@ -915,7 +915,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "type1",
+    "type1".tag(IgnoreForScala3CompilerPC),
     s"""|object Main {
         |  val foo: Map[Int, ListBuffe@@]
         |}
@@ -1639,7 +1639,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "type-with-params",
+    "type-with-params".tag(IgnoreForScala3CompilerPC),
     s"""|object O {
         | type TTT[A <: Int] = List[A]
         | val t: TT@@
@@ -1653,7 +1653,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "type-with-params-with-detail",
+    "type-with-params-with-detail".tag(IgnoreForScala3CompilerPC),
     s"""|object O {
         | type TTT[A <: Int] = List[A]
         | val t: TT@@
@@ -1666,7 +1666,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "type-lambda".tag(IgnoreScala2),
+    "type-lambda".tag(IgnoreScala2.and(IgnoreForScala3CompilerPC)),
     s"""|object O {
         | type TTT = [A <: Int] =>> List[A]
         | val t: TT@@
@@ -1677,7 +1677,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "type-lambda2".tag(IgnoreScala2),
+    "type-lambda2".tag(IgnoreScala2.and(IgnoreForScala3CompilerPC)),
     s"""|object O {
         | type TTT[K <: Int] = [V] =>> Map[K, V]
         | val t: TT@@
@@ -1688,7 +1688,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "type-lambda2-with-detail".tag(IgnoreScala2),
+    "type-lambda2-with-detail".tag(IgnoreScala2.and(IgnoreForScala3CompilerPC)),
     s"""|object O {
         | type TTT[K <: Int] = [V] =>> Map[K, V]
         | val t: TT@@
@@ -1698,7 +1698,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "type-bound",
+    "type-bound".tag(IgnoreForScala3CompilerPC),
     s"""|trait O {
         | type TTT <: Int
         | val t: TT@@
@@ -1711,7 +1711,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "class-with-params",
+    "class-with-params".tag(IgnoreForScala3CompilerPC),
     s"""|object O {
         | class AClass[A <: Int]
         | object AClass

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -764,7 +764,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
       "3" ->
         """|Future[T] scala.concurrent
            |Future scala.concurrent
-           |Future[T] - java.util.concurrent
+           |Future[V] - java.util.concurrent
            |""".stripMargin,
     ),
   )
@@ -790,7 +790,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
            |FutureOps - scala.jdk.FutureConverters
            |""".stripMargin,
       "3" ->
-        """|Future[T] java.util.concurrent
+        """|Future[V] java.util.concurrent
            |Future java.util.concurrent
            |Future[T] - scala.concurrent
            |""".stripMargin,

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -742,7 +742,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
   )
 
   check(
-    "ordering-1",
+    "ordering-1".tag(IgnoreForScala3CompilerPC),
     """|import scala.concurrent.Future
        |object Main {
        |  def foo(
@@ -770,7 +770,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
   )
 
   check(
-    "ordering-2",
+    "ordering-2".tag(IgnoreForScala3CompilerPC),
     """|import java.util.concurrent.Future
        |object Main {
        |  def foo(

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -651,15 +651,15 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |  val <<c>> = new Foo { type T = Int; type G = Long}
        |}
        |""".stripMargin,
-   """|object O{
-      |  trait Foo {
-      |    type T
-      |    type G
-      |  }
-      |
-      |  val c: Foo{type T = Int; type G = Long} = new Foo { type T = Int; type G = Long}
-      |}
-      |""".stripMargin
+    """|object O{
+       |  trait Foo {
+       |    type T
+       |    type G
+       |  }
+       |
+       |  val c: Foo{type T = Int; type G = Long} = new Foo { type T = Int; type G = Long}
+       |}
+       |""".stripMargin,
   )
 
   checkEdit(

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -637,14 +637,7 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   )
 
   val defaultRefinedTypes: String =
-    """|object O{
-       |  trait Foo {
-       |    type T
-       |    type G
-       |  }
-       |
-       |  val c: Foo{type T = Int; type G = Long} = new Foo { type T = Int; type G = Long}
-       |}
+    """|
        |""".stripMargin
 
   checkEdit(
@@ -658,31 +651,16 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |  val <<c>> = new Foo { type T = Int; type G = Long}
        |}
        |""".stripMargin,
-    defaultRefinedTypes,
-    compat = Map(
-      scala3PresentationCompilerVersion -> defaultRefinedTypes,
-      "3" ->
-        """|object O{
-           |  trait Foo {
-           |    type T
-           |    type G
-           |  }
-           |
-           |  val c: Foo{type T >: Int <: Int; type G >: Long <: Long} = new Foo { type T = Int; type G = Long}
-           |}
-           |""".stripMargin,
-    ),
+   """|object O{
+      |  trait Foo {
+      |    type T
+      |    type G
+      |  }
+      |
+      |  val c: Foo{type T = Int; type G = Long} = new Foo { type T = Int; type G = Long}
+      |}
+      |""".stripMargin
   )
-
-  val defaultRefinedTypes2: String =
-    """|object O{
-       |  trait Foo {
-       |    type T
-       |  }
-       |  val c = new Foo { type T = Int }
-       |  val d: Foo{type T = Int} = c
-       |}
-       |""".stripMargin
 
   checkEdit(
     "refined-types2",
@@ -694,30 +672,15 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |  val <<d>> = c
        |}
        |""".stripMargin,
-    defaultRefinedTypes2,
-    compat = Map(
-      scala3PresentationCompilerVersion -> defaultRefinedTypes2,
-      "3" ->
-        """|object O{
-           |  trait Foo {
-           |    type T
-           |  }
-           |  val c = new Foo { type T = Int }
-           |  val d: Foo{type T >: Int <: Int} = c
-           |}
-           |""".stripMargin,
-    ),
-  )
-
-  val defaultRefinedTypes3: String =
     """|object O{
        |  trait Foo {
        |    type T
        |  }
-       |
-       |  val c: Foo{type T = Int} = new Foo { type T = Int }
+       |  val c = new Foo { type T = Int }
+       |  val d: Foo{type T = Int} = c
        |}
-       |""".stripMargin
+       |""".stripMargin,
+  )
 
   checkEdit(
     "refined-types3",
@@ -729,33 +692,15 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |  val <<c>> = new Foo { type T = Int }
        |}
        |""".stripMargin,
-    defaultRefinedTypes3,
-    compat = Map(
-      scala3PresentationCompilerVersion -> defaultRefinedTypes3,
-      "3" ->
-        """|object O{
-           |  trait Foo {
-           |    type T
-           |  }
-           |
-           |  val c: Foo{type T >: Int <: Int} = new Foo { type T = Int }
-           |}
-           |""".stripMargin,
-    ),
-  )
-
-  val defaultRefinedTypes4: String =
-    """|trait Foo extends Selectable {
-       |  type T
-       |}
+    """|object O{
+       |  trait Foo {
+       |    type T
+       |  }
        |
-       |val c: Foo{type T = Int; val x: Int; def y: Int; val z: Int; def z_=(x$1: Int): Unit} = new Foo {
-       |  type T = Int
-       |  val x = 0
-       |  def y = 0
-       |  var z = 0
+       |  val c: Foo{type T = Int} = new Foo { type T = Int }
        |}
-       |""".stripMargin
+       |""".stripMargin,
+  )
 
   checkEdit(
     "refined-types4".tag(IgnoreScala2),
@@ -770,22 +715,17 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
        |  var z = 0
        |}
        |""".stripMargin,
-    defaultRefinedTypes4,
-    compat = Map(
-      scala3PresentationCompilerVersion -> defaultRefinedTypes4,
-      "3" ->
-        """|trait Foo extends Selectable {
-           |  type T
-           |}
-           |
-           |val c: Foo{type T >: Int <: Int; val x: Int; def y: Int; val z: Int; def z_=(x$1: Int): Unit} = new Foo {
-           |  type T = Int
-           |  val x = 0
-           |  def y = 0
-           |  var z = 0
-           |}
-           |""".stripMargin,
-    ),
+    """|trait Foo extends Selectable {
+       |  type T
+       |}
+       |
+       |val c: Foo{type T = Int; val x: Int; def y: Int; val z: Int; def z_=(x$1: Int): Unit} = new Foo {
+       |  type T = Int
+       |  val x = 0
+       |  def y = 0
+       |  var z = 0
+       |}
+       |""".stripMargin,
   )
 
   checkEdit(


### PR DESCRIPTION
This PR contains the following changes:
1. better printing of type params when there is a bracket suffix. We also print the bounds now and keep the original type param names.
2. we don't print the type params coming from bracket suffix in some situations, e.g. for types, where it is printed anyway
3. add completion suffix to `Scope` completions