### PR TITLE
bugfix: Semantic tokens for  multiline strings in Scala3 worksheets

### DIFF
--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -903,24 +903,30 @@ abstract class BaseWorksheetLspSuite(
     }
 
   test("semantic-highlighting") {
-
+    val tripleQ = "\"\"\""
     val expected =
       if (scalaVersion == V.scala212)
-        """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
-           |<<val>>/*keyword*/ <<hi1>>/*variable,definition,readonly*/ =
-           |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
-           |<<val>>/*keyword*/ <<hi2>>/*variable,definition,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
-           |
-           |<<val>>/*keyword*/ <<hellos>>/*variable,definition,readonly*/ = <<List>>/*class*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
-           |""".stripMargin
+        s"""|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
+            |<<val>>/*keyword*/ <<hi1>>/*variable,definition,readonly*/ =
+            |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
+            |<<val>>/*keyword*/ <<hi2>>/*variable,definition,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
+            |
+            |<<val>>/*keyword*/ <<hellos>>/*variable,definition,readonly*/ = <<List>>/*class*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
+            |<<val>>/*keyword*/ <<str>>/*variable,definition,readonly*/ = <<$tripleQ>>/*string*/
+            |<<  hello>>/*string*/
+            |<<  world$tripleQ>>/*string*/.<<stripMargin>>/*method*/
+            |""".stripMargin
       else
-        """|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
-           |<<val>>/*keyword*/ <<hi1>>/*variable,definition,readonly*/ =
-           |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
-           |<<val>>/*keyword*/ <<hi2>>/*variable,definition,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
-           |
-           |<<val>>/*keyword*/ <<hellos>>/*variable,definition,readonly*/ = <<List>>/*class*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
-           |""".stripMargin
+        s"""|<<case>>/*keyword*/ <<class>>/*keyword*/ <<Hi>>/*class*/(<<a>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<b>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/, <<c>>/*variable,declaration,readonly*/: <<Int>>/*class,abstract*/)
+            |<<val>>/*keyword*/ <<hi1>>/*variable,definition,readonly*/ =
+            |  <<Hi>>/*class*/(<<1>>/*number*/, <<2>>/*number*/, <<3>>/*number*/)
+            |<<val>>/*keyword*/ <<hi2>>/*variable,definition,readonly*/ = <<Hi>>/*class*/(<<4>>/*number*/, <<5>>/*number*/, <<6>>/*number*/)
+            |
+            |<<val>>/*keyword*/ <<hellos>>/*variable,definition,readonly*/ = <<List>>/*class*/(<<hi1>>/*variable,readonly*/, <<hi2>>/*variable,readonly*/)
+            |<<val>>/*keyword*/ <<str>>/*variable,definition,readonly*/ = <<$tripleQ>>/*string*/
+            |<<  hello>>/*string*/
+            |<<  world$tripleQ>>/*string*/.<<stripMargin>>/*method*/
+            |""".stripMargin
 
     val fileContent =
       TestSemanticTokens.removeSemanticHighlightDecorations(expected)


### PR DESCRIPTION
For multiline strings, we highlight the entire line, so we need to adjust the length by removing additional indent