### PR TITLE
Revert creating .scala-build in temporary directory

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -7,6 +7,8 @@ import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
@@ -66,9 +68,11 @@ class ScalaCli(
   private val isCancelled = new AtomicBoolean(false)
   def cancel(): Unit =
     if (isCancelled.compareAndSet(false, true))
-      try disconnectOldBuildServer()
-      catch {
+      try {
+        disconnectOldBuildServer().asJava.get(100, TimeUnit.MILLISECONDS)
+      } catch {
         case NonFatal(_) =>
+        case _: TimeoutException =>
       }
 
   private val state =

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -7,9 +7,6 @@ import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
@@ -22,7 +19,6 @@ import scala.util.Properties
 import scala.util.Success
 import scala.util.control.NonFatal
 
-import scala.meta.internal.async.ConcurrentQueue
 import scala.meta.internal.bsp.BuildChange
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.BuildInfo
@@ -64,16 +60,6 @@ class ScalaCli(
     parseTreesAndPublishDiags: Seq[AbsolutePath] => Future[Unit],
 )(implicit ec: ExecutionContextExecutorService)
     extends Cancelable {
-
-  private val createdFiles = new ConcurrentLinkedQueue[AbsolutePath]()
-  private def registerFile(path: AbsolutePath) = {
-    createdFiles.add(path)
-    path
-  }
-  private def localTmpWorkspace(path: AbsolutePath) = {
-    val root = if (path.isDirectory) path else path.parent
-    root.resolve(s".metals-scala-cli/")
-  }
   private val scalaCliBuildDirectory =
     new AtomicReference[Option[AbsolutePath]](None)
 
@@ -83,13 +69,15 @@ class ScalaCli(
   def cancel(): Unit =
     if (isCancelled.compareAndSet(false, true))
       try {
-        scalaCliBuildDirectory.set(None)
-        disconnectOldBuildServer().asJava.get(100, TimeUnit.MILLISECONDS)
+        disconnectOldBuildServer().map { _ =>
+          scalaCliBuildDirectory.get() match {
+            case Some(dir) =>
+              dir.deleteRecursively()
+            case _ =>
+          }
+        }
       } catch {
         case NonFatal(_) =>
-        case _: TimeoutException =>
-      } finally {
-        ConcurrentQueue.pollAll(createdFiles).foreach(_.deleteRecursively())
       }
 
   private val state =
@@ -226,34 +214,20 @@ class ScalaCli(
     ifConnectedOrElse(st => Option(st.path))(None)
 
   def start(path: AbsolutePath): Future[Unit] = {
-    val workspace = {
-      val globalTmpDir =
-        scalaCliBuildDirectory.get() match {
-          case Some(workspace) => workspace
-          case None =>
-            val tmpFile = registerFile {
-              AbsolutePath(
-                Files.createTempDirectory(s"metals-scala-cli")
-              )
+    val workspace =
+      scalaCliBuildDirectory.get() match {
+        case Some(workspace) => workspace
+        case None =>
+          val tmpFile = AbsolutePath(
+            Files.createTempDirectory(s"metals-scala-cli")
+          )
+          val Some(workspace) =
+            scalaCliBuildDirectory.updateAndGet {
+              case None => Some(tmpFile)
+              case some => some
             }
-            val Some(workspace) =
-              scalaCliBuildDirectory.updateAndGet {
-                case None => Some(tmpFile)
-                case some => some
-              }
-            workspace
-        }
-
-      // When path and workspace have different roots on Windows `scala-cli` throws an error,
-      // so we fallback to creating a tmp dir relative to `path`.
-      if (globalTmpDir.toNIO.getRoot() == path.toNIO.getRoot()) globalTmpDir
-      else
-        registerFile {
-          val workspace = localTmpWorkspace(path)
-          if (!workspace.exists) Files.createDirectory(workspace.toNIO)
           workspace
-        }
-    }
+      }
 
     disconnectOldBuildServer().onComplete {
       case Failure(e) =>

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -60,23 +60,14 @@ class ScalaCli(
     parseTreesAndPublishDiags: Seq[AbsolutePath] => Future[Unit],
 )(implicit ec: ExecutionContextExecutorService)
     extends Cancelable {
-  private val scalaCliBuildDirectory =
-    new AtomicReference[Option[AbsolutePath]](None)
 
   import ScalaCli.ConnectionState
 
   private val isCancelled = new AtomicBoolean(false)
   def cancel(): Unit =
     if (isCancelled.compareAndSet(false, true))
-      try {
-        disconnectOldBuildServer().map { _ =>
-          scalaCliBuildDirectory.get() match {
-            case Some(dir) =>
-              dir.deleteRecursively()
-            case _ =>
-          }
-        }
-      } catch {
+      try disconnectOldBuildServer()
+      catch {
         case NonFatal(_) =>
       }
 
@@ -214,30 +205,13 @@ class ScalaCli(
     ifConnectedOrElse(st => Option(st.path))(None)
 
   def start(path: AbsolutePath): Future[Unit] = {
-    val workspace =
-      scalaCliBuildDirectory.get() match {
-        case Some(workspace) => workspace
-        case None =>
-          val tmpFile = AbsolutePath(
-            Files.createTempDirectory(s"metals-scala-cli")
-          )
-          val Some(workspace) =
-            scalaCliBuildDirectory.updateAndGet {
-              case None => Some(tmpFile)
-              case some => some
-            }
-          workspace
-      }
-
     disconnectOldBuildServer().onComplete {
       case Failure(e) =>
         scribe.warn("Error disconnecting old Scala CLI server", e)
       case Success(()) =>
     }
 
-    val command =
-      cliCommand :+ "bsp" :+ "--workspace" :+ workspace.toString :+ path
-        .toString()
+    val command = cliCommand :+ "bsp" :+ path.toString()
 
     val connDir = if (path.isDirectory) path else path.parent
 


### PR DESCRIPTION
This causes issues with semanticdb, because source root is also set to that build directory and semanticdb ends up in the wrong place.