### PR TITLE
improvement: make new file independent of workspace root

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -626,11 +626,10 @@ class MetalsLspService(
     )
 
   private val newFileProvider: NewFileProvider = new NewFileProvider(
-    folder,
     languageClient,
     packageProvider,
-    focusedDocument,
     scalaVersionSelector,
+    clientConfig.icons,
   )
 
   private val symbolSearch: MetalsSymbolSearch = new MetalsSymbolSearch(

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -923,7 +923,10 @@ class WorkspaceLspService(
         ).asJavaObject
 
       case ServerCommands.NewScalaFile(args) =>
-        val directoryURI = args.lift(0).flatten
+        val directoryURI = args
+          .lift(0)
+          .flatten
+          .orElse(focusedDocument.map(_.parent.toURI.toString()))
         val name = args.lift(1).flatten
         val fileType = args.lift(2).flatten
         directoryURI
@@ -931,7 +934,10 @@ class WorkspaceLspService(
           .getOrElse(fallbackService)
           .createFile(directoryURI, name, fileType, isScala = true)
       case ServerCommands.NewJavaFile(args) =>
-        val directoryURI = args.lift(0).flatten
+        val directoryURI = args
+          .lift(0)
+          .flatten
+          .orElse(focusedDocument.map(_.parent.toURI.toString()))
         val name = args.lift(1).flatten
         val fileType = args.lift(2).flatten
         directoryURI

--- a/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
@@ -648,9 +648,12 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
              |{
              |  "a": { "scalaVersion" : "$localScalaVersion" }
              |}
+             |/focusedDoc.txt
+             |
              |$existingFiles
           """.stripMargin
         )
+        _ <- server.didFocus("focusedDoc.txt")
         _ <- server.executeCommand(command, args: _*)
         _ = {
           assertNoDiff(


### PR DESCRIPTION
In case no `directoryUri` provided and no current `focusedFile` ask user where to create new file. Previously `workspace` was used as fallback. In preparation for single file support we can't depend on that strategy anymore. Connected to: https://github.com/scalameta/metals/pull/5531.