### PR TITLE
chore: Add support for Scala 3.3.3

### DIFF
--- a/mtags/src/main/scala-3.3.3/scala/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-3.3.3/scala/meta/internal/pc/Compat.scala
@@ -1,0 +1,4 @@
+package scala.meta.internal.pc
+
+object Compat:
+  val EvidenceParamName = dotty.tools.dotc.core.NameKinds.ContextBoundParamName

--- a/mtags/src/main/scala-3.3.3/scala/meta/internal/pc/printer/RefinedDotcPrinter.scala
+++ b/mtags/src/main/scala-3.3.3/scala/meta/internal/pc/printer/RefinedDotcPrinter.scala
@@ -1,0 +1,30 @@
+package scala.meta.internal.pc.printer
+
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Flags.*
+import dotty.tools.dotc.core.StdNames.*
+import dotty.tools.dotc.core.Types.*
+import dotty.tools.dotc.printing.RefinedPrinter
+import dotty.tools.dotc.printing.Texts.Text
+
+/* In 3.4.x some changes were made to printer,
+    but haven't managed to port all of them yet to the LTS */
+abstract class RefinedDotcPrinter(_ctx: Context) extends RefinedPrinter(_ctx):
+
+  def toTextPrefix(tp: Type) =
+    tp match
+      case tp: NamedType => super.toTextPrefixOf(tp)
+      case tp => Text()
+
+  override def toText(tp: Type): Text =
+    tp match
+      case tp: TermRef
+          if !tp.denotationIsCurrent && !homogenizedView ||
+            tp.symbol.is(Module) || tp.symbol.name == nme.IMPORT =>
+        toTextPrefix(tp.prefix) ~ selectionString(tp) ~ ".type"
+      case tp: TermRef =>
+        toTextPrefix(tp.prefix) ~ selectionString(tp)
+      case tr: TypeRef =>
+        super.toText(tr)
+      case _ => super.toText(tp)
+end RefinedDotcPrinter

--- a/project/V.scala
+++ b/project/V.scala
@@ -5,8 +5,8 @@ object V {
   val scala211 = "2.11.12"
   val scala212 = "2.12.19"
   val scala213 = "2.13.13"
-  val scala3 = "3.3.2"
-  val firstScala3PCVersion = "3.3.3"
+  val scala3 = "3.3.3"
+  val firstScala3PCVersion = "3.3.4"
   val wrapperMetalsVersion = "3.4.0-RC1-bin-20231127-41e7d95-NIGHTLY"
 
   // When you can add to removedScalaVersions in MtagsResolver.scala with the last released version
@@ -115,7 +115,7 @@ object V {
 
   // whenever version is removed please add it to MtagsResolver under last supported Metals version
   def deprecatedScala3Versions =
-    Seq("3.2.1", "3.2.0", "3.1.2", "3.1.1", "3.1.0")
+    Seq("3.3.2", "3.2.1", "3.2.0", "3.1.2", "3.1.1", "3.1.0")
 
   // NOTE if you had a new Scala Version make sure it's contained in quickPublishScalaVersions
   def scala3Versions = nonDeprecatedScala3Versions ++ deprecatedScala3Versions

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -587,7 +587,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
                     |unsafe - scala.caps (commit: '')
                     |unsafeNulls - scala.runtime.stdLibPatches.language (commit: '')
                     |""".stripMargin,
-      "3.3.2" -> """|using (commit: '')
+      "3.3.3" -> """|using (commit: '')
                     |unsafeExceptions scala (commit: '')
                     |unchecked scala (commit: '')
                     |unsafe - caps (commit: '')
@@ -632,7 +632,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
                     |unsafe - scala.caps
                     |unsafeNulls - scala.runtime.stdLibPatches.language
                     |unshared(): unshared""".stripMargin,
-      "3.3.2" -> """|unsafeExceptions scala
+      "3.3.3" -> """|unsafeExceptions scala
                     |unchecked scala
                     |unsafe - caps
                     |unsafeNulls - scala.runtime.stdLibPatches.language

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -450,7 +450,7 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
   )
 
   checkEdit(
-    "jlang".tag(IgnoreScalaVersion("3.3.2")),
+    "jlang".tag(IgnoreScalaVersion("3.3.3")),
     """|abstract class Mutable {
        |  def foo: java.lang.StringBuilder
        |}

--- a/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
@@ -67,7 +67,7 @@ class CompletionPatternSuite extends BaseCompletionSuite {
            |macros - scala.languageFeature.experimental
            |macroImpl - scala.reflect.macros.internal
            |""".stripMargin,
-      "3.3.2" ->
+      "3.3.3" ->
         """|main scala
            |macros - languageFeature.experimental
            |macroImpl(referenceToMacroImpl: Any): macroImpl

--- a/tests/cross/src/test/scala/tests/pc/CompletionScalaCliSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScalaCliSuite.scala
@@ -106,7 +106,7 @@ class CompletionScalaCliSuite extends BaseCompletionSuite {
   check(
     "plugin".tag(
       IgnoreScalaVersion(version =>
-        Set("2.12.16", "2.12.19", "2.13.13", "3.3.2")(version) ||
+        Set("2.12.16", "2.12.19", "2.13.13", "3.3.3")(version) ||
           version.contains(
             "NIGHTLY"
           ) || version.contains(

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredTypeSuite.scala
@@ -452,7 +452,7 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite {
   )
 
   checkEdit(
-    "path".tag(IgnoreScalaVersion("3.3.2")),
+    "path".tag(IgnoreScalaVersion("3.3.3")),
     """|import java.nio.file.Paths
        |object ExplicitResultTypesPrefix {
        |  class Path

--- a/tests/mtest/src/main/scala/tests/BaseSuite.scala
+++ b/tests/mtest/src/main/scala/tests/BaseSuite.scala
@@ -20,7 +20,7 @@ abstract class BaseSuite extends munit.FunSuite with Assertions {
   val FlakyWindows = new Tag("FlakyWindows")
 
   val scala3PresentationCompilerVersion: String =
-    s">=3.3.3"
+    s">=3.3.4"
 
   Testing.enable()
 


### PR DESCRIPTION
Scala 3.3.2 was broken so we put it straight away to deprecate