### PR TITLE
bugfix: exhaustive match on stale symbols

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -772,10 +772,9 @@ class MetalsGlobal(
       def loop(sym: Symbol): Unit = {
         sym.knownDirectSubclasses.foreach { child =>
           val unique = semanticdbSymbol(child)
-          if (!isVisited(unique)) {
+          if (!isVisited(unique) && !child.isStale) {
             isVisited += unique
             if (child.name.containsName(CURSOR)) ()
-            else if (child.isStale) ()
             else if (child.name == tpnme.LOCAL_CHILD) ()
             else if (child.isSealed && (child.isAbstract || child.isTrait)) {
               loop(child)

--- a/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionMatchSuite.scala
@@ -734,4 +734,27 @@ class CompletionMatchSuite extends BaseCompletionSuite {
     filter = _.contains("exhaustive"),
   )
 
+  check(
+    "stale-symbols",
+    """
+      |package example
+      |      
+      |object Main {
+      |  val x: ScalaTargetType = ???
+      |  val y = x match@@
+      |}
+      |sealed trait ScalaTargetType
+      |object ScalaTargetType {
+      |  case object Scala2 extends ScalaTargetType
+      |  case object Scala3 extends ScalaTargetType
+      |  case object JS extends ScalaTargetType
+      |  case object Native extends ScalaTargetType
+      |  case object Typelevel extends ScalaTargetType
+      |  case object ScalaCli extends ScalaTargetType
+      |}""".stripMargin,
+    """|match
+       |match (exhaustive) ScalaTargetType (6 cases)
+       |""".stripMargin,
+  )
+
 }


### PR DESCRIPTION
It doesn't reproduce in tests, but for case classes/objects defined inside an object we get stale symbols and filter out the not-stale ones