### PR TITLE
bugfix: move bsp config for detected project root

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
@@ -47,21 +47,22 @@ final class BspConfigGenerator(
           try {
             val bsp = ".bsp"
             workspace.resolve(bsp).createDirectories()
-            val buildToolBspDir = buildTool.projectRoot.resolve(bsp).toNIO
+            val buildToolBspDir = buildTool.projectRoot.resolve(bsp)
             val workspaceBspDir = workspace.resolve(bsp).toNIO
             buildToolBspDir.toFile.listFiles().foreach { file =>
               val path = file.toPath()
               if (!file.isDirectory() && path.filename.endsWith(".json")) {
-                val to =
-                  workspaceBspDir.resolve(path.relativize(buildToolBspDir))
+                val to = workspaceBspDir.resolve(path.filename)
                 Files.move(path, to, StandardCopyOption.REPLACE_EXISTING)
               }
             }
-            Files.delete(buildToolBspDir)
+            buildToolBspDir.deleteRecursively()
             Generated
           } catch {
-            case NonFatal(_) =>
-              Failed(Right("Could not move bsp config from project root"))
+            case NonFatal(e) =>
+              val message = s"Could not move bsp config from project root: $e"
+              scribe.error(message)
+              Failed(Right(message))
           }
         case status => status
       }

--- a/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
+++ b/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
@@ -249,6 +249,29 @@ class ScalaCliSuite extends BaseScalaCliSuite(V.scala3) {
     } yield ()
   }
 
+  test("inner") {
+    for {
+      _ <- scalaCliInitialize(useBsp = false)(
+        s"""|/inner/project.scala
+            |//> using scala "$scalaVersion"
+            |//> using lib "com.lihaoyi::utest::0.8.1"
+            |/inner/MyTests.scala
+            |import utest._
+            |
+            |object MyTests extends TestSuite {
+            |  val tests = Tests {
+            |    test("foo") {
+            |      assert(2 + 2 == 4)
+            |    }
+            |  }
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen("inner/MyTests.scala")
+      _ = assert(!client.workspaceDiagnostics.contains("Not found: utest"))
+    } yield ()
+  }
+
   test("relative-semanticdb-root") {
     for {
       _ <- scalaCliInitialize(useBsp = false)(


### PR DESCRIPTION
Bugfix for moving the generated bsp configuration from custom project root to workspace root. The tests were only for `bloop`. 