### PR TITLE
Worksheets documentation imprecision

### DIFF
--- a/metals-docs/src/main/scala/docs/WorksheetModifier.scala
+++ b/metals-docs/src/main/scala/docs/WorksheetModifier.scala
@@ -36,7 +36,7 @@ class WorksheetModifier extends StringModifier {
         |This format is important since this is what tells Metals that it's meant to be
         |treated as a worksheet and not just a Scala script. Where you create the
         |script also matters. If you'd like to use classes and values from your
-        |project, you need to make sure the worksheet is created inside of your `src`
+        |project, you need to make sure the worksheet is created inside of your `src/main/scala`
         |directory. You can still create a worksheet in other places, but you will
         |only have access to the standard library and your dependencies.
         |


### PR DESCRIPTION
In the `VSCode` documentation about worksheet, it said that the file must be in the `src` folder to use tokens from the project. More precisely it seems it needs to be in the `src/main/scala`
I tried with the file in `src/`, `src/main/` and `src/main/scala`, only the latter worked properly