### PR TITLE
bugfix: Take into account JVM_OPTS and SBT_OPTS env variables

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -109,8 +109,8 @@ case class SbtBuildTool(
         List(
           javaArgs,
           sbtVersion,
-          SbtOpts.fromWorkspace(workspace),
-          JvmOpts.fromWorkspace(workspace),
+          SbtOpts.fromWorkspaceOrEnv(workspace),
+          JvmOpts.fromWorkspaceOrEnv(workspace),
           jarArgs,
           sbtArgs,
         ).flatten

--- a/metals/src/main/scala/scala/meta/internal/metals/JvmOpts.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JvmOpts.scala
@@ -14,13 +14,13 @@ import scala.meta.io.AbsolutePath
  */
 object JvmOpts {
 
-  def fromWorkspace(workspace: AbsolutePath): List[String] = {
+  def fromWorkspaceOrEnv(workspace: AbsolutePath): List[String] = {
     val jvmOpts = workspace.resolve(".jvmopts")
     if (jvmOpts.isFile && Files.isReadable(jvmOpts.toNIO)) {
       val text = FileIO.slurp(jvmOpts, StandardCharsets.UTF_8)
       text.linesIterator.map(_.trim).filter(_.startsWith("-")).toList
     } else {
-      Nil
+      fromEnvironment
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/SbtOpts.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SbtOpts.scala
@@ -14,13 +14,13 @@ import scala.meta.io.AbsolutePath
  */
 object SbtOpts {
 
-  def fromWorkspace(workspace: AbsolutePath): List[String] = {
+  def fromWorkspaceOrEnv(workspace: AbsolutePath): List[String] = {
     val sbtOpts = workspace.resolve(".sbtopts")
     if (sbtOpts.isFile && Files.isReadable(sbtOpts.toNIO)) {
       val text = FileIO.slurp(sbtOpts, StandardCharsets.UTF_8)
       process(text.linesIterator.map(_.trim).toList)
     } else {
-      Nil
+      fromEnvironment
     }
   }
 

--- a/tests/unit/src/test/scala/tests/SbtOptsSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtOptsSuite.scala
@@ -12,8 +12,8 @@ class SbtOptsSuite extends BaseSuite {
     test(name) {
       val root = FileLayout.fromString(original)
       val obtained =
-        SbtOpts.fromWorkspace(root).mkString("\n") ++
-          JvmOpts.fromWorkspace(root).mkString("\n")
+        SbtOpts.fromWorkspaceOrEnv(root).mkString("\n") ++
+          JvmOpts.fromWorkspaceOrEnv(root).mkString("\n")
       assertNoDiff(obtained, expected)
     }
   }


### PR DESCRIPTION
Previously, they seemed to be ignored. Now, we fallback if the file doesn't exist.

Related to https://github.com/scalameta/metals/discussions/5775