### PR TITLE
bugfix: Make sure we are using latest known scalameta version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ def isScala213(v: Option[(Long, Long)]): Boolean = v.contains((2, 13))
 def isScala2(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 2)
 def isScala3(v: Option[(Long, Long)]): Boolean = v.exists(_._1 == 3)
 def isScala3WithPresentationCompiler(v: String): Boolean =
-  (DottyVersion.parse(v), DottyVersion.parse(V.firstScala3PCVersion)) match {
+  (Version.parse(v), Version.parse(V.firstScala3PCVersion)) match {
     case (Some(v), Some(firstScala3PCVersion)) => v >= firstScala3PCVersion
     case _ => false
   }

--- a/project/Scala3NightlyVersions.scala
+++ b/project/Scala3NightlyVersions.scala
@@ -7,15 +7,15 @@ object Scala3NightlyVersions {
       "3.2.0-RC1-bin-20220307-6dc591a-NIGHTLY",
       "3.2.0-RC1-bin-20220308-29073f1-NIGHTLY",
       "3.1.3-RC1-bin-20220406-73cda0c-NIGHTLY",
-    ).flatMap(DottyVersion.parse)
+    ).flatMap(Version.parse)
 
   /**
    * Fetches last 5 nightly releases.
    * They should come at least after the last supported scala3 version
    * otherwise there is no point to use these versions.
    */
-  def nightlyReleasesAfter(version: String): List[DottyVersion] = {
-    val lastVersion = DottyVersion.parse(version) match {
+  def nightlyReleasesAfter(version: String): List[Version] = {
+    val lastVersion = Version.parse(version) match {
       case Some(v) => v
       case None =>
         throw new Exception(s"Can't parse dotty versions from $version")
@@ -34,7 +34,7 @@ object Scala3NightlyVersions {
     }
   }
 
-  def nonPublishedNightlyVersions(): List[DottyVersion] = {
+  def nonPublishedNightlyVersions(): List[Version] = {
     val all = fetchScala3NightlyVersions()
     lastPublishedMtagsForNightly() match {
       case None =>
@@ -45,7 +45,7 @@ object Scala3NightlyVersions {
     }
   }
 
-  private def fetchScala3NightlyVersions(): List[DottyVersion] = {
+  private def fetchScala3NightlyVersions(): List[Version] = {
     coursierapi.Complete
       .create()
       .withInput("org.scala-lang:scala3-compiler_3:")
@@ -53,12 +53,12 @@ object Scala3NightlyVersions {
       .getCompletions()
       .asScala
       .filter(_.endsWith("NIGHTLY"))
-      .flatMap(DottyVersion.parse)
+      .flatMap(Version.parse)
       .filter(!broken.contains(_))
       .toList
   }
 
-  private def lastPublishedMtagsForNightly(): Option[DottyVersion] = {
+  private def lastPublishedMtagsForNightly(): Option[Version] = {
     coursierapi.Complete
       .create()
       .withInput("org.scalameta:mtags_3")
@@ -67,7 +67,7 @@ object Scala3NightlyVersions {
       .asScala
       .filter(_.endsWith("NIGHTLY"))
       .map(_.stripPrefix("mtags_"))
-      .flatMap(DottyVersion.parse)
+      .flatMap(Version.parse)
       .sorted
       .lastOption
   }

--- a/project/SemanticDbSupport.scala
+++ b/project/SemanticDbSupport.scala
@@ -11,6 +11,9 @@ object SemanticDbSupport {
   private val AllScalaVersions =
     Scala213Versions ++ Scala212Versions ++ Scala211Versions
 
+  private val latestVersion = Version
+    .parse(V.scalameta)
+    .getOrElse(sys.error("Failed to parse V.scalameta version"))
   val last: Map[String, String] = AllScalaVersions.flatMap { scalaVersion =>
     coursierapi.Complete
       .create()
@@ -20,7 +23,11 @@ object SemanticDbSupport {
       .complete()
       .getCompletions()
       .asScala
-      .lastOption
+      .reverse
+      .collectFirst {
+        case version if Version.parse(version).exists(latestVersion >= _) =>
+          version
+      }
       .map(scalaVersion -> _)
   }.toMap
 

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,6 +1,6 @@
 import scala.util.Try
 
-final case class DottyVersion(
+final case class Version(
     major: Int,
     minor: Int,
     patch: Int,
@@ -9,7 +9,7 @@ final case class DottyVersion(
     original: String,
 ) {
 
-  def >(o: DottyVersion): Boolean = {
+  def >(o: Version): Boolean = {
     val diff = toList
       .zip(o.toList)
       .collectFirst {
@@ -19,7 +19,7 @@ final case class DottyVersion(
     diff > 0
   }
 
-  def >=(o: DottyVersion): Boolean = this == o || this > o
+  def >=(o: Version): Boolean = this == o || this > o
 
   override def toString(): String = original
 
@@ -33,8 +33,8 @@ final case class DottyVersion(
     )
 }
 
-object DottyVersion {
-  def parse(v: String): Option[DottyVersion] = {
+object Version {
+  def parse(v: String): Option[Version] = {
     Try {
       val parts = v.split("\\.|-RC|-")
       if (parts.size < 3) None
@@ -44,19 +44,19 @@ object DottyVersion {
         // format is "$major.$minor.$patch-RC$rc-bin-$date-hash-NIGHTLY"
         // or when locally published "$major.$minor.$patch-RC$rc-bin-SNAPSHOT"
         if (parts.lift(5) == Some("SNAPSHOT")) {
-          Some(DottyVersion(major, minor, patch, rc, None, v))
+          Some(Version(major, minor, patch, rc, None, v))
         } else {
           val date = parts.lift(5).map(_.toInt)
-          Some(DottyVersion(major, minor, patch, rc, date, v))
+          Some(Version(major, minor, patch, rc, date, v))
         }
       }
 
     }.toOption.flatten
   }
 
-  implicit val ordering: Ordering[DottyVersion] =
-    new Ordering[DottyVersion] {
-      override def compare(x: DottyVersion, y: DottyVersion): Int =
+  implicit val ordering: Ordering[Version] =
+    new Ordering[Version] {
+      override def compare(x: Version, y: Version): Int =
         if (x == y) 0
         else if (x > y) 1
         else -1


### PR DESCRIPTION
PReviously, we were using the latest published scalameta version, which was caused by me setting first latest semanticdb version (that is not an issue), but then I also added the same scalameta version in order to not have potential mismatches between the two. This caused a breaking change in scalameta internal code to break metals CI. Now, we set the maximum version to be V.scalameta