### PR TITLE
docs: Move acknowledgements/team to the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,36 +21,12 @@ https://scalameta.org/metals/docs/contributors/getting-started.html
 
 To learn more about how Metals works, see [./architecture.md](./architecture.md). It explains the high-level layout of the source code. Do skim through that document.
 
-### Team
+### Acknowledgements and Development
 
-The current maintainers (people who can merge pull requests) are:
-
-- Adrien Piquerez - [`@adpi2`](https://github.com/adpi2)
-- Arthur McGibbon - [`@Arthurm1`](https://github.com/Arthurm1)
-- Chris Kipp - [`@ckipp01`](https://github.com/ckipp01)
-- Kamil Podsiadło - [`@kpodsiad`](https://github.com/kpodsiad)
-- Ólafur Páll Geirsson - [`@olafurpg`](https://github.com/olafurpg)
-- Rikito Taniguchi - [`@tanishiking`](https://github.com/tanishiking)
-- Tomasz Godzik - [`@tgodzik`](https://github.com/tgodzik)
-- Vadim Chelyshov - [`@dos65`](https://github.com/dos65)
-
-Past maintainers:
-
-- Alexey Alekhin - [`@laughedelic`](https://github.com/laughedelic)
-- Gabriele Petronella - [`@gabro`](https://github.com/gabro)
-- Johan Mudsam - [`@mudsam`](https://github.com/mudsam)
-- Krzysztof Bochenek - [`@kpbochenek`](https://github.com/kpbochenek)
-- Jorge Vicente Cantero - [`@jvican`](https://github.com/jvican)
-- Marek Żarnowski - [`@marek1840`](https://github.com/marek1840)
-- Shane Delmore - [`@ShaneDelmore`](https://github.com/ShaneDelmore)
-
-## Acknowledgement
-
-Huge thanks to [`@dragos`](https://github.com/dragos) for his work on a Scala
-implementation of the LSP (see: https://github.com/dragos/dragos-vscode-scala).
-This project helped us get quickly started with LSP. Since then, we have
-refactored the project's original sources to the point where only a few simple
-case classes remain.
+For more information on the current maintainers, companies that have/are
+sponsoring the development of Metals, and acknowledgements of previous work,
+please see
+[https://scalameta.org/metals/docs/acknowledgements/development.html](https://scalameta.org/metals/docs/acknowledgements/development.html).
 
 ## Alternatives
 

--- a/docs/acknowledgements/development.md
+++ b/docs/acknowledgements/development.md
@@ -1,0 +1,62 @@
+---
+id: development
+title: The Development of Metals
+---
+
+Metals is a open-source project that drew inspiration from various places
+including previous LSP servers, other ecosystems, and fresh ideas of the time.
+Metals has also been graciously given developer time and focus from
+organizations like [The Scala Center](https://scala.epfl.ch/) where the project
+originated and also companies like [Virtus Lab](https://virtuslab.com/) that now
+lead the effort in the development and maintenance of the project.
+
+## The Team
+
+While Metals has had many community contributors, here are the past and
+present maintainers of the project.
+
+_The current maintainers (people who can merge pull requests) are:_
+
+- Adrien Piquerez - [`@adpi2`](https://github.com/adpi2)
+- Arthur McGibbon - [`@Arthurm1`](https://github.com/Arthurm1)
+- Chris Kipp - [`@ckipp01`](https://github.com/ckipp01)
+- Jakub Cieśluk - [`@jkciesluk`](https://github.com/jkciesluk)
+- Kamil Podsiadło - [`@kpodsiad`](https://github.com/kpodsiad)
+- Katarzyna Marek - [`@kasiaMarek`](https://github.com/kasiaMarek)
+- Ólafur Páll Geirsson - [`@olafurpg`](https://github.com/olafurpg)
+- Rikito Taniguchi - [`@tanishiking`](https://github.com/tanishiking)
+- Tomasz Godzik - [`@tgodzik`](https://github.com/tgodzik)
+- Vadim Chelyshov - [`@dos65`](https://github.com/dos65)
+
+_Past maintainers:_
+
+- Alexey Alekhin - [`@laughedelic`](https://github.com/laughedelic)
+- Gabriele Petronella - [`@gabro`](https://github.com/gabro)
+- Johan Mudsam - [`@mudsam`](https://github.com/mudsam)
+- Krzysztof Bochenek - [`@kpbochenek`](https://github.com/kpbochenek)
+- Jorge Vicente Cantero - [`@jvican`](https://github.com/jvican)
+- Marek Żarnowski - [`@marek1840`](https://github.com/marek1840)
+- Shane Delmore - [`@ShaneDelmore`](https://github.com/ShaneDelmore)
+
+
+## Previous LSP work
+
+Huge thanks to [`@dragos`](https://github.com/dragos) for his work on a Scala
+implementation of the LSP (see: https://github.com/dragos/dragos-vscode-scala).
+This project helped us get quickly started with LSP. Since then, we have
+refactored the project's original sources to the point where only a few simple
+case classes remain.
+
+### Company Sponsorships
+
+Metals is developed by the [Scala Center](https://scala.epfl.ch/) in conjunction
+with various companies from the past and preset. The following companies have
+contributed significant developer time to the project.
+
+Currently:
+
+- [Virtus Lab](https://virtuslab.com/)
+
+In the past:
+
+- [Lunatech](https://lunatech.com/)

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -39,6 +39,9 @@
     "Troubleshooting": [
       "troubleshooting/proxy",
       "troubleshooting/faq"
+    ],
+    "Acknowledgements": [
+      "acknowledgements/development"
     ]
   }
 }


### PR DESCRIPTION
This came from a conversation offline with @tgodzik about the current company efforts towards maintaining Metals. This makes a couple changes:

- Tries to accurately show what companies are currently backing Metals
- Moves the acknowledgements and current team to the website instead of the readme. Arguably a lot of people may not ever see the readme, and this way this information can be more widely accessed by people viewing the website, not just the code.