### PR TITLE
chore: Add more information about classpath and compiler options when severe error happens

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/CompilerAccess.scala
@@ -28,8 +28,18 @@ abstract class CompilerAccess[Reporter, Compiler](
     config: PresentationCompilerConfig,
     sh: Option[ScheduledExecutorService],
     newCompiler: () => CompilerWrapper[Reporter, Compiler],
-    shouldResetJobQueue: Boolean
+    shouldResetJobQueue: Boolean,
+    additionalReportingData: () => String
 )(implicit ec: ExecutionContextExecutor, rc: ReportContext) {
+
+  def this(
+      config: PresentationCompilerConfig,
+      sh: Option[ScheduledExecutorService],
+      newCompiler: () => CompilerWrapper[Reporter, Compiler],
+      shouldResetJobQueue: Boolean
+  )(implicit ec: ExecutionContextExecutor, rc: ReportContext) =
+    this(config, sh, newCompiler, shouldResetJobQueue, () => "")
+
   private val logger: Logger =
     Logger.getLogger(classOf[CompilerAccess[_, _]].getName)
 
@@ -198,6 +208,9 @@ abstract class CompilerAccess[Reporter, Compiler](
       Report(
         "compiler-error",
         s"""|occurred in the presentation compiler.
+            |
+            |presentation compiler configuration:
+            |${additionalReportingData()}
             |
             |action parameters:
             |${params.map(_.printed()).getOrElse("<NONE>")}

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaCompilerAccess.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaCompilerAccess.scala
@@ -43,13 +43,15 @@ class ScalaCompilerWrapper(global: MetalsGlobal)
 class ScalaCompilerAccess(
     config: PresentationCompilerConfig,
     sh: Option[ScheduledExecutorService],
-    newCompiler: () => ScalaCompilerWrapper
+    newCompiler: () => ScalaCompilerWrapper,
+    additionalReportingData: () => String
 )(implicit ec: ExecutionContextExecutor, rc: ReportContext)
     extends CompilerAccess[StoreReporter, MetalsGlobal](
       config,
       sh,
       newCompiler,
-      shouldResetJobQueue = false
+      shouldResetJobQueue = false,
+      additionalReportingData
     ) {
 
   def newReporter = new StoreReporter

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -110,7 +110,17 @@ case class ScalaPresentationCompiler(
     new ScalaCompilerAccess(
       config,
       sh,
-      () => new ScalaCompilerWrapper(newCompiler())
+      () => new ScalaCompilerWrapper(newCompiler()),
+      { () =>
+        s"""|Scala version: $scalaVersion
+            |Classpath:
+            |${classpath
+             .map(path => s"$path [${if (path.exists) "exists" else "missing"} ]")
+             .mkString(", ")}
+            |Options:
+            |${options.mkString(" ")}
+            |""".stripMargin
+      }
     )(
       ec,
       reportContex

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
@@ -13,6 +13,7 @@ class Scala3CompilerAccess(
     config: PresentationCompilerConfig,
     sh: Option[ScheduledExecutorService],
     newCompiler: () => Scala3CompilerWrapper,
+    additionalReportingData: () => String,
 )(using ec: ExecutionContextExecutor, rc: ReportContext)
     extends CompilerAccess[StoreReporter, MetalsDriver](
       config,
@@ -22,6 +23,7 @@ class Scala3CompilerAccess(
        * Otherwise it will block indefinetely in case of infinite loops.
        */
       shouldResetJobQueue = true,
+      additionalReportingData,
     ):
 
   def newReporter = new StoreReporter(null)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -20,6 +20,7 @@ import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.metals.ReportLevel
 import scala.meta.internal.metals.StdReportContext
 import scala.meta.internal.mtags.BuildInfo
+import scala.meta.internal.mtags.MtagsEnrichments.given
 import scala.meta.internal.pc.completions.CompletionProvider
 import scala.meta.internal.pc.completions.OverrideCompletions
 import scala.meta.pc.*
@@ -64,6 +65,15 @@ case class ScalaPresentationCompiler(
       config,
       sh,
       () => new Scala3CompilerWrapper(newDriver),
+      () =>
+        s"""|Scala version: $scalaVersion
+            |Classpath:
+            |${classpath
+             .map(path => s"$path [${if path.exists then "exists" else "missing"} ]")
+             .mkString(", ")}
+            |Options:
+            |${options.mkString(" ")}
+            |""".stripMargin,
     )(using
       ec
     )


### PR DESCRIPTION
Related to https://github.com/scalameta/metals/issues/5272