### PR TITLE
bugfix: debug-completion depends on order of stackTrace being requested

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
@@ -4,6 +4,7 @@ import java.net.Socket
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
+import scala.collection.concurrent.TrieMap
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
@@ -11,7 +12,6 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 import scala.util.control.NonFatal
-import scala.collection.concurrent.TrieMap
 
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.Compilers

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Debugger.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Debugger.scala
@@ -26,6 +26,7 @@ import org.eclipse.lsp4j.debug.StackTraceArguments
 import org.eclipse.lsp4j.debug.StackTraceResponse
 import org.eclipse.lsp4j.debug.StepInArguments
 import org.eclipse.lsp4j.debug.StepOutArguments
+import org.eclipse.lsp4j.debug.ThreadsResponse
 import org.eclipse.lsp4j.debug.VariablesArguments
 import org.eclipse.lsp4j.debug.VariablesResponse
 
@@ -171,6 +172,10 @@ final class Debugger(server: RemoteServer)(implicit ec: ExecutionContext) {
     server
       .variables(args)
       .asScala
+  }
+
+  def threads(): Future[ThreadsResponse] = {
+    server.threads().asScala
   }
 
   def shutdown(timeout: Int = 20): Future[Unit] = {

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/RemoteServer.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/RemoteServer.scala
@@ -127,6 +127,10 @@ private[debug] final class RemoteServer(
     sendRequest(DebugProtocol.DisconnectRequest.name, args)
   }
 
+  override def threads(): CompletableFuture[ThreadsResponse] = {
+    sendRequest("threads", null)
+  }
+
   private def listen(): Unit = {
     remote.listen {
       case response: Response =>

--- a/tests/unit/src/main/scala/tests/BaseDapSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseDapSuite.scala
@@ -67,10 +67,17 @@ abstract class BaseDapSuite(
       buildTarget: String,
       main: String,
       stoppageHandler: Stoppage.Handler = Stoppage.Handler.Continue,
+      requestOtherThreadStackTrace: Boolean = false,
   ): Future[TestDebugger] = {
     val kind = DebugSessionParamsDataKind.SCALA_MAIN_CLASS
     val mainClass = new ScalaMainClass(main, emptyList(), emptyList())
-    server.startDebugging(buildTarget, kind, mainClass, stoppageHandler)
+    server.startDebugging(
+      buildTarget,
+      kind,
+      mainClass,
+      stoppageHandler,
+      requestOtherThreadStackTrace,
+    )
   }
 
   def setBreakpoints(

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -671,6 +671,7 @@ final case class TestingServer(
       kind: String,
       parameter: AnyRef,
       stoppageHandler: Stoppage.Handler = Stoppage.Handler.Continue,
+      requestOtherThreadStackTrace: Boolean = false,
   ): Future[TestDebugger] = {
 
     assertSystemExit(parameter)
@@ -682,7 +683,11 @@ final case class TestingServer(
     executeCommandUnsafe(ServerCommands.StartDebugAdapter.id, Seq(params))
       .collect { case DebugSession(_, uri) =>
         scribe.info(s"Starting debug session for $uri")
-        TestDebugger(URI.create(uri), stoppageHandler)
+        TestDebugger(
+          URI.create(uri),
+          stoppageHandler,
+          requestOtherThreadStackTrace,
+        )
       }
   }
 


### PR DESCRIPTION
Some DAP client, when receiving Stoppage event, will get a list of all threads and iterate through that list to get each thread's stack-trace eagerly. One example of this is [nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui/blob/master/lua/dapui/components/threads.lua#L71-L75).

Since **metals** maintains only the latest stack-trace response to use for frame-searching during debug-completion, debug-completion won't work if the frame-id in debug-completion request is not in the latest stack-trace response.

IMO, the behavior of debug-completion shouldn't depends on the order of stack-trace requests. And ideally, DAP server shouldn't even depends on the stack-trace being requested at all for debug-completion to work. However, since **metals** is currently just a proxy for scala-debug-adapter, I think the latter requirement can be relaxed.

So, this PR is trying to satisfy the first requirement where debug-completion will work regardless of the order of stack-trace requests. If DAP client, at least once, requests for the stack-trace, the debug-completion for any frame in that stack-trace will work.