### PR TITLE
 improvement: Forward DAP errors properly to the client

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -585,31 +585,6 @@ object Messages {
       show = true,
     )
 
-  object DebugClassNotFound {
-
-    def invalidTargetClass(cls: String, target: String): MessageParams = {
-      new MessageParams(
-        MessageType.Error,
-        s"Class '$cls' not found in build target '$target'.",
-      )
-    }
-
-    def invalidTarget(target: String): MessageParams = {
-      new MessageParams(
-        MessageType.Error,
-        s"Target '$target' not found.",
-      )
-    }
-
-    def invalidClass(cls: String): MessageParams = {
-      new MessageParams(
-        MessageType.Error,
-        s"Class '$cls' not found.",
-      )
-    }
-
-  }
-
   object MissingScalafmtConf {
     def tryAgain(isAgain: Boolean): String =
       if (isAgain) ", try formatting again"

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1904,11 +1904,10 @@ class MetalsLspService(
   def analyzeStackTrace(content: String): Option[ExecuteCommandParams] =
     stacktraceAnalyzer.analyzeCommand(content)
 
-  def debugDiscovery(params: DebugDiscoveryParams): CompletableFuture[Object] =
+  def debugDiscovery(params: DebugDiscoveryParams): Future[DebugSession] =
     debugProvider
       .debugDiscovery(params)
       .flatMap(debugProvider.asSession)
-      .asJavaObject
 
   def findBuildTargetByDisplayName(target: String): Option[b.BuildTarget] =
     buildTargets.findByDisplayName(target)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
@@ -39,8 +39,9 @@ class BuildTargetClassesFinder(
         // We check whether there is a main in dependencies that is not reported via BSP
         case ClassNotFoundInBuildTargetException(className, target) =>
           revertToDependencies(className, Some(target))
-        case _: ClassNotFoundException =>
+        case _: NoClassFoundException =>
           revertToDependencies(className, buildTarget = None)
+        case _ => Nil
       }
       found match {
         case Nil => Failure(ex)
@@ -109,7 +110,7 @@ class BuildTargetClassesFinder(
           }
           .reverse
       if (classes.nonEmpty) Success(classes)
-      else Failure(new ClassNotFoundException(className))
+      else Failure(new NoClassFoundException(className))
     } { targetName =>
       buildTargets
         .findByDisplayName(targetName)
@@ -148,15 +149,19 @@ class BuildTargetClassesFinder(
 case class BuildTargetNotFoundException(buildTargetName: String)
     extends Exception(s"Build target not found: $buildTargetName")
 
-case class BuildTargetUndefinedException()
-    extends Exception("Debugger configuration is missing 'buildTarget' param.")
-
 case class ClassNotFoundInBuildTargetException(
     className: String,
     buildTarget: b.BuildTarget,
 ) extends Exception(
       s"Class '$className' not found in build target '${buildTarget.getDisplayName()}'"
     )
+
+case class NoClassFoundException(
+    className: String
+) extends Exception(
+      s"Class '$className' not found in any build target"
+    )
+
 case class BuildTargetNotFoundForPathException(path: AbsolutePath)
     extends Exception(
       s"No build target could be found for the path: ${path.toString()}"

--- a/tests/unit/src/test/scala/tests/DebugDiscoverySuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugDiscoverySuite.scala
@@ -12,6 +12,8 @@ import scala.meta.internal.metals.debug.DotEnvFileParser.InvalidEnvFileException
 import scala.meta.internal.metals.debug.NoTestsFoundException
 import scala.meta.io.AbsolutePath
 
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
+
 // note(@tgodzik) all test have `System.exit(0)` added to avoid occasional issue due to:
 // https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment
 class DebugDiscoverySuite
@@ -148,10 +150,10 @@ class DebugDiscoverySuite
             "runOrTestFile",
           ).toJson
         )
-        .recover { case e @ DebugProvider.NoRunOptionException => e }
+        .recover { case e: ResponseErrorException => e.getMessage }
     } yield assertNoDiff(
       result.toString(),
-      DebugProvider.NoRunOptionException.toString(),
+      DebugProvider.NoRunOptionException.getMessage(),
     )
   }
 
@@ -215,12 +217,10 @@ class DebugDiscoverySuite
             "run",
           ).toJson
         )
