### PR TITLE
fix: Don't collect map, flatMap, withFilter in for-comprehension

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcCollector.scala
@@ -408,7 +408,9 @@ abstract class PcCollector[T](
          * All select statements such as:
          * val a = hello.<<b>>
          */
-        case sel: Select if sel.span.isCorrect && filter(sel) =>
+        case sel: Select
+            if sel.span.isCorrect && filter(sel) &&
+              !isForComprehensionMethod(sel) =>
           occurences + collect(
             sel,
             pos.withSpan(selectNameSpan(sel)),
@@ -559,6 +561,17 @@ abstract class PcCollector[T](
         Span(span.start, span.start + realName.length, point)
       else Span(point, span.end, point)
     else span
+
+  private val forCompMethods =
+    Set(nme.map, nme.flatMap, nme.withFilter, nme.foreach)
+
+  // We don't want to collect synthethic `map`, `withFilter`, `foreach` and `flatMap` in for-comprenhensions
+  private def isForComprehensionMethod(sel: Select): Boolean =
+    val syntheticName = sel.name match
+      case name: TermName => forCompMethods(name)
+      case _ => false
+    val wrongSpan = sel.qualifier.span.contains(sel.nameSpan)
+    syntheticName && wrongSpan
 end PcCollector
 
 object PcCollector:

--- a/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
@@ -782,4 +782,88 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite {
       |  }
       |}""".stripMargin,
   )
+
+  check(
+    "for-comp-map",
+    """|object Main {
+       |  val x = List(1).<<m@@ap>>(_ + 1)
+       |  val y = for {
+       |    a <- List(1)
+       |  } yield a + 1
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "for-comp-map1",
+    """|object Main {
+       |  val x = List(1).<<m@@ap>>(_ + 1)
+       |  val y = for {
+       |    a <- List(1)
+       |    if true
+       |  } yield a + 1
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "for-comp-foreach",
+    """|object Main {
+       |  val x = List(1).<<for@@each>>(_ => ())
+       |  val y = for {
+       |    a <- List(1)
+       |  } {}
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "for-comp-withFilter",
+    """|object Main {
+       |  val x = List(1).<<with@@Filter>>(_ => true)
+       |  val y = for {
+       |    a <- List(1)
+       |    if true
+       |  } {}
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "for-comp-withFilter1",
+    """|object Main {
+       |  val x = List(1).withFilter(_ => true).<<m@@ap>>(_ + 1)
+       |  val y = for {
+       |    a <- List(1)
+       |    if true
+       |  } yield a + 1
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "for-comp-flatMap1",
+    """|object Main {
+       |  val x = List(1).<<flat@@Map>>(_ => List(1))
+       |  val y = for {
+       |    a <- List(1)
+       |    b <- List(2)
+       |    if true
+       |  } yield a + 1
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "for-comp-flatMap2",
+    """|object Main {
+       |  val x = List(1).withFilter(_ => true).<<flat@@Map>>(_ => List(1))
+       |  val y = for {
+       |    a <- List(1)
+       |    if true
+       |    b <- List(2)
+       |  } yield a + 1
+       |}
+       |""".stripMargin,
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
@@ -475,4 +475,17 @@ class PcRenameSuite extends BasePcRenameSuite {
        |} yield <<a@@bc>>
        |""".stripMargin,
   )
+
+  check(
+    "map-method",
+    """|case class Bar(x: List[Int]) {
+       |  def <<ma@@p>>(f: Int => Int): Bar = Bar(x.map(f))
+       |}
+       |
+       |val f = 
+       |  for {
+       |    b <- Bar(List(1,2,3))
+       |  } yield b
+       |""".stripMargin,
+  )
 }


### PR DESCRIPTION
We don't want rename/highlight and other PC features to include occurrences in for-comp