### PR TITLE
bugfix: Document highlight on anon-fun parameters in Scala 2

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcCollector.scala
@@ -223,11 +223,22 @@ abstract class PcCollector[T](
          * For comprehensions have two owners, one for the enumerators and one for
          * yield. This is a heuristic to find that out.
          */
-        def isForComprehensionOwner(named: NameTree) =
-          soughtNames(named.name) &&
-            named.symbol.owner.isAnonymousFunction && owners.exists(owner =>
-              pos.isDefined && owner.pos.isDefined && owner.pos.point == named.symbol.owner.pos.point
+        def isForComprehensionOwner(named: NameTree) = {
+          if (named.symbol.pos.isDefined) {
+            def alternativeSymbol = sought.exists(symbol =>
+              symbol.name == named.name &&
+                symbol.pos.isDefined &&
+                symbol.pos.start == named.symbol.pos.start
             )
+            def sameOwner = {
+              val owner = named.symbol.owner
+              owner.isAnonymousFunction && owners.exists(o =>
+                pos.isDefined && o.pos.isDefined && o.pos.point == owner.pos.point
+              )
+            }
+            alternativeSymbol && sameOwner
+          } else false
+        }
 
         def soughtOrOverride(sym: Symbol) =
           sought(sym) || sym.allOverriddenSymbols.exists(sought(_))

--- a/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/DocumentHighlightSuite.scala
@@ -837,6 +837,21 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite {
   )
 
   check(
+    "for-comp-bind2",
+    """
+      |object Main {
+      |  val abc = for {
+      |    <<f@@oo>> <- List(1)
+      |    baz = <<foo>> + 1
+      |    a <- List(<<foo>>, 123)
+      |  } yield {
+      |    val x = <<foo>> + baz
+      |    x
+      |  }
+      |}""".stripMargin
+  )
+
+  check(
     "for-comp-map",
     """|object Main {
        |  val x = List(1).<<m@@ap>>(_ + 1)
@@ -989,6 +1004,18 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite {
       |    someLongName: Int => 
       |      val <<ab@@c>> = 2
       |      someLongName + <<abc>>
+      |  }
+      |}""".stripMargin
+  )
+
+  check(
+    "map-bind6",
+    """
+      |object Main {
+      |  List("test").map {
+      |        case <<string@@Name>>: String if <<stringName>>.startsWith("a") => <<stringName>> + "a"
+      |        case stringName: String if stringName.startsWith("b") => stringName + "b"
+      |        case stringName: String => stringName + "c"
       |  }
       |}""".stripMargin
   )


### PR DESCRIPTION
Previously anonymous function params with the same name were not distinguished