### PR TITLE
refactor: Use default concurrency queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,8 @@ on:
   pull_request:
 
 concurrency:
-  # Taken from gradle/gradle
-  # On main, we don't want any jobs cancelled so the sha is used to name the group
-  # On PR branches, we cancel the job if new commits are pushed
-  group: ${{ (github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags') ) && format('contributor-pr-base-{0}', github.sha) || format('contributor-pr-{0}', github.ref) }}
-  cancel-in-progress: true
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   unit:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [main]
     tags: ["*"]
+concurrency:
+  group: release-${{ github.ref }}
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -17,19 +19,6 @@ jobs:
           cache: 'sbt'
       - name: Publish
         run: |
-          LOCKED=true
-          while [ $LOCKED = true ]; do
-            # if there are several release jobs at the same time
-            # allow to continue the one which id is less than others
-            FIRST_IN_PROGRESS=$(gh api /repos/scalameta/metals/actions/workflows/release.yml/runs -q ".workflow_runs[]|select(.status==\"in_progress\")|.id"  | sort | head -n 1)
-            if [ "$FIRST_IN_PROGRESS" == "$GITHUB_RUN_ID" ]; then
-              LOCKED=false
-            else
-              echo "Waiting the completion of other release job..."
-              sleep 20
-            fi
-          done
-
           COMMAND="ci-release"
           UPDATE_DOCS=true
           if [[ $GITHUB_REF == "refs/tags"* ]] && [[ $GITHUB_REF_NAME == "mtags_v"* ]]; then


### PR DESCRIPTION
Previously, when specifying job concurrency we would only do it for branches so that jobs on main branch are not cancelled, which would happen (github was not queueing jobs). It seems that now it will properly queue the jobs so we simplify it all similar to how Scala CLI does things