### PR TITLE
refactor: differentiate between files and directories in sources

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
@@ -105,7 +105,7 @@ class BuildTargetInfo(buildTargets: BuildTargets) {
         "Base Directory",
         List(URIEncoderDecoder.decode(info.baseDirectory)),
       )
-      output ++= getSection("Source Directories", getSources(info))
+      output ++= getSection("Sources", getSources(info))
     })
 
     val scalaClassesDir = scalaInfo.map(_.classDirectory)
@@ -222,9 +222,12 @@ class BuildTargetInfo(buildTargets: BuildTargets) {
     buildTargets.sourceItemsToBuildTargets
       .filter(_._2.iterator.asScala.contains(target.getId()))
       .toList
-      .map { case (path, _) =>
-        val generated = buildTargets.checkIfGeneratedDir(path)
-        s"$path${if (generated) " (generated)" else ""}"
+      .map {
+        case (path, _) if buildTargets.checkIfGeneratedDir(path) =>
+          s"${path}/* (generated)"
+        case (path, _) if path.isDirectory => s"${path}/*"
+        case (path, _) if !path.exists => s"${path}/* (empty)"
+        case (path, _) => path.toString()
       }
       .sorted
   }

--- a/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/FileDecoderProviderLspSuite.scala
@@ -484,7 +484,7 @@ class FileDecoderProviderSbtLspSuite
     result =>
       FileDecoderProviderLspSuite.filterSections(
         result,
-        Set("Target", "Scala Version", "Base Directory", "Source Directories"),
+        Set("Target", "Scala Version", "Base Directory", "Sources"),
       ),
     "somefolder",
   )
@@ -1272,9 +1272,9 @@ object FileDecoderProviderLspSuite {
         |Base Directory
         |  file:@workspace/somefolder/a/
         |
-        |Source Directories
-        |  @workspace/somefolder/a/src/main/java
-        |  @workspace/somefolder/a/src/main/scala
-        |  @workspace/somefolder/a/src/main/scala-3
-        |  @workspace/somefolder/a/target/scala-${V.scala3}/src_managed/main (generated)""".stripMargin
+        |Sources
+        |  @workspace/somefolder/a/src/main/java/* (empty)
+        |  @workspace/somefolder/a/src/main/scala-3/* (empty)
+        |  @workspace/somefolder/a/src/main/scala/*
+        |  @workspace/somefolder/a/target/scala-${V.scala3}/src_managed/main/* (generated)""".stripMargin
 }


### PR DESCRIPTION
So I noticed that when using the "Show build target info" feature while
using scala-cli it would show individual files under the "Source
Directories". I know it's a bit of a nit, but I thought it might be
nicer to rename this to "Sources" and then do a better job at indicating
which are files, which are directories, and which ones don't exist. If
we agree this is better I can fix the related tests as well.


_Before_
<img width="952" alt="Screenshot 2023-10-19 at 13 14 23" src="https://github.com/scalameta/metals/assets/13974112/d5f35f0c-761f-4ebe-8f91-035bd3d68f28">
<img width="602" alt="Screenshot 2023-10-19 at 13 14 50" src="https://github.com/scalameta/metals/assets/13974112/94c2467f-64d9-4a39-8f97-289ad3566ee3">

_After_

<img width="971" alt="Screenshot 2023-10-19 at 13 09 31" src="https://github.com/scalameta/metals/assets/13974112/78cd2792-31c4-4c8d-9596-b4b51867547e">
<img width="601" alt="Screenshot 2023-10-19 at 13 10 03" src="https://github.com/scalameta/metals/assets/13974112/5c2404ae-c392-49fd-b3ca-ccfd1bb54f91">

