### PR TITLE
improvement: Add debug information when no references are shown

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
@@ -30,11 +30,6 @@ object JavaBinary {
       .flatMap(home =>
         List(binaryName, binaryName + ".exe").map(home.resolve("bin").resolve)
       )
-      .map { path =>
-        scribe.debug(s"""java binary path: $path
-                        |path exists: ${path.exists}""".stripMargin)
-        path
-      }
       .collectFirst {
         case path if path.exists => path
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -145,6 +145,11 @@ final class ReferenceProvider(
             occerencesForRenamedImport(source, params, doc)
           else posOccurrences
         }
+        if (results.isEmpty) {
+          scribe.debug(
+            s"No symbol found at ${params.getPosition()} for $source"
+          )
+        }
         results.map { result =>
           val occurrence = result.occurrence.get
           val distance = result.distance
@@ -164,6 +169,7 @@ final class ReferenceProvider(
           ReferencesResult(occurrence.symbol, locations)
         }
       case None =>
+        scribe.debug(s"No semanticdb for $source")
         // NOTE(olafur): we block here instead of returning a Future because it
         // requires a significant refactoring to make the reference provider and
         // its dependencies (including rename provider) asynchronous. The remote


### PR DESCRIPTION
This started shwoing up for me, but can't reproduce it.

I also removed debug about missing java home, since it shows a lot and doesn't help. We already show the candidates in the doctor if no src zip was found.