### PR TITLE
bugfix: BuildTargetInfo for mill-build

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
@@ -12,12 +12,11 @@ import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 
 class BuildTargetInfo(buildTargets: BuildTargets) {
 
-  def buildTargetDetails(targetName: String): String = {
+  def buildTargetDetails(targetName: String, uri: String): String = {
     buildTargets.all
-      .filter(_.getDisplayName == targetName)
-      .map(_.getId())
-      .headOption
-      .map(buildTargetDetail)
+      .find(_.getDisplayName == targetName)
+      .orElse(buildTargets.all.find(_.getId.getUri.toString == uri))
+      .map(target => buildTargetDetail(target.getId()))
       .getOrElse(s"Build target $targetName not found")
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -300,7 +300,12 @@ final class FileDecoderProvider(
       .toAbsolutePathSafe
       .map { path =>
         val targetName = path.filename.stripSuffix(".metals-buildtarget")
-        new BuildTargetInfo(buildTargets).buildTargetDetails(targetName)
+        // display name for mill-build is `mill-build/` and `mill-build/mill-build/` for meta builds
+        val withoutSuffix = uri.toString().stripSuffix("/.metals-buildtarget")
+        new BuildTargetInfo(buildTargets).buildTargetDetails(
+          targetName,
+          withoutSuffix,
+        )
       }
       .getOrElse(s"Error transforming $uri to path")
     DecoderResponse.success(uri, text)


### PR DESCRIPTION
mill-build build target display name ends with `/` and build target info for it was not displayed.