### PR TITLE
bugfix: Wrong span in extension methods in context functions

### DIFF
--- a/tests/cross/src/test/scala/tests/highlight/Scala3DocumentHighlightSuite.scala
+++ b/tests/cross/src/test/scala/tests/highlight/Scala3DocumentHighlightSuite.scala
@@ -385,4 +385,109 @@ class Scala3DocumentHighlightSuite extends BaseDocumentHighlightSuite {
        |""".stripMargin
   )
 
+  check(
+    "i5977",
+    """
+      |sealed trait ExtensionProvider {
+      |  extension [A] (self: A) {
+      |    def typeArg[B <: A]: B
+      |    def <<inferredTypeArg>>[C](value: C): C
+      |  }
+      |}
+      |
+      |object Repro {
+      |  def usage[A](f: ExtensionProvider ?=> A => Any): Any = ???
+      |
+      |  usage[Int](_.<<infe@@rredTypeArg>>("str"))
+      |  usage[Int](_.<<inferredTypeArg>>[String]("str"))
+      |  usage[Option[Int]](_.typeArg[Some[Int]].value.<<inferredTypeArg>>("str"))
+      |  usage[Option[Int]](_.typeArg[Some[Int]].value.<<inferredTypeArg>>[String]("str"))
+      |}
+      |""".stripMargin
+  )
+
+  check(
+    "i5977-1",
+    """
+      |sealed trait ExtensionProvider {
+      |  extension [A] (self: A) {
+      |    def typeArg[B <: A]: B
+      |    def <<inferredTypeArg>>[C](value: C): C
+      |  }
+      |}
+      |
+      |object Repro {
+      |  def usage[A](f: ExtensionProvider ?=> A => Any): Any = ???
+      |
+      |  usage[Int](_.<<inferredTypeArg>>("str"))
+      |  usage[Int](_.<<infe@@rredTypeArg>>[String]("str"))
+      |  usage[Option[Int]](_.typeArg[Some[Int]].value.<<inferredTypeArg>>("str"))
+      |  usage[Option[Int]](_.typeArg[Some[Int]].value.<<inferredTypeArg>>[String]("str"))
+      |}
+      |""".stripMargin
+  )
+
+  check(
+    "i5977-2",
+    """
+      |sealed trait ExtensionProvider {
+      |  extension [A] (self: A) {
+      |    def typeArg[B <: A]: B
+      |    def <<inferredTypeArg>>[C](value: C): C
+      |  }
+      |}
+      |
+      |object Repro {
+      |  def usage[A](f: ExtensionProvider ?=> A => Any): Any = ???
+      |
+      |  usage[Int](_.<<inferredTypeArg>>("str"))
+      |  usage[Int](_.<<inferredTypeArg>>[String]("str"))
+      |  usage[Option[Int]](_.typeArg[Some[Int]].value.<<inferr@@edTypeArg>>("str"))
+      |  usage[Option[Int]](_.typeArg[Some[Int]].value.<<inferredTypeArg>>[String]("str"))
+      |}
+      |""".stripMargin
+  )
+
+  check(
+    "i5977-3",
+    """
+      |sealed trait ExtensionProvider {
+      |  extension [A] (self: A) {
+      |    def typeArg[B <: A]: B
+      |    def <<inferredTypeArg>>[C](value: C): C
+      |  }
+      |}
+      |
+      |object Repro {
+      |  def usage[A](f: ExtensionProvider ?=> A => Any): Any = ???
+      |
+      |  usage[Int](_.<<inferredTypeArg>>("str"))
+      |  usage[Int](_.<<inferredTypeArg>>[String]("str"))
+      |  usage[Option[Int]](_.typeArg[Some[Int]].value.<<inferredTypeArg>>("str"))
+      |  usage[Option[Int]](_.typeArg[Some[Int]].value.<<inferred@@TypeArg>>[String]("str"))
+      |}
+      |""".stripMargin
+  )
+
+  check(
+    "i5977-4",
+    """
+      |sealed trait ExtensionProvider {
+      |  extension [A] (self: A) {
+      |    def typeArg[B <: A]: B
+      |    def <<inferre@@dTypeArg>>[C](value: C): C
+      |  }
+      |}
+      |
+      |object Repro {
+      |  def usage[A](f: ExtensionProvider ?=> A => Any): Any = ???
+      |
+      |  usage[Int](_.<<inferredTypeArg>>("str"))
+      |  usage[Int](_.<<inferredTypeArg>>[String]("str"))
+      |  usage[Option[Int]](_.typeArg[Some[Int]].value.<<inferredTypeArg>>("str"))
+      |  usage[Option[Int]](_.typeArg[Some[Int]].value.<<inferredTypeArg>>[String]("str"))
+      |}
+      |""".stripMargin
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -390,4 +390,160 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |""".stripMargin,
     "extension [K](vmap: Logarithm) def multiply(k: Logarithm): Logarithm".hover
   )
