### PR TITLE
bugfix: handle nested java jars

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaToplevelMtags.scala
@@ -27,6 +27,14 @@ class JavaToplevelMtags(val input: Input.VirtualFile) extends MtagsIndexer {
     }
   }
 
+  def readPackage: List[String] = {
+    fetchToken // start of file
+    fetchToken match {
+      case Token.Package => readPaths.map(_.value)
+      case _ => Nil
+    }
+  }
+
   private def loop: Unit = {
     val token = fetchToken
     token match {

--- a/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
@@ -11,6 +11,7 @@ import scala.util.control.NonFatal
 import scala.meta.Dialect
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.io.PathIO
+import scala.meta.internal.mtags.JavaToplevelMtags
 import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.{semanticdb => s}
@@ -65,6 +66,8 @@ class SymbolIndexBucket(
           root.listRecursive.toList.flatMap {
             case source if source.isScala =>
               addSourceFile(source, None).map(sym => (sym, source))
+            case source if source.isJava =>
+              addJavaSourceFile(source).map(sym => (sym, source))
             case _ =>
               List.empty
           }
@@ -88,6 +91,33 @@ class SymbolIndexBucket(
           case None => Some(Set(path))
         }
       }
+    }
+  }
+
+  /* Sometimes source jars have additional nested directories,
+   * in that case java toplevel is not "trivial".
+   * See: https://github.com/scalameta/metals/issues/3815
+   */
+  def addJavaSourceFile(source: AbsolutePath): List[String] = {
+    new JavaToplevelMtags(source.toInput).readPackage match {
+      case Nil => Nil
+      case packageParts =>
+        val className = source.filename.stripSuffix(".java")
+        val symbol = packageParts.mkString("", "/", s"/$className#")
+        if (
+          isTrivialToplevelSymbol(
+            source.toURI.toString,
+            symbol,
+            extension = "java"
+          )
+        ) Nil
+        else {
+          toplevels.updateWith(symbol) {
+            case Some(acc) => Some(acc + source)
+            case None => Some(Set(source))
+          }
+          List(symbol)
+        }
     }
   }
 
@@ -121,9 +151,13 @@ class SymbolIndexBucket(
   // Returns true if symbol is com/foo/Bar# and path is /com/foo/Bar.scala
   // Such symbols are "trivial" because their definition location can be computed
   // on the fly.
-  private def isTrivialToplevelSymbol(path: String, symbol: String): Boolean = {
+  private def isTrivialToplevelSymbol(
+      path: String,
+      symbol: String,
+      extension: String = "scala"
+  ): Boolean = {
     val pathBuffer =
-      CharBuffer.wrap(path).subSequence(1, path.length - ".scala".length)
+      CharBuffer.wrap(path).subSequence(1, path.length - extension.length - 1)
     val symbolBuffer =
       CharBuffer.wrap(symbol).subSequence(0, symbol.length - 1)
     pathBuffer.equals(symbolBuffer)


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/3815

This will slow down indexing, since now we read in java files, which we weren't doing before. However, [go to implementation for dependency sources](https://github.com/scalameta/metals/pull/5623), will require of us to read in those files anyway. 