### PR TITLE
bugfix: hang on `initialize`

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -916,9 +916,14 @@ class MetalsLspService(
     cancel()
   }
 
-  def onUserConfigUpdate(newConfig: UserConfiguration): Future[Unit] = {
+  def setUserConfig(newConfig: UserConfiguration): UserConfiguration = {
     val old = userConfig
     userConfig = newConfig
+    old
+  }
+
+  def onUserConfigUpdate(newConfig: UserConfiguration): Future[Unit] = {
+    val old = setUserConfig(newConfig)
     if (userConfig.excludedPackages != old.excludedPackages) {
       excludedPackageHandler = ExcludedPackagesHandler.fromUserConfiguration(
         userConfig.excludedPackages.getOrElse(Nil)

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceFolders.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceFolders.scala
@@ -62,7 +62,7 @@ class WorkspaceFolders(
 
       val services = newServices.filterNot(isIn(prev, _))
       for {
-        _ <- userConfigSync.syncUserConfiguration(services)
+        _ <- userConfigSync.initSyncUserConfiguration(services)
         _ <- Future.sequence(services.map(_.initialized()))
         _ <- Future(prev.filter(shouldBeRemoved).foreach(_.onShutdown()))
       } yield ()
@@ -86,7 +86,7 @@ class WorkspaceFolders(
       case None =>
         setupLogger()
         userConfigSync
-          .syncUserConfiguration(List(newService))
+          .initSyncUserConfiguration(List(newService))
           .map(_ => newService.initialized())
         newService
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -1112,7 +1112,7 @@ class WorkspaceLspService(
   def initialized(): Future[Unit] = {
     statusBar.start(sh, 0, 1, ju.concurrent.TimeUnit.SECONDS)
     for {
-      _ <- userConfigSync.syncUserConfiguration(folderServices)
+      _ <- userConfigSync.initSyncUserConfiguration(folderServices)
       _ <- Future.sequence(folderServices.map(_.initialized()))
       _ <- Future(startHttpServer())
     } yield ()


### PR DESCRIPTION
Previously: metals would hang on `initialize`. We used `MetalsLspService .onUserConfigUpdate` for initial user config sync (before calling initialise), which in some cases could wait for `buildServerPromise`. 

It work before https://github.com/scalameta/metals/pull/5709, since `didChangeConfiguration` would always execute first, so the initial sync detected no changes (thus never waited for the build server promise). After that PR, on `didChangeConfiguration` we make a call to the client, so it takes longer and the initial sync executes first.