### PR TITLE
improvement: log awaiting user response in BloopInstall

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
@@ -127,6 +127,7 @@ final class BloopInstall(
           scribe.info(s"skipping build import with status '${result.name}'")
           Future.successful(result)
         case _ =>
+          scribe.debug("Awaiting user response...")
           for {
             userResponse <- requestImport(
               buildTools,


### PR DESCRIPTION
Just opening a draft PR, this would've helped me out a bunch when I accidentally had VSCode Notifications silenced (which is a questionable UI decision on VSCode's part but 🤷‍♀️)

Relatedly, it may be worth mentioning in Troubleshooting how easy it is to silence notifications which are needed by Metals for importing projects. If you click the crossed-out bell icon as shown in this screenshot, the prompts are silenced:

![Screenshot 2023-08-29 at 2 45 46 PM](https://github.com/scalameta/metals/assets/8584418/8e0cfcc6-f5b5-4f46-bd05-84188cfd792f)
