### PR TITLE
improvement: show bsp as connected after the first message from build server

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ServerLivenessMonitor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerLivenessMonitor.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.concurrent.duration.Duration
@@ -23,7 +24,7 @@ trait RequestMonitor {
   def lastIncoming: Option[Long]
 }
 
-class RequestMonitorImpl extends RequestMonitor {
+class RequestMonitorImpl(bspStatus: BspStatus) extends RequestMonitor {
   @volatile private var lastOutgoing_ : Option[Long] = None
   @volatile private var lastIncoming_ : Option[Long] = None
 
@@ -44,7 +45,10 @@ class RequestMonitorImpl extends RequestMonitor {
     }
 
   private def outgoingMessage() = lastOutgoing_ = now
-  private def incomingMessage(): Unit = lastIncoming_ = now
+  private def incomingMessage(): Unit = {
+    bspStatus.connected()
+    lastIncoming_ = now
+  }
   private def now = Some(System.currentTimeMillis())
 
   def lastOutgoing: Option[Long] = lastOutgoing_
@@ -54,22 +58,14 @@ class RequestMonitorImpl extends RequestMonitor {
 class ServerLivenessMonitor(
     requestMonitor: RequestMonitor,
     ping: () => Unit,
-    client: MetalsLanguageClient,
     metalsIdleInterval: Duration,
     pingInterval: Duration,
-    serverName: String,
-    icons: Icons,
+    bspStatus: BspStatus,
 ) {
   private val state: AtomicReference[ServerLivenessMonitor.State] =
     new AtomicReference(ServerLivenessMonitor.Idle)
-  @volatile private var isServerResponsive = true
   val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(1)
-  val connectedParams: MetalsStatusParams =
-    ServerLivenessMonitor.connectedParams(serverName, icons)
-  val noResponseParams: MetalsStatusParams =
-    ServerLivenessMonitor.noResponseParams(serverName, icons)
 
-  client.metalsStatus(connectedParams)
   scribe.debug("starting server liveness monitor")
 
   def runnable(): Runnable = new Runnable {
@@ -99,12 +95,9 @@ class ServerLivenessMonitor(
           case _ =>
         }
         if (currState == ServerLivenessMonitor.Running) {
-          if (notResponding && isServerResponsive) {
-            scribe.debug("server liveness monitor detected no response")
-            client.metalsStatus(noResponseParams)
-          } else if (!notResponding && !isServerResponsive)
-            client.metalsStatus(connectedParams)
-          isServerResponsive = !notResponding
+          if (notResponding) {
+            bspStatus.noResponse()
+          }
         }
         scribe.debug("server liveness monitor: pinging build server...")
         ping()
@@ -122,13 +115,13 @@ class ServerLivenessMonitor(
     TimeUnit.MILLISECONDS,
   )
 
-  def isBuildServerResponsive: Boolean = isServerResponsive
+  def isBuildServerResponsive: Boolean = bspStatus.isBuildServerResponsive
 
   def shutdown(): Unit = {
     scribe.debug("shutting down server liveness monitor")
     scheduled.cancel(true)
     scheduler.shutdown()
-    client.metalsStatus(ServerLivenessMonitor.disconnectedParams)
+    bspStatus.connected()
   }
 
   def getState: ServerLivenessMonitor.State = state.get()
@@ -147,6 +140,29 @@ object ServerLivenessMonitor {
   object FirstPing extends State
   object Running extends State
 
+}
+
+class BspStatus(
+    client: MetalsLanguageClient,
+    serverName: String,
+    icons: Icons,
+) {
+  private val isServerResponsive = new AtomicBoolean(false)
+
+  def connected(): Unit =
+    if (isServerResponsive.compareAndSet(false, true))
+      client.metalsStatus(BspStatus.connectedParams(serverName, icons))
+  def noResponse(): Unit =
+    if (isServerResponsive.compareAndSet(true, false)) {
+      scribe.debug("server liveness monitor detected no response")
+      client.metalsStatus(BspStatus.noResponseParams(serverName, icons))
+    }
+  def disconnected(): Unit = client.metalsStatus(BspStatus.disconnectedParams)
+
+  def isBuildServerResponsive: Boolean = isServerResponsive.get()
+}
+
+object BspStatus {
   def connectedParams(serverName: String, icons: Icons): MetalsStatusParams =
     MetalsStatusParams(
       s"$serverName ${icons.link}",
@@ -167,5 +183,4 @@ object ServerLivenessMonitor {
       command = ServerCommands.ConnectBuildServer.id,
       commandTooltip = "Reconnect.",
     ).withStatusType(StatusType.bsp)
-
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerLivenessMonitor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerLivenessMonitor.scala
@@ -121,7 +121,7 @@ class ServerLivenessMonitor(
     scribe.debug("shutting down server liveness monitor")
     scheduled.cancel(true)
     scheduler.shutdown()
-    bspStatus.connected()
+    bspStatus.disconnected()
   }
 
   def getState: ServerLivenessMonitor.State = state.get()

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -16,6 +16,7 @@ import scala.meta.internal.builds.BspErrorHandler
 import scala.meta.internal.builds.BuildTool
 import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.decorations.PublishDecorationsParams
+import scala.meta.internal.metals.BspStatus
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.FileOutOfScalaCliBspScope
@@ -23,7 +24,6 @@ import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ServerCommands
-import scala.meta.internal.metals.ServerLivenessMonitor
 import scala.meta.internal.metals.TextEdits
 import scala.meta.internal.metals.WorkspaceChoicePopup
 import scala.meta.internal.metals.clients.language.MetalsInputBoxParams
@@ -373,7 +373,7 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
         ) {
           bspError
         } else if (
-          params.getMessage() == ServerLivenessMonitor
+          params.getMessage() == BspStatus
             .noResponseParams("Bill", Icons.default)
             .logMessage(Icons.default)
         ) {

--- a/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
@@ -2,11 +2,11 @@ package tests
 
 import scala.concurrent.duration.Duration
 
+import scala.meta.internal.metals.BspStatus
 import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsServerConfig
-import scala.meta.internal.metals.ServerLivenessMonitor
 
 import bill.Bill
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
@@ -60,7 +60,7 @@ class ServerLivenessMonitorLspSuite extends BaseLspSuite("liveness-monitor") {
         )
       )
       _ = Thread.sleep(sleepTime)
-      noResponseParams = ServerLivenessMonitor.noResponseParams(
+      noResponseParams = BspStatus.noResponseParams(
         "Bill",
         Icons.default,
       )


### PR DESCRIPTION
Previously:
 after a no response error, if the build server started responding, we'd have to wait a minute for the status to get fix.

Now: the moment when we get a message from build server we fix the status.