### PR TITLE
chore: port `extension-methods-complex` test fix from dotty

### DIFF
--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -144,7 +144,7 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |class C
        |object Foo:
        |    extension [T](using A)(s: T)(using B)
-       |        def double[G](using C)(times: G) = (s.toString + s.toString) * times
+       |        def double[G <: Int](using C)(times: G) = (s.toString + s.toString) * times
        |    end extension
        |    given A with {}
        |    given B with {}
@@ -152,7 +152,7 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |    "".<<doub@@le(1)>>
        |end Foo
        |""".stripMargin,
-    "extension [T](using A)(s: T) def double(using B)[G](using C)(times: G): String".hover,
+    "extension [T](using A)(s: T) def double(using B)[G <: Int](using C)(times: G): String".hover,
   )
 
   check(


### PR DESCRIPTION
fix `HoverScala3TypeSuite.extension-methods-complex` test after https://github.com/lampepfl/dotty/commit/d521be5a7aae3eb62f06d8a3b57c51c04a21cea8