### PR TITLE
improvement: Set icons properly for all parts of tree view

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/tvp/ClasspathTreeView.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/ClasspathTreeView.scala
@@ -28,17 +28,19 @@ class ClasspathTreeView[Value, Key](
     valueTooltip: Value => String,
     toplevels: () => Iterator[Value],
     loadSymbols: (Key, String) => Iterator[TreeViewSymbolInformation],
+    toplevelIcon: String,
 ) {
   val scheme: String = s"$schemeId-${folder.path.toString()}"
   val rootUri: String = scheme + ":"
 
-  def root(showFolderName: Boolean): TreeViewNode = {
+  def root(showFolderName: Boolean, icon: String): TreeViewNode = {
     val folderPart = if (showFolderName) s" (${folder.nameOrUri})" else ""
     TreeViewNode(
       viewId,
       rootUri,
       title + folderPart + s" (${toplevels().size})",
       collapseState = MetalsTreeItemCollapseState.collapsed,
+      icon = icon,
     )
   }
 
@@ -50,7 +52,7 @@ class ClasspathTreeView[Value, Key](
 
   def children(uri: String): Array[TreeViewNode] = {
     if (uri == rootUri) {
-      TreeViewNode.sortAlphabetically(toplevels().map(toViewNode).toArray)
+      TreeViewNode.sortAlphabetically(toplevels().map(toplevelNode).toArray)
     } else {
       val node = fromUri(uri)
 
@@ -119,6 +121,7 @@ class ClasspathTreeView[Value, Key](
           case k.FIELD => "symbol-field"
           case k.TYPE_PARAMETER => "symbol-type-parameter"
           case k.TYPE => "symbol-type-parameter"
+          case k.PACKAGE => "symbol-folder"
           case _ => null
         }
 
@@ -170,7 +173,7 @@ class ClasspathTreeView[Value, Key](
     }
   }
 
-  def toViewNode(value: Value): TreeViewNode = {
+  def toplevelNode(value: Value): TreeViewNode = {
     val uri = toUri(id(value)).toUri
     TreeViewNode(
       viewId,
@@ -178,6 +181,7 @@ class ClasspathTreeView[Value, Key](
       valueTitle(value),
       tooltip = valueTooltip(value),
       collapseState = MetalsTreeItemCollapseState.collapsed,
+      icon = toplevelIcon,
     )
   }
 

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -60,7 +60,8 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
   lazy val expectedLibrariesString: String =
     (this.expectedLibraries.toVector
       .map { (s: String) =>
-        if (s != jdkSourcesName) s"${s}.jar -" else s"$jdkSourcesName -"
+        if (s != jdkSourcesName) s"${s}.jar package -"
+        else s"$jdkSourcesName package -"
       })
       .mkString("\n")
 
@@ -125,8 +126,8 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
       )
       _ = server.assertTreeViewChildren(
         s"projects-$folder:${server.buildTarget("a")}",
-        """|_empty_/ -
-           |a/ -
+        """|_empty_/ symbol-folder -
+           |a/ symbol-folder -
            |""".stripMargin,
       )
       _ = server.assertTreeViewChildren(
@@ -207,7 +208,7 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
       _ = {
         server.assertTreeViewChildren(
           s"libraries-$folder:${server.jar("sourcecode")}",
-          "sourcecode/ +",
+          "sourcecode/ symbol-folder +",
         )
         server.assertTreeViewChildren(
           s"libraries-$folder:",
@@ -232,12 +233,12 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
         )
         server.assertTreeViewChildren(
           s"libraries-$folder:${server.jar("circe-core")}!/_root_/",
-          """|io/ +
+          """|io/ symbol-folder +
              |""".stripMargin,
         )
         server.assertTreeViewChildren(
           s"libraries-$folder:${server.jar("cats-core")}!/_root_/",
-          """|cats/ +
+          """|cats/ symbol-folder +
              |""".stripMargin,
         )
         server.assertTreeViewChildren(
@@ -265,11 +266,11 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
             "class Paths",
           ),
           s"""|root
-              |  Libraries (22)
-              |    $jdkSourcesName
-              |      java/
-              |        nio/
-              |          file/
+              |  Libraries (22) library
+              |    $jdkSourcesName package
+              |      java/ symbol-folder
+              |        nio/ symbol-folder
+              |          file/ symbol-folder
               |            Paths symbol-class
               |""".stripMargin,
         )
@@ -292,19 +293,19 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
             "sourcecode/SourceContext.scala",
             "object File",
             isIgnored = { label =>
-              label.endsWith(".jar") &&
+              label.endsWith(".jar package") &&
               !label.contains("sourcecode")
             },
           ),
           s"""|root
-              |  Projects (0)
-              |  Libraries (22)
-              |  Libraries (22)
-              |    $jdkSourcesName
-              |    sourcecode_2.13-0.1.7-sources.jar
-              |    sourcecode_2.13-0.1.7-sources.jar
-              |      sourcecode/
-              |      sourcecode/
+              |  Projects (0) project
+              |  Libraries (22) library
+              |  Libraries (22) library
+              |    $jdkSourcesName package
+              |    sourcecode_2.13-0.1.7-sources.jar package
+              |    sourcecode_2.13-0.1.7-sources.jar package
+              |      sourcecode/ symbol-folder
+              |      sourcecode/ symbol-folder
               |        Args symbol-class
               |        Args symbol-object
               |        ArgsMacros symbol-interface
@@ -345,27 +346,27 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
             "org/eclipse/lsp4j/services/LanguageClient.java",
             "registerCapability",
             isIgnored = { label =>
-              label.endsWith(".jar") &&
+              label.endsWith(".jar package") &&
               !label.contains("lsp4j-0")
             },
           ),
           s"""|root
-              |  Projects (0)
-              |  Libraries (${expectedLibrariesCount})
-              |  Libraries (${expectedLibrariesCount})
-              |    $jdkSourcesName
-              |    org.eclipse.lsp4j-0.5.0-sources.jar
-              |    org.eclipse.lsp4j-0.5.0-sources.jar
-              |      org/
-              |      org/
-              |        eclipse/
-              |        eclipse/
-              |          lsp4j/
-              |          lsp4j/
-              |            adapters/
-              |            launch/
-              |            services/
-              |            util/
+              |  Projects (0) project
+              |  Libraries (${expectedLibrariesCount}) library
+              |  Libraries (${expectedLibrariesCount}) library
+              |    $jdkSourcesName package
+              |    org.eclipse.lsp4j-0.5.0-sources.jar package
+              |    org.eclipse.lsp4j-0.5.0-sources.jar package
+              |      org/ symbol-folder
+              |      org/ symbol-folder
+              |        eclipse/ symbol-folder
+              |        eclipse/ symbol-folder
+              |          lsp4j/ symbol-folder
+              |          lsp4j/ symbol-folder
+              |            adapters/ symbol-folder
+              |            launch/ symbol-folder
+              |            services/ symbol-folder
+              |            util/ symbol-folder
               |            ApplyWorkspaceEditParams symbol-class
               |            ApplyWorkspaceEditResponse symbol-class
               |            ClientCapabilities symbol-class
@@ -529,7 +530,7 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
               |            WorkspaceFoldersOptions symbol-class
               |            WorkspaceServerCapabilities symbol-class
               |            WorkspaceSymbolParams symbol-class
-              |            services/
+              |            services/ symbol-folder
               |              LanguageClient symbol-interface
               |              LanguageClientAware symbol-interface
               |              LanguageClientExtensions symbol-interface


### PR DESCRIPTION
Previously, only some nodes would have their icons set, which would result with some having folder icons added by VS Code but not all. Now, we set icons for each node manually.

The only problem I have is with packages, which doesn't really have a great icon anywhere. symbol-package is the same as symbol-object, which is too similar. So I decided to go with folder, which seems the next best thing.

![Screenshot from 2023-11-10 16-38-00](https://github.com/scalameta/metals/assets/3807253/c69f0147-2fce-4dc7-92ad-d57aa9c74ad0)
