### PR TITLE
chore: use enum with default value for modelling show inferred types

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SemanticdbTreePrinter.scala
@@ -221,8 +221,7 @@ class SemanticdbTreePrinter(
          *  hello<<[String]>>("")
          */
         case tree @ s.TypeApplyTree(_: s.OriginalTree | _: s.SelectTree, _)
-            if !ignoreTypesTrees && userConfig.showInferredType
-              .contains("true") =>
+            if !ignoreTypesTrees && userConfig.showInferredType.showAll =>
           gatherSynthetics(tree)
         /**
          *  implicit def implicitFun(object: T): R = ???

--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -201,9 +201,7 @@ final class SyntheticsDecorationProvider(
   }
 
   private def areSyntheticsEnabled: Boolean = {
-    val showInferredType = !userConfig().showInferredType.contains(
-      "false"
-    ) && userConfig().showInferredType.nonEmpty
+    val showInferredType = !userConfig().showInferredType.showAll
     userConfig().showImplicitArguments || showInferredType || userConfig().showImplicitConversionsAndClasses
   }
 
@@ -448,10 +446,7 @@ final class SyntheticsDecorationProvider(
       } yield decorationOptions(lspRange, decoration)
 
       val typDecorations =
-        if (
-          userConfig().showInferredType.contains("true") |
-            userConfig().showInferredType.contains("minimal")
-        )
+        if (userConfig().showInferredType.isNotDisabled)
           typeDecorations(path, textDocument, decorationPrinter)
         else Nil
       decorations ++ typDecorations
@@ -495,7 +490,7 @@ final class SyntheticsDecorationProvider(
           if (param.decltpe.isEmpty) List(param.name.pos.toSemanticdb) else Nil
         case cs: m.Case =>
           // if the case is too long then it'll be too messy
-          if (userConfig().showInferredType.contains("minimal"))
+          if (userConfig().showInferredType.showCases)
             visit(cs.body) // don't show type hint for cases inside match
           else explorePatterns(List(cs.pat)) ++ visit(cs.body)
         case vl: m.Defn.Val =>


### PR DESCRIPTION
quick prototype showing what I meant in https://github.com/scalameta/metals-vscode/pull/1412#discussion_r1280430409
1. Can we use default value to remove `Option` for this config? Does it make a difference to treat no value case as off?
2. I'd ask a few "what if" questions about possible future variants for this enum. Maybe what we need is more granular, json-like config? For example {"case": false, "vals": true, ...}. I find some value in such config and I'd use it myself. Would it be useful for other users and project thought?
3. UserConfiguration might need some refactor to support fallback/legacy encoding of options without treating failures as errors, for now I went with the quickest way - boolean flag.
cc: @tgodzik