### PR TITLE
improvement: fetch missing dependency sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -487,8 +487,9 @@ lazy val metals = project
       // For reading classpaths.
       // for fetching ch.epfl.scala:bloop-frontend and other library dependencies
       "io.get-coursier" % "interface" % V.coursierInterfaces,
-      // for comparing versions
-      "io.get-coursier" %% "versions" % "0.3.2",
+      // for comparing versions && fetching from sbt maven repository
+      "io.get-coursier" %% "coursier" % V.coursier,
+      "io.get-coursier" %% "coursier-sbt-maven-repository" % V.coursier,
       // for logging
       "com.outr" %% "scribe" % V.scribe,
       "com.outr" %% "scribe-file" % V.scribe,

--- a/metals-bench/src/main/scala/bench/ClasspathFuzzBench.scala
+++ b/metals-bench/src/main/scala/bench/ClasspathFuzzBench.scala
@@ -46,7 +46,7 @@ class ClasspathFuzzBench {
   @BenchmarkMode(Array(Mode.SingleShotTime))
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   def run(): Seq[SymbolInformation] = {
-    symbols.search(query)
+    symbols.search(query, None)
   }
 
 }

--- a/metals-bench/src/main/scala/bench/WorkspaceFuzzBench.scala
+++ b/metals-bench/src/main/scala/bench/WorkspaceFuzzBench.scala
@@ -37,7 +37,7 @@ class WorkspaceFuzzBench {
   @BenchmarkMode(Array(Mode.SingleShotTime))
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   def upper(): Seq[SymbolInformation] = {
-    symbols.search(query)
+    symbols.search(query, None)
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -175,8 +175,9 @@ final class DefinitionProvider(
         else true
       }
 
+      val dialect = scalaVersionSelector.dialectFromBuildTarget(path)
       val locs = workspaceSearch
-        .searchExactFrom(ident.value, path, token)
+        .searchExactFrom(ident.value, path, token, dialect)
 
       val reducedGuesses =
         if (locs.size > 1)

--- a/metals/src/main/scala/scala/meta/internal/metals/JarSourcesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JarSourcesProvider.scala
@@ -1,0 +1,106 @@
+package scala.meta.internal.metals
+
+import java.nio.file.Path
+
+import scala.util.Success
+import scala.util.Try
+import scala.xml.XML
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.semver.SemVer
+import scala.meta.io.AbsolutePath
+
+import coursierapi.Dependency
+import coursierapi.Fetch
+
+object JarSourcesProvider {
+
+  private val sbtRegex = "sbt-(.*)".r
+
+  def fetchSources(jars: Seq[String]): Seq[String] = {
+    def sourcesPath(jar: String) = s"${jar.stripSuffix(".jar")}-sources.jar"
+
+    val (haveSources, toDownload) = jars.partition { jar =>
+      sourcesPath(jar).toAbsolutePathSafe.exists(_.exists)
+    }
+
+    val dependencies = toDownload.flatMap { jarPath =>
+      val pomPath = s"${jarPath.stripSuffix(".jar")}.pom"
+      val dependency =
+        for {
+          pom <- pomPath.toAbsolutePathSafe
+          if pom.exists
+          dependency <- getDependency(pom)
+        } yield dependency
+
+      dependency.orElse { jarPath.toAbsolutePathSafe.flatMap(sbtFallback) }
+    }.distinct
+
+    val fetchedSources =
+      dependencies.flatMap { dep =>
+        Try(fetchDependencySources(dep)).toEither match {
+          case Right(fetched) => fetched.map(_.toUri().toString())
+          case Left(error) =>
+            scribe.warn(
+              s"could not fetch dependency sources for $dep, error: $error"
+            )
+            None
+        }
+      }
+    val existingSources = haveSources.map(sourcesPath)
+    fetchedSources ++ existingSources
+
+  }
+
+  private def sbtFallback(jar: AbsolutePath): Option[Dependency] = {
+    val filename = jar.filename.stripSuffix(".jar")
+    filename match {
+      case sbtRegex(versionStr) if Try().isSuccess =>
+        Try(SemVer.Version.fromString(versionStr)) match {
+          case Success(version) if version.toString == versionStr =>
+            Some(Dependency.of("org.scala-sbt", "sbt", versionStr))
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+
+  private def getDependency(pom: AbsolutePath) = {
+    val xml = XML.loadFile(pom.toFile)
+    val groupId = (xml \ "groupId").text
+    val version = (xml \ "version").text
+    val artifactId = (xml \ "artifactId").text
+    Option
+      .when(groupId.nonEmpty && version.nonEmpty && artifactId.nonEmpty) {
+        Dependency.of(groupId, artifactId, version)
+      }
+      .filterNot(dep => isSbtDap(dep) || isMetalsPlugin(dep))
+  }
+
+  private def isSbtDap(dependency: Dependency) = {
+    dependency.getModule().getOrganization() == "ch.epfl.scala" &&
+    dependency.getModule().getName() == "sbt-debug-adapter" &&
+    dependency.getVersion() == BuildInfo.debugAdapterVersion
+  }
+
+  private def isMetalsPlugin(dependency: Dependency) = {
+    dependency.getModule().getOrganization() == "org.scalameta" &&
+    dependency.getModule().getName() == "sbt-metals" &&
+    dependency.getVersion() == BuildInfo.metalsVersion
+  }
+
+  private def fetchDependencySources(
+      dependency: Dependency
+  ): List[Path] = {
+    Fetch
+      .create()
+      .withDependencies(dependency)
+      .addClassifiers("sources")
+      .fetchResult()
+      .getFiles()
+      .asScala
+      .map(_.toPath())
+      .toList
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1677,7 +1677,8 @@ class MetalsLspService(
   ): Future[List[SymbolInformation]] =
     indexingPromise.future.map { _ =>
       val timer = new Timer(time)
-      val result = workspaceSymbols.search(params.getQuery, token).toList
+      val result =
+        workspaceSymbols.search(params.getQuery, token, currentDialect).toList
       if (clientConfig.initialConfig.statistics.isWorkspaceSymbol) {
         scribe.info(
           s"time: found ${result.length} results for query '${params.getQuery}' in $timer"
@@ -1687,8 +1688,11 @@ class MetalsLspService(
     }
 
   def workspaceSymbol(query: String): Seq[SymbolInformation] = {
-    workspaceSymbols.search(query)
+    workspaceSymbols.search(query, currentDialect)
   }
+
+  private def currentDialect =
+    focusedDocument().flatMap(scalaVersionSelector.dialectFromBuildTarget)
 
   def indexSources(): Future[Unit] = Future {
     indexer.indexWorkspaceSources(buildTargets.allWritableData)

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -41,7 +41,7 @@ import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
 
-import coursier.version.Version
+import coursier.core.Version
 
 // todo https://github.com/scalameta/metals/issues/4788
 // clean () =>, use plain values

--- a/tests/slow/src/test/scala/tests/scalacli/ScalaCliActionsSuite.scala
+++ b/tests/slow/src/test/scala/tests/scalacli/ScalaCliActionsSuite.scala
@@ -6,7 +6,7 @@ import scala.meta.internal.metals.codeactions.ImportMissingSymbol
 import scala.meta.internal.mtags.BuildInfo.scalaCompilerVersion
 import scala.meta.internal.mtags.CoursierComplete
 
-import coursier.version.Version
+import coursier.core.Version
 
 class ScalaCliActionsSuite
     extends BaseScalaCLIActionSuite("actionableDiagnostic") {

--- a/tests/unit/src/main/scala/tests/BaseWorkspaceSymbolSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorkspaceSymbolSuite.scala
@@ -25,7 +25,7 @@ abstract class BaseWorkspaceSymbolSuite extends BaseSuite {
       expected: String,
   )(implicit loc: Location): Unit = {
     test(query) {
-      val result = symbols.search(query)
+      val result = symbols.search(query, None)
       val obtained =
         if (result.length > 100) s"${result.length} results"
         else {

--- a/tests/unit/src/main/scala/tests/Library.scala
+++ b/tests/unit/src/main/scala/tests/Library.scala
@@ -25,8 +25,11 @@ object Library {
       Classpath(PackageIndex.bootClasspath.map(AbsolutePath.apply)),
       Classpath(JdkSources().right.get :: Nil),
     )
-  def catsSources: Seq[AbsolutePath] =
-    fetchSources("org.typelevel", "cats-core_2.12", "2.0.0-M4")
+
+  def catsDependency: Dependency =
+    Dependency.of("org.typelevel", "cats-core_2.12", "2.0.0-M4")
+  def catsSources: Seq[AbsolutePath] = fetchSources(catsDependency)
+  def cats: Seq[AbsolutePath] = fetch(catsDependency)
 
   def scala3: Library = {
     val binaryVersion =
@@ -102,17 +105,17 @@ object Library {
     )
   }
 
-  def fetchSources(
-      org: String,
-      artifact: String,
-      version: String,
+  def fetchSources(dependency: Dependency): Seq[AbsolutePath] =
+    fetch(dependency, Set("sources"))
+
+  def fetch(
+      dependency: Dependency,
+      classifiers: Set[String] = Set.empty,
   ): Seq[AbsolutePath] =
     Fetch
       .create()
-      .withDependencies(
-        Dependency.of(org, artifact, version).withTransitive(false)
-      )
-      .withClassifiers(Set("sources").asJava)
+      .withDependencies(dependency.withTransitive(false))
+      .withClassifiers(classifiers.asJava)
       .fetch()
       .asScala
       .toSeq

--- a/tests/unit/src/main/scala/tests/debug/BaseStepDapSuite.scala
+++ b/tests/unit/src/main/scala/tests/debug/BaseStepDapSuite.scala
@@ -89,6 +89,7 @@ abstract class BaseStepDapSuite(
         .at("a/src/main/scala/a/ScalaMain.scala", line = 5)(StepIn)
         .at("a/src/main/java/a/JavaClass.java", line = 5)(StepOut)
         .at("a/src/main/scala/a/ScalaMain.scala", line = 6)(Continue),
+    focusFile = "a/src/main/scala/a/ScalaMain.scala",
   )
 
   assertSteps("step-into-scala-lib", withoutVirtualDocs = true)(
@@ -162,12 +163,14 @@ abstract class BaseStepDapSuite(
       steps
         .at("a/src/main/scala/a/Main.scala", line = 6)(Continue)
         .at("a/src/main/scala/a/Main.scala", line = 13)(Continue),
+    focusFile = "a/src/main/scala/a/Main.scala",
   )
 
   def assertSteps(name: TestOptions, withoutVirtualDocs: Boolean = false)(
       sources: String,
       main: String,
       instrument: StepNavigator => StepNavigator,
+      focusFile: String = "a/src/main/scala/Main.scala",
   )(implicit loc: Location): Unit = {
     test(name, withoutVirtualDocs) {
       cleanWorkspace()
@@ -176,6 +179,7 @@ abstract class BaseStepDapSuite(
 
       for {
         _ <- initialize(workspaceLayout)
+        _ <- server.didFocus(focusFile)
         navigator = instrument(StepNavigator(workspace))
         debugger <- debugMain("a", main, navigator)
         _ <- debugger.initialize

--- a/tests/unit/src/test/scala/tests/JarSourcesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/JarSourcesProviderSuite.scala
@@ -1,0 +1,19 @@
+package tests
+
+import scala.meta.internal.metals.JarSourcesProvider
+import scala.meta.internal.metals.MetalsEnrichments._
+
+class JarSourcesProviderSuite extends BaseSuite {
+
+  test("download-deps") {
+    val downloadedSources =
+      JarSourcesProvider.fetchSources(Library.cats.map(_.toURI.toString()))
+    assert(downloadedSources.nonEmpty)
+    downloadedSources.foreach { pathStr =>
+      val path = pathStr.toAbsolutePath
+      assert(path.exists)
+      assert(path.filename.endsWith("-sources.jar"))
+    }
+  }
+
+}

--- a/tests/unit/src/test/scala/tests/JarSourcesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/JarSourcesProviderSuite.scala
@@ -1,9 +1,15 @@
 package tests
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 import scala.meta.internal.metals.JarSourcesProvider
 import scala.meta.internal.metals.MetalsEnrichments._
+
+import coursier.core.Dependency
+import coursier.core.Module
+import coursier.core.ModuleName
+import coursier.core.Organization
 
 class JarSourcesProviderSuite extends BaseSuite {
 
@@ -22,6 +28,35 @@ class JarSourcesProviderSuite extends BaseSuite {
         assert(path.filename.endsWith("-sources.jar"))
       }
     }
+  }
+
+  private val sbtDap = {
+    val attributes = Map("scalaVersion" -> "2.12", "sbtVersion" -> "1.0")
+    val module = Module(
+      Organization("ch.epfl.scala"),
+      ModuleName("sbt-debug-adapter"),
+      attributes,
+    )
+    Dependency(module, "3.1.4")
+  }
+
+  private val metalsSbt = {
+    val attributes = Map("scalaVersion" -> "2.12", "sbtVersion" -> "1.0")
+    val module = Module(
+      Organization("org.scalameta"),
+      ModuleName("sbt-metals"),
+      attributes,
+    )
+    Dependency(module, "1.1.0")
+  }
+
+  test("download-sbt-plugins") {
+    for {
+      sources <- Future.sequence(
+        List(sbtDap, metalsSbt).map(JarSourcesProvider.fetchDependencySources)
+      )
+      _ = sources.foreach(sources => assert(sources.nonEmpty))
+    } yield ()
   }
 
 }

--- a/tests/unit/src/test/scala/tests/JarSourcesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/JarSourcesProviderSuite.scala
@@ -1,18 +1,26 @@
 package tests
 
+import scala.concurrent.ExecutionContext
+
 import scala.meta.internal.metals.JarSourcesProvider
 import scala.meta.internal.metals.MetalsEnrichments._
 
 class JarSourcesProviderSuite extends BaseSuite {
 
+  private implicit val ctx: ExecutionContext = this.munitExecutionContext
+
   test("download-deps") {
-    val downloadedSources =
-      JarSourcesProvider.fetchSources(Library.cats.map(_.toURI.toString()))
-    assert(downloadedSources.nonEmpty)
-    downloadedSources.foreach { pathStr =>
-      val path = pathStr.toAbsolutePath
-      assert(path.exists)
-      assert(path.filename.endsWith("-sources.jar"))
+    for {
+      downloadedSources <- JarSourcesProvider.fetchSources(
+        Library.cats.map(_.toURI.toString())
+      )
+    } yield {
+      assert(downloadedSources.nonEmpty)
+      downloadedSources.foreach { pathStr =>
+        val path = pathStr.toAbsolutePath
+        assert(path.exists)
+        assert(path.filename.endsWith("-sources.jar"))
+      }
     }
   }
 


### PR DESCRIPTION
When build server fails to provide dependency sources for a build target metals will try to resolve/download the missing sources.
resolves: https://github.com/scalameta/metals/issues/4780