### PR TITLE
improvement: Add fallback for inlay hints

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -34,6 +34,7 @@ import scala.meta.pc.HoverSignature
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.PresentationCompiler
 import scala.meta.pc.SymbolSearch
+import scala.meta.pc.SyntheticDecorationsParams
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import ch.epfl.scala.bsp4j.CompileReport
@@ -45,6 +46,7 @@ import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DocumentHighlight
 import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.InlayHint
+import org.eclipse.lsp4j.InlayHintKind
 import org.eclipse.lsp4j.InlayHintParams
 import org.eclipse.lsp4j.RenameParams
 import org.eclipse.lsp4j.SelectionRange
@@ -568,8 +570,24 @@ class Compilers(
       token: CancelToken,
   ): Future[ju.List[InlayHint]] = {
     withPCAndAdjustLsp(params) { (pc, pos, adjust) =>
-      val rangeParams =
-        CompilerRangeParamsUtils.fromPos(pos, token)
+      def inlayHintsFallback(
+          params: SyntheticDecorationsParams
+      ): Future[ju.List[InlayHint]] = {
+        pc.syntheticDecorations(params)
+          .asScala
+          .map(
+            _.map { d =>
+              val hint = new InlayHint()
+              hint.setPosition(d.range().getStart())
+              hint.setLabel(d.label())
+              val kind =
+                if (d.kind() <= 2) InlayHintKind.Type
+                else InlayHintKind.Parameter
+              hint.setKind(kind)
+              hint
+            }
+          )
+      }
 
       def adjustInlayHints(
           inlayHints: ju.List[InlayHint]
@@ -587,6 +605,8 @@ class Compilers(
           .asJava
       }
 
+      val rangeParams =
+        CompilerRangeParamsUtils.fromPos(pos, token)
       val pcParams = CompilerInlayHintsParams(
         rangeParams,
         typeParameters = userConfig().showInferredType.contains("true"),
@@ -595,10 +615,18 @@ class Compilers(
         implicitParameters = userConfig().showImplicitArguments,
         implicitConversions = userConfig().showImplicitConversionsAndClasses,
       )
+
       pc
         .inlayHints(pcParams)
         .asScala
-        .map(adjustInlayHints)
+        .flatMap { hints =>
+          if (hints.isEmpty) {
+            inlayHintsFallback(pcParams.toSyntheticDecorationsParams)
+              .map(adjustInlayHints)
+          } else {
+            Future.successful(adjustInlayHints(hints))
+          }
+        }
     }
       .getOrElse(Future.successful(Nil.asJava))
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -584,6 +584,7 @@ class Compilers(
                 if (d.kind() <= 2) InlayHintKind.Type
                 else InlayHintKind.Parameter
               hint.setKind(kind)
+              hint.setData(Array(""))
               hint
             }
           )

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/CompilerInlayHintsParams.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/CompilerInlayHintsParams.scala
@@ -17,4 +17,14 @@ case class CompilerInlayHintsParams(
   override def token(): CancelToken = rangeParams.token
   override def offset(): Int = rangeParams.offset
   override def endOffset(): Int = rangeParams.endOffset
+
+  def toSyntheticDecorationsParams: CompilerSyntheticDecorationsParams = {
+    CompilerSyntheticDecorationsParams(
+      rangeParams,
+      inferredTypes = inferredTypes,
+      typeParameters = typeParameters,
+      implicitConversions = implicitConversions,
+      implicitParameters = implicitParameters
+    )
+  }
 }

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/CompilerSyntheticDecorationsParams.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/CompilerSyntheticDecorationsParams.scala
@@ -1,0 +1,19 @@
+package scala.meta.internal.metals
+
+import java.net.URI
+
+import scala.meta.pc.CancelToken
+import scala.meta.pc.SyntheticDecorationsParams
+import scala.meta.pc.VirtualFileParams
+
+case class CompilerSyntheticDecorationsParams(
+    virtualFileParams: VirtualFileParams,
+    inferredTypes: Boolean,
+    typeParameters: Boolean,
+    implicitParameters: Boolean,
+    implicitConversions: Boolean
+) extends SyntheticDecorationsParams {
+  override def uri(): URI = virtualFileParams.uri
+  override def text(): String = virtualFileParams.text
+  override def token(): CancelToken = virtualFileParams.token
+}

--- a/tests/slow/src/test/scala/tests/feature/InlayHintsFallbackSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/InlayHintsFallbackSuite.scala
@@ -1,0 +1,43 @@
+package tests.feature
+
+import tests.BaseInlayHintsLspSuite
+
+class InlayHintsFallbackSuite
+    extends BaseInlayHintsLspSuite(
+      "inlayHints-fallback",
+      "3.4.0",
+    ) {
+
+  check(
+    "all-synthetics",
+    """|import scala.concurrent.Future
+       |case class Location(city: String)
+       |object Main{
+       |  def hello()(implicit name: String, from: Location)/*: Unit*/ = {
+       |    println(s"Hello $$name from $${from.city}")
+       |  }
+       |  implicit val andy : String = "Andy"
+       |
+       |  def greeting()/*: Unit*/ = {
+       |    implicit val boston/*: Location*/ = Location("Boston")
+       |    hello()/*(andy, boston)*/
+       |    hello()/*(andy, boston)*/;    hello()/*(andy, boston)*/
+       |  }
+       |  
+       |  val ordered/*: String*/ = /*augmentString(*/"acb"/*)*/.sorted/*(Char)*/
+       |  /*augmentString(*/"foo"/*)*/.map(c/*: Char*/ => c.toInt)
+       |  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+       |  Future{
+       |    println("")
+       |  }/*(ec)*/
+       |}
+       |""".stripMargin,
+    config = Some(
+      """|"show-implicit-arguments": true,
+         |"show-implicit-conversions-and-classes": true,
+         |"show-inferred-type": minimal
+         |""".stripMargin
+    ),
+  )
+
+}

--- a/tests/unit/src/main/scala/tests/BaseInlayHintsLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseInlayHintsLspSuite.scala
@@ -1,0 +1,54 @@
+package tests
+
+import munit.Location
+import munit.TestOptions
+import tests.BaseLspSuite
+import tests.TestInlayHints
+
+abstract class BaseInlayHintsLspSuite(name: String, scalaVersion: String)
+    extends BaseLspSuite(name) {
+  def check(
+      name: TestOptions,
+      expected: String,
+      config: Option[String] = None,
+      dependencies: List[String] = Nil,
+  )(implicit
+      loc: Location
+  ): Unit = {
+    val initConfig = config
+      .map(config => s"""{
+                        |$config
+                        |}
+                        |""".stripMargin)
+      .getOrElse("""{
+                   |  "show-implicit-arguments": true,
+                   |  "show-implicit-conversions-and-classes": true,
+                   |  "show-inferred-type": "true"
+                   |}
+                   |""".stripMargin)
+    val fileName = "Main.scala"
+    val code = TestInlayHints.removeInlayHints(expected)
+    test(name) {
+      for {
+        _ <- initialize(
+          s"""/metals.json
+             |{"a":{
+             |  "scalaVersion": "$scalaVersion",
+             |  "libraryDependencies": ${toJsonArray(dependencies)}
+             |}}
+             |/a/src/main/scala/a/$fileName
+             |$code
+          """.stripMargin
+        )
+        _ <- server.didOpen(s"a/src/main/scala/a/$fileName")
+        _ <- server.didChangeConfiguration(initConfig)
+        _ <- server.assertInlayHints(
+          s"a/src/main/scala/a/$fileName",
+          code,
+          expected,
+          workspace,
+        )
+      } yield ()
+    }
+  }
+}

--- a/tests/unit/src/main/scala/tests/TestMtagsResolver.scala
+++ b/tests/unit/src/main/scala/tests/TestMtagsResolver.scala
@@ -14,17 +14,12 @@ class TestMtagsResolver extends MtagsResolver {
 
   val default: MtagsResolver = MtagsResolver.default()
 
-  /**
-   * We don't need to check unsupported versions in tests and that makes the tests run longer.
-   */
   override def resolve(scalaVersion: String): Option[MtagsBinaries] = {
-    if (ScalaVersions.isSupportedAtReleaseMomentScalaVersion(scalaVersion))
-      default.resolve(scalaVersion).orElse(Some(MtagsBinaries.BuildIn))
-    else None
-  }
-
-  override def isSupportedScalaVersion(version: String): Boolean = {
-    ScalaVersions.isSupportedAtReleaseMomentScalaVersion(version)
+    default.resolve(scalaVersion).orElse {
+      if (ScalaVersions.isSupportedAtReleaseMomentScalaVersion(scalaVersion))
+        Some(MtagsBinaries.BuildIn)
+      else None
+    }
   }
 
   override def isSupportedInOlderVersion(version: String): Boolean =


### PR DESCRIPTION
For Scala 3.nightly, it maps old synthetic decorations to inlay hints. Its needed because inlay hints are not available for every Scala version