### PR TITLE
improvement: Request jvmRunEnvironment lazily

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -216,6 +216,7 @@ final case class Indexer(
         val data = buildTool.data
         val importedBuild = buildTool.importedBuild
         data.reset()
+        buildTargetClasses.clear()
         data.addWorkspaceBuildTargets(importedBuild.workspaceBuildTargets)
         data.addScalacOptions(
           importedBuild.scalacOptions,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1631,13 +1631,13 @@ class MetalsLspService(
       params: CodeLensParams
   ): CompletableFuture[util.List[CodeLens]] =
     CancelTokens.future { _ =>
-      buildServerPromise.future.map { _ =>
+      buildServerPromise.future.flatMap { _ =>
         timerProvider.timedThunk(
           "code lens generation",
           thresholdMillis = 1.second.toMillis,
         ) {
           val path = params.getTextDocument.getUri.toAbsolutePath
-          codeLensProvider.findLenses(path).toList.asJava
+          codeLensProvider.findLenses(path).map(_.toList.asJava)
         }
       }
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/CodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/CodeLens.scala
@@ -1,5 +1,7 @@
 package scala.meta.internal.metals.codelenses
 
+import scala.concurrent.Future
+
 import scala.meta.internal.implementation.TextDocumentWithPath
 import scala.meta.io.AbsolutePath
 
@@ -8,8 +10,11 @@ import org.eclipse.{lsp4j => l}
 trait CodeLens {
   def isEnabled: Boolean
 
-  def codeLenses(textDocumentWithPath: TextDocumentWithPath): Seq[l.CodeLens] =
-    Seq.empty
+  def codeLenses(
+      textDocumentWithPath: TextDocumentWithPath
+  ): Future[Seq[l.CodeLens]] =
+    Future.successful(Seq.empty)
 
-  def codeLenses(path: AbsolutePath): Seq[l.CodeLens] = Seq.empty
+  def codeLenses(path: AbsolutePath): Future[Seq[l.CodeLens]] =
+    Future.successful(Seq.empty)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/SuperMethodCodeLens.scala
@@ -1,5 +1,8 @@
 package scala.meta.internal.metals.codelenses
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
 import scala.meta.internal.implementation.SuperMethodProvider
 import scala.meta.internal.implementation.TextDocumentWithPath
 import scala.meta.internal.metals.Buffers
@@ -21,13 +24,14 @@ final class SuperMethodCodeLens(
     userConfig: () => UserConfiguration,
     clientConfig: ClientConfiguration,
     trees: Trees,
-) extends CodeLens {
+)(implicit val ec: ExecutionContext)
+    extends CodeLens {
 
   override def isEnabled: Boolean = userConfig().superMethodLensesEnabled
 
   override def codeLenses(
       textDocumentWithPath: TextDocumentWithPath
-  ): Seq[l.CodeLens] = {
+  ): Future[Seq[l.CodeLens]] = Future {
     val textDocument = textDocumentWithPath.textDocument
     val path = textDocumentWithPath.filePath
 

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/WorksheetCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/WorksheetCodeLens.scala
@@ -1,5 +1,8 @@
 package scala.meta.internal.metals.codelenses
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
 import scala.meta.internal.metals.ClientCommands.CopyWorksheetOutput
 import scala.meta.internal.metals.ClientConfiguration
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -7,13 +10,15 @@ import scala.meta.io.AbsolutePath
 
 import org.eclipse.{lsp4j => l}
 
-class WorksheetCodeLens(clientConfig: ClientConfiguration) extends CodeLens {
+class WorksheetCodeLens(clientConfig: ClientConfiguration)(implicit
+    val ec: ExecutionContext
+) extends CodeLens {
 
   override def isEnabled: Boolean = clientConfig.isCopyWorksheetOutputProvider
 
   override def codeLenses(
       path: AbsolutePath
-  ): Seq[l.CodeLens] = {
+  ): Future[Seq[l.CodeLens]] = Future {
     if (path.isWorksheet) {
       val command = CopyWorksheetOutput.toLsp(path.toURI)
       val startPosition = new l.Position(0, 0)

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -130,7 +130,7 @@ final class TestSuitesProvider(
 
   override def codeLenses(
       textDocumentWithPath: TextDocumentWithPath
-  ): Seq[l.CodeLens] = {
+  ): Future[Seq[l.CodeLens]] = Future {
     val path = textDocumentWithPath.filePath
     for {
       target <- buildTargets.inverseSources(path).toList


### PR DESCRIPTION
Previously, we would eagerly request jvmEnvironment for all known main classes, which in case of Bazel might cause a lot of queries. This might also not be efficient in some other cases. Now, we only request and cache jvmRunEnvironment when needed.