### PR TITLE
bugfix: Extension method completion with name conflict

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
@@ -261,6 +261,10 @@ class CompletionProvider(
                   mkItem(
                     "{" + sym.fullNameBackticked + completionTextSuffix + "}"
                   )
+                case _ if v.isExtensionMethod =>
+                  mkItem(
+                    ident.backticked(backtickSoftKeyword) + completionTextSuffix
+                  )
                 case _ =>
                   mkItem(
                     sym.fullNameBackticked(

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -44,6 +44,7 @@ object CompletionValue:
     def symbol: Symbol
     def isFromWorkspace: Boolean = false
     def completionItemDataKind = CompletionItemData.None
+    def isExtensionMethod: Boolean = false
 
     override def completionData(
         buildTargetIdentifier: String
@@ -125,6 +126,7 @@ object CompletionValue:
   ) extends Symbolic:
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Method
+    override def isExtensionMethod: Boolean = true
     override def description(printer: MetalsPrinter)(using Context): String =
       s"${printer.completionSymbol(symbol)} (extension)"
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionExtensionMethodSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionExtensionMethodSuite.scala
@@ -130,6 +130,36 @@ class CompletionExtensionMethodSuite extends BaseCompletionSuite {
        |""".stripMargin
   )
 
+  checkEdit(
+    "name-conflict",
+    """|package example
+       |
+       |import example.enrichments.*
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def plus(other: Int): Int = num + other
+       |
+       |def main = {
+       |  val plus = 100.plus(19)
+       |  val y = 19.pl@@
+       |}
+       |""".stripMargin,
+    """|package example
+       |
+       |import example.enrichments.*
+       |
+       |object enrichments:
+       |  extension (num: Int)
+       |    def plus(other: Int): Int = num + other
+       |
+       |def main = {
+       |  val plus = 100.plus(19)
+       |  val y = 19.plus($0)
+       |}
+       |""".stripMargin
+  )
+
   // NOTE: In 3.1.3, package object name includes the whole path to file
   // eg. in 3.2.2 we get `A$package`, but in 3.1.3 `/some/path/to/file/A$package`
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -988,4 +988,29 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |MyType - demo.other""".stripMargin
   )
 
+  checkEdit(
+    "method-name-conflict".tag(IgnoreScala2),
+    """|package demo
+       |
+       |object O {
+       |  def mmmm(x: Int) = x + 3
+       |  class Test {
+       |    val mmmm = "abc"
+       |    val foo = mmmm@@
+       |  }
+       |}
+       |""".stripMargin,
+    """|package demo
+       |
+       |object O {
+       |  def mmmm(x: Int) = x + 3
+       |  class Test {
+       |    val mmmm = "abc"
+       |    val foo = demo.O.mmmm($0)
+       |  }
+       |}
+       |""".stripMargin,
+    filter = _.contains("mmmm(x: Int)")
+  )
+
 }


### PR DESCRIPTION
When symbol with the same name as extension method was present in scope, completion edit would insert full symbol name of this method, which was incorrect.

```scala
package example

|import example.enrichments.*

object enrichments:
  extension (num: Int)
    def plus(other: Int): Int = num + other

def main = {
  val plus = 100.plus(19)
  val y = 19.pl@@ // resulted in
  val y = 19.example.enrichments.plus($0)
}
```