### PR TITLE
bugfix: don't show build server not responding error just after coming out of idle

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -428,7 +428,7 @@ object BuildServerConnection {
     def setupServer(): Future[LauncherConnection] = {
       connect().map { case conn @ SocketConnection(_, output, input, _, _) =>
         val tracePrinter = Trace.setupTracePrinter("BSP", workspace)
-        val requestMonitor = new RequestMonitor
+        val requestMonitor = new RequestMonitorImpl
         val launcher = new Launcher.Builder[MetalsBuildServer]()
           .traceMessages(tracePrinter.orNull)
           .setOutput(output)
@@ -461,7 +461,7 @@ object BuildServerConnection {
           result.getCapabilities(),
           new ServerLivenessMonitor(
             requestMonitor,
-            server,
+            () => server.workspaceBuildTargets(),
             languageClient,
             result.getDisplayName(),
             config.metalsToIdleTime,

--- a/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
@@ -10,7 +10,7 @@ import bill.Bill
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import ch.epfl.scala.bsp4j.ScalaMainClassesParams
 
-class ServerLivenessMonitorSuite extends BaseLspSuite("liveness-monitor") {
+class ServerLivenessMonitorLspSuite extends BaseLspSuite("liveness-monitor") {
   override def serverConfig: MetalsServerConfig =
     MetalsServerConfig.default.copy(
       metalsToIdleTime = Duration("3m"),

--- a/tests/unit/src/test/scala/tests/ServerLivenessMonitorSuite.scala
+++ b/tests/unit/src/test/scala/tests/ServerLivenessMonitorSuite.scala
@@ -1,0 +1,93 @@
+package tests
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.collection.immutable.Queue
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutorService
+import scala.concurrent.duration.Duration
+
+import scala.meta.internal.metals.RequestMonitor
+import scala.meta.internal.metals.ServerLivenessMonitor
+import scala.meta.internal.metals.clients.language.NoopLanguageClient
+
+import org.eclipse.lsp4j.MessageActionItem
+import org.eclipse.lsp4j.ShowMessageRequestParams
+
+class ServerLivenessMonitorSuite extends BaseSuite {
+  implicit val ex: ExecutionContextExecutorService =
+    ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
+
+  test("basic") {
+    val pingInterval = Duration("3s")
+    val server = new ResponsiveServer(pingInterval)
+    val client = new CountMessageRequestsClient
+    val livenessMonitor = new ServerLivenessMonitor(
+      server,
+      () => server.sendRequest(true),
+      client,
+      serverName = "responsive server",
+      metalsIdleInterval = pingInterval * 4,
+      pingInterval,
+    )
+    Thread.sleep(pingInterval.toMillis * 3 / 2)
+    assertEquals(livenessMonitor.getState, ServerLivenessMonitor.Idle)
+    server.sendRequest(false)
+    Thread.sleep(pingInterval.toMillis * 2)
+    assertNotEquals(livenessMonitor.getState, ServerLivenessMonitor.Idle)
+    Thread.sleep(pingInterval.toMillis * 5)
+    assertEquals(livenessMonitor.getState, ServerLivenessMonitor.Idle)
+    server.sendRequest(false)
+    Thread.sleep(pingInterval.toMillis)
+    server.sendRequest(false)
+    server.sendRequest(false)
+    Thread.sleep(pingInterval.toMillis * 2)
+    server.sendRequest(false)
+    assertEquals(livenessMonitor.getState, ServerLivenessMonitor.Running)
+    assert(client.showMessageRequests == 0)
+  }
+}
+
+/**
+ * A mock implementation of a responsive build server,
+ * that keeps timestamps of the last incoming and last outgoing, non-ping requests.
+ * For every `sendRequest` a response is scheduled to be recorded after `pingInterval`.
+ */
+class ResponsiveServer(pingInterval: Duration) extends RequestMonitor {
+  private val respondAfter = pingInterval.toMillis
+  @volatile private var lastOutgoing_ : Option[Long] = None
+  private val nextIncoming: AtomicReference[Queue[Long]] = new AtomicReference(
+    Queue()
+  )
+
+  def sendRequest(isPing: Boolean): Queue[Long] = {
+    if (!isPing) lastOutgoing_ = Some(now)
+    nextIncoming.getAndUpdate(_.appended(now + respondAfter))
+  }
+
+  private def now = System.currentTimeMillis()
+
+  override def lastOutgoing: Option[Long] = lastOutgoing_
+
+  override def lastIncoming: Option[Long] = {
+    val now_ = now
+    nextIncoming.updateAndGet { queue =>
+      queue.findLast(_ <= now_) match {
+        case None => queue
+        case Some(last) => queue.dropWhile(_ != last)
+      }
+    }.headOption
+  }
+}
+
+class CountMessageRequestsClient extends NoopLanguageClient {
+  var showMessageRequests = 0
+  override def showMessageRequest(
+      params: ShowMessageRequestParams
+  ): CompletableFuture[MessageActionItem] = {
+    showMessageRequests += 1
+    CompletableFuture.completedFuture(new MessageActionItem("OK"))
+  }
+}


### PR DESCRIPTION
Just after metals comes out of idle state, we might have new outgoing messages but no responses to those messages yet.
This PR makes sure we don't report this as unresponsive build server.