### PR TITLE
bugfix: Don't show synthetics if not an inline decorations provider

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1113,9 +1113,8 @@ class MetalsLspService(
       force: Boolean = false,
   ): Future[Unit] = {
     CancelTokens.future { token =>
-      val shouldShow =
-        force ||
-          userConfig.areSyntheticsEnabled()
+      val shouldShow = (force || userConfig.areSyntheticsEnabled()) &&
+        clientConfig.isInlineDecorationProvider()
       if (shouldShow) {
         compilers.syntheticDecorations(path, token).map { decorations =>
           val params = new PublishDecorationsParams(


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/5843