### PR TITLE
bugfix: Allow run in Mill BSP and remove non working test lenses

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -72,6 +72,8 @@ class BuildServerConnection private (
 
   // the name is set before when establishing conenction
   def name: String = initialConnection.socketConnection.serverName
+  private def capabilities: BuildServerCapabilities =
+    initialConnection.capabilities
 
   def isBloop: Boolean = name == BloopServers.name
 
@@ -82,6 +84,13 @@ class BuildServerConnection private (
   def isScalaCLI: Boolean = ScalaCli.names(name)
 
   def isAmmonite: Boolean = name == Ammonite.name
+
+  def isDebuggingProvider: Boolean =
+    Option(capabilities.getDebugProvider())
+      .exists(_.getLanguageIds().contains("scala"))
+
+  def isJvmEnvironmentSupported: Boolean =
+    capabilities.getJvmRunEnvironmentProvider()
 
   /* Currently only Bloop and sbt support running single test cases
    * and ScalaCLI uses Bloop underneath.

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1535,13 +1535,15 @@ class MetalsLspService(
   override def codeLens(
       params: CodeLensParams
   ): CompletableFuture[util.List[CodeLens]] =
-    CancelTokens { _ =>
-      timerProvider.timedThunk(
-        "code lens generation",
-        thresholdMillis = 1.second.toMillis,
-      ) {
-        val path = params.getTextDocument.getUri.toAbsolutePath
-        codeLensProvider.findLenses(path).toList.asJava
+    CancelTokens.future { _ =>
+      buildServerPromise.future.map { _ =>
+        timerProvider.timedThunk(
+          "code lens generation",
+          thresholdMillis = 1.second.toMillis,
+        ) {
+          val path = params.getTextDocument.getUri.toAbsolutePath
+          codeLensProvider.findLenses(path).toList.asJava
+        }
       }
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -76,9 +76,13 @@ final class BuildTargetClasses(
             .mainClasses(new b.ScalaMainClassesParams(targetsList))
             .map(cacheMainClasses(classes, _))
 
-          val updateTestClasses = connection
-            .testClasses(new b.ScalaTestClassesParams(targetsList))
-            .map(cacheTestClasses(classes, _))
+          // Currently tests are only run using DAP
+          val updateTestClasses =
+            if (connection.isDebuggingProvider || connection.isSbt)
+              connection
+                .testClasses(new b.ScalaTestClassesParams(targetsList))
+                .map(cacheTestClasses(classes, _))
+            else Future.unit
 
           val jvmRunEnvironment = connection
             .jvmRunEnvironment(new b.JvmRunEnvironmentParams(targetsList))

--- a/project/V.scala
+++ b/project/V.scala
@@ -32,7 +32,7 @@ object V {
   val kindProjector = "0.13.2"
   val lsp4jV = "0.20.1"
   val mavenBloop = "2.0.0"
-  val mill = "0.11.1"
+  val mill = "0.11.2"
   val mdoc = "2.3.7"
   val munit = "1.0.0-M8"
   val pprint = "0.7.3"

--- a/tests/slow/src/test/scala/tests/mill/MillServerCodeLensSuite.scala
+++ b/tests/slow/src/test/scala/tests/mill/MillServerCodeLensSuite.scala
@@ -1,0 +1,69 @@
+package tests.mill
+
+import scala.concurrent.duration.Duration
+
+import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.metals.{BuildInfo => V}
+
+import tests.BaseCodeLensLspSuite
+import tests.MillBuildLayout
+import tests.MillServerInitializer
+
+class MillServerCodeLensSuite
+    extends BaseCodeLensLspSuite("mill-server-lenses", MillServerInitializer) {
+
+  override def munitTimeout: Duration = Duration("4min")
+
+  test("run-mill-lens", maxRetry = 3) {
+    cleanWorkspace()
+    writeLayout(
+      MillBuildLayout(
+        """|/MillMinimal/src/Main.scala
+           |package foo
+           |
+           |object Main {
+           |  def main(args: Array[String]): Unit = {
+           |     println("Hello java!")
+           |  }
+           |}
+           |/MillMinimal/test/src/Foo.scala
+           |// no test lense as debug is not supported
+           |class Foo extends munit.FunSuite {}
+           |""".stripMargin,
+        V.scala213,
+        V.millVersion,
+        includeMunit = true,
+      )
+    )
+
+    for {
+      _ <- server.initialize()
+      _ <- server.initialized()
+      _ <- server.executeCommand(ServerCommands.GenerateBspConfig)
+      _ <- server.didOpen("MillMinimal/src/Main.scala")
+      _ <- server.didSave("MillMinimal/src/Main.scala")(identity)
+      _ = assertNoDiagnostics()
+      _ <- assertCodeLenses(
+        "MillMinimal/src/Main.scala",
+        """|package foo
+           |
+           |<<run>>
+           |object Main {
+           |  def main(args: Array[String]): Unit = {
+           |     println("Hello java!")
+           |  }
+           |}""".stripMargin,
+      )
+      _ <- assertCodeLenses(
+        "MillMinimal/test/src/Foo.scala",
+        """|// no test lense as debug is not supported
+           |class Foo extends munit.FunSuite {}
+           |""".stripMargin,
+      )
+      lenses <- server.codeLenses("MillMinimal/src/Main.scala")
+      _ = assert(lenses.size > 0, "No lenses were generated!")
+      command = lenses.head.getCommand()
+      _ = assertEquals(runFromCommand(command), Some("Hello java!"))
+    } yield ()
+  }
+}

--- a/tests/unit/src/main/scala/tests/BaseCodeLensLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseCodeLensLspSuite.scala
@@ -2,10 +2,90 @@ package tests
 
 import scala.concurrent.Future
 
+import scala.meta.internal.builds.ShellRunner
+import scala.meta.internal.metals.MetalsEnrichments._
+
+import ch.epfl.scala.bsp4j.DebugSessionParams
+import com.google.gson.JsonObject
 import munit.Location
 import munit.TestOptions
+import org.eclipse.lsp4j.Command
 
-abstract class BaseCodeLensLspSuite(name: String) extends BaseLspSuite(name) {
+abstract class BaseCodeLensLspSuite(
+    name: String,
+    initializer: BuildServerInitializer = QuickBuildInitializer,
+) extends BaseLspSuite(name, initializer) {
+
+  protected def runFromCommand(cmd: Command): Option[String] = {
+    cmd.getArguments().asScala.toList match {
+      case (params: DebugSessionParams) :: _ =>
+        params.getData() match {
+          case obj: JsonObject =>
+            val cmd = obj
+              .get("shellCommand")
+              .getAsString()
+              // need to remove all escapes since ShellRunner does escaping itself
+              // for windows
+              .replace("\\\"", "")
+              .replace("\"\\", "\\")
+              // for linux
+              .replace("/\"", "/")
+              .replace("\"/", "/")
+              // when testing on Windows Program Files is problematic when splitting into list
+              .replace("Program Files", "ProgramFiles")
+              .replace("run shell command", "runshellcommand")
+              .split("\\s+")
+              .map(
+                // remove from escaped classpath
+                _.stripPrefix("\"")
+                  .stripSuffix("\"")
+                  // Add back spaces
+                  .replace("ProgramFiles", "Program Files")
+                  .replace("runshellcommand", "run shell command")
+              )
+            ShellRunner
+              .runSync(cmd.toList, workspace, redirectErrorOutput = false)
+              .map(_.trim())
+              .orElse {
+                scribe.error(
+                  "Couldn't run command specified in shellCommand."
+                )
+                scribe.error("The command run was:\n" + cmd.mkString(" "))
+                None
+              }
+          case _ => None
+        }
+
+      case _ => None
+    }
+  }
+
+  protected def testRunShellCommand(name: String): Unit =
+    test(name) {
+      cleanWorkspace()
+      for {
+        _ <- initialize(
+          s"""|/metals.json
+              |{
+              |  "a": {}
+              |}
+              |/a/src/main/scala/a/Main.scala
+              |package foo
+              |
+              |object Main {
+              |  def main(args: Array[String]): Unit = {
+              |     println("Hello java!")
+              |  }
+              |}
+              |""".stripMargin
+        )
+        _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+        lenses <- server.codeLenses("a/src/main/scala/a/Main.scala")
+        _ = assert(lenses.size > 0, "No lenses were generated!")
+        command = lenses.head.getCommand()
+        _ = assertEquals(runFromCommand(command), Some("Hello java!"))
+      } yield ()
+    }
 
   def check(
       name: TestOptions,

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -112,7 +112,7 @@ abstract class BaseLspSuite(
 
   def test(
       testOpts: TestOptions,
-      withoutVirtualDocs: Boolean,
+      withoutVirtualDocs: Boolean = false,
       maxRetry: Int = 0,
   )(
       fn: => Future[Unit]

--- a/tests/unit/src/main/scala/tests/BuildServerLayout.scala
+++ b/tests/unit/src/main/scala/tests/BuildServerLayout.scala
@@ -43,23 +43,45 @@ object SbtBuildLayout extends BuildToolLayout {
 }
 
 object MillBuildLayout extends BuildToolLayout {
+
   override def apply(sourceLayout: String, scalaVersion: String): String =
+    apply(sourceLayout, scalaVersion, includeMunit = false)
+
+  def apply(
+      sourceLayout: String,
+      scalaVersion: String,
+      includeMunit: Boolean,
+  ): String = {
+    val munitModule =
+      if (includeMunit)
+        """|object test extends ScalaTests with TestModule.Munit {
+           |    def ivyDeps = Agg(
+           |      ivy"org.scalameta::munit::0.7.29"
+           |    )
+           |  }  
+           |""".stripMargin
+      else ""
+
     s"""|/build.sc
         |import mill._, scalalib._
         |
         |object MillMinimal extends ScalaModule {
         |  def scalaVersion = "${scalaVersion}"
+        |  $munitModule
         |}
         |$sourceLayout
         |""".stripMargin
+  }
 
   def apply(
       sourceLayout: String,
       scalaVersion: String,
       millVersion: String,
+      includeMunit: Boolean = false,
   ): String =
     s"""|/.mill-version
         |$millVersion
         |${apply(sourceLayout, scalaVersion)}
+        |${apply(sourceLayout, scalaVersion, includeMunit)}
         |""".stripMargin
 }

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1945,6 +1945,7 @@ object TestingServer {
   val TestDefault: InitializationOptions =
     InitializationOptions.Default.copy(
       debuggingProvider = Some(true),
+      runProvider = Some(true),
       treeViewProvider = Some(true),
       slowTaskProvider = Some(true),
     )

--- a/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
@@ -1,12 +1,6 @@
 package tests
 
-import scala.meta.internal.builds.ShellRunner
-import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.UserConfiguration
-
-import ch.epfl.scala.bsp4j.DebugSessionParams
-import com.google.gson.JsonObject
-import org.eclipse.lsp4j.Command
 
 class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
   override protected val changeSpacesToDash = false
@@ -310,77 +304,6 @@ class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
         |}
         |""".stripMargin
   )
-
-  private def runFromCommand(cmd: Command) = {
-    cmd.getArguments().asScala.toList match {
-      case (params: DebugSessionParams) :: _ =>
-        params.getData() match {
-          case obj: JsonObject =>
-            val cmd = obj
-              .get("shellCommand")
-              .getAsString()
-              // need to remove all escapes since ShellRunner does escaping itself
-              // for windows
-              .replace("\\\"", "")
-              .replace("\"\\", "\\")
-              // for linux
-              .replace("/\"", "/")
-              .replace("\"/", "/")
-              // when testing on Windows Program Files is problematic when splitting into list
-              .replace("Program Files", "ProgramFiles")
-              .replace("run shell command", "runshellcommand")
-              .split("\\s+")
-              .map(
-                // remove from escaped classpath
-                _.stripPrefix("\"")
-                  .stripSuffix("\"")
-                  // Add back spaces
-                  .replace("ProgramFiles", "Program Files")
-                  .replace("runshellcommand", "run shell command")
-              )
-            ShellRunner
-              .runSync(cmd.toList, workspace, redirectErrorOutput = false)
-              .map(_.trim())
-              .orElse {
-                scribe.error(
-                  "Couldn't run command specified in shellCommand."
-                )
-                scribe.error("The command run was:\n" + cmd.mkString(" "))
-                None
-              }
-          case _ => None
-        }
-
-      case _ => None
-    }
-  }
-
-  def testRunShellCommand(name: String): Unit =
-    test(name) {
-      cleanWorkspace()
-      for {
-        _ <- initialize(
-          s"""|/metals.json
-              |{
-              |  "a": {}
-              |}
-              |/a/src/main/scala/a/Main.scala
-              |package foo
-              |
-              |object Main {
-              |  def main(args: Array[String]): Unit = {
-              |     println("Hello java!")
-              |  }
-              |}
-              |""".stripMargin
-        )
-        _ <- server.didOpen("a/src/main/scala/a/Main.scala")
-        lenses <- server.codeLenses("a/src/main/scala/a/Main.scala")
-        _ = assert(lenses.size > 0, "No lenses were generated!")
-        command = lenses.head.getCommand()
-        _ = assertEquals(runFromCommand(command), Some("Hello java!"))
-      } yield ()
-    }
 
   testRunShellCommand("run-shell-command")
   testRunShellCommand("run shell command")


### PR DESCRIPTION
Previously, we would show test code lense for Mill BSP, which did not work and not show run lenses which could work with newer Mill versions. Now, we only show run code lense, which can change id debug is supported by mill or we implement an alternative way of running tests.