### PR TITLE
improvement: show workspace completions for short queries

### DIFF
--- a/metals-bench/src/main/scala/bench/ClasspathOnlySymbolSearch.scala
+++ b/metals-bench/src/main/scala/bench/ClasspathOnlySymbolSearch.scala
@@ -40,7 +40,7 @@ class ClasspathOnlySymbolSearch(classpath: ClasspathSearch)
       buildTargetIdentifier: String,
       visitor: SymbolSearchVisitor,
   ): SymbolSearch.Result = {
-    classpath.search(WorkspaceSymbolQuery.exact(query), visitor)
+    classpath.search(WorkspaceSymbolQuery.exact(query), visitor)._1
   }
 
   override def searchMethods(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsSymbolSearch.scala
@@ -94,11 +94,18 @@ class MetalsSymbolSearch(
       buildTargetIdentifier: String,
       visitor: SymbolSearchVisitor,
   ): SymbolSearch.Result = {
-    wsp.search(
-      WorkspaceSymbolQuery.exact(query),
-      visitor,
-      Some(new BuildTargetIdentifier(buildTargetIdentifier)),
-    )
+    def search(query: WorkspaceSymbolQuery) =
+      wsp.search(
+        query,
+        visitor,
+        Some(new BuildTargetIdentifier(buildTargetIdentifier)),
+      )
+
+    val wQuery = WorkspaceSymbolQuery.exact(query)
+    val (result, count) = search(wQuery)
+    if (wQuery.isShortQuery && count == 0)
+      search(WorkspaceSymbolQuery.exact(query, isShortQueryRetry = true))._1
+    else result
   }
 
   override def searchMethods(

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -101,7 +101,8 @@ class StandaloneSymbolSearch(
       buildTargetIdentifier: String,
       visitor: SymbolSearchVisitor,
   ): Result = {
-    val res = classpathSearch.search(WorkspaceSymbolQuery.exact(query), visitor)
+    val (res, _) =
+      classpathSearch.search(WorkspaceSymbolQuery.exact(query), visitor)
     workspaceFallback
       .map(_.search(query, buildTargetIdentifier, visitor))
       .getOrElse(res)

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/Fuzzy.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/Fuzzy.scala
@@ -124,14 +124,30 @@ class Fuzzy {
     }
   }
 
-  def isExactMatch(query: String, filename: CharSequence): Boolean = {
+  def startsWith(query: String, filename: CharSequence): Boolean = {
     val sb = lastIndex(filename)
-    val sa = sb - query.length()
-    if (sa < 0) {
-      false
-    } else {
-      exactMatch(query, filename, sa, sb)
+    val st = findStartIndex(filename, sb)
+    if (sb - st < query.length()) false
+    else {
+      var idx = 0
+      while (idx < query.length) {
+        if (query.charAt(idx) != filename.charAt(st + idx)) return false
+        idx += 1
+      }
+      true
     }
+  }
+
+  def findStartIndex(symbol: CharSequence, lastIndex: Int): Int = {
+    var start = 0
+    var i = 0
+    while (i < lastIndex) {
+      if (symbol.charAt(i) == '$') {
+        start = i + 1
+      }
+      i += 1
+    }
+    if (start < lastIndex) start else 0
   }
 
   private def lastIndex(symbol: CharSequence): Int = {
@@ -360,8 +376,8 @@ class Fuzzy {
   def bloomFilterQueryStrings(
       query: String,
       includeTrigrams: Boolean = true
-  ): Iterable[CharSequence] = {
-    if (query.length < ExactSearchLimit) {
+  ): Iterable[CharSequence] =
+    if (query.isEmpty()) {
       List(ExactCharSequence(query))
     } else {
       val result = mutable.Set.empty[CharSequence]
@@ -396,7 +412,6 @@ class Fuzzy {
       }
       result
     }
-  }
 
   /**
    * Returns true if all characters in the query have a case in-sensitive matching character in the symbol, in-order

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/PrefixCharSequence.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/PrefixCharSequence.scala
@@ -3,10 +3,10 @@ package scala.meta.internal.metals
 /**
  * A char sequence that represents an exact symbol search.
  *
- * For example, `ExactSymbolSearch("S")` is added to a bloom filter
- * to indicate a souce file has a symbol with the exact name "S".
+ * For example, `PrefixCharSequence("S")` is added to a bloom filter
+ * to indicate a source file has a symbol starting with "S".
  */
-case class ExactCharSequence(value: CharSequence) extends CharSequence {
+case class PrefixCharSequence(value: CharSequence) extends CharSequence {
   override def length(): Int = value.length() + 1
 
   override def charAt(index: Int): Char = {

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -3,7 +3,6 @@ package tests.pc
 import tests.BaseCompletionSuite
 
 class CompletionKeywordSuite extends BaseCompletionSuite {
-
   override protected def ignoreScalaVersion: Option[IgnoreScalaVersion] =
     Some(IgnoreForScala3CompilerPC)
 
@@ -40,6 +39,11 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     "",
+    compat = Map(
+      "3" -> """|transient scala (commit: '')
+                |transparentTrait(): transparentTrait (commit: '')
+                |transparentTrait - scala.annotation (commit: '')""".stripMargin
+    ),
     includeCommitCharacter = true
   )
 
@@ -59,6 +63,11 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     "",
+    compat = Map(
+      "3" -> """|transient scala (commit: '')
+                |transparentTrait(): transparentTrait (commit: '')
+                |transparentTrait - scala.annotation (commit: '')""".stripMargin
+    ),
     includeCommitCharacter = true
   )
 
@@ -171,6 +180,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
         """|value: Int
            |val
            |var
+           |varargs(): varargs
            |varargs - scala.annotation
            |""".stripMargin
     )
@@ -189,8 +199,8 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |""".stripMargin,
     """|val
        |var
-       |varargs - scala.annotation
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(2)
   )
 
   check(
@@ -209,7 +219,8 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     includeCommitCharacter = true,
     compat = Map(
       "2" -> ""
-    )
+    ),
+    topLines = Some(1)
   )
 
   check(
@@ -441,7 +452,8 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |  protected de@@
       |}
     """.stripMargin,
-    "def"
+    "def",
+    topLines = Some(1)
   )
 
   check(
@@ -455,7 +467,8 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     """.stripMargin,
     """val
       |var
-      |""".stripMargin
+      |""".stripMargin,
+    topLines = Some(2)
   )
 
   check(
@@ -513,7 +526,8 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     includeCommitCharacter = true,
     compat = Map(
       "2" -> ""
-    )
+    ),
+    topLines = Some(1)
   )
 
   check(
@@ -521,7 +535,11 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     """|object A{
        |  def hello(a: String, u@@)
        |}""".stripMargin,
-    ""
+    "",
+    compat = Map(
+      "3" -> "unsafeExceptions scala"
+    ),
+    topLines = Some(1)
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -4,6 +4,9 @@ import tests.BaseCompletionSuite
 
 class CompletionKeywordSuite extends BaseCompletionSuite {
 
+  override protected def ignoreScalaVersion: Option[IgnoreScalaVersion] =
+    Some(IgnoreForScala3CompilerPC)
+
   check(
     "super-template",
     """
@@ -149,6 +152,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     """|value: Int
        |val
        |var
+       |varargs - scala.annotation
        |override def equals(x$1: Any): Boolean
        |override def hashCode(): Int
        |override def finalize(): Unit
@@ -158,6 +162,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
         """|value: Int
            |val
            |var
+           |varargs - scala.annotation
            |override def equals(x$1: Object): Boolean
            |override def hashCode(): Int
            |override def finalize(): Unit
@@ -166,6 +171,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
         """|value: Int
            |val
            |var
+           |varargs - scala.annotation
            |""".stripMargin
     )
   )
@@ -183,6 +189,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |""".stripMargin,
     """|val
        |var
+       |varargs - scala.annotation
        |""".stripMargin
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -199,8 +199,15 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |""".stripMargin,
     """|val
        |var
+       |varargs - scala.annotation
        |""".stripMargin,
-    topLines = Some(2)
+    compat = Map(
+      "3" -> """|val
+                |var
+                |varargs(): varargs
+                |varargs - scala.annotation
+                |""".stripMargin
+    )
   )
 
   check(
@@ -215,12 +222,16 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|given (commit: '')
+       |given_FromString_Int - scala.util.CommandLineParser.FromString (commit: '')
+       |given_FromString_Byte - scala.util.CommandLineParser.FromString (commit: '')
+       |given_FromString_Long - scala.util.CommandLineParser.FromString (commit: '')
+       |given_FromString_Float - scala.util.CommandLineParser.FromString (commit: '')
        |""".stripMargin,
     includeCommitCharacter = true,
     compat = Map(
       "2" -> ""
     ),
-    topLines = Some(1)
+    topLines = Some(5)
   )
 
   check(
@@ -235,8 +246,13 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|value: Int
+       |varargs - scala.annotation
        |""".stripMargin,
-    topLines = Some(1)
+    compat = Map(
+      "3" -> """|value: Int
+                |varargs(): varargs
+                |varargs - scala.annotation""".stripMargin
+    )
   )
 
   checkEditLine(
@@ -453,7 +469,15 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |}
     """.stripMargin,
     "def",
-    topLines = Some(1)
+    topLines = Some(5),
+    compat = Map(
+      "3" -> """|def
+                |deprecated scala
+                |deprecatedInheritance scala
+                |deprecatedName scala
+                |deprecatedOverriding scala
+                |""".stripMargin
+    )
   )
 
   check(
@@ -468,7 +492,13 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     """val
       |var
       |""".stripMargin,
-    topLines = Some(2)
+    compat = Map(
+      "3" -> """|val
+                |var
+                |varargs(): varargs
+                |varargs - scala.annotation
+                |""".stripMargin
+    )
   )
 
   check(
@@ -522,12 +552,21 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
        |  def hello(u@@)
        |}""".stripMargin,
     """|using (commit: '')
-       |""".stripMargin,
+       |unsafeExceptions scala (commit: '')
+       |unchecked scala (commit: '')
+       |unsafeNulls - scala.runtime.stdLibPatches.language (commit: '')
+       |unshared(): unshared (commit: '')""".stripMargin,
     includeCommitCharacter = true,
     compat = Map(
-      "2" -> ""
+      "2" -> "",
+      "3.3" -> """|using (commit: '')
+                  |unsafeExceptions scala (commit: '')
+                  |unchecked scala (commit: '')
+                  |unsafe - scala.caps (commit: '')
+                  |unsafeNulls - scala.runtime.stdLibPatches.language (commit: '')
+                  |""".stripMargin
     ),
-    topLines = Some(1)
+    topLines = Some(5)
   )
 
   check(
@@ -537,9 +576,18 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
        |}""".stripMargin,
     "",
     compat = Map(
-      "3" -> "unsafeExceptions scala"
+      "3" -> """|unsafeExceptions scala
+                |unchecked scala
+                |unsafeNulls - scala.runtime.stdLibPatches.language
+                |unshared(): unshared
+                |uncheckedStable(): uncheckedStable""".stripMargin,
+      "3.3" -> """|unsafeExceptions scala
+                  |unchecked scala
+                  |unsafe - scala.caps
+                  |unsafeNulls - scala.runtime.stdLibPatches.language
+                  |unshared(): unshared""".stripMargin
     ),
-    topLines = Some(1)
+    topLines = Some(5)
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
@@ -60,7 +60,19 @@ class CompletionPatternSuite extends BaseCompletionSuite {
       |    case ma@@
       |  }
       |}""".stripMargin,
-    ""
+    "",
+    compat = Map(
+      scala3PresentationCompilerVersion ->
+        """|main scala
+           |macros - scala.languageFeature.experimental
+           |macroImpl - scala.reflect.macros.internal
+           |""".stripMargin,
+      "3" -> """|main scala
+                |macros - scala.languageFeature.experimental
+                |macroImpl(referenceToMacroImpl: Any): macroImpl
+                |macroImpl - scala.reflect.macros.internal
+                |""".stripMargin
+    )
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
@@ -67,6 +67,12 @@ class CompletionPatternSuite extends BaseCompletionSuite {
            |macros - scala.languageFeature.experimental
            |macroImpl - scala.reflect.macros.internal
            |""".stripMargin,
+      "3.3.2" ->
+        """|main scala
+           |macros - languageFeature.experimental
+           |macroImpl(referenceToMacroImpl: Any): macroImpl
+           |macroImpl - scala.reflect.macros.internal
+           |""".stripMargin,
       "3" -> """|main scala
                 |macros - scala.languageFeature.experimental
                 |macroImpl(referenceToMacroImpl: Any): macroImpl

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -474,11 +474,11 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
        |WindowEvent -  java.awt.event
        |""".stripMargin,
     compat = Map(
-      "2.13" -> """|Widget -  example
-                   |Window -  java.awt
-                   |WindowPeer -  java.awt.peer
-                   |WithFilter -  scala.collection
-                   |""".stripMargin
+      ">=2.13.0" -> """|Widget -  example
+                       |Window -  java.awt
+                       |WindowPeer -  java.awt.peer
+                       |WithFilter -  scala.collection
+                       |""".stripMargin
     ),
     includeDetail = true,
     topLines = Some(4)

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -103,7 +103,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|MyType
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(1)
   )
 
   checkSnippet(
@@ -119,7 +120,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|MyType
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(1)
   )
 
   checkSnippet(
@@ -435,16 +437,26 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
         |  Wi@@
         |}
         |""".stripMargin,
-    "Widget -  example",
+    """|Widget -  example
+       |Window -  java.awt
+       |WindowPeer -  java.awt.peer
+       |WindowEvent -  java.awt.event
+       |""".stripMargin,
     compat = Map(
       "3" ->
         """|Widget -  example
            |Widget($0) - (name: String): Widget
            |Widget($0) - (age: Int): Widget
            |Widget($0) - (name: String, age: Int): Widget
