### PR TITLE
bugfix: add `moduleClass` imported symbols in `IndexedContext`

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/IndexedContext.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/IndexedContext.scala
@@ -8,6 +8,7 @@ import scala.meta.internal.pc.IndexedContext.Result
 
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Flags.*
+import dotty.tools.dotc.core.NameOps.moduleClassName
 import dotty.tools.dotc.core.Names.*
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Types.*
@@ -172,7 +173,11 @@ object IndexedContext:
       initial ++ fromPackageObjects
 
     def fromImport(site: Type, name: Name)(using Context): List[Symbol] =
-      List(site.member(name.toTypeName), site.member(name.toTermName))
+      List(
+        site.member(name.toTypeName),
+        site.member(name.toTermName),
+        site.member(name.moduleClassName),
+      )
         .flatMap(_.alternatives)
         .map(_.symbol)
 

--- a/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
@@ -556,6 +556,30 @@ class Scala3CodeActionLspSuite
     ),
   )
 
+  checkEdit(
+    "alias-rename",
+    s"""|/metals.json
+        |{"a":
+        |  {  "scalaVersion" : "$scalaVersion",
+        |     "libraryDependencies": [
+        |      "org.typelevel::cats-parse:0.3.7"
+        |    ]
+        |  }
+        |}
+        |/${toPath("A.scala")}
+        |import cats.parse.{Parser => P}
+        |def <<read>>(txt: String) = {
+        |  P.string("a").parseAll(txt)
+        |}
+        |""".stripMargin,
+    InsertInferredType.insertType,
+    """|import cats.parse.{Parser => P}
+       |def read(txt: String): Either[P.Error, Unit] = {
+       |  P.string("a").parseAll(txt)
+       |}
+       |""".stripMargin,
+  )
+
   check(
     "issue",
     """|object Main {


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/5682