### PR TITLE
bugfix: Support Java when using sbt server via BSP

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -889,8 +889,10 @@ class Compilers(
   def loadJavaCompiler(
       targetId: BuildTargetIdentifier
   ): Option[PresentationCompiler] = {
-    val target = buildTargets.javaTarget(targetId)
-    target.flatMap(loadJavaCompilerForTarget)
+    val targetClasspath = buildTargets.targetClasspath(targetId)
+    targetClasspath.flatMap(classpath =>
+      loadJavaCompilerForTarget(targetId.getUri, classpath)
+    )
   }
 
   def loadCompilerForTarget(
@@ -917,18 +919,14 @@ class Compilers(
   }
 
   def loadJavaCompilerForTarget(
-      target: JavaTarget
+      targetUri: String,
+      classpath: List[String],
   ): Option[PresentationCompiler] = {
     val pc = JavaPresentationCompiler()
-
-    val name = target.javac.getTarget.getUri
-    val classpath =
-      target.javac.classpath.toAbsoluteClasspath.map(_.toNIO).toSeq
-
     Some(
       configure(pc, search).newInstance(
-        name,
-        classpath.asJava,
+        targetUri,
+        classpath.toAbsoluteClasspath.map(_.toNIO).toSeq.asJava,
         log.asJava,
       )
     )

--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -509,7 +509,10 @@ final class FileDecoderProvider(
       sourceRoot <- buildTargets.inverseSourceItem(sourceFile)
       (classDir, targetroot) <-
         if (sourceFile.isJava)
-          findJavaBuildTargetMetadata(targetId)
+          // sbt doesn't provide separate javac info
+          findJavaBuildTargetMetadata(targetId).orElse(
+            findScalaBuildTargetMetadata(targetId)
+          )
         else
           findScalaBuildTargetMetadata(targetId)
     } yield BuildTargetMetadata(

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
@@ -468,6 +468,8 @@ final class Doctor(
     val recommendedFix = problemResolver
       .recommendation(scalaTarget)
       .orElse {
+        if (javaTarget.isEmpty)
+          scribe.debug("No javac information found from the build server")
         javaTarget.flatMap(target => problemResolver.recommendation(target))
       }
     val (targetType, diagnosticsStatus) =

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/DoctorExplanation.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/DoctorExplanation.scala
@@ -170,9 +170,10 @@ object DoctorExplanation {
   case object JavaSupport extends DoctorExplanation {
     val title = "Java Support:"
     val correctMessage: String =
-      s"${Icons.unicode.check} - working non-interactive features (references, rename etc.)"
+      s"${Icons.unicode.check} - hover, completions and index based features supported"
     val incorrectMessage: String =
-      s"""|${Icons.unicode.error} - missing semanticdb plugin, might not be added automatically by the build server (which is only done when using Bloop)
+      s"""|${Icons.unicode.error} - missing semanticdb plugin, might not be added automatically by the build server.
+          |${Icons.unicode.alert} - no Java information available in the build server
           |${Icons.unicode.info} - build target doesn't support Java files""".stripMargin
 
     def show(allTargetsInfo: Seq[DoctorTargetInfo]): Boolean =

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
@@ -81,7 +81,8 @@ class ProblemResolver(
         case _ =>
       }
     }
-    for {
+
+    val javaIssues = for {
       target <- javaTargets
       issue <- findProblem(target)
     } yield {
@@ -91,6 +92,7 @@ class ProblemResolver(
         case _: WrongJavaReleaseVersion => misconfiguredProjects += 1
         case _: MissingJavaTargetRoot => misconfiguredProjects += 1
       }
+      issue.message
     }
 
     val unsupportedMessage = if (unsupportedVersions.nonEmpty) {
@@ -166,7 +168,7 @@ class ProblemResolver(
       unsupportedSbtMessage,
       futureSbtMessage,
       semanticdbMessage,
-    ).flatten
+    ).flatten ++ javaIssues
 
     def scalaVersionsMessages = List(
       deprecatedMessage,

--- a/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
@@ -455,6 +455,44 @@ class FileDecoderProviderSbtLspSuite
         Set("Target", "Scala Version", "Base Directory", "Source Directories"),
       ),
   )
+
+  check(
+    "sbt-java-semanticdb",
+    SbtBuildLayout(
+      s"""|/a/src/main/java/a/A.java
+          |package a;
+          |public class A {}
+          |""".stripMargin,
+      V.scala3,
+    ),
+    "a/src/main/java/a/A.java",
+    None,
+    "semanticdb-detailed",
+    Right(
+      """|a/src/main/java/a/A.java
+         |------------------------
+         |
+         |Summary:
+         |Schema => SemanticDB v4
+         |Uri => a/src/main/java/a/A.java
+         |Text => empty
+         |Language => Java
+         |Symbols => 2 entries
+         |Occurrences => 3 entries
+         |
+         |Symbols:
+         |a/A# => class A extends Object { +1 decls } <: java/lang/Object#
+         |  Object => java/lang/Object#
+         |a/A#`<init>`(). => ctor <init>(): Unit
+         |  Unit => scala/Unit#
+         |
+         |Occurrences:
+         |[0:8..0:9) => a/
+         |[1:13..1:14) <= a/A#
+         |[1:13..1:14) <= a/A#`<init>`().
+         |""".stripMargin
+    ),
+  )
 }
 
 trait FileDecoderProviderLspSpec { self: BaseLspSuite =>
@@ -502,6 +540,7 @@ trait FileDecoderProviderLspSpec { self: BaseLspSuite =>
       customUri: Option[String] = None,
   ): Unit = {
     test(testName) {
+      cleanWorkspace()
       picked.foreach { pickedItem =>
         client.showMessageRequestHandler = { params =>
           params.getActions().asScala.find(_.getTitle == pickedItem)

--- a/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
@@ -432,4 +432,36 @@ class SbtServerSuite
     } yield ()
   }
 
+  test("java-hover") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        SbtBuildLayout(
+          """|/a/src/main/java/a/A.java
+             |package a;
+             |public class A{
+             |  String name = "";
+             |}
+             |""".stripMargin,
+          V.scala213,
+        )
+      )
+      _ <- server.hover("a/src/main/java/A.java", "String na@@me", workspace)
+      _ <- server.didOpen("build.sbt")
+      _ <- server.didSave("build.sbt")(identity)
+      _ <- server.assertHover(
+        "a/src/main/java/a/Main.java",
+        """"|package a;
+           |public class A{
+           |  String na@@me = "";
+           |}
+           |""".stripMargin,
+        """|```java
+           |java.lang.String name
+           |```
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+
 }

--- a/tests/unit/src/main/scala/tests/BuildServerInitializer.scala
+++ b/tests/unit/src/main/scala/tests/BuildServerInitializer.scala
@@ -106,7 +106,13 @@ object SbtServerInitializer extends BuildServerInitializer {
       initializeResult <- server.initialize()
       _ <- server.initialized()
       // choose sbt as the Bsp Server
-      _ = client.selectBspServer = { _ => new MessageActionItem("sbt") }
+      _ = client.selectBspServer = { items =>
+        items.find(_.getTitle().contains("sbt")).getOrElse {
+          throw new RuntimeException(
+            "sbt was expected in the test, but not found"
+          )
+        }
+      }
       _ <- server.executeCommand(ServerCommands.BspSwitch)
     } yield {
       if (!expectError) {


### PR DESCRIPTION
Previously, because sbt doesn't implement javacOptions endpoint we would not provide support for Java files. Now, we fallback to the information provided from the Scala build target, which should be enough for the current features.