### PR TITLE
Trigger HCR after compilation

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -204,6 +204,9 @@ final class Compilations(
     Future.sequence(expansions).map(_.flatten)
   }
 
+  def compileAll(): Future[Map[BuildTargetIdentifier, b.CompileResult]] =
+    compile(None)(buildTargets.allBuildTargetIds).future
+
   private def compile(timeout: Option[Timeout])(
       targets: Seq[b.BuildTargetIdentifier]
   ): CancelableFuture[Map[BuildTargetIdentifier, b.CompileResult]] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -204,9 +204,6 @@ final class Compilations(
     Future.sequence(expansions).map(_.flatten)
   }
 
-  def compileAll(): Future[Map[BuildTargetIdentifier, b.CompileResult]] =
-    compile(None)(buildTargets.allBuildTargetIds).future
-
   private def compile(timeout: Option[Timeout])(
       targets: Seq[b.BuildTargetIdentifier]
   ): CancelableFuture[Map[BuildTargetIdentifier, b.CompileResult]] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
@@ -180,6 +180,13 @@ object DebugProtocol {
     }
   }
 
+  object HotCodeReplace {
+    def unapply(request: RequestMessage): Option[RequestMessage] = {
+      if (request.getMethod != "redefineClasses") None
+      else Some(request)
+    }
+  }
+
   object StackTraceResponse {
     def unapply(
         response: DebugResponseMessage

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -299,6 +299,7 @@ class DebugProvider(
         statusBar,
         sourceMapper,
         compilations,
+        targets,
       )
     }
     val server = new DebugServer(sessionName, uri, proxyFactory)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -298,6 +298,7 @@ class DebugProvider(
         clientConfig.disableColorOutput(),
         statusBar,
         sourceMapper,
+        compilations,
       )
     }
     val server = new DebugServer(sessionName, uri, proxyFactory)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
@@ -190,8 +190,7 @@ private[debug] final class DebugProxy(
     case HotCodeReplace(req) =>
       scribe.info("Hot code replace triggered")
       compilations
-        .compile(sourceMapper.buildTargets.allBuildTargetIds)
-        .future
+        .compileAll()
         .onComplete { res =>
           res match {
             case _: Success[?] => server.send(req)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/MetalsDebugAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/MetalsDebugAdapter.scala
@@ -11,7 +11,7 @@ import org.eclipse.lsp4j.debug.SetBreakpointsArguments
  * - a file in a build target SourceItem
  * - a file in a build target DependencySourcesItem
  *
- * If it is a file in a DependencySourcesItem, the [[MetalsDebugAdapter2x]] maps it to
+ * If it is a file in a DependencySourcesItem, the [[MetalsDebugAdapter]] maps it to
  * its corresponding file in the .metals/readonly/dependencies/ folder.
  */
 private[debug] class MetalsDebugAdapter(sourcePathAdapter: SourcePathAdapter) {


### PR DESCRIPTION
Follow up of the implementation of hot code replace (HCR) in the scala-debug-adapter ([link](https://github.com/scalacenter/scala-debug-adapter/pull/553)) and in the vscode extension ([link](https://github.com/scalameta/metals-vscode/pull/1419)). Trigger a 2nd compilation (after the first one due to saving) to ensure that HCR does not happen during compilation