### PR TITLE
chore: Try to fix issues with sbt integration tests

### DIFF
--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -671,15 +671,18 @@ final case class TestingServer(
   // note(@tgodzik) all test should have `System.exit(0)` added to avoid occasional issue due to:
   // https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment
   private def assertSystemExit(parameter: AnyRef) = {
-    def check() = {
+    def check() = try {
+      val nonTarget = workspace.list.filter(_.filename != "target")
       val workspaceFiles =
-        workspace.listRecursive.filter(_.isScalaOrJava).toList
+        nonTarget.flatMap(_.listRecursive.filter(_.isScalaOrJava).toList)
       val usesSystemExit =
         workspaceFiles.exists(_.text.contains("System.exit(0)"))
       if (!usesSystemExit)
         throw new RuntimeException(
           "All debug test for main classes should have `System.exit(0)`"
         )
+    } catch {
+      case _: IOException =>
     }
 
     parameter match {


### PR DESCRIPTION
It seems that while listing files we are getting an exception, because one of the files was temporary. Since we should get IOException there and just are interested about RuntimeException this is fine to wrap in try.

The stack trace in question:
```
[error] ==> X tests.sbt.SbtStepDapSuite.step-into-scala-lib-virtualdoc  28.064s java.io.UncheckedIOException: java.nio.file.NoSuchFileException: /home/runner/work/metals/metals/tests/slow/target/e2e/sbt-debug-step/step-into-scala-lib-virtualdoc/target/scala-2.13/test-classes.bak
[error]     at java.nio.file.FileTreeIterator.fetchNextIfNeeded(FileTreeIterator.java:87)
[error]     at java.nio.file.FileTreeIterator.hasNext(FileTreeIterator.java:103)
[error]     at java.util.Spliterators$IteratorSpliterator.tryAdvance(Spliterators.java:1855)
[error]     at java.util.stream.StreamSpliterators$WrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:292)
[error]     at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:206)
[error]     at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:169)
[error]     at java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:298)
[error]     at java.util.Spliterators$1Adapter.hasNext(Spliterators.java:681)
[error]     at scala.collection.convert.JavaCollectionWrappers$JIteratorWrapper.hasNext(JavaCollectionWrappers.scala:41)
[error]     at geny.Generator$SelfClosing.generate(Generator.scala:228)
[error]     at geny.Generator$Mapped.generate(Generator.scala:283)
[error]     at geny.Generator$Filtered.generate(Generator.scala:276)
[error]     at geny.Generator.foreach(Generator.scala:49)
[error]     at geny.Generator.foreach$(Generator.scala:49)
[error]     at geny.Generator$Filtered.foreach(Generator.scala:274)
[error]     at geny.Generator.toBuffer(Generator.scala:127)
[error]     at geny.Generator.toBuffer$(Generator.scala:125)
[error]     at geny.Generator$Filtered.toBuffer(Generator.scala:274)
[error]     at geny.Generator.toList(Generator.scala:133)
[error]     at geny.Generator.toList$(Generator.scala:133)
[error]     at geny.Generator$Filtered.toList(Generator.scala:274)
[error]     at tests.TestingServer.check$1(TestingServer.scala:676)
[error]     at tests.TestingServer.assertSystemExit(TestingServer.scala:687)
[error]     at tests.TestingServer.startDebugging(TestingServer.scala:659)
[error]     at tests.BaseDapSuite.debugMain(BaseDapSuite.scala:73)
[error]     at tests.debug.BaseStepDapSuite.$anonfun$assertSteps$3(BaseStepDapSuite.scala:180)
[error]     at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:470)
[error]     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[error]     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[error]     at java.lang.Thread.run(Thread.java:833)
[error] Caused by: java.nio.file.NoSuchFileException: /home/runner/work/metals/metals/tests/slow/target/e2e/sbt-debug-step/step-into-scala-lib-virtualdoc/target/scala-2.13/test-classes.bak
[error]     at sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
[error]     at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
[error]     at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
[error]     at sun.nio.fs.UnixFileSystemProvider.newDirectoryStream(UnixFileSystemProvider.java:440)
[error]     at java.nio.file.Files.newDirectoryStream(Files.java:482)
[error]     at java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:301)
[error]     at java.nio.file.FileTreeWalker.next(FileTreeWalker.java:374)
[error]     at java.nio.file.FileTreeIterator.fetchNextIfNeeded(FileTreeIterator.java:83)
[error]     ... 29 more
```