### PR TITLE
bugfix: Don't try to add interpolation completions at a wrong position

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/InterpolationSplice.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/InterpolationSplice.scala
@@ -21,7 +21,7 @@ object InterpolationSplice {
     ) {
       i -= 1
     }
-    val isCandidate = i > 0 &&
+    val isCandidate = i > 0 && i != offset &&
       chars(i) == '$' && {
         val start = chars(i + 1) match {
           case '{' => i + 2

--- a/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionInterpolatorSuite.scala
@@ -5,6 +5,23 @@ import tests.pc.CrossTestEnrichments._
 
 class CompletionInterpolatorSuite extends BaseCompletionSuite {
 
+  check(
+    "wrong",
+    """|object Main {
+       |  println("Z@@${zScores_y.mkString(", ")}")
+       |}
+       |""".stripMargin,
+    ""
+  )
+  check(
+    "wrong2",
+    """|object Main {
+       |   val idx = if(i.toString.length == 2) s"00$i" else s"00@@$i"
+       |}
+       |""".stripMargin,
+    ""
+  )
+
   checkEdit(
     "string",
     """|object Main {


### PR DESCRIPTION
The only issue here is the exception thrown, but it's better to fix it.