### PR TITLE
bugfix: Don't show keywords or constructors on select

### DIFF
--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -43,6 +43,7 @@ public abstract class PresentationCompiler {
 	 *
 	 */
 	public CompletableFuture<List<Node>> semanticTokens(VirtualFileParams params) {
+		
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 

--- a/tests/javapc/src/main/scala/tests/pc/BaseJavaCompletionSuite.scala
+++ b/tests/javapc/src/main/scala/tests/pc/BaseJavaCompletionSuite.scala
@@ -17,12 +17,17 @@ class BaseJavaCompletionSuite extends BaseJavaPCSuite {
       original: String,
       expected: String,
       filename: String = "A.java",
+      filterText: Option[String] = None,
   ): Unit = {
     test(name) {
       val items = getItems(original, filename)
+      val filtered = filterText match {
+        case None => items
+        case Some(text) => items.filter(_.getLabel().contains(text))
+      }
       val out = new StringBuilder()
 
-      items.foreach { item =>
+      filtered.foreach { item =>
         out.append(item.getLabel)
         out.append("\n")
       }

--- a/tests/javapc/src/test/scala/pc/CompletionMemberSelectSuite.scala
+++ b/tests/javapc/src/test/scala/pc/CompletionMemberSelectSuite.scala
@@ -143,4 +143,24 @@ class CompletionMemberSelectSuite extends BaseJavaCompletionSuite {
        |println()
        |""".stripMargin,
   )
+
+  check(
+    "completable-future-select",
+    """
+      |
+      |import java.util.concurrent.CompletableFuture;
+      |
+      |class Perfect {
+      |  
+      |  void println() {
+      |    CompletableFuture.@@
+      |  }
+      |}
+      |""".stripMargin,
+    """|clone()
+       |cleanStack()
+       |""".stripMargin,
+    // let's make sure we don't get any <clinit> method
+    filterText = Some("cl"),
+  )
 }

--- a/tests/javapc/src/test/scala/pc/CompletionMemberSelectSuite.scala
+++ b/tests/javapc/src/test/scala/pc/CompletionMemberSelectSuite.scala
@@ -117,4 +117,30 @@ class CompletionMemberSelectSuite extends BaseJavaCompletionSuite {
        |subSequence(int arg0, int arg1)
        |""".stripMargin,
   )
+
+  check(
+    "empty-select",
+    """
+      |class Perfect {
+      |  
+      |  void println() {
+      |    Perfect perfect = new Perfect();
+      |    perfect.@@
+      |  }
+      |}
+      |""".stripMargin,
+    """|getClass()
+       |hashCode()
+       |equals(java.lang.Object arg0)
+       |clone()
+       |toString()
+       |notify()
+       |notifyAll()
+       |wait()
+       |wait(long arg0)
+       |wait(long arg0, int arg1)
+       |finalize()
+       |println()
+       |""".stripMargin,
+  )
 }


### PR DESCRIPTION
Previously, Java completions would show keywords even in select position, which would always be invalid.

Now, we only show them on scope completions and also filter out constructors