### PR TITLE
Completions should prepend instead of replace to match Scala 2 behaviour

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionPos.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionPos.scala
@@ -29,9 +29,10 @@ case class CompletionPos(
 
   def sourcePos: SourcePosition = cursorPos.withSpan(Spans.Span(start, end))
 
-  def toEditRange: l.Range =
+  def stripSuffixEditRange: l.Range =
     new l.Range(cursorPos.offsetToPos(start), cursorPos.offsetToPos(end))
-  end toEditRange
+  def toEditRange: l.Range =
+    cursorPos.withStart(start).withEnd(cursorPos.point).toLsp
 end CompletionPos
 
 object CompletionPos:

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1937,4 +1937,56 @@ class CompletionSuite extends BaseCompletionSuite {
        |""".stripMargin,
   )
 
+  checkEdit(
+    "prepend-instead-of-replace",
+    """|object O {
+       |  printl@@println()
+       |}
+       |""".stripMargin,
+    """|object O {
+       |  printlnprintln()
+       |}
+       |""".stripMargin,
+    assertSingleItem = false,
+  )
+
+  checkEdit(
+    "prepend-instead-of-replace-duplicate-word",
+    """|object O {
+       |  println@@println()
+       |}
+       |""".stripMargin,
+    """|object O {
+       |  printlnprintln()
+       |}
+       |""".stripMargin,
+    assertSingleItem = false,
+  )
+
+  checkEdit(
+    "replace-when-inside",
+    """|object O {
+       |  print@@ln()
+       |}
+       |""".stripMargin,
+    """|object O {
+       |  println()
+       |}
+       |""".stripMargin,
+    assertSingleItem = false,
+  )
+
+  checkEdit(
+    "replace-exact-same",
+    """|object O {
+       |  println@@()
+       |}
+       |""".stripMargin,
+    """|object O {
+       |  println()
+       |}
+       |""".stripMargin,
+    assertSingleItem = false,
+  )
+
 }


### PR DESCRIPTION
Back-backport the changes in dotty which will match the completion behaviour for Scala 2 and Scala 3. Related PR https://github.com/lampepfl/dotty/pull/18803