### PR TITLE
improvement: Try to use scala CLI format if it exists

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
@@ -4,6 +4,8 @@ import scala.meta.io.RelativePath
 object Directories {
   def database: RelativePath =
     RelativePath(".metals").resolve("metals.h2.db")
+  def hiddenScalafmt: RelativePath =
+    RelativePath(".metals").resolve(".scalafmt.conf")
   def readonly: RelativePath =
     RelativePath(".metals").resolve("readonly")
   def tmp: RelativePath =

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -205,10 +205,6 @@ final class FormattingProvider(
               tables.dismissedNotifications.ChangeScalafmtVersion
                 .dismiss(24, TimeUnit.HOURS)
               None
-            } else if (item == Messages.dontShowAgain) {
-              tables.dismissedNotifications.ChangeScalafmtVersion
-                .dismissForever()
-              None
             } else None
           }
       }
@@ -224,16 +220,15 @@ final class FormattingProvider(
         if (
           item == MissingScalafmtConf.createFile || item == MissingScalafmtConf.runDefaults
         ) {
-          val toWrite =
-            if (item == MissingScalafmtConf.createFile)
-              projectRoot.resolve(defaultScalafmtLocation)
-            else projectRoot.resolve(Directories.hiddenScalafmt)
-          Files
-            .write(
-              toWrite.toNIO,
-              initialConfig().getBytes(StandardCharsets.UTF_8),
-            )
-          client.showMessage(MissingScalafmtConf.fixedParams(isCancelled))
+          val relative =
+            if (item == MissingScalafmtConf.createFile) defaultScalafmtLocation
+            else Directories.hiddenScalafmt
+          val toWrite = projectRoot.resolve(relative)
+          Files.write(
+            toWrite.toNIO,
+            initialConfig().getBytes(StandardCharsets.UTF_8),
+          )
+          client.showMessage(MissingScalafmtConf.fixedParams(relative))
           Some(toWrite)
         } else if (item == Messages.notNow) {
           tables.dismissedNotifications.CreateScalafmtFile

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -234,10 +234,6 @@ final class FormattingProvider(
           tables.dismissedNotifications.CreateScalafmtFile
             .dismiss(24, TimeUnit.HOURS)
           None
-        } else if (item == Messages.dontShowAgain) {
-          tables.dismissedNotifications.CreateScalafmtFile
-            .dismissForever()
-          None
         } else None
       }
     } else Future.successful(None)
@@ -425,13 +421,10 @@ final class FormattingProvider(
     val configpath = userConfig().scalafmtConfigPath
     val default: Option[AbsolutePath] = {
       val defaultLocation = projectRoot.resolve(defaultScalafmtLocation)
-      lazy val scalacliDefault =
+      val scalacliDefault =
         projectRoot.resolve(".scala-build/.scalafmt.conf")
-      lazy val hiddenDefault = projectRoot.resolve(Directories.hiddenScalafmt)
-      if (defaultLocation.exists) Some(defaultLocation)
-      else if (scalacliDefault.exists) Some(scalacliDefault)
-      else if (hiddenDefault.exists) Some(hiddenDefault)
-      else None
+      val hiddenDefault = projectRoot.resolve(Directories.hiddenScalafmt)
+      List(defaultLocation, scalacliDefault, hiddenDefault).find(_.exists)
     }
     configpath.orElse(default)
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -12,6 +12,7 @@ import scala.meta.internal.metals.clients.language.MetalsSlowTaskParams
 import scala.meta.internal.metals.clients.language.MetalsStatusParams
 import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
+import scala.meta.io.RelativePath
 
 import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
@@ -615,20 +616,20 @@ object Messages {
       else ""
 
     def createFile = new MessageActionItem("Create .scalafmt.conf")
-    def runDefaults = new MessageActionItem("Run with defaults")
+    def runDefaults = new MessageActionItem("Run anyway")
 
-    def fixedParams(isAgain: Boolean): MessageParams =
+    def fixedParams(where: RelativePath): MessageParams =
       new MessageParams(
         MessageType.Info,
-        s"Created .scalafmt.conf${tryAgain(isAgain)}.",
+        s"Created $where.",
       )
 
     def isCreateScalafmtConf(params: ShowMessageRequestParams): Boolean =
       params.getMessage == createScalafmtConfMessage
 
     def createScalafmtConfMessage: String =
-      s"Unable to format since this workspace has no .scalafmt.conf file. " +
-        s"To fix this problem, create an empty .scalafmt.conf and try again."
+      s"No .scalafmt.conf file detected. " +
+        s"How would you like to proceed:"
 
     def params(): ShowMessageRequestParams = {
       val params = new ShowMessageRequestParams()
@@ -639,7 +640,6 @@ object Messages {
           createFile,
           runDefaults,
           notNow,
-          dontShowAgain,
         ).asJava
       )
       params

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -615,6 +615,7 @@ object Messages {
       else ""
 
     def createFile = new MessageActionItem("Create .scalafmt.conf")
+    def runDefaults = new MessageActionItem("Run with defaults")
 
     def fixedParams(isAgain: Boolean): MessageParams =
       new MessageParams(
@@ -636,6 +637,7 @@ object Messages {
       params.setActions(
         List(
           createFile,
+          runDefaults,
           notNow,
           dontShowAgain,
         ).asJava


### PR DESCRIPTION
Scalafmt needs to habe a config file to run formatting. Previously, metals required it to be in the main workspace directory or to be defined via configuration. Now, we will also try to use the default scalafmt config from Scala CLI