### PR TITLE
bugfix: revert back to using embedded `sbt` launcher for Windows

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -87,18 +87,21 @@ case class SbtBuildTool(
   }
 
   private def findSbtInPath(): Option[String] = {
-    val envPaths =
-      Option(System.getenv("PATH")) match {
-        case Some(paths) if scala.util.Properties.isWin =>
-          paths.split(";").toList
-        case Some(paths) => paths.split(":").toList
-        case None => Nil
-      }
+    // on Windows sbt is not an executable
+    // look: https://github.com/scalameta/metals/issues/6104
+    if (scala.util.Properties.isWin) None
+    else {
+      val envPaths =
+        Option(System.getenv("PATH")) match {
+          case Some(paths) => paths.split(":").toList
+          case None => Nil
+        }
 
-    val allPaths = projectRoot :: envPaths.map(AbsolutePath(_))
-    allPaths.collectFirst { path =>
-      path.resolve("sbt") match {
-        case sbtPath if sbtPath.exists => sbtPath.toString()
+      val allPaths = projectRoot :: envPaths.map(AbsolutePath(_))
+      allPaths.collectFirst { path =>
+        path.resolve("sbt") match {
+          case sbtPath if sbtPath.exists => sbtPath.toString()
+        }
       }
     }
   }


### PR DESCRIPTION
https://github.com/scalameta/metals/issues/6104

This is a quick fix for a breaking change on WIndows. We might want to find the correct executable in "PATH" on Windows in the future.