### PR TITLE
fix: use client commands inside of BSP status

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/ConnectionBspStatus.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/ConnectionBspStatus.scala
@@ -4,10 +4,10 @@ import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.meta.internal.metals.BspStatus
+import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ReportContext
-import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.clients.language.MetalsStatusParams
 import scala.meta.internal.metals.clients.language.StatusType
 import scala.meta.io.AbsolutePath
@@ -124,7 +124,7 @@ object ConnectionBspStatus {
       "error",
       show = true,
       tooltip = s"Build sever ($serverName) is not responding.",
-      command = ServerCommands.ConnectBuildServer.id,
+      command = ClientCommands.ConnectBuildServer.id,
       commandTooltip = "Reconnect.",
     ).withStatusType(StatusType.bsp)
 
@@ -139,7 +139,7 @@ object ConnectionBspStatus {
       "warn",
       show = true,
       tooltip = message.trimTo(TOOLTIP_MAX_LENGTH),
-      command = ServerCommands.RunDoctor.id,
+      command = ClientCommands.RunDoctor.id,
       commandTooltip = "Open doctor.",
     ).withStatusType(StatusType.bsp)
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala
@@ -360,6 +360,12 @@ object ClientCommands {
     "[string], the markdown representation of the stacktrace",
   )
 
+  val ConnectBuildServer = new Command(
+    "metals-build-connect",
+    "Connect to build server.",
+    ServerCommands.ConnectBuildServer.description,
+  )
+
   def all: List[BaseCommand] =
     List(
       OpenFolder,
@@ -374,5 +380,6 @@ object ClientCommands {
       CopyWorksheetOutput,
       StartRunSession,
       StartDebugSession,
+      ConnectBuildServer,
     )
 }


### PR DESCRIPTION
These commands that are attached to status' are meant for the client to execute and send to the server. I noticed this because in nvim-metals I've gotten multiple reports of these commands not working when they arrive since normally the client commands are prefaced with `metals-` whereas the server ones aren't. I'm not sure how this was working in VS Code or if it was, but I believe this change is correct.