### PR TITLE
correctly backtick toplevel source object when needed in mtags

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaMtags.scala
@@ -38,7 +38,7 @@ class ScalaMtags(val input: Input.VirtualFile, dialect: Dialect)
       case None =>
         val srcName = input.filename.stripSuffix(".scala")
         val name = s"$srcName$$package"
-        val value = (s"$name.", new OverloadDisambiguator())
+        val value = (name, new OverloadDisambiguator())
         _toplevelSourceRef = Some(value)
         withOwner(currentOwner) {
           val pos = Position.Range(input, 0, 0)
@@ -407,7 +407,7 @@ class ScalaMtags(val input: Input.VirtualFile, dialect: Dialect)
 
   private def fileOwner: String =
     if (isPackageOwner)
-      s"$currentOwner$toplevelSourceOwner"
+      symbol(Descriptor.Term(toplevelSourceOwner))
     else currentOwner
 
   private def isPackageOwner: Boolean = currentOwner.endsWith("/")

--- a/tests/input/src/main/scala-3/example/dotted.filename.scala
+++ b/tests/input/src/main/scala-3/example/dotted.filename.scala
@@ -1,0 +1,3 @@
+package example
+
+type Toplevel = Int

--- a/tests/unit/src/test/resources/decorations3/example/dotted.filename.scala
+++ b/tests/unit/src/test/resources/decorations3/example/dotted.filename.scala
@@ -1,0 +1,3 @@
+package example
+
+type Toplevel = Int

--- a/tests/unit/src/test/resources/definition-scala3/example/dotted.filename.scala
+++ b/tests/unit/src/test/resources/definition-scala3/example/dotted.filename.scala
@@ -1,0 +1,3 @@
+package example
+
+type Toplevel/*dotted.filename.scala*/ = Int/*Int.scala*/

--- a/tests/unit/src/test/resources/documentSymbol-scala3/example/dotted.filename.scala
+++ b/tests/unit/src/test/resources/documentSymbol-scala3/example/dotted.filename.scala
@@ -1,0 +1,3 @@
+/*example(Package):3*/package example
+
+/*example.Toplevel(TypeParameter):3*/type Toplevel = Int

--- a/tests/unit/src/test/resources/expect/toplevels-scala3.expect
+++ b/tests/unit/src/test/resources/expect/toplevels-scala3.expect
@@ -49,6 +49,7 @@ example/TypeEnum.scala -> example/TypeEnum#
 example/TypeParameters.scala -> example/TypeParameters#
 example/VarArgs.scala -> example/VarArgs#
 example/Vars.scala -> example/Vars.
+example/dotted.filename.scala -> example/`dotted.filename$package`.
 example/nested/DoublePackage.scala -> example/nested/x/DoublePackage#
 example/nested/DoublePackage.scala -> example/nested2/y/DoublePackage#
 example/nested/ExampleNested.scala -> example/nested/ExampleNested#

--- a/tests/unit/src/test/resources/mtags-scala3/example/dotted.filename.scala
+++ b/tests/unit/src/test/resources/mtags-scala3/example/dotted.filename.scala
@@ -1,0 +1,3 @@
+/*example.`dotted.filename$package`.*/package example
+
+type Toplevel/*example.`dotted.filename$package`.Toplevel#*/ = Int

--- a/tests/unit/src/test/resources/semanticTokens3/example/dotted.filename.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/dotted.filename.scala
@@ -1,0 +1,3 @@
+<<package>>/*keyword*/ <<example>>/*namespace*/
+
+<<type>>/*keyword*/ <<Toplevel>>/*type,definition*/ = <<Int>>/*class,abstract*/

--- a/tests/unit/src/test/resources/semanticdb-scala3/example/dotted.filename.scala
+++ b/tests/unit/src/test/resources/semanticdb-scala3/example/dotted.filename.scala
@@ -1,0 +1,3 @@
+package example
+
+type Toplevel/*example.`dotted.filename$package`.Toplevel#*/ = Int/*scala.Int#*/

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/dotted.filename.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/dotted.filename.scala
@@ -1,0 +1,3 @@
+package example
+
+type/*example.`dotted.filename$package`.*/ Toplevel = Int


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/6051