### PR TITLE
fix: workaround for wrong span in hover scala 3.3.1

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -121,7 +121,10 @@ object MetalsInteractive:
     def contains(tree: Tree): Boolean = tree match
       case select: Select =>
         // using `nameSpan` as SourceTree for Select (especially symbolic-infix e.g. `::` of `1 :: Nil`) miscalculate positions
-        select.nameSpan.contains(sourcePos.span)
+        select.nameSpan.contains(sourcePos.span) ||
+        (select.span.contains(sourcePos.span) &&
+          !select.qualifier.span.contains(sourcePos.span) &&
+          select.qualifier.symbol.is(Flags.Synthetic))
       case tree: Ident =>
         tree.sourcePos.contains(sourcePos)
       case tree: NamedDefTree =>

--- a/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverTermSuite.scala
@@ -519,4 +519,23 @@ class HoverTermSuite extends BaseHoverSuite {
     "def this(): tailrec".hover
   )
 
+  check(
+    "apply-chain".tag(IgnoreScala2),
+    """
+      |trait Consumer {
+      |  def subConsumer: Consumer
+      |  def consume(value: Int)(n: Int): Unit
+      |}
+      |
+      |object O {
+      |  val consumer: Consumer = ???
+      |  val m = consumer.subConsumer.<<co@@nsume>>
+      |}
+      |""".stripMargin,
+    """|```scala
+       |def consume(value: Int)(n: Int): Unit
+       |```
+       |""".stripMargin
+  )
+
 }


### PR DESCRIPTION
Connected to: https://github.com/scalameta/metals/issues/5869. This is fixed in dotty (probably the incorrect position was fixed in the compiler) and works for current nightly. 