### PR TITLE
bugfix: use text document version for initial package edit

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -1101,6 +1101,14 @@ object MetalsEnrichments
   implicit class XtensionClientCapabilities(
       params: l.InitializeParams
   ) {
+    def supportsVersionedWorkspaceEdits: Boolean =
+      (for {
+        capabilities <- Option(params.getCapabilities)
+        workspace <- Option(capabilities.getWorkspace)
+        workspaceEdit <- Option(workspace.getWorkspaceEdit)
+        docChanges <- Option(workspaceEdit.getDocumentChanges)
+      } yield docChanges.booleanValue).getOrElse(false)
+
     def supportsHierarchicalDocumentSymbols: Boolean =
       (for {
         capabilities <- Option(params.getCapabilities)

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1068,8 +1068,13 @@ class MetalsLspService(
     // Update in-memory buffer contents from LSP client
     buffers.put(path, params.getTextDocument.getText)
 
+    val optVersion =
+      Option.when(initializeParams.supportsVersionedWorkspaceEdits)(
+        params.getTextDocument().getVersion()
+      )
+
     packageProvider
-      .workspaceEdit(path)
+      .workspaceEdit(path, params.getTextDocument().getText(), optVersion)
       .map(new ApplyWorkspaceEditParams(_))
       .foreach(languageClient.applyEdit)
 


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/2869

It turns out, that VSCode is able to deal with this if only metals supports text document version.