### PR TITLE
improvement: Regenerate Bazel files if any are missing

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
@@ -87,7 +87,7 @@ object BazelBuildTool {
   private def hasProjectView(dir: AbsolutePath): Option[AbsolutePath] =
     dir.list.find(_.filename.endsWith(".bazelproject"))
 
-  private def existingProjectView(
+  def existingProjectView(
       projectRoot: AbsolutePath
   ): Option[AbsolutePath] =
     List(projectRoot, projectRoot.resolve("ijwb"), projectRoot.resolve(".ijwb"))

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -61,9 +61,13 @@ final class BuildTools(
   private def hasJsonFile(dir: AbsolutePath): Boolean = {
     dir.list.exists(_.extension == "json")
   }
+
   def isBazelBsp: Boolean = {
-    workspace.resolve(".bazelbsp").isDirectory
+    workspace.resolve(".bazelbsp").isDirectory &&
+    BazelBuildTool.existingProjectView(workspace).nonEmpty &&
+    isBsp
   }
+
   // Returns true if there's a build.sbt file or project/build.properties with sbt.version
   def sbtProject: Option[AbsolutePath] = searchForBuildTool { root =>
     root.resolve("build.sbt").isFile || {


### PR DESCRIPTION
Partly fixes https://github.com/scalameta/metals/issues/6131

It seems that Bazel BSP creates empty projectview if it doesn't exist.