### PR TITLE
bugfix: Future filter error during connecting to build server

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BuildToolSelector.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildToolSelector.scala
@@ -23,9 +23,9 @@ final class BuildToolSelector(
       buildTools: List[BuildTool]
   ): Future[Option[BuildTool]] =
     tables.buildTool.selectedBuildTool match {
-      case Some(chosen) =>
+      case Some(chosen) if buildTools.exists(_.executableName == chosen) =>
         Future(buildTools.find(_.executableName == chosen))
-      case None =>
+      case _ =>
         buildTools match {
           case buildTool :: Nil =>
             tables.buildTool.chooseBuildTool(buildTool.executableName)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1957,11 +1957,10 @@ class MetalsLspService(
       case Nil => Future(None)
       case buildTools =>
         for {
-          Some(buildTool) <- buildToolSelector.checkForChosenBuildTool(
+          buildTool <- buildToolSelector.checkForChosenBuildTool(
             buildTools
           )
-          if isCompatibleVersion(buildTool)
-        } yield Some(buildTool)
+        } yield buildTool.filter(isCompatibleVersion)
     }
   }
 


### PR DESCRIPTION
If we get to the state that selected build tool is no longer available, Metals would crash. This happend in `MetalsLspService.buildTool` if `BuildToolSelector.checkForChosenBuildTool` returned Future(None).

connected to https://github.com/scalameta/metals/issues/5761