### PR TITLE
improvement: add custom bsp as possible build tool

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -204,6 +204,10 @@ class BspConnector(
     }
   }
 
+  /**
+   * Looks for a build tool matching the chosen build server, and sets it as the chosen build server.
+   * Only for `bloop` there will be no matching build tool and the previously chosen one remains.
+   */
   private def optSetBuildTool(buildServerName: String): Unit =
     buildTools.loadSupported
       .find {

--- a/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
@@ -37,7 +37,7 @@ final class BloopInstall(
   override def toString: String = s"BloopInstall($workspace)"
 
   def runUnconditionally(
-      buildTool: BuildTool,
+      buildTool: BloopInstallProvider,
       isImportInProcess: AtomicBoolean,
   ): Future[WorkspaceLoadedStatus] = {
     if (isImportInProcess.compareAndSet(false, true)) {
@@ -121,7 +121,7 @@ final class BloopInstall(
   // notifications. This method is synchronized to prevent asking the user
   // twice whether to import the build.
   def runIfApproved(
-      buildTool: BuildTool,
+      buildTool: BloopInstallProvider,
       digest: String,
       isImportInProcess: AtomicBoolean,
   ): Future[WorkspaceLoadedStatus] =

--- a/metals/src/main/scala/scala/meta/internal/builds/BloopInstallProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopInstallProvider.scala
@@ -9,7 +9,7 @@ import scala.meta.io.AbsolutePath
 trait BloopInstallProvider extends BuildTool {
 
   /**
-   * Method used to generate the necesary .bloop files for the
+   * Method used to generate the necessary .bloop files for the
    * build tool.
    */
   def bloopInstall(
@@ -22,4 +22,6 @@ trait BloopInstallProvider extends BuildTool {
    * Args necessary for build tool to generate the .bloop files.
    */
   def bloopInstallArgs(workspace: AbsolutePath): List[String]
+
+  override val isBloopInstallProvider = true
 }

--- a/metals/src/main/scala/scala/meta/internal/builds/BloopInstallProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopInstallProvider.scala
@@ -6,7 +6,7 @@ import scala.meta.io.AbsolutePath
 /**
  * Helper trait for build tools that have a Bloop plugin
  */
-trait BloopInstallProvider { this: BuildTool =>
+trait BloopInstallProvider extends BuildTool {
 
   /**
    * Method used to generate the necesary .bloop files for the

--- a/metals/src/main/scala/scala/meta/internal/builds/BspOnly.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BspOnly.scala
@@ -1,0 +1,14 @@
+package scala.meta.internal.builds
+
+import scala.meta.io.AbsolutePath
+
+/**
+ * Build tool for custom bsp detected in `.bsp/<name>.json`
+ */
+case class BspOnly(
+    override val executableName: String,
+    override val projectRoot: AbsolutePath,
+) extends BuildTool {
+  override def digest(workspace: AbsolutePath): Option[String] = Some("OK")
+  override val forcesBuildServer = true
+}

--- a/metals/src/main/scala/scala/meta/internal/builds/BspOnly.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BspOnly.scala
@@ -1,5 +1,9 @@
 package scala.meta.internal.builds
 
+import java.security.MessageDigest
+
+import scala.meta.internal.builds.Digest
+import scala.meta.internal.mtags.MD5
 import scala.meta.io.AbsolutePath
 
 /**
@@ -9,6 +13,12 @@ case class BspOnly(
     override val executableName: String,
     override val projectRoot: AbsolutePath,
 ) extends BuildTool {
-  override def digest(workspace: AbsolutePath): Option[String] = Some("OK")
+  override def digest(workspace: AbsolutePath): Option[String] = {
+    val digest = MessageDigest.getInstance("MD5")
+    val isSuccess =
+      Digest.digestJson(workspace.resolve(s"$executableName.json"), digest)
+    if (isSuccess) Some(MD5.bytesToHex(digest.digest()))
+    else None
+  }
   override val forcesBuildServer = true
 }

--- a/metals/src/main/scala/scala/meta/internal/builds/BspOnly.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BspOnly.scala
@@ -7,16 +7,17 @@ import scala.meta.internal.mtags.MD5
 import scala.meta.io.AbsolutePath
 
 /**
- * Build tool for custom bsp detected in `.bsp/<name>.json`
+ * Build tool for custom bsp detected in `.bsp/<name>.json` or `bspGlobalDirectories`
  */
 case class BspOnly(
     override val executableName: String,
     override val projectRoot: AbsolutePath,
+    pathToBspConfig: AbsolutePath,
 ) extends BuildTool {
   override def digest(workspace: AbsolutePath): Option[String] = {
     val digest = MessageDigest.getInstance("MD5")
     val isSuccess =
-      Digest.digestJson(workspace.resolve(s"$executableName.json"), digest)
+      Digest.digestJson(pathToBspConfig, digest)
     if (isSuccess) Some(MD5.bytesToHex(digest.digest()))
     else None
   }

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
@@ -24,6 +24,8 @@ trait BuildTool {
 
   val forcesBuildServer = false
 
+  val isBloopInstallProvider = false
+
 }
 
 object BuildTool {

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -130,16 +130,15 @@ final class BuildTools(
         .listFiles()
         .collect {
           case file
-              if file.isFile() && file.getName().endsWith(".json") && !knowBsps(
-                file.getName().stripSuffix(".json")
-              ) =>
+              if file.isFile() && file.getName().endsWith(".json") &&
+                !knownBsps(file.getName().stripSuffix(".json")) =>
             BspOnly(file.getName().stripSuffix(".json"), root)
         }
         .toList
     } else Nil
   }
 
-  private def knowBsps =
+  private def knownBsps =
     Set(SbtBuildTool.name, MillBuildTool.name) ++ ScalaCli.names
 
   private def customProjectRoot =
@@ -230,6 +229,11 @@ final class BuildTools(
       Some(MavenBuildTool.name)
     else if (isMill && MillBuildTool.isMillRelatedPath(path))
       Some(MillBuildTool.name)
+    else if (
+      path.isFile && path.filename.endsWith(".json") &&
+      path.parent.filename == ".bsp"
+    )
+      Some(path.filename.stripSuffix(".json"))
     else None
   }
 

--- a/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/Digest.scala
@@ -4,6 +4,8 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.security.MessageDigest
 
+import scala.util.Success
+import scala.util.Try
 import scala.util.control.NonFatal
 import scala.xml.Comment
 import scala.xml.Node
@@ -14,6 +16,8 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.mtags.MD5
 import scala.meta.internal.parsing.Trees
 import scala.meta.io.AbsolutePath
+
+import ujson.BytesRenderer
 
 case class Digest(
     md5: String,
@@ -172,6 +176,19 @@ object Digest {
     } catch {
       case NonFatal(_) =>
         false
+    }
+  }
+
+  def digestJson(
+      file: AbsolutePath,
+      digest: MessageDigest,
+  ): Boolean = {
+    Try(ujson.read(file.readText)) match {
+      case Success(json) =>
+        val bytes = json.transform(BytesRenderer()).toByteArray()
+        digest.update(bytes)
+        true
+      case _ => false
     }
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -20,7 +20,8 @@ case class GradleBuildTool(
     userConfig: () => UserConfiguration,
     projectRoot: AbsolutePath,
 ) extends BuildTool
-    with BloopInstallProvider {
+    with BloopInstallProvider
+    with VersionRecommendation {
 
   private val initScriptName = "init-script.gradle"
   private val gradleBloopVersion = BuildInfo.gradleBloopVersion

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -10,7 +10,8 @@ case class MavenBuildTool(
     userConfig: () => UserConfiguration,
     projectRoot: AbsolutePath,
 ) extends BuildTool
-    with BloopInstallProvider {
+    with BloopInstallProvider
+    with VersionRecommendation {
 
   private lazy val embeddedMavenLauncher: AbsolutePath = {
     val out = BuildTool.copyFromResource(tempDir, "maven-wrapper.jar")

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -14,7 +14,8 @@ case class MillBuildTool(
     projectRoot: AbsolutePath,
 ) extends BuildTool
     with BloopInstallProvider
-    with BuildServerProvider {
+    with BuildServerProvider
+    with VersionRecommendation {
 
   private def getMillVersion(workspace: AbsolutePath): String = {
     import scala.meta.internal.jdk.CollectionConverters._

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -26,7 +26,8 @@ case class SbtBuildTool(
     userConfig: () => UserConfiguration,
 ) extends BuildTool
     with BloopInstallProvider
-    with BuildServerProvider {
+    with BuildServerProvider
+    with VersionRecommendation {
 
   import SbtBuildTool._
 

--- a/metals/src/main/scala/scala/meta/internal/builds/ScalaCliBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ScalaCliBuildTool.scala
@@ -17,7 +17,8 @@ class ScalaCliBuildTool(
     val projectRoot: AbsolutePath,
     userConfig: () => UserConfiguration,
 ) extends BuildTool
-    with BuildServerProvider {
+    with BuildServerProvider
+    with VersionRecommendation {
 
   lazy val runScalaCliCommand: Option[Seq[String]] =
     ScalaCli.localScalaCli(userConfig())
@@ -47,12 +48,6 @@ class ScalaCliBuildTool(
       )
     )
 
-  override def bloopInstall(
-      workspace: AbsolutePath,
-      systemProcess: List[String] => Future[WorkspaceLoadedStatus],
-  ): Future[WorkspaceLoadedStatus] =
-    Future.successful(WorkspaceLoadedStatus.Dismissed)
-
   override def digest(workspace: AbsolutePath): Option[String] =
     ScalaCliDigest.current(workspace)
 
@@ -64,16 +59,19 @@ class ScalaCliBuildTool(
 
   override def executableName: String = ScalaCliBuildTool.name
 
-  override def isBloopDefaultBsp = false
+  override val forcesBuildServer = true
+
+  def isBspGenerated(workspace: AbsolutePath): Boolean =
+    ScalaCliBuildTool.pathsToScalaCliBsp(workspace).exists(_.isFile)
 
 }
 
 object ScalaCliBuildTool {
   def name = "scala-cli"
-  def pathsToScalaCliBsp(root: AbsolutePath): List[AbsolutePath] = List(
-    root.resolve(".bsp").resolve("scala-cli.json"),
-    root.resolve(".bsp").resolve("scala.json"),
-  )
+  def pathsToScalaCliBsp(root: AbsolutePath): List[AbsolutePath] =
+    ScalaCli.names.toList.map(name =>
+      root.resolve(".bsp").resolve(s"$name.json")
+    )
 
   def apply(
       workspace: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/builds/VersionRecommendation.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/VersionRecommendation.scala
@@ -1,0 +1,7 @@
+package scala.meta.internal.builds
+
+trait VersionRecommendation { self: BuildTool =>
+  def minimumVersion: String
+  def recommendedVersion: String
+  def version: String
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -40,7 +40,7 @@ object Configs {
           new FileSystemWatcher(
             Either.forLeft(s"$root/.metals/.reports/bloop/*/*")
           ),
-          new FileSystemWatcher(Either.forLeft(s"$root/.bsp/*.json")),
+          new FileSystemWatcher(Either.forLeft(s"$root/**/.bsp/*.json")),
         ).asJava
       )
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -40,6 +40,7 @@ object Configs {
           new FileSystemWatcher(
             Either.forLeft(s"$root/.metals/.reports/bloop/*/*")
           ),
+          new FileSystemWatcher(Either.forLeft(s"$root/.bsp/*.json")),
         ).asJava
       )
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -19,6 +19,7 @@ import scala.meta.dialects._
 import scala.meta.inputs.Input
 import scala.meta.internal.bsp.BspSession
 import scala.meta.internal.bsp.BuildChange
+import scala.meta.internal.builds.BspOnly
 import scala.meta.internal.builds.BuildTool
 import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.builds.Digest.Status
@@ -88,25 +89,33 @@ final case class Indexer(
       buildTool: BuildTool,
       checksum: String,
       importBuild: BspSession => Future[Unit],
+      reconnectToBuildServer: () => Future[BuildChange],
   ): Future[BuildChange] = {
     def reloadAndIndex(session: BspSession): Future[BuildChange] = {
       workspaceReload().persistChecksumStatus(Status.Started, buildTool)
 
-      session
-        .workspaceReload()
-        .flatMap(_ => importBuild(session))
-        .map { _ =>
-          scribe.info("Correctly reloaded workspace")
-          profiledIndexWorkspace(doctorCheck)
-          workspaceReload().persistChecksumStatus(Status.Installed, buildTool)
-          BuildChange.Reloaded
-        }
-        .recoverWith { case NonFatal(e) =>
-          scribe.error(s"Unable to reload workspace: ${e.getMessage()}")
-          workspaceReload().persistChecksumStatus(Status.Failed, buildTool)
-          languageClient.showMessage(Messages.ReloadProjectFailed)
-          Future.successful(BuildChange.Failed)
-        }
+      buildTool match {
+        case _: BspOnly => reconnectToBuildServer()
+        case _ =>
+          session
+            .workspaceReload()
+            .flatMap(_ => importBuild(session))
+            .map { _ =>
+              scribe.info("Correctly reloaded workspace")
+              profiledIndexWorkspace(doctorCheck)
+              workspaceReload().persistChecksumStatus(
+                Status.Installed,
+                buildTool,
+              )
+              BuildChange.Reloaded
+            }
+            .recoverWith { case NonFatal(e) =>
+              scribe.error(s"Unable to reload workspace: ${e.getMessage()}")
+              workspaceReload().persistChecksumStatus(Status.Failed, buildTool)
+              languageClient.showMessage(Messages.ReloadProjectFailed)
+              Future.successful(BuildChange.Failed)
+            }
+      }
     }
 
     bspSession() match {

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -5,6 +5,7 @@ import java.nio.file.Path
 import scala.collection.mutable
 
 import scala.meta.internal.builds.BuildTool
+import scala.meta.internal.builds.VersionRecommendation
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.BloopJsonUpdateCause.BloopJsonUpdateCause
 import scala.meta.internal.metals.clients.language.MetalsInputBoxParams
@@ -193,13 +194,13 @@ object Messages {
   }
 
   object ChooseBuildTool {
+    def message =
+      "Multiple build definitions found. Which would you like to use?"
     def params(builtTools: List[BuildTool]): ShowMessageRequestParams = {
       val messageActionItems =
         builtTools.map(bt => new MessageActionItem(bt.executableName))
       val params = new ShowMessageRequestParams()
-      params.setMessage(
-        "Multiple build definitions found. Which would you like to use?"
-      )
+      params.setMessage(message)
       params.setType(MessageType.Info)
       params.setActions(messageActionItems.asJava)
       params
@@ -288,7 +289,7 @@ object Messages {
 
     def learnMoreUrl: String = Urls.docs("import-build")
 
-    def params(tool: BuildTool): ShowMessageRequestParams = {
+    def params(tool: VersionRecommendation): ShowMessageRequestParams = {
       def toFixMessage =
         s"To fix this problem, upgrade to $tool ${tool.recommendedVersion} "
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -2153,6 +2153,7 @@ class MetalsLspService(
           found.buildTool,
           found.digest,
           importBuild,
+          quickConnectToBuildServer,
         )
       case None =>
         Future.successful(BuildChange.None)

--- a/metals/src/main/scala/scala/meta/internal/metals/PopupChoiceReset.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/PopupChoiceReset.scala
@@ -28,7 +28,6 @@ class PopupChoiceReset(
     val result = if (value == BuildTool) {
       scribe.info("Resetting build tool selection.")
       tables.buildTool.reset()
-      tables.buildServers.reset()
       slowConnect().ignoreValue
     } else if (value == BuildImport) {
       tables.dismissedNotifications.ImportChanges.reset()

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -68,6 +68,18 @@ case class UserConfiguration(
     ) && this.showInferredType.nonEmpty
     showImplicitArguments || showInferredType || showImplicitConversionsAndClasses
   }
+
+  def getCustomProjectRoot(workspace: AbsolutePath): Option[AbsolutePath] =
+    customProjectRoot
+      .map(relativePath => workspace.resolve(relativePath.trim()))
+      .filter { projectRoot =>
+        val exists = projectRoot.toFile.exists
+        if (!exists) {
+          scribe.error(s"custom project root $projectRoot does not exist")
+        }
+        exists
+      }
+
 }
 
 object UserConfiguration {

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -425,6 +425,7 @@ object ScalaCli {
   def scalaCliBspJsonContent(
       args: List[String] = Nil,
       projectRoot: String = ".",
+      bspName: String = "scala-cli",
   ): String = {
     val argv = List(
       ScalaCli.javaCommand,
@@ -435,7 +436,7 @@ object ScalaCli {
       projectRoot,
     ) ++ args
     val bsjJson = ujson.Obj(
-      "name" -> "scala-cli",
+      "name" -> bspName,
       "argv" -> argv,
       "version" -> BuildInfo.scalaCliVersion,
       "bspVersion" -> scalaCliBspVersion,

--- a/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
+++ b/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
@@ -12,6 +12,7 @@ import scala.meta.internal.metals.SlowTaskConfig
 import scala.meta.internal.metals.scalacli.ScalaCli
 import scala.meta.internal.metals.{BuildInfo => V}
 
+import org.eclipse.{lsp4j => l}
 import tests.FileLayout
 
 class ScalaCliSuite extends BaseScalaCliSuite(V.scala3) {
@@ -267,6 +268,18 @@ class ScalaCliSuite extends BaseScalaCliSuite(V.scala3) {
       _ <- server.initialized()
       _ = FileLayout.fromString(simpleFileLayout, workspace)
       _ = FileLayout.fromString(bspLayout, workspace)
+      _ <- server.fullServer
+        .didChangeWatchedFiles(
+          new l.DidChangeWatchedFilesParams(
+            List(
+              new l.FileEvent(
+                workspace.resolve(".bsp/scala-cli.json").toURI.toString(),
+                l.FileChangeType.Created,
+              )
+            ).asJava
+          )
+        )
+        .asScala
       _ <- server.server.indexingPromise.future
       _ <- server.didOpen("MyTests.scala")
       _ <- assertDefinitionAtLocation(

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -302,9 +302,6 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
         .map(tool => createParams(tool.toString()))
         .contains(params)
     }
-    // NOTE: (ckipp01) Just for easiness of testing, we are going to just look
-    // for sbt and mill builds together, which are most common. The logic however
-    // is identical for all build tools.
 
     def isNewBuildToolDetectedMessage(): Boolean = {
       val buildTools = BuildTools.default().allAvailable

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -14,6 +14,7 @@ import scala.concurrent.Promise
 import scala.meta.inputs.Input
 import scala.meta.internal.bsp.ConnectionBspStatus
 import scala.meta.internal.builds.BuildTool
+import scala.meta.internal.builds.BspErrorHandler
 import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.decorations.PublishDecorationsParams
 import scala.meta.internal.metals.Buffers
@@ -306,17 +307,6 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
     // NOTE: (ckipp01) Just for easiness of testing, we are going to just look
     // for sbt and mill builds together, which are most common. The logic however
     // is identical for all build tools.
-    def isSameMessageFromList(
-        createParams: List[BuildTool] => ShowMessageRequestParams
-    ): Boolean = {
-      val buildTools = BuildTools
-        .default()
-        .allAvailable
-        .filter(bt => bt.executableName == "sbt" || bt.executableName == "mill")
-
-      val targetParams = createParams(buildTools)
-      params == targetParams
-    }
 
     def isNewBuildToolDetectedMessage(): Boolean = {
       val buildTools = BuildTools.default().allAvailable
@@ -347,7 +337,7 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
           getDoctorInformation
         } else if (BspSwitch.isSelectBspServer(params)) {
           selectBspServer(params.getActions.asScala.toSeq)
-        } else if (isSameMessageFromList(ChooseBuildTool.params)) {
+        } else if (params.getMessage == ChooseBuildTool.message) {
           chooseBuildTool(params.getActions.asScala.toSeq)
         } else if (MissingScalafmtConf.isCreateScalafmtConf(params)) {
           createScalaFmtConf

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -13,8 +13,6 @@ import scala.concurrent.Promise
 
 import scala.meta.inputs.Input
 import scala.meta.internal.bsp.ConnectionBspStatus
-import scala.meta.internal.builds.BuildTool
-import scala.meta.internal.builds.BspErrorHandler
 import scala.meta.internal.builds.BuildTools
 import scala.meta.internal.decorations.PublishDecorationsParams
 import scala.meta.internal.metals.Buffers

--- a/tests/unit/src/test/scala/tests/BillLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BillLspSuite.scala
@@ -187,9 +187,7 @@ class BillLspSuite extends BaseLspSuite("bill") {
     testRoundtripCompilation()
   }
 
-  def testSelectServerDialogue(
-      additionalMessages: List[String] = Nil
-  ): Future[Unit] = {
+  def testSelectServerDialogue(): Future[Unit] = {
     // when asked, choose the Bob build tool
     client.selectBspServer = { actions =>
       actions.find(_.getTitle == "Bob").get
@@ -203,11 +201,11 @@ class BillLspSuite extends BaseLspSuite("bill") {
       )
       _ = assertNoDiff(
         client.workspaceMessageRequests,
-        (additionalMessages ++
-          List(
-            Messages.BspSwitch.message,
-            Messages.CheckDoctor.allProjectsMisconfigured,
-          )).mkString("\n"),
+        List(
+          Messages.ChooseBuildTool.message,
+          Messages.BspSwitch.message,
+          Messages.CheckDoctor.allProjectsMisconfigured,
+        ).mkString("\n"),
       )
     } yield ()
   }
@@ -216,7 +214,7 @@ class BillLspSuite extends BaseLspSuite("bill") {
     cleanWorkspace()
     Bill.installWorkspace(workspace.toNIO, "Bill")
     Bill.installWorkspace(workspace.toNIO, "Bob")
-    testSelectServerDialogue(List(Messages.ChooseBuildTool.message))
+    testSelectServerDialogue()
   }
 
   test("mix") {

--- a/tests/unit/src/test/scala/tests/BillLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BillLspSuite.scala
@@ -187,7 +187,9 @@ class BillLspSuite extends BaseLspSuite("bill") {
     testRoundtripCompilation()
   }
 
-  def testSelectServerDialogue(): Future[Unit] = {
+  def testSelectServerDialogue(
+      additionalMessages: List[String] = Nil
+  ): Future[Unit] = {
     // when asked, choose the Bob build tool
     client.selectBspServer = { actions =>
       actions.find(_.getTitle == "Bob").get
@@ -201,10 +203,11 @@ class BillLspSuite extends BaseLspSuite("bill") {
       )
       _ = assertNoDiff(
         client.workspaceMessageRequests,
-        List(
-          Messages.BspSwitch.message,
-          Messages.CheckDoctor.allProjectsMisconfigured,
-        ).mkString("\n"),
+        (additionalMessages ++
+          List(
+            Messages.BspSwitch.message,
+            Messages.CheckDoctor.allProjectsMisconfigured,
+          )).mkString("\n"),
       )
     } yield ()
   }
@@ -213,7 +216,7 @@ class BillLspSuite extends BaseLspSuite("bill") {
     cleanWorkspace()
     Bill.installWorkspace(workspace.toNIO, "Bill")
     Bill.installWorkspace(workspace.toNIO, "Bob")
-    testSelectServerDialogue()
+    testSelectServerDialogue(List(Messages.ChooseBuildTool.message))
   }
 
   test("mix") {


### PR DESCRIPTION
Previously: For custom BSP we would still use some other build tool if discovered.
Now: Custom BSP is in itself treated as a build tool, we look for `.bsp` configs in:
 1. root directory,
 1. custom project root directory,
 1. `bspGlobalInstallDirectories`.
 
 As a followup we should deduplicate code in build servers and build tools discovery and selection: 
   1. `BspServers.findAvailableServers` repeats a lot from `BuildTools.loadSupported`,
   1. build tool selection adjust build server selection when needed and the other way around.