### PR TITLE
improvement: Lazily resolve classpath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
         shard: [1, 2]
         include:
           - os: ubuntu-latest
-            java: "8"
+            java: "11"
             shard: 1
           - os: ubuntu-latest
-            java: "8"
+            java: "11"
             shard: 2
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,9 @@ jobs:
             java: "17"
           - type: sbt-metals jdk8
             command: bin/test.sh sbt-metals/scripted
-            name: Sbt-metals/scripted jdk8
+            name: Sbt-metals/scripted jdk11
             os: ubuntu-latest
-            java: "8"
+            java: "11"
           - type: maven
             command: bin/test.sh 'slow/testOnly -- tests.maven.*'
             name: Maven integration

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,6 +1,6 @@
 -Xss4m
 -Xms1G
--Xmx3G
+-Xmx2G
 -XX:ReservedCodeCacheSize=1024m
 -XX:+TieredCompilation
 -Dfile.encoding=UTF-8

--- a/build.sbt
+++ b/build.sbt
@@ -203,7 +203,7 @@ val sharedScalacOptions = List(
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case partialVersion
-          // Scala 2.12.16 aand lower break within the tests if target is set to 11
+          // Scala 2.12.16 and lower break within the tests if target is set to 11
           if isScala211(partialVersion) ||
             scalaVersion.value == "2.12.16" ||
             isScala212(partialVersion) && V.deprecatedScala2Versions
@@ -843,8 +843,6 @@ lazy val slow = project
   .settings(
     testSettings,
     sharedSettings,
-    // Test / javaOptions += "-Xmx2G",
-    // Test / javaOptions += "-XX:+HeapDumpOnOutOfMemoryError",
     Test / testOnly := (Test / testOnly)
       .dependsOn((`sbt-metals` / publishLocal), publishBinaryMtags)
       .evaluated,

--- a/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
@@ -65,7 +65,7 @@ case class BazelBuildTool(
 object BazelBuildTool {
   val name: String = "bazel"
   val bspName: String = "bazelbsp"
-  val version: String = "3.1.0-20240313-89141af-NIGHTLY"
+  val version: String = "3.1.0-20240328-e62f321-NIGHTLY"
 
   val mainClass = "org.jetbrains.bsp.bazel.install.Install"
 

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
@@ -129,13 +129,28 @@ class BuildTargetInfo(buildTargets: BuildTargets) {
       )
     }
 
-    val scalaClassPath = scalaInfo
-      .flatMap(_.classpath) match {
-      case None => List("<unresolved>")
-      case Some(classpath) =>
-        getClassPath(classpath.map(_.toAbsolutePath), targetId)
+    val scalaClassPath =
+      scalaInfo.flatMap(_.classpath).getOrElse(Nil).map(_.toAbsolutePath)
+    val javaClassPath =
+      javaInfo.flatMap(_.classpath).getOrElse(Nil).map(_.toAbsolutePath)
+    if (scalaClassPath == javaClassPath)
+      if (scalaClassPath.isEmpty)
+        List("<unresolved>")
+      else
+        output ++= getSection(
+          "Classpath",
+          getClassPath(scalaClassPath, targetId),
+        )
+    else {
+      output ++= getSection(
+        "Java Classpath",
+        getClassPath(javaClassPath, targetId),
+      )
+      output ++= getSection(
+        "Scala Classpath",
+        getClassPath(scalaClassPath, targetId),
+      )
     }
-    output ++= getSection("Classpath", scalaClassPath)
     output += ""
     output.mkString(System.lineSeparator())
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargetInfo.scala
@@ -130,7 +130,7 @@ class BuildTargetInfo(buildTargets: BuildTargets) {
     }
 
     val scalaClassPath = scalaInfo
-      .flatMap(_.lazyClasspath) match {
+      .flatMap(_.classpath) match {
       case None => List("<unresolved>")
       case Some(classpath) =>
         getClassPath(classpath.map(_.toAbsolutePath), targetId)

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -9,6 +9,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.Promise
 import scala.util.control.NonFatal
 
 import scala.meta.internal.io.PathIO
@@ -117,9 +118,10 @@ final class BuildTargets private (
     data.fromOptions(_.javaTarget(id))
 
   def fullClasspath(
-      id: BuildTargetIdentifier
+      id: BuildTargetIdentifier,
+      cancelPromise: Promise[Unit],
   )(implicit ec: ExecutionContext): Option[Future[List[AbsolutePath]]] =
-    targetClasspath(id).map { lazyClasspath =>
+    targetClasspath(id, cancelPromise).map { lazyClasspath =>
       lazyClasspath.map { classpath =>
         classpath.map(_.toAbsolutePath).collect {
           case path if path.isJar || path.isDirectory =>
@@ -134,9 +136,10 @@ final class BuildTargets private (
     data.fromOptions(_.targetJarClasspath(id))
 
   def targetClasspath(
-      id: BuildTargetIdentifier
+      id: BuildTargetIdentifier,
+      cancelPromise: Promise[Unit],
   )(implicit executionContext: ExecutionContext): Option[Future[List[String]]] =
-    data.fromOptions(_.targetClasspath(id))
+    data.fromOptions(_.targetClasspath(id, cancelPromise))
 
   def targetClassDirectories(
       id: BuildTargetIdentifier

--- a/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
@@ -1,0 +1,344 @@
+package scala.meta.internal.metals
+
+import java.nio.file.Path
+import java.util.concurrent.ScheduledExecutorService
+import java.{util => ju}
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContextExecutorService
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.util.Try
+import scala.util.control.NonFatal
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.parsing.Trees
+import scala.meta.internal.pc.EmptySymbolSearch
+import scala.meta.internal.pc.JavaPresentationCompiler
+import scala.meta.internal.pc.ScalaPresentationCompiler
+import scala.meta.io.AbsolutePath
+import scala.meta.pc.PresentationCompiler
+import scala.meta.pc.SymbolSearch
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import org.eclipse.lsp4j.InitializeParams
+
+class CompilerConfiguration(
+    workspace: AbsolutePath,
+    config: ClientConfiguration,
+    userConfig: () => UserConfiguration,
+    buildTargets: BuildTargets,
+    buffers: Buffers,
+    embedded: Embedded,
+    sh: ScheduledExecutorService,
+    initializeParams: InitializeParams,
+    excludedPackages: () => ExcludedPackagesHandler,
+    trees: Trees,
+    mtagsResolver: MtagsResolver,
+    sourceMapper: SourceMapper,
+)(implicit ec: ExecutionContextExecutorService, rc: ReportContext) {
+
+  private val plugins = new CompilerPlugins()
+
+  sealed trait MtagsPresentationCompiler {
+    def await: PresentationCompiler
+  }
+
+  case class StandaloneCompiler(
+      scalaVersion: String,
+      symbolSearch: SymbolSearch,
+      classpath: Seq[Path],
+  ) extends MtagsPresentationCompiler {
+    private val mtags =
+      mtagsResolver.resolve(scalaVersion).getOrElse(MtagsBinaries.BuildIn)
+
+    val standalone: PresentationCompiler =
+      fromMtags(
+        mtags,
+        options = Nil,
+        classpath ++ Embedded.scalaLibrary(scalaVersion),
+        "default",
+        symbolSearch,
+      )
+
+    def await: PresentationCompiler = standalone
+  }
+
+  object StandaloneCompiler {
+
+    def apply(
+        scalaVersion: String,
+        classpath: Seq[Path],
+        sources: Seq[Path],
+        workspaceFallback: Option[SymbolSearch],
+    ): StandaloneCompiler = {
+      val search =
+        createStandaloneSearch(classpath, sources, workspaceFallback)
+      StandaloneCompiler(
+        scalaVersion,
+        search,
+        classpath,
+      )
+    }
+  }
+
+  trait LazyCompiler extends MtagsPresentationCompiler {
+
+    def buildTargetId: BuildTargetIdentifier
+    protected def fallback: PresentationCompiler
+    protected def newCompiler(classpath: Seq[Path]): PresentationCompiler
+
+    protected val presentationCompilerRef =
+      new ju.concurrent.atomic.AtomicReference[PresentationCompiler]()
+
+    private val wasResolved = new ju.concurrent.atomic.AtomicBoolean(false)
+    protected val presentationCompilerFuture: Future[PresentationCompiler] =
+      buildTargets
+        .targetClasspath(buildTargetId)
+        .getOrElse(Future.successful(Nil))
+        .map { classpath =>
+          // set wasResolved to avoid races on timeout below
+          wasResolved.set(true)
+          // Request finished, we can remove and shut down the fallback
+          Option(presentationCompilerRef.getAndSet(null)).foreach(_.shutdown())
+          val classpathSeq = classpath.toAbsoluteClasspath.map(_.toNIO).toSeq
+          newCompiler(classpathSeq)
+        }
+
+    def await: PresentationCompiler = {
+      val compilerConfig = config.initialConfig.compilers
+      try {
+        val pc = presentationCompilerRef.get()
+        if (pc != null) {
+          pc
+        } else {
+          val result = Await.result(
+            presentationCompilerFuture,
+            Duration(compilerConfig.timeoutDelay, compilerConfig.timeoutUnit),
+          )
+          presentationCompilerRef.set(result)
+          result
+        }
+      } catch {
+        case _: ju.concurrent.TimeoutException =>
+          scribe.warn(
+            s"Still waiting for information about classpath, using standalone compiler for now"
+          )
+          val pc = presentationCompilerRef.updateAndGet { old =>
+            if (old != null) old
+            else if (!wasResolved.get()) fallback
+            else null
+          }
+          if (pc != null) pc
+          // null is only returned if classpath was resolved while we were waiting and there was a race
+          else await
+      }
+    }
+  }
+
+  case class ScalaLazyCompiler(
+      scalaTarget: ScalaTarget,
+      mtags: MtagsBinaries,
+      search: SymbolSearch,
+      additionalClasspath: Seq[Path] = Nil,
+  ) extends LazyCompiler {
+
+    def buildTargetId: BuildTargetIdentifier = scalaTarget.id
+
+    protected def newCompiler(classpath: Seq[Path]): PresentationCompiler = {
+      val name = scalaTarget.scalac.getTarget().getUri
+      val options = enrichWithReleaseOption(scalaTarget)
+      fromMtags(mtags, options, classpath ++ additionalClasspath, name, search)
+        .withBuildTargetName(scalaTarget.displayName)
+    }
+
+    protected def fallback: PresentationCompiler =
+      StandaloneCompiler(
+        scalaTarget.scalaVersion,
+        Nil,
+        Nil,
+        Some(search),
+      ).standalone
+
+  }
+
+  object ScalaLazyCompiler {
+
+    def forWorksheet(
+        scalaTarget: ScalaTarget,
+        mtags: MtagsBinaries,
+        classpath: Seq[Path],
+        sources: Seq[Path],
+        workspaceFallback: SymbolSearch,
+    ): ScalaLazyCompiler = {
+
+      val worksheetSearch =
+        createStandaloneSearch(classpath, sources, Some(workspaceFallback))
+
+      ScalaLazyCompiler(
+        scalaTarget,
+        mtags,
+        worksheetSearch,
+        classpath,
+      )
+    }
+  }
+
+  case class JavaLazyCompiler(
+      targetId: BuildTargetIdentifier,
+      search: SymbolSearch,
+  ) extends LazyCompiler {
+
+    def buildTargetId: BuildTargetIdentifier = targetId
+
+    protected def newCompiler(classpath: Seq[Path]): PresentationCompiler = {
+      val pc = JavaPresentationCompiler()
+      configure(pc, search)
+        .newInstance(
+          targetId.getUri(),
+          classpath.asJava,
+          log.asJava,
+        )
+    }
+
+    protected def fallback: JavaPresentationCompiler =
+      JavaPresentationCompiler()
+  }
+
+  private def configure(
+      pc: PresentationCompiler,
+      search: SymbolSearch,
+  ): PresentationCompiler =
+    pc.withSearch(search)
+      .withExecutorService(ec)
+      .withWorkspace(workspace.toNIO)
+      .withScheduledExecutorService(sh)
+      .withReportsLoggerLevel(MetalsServerConfig.default.loglevel)
+      .withConfiguration {
+        val options =
+          InitializationOptions.from(initializeParams).compilerOptions
+        config.initialConfig.compilers
+          .update(options)
+          .copy(
+            _symbolPrefixes = userConfig().symbolPrefixes,
+            isCompletionSnippetsEnabled =
+              initializeParams.supportsCompletionSnippets,
+            _isStripMarginOnTypeFormattingEnabled =
+              () => userConfig().enableStripMarginOnTypeFormatting,
+          )
+      }
+
+  private def fromMtags(
+      mtags: MtagsBinaries,
+      options: Seq[String],
+      classpathSeq: Seq[Path],
+      name: String,
+      symbolSearch: SymbolSearch,
+  ): PresentationCompiler = {
+    val pc = mtags match {
+      case MtagsBinaries.BuildIn => new ScalaPresentationCompiler()
+      case artifacts: MtagsBinaries.Artifacts =>
+        embedded.presentationCompiler(artifacts, classpathSeq)
+    }
+
+    val filteredOptions = plugins.filterSupportedOptions(options)
+    configure(pc, symbolSearch)
+      .newInstance(
+        name,
+        classpathSeq.asJava,
+        (log ++ filteredOptions).asJava,
+      )
+  }
+
+  private def createStandaloneSearch(
+      classpath: Seq[Path],
+      sources: Seq[Path],
+      workspaceFallback: Option[SymbolSearch],
+  ): SymbolSearch = try {
+    new StandaloneSymbolSearch(
+      workspace,
+      classpath.map(AbsolutePath(_)),
+      sources.map(AbsolutePath(_)),
+      buffers,
+      excludedPackages,
+      trees,
+      buildTargets,
+      saveSymbolFileToDisk = !config.isVirtualDocumentSupported(),
+      sourceMapper,
+      workspaceFallback,
+    )
+  } catch {
+    case NonFatal(e) => {
+      scribe.error(
+        "Could not create standalone symbol search, please report an issue.",
+        e,
+      )
+      EmptySymbolSearch
+    }
+  }
+
+  private def enrichWithReleaseOption(scalaTarget: ScalaTarget) = {
+    val scalacOptions = scalaTarget.scalac.getOptions().asScala.toSeq
+    def existsReleaseSetting = scalacOptions.exists(opt =>
+      opt.startsWith("-release") ||
+        opt.startsWith("--release") ||
+        opt.startsWith("-java-output-version")
+    )
+    if (existsReleaseSetting) scalacOptions
+    else {
+      def optBuildTargetJvmVersion =
+        scalaTarget.jvmVersion
+          .flatMap(version => JdkVersion.parse(version))
+          .orElse {
+            val javaHome =
+              scalaTarget.jvmHome
+                .flatMap(_.toAbsolutePathSafe)
+                .orElse {
+                  for {
+                    javaHomeString <- userConfig().javaHome.map(_.trim())
+                    if (javaHomeString.nonEmpty)
+                    javaHome <- Try(AbsolutePath(javaHomeString)).toOption
+                  } yield javaHome
+                }
+            JdkVersion.maybeJdkVersionFromJavaHome(javaHome)
+          }
+
+      val releaseVersion =
+        for {
+          jvmVersion <- optBuildTargetJvmVersion
+          metalsJavaVersion <- Option(sys.props("java.version"))
+            .flatMap(JdkVersion.parse)
+          _ <-
+            if (jvmVersion.major < metalsJavaVersion.major) Some(())
+            else if (metalsJavaVersion.major > jvmVersion.major) {
+              scribe.warn(
+                s"""|Your project uses JDK version ${jvmVersion.major} and
+                    |Metals server is running on JDK version ${metalsJavaVersion.major}.
+                    |This might cause incorrect completions, since
+                    |Metals JDK version should be greater or equal the project's JDK version.
+                    |""".stripMargin
+              )
+              None
+            } else None
+        } yield jvmVersion.major
+
+      releaseVersion match {
+        case Some(version) =>
+          scalacOptions ++ List("-release", version.toString())
+        case _ => scalacOptions
+      }
+    }
+  }
+
+  private def log: List[String] =
+    if (config.initialConfig.compilers.debug) {
+      List(
+        "-Ypresentation-debug",
+        "-Ypresentation-verbose",
+        "-Ypresentation-log",
+        workspace.resolve(Directories.pc).toString(),
+      )
+    } else {
+      Nil
+    }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -156,8 +156,8 @@ class Compilers(
     cache.values.count(_.await.isLoaded())
 
   override def cancel(): Unit = {
-    Cancelable.cancelEach(cache.values)(_.await.shutdown())
-    Cancelable.cancelEach(worksheetsCache.values)(_.await.shutdown())
+    Cancelable.cancelEach(cache.values)(_.shutdown())
+    Cancelable.cancelEach(worksheetsCache.values)(_.shutdown())
     cache.clear()
     worksheetsCache.clear()
     worksheetsDigests.clear()

--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -9,6 +9,7 @@ import javax.annotation.Nullable
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.Promise
 import scala.util.Failure
 import scala.util.Properties
 import scala.util.Success
@@ -597,7 +598,7 @@ final class FileDecoderProvider(
           .map(_.id)
       )
     buildTarget
-      .flatMap(id => buildTargets.targetClasspath(id))
+      .flatMap(id => buildTargets.targetClasspath(id, Promise[Unit]()))
       .getOrElse(Future.successful(Nil))
       .map(_.map(_.toAbsolutePath))
       .flatMap { classpaths =>

--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -597,84 +597,87 @@ final class FileDecoderProvider(
           )
           .map(_.id)
       )
-    val classpaths = buildTarget
-      .flatMap(id =>
-        buildTargets
-          .targetClasspath(id)
-          .map(path => path.toAbsoluteClasspath.toList)
-      )
-      .getOrElse(Nil)
-    val classesDirs = buildTarget
-      .map(id =>
-        buildTargets.targetClassDirectories(id).toAbsoluteClasspath.toList
-      )
-      .getOrElse(Nil)
-    val extraClassPaths = classesDirs ::: classpaths
-    val extraClassPath =
-      if (extraClassPaths.nonEmpty)
-        List("--extraclasspath", extraClassPaths.mkString(File.pathSeparator))
-      else Nil
+    buildTarget
+      .flatMap(id => buildTargets.targetClasspath(id))
+      .getOrElse(Future.successful(Nil))
+      .map(_.map(_.toAbsolutePath))
+      .flatMap { classpaths =>
+        val classesDirs = buildTarget
+          .map(id =>
+            buildTargets.targetClassDirectories(id).toAbsoluteClasspath.toList
+          )
+          .getOrElse(Nil)
+        val extraClassPaths = classesDirs ::: classpaths
 
-    // if the class file is in the classes dir then use that classes dir to allow CFR to use the other classes
-    val (parent, className) = classesDirs
-      .find(classesPath => path.isInside(classesPath))
-      .map(classesPath => {
-        val classPath = path.toRelative(classesPath)
-        val className = classPath.toString
-        (classesPath, className)
-      })
-      .getOrElse({
-        val parent = path.parent
-        val className = path.filename
-        (parent, className)
-      })
-
-    val args = extraClassPath :::
-      List(
-        // elideScala - must be lowercase - hide @@ScalaSignature and serialVersionUID for aesthetic reasons
-        "--elidescala",
-        "true",
-        // analyseAs - must be lowercase
-        "--analyseas",
-        "CLASS",
-        s"$className",
-      )
-
-    val sbOut = new StringBuilder()
-    val sbErr = new StringBuilder()
-    try {
-      shellRunner
-        .runJava(
-          cfrDependency,
-          cfrMain,
-          parent,
-          args,
-          userConfig().javaHome,
-          redirectErrorOutput = false,
-          s => {
-            sbOut.append(s)
-            sbOut.append(Properties.lineSeparator)
-          },
-          s => {
-            sbErr.append(s)
-            sbErr.append(Properties.lineSeparator)
-          },
-          propagateError = true,
-        )
-        .map(_ => {
-          if (sbOut.isEmpty && sbErr.nonEmpty)
-            DecoderResponse.failed(
-              path.toURI,
-              s"$cfrDependency\n$cfrMain\n$parent\n$args\n${sbErr.toString}",
+        val extraClassPath =
+          if (extraClassPaths.nonEmpty)
+            List(
+              "--extraclasspath",
+              extraClassPaths.mkString(File.pathSeparator),
             )
-          else
-            DecoderResponse.success(path.toURI, sbOut.toString)
-        })
-    } catch {
-      case NonFatal(e) =>
-        scribe.error(e.toString())
-        Future.successful(DecoderResponse.failed(path.toURI, e))
-    }
+          else Nil
+
+        // if the class file is in the classes dir then use that classes dir to allow CFR to use the other classes
+        val (parent, className) = classesDirs
+          .find(classesPath => path.isInside(classesPath))
+          .map(classesPath => {
+            val classPath = path.toRelative(classesPath)
+            val className = classPath.toString
+            (classesPath, className)
+          })
+          .getOrElse({
+            val parent = path.parent
+            val className = path.filename
+            (parent, className)
+          })
+
+        val args = extraClassPath :::
+          List(
+            // elideScala - must be lowercase - hide @@ScalaSignature and serialVersionUID for aesthetic reasons
+            "--elidescala",
+            "true",
+            // analyseAs - must be lowercase
+            "--analyseas",
+            "CLASS",
+            s"$className",
+          )
+
+        val sbOut = new StringBuilder()
+        val sbErr = new StringBuilder()
+        try {
+          shellRunner
+            .runJava(
+              cfrDependency,
+              cfrMain,
+              parent,
+              args,
+              userConfig().javaHome,
+              redirectErrorOutput = false,
+              s => {
+                sbOut.append(s)
+                sbOut.append(Properties.lineSeparator)
+              },
+              s => {
+                sbErr.append(s)
+                sbErr.append(Properties.lineSeparator)
+              },
+              propagateError = true,
+            )
+            .map(_ => {
+              if (sbOut.isEmpty && sbErr.nonEmpty)
+                DecoderResponse.failed(
+                  path.toURI,
+                  s"$cfrDependency\n$cfrMain\n$parent\n$args\n${sbErr.toString}",
+                )
+              else
+                DecoderResponse.success(path.toURI, sbOut.toString)
+            })
+        } catch {
+          case NonFatal(e) =>
+            scribe.error(e.toString())
+            Future.successful(DecoderResponse.failed(path.toURI, e))
+        }
+      }
   }
 
   private def decodeFromSemanticDB(
@@ -739,12 +742,14 @@ final class FileDecoderProvider(
       pathInfo: PathInfo
   ): Future[DecoderResponse] =
     compilers.loadCompiler(pathInfo.targetId) match {
-      case Some(pc) =>
-        pc.getTasty(
-          pathInfo.path.toURI,
-          clientConfig.isHttpEnabled(),
-        ).asScala
-          .map(DecoderResponse.success(pathInfo.path.toURI, _))
+      case Some(lazyPc) =>
+        lazyPc.flatMap {
+          _.getTasty(
+            pathInfo.path.toURI,
+            clientConfig.isHttpEnabled(),
+          ).asScala
+            .map(DecoderResponse.success(pathInfo.path.toURI, _))
+        }
       case None =>
         Future.successful(
           DecoderResponse.failed(

--- a/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileDecoderProvider.scala
@@ -87,7 +87,6 @@ final class FileDecoderProvider(
     fileSystemSemanticdbs: FileSystemSemanticdbs,
     interactiveSemanticdbs: InteractiveSemanticdbs,
     languageClient: MetalsLanguageClient,
-    clientConfig: ClientConfiguration,
     classFinder: ClassFinder,
 )(implicit ec: ExecutionContext) {
 
@@ -741,15 +740,11 @@ final class FileDecoderProvider(
   private def decodeFromTastyFile(
       pathInfo: PathInfo
   ): Future[DecoderResponse] =
-    compilers.loadCompiler(pathInfo.targetId) match {
-      case Some(lazyPc) =>
-        lazyPc.flatMap {
-          _.getTasty(
-            pathInfo.path.toURI,
-            clientConfig.isHttpEnabled(),
-          ).asScala
-            .map(DecoderResponse.success(pathInfo.path.toURI, _))
-        }
+    compilers.getTasty(pathInfo.targetId, pathInfo.path) match {
+      case Some(tasty) =>
+        tasty
+          .map(DecoderResponse.success(pathInfo.path.toURI, _))
+
       case None =>
         Future.successful(
           DecoderResponse.failed(

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -165,7 +165,7 @@ final case class Indexer(
         timerProvider.timedThunk("indexed workspace", onlyIf = true) {
           try indexWorkspace(check)
           finally {
-            Future(scalafixProvider().load())
+            scalafixProvider().load()
             indexingPromise().trySuccess(())
           }
         }

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
@@ -13,7 +13,7 @@ case class JavaTarget(
     info: BuildTarget,
     javac: JavacOptionsItem,
     bspConnection: Option[BuildServerConnection],
-) {
+) extends JvmTarget {
   def displayName: String = info.getName
 
   def dataKind: String = info.dataKind
@@ -42,6 +42,22 @@ case class JavaTarget(
   def sourceVersion: Option[String] = javac.sourceVersion
 
   def targetroot: Option[AbsolutePath] = javac.targetroot.map(_.resolveIfJar)
+
+  /**
+   * If the build server supports lazy classpath resolution, we will
+   * not get any classpath data eagerly and we should not
+   * use this endpoint. It should only be used as a fallback.
+   *
+   * This is due to the fact that we don't request classpath as it
+   * can be resonably expensive.
+   *
+   * @return non empty classpath only if it was resolved prior
+   */
+  def classpath: Option[List[String]] =
+    if (javac.getClasspath().isEmpty)
+      None
+    else
+      Some(javac.getClasspath().asScala.toList)
 
   /**
    * Typically to verify that SemanticDB is enabled correctly we check the javacOptions to ensure

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaTarget.scala
@@ -1,7 +1,5 @@
 package scala.meta.internal.metals
 
-import java.nio.file.Path
-
 import scala.meta.internal.builds.MillBuildTool
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.semver.SemVer
@@ -21,12 +19,6 @@ case class JavaTarget(
   def dataKind: String = info.dataKind
 
   def baseDirectory: String = info.baseDirectory
-
-  def fullClasspath: List[Path] =
-    javac.classpath.map(_.toAbsolutePath).collect {
-      case path if path.isJar || path.isDirectory =>
-        path.toNIO
-    }
 
   def options: List[String] = javac.getOptions().asScala.toList
 

--- a/metals/src/main/scala/scala/meta/internal/metals/JvmTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JvmTarget.scala
@@ -1,8 +1,44 @@
 package scala.meta.internal.metals
 
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+
 trait JvmTarget {
 
+  /**
+   * If the build server supports lazy classpath resolution, we will
+   * not get any classpath data eagerly and we should not
+   * use this endpoint. It should only be used as a fallback.
+   *
+   * This is due to the fact that we don't request classpath as it
+   * can be resonably expensive.
+   *
+   * @return non empty classpath only if it was resolved prior
+   */
   def classpath: Option[List[String]]
 
   def classDirectory: String
+
+  /**
+   * This method collects jars from classpath defined in scalacOptions.
+   *
+   * If the build server supports lazy classpath resolution, we will
+   * not get any classpath data eagerly and we should not
+   * use this endpoint. It should only be used as a fallback.
+   *
+   * This is due to the fact that we don't request classpath as it
+   * can be resonably expensive.
+   *
+   * We should use the buildTargetDependencyModules information
+   * from the indexer instead.
+   *
+   * @return non empty classpath jar list if it was resolved prior
+   */
+  def jarClasspath: Option[List[AbsolutePath]] =
+    classpath.map(collectJars)
+
+  private def collectJars(paths: List[String]) =
+    paths
+      .filter(_.endsWith(".jar"))
+      .map(_.toAbsolutePath)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/JvmTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JvmTarget.scala
@@ -1,0 +1,8 @@
+package scala.meta.internal.metals
+
+trait JvmTarget {
+
+  def classpath: Option[List[String]]
+
+  def classDirectory: String
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -777,7 +777,6 @@ class MetalsLspService(
       fileSystemSemanticdbs,
       interactiveSemanticdbs,
       languageClient,
-      clientConfig,
       new ClassFinder(trees),
     )
 
@@ -792,7 +791,7 @@ class MetalsLspService(
     tables,
   )
 
-  def loadedPresentationCompilerCount(): Future[Int] =
+  def loadedPresentationCompilerCount(): Int =
     compilers.loadedPresentationCompilerCount()
 
   val treeView =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -792,7 +792,7 @@ class MetalsLspService(
     tables,
   )
 
-  def loadedPresentationCompilerCount(): Int =
+  def loadedPresentationCompilerCount(): Future[Int] =
     compilers.loadedPresentationCompilerCount()
 
   val treeView =

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -111,29 +111,6 @@ case class ScalaTarget(
     else
       Some(scalac.getClasspath().asScala.toList)
 
-  /**
-   * This method collects jars from classpath defined in scalacOptions.
-   *
-   * If the build server supports lazy classpath resolution, we will
-   * not get any classpath data eagerly and we should not
-   * use this endpoint. It should only be used as a fallback.
-   *
-   * This is due to the fact that we don't request classpath as it
-   * can be resonably expensive.
-   *
-   * We should use the buildTargetDependencyModules information
-   * from the indexer instead.
-   *
-   * @return non empty classpath jar list if it was resolved prior
-   */
-  def jarClasspath: Option[List[AbsolutePath]] =
-    classpath.map(collectJars)
-
-  private def collectJars(paths: List[String]) =
-    paths
-      .filter(_.endsWith(".jar"))
-      .map(_.toAbsolutePath)
-
   def classDirectory: String = scalac.getClassDirectory()
 
   def scalaVersion: String = scalaInfo.getScalaVersion()

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -22,7 +22,7 @@ case class ScalaTarget(
     autoImports: Option[Seq[String]],
     sbtVersion: Option[String],
     bspConnection: Option[BuildServerConnection],
-) {
+) extends JvmTarget {
 
   def isSbt = sbtVersion.isDefined
 
@@ -105,7 +105,7 @@ case class ScalaTarget(
    *
    * @return non empty classpath only if it was resolved prior
    */
-  def lazyClasspath: Option[List[String]] =
+  def classpath: Option[List[String]] =
     if (scalac.getClasspath().isEmpty)
       None
     else
@@ -126,8 +126,8 @@ case class ScalaTarget(
    *
    * @return non empty classpath jar list if it was resolved prior
    */
-  def lazyJarClasspath: Option[List[AbsolutePath]] =
-    lazyClasspath.map(collectJars)
+  def jarClasspath: Option[List[AbsolutePath]] =
+    classpath.map(collectJars)
 
   private def collectJars(paths: List[String]) =
     paths

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -52,12 +52,12 @@ case class ScalafixProvider(
     TrieMap.empty[ScalafixRulesClasspathKey, URLClassLoader]
 
   // Warms up the Scalafix instance so that the first organize imports request responds faster.
-  def load(): Unit = {
+  def load(): Future[Unit] = {
     if (!Testing.isEnabled) {
       val tmp = workspace
         .resolve(Directories.tmp)
         .resolve(s"Main${Random.nextLong()}.scala")
-      try {
+      Future {
         val targets =
           buildTargets.allScala.toList.groupBy(_.scalaVersion).flatMap {
             case (_, targets) => targets.headOption
@@ -73,21 +73,25 @@ case class ScalafixProvider(
               produceSemanticdb = true,
               List(organizeImportRuleName),
             )
-        val evaluatedCorrectly = testEvaluation.forall {
-          case Success(evaluation) => evaluation.isSuccessful()
-          case _ => false
+        Future.sequence(testEvaluation)
+      }.flatten
+        .map { results =>
+          results.forall(_.isSuccessful())
         }
-        if (!evaluatedCorrectly) scribe.debug("Could not warm up Scalafix")
-      } catch {
-        case e: Throwable =>
+        .map { evaluated =>
+          if (!evaluated) scribe.debug("Could not warm up Scalafix")
+
+        }
+        .recover { e: Throwable =>
           scribe.debug(
             s"Scalafix issue while warming up due to issue: ${e.getMessage()}",
             e,
           )
-      } finally {
-        if (tmp.exists) tmp.delete()
-      }
-    }
+        }
+        .andThen { case _ =>
+          if (tmp.exists) tmp.delete()
+        }
+    } else Future.successful(())
   }
 
   def runAllRules(file: AbsolutePath): Future[List[l.TextEdit]] = {
@@ -136,56 +140,58 @@ case class ScalafixProvider(
           rules,
         )
 
-      scalafixEvaluation match {
-        case Failure(exception) =>
+      scalafixEvaluation
+        .recover { case exception =>
           reportScalafixError(
             "Unable to run scalafix, please check logs for more info.",
             exception,
           )
-          Future.failed(exception)
-        case Success(results)
-            if !scalafixSucceded(results) && hasStaleOrMissingSemanticdb(
-              results
-            ) && buildClient.buildHasErrors(file) =>
-          val msg = "Attempt to organize your imports failed. " +
-            "It looks like you have compilation issues causing your semanticdb to be stale. " +
-            "Ensure everything is compiling and try again."
-          scribe.warn(
-            msg
-          )
-          languageClient.showMessage(
-            MessageType.Warning,
-            msg,
-          )
-          Future.successful(Nil)
-        case Success(results) if !scalafixSucceded(results) =>
-          val scalafixError = getMessageErrorFromScalafix(results)
-          val exception = ScalafixRunException(scalafixError)
-          if (
-            scalafixError.startsWith("Unknown rule") ||
-            scalafixError.startsWith("Class not found")
-          ) {
-            languageClient
-              .showMessage(Messages.unknownScalafixRules(scalafixError))
-          }
+          throw exception
+        }
+        .flatMap {
+          case results
+              if !scalafixSucceded(results) && hasStaleOrMissingSemanticdb(
+                results
+              ) && buildClient.buildHasErrors(file) =>
+            val msg = "Attempt to organize your imports failed. " +
+              "It looks like you have compilation issues causing your semanticdb to be stale. " +
+              "Ensure everything is compiling and try again."
+            scribe.warn(
+              msg
+            )
+            languageClient.showMessage(
+              MessageType.Warning,
+              msg,
+            )
+            Future.successful(Nil)
+          case results if !scalafixSucceded(results) =>
+            val scalafixError = getMessageErrorFromScalafix(results)
+            val exception = ScalafixRunException(scalafixError)
+            if (
+              scalafixError.startsWith("Unknown rule") ||
+              scalafixError.startsWith("Class not found")
+            ) {
+              languageClient
+                .showMessage(Messages.unknownScalafixRules(scalafixError))
+            }
 
-          scribe.error(scalafixError, exception)
-          if (!retried && hasStaleOrMissingSemanticdb(results)) {
-            // Retry, since the semanticdb might be stale
-            runScalafixRules(file, scalaTarget, rules, retried = true)
-          } else {
-            Future.failed(exception)
-          }
-        case Success(results) =>
-          Future.successful {
-            val edits = for {
-              fileEvaluation <- results.getFileEvaluations().headOption
-              patches <- fileEvaluation.previewPatches().asScala
-            } yield textEditsFrom(patches, inBuffers)
-            edits.getOrElse(Nil)
-          }
+            scribe.error(scalafixError, exception)
+            if (!retried && hasStaleOrMissingSemanticdb(results)) {
+              // Retry, since the semanticdb might be stale
+              runScalafixRules(file, scalaTarget, rules, retried = true)
+            } else {
+              Future.failed(exception)
+            }
+          case results =>
+            Future.successful {
+              val edits = for {
+                fileEvaluation <- results.getFileEvaluations().headOption
+                patches <- fileEvaluation.previewPatches().asScala
+              } yield textEditsFrom(patches, inBuffers)
+              edits.getOrElse(Nil)
+            }
 
-      }
+        }
     }
   }
 
@@ -337,7 +343,7 @@ case class ScalafixProvider(
       inBuffers: String,
       produceSemanticdb: Boolean,
       rules: List[String],
-  ): Try[ScalafixEvaluation] = {
+  ): Future[ScalafixEvaluation] = {
     val isScala3 = ScalaVersions.isScala3Version(scalaTarget.scalaVersion)
     val scalaBinaryVersion =
       if (isScala3) "2.13" else scalaTarget.scalaBinaryVersion
@@ -374,11 +380,15 @@ case class ScalafixProvider(
       )
     // It seems that Scalafix ignores the targetroot parameter and searches the classpath
     // Prepend targetroot to make sure that it's picked up first always
-    val classpath =
-      (targetRoot.toList ++ scalaTarget.fullClasspath).asJava
+    val lazyClasspath = buildTargets
+      .fullClasspath(scalaTarget.id)
+      .getOrElse(Future.successful(Nil))
+      .map { classpath =>
+        (targetRoot.toList ++ classpath.map(_.toNIO)).asJava
+      }
 
     val isSource3 = scalaTarget.scalac.getOptions().contains("-Xsource:3")
-    for {
+    val result = for {
       api <- getScalafix(scalaBinaryVersion)
       urlClassLoaderWithExternalRule <- getRuleClassLoader(
         scalafixRulesKey,
@@ -399,22 +409,25 @@ case class ScalafixProvider(
         list
       }
 
-      val evaluated = api
-        .newArguments()
-        .withScalaVersion(scalaVersion)
-        .withClasspath(classpath)
-        .withToolClasspath(urlClassLoaderWithExternalRule)
-        .withConfig(scalafixConf(isScala3 || isSource3).asJava)
-        .withRules(rules.asJava)
-        .withPaths(List(diskFilePath.toNIO).asJava)
-        .withSourceroot(sourceroot.toNIO)
-        .withScalacOptions(scalacOptions)
-        .evaluate()
+      lazyClasspath.map { classpath =>
+        val evaluated = api
+          .newArguments()
+          .withScalaVersion(scalaVersion)
+          .withClasspath(classpath)
+          .withToolClasspath(urlClassLoaderWithExternalRule)
+          .withConfig(scalafixConf(isScala3 || isSource3).asJava)
+          .withRules(rules.asJava)
+          .withPaths(List(diskFilePath.toNIO).asJava)
+          .withSourceroot(sourceroot.toNIO)
+          .withScalacOptions(scalacOptions)
+          .evaluate()
 
-      if (produceSemanticdb)
-        targetRoot.foreach(AbsolutePath(_).deleteRecursively())
-      evaluated
+        if (produceSemanticdb)
+          targetRoot.foreach(AbsolutePath(_).deleteRecursively())
+        evaluated
+      }
     }
+    result.flatten
   }
 
   private def reportScalafixError(
@@ -440,15 +453,15 @@ case class ScalafixProvider(
 
   private def getScalafix(
       scalaBinaryVersion: ScalaBinaryVersion
-  ): Try[Scalafix] = {
+  ): Future[Scalafix] = {
     scalafixCache.get(scalaBinaryVersion) match {
-      case Some(value) => Success(value)
+      case Some(value) => Future.successful(value)
       case None =>
         statusBar.trackBlockingTask("Downloading scalafix") {
           val scalafix =
-            if (scalaBinaryVersion == "2.11") Try(scala211Fallback)
+            if (scalaBinaryVersion == "2.11") Future(scala211Fallback)
             else
-              Try(Scalafix.fetchAndClassloadInstance(scalaBinaryVersion))
+              Future(Scalafix.fetchAndClassloadInstance(scalaBinaryVersion))
           scalafix.foreach(api => scalafixCache.update(scalaBinaryVersion, api))
           scalafix
         }
@@ -475,9 +488,9 @@ case class ScalafixProvider(
   private def getRuleClassLoader(
       scalfixRulesKey: ScalafixRulesClasspathKey,
       scalafixClassLoader: ClassLoader,
-  ): Try[URLClassLoader] = {
+  ): Future[URLClassLoader] = {
     rulesClassloaderCache.get(scalfixRulesKey) match {
-      case Some(value) => Success(value)
+      case Some(value) => Future.successful(value)
       case None =>
         statusBar.trackBlockingTask(
           "Downloading scalafix rules' dependencies"
@@ -496,7 +509,7 @@ case class ScalafixProvider(
             else None
 
           val allRules =
-            Try(
+            Future(
               Embedded.rulesClasspath(
                 rulesDependencies.toList ++ organizeImportRule
               )
@@ -583,8 +596,8 @@ object ScalafixProvider {
       userConfig: UserConfiguration,
       rules: List[String],
   ): Set[Dependency] = {
-    val fromSettings = userConfig.scalafixRulesDependencies.flatMap {
-      dependencyString =>
+    val fromSettings =
+      userConfig.scalafixRulesDependencies.flatMap { dependencyString =>
         Try {
           Dependency.parse(
             dependencyString,
@@ -597,7 +610,7 @@ object ScalafixProvider {
           case Success(dep) =>
             Some(dep)
         }
-    }
+      }
     val builtInRuleDeps = builtInRules(scalaBinaryVersion)
 
     val allDeps = fromSettings ++ rules.flatMap(builtInRuleDeps.get)

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -132,6 +132,7 @@ object StandaloneSymbolSearch {
       buildTargets: BuildTargets,
       saveSymbolFileToDisk: Boolean,
       sourceMapper: SourceMapper,
+      workspaceFallback: Option[SymbolSearch] = None,
   )(implicit rc: ReportContext): StandaloneSymbolSearch = {
     val (sourcesWithExtras, classpathWithExtras) =
       addScalaAndJava(
@@ -151,32 +152,7 @@ object StandaloneSymbolSearch {
       buildTargets,
       saveSymbolFileToDisk,
       sourceMapper,
-    )
-  }
-  def apply(
-      scalaVersion: String,
-      workspace: AbsolutePath,
-      buffers: Buffers,
-      excludedPackages: () => ExcludedPackagesHandler,
-      userConfig: () => UserConfiguration,
-      trees: Trees,
-      buildTargets: BuildTargets,
-      saveSymbolFileToDisk: Boolean,
-      sourceMapper: SourceMapper,
-  )(implicit rc: ReportContext): StandaloneSymbolSearch = {
-    val (sourcesWithExtras, classpathWithExtras) =
-      addScalaAndJava(scalaVersion, Nil, Nil, userConfig().javaHome)
-
-    new StandaloneSymbolSearch(
-      workspace,
-      classpathWithExtras,
-      sourcesWithExtras,
-      buffers,
-      excludedPackages,
-      trees,
-      buildTargets,
-      saveSymbolFileToDisk,
-      sourceMapper,
+      workspaceFallback,
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
@@ -289,7 +289,7 @@ class ProblemResolver(
         }
 
         val munit = raw".*org/scalameta/munit_.*/(\d).(\d+).(\d+).*".r
-        scalaTarget.scalac.getClasspath().asScala.collectFirst {
+        scalaTarget.lazyClasspath.toList.flatten.collectFirst {
           case dep @ munit(major, minor, patch)
               if isInvalid(major.toInt, minor.toInt, patch.toInt, dep) =>
             OutdatedMunitInterfaceVersion
@@ -302,7 +302,7 @@ class ProblemResolver(
       else {
         val novocode = ".*com/novocode/junit-interface.*".r
         val junit = raw".*com/github/sbt/junit-interface/(\d).(\d+).(\d+).*".r
-        scalaTarget.scalac.getClasspath().asScala.collectFirst {
+        scalaTarget.lazyClasspath.toList.flatten.collectFirst {
           case novocode() => OutdatedJunitInterfaceVersion
           case junit(major, minor, patch)
               if (major.toInt == 0 && (minor.toInt <= 13 && patch.toInt <= 2)) =>

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
@@ -289,7 +289,7 @@ class ProblemResolver(
         }
 
         val munit = raw".*org/scalameta/munit_.*/(\d).(\d+).(\d+).*".r
-        scalaTarget.lazyClasspath.toList.flatten.collectFirst {
+        scalaTarget.classpath.toList.flatten.collectFirst {
           case dep @ munit(major, minor, patch)
               if isInvalid(major.toInt, minor.toInt, patch.toInt, dep) =>
             OutdatedMunitInterfaceVersion
@@ -302,7 +302,7 @@ class ProblemResolver(
       else {
         val novocode = ".*com/novocode/junit-interface.*".r
         val junit = raw".*com/github/sbt/junit-interface/(\d).(\d+).(\d+).*".r
-        scalaTarget.lazyClasspath.toList.flatten.collectFirst {
+        scalaTarget.classpath.toList.flatten.collectFirst {
           case novocode() => OutdatedJunitInterfaceVersion
           case junit(major, minor, patch)
               if (major.toInt == 0 && (minor.toInt <= 13 && patch.toInt <= 2)) =>

--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -13,6 +13,7 @@ import scala.collection.concurrent.TrieMap
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 
 import scala.meta._
@@ -454,7 +455,7 @@ class WorksheetProvider(
         try {
           val awaitClasspath = Await.result(
             buildTargets
-              .targetClasspath(target)
+              .targetClasspath(target, Promise[Unit]())
               .getOrElse(Future.successful(Nil)),
             Duration(
               5,

--- a/project/V.scala
+++ b/project/V.scala
@@ -22,7 +22,7 @@ object V {
   val betterMonadicFor = "0.3.1"
   val bloop = "1.5.17"
   val bloopConfig = "1.5.5"
-  val bsp = "2.1.1"
+  val bsp = "2.2.0-M2"
   val coursier = "2.1.9"
   val coursierInterfaces =
     "1.0.19" // changing coursier interfaces version may be not binary compatible.

--- a/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
@@ -99,7 +99,7 @@ class HoverDocSuite extends BaseHoverSuite {
   )
 
   check(
-    "java-method".tag(IgnoreScalaVersion(_ => isJava8)),
+    "java-method",
     """|import java.nio.file.Paths
        |
        |object O{

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -81,24 +81,7 @@ class CompletionDocSuite extends BaseCompletionSuite {
       |  java.util.OptionalInt@@
       |}
     """.stripMargin,
-    if (isJava8)
-      """|> A container object which may or may not contain a `int` value.
-         |If a value is present, `isPresent()` will return `true` and
-         |`getAsInt()` will return the value.
-         |
-         |Additional methods that depend on the presence or absence of a contained
-         |value are provided, such as [orElse()](#orElse(int))
-         |(return a default value if value not present) and
-         |[ifPresent()](#ifPresent(java.util.function.IntConsumer)) (execute a block
-         |of code if the value is present).
-         |
-         |This is a [value-based]()
-         |class; use of identity-sensitive operations (including reference equality
-         |(`==`), identity hash code, or synchronization) on instances of
-         |`OptionalInt` may have unpredictable results and should be avoided.
-         |OptionalInt java.util
-         |""".stripMargin
-    else if (isJava17)
+    if (isJava17)
       """|> A container object which may or may not contain an `int` value.
          |If a value is present, `isPresent()` returns `true`. If no
          |value is present, the object is considered *empty* and

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -396,7 +396,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "fuzzy1".tag(IgnoreScalaVersion(_ => isJava8)),
+    "fuzzy1",
     """
       |object A {
       |  new PBuil@@
@@ -564,7 +564,7 @@ class CompletionSuite extends BaseCompletionSuite {
   )
 
   check(
-    "import3".tag(IgnoreScalaVersion(_ => isJava8)),
+    "import3",
     """
       |import Path@@
       |""".stripMargin,

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -24,8 +24,8 @@ abstract class BaseSuite extends munit.FunSuite with Assertions {
 
   Testing.enable()
 
-  def isJava8: Boolean =
-    !Properties.isJavaAtLeast("9")
+  def isJava11: Boolean =
+    Properties.isJavaAtLeast("11")
 
   def isJava17: Boolean =
     Properties.isJavaAtLeast("17")
@@ -47,7 +47,7 @@ abstract class BaseSuite extends munit.FunSuite with Assertions {
     else userHome.resolve(".cache/coursier")
 
   def isValidScalaVersionForEnv(scalaVersion: String): Boolean =
-    this.isJava8 || SemVer.isCompatibleVersion(
+    SemVer.isCompatibleVersion(
       BaseSuite.minScalaVersionForJDK9OrHigher,
       scalaVersion
     ) || scalaVersion.startsWith("3.")

--- a/tests/unit/src/main/scala/bill/Bill.scala
+++ b/tests/unit/src/main/scala/bill/Bill.scala
@@ -73,6 +73,9 @@ object Bill {
   val logName = ".bill-metals.log"
 
   class Server() extends BuildServer with ScalaBuildServer {
+
+    override def onRunReadStdin(params: ReadParams): Unit = ()
+
     private var sleepBeforePingResponse: Option[Duration] = None
     val languages: util.List[String] = Collections.singletonList("scala")
     var client: BuildClient = _
@@ -525,6 +528,11 @@ object Bill {
     import scala.meta.internal.metals.MetalsEnrichments._
     val server = new Server()
     val client = new BuildClient {
+
+      override def onRunPrintStdout(params: PrintParams): Unit = ???
+
+      override def onRunPrintStderr(params: PrintParams): Unit = ???
+
       override def onBuildShowMessage(params: ShowMessageParams): Unit = ???
       override def onBuildLogMessage(params: LogMessageParams): Unit = ???
       override def onBuildTaskStart(params: TaskStartParams): Unit = ???

--- a/tests/unit/src/main/scala/tests/debug/BaseStepDapSuite.scala
+++ b/tests/unit/src/main/scala/tests/debug/BaseStepDapSuite.scala
@@ -129,7 +129,6 @@ abstract class BaseStepDapSuite(
     instrument = steps => {
       val (javaLibFile, javaLibLine) =
         if (isJava17) ("java.base/java/io/PrintStream.java", 1027)
-        else if (isJava8) ("java/io/PrintStream.java", 805)
         else ("java.base/java/io/PrintStream.java", 881)
       steps
         .at("a/src/main/scala/Main.scala", line = 5)(StepIn)

--- a/tests/unit/src/test/scala/tests/CompilersLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompilersLspSuite.scala
@@ -38,18 +38,20 @@ class CompilersLspSuite extends BaseCompletionLspSuite("compilers") {
           )
         }
       )
+      count <- server.server.loadedPresentationCompilerCount()
       _ = assertEquals(
         2,
-        server.server.loadedPresentationCompilerCount(),
+        count,
       )
       _ <-
         server.didSave("b/src/main/scala/b/B.scala")(_ => "package b; object B")
       _ <-
         server.didSave("a/src/main/scala/a/A.scala")(_ => "package a; class A")
       _ = assertNoDiagnostics()
+      countAfter <- server.server.loadedPresentationCompilerCount()
       _ = assertEquals(
         0,
-        server.server.loadedPresentationCompilerCount(),
+        countAfter,
       )
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/CompilersLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompilersLspSuite.scala
@@ -38,7 +38,7 @@ class CompilersLspSuite extends BaseCompletionLspSuite("compilers") {
           )
         }
       )
-      count <- server.server.loadedPresentationCompilerCount()
+      count = server.server.loadedPresentationCompilerCount()
       _ = assertEquals(
         2,
         count,
@@ -48,7 +48,7 @@ class CompilersLspSuite extends BaseCompletionLspSuite("compilers") {
       _ <-
         server.didSave("a/src/main/scala/a/A.scala")(_ => "package a; class A")
       _ = assertNoDiagnostics()
-      countAfter <- server.server.loadedPresentationCompilerCount()
+      countAfter = server.server.loadedPresentationCompilerCount()
       _ = assertEquals(
         0,
         countAfter,

--- a/tests/unit/src/test/scala/tests/ImplementationLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ImplementationLspSuite.scala
@@ -641,7 +641,7 @@ class ImplementationLspSuite extends BaseImplementationSuite("implementation") {
        |""".stripMargin,
   )
 
-  if (!isJava8) {
+  if (!isJava11) {
     checkSymbols(
       "exception",
       """package a

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -272,10 +272,9 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
           """|java.nio.file.Paths Class
              |""".stripMargin,
         )
-        val withBase = if (!isJava8) "java.base/" else ""
         assertNoDiff(
           server.treeViewReveal(
-            withBase + "java/nio/file/Paths.java",
+            "java.base/java/nio/file/Paths.java",
             "class Paths",
           ),
           s"""|root

--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -322,38 +322,21 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
       _ <- server.didOpen("a/src/main/scala/a/Before.scala")
       _ = assertNoDiff(
         server.workspaceSymbol("Future"),
-        if (isJava17) {
-          """|scala.concurrent.Future
-             |scala.concurrent.Future
-             |java.util.concurrent.Future
-             |scala.sys.process.ProcessImpl#Future
-             |scala.jdk.FutureConverters.FutureOps
-             |java.util.concurrent.FutureTask
-             |java.util.concurrent.RunnableFuture
-             |java.util.concurrent.ExecutorCompletionService#QueueingFuture
-             |java.util.concurrent.ScheduledFuture
-             |scala.jdk.FutureConverters
-             |scala.jdk.javaapi.FutureConverters
-             |java.util.concurrent.CompletableFuture
-             |java.util.concurrent.ScheduledThreadPoolExecutor#ScheduledFutureTask
-             |scala.concurrent.impl.FutureConvertersImpl
-             |""".stripMargin
-        } else {
-          """|scala.concurrent.Future
-             |scala.concurrent.Future
-             |java.util.concurrent.Future
-             |scala.sys.process.ProcessImpl#Future
-             |scala.jdk.FutureConverters.FutureOps
-             |java.util.concurrent.FutureTask
-             |java.io.ObjectStreamClass#EntryFuture
-             |java.util.concurrent.RunnableFuture
-             |java.util.concurrent.ExecutorCompletionService#QueueingFuture
-             |java.util.concurrent.ScheduledFuture
-             |scala.jdk.FutureConverters
-             |scala.jdk.javaapi.FutureConverters
-             |java.util.concurrent.CompletableFuture
-             |java.util.concurrent.ScheduledThreadPoolExecutor#ScheduledFutureTask""".stripMargin
-        },
+        """|scala.concurrent.Future
+           |scala.concurrent.Future
+           |java.util.concurrent.Future
+           |scala.sys.process.ProcessImpl#Future
+           |scala.jdk.FutureConverters.FutureOps
+           |java.util.concurrent.FutureTask
+           |java.util.concurrent.RunnableFuture
+           |java.util.concurrent.ExecutorCompletionService#QueueingFuture
+           |java.util.concurrent.ScheduledFuture
+           |scala.jdk.FutureConverters
+           |scala.jdk.javaapi.FutureConverters
+           |java.util.concurrent.CompletableFuture
+           |java.util.concurrent.ScheduledThreadPoolExecutor#ScheduledFutureTask
+           |scala.concurrent.impl.FutureConvertersImpl
+           |""".stripMargin,
       )
       _ <- server.didChangeConfiguration(
         """|{
@@ -365,25 +348,14 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
       )
       _ = assertNoDiff(
         server.workspaceSymbol("Future"),
-        if (isJava17)
-          """|scala.concurrent.Future
-             |scala.concurrent.Future
-             |scala.sys.process.ProcessImpl#Future
-             |scala.jdk.FutureConverters.FutureOps
-             |scala.jdk.FutureConverters
-             |scala.jdk.javaapi.FutureConverters
-             |scala.concurrent.impl.FutureConvertersImpl
-             |""".stripMargin
-        else
-          """|scala.concurrent.Future
-             |scala.concurrent.Future
-             |scala.sys.process.ProcessImpl#Future
-             |scala.jdk.FutureConverters.FutureOps
-             |java.io.ObjectStreamClass#EntryFuture
-             |scala.jdk.FutureConverters
-             |scala.jdk.javaapi.FutureConverters
-             |scala.concurrent.impl.FutureConvertersImpl
-             |""".stripMargin,
+        """|scala.concurrent.Future
+           |scala.concurrent.Future
+           |scala.sys.process.ProcessImpl#Future
+           |scala.jdk.FutureConverters.FutureOps
+           |scala.jdk.FutureConverters
+           |scala.jdk.javaapi.FutureConverters
+           |scala.concurrent.impl.FutureConvertersImpl
+           |""".stripMargin,
       )
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
@@ -236,19 +236,19 @@ class CompletionDapSuite
     "java-member",
     expression = "name.s@@",
     expectedCompletions =
-      if (isJava8)
-        """|serialVersionUID
-           |serialPersistentFields
-           |startsWith(java.lang.String arg0, int arg1)
-           |startsWith(java.lang.String arg0)
-           |substring(int arg0)
-           |""".stripMargin
-      else
+      if (isJava17)
         """|serialVersionUID
            |serialPersistentFields
            |safeTrim(byte[] arg0, int arg1, boolean arg2)
            |scale(int arg0, float arg1)
            |startsWith(java.lang.String arg0, int arg1)
+           |""".stripMargin
+      else
+        """|serialVersionUID
+           |serialPersistentFields
+           |startsWith(java.lang.String arg0, int arg1)
+           |startsWith(java.lang.String arg0)
+           |substring(int arg0)
            |""".stripMargin,
     expectedEdit = "name.serialVersionUID",
     topLines = Some(5),


### PR DESCRIPTION
Previously, when indexing we would request both scalacOptions and javacOption, which both contain classpath. Unfortunately, resolving classpath is sometimes quite expensive. 

To fix that I recently, I introduced a new endpoint for resolving the [classpath](https://build-server-protocol.github.io/docs/extensions/jvm#buildtargetjvmcompileclasspath-request) which enables us to get the classpath separately instead of having it sent with scalacOptions. In case client sets it's capability as jvmClasspathReceiver it will get ScalacOptions and JavacOptions without classpath and we will be able to get the compiler options data without possibly expensive computation.

This means we need resolve classpath lazily on demand, which changes a lot of the code to use Future (doesn't look great, but I haven't figured out a way around it) and for some cases where we cannot avoid getting classpath jars I changed the request to get them via [dependencyModules](https://build-server-protocol.github.io/docs/specification#buildtargetdependencymodules-request) endpoint.

All this should make the older tools and Bazel work at the same time without any changes to other tools than Bazel BSP.

Also fixes https://github.com/scalameta/metals/issues/6135