### PR TITLE
bugfix: Don't search for symbol occurrence with empty position

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -296,7 +296,10 @@ final class DefinitionProvider(
       queryPosition <- queryPositionOpt
       occurrence <-
         snapshot.occurrences
-          .find(_.encloses(queryPosition, true))
+          .find(occ =>
+            // empty range is set for anon classes definition
+            occ.range.exists(!_.isPoint) && occ.encloses(queryPosition, true)
+          )
           // In case of macros we might need to get the postion from the presentation compiler
           .orElse(fromMtags(source, queryPosition))
     } yield occurrence


### PR DESCRIPTION
Previously, we would use the first occurrence we found for a couple of things such as definition, which could result in a wrong symbol being picked up (symbol definition for anonymous class).

Now, we filter out empty occurrences since they should not be used for those purpose while still being useful for finding implementations.

Fixes https://github.com/scalameta/metals/issues/5833

I can't reproduce it reliably enough to add a test, but this is super minor.