### PR TITLE
bugfix: Release mtagsShared together with mtags when running single version release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             METALS_VERSION=$(echo $GITHUB_REF_NAME | cut -d "_" -f2 | cut -c2-)
             SCALA_VERSION=$(echo $GITHUB_REF_NAME | cut -d "_" -f3)
             if [ ! -z $METALS_VERSION ] && [ ! -z $SCALA_VERSION ]; then
-              export CI_RELEASE="++$SCALA_VERSION! mtags/publishSigned"
+              export CI_RELEASE="++$SCALA_VERSION! mtags/publishSigned mtagsShared/publishSigned"
               UPDATE_DOCS=false
               COMMAND="; set ThisBuild/version :=\"$METALS_VERSION\"; $COMMAND"
             else


### PR DESCRIPTION
I realised we were not releasing fully :sweat: 

Will go ahead and merge quickly as it's needed for us.