### PR TITLE
bugfix: Add output classes directory to classpath for PC

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -1007,8 +1007,12 @@ object MetalsEnrichments
         .map(_.stripPrefix(flag))
     }
 
-    def classpath: List[String] =
-      item.getClasspath.asScala.toList
+    def classpath: List[String] = {
+      val outputClasses = item.getClassDirectory
+      val classes = item.getClasspath.asScala.toList
+      if (classes.contains(outputClasses)) classes
+      else outputClasses :: classes
+    }
 
     def jarClasspath: List[AbsolutePath] =
       classpath


### PR DESCRIPTION
It was there already for bloop and sbt, but not for mill. Because of this, presentation compiler didn't see symbols from workspace.

fixes https://github.com/scalameta/metals/issues/5774