### PR TITLE
tests: filter out `java.lang.classfile` for JDK 22

### DIFF
--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -35,6 +35,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
     result
   }
 
+  // NOTE: this filters out things from `java.lang.classfile` which was added in JDK 22
   private def getItems(
       original: String,
       filename: String = "A.scala"
@@ -49,6 +50,7 @@ abstract class BaseCompletionSuite extends BasePCSuite {
       )
     )
     result.getItems.asScala
+      .filterNot(item => item.getLabel().contains("- java.lang.classfile"))
       .sortBy(item => Option(item.getSortText).getOrElse(item.getLabel()))
       .toSeq
   }


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/6295

I added a generic filter, so we don't have to be bothered with this when adding new test cases.