### PR TITLE
WIP: feature: Support NIR file decoding

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/parsing/ClassFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/ClassFinder.scala
@@ -250,16 +250,19 @@ sealed trait ClassFinderGranularity {
 
   def isTasty: Boolean = this match {
     case ClassFiles => false
+    case NIR => false
     case Tasty => true
   }
 
   def extension: String = this match {
     case ClassFiles => ".class"
+    case NIR => ".nir"
     case Tasty => ".tasty"
   }
 }
 
 object ClassFinderGranularity {
   case object ClassFiles extends ClassFinderGranularity
+  case object NIR extends ClassFinderGranularity
   case object Tasty extends ClassFinderGranularity
 }


### PR DESCRIPTION
Adds support for decoding `NIR` files using `scala-native-cli` tooling. 

WIP:

* how to select the class from the native target? This selects the preferred target (?) then replaces ".java" with ".nir". Which does not work in general.
* tests?

NIR decoded, with minor changes to emacs lsp-metals, looks like:

![image](https://github.com/scalameta/metals/assets/34317/244d373a-9db7-43f6-b97c-362a5863e92c)
