### PR TITLE
chore: Change to slf4j2 to avoid too much logging in flyway

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -498,7 +498,7 @@ lazy val metals = project
       // for logging
       "com.outr" %% "scribe" % V.scribe,
       "com.outr" %% "scribe-file" % V.scribe,
-      "com.outr" %% "scribe-slf4j" % V.scribe, // needed for flyway database migrations
+      "com.outr" %% "scribe-slf4j2" % V.scribe, // needed for flyway database migrations
       // for JSON formatted doctor
       "com.lihaoyi" %% "ujson" % "3.1.5",
       // For fetching projects' templates


### PR DESCRIPTION
Previously, we would get all the messages up to debug level from flyway, which added a lot of overhead. It seems that this is due to the fact that flyway has issues detecting slf4j loggers and especially scribe, which implements it. Changing to slf4j2 helped here and we get much less data.