### PR TITLE
bugfix: Don't tokenize if the source hasn't changed

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -139,7 +139,7 @@ final class DefinitionProvider(
       sourceText <- buffers.get(path)
       virtualFile = Input.VirtualFile(path.toURI.toString(), sourceText)
       metaPos <- pos.toMeta(virtualFile)
-      tokens <- trees.tokenized(virtualFile).toOption
+      tokens <- trees.tokenized(path)
       ident <- tokens.collectFirst {
         case id: Token.Ident if id.pos.encloses(metaPos) => id
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -243,13 +243,16 @@ final class Diagnostics(
     for {
       d <- syntaxError.get(path)
       // De-duplicate only the most common and basic syntax errors.
+      isSameMessage = all.asScala.exists(diag =>
+        diag.getRange() == d.getRange() && diag.getMessage() == d.getMessage()
+      )
       isDuplicate =
         d.getMessage.startsWith("identifier expected but") &&
           all.asScala.exists { other =>
             other.getMessage.startsWith("identifier expected") &&
-            other.getRange == d.getRange
+            other.getRange().getStart() == d.getRange().getStart()
           }
-      if !isDuplicate
+      if !isDuplicate && !isSameMessage
     } {
       all.add(d)
     }
@@ -272,7 +275,6 @@ final class Diagnostics(
       snapshot,
       current,
       trees,
-      doNothingWhenUnchanged = false,
     )
     edit match {
       case Right(edit) =>

--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/OnTypeFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/OnTypeFormattingProvider.scala
@@ -55,7 +55,6 @@ class OnTypeFormattingProvider(
       startPos <- range.getStart.toMeta(virtualFile)
       endPos <- range.getEnd.toMeta(virtualFile)
     } yield {
-      val tokensOpt = trees.tokenized(virtualFile).toOption
       val onTypeformatterParams =
         OnTypeFormatterParams(
           sourceText,
@@ -63,7 +62,7 @@ class OnTypeFormattingProvider(
           triggerChar,
           startPos,
           endPos,
-          tokensOpt,
+          trees.tokenized(path),
         )
       formatters.acceptFirst(formater =>
         formater.contribute(onTypeformatterParams)

--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/RangeFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/RangeFormattingProvider.scala
@@ -51,7 +51,6 @@ class RangeFormattingProvider(
       startPos <- range.getStart.toMeta(virtualFile)
       endPos <- range.getEnd.toMeta(virtualFile)
     } yield {
-      val tokensOpt = trees.tokenized(virtualFile).toOption
       val rangeFormatterParams =
         RangeFormatterParams(
           sourceText,
@@ -59,7 +58,7 @@ class RangeFormattingProvider(
           formattingOptions,
           startPos,
           endPos,
-          tokensOpt,
+          trees.tokenized(path),
         )
       formatters.acceptFirst(formater =>
         formater.contribute(rangeFormatterParams)

--- a/metals/src/main/scala/scala/meta/internal/parsing/TokenEditDistance.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/TokenEditDistance.scala
@@ -470,7 +470,6 @@ object TokenEditDistance {
       originalInput: Input.VirtualFile,
       revisedInput: Input.VirtualFile,
       trees: Trees,
-      doNothingWhenUnchanged: Boolean = true,
   ): Either[String, TokenEditDistance] = {
     val isScala =
       originalInput.path.isScalaFilename &&
@@ -484,7 +483,7 @@ object TokenEditDistance {
       Right(Unchanged)
     } else if (originalInput.value.isEmpty() || revisedInput.value.isEmpty()) {
       Right(NoMatch)
-    } else if (doNothingWhenUnchanged && originalInput == revisedInput) {
+    } else if (originalInput == revisedInput) {
       Right(Unchanged)
     } else if (isJava) {
       val tokenizedRevised = JavaTokens.tokenize(revisedInput)

--- a/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
@@ -14,6 +14,7 @@ import scala.meta.io.AbsolutePath
 import scala.meta.parsers.Parse
 import scala.meta.parsers.ParseException
 import scala.meta.parsers.Parsed
+import scala.meta.tokens.Tokens
 
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DiagnosticSeverity
@@ -119,8 +120,19 @@ final class Trees(
     }
   }
 
-  def tokenized(input: inputs.Input.VirtualFile): Tokenized =
-    scalaVersionSelector.getDialect(input.path.toAbsolutePath)(input).tokenize
+  def tokenized(path: AbsolutePath): Option[Tokens] = {
+    for {
+      sourceText <- buffers.get(path)
+      virtualFile = Input.VirtualFile(path.toURI.toString(), sourceText)
+      tokens <- tokenized(virtualFile).toOption
+    } yield tokens
+  }
+
+  def tokenized(input: inputs.Input.VirtualFile): Tokenized = {
+    scalaVersionSelector
+      .getDialect(input.path.toAbsolutePath)(input)
+      .tokenize
+  }
 
   private def parse(
       path: AbsolutePath,

--- a/tests/slow/src/test/scala/tests/feature/SyntaxErrorLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/SyntaxErrorLspSuite.scala
@@ -107,10 +107,10 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
         client.workspaceDiagnostics,
         """|a/src/main/scala/Main.scala:1:8: error: identifier expected but 'object' found.
            |object object A
-           |       ^^^^^^
+           |       ^
            |a/src/main/scala/Main.scala:2:8: error: identifier expected but 'object' found.
            |object object B
-           |       ^^^^^^
+           |       ^
            |""".stripMargin,
       )
       _ <- server.didChange("a/src/main/scala/Main.scala")(t => "\n" + t)

--- a/tests/unit/src/test/scala/tests/scalafix/ScalafixProviderLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/scalafix/ScalafixProviderLspSuite.scala
@@ -62,7 +62,7 @@ class ScalafixProviderLspSuite extends BaseLspSuite("scalafix-provider") {
            |^^^^^^^^^^^^^^^^^^^
            |a/src/main/scala/Main.scala:7:15: warning: private val notUsed in object Main is never used
            |  private val notUsed = 123 
-           |              ^^^^^^^
+           |              ^
            |""".stripMargin,
       )
       textParams =


### PR DESCRIPTION
Previously, when sending diagnostics we would always tokenize the file even if it was the same and this actually was causing some OOM if there were to many diagnostics sent.
    
This doesn't seem necessary at all and was most likely done to satisfy some tests.