### PR TITLE
feature: Add option to run verbose compilation

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -25,6 +25,7 @@ final class Compilations(
     isCurrentlyFocused: b.BuildTargetIdentifier => Boolean,
     compileWorksheets: Seq[AbsolutePath] => Future[Unit],
     onStartCompilation: () => Unit,
+    userConfiguration: () => UserConfiguration,
 )(implicit ec: ExecutionContext) {
 
   // we are maintaining a separate queue for cascade compilation since those must happen ASAP
@@ -228,6 +229,11 @@ final class Compilations(
       targets: Seq[b.BuildTargetIdentifier],
   ): CancelableFuture[b.CompileResult] = {
     val params = new b.CompileParams(targets.asJava)
+    if (
+      userConfiguration().verboseCompilation && (connection.isBloop || connection.isScalaCLI)
+    ) {
+      params.setArguments(List("--verbose").asJava)
+    }
     targets.foreach(target => isCompiling(target) = true)
     val compilation = connection.compile(params)
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -258,6 +258,7 @@ class MetalsLspService(
     buildTarget => focusedDocumentBuildTarget.get() == buildTarget,
     worksheets => onWorksheetChanged(worksheets),
     onStartCompilation,
+    () => userConfig,
   )
   private val fileWatcher = register(
     new FileWatcher(

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -54,6 +54,7 @@ case class UserConfiguration(
     javaFormatConfig: Option[JavaFormatConfig] = None,
     scalafixRulesDependencies: List[String] = Nil,
     customProjectRoot: Option[String] = None,
+    verboseCompilation: Boolean = false,
     scalaCliLauncher: Option[String] = None,
 ) {
 
@@ -329,6 +330,15 @@ object UserConfiguration {
         """Optional relative path to your project's root.
           |If you want your project root to be the workspace/workspace root set it to "." .""".stripMargin,
       ),
+      UserConfigurationOption(
+        "verbose-compilation",
+        "false",
+        "true",
+        "Show all compilation debugging information",
+        """|If a build server supports it (for example Bloop or Scala CLI), setting it to true
+           |will make the logs contain all the possible debugging information including
+           |about incremental compilation in Zinc.""".stripMargin,
+      ),
     )
 
   def fromJson(
@@ -542,6 +552,8 @@ object UserConfiguration {
       getStringListKey("scalafix-rules-dependencies").getOrElse(Nil)
 
     val customProjectRoot = getStringKey("custom-project-root")
+    val verboseCompilation =
+      getBooleanKey("verbose-compilation").getOrElse(false)
 
     if (errors.isEmpty) {
       Right(
@@ -574,6 +586,7 @@ object UserConfiguration {
           javaFormatConfig,
           scalafixRulesDependencies,
           customProjectRoot,
+          verboseCompilation,
         )
       )
     } else {


### PR DESCRIPTION
Previously, there was no easy way to run verbose compilation and see what is going on underneath in Zinc. Now, it's possible, which might be super useful for debugging incremental compilation issues.

Closes https://github.com/scalameta/metals/issues/5773