### PR TITLE
Make SbtBuildTool respect crossScalaVersions

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -44,7 +44,7 @@ case class SbtBuildTool(
   override def bloopInstallArgs(workspace: AbsolutePath): List[String] = {
     val bloopInstallArgs = List[String](
       "-Dbloop.export-jar-classifiers=sources",
-      "bloopInstall",
+      "+bloopInstall",
     )
     val allArgs = composeArgs(bloopInstallArgs, workspace, tempDir)
     removeLegacyGlobalPlugin()


### PR DESCRIPTION
Currently when using metals via sbt it only creates the bloop definition file for the configured `scalaVersion`. This means for projects that support multiple `scalaVersions`, in particular Scala 2 vs Scala 3 metals fails to work on the scala versions **not** configured by `scalaVersion`, giving a `"No build target found"`

From what I have noticed is that the problem is only between Scala 2 and Scala 3 and not specific versions within Scala 2 (although I may be half wrong here as I would suspect due to stdlib differences between different Scala 2 versions it can have an impact here as well).

References: https://github.com/scalameta/metals-feature-requests/issues/13