### PR TITLE
refactor: generate mill BSP file with `--jobs 0`

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -136,7 +136,7 @@ case class MillBuildTool(
       workspace: AbsolutePath
   ): Option[List[String]] =
     Option.when(workspaceSupportsBsp(workspace: AbsolutePath)) {
-      val cmd = "mill.bsp.BSP/install" :: Nil
+      val cmd = "mill.bsp.BSP/install" :: "--jobs" :: "0" :: Nil
       putTogetherArgs(cmd, getMillVersion(projectRoot), workspace)
     }
 


### PR DESCRIPTION
When jobs isn't specified this will default to 1 [disabling parallel task execution](https://mill-build.com/mill/Intro_to_Mill.html#_parallel_task_execution). This can cause really slow import times for big builds. For example on my modern M1 macbook, it takes around 20 minutes to import the Mill codebase. The docs linked say the following:

> To use as many threads as your machine has (logical) processor cores use --jobs 0.

So we switch it to that.