-        .recover { case e: BuildTargetContainsNoMainException =>
-          e
-        }
+        .recover { case e: ResponseErrorException => e.getMessage }
     } yield assertNoDiff(
       result.toString,
-      BuildTargetContainsNoMainException("a").toString(),
+      BuildTargetContainsNoMainException("a").getMessage(),
     )
   }
 
@@ -247,12 +247,10 @@ class DebugDiscoverySuite
             "run",
           ).toJson
         )
-        .recover { case WorkspaceErrorsException =>
-          WorkspaceErrorsException
-        }
+        .recover { case e: ResponseErrorException => e.getMessage }
     } yield assertNoDiff(
       result.toString,
-      WorkspaceErrorsException.toString(),
+      WorkspaceErrorsException.getMessage(),
     )
   }
 
@@ -324,10 +322,10 @@ class DebugDiscoverySuite
             envFile = fakePath,
           ).toJson
         )
-        .recover { case e: InvalidEnvFileException => e }
+        .recover { case e: ResponseErrorException => e.getMessage }
     } yield assertNoDiff(
       result.toString,
-      InvalidEnvFileException(AbsolutePath(fakePath)).toString(),
+      InvalidEnvFileException(AbsolutePath(fakePath)).getMessage(),
     )
   }
 
@@ -426,10 +424,10 @@ class DebugDiscoverySuite
             "testTarget",
           ).toJson
         )
-        .recover { case e: NoTestsFoundException => e }
+        .recover { case e: ResponseErrorException => e.getMessage }
     } yield assertNoDiff(
       result.toString(),
-      NoTestsFoundException("build target", "a").toString(),
+      NoTestsFoundException("build target", "a").getMessage(),
     )
   }
 
@@ -460,12 +458,10 @@ class DebugDiscoverySuite
             "testFile",
           ).toJson
         )
-        .recover { case SemanticDbNotFoundException =>
-          SemanticDbNotFoundException
-        }
+        .recover { case e: ResponseErrorException => e.getMessage }
     } yield assertNoDiff(
       result.toString,
-      SemanticDbNotFoundException.toString(),
+      SemanticDbNotFoundException.getMessage(),
     )
   }
 }

--- a/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
@@ -16,6 +16,7 @@ import scala.meta.internal.metals.debug.DebugProvider.WorkspaceErrorsException
 
 import ch.epfl.scala.bsp4j.DebugSessionParamsDataKind
 import ch.epfl.scala.bsp4j.ScalaMainClass
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 
 // note(@tgodzik) all test have `System.exit(0)` added to avoid occasional issue due to:
 // https://stackoverflow.com/questions/2225737/error-jdwp-unable-to-get-jni-1-2-environment
@@ -410,12 +411,12 @@ class DebugProtocolSuite
               singletonList("Foo"),
             ).toJson
           )
-          .recover { case WorkspaceErrorsException =>
-            WorkspaceErrorsException
+          .recover { case e: ResponseErrorException =>
+            e.getMessage()
           }
-    } yield assertDiffEqual(
+    } yield assertNoDiff(
       result.toString(),
-      WorkspaceErrorsException.toString(),
+      WorkspaceErrorsException.getMessage(),
     )
   }
 
@@ -484,12 +485,12 @@ class DebugProtocolSuite
               "a.Foo"
             ).toJson
           )
-          .recover { case WorkspaceErrorsException =>
-            WorkspaceErrorsException
+          .recover { case e: ResponseErrorException =>
+            e.getMessage()
           }
-    } yield assertContains(
+    } yield assertNoDiff(
       result.toString(),
-      WorkspaceErrorsException.toString(),
+      WorkspaceErrorsException.getMessage(),
     )
   }
 }


### PR DESCRIPTION
Previously, we would not show the errors coming from debug discovery and no errors would be forwarded to the client.

Now, we do those two things:
- we no longer hide the discovery errors, but in case no folder contained valid run configuration, we try to show the most relevant error
- instead of throwing a random exception we use LSP build-in one, which is sent back to the client properly and will be displayed

Closes scalameta/metals-vscode#1438