### PR TITLE
chore: Improve Bazel navigation message

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -281,7 +281,7 @@ object Messages {
       s"Multiple problems detected in your build."
 
     def bazelNavigation: String =
-      "Code navigation for Bazel projects is not supported yet."
+      "Global rename and references for Bazel projects is not supported yet."
 
     val misconfiguredTestFrameworks: String =
       "Test Explorer won't work due to mis-configuration." + moreInfo


### PR DESCRIPTION
Previously, it would say that no navigation is supported, however go to definition does work. Now, it points to the exact features that do not work.