### PR TITLE
bugfix: Remove old semanticdb files when not needed

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/decorations/SyntheticsDecorationProvider.scala
@@ -21,7 +21,6 @@ import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metap.PrinterSymtab
 import scala.meta.internal.mtags.Md5Fingerprints
-import scala.meta.internal.mtags.SemanticdbPath
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.parsing.TokenEditDistance
 import scala.meta.internal.parsing.Trees
@@ -80,7 +79,7 @@ final class SyntheticsDecorationProvider(
     }
   }
 
-  override def onDelete(path: SemanticdbPath): Unit = ()
+  override def onDelete(path: AbsolutePath): Unit = ()
   override def reset(): Unit = ()
 
   override def onChange(

--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -18,7 +18,6 @@ import scala.meta.internal.metals.ScalaVersionSelector
 import scala.meta.internal.metals.SemanticdbFeatureProvider
 import scala.meta.internal.mtags.GlobalSymbolIndex
 import scala.meta.internal.mtags.Mtags
-import scala.meta.internal.mtags.SemanticdbPath
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.mtags.SymbolDefinition
 import scala.meta.internal.mtags.{Symbol => MSymbol}
@@ -59,7 +58,7 @@ final class ImplementationProvider(
     implementationsInPath.clear()
   }
 
-  override def onDelete(path: SemanticdbPath): Unit = {
+  override def onDelete(path: AbsolutePath): Unit = {
     implementationsInPath.remove(path.toNIO)
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -62,11 +62,14 @@ final class InteractiveSemanticdbs(
       source: AbsolutePath
   ): TextDocumentLookup = textDocument(source, unsavedContents = None)
 
+  def onClose(path: AbsolutePath): Unit = {
+    textDocumentCache.remove(path)
+  }
+
   def textDocument(
       source: AbsolutePath,
       unsavedContents: Option[String],
   ): TextDocumentLookup = {
-
     def doesNotBelongToBuildTarget = buildTargets.inverseSources(source).isEmpty
     def shouldTryCalculateInteractiveSemanticdb = {
       source.isLocalFileSystem(workspace) && (

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1168,6 +1168,7 @@ class MetalsLspService(
     compilers.didClose(path)
     trees.didClose(path)
     diagnostics.onClose(path)
+    interactiveSemanticdbs.onClose(path)
   }
 
   override def didSave(

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -13,7 +13,6 @@ import scala.meta.Importee
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ResolvedSymbolOccurrence
 import scala.meta.internal.mtags.DefinitionAlternatives.GlobalSymbol
-import scala.meta.internal.mtags.SemanticdbPath
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.mtags.Symbol
 import scala.meta.internal.parsing.TokenEditDistance
@@ -56,7 +55,7 @@ final class ReferenceProvider(
     index.clear()
   }
 
-  override def onDelete(file: SemanticdbPath): Unit = {
+  override def onDelete(file: AbsolutePath): Unit = {
     index.remove(file.toNIO)
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticdbIndexer.scala
@@ -17,7 +17,7 @@ import com.google.protobuf.InvalidProtocolBufferException
 
 trait SemanticdbFeatureProvider {
   def onChange(docs: TextDocuments, path: AbsolutePath): Unit
-  def onDelete(path: SemanticdbPath): Unit
+  def onDelete(path: AbsolutePath): Unit
   def reset(): Unit
 }
 
@@ -40,7 +40,10 @@ class SemanticdbIndexer(
   }
 
   def onDelete(semanticdbFile: SemanticdbPath): Unit = {
-    providers.foreach(_.onDelete(semanticdbFile))
+    SemanticdbClasspath.toScala(workspace, semanticdbFile).foreach {
+      sourceFile =>
+        providers.foreach(_.onDelete(sourceFile))
+    }
   }
 
   /**

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -32,7 +32,6 @@ import scala.meta.internal.metals.testProvider.frameworks.MunitTestFinder
 import scala.meta.internal.metals.testProvider.frameworks.ScalatestTestFinder
 import scala.meta.internal.mtags
 import scala.meta.internal.mtags.GlobalSymbolIndex
-import scala.meta.internal.mtags.SemanticdbPath
 import scala.meta.internal.mtags.Semanticdbs
 import scala.meta.internal.parsing.Trees
 import scala.meta.internal.semanticdb
@@ -105,7 +104,7 @@ final class TestSuitesProvider(
       case _ => ()
     }
 
-  override def onDelete(file: SemanticdbPath): Unit = ()
+  override def onDelete(file: AbsolutePath): Unit = ()
   override def reset(): Unit = ()
 
   def onFileDelete(file: AbsolutePath): Unit = {


### PR DESCRIPTION
Previously, we would try to remove semanticdb files from indexes while we used the actual source file. Now, we properly remove files in all indexes and also from interactive semanticdb.

Related to https://github.com/scalameta/metals/issues/5748