### PR TITLE
improvement: handle java home setting

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -99,10 +99,7 @@ final class BspServers(
         args,
         projectDirectory,
         redirectErrorOutput = false,
-        JdkSources
-          .defaultJavaHome(userConfig().javaHome)
-          .map("JAVA_HOME" -> _.toString())
-          .toMap,
+        JdkSources.envVariables(userConfig().javaHome),
         processOut = None,
         processErr = Some(l => scribe.info("BSP server: " + l)),
         discardInput = false,

--- a/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ShellRunner.scala
@@ -12,6 +12,7 @@ import scala.util.Properties
 
 import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.JavaBinary
+import scala.meta.internal.metals.JdkSources
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MutableCancelable
 import scala.meta.internal.metals.StatusBar
@@ -118,7 +119,7 @@ class ShellRunner(
       logInfo: Boolean = true,
   ): Future[Int] = {
     val elapsed = new Timer(time)
-    val env = additionalEnv ++ javaHome.map("JAVA_HOME" -> _).toMap
+    val env = additionalEnv ++ JdkSources.envVariables(javaHome)
     val ps = SystemProcess.run(
       args,
       directory,

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -257,14 +257,6 @@ final class BloopServers(
   }
 
   /**
-   * Determine whether or not we need to update the javaHome setting in the bloop.json file.
-   *
-   * @param metalsJavaHome javaHome being passed in from the user
-   * @param bloopJavaHome bloop javaHome that is in the global config
-   * @return whether or not the javaHome needs to be updated
-   */
-
-  /**
    * First we check if the user requested to update the Bloop JVM
    * properties through the extension.
    * <p>If so, we also check if the Bloop's Global Json file exists

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -222,7 +222,7 @@ final class BloopServers(
         case messageActionItem
             if messageActionItem == Messages.BloopJvmPropertiesChange.reconnect =>
           writeJVMPropertiesToBloopGlobalJsonFile(
-            maybeBloopJvmProperties,
+            maybeBloopJvmProperties
           ) match {
             case Failure(exception) => Future.failed(exception)
             case Success(_) =>
@@ -263,7 +263,6 @@ final class BloopServers(
    * @param bloopJavaHome bloop javaHome that is in the global config
    * @return whether or not the javaHome needs to be updated
    */
-  
 
   /**
    * First we check if the user requested to update the Bloop JVM
@@ -375,8 +374,9 @@ final class BloopServers(
       userConfiguration: UserConfiguration
   ) = {
     def metalsJavaHome =
-      sys.env.get("JAVA_HOME")
-      .orElse(sys.props.get("java.home"))
+      sys.env
+        .get("JAVA_HOME")
+        .orElse(sys.props.get("java.home"))
     // we should set up Java before running Bloop in order to not restart it
     bloopJsonPath match {
       case Some(bloopPath) if !bloopPath.exists =>

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -244,7 +244,7 @@ final class BloopServers(
         if bloopPath.canWrite
         (maybeBloopGlobalJsonJavaHome, maybeBloopGlobalJsonJvmProperties) =
           maybeLoadBloopGlobalJsonFile(bloopPath)
-        if(requestedBloopJvmProperties != maybeBloopGlobalJsonJvmProperties)
+        if (requestedBloopJvmProperties != maybeBloopGlobalJsonJvmProperties)
       } yield updateBloopJvmProperties(
         requestedBloopJvmProperties,
         reconnect,

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -132,9 +132,7 @@ class Compilers(
       val releaseVersion =
         for {
           jvmVersion <- optBuildTargetJvmVersion
-          metalsJavaVersion <- JdkVersion.maybeJdkVersionFromJavaHome(
-            JdkSources.defaultJavaHome(None).headOption
-          )
+          metalsJavaVersion <- Option(sys.props("java.version")).flatMap(JdkVersion.parse)
           if (jvmVersion.major < metalsJavaVersion.major)
         } yield jvmVersion.major
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -113,18 +113,21 @@ class Compilers(
     if (existsReleaseSetting) scalacOptions
     else {
       def optBuildTargetJvmVersion =
-        scalaTarget.jvmVersion.flatMap(version => JdkVersion.parse(version)).orElse{
-          val javaHome =
-              scalaTarget.jvmHome.flatMap(_.toAbsolutePathSafe)
-                .orElse{
+        scalaTarget.jvmVersion
+          .flatMap(version => JdkVersion.parse(version))
+          .orElse {
+            val javaHome =
+              scalaTarget.jvmHome
+                .flatMap(_.toAbsolutePathSafe)
+                .orElse {
                   for {
                     javaHomeString <- userConfig().javaHome.map(_.trim())
                     if (javaHomeString.nonEmpty)
                     javaHome <- Try(AbsolutePath(javaHomeString)).toOption
                   } yield javaHome
                 }
-          JdkVersion.maybeJdkVersionFromJavaHome(javaHome)
-        }
+            JdkVersion.maybeJdkVersionFromJavaHome(javaHome)
+          }
 
       val releaseVersion =
         for {

--- a/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JavaBinary.scala
@@ -37,7 +37,7 @@ object JavaBinary {
 
   private def fromAbsolutePath(javaPath: Iterable[AbsolutePath]) = {
     javaPath
-      .flatMap(home => List(home.resolve("bin"), home.resolve("bin/jre")))
+      .flatMap(home => List(home.resolve("bin"), home.resolve("jre/bin")))
       .flatMap(bin => List("java", "java.exe").map(bin.resolve))
       .withFilter(_.exists)
       .flatMap(binary => List(binary.dealias, binary))

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -7,7 +7,6 @@ import scala.collection.mutable
 import scala.meta.internal.builds.BuildTool
 import scala.meta.internal.builds.VersionRecommendation
 import scala.meta.internal.jdk.CollectionConverters._
-import scala.meta.internal.metals.BloopJsonUpdateCause.BloopJsonUpdateCause
 import scala.meta.internal.metals.clients.language.MetalsInputBoxParams
 import scala.meta.internal.metals.clients.language.MetalsSlowTaskParams
 import scala.meta.internal.metals.clients.language.MetalsStatusParams
@@ -388,36 +387,6 @@ object Messages {
     }
   }
 
-  object BloopGlobalJsonFilePremodified {
-    def applyAndRestart: MessageActionItem =
-      new MessageActionItem("Apply and Restart Bloop")
-
-    def useGlobalFile: MessageActionItem =
-      new MessageActionItem("Use the Global File's JVM Properties")
-
-    def openGlobalJsonFile: MessageActionItem =
-      new MessageActionItem("Open the Global File")
-
-    def params(
-        bloopJsonUpdateCause: BloopJsonUpdateCause
-    ): ShowMessageRequestParams = {
-      val params = new ShowMessageRequestParams()
-      params.setMessage(
-        s"""|Setting $bloopJsonUpdateCause will result in updating Bloop's global Json file by Metals, which has been previously modified manually!
-            |Do you want to replace them with the new properties and restart the running Bloop server?""".stripMargin
-      )
-      params.setType(MessageType.Warning)
-      params.setActions(
-        List(
-          applyAndRestart,
-          useGlobalFile,
-          openGlobalJsonFile,
-        ).asJava
-      )
-      params
-    }
-  }
-
   object BloopJvmPropertiesChange {
     def reconnect: MessageActionItem =
       new MessageActionItem("Apply and restart Bloop")
@@ -425,12 +394,10 @@ object Messages {
     def notNow: MessageActionItem =
       new MessageActionItem("Not now")
 
-    def params(
-        bloopJsonUpdateCause: BloopJsonUpdateCause
-    ): ShowMessageRequestParams = {
+    def params(): ShowMessageRequestParams = {
       val params = new ShowMessageRequestParams()
       params.setMessage(
-        s"""|Setting $bloopJsonUpdateCause will result in updating Bloop's global Json file, by Metals.
+        s"""|Setting Bloop JVM Properties will result in updating Bloop's global Json file, by Metals.
             |Bloop will need to be restarted in order for these changes to take effect.""".stripMargin
       )
       params.setType(MessageType.Warning)

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -1019,6 +1019,29 @@ object Messages {
     }
   }
 
+  object ProjectJavaHomeUpdate {
+    val restart: MessageActionItem =
+      new MessageActionItem("Restart/Reconnect to the build server")
+
+    val notNow: MessageActionItem =
+      new MessageActionItem("Not now")
+
+    def params(): ShowMessageRequestParams = {
+      val params = new ShowMessageRequestParams()
+      params.setMessage(
+        s"Java home has been updated, do you want to restart/reconnect to the BSP server?"
+      )
+      params.setType(MessageType.Info)
+      params.setActions(
+        List(
+          restart,
+          notNow,
+        ).asJava
+      )
+      params
+    }
+  }
+
   object RequestTimeout {
 
     val cancel = new MessageActionItem("Cancel")

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -993,10 +993,11 @@ object Messages {
     val notNow: MessageActionItem =
       new MessageActionItem("Not now")
 
-    def params(): ShowMessageRequestParams = {
+    def params(isRestart: Boolean): ShowMessageRequestParams = {
       val params = new ShowMessageRequestParams()
       params.setMessage(
-        s"Java home has been updated, do you want to restart/reconnect to the BSP server?"
+        s"Java home has been updated, do you want to ${if (isRestart) "restart"
+          else "reconnect"} to the BSP server?"
       )
       params.setType(MessageType.Info)
       params.setActions(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1016,7 +1016,6 @@ class MetalsLspService(
             .flatMap { _ =>
               bloopServers.ensureDesiredJvmSettings(
                 userConfig.bloopJvmProperties,
-                userConfig.javaHome,
                 () => autoConnectToBuildServer(),
               )
             }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1019,6 +1019,11 @@ class MetalsLspService(
                 () => autoConnectToBuildServer(),
               )
             }
+            .flatMap{ _ =>
+              if(userConfig.javaHome != old.javaHome) {
+                slowConnectToBuildServer(forceImport = true)
+              } else Future.unit
+            }
         } else if (
           userConfig.ammoniteJvmProperties != old.ammoniteJvmProperties && buildTargets.allBuildTargetIds
             .exists(Ammonite.isAmmBuildTarget)
@@ -1034,7 +1039,9 @@ class MetalsLspService(
                 Future.successful(())
             }
         } else {
-          Future.successful(())
+          if(userConfig.javaHome != old.javaHome) {
+            restartBspServer()
+          } else Future.successful(())
         }
       }
       .getOrElse(Future.successful(()))

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1014,10 +1014,12 @@ class MetalsLspService(
               () => autoConnectToBuildServer,
             )
             .flatMap { _ =>
-              bloopServers.ensureDesiredJvmSettings(
-                userConfig.bloopJvmProperties,
-                () => autoConnectToBuildServer(),
-              )
+              userConfig.bloopJvmProperties.map(
+                bloopServers.ensureDesiredJvmSettings(
+                  _,
+                  () => autoConnectToBuildServer(),
+                )
+              ).getOrElse(Future.unit)
             }
             .flatMap { _ =>
               if (userConfig.javaHome != old.javaHome) {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -979,7 +979,10 @@ class MetalsLspService(
       }
     }
 
-    if (userConfig.symbolPrefixes != old.symbolPrefixes) {
+    if (
+      userConfig.symbolPrefixes != old.symbolPrefixes ||
+      userConfig.javaHome != old.javaHome
+    ) {
       compilers.restartAll()
     }
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
@@ -286,3 +286,13 @@ final class PcInlayHintsProvider(
   }
 
 }
+
+sealed trait ImplicitParamSym extends Any {
+  def isContextBound: Boolean
+}
+case class Param(sym: Symbol) extends AnyVal with ImplicitParamSym {
+  def isContextBound: Boolean = false
+}
+case class ContextBound(sym: Symbol) extends AnyVal {
+  def isContextBound: Boolean = true
+}

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
@@ -286,13 +286,3 @@ final class PcInlayHintsProvider(
   }
 
 }
-
-sealed trait ImplicitParamSym extends Any {
-  def isContextBound: Boolean
-}
-case class Param(sym: Symbol) extends AnyVal with ImplicitParamSym {
-  def isContextBound: Boolean = false
-}
-case class ContextBound(sym: Symbol) extends AnyVal {
-  def isContextBound: Boolean = true
-}

--- a/tests/slow/src/test/scala/tests/mill/MillServerSuite.scala
+++ b/tests/slow/src/test/scala/tests/mill/MillServerSuite.scala
@@ -13,6 +13,7 @@ import scala.meta.internal.metals.{BuildInfo => V}
 import scala.meta.io.AbsolutePath
 
 import tests.BaseImportSuite
+import tests.JavaHomeChangeTest
 import tests.MillBuildLayout
 import tests.MillServerInitializer
 
@@ -20,7 +21,8 @@ import tests.MillServerInitializer
  * Basic suite to ensure that a connection to a Mill server can be made.
  */
 class MillServerSuite
-    extends BaseImportSuite("mill-server", MillServerInitializer) {
+    extends BaseImportSuite("mill-server", MillServerInitializer)
+    with JavaHomeChangeTest {
 
   val preBspVersion = "0.9.10"
   val supportedBspVersion = V.millVersion
@@ -172,4 +174,16 @@ class MillServerSuite
 
     } yield {}
   }
+
+  checkJavaHomeUpdate(
+    "mill-java-home-update",
+    fileContent => s"""|/build.sc
+                       |import mill._, scalalib._
+                       |object a extends ScalaModule {
+                       |  def scalaVersion = "${V.scala213}"
+                       |}
+                       |$fileContent
+                       |""".stripMargin,
+  )
+
 }

--- a/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
@@ -21,6 +21,7 @@ import scribe.output.LogOutput
 import scribe.output.format.OutputFormat
 import scribe.writer.Writer
 import tests.BaseImportSuite
+import tests.JavaHomeChangeTest
 import tests.SbtBuildLayout
 import tests.SbtServerInitializer
 import tests.ScriptsAssertions
@@ -31,7 +32,8 @@ import tests.TestSemanticTokens
  */
 class SbtServerSuite
     extends BaseImportSuite("sbt-server", SbtServerInitializer)
-    with ScriptsAssertions {
+    with ScriptsAssertions
+    with JavaHomeChangeTest {
 
   val preBspVersion = "1.3.13"
   val supportedMetaBuildVersion = "1.7.0"
@@ -523,5 +525,10 @@ class SbtServerSuite
       _ = assertNoDiff(res.head.getUri().toAbsolutePath.filename, "Keys.scala")
     } yield ()
   }
+
+  checkJavaHomeUpdate(
+    "sbt-java-home-update",
+    fileContent => SbtBuildLayout(fileContent, V.scala213),
+  )
 
 }

--- a/tests/unit/src/main/scala/tests/JavaHomeChangeTest.scala
+++ b/tests/unit/src/main/scala/tests/JavaHomeChangeTest.scala
@@ -1,0 +1,65 @@
+package tests
+
+import scala.meta.internal.metals.Messages
+
+import coursierapi.JvmManager
+import munit.Location
+import munit.TestOptions
+
+trait JavaHomeChangeTest { self: BaseLspSuite =>
+  val pathToJava11: String = JvmManager.create().get("11").toString()
+
+  def checkJavaHomeUpdate(
+      name: TestOptions,
+      makeLayout: String => String,
+      errorMessage: String =
+        """|a/src/main/scala/a/A.scala:2:8: error: object random is not a member of package java.util
+           |did you mean Random?
+           |import java.util.random.RandomGenerator
+           |       ^^^^^^^^^^^^^^^^
+           |a/src/main/scala/a/A.scala:4:13: error: not found: value RandomGenerator
+           |  val gen = RandomGenerator.of("name")
+           |            ^^^^^^^^^^^^^^^
+           |""".stripMargin,
+  )(implicit loc: Location): Unit = {
+    test(name) {
+      val java11Code =
+        """|package a
+           |object O
+           |""".stripMargin
+      val java17Code =
+        """|package a
+           |import java.util.random.RandomGenerator
+           |object O {
+           |  val gen = RandomGenerator.of("name")
+           |}
+           |""".stripMargin
+      cleanWorkspace()
+      client.shouldReloadAfterJavaHomeUpdate =
+        Messages.ProjectJavaHomeUpdate.restart
+      for {
+        _ <- initialize(
+          makeLayout(
+            s"""|/a/src/main/scala/a/A.scala
+                |$java17Code
+                |""".stripMargin
+          )
+        )
+        _ <- server.didOpen("a/src/main/scala/a/A.scala")
+        _ = assertNoDiagnostics()
+        _ <- server.didChange("a/src/main/scala/a/A.scala")(_ => java11Code)
+        _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
+        _ = assertNoDiagnostics()
+        _ <- server.server.onUserConfigUpdate(
+          userConfig.copy(javaHome = Some(pathToJava11))
+        )
+        _ <- server.didChange("a/src/main/scala/a/A.scala")(_ => java17Code)
+        _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
+        _ = assertNoDiff(
+          client.workspaceDiagnostics,
+          errorMessage,
+        )
+      } yield ()
+    }
+  }
+}

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -374,7 +374,11 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
         ) {
           chooseWorkspaceFolder(params.getActions().asScala.toSeq)
         } else if (
-          params.getMessage() == ProjectJavaHomeUpdate.params().getMessage()
+          List(true, false)
+            .map(isRestart =>
+              ProjectJavaHomeUpdate.params(isRestart).getMessage()
+            )
+            .contains(params.getMessage())
         ) {
           shouldReloadAfterJavaHomeUpdate
         } else {

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -92,6 +92,7 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
   var importScalaCliScript = new MessageActionItem(ImportScalaScript.dismiss)
   var resetWorkspace = new MessageActionItem(ResetWorkspace.cancel)
   var regenerateAndRestartScalaCliBuildSever = FileOutOfScalaCliBspScope.ignore
+  var shouldReloadAfterJavaHomeUpdate = ProjectJavaHomeUpdate.notNow
 
   val resources = new ResourceOperations(buffers)
   val diagnostics: TrieMap[AbsolutePath, Seq[Diagnostic]] =
@@ -372,6 +373,10 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
           params.getMessage().startsWith("For which folder would you like to")
         ) {
           chooseWorkspaceFolder(params.getActions().asScala.toSeq)
+        } else if (
+          params.getMessage() == ProjectJavaHomeUpdate.params().getMessage()
+        ) {
+          shouldReloadAfterJavaHomeUpdate
         } else {
           throw new IllegalArgumentException(params.toString)
         }

