### PR TITLE
Skip sourceroot and targetroot for in JavaTarget when semanticDbEnabl…

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
@@ -33,9 +33,11 @@ case class JavaTarget(
   def isSemanticdbEnabled: Boolean =
     javac.isSemanticdbEnabled || semanticDbEnabledAlternatively
 
-  def isSourcerootDeclared: Boolean = javac.isSourcerootDeclared
+  def isSourcerootDeclared: Boolean =
+    javac.isSourcerootDeclared || semanticDbEnabledAlternatively
 
-  def isTargetrootDeclared: Boolean = javac.isTargetrootDeclared
+  def isTargetrootDeclared: Boolean =
+    javac.isTargetrootDeclared || semanticDbEnabledAlternatively
 
   def classDirectory: String = javac.getClassDirectory()
 


### PR DESCRIPTION
…edAlternatively

Mill handles semanticdb differently and the Scala compilation is already skipping these checks. Two checks were missing though, for Java compilation.

### Before
![before](https://github.com/scalameta/metals/assets/5793054/3bc0f510-7a84-4f36-8243-020a919dbea1)


### After
![after](https://github.com/scalameta/metals/assets/5793054/4412cc6d-5772-44ef-921f-5413cb5e688c)
