### PR TITLE
Fix parsing of enum in DAP messages

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/JsonParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JsonParser.scala
@@ -19,7 +19,7 @@ object JsonParser {
 
   implicit class XtensionSerializableToJson(data: Any) {
     def toJson: JsonElement = {
-      JsonParser.gson.toJsonTree(data)
+      gson.toJsonTree(data)
     }
 
     def toJsonObject: JsonObject = {
@@ -30,7 +30,7 @@ object JsonParser {
   implicit class XtensionSerializedAsJson(json: JsonElement) {
     def as[A: ClassTag]: Try[A] = {
       val targetType = classTag[A].runtimeClass.asInstanceOf[Class[A]]
-      Try(JsonParser.gson.fromJson(json, targetType))
+      Try(gson.fromJson(json, targetType))
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DapJsonParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DapJsonParser.scala
@@ -1,0 +1,44 @@
+package scala.meta.internal.metals.debug
+
+import scala.reflect.ClassTag
+import scala.reflect.classTag
+import scala.util.Try
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import org.eclipse.lsp4j.jsonrpc.debug.adapters.DebugEnumTypeAdapter
+
+object DapJsonParser {
+  private val gson: Gson = new GsonBuilder()
+    .registerTypeAdapterFactory(
+      // seriliaze Java enum to lower case
+      new DebugEnumTypeAdapter.Factory
+    )
+    .create
+
+  implicit class XtensionSerializedJson(string: String) {
+    def parseJson: JsonElement = {
+      com.google.gson.JsonParser.parseString(string)
+    }
+  }
+
+  implicit class XtensionSerializableToJson(data: Any) {
+    def toJson: JsonElement = {
+      gson.toJsonTree(data)
+    }
+
+    def toJsonObject: JsonObject = {
+      data.toJson.getAsJsonObject
+    }
+  }
+
+  implicit class XtensionSerializedAsJson(json: JsonElement) {
+    def as[A: ClassTag]: Try[A] = {
+      val targetType = classTag[A].runtimeClass.asInstanceOf[Class[A]]
+      Try(gson.fromJson(json, targetType))
+    }
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DapJsonParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DapJsonParser.scala
@@ -13,7 +13,7 @@ import org.eclipse.lsp4j.jsonrpc.debug.adapters.DebugEnumTypeAdapter
 object DapJsonParser {
   private val gson: Gson = new GsonBuilder()
     .registerTypeAdapterFactory(
-      // seriliaze Java enum to lower case
+      // serialize Java enum to lower case
       new DebugEnumTypeAdapter.Factory
     )
     .create

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProtocol.scala
@@ -29,7 +29,7 @@ import org.eclipse.lsp4j.{debug => dap}
 import org.eclipse.{lsp4j => l}
 
 object DebugProtocol {
-  import scala.meta.internal.metals.JsonParser._
+  import scala.meta.internal.metals.debug.DapJsonParser._
   val FirstMessageId = 1
 
   val serverName = "dap-server"


### PR DESCRIPTION
I want to use [presentationHint](https://github.com/eclipse-lsp4j/lsp4j/blob/88868d3506d317b12cf0bfd1e82a254489f8c47b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend#L2979) in DAP messages but I can't because the current JSON parser does not handle Java enums correctly. It should be serialized to `"presentationHint": "deemphasize"` and not `"presentationHint": "DEEMPHASIZE"`.

lsp4j has two different enum type handlers for DAP ([here](https://github.com/eclipse-lsp4j/lsp4j/blob/88868d3506d317b12cf0bfd1e82a254489f8c47b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/json/DebugMessageJsonHandler.java#L34-L35)) and for LSP ([here](https://github.com/eclipse-lsp4j/lsp4j/blob/88868d3506d317b12cf0bfd1e82a254489f8c47b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/MessageJsonHandler.java#L81-L87)). In this PR I use the `DebugEnumTypeAdapter` from lsp4j to configure the DAP `gson` instance.

