### PR TITLE
bugfix: Don't enable * kind project syntax by default

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -38,8 +38,15 @@ case class ScalaTarget(
             Scala213Source3
           case Scala212 if containsSource3 =>
             Scala212Source3
-          case Scala3 if other.contains("NIGHTLY") =>
-            Scala3.withAllowFewerBraces(true)
+          case Scala3
+              if scalac
+                .getOptions()
+                .asScala
+                .exists(_.startsWith("-Ykind-projector")) =>
+            dialect.withAllowStarAsTypePlaceholder(true)
+          case Scala3 =>
+            // set to false since this needs an additional compiler option
+            Scala3.withAllowStarAsTypePlaceholder(false)
           case other => other
         }
     }

--- a/tests/slow/src/test/scala/tests/feature/CrossDiagnosticsSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CrossDiagnosticsSuite.scala
@@ -1,0 +1,32 @@
+package tests.feature
+
+import scala.meta.internal.metals.{BuildInfo => V}
+
+import tests.BaseLspSuite
+
+class CrossDiagnosticsSuite extends BaseLspSuite("slow-diagnostics") {
+
+  test("kind-projector") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": { "scalaVersion": "${V.scala3}" }
+           |}
+           |/a/src/main/scala/a/A.scala
+           |
+           |object *
+           |
+           |given Conversion[*.type, List[*.type]] with
+           |  def apply(ast: *.type) = ast :: Nil
+           |
+        """.stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ <- server.didChange("a/src/main/scala/a/A.scala")(txt => txt + "\n")
+      _ = assertNoDiagnostics()
+    } yield ()
+  }
+}


### PR DESCRIPTION
Previously, the default Scala3 dialect would assume kind projector syntax, but that is only true if the proper setting is on.

Now, we only turn it on if defined in scalac options to be on a safe side. There is no current features that depend on it, but it's probably better to have the right trees.

Fixes https://github.com/scalameta/metals/issues/5573