### PR TITLE
improvement: Generate semanticdb if not found

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -462,7 +462,7 @@ final case class Indexer(
     } {
       isVisited.add(sourceUri)
       try {
-        if (path.isJar) {
+        if (path.isJar && path.exists) {
           usedJars += path
           addSourceJarSymbols(path)
         } else if (path.isDirectory) {


### PR DESCRIPTION
Previously, if a build tool didn't generate semanticdb we would not get any scalafix, including organize imports, working. Now, we fallback to having semanticdb generated by the presentation compiler.

Also, a small fix to make sure we don't try to index source jars that don't exists (happened in case of Bazel)