--- a/tests/unit/src/test/scala/tests/BloopJavaHomeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BloopJavaHomeLspSuite.scala
@@ -9,8 +9,6 @@ class BloopJavaHomeLspSuite extends BaseLspSuite("java-home") {
   val jsonFilePath: Option[AbsolutePath] =
     BloopServers.getBloopFilePath("bloop.json")
   val jsonFile: Option[AbsolutePath] = jsonFilePath.filter(_.exists)
-  val lockFile: Option[AbsolutePath] =
-    BloopServers.getBloopFilePath("created_by_metals.lock").filter(_.exists)
   val contents: Option[String] = jsonFile.map(_.readText)
 
   val javaHome: String =
@@ -18,7 +16,6 @@ class BloopJavaHomeLspSuite extends BaseLspSuite("java-home") {
 
   def stashBloopJson(): Unit = {
     jsonFile.foreach(_.delete())
-    lockFile.foreach(_.delete())
   }
 
   def unStashBloopJson(): Unit = {
@@ -26,11 +23,6 @@ class BloopJavaHomeLspSuite extends BaseLspSuite("java-home") {
       file.delete()
       file.touch()
       file.writeText(content)
-    }
-    lockFile.zip(jsonFile).foreach { case (lockfile, jsonFile) =>
-      lockfile.delete()
-      lockfile.touch()
-      lockfile.writeText(jsonFile.toNIO.toFile().lastModified().toString())
     }
   }
 
@@ -44,7 +36,7 @@ class BloopJavaHomeLspSuite extends BaseLspSuite("java-home") {
     super.beforeEach(context)
   }
 
-  test("broken-home") {
+  test("incorrect-home") {
     cleanWorkspace()
     jsonFilePath.foreach(
       _.writeText(

--- a/tests/unit/src/test/scala/tests/BloopJavaHomeLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BloopJavaHomeLspSuite.scala
@@ -11,8 +11,7 @@ class BloopJavaHomeLspSuite extends BaseLspSuite("java-home") {
   val jsonFile: Option[AbsolutePath] = jsonFilePath.filter(_.exists)
   val contents: Option[String] = jsonFile.map(_.readText)
 
-  val javaHome: String =
-    sys.env.get("JAVA_HOME").orElse(sys.props.get("java.home")).getOrElse("")
+  val javaHome: String = sys.props.get("java.home").getOrElse("")
 
   def stashBloopJson(): Unit = {
     jsonFile.foreach(_.delete())

--- a/tests/unit/src/test/scala/tests/Java8Suite.scala
+++ b/tests/unit/src/test/scala/tests/Java8Suite.scala
@@ -2,6 +2,7 @@ package tests
 
 import scala.meta.internal.metals.UserConfiguration
 
+import com.google.gson.JsonPrimitive
 import coursierapi.JvmManager
 
 class Java8Suite extends BaseCompletionLspSuite("completion-java-8") {
@@ -9,12 +10,15 @@ class Java8Suite extends BaseCompletionLspSuite("completion-java-8") {
   override def userConfig: UserConfiguration =
     UserConfiguration(javaHome = Some(pathToJava8))
 
+  def escapedPathToJava8: String =
+    new JsonPrimitive(pathToJava8).toString()
+
   test("java-8-completions") {
     cleanWorkspace()
     for {
       _ <- initialize(s"""|/metals.json
                           |{
-                          |  "a": { "platformJavaHome": "$pathToJava8" }
+                          |  "a": { "platformJavaHome": $escapedPathToJava8 }
                           |}
                           |/.metals/bsp.trace.json
                           |
@@ -38,7 +42,7 @@ class Java8Suite extends BaseCompletionLspSuite("completion-java-8") {
     for {
       _ <- initialize(s"""|/metals.json
                           |{
-                          |  "a": { "platformJavaHome": "$pathToJava8" }
+                          |  "a": { "platformJavaHome": $escapedPathToJava8 }
                           |}
                           |/a/src/main/scala/a/A.scala
                           |object A {

--- a/tests/unit/src/test/scala/tests/Java8Suite.scala
+++ b/tests/unit/src/test/scala/tests/Java8Suite.scala
@@ -1,0 +1,57 @@
+package tests
+
+import scala.meta.internal.metals.UserConfiguration
+
+import coursierapi.JvmManager
+
+class Java8Suite extends BaseCompletionLspSuite("completion-java-8") {
+  val pathToJava8: String = JvmManager.create().get("8").toString()
+  override def userConfig: UserConfiguration =
+    UserConfiguration(javaHome = Some(pathToJava8))
+
+  test("java-8-completions") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(s"""|/metals.json
+                          |{
+                          |  "a": { "platformJavaHome": "$pathToJava8" }
+                          |}
+                          |/.metals/bsp.trace.json
+                          |
+                          |/a/src/main/scala/a/A.scala
+                          |import java.nio.file.Path
+                          |object A {
+                          |  // @@
+                          |}
+                          |""".stripMargin)
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ = assertNoDiagnostics()
+      _ <- assertCompletion(
+        "val p = Path.o@@",
+        """|""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("java-8-workspace-completions") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(s"""|/metals.json
+                          |{
+                          |  "a": { "platformJavaHome": "$pathToJava8" }
+                          |}
+                          |/a/src/main/scala/a/A.scala
+                          |object A {
+                          |  // @@
+                          |}
+                          |""".stripMargin)
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ = assertNoDiagnostics()
+      _ <- assertCompletion(
+        "HttpClient@@",
+        "",
+      )
+    } yield ()
+  }
+
+}


### PR DESCRIPTION
Aim of this PR is to separate java used by Metals from java used for the project.
- Adds `-release` option to scalac options when project's jvm version < Metals jvm version to offer correct completions. Note that this works only for Scala 2 compiler completions. (For workspace completions we already index correct java sources)
- Starts bloop with the same JDK that Metals is started with.
- On user java home config update (java home that should be used for the project) propagates that change to build server (working for bloop, sbt and mill):
   - for Bloop done via reimport,
   - for sbt we restart the build server.

 https://github.com/scalameta/metals/issues/3923
 resolves: https://github.com/scalameta/metals/issues/5959 (now we will always run `bloop` with Metals java)