### PR TITLE
bugfix: Show non jvm lenses even if client is not a run provider

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -337,7 +337,7 @@ final class RunTestCodeLens(
         command("debug", StartDebugSession, params),
       )
     // run provider needs shell command to run currently, we don't support pure run inside metals for JVM
-    else if ((shellCommandAdded || !isJVM) && clientConfig.isRunProvider())
+    else if (shellCommandAdded && clientConfig.isRunProvider() || !isJVM)
       List(command("run", StartRunSession, params))
     else Nil
   }


### PR DESCRIPTION
We use DAP in that case anyway, so the run capability for client is not needed.

We could resign from running via shell maybe if it's quick enough :thinking: 