### PR TITLE
bugfix: emit type for enum cases when needed

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaMtags.scala
@@ -252,7 +252,7 @@ class ScalaMtags(val input: Input.VirtualFile, dialect: Dialect)
           enterTermParameters(t.ctor.paramss, isPrimaryCtor = true)
           continue()
         case t: Defn.Enum =>
-          tpe(t.name, Kind.CLASS, 0)
+          tpe(t.name, Kind.CLASS, Property.ENUM.value)
           enterTypeParameters(t.tparams)
           enterTermParameters(t.ctor.paramss, isPrimaryCtor = true)
           continue()
@@ -261,7 +261,15 @@ class ScalaMtags(val input: Input.VirtualFile, dialect: Dialect)
             withOwner(ownerCompanion)(term(c, Kind.OBJECT, 0))
           )
         case t: Defn.EnumCase =>
-          withOwner(ownerCompanion)(term(t.name, Kind.OBJECT, 0))
+          t.ctor match {
+            case Ctor.Primary(_, _, _ :: _) =>
+              withOwner(ownerCompanion) {
+                tpe(t.name, Kind.CLASS, 0)
+                enterTypeParameters(t.tparams)
+                enterTermParameters(t.ctor.paramss, isPrimaryCtor = true)
+              }
+            case _ => withOwner(ownerCompanion)(term(t.name, Kind.OBJECT, 0))
+          }
         case t: Defn.Trait =>
           tpe(t.name, Kind.TRAIT, 0); continue()
           enterTypeParameters(t.tparams)

--- a/tests/input/src/main/scala-3/example/TypeEnum.scala
+++ b/tests/input/src/main/scala-3/example/TypeEnum.scala
@@ -1,0 +1,5 @@
+package example
+
+enum TypeEnum:
+  case Product(val id: String)
+  case Coproduct()

--- a/tests/unit/src/test/resources/definition-scala3/example/TypeEnum.scala
+++ b/tests/unit/src/test/resources/definition-scala3/example/TypeEnum.scala
@@ -1,0 +1,5 @@
+package example
+
+enum TypeEnum/*TypeEnum.scala*/:
+  case Product/*TypeEnum.scala*/(val id/*TypeEnum.scala*/: String/*Predef.scala*/)
+  case Coproduct/*TypeEnum.scala*/()

--- a/tests/unit/src/test/resources/documentSymbol-scala3/example/TypeEnum.scala
+++ b/tests/unit/src/test/resources/documentSymbol-scala3/example/TypeEnum.scala
@@ -1,0 +1,5 @@
+/*example(Package):5*/package example
+
+/*example.TypeEnum(Enum):5*/enum TypeEnum:
+  /*example.TypeEnum.Product(EnumMember):4*/case Product(val id: String)
+  /*example.TypeEnum.Coproduct(EnumMember):5*/case Coproduct()

--- a/tests/unit/src/test/resources/expect/toplevels-scala3.expect
+++ b/tests/unit/src/test/resources/expect/toplevels-scala3.expect
@@ -41,6 +41,7 @@ example/Scalalib.scala -> example/Scalalib#
 example/StructuralTypes.scala -> example/StructuralTypes.
 example/ToplevelDefVal.scala -> example/ToplevelDefVal$package.
 example/TryCatch.scala -> example/TryCatch#
+example/TypeEnum.scala -> example/TypeEnum#
 example/TypeParameters.scala -> example/TypeParameters#
 example/VarArgs.scala -> example/VarArgs#
 example/Vars.scala -> example/Vars.

--- a/tests/unit/src/test/resources/mtags-scala3/example/TypeEnum.scala
+++ b/tests/unit/src/test/resources/mtags-scala3/example/TypeEnum.scala
@@ -1,0 +1,5 @@
+package example
+
+enum TypeEnum/*example.TypeEnum#*/:
+  case Product/*example.TypeEnum.Product#*/(val id/*example.TypeEnum.Product#id.*/: String)
+  case Coproduct/*example.TypeEnum.Coproduct#*/()

--- a/tests/unit/src/test/resources/semanticTokens3/example/TypeEnum.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/TypeEnum.scala
@@ -1,0 +1,5 @@
+<<package>>/*keyword*/ <<example>>/*namespace*/
+
+<<enum>>/*keyword*/ <<TypeEnum>>/*enum,abstract*/:
+  <<case>>/*keyword*/ <<Product>>/*enum*/(<<val>>/*keyword*/ <<id>>/*variable,declaration,readonly*/: <<String>>/*type*/)
+  <<case>>/*keyword*/ <<Coproduct>>/*enum*/()

