### PR TITLE
bugfix: Fix issues with select in debugger completions

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/ClientConfigurationAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/ClientConfigurationAdapter.scala
@@ -20,7 +20,7 @@ import org.eclipse.lsp4j.debug.SourceBreakpoint
  */
 private[debug] final case class ClientConfigurationAdapter(
     pathFormat: String,
-    linesStartAt1: Boolean,
+    val linesStartAt1: Boolean,
     sourceMapper: SourceMapper,
 ) {
   // The scala-debug-adapter uses the JVM class file format

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
@@ -135,6 +135,7 @@ private[debug] final class DebugProxy(
           new Position(frame.getLine() - 1, 0),
           EmptyCancelToken,
           args,
+          isZeroBased = !clientAdapter.linesStartAt1,
         )
       }
       completions

--- a/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
@@ -250,7 +250,7 @@ class CompletionDapSuite
            |scale(int arg0, float arg1)
            |startsWith(java.lang.String arg0, int arg1)
            |""".stripMargin,
-    expectedEdit = "serialVersionUID",
+    expectedEdit = "name.serialVersionUID",
     topLines = Some(5),
   )(
     """|/a/src/main/java/a/Main.java


### PR DESCRIPTION
Previously, we set the wrong start of the expression since we actually need to calculate that when insertText is used. Now, we calculate it based on the current identifier.

We should use TextEdit in the future, which should work better. I also realized that start actually needs to take into account if the client starts at 1 or 0.