### PR TITLE
bugfix: Don't show default argument values if type is Any

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -120,7 +120,8 @@ trait ArgCompletions { this: MetalsGlobal =>
       }
 
       completions match {
-        case members: CompletionResult.ScopeMembers =>
+        case members: CompletionResult.ScopeMembers
+            if paramType != definitions.AnyTpe =>
           members.results
             .collect {
               case mem

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -873,7 +873,8 @@ class Completions(
       val fuzzyCache = mutable.Map.empty[CompletionValue, Int]
 
       def compareLocalSymbols(s1: Symbol, s2: Symbol): Int =
-        if s1.isLocal && s2.isLocal then
+        if s1.isLocal && s2.isLocal && s1.sourcePos.exists && s2.sourcePos.exists
+        then
           val firstIsAfter = s1.srcPos.isAfter(s2.srcPos)
           if firstIsAfter then -1 else 1
         else 0

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/NamedArgCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/NamedArgCompletions.scala
@@ -21,6 +21,7 @@ import dotty.tools.dotc.core.SymDenotations.NoDenotation
 import dotty.tools.dotc.core.Symbols
 import dotty.tools.dotc.core.Symbols.NoSymbol
 import dotty.tools.dotc.core.Symbols.Symbol
+import dotty.tools.dotc.core.Symbols.defn
 import dotty.tools.dotc.core.Types.AndType
 import dotty.tools.dotc.core.Types.AppliedType
 import dotty.tools.dotc.core.Types.MethodType
@@ -306,15 +307,17 @@ object NamedArgCompletions:
 
     val completionSymbols = indexedContext.scopeSymbols
     def matchingTypesInScope(paramType: Type): List[String] =
-      completionSymbols
-        .collect {
-          case sym
-              if sym.info <:< paramType && sym.isTerm && !sym.info.isErroneous && !sym.info.isNullType && !sym.info.isNothingType && !sym
-                .is(Flags.Method) && !sym.is(Flags.Synthetic) =>
-            sym.decodedName
-        }
-        .filter(name => name != "Nil" && name != "None")
-        .sorted
+      if paramType != defn.AnyType then
+        completionSymbols
+          .collect {
+            case sym
+                if sym.info <:< paramType && sym.isTerm && !sym.info.isErroneous && !sym.info.isNullType && !sym.info.isNothingType && !sym
+                  .is(Flags.Method) && !sym.is(Flags.Synthetic) =>
+              sym.decodedName
+          }
+          .filter(name => name != "Nil" && name != "None")
+          .sorted
+      else Nil
 
     def findDefaultValue(param: ParamSymbol): String =
       val matchingType = matchingTypesInScope(param.info)

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -20,6 +20,33 @@ class CompletionIssueSuite extends BaseCompletionSuite {
   }
 
   check(
+    "comparison".tag(IgnoreForScala3CompilerPC),
+    """package a
+      |object w {
+      |  abstract class T(x: Int) {
+      |    def met(x: Int): Unit = {
+      |      println(x@@)
+      |    }
+      |  }}
+      |""".stripMargin,
+    """|x: Int
+       |x = : Any""".stripMargin,
+    topLines = Some(4),
+    compat = Map(
+      "2.12" ->
+        """|x: Int
+           |x = : Any
+           |xml scala
+           |""".stripMargin,
+      "2.11" ->
+        """|x: Int
+           |x = : Any
+           |xml scala
+           |""".stripMargin
+    )
+  )
+
+  check(
     "mutate".tag(IgnoreScala3),
     """package a
       |class Foo@@


### PR DESCRIPTION
This also caused:
```
java.base/java.util.TimSort.mergeLo(TimSort.java:781)
	java.base/java.util.TimSort.mergeAt(TimSort.java:518)
	java.base/java.util.TimSort.mergeForceCollapse(TimSort.java:461)
	java.base/java.util.TimSort.sort(TimSort.java:254)
	java.base/java.util.Arrays.sort(Arrays.java:1233)
	scala.collection.SeqOps.sorted(Seq.scala:727)
	scala.collection.SeqOps.sorted$(Seq.scala:719)
	scala.collection.immutable.List.scala$collection$immutable$StrictOptimizedSeqOps$$super$sorted(List.scala:79)
	scala.collection.immutable.StrictOptimizedSeqOps.sorted(StrictOptimizedSeqOps.scala:78)
	scala.collection.immutable.StrictOptimizedSeqOps.sorted$(StrictOptimizedSeqOps.scala:78)
	scala.collection.immutable.List.sorted(List.scala:79)
	scala.meta.internal.pc.completions.Completions.completions(Completions.scala:210)
	scala.meta.internal.pc.completions.CompletionProvider.completions(CompletionProvider.scala:86)
	scala.meta.internal.pc.ScalaPresentationCompiler.complete$$anonfun$1(ScalaPresentationCompiler.scala:136)
```