### PR TITLE
bugfix: deduplicate references results

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -428,7 +428,7 @@ final class ReferenceProvider(
       includeSynthetics: Synthetic => Boolean,
       isJava: Boolean,
   ): Seq[Location] = {
-    val buf = Seq.newBuilder[Location]
+    val buf = Set.newBuilder[Location]
     def add(range: s.Range): Unit = {
       val revised = distance.toRevised(range.startLine, range.startCharacter)
       val dirtyLocation = range.toLocation(uri)
@@ -470,7 +470,7 @@ final class ReferenceProvider(
       range <- synthetic.range.toList
     } add(range)
 
-    buf.result().sortWith(sortByLocationPosition)
+    buf.result().toSeq.sortWith(sortByLocationPosition)
   }
 
   private def sortByLocationPosition(l1: Location, l2: Location): Boolean = {


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/2494

Sometimes there are multiple occurrences in the same location, e.g. import can be both occurrence of the object and class, in case of `find references` that may lead to duplication in results.