### PR TITLE
improvement: Show direct members first

### DIFF
--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaCompletionProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaCompletionProvider.scala
@@ -64,9 +64,11 @@ class JavaCompletionProvider(
 
   private def identifierScore(element: Element): Int = {
     val name = element.getSimpleName().toString().toLowerCase()
-    if (name.startsWith(identifier)) 0
-    else if (name.contains(identifier)) 1
-    else 2
+    name.indexOf(identifier) match {
+      case 0 => 0
+      case -1 => 2
+      case _ => 1
+    }
   }
 
   private def memberScore(element: Element, containingElement: Element): Int = {

--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaMetalsGlobal.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaMetalsGlobal.scala
@@ -1,7 +1,10 @@
 package scala.meta.internal.pc
 
 import java.net.URI
+import javax.tools.Diagnostic
+import javax.tools.DiagnosticListener
 import javax.tools.JavaCompiler
+import javax.tools.JavaFileObject
 import javax.tools.ToolProvider
 
 import scala.jdk.CollectionConverters._
@@ -19,6 +22,13 @@ class JavaMetalsGlobal(
 
   private val COMPILER: JavaCompiler = ToolProvider.getSystemJavaCompiler()
 
+  private val noopDiagnosticListener = new DiagnosticListener[JavaFileObject] {
+
+    // ignore errors since presentation compiler will have a lot of transient ones
+    override def report(diagnostic: Diagnostic[_ <: JavaFileObject]): Unit = ()
+
+  }
+
   def compilationTask(sourceCode: String, uri: URI): JavacTask = {
     val javaFileObject = SourceJavaFileObject.make(sourceCode, uri)
 
@@ -26,7 +36,7 @@ class JavaMetalsGlobal(
       .getTask(
         null,
         null,
-        null,
+        noopDiagnosticListener,
         null,
         null,
         List(javaFileObject).asJava

--- a/tests/javapc/src/main/scala/tests/pc/BaseJavaCompletionSuite.scala
+++ b/tests/javapc/src/main/scala/tests/pc/BaseJavaCompletionSuite.scala
@@ -8,6 +8,7 @@ import scala.meta.internal.metals.CompilerOffsetParams
 import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.pc.CancelToken
 
+import munit.Location
 import munit.TestOptions
 import org.eclipse.lsp4j.CompletionItem
 
@@ -18,7 +19,7 @@ class BaseJavaCompletionSuite extends BaseJavaPCSuite {
       expected: String,
       filename: String = "A.java",
       filterText: Option[String] = None,
-  ): Unit = {
+  )(implicit loc: Location): Unit = {
     test(name) {
       val items = getItems(original, filename)
       val filtered = filterText match {

--- a/tests/javapc/src/test/scala/pc/CompletionMemberSelectSuite.scala
+++ b/tests/javapc/src/test/scala/pc/CompletionMemberSelectSuite.scala
@@ -129,7 +129,8 @@ class CompletionMemberSelectSuite extends BaseJavaCompletionSuite {
       |  }
       |}
       |""".stripMargin,
-    """|getClass()
+    """|println()
+       |getClass()
        |hashCode()
        |equals(java.lang.Object arg0)
        |clone()
@@ -140,7 +141,6 @@ class CompletionMemberSelectSuite extends BaseJavaCompletionSuite {
        |wait(long arg0)
        |wait(long arg0, int arg1)
        |finalize()
-       |println()
        |""".stripMargin,
   )
 
@@ -157,8 +157,8 @@ class CompletionMemberSelectSuite extends BaseJavaCompletionSuite {
       |  }
       |}
       |""".stripMargin,
-    """|clone()
-       |cleanStack()
+    """|cleanStack()
+       |clone()
        |""".stripMargin,
     // let's make sure we don't get any <clinit> method
     filterText = Some("cl"),


### PR DESCRIPTION
Previously, we would show all members irrelevant if they were actually declared in the class or parents such as Object. Now, we show direct members first.

Also, changed the compielr to not report errors while typing.