### PR TITLE
feat: Add hover on class,object,type def in Scala 2

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
@@ -167,6 +167,23 @@ class HoverProvider(val compiler: MetalsGlobal, params: OffsetParams)(implicit
           range = pos,
           Some(report)
         )
+      // Class, object, type definitions, matches only if the cursor is over the definition name.
+      case t: MemberDef
+          if (t.namePosition
+            .includes(pos) || pos.includes(
+            t.namePosition
+          )) && t.symbol != null =>
+        val symbol = tree.symbol
+        val tpe = seenFromType(tree, symbol)
+        toHover(
+          symbol = symbol,
+          keyword = symbol.keyString,
+          seenFrom = tpe,
+          tpe = tpe,
+          pos = pos,
+          range = t.namePosition,
+          Some(report)
+        )
       case _ =>
         // Don't show hover for non-identifiers.
         None

--- a/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
@@ -137,9 +137,9 @@ class HoverDefnSuite extends BaseHoverSuite {
 
   check(
     "object",
-    """object M@@yObject
+    """object <<M@@yObject>>
       |""".stripMargin,
-    "",
+    "object object.MyObject".hover,
     compat = Map(
       "3" -> "object MyObject: `object`".hover
     ),
@@ -147,9 +147,9 @@ class HoverDefnSuite extends BaseHoverSuite {
 
   check(
     "trait",
-    """trait M@@yTrait
+    """trait <<M@@yTrait>>
       |""".stripMargin,
-    "",
+    "abstract trait MyTrait: MyTrait".hover,
     compat = Map(
       "3" -> "trait MyTrait: MyTrait".hover
     ),
@@ -157,12 +157,17 @@ class HoverDefnSuite extends BaseHoverSuite {
 
   check(
     "class",
-    """trait M@@yClass
+    """class <<M@@yClass>>
       |""".stripMargin,
-    "",
-    compat = Map(
-      "3" -> "trait MyClass: MyClass".hover
-    ),
+    "class MyClass: MyClass".hover,
+  )
+
+  check(
+    "type",
+    """|object a {
+       |  type <<M@@yType>> = Int
+       |}""".stripMargin,
+    "type MyType: MyType".hover,
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/hover/HoverNegativeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverNegativeSuite.scala
@@ -53,6 +53,22 @@ class HoverNegativeSuite extends BaseHoverSuite {
   )
 
   checkNegative(
+    "object-keyword",
+    """obj@@ect a {
+      |  val x = 42
+      |}
+      |""".stripMargin,
+  )
+
+  checkNegative(
+    "type-keyword",
+    """object a {
+      |  ty@@pe Alpha = Int
+      |}
+      |""".stripMargin,
+  )
+
+  checkNegative(
     "val-equal",
     """object a {
       |  val x =@@ 42


### PR DESCRIPTION
Previously there was no hover shown on class/object/type definition.