### PR TITLE
bugfix: fix SymbolNotFound regex

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
@@ -28,10 +28,10 @@ object ScalacDiagnostic {
   }
 
   object SymbolNotFound {
-    private val regex = """(n|N)ot found: (value|type)?\s?(\w+)""".r
+    private val regex = """(n|N)ot found: (value|type)?\s?(\w+)(\s|\S)*""".r
     def unapply(d: l.Diagnostic): Option[String] =
       d.getMessage().trim() match {
-        case regex(_, _, name) => Some(name)
+        case regex(_, _, name, _) => Some(name)
         case _ => None
       }
   }

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -261,4 +261,27 @@ class ImportMissingSymbolLspSuite
        |""".stripMargin,
   )
 
+  check(
+    "scalac-explain-flag",
+    """|package a
+       |
+       |object A {
+       |  val f = <<Future>>.successful(2)
+       |}
+       |""".stripMargin,
+    s"""|${ImportMissingSymbol.title("Future", "scala.concurrent")}
+        |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
+        |${CreateNewSymbol.title("Future")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.concurrent.Future
+       |
+       |object A {
+       |  val f = Future.successful(2)
+       |}
+       |""".stripMargin,
+    scalaVersion = "3.3.1",
+    scalacOptions = List("-explain"),
+  )
 }


### PR DESCRIPTION
This fixes the bug where the user has `-explain` `scalac` flag set
and executing Code Actions on a missing symbol did not offer to import
the symbol, due to extra text the regex previously failed to parse.