+
+  check(
+    "i5976",
+    """|sealed trait ExtensionProvider {
+       |  extension [A] (self: A) {
+       |    def typeArg[B <: A]: B
+       |    def noTypeArg: A
+       |  }
+       |}
+       |
+       |object Repro {
+       |  def usage[A](f: ExtensionProvider ?=> A => Any): Any = ???
+       |
+       |  usage[Option[Int]](_.typeArg[Some[Int]].value.noTyp@@eArg.typeArg[Int])
+       |}
+       |""".stripMargin,
+    """|**Expression type**:
+       |```scala
+       |Int
+       |```
+       |**Symbol signature**:
+       |```scala
+       |extension [A](self: A) def noTypeArg: A
+       |```
+       |""".stripMargin
+  )
+
+  check(
+    "i5976-1",
+    """|sealed trait ExtensionProvider {
+       |  extension [A] (self: A) {
+       |    def typeArg[B <: A]: B
+       |    def noTypeArg: A
+       |  }
+       |}
+       |
+       |object Repro {
+       |  def usage[A](f: ExtensionProvider ?=> A => Any): Any = ???
+       |
+       |  usage[Option[Int]](_.type@@Arg[Some[Int]].value.noTypeArg.typeArg[Int])
+       |}
+       |""".stripMargin,
+    """|**Expression type**:
+       |```scala
+       |Some[Int]
+       |```
+       |**Symbol signature**:
+       |```scala
+       |extension [A](self: A) def typeArg[B <: A]: B
+       |```
+       |""".stripMargin
+  )
+
+  check(
+    "i5977",
+    """|sealed trait ExtensionProvider {
+       |  extension [A] (self: A) {
+       |    def typeArg[B <: A]: B
+       |    def inferredTypeArg[C](value: C): C
+       |  }
+       |}
+       |
+       |object Repro {
+       |  def usage[A](f: ExtensionProvider ?=> A => Any): Any = ???
+       |  
+       |  usage[Option[Int]](_.infer@@redTypeArg("str"))
+       |}
+       |""".stripMargin,
+    """|**Expression type**:
+       |```scala
+       |String
+       |```
+       |**Symbol signature**:
+       |```scala
+       |extension [A](self: A) def inferredTypeArg[C](value: C): C
+       |```
+       |""".stripMargin
+  )
+
+  check(
+    "i5977-1",
+    """|sealed trait ExtensionProvider {
+       |  extension [A] (self: A) {
+       |    def typeArg[B <: A]: B
+       |    def inferredTypeArg[C](value: C): C
+       |  }
+       |}
+       |
+       |object Repro {
+       |  def usage[A](f: ExtensionProvider ?=> A => Any): Any = ???
+       |  
+       |  usage[Option[Int]](_.infer@@redTypeArg[String]("str"))
+       |}
+       |""".stripMargin,
+    """|**Expression type**:
+       |```scala
+       |String
+       |```
+       |**Symbol signature**:
+       |```scala
+       |extension [A](self: A) def inferredTypeArg[C](value: C): C
+       |```
+       |""".stripMargin
+  )
+
+  check(
+    "i5977-2",
+    """|sealed trait ExtensionProvider {
+       |  extension [A] (self: A) {
+       |    def typeArg[B <: A]: B
+       |    def inferredTypeArg[C](value: C): C
+       |  }
+       |}
+       |
+       |object Repro {
+       |  def usage[A](f: ExtensionProvider ?=> A => Any): Any = ???
+       |  
+       |  usage[Option[Int]](_.typeArg[Some[Int]].value.infer@@redTypeArg("str"))
+       |}
+       |""".stripMargin,
+    """|**Expression type**:
+       |```scala
+       |String
+       |```
+       |**Symbol signature**:
+       |```scala
+       |extension [A](self: A) def inferredTypeArg[C](value: C): C
+       |```
+       |""".stripMargin
+  )
+
+  check(
+    "i5977-3",
+    """|sealed trait ExtensionProvider {
+       |  extension [A] (self: A) {
+       |    def typeArg[B <: A]: B
+       |    def inferredTypeArg[C](value: C): C
+       |  }
+       |}
+       |
+       |object Repro {
+       |  def usage[A](f: ExtensionProvider ?=> A => Any): Any = ???
+       |  
+       |  usage[Option[Int]](_.typeArg[Some[Int]].value.infer@@redTypeArg[String]("str"))
+       |}
+       |""".stripMargin,
+    """|**Expression type**:
+       |```scala
+       |String
+       |```
+       |**Symbol signature**:
+       |```scala
+       |extension [A](self: A) def inferredTypeArg[C](value: C): C
+       |```
+       |""".stripMargin
+  )
 }

