### PR TITLE
bugfix: Fix java support for different files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaInteractiveSemanticdb.scala
@@ -72,7 +72,7 @@ class JavaInteractiveSemanticdb(
       // so can't use Metals SourceJavaFileObject
       val javaFileObject = JavaMetalsGlobal.makeFileObject(localSource.toFile)
 
-      val javacTask = JavaMetalsGlobal.compilationTask(
+      val javacTask = JavaMetalsGlobal.classpathCompilationTask(
         javaFileObject,
         Some(printWriter),
         allOptions,

--- a/metals/src/main/scala/scala/meta/internal/parsing/JavaFoldingRangeExtractor.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/JavaFoldingRangeExtractor.scala
@@ -122,7 +122,7 @@ final object JavaFoldingRangeExtractor {
       text: String,
       path: AbsolutePath,
   ): Option[(Trees, CompilationUnitTree)] = {
-    val javacTask = JavaMetalsGlobal.compilationTask(text, path.toURI)
+    val javacTask = JavaMetalsGlobal.baseCompilationTask(text, path.toURI)
     val elems = javacTask.parse()
     javacTask.analyze()
     val trees = Trees.instance(javacTask)

--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaCompletionProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaCompletionProvider.scala
@@ -46,7 +46,7 @@ class JavaCompletionProvider(
           params.text().substring(params.offset())
       else params.text()
     val task: JavacTask =
-      JavaMetalsGlobal.compilationTask(textWithSemicolon, params.uri())
+      compiler.compilationTask(textWithSemicolon, params.uri())
     val scanner = JavaMetalsGlobal.scanner(task)
     val position =
       CursorPosition(params.offset(), params.offset(), params.offset())

--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaHoverProvider.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaHoverProvider.scala
@@ -50,7 +50,7 @@ class JavaHoverProvider(
 
   def hoverOffset(params: OffsetParams): Option[HoverSignature] = {
     val task: JavacTask =
-      JavaMetalsGlobal.compilationTask(params.text(), params.uri())
+      compiler.compilationTask(params.text(), params.uri())
     val scanner = JavaMetalsGlobal.scanner(task)
     val types = task.getTypes()
     val elements = task.getElements()

--- a/mtags-java/src/main/scala/scala/meta/internal/pc/JavaPresentationCompiler.scala
+++ b/mtags-java/src/main/scala/scala/meta/internal/pc/JavaPresentationCompiler.scala
@@ -9,7 +9,6 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
 
-import scala.collection.Seq
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
 import scala.jdk.CollectionConverters._
@@ -46,7 +45,7 @@ case class JavaPresentationCompiler(
     workspace: Option[Path] = None
 ) extends PresentationCompiler {
 
-  private val javaCompiler = new JavaMetalsGlobal(search, config)
+  private val javaCompiler = new JavaMetalsGlobal(search, config, classpath)
 
   override def complete(
       params: OffsetParams
@@ -186,7 +185,7 @@ case class JavaPresentationCompiler(
   ): PresentationCompiler =
     copy(
       buildTargetIdentifier = buildTargetIdentifier,
-      classpath = classpath.asScala,
+      classpath = classpath.asScala.toSeq,
       options = options.asScala.toList
     )
 

--- a/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
@@ -43,7 +43,7 @@ class CompletionCrossLspSuite
         "extends Serializable@@",
         """|DefaultSerializable - scala.collection.generic
            |NotSerializableException - java.io
-           |Serializable a
+           |Serializable  a
            |Serializable - java.io
            |SerializablePermission - java.io
            |""".stripMargin,

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1106,7 +1106,7 @@ final case class TestingServer(
         val shouldIncludeDetail = item.getDetail != null && includeDetail
         val detail =
           if (shouldIncludeDetail && !label.contains(item.getDetail))
-            item.getDetail
+            " " + item.getDetail
           else ""
         label + detail
       }

--- a/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
@@ -343,4 +343,41 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
       )
     } yield ()
   }
+
+  test("java") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """/metals.json
+          |{
+          |  "a": {}
+          |}
+          |/a/src/main/java/a/A.java
+          |package a;
+          |
+          |public class A {
+          |  String name = "";
+          |}
+          |/a/src/main/java/a/B.java
+          |package a;
+          |
+          |public class B {
+          |  A a = new A();
+          |  public void main(){
+          |    // @@
+          |  }
+          |}
+          |""".stripMargin
+      )
+      _ <- server.didSave("a/src/main/java/a/B.java")(identity)
+      _ <- assertCompletion(
+        "a.n@@",
+        """|name java.lang.String
+           |notify() void
+           |notifyAll() void
+           |""".stripMargin,
+        filename = Some("a/src/main/java/a/B.java"),
+      )
+    } yield ()
+  }
 }


### PR DESCRIPTION
Previously, we wouldn't include the classpath, so completions/hover would only work locally.

Now, we add the compiled classpath, so things should work as expected.

Fixes https://github.com/scalameta/metals/issues/5829