### PR TITLE
chore: remove leftover distinct

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcSemanticTokensProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcSemanticTokensProvider.scala
@@ -90,7 +90,6 @@ final class PcSemanticTokensProvider(
     Collector
       .result()
       .flatten
-      .distinct
       .sortWith((n1, n2) =>
         if n1.start() == n2.start() then n1.end() < n2.end()
         else n1.start() < n2.start()


### PR DESCRIPTION
It was a leftover after merging PC decorations and could cause a slowdown.