### PR TITLE
Remove context of path wrapper which caused multiple compiler crashes

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -4,7 +4,6 @@ import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 import scala.meta.internal.jdk.CollectionConverters.*
-import scala.meta.internal.pc.MetalsInteractive
 import scala.meta.internal.pc.SemanticdbSymbols
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.RangeParams
@@ -66,7 +65,7 @@ object MtagsEnrichments extends ScalametaCommonEnrichments:
         Interactive.pathTo(newctx.compilationUnit.tpdTree, pos.span)(using
           newctx
         )
-      MetalsInteractive.contextOfPath(tpdPath)(using newctx)
+      Interactive.contextOfPath(tpdPath)(using newctx)
     end localContext
 
   end extension

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -44,7 +44,7 @@ final class AutoImportsProvider(
       Interactive.pathTo(newctx.compilationUnit.tpdTree, pos.span)(using newctx)
 
     val indexedContext = IndexedContext(
-      MetalsInteractive.contextOfPath(path)(using newctx)
+      Interactive.contextOfPath(path)(using newctx)
     )
     import indexedContext.ctx
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/ExtractMethodProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/ExtractMethodProvider.scala
@@ -6,7 +6,6 @@ import scala.meta as m
 
 import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.mtags.MtagsEnrichments.*
-import scala.meta.internal.pc.MetalsInteractive.*
 import scala.meta.internal.pc.printer.MetalsPrinter
 import scala.meta.internal.pc.printer.MetalsPrinter.IncludeDefaultParam
 import scala.meta.pc.OffsetParams
@@ -49,7 +48,7 @@ final class ExtractMethodProvider(
       Interactive.pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
     given locatedCtx: Context =
       val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
-      MetalsInteractive.contextOfPath(path)(using newctx)
+      Interactive.contextOfPath(path)(using newctx)
     val indexedCtx = IndexedContext(locatedCtx)
     val printer =
       MetalsPrinter.standard(indexedCtx, search, IncludeDefaultParam.Never)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/HoverProvider.scala
@@ -94,7 +94,7 @@ object HoverProvider:
     else
       val skipCheckOnName =
         !pos.isPoint // don't check isHoveringOnName for RangeHover
-      val printerCtx = MetalsInteractive.contextOfPath(path)
+      val printerCtx = Interactive.contextOfPath(path)
       val printer = MetalsPrinter.standard(
         IndexedContext(printerCtx),
         search,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/MetalsInteractive.scala
@@ -5,9 +5,7 @@ import scala.annotation.tailrec
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.ast.untpd
-import dotty.tools.dotc.core.ContextOps.*
 import dotty.tools.dotc.core.Contexts.*
-import dotty.tools.dotc.core.CyclicReference
 import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.Names.Name
@@ -19,65 +17,6 @@ import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.util.SourcePosition
 
 object MetalsInteractive:
-
-  // This is a copy of dotty.tools.dotc.Interactive.contextOfPath
-  // with a minor fix in how it processes `Template`
-  //
-  // Might be removed after merging https://github.com/lampepfl/dotty/pull/12783
-  def contextOfPath(path: List[Tree])(using Context): Context = path match
-    case Nil | _ :: Nil =>
-      ctx.fresh
-    case nested :: encl :: rest =>
-      val outer = contextOfPath(encl :: rest)
-      try
-        encl match
-          case tree @ PackageDef(pkg, stats) =>
-            assert(tree.symbol.exists)
-            if nested `eq` pkg then outer
-            else
-              contextOfStat(
-                stats,
-                nested,
-                pkg.symbol.moduleClass,
-                outer.packageContext(tree, tree.symbol),
-              )
-          case tree: DefDef =>
-            assert(tree.symbol.exists)
-            val localCtx = outer.localContext(tree, tree.symbol).setNewScope
-            for params <- tree.paramss; param <- params do
-              localCtx.enter(param.symbol)
-            // Note: this overapproximates visibility a bit, since value parameters are only visible
-            // in subsequent parameter sections
-            localCtx
-          case tree: MemberDef if tree.symbol.exists =>
-            outer.localContext(tree, tree.symbol)
-          case tree @ Block(stats, expr) =>
-            val localCtx = outer.fresh.setNewScope
-            stats.foreach {
-              case stat: MemberDef => localCtx.enter(stat.symbol)
-              case _ =>
-            }
-            contextOfStat(stats, nested, ctx.owner, localCtx)
-          case tree @ CaseDef(pat, guard, rhs) if nested `eq` rhs =>
-            val localCtx = outer.fresh.setNewScope
-            pat.foreachSubTree {
-              case bind: Bind => localCtx.enter(bind.symbol)
-              case _ =>
-            }
-            localCtx
-          case tree @ Template(constr, _, self, _) =>
-            if (constr :: self :: tree.parents).contains(nested) then outer
-            else
-              contextOfStat(
-                tree.body,
-                nested,
-                tree.symbol,
-                outer.inClassContext(self.symbol),
-              )
-          case _ =>
-            outer
-      catch case ex: CyclicReference => outer
-      end try
 
   def contextOfStat(
       stats: List[Tree],

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcInlineValueProviderImpl.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcInlineValueProviderImpl.scala
@@ -158,7 +158,7 @@ final class PcInlineValueProviderImpl(
       val path =
         Interactive.pathTo(unit.tpdTree, occurence.pos.span)(using newctx)
       val indexedContext = IndexedContext(
-        MetalsInteractive.contextOfPath(path)(using newctx)
+        Interactive.contextOfPath(path)(using newctx)
       )
       import indexedContext.ctx
       val conflictingSymbols = symbols

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcSyntheticDecorationProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcSyntheticDecorationProvider.scala
@@ -108,7 +108,7 @@ class PcSyntheticDecorationsProvider(
   ): String =
     val tpdPath =
       Interactive.pathTo(unit.tpdTree, pos.span)
-    val indexedCtx = IndexedContext(MetalsInteractive.contextOfPath(tpdPath))
+    val indexedCtx = IndexedContext(Interactive.contextOfPath(tpdPath))
     val shortenedNames = new ShortenedNames(indexedCtx)
     val printer = MetalsPrinter.forInferredType(
       shortenedNames,

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
@@ -58,7 +58,7 @@ class CompletionProvider(
             newctx
           )
         val locatedCtx =
-          MetalsInteractive.contextOfPath(tpdPath)(using newctx)
+          Interactive.contextOfPath(tpdPath)(using newctx)
         val indexedCtx = IndexedContext(locatedCtx)
         val completionPos =
           CompletionPos.infer(pos, params, path)(using newctx)

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -189,7 +189,7 @@ object OverrideCompletions:
         case path => path
 
     val indexedContext = IndexedContext(
-      MetalsInteractive.contextOfPath(path)(using newctx)
+      Interactive.contextOfPath(path)(using newctx)
     )
     import indexedContext.ctx
 


### PR DESCRIPTION
https://github.com/lampepfl/dotty/pull/12783 has been fixed for a very long time and this method caused multiple crashes according to reports.