### PR TITLE
improvement: Only save scala or java fingerprints

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -937,7 +937,9 @@ class MetalsLspService(
   }
 
   def onShutdown(): Unit = {
-    tables.fingerprints.save(fingerprints.getAllFingerprints())
+    tables.fingerprints.save(fingerprints.getAllFingerprints().filter {
+      case (path, _) => path.isScalaOrJava && !path.isDependencySource(folder)
+    })
     cancel()
   }
 


### PR DESCRIPTION
I noticed in a Bazel workspace that we also save other files, which is not neccessary for semanticdb.