### PR TITLE
fix: check that implicit method owner is static in completions

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -413,7 +413,7 @@ class CompletionProvider(
     val visitor = new CompilerSearchVisitor(
       context,
       sym =>
-        if (sym.safeOwner.isImplicit) {
+        if (sym.safeOwner.isImplicit && sym.owner.isStatic) {
           val ownerConstructor = sym.owner.info.member(nme.CONSTRUCTOR)
           def typeParams = sym.owner.info.typeParams
           ownerConstructor.info.paramss match {

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -2292,4 +2292,24 @@ class CompletionSuite extends BaseCompletionSuite {
     ""
   )
 
+  // currently because of the way indexing works
+  // the potentially correct completion symbol `a/A.Xtension#foofoo().` won't be created
+  // this test just checks that `a/A#Xtension#foofoo().` is not shown
+  check(
+    "implicit-class-owner-must-be-static",
+    """|package a
+       |object A extends A {}
+       |class A {
+       |  implicit class Xtension(i: Int){
+       |    def foofoo() = ???
+       |  }
+       |}
+       |
+       |object O {
+       |  val f = 1.foofoo@@
+       |}
+       |""".stripMargin,
+    ""
+  )
+
 }


### PR DESCRIPTION
fixes: https://github.com/scalameta/metals/issues/6274