### PR TITLE
improvement: Automatically add colon to get better completions for Java

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/NamedArgCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/NamedArgCompletions.scala
@@ -10,7 +10,6 @@ import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.Constants.Constant
 import dotty.tools.dotc.core.ContextOps.localContext
 import dotty.tools.dotc.core.Contexts.Context
-import dotty.tools.dotc.core.Definitions
 import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Flags.Method
 import dotty.tools.dotc.core.NameKinds.DefaultGetterName

--- a/tests/javapc/src/main/scala/tests/pc/BaseJavaCompletionSuite.scala
+++ b/tests/javapc/src/main/scala/tests/pc/BaseJavaCompletionSuite.scala
@@ -20,7 +20,6 @@ class BaseJavaCompletionSuite extends BaseJavaPCSuite {
   ): Unit = {
     test(name) {
       val items = getItems(original, filename)
-
       val out = new StringBuilder()
 
       items.foreach { item =>

--- a/tests/javapc/src/test/scala/pc/CompletionMemberSelectSuite.scala
+++ b/tests/javapc/src/test/scala/pc/CompletionMemberSelectSuite.scala
@@ -48,4 +48,73 @@ class CompletionMemberSelectSuite extends BaseJavaCompletionSuite {
       |NUMBER
       |""".stripMargin,
   )
+
+  check(
+    "after-statement",
+    """
+      |class Perfect {
+      |  
+      |  void println() {
+      |    String name = "Tom";
+      |    name.sub@@
+      |    System.out.println("Perfect " + name);
+      |  }
+      |}
+      |""".stripMargin,
+    """|substring(int arg0)
+       |substring(int arg0, int arg1)
+       |subSequence(int arg0, int arg1)
+       |""".stripMargin,
+  )
+
+  check(
+    "same-line",
+    """
+      |class Perfect {
+      |  
+      |  void println() {
+      |    String name = "Tom";
+      |    name.sub@@  System.out.println("Perfect " + name);
+      |  }
+      |}
+      |""".stripMargin,
+    """|substring(int arg0)
+       |substring(int arg0, int arg1)
+       |subSequence(int arg0, int arg1)
+       |""".stripMargin,
+  )
+
+  check(
+    "inside-parens-no-space",
+    """
+      |class Perfect {
+      |  
+      |  void println() {
+      |    String name = "Tom";
+      |    System.out.println(name.sub@@);
+      |  }
+      |}
+      |""".stripMargin,
+    """|substring(int arg0)
+       |substring(int arg0, int arg1)
+       |subSequence(int arg0, int arg1)
+       |""".stripMargin,
+  )
+
+  check(
+    "inside-word",
+    """
+      |class Perfect {
+      |  
+      |  void println() {
+      |    String name = "Tom";
+      |    System.out.println(name.sub@@S );
+      |  }
+      |}
+      |""".stripMargin,
+    """|substring(int arg0)
+       |substring(int arg0, int arg1)
+       |subSequence(int arg0, int arg1)
+       |""".stripMargin,
+  )
 }


### PR DESCRIPTION
Previously, if there was anything following the place you were trying to get a completion in, you would not get any suggestions since the following names would be take into account. Now, we add `;` after anything you are trying to complete if the next symbol is a whitespace to separate the current completion from the following statements.

I also noticed that we don't set proper snippet format for the items, so I added that.