### PR TITLE
Bump swoval to v2.1.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -434,7 +434,7 @@ lazy val metals = project
       // for measuring memory footprint
       "org.openjdk.jol" % "jol-core" % "0.17",
       // for file watching
-      "com.swoval" % "file-tree-views" % "2.1.10",
+      "com.swoval" % "file-tree-views" % "2.1.11",
       // for http client
       "io.undertow" % "undertow-core" % "2.2.20.Final",
       "org.jboss.xnio" % "xnio-nio" % "3.8.10.Final",


### PR DESCRIPTION
This release fixes slow performance on Windows for listing deeply nested directories. See https://github.com/swoval/swoval/issues/161. The user confirmed that the performance goes from about 14 minutes to 10 seconds to initialize file watching in their repo after this change.