### PR TITLE
test: fix `ScalaCliSuite.connecting-scalacli`

### DIFF
--- a/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
+++ b/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
@@ -8,7 +8,6 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.SlowTaskConfig
-import scala.meta.internal.metals.StatusBarConfig
 import scala.meta.internal.metals.scalacli.ScalaCli
 import scala.meta.internal.metals.{BuildInfo => V}
 
@@ -16,10 +15,7 @@ import tests.FileLayout
 
 class ScalaCliSuite extends BaseScalaCliSuite(V.scala3) {
   override def serverConfig: MetalsServerConfig =
-    MetalsServerConfig.default.copy(
-      slowTask = SlowTaskConfig.on,
-      statusBar = StatusBarConfig.showMessage,
-    )
+    MetalsServerConfig.default.copy(slowTask = SlowTaskConfig.on)
 
   private def simpleFileTest(useBsp: Boolean): Future[Unit] =
     for {


### PR DESCRIPTION
Connected to: https://github.com/scalameta/metals/actions/runs/6353179361/job/17257344448?pr=5696#step:4:3174

It only fails sometimes, since showing bsp status as request messages doesn't always work.