### PR TITLE
bugfix: allow for mixed multiple custom and known build servers

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BspOnly.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BspOnly.scala
@@ -22,4 +22,6 @@ case class BspOnly(
     else None
   }
   override val forcesBuildServer = true
+
+  override def isBspGenerated(workspace: AbsolutePath): Boolean = true
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -199,6 +199,7 @@ class MetalsLspService(
     bspGlobalDirectories,
     () => userConfig,
     () => tables.buildServers.selectedServer().nonEmpty,
+    charset,
   )
 
   def javaHome = userConfig.javaHome
@@ -2147,6 +2148,11 @@ class MetalsLspService(
         )
       case Some(BuildTool.Found(buildTool: BuildServerProvider, _)) =>
         slowConnectToBuildToolBsp(buildTool, forceImport, isSelected(buildTool))
+      // Used when there are multiple `.bsp/<name>.json` configs and a known build tool (e.g. sbt)
+      case Some(BuildTool.Found(buildTool, _))
+          if buildTool.isBspGenerated(folder) =>
+        maybeChooseServer(buildTool.buildServerName, isSelected(buildTool))
+        quickConnectToBuildServer()
       // Used in tests, `.bloop` folder exists but no build tool is detected
       case _ => quickConnectToBuildServer()
     }

--- a/tests/slow/src/test/scala/tests/MultipleBuildFilesLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/MultipleBuildFilesLspSuite.scala
@@ -86,4 +86,26 @@ class MultipleBuildFilesLspSuite
     } yield ()
   }
 
+  test("custom-bsp-2") {
+    cleanWorkspace()
+    client.chooseBuildTool = actions =>
+      actions
+        .find(_.getTitle == "Custom")
+        .getOrElse(throw new Exception("no Custom as build tool"))
+    for {
+      _ <- initialize(
+        s"""|/.bsp/custom.json
+            |${ScalaCli.scalaCliBspJsonContent(bspName = "Custom")}
+            |/.bsp/other-custom.json
+            |${ScalaCli.scalaCliBspJsonContent(bspName = "Other custom")}
+            |/build.sbt
+            |scalaVersion := "${V.scala213}"
+            |""".stripMargin
+      )
+      _ <- server.server.indexingPromise.future
+      _ = assert(server.server.bspSession.nonEmpty)
+      _ = assert(server.server.bspSession.get.main.name == "Custom")
+    } yield ()
+  }
+
 }


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/6261

This resolves two issues:
1. fixes connecting to custom bsp in presence of multiple bsp configs and a known build tool (e.g. `sbt`) in workspace
2. allows for `<name>.json` to differ from `"name"` in bsp config