### PR TITLE
bugfix: Use buildServerName instead of executableName in BSP

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
@@ -35,7 +35,7 @@ final class BspConfigGenerator(
   ): Future[BspConfigGenerationStatus] =
     shellRunner
       .run(
-        s"${buildTool.getBuildServerName} bspConfig",
+        s"${buildTool.buildServerName} bspConfig",
         args,
         buildTool.projectRoot,
         buildTool.redirectErrorOutput,
@@ -92,7 +92,7 @@ final class BspConfigGenerator(
       .asScala
       .map { choice =>
         buildTools.find(buildTool =>
-          new MessageActionItem(buildTool.getBuildServerName) == choice
+          new MessageActionItem(buildTool.buildServerName) == choice
         )
       }
   }

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -212,10 +212,7 @@ class BspConnector(
     buildTools.loadSupported
       .find {
         case _: ScalaCliBuildTool if ScalaCli.names(buildServerName) => true
-        case buildTool: BuildServerProvider
-            if buildTool.buildServerName.contains(buildServerName) =>
-          true
-        case buildTool => buildTool.executableName == buildServerName
+        case buildTool => buildTool.buildServerName == buildServerName
       }
       .foreach(buildTool =>
         tables.buildTool.chooseBuildTool(buildTool.executableName)
@@ -289,9 +286,9 @@ class BspConnector(
         case buildTool: BuildServerProvider
             if !foundServers
               .exists(details =>
-                details.getName() == buildTool.getBuildServerName
+                details.getName() == buildTool.buildServerName
               ) =>
-          buildTool.getBuildServerName -> Left(buildTool)
+          buildTool.buildServerName -> Left(buildTool)
       }
       .toMap
 
@@ -329,14 +326,14 @@ class BspConnector(
         status: BspConfigGenerationStatus,
     ): Boolean = status match {
       case BspConfigGenerationStatus.Generated =>
-        tables.buildServers.chooseServer(buildTool.getBuildServerName)
+        tables.buildServers.chooseServer(buildTool.buildServerName)
         true
       case Cancelled => false
       case Failed(exit) =>
         exit match {
           case Left(exitCode) =>
             scribe.error(
-              s"Creation of .bsp/${buildTool.getBuildServerName} failed with exit code: $exitCode"
+              s"Creation of .bsp/${buildTool.buildServerName} failed with exit code: $exitCode"
             )
             client.showMessage(
               Messages.BspProvider.genericUnableToCreateConfig

--- a/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
@@ -67,7 +67,7 @@ final class BloopInstall(
   }
 
   private def runArgumentsUnconditionally(
-      buildTool: BuildTool,
+      buildTool: BloopInstallProvider,
       args: List[String],
       javaHome: Option[String],
   ): Future[WorkspaceLoadedStatus] = {
@@ -155,7 +155,7 @@ final class BloopInstall(
 
   private def persistChecksumStatus(
       status: Status,
-      buildTool: BuildTool,
+      buildTool: BloopInstallProvider,
   ): Unit = {
     buildTool.digest(workspace).foreach { checksum =>
       tables.digests.setStatus(checksum, status)
@@ -164,7 +164,7 @@ final class BloopInstall(
 
   private def requestImport(
       buildTools: BuildTools,
-      buildTool: BuildTool,
+      buildTool: BloopInstallProvider,
       languageClient: MetalsLanguageClient,
       digest: String,
   )(implicit ec: ExecutionContext): Future[Confirmation] = {

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildServerProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildServerProvider.scala
@@ -34,13 +34,4 @@ trait BuildServerProvider extends BuildTool {
    */
   protected def createBspFileArgs(workspace: AbsolutePath): Option[List[String]]
 
-  /**
-   * Name of the build server if different than the actual build-tool that is
-   * serving as a build server.
-   *
-   * Ex. mill isn't mill, but rather mill-bsp
-   */
-  def buildServerName: Option[String] = None
-
-  def getBuildServerName: String = buildServerName.getOrElse(executableName)
 }

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
@@ -26,6 +26,14 @@ trait BuildTool {
 
   val isBloopInstallProvider = false
 
+  /**
+   * Name of the build server if different than the actual build-tool that is
+   * serving as a build server.
+   *
+   * Ex. mill isn't mill, but rather mill-bsp
+   */
+  def buildServerName = executableName
+
 }
 
 object BuildTool {

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -157,7 +157,7 @@ case class MillBuildTool(
     }
   }
 
-  override val buildServerName: Option[String] = Some(MillBuildTool.bspName)
+  override def buildServerName: String = MillBuildTool.bspName
 }
 
 object MillBuildTool {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -917,8 +917,8 @@ class MetalsLspService(
       chosenBuildServer = found match {
         case Some(BuildTool.Found(buildServer, _))
             if buildServer.forcesBuildServer =>
-          tables.buildServers.chooseServer(buildServer.executableName)
-          Some(buildServer.executableName)
+          tables.buildServers.chooseServer(buildServer.buildServerName)
+          Some(buildServer.buildServerName)
         case _ => tables.buildServers.selectedServer()
       }
       _ <- Future
@@ -1977,7 +1977,7 @@ class MetalsLspService(
     ): Unit =
       status match {
         case Generated =>
-          tables.buildServers.chooseServer(buildTool.getBuildServerName)
+          tables.buildServers.chooseServer(buildTool.buildServerName)
           quickConnectToBuildServer().ignoreValue
         case Cancelled => ()
         case Failed(exit) =>
@@ -2114,7 +2114,7 @@ class MetalsLspService(
         slowConnectToBloopServer(forceImport, buildTool, digest)
       case Some(BuildTool.Found(buildTool: ScalaCliBuildTool, _))
           if !buildTool.isBspGenerated(folder) =>
-        tables.buildServers.chooseServer(buildTool.executableName)
+        tables.buildServers.chooseServer(buildTool.buildServerName)
         buildTool
           .generateBspConfig(
             folder,
@@ -2124,9 +2124,9 @@ class MetalsLspService(
           .flatMap(_ => quickConnectToBuildServer())
       case Some(BuildTool.Found(buildTool, _))
           if !chosenBuildServer.exists(
-            _ == buildTool.executableName
+            _ == buildTool.buildServerName
           ) && buildTool.forcesBuildServer =>
-        tables.buildServers.chooseServer(buildTool.executableName)
+        tables.buildServers.chooseServer(buildTool.buildServerName)
         quickConnectToBuildServer()
       case Some(found) =>
         indexer.reloadWorkspaceAndIndex(


### PR DESCRIPTION
It was causing issues in case of mill, where bsp name differs