### PR TITLE
improvement: Make debug completions work for Java files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
+import scala.util.control.NonFatal
 
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.Compilers
@@ -138,6 +139,10 @@ private[debug] final class DebugProxy(
       }
       completions
         .getOrElse(Future.failed(new Exception("No source data available")))
+        .recover { case NonFatal(t) =>
+          scribe.error("Could not find any completions for the debugger", t)
+          Nil
+        }
         .map { items =>
           val responseArgs = new CompletionsResponse()
           responseArgs.setTargets(items.toArray)

--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaCompletionProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaCompletionProvider.scala
@@ -101,6 +101,7 @@ class JavaCompletionProvider(
       case dt: DeclaredType => completeDeclaredType(task, dt)
       case _: ArrayType => completeArrayType()
       case tv: TypeVariable => completeTypeVariable(task, tv)
+      case _ => new CompletionList()
     }
   }
 

--- a/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
@@ -206,6 +206,68 @@ class CompletionDapSuite
        |""".stripMargin
   )
 
+  assertCompletion(
+    "java-scope",
+    expression = "n@@",
+    expectedCompletions = """|name
+                             |notify()
+                             |notifyAll()
+                             |new
+                             |""".stripMargin,
+    expectedEdit = "name",
+    topLines = None,
+  )(
+    """|/a/src/main/java/a/Main.java
+       |package a;
+       |
+       |class Main{
+       |
+       |  public static void main(String[] args) {
+       |     String name = "Tom";
+       |>>   System.out.println(name);
+       |     System.exit(0);
+       |  }
+       |}
+       |
+       |""".stripMargin
+  )
+
+  assertCompletion(
+    "java-member",
+    expression = "name.s@@",
+    expectedCompletions =
+      if (isJava8)
+        """|serialVersionUID
+           |serialPersistentFields
+           |startsWith(java.lang.String arg0, int arg1)
+           |startsWith(java.lang.String arg0)
+           |substring(int arg0)
+           |""".stripMargin
+      else
+        """|serialVersionUID
+           |serialPersistentFields
+           |safeTrim(byte[] arg0, int arg1, boolean arg2)
+           |scale(int arg0, float arg1)
+           |startsWith(java.lang.String arg0, int arg1)
+           |""".stripMargin,
+    expectedEdit = "serialVersionUID",
+    topLines = Some(5),
+  )(
+    """|/a/src/main/java/a/Main.java
+       |package a;
+       |
+       |class Main{
+       |
+       |  public static void main(String[] args) {
+       |     String name = "Tom";
+       |>>   System.out.println(name);
+       |     System.exit(0);
+       |  }
+       |}
+       |
+       |""".stripMargin
+  )
+
   def assertCompletion(
       name: TestOptions,
       expression: String,


### PR DESCRIPTION
Previously, when trying completions in Java files these would hang and not return anything. Now, we complete correctly as in Scala files.

This is not yet super useful, but we should get also expression evaluation for Java files soon.