### PR TITLE
test: increase timeout on worksheet inf loop test

### DIFF
--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetInfiniteLoopSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetInfiniteLoopSuite.scala
@@ -21,10 +21,10 @@ class WorksheetInfiniteLoopSuite
     super.userConfig.copy(
       worksheetScreenWidth = 40,
       worksheetCancelTimeout = 1,
-      worksheetTimeout = 4,
+      worksheetTimeout = 8,
     )
 
-  test("infinite-loop") {
+  test("infinite-loop", maxRetry = 3) {
     for {
       _ <- initialize(
         s"""


### PR DESCRIPTION
This test seems to fail on Mac OS quite a lot. Eval worksheet reaches timeout, so I'm increasing timeout and adding retry.
https://github.com/scalameta/metals/actions/runs/8525141762/job/23351371215?pr=6273#step:4:7995