### PR TITLE
bugfix: Catch exception from the compiler when coursier api is on cla…

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompilerSearchVisitor.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompilerSearchVisitor.scala
@@ -23,6 +23,9 @@ class CompilerSearchVisitor(
   private def isAccessible(sym: Symbol): Boolean = try
     sym != NoSymbol && sym.isPublic && sym.isStatic
   catch
+    case err: AssertionError =>
+      logger.log(Level.WARNING, err.getMessage())
+      false
     case NonFatal(e) =>
       reports.incognito.create(
         Report(
@@ -65,8 +68,14 @@ class CompilerSearchVisitor(
       .stripSuffix("$")
       .split("\\$")
 
-    val added = toSymbols(pkg, innerPath.toList).filter(visitSymbol)
+    val added =
+      try toSymbols(pkg, innerPath.toList).filter(visitSymbol)
+      catch
+        case NonFatal(e) =>
+          logger.log(Level.WARNING, e.getMessage(), e)
+          Nil
     added.size
+  end visitClassfile
 
   def visitWorkspaceSymbol(
       path: java.nio.file.Path,

--- a/tests/cross/src/test/scala/tests/pc/ShadowingCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/ShadowingCompletionSuite.scala
@@ -1,0 +1,29 @@
+package tests.pc
+
+import coursierapi.Dependency
+import tests.BaseCompletionSuite
+
+class ShadowingCompletionSuite extends BaseCompletionSuite {
+
+  override protected def extraDependencies(
+      scalaVersion: String
+  ): Seq[Dependency] = Seq(
+    Dependency.of("io.get-coursier", "interface", "1.0.18")
+  )
+
+  check(
+    "buffer".tag(IgnoreForScala3CompilerPC),
+    """package pkg
+      |object Main {
+      |  val x = ListBuff@@
+      |}
+      |""".stripMargin,
+    """|ListBuffer[A](elems: A*): CC[A]
+       |ListBuffer(i: Int): A
+       |ListBuffer - scala.collection.mutable
+       |""".stripMargin,
+    compat = Map(
+      "2" -> "ListBuffer - scala.collection.mutable"
+    ),
+  )
+}


### PR DESCRIPTION
…sspath

We previously fixed another issue connected to this, when no completions would be available because `isPublic` would throw an exception. Now, it turns out we needed to wrap `toSymbols` methods, otherwise we would not get the duplicated symbols (which are also shadowed)

Connected to https://github.com/lampepfl/dotty/issues/16175