### PR TITLE
improvement: start liveness monitor only for main bsp connection

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -77,7 +77,8 @@ class BspConnector(
       shellRunner: ShellRunner,
   )(implicit ec: ExecutionContext): Future[Option[BspSession]] = {
     def connect(
-        workspace: AbsolutePath
+        workspace: AbsolutePath,
+        addLivenessMonitor: Boolean,
     ): Future[Option[BuildServerConnection]] = {
       scribe.info("Attempting to connect to the build server...")
       resolve() match {
@@ -85,7 +86,9 @@ class BspConnector(
           scribe.info("No build server found")
           Future.successful(None)
         case ResolvedBloop =>
-          bloopServers.newServer(workspace, userConfiguration).map(Some(_))
+          bloopServers
+            .newServer(workspace, userConfiguration, addLivenessMonitor)
+            .map(Some(_))
         case ResolvedBspOne(details)
             if details.getName() == SbtBuildTool.name =>
           tables.buildServers.chooseServer(SbtBuildTool.name)
@@ -94,7 +97,11 @@ class BspConnector(
             for {
               _ <- SbtBuildTool(workspace, () => userConfiguration)
                 .ensureCorrectJavaVersion(shellRunner, workspace, client)
-              connection <- bspServers.newServer(workspace, details)
+              connection <- bspServers.newServer(
+                workspace,
+                details,
+                addLivenessMonitor,
+              )
               _ <-
                 if (shouldReload) connection.workspaceReload()
                 else Future.successful(())
@@ -104,7 +111,9 @@ class BspConnector(
             .map(Some(_))
         case ResolvedBspOne(details) =>
           tables.buildServers.chooseServer(details.getName())
-          bspServers.newServer(workspace, details).map(Some(_))
+          bspServers
+            .newServer(workspace, details, addLivenessMonitor)
+            .map(Some(_))
         case ResolvedMultiple(_, availableServers) =>
           val distinctServers = availableServers
             .groupBy(_.getName())
@@ -136,26 +145,33 @@ class BspConnector(
                 )
               )
             _ = tables.buildServers.chooseServer(item.getName())
-            conn <- bspServers.newServer(workspace, item)
+            conn <- bspServers.newServer(
+              workspace,
+              item,
+              addLivenessMonitor,
+            )
           } yield Some(conn)
       }
     }
 
-    connect(workspace).flatMap { possibleBuildServerConn =>
-      possibleBuildServerConn match {
-        case None => Future.successful(None)
-        case Some(buildServerConn)
-            if buildServerConn.isBloop && buildTools.isSbt =>
-          // NOTE: (ckipp01) we special case this here since sbt bsp server
-          // doesn't yet support metabuilds. So in the future when that
-          // changes, re-work this and move the creation of this out above
-          val metaConns = sbtMetaWorkspaces(workspace).map(connect(_))
-          Future
-            .sequence(metaConns)
-            .map(meta => Some(BspSession(buildServerConn, meta.flatten)))
-        case Some(buildServerConn) =>
-          Future(Some(BspSession(buildServerConn, List.empty)))
-      }
+    connect(workspace, addLivenessMonitor = true).flatMap {
+      possibleBuildServerConn =>
+        possibleBuildServerConn match {
+          case None => Future.successful(None)
+          case Some(buildServerConn)
+              if buildServerConn.isBloop && buildTools.isSbt =>
+            // NOTE: (ckipp01) we special case this here since sbt bsp server
+            // doesn't yet support metabuilds. So in the future when that
+            // changes, re-work this and move the creation of this out above
+            val metaConns = sbtMetaWorkspaces(workspace).map(
+              connect(_, addLivenessMonitor = false)
+            )
+            Future
+              .sequence(metaConns)
+              .map(meta => Some(BspSession(buildServerConn, meta.flatten)))
+          case Some(buildServerConn) =>
+            Future(Some(BspSession(buildServerConn, List.empty)))
+        }
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -68,6 +68,7 @@ final class BspServers(
   def newServer(
       projectDirectory: AbsolutePath,
       details: BspConnectionDetails,
+      addLivenessMonitor: Boolean,
   ): Future[BuildServerConnection] = {
 
     def newConnection(): Future[SocketConnection] = {
@@ -140,6 +141,7 @@ final class BspServers(
       tables.dismissedNotifications.ReconnectBsp,
       config,
       details.getName(),
+      addLivenessMonitor,
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -80,6 +80,7 @@ final class BloopServers(
   def newServer(
       workspace: AbsolutePath,
       userConfiguration: UserConfiguration,
+      addLivenessMonitor: Boolean,
   ): Future[BuildServerConnection] = {
     val bloopVersion = userConfiguration.currentBloopVersion
     BuildServerConnection
@@ -92,6 +93,7 @@ final class BloopServers(
         tables.dismissedNotifications.ReconnectBsp,
         config,
         name,
+        addLivenessMonitor,
       )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1640,7 +1640,9 @@ class MetalsLspService(
     val shutdownBsp =
       bspSession match {
         case Some(session) if session.main.isBloop =>
-          Future.successful(bloopServers.shutdownServer())
+          for {
+            _ <- disconnectOldBuildServer()
+          } yield bloopServers.shutdownServer()
         case Some(session) if session.main.isSbt =>
           for {
             currentBuildTool <- supportedBuildTool
@@ -2133,7 +2135,11 @@ class MetalsLspService(
     (for {
       _ <- disconnectOldBuildServer()
       maybeSession <- timerProvider.timed("Connected to build server", true) {
-        bspConnector.connect(folder, userConfig(), shellRunner)
+        bspConnector.connect(
+          folder,
+          userConfig(),
+          shellRunner,
+        )
       }
       result <- maybeSession match {
         case Some(session) =>

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
@@ -445,7 +445,7 @@ final class Doctor(
   private def isServerResponsive: Option[Boolean] =
     currentBuildServer().flatMap { conn =>
       val isResponsiveFuture = conn.main.isBuildServerResponsive
-      Try(Await.result(isResponsiveFuture, Duration("1s"))).toOption
+      Try(Await.result(isResponsiveFuture, Duration("1s"))).toOption.flatten
     }
 
   private def extractScalaTargetInfo(


### PR DESCRIPTION
Start liveness monitor only for main bsp connection.
Add restart bsp server to not responsive bsp notifications options.