### PR TITLE
improvement: Send error back to client to show

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DebugSession.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DebugSession.scala
@@ -1,3 +1,19 @@
 package scala.meta.internal.metals
 
-final case class DebugSession(name: String, uri: String)
+import javax.annotation.Nullable
+
+final case class DebugSession(
+    @Nullable name: String,
+    @Nullable uri: String,
+    @Nullable error: String,
+)
+
+object DebugSession {
+
+  def success(name: String, uri: String): DebugSession = {
+    DebugSession(name, uri, null)
+  }
+  def failure(message: String): DebugSession = {
+    DebugSession(null, null, message)
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1908,6 +1908,7 @@ class MetalsLspService(
     debugProvider
       .debugDiscovery(params)
       .flatMap(debugProvider.asSession)
+      .recover(t => DebugSession.failure(t.getMessage()))
       .asJavaObject
 
   def findBuildTargetByDisplayName(target: String): Option[b.BuildTarget] =

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -404,7 +404,7 @@ class DebugProvider(
       )
     } yield {
       statusBar.addMessage("Started debug server!")
-      DebugSession(server.sessionName, server.uri.toString)
+      DebugSession.success(server.sessionName, server.uri.toString)
     }
   }
 

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -666,7 +666,7 @@ final case class TestingServer(
     params.setDataKind(kind)
     params.setData(parameter.toJson)
     executeCommandUnsafe(ServerCommands.StartDebugAdapter.id, Seq(params))
-      .collect { case DebugSession(_, uri) =>
+      .collect { case DebugSession(_, uri, _) =>
         scribe.info(s"Starting debug session for $uri")
         TestDebugger(URI.create(uri), stoppageHandler)
       }
@@ -708,8 +708,19 @@ final case class TestingServer(
   ): Future[TestDebugger] = {
     assertSystemExit(params)
     executeCommandUnsafe(ServerCommands.StartDebugAdapter.id, Seq(params))
-      .collect { case DebugSession(_, uri) =>
+      .collect { case DebugSession(_, uri, _) =>
         TestDebugger(URI.create(uri), stoppageHandler)
+      }
+  }
+
+  def assertDebuggingError(
+      params: AnyRef,
+      expected: String,
+  ): Future[Unit] = {
+    assertSystemExit(params)
+    executeCommandUnsafe(ServerCommands.StartDebugAdapter.id, Seq(params))
+      .collect { case DebugSession(_, _, msg) =>
+        Assertions.assertNoDiff(msg, expected)
       }
   }
 

--- a/tests/unit/src/test/scala/tests/DebugDiscoverySuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugDiscoverySuite.scala
@@ -142,17 +142,14 @@ class DebugDiscoverySuite
       )
       _ <- server.didOpen(notATestPath)
       result <- server
-        .startDebuggingUnresolved(
+        .assertDebuggingError(
           new DebugDiscoveryParams(
             server.toPath(notATestPath).toURI.toString,
             "runOrTestFile",
-          ).toJson
+          ).toJson,
+          DebugProvider.NoRunOptionException.getMessage(),
         )
-        .recover { case e @ DebugProvider.NoRunOptionException => e }
-    } yield assertNoDiff(
-      result.toString(),
-      DebugProvider.NoRunOptionException.toString(),
-    )
+    } yield ()
   }
 
   test("run-multiple") {
@@ -209,19 +206,14 @@ class DebugDiscoverySuite
       )
       _ <- server.didOpen(mainPath)
       result <- server
-        .startDebuggingUnresolved(
+        .assertDebuggingError(
           new DebugDiscoveryParams(
             server.toPath(mainPath).toURI.toString,
             "run",
-          ).toJson
+          ).toJson,
+          BuildTargetContainsNoMainException("a").getMessage(),
         )
-        .recover { case e: BuildTargetContainsNoMainException =>
-          e
-        }
-    } yield assertNoDiff(
-      result.toString,
-      BuildTargetContainsNoMainException("a").toString(),
-    )
+    } yield ()
   }
 
   test("workspace-error") {
@@ -241,19 +233,14 @@ class DebugDiscoverySuite
       )
       _ <- server.didOpen(mainPath)
       result <- server
-        .startDebuggingUnresolved(
+        .assertDebuggingError(
           new DebugDiscoveryParams(
             server.toPath(mainPath).toURI.toString,
             "run",
-          ).toJson
+          ).toJson,
+          WorkspaceErrorsException.getMessage(),
         )
-        .recover { case WorkspaceErrorsException =>
-          WorkspaceErrorsException
-        }
-    } yield assertNoDiff(
-      result.toString,
-      WorkspaceErrorsException.toString(),
-    )
+    } yield ()
   }
 
   test("other-target-error") {
@@ -317,18 +304,16 @@ class DebugDiscoverySuite
       _ <- server.didSave(mainPath)(identity)
       _ <- server.waitFor(TimeUnit.SECONDS.toMillis(10))
       result <- server
-        .startDebuggingUnresolved(
+        .assertDebuggingError(
           new DebugDiscoveryParams(
             path = server.toPath(mainPath).toURI.toString,
             runType = "run",
             envFile = fakePath,
-          ).toJson
+          ).toJson,
+          InvalidEnvFileException(AbsolutePath(fakePath)).getMessage(),
         )
         .recover { case e: InvalidEnvFileException => e }
-    } yield assertNoDiff(
-      result.toString,
-      InvalidEnvFileException(AbsolutePath(fakePath)).toString(),
-    )
+    } yield ()
   }
 
   test("testFile") {
@@ -420,17 +405,14 @@ class DebugDiscoverySuite
       )
       _ <- server.didOpen(notATestPath)
       result <- server
-        .startDebuggingUnresolved(
+        .assertDebuggingError(
           new DebugDiscoveryParams(
             server.toPath(notATestPath).toURI.toString,
             "testTarget",
-          ).toJson
+          ).toJson,
+          NoTestsFoundException("build target", "a").getMessage(),
         )
-        .recover { case e: NoTestsFoundException => e }
-    } yield assertNoDiff(
-      result.toString(),
-      NoTestsFoundException("build target", "a").toString(),
-    )
+    } yield ()
   }
 
   test("no-semanticdb") {
@@ -454,18 +436,13 @@ class DebugDiscoverySuite
       _ <- server.waitFor(TimeUnit.SECONDS.toMillis(10))
       _ = cleanCompileCache("a")
       result <- server
-        .startDebuggingUnresolved(
+        .assertDebuggingError(
           new DebugDiscoveryParams(
             server.toPath(fooPath).toURI.toString,
             "testFile",
-          ).toJson
+          ).toJson,
+          SemanticDbNotFoundException.getMessage(),
         )
-        .recover { case SemanticDbNotFoundException =>
-          SemanticDbNotFoundException
-        }
-    } yield assertNoDiff(
-      result.toString,
-      SemanticDbNotFoundException.toString(),
-    )
+    } yield ()
   }
 }


### PR DESCRIPTION
Previously, it would be very difficult to show a proper error message to the user. Especially in VS Code a generic message was show, which was very confusing for users.

Now, we send the error message in the response so that the client can handle it as they want.

I wonder if we should keep displaying the message, but not sure if it's not better to just change the clients here to show the error.

Related to https://github.com/scalameta/metals-vscode/pull/1438