### PR TITLE
bugfix: skip empty lines when calculating indent for auto import

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/AutoImportPosition.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/AutoImportPosition.scala
@@ -1,5 +1,7 @@
 package scala.meta.internal.pc
 
+import scala.annotation.tailrec
+
 /**
  * A position to insert new imports
  *
@@ -19,6 +21,7 @@ case class AutoImportPosition(
 }
 
 object AutoImportPosition {
+  private val endOfLineCharacters = Set('\r', '\n')
 
   // Infers the indentation at the completion position by counting the number of leading
   // spaces in the line.
@@ -26,11 +29,17 @@ object AutoImportPosition {
   // class Main {
   //   def foo<COMPLETE> // inferred indent is 2 spaces.
   // }
+  @tailrec
   def inferIndent(lineStart: Int, text: String): Int = {
     var i = 0
     while (lineStart + i < text.length && text.charAt(lineStart + i) == ' ') {
       i += 1
     }
-    i
+
+    val pos = lineStart + i
+    if (pos < text.length() && endOfLineCharacters(text.charAt(pos))) {
+      // skip any empty lines
+      inferIndent(pos + 1, text)
+    } else i
   }
 }

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -233,4 +233,32 @@ class ImportMissingSymbolLspSuite
     expectNoDiagnostics = false,
   )
 
+  check(
+    "i5567",
+    """package p {
+      |
+      |  import scala.collection.mutable
+      |
+      |  class C {
+      |    def f = mutable.Map.empty[Int, Int]
+      |    val p = <<Instant.now>>
+      |  }
+      |}
+      |""".stripMargin,
+    s"""|${ImportMissingSymbol.title("Instant", "java.time")}
+        |${CreateNewSymbol.title("Instant")}
+        |""".stripMargin,
+    """|package p {
+       |
+       |  import scala.collection.mutable
+       |  import java.time.Instant
+       |
+       |  class C {
+       |    def f = mutable.Map.empty[Int, Int]
+       |    val p = Instant.now
+       |  }
+       |}
+       |""".stripMargin,
+  )
+
 }


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/5567