### PR TITLE
bugfix: workaround for missing span in reference to an extension method defined in the companion object

### DIFF
--- a/tests/cross/src/test/scala/tests/highlight/Scala3DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/Scala3DocumentHighlightSuite.scala
@@ -308,4 +308,35 @@ class Scala3DocumentHighlightSuite extends BaseDocumentHighlightSuite {
        |""".stripMargin,
   )
 
+  check(
+    "i5630",
+    """|class MyIntOut(val value: Int)
+       |object MyIntOut:
+       |  extension (i: MyIntOut) def <<uneven>> = i.value % 2 == 1
+       |
+       |val a = MyIntOut(1)
+       |val m = a.<<un@@even>>
+       |""".stripMargin,
+  )
+
+  check(
+    "i5630-2",
+    """|class MyIntOut(val value: Int)
+       |object MyIntOut:
+       |  extension (i: MyIntOut) def <<uneven>>(u: Int) = i.value % 2 == 1
+       |
+       |val a = MyIntOut(1).<<un@@even>>(3)
+       |""".stripMargin,
+  )
+
+  check(
+    "i5630-infix",
+    """|class MyIntOut(val value: Int)
+       |object MyIntOut:
+       |  extension (i: MyIntOut) def <<++>>(u: Int) = i.value + u
+       |
+       |val a = MyIntOut(1) <<+@@+>> 3
+       |""".stripMargin,
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -364,4 +364,16 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
     """|val ddd: Int
        |""".stripMargin.hover,
   )
+
+  check(
+    "i5630",
+    """|class MyIntOut(val value: Int)
+       |object MyIntOut:
+       |  extension (i: MyIntOut) def uneven = i.value % 2 == 1
+       |
+       |val a = MyIntOut(1).un@@even
+       |""".stripMargin,
+    """|extension (i: MyIntOut) def uneven: Boolean
+       |""".stripMargin.hover,
+  )
 }

--- a/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcDefinitionSuite.scala
@@ -559,4 +559,14 @@ class PcDefinitionSuite extends BasePcDefinitionSuite {
        |""".stripMargin,
   )
 
+  check(
+    "i5630".tag(IgnoreScala2.and(IgnoreForScala3CompilerPC)),
+    """|class MyIntOut(val value: Int)
+       |object MyIntOut:
+       |  extension (i: MyIntOut) def <<uneven>> = i.value % 2 == 1
+       |
+       |val a = MyIntOut(1).un@@even
+       |""".stripMargin,
+  )
+
 }


### PR DESCRIPTION
Workaround for missing span in:
```Demo.scala
class MyIntOut(val value: Int)
object MyIntOut:
  extension (i: MyIntOut) def <<uneven>> = i.value % 2 == 1

val a = MyIntOut(1).un@@even
```
to provide correct:
 1. semantic highlighting,
 2. highlight,
 3. go to definition.

https://github.com/scalameta/metals/issues/5630