### PR TITLE
improvement: Also start Scala CLI if the focused file was Scala

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -2216,7 +2216,7 @@ class MetalsLspService(
     if (
       !buildTools.isAutoConnectable()
       && buildTools.loadSupported.isEmpty
-      && folder.isScalaProject()
+      && (folder.isScalaProject() || focusedDocument().exists(_.isScala))
     ) scalaCli.setupIDE(folder)
     else Future.successful(())
   }


### PR DESCRIPTION
Previously, we would only search through some directories to check if a project is a Scala one. Now, we also check for focused document.

This should work since focused document will only really get Scala file updates and the server will only start if any Scala files were opened. And it's basically a fallback.

The other solution would be to search more directories instead of the standard ones

Fixes https://github.com/scalameta/metals/issues/6280