### PR TITLE
improvement: move bsp responsiveness into status

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -342,6 +342,12 @@ object ClientCommands {
     "[string], the markdown representation of the stacktrace",
   )
 
+  val ReconnectBsp = new Command(
+    "reconnect-bsp",
+    "Reconnect with the build server.",
+    """The client should send back "build-connect". """,
+  )
+
   def all: List[BaseCommand] =
     List(
       OpenFolder,
@@ -356,5 +362,6 @@ object ClientCommands {
       CopyWorksheetOutput,
       StartRunSession,
       StartDebugSession,
+      ReconnectBsp,
     )
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -342,12 +342,6 @@ object ClientCommands {
     "[string], the markdown representation of the stacktrace",
   )
 
-  val ReconnectBsp = new Command(
-    "reconnect-bsp",
-    "Reconnect with the build server.",
-    """The client should send back "build-connect". """,
-  )
-
   def all: List[BaseCommand] =
     List(
       OpenFolder,
@@ -362,6 +356,5 @@ object ClientCommands {
       CopyWorksheetOutput,
       StartRunSession,
       StartDebugSession,
-      ReconnectBsp,
     )
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -47,6 +47,13 @@ final class ClientConfiguration(
         .getOrElse(StatusBarState.Off),
     )
 
+  def bspStatusBarState(): StatusBarState.StatusBarState =
+    extract(
+      initializationOptions.bspStatusBarState,
+      StatusBarState.fromString(initialConfig.bspStatusBar.value),
+      StatusBarState.ShowMessage,
+    )
+
   def globSyntax(): GlobSyntaxConfig =
     initializationOptions.globSyntax
       .flatMap(GlobSyntaxConfig.fromString)

--- a/metals/src/main/scala/scala/meta/internal/metals/Icons.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Icons.scala
@@ -100,6 +100,6 @@ object Icons {
     override def error: String = span("error")
     override def rightArrow: String = "⇒"
     override def ellipsis: String = "…"
-    def link: String = "connected"
+    override def link: String = span("link")
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Icons.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Icons.scala
@@ -12,6 +12,7 @@ abstract class Icons {
   def folder: String
   def github: String
   def error: String
+  def link: String
   final def all: List[String] =
     List(
       rocket,
@@ -23,6 +24,7 @@ abstract class Icons {
       folder,
       github,
       error,
+      link,
     )
 }
 object Icons {
@@ -53,6 +55,7 @@ object Icons {
     override def error: String = "❌"
     override def rightArrow: String = "⇒"
     override def ellipsis: String = "…"
+    override def link: String = "🔗"
   }
   case object none extends Icons {
     override def rocket: String = ""
@@ -66,6 +69,7 @@ object Icons {
     override def error: String = ""
     override def rightArrow: String = "=>"
     override def ellipsis: String = "..."
+    override def link: String = ""
   }
   // icons for vscode can be found here("Icons in Labels"):
   // https://code.visualstudio.com/api/references/icons-in-labels
@@ -81,6 +85,7 @@ object Icons {
     override def error: String = "$(error)"
     override def rightArrow: String = "⇒"
     override def ellipsis: String = "…"
+    override def link: String = "$(link)"
   }
   case object atom extends Icons {
     private def span(id: String) = s"<span class='icon icon-$id'></span> "
@@ -95,5 +100,6 @@ object Icons {
     override def error: String = span("error")
     override def rightArrow: String = "⇒"
     override def ellipsis: String = "…"
+    def link: String = "connected"
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -49,6 +49,7 @@ import org.eclipse.{lsp4j => l}
  * @param disableColorOutput in the situation where your DAP client may not handle color codes in
  *                            the output, you can enable this to strip them.
  * @param doctorVisibilityProvider if the clients implements `metals/doctorVisibilityDidChange`
+ * @param bspStatusBarProvider if the client supports `metals/status` with "bsp" status type
  */
 final case class InitializationOptions(
     compilerOptions: CompilerInitializationOptions,
@@ -77,12 +78,16 @@ final case class InitializationOptions(
     copyWorksheetOutputProvider: Option[Boolean],
     disableColorOutput: Option[Boolean],
     doctorVisibilityProvider: Option[Boolean],
+    bspStatusBarProvider: Option[String],
 ) {
   def doctorFormat: Option[DoctorFormat.DoctorFormat] =
     doctorProvider.flatMap(DoctorFormat.fromString)
 
   def statusBarState: Option[StatusBarState.StatusBarState] =
     statusBarProvider.flatMap(StatusBarState.fromString)
+
+  def bspStatusBarState: Option[StatusBarState.StatusBarState] =
+    bspStatusBarProvider.flatMap(StatusBarState.fromString)
 }
 
 object InitializationOptions {
@@ -90,6 +95,7 @@ object InitializationOptions {
 
   val Default: InitializationOptions = InitializationOptions(
     CompilerInitializationOptions.default,
+    None,
     None,
     None,
     None,
@@ -172,6 +178,7 @@ object InitializationOptions {
       disableColorOutput = jsonObj.getBooleanOption("disableColorOutput"),
       doctorVisibilityProvider =
         jsonObj.getBooleanOption("doctorVisibilityProvider"),
+      bspStatusBarProvider = jsonObj.getStringOption("bspStatusBarProvider"),
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -13,7 +13,8 @@ import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
  * that instead you configure Metals via `InitializationOptions`.
  *
  * @param globSyntax pattern used for `DidChangeWatchedFilesRegistrationOptions`.
- * @param statusBar how to handle metals/status notifications.
+ * @param statusBar how to handle metals/status notifications with {"statusType": "metals"}.
+ * @param bspStatusBar how to handle metals/status notifications with {"statusType": "bsp"}.
  * @param slowTask how to handle metals/slowTask requests.
  * @param executeClientCommand whether client provides the ability to support the
  *                             `metals/executeClientCommand` command.

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -49,6 +49,7 @@ import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
 final case class MetalsServerConfig(
     globSyntax: GlobSyntaxConfig = GlobSyntaxConfig.default,
     statusBar: StatusBarConfig = StatusBarConfig.default,
+    bspStatusBar: StatusBarConfig = StatusBarConfig.bspDefault,
     slowTask: SlowTaskConfig = SlowTaskConfig.default,
     executeClientCommand: ExecuteClientCommandConfig =
       ExecuteClientCommandConfig.default,

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerLivenessMonitor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerLivenessMonitor.scala
@@ -151,7 +151,7 @@ object ServerLivenessMonitor {
       "error",
       show = true,
       tooltip = s"Build sever ($serverName) is not responding.",
-      command = ClientCommands.ReconnectBsp.id,
+      command = ServerCommands.ConnectBuildServer.id,
       commandTooltip = "Reconnect.",
     ).withStatusType(StatusType.bsp)
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerLivenessMonitor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerLivenessMonitor.scala
@@ -150,9 +150,9 @@ object ServerLivenessMonitor {
       s"$serverName ${icons.error}",
       "error",
       show = true,
-      tooltip =
-        s"Broken connection, build sever ($serverName) is not responding. Press to reconnect.",
+      tooltip = s"Build sever ($serverName) is not responding.",
       command = ClientCommands.ReconnectBsp.id,
+      commandTooltip = "Press to reconnect.",
     ).withStatusType(StatusType.bsp)
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerLivenessMonitor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerLivenessMonitor.scala
@@ -152,7 +152,7 @@ object ServerLivenessMonitor {
       show = true,
       tooltip = s"Build sever ($serverName) is not responding.",
       command = ClientCommands.ReconnectBsp.id,
-      commandTooltip = "Press to reconnect.",
+      commandTooltip = "Reconnect.",
     ).withStatusType(StatusType.bsp)
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBarConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBarConfig.scala
@@ -16,4 +16,8 @@ object StatusBarConfig {
     new StatusBarConfig(
       System.getProperty("metals.status-bar", "off")
     )
+  def bspDefault =
+    new StatusBarConfig(
+      System.getProperty("metals.bsp-status-bar", "show-message")
+    )
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -119,7 +119,7 @@ class WorkspaceLspService(
 
   private val languageClient = {
     val languageClient =
-      new ConfiguredLanguageClient(client, clientConfig, () => userConfig)
+      new ConfiguredLanguageClient(client, clientConfig, () => userConfig, this)
     // Set the language client so that we can forward log messages to the client
     LanguageClientLogger.languageClient = Some(languageClient)
     cancelables.add(() => languageClient.shutdown())

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
@@ -52,10 +52,10 @@ final class ConfiguredLanguageClient(
         case _ => clientConfig.statusBarState()
       }
 
+    val logMessage = params.logMessage(clientConfig.icons())
     statusBarState match {
       case On => underlying.metalsStatus(params)
-      case ShowMessage
-          if params.logMessage.nonEmpty && !pendingShowMessage.get() =>
+      case ShowMessage if logMessage.nonEmpty && !pendingShowMessage.get() =>
         if (params.command != null && params.command.nonEmpty) {
           val action = new MessageActionItem(
             Option(params.commandTooltip)
@@ -63,7 +63,7 @@ final class ConfiguredLanguageClient(
               .getOrElse(params.command)
           )
           val requestParams = new ShowMessageRequestParams()
-          requestParams.setMessage(params.logMessage)
+          requestParams.setMessage(logMessage)
           requestParams.setType(level)
           requestParams.setActions(List(action).asJava)
           underlying.showMessageRequest(requestParams).asScala.map {
@@ -74,10 +74,10 @@ final class ConfiguredLanguageClient(
             case _ =>
           }
         } else {
-          underlying.showMessage(new MessageParams(level, params.logMessage))
+          underlying.showMessage(new MessageParams(level, logMessage))
         }
-      case LogMessage if params.logMessage.nonEmpty =>
-        underlying.logMessage(new MessageParams(level, params.logMessage))
+      case LogMessage if logMessage.nonEmpty =>
+        underlying.logMessage(new MessageParams(level, logMessage))
       case _ =>
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsLanguageClient.scala
@@ -3,6 +3,8 @@ package scala.meta.internal.metals.clients.language
 import java.util.concurrent.CompletableFuture
 import javax.annotation.Nullable
 
+import scala.util.Try
+
 import scala.meta.internal.decorations.DecorationClient
 import scala.meta.internal.tvp._
 
@@ -122,19 +124,41 @@ case class RawMetalsQuickPickResult(
  * Arguments for the metals/status notification.
  *
  * @param text The text to display in the status bar.
+ * @param level info, warn, error
  * @param show if true, show the status bar.
  * @param hide if true, hide the status bar.
  * @param tooltip optional display this message when the user hovers over the status bar item.
  * @param command optional command that the client should trigger when the user clicks on
  *                the status bar item.
+ * @param statusType is this a bsp or metals status.
  */
 case class MetalsStatusParams(
     text: String,
+    @Nullable level: String = "info",
     @Nullable show: java.lang.Boolean = null,
     @Nullable hide: java.lang.Boolean = null,
     @Nullable tooltip: String = null,
     @Nullable command: String = null,
-)
+    @Nullable statusType: String = StatusType.metals.toString(),
+) {
+
+  def logMessage: String =
+    if (statusType == StatusType.bsp.toString())
+      if (level == "info") ""
+      else s"$text: $tooltip"
+    else text
+
+  def getStatusType: StatusType.Value =
+    Try(StatusType.withName(statusType)).toOption.getOrElse(StatusType.metals)
+
+  def withStatusType(statusType: StatusType.StatusType): MetalsStatusParams =
+    this.copy(statusType = statusType.toString())
+}
+
+object StatusType extends Enumeration {
+  type StatusType = Value
+  val metals, bsp = Value
+}
 
 case class MetalsSlowTaskParams(
     message: String,

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsLanguageClient.scala
@@ -6,6 +6,7 @@ import javax.annotation.Nullable
 import scala.util.Try
 
 import scala.meta.internal.decorations.DecorationClient
+import scala.meta.internal.metals.Icons
 import scala.meta.internal.tvp._
 
 import org.eclipse.lsp4j.ExecuteCommandParams
@@ -143,11 +144,16 @@ case class MetalsStatusParams(
     @Nullable statusType: String = StatusType.metals.toString(),
 ) {
 
-  def logMessage: String =
+  def logMessage(icons: Icons): String = {
+    val decodedText =
+      if (icons != Icons.unicode && icons != Icons.none)
+        icons.all.foldLeft(text)((acc, icon) => acc.replace(icon, ""))
+      else text
     if (statusType == StatusType.bsp.toString())
       if (level == "info") ""
-      else s"$text: $tooltip"
-    else text
+      else s"$decodedText: $tooltip"
+    else decodedText
+  }
 
   def getStatusType: StatusType.Value =
     Try(StatusType.withName(statusType)).toOption.getOrElse(StatusType.metals)

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsLanguageClient.scala
@@ -139,6 +139,7 @@ case class MetalsStatusParams(
     @Nullable hide: java.lang.Boolean = null,
     @Nullable tooltip: String = null,
     @Nullable command: String = null,
+    @Nullable commandTooltip: String = null,
     @Nullable statusType: String = StatusType.metals.toString(),
 ) {
 

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -37,11 +37,11 @@ import scala.meta.internal.metals.StatusBar
 import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.TargetData
 import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
 
 import coursier.version.Version
-import org.eclipse.lsp4j.services.LanguageClient
 
 // todo https://github.com/scalameta/metals/issues/4788
 // clean () =>, use plain values
@@ -54,7 +54,7 @@ class ScalaCli(
     diagnostics: () => Diagnostics,
     tables: Tables,
     buildClient: () => MetalsBuildClient,
-    languageClient: LanguageClient,
+    languageClient: MetalsLanguageClient,
     config: () => MetalsServerConfig,
     userConfig: () => UserConfiguration,
     parseTreesAndPublishDiags: Seq[AbsolutePath] => Future[Unit],

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -6,7 +6,6 @@ import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Future
-import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 
 import scala.meta.internal.io.PathIO
@@ -18,7 +17,6 @@ import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.MtagsResolver
 import scala.meta.internal.metals.RecursivelyDelete
-import scala.meta.internal.metals.ServerLivenessMonitor
 import scala.meta.internal.metals.SlowTaskConfig
 import scala.meta.internal.metals.Time
 import scala.meta.internal.metals.UserConfiguration
@@ -224,11 +222,4 @@ abstract class BaseLspSuite(
       }
     }
   }
-}
-
-object ServerLivenessTestData {
-  val serverName = "Bill"
-  val pingInterval: Duration = Duration("3s")
-  def serverNotRespondingMessage: String =
-    ServerLivenessMonitor.ServerNotResponding.message(pingInterval, serverName)
 }

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -19,9 +19,11 @@ import scala.meta.internal.decorations.PublishDecorationsParams
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.FileOutOfScalaCliBspScope
+import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.metals.ServerLivenessMonitor
 import scala.meta.internal.metals.TextEdits
 import scala.meta.internal.metals.WorkspaceChoicePopup
 import scala.meta.internal.metals.clients.language.MetalsInputBoxParams
@@ -370,6 +372,12 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
           params.getMessage().startsWith(BspErrorHandler.errorHeader)
         ) {
           bspError
+        } else if (
+          params.getMessage() == ServerLivenessMonitor
+            .noResponseParams("Bill", Icons.default)
+            .logMessage(Icons.default)
+        ) {
+          new MessageActionItem("ok")
         } else {
           throw new IllegalArgumentException(params.toString)
         }

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -22,7 +22,6 @@ import scala.meta.internal.metals.FileOutOfScalaCliBspScope
 import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ServerCommands
-import scala.meta.internal.metals.ServerLivenessMonitor
 import scala.meta.internal.metals.TextEdits
 import scala.meta.internal.metals.WorkspaceChoicePopup
 import scala.meta.internal.metals.clients.language.MetalsInputBoxParams
@@ -87,8 +86,6 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
   }
   var importScalaCliScript = new MessageActionItem(ImportScalaScript.dismiss)
   var resetWorkspace = new MessageActionItem(ResetWorkspace.cancel)
-  var buildServerNotResponding =
-    ServerLivenessMonitor.ServerNotResponding.dismiss
   var regenerateAndRestartScalaCliBuildSever = FileOutOfScalaCliBspScope.ignore
   var bspError = BspErrorHandler.dismiss
 
@@ -358,10 +355,6 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
           importScalaCliScript
         } else if (ResetWorkspace.params() == params) {
           resetWorkspace
-        } else if (
-          params.getMessage == ServerLivenessTestData.serverNotRespondingMessage
-        ) {
-          buildServerNotResponding
         } else if (
           params
             .getMessage()

--- a/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
@@ -66,7 +66,7 @@ class ServerLivenessMonitorLspSuite extends BaseLspSuite("liveness-monitor") {
       )
       _ = assertNoDiff(
         server.client.workspaceShowMessages,
-        noResponseParams.logMessage,
+        noResponseParams.logMessage(Icons.none),
       )
       _ = assertEquals(isServerResponsive, Some(false))
       _ = Thread.sleep(sleepTime)

--- a/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
@@ -2,23 +2,26 @@ package tests
 
 import scala.concurrent.duration.Duration
 
+import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.ServerLivenessMonitor
 
 import bill.Bill
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import ch.epfl.scala.bsp4j.ScalaMainClassesParams
 
 class ServerLivenessMonitorLspSuite extends BaseLspSuite("liveness-monitor") {
+  val pingInterval: Duration = Duration("3s")
   override def serverConfig: MetalsServerConfig =
     MetalsServerConfig.default.copy(
       metalsToIdleTime = Duration("3m"),
-      pingInterval = ServerLivenessTestData.pingInterval,
+      pingInterval = pingInterval,
     )
 
   test("handle-not-responding-server") {
-    val sleepTime = ServerLivenessTestData.pingInterval.toMillis * 4
+    val sleepTime = pingInterval.toMillis * 4
     cleanWorkspace()
     Bill.installWorkspace(workspace.toNIO)
 
@@ -51,22 +54,22 @@ class ServerLivenessMonitorLspSuite extends BaseLspSuite("liveness-monitor") {
           List(
             new BuildTargetIdentifier("break"),
             new BuildTargetIdentifier(
-              (ServerLivenessTestData.pingInterval * 6).toString()
+              (pingInterval * 6).toString()
             ),
           ).asJava
         )
       )
       _ = Thread.sleep(sleepTime)
+      noResponseParams = ServerLivenessMonitor.noResponseParams(
+        "Bill",
+        Icons.default,
+      )
       _ = assertNoDiff(
-        server.client.workspaceMessageRequests,
-        List(
-          Messages.CheckDoctor.allProjectsMisconfigured,
-          ServerLivenessTestData.serverNotRespondingMessage,
-        ).mkString("\n"),
+        server.client.workspaceShowMessages,
+        noResponseParams.logMessage,
       )
       _ = assertEquals(isServerResponsive, Some(false))
       _ = Thread.sleep(sleepTime)
-      // we start getting responses from initial pings
       _ = assertEquals(isServerResponsive, Some(true))
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
@@ -65,8 +65,9 @@ class ServerLivenessMonitorLspSuite extends BaseLspSuite("liveness-monitor") {
         Icons.default,
       )
       _ = assertNoDiff(
-        server.client.workspaceShowMessages,
-        noResponseParams.logMessage(Icons.none),
+        server.client.workspaceMessageRequests,
+        s"""|${Messages.CheckDoctor.allProjectsMisconfigured}
+            |${noResponseParams.logMessage(Icons.default)}""".stripMargin,
       )
       _ = assertEquals(isServerResponsive, Some(false))
       _ = Thread.sleep(sleepTime)


### PR DESCRIPTION
Previously a message request would pop up when the build sever was not responding. Now we make this into a status.

Changes in the client API:
 - Adds `bspStatusBarProvider` field to initialisation params, same as `statusBarProvider` has possibile values "on", "off", "log-message", "show-message". Default being "show-message".
 - Adds `level` field to `MetalsStatusParams`, possible values "info", "warn", "error" (can be mapped by client to e.g. color)
 - Adds `commandTooltip` field to `MetalsStatusParams`.
 
BSP status in VSCode:
- connected

<img width="451" alt="Screenshot 2023-09-22 at 12 43 02" src="https://github.com/scalameta/metals/assets/26606662/ab4b6c2a-7f85-4374-af2d-3edaa1f9ad61">

- no response

![Screenshot 2023-09-27 at 16 07 22](https://github.com/scalameta/metals/assets/26606662/71119a0b-3eef-4a97-a0de-05b139a2411d)

- default behaviour if the client doesn't support bsp status
![Screenshot 2023-09-28 at 13 07 25](https://github.com/scalameta/metals/assets/26606662/dc4f84c9-e4b5-4386-b64d-6d411ac7c2f1)


