### PR TITLE
bugfix: Fix restarting bazel

### DIFF
--- a/docs/build-tools/bazel.md
+++ b/docs/build-tools/bazel.md
@@ -164,3 +164,13 @@ targets manually in `projectview.bazel`. This will speed up the import process
 significantly.
 
 There is work ongoing to improve the performance of Bazel in Metals.
+
+## Troubleshooting
+
+### Bazel is restarting between CLI and Metals
+
+This possibly means that some of the environment variables are set to different
+values between what Metals and Bazel are using. Some of the variables that
+influence this are PATH, PWD, JAVA_HOME and others. Make sure that these are set
+to the same values in both environments. If possible let us know if we can improve
+the default behaviour of Metals to avoid this issue.

--- a/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
+++ b/metals/src/main/scala/scala/meta/internal/process/SystemProcess.scala
@@ -40,6 +40,7 @@ object SystemProcess {
       builder.directory(cwd.toNIO.toFile)
       val envMap = builder.environment()
       envMap.putAll(env.asJava)
+      envMap.put("PWD", cwd.toString())
 
       builder.redirectErrorStream(redirectErrorOutput)
       val ps = builder.start()


### PR DESCRIPTION
Previously, the PWD given to Metals server would be that of user home. Now, we override it to always point to the current project directory.

Fixes https://github.com/scalameta/metals/issues/6094