### PR TITLE
fix: Semantic tokens misaligned in triple quote s-string

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
@@ -57,7 +57,8 @@ object SemanticTokensProvider {
           delta = delta.moveLine(1)
         }
       }
-      delta = Line(0, lines.last.length())
+      if (lines.last.isEmpty()) delta = Line(1, 0)
+      else delta = Line(0, lines.last.length())
     } else {
       val lines = text.split("\n", -1)
       if (lines.length > 1) delta = delta.moveLine(lines.length - 1)

--- a/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
@@ -220,6 +220,28 @@ class SemanticTokensLspSuite extends BaseLspSuite("SemanticTokens") {
        |}""".stripMargin,
   )
 
+  check(
+    "interpolated-string",
+    s"""|<<package>>/*keyword*/ <<a>>/*namespace*/
+        |<<object>>/*keyword*/ <<A>>/*class*/ {
+        |<<s>>/*keyword*/<<\"\"\">>/*string*/
+        |<<some text>>/*string*/
+        |<<\"\"\">>/*string*/
+        |}
+        |""".stripMargin,
+  )
+
+  check(
+    "interpolated-string2",
+    s"""|<<package>>/*keyword*/ <<a>>/*namespace*/
+        |<<object>>/*keyword*/ <<A>>/*class*/ {
+        |<<s>>/*keyword*/<<\"\"\">>/*string*/
+        |<<some text>>/*string*/
+        |<< >>/*string*/<<\"\"\">>/*string*/
+        |}
+        |""".stripMargin,
+  )
+
   def check(
       name: TestOptions,
       expected: String,


### PR DESCRIPTION
closes https://github.com/scalameta/metals/issues/5553