### PR TITLE
feat: cancel worksheet evaluations when canceling compilation

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1818,6 +1818,11 @@ class MetalsLspService(
   def cleanCompile(): Future[Unit] = compilations.recompileAll()
 
   def cancelCompile(): Future[Unit] = Future {
+    // We keep this in here to provide a way for clients that aren't slowTask providers
+    // to be able to cancel a long-running worksheet evaluation by canceling compilation.
+    if (focusedDocument().exists(_.isWorksheet))
+      worksheetProvider.cancel()
+
     compilations.cancel()
     scribe.info("compilation cancelled")
   }


### PR DESCRIPTION
This is sort of a hack, but this is meant to be for clients that don't
have slowTask abilities, which means they can't cancel long-running
tasks. In the situation where you're in a worksheet and have something
that you want to cancel, this allows you to trigger a cancel
compilation, which will do that and also cancel the ongoing evaluation
if the user is in a worksheet.
