### PR TITLE
bugfix: Show properly completions for higher order functions

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -625,11 +625,23 @@ class MetalsGlobal(
       code: String,
       filename: String,
       cursor: Option[Int],
-      cursorName: String = CURSOR
+      cursorName: String = CURSOR,
+      withComma: Boolean = false
   ): RichCompilationUnit = {
+    // helps to deal with f(_.) where f has a second parameter
+    def nextIsParen(offset: Int): Boolean = {
+      val next = code(offset)
+      if (next == ')') true
+      else if (next == ' ' && offset + 1 < code.size) nextIsParen(offset + 1)
+      else false
+    }
     val codeWithCursor = cursor match {
       case Some(offset) =>
-        code.take(offset) + cursorName + code.drop(offset)
+        val inside =
+          if (withComma && offset < code.size && nextIsParen(offset))
+            cursorName + ","
+          else cursorName
+        code.take(offset) + inside + code.drop(offset)
       case _ => code
     }
     val unit = newCompilationUnit(codeWithCursor, filename)

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -273,6 +273,25 @@ class CompletionIssueSuite extends BaseCompletionSuite {
     "match"
   )
 
+  check(
+    "higher-order",
+    """|
+       |class Foo {
+       |  def Bar: Double = 2.0
+       |  def Baz: Double = 1.0
+       |}
+       |
+       |object Bar {
+       |  def higherOrder2(f: Foo => Double, s: String): Nothing = ???
+       |  higherOrder2(_.@@)
+       |}
+       |""".stripMargin,
+    """|Bar: Double
+       |Baz: Double
+       |""".stripMargin,
+    topLines = Some(2)
+  )
+
   // The tests shows `x$1` but it's because the dependency is not indexed
   checkEdit(
     "default-java-override",


### PR DESCRIPTION
Previously, Scala 2 would not show anything when at `f(_.@@)` and f had more than one parameter. The completions from the compiler would be empty.

Now, we retry with a coma in that case.

Scala 3 was working properly.

Fixes https://github.com/scalameta/metals/issues/5836