### PR TITLE
User configuration per workspace folder

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
@@ -13,6 +13,7 @@ import scala.meta.internal.builds.ShellRunner
 import scala.meta.internal.metals.Messages.BspProvider
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.StatusBar
+import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.io.AbsolutePath
 
@@ -26,6 +27,7 @@ final class BspConfigGenerator(
     languageClient: MetalsLanguageClient,
     shellRunner: ShellRunner,
     statusBar: StatusBar,
+    userConfig: () => UserConfiguration,
 )(implicit ec: ExecutionContext) {
   def runUnconditionally(
       buildTool: BuildServerProvider,
@@ -37,6 +39,7 @@ final class BspConfigGenerator(
         args,
         buildTool.projectRoot,
         buildTool.redirectErrorOutput,
+        userConfig().javaHome,
       )
       .map(BspConfigGenerationStatus.fromExitCode)
       .map {

--- a/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/NewProjectProvider.scala
@@ -67,7 +67,7 @@ class NewProjectProvider(
       NewProjectProvider.back +: allTemplates.toSeq
     }
 
-  def createNewProjectFromTemplate(): Future[Unit] = {
+  def createNewProjectFromTemplate(javaHome: Option[String]): Future[Unit] = {
     val base = workspace.parent
     val withTemplate = askForTemplate(
       NewProjectProvider.curatedTemplates(icons)
@@ -86,6 +86,7 @@ class NewProjectProvider(
             inputPath,
             template.label.replace(s"${icons.github}", ""),
             projectName,
+            javaHome,
           )
         // It's fine to just return if the user resigned
         case _ => Future.successful(())
@@ -96,6 +97,7 @@ class NewProjectProvider(
       inputPath: AbsolutePath,
       template: String,
       projectName: String,
+      javaHome: Option[String],
   ): Future[Unit] = {
     val projectPath = inputPath.resolve(projectName.toLowerCase())
     val parent = projectPath.parent
@@ -110,6 +112,7 @@ class NewProjectProvider(
         giterMain,
         parent,
         command,
+        javaHome,
       )
       .flatMap {
         case ExitCodes.Success =>

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -78,6 +78,7 @@ case class SbtBuildTool(
       shutdownArgs,
       projectRoot,
       true,
+      userConfig().javaHome,
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -543,6 +543,7 @@ final class FileDecoderProvider(
           ),
           path.parent,
           redirectErrorOutput = false,
+          userConfig().javaHome,
           Map.empty,
           s => {
             sbOut.append(s)
@@ -642,6 +643,7 @@ final class FileDecoderProvider(
           cfrMain,
           parent,
           args,
+          userConfig().javaHome,
           redirectErrorOutput = false,
           s => {
             sbOut.append(s)

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfigurationSync.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfigurationSync.scala
@@ -1,0 +1,83 @@
+package scala.meta.internal.metals
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import org.eclipse.lsp4j
+
+class UserConfigurationSync(
+    initializeParams: lsp4j.InitializeParams,
+    languageClient: MetalsLanguageClient,
+    clientConfig: ClientConfiguration,
+)(implicit ec: ExecutionContext) {
+  private val section = "metals"
+  private val supportsConfiguration: Boolean = (for {
+    capabilities <- Option(initializeParams.getCapabilities)
+    workspace <- Option(capabilities.getWorkspace)
+    out <- Option(workspace.getConfiguration())
+  } yield out.booleanValue()).getOrElse(false)
+
+  def syncUserConfiguration(services: List[MetalsLspService]): Future[Unit] =
+    optSyncUserConfiguration(services).getOrElse(Future.successful(()))
+
+  def onDidChangeConfiguration(
+      params: lsp4j.DidChangeConfigurationParams,
+      services: List[MetalsLspService],
+  ): Future[Unit] =
+    optSyncUserConfiguration(services)
+      .orElse {
+        val fullJson =
+          params.getSettings.asInstanceOf[JsonElement].getAsJsonObject
+        for {
+          metalsSection <- Option(fullJson.getAsJsonObject(section))
+          newConfig <- userConfigFrom(metalsSection)
+        } yield Future
+          .sequence(services.map(_.onUserConfigUpdate(newConfig)))
+          .ignoreValue
+      }
+      .getOrElse(Future.successful(()))
+
+  private def optSyncUserConfiguration(
+      services: List[MetalsLspService]
+  ): Option[Future[Unit]] =
+    Option.when(supportsConfiguration) {
+      val items = services.map { service =>
+        val configItem = new lsp4j.ConfigurationItem()
+        configItem.setScopeUri(service.path.toURI.toString())
+        configItem.setSection(section)
+        configItem
+      }
+      val params = new lsp4j.ConfigurationParams(items.asJava)
+      for {
+        items <- languageClient.configuration(params).asScala
+        res <- Future
+          .sequence(
+            items.asScala.toList.zip(services).map {
+              case (_: JsonNull, _) => Future.successful(())
+              case (item, folder) =>
+                val json = item.asInstanceOf[JsonElement].getAsJsonObject()
+                userConfigFrom(json)
+                  .map(folder.onUserConfigUpdate)
+                  .getOrElse(Future.successful(()))
+            }
+          )
+          .ignoreValue
+      } yield res
+    }
+
+  private def userConfigFrom(
+      json: JsonObject
+  ): Option[UserConfiguration] =
+    UserConfiguration.fromJson(json, clientConfig) match {
+      case Left(errors) =>
+        errors.foreach { error => scribe.error(s"config error: $error") }
+        None
+      case Right(newUserConfig) => Some(newUserConfig)
+    }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceFolders.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceFolders.scala
@@ -13,6 +13,7 @@ class WorkspaceFolders(
     shutdownMetals: () => Future[Unit],
     redirectSystemOut: Boolean,
     initialServerConfig: MetalsServerConfig,
+    syncUserConfiguration: List[MetalsLspService] => Future[Unit],
 )(implicit ec: ExecutionContext) {
 
   private val folderServices: AtomicReference[WorkspaceFoldersServices] = {
@@ -59,10 +60,10 @@ class WorkspaceFolders(
 
       setupLogger()
 
+      val services = newServices.filterNot(isIn(prev, _))
       for {
-        _ <- Future.sequence(
-          newServices.filterNot(isIn(prev, _)).map(_.initialized())
-        )
+        _ <- syncUserConfiguration(services)
+        _ <- Future.sequence(services.map(_.initialized()))
         _ <- Future(prev.filter(shouldBeRemoved).foreach(_.onShutdown()))
       } yield ()
     }
@@ -84,7 +85,9 @@ class WorkspaceFolders(
       case Some(service) => service
       case None =>
         setupLogger()
-        newService.initialized()
+        for {
+          _ <- syncUserConfiguration(List(newService))
+        } newService.initialized()
         newService
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
@@ -10,7 +10,6 @@ import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.ClientConfiguration
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ServerCommands
-import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.WorkspaceLspService
 import scala.meta.internal.metals.config.StatusBarState
 import scala.meta.internal.metals.config.StatusBarState.LogMessage
@@ -33,7 +32,6 @@ import org.eclipse.lsp4j.ShowMessageRequestParams
 final class ConfiguredLanguageClient(
     initial: MetalsLanguageClient,
     clientConfig: ClientConfiguration,
-    userConfig: () => UserConfiguration,
     service: WorkspaceLspService,
 )(implicit ec: ExecutionContext)
     extends DelegatingLanguageClient(initial) {
@@ -136,10 +134,7 @@ final class ConfiguredLanguageClient(
   }
 
   override def refreshSemanticTokens(): CompletableFuture[Void] = {
-    if (
-      userConfig().enableSemanticHighlighting &&
-      clientConfig.semanticTokensRefreshSupport()
-    ) {
+    if (clientConfig.semanticTokensRefreshSupport()) {
       underlying
         .refreshSemanticTokens()
         .handle { (msg, ex) =>


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/5699

Previously:
 - common config for all workspace folders
 - for initial sync we used `workspace/configuration` if supported by the client
 - next updates done `DidChangeConfiguration`
 
 Now:
  - a config for each workspace folder
  - for initial sync `workspace/configuration` if supported by the client
  - next updates triggered by `DidChangeConfiguration`
      - `workspace/configuration` used if supported
      - info from `DidChangeConfiguration` notification used otherwise