### PR TITLE
improvement: Don't require compilation for semanticdb

### DIFF
--- a/metals-bench/src/main/scala/bench/ClasspathSymbolsBench.scala
+++ b/metals-bench/src/main/scala/bench/ClasspathSymbolsBench.scala
@@ -17,6 +17,7 @@ import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.TearDown
 import tests.Library
+import tests.TreeUtils
 
 @State(Scope.Benchmark)
 class ClasspathSymbolsBench {
@@ -36,7 +37,8 @@ class ClasspathSymbolsBench {
   def run(): Unit = {
     implicit val reporting = EmptyReportContext
     val jars = new IndexedSymbols(
-      isStatisticsEnabled = false
+      isStatisticsEnabled = false,
+      TreeUtils.getTrees(scalaVersion = None)._2,
     )
     classpath.foreach { jar =>
       jars.jarSymbols(jar, "cats/", dialects.Scala213)

--- a/metals-bench/src/main/scala/bench/ClasspathSymbolsBench.scala
+++ b/metals-bench/src/main/scala/bench/ClasspathSymbolsBench.scala
@@ -36,9 +36,11 @@ class ClasspathSymbolsBench {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   def run(): Unit = {
     implicit val reporting = EmptyReportContext
+    val (buffers, trees) = TreeUtils.getTrees(scalaVersion = None)
     val jars = new IndexedSymbols(
       isStatisticsEnabled = false,
-      TreeUtils.getTrees(scalaVersion = None)._2,
+      trees,
+      buffers,
     )
     classpath.foreach { jar =>
       jars.jarSymbols(jar, "cats/", dialects.Scala213)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -795,6 +795,7 @@ class MetalsLspService(
       languageClient,
       clientConfig,
       trees,
+      buffers,
     )
 
   private val popupChoiceReset: PopupChoiceReset = new PopupChoiceReset(

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -251,10 +251,12 @@ class FolderTreeViewProvider(
     languageClient: MetalsLanguageClient,
     clientConfig: ClientConfiguration,
     trees: Trees,
+    buffers: Buffers,
 )(implicit context: ReportContext) {
   val classpath = new IndexedSymbols(
     isStatisticsEnabled = clientConfig.initialConfig.statistics.isTreeView,
     trees,
+    buffers,
   )
 
   def dialectOf(path: AbsolutePath): Option[Dialect] =
@@ -312,9 +314,7 @@ class FolderTreeViewProvider(
     },
     loadSymbols = { (id, symbol) =>
       val tops = for {
-        scalaTarget <- buildTargets.scalaTarget(id).iterator
-        source <- buildTargets.buildTargetSources(id)
-        dialect = scalaTarget.dialect(source)
+        source <- buildTargets.buildTargetSources(id).iterator
       } yield classpath.workspaceSymbols(source, symbol)
       tops.flatten
     },

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaMtags.scala
@@ -9,6 +9,7 @@ import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.semanticdb.SymbolInformation.Kind
 import scala.meta.internal.semanticdb.SymbolInformation.Property
 import scala.meta.internal.trees._
+import scala.meta.parsers.Parsed
 import scala.meta.transversers.SimpleTraverser
 
 object ScalaMtags {
@@ -16,12 +17,16 @@ object ScalaMtags {
     new ScalaMtags(input, dialect)
   }
 }
-class ScalaMtags(val input: Input.VirtualFile, dialect: Dialect)
-    extends SimpleTraverser
+class ScalaMtags(
+    val input: Input.VirtualFile,
+    dialect: Dialect,
+    parsedTree: Option[Source] = None
+) extends SimpleTraverser
     with MtagsIndexer {
 
   private val root: Parsed[Source] =
-    dialect(input).parse[Source]
+    parsedTree.map(Parsed.Success(_)).getOrElse(dialect(input).parse[Source])
+
   def source: Source = root.get
   override def language: Language = Language.SCALA
   override def indexRoot(): Unit = {

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -81,6 +81,12 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
                         |class Zero {
                         | val a = 1
                         |}
+                        |/a/src/main/java/a/JavaClass.java
+                        |package a;
+                        |public class JavaClass {
+                        | String name;
+                        | String surname;
+                        |}
                         |/a/src/main/scala/a/First.scala
                         |package a
                         |class First {
@@ -144,6 +150,7 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
         s"projects-$folder:${server.buildTarget("a")}!/a/",
         """|First symbol-class -
            |First symbol-object
+           |JavaClass symbol-class -
            |Second symbol-class -
            |Second symbol-object
            |""".stripMargin,
@@ -152,6 +159,12 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
         s"projects-$folder:${server.buildTarget("a")}!/a/First#",
         """|a() symbol-method
            |b symbol-field
+           |""".stripMargin,
+      )
+      _ = server.assertTreeViewChildren(
+        s"projects-$folder:${server.buildTarget("a")}!/a/JavaClass#",
+        """|name symbol-field
+           |surname symbol-field
            |""".stripMargin,
       )
       _ = server.assertTreeViewChildren(

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -150,15 +150,15 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
       )
       _ = server.assertTreeViewChildren(
         s"projects-$folder:${server.buildTarget("a")}!/a/First#",
-        """|b symbol-field
-           |a() symbol-method
+        """|a() symbol-method
+           |b symbol-field
            |""".stripMargin,
       )
       _ = server.assertTreeViewChildren(
         s"projects-$folder:${server.buildTarget("a")}!/a/Second#",
-        """|c symbol-variable
+        """|a() symbol-method
            |b symbol-field
-           |a() symbol-method
+           |c symbol-variable
            |""".stripMargin,
       )
       _ <- server.didSave("a/src/main/scala/a/Zero.scala") { text =>


### PR DESCRIPTION
Previously, Metals would need semanticdb for project view, which means when using build tools that don't provide it, no files would be shown. Now, we just use the usual ScalaMtags for those files.