### PR TITLE
improvement: Change BSP ping message to empty buildtarget/compile

### DIFF
--- a/tests/unit/src/main/scala/bill/Bill.scala
+++ b/tests/unit/src/main/scala/bill/Bill.scala
@@ -195,9 +195,6 @@ object Bill {
     }
     override def workspaceBuildTargets()
         : CompletableFuture[WorkspaceBuildTargetsResult] = {
-      sleepBeforePingResponse.foreach(duration =>
-        Thread.sleep(duration.toMillis)
-      )
       CompletableFuture.completedFuture {
         new WorkspaceBuildTargetsResult(Collections.singletonList(target))
       }
@@ -318,6 +315,11 @@ object Bill {
     override def buildTargetCompile(
         params: CompileParams
     ): CompletableFuture[CompileResult] = {
+      if (params.getTargets().isEmpty()) {
+        sleepBeforePingResponse.foreach(duration =>
+          Thread.sleep(duration.toMillis)
+        )
+      }
       CompletableFuture.completedFuture {
         reporter.reset()
         val run = new g.Run()


### PR DESCRIPTION
`workspace/buildTargets` was causing unnecessary operations in bazelbsp. This new method should be faster and doesn't require any actions from the build server