### PR TITLE
bugfix: incorrect debug completion when line is not sent from DAP client

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
@@ -146,6 +146,9 @@ private[debug] final class DebugProxy(
       }
 
     case request @ CompletionRequest(args) =>
+      if (args.getLine == null) {
+        args.setLine(1)
+      }
       val completions = for {
         frame <- lastFrames.find(_.getId() == args.getFrameId())
       } yield {

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Completer.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Completer.scala
@@ -6,7 +6,7 @@ import scala.meta.internal.metals.debug.DebugStep.Complete
 
 import org.eclipse.lsp4j.debug.CompletionsResponse
 
-final class Completer(expression: String) extends Stoppage.Handler {
+final class Completer(expression: String, isLineNullable: Boolean = false) extends Stoppage.Handler {
   var response: CompletionsResponse = _
 
   override def apply(stoppage: Stoppage): DebugStep = {
@@ -24,6 +24,7 @@ final class Completer(expression: String) extends Stoppage.Handler {
       response = _,
       line,
       column,
+      isLineNullable
     )
   }
 

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Completer.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Completer.scala
@@ -6,7 +6,8 @@ import scala.meta.internal.metals.debug.DebugStep.Complete
 
 import org.eclipse.lsp4j.debug.CompletionsResponse
 
-final class Completer(expression: String, isLineNullable: Boolean = false) extends Stoppage.Handler {
+final class Completer(expression: String, isLineNullable: Boolean = false)
+    extends Stoppage.Handler {
   var response: CompletionsResponse = _
 
   override def apply(stoppage: Stoppage): DebugStep = {
@@ -24,7 +25,7 @@ final class Completer(expression: String, isLineNullable: Boolean = false) exten
       response = _,
       line,
       column,
-      isLineNullable
+      isLineNullable,
     )
   }
 

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/DebugStep.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/DebugStep.scala
@@ -21,5 +21,6 @@ object DebugStep {
       callback: CompletionsResponse => Unit,
       line: Int,
       character: Int,
+      isLineNullable: Boolean = false
   ) extends DebugStep
 }

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/DebugStep.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/DebugStep.scala
@@ -21,6 +21,6 @@ object DebugStep {
       callback: CompletionsResponse => Unit,
       line: Int,
       character: Int,
-      isLineNullable: Boolean = false
+      isLineNullable: Boolean = false,
   ) extends DebugStep
 }

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Debugger.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Debugger.scala
@@ -107,11 +107,13 @@ final class Debugger(server: RemoteServer)(implicit ec: ExecutionContext) {
           .asScala
           .map(callback)
           .flatMap(_ => step(threadId, nextStep))
-      case DebugStep.Complete(expression, frameId, callback, line, character) =>
+      case DebugStep.Complete(expression, frameId, callback, line, character, isLineNullable) =>
         val args = new CompletionsArguments()
         args.setFrameId(frameId)
         args.setText(expression)
-        args.setLine(line)
+        if (!isLineNullable) {
+          args.setLine(line)
+        }
         args.setColumn(character)
         server.completions(args).asScala.flatMap { completions =>
           callback(completions)

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Debugger.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Debugger.scala
@@ -107,7 +107,14 @@ final class Debugger(server: RemoteServer)(implicit ec: ExecutionContext) {
           .asScala
           .map(callback)
           .flatMap(_ => step(threadId, nextStep))
-      case DebugStep.Complete(expression, frameId, callback, line, character, isLineNullable) =>
+      case DebugStep.Complete(
+            expression,
+            frameId,
+            callback,
+            line,
+            character,
+            isLineNullable,
+          ) =>
         val args = new CompletionsArguments()
         args.setFrameId(frameId)
         args.setText(expression)

--- a/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
@@ -280,7 +280,7 @@ class CompletionDapSuite
                              |toString(): String
                              |""".stripMargin,
     expectedEdit = "1.toShort",
-    isLineNullable = true
+    isLineNullable = true,
   )(
     """|/a/src/main/scala/a/Main.scala
        |package a

--- a/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
@@ -268,6 +268,34 @@ class CompletionDapSuite
        |""".stripMargin
   )
 
+  assertCompletion(
+    "basic-with-line-as-null",
+    expression = "1.toS@@",
+    expectedCompletions = """|toShort: Short
+                             |toBinaryString: String
+                             |toDegrees: Double
+                             |toHexString: String
+                             |toOctalString: String
+                             |toRadians: Double
+                             |toString(): String
+                             |""".stripMargin,
+    expectedEdit = "1.toShort",
+    isLineNullable = true
+  )(
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |
+       |object Main {
+       |  class Preceding
+       |
+       |  def main(args: Array[String]): Unit = {
+       |>>  println()
+       |    System.exit(0)
+       |  }
+       |}
+       |""".stripMargin
+  )
+
   def assertCompletion(
       name: TestOptions,
       expression: String,
@@ -276,6 +304,7 @@ class CompletionDapSuite
       main: Option[String] = None,
       topLines: Option[Int] = None,
       noResults: Boolean = false,
+      isLineNullable: Boolean = false,
   )(
       source: String
   )(implicit loc: Location): Unit = {
@@ -284,7 +313,7 @@ class CompletionDapSuite
 
       val debugLayout = DebugWorkspaceLayout(source, workspace)
       val workspaceLayout = QuickBuildLayout(debugLayout.toString, scalaVersion)
-      val completer = new Completer(expression)
+      val completer = new Completer(expression, isLineNullable = isLineNullable)
 
       for {
         _ <- initialize(workspaceLayout)


### PR DESCRIPTION
Currently, There is some DAP client ([nvim-dap](https://github.com/mfussenegger/nvim-dap)) which doesn't send `CompletionsRequest. arguments.line` field to *metals*.

https://github.com/mfussenegger/nvim-dap/blob/9adbfdca13afbe646d09a8d7a86d5d031fb9c5a5/lua/dap/repl.lua#L477-L480

This is fine since `line` is an optional argument and according to DAP specification, when `line` is not sent as part of `CompletionsArguments`, the DAP server should assume `line` to be `1`.

<img width="664" alt="Screenshot 2567-01-13 at 22 43 45" src="https://github.com/scalameta/metals/assets/21259908/6b23674e-8753-4a68-be18-70e47ba81ee5">

However, *metals* is not working correctly when `line` is not being set. This PR aims to fix this bug by handling the case where `line = null` properly