### PR TITLE
Bump swoval to 2.1.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -434,7 +434,7 @@ lazy val metals = project
       // for measuring memory footprint
       "org.openjdk.jol" % "jol-core" % "0.17",
       // for file watching
-      "com.swoval" % "file-tree-views" % "2.1.11",
+      "com.swoval" % "file-tree-views" % "2.1.12",
       // for http client
       "io.undertow" % "undertow-core" % "2.2.20.Final",
       "org.jboss.xnio" % "xnio-nio" % "3.8.10.Final",


### PR DESCRIPTION
Sorry for the churn but I discovered a small regression that caused sbt's tests to fail in 2.1.11 (https://github.com/sbt/io/pull/352). The 2.1.12 release fixes the regression (https://github.com/sbt/io/pull/353) while still making the switch from the jni based directory lister to the nio based directory lister on windows. It is possible that the fix https://github.com/swoval/swoval/pull/173 might make 2.1.12 somewhat slower than 2.1.11 on Windows because it restores some additional directory scanning during registration. My intuition is that it should not go back up to 14 minutes for the reporting user's use case but it might not be as quick as 10 seconds.