### PR TITLE
improvement: Don't publish diagnostics for dependencies

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -364,9 +364,7 @@ class MetalsLspService(
         folder,
         buildTargets,
         charset,
-        languageClient,
         tables,
-        statusBar,
         () => compilers,
         clientConfig,
         () => semanticDBIndexer,
@@ -1076,11 +1074,7 @@ class MetalsLspService(
     } yield ()
 
     if (path.isDependencySource(folder)) {
-      CancelTokens { _ =>
-        // publish diagnostics
-        interactiveSemanticdbs.didFocus(path)
-        ()
-      }
+      CompletableFuture.completedFuture(())
     } else {
       buildServerPromise.future.flatMap { _ =>
         def load(): Future[Unit] = {
@@ -1135,8 +1129,6 @@ class MetalsLspService(
     buildTargets
       .inverseSources(path)
       .foreach(focusedDocumentBuildTarget.set)
-    // unpublish diagnostic for dependencies
-    interactiveSemanticdbs.didFocus(path)
     // Don't trigger compilation on didFocus events under cascade compilation
     // because save events already trigger compile in inverse dependencies.
     if (path.isDependencySource(folder)) {


### PR DESCRIPTION
Previously, we would publish dependency diagnsotics as info diagnostics, but that has never proved useful and it might be false positive as we don't have the full build definition of dependencies. Now, we don't publish them at all.