### PR TITLE
Change method to work with explicit nulls

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -259,6 +259,10 @@ lazy val mtagsShared = project
         .filterNot(isScala3WithPresentationCompiler),
     crossVersion := CrossVersion.full,
     Compile / packageSrc / publishArtifact := true,
+    Compile / scalacOptions ++= crossSetting(
+      scalaVersion.value,
+      if3 = List("-Yexplicit-nulls", "-language:unsafeNulls"),
+    ),
     libraryDependencies ++= List(
       "org.lz4" % "lz4-java" % "1.8.0",
       "com.google.protobuf" % "protobuf-java" % "3.24.3",

--- a/build.sbt
+++ b/build.sbt
@@ -259,10 +259,11 @@ lazy val mtagsShared = project
         .filterNot(isScala3WithPresentationCompiler),
     crossVersion := CrossVersion.full,
     Compile / packageSrc / publishArtifact := true,
-    Compile / scalacOptions ++= crossSetting(
-      scalaVersion.value,
-      if3 = List("-Yexplicit-nulls", "-language:unsafeNulls"),
-    ),
+    Compile / scalacOptions ++= {
+      if (scalaVersion.value == V.scala3)
+        List("-Yexplicit-nulls", "-language:unsafeNulls")
+      else Nil
+    },
     libraryDependencies ++= List(
       "org.lz4" % "lz4-java" % "1.8.0",
       "com.google.protobuf" % "protobuf-java" % "3.24.3",

--- a/mtags-shared/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -42,21 +42,19 @@ trait CommonMtagsEnrichments {
       cls: java.lang.Class[T],
       gson: Option[Gson] = None
   ): Option[T] =
-    for {
-      data <- Option(obj)
-      value <-
-        try {
-          Option(
-            gson
-              .getOrElse(new Gson())
-              .fromJson[T](data.asInstanceOf[JsonElement], cls)
-          )
-        } catch {
-          case NonFatal(e) =>
-            logger.log(Level.SEVERE, s"decode error: $cls", e)
-            None
-        }
-    } yield value
+    Option(obj).flatMap { data =>
+      try {
+        Option(
+          gson
+            .getOrElse(new Gson())
+            .fromJson[T](data.asInstanceOf[JsonElement], cls)
+        )
+      } catch {
+        case NonFatal(e) =>
+          logger.log(Level.SEVERE, s"decode error: $cls", e)
+          None
+      }
+    }
 
   implicit class XtensionJEitherCross[A, B](either: JEither[A, B]) {
     def asScala: Either[A, B] =


### PR DESCRIPTION
Change required to work with `-Yexplicit-nulls` according to https://github.com/lampepfl/dotty/issues/18775
This is a blocker for adding `-Yexpliict-nulls` in the presentation compiler module that will guarantee soundness. https://github.com/lampepfl/dotty/pull/18776

This also may require a minor release.