### PR TITLE
bugfix: don't show inferred type for val def bind

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcSyntheticDecorationsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcSyntheticDecorationsProvider.scala
@@ -197,7 +197,7 @@ final class PcSyntheticDecorationsProvider(
      * val <<t>> @ ... =
      */
     private def isValDefBind(vd: ValDef) = {
-      val (_, afterDef) = vd.pos.source.content.splitAt(vd.namePosition.end)
+      val afterDef = text.drop(vd.namePosition.end)
       val index = indexAfterSpacesAndComments(afterDef)
       index >= 0 && index < afterDef.size && afterDef(index) == '@'
     }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcSyntheticDecorationsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcSyntheticDecorationsProvider.scala
@@ -152,7 +152,8 @@ final class PcSyntheticDecorationsProvider(
           if hasMissingTypeAnnot(vd, tpt) &&
             !primaryConstructorParam(vd.symbol) &&
             isNotInUnapply(vd) &&
-            !isCompilerGeneratedSymbol(vd.symbol) =>
+            !isCompilerGeneratedSymbol(vd.symbol) &&
+            !isValDefBind(vd) =>
         Some(vd.symbol.tpe.widen.finalResultType, vd.namePosition)
       case dd @ DefDef(_, _, _, _, tpt, _)
           if hasMissingTypeAnnot(dd, tpt) &&
@@ -191,6 +192,15 @@ final class PcSyntheticDecorationsProvider(
 
     private def isNotInUnapply(vd: ValDef) =
       !vd.rhs.pos.isRange || vd.rhs.pos.start > vd.namePosition.end
+
+    /* If is left part of val definition bind:
+     * val <<t>> @ ... =
+     */
+    private def isValDefBind(vd: ValDef) = {
+      val (_, afterDef) = vd.pos.source.content.splitAt(vd.namePosition.end)
+      val index = indexAfterSpacesAndComments(afterDef)
+      index >= 0 && index < afterDef.size && afterDef(index) == '@'
+    }
   }
 
   private def syntheticTupleApply(sel: Select): Boolean = {

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcSyntheticDecorationProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcSyntheticDecorationProvider.scala
@@ -221,7 +221,8 @@ object InferredType:
     tree match
       case vd @ ValDef(_, tpe, _)
           if isValidSpan(tpe.span, vd.nameSpan) &&
-            !vd.symbol.is(Flags.Enum) =>
+            !vd.symbol.is(Flags.Enum) &&
+            !isValDefBind(vd) =>
         if vd.symbol == vd.symbol.sourceSymbol then
           Some(tpe.tpe, tpe.sourcePos.withSpan(vd.nameSpan), vd)
         else None
@@ -244,6 +245,14 @@ object InferredType:
     tpeSpan.isZeroExtent &&
       nameSpan.exists &&
       !nameSpan.isZeroExtent
+
+  /* If is left part of val definition bind:
+   * val <<t>> @ ... =
+   */
+  private def isValDefBind(vd: ValDef)(using Context) =
+    val (_, afterDef) = vd.source.content().splitAt(vd.nameSpan.end)
+    val index = indexAfterSpacesAndComments(afterDef)
+    index >= 0 && index < afterDef.size && afterDef(index) == '@'
 
 end InferredType
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcSyntheticDecorationProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcSyntheticDecorationProvider.scala
@@ -37,6 +37,7 @@ class PcSyntheticDecorationsProvider(
   driver.run(uri, source)
   given ctx: Context = driver.currentCtx
   val unit = driver.currentCtx.run.units.head
+  given InferredType.Text = InferredType.Text(text)
 
   def tpdTree = unit.tpdTree
   def provide(): List[SyntheticDecoration] =
@@ -217,12 +218,16 @@ object TypeParameters:
 end TypeParameters
 
 object InferredType:
-  def unapply(tree: Tree)(using Context) =
+  opaque type Text = Array[Char]
+  object Text:
+    def apply(text: Array[Char]): Text = text
+
+  def unapply(tree: Tree)(using text: Text, cxt: Context) =
     tree match
       case vd @ ValDef(_, tpe, _)
           if isValidSpan(tpe.span, vd.nameSpan) &&
             !vd.symbol.is(Flags.Enum) &&
-            !isValDefBind(vd) =>
+            !isValDefBind(text, vd) =>
         if vd.symbol == vd.symbol.sourceSymbol then
           Some(tpe.tpe, tpe.sourcePos.withSpan(vd.nameSpan), vd)
         else None
@@ -249,8 +254,8 @@ object InferredType:
   /* If is left part of val definition bind:
    * val <<t>> @ ... =
    */
-  private def isValDefBind(vd: ValDef)(using Context) =
-    val (_, afterDef) = vd.source.content().splitAt(vd.nameSpan.end)
+  def isValDefBind(text: Text, vd: ValDef)(using Context) =
+    val afterDef = text.drop(vd.nameSpan.end)
     val index = indexAfterSpacesAndComments(afterDef)
     index >= 0 && index < afterDef.size && afterDef(index) == '@'
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalametaCommonEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalametaCommonEnrichments.scala
@@ -33,6 +33,33 @@ import org.eclipse.{lsp4j => l}
 object ScalametaCommonEnrichments extends ScalametaCommonEnrichments {}
 trait ScalametaCommonEnrichments extends CommonMtagsEnrichments {
 
+  def indexAfterSpacesAndComments(text: Array[Char]): Int = {
+    var isInComment = false
+    var startedStateChange = false
+    val index = text.indexWhere {
+      case '/' if !isInComment && !startedStateChange =>
+        startedStateChange = true
+        false
+      case '*' if !isInComment && startedStateChange =>
+        startedStateChange = false
+        isInComment = true
+        false
+      case '/' if isInComment && startedStateChange =>
+        startedStateChange = false
+        isInComment = false
+        false
+      case '*' if isInComment && !startedStateChange =>
+        startedStateChange = true
+        false
+      case c if isInComment || c.isSpaceChar || c == '\t' =>
+        startedStateChange = false
+        false
+      case _ => true
+    }
+    if (startedStateChange) index - 1
+    else index
+  }
+
   private def logger: Logger =
     Logger.getLogger(classOf[ScalametaCommonEnrichments].getName)
 

--- a/tests/cross/src/test/scala/tests/pc/SyntheticDecorationsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SyntheticDecorationsSuite.scala
@@ -566,4 +566,28 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite {
        |}
        |""".stripMargin
   )
+
+  check(
+    "val-def-with-bind",
+    """|object O {
+       |  val tupleBound @ (one, two) = ("1", "2")
+       |}
+       |""".stripMargin,
+    """|object O {
+       |  val tupleBound @ (one: String, two: String) = ("1", "2")
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "val-def-with-bind-and-comment",
+    """|object O {
+       |  val tupleBound /* comment */ @ (one, two) = ("1", "2")
+       |}
+       |""".stripMargin,
+    """|object O {
+       |  val tupleBound /* comment */ @ (one: String, two: String) = ("1", "2")
+       |}
+       |""".stripMargin
+  )
 }

--- a/tests/unit/src/test/scala/tests/SkipCommentsSuite.scala
+++ b/tests/unit/src/test/scala/tests/SkipCommentsSuite.scala
@@ -1,0 +1,46 @@
+package tests
+
+import scala.meta.internal.metals.MetalsEnrichments._
+
+import munit.TestOptions
+
+class SkipCommentsSuite extends munit.FunSuite with Assertions {
+
+  check(
+    "drop-all",
+    "  /* bhjv */ /* bhjbi */",
+  )
+
+  check(
+    "between-comments",
+    "  /* bhjv */ @ /* bhjbi */",
+    Some('@'),
+  )
+
+  check(
+    "not-comment",
+    "  /@",
+    Some('/'),
+  )
+
+  check(
+    "tab",
+    "\t /*cbu * whec*/",
+  )
+
+  def check(
+      name: TestOptions,
+      text: String,
+      nextChar: Option[Char] = None,
+  ): Unit =
+    test(name) {
+      val index = indexAfterSpacesAndComments(text.toCharArray())
+      def clue = s"text: $text, index: $index"
+      nextChar match {
+        case None => assert(index < 0 || index >= text.size, clue)
+        case Some(c) =>
+          assertEquals(text.charAt(index), c, clue)
+      }
+    }
+
+}

--- a/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/decorations/SyntheticDecorationsLspSuite.scala
@@ -494,7 +494,7 @@ class SyntheticDecorationsLspSuite extends BaseLspSuite("implicits") {
            |  val List[Int](l1: Int, l2: Int) = List[Int](12, 13)
            |  println("Hello!")
            |  val abc: Int = 123
-           |  val tupleBound: (String, String) @ (one: String, two: String) = ("1", "2")
+           |  val tupleBound @ (one: String, two: String) = ("1", "2")
            |  val tupleExplicit: (String, String) = Tuple2[String, String]("1", "2")
            |  val tupleExplicitApply: (String, String) = Tuple2.apply[String, String]("1", "2")
            |  var variable: Int = 123


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/5835

There seems to be no reasonable way to distinguish  `t` from `t1` in `val t @ (t1, t2,) = (1,2)` in typed trees. We could do this on untyped but I think it will be faster this way.