### PR TITLE
chore: Add support for Scala 3.3.1-RC5

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
@@ -64,6 +64,7 @@ object MtagsResolver {
     "3.3.1-RC1" -> "0.11.12",
     "3.3.1-RC2" -> "0.11.12",
     "3.3.1-RC3" -> "0.11.12",
+    "3.3.1-RC4" -> "1.0.0",
   )
 
   class Default extends MtagsResolver {

--- a/project/V.scala
+++ b/project/V.scala
@@ -8,7 +8,7 @@ object V {
   val scala3 = "3.3.0"
   val firstScala3PCVersion = "3.3.2-RC1-bin-20230721-492f777-NIGHTLY"
   // When you can add to removedScalaVersions in MtagsResolver.scala with the last released version
-  val scala3RC: Option[String] = Some("3.3.1-RC4")
+  val scala3RC: Option[String] = Some("3.3.1-RC5")
   val sbtScala = "2.12.17"
   val ammonite212Version = "2.12.18"
   val ammonite213Version = "2.13.11"


### PR DESCRIPTION
If everything goes right this should be the last RC version we should release Metals for.