### PR TITLE
improvement: add semantic tokens for escape sequences

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
@@ -414,12 +414,11 @@ object SemanticTokensProvider {
     var delta = initialDelta
     val currentPart = new StringBuilder()
 
-    def emitToken(token: String, tokenType: Int, tokenModifiers: Int = 0) {
+    def emitToken(token: String, tokenType: Int) {
       val (toAdd, newDelta) = convertTokensToIntList(
         token,
         delta,
         tokenType,
-        tokenModifiers,
       )
       buffer.addAll(toAdd)
       delta = newDelta
@@ -436,8 +435,7 @@ object SemanticTokensProvider {
     def emitEscape(special: String) =
       emitToken(
         special,
-        getTypeId(SemanticTokenTypes.Operator),
-        1 << getModifierId(SemanticTokenModifiers.Documentation),
+        getTypeId(SemanticTokenTypes.Regexp),
       )
 
     @tailrec

--- a/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
@@ -242,6 +242,18 @@ class SemanticTokensLspSuite extends BaseLspSuite("SemanticTokens") {
         |""".stripMargin,
   )
 
+  check(
+    "escapes",
+    s"""|<<object>>/*keyword*/ <<O>>/*class*/ {
+        |  <<val>>/*keyword*/ <<stringEscape>>/*variable,definition,readonly*/ = <<"smth >>/*string*/<<\\n>>/*operator,documentation*/<<\\">>/*operator,documentation*/<< rest>>/*string*/<<\\n>>/*operator,documentation*/<<">>/*string*/
+        |  <<val>>/*keyword*/ <<multilineString>>/*variable,definition,readonly*/ = <<\"\"\"\\n\"\"\">>/*string*/
+        |  <<val>>/*keyword*/ <<charEscape>>/*variable,definition,readonly*/ = <<'>>/*string*/<<\\n>>/*operator,documentation*/<<'>>/*string*/
+        |  <<val>>/*keyword*/ <<interpolatorEscape>>/*variable,definition,readonly*/ = <<s>>/*keyword*/<<">>/*string*/<<$$$$>>/*operator,documentation*/<<smth >>/*string*/<<\\n>>/*operator,documentation*/<<\\">>/*operator,documentation*/<< rest>>/*string*/<<">>/*string*/
+        |  <<val>>/*keyword*/ <<unicode>>/*variable,definition,readonly*/ = <<s>>/*keyword*/<<\"\"\">>/*string*/<<\\u202c>>/*operator,documentation*/<<\"\"\">>/*string*/
+        |}
+        |""".stripMargin,
+  )
+
   def check(
       name: TestOptions,
       expected: String,

--- a/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
@@ -245,11 +245,11 @@ class SemanticTokensLspSuite extends BaseLspSuite("SemanticTokens") {
   check(
     "escapes",
     s"""|<<object>>/*keyword*/ <<O>>/*class*/ {
-        |  <<val>>/*keyword*/ <<stringEscape>>/*variable,definition,readonly*/ = <<"smth >>/*string*/<<\\n>>/*operator,documentation*/<<\\">>/*operator,documentation*/<< rest>>/*string*/<<\\n>>/*operator,documentation*/<<">>/*string*/
+        |  <<val>>/*keyword*/ <<stringEscape>>/*variable,definition,readonly*/ = <<"smth >>/*string*/<<\\n>>/*regexp*/<<\\">>/*regexp*/<< rest>>/*string*/<<\\n>>/*regexp*/<<">>/*string*/
         |  <<val>>/*keyword*/ <<multilineString>>/*variable,definition,readonly*/ = <<\"\"\"\\n\"\"\">>/*string*/
-        |  <<val>>/*keyword*/ <<charEscape>>/*variable,definition,readonly*/ = <<'>>/*string*/<<\\n>>/*operator,documentation*/<<'>>/*string*/
-        |  <<val>>/*keyword*/ <<interpolatorEscape>>/*variable,definition,readonly*/ = <<s>>/*keyword*/<<">>/*string*/<<$$$$>>/*operator,documentation*/<<smth >>/*string*/<<\\n>>/*operator,documentation*/<<\\">>/*operator,documentation*/<< rest>>/*string*/<<">>/*string*/
-        |  <<val>>/*keyword*/ <<unicode>>/*variable,definition,readonly*/ = <<s>>/*keyword*/<<\"\"\">>/*string*/<<\\u202c>>/*operator,documentation*/<<\"\"\">>/*string*/
+        |  <<val>>/*keyword*/ <<charEscape>>/*variable,definition,readonly*/ = <<'>>/*string*/<<\\n>>/*regexp*/<<'>>/*string*/
+        |  <<val>>/*keyword*/ <<interpolatorEscape>>/*variable,definition,readonly*/ = <<s>>/*keyword*/<<">>/*string*/<<$$$$>>/*regexp*/<<smth >>/*string*/<<\\n>>/*regexp*/<<\\">>/*regexp*/<< rest>>/*string*/<<">>/*string*/
+        |  <<val>>/*keyword*/ <<unicode>>/*variable,definition,readonly*/ = <<s>>/*keyword*/<<\"\"\">>/*string*/<<\\u202c>>/*regexp*/<<\"\"\">>/*string*/
         |}
         |""".stripMargin,
   )


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/5433

The choice of `{ type: "operator", modifier: "documentation" }`, is fairly random, I don't want to use keyword, which is already used for `$` in string interpolators. I'm open to suggestions on that matter.