-           |""".stripMargin
+           |""".stripMargin,
+      "2.13" -> """|Widget -  example
+                   |Window -  java.awt
+                   |WindowPeer -  java.awt.peer
+                   |WithFilter -  scala.collection
+                   |""".stripMargin
     ),
-    includeDetail = true
+    includeDetail = true,
+    topLines = Some(4)
   )
 
   checkSnippet(
@@ -456,13 +468,20 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
         |  Wi@@
         |}
         |""".stripMargin,
-    "Widget -  example",
+    """|Widget -  example
+       |Window -  java.awt
+       |WindowPeer -  java.awt.peer
+       |WindowEvent -  java.awt.event
+       |""".stripMargin,
     compat = Map(
-      "3" ->
-        """|Widget -  example
-           |""".stripMargin
+      "2.13" -> """|Widget -  example
+                   |Window -  java.awt
+                   |WindowPeer -  java.awt.peer
+                   |WithFilter -  scala.collection
+                   |""".stripMargin
     ),
-    includeDetail = true
+    includeDetail = true,
+    topLines = Some(4)
   )
 
   // https://github.com/scalameta/metals/issues/4004

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -104,7 +104,11 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
       |""".stripMargin,
     """|MyType
        |""".stripMargin,
-    topLines = Some(1)
+    compat = Map(
+      "2.11" -> """|MyType
+                   |MTOM
+                   |MTOMFeature""".stripMargin
+    )
   )
 
   checkSnippet(
@@ -121,7 +125,11 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
       |""".stripMargin,
     """|MyType
        |""".stripMargin,
-    topLines = Some(1)
+    compat = Map(
+      "2.11" -> """|MyType
+                   |MTOM
+                   |MTOMFeature""".stripMargin
+    )
   )
 
   checkSnippet(

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -429,7 +429,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "import-star-multi-import",
+    "import-star-multi-import".tag(IgnoreForScala3CompilerPC),
     """
       |import scala.collection.immutable.List.{range => r, *@@}
       |""".stripMargin,
@@ -1710,7 +1710,8 @@ class CompletionSuite extends BaseCompletionSuite {
     compat = Map(
       "3" -> "TTT[A <: Int]"
     ),
-    includeDetail = false
+    includeDetail = false,
+    topLines = Some(1)
   )
 
   check(
@@ -1723,7 +1724,8 @@ class CompletionSuite extends BaseCompletionSuite {
     "TTT[A] = O.TTT",
     compat = Map(
       "3" -> "TTT[A <: Int] = List[A]"
-    )
+    ),
+    topLines = Some(1)
   )
 
   check(
@@ -1734,7 +1736,8 @@ class CompletionSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "TTT[A <: Int]",
-    includeDetail = false
+    includeDetail = false,
+    topLines = Some(1)
   )
 
   check(
@@ -1745,7 +1748,8 @@ class CompletionSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "TTT[K <: Int]",
-    includeDetail = false
+    includeDetail = false,
+    topLines = Some(1)
   )
 
   check(
@@ -1755,7 +1759,8 @@ class CompletionSuite extends BaseCompletionSuite {
         | val t: TT@@
         |}
         |""".stripMargin,
-    "TTT[K <: Int] = [V] =>> Map[K, V]"
+    "TTT[K <: Int] = [V] =>> Map[K, V]",
+    topLines = Some(1)
   )
 
   check(
@@ -1768,7 +1773,8 @@ class CompletionSuite extends BaseCompletionSuite {
     "TTT<: O.TTT",
     compat = Map(
       "3" -> "TTT <: Int"
-    )
+    ),
+    topLines = Some(1)
   )
 
   check(
@@ -1798,7 +1804,8 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension (x: Fo@@)
        |""".stripMargin,
     """|Foo extension-definition-scope
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(1)
   )
 
   check(
@@ -1822,7 +1829,8 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension [A <: Fo@@]
        |""".stripMargin,
     """|Foo extension-definition-type-parameter
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(1)
   )
 
   check(
@@ -1846,7 +1854,8 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension (using Fo@@)
        |""".stripMargin,
     """|Foo extension-definition-using-param-clause
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(1)
   )
 
   check(
@@ -1858,7 +1867,8 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension (x: Int)(using Fo@@)
        |""".stripMargin,
     """|Foo extension-definition-mix-1
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(1)
   )
 
   check(
@@ -1870,7 +1880,8 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension (using Fo@@)(x: Int)(using Foo)
        |""".stripMargin,
     """|Foo extension-definition-mix-2
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(1)
   )
 
   check(
@@ -1882,7 +1893,8 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension (using Foo)(x: Int)(using Fo@@)
        |""".stripMargin,
     """|Foo extension-definition-mix-3
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(1)
   )
 
   check(
@@ -1894,7 +1906,8 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension [A](x: Fo@@)
        |""".stripMargin,
     """|Foo extension-definition-mix-4
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(1)
   )
 
   check(
@@ -1906,7 +1919,8 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension [A](using Fo@@)(x: Int)
        |""".stripMargin,
     """|Foo extension-definition-mix-5
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(1)
   )
 
   check(
@@ -1918,7 +1932,8 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension [A](using Foo)(x: Fo@@)
        |""".stripMargin,
     """|Foo extension-definition-mix-6
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(1)
   )
 
   check(
@@ -1930,7 +1945,8 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension [A](using Foo)(x: Fo@@)(using Foo)
        |""".stripMargin,
     """|Foo extension-definition-mix-7
-       |""".stripMargin
+       |""".stripMargin,
+    topLines = Some(1)
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1711,8 +1711,7 @@ class CompletionSuite extends BaseCompletionSuite {
     compat = Map(
       "3" -> "TTT[A <: Int]"
     ),
-    includeDetail = false,
-    topLines = Some(1)
+    includeDetail = false
   )
 
   check(
@@ -1725,8 +1724,7 @@ class CompletionSuite extends BaseCompletionSuite {
     "TTT[A] = O.TTT",
     compat = Map(
       "3" -> "TTT[A <: Int] = List[A]"
-    ),
-    topLines = Some(1)
+    )
   )
 
   check(
@@ -1737,8 +1735,7 @@ class CompletionSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "TTT[A <: Int]",
-    includeDetail = false,
-    topLines = Some(1)
+    includeDetail = false
   )
 
   check(
@@ -1749,8 +1746,7 @@ class CompletionSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     "TTT[K <: Int]",
-    includeDetail = false,
-    topLines = Some(1)
+    includeDetail = false
   )
 
   check(
@@ -1760,8 +1756,7 @@ class CompletionSuite extends BaseCompletionSuite {
         | val t: TT@@
         |}
         |""".stripMargin,
-    "TTT[K <: Int] = [V] =>> Map[K, V]",
-    topLines = Some(1)
+    "TTT[K <: Int] = [V] =>> Map[K, V]"
   )
 
   check(
@@ -1774,8 +1769,7 @@ class CompletionSuite extends BaseCompletionSuite {
     "TTT<: O.TTT",
     compat = Map(
       "3" -> "TTT <: Int"
-    ),
-    topLines = Some(1)
+    )
   )
 
   check(
@@ -1805,8 +1799,17 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension (x: Fo@@)
        |""".stripMargin,
     """|Foo extension-definition-scope
-       |""".stripMargin,
-    topLines = Some(1)
+       |Font - java.awt
+       |Form - java.text.Normalizer
+       |Format - java.text
+       |FontPeer - java.awt.peer
+       |FormView - javax.swing.text.html
+       |Formatter - java.util
+       |Formatter - java.util.logging
+       |FocusEvent - java.awt.event
+       |FontMetrics - java.awt
+       |Found - scala.collection.Searching
+       |""".stripMargin
   )
 
   check(
@@ -1830,8 +1833,17 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension [A <: Fo@@]
        |""".stripMargin,
     """|Foo extension-definition-type-parameter
-       |""".stripMargin,
-    topLines = Some(1)
+       |Font - java.awt
+       |Form - java.text.Normalizer
+       |Format - java.text
+       |FontPeer - java.awt.peer
+       |FormView - javax.swing.text.html
+       |Formatter - java.util
+       |Formatter - java.util.logging
+       |FocusEvent - java.awt.event
+       |FontMetrics - java.awt
+       |Found - scala.collection.Searching
+       |""".stripMargin
   )
 
   check(
@@ -1855,8 +1867,17 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension (using Fo@@)
        |""".stripMargin,
     """|Foo extension-definition-using-param-clause
-       |""".stripMargin,
-    topLines = Some(1)
+       |Font - java.awt
+       |Form - java.text.Normalizer
+       |Format - java.text
+       |FontPeer - java.awt.peer
+       |FormView - javax.swing.text.html
+       |Formatter - java.util
+       |Formatter - java.util.logging
+       |FocusEvent - java.awt.event
+       |FontMetrics - java.awt
+       |Found - scala.collection.Searching
+       |""".stripMargin
   )
 
   check(
@@ -1868,8 +1889,17 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension (x: Int)(using Fo@@)
        |""".stripMargin,
     """|Foo extension-definition-mix-1
-       |""".stripMargin,
-    topLines = Some(1)
+       |Font - java.awt
+       |Form - java.text.Normalizer
+       |Format - java.text
+       |FontPeer - java.awt.peer
+       |FormView - javax.swing.text.html
+       |Formatter - java.util
+       |Formatter - java.util.logging
+       |FocusEvent - java.awt.event
+       |FontMetrics - java.awt
+       |Found - scala.collection.Searching
+       |""".stripMargin
   )
 
   check(
@@ -1881,8 +1911,17 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension (using Fo@@)(x: Int)(using Foo)
        |""".stripMargin,
     """|Foo extension-definition-mix-2
-       |""".stripMargin,
-    topLines = Some(1)
+       |Font - java.awt
+       |Form - java.text.Normalizer
+       |Format - java.text
+       |FontPeer - java.awt.peer
+       |FormView - javax.swing.text.html
+       |Formatter - java.util
+       |Formatter - java.util.logging
+       |FocusEvent - java.awt.event
+       |FontMetrics - java.awt
+       |Found - scala.collection.Searching
+       |""".stripMargin
   )
 
   check(
@@ -1894,8 +1933,17 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension (using Foo)(x: Int)(using Fo@@)
        |""".stripMargin,
     """|Foo extension-definition-mix-3
-       |""".stripMargin,
-    topLines = Some(1)
+       |Font - java.awt
+       |Form - java.text.Normalizer
+       |Format - java.text
+       |FontPeer - java.awt.peer
+       |FormView - javax.swing.text.html
+       |Formatter - java.util
+       |Formatter - java.util.logging
+       |FocusEvent - java.awt.event
+       |FontMetrics - java.awt
+       |Found - scala.collection.Searching
+       |""".stripMargin
   )
 
   check(
@@ -1907,8 +1955,17 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension [A](x: Fo@@)
        |""".stripMargin,
     """|Foo extension-definition-mix-4
-       |""".stripMargin,
-    topLines = Some(1)
+       |Font - java.awt
+       |Form - java.text.Normalizer
+       |Format - java.text
+       |FontPeer - java.awt.peer
+       |FormView - javax.swing.text.html
+       |Formatter - java.util
+       |Formatter - java.util.logging
+       |FocusEvent - java.awt.event
+       |FontMetrics - java.awt
+       |Found - scala.collection.Searching
+       |""".stripMargin
   )
 
   check(
@@ -1920,8 +1977,17 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension [A](using Fo@@)(x: Int)
        |""".stripMargin,
     """|Foo extension-definition-mix-5
-       |""".stripMargin,
-    topLines = Some(1)
+       |Font - java.awt
+       |Form - java.text.Normalizer
+       |Format - java.text
+       |FontPeer - java.awt.peer
+       |FormView - javax.swing.text.html
+       |Formatter - java.util
+       |Formatter - java.util.logging
+       |FocusEvent - java.awt.event
+       |FontMetrics - java.awt
+       |Found - scala.collection.Searching
+       |""".stripMargin
   )
 
   check(
@@ -1933,8 +1999,17 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension [A](using Foo)(x: Fo@@)
        |""".stripMargin,
     """|Foo extension-definition-mix-6
-       |""".stripMargin,
-    topLines = Some(1)
+       |Font - java.awt
+       |Form - java.text.Normalizer
+       |Format - java.text
+       |FontPeer - java.awt.peer
+       |FormView - javax.swing.text.html
+       |Formatter - java.util
+       |Formatter - java.util.logging
+       |FocusEvent - java.awt.event
+       |FontMetrics - java.awt
+       |Found - scala.collection.Searching
+       |""".stripMargin
   )
 
   check(
@@ -1946,8 +2021,17 @@ class CompletionSuite extends BaseCompletionSuite {
        |  extension [A](using Foo)(x: Fo@@)(using Foo)
        |""".stripMargin,
     """|Foo extension-definition-mix-7
-       |""".stripMargin,
-    topLines = Some(1)
+       |Font - java.awt
+       |Form - java.text.Normalizer
+       |Format - java.text
+       |FontPeer - java.awt.peer
+       |FormView - javax.swing.text.html
+       |Formatter - java.util
+       |Formatter - java.util.logging
+       |FocusEvent - java.awt.event
+       |FontMetrics - java.awt
+       |Found - scala.collection.Searching
+       |""".stripMargin
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -437,6 +437,7 @@ class CompletionSuite extends BaseCompletionSuite {
     compat = Map(
       "3" ->
         """|*
+           |*: scala
            |""".stripMargin
     )
   )

--- a/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
+++ b/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
@@ -81,7 +81,7 @@ class TestingSymbolSearch(
   ): SymbolSearch.Result = {
     val query = WorkspaceSymbolQuery.exact(textQuery)
     workspace.search(query, visitor)
-    classpath.search(query, visitor)
+    classpath.search(query, visitor)._1
   }
 
   override def searchMethods(

--- a/tests/slow/src/test/scala/tests/feature/ClasspathSymbolRegressionSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/ClasspathSymbolRegressionSuite.scala
@@ -183,7 +183,18 @@ abstract class ClasspathSymbolRegressionSuite extends BaseWorkspaceSymbolSuite {
   check(
     "IO",
     """|akka.io.IO Object
+       |akka.stream.AbruptIOTerminationException Class
+       |akka.stream.IOResult Class
+       |akka.stream.IOResult Object
        |com.typesafe.config.ConfigException#IO Class
+       |java.io.IOError Class
+       |net.razorvine.pyro.IOUtil Class
+       |org.apache.commons.compress.utils.IOUtils Class
+       |org.apache.commons.io.IOCase Class
+       |org.apache.commons.io.IOUtils Class
+       |org.apache.hadoop.io.IOUtils Class
+       |org.apache.spark.network.util.IOMode Class
+       |org.apache.zookeeper.common.IOUtils Class
        |org.eclipse.jetty.util.IO Class
        |org.mortbay.util.IO Class
        |""".stripMargin,

--- a/tests/slow/src/test/scala/tests/feature/ClasspathSymbolRegressionSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/ClasspathSymbolRegressionSuite.scala
@@ -183,7 +183,6 @@ abstract class ClasspathSymbolRegressionSuite extends BaseWorkspaceSymbolSuite {
   check(
     "IO",
     """|akka.io.IO Object
-       |akka.stream.AbruptIOTerminationException Class
        |akka.stream.IOResult Class
        |akka.stream.IOResult Object
        |com.typesafe.config.ConfigException#IO Class

--- a/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
@@ -382,7 +382,7 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
   }
 
   test("scope") {
-      cleanWorkspace()
+    cleanWorkspace()
     for {
       _ <- initialize(
         """/metals.json

--- a/tests/unit/src/test/scala/tests/FuzzySuite.scala
+++ b/tests/unit/src/test/scala/tests/FuzzySuite.scala
@@ -139,8 +139,4 @@ class FuzzySuite extends BaseSuite {
     // reasonable despite pathological input.
     assert(bloom.bloom.expectedFpp() < 0.02)
   }
-
-  test("shortClassName") {
-    assert(!Fuzzy.isExactMatch("AA", "A.class"))
-  }
 }

--- a/tests/unit/src/test/scala/tests/FuzzySuite.scala
+++ b/tests/unit/src/test/scala/tests/FuzzySuite.scala
@@ -31,7 +31,7 @@ class FuzzySuite extends BaseSuite {
 
   checkOK("::", "scala/collection/immutable/`::`#")
   checkOK("IO", "scala/IO#")
-  checkOK("IS", "scala/InputOutputStream#")
+  checkOK("ISt", "scala/InputOutputStream#")
   checkNO("Mon", "ModuleKindJS")
   checkNO("Min", "MavenPluginIntegration")
   checkOK("DoSymPro", "DocumentSymbolProvider")


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/5619

Previously: for query shorter than 3, we'd only show exact matches in completions (for classpath/workspace symbols), now we show all that have the correct prefix. Not exact matches from classpath are capped at 10, additionally we cap workspace symbols for those short queries at 100. If no prefix matches are found, we retry allowing for full fuzzy match.

Also fixes sorting in Scala 3, so keyword completions are offered before workspace/classpath ones.