### PR TITLE
bugfix: fix resolving main class/ test suite for multi-root projects

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1832,29 +1832,15 @@ class MetalsLspService(
   ): Future[DebugSession] =
     debugProvider.createDebugSession(target).flatMap(debugProvider.asSession)
 
-  def findTestClassAndItsBuildTarget(
+  def testClassSearch(
       params: DebugUnresolvedTestClassParams
-  ): Future[List[(String, b.BuildTarget)]] =
-    debugProvider.findTestClassAndItsBuildTarget(params)
+  ): DebugProvider.TestClassSearch =
+    new DebugProvider.TestClassSearch(debugProvider, params)
 
-  def startTestSuiteForResolved(
-      targets: List[(String, b.BuildTarget)],
-      params: DebugUnresolvedTestClassParams,
-  ): Future[DebugSession] = debugProvider
-    .buildTestClassParams(targets, params)
-    .flatMap(debugProvider.asSession)
-
-  def findMainClassAndItsBuildTarget(
+  def mainClassSearch(
       params: DebugUnresolvedMainClassParams
-  ): Future[List[(b.ScalaMainClass, b.BuildTarget)]] =
-    debugProvider.findMainClassAndItsBuildTarget(params)
-
-  def startMainClass(
-      foundClasses: List[(b.ScalaMainClass, b.BuildTarget)],
-      params: DebugUnresolvedMainClassParams,
-  ): Future[DebugSession] = debugProvider
-    .buildMainClassParams(foundClasses, params)
-    .flatMap(debugProvider.asSession)
+  ): DebugProvider.MainClassSearch =
+    new DebugProvider.MainClassSearch(debugProvider, params)
 
   def supportsBuildTarget(
       target: b.BuildTargetIdentifier

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -826,15 +826,14 @@ class WorkspaceLspService(
             Future.failed(DebugProvider.WorkspaceErrorsException).asJavaObject
         }
       case ServerCommands.StartMainClass(params) if params.mainClass != null =>
-        onFirstSatifying(_.findMainClassAndItsBuildTarget(params))(
-          _.nonEmpty,
-          (service, buildTargets) =>
-            service.startMainClass(buildTargets, params),
-          () => {
+        DebugProvider
+          .getResultFromSearches(
+            folderServices.map(_.mainClassSearch(params))
+          ) {
             displayNotFound("Main class", params.mainClass)
             Future.failed(new ju.NoSuchElementException(params.mainClass))
-          },
-        ).asJavaObject
+          }
+          .asJavaObject
 
       case ServerCommands.StartTestSuite(params)
           if params.target != null && params.requestData != null =>
@@ -851,15 +850,14 @@ class WorkspaceLspService(
         ).asJavaObject
       case ServerCommands.ResolveAndStartTestSuite(params)
           if params.testClass != null =>
-        onFirstSatifying(_.findTestClassAndItsBuildTarget(params))(
-          _.nonEmpty,
-          (service, buildTargets) =>
-            service.startTestSuiteForResolved(buildTargets, params),
-          () => {
+        DebugProvider
+          .getResultFromSearches(
+            folderServices.map(_.testClassSearch(params))
+          ) {
             displayNotFound("Test class", params.testClass)
             Future.failed(new ju.NoSuchElementException(params.testClass))
-          },
-        ).asJavaObject
+          }
+          .asJavaObject
       case ServerCommands.StartAttach(params) if params.hostName != null =>
         onFirstSatifying(service =>
           Future.successful(

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -923,7 +923,6 @@ object DebugProvider {
         "Build misconfiguration. No semanticdb can be found for you file, please check the doctor."
       )
 
-
   val specialChars: Set[Char] = ".+*?^()[]{}|&$".toSet
 
   def escapeTestName(testName: String): String =
@@ -935,18 +934,15 @@ object DebugProvider {
   sealed abstract class ClassSearch[A](debugProvider: DebugProvider)(implicit
       ec: ExecutionContext
   ) {
-    private val searchStarted = new ju.concurrent.atomic.AtomicBoolean(false)
     private val searchPromise = Promise[Try[A]]()
     protected def search(): Try[A]
     protected def dapSessionParams(res: A): Future[DebugSessionParams]
     def createDapSession(args: A): Future[DebugSession] =
       dapSessionParams(args).flatMap(debugProvider.asSession(_))
     def searchResult: Future[(Option[A], ClassSearch[A])] = {
-      if (searchStarted.compareAndSet(false, true)) {
-        Future {
-          val resolved = search()
-          searchPromise.trySuccess(resolved)
-        }
+      Future {
+        val resolved = search()
+        searchPromise.trySuccess(resolved)
       }
       searchPromise.future.map(e => (e.toOption, this))
     }


### PR DESCRIPTION
Previously: resolving main class or test suite was not properly adjusted for multiple workspace folders, the future failed with a `ClassNotFoundException` when the class was found in a workspace folder.
Now: We only fail the future if for *all* workspace folder the class is not found.

resolves: https://github.com/scalameta/metals/issues/5512