### PR TITLE
bugfix: Document highlight on named arguments

### DIFF
--- a/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
@@ -80,6 +80,59 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite {
   )
 
   check(
+    "named-args2",
+    """
+      |object Main {
+      |  def foo = check("abc")(
+      |    directory = "foo",
+      |    <<file@@name>> = 1,
+      |  )
+      |
+      |  private def check(name: String)(
+      |    directory: String,
+      |    <<filename>>: Int,
+      |    otherDefault: String = "default"
+      |  ): Unit = ()
+      |}""".stripMargin,
+  )
+
+  check(
+    "named-args2",
+    """
+      |object Main {
+      |  def foo = check("abc")(
+      |    directory = "foo",
+      |    <<file@@name>> = 1,
+      |  )
+      |
+      |  private def check(name: String)(
+      |    directory: String,
+      |    <<filename>>: Int,
+      |    otherDefault: String = "default"
+      |  ): Unit = ()
+      |}""".stripMargin,
+  )
+
+  check(
+    "named-args3",
+    """
+      |package example
+      |
+      |object Main {
+      |  check("abc")(
+      |    directory = Some("foo"),
+      |    <<filename>> = 1
+      |  )(loc = true)
+      |
+      |  private def check(name: String)(
+      |      directory: Option[String],
+      |      <<fil@@ename>>: Int,
+      |      otherDefault: String = "default"
+      |  )(loc: Boolean): Unit = ()
+      |}""".stripMargin,
+  )
+
+  check(
     "scopes",
     """
       |object Main {


### PR DESCRIPTION
For methods with multiple parameter lists and default args, the tree looks like this:
 `Block(List(val x&1, val x&2, ...), Apply(<<method>>, List(x&1, x&2, ...)))`, so we need to extract this `Apply`.

Also, if rhs of named argument is complex, the position is often incorrect, so we need to use `include` for `namedArgCache`

fixes to https://github.com/scalameta/metals/issues/5779