--- a/tests/cross/src/test/scala/tests/tokens/SemanticTokensScala3Suite.scala
+++ b/tests/cross/src/test/scala/tests/tokens/SemanticTokensScala3Suite.scala
@@ -161,4 +161,24 @@ class SemanticTokensScala3Suite extends BaseSemanticTokensSuite {
       |}""".stripMargin
   )
 
+  check(
+    "i5977",
+    """
+      |sealed trait <<ExtensionProvider>>/*interface,abstract*/ {
+      |  extension [<<A>>/*typeParameter,definition,abstract*/] (<<self>>/*parameter,declaration,readonly*/: <<A>>/*typeParameter,abstract*/) {
+      |    def <<typeArg>>/*method,declaration*/[<<B>>/*typeParameter,definition,abstract*/]: <<B>>/*typeParameter,abstract*/
+      |    def <<inferredTypeArg>>/*method,declaration*/[<<C>>/*typeParameter,definition,abstract*/](<<value>>/*parameter,declaration,readonly*/: <<C>>/*typeParameter,abstract*/): <<C>>/*typeParameter,abstract*/
+      |}
+      |
+      |object <<Repro>>/*class*/ {
+      |  def <<usage>>/*method,definition*/[<<A>>/*typeParameter,definition,abstract*/](<<f>>/*parameter,declaration,readonly*/: <<ExtensionProvider>>/*interface,abstract*/ ?=> <<A>>/*typeParameter,abstract*/ => <<Any>>/*class,abstract*/): <<Any>>/*class,abstract*/ = <<???>>/*method*/
+      |
+      |  <<usage>>/*method*/[<<Int>>/*class,abstract*/](<<_>>/*parameter,readonly*/.<<inferredTypeArg>>/*method*/("str"))
+      |  <<usage>>/*method*/[<<Int>>/*class,abstract*/](<<_>>/*parameter,readonly*/.<<inferredTypeArg>>/*method*/[<<String>>/*type*/]("str"))
+      |  <<usage>>/*method*/[<<Option>>/*class,abstract*/[<<Int>>/*class,abstract*/]](<<_>>/*parameter,readonly*/.<<typeArg>>/*method*/[<<Some>>/*class*/[<<Int>>/*class,abstract*/]].<<value>>/*variable,readonly*/.<<inferredTypeArg>>/*method*/("str"))
+      |  <<usage>>/*method*/[<<Option>>/*class,abstract*/[<<Int>>/*class,abstract*/]](<<_>>/*parameter,readonly*/.<<typeArg>>/*method*/[<<Some>>/*class*/[<<Int>>/*class,abstract*/]].<<value>>/*variable,readonly*/.<<inferredTypeArg>>/*method*/[<<String>>/*type*/]("str"))
+      |}
+      |""".stripMargin
+  )
+
 }


### PR DESCRIPTION
closes https://github.com/scalameta/metals/issues/5977
closes https://github.com/scalameta/metals/issues/5976