### PR TITLE
improvement: Better labels for workspace methods completions

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionValue.scala
@@ -6,6 +6,7 @@ import scala.meta.internal.pc.printer.MetalsPrinter
 
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Flags.*
+import dotty.tools.dotc.core.StdNames.nme
 import dotty.tools.dotc.core.Symbols.Symbol
 import dotty.tools.dotc.core.Types.Type
 import dotty.tools.dotc.transform.SymUtils.*
@@ -85,7 +86,9 @@ object CompletionValue:
       else if symbol.isType then labelWithSuffix(printer)
       else s"$label: ${description(printer)}"
 
-    private def labelWithSuffix(printer: MetalsPrinter)(using Context): String =
+    protected def labelWithSuffix(
+        printer: MetalsPrinter
+    )(using Context): String =
       if snippetSuffix.addLabelSnippet
       then
         val printedParams = symbol.info.typeParams.map(p =>
@@ -114,6 +117,12 @@ object CompletionValue:
       override val snippetSuffix: CompletionSuffix,
       override val importSymbol: Symbol,
   ) extends Symbolic:
+    override def labelWithDescription(
+        printer: MetalsPrinter
+    )(using Context): String =
+      if symbol.is(Method) && symbol.name != nme.apply then
+        s"${labelWithSuffix(printer)} - ${printer.fullName(symbol.effectiveOwner)}"
+      else super.labelWithDescription(printer)
     override def isFromWorkspace: Boolean = true
 
   /**

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -131,11 +131,10 @@ class MetalsPrinter(
     val typeSymbol = info.typeSymbol
 
     if sym.is(Flags.Package) || sym.isClass then
-      " " + dotcPrinter.fullName(sym.effectiveOwner)
+      " " + fullName(sym.effectiveOwner)
     else if sym.is(Flags.Module) || typeSymbol.is(Flags.Module) then
-      if typeSymbol != NoSymbol then
-        " " + dotcPrinter.fullName(typeSymbol.effectiveOwner)
-      else " " + dotcPrinter.fullName(sym.effectiveOwner)
+      if typeSymbol != NoSymbol then " " + fullName(typeSymbol.effectiveOwner)
+      else " " + fullName(sym.effectiveOwner)
     else if sym.is(Flags.Method) then
       defaultMethodSignature(sym, info, onlyMethodParams = true)
     else if sym.isType
@@ -146,6 +145,9 @@ class MetalsPrinter(
     else tpe(info)
     end if
   end completionSymbol
+
+  def fullName(sym: Symbol): String =
+    dotcPrinter.fullName(sym)
 
   /**
    * Compute method signature for the given (method) symbol.

--- a/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWorkspaceSuite.scala
@@ -891,7 +891,9 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
   )
 
   check(
-    "nested-pkg".tag(IgnoreScalaVersion.forLessThan("3.2.2")),
+    "nested-pkg".tag(
+      IgnoreScalaVersion.forLessThan("3.2.2").and(IgnoreForScala3CompilerPC)
+    ),
     """|package a:
        |  package c: // some comment
        |    def increment2 = 2
@@ -905,13 +907,15 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  def main: Unit = incre@@
        |""".stripMargin,
     """|increment3: Int
-       |increment: Int
-       |increment2: Int
+       |increment - a: Int
+       |increment2 - a.c: Int
        |""".stripMargin
   )
 
   check(
-    "indent-method".tag(IgnoreScalaVersion.forLessThan("3.2.2")),
+    "indent-method".tag(
+      IgnoreScalaVersion.forLessThan("3.2.2").and(IgnoreForScala3CompilerPC)
+    ),
     """|package a:
        |  val y = 123
        |  given intGiven: Int = 123
@@ -926,8 +930,8 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |package c:
        |  def main() = foo@@
        |""".stripMargin,
-    """|fooBar(x: Int): Int
-       |fooBar(x: String): Int
+    """|fooBar - a(x: Int): Int
+       |fooBar - a.b(x: String): Int
        |""".stripMargin
   )
 
@@ -989,7 +993,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "method-name-conflict".tag(IgnoreScala2),
+    "method-name-conflict".tag(IgnoreScala2.and(IgnoreForScala3CompilerPC)),
     """|package demo
        |
        |object O {
@@ -1010,7 +1014,23 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite {
        |  }
        |}
        |""".stripMargin,
-    filter = _.contains("mmmm(x: Int)")
+    filter = _.contains("mmmm - demo.O")
+  )
+
+  check(
+    "method-label".tag(IgnoreForScala3CompilerPC),
+    """|package demo
+       |
+       |object O {
+       | def method(i: Int): Int = i + 1
+       |}
+       |
+       |object Main {
+       |  val x = meth@@
+       |}
+       |""".stripMargin,
+    """|method - demo.O(i: Int): Int
+       |""".stripMargin
   )
 
 }


### PR DESCRIPTION
Aligns labels in completions for methods from workspace is Scala 3 to work the same as for Scala 2. 
Previously the label did not contain information about the source of the method.