### PR TITLE
improvement: Use dependencyModule for resolving sources

### DIFF
--- a/metals-bench/src/main/scala/bench/ClasspathSymbolsBench.scala
+++ b/metals-bench/src/main/scala/bench/ClasspathSymbolsBench.scala
@@ -3,6 +3,7 @@ package bench
 import java.util.concurrent.TimeUnit
 
 import scala.meta.dialects
+import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.EmptyReportContext
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.tvp.IndexedSymbols
@@ -41,6 +42,7 @@ class ClasspathSymbolsBench {
       isStatisticsEnabled = false,
       trees,
       buffers,
+      BuildTargets.empty,
     )
     classpath.foreach { jar =>
       jars.jarSymbols(jar, "cats/", dialects.Scala213)

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -132,6 +132,10 @@ class BuildServerConnection private (
   def isDependencySourcesSupported: Boolean =
     capabilities.getDependencySourcesProvider()
 
+  // Scala CLI breaks when we try to use the `buildTarget/dependencyModules` request
+  def isDependencyModulesSupported: Boolean =
+    capabilities.getDependencyModulesProvider() && !isScalaCLI
+
   /* Currently only Bloop and sbt support running single test cases
    * and ScalaCLI uses Bloop underneath.
    */
@@ -386,6 +390,17 @@ class BuildServerConnection private (
     else
       Future.successful(
         new WrappedSourcesResult(List.empty[WrappedSourcesItem].asJava)
+      )
+  }
+
+  def buildTargetDependencyModules(
+      params: DependencyModulesParams
+  ): Future[DependencyModulesResult] = {
+    if (isDependencyModulesSupported)
+      register(server => server.buildTargetDependencyModules(params)).asScala
+    else
+      Future.successful(
+        new DependencyModulesResult(List.empty[DependencyModulesItem].asJava)
       )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ImportedBuild.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ImportedBuild.scala
@@ -21,6 +21,7 @@ case class ImportedBuild(
     sources: SourcesResult,
     dependencySources: DependencySourcesResult,
     wrappedSources: WrappedSourcesResult,
+    dependencyModules: DependencyModulesResult,
 ) {
   def ++(other: ImportedBuild): ImportedBuild = {
     val updatedBuildTargets = new WorkspaceBuildTargetsResult(
@@ -41,6 +42,9 @@ case class ImportedBuild(
     val updatedWrappedSources = new WrappedSourcesResult(
       (wrappedSources.getItems.asScala ++ other.wrappedSources.getItems.asScala).asJava
     )
+    val updatedDependencyModules = new DependencyModulesResult(
+      (dependencyModules.getItems.asScala ++ other.dependencyModules.getItems.asScala).asJava
+    )
     ImportedBuild(
       updatedBuildTargets,
       updatedScalacOptions,
@@ -48,6 +52,7 @@ case class ImportedBuild(
       updatedSources,
       updatedDependencySources,
       updatedWrappedSources,
+      updatedDependencyModules,
     )
   }
 
@@ -66,6 +71,7 @@ object ImportedBuild {
       new SourcesResult(ju.Collections.emptyList()),
       new DependencySourcesResult(ju.Collections.emptyList()),
       new WrappedSourcesResult(ju.Collections.emptyList()),
+      new DependencyModulesResult(ju.Collections.emptyList()),
     )
 
   def fromConnection(
@@ -93,6 +99,9 @@ object ImportedBuild {
       wrappedSources <- conn.buildTargetWrappedSources(
         new WrappedSourcesParams(ids)
       )
+      dependencyModules <- conn.buildTargetDependencyModules(
+        new DependencyModulesParams(ids)
+      )
     } yield {
       ImportedBuild(
         workspaceBuildTargets,
@@ -101,6 +110,7 @@ object ImportedBuild {
         sources,
         dependencySources,
         wrappedSources,
+        dependencyModules,
       )
     }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -226,6 +226,10 @@ final case class Indexer(
           bspSession().map(_.mainConnection),
         )
 
+        data.addDependencyModules(
+          importedBuild.dependencyModules
+        )
+
         // For "wrapped sources", we create dedicated TargetData.MappedSource instances,
         // able to convert back and forth positions from the user-facing file to
         // the compiler-facing actual underlying source.

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -131,6 +131,15 @@ object MetalsEnrichments
     }
   }
 
+  implicit class XtensionDependencyModule(module: b.DependencyModule) {
+    def asMavenDependencyModule: Option[b.MavenDependencyModule] = {
+      if (module.getDataKind() == b.DependencyModuleDataKind.MAVEN)
+        decodeJson(module.getData, classOf[b.MavenDependencyModule])
+      else
+        None
+    }
+  }
+
   implicit class XtensionTaskStart(task: b.TaskStartParams) {
     def asCompileTask: Option[b.CompileTask] = {
       decodeJson(task.getData, classOf[b.CompileTask])

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -236,7 +236,7 @@ object StandaloneSymbolSearch {
 
     download(scalaVersion).toSeq
       .map(path => AbsolutePath(path))
-      .partition(_.toString.endsWith("-sources.jar"))
+      .partition(_.isSourcesJar)
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/SourcePathAdapter.scala
@@ -26,7 +26,7 @@ private[debug] final class SourcePathAdapter(
       )
     ) {
       // if sourcePath is a dependency source file
-      // we retrieve the original source jar and we build the uri innside the source jar filesystem
+      // we retrieve the original source jar and we build the uri inside the source jar filesystem
       for {
         dependencySource <- sourcePath.toRelativeInside(dependencies)
         dependencyFolder <- dependencySource.toNIO.iterator.asScala.headOption

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -257,6 +257,7 @@ class FolderTreeViewProvider(
     isStatisticsEnabled = clientConfig.initialConfig.statistics.isTreeView,
     trees,
     buffers,
+    buildTargets,
   )
 
   def dialectOf(path: AbsolutePath): Option[Dialect] =
@@ -437,11 +438,10 @@ class FolderTreeViewProvider(
 
       val result = buildTargets
         .inferBuildTarget(List(closestToplevel))
-        .map { inferred =>
-          val sourceJar = inferred.jar.parent.resolve(
-            inferred.jar.filename.replace(".jar", "-sources.jar")
-          )
-          libraries.toUri(sourceJar, inferred.symbol).parentChain
+        .flatMap { inferred =>
+          inferred.sourceJar.map { sourceJar =>
+            libraries.toUri(sourceJar, inferred.symbol).parentChain
+          }
         }
       result.orElse(jdkSources)
     } else {


### PR DESCRIPTION
Previously, we would assume that the source jar is in the same directory as the normal jar. Now we use dependencyModules for that and only fallback to the previous logic if we can't find the jar in dependency modules.

This extracts part of the lazy classpath PR

Fixes https://github.com/scalameta/metals/issues/6182