### PR TITLE
bugfix: Fix PcCollector for Scala 2 in anon-fun parameters

### DIFF
--- a/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
@@ -930,4 +930,67 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite {
        |}
        |""".stripMargin
   )
+
+  check(
+    "map-bind".tag(IgnoreScala3),
+    """
+      |object Main {
+      |  List(1).map {
+      |    <<abc>>: Int => <<ab@@c>> + 1
+      |  }
+      |}""".stripMargin
+  )
+
+  check(
+    "map-bind1".tag(IgnoreScala3),
+    """
+      |object Main {
+      |  List(1).foldLeft(0){
+      |    (<<abc>>: Int, bde: Int) => <<ab@@c>> + bde
+      |  }
+      |}""".stripMargin
+  )
+
+  check(
+    "map-bind2".tag(IgnoreScala3),
+    """
+      |object Main {
+      |  List(1).map {
+      |    someLongName:@@ Int => someLongName + 1
+      |  }
+      |}""".stripMargin
+  )
+
+  check(
+    "map-bind3".tag(IgnoreScala3),
+    """
+      |object Main {
+      |  List(1).map {
+      |    someVeryLongName: Int =@@> someVeryLongName + 1
+      |  }
+      |}""".stripMargin
+  )
+
+  check(
+    "map-bind4".tag(IgnoreScala3),
+    """
+      |object Main {
+      |  List(1).map {
+      |    someLongName: <<I@@nt>> => someLongName + 1
+      |  }
+      |}""".stripMargin
+  )
+
+  check(
+    "map-bind5".tag(IgnoreScala3),
+    """
+      |object Main {
+      |  List(1).map {
+      |    someLongName: Int => 
+      |      val <<ab@@c>> = 2
+      |      someLongName + <<abc>>
+      |  }
+      |}""".stripMargin
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
+++ b/tests/cross/src/test/scala/tests/tokens/SemanticTokensSuite.scala
@@ -332,4 +332,14 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite {
        |""".stripMargin
   )
 
+  check(
+    "map-bind".tag(IgnoreScala3),
+    """
+      |object <<Main>>/*class*/ {
+      |  <<List>>/*class*/(1).<<foldLeft>>/*method*/(0){
+      |    (<<abc>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/, <<bde>>/*parameter,declaration,readonly*/: <<Int>>/*class,abstract*/) => <<abc>>/*parameter,readonly*/ <<+>>/*method,abstract*/ <<bde>>/*parameter,readonly*/
+      |  }
+      |}""".stripMargin
+  )
+
 }


### PR DESCRIPTION
Anonymous function parameters with type annotation have incorrect name position on definition, so we need to handle them separately.

Closes https://github.com/scalameta/metals/issues/5840 and https://github.com/scalameta/metals/issues/5837