### PR TITLE
bugfix: do not emit cases in  pattern match as enum cases

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/Mtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/Mtags.scala
@@ -93,14 +93,15 @@ object Mtags {
 
   def allToplevels(
       input: Input.VirtualFile,
-      dialect: Dialect
+      dialect: Dialect,
+      includeMembers: Boolean = true
   )(implicit rc: ReportContext = EmptyReportContext): TextDocument = {
     input.toLanguage match {
       case Language.JAVA =>
         new JavaMtags(input, includeMembers = true).index()
       case Language.SCALA =>
         val mtags =
-          new ScalaToplevelMtags(input, true, includeMembers = true, dialect)
+          new ScalaToplevelMtags(input, true, includeMembers, dialect)
         mtags.index()
       case _ =>
         TextDocument()

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/EmptyPackage.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/EmptyPackage.scala
@@ -1,0 +1,1 @@
+class EmptyPackage/*_empty_.EmptyPackage#*/

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/AbstractGiven.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/AbstractGiven.scala
@@ -1,0 +1,4 @@
+package example
+
+abstract class AbstractGiven/*example.AbstractGiven#*/:
+  given int: Int

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/AndOrType.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/AndOrType.scala
@@ -1,0 +1,8 @@
+package example
+
+trait Cancelable/*example.Cancelable#*/
+trait Movable/*example.Movable#*/
+
+type/*example.AndOrType$package.*/ Y = (Cancelable & Movable)
+
+type X = String | Int

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/AnonymousClasses.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/AnonymousClasses.scala
@@ -1,0 +1,3 @@
+package example
+
+class AnonymousClasses/*example.AnonymousClasses#*/ {}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/ColorEnum.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/ColorEnum.scala
@@ -1,0 +1,6 @@
+package example
+
+enum Color/*example.Color#*/(val rgb: Int):
+  case Red/*example.Color.Red.*/ extends Color(0xff0000)
+  case Green/*example.Color.Green.*/ extends Color(0x00ff00)
+  case Blue/*example.Color.Blue.*/ extends Color(0x0000ff)

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Comments.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Comments.scala
@@ -1,0 +1,9 @@
+package example
+
+class /* comment */ Comments/*example.Comments#*/ {
+  object /* comment */ A/*example.Comments#A.*/
+  trait /* comment */ A/*example.Comments#A#*/
+  val /* comment */ a = 1
+  def /* comment */ b = 1
+  var /* comment */ c = 1
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Companion.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Companion.scala
@@ -1,0 +1,5 @@
+package example
+
+abstract class Companion/*example.Companion#*/() extends Object() {}
+
+object Companion/*example.Companion.*/ {}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/EtaExpansion.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/EtaExpansion.scala
@@ -1,0 +1,5 @@
+package example
+
+class EtaExpansion/*example.EtaExpansion#*/ {
+  List(1).map(identity)
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Extension.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Extension.scala
@@ -1,0 +1,11 @@
+package example
+
+extension/*example.Extension$package.*/ (i: Int) def asString: String = i.toString
+
+extension (s: String)
+  def asInt: Int = s.toInt
+  def double: String = s * 2
+
+trait AbstractExtension/*example.AbstractExtension#*/:
+  extension (d: Double)
+    def abc: String

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/FooEnum.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/FooEnum.scala
@@ -1,0 +1,5 @@
+package example
+
+enum FooEnum/*example.FooEnum#*/:
+  case Bar/*example.FooEnum.Bar.*/, Baz/*example.FooEnum.Baz.*/
+object FooEnum/*example.FooEnum.*/

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/ForComprehensions.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/ForComprehensions.scala
@@ -1,0 +1,40 @@
+package example
+
+class ForComprehensions/*example.ForComprehensions#*/ {
+  for {
+    a <- List(1)
+    b <- List(a)
+    if (
+      a,
+      b,
+    ) == (1, 2)
+    (
+      c,
+      d,
+    ) <- List((a, b))
+    if (
+      a,
+      b,
+      c,
+      d,
+    ) == (1, 2, 3, 4)
+    e = (
+      a,
+      b,
+      c,
+      d,
+    )
+    if e == (1, 2, 3, 4)
+    f <- List(e)
+  } yield {
+    (
+      a,
+      b,
+      c,
+      d,
+      e,
+      f,
+    )
+  }
+
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/GivenAlias.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/GivenAlias.scala
@@ -1,0 +1,47 @@
+package example
+
+given/*example.GivenAlias$package.*/ intValue: Int = 4
+given String = "str"
+given (using i: Int): Double = 4.0
+given [T]: List[T] = Nil
+given given_Char: Char = '?'
+given `given_Float`: Float = 3.0
+given `* *` : Long = 5
+
+def method(using Int) = ""
+
+object X/*example.X.*/:
+  given Double = 4.0
+  val double = given_Double
+
+  given of[A]: Option[A] = ???
+
+trait Xg/*example.Xg#*/:
+  def doX: Int
+
+trait Yg/*example.Yg#*/:
+  def doY: String
+
+trait Zg/*example.Zg#*/[T]:
+  def doZ: List[T]
+
+given Xg with
+  def doX = 7
+
+given (using Xg): Yg with
+  def doY = "7"
+
+given [T]: Zg[T] with
+  def doZ: List[T] = Nil
+
+val a = intValue
+val b = given_String
+val c = X.given_Double
+val d = given_List_T[Int]
+val e = given_Char
+val f = given_Float
+val g = `* *`
+val i = X.of[Int]
+val x = given_Xg
+val y = given_Yg
+val z = given_Zg_T[String]

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/ImplicitClasses.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/ImplicitClasses.scala
@@ -1,0 +1,10 @@
+package example
+
+object ImplicitClasses/*example.ImplicitClasses.*/ {
+  implicit class Xtension/*example.ImplicitClasses.Xtension#*/(number: Int) {
+    def increment: Int = number + 1
+  }
+  implicit class XtensionAnyVal/*example.ImplicitClasses.XtensionAnyVal#*/(private val number: Int) extends AnyVal {
+    def double: Int = number * 2
+  }
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Imports.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Imports.scala
@@ -1,0 +1,10 @@
+package example
+
+import util.{Failure => NotGood}
+import math.{floor => _, _}
+
+class Imports/*example.Imports#*/ {
+  // rename reference
+  NotGood(null)
+  max(1, 2)
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/JavaThenScala.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/JavaThenScala.scala
@@ -1,0 +1,5 @@
+package example
+
+class JavaThenScala/*example.JavaThenScala#*/ {
+  new JavaClass(42)
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/LocalDeclarations.scala
@@ -1,0 +1,21 @@
+package example.nested
+
+trait LocalDeclarations/*example.nested.LocalDeclarations#*/:
+  def foo(): Unit
+
+trait Foo/*example.nested.Foo#*/:
+  val y = 3
+
+object LocalDeclarations/*example.nested.LocalDeclarations.*/:
+  def create(): LocalDeclarations =
+    def bar(): Unit = ()
+
+    val x = new:
+      val x = 2
+
+    val y = new Foo {}
+
+    val yy = y.y
+
+    new LocalDeclarations with Foo:
+      override def foo(): Unit = bar()

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Locals.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Locals.scala
@@ -1,0 +1,8 @@
+package example
+
+class Locals/*example.Locals#*/ {
+  {
+    val x = 2
+    x + 2
+  }
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/MethodOverload.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/MethodOverload.scala
@@ -1,0 +1,9 @@
+package example
+
+class MethodOverload/*example.MethodOverload#*/(b: String) {
+  def this() = this("")
+  def this(c: Int) = this("")
+  val a = 2
+  def a(x: Int) = 2
+  def a(x: Int, y: Int) = 2
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Miscellaneous.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Miscellaneous.scala
@@ -1,0 +1,16 @@
+package example
+
+class Miscellaneous/*example.Miscellaneous#*/ {
+  // backtick identifier
+  val `a b` = 42
+
+  // block with only wildcard value
+  def apply(): Unit = {
+    val _ = 42
+  }
+  // infix + inferred apply/implicits/tparams
+  (List(1)
+    .map(_ + 1)
+    ++
+      List(3))
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/NamedArguments.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/NamedArguments.scala
@@ -1,0 +1,34 @@
+package example
+
+case class User/*example.User#*/(
+    name: String = {
+      // assert default values have occurrences
+      Map.toString
+    }
+)
+object NamedArguments/*example.NamedArguments.*/ {
+  final val susan = "Susan"
+  val user1 =
+    User
+      .apply(
+        name = "John"
+      )
+  val user2: User =
+    User(
+      name = susan
+    ).copy(
+      name = susan
+    )
+
+  // anonymous classes
+  @deprecated(
+    message = "a",
+    since = susan,
+  ) def b = 1
+
+  // vararg
+  List(
+    elems = 2
+  )
+
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Ord.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Ord.scala
@@ -1,0 +1,12 @@
+package example
+
+trait Ord/*example.Ord#*/[T]:
+  def compare(x: T, y: T): Int
+
+given/*example.Ord$package.*/ intOrd: Ord[Int] with
+  def compare(x: Int, y: Int) =
+    if x < y then -1 else if x > y then +1 else 0
+
+given Ord[String] with
+  def compare(x: String, y: String) =
+    x.compare(y)

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/PatternMatching.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/PatternMatching.scala
@@ -1,0 +1,24 @@
+package example
+
+class PatternMatching/*example.PatternMatching#*/ {
+  val some = Some(1)
+  some match {
+    case Some(number) =>
+      number
+  }
+
+  // tuple deconstruction
+  val (left, right) = (1, 2)
+  (left, right)
+
+  // val deconstruction
+  val Some(number1) =
+    some
+  println(number1)
+
+  def localDeconstruction = {
+    val Some(number2) =
+      some
+    number2
+  }
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Scalalib.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Scalalib.scala
@@ -1,0 +1,26 @@
+package example
+
+class Scalalib/*example.Scalalib#*/ {
+  val nil = List()
+  val lst = List[
+    (
+        Nothing,
+        Null,
+        Singleton,
+        Any,
+        AnyRef,
+        AnyVal,
+        Int,
+        Short,
+        Double,
+        Float,
+        Char,
+    )
+  ](null)
+  lst.isInstanceOf[Any]
+  lst.asInstanceOf[Any]
+  println(lst.##)
+  lst ne lst
+  lst eq lst
+  lst == lst
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/StructuralTypes.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/StructuralTypes.scala
@@ -1,0 +1,20 @@
+package example
+
+import reflect.Selectable.reflectiveSelectable
+
+object StructuralTypes/*example.StructuralTypes.*/:
+  type User = {
+    def name: String
+    def age: Int
+  }
+
+  val user = null.asInstanceOf[User]
+  user.name
+  user.age
+
+  val V: Object {
+    def scalameta: String
+  } = new:
+    def scalameta = "4.0"
+  V.scalameta
+end StructuralTypes

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/ToplevelDefVal.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/ToplevelDefVal.scala
@@ -1,0 +1,8 @@
+package example
+
+def/*example.ToplevelDefVal$package.*/ foo(): Int = 42
+
+val abc: String = "sds"
+
+// tests jar's indexing on Windows
+type SourceToplevelTypeFromDepsRef = EmptyTuple

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/TryCatch.scala
@@ -1,0 +1,14 @@
+package example
+
+class TryCatch/*example.TryCatch#*/ {
+  try {
+    val x = 2
+    x + 2
+  } catch {
+    case t: Throwable =>
+      t.printStackTrace()
+  } finally {
+    val text = ""
+    text + ""
+  }
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/TypeEnum.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/TypeEnum.scala
@@ -1,0 +1,5 @@
+package example
+
+enum TypeEnum/*example.TypeEnum#*/:
+  case Product/*example.TypeEnum.Product#*/(val id: String)
+  case Coproduct/*example.TypeEnum.Coproduct#*/()

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/TypeParameters.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/TypeParameters.scala
@@ -1,0 +1,8 @@
+package example
+
+class TypeParameters/*example.TypeParameters#*/[A] {
+  def method[B] = 42
+  trait TraitParameter/*example.TypeParameters#TraitParameter#*/[C]
+  type AbstractTypeAlias[D]
+  type TypeAlias[E] = List[E]
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/VarArgs.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/VarArgs.scala
@@ -1,0 +1,6 @@
+package example
+
+class VarArgs/*example.VarArgs#*/ {
+  def add(a: Int*) = a
+  def add2(a: Seq[Int]*) = a
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Vars.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/Vars.scala
@@ -1,0 +1,9 @@
+package example
+
+object Vars/*example.Vars.*/ {
+  var a = 2
+
+  a = 2
+
+  Vars.a = 3
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/nested/DoublePackage.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/nested/DoublePackage.scala
@@ -1,0 +1,9 @@
+package example
+
+package nested.x {
+  class DoublePackage/*example.nested.x.DoublePackage#*/ {}
+}
+
+package nested2.y {
+  class DoublePackage/*example.nested2.y.DoublePackage#*/ {}
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/nested/ExampleNested.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/nested/ExampleNested.scala
@@ -1,0 +1,3 @@
+package example.nested
+
+class ExampleNested/*example.nested.ExampleNested#*/ {}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/nested/LocalClass.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/nested/LocalClass.scala
@@ -1,0 +1,7 @@
+package example.nested
+
+class LocalClass/*example.nested.LocalClass#*/ {
+  def foo(): Unit = {
+    case class LocalClass()
+  }
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/nested/package.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/nested/package.scala
@@ -1,0 +1,9 @@
+package example
+
+package object nested/*example.nested.package.*/ {
+
+  class PackageObjectNestedClass/*example.nested.package.PackageObjectNestedClass#*/
+
+}
+
+class PackageObjectSibling/*example.PackageObjectSibling#*/

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/package.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/package.scala
@@ -1,0 +1,5 @@
+package object example/*example.package.*/ {
+
+  class PackageObjectClass/*example.package.PackageObjectClass#*/
+
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/type/Backtick.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/type/Backtick.scala
@@ -1,0 +1,3 @@
+package example.`type`
+
+class Backtick/*example.type.Backtick#*/ {}

--- a/tests/unit/src/test/resources/toplevel-with-inner/EmptyPackage.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/EmptyPackage.scala
@@ -1,0 +1,1 @@
+class EmptyPackage/*_empty_.EmptyPackage#*/

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/AnonymousClasses.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/AnonymousClasses.scala
@@ -1,0 +1,3 @@
+package example
+
+class AnonymousClasses/*example.AnonymousClasses#*/ {}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/Comments.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/Comments.scala
@@ -1,0 +1,9 @@
+package example
+
+class /* comment */ Comments/*example.Comments#*/ {
+  object /* comment */ A/*example.Comments#A.*/
+  trait /* comment */ A/*example.Comments#A#*/
+  val /* comment */ a = 1
+  def /* comment */ b = 1
+  var /* comment */ c = 1
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/Companion.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/Companion.scala
@@ -1,0 +1,5 @@
+package example
+
+abstract class Companion/*example.Companion#*/() extends Object() {}
+
+object Companion/*example.Companion.*/ {}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/Definitions.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/Definitions.scala
@@ -1,0 +1,18 @@
+package example
+
+import io.circe.derivation.deriveDecoder
+import io.circe.derivation.deriveEncoder
+
+class Definitions/*example.Definitions#*/ {
+  Predef.any2stringadd(1)
+  List[
+    java.util.Map.Entry[
+      java.lang.Integer,
+      java.lang.Double,
+    ]
+  ](
+    elems = null
+  )
+  println(deriveDecoder[MacroAnnotation])
+  println(deriveEncoder[MacroAnnotation])
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/EtaExpansion.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/EtaExpansion.scala
@@ -1,0 +1,5 @@
+package example
+
+class EtaExpansion/*example.EtaExpansion#*/ {
+  List(1).map(identity)
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/ExampleSuite.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/ExampleSuite.scala
@@ -1,0 +1,5 @@
+package example
+
+object ExampleSuite/*example.ExampleSuite.*/ {
+  println(NamedArguments.user2)
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/ForComprehensions.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/ForComprehensions.scala
@@ -1,0 +1,40 @@
+package example
+
+class ForComprehensions/*example.ForComprehensions#*/ {
+  for {
+    a <- List(1)
+    b <- List(a)
+    if (
+      a,
+      b,
+    ) == (1, 2)
+    (
+      c,
+      d,
+    ) <- List((a, b))
+    if (
+      a,
+      b,
+      c,
+      d,
+    ) == (1, 2, 3, 4)
+    e = (
+      a,
+      b,
+      c,
+      d,
+    )
+    if e == (1, 2, 3, 4)
+    f <- List(e)
+  } yield {
+    (
+      a,
+      b,
+      c,
+      d,
+      e,
+      f,
+    )
+  }
+
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/ImplicitClasses.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/ImplicitClasses.scala
@@ -1,0 +1,10 @@
+package example
+
+object ImplicitClasses/*example.ImplicitClasses.*/ {
+  implicit class Xtension/*example.ImplicitClasses.Xtension#*/(number: Int) {
+    def increment: Int = number + 1
+  }
+  implicit class XtensionAnyVal/*example.ImplicitClasses.XtensionAnyVal#*/(private val number: Int) extends AnyVal {
+    def double: Int = number * 2
+  }
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/ImplicitConversions.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/ImplicitConversions.scala
@@ -1,0 +1,28 @@
+package example
+
+class ImplicitConversions/*example.ImplicitConversions#*/ {
+  implicit def string2Number(
+      string: String
+  ): Int = 42
+  val message = ""
+  val number = 42
+  val tuple = (1, 2)
+  val char: Char = 'a'
+
+  // extension methods
+  message
+    .stripSuffix("h")
+  tuple + "Hello"
+
+  // implicit conversions
+  val x: Int = message
+
+  // interpolators
+  s"Hello $message $number"
+  s"""Hello
+     |$message
+     |$number""".stripMargin
+
+  val a: Int = char
+  val b: Long = char
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/Imports.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/Imports.scala
@@ -1,0 +1,10 @@
+package example
+
+import util.{Failure => NotGood}
+import math.{floor => _, _}
+
+class Imports/*example.Imports#*/ {
+  // rename reference
+  NotGood(null)
+  max(1, 2)
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/JavaThenScala.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/JavaThenScala.scala
@@ -1,0 +1,5 @@
+package example
+
+class JavaThenScala/*example.JavaThenScala#*/ {
+  new JavaClass(42)
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/Locals.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/Locals.scala
@@ -1,0 +1,8 @@
+package example
+
+class Locals/*example.Locals#*/ {
+  {
+    val x = 2
+    x + 2
+  }
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/MacroAnnotation.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/MacroAnnotation.scala
@@ -1,0 +1,25 @@
+package example
+
+import io.circe.derivation.annotations.JsonCodec
+
+@JsonCodec
+// FIXME: https://github.com/scalameta/scalameta/issues/1789
+case class MacroAnnotation/*example.MacroAnnotation#*/(
+    name: String
+) {
+  def method = 42
+}
+
+object MacroAnnotations/*example.MacroAnnotations.*/ {
+  import scala.meta._
+  // IntelliJ has never managed to goto definition for the inner classes from Trees.scala
+  // due to the macro annotations.
+  val x: Defn.Class = Defn.Class(
+    Nil,
+    Type.Name("test"),
+    Nil,
+    Ctor.Primary(Nil, Term.Name("this"), Nil),
+    Template(Nil, Nil, Self(Name.Anonymous(), None), Nil),
+  )
+  val y: Mod.Final = Mod.Final()
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/MethodOverload.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/MethodOverload.scala
@@ -1,0 +1,9 @@
+package example
+
+class MethodOverload/*example.MethodOverload#*/(b: String) {
+  def this() = this("")
+  def this(c: Int) = this("")
+  val a = 2
+  def a(x: Int) = 2
+  def a(x: Int, y: Int) = 2
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/Miscellaneous.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/Miscellaneous.scala
@@ -1,0 +1,16 @@
+package example
+
+class Miscellaneous/*example.Miscellaneous#*/ {
+  // backtick identifier
+  val `a b` = 42
+
+  // block with only wildcard value
+  def apply(): Unit = {
+    val _ = 42
+  }
+  // infix + inferred apply/implicits/tparams
+  (List(1)
+    .map(_ + 1)
+    ++
+      List(3))
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/NamedArguments.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/NamedArguments.scala
@@ -1,0 +1,34 @@
+package example
+
+case class User/*example.User#*/(
+    name: String = {
+      // assert default values have occurrences
+      Map.toString
+    }
+)
+object NamedArguments/*example.NamedArguments.*/ {
+  final val susan = "Susan"
+  val user1 =
+    User
+      .apply(
+        name = "John"
+      )
+  val user2: User =
+    User(
+      name = susan
+    ).copy(
+      name = susan
+    )
+
+  // anonymous classes
+  @deprecated(
+    message = "a",
+    since = susan,
+  ) def b = 1
+
+  // vararg
+  List(
+    elems = 2
+  )
+
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/PatternMatching.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/PatternMatching.scala
@@ -1,0 +1,24 @@
+package example
+
+class PatternMatching/*example.PatternMatching#*/ {
+  val some = Some(1)
+  some match {
+    case Some(number) =>
+      number
+  }
+
+  // tuple deconstruction
+  val (left, right) = (1, 2)
+  (left, right)
+
+  // val deconstruction
+  val Some(number1) =
+    some
+  println(number1)
+
+  def localDeconstruction = {
+    val Some(number2) =
+      some
+    number2
+  }
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/ReflectiveInvocation.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/ReflectiveInvocation.scala
@@ -1,0 +1,9 @@
+package example
+
+class ReflectiveInvocation/*example.ReflectiveInvocation#*/ {
+  new Serializable {
+    def message = "message"
+    // reflective invocation
+  }.message
+
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/Scalalib.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/Scalalib.scala
@@ -1,0 +1,26 @@
+package example
+
+class Scalalib/*example.Scalalib#*/ {
+  val nil = List()
+  val lst = List[
+    (
+        Nothing,
+        Null,
+        Singleton,
+        Any,
+        AnyRef,
+        AnyVal,
+        Int,
+        Short,
+        Double,
+        Float,
+        Char,
+    )
+  ](null)
+  lst.isInstanceOf[Any]
+  lst.asInstanceOf[Any]
+  println(lst.##)
+  lst ne lst
+  lst eq lst
+  lst == lst
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/StructuralTypes.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/StructuralTypes.scala
@@ -1,0 +1,19 @@
+package example
+
+object StructuralTypes/*example.StructuralTypes.*/ {
+  type User = {
+    def name: String
+    def age: Int
+  }
+
+  val user = null.asInstanceOf[User]
+  user.name
+  user.age
+
+  val V: Object {
+    def scalameta: String
+  } = new {
+    def scalameta = "4.0"
+  }
+  V.scalameta
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/TryCatch.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/TryCatch.scala
@@ -1,0 +1,14 @@
+package example
+
+class TryCatch/*example.TryCatch#*/ {
+  try {
+    val x = 2
+    x + 2
+  } catch {
+    case t: Throwable =>
+      t.printStackTrace()
+  } finally {
+    val text = ""
+    text + ""
+  }
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/TypeParameters.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/TypeParameters.scala
@@ -1,0 +1,8 @@
+package example
+
+class TypeParameters/*example.TypeParameters#*/[A] {
+  def method[B] = 42
+  trait TraitParameter/*example.TypeParameters#TraitParameter#*/[C]
+  type AbstractTypeAlias[D]
+  type TypeAlias[E] = List[E]
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/VarArgs.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/VarArgs.scala
@@ -1,0 +1,6 @@
+package example
+
+class VarArgs/*example.VarArgs#*/ {
+  def add(a: Int*) = a
+  def add2(a: Seq[Int]*) = a
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/Vars.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/Vars.scala
@@ -1,0 +1,9 @@
+package example
+
+object Vars/*example.Vars.*/ {
+  var a = 2
+
+  a = 2
+
+  Vars.a = 3
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/nested/DoublePackage.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/nested/DoublePackage.scala
@@ -1,0 +1,9 @@
+package example
+
+package nested.x {
+  class DoublePackage/*example.nested.x.DoublePackage#*/ {}
+}
+
+package nested2.y {
+  class DoublePackage/*example.nested2.y.DoublePackage#*/ {}
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/nested/ExampleNested.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/nested/ExampleNested.scala
@@ -1,0 +1,3 @@
+package example.nested
+
+class ExampleNested/*example.nested.ExampleNested#*/ {}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/nested/LocalClass.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/nested/LocalClass.scala
@@ -1,0 +1,7 @@
+package example.nested
+
+class LocalClass/*example.nested.LocalClass#*/ {
+  def foo(): Unit = {
+    case class LocalClass()
+  }
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/nested/LocalDeclarations.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/nested/LocalDeclarations.scala
@@ -1,0 +1,28 @@
+package example.nested
+
+trait LocalDeclarations/*example.nested.LocalDeclarations#*/ {
+  def foo(): Unit
+}
+
+trait Foo/*example.nested.Foo#*/ {
+  val y = 3
+}
+
+object LocalDeclarations/*example.nested.LocalDeclarations.*/ {
+  def create(): LocalDeclarations = {
+    def bar(): Unit = ()
+
+    val x = new {
+      val x = 2
+    }
+
+    val y = new Foo {}
+
+    x.x + y.y
+
+    new LocalDeclarations with Foo {
+      override def foo(): Unit = bar()
+    }
+
+  }
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/nested/package.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/nested/package.scala
@@ -1,0 +1,9 @@
+package example
+
+package object nested/*example.nested.package.*/ {
+
+  class PackageObjectNestedClass/*example.nested.package.PackageObjectNestedClass#*/
+
+}
+
+class PackageObjectSibling/*example.PackageObjectSibling#*/

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/package.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/package.scala
@@ -1,0 +1,5 @@
+package object example/*example.package.*/ {
+
+  class PackageObjectClass/*example.package.PackageObjectClass#*/
+
+}

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/type/Backtick.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/type/Backtick.scala
@@ -1,0 +1,3 @@
+package example.`type`
+
+class Backtick/*example.type.Backtick#*/ {}

--- a/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
@@ -54,7 +54,7 @@ class ScalaToplevelSuite extends BaseSuite {
       "_empty_/C#i.", "_empty_/D#", "_empty_/D.Da.", "_empty_/D.Db.",
       "_empty_/D#getI().", "_empty_/D#i.",
     ),
-    all = true,
+    mode = All,
     dialect = dialects.Scala3,
   )
 
@@ -101,7 +101,7 @@ class ScalaToplevelSuite extends BaseSuite {
       "_empty_/B#X#", "_empty_/B#foo().", "_empty_/C#", "_empty_/D#",
       "_empty_/D.Da.", "_empty_/D.Db.",
     ),
-    all = true,
+    mode = All,
   )
 
   check(
@@ -125,7 +125,7 @@ class ScalaToplevelSuite extends BaseSuite {
       "z/Test$package.abc().",
       "z/Test$package.foo().",
     ),
-    all = true,
+    mode = All,
   )
 
   check(
@@ -159,7 +159,7 @@ class ScalaToplevelSuite extends BaseSuite {
       "z/Test$package.",
       "z/Test$package.X#",
     ),
-    all = true,
+    mode = All,
   )
 
   check(
@@ -187,7 +187,7 @@ class ScalaToplevelSuite extends BaseSuite {
     List(
       "pkg/", "pkg/A#", "pkg/A#Z#", "pkg/B.", "pkg/B.Y#", "pkg/B.Y#L#", "pkg/C#",
     ),
-    all = true,
+    mode = All,
   )
 
   check(
@@ -206,7 +206,7 @@ class ScalaToplevelSuite extends BaseSuite {
     List(
       "pkg/", "pkg/A#", "pkg/A#Z#", "pkg/B.", "pkg/B.Y#", "pkg/B.Y#L#",
     ),
-    all = true,
+    mode = All,
   )
 
   check(
@@ -325,7 +325,7 @@ class ScalaToplevelSuite extends BaseSuite {
       "a/", "a/A.", "a/A.B1.", "a/A.B1.C1#", "a/A.B1.C1#a.", "a/A.B2.",
       "a/A.B2.C2#", "a/A.B2.C2#a.",
     ),
-    all = true,
+    mode = All,
     dialect = dialects.Scala213,
   )
 
@@ -347,7 +347,7 @@ class ScalaToplevelSuite extends BaseSuite {
       "a/A.bar.",
       "a/A.foo.",
     ),
-    all = true,
+    mode = All,
     dialect = dialects.Scala3,
   )
 
@@ -368,7 +368,7 @@ class ScalaToplevelSuite extends BaseSuite {
       "a/Test$package.bar.",
       "a/Test$package.foo.",
     ),
-    all = true,
+    mode = All,
     dialect = dialects.Scala3,
   )
 
@@ -385,7 +385,7 @@ class ScalaToplevelSuite extends BaseSuite {
       "a/", "a/Test$package.", "a/Test$package.foo.", "a/Test$package.bar.",
       "a/Test$package.baz.",
     ),
-    all = true,
+    mode = All,
     dialect = dialects.Scala3,
   )
 
@@ -406,7 +406,7 @@ class ScalaToplevelSuite extends BaseSuite {
       "a/", "a/O.", "a/O.s1.", "a/O.s2.", "a/O.s3().", "a/O.s4().", "a/O.extr.",
       "a/O.extr1.", "a/O.extr2.", "a/O.r.", "a/O.p.",
     ),
-    all = true,
+    mode = All,
   )
 
   check(
@@ -418,7 +418,7 @@ class ScalaToplevelSuite extends BaseSuite {
        |}
        |""".stripMargin,
     List("p/", "p/B#"),
-    all = true,
+    mode = All,
   )
 
   check(
@@ -432,7 +432,7 @@ class ScalaToplevelSuite extends BaseSuite {
        |}
        |""".stripMargin,
     List("p/", "p/A#", "p/A#name.", "p/A#isH.", "p/A#V."),
-    all = true,
+    mode = All,
   )
 
   check(
@@ -454,7 +454,7 @@ class ScalaToplevelSuite extends BaseSuite {
       "a/Test$package.given_Char().", "a/Test$package.given_Float().",
       "a/Test$package.intValue().", "a/Test$package.listOrd()."),
     dialect = dialects.Scala3,
-    all = true,
+    mode = All,
   )
 
   check(
@@ -475,7 +475,7 @@ class ScalaToplevelSuite extends BaseSuite {
       "a/Planets#num.", "a/Planets.Venus.", "a/NotPlanets#",
       "a/NotPlanets.Vase."),
     dialect = dialects.Scala3,
-    all = true,
+    mode = All,
   )
 
   check(
@@ -498,7 +498,7 @@ class ScalaToplevelSuite extends BaseSuite {
       "a/Planets#num.", "a/Planets.Venus.", "a/NotPlanets#",
       "a/NotPlanets.Vase."),
     dialect = dialects.Scala3,
-    all = true,
+    mode = All,
   )
 
   check(
@@ -517,7 +517,63 @@ class ScalaToplevelSuite extends BaseSuite {
       "a/Planets.Earth#v.", "a/Planets.Mercury#", "a/Planets#num.",
       "a/Planets.Venus#", "a/NotPlanets#", "a/NotPlanets.Vase."),
     dialect = dialects.Scala3,
-    all = true,
+    mode = All,
+  )
+
+  check(
+    "i5500",
+    """|package a
+       |abstract class TypeProxy extends Type {
+       |  def superType(using Context): Type = underlying match {
+       |    case TypeBounds(_, hi) => hi
+       |    case st => st
+       |  }
+       |}
+       |""".stripMargin,
+    List("a/", "a/TypeProxy#"),
+    dialect = dialects.Scala3,
+    mode = ToplevelWithInner,
+  )
+
+  check(
+    "class-in-def",
+    """|package a
+       |def ee =
+       |  class AClass
+       |  1
+       |""".stripMargin,
+    List("a/", "a/Test$package."),
+    dialect = dialects.Scala3,
+    mode = ToplevelWithInner,
+  )
+
+  check(
+    "if-in-class",
+    """|class A(i : Int):
+       |  if i > 0
+       |  then
+       |    def a(j: Int) = j
+       |    a(i)
+       |  else ???
+       |""".stripMargin,
+    List("_empty_/A#"),
+    mode = All,
+    dialect = dialects.Scala3,
+  )
+
+  check(
+    "for-loop",
+    """|class A:
+       |  for
+       |    _ <- Some(1)
+       |    _ <- 
+       |      def a(i: Int) = if i > 0 then Some(i) else None
+       |      a(3)
+       |  yield ()
+       |""".stripMargin,
+    List("_empty_/A#"),
+    mode = All,
+    dialect = dialects.Scala3,
   )
 
   check(
@@ -538,27 +594,28 @@ class ScalaToplevelSuite extends BaseSuite {
     List("s/", "s/Test$package.", "s/Test$package.Cow#", "s/Cow.",
       "s/Cow.apply()."),
     dialect = dialects.Scala3,
-    all = true,
+    mode = All,
   )
 
   def check(
       options: TestOptions,
       code: String,
       expected: List[String],
-      all: Boolean = false,
+      mode: Mode = Toplevel,
       dialect: Dialect = dialects.Scala3,
   )(implicit location: munit.Location): Unit = {
     test(options) {
       val input = Input.VirtualFile("Test.scala", code)
       val obtained =
-        if (all) {
-          Mtags
-            .allToplevels(input, dialect)
-            .occurrences
-            .map(_.symbol)
-            .toList
-        } else {
-          Mtags.toplevels(input, dialect)
+        mode match {
+          case All | ToplevelWithInner =>
+            val includeMembers = mode == All
+            Mtags
+              .allToplevels(input, dialect, includeMembers)
+              .occurrences
+              .map(_.symbol)
+              .toList
+          case Toplevel => Mtags.toplevels(input, dialect)
         }
       assertNoDiff(
         obtained.sorted.mkString("\n"),
@@ -573,5 +630,16 @@ class ScalaToplevelSuite extends BaseSuite {
   ): Unit = {
     assertNoDiff(obtained.sorted.mkString("\n"), expected.sorted.mkString("\n"))
   }
+
+  sealed trait Mode
+  // includeInnerClasses = false
+  // includeMembers = false
+  case object Toplevel extends Mode
+  // includeInnerClasses = true
+  // includeMembers = false
+  case object ToplevelWithInner extends Mode
+  // includeInnerClasses = true
+  // includeMembers = true
+  case object All extends Mode
 
 }

--- a/tests/unit/src/test/scala/tests/ToplevelWithInnerSuite.scala
+++ b/tests/unit/src/test/scala/tests/ToplevelWithInnerSuite.scala
@@ -1,0 +1,43 @@
+package tests
+
+import scala.meta.Dialect
+import scala.meta.dialects
+import scala.meta.internal.mtags.Mtags
+import scala.meta.internal.mtags.Semanticdbs
+
+abstract class ToplevelWithInnerSuite(
+    inputProperties: => InputProperties,
+    directory: String,
+    dialect: Dialect,
+) extends DirectoryExpectSuite(directory) {
+
+  override lazy val input: InputProperties = inputProperties
+
+  def testCases(): List[ExpectTestCase] = {
+    input.allFiles.collect {
+      case file if file.isScala =>
+        ExpectTestCase(
+          file,
+          { () =>
+            val input = file.input
+            val toplevelMtags =
+              Mtags.allToplevels(input, dialect, includeMembers = false)
+            Semanticdbs.printTextDocument(toplevelMtags)
+          },
+        )
+    }
+  }
+}
+
+class ToplevelWithInnerScala2Suite
+    extends ToplevelWithInnerSuite(
+      InputProperties.scala2(),
+      "toplevel-with-inner",
+      dialects.Scala213,
+    )
+class ToplevelWithInnerScala3Suite
+    extends ToplevelWithInnerSuite(
+      InputProperties.scala3(),
+      "toplevel-with-inner-scala3",
+      dialects.Scala3,
+    )


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/5500

I also:
 1. added tests for toplevels with inner classes but w/o members
 2. added more kw after which we might have expressions
 3. skip correctly def/val/... bodies
 4. fixed scopes after enum