### PR TITLE
bugfix: Match on executable name in GenerateBspConfig

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConfigGenerator.scala
@@ -92,7 +92,7 @@ final class BspConfigGenerator(
       .asScala
       .map { choice =>
         buildTools.find(buildTool =>
-          new MessageActionItem(buildTool.buildServerName) == choice
+          new MessageActionItem(buildTool.executableName) == choice
         )
       }
   }


### PR DESCRIPTION
If we use mill or bazel, buildServerName and executableName differ, which caused Metals to crash