--- a/tests/unit/src/test/resources/semanticdb-scala3/example/TypeEnum.scala
+++ b/tests/unit/src/test/resources/semanticdb-scala3/example/TypeEnum.scala
@@ -1,0 +1,5 @@
+package example
+
+enum TypeEnum/*example.TypeEnum#*/:
+  case Product/*example.TypeEnum.Product#*/(val id/*example.TypeEnum.Product#id.*/: String/*scala.Predef.String#*/)
+  case Coproduct/*example.TypeEnum.Coproduct#*/()

--- a/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
@@ -51,7 +51,7 @@ class ScalaToplevelSuite extends BaseSuite {
     List(
       "_empty_/A.", "_empty_/A.foo().", "_empty_/A.Z#", "_empty_/B#",
       "_empty_/B#X#", "_empty_/B#foo().", "_empty_/B#v.", "_empty_/C#",
-      "_empty_/C#i.", "_empty_/D#", "_empty_/D#Da.", "_empty_/D#Db.",
+      "_empty_/C#i.", "_empty_/D#", "_empty_/D.Da.", "_empty_/D.Db.",
       "_empty_/D#getI().", "_empty_/D#i.",
     ),
     all = true,
@@ -99,7 +99,7 @@ class ScalaToplevelSuite extends BaseSuite {
     List(
       "_empty_/A.", "_empty_/A.foo().", "_empty_/A.Z#", "_empty_/B#",
       "_empty_/B#X#", "_empty_/B#foo().", "_empty_/C#", "_empty_/D#",
-      "_empty_/D#Da.", "_empty_/D#Db.",
+      "_empty_/D.Da.", "_empty_/D.Db.",
     ),
     all = true,
   )
@@ -471,9 +471,9 @@ class ScalaToplevelSuite extends BaseSuite {
        |
        |enum NotPlanets{ case Vase }
        |""".stripMargin,
-    List("a/", "a/Planets#", "a/Planets#Earth.", "a/Planets#Mercury.",
-      "a/Planets#num.", "a/Planets#Venus.", "a/NotPlanets#",
-      "a/NotPlanets#Vase."),
+    List("a/", "a/Planets#", "a/Planets.Earth.", "a/Planets.Mercury.",
+      "a/Planets#num.", "a/Planets.Venus.", "a/NotPlanets#",
+      "a/NotPlanets.Vase."),
     dialect = dialects.Scala3,
     all = true,
   )
@@ -494,9 +494,28 @@ class ScalaToplevelSuite extends BaseSuite {
        |enum NotPlanets:
        |  case Vase
        |""".stripMargin,
-    List("a/", "a/Planets#", "a/Planets#Earth.", "a/Planets#Mercury.",
-      "a/Planets#num.", "a/Planets#Venus.", "a/NotPlanets#",
-      "a/NotPlanets#Vase."),
+    List("a/", "a/Planets#", "a/Planets.Earth.", "a/Planets.Mercury.",
+      "a/Planets#num.", "a/Planets.Venus.", "a/NotPlanets#",
+      "a/NotPlanets.Vase."),
+    dialect = dialects.Scala3,
+    all = true,
+  )
+
+  check(
+    "cases-for-enum-class",
+    """|package a
+       |enum Planets(val num: Int):
+       |  case Mercury() extends Planets(1)
+       |  case Venus[A]() extends Planets(2)
+       |  case Earth(val v: Int) extends Planets(3)
+       |  def mmm() = ???
+       |
+       |enum NotPlanets:
+       |  case Vase
+       |""".stripMargin,
+    List("a/", "a/Planets#", "a/Planets#mmm().", "a/Planets.Earth#",
+      "a/Planets.Earth#v.", "a/Planets.Mercury#", "a/Planets#num.",
+      "a/Planets.Venus#", "a/NotPlanets#", "a/NotPlanets.Vase."),
     dialect = dialects.Scala3,
     all = true,
   )


### PR DESCRIPTION
1. emit type and params for enum cases when it has some parameters' list in `ScalaMtags`
2. emit type and and val params for enum cases when it has some parameters' list in `ScalaTopLevelMtags`
3. when finding a correct file in symbol index fallback to companion class as alternative

resolves: https://github.com/scalameta/metals/issues/5494