### PR TITLE
bugfix: Don't read file for InteractiveSemanticdbdb if it doesn't exist

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals
 
+import java.nio.charset.Charset
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicReference
 
@@ -32,6 +33,7 @@ import org.eclipse.{lsp4j => l}
 final class InteractiveSemanticdbs(
     workspace: AbsolutePath,
     buildTargets: BuildTargets,
+    charset: Charset,
     client: MetalsLanguageClient,
     tables: Tables,
     statusBar: StatusBar,
@@ -86,7 +88,7 @@ final class InteractiveSemanticdbs(
         source,
         (path, existingDoc) => {
           unsavedContents.orElse(buffers.get(source).orElse {
-            if (source.exists) Some(source.readText)
+            if (source.exists) Some(source.readText(charset))
             else None
           }) match {
             case None => null

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -359,6 +359,7 @@ class MetalsLspService(
       new InteractiveSemanticdbs(
         folder,
         buildTargets,
+        charset,
         languageClient,
         tables,
         statusBar,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -359,7 +359,6 @@ class MetalsLspService(
       new InteractiveSemanticdbs(
         folder,
         buildTargets,
-        charset,
         languageClient,
         tables,
         statusBar,
@@ -367,6 +366,7 @@ class MetalsLspService(
         clientConfig,
         () => semanticDBIndexer,
         javaInteractiveSemanticdb,
+        buffers,
       )
     )
   }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalametaCommonEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalametaCommonEnrichments.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.mtags
 
 import java.net.URI
+import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
@@ -285,8 +286,12 @@ trait ScalametaCommonEnrichments extends CommonMtagsEnrichments {
       }
     }
 
+    def readText(charset: Charset): String = {
+      FileIO.slurp(path, charset)
+    }
+
     def readText: String = {
-      FileIO.slurp(path, StandardCharsets.UTF_8)
+      readText(StandardCharsets.UTF_8)
     }
 
     def readTextOpt: Option[String] = {


### PR DESCRIPTION
Previously, we would assume that any file that we want to calculate InteractiveSemanticdb for exists on the filesystem, which is not true. For example renamed files if renamed from terminal will stick in the editor and cause exceptions to be throw. Now, we also try to read it from buffers and from filesystem as a fallback if it exists on the filesystem.