### PR TITLE
improvement: don't create service for folders w/ non-Scala projects

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -303,9 +303,14 @@ object MetalsEnrichments
 
   implicit class XtensionAbsolutePathBuffers(path: AbsolutePath) {
 
-    def isScalaProject(extendSearchToScriptsAndSbt: Boolean = true): Boolean = {
-      val isScala: String => Boolean =
-        if (extendSearchToScriptsAndSbt) _.isScalaFilename else _.isScala
+    def isScalaProject(): Boolean =
+      containsProjectFilesSatisfying(_.isScala)
+    def isMetalsProject(): Boolean =
+      containsProjectFilesSatisfying(_.isScalaOrJavaFilename)
+
+    private def containsProjectFilesSatisfying(
+        fileNamePredicate: String => Boolean
+    ): Boolean = {
       val directoriesToCheck = Set("test", "src", "it")
       def dirFilter(f: File) = directoriesToCheck(f.getName()) || f
         .listFiles()
@@ -316,7 +321,7 @@ object MetalsEnrichments
       ): Boolean = {
         file.listFiles().exists { file =>
           if (file.isDirectory()) dirFilter(file) && isScalaDir(file)
-          else isScala(file.getName())
+          else fileNamePredicate(file.getName())
         }
       }
       path.isDirectory && isScalaDir(path.toFile, dirFilter)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -130,7 +130,7 @@ class MetalsLspService(
     folder: AbsolutePath,
     folderVisibleName: Option[String],
     headDoctor: HeadDoctor,
-) extends Folder(folder, folderVisibleName, isKnownScalaProject = true)
+) extends Folder(folder, folderVisibleName, isKnownMetalsProject = true)
     with Cancelable
     with TextDocumentService {
   import serverInputs._
@@ -2052,7 +2052,7 @@ class MetalsLspService(
     if (
       !buildTools.isAutoConnectable()
       && buildTools.loadSupported.isEmpty
-      && folder.isScalaProject(extendSearchToScriptsAndSbt = false)
+      && folder.isScalaProject()
     ) {
       scalaCli.setupIDE(folder)
     } else Future.successful(())

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -2,7 +2,6 @@ package scala.meta.internal.metals
 
 import java.net.URI
 import java.nio.file._
-import java.sql.Connection
 import java.util
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ScheduledExecutorService
@@ -128,10 +127,11 @@ class MetalsLspService(
     shellRunner: ShellRunner,
     timerProvider: TimerProvider,
     initTreeView: () => Unit,
-    val folder: AbsolutePath,
+    folder: AbsolutePath,
     folderVisibleName: Option[String],
     headDoctor: HeadDoctor,
-) extends Cancelable
+) extends Folder(folder, folderVisibleName, isKnownScalaProject = true)
+    with Cancelable
     with TextDocumentService {
   import serverInputs._
 
@@ -781,7 +781,7 @@ class MetalsLspService(
 
   val treeView =
     new FolderTreeViewProvider(
-      Folder(folder, folderVisibleName),
+      new Folder(folder, folderVisibleName, true),
       buildTargets,
       () => buildClient.ongoingCompilations(),
       definitionIndex,
@@ -847,7 +847,7 @@ class MetalsLspService(
     cancelable
   }
 
-  def loadFingerPrints(): Unit = {
+  private def loadFingerPrints(): Unit = {
     // load fingerprints from last execution
     fingerprints.addAll(tables.fingerprints.load())
   }
@@ -859,7 +859,7 @@ class MetalsLspService(
       token: CancelToken,
   ): Future[Unit] = codeActionProvider.executeCommands(params, token)
 
-  def registerNiceToHaveFilePatterns(): Unit = {
+  private def registerNiceToHaveFilePatterns(): Unit = {
     for {
       params <- Option(initializeParams)
       capabilities <- Option(params.getCapabilities)
@@ -885,9 +885,11 @@ class MetalsLspService(
 
   val isInitialized = new AtomicBoolean(false)
 
-  def connectTables(): Connection = tables.connect()
+  def initialized(): Future[Unit] = {
+    loadFingerPrints()
+    registerNiceToHaveFilePatterns()
+    tables.connect()
 
-  def initialized(): Future[Unit] =
     for {
       _ <- maybeSetupScalaCli()
       _ <-
@@ -902,6 +904,7 @@ class MetalsLspService(
             )
           )
     } yield ()
+  }
 
   def onShutdown(): Unit = {
     tables.fingerprints.save(fingerprints.getAllFingerprints())
@@ -2049,9 +2052,10 @@ class MetalsLspService(
     if (
       !buildTools.isAutoConnectable()
       && buildTools.loadSupported.isEmpty
-      && folder.hasScalaFiles
-    ) scalaCli.setupIDE(folder)
-    else Future.successful(())
+      && folder.isScalaProject(extendSearchToScriptsAndSbt = false)
+    ) {
+      scalaCli.setupIDE(folder)
+    } else Future.successful(())
   }
 
   private def slowConnectToBloopServer(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -2053,9 +2053,8 @@ class MetalsLspService(
       !buildTools.isAutoConnectable()
       && buildTools.loadSupported.isEmpty
       && folder.isScalaProject()
-    ) {
-      scalaCli.setupIDE(folder)
-    } else Future.successful(())
+    ) scalaCli.setupIDE(folder)
+    else Future.successful(())
   }
 
   private def slowConnectToBloopServer(

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceFolders.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceFolders.scala
@@ -75,7 +75,7 @@ class WorkspaceFolders(
         if (!isIn(services, folder)) {
           WorkspaceFoldersServices(
             services :+ newService,
-            nonScalaProjects.filter(_ == folder),
+            nonScalaProjects.filterNot(_ == folder),
           )
         } else wfs
     }
@@ -99,14 +99,6 @@ class WorkspaceFolders(
   private def isIn(services: List[Folder], service: Folder) =
     services.exists(_.path == service.path)
 
-}
-
-trait MetalsLspServiceCreator {
-  def apply(
-      folder: Folder,
-      updateLoggerFiles: () => Future[Unit],
-      forceIsScalaProject: Boolean = false,
-  ): MetalsLspService
 }
 
 case class WorkspaceFoldersServices(

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceFolders.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceFolders.scala
@@ -17,7 +17,7 @@ class WorkspaceFolders(
 
   private val folderServices: AtomicReference[WorkspaceFoldersServices] = {
     val (scalaProjects, nonScalaProjects) =
-      initialFolders.partition(_.isScalaProject) match {
+      initialFolders.partition(_.isMetalsProject) match {
         case (Nil, nonScala) => (List(nonScala.head), nonScala.tail)
         case t => t
       }
@@ -37,7 +37,7 @@ class WorkspaceFolders(
     def shouldBeRemoved(folder: Folder) =
       actualToRemove.exists(_.path == folder.path)
 
-    val (newScala, newNonScala) = toAdd.partition(_.isScalaProject)
+    val (newScala, newNonScala) = toAdd.partition(_.isMetalsProject)
     val newServices = newScala.map(createService(_))
     if (newServices.isEmpty && getFolderServices.forall(shouldBeRemoved)) {
       shutdownMetals()

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceFolders.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceFolders.scala
@@ -10,16 +10,23 @@ import scala.meta.internal.metals.logging.MetalsLogger
 class WorkspaceFolders(
     initialFolders: List[Folder],
     createService: Folder => MetalsLspService,
-    onInitialize: MetalsLspService => Future[Unit],
-    shoutdownMetals: () => Future[Unit],
+    shutdownMetals: () => Future[Unit],
     redirectSystemOut: Boolean,
     initialServerConfig: MetalsServerConfig,
 )(implicit ec: ExecutionContext) {
 
-  private val folderServices: AtomicReference[List[MetalsLspService]] =
-    new AtomicReference(initialFolders.map(createService))
+  private val folderServices: AtomicReference[WorkspaceFoldersServices] = {
+    val (scalaProjects, nonScalaProjects) =
+      initialFolders.partition(_.isScalaProject) match {
+        case (Nil, nonScala) => (List(nonScala.head), nonScala.tail)
+        case t => t
+      }
+    val services = scalaProjects.map(createService(_))
+    new AtomicReference(WorkspaceFoldersServices(services, nonScalaProjects))
+  }
 
-  def getFolderServices: List[MetalsLspService] = folderServices.get()
+  def getFolderServices: List[MetalsLspService] = folderServices.get().services
+  def nonScalaProjects: List[Folder] = folderServices.get().nonScalaFolders
 
   def changeFolderServices(
       toRemove: List[Folder],
@@ -27,39 +34,82 @@ class WorkspaceFolders(
   ): Future[Unit] = {
     val actualToRemove =
       toRemove.filterNot(folder => toAdd.exists(_.path == folder.path))
-    def shouldBeRemoved(service: MetalsLspService) =
-      actualToRemove.exists(_.path == service.folder)
-    def isIn(services: List[MetalsLspService], service: MetalsLspService) =
-      services.exists(_.folder == service.folder)
+    def shouldBeRemoved(folder: Folder) =
+      actualToRemove.exists(_.path == folder.path)
 
-    val newServices = toAdd.map { folder =>
-      val newService = createService(folder)
-      newService.loadFingerPrints()
-      newService.registerNiceToHaveFilePatterns()
-      newService.connectTables()
-      newService
-    }
+    val (newScala, newNonScala) = toAdd.partition(_.isScalaProject)
+    val newServices = newScala.map(createService(_))
     if (newServices.isEmpty && getFolderServices.forall(shouldBeRemoved)) {
-      shoutdownMetals()
+      shutdownMetals()
     } else {
-      val prev =
-        folderServices.getAndUpdate { current =>
-          val afterRemove = current.filterNot(shouldBeRemoved)
-          val newToAdd = newServices.filterNot(isIn(current, _))
-          afterRemove ++ newToAdd
+      val WorkspaceFoldersServices(prev, _) =
+        folderServices.getAndUpdate {
+          case WorkspaceFoldersServices(services, nonScalaProjects) =>
+            val updatedServices =
+              services.filterNot(shouldBeRemoved) ++
+                newServices.filterNot(isIn(services, _))
+            val updatedNonScala =
+              nonScalaProjects.filterNot(shouldBeRemoved) ++
+                newNonScala.filterNot(isIn(nonScalaProjects ++ services, _))
+            WorkspaceFoldersServices(
+              updatedServices,
+              updatedNonScala,
+            )
         }
-      MetalsLogger.setupLspLogger(
-        folderServices.get().map(_.folder),
-        redirectSystemOut,
-        initialServerConfig,
-      )
+
+      setupLogger()
+
       for {
         _ <- Future.sequence(
-          newServices.filterNot(isIn(prev, _)).map(onInitialize)
+          newServices.filterNot(isIn(prev, _)).map(_.initialized())
         )
         _ <- Future(prev.filter(shouldBeRemoved).foreach(_.onShutdown()))
       } yield ()
     }
   }
 
+  def convertToScalaProject(folder: Folder): MetalsLspService = {
+    val newService = createService(folder)
+    val WorkspaceFoldersServices(prev, _) = folderServices.getAndUpdate {
+      case wfs @ WorkspaceFoldersServices(services, nonScalaProjects) =>
+        if (!isIn(services, folder)) {
+          WorkspaceFoldersServices(
+            services :+ newService,
+            nonScalaProjects.filter(_ == folder),
+          )
+        } else wfs
+    }
+
+    prev.find(_.path == folder.path) match {
+      case Some(service) => service
+      case None =>
+        setupLogger()
+        newService.initialized()
+        newService
+    }
+  }
+
+  private def setupLogger() =
+    MetalsLogger.setupLspLogger(
+      getFolderServices.map(_.path),
+      redirectSystemOut,
+      initialServerConfig,
+    )
+
+  private def isIn(services: List[Folder], service: Folder) =
+    services.exists(_.path == service.path)
+
 }
+
+trait MetalsLspServiceCreator {
+  def apply(
+      folder: Folder,
+      updateLoggerFiles: () => Future[Unit],
+      forceIsScalaProject: Boolean = false,
+  ): MetalsLspService
+}
+
+case class WorkspaceFoldersServices(
+    services: List[MetalsLspService],
+    nonScalaFolders: List[Folder],
+)

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -324,7 +324,7 @@ class WorkspaceLspService(
     focusedDocument = Some(path)
     val service = getServiceForOpt(path)
       .orElse {
-        if (path.isScalaFilename) {
+        if (path.filename.isScalaOrJavaFilename) {
           getFolderForOpt(path, nonScalaProjects)
             .map(workspaceFolders.convertToScalaProject)
         } else None
@@ -542,13 +542,13 @@ class WorkspaceLspService(
         params
           .getEvent()
           .getRemoved()
-          .map(Folder(_, isKnownScalaProject = false))
+          .map(Folder(_, isKnownMetalsProject = false))
           .asScala
           .toList,
         params
           .getEvent()
           .getAdded()
-          .map(Folder(_, isKnownScalaProject = false))
+          .map(Folder(_, isKnownMetalsProject = false))
           .asScala
           .toList,
       )
@@ -1280,11 +1280,11 @@ class WorkspaceLspService(
 class Folder(
     val path: AbsolutePath,
     val visibleName: Option[String],
-    isKnownScalaProject: Boolean,
+    isKnownMetalsProject: Boolean,
 ) {
-  lazy val isScalaProject: Boolean =
-    isKnownScalaProject || path.resolve(".metals").exists || path
-      .isScalaProject()
+  lazy val isMetalsProject: Boolean =
+    isKnownMetalsProject || path.resolve(".metals").exists || path
+      .isMetalsProject()
   def nameOrUri: String = visibleName.getOrElse(path.toString())
 }
 
@@ -1294,12 +1294,12 @@ object Folder {
   )
   def apply(
       folder: lsp4j.WorkspaceFolder,
-      isKnownScalaProject: Boolean,
+      isKnownMetalsProject: Boolean,
   ): Folder = {
     val name = Option(folder.getName()) match {
       case Some("") => None
       case maybeValue => maybeValue
     }
-    new Folder(folder.getUri().toAbsolutePath, name, isKnownScalaProject)
+    new Folder(folder.getUri().toAbsolutePath, name, isKnownMetalsProject)
   }
 }

--- a/metals/src/main/scala/scala/meta/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/metals/MetalsLanguageServer.scala
@@ -140,12 +140,12 @@ class MetalsLanguageServer(
                 new Folder(
                   root.toAbsolutePath,
                   Some("root"),
-                  isKnownScalaProject = true,
+                  isKnownMetalsProject = true,
                 )
               )
               .toList
-          case head :: Nil => List(Folder(head, isKnownScalaProject = true))
-          case many => many.map(Folder(_, isKnownScalaProject = false))
+          case head :: Nil => List(Folder(head, isKnownMetalsProject = true))
+          case many => many.map(Folder(_, isKnownMetalsProject = false))
         }
       }
 
@@ -174,7 +174,7 @@ class MetalsLanguageServer(
 
           val folderPathsWithScala =
             folders.collect {
-              case folder if folder.isScalaProject => folder.path
+              case folder if folder.isMetalsProject => folder.path
             } match {
               case Nil =>
                 scribe.warn(

--- a/metals/src/main/scala/scala/meta/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/metals/MetalsLanguageServer.scala
@@ -201,7 +201,7 @@ class MetalsLanguageServer(
           serverState.set(ServerState.Initialized(service))
           metalsService.underlying = service
 
-          folderPaths.foreach(folder =>
+          folderPathsWithScala.foreach(folder =>
             new StdReportContext(folder.toNIO).cleanUpOldReports()
           )
 

--- a/metals/src/main/scala/scala/meta/metals/MetalsLanguageServer.scala
+++ b/metals/src/main/scala/scala/meta/metals/MetalsLanguageServer.scala
@@ -126,19 +126,27 @@ class MetalsLanguageServer(
         )
         .asJava
     } else {
-      val folders = {
-        val workspaceFolders =
+      val folders: List[Folder] = {
+        val allFolders =
           Option(params.getWorkspaceFolders())
             .map(_.asScala)
             .toList
             .flatten
-            .map(Folder.apply)
-        if (workspaceFolders.nonEmpty) workspaceFolders
-        else
-          Option(params.getRootUri())
-            .orElse(Option(params.getRootPath()))
-            .map(root => Folder(root.toAbsolutePath, Some("root")))
-            .toList
+        allFolders match {
+          case Nil =>
+            Option(params.getRootUri())
+              .orElse(Option(params.getRootPath()))
+              .map(root =>
+                new Folder(
+                  root.toAbsolutePath,
+                  Some("root"),
+                  isKnownScalaProject = true,
+                )
+              )
+              .toList
+          case head :: Nil => List(Folder(head, isKnownScalaProject = true))
+          case many => many.map(Folder(_, isKnownScalaProject = false))
+        }
       }
 
       folders match {
@@ -163,8 +171,21 @@ class MetalsLanguageServer(
           val folderPaths = folders.map(_.path)
 
           setupJna()
+
+          val folderPathsWithScala =
+            folders.collect {
+              case folder if folder.isScalaProject => folder.path
+            } match {
+              case Nil =>
+                scribe.warn(
+                  s"No scala project detected. The logs will be in the first workspace folder: ${folderPaths.head}"
+                )
+                List(folderPaths.head)
+              case paths => paths
+            }
+
           MetalsLogger.setupLspLogger(
-            folderPaths,
+            folderPathsWithScala,
             redirectSystemOut,
             serverInputs.initialServerConfig,
           )

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/ReportContext.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/ReportContext.scala
@@ -31,8 +31,7 @@ trait Reporter {
 
 class StdReportContext(workspace: Path, level: ReportLevel = ReportLevel.Info)
     extends ReportContext {
-  lazy val reportsDir: Path =
-    workspace.resolve(StdReportContext.reportsDir).createDirectories()
+  val reportsDir: Path = workspace.resolve(StdReportContext.reportsDir)
 
   val unsanitized =
     new StdReporter(
@@ -61,17 +60,18 @@ class StdReportContext(workspace: Path, level: ReportLevel = ReportLevel.Info)
 
   override def deleteAll(): Unit = {
     all.foreach(_.deleteAll())
-    Files.delete(reportsDir.resolve(StdReportContext.ZIP_FILE_NAME))
+    val zipFile = reportsDir.resolve(StdReportContext.ZIP_FILE_NAME)
+    if (Files.exists(zipFile)) Files.delete(zipFile)
   }
 }
 
 class StdReporter(workspace: Path, pathToReports: Path, level: ReportLevel)
     extends Reporter {
-  private lazy val reportsDir =
-    workspace.resolve(pathToReports).createDirectories()
+  private lazy val maybeReportsDir: Path = workspace.resolve(pathToReports)
+  private lazy val reportsDir = maybeReportsDir.createDirectories()
   private val limitedFilesManager =
     new LimitedFilesManager(
-      reportsDir,
+      maybeReportsDir,
       StdReportContext.MAX_NUMBER_OF_REPORTS,
       "r_.*_"
     )

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/utils/LimitedFilesManager.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/utils/LimitedFilesManager.scala
@@ -22,11 +22,14 @@ class LimitedFilesManager(
     } else List()
   }
 
-  def directoriesWithDate: List[File] = directory
-    .toFile()
-    .listFiles()
-    .toList
-    .filter(d => d.isDirectory() && TimeFormatter.hasDateName(d.getName()))
+  def directoriesWithDate: List[File] =
+    if (Files.exists(directory) && Files.isDirectory(directory))
+      directory
+        .toFile()
+        .listFiles()
+        .toList
+        .filter(d => d.isDirectory() && TimeFormatter.hasDateName(d.getName()))
+    else List()
 
   def deleteOld(limit: Int = fileLimit): List[TimestampedFile] = {
     val files = getAllFiles()

--- a/tests/slow/src/main/scala/tests/scalacli/BaseScalaCliSuite.scala
+++ b/tests/slow/src/main/scala/tests/scalacli/BaseScalaCliSuite.scala
@@ -66,7 +66,7 @@ abstract class BaseScalaCliSuite(protected val scalaVersion: String)
       server.client.showMessageRequestHandler
     server.client.showMessageRequestHandler = { params =>
       def useBsp = Files.exists(
-        server.server.folder
+        server.server.path
           .resolve(".bsp/scala-cli.json")
           .toNIO
       )

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -594,7 +594,7 @@ final case class TestingServer(
     fullServer.folderServices.foreach { service =>
       require(
         service.bspSession.isDefined,
-        s"Build server ${service.folder} did not initialize",
+        s"Build server ${service.path} did not initialize",
       )
     }
   }

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -95,7 +95,7 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
             |${TreeViewProvider.Compile} <root>
             |""".stripMargin,
       )
-      folder = server.server.folder
+      folder = server.server.path
       _ = server.assertTreeViewChildren(
         s"projects-$folder:${server.buildTarget("a")}",
         "",
@@ -158,7 +158,7 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
           |}
           |""".stripMargin
       )
-      folder = server.server.folder
+      folder = server.server.path
       _ = {
         server.assertTreeViewChildren(
           s"libraries-$folder:${server.jar("sourcecode")}",
@@ -500,7 +500,7 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
           |}
           |""".stripMargin
       )
-      folder = server.server.folder
+      folder = server.server.path
       // Trigger a compilation of Second.scala
       _ <- server.didOpen("b/src/main/scala/b/Second.scala")
       _ = server.assertTreeViewChildren(

--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -1064,7 +1064,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
       targetName,
       targetUri,
       "root",
-      server.server.folder.toNIO.toString,
+      server.server.path.toNIO.toString,
       events,
     )
 }


### PR DESCRIPTION
Previously: We had no distinction between workspace folders that are `Scala` projects and those that aren't.
Now: We create `MetalsLspService` only for `Scala` projects.

I consider something to be a Scala (metals) project if there is:
 1. `.metals` folder
 2. a toplevel scala+ (`.scala`, `.sc`, `.sbt`) file
 3. a scala+ file in `.\src`, `.\it` , `.\test`, `.\*\src`, `.\*\it` , `.\*\test`
 4. a scala+ file that belongs to that workspace folder was opened
 
 resolves: https://github.com/scalameta/metals/issues/5558
 