### PR TITLE
bugfix: handle CR

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -9,7 +9,6 @@ import scala.concurrent.Future
 import scala.util.Try
 import scala.{meta => m}
 
-import scala.meta.inputs.Input
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.ClientConfiguration
@@ -551,8 +550,8 @@ final class SyntheticsDecorationProvider(
     val uri = path.toURI.toString
     val typeDecorations = for {
       tree <- trees.get(path).toIterable
-      textDocumentInput = Input.VirtualFile(uri, textDocument.text)
-      treeInput = Input.VirtualFile(uri, tree.pos.input.text)
+      textDocumentInput = VirtualFile(uri, textDocument.text)
+      treeInput = VirtualFile(uri, tree.pos.input.text)
       semanticDbToTreeEdit = TokenEditDistance(
         textDocumentInput,
         treeInput,

--- a/metals/src/main/scala/scala/meta/internal/metals/Buffers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Buffers.scala
@@ -2,7 +2,6 @@ package scala.meta.internal.metals
 
 import scala.collection.concurrent.TrieMap
 
-import scala.meta.inputs.Input
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.parsing.TokenEditDistance
 import scala.meta.internal.parsing.Trees
@@ -26,7 +25,7 @@ case class Buffers(
       trees: Trees,
   ): TokenEditDistance = {
     val bufferInput = source.toInputFromBuffers(this)
-    val snapshotInput = Input.VirtualFile(bufferInput.path, snapshot)
+    val snapshotInput = VirtualFile(bufferInput.path, snapshot)
     TokenEditDistance(snapshotInput, bufferInput, trees).getOrElse(
       TokenEditDistance.NoMatch
     )

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -136,7 +136,7 @@ final class DefinitionProvider(
 
     val defResult = for {
       sourceText <- buffers.get(path)
-      virtualFile = Input.VirtualFile(path.toURI.toString(), sourceText)
+      virtualFile = VirtualFile(path.toURI.toString(), sourceText)
       metaPos <- pos.toMeta(virtualFile)
       tokens <- trees.tokenized(virtualFile).toOption
       ident <- tokens.collectFirst {

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -276,7 +276,7 @@ final case class Indexer(
                 val updatedContent =
                   sourceItem.getTopWrapper + content + sourceItem.getBottomWrapper
                 (
-                  Input.VirtualFile(
+                  VirtualFile(
                     generatedPath.toNIO.toString
                       .stripSuffix(".scala") + ".sc.scala",
                     updatedContent,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -294,7 +294,7 @@ object MetalsEnrichments
     def toUriInput: Input.VirtualFile = {
       val uri = path.toAbsolutePath.toUri.toString
       val text = new String(Files.readAllBytes(path), StandardCharsets.UTF_8)
-      Input.VirtualFile(uri, text)
+      VirtualFile(uri, text)
     }
 
     def isSemanticdb: Boolean =
@@ -489,7 +489,7 @@ object MetalsEnrichments
      */
     def toInputFromBuffers(buffers: Buffers): m.Input.VirtualFile = {
       buffers.get(path) match {
-        case Some(text) => Input.VirtualFile(path.toURI.toString(), text)
+        case Some(text) => VirtualFile(path.toURI.toString(), text)
         case None => path.toInput
       }
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/PackageProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/PackageProvider.scala
@@ -659,7 +659,7 @@ class PackageProvider(
     val result = for {
       content <- path.content()
     } yield {
-      val input = Input.VirtualFile(filename, content)
+      val input = VirtualFile(filename, content)
 
       def isPackageObjectLike(symbol: String) =
         Set("package", filenamePart ++ "$package").contains(symbol)

--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/OnTypeFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/OnTypeFormattingProvider.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.metals.formatting
 
-import scala.meta.inputs.Input
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.UserConfiguration
@@ -51,7 +50,7 @@ class OnTypeFormattingProvider(
 
     val edits = for {
       sourceText <- buffers.get(path)
-      virtualFile = Input.VirtualFile(path.toURI.toString(), sourceText)
+      virtualFile = VirtualFile(path.toURI.toString(), sourceText)
       startPos <- range.getStart.toMeta(virtualFile)
       endPos <- range.getEnd.toMeta(virtualFile)
     } yield {

--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/RangeFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/RangeFormattingProvider.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.metals.formatting
 
-import scala.meta.inputs.Input
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.UserConfiguration
@@ -47,7 +46,7 @@ class RangeFormattingProvider(
     val formattingOptions = params.getOptions
     val edits = for {
       sourceText <- buffers.get(path)
-      virtualFile = Input.VirtualFile(path.toURI.toString(), sourceText)
+      virtualFile = VirtualFile(path.toURI.toString(), sourceText)
       startPos <- range.getStart.toMeta(virtualFile)
       endPos <- range.getEnd.toMeta(virtualFile)
     } yield {

--- a/metals/src/main/scala/scala/meta/internal/parsing/FoldingRangeProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/FoldingRangeProvider.scala
@@ -3,7 +3,6 @@ package scala.meta.internal.parsing
 import java.util
 import java.util.Collections
 
-import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -26,9 +25,9 @@ final class FoldingRangeProvider(
       if filePath.isScala
       tree <- trees.get(filePath)
     } yield {
-      val revised = Input.VirtualFile(filePath.toURI.toString(), code)
+      val revised = VirtualFile(filePath.toURI.toString(), code)
       val fromTree =
-        Input.VirtualFile(filePath.toURI.toString(), tree.pos.input.text)
+        VirtualFile(filePath.toURI.toString(), tree.pos.input.text)
       val distance = TokenEditDistance(fromTree, revised, trees).getOrElse(
         TokenEditDistance.NoMatch
       )

--- a/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
@@ -131,7 +131,7 @@ final class Trees(
     } yield try {
       val skipFistShebang =
         if (text.startsWith("#!")) text.replaceFirst("#!", "//") else text
-      val input = Input.VirtualFile(path.toURI.toString(), skipFistShebang)
+      val input = VirtualFile(path.toURI.toString(), skipFistShebang)
       if (path.isAmmoniteScript || path.isMill) {
         val ammoniteInput = Input.Ammonite(input)
         dialect(ammoniteInput).parse(Parse.parseAmmonite)

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalametaCommonEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalametaCommonEnrichments.scala
@@ -377,7 +377,7 @@ trait ScalametaCommonEnrichments extends CommonMtagsEnrichments {
     def toInput: Input.VirtualFile = {
       val text = FileIO.slurp(path, StandardCharsets.UTF_8)
       val file = path.toURI.toString()
-      Input.VirtualFile(file, text)
+      VirtualFile(file, text)
     }
 
     def jarPath: Option[AbsolutePath] = {
@@ -524,6 +524,21 @@ trait ScalametaCommonEnrichments extends CommonMtagsEnrichments {
       info.kind.isRelevantKind && query.matches(info.symbol)
     }
 
+  }
+
+  object VirtualFile {
+    def apply(path: String, value: String): Input.VirtualFile = {
+      val buffer = new StringBuilder()
+      var isLastCR = false
+      value.foreach { char =>
+        val isCR = char == '\r'
+        def CRSubstitute = if (char == '\n') ' ' else '\n'
+        if (isLastCR) buffer.append(CRSubstitute)
+        if (!isCR) buffer.append(char)
+        isLastCR = isCR
+      }
+      Input.VirtualFile(path, buffer.result())
+    }
   }
 
 }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
@@ -11,7 +11,6 @@ import scala.util.Properties
 import scala.util.control.NonFatal
 
 import scala.meta.Dialect
-import scala.meta.inputs.Input
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.mtags.ScalametaCommonEnrichments._
@@ -129,7 +128,7 @@ class SymbolIndexBucket(
       dialect: Dialect
   ): List[String] = {
     val text = FileIO.slurp(source, StandardCharsets.UTF_8)
-    val input = Input.VirtualFile(uri, text)
+    val input = VirtualFile(uri, text)
     val sourceToplevels = mtags.toplevels(input, dialect)
     if (source.isAmmoniteScript)
       sourceToplevels

--- a/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
+++ b/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
@@ -5,7 +5,6 @@ import java.nio.file.Files
 import java.util.Optional
 import java.{util => ju}
 
-import scala.meta.inputs.Input
 import scala.meta.internal.metals.ClasspathSearch
 import scala.meta.internal.metals.Docstrings
 import scala.meta.internal.metals.EmptyReportContext
@@ -15,6 +14,7 @@ import scala.meta.internal.metals.WorkspaceSymbolQuery
 import scala.meta.internal.mtags.GlobalSymbolIndex
 import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.OnDemandSymbolIndex
+import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 import scala.meta.internal.mtags.Symbol
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.pc.ParentSymbols
@@ -73,7 +73,7 @@ class TestingSymbolSearch(
         import scala.collection.JavaConverters._
         val filename = value.path.toNIO.getFileName().toString()
         val content = new String(Files.readAllBytes(value.path.toNIO))
-        val input = Input.VirtualFile(
+        val input = VirtualFile(
           filename,
           content,
         )

--- a/tests/mtest/src/main/scala/tests/TestingWorkspaceSearch.scala
+++ b/tests/mtest/src/main/scala/tests/TestingWorkspaceSearch.scala
@@ -5,13 +5,12 @@ import java.nio.file.Paths
 import scala.collection.mutable
 
 import scala.meta.Dialect
-import scala.meta.inputs.Input
 import scala.meta.internal.metals.EmptyReportContext
 import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.metals.SemanticdbDefinition
 import scala.meta.internal.metals.WorkspaceSymbolInformation
 import scala.meta.internal.metals.WorkspaceSymbolQuery
-import scala.meta.internal.mtags.ScalametaCommonEnrichments.XtensionWorkspaceSymbolQuery
+import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 import scala.meta.pc.SymbolSearchVisitor
 
 object TestingWorkspaceSearch {
@@ -32,7 +31,7 @@ class TestingWorkspaceSearch(implicit rc: ReportContext = EmptyReportContext) {
       (path, (text, dialect)) <- inputs
     } {
       SemanticdbDefinition.foreach(
-        Input.VirtualFile(path, text),
+        VirtualFile(path, text),
         dialect,
         includeMembers = true,
       ) { defn =>

--- a/tests/unit/src/main/scala/tests/Library.scala
+++ b/tests/unit/src/main/scala/tests/Library.scala
@@ -59,6 +59,13 @@ object Library {
     ).sources.entries
       .filter(_.toString.endsWith("bindings-rxjava-2.0.0-sources.jar"))
 
+  def msal4jSources: List[AbsolutePath] =
+    fetchSources(
+      "azure",
+      List(Dependency.of("com.microsoft.azure", "msal4j", "1.13.8")),
+    ).sources.entries
+      .filter(_.toString().endsWith("msal4j-1.13.8-sources.jar"))
+
   def allScala2: List[Library] = {
     import mtags.BuildInfo.scalaCompilerVersion
 

--- a/tests/unit/src/test/scala/tests/ToplevelLibrarySuite.scala
+++ b/tests/unit/src/test/scala/tests/ToplevelLibrarySuite.scala
@@ -23,7 +23,8 @@ class ToplevelLibrarySuite extends BaseSuite {
     "/dotty/tools/dotc/transform/patmat/Space.scala",
   )
 
-  val javaTestClasspath: List[AbsolutePath] = Library.damlrxjavaSources
+  val javaTestClasspath: List[AbsolutePath] =
+    Library.damlrxjavaSources ++ Library.msal4jSources
 
   scala2TestClasspath.foreach { entry =>
     test(entry.toNIO.getFileName.toString) {


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/5369

`scala.meta.inputs.Input.VirtualFile` counts as new line only `\n`, where the library used by `JavaMtags` and editors (at least VSCode) count all `\r\n`,` \n`, and `\r` as new lines.

This is a workaround mapping the file content but maybe this should actually be adjusted in `scala.meta.inputs.Input.VirtualFile`, @tgodzik ?