### PR TITLE
chore: Don't try formatting in auto releases

### DIFF
--- a/.github/workflows/mtags-auto-release.yml
+++ b/.github/workflows/mtags-auto-release.yml
@@ -39,7 +39,7 @@ jobs:
             git commit --allow-empty -m "Release mtags-${{ github.event.inputs.scala_version }} for ${{github.event.inputs.metals_version}}"
             TAG_NAME="mtags_${{ github.event.inputs.metals_version }}_${{ github.event.inputs.scala_version }}"
             git tag $TAG_NAME
-            git push origin $TAG_NAME 
+            git push --no-verify origin $TAG_NAME 
           fi
         env:
           GIT_USER: scalameta@scalameta.org


### PR DESCRIPTION
Started getting errors that main is not recognized despite the fact that `fetch-depth: 0` should address that. As we only need it in the hook, this should be fine.