### PR TITLE
improvement: Also run from Java when running from config

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -38,6 +38,7 @@ import scala.meta.internal.metals.codelenses.RunTestCodeLens
 import scala.meta.internal.metals.codelenses.SuperMethodCodeLens
 import scala.meta.internal.metals.codelenses.WorksheetCodeLens
 import scala.meta.internal.metals.debug.BuildTargetClasses
+import scala.meta.internal.metals.debug.DebugDiscovery
 import scala.meta.internal.metals.debug.DebugProvider
 import scala.meta.internal.metals.doctor.Doctor
 import scala.meta.internal.metals.doctor.HeadDoctor
@@ -74,7 +75,6 @@ import org.eclipse.lsp4j.ExecuteCommandParams
 import org.eclipse.lsp4j._
 import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
 import org.eclipse.{lsp4j => l}
-import scala.meta.internal.metals.debug.DebugDiscovery
 
 /**
  * Metals implementation of the Scala Language Service.

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -74,6 +74,7 @@ import org.eclipse.lsp4j.ExecuteCommandParams
 import org.eclipse.lsp4j._
 import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
 import org.eclipse.{lsp4j => l}
+import scala.meta.internal.metals.debug.DebugDiscovery
 
 /**
  * Metals implementation of the Scala Language Service.
@@ -1445,6 +1446,16 @@ abstract class MetalsLspService(
       workDoneProgress,
     )
 
+  protected val debugDiscovery: DebugDiscovery = new DebugDiscovery(
+    buildTargetClasses,
+    buildTargets,
+    buildClient,
+    languageClient,
+    semanticdbs,
+    () => userConfig,
+    folder,
+  )
+
   protected val debugProvider: DebugProvider = register(
     new DebugProvider(
       folder,
@@ -1456,7 +1467,6 @@ abstract class MetalsLspService(
       definitionIndex,
       stacktraceAnalyzer,
       clientConfig,
-      semanticdbs,
       compilers,
       statusBar,
       workDoneProgress,
@@ -1468,7 +1478,7 @@ abstract class MetalsLspService(
   buildClient.registerLogForwarder(debugProvider)
 
   def debugDiscovery(params: DebugDiscoveryParams): Future[DebugSession] =
-    debugProvider
+    debugDiscovery
       .debugDiscovery(params)
       .flatMap(debugProvider.asSession)
 
@@ -1502,7 +1512,7 @@ abstract class MetalsLspService(
   def discoverMainClasses(
       unresolvedParams: DebugDiscoveryParams
   ): Future[b.DebugSessionParams] =
-    debugProvider.runCommandDiscovery(unresolvedParams)
+    debugDiscovery.runCommandDiscovery(unresolvedParams)
 
   def supportsBuildTarget(
       target: b.BuildTargetIdentifier

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -836,8 +836,10 @@ case class DebugUnresolvedAttachRemoteParams(
 )
 
 case class DebugDiscoveryParams(
-    path: String,
+    @Nullable path: String,
     runType: String,
+    @Nullable mainClass: String = null,
+    @Nullable buildTarget: String = null,
     @Nullable args: java.util.List[String] = null,
     @Nullable jvmOptions: java.util.List[String] = null,
     @Nullable env: java.util.Map[String, String] = null,

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -798,12 +798,12 @@ class WorkspaceLspService(
         val discovered = Option(unresolvedParams.path) match {
           case None =>
             Future
-              .sequence {
+              .find {
                 folderServices
                   .map {
                     _.discoverMainClasses(unresolvedParams)
                   }
-              }
+              }(_ => true)
               .flatMap { mains =>
                 mains.headOption.fold(
                   Future.failed[DebugSessionParams](

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -24,6 +24,7 @@ import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.config.StatusBarState
 import scala.meta.internal.metals.debug.DebugProvider
+import scala.meta.internal.metals.debug.DiscoveryFailures
 import scala.meta.internal.metals.doctor.DoctorVisibilityDidChangeParams
 import scala.meta.internal.metals.doctor.HeadDoctor
 import scala.meta.internal.metals.findfiles.FindTextInDependencyJarsRequest
@@ -94,7 +95,6 @@ import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.WorkspaceSymbolParams
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 import org.eclipse.lsp4j.jsonrpc.messages
-import scala.meta.internal.metals.debug.NoClassFoundException
 
 class WorkspaceLspService(
     ec: ExecutionContextExecutorService,
@@ -807,7 +807,8 @@ class WorkspaceLspService(
               .flatMap { mains =>
                 mains.headOption.fold(
                   Future.failed[DebugSessionParams](
-                    NoClassFoundException(unresolvedParams.mainClass)
+                    DiscoveryFailures
+                      .NoMainClassFoundException(unresolvedParams.mainClass)
                   )
                 )(Future.successful(_))
               }

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -19,7 +19,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.TestUserInterfaceKind
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.debug.BuildTargetClasses
-import scala.meta.internal.metals.debug.DebugProvider
+import scala.meta.internal.metals.debug.DebugDiscovery
 import scala.meta.internal.metals.debug.ExtendedScalaMainClass
 import scala.meta.internal.parsing.TokenEditDistance
 import scala.meta.internal.parsing.Trees
@@ -228,7 +228,7 @@ final class RunTestCodeLens(
           if (clientConfig.isDebuggingProvider())
             testClasses(target, classes, symbol, isJVM)
           else Nil
-        val fromAnnot = DebugProvider
+        val fromAnnot = DebugDiscovery
           .mainFromAnnotation(occurrence, textDocument)
           .flatMap { symbol =>
             classes.mainClasses
@@ -275,7 +275,7 @@ final class RunTestCodeLens(
 
     val fromAnnotations = textDocument.occurrences.flatMap { occ =>
       for {
-        sym <- DebugProvider.mainFromAnnotation(occ, textDocument)
+        sym <- DebugDiscovery.mainFromAnnotation(occ, textDocument)
         cls <- classes.mainClasses.get(sym)
         range <- occurrenceRange(occ, distance)
       } yield mainCommand(target, cls, isJVM).map { cmd =>

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugDiscovery.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugDiscovery.scala
@@ -1,0 +1,419 @@
+package scala.meta.internal.metals.debug
+
+import java.util.Collections.singletonList
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.Success
+
+import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.DebugDiscoveryParams
+import scala.meta.internal.metals.JavaBinary
+import scala.meta.internal.metals.JsonParser._
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.MetalsBuildClient
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.clients.language.MetalsQuickPickItem
+import scala.meta.internal.metals.clients.language.MetalsQuickPickParams
+import scala.meta.internal.metals.config.RunType
+import scala.meta.internal.metals.config.RunType._
+import scala.meta.internal.metals.debug.DebugProvider.NoRunOptionException
+import scala.meta.internal.metals.debug.DebugProvider.SemanticDbNotFoundException
+import scala.meta.internal.metals.debug.DebugProvider.UndefinedPathException
+import scala.meta.internal.metals.debug.DebugProvider.WorkspaceErrorsException
+import scala.meta.internal.mtags.Semanticdbs
+import scala.meta.internal.mtags.DefinitionAlternatives.GlobalSymbol
+import scala.meta.internal.mtags.Symbol
+import scala.meta.io.AbsolutePath
+
+import ch.epfl.scala.{bsp4j => b}
+import com.google.gson.JsonElement
+import scala.meta.internal.semanticdb.SymbolOccurrence
+import scala.meta.internal.semanticdb.TextDocument
+
+class DebugDiscovery(
+    buildTargetClasses: BuildTargetClasses,
+    buildTargets: BuildTargets,
+    buildClient: MetalsBuildClient,
+    languageClient: MetalsLanguageClient,
+    semanticdbs: () => Semanticdbs,
+    userConfig: () => UserConfiguration,
+    workspace: AbsolutePath,
+) {
+
+  /**
+   * Tries to discover the main class to run and returns
+   * DebugSessionParams that contains the shellCommand field.
+   * This is used so that clients can easily run the full command
+   * if they want.
+   */
+  def runCommandDiscovery(
+      unresolvedParams: DebugDiscoveryParams
+  )(implicit ec: ExecutionContext): Future[b.DebugSessionParams] = {
+    debugDiscovery(unresolvedParams).flatMap(enrichWithMainShellCommand)
+  }
+
+  /**
+   * Given fully unresolved params this figures out the runType that was passed
+   * in and then discovers either the main methods for the build target the
+   * path belongs to or finds the tests for the current file or build target
+   */
+  def debugDiscovery(
+      params: DebugDiscoveryParams
+  )(implicit ec: ExecutionContext): Future[b.DebugSessionParams] = {
+    val runTypeO = RunType.fromString(params.runType)
+    val pathOpt = Option(params.path).map(_.toAbsolutePath)
+    val buildTargetO = pathOpt.flatMap(buildTargets.inverseSources(_)).orElse {
+      Option(params.buildTarget)
+        .flatMap(buildTargets.findByDisplayName)
+        .map(_.getId())
+    }
+
+    lazy val mainClasses = (bti: b.BuildTargetIdentifier) =>
+      buildTargetClasses.classesOf(bti).mainClasses
+
+    lazy val testClasses = (bti: b.BuildTargetIdentifier) =>
+      buildTargetClasses.classesOf(bti).testClasses
+
+    (runTypeO, buildTargetO, pathOpt) match {
+      case (_, Some(buildTarget), _)
+          if buildClient.buildHasErrors(buildTarget) =>
+        Future.failed(WorkspaceErrorsException)
+      case (_, None, Some(path)) =>
+        Future.failed(BuildTargetNotFoundForPathException(path))
+      case (None, _, _) =>
+        Future.failed(RunType.UnknownRunTypeException(params.runType))
+      case (Some(Run), target, _) =>
+        val targetIds = target match {
+          case None => buildTargets.allBuildTargetIds
+          case Some(value) => List(value)
+        }
+        val requestedMain = Option(params.mainClass)
+        val targetToMainClasses = targetIds
+          .map { target =>
+            target ->
+              mainClasses(target).values.toList.filter(cls =>
+                requestedMain.isEmpty || requestedMain.contains(
+                  cls.getClassName()
+                )
+              )
+
+          }
+          .filter { case (_, mains) => mains.nonEmpty }
+          .toMap
+        if (targetToMainClasses.nonEmpty)
+          verifyMain(
+            targetToMainClasses,
+            params,
+          )
+        else
+          Future.failed(
+            MainClassException(
+              params,
+              targetIds.nonEmpty,
+              buildTargets.all.map(_.getDisplayName).toSeq,
+            )
+          )
+      case (Some(RunOrTestFile), Some(target), _) =>
+        resolveInFile(
+          target,
+          mainClasses(target),
+          testClasses(target),
+          params,
+        )
+      case (Some(TestFile), Some(target), path)
+          if testClasses(target).isEmpty =>
+        Future.failed(
+          NoTestsFoundException("file", path.toString())
+        )
+      case (Some(TestTarget), Some(target), _) if testClasses(target).isEmpty =>
+        Future.failed(
+          NoTestsFoundException("build target", displayName(target))
+        )
+      case (Some(TestTarget), None, _) =>
+        Future.failed(NoBuildTargetSpecified)
+      case (Some(TestFile), Some(target), Some(path)) =>
+        semanticdbs()
+          .textDocument(path)
+          .documentIncludingStale
+          .fold[Future[Seq[BuildTargetClasses.FullyQualifiedClassName]]] {
+            Future.failed(SemanticDbNotFoundException)
+          } { textDocument =>
+            Future {
+              for {
+                symbolInfo <- textDocument.symbols
+                symbol = symbolInfo.symbol
+                testSymbolInfo <- testClasses(target).get(symbol)
+              } yield testSymbolInfo.fullyQualifiedName
+            }
+          }
+          .map { tests =>
+            val params = new b.DebugSessionParams(
+              singletonList(target)
+            )
+            params.setDataKind(
+              b.TestParamsDataKind.SCALA_TEST_SUITES
+            )
+            params.setData(tests.asJava.toJson)
+            params
+          }
+      case (Some(TestTarget), Some(target), _) =>
+        Future {
+          val params = new b.DebugSessionParams(
+            singletonList(target)
+          )
+          params.setDataKind(b.TestParamsDataKind.SCALA_TEST_SUITES)
+          params.setData(
+            testClasses(target).values
+              .map(_.fullyQualifiedName)
+              .toList
+              .asJava
+              .toJson
+          )
+          params
+        }
+      case (Some(tpe @ (TestFile | RunOrTestFile)), _, None) =>
+        Future.failed(UndefinedPathException(tpe))
+
+    }
+
+  }
+
+  private def verifyMain(
+      classes: Map[b.BuildTargetIdentifier, List[b.ScalaMainClass]],
+      params: DebugDiscoveryParams,
+  )(implicit ec: ExecutionContext): Future[b.DebugSessionParams] = {
+
+    classes.toList match {
+      case (buildTarget, main :: Nil) :: Nil =>
+        createMainParams(
+          params,
+          main,
+          buildTarget,
+        )
+      case multiple =>
+        requestMain(multiple.flatMap(_._2)).flatMap { main =>
+          val buildTarget = classes.find(_._2.contains(main)).map(_._1)
+          createMainParams(
+            params,
+            main,
+            buildTarget.get,
+          )
+        }
+
+    }
+  }
+
+  private def enrichWithMainShellCommand(
+      params: b.DebugSessionParams
+  )(implicit ec: ExecutionContext): Future[b.DebugSessionParams] = {
+    val future = params.getData() match {
+      case json: JsonElement
+          if params.getDataKind == b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS =>
+        json.as[b.ScalaMainClass] match {
+          case Success(main) if params.getTargets().size > 0 =>
+            val javaBinary = buildTargets
+              .scalaTarget(params.getTargets().get(0))
+              .flatMap(scalaTarget =>
+                JavaBinary.javaBinaryFromPath(scalaTarget.jvmHome)
+              )
+              .orElse(userConfig().usedJavaBinary)
+            buildTargetClasses
+              .jvmRunEnvironment(params.getTargets().get(0))
+              .map { envItem =>
+                val updatedData = envItem.zip(javaBinary) match {
+                  case None =>
+                    main.toJson
+                  case Some((env, javaHome)) =>
+                    ExtendedScalaMainClass(
+                      main,
+                      env,
+                      javaHome,
+                      workspace,
+                    ).toJson
+                }
+                params.setData(updatedData)
+              }
+          case _ => Future.unit
+        }
+
+      case _ => Future.unit
+    }
+
+    future.map { _ =>
+      params
+    }
+  }
+
+  private def resolveInFile(
+      buildTarget: b.BuildTargetIdentifier,
+      classes: TrieMap[
+        BuildTargetClasses.Symbol,
+        b.ScalaMainClass,
+      ],
+      testClasses: TrieMap[
+        BuildTargetClasses.Symbol,
+        BuildTargetClasses.TestSymbolInfo,
+      ],
+      params: DebugDiscoveryParams,
+  )(implicit ec: ExecutionContext) = {
+    val path = params.path.toAbsolutePath
+    semanticdbs()
+      .textDocument(path)
+      .documentIncludingStale
+      .fold[Future[b.DebugSessionParams]] {
+        Future.failed(SemanticDbNotFoundException)
+      } { textDocument =>
+        lazy val tests = for {
+          symbolInfo <- textDocument.symbols
+          symbol = symbolInfo.symbol
+          testSymbolInfo <- testClasses.get(symbol)
+        } yield testSymbolInfo.fullyQualifiedName
+        val mains = for {
+          occurrence <- textDocument.occurrences
+          if occurrence.role.isDefinition || occurrence.symbol == "scala/main#"
+          symbol = occurrence.symbol
+          mainClass <- {
+            val normal = classes.get(symbol)
+            val fromAnnot = DebugDiscovery
+              .mainFromAnnotation(occurrence, textDocument)
+              .flatMap(classes.get(_))
+            List(normal, fromAnnot).flatten
+          }
+        } yield mainClass
+        if (mains.nonEmpty) {
+          verifyMain(Map(buildTarget -> mains.toList), params)
+        } else if (tests.nonEmpty) {
+          Future {
+            val params = new b.DebugSessionParams(singletonList(buildTarget))
+            params.setDataKind(b.TestParamsDataKind.SCALA_TEST_SUITES)
+            params.setData(tests.asJava.toJson)
+            params
+          }
+
+        } else {
+          Future.failed(NoRunOptionException)
+        }
+      }
+  }
+
+  private def createMainParams(
+      params: DebugDiscoveryParams,
+      main: b.ScalaMainClass,
+      buildTargetIdentifier: b.BuildTargetIdentifier,
+  )(implicit ec: ExecutionContext): Future[b.DebugSessionParams] = {
+    val env = Option(params.env).toList.flatMap(DebugProvider.createEnvList)
+    DebugProvider.createMainParams(
+      workspace,
+      main,
+      buildTargetIdentifier,
+      Option(params.args),
+      Option(params.jvmOptions),
+      env,
+      Option(params.envFile),
+    )
+  }
+
+  /**
+   * Given a BuildTargetIdentifier either get the displayName of that build
+   * target or default to the full URI to display to the user.
+   */
+  private def displayName(buildTargetIdentifier: b.BuildTargetIdentifier) =
+    buildTargets
+      .info(buildTargetIdentifier)
+      .map(_.getDisplayName)
+      .getOrElse(buildTargetIdentifier.getUri)
+
+  private def requestMain(
+      mainClasses: List[b.ScalaMainClass]
+  )(implicit ec: ExecutionContext): Future[b.ScalaMainClass] = {
+    languageClient
+      .metalsQuickPick(
+        new MetalsQuickPickParams(
+          mainClasses.map { m =>
+            val cls = m.getClassName()
+            new MetalsQuickPickItem(cls, cls)
+          }.asJava,
+          placeHolder = Messages.MainClass.message,
+        )
+      )
+      .asScala
+      .collect { case Some(choice) =>
+        mainClasses.find { clazz =>
+          clazz.getClassName() == choice.itemId
+        }
+      }
+      .collect { case Some(main) => main }
+  }
+
+}
+
+object DebugDiscovery {
+
+  /**
+   * Given an occurence and a text document return the symbol of a main method
+   * that could be defined using the Scala 3 @main annotation.
+   *
+   * @param occurrence The symbol occurence you're checking against the document.
+   * @param textDocument The document of the current file.
+   * @return Possible symbol name of main.
+   */
+  def mainFromAnnotation(
+      occurrence: SymbolOccurrence,
+      textDocument: TextDocument,
+  ): Option[String] = {
+    if (occurrence.symbol == "scala/main#") {
+      occurrence.range match {
+        case Some(range) =>
+          val closestOccurence = textDocument.occurrences.minBy { occ =>
+            occ.range
+              .filter { rng =>
+                occ.symbol != "scala/main#" &&
+                rng.endLine - range.endLine >= 0 &&
+                rng.endCharacter - rng.startCharacter > 0
+              }
+              .map(rng =>
+                (
+                  rng.endLine - range.endLine,
+                  rng.endCharacter - range.endCharacter,
+                )
+              )
+              .getOrElse((Int.MaxValue, Int.MaxValue))
+          }
+          dropSourceFromToplevelSymbol(closestOccurence.symbol)
+
+        case None => None
+      }
+    } else {
+      None
+    }
+
+  }
+
+  import scala.meta.internal.semanticdb.Scala._
+
+  /**
+   * Converts Scala3 sorceToplevelSymbol into a plain one that corresponds to class name.
+   * From `3.1.0` plain names were removed from occurrences because they are synthetic.
+   * Example:
+   *   `foo/Foo$package.mainMethod().` -> `foo/mainMethod#`
+   */
+  private def dropSourceFromToplevelSymbol(symbol: String): Option[String] = {
+    Symbol(symbol) match {
+      case GlobalSymbol(
+            GlobalSymbol(
+              owner,
+              Descriptor.Term(_),
+            ),
+            Descriptor.Method(name, _),
+          ) =>
+        val converted = GlobalSymbol(owner, Descriptor.Term(name))
+        Some(converted.value)
+      case _ =>
+        None
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -9,7 +9,6 @@ import java.util.Collections.singletonList
 import java.util.concurrent.TimeUnit
 import java.{util => ju}
 
-import scala.collection.concurrent.TrieMap
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
@@ -25,11 +24,9 @@ import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.ClientConfiguration
 import scala.meta.internal.metals.Compilations
 import scala.meta.internal.metals.Compilers
-import scala.meta.internal.metals.DebugDiscoveryParams
 import scala.meta.internal.metals.DebugSession
 import scala.meta.internal.metals.DebugUnresolvedMainClassParams
 import scala.meta.internal.metals.DebugUnresolvedTestClassParams
-import scala.meta.internal.metals.JavaBinary
 import scala.meta.internal.metals.JsonParser._
 import scala.meta.internal.metals.JvmOpts
 import scala.meta.internal.metals.Messages
@@ -47,8 +44,6 @@ import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.WorkDoneProgress
 import scala.meta.internal.metals.clients.language.LogForwarder
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
-import scala.meta.internal.metals.clients.language.MetalsQuickPickItem
-import scala.meta.internal.metals.clients.language.MetalsQuickPickParams
 import scala.meta.internal.metals.clients.language.MetalsStatusParams
 import scala.meta.internal.metals.config.RunType
 import scala.meta.internal.metals.config.RunType._
@@ -60,13 +55,7 @@ import scala.meta.internal.metals.debug.server.MetalsDebugToolsResolver
 import scala.meta.internal.metals.debug.server.MetalsDebuggee
 import scala.meta.internal.metals.debug.server.TestSuiteDebugAdapter
 import scala.meta.internal.metals.testProvider.TestSuitesProvider
-import scala.meta.internal.mtags.DefinitionAlternatives.GlobalSymbol
 import scala.meta.internal.mtags.OnDemandSymbolIndex
-import scala.meta.internal.mtags.Semanticdbs
-import scala.meta.internal.mtags.Symbol
-import scala.meta.internal.semanticdb.Scala.Descriptor
-import scala.meta.internal.semanticdb.SymbolOccurrence
-import scala.meta.internal.semanticdb.TextDocument
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
@@ -93,7 +82,6 @@ class DebugProvider(
     index: OnDemandSymbolIndex,
     stacktraceAnalyzer: StacktraceAnalyzer,
     clientConfig: ClientConfiguration,
-    semanticdbs: () => Semanticdbs,
     compilers: Compilers,
     statusBar: StatusBar,
     workDoneProgress: WorkDoneProgress,
@@ -428,38 +416,6 @@ class DebugProvider(
     }
   }
 
-  /**
-   * Given a BuildTargetIdentifier either get the displayName of that build
-   * target or default to the full URI to display to the user.
-   */
-  private def displayName(buildTargetIdentifier: BuildTargetIdentifier) =
-    buildTargets
-      .info(buildTargetIdentifier)
-      .map(_.getDisplayName)
-      .getOrElse(buildTargetIdentifier.getUri)
-
-  private def requestMain(
-      mainClasses: List[ScalaMainClass]
-  )(implicit ec: ExecutionContext): Future[ScalaMainClass] = {
-    languageClient
-      .metalsQuickPick(
-        new MetalsQuickPickParams(
-          mainClasses.map { m =>
-            val cls = m.getClassName()
-            new MetalsQuickPickItem(cls, cls)
-          }.asJava,
-          placeHolder = Messages.MainClass.message,
-        )
-      )
-      .asScala
-      .collect { case Some(choice) =>
-        mainClasses.find { clazz =>
-          clazz.getClassName() == choice.itemId
-        }
-      }
-      .collect { case Some(main) => main }
-  }
-
   private def buildServerConnect(parameters: b.DebugSessionParams) = for {
     targetId <- parameters.getTargets().asScala.headOption
     buildServer <- buildTargets.buildServerOf(targetId)
@@ -467,138 +423,6 @@ class DebugProvider(
 
   private def supportsTestSelection(targetId: b.BuildTargetIdentifier) = {
     buildTargets.buildServerOf(targetId).exists(_.supportsTestSelection)
-  }
-
-  private def envFromFile(
-      envFile: Option[String]
-  )(implicit ec: ExecutionContext): Future[List[String]] =
-    envFile
-      .map { file =>
-        val path = AbsolutePath(file)(workspace)
-        DotEnvFileParser
-          .parse(path)
-          .map(_.map { case (key, value) => s"$key=$value" }.toList)
-      }
-      .getOrElse(Future.successful(List.empty))
-
-  private def createMainParams(
-      params: DebugDiscoveryParams,
-      main: ScalaMainClass,
-      buildTargetIdentifier: BuildTargetIdentifier,
-  )(implicit ec: ExecutionContext): Future[DebugSessionParams] = {
-    val env = Option(params.env).toList.flatMap(createEnvList)
-    createMainParams(
-      main,
-      buildTargetIdentifier,
-      Option(params.args),
-      Option(params.jvmOptions),
-      env,
-      Option(params.envFile),
-    )
-  }
-
-  private def createMainParams(
-      main: ScalaMainClass,
-      target: BuildTargetIdentifier,
-      args: Option[ju.List[String]],
-      jvmOptions: Option[ju.List[String]],
-      env: List[String],
-      envFile: Option[String],
-  )(implicit ec: ExecutionContext): Future[DebugSessionParams] = {
-    main.setArguments(args.getOrElse(ju.Collections.emptyList()))
-    main.setJvmOptions(
-      jvmOptions.getOrElse(ju.Collections.emptyList())
-    )
-    envFromFile(envFile).map { envFromFile =>
-      main.setEnvironmentVariables((envFromFile ::: env).asJava)
-      val params = new b.DebugSessionParams(singletonList(target))
-      params.setDataKind(b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS)
-      params.setData(main.toJson)
-      params
-    }
-  }
-
-  private def createEnvList(env: ju.Map[String, String]) = {
-    env.asScala.map { case (key, value) =>
-      s"$key=$value"
-    }.toList
-  }
-
-  private def verifyMain(
-      classes: Map[BuildTargetIdentifier, List[ScalaMainClass]],
-      params: DebugDiscoveryParams,
-  )(implicit ec: ExecutionContext): Future[DebugSessionParams] = {
-
-    classes.toList match {
-      case (buildTarget, main :: Nil) :: Nil =>
-        createMainParams(
-          params,
-          main,
-          buildTarget,
-        )
-      case multiple =>
-        requestMain(multiple.flatMap(_._2)).flatMap { main =>
-          val buildTarget = classes.find(_._2.contains(main)).map(_._1)
-          createMainParams(
-            params,
-            main,
-            buildTarget.get,
-          )
-        }
-
-    }
-  }
-
-  private def resolveInFile(
-      buildTarget: BuildTargetIdentifier,
-      classes: TrieMap[
-        BuildTargetClasses.Symbol,
-        ScalaMainClass,
-      ],
-      testClasses: TrieMap[
-        BuildTargetClasses.Symbol,
-        BuildTargetClasses.TestSymbolInfo,
-      ],
-      params: DebugDiscoveryParams,
-  )(implicit ec: ExecutionContext) = {
-    val path = params.path.toAbsolutePath
-    semanticdbs()
-      .textDocument(path)
-      .documentIncludingStale
-      .fold[Future[DebugSessionParams]] {
-        Future.failed(SemanticDbNotFoundException)
-      } { textDocument =>
-        lazy val tests = for {
-          symbolInfo <- textDocument.symbols
-          symbol = symbolInfo.symbol
-          testSymbolInfo <- testClasses.get(symbol)
-        } yield testSymbolInfo.fullyQualifiedName
-        val mains = for {
-          occurrence <- textDocument.occurrences
-          if occurrence.role.isDefinition || occurrence.symbol == "scala/main#"
-          symbol = occurrence.symbol
-          mainClass <- {
-            val normal = classes.get(symbol)
-            val fromAnnot = DebugProvider
-              .mainFromAnnotation(occurrence, textDocument)
-              .flatMap(classes.get(_))
-            List(normal, fromAnnot).flatten
-          }
-        } yield mainClass
-        if (mains.nonEmpty) {
-          verifyMain(Map(buildTarget -> mains.toList), params)
-        } else if (tests.nonEmpty) {
-          Future {
-            val params = new b.DebugSessionParams(singletonList(buildTarget))
-            params.setDataKind(b.TestParamsDataKind.SCALA_TEST_SUITES)
-            params.setData(tests.asJava.toJson)
-            params
-          }
-
-        } else {
-          Future.failed(NoRunOptionException)
-        }
-      }
   }
 
   /**
@@ -631,189 +455,6 @@ class DebugProvider(
     }
   }
 
-  /**
-   * Tries to discover the main class to run and returns
-   * DebugSessionParams that contains the shellCommand field.
-   * This is used so that clients can easily run the full command
-   * if they want.
-   */
-  def runCommandDiscovery(
-      unresolvedParams: DebugDiscoveryParams
-  )(implicit ec: ExecutionContext): Future[b.DebugSessionParams] = {
-    debugDiscovery(unresolvedParams).flatMap(enrichWithMainShellCommand)
-  }
-
-  private def enrichWithMainShellCommand(
-      params: b.DebugSessionParams
-  )(implicit ec: ExecutionContext): Future[b.DebugSessionParams] = {
-    val future = params.getData() match {
-      case json: JsonElement
-          if params.getDataKind == b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS =>
-        json.as[b.ScalaMainClass] match {
-          case Success(main) if params.getTargets().size > 0 =>
-            val javaBinary = buildTargets
-              .scalaTarget(params.getTargets().get(0))
-              .flatMap(scalaTarget =>
-                JavaBinary.javaBinaryFromPath(scalaTarget.jvmHome)
-              )
-              .orElse(userConfig().usedJavaBinary)
-            buildTargetClasses
-              .jvmRunEnvironment(params.getTargets().get(0))
-              .map { envItem =>
-                val updatedData = envItem.zip(javaBinary) match {
-                  case None =>
-                    main.toJson
-                  case Some((env, javaHome)) =>
-                    ExtendedScalaMainClass(
-                      main,
-                      env,
-                      javaHome,
-                      workspace,
-                    ).toJson
-                }
-                params.setData(updatedData)
-              }
-          case _ => Future.unit
-        }
-
-      case _ => Future.unit
-    }
-
-    future.map { _ =>
-      params
-    }
-  }
-
-  /**
-   * Given fully unresolved params this figures out the runType that was passed
-   * in and then discovers either the main methods for the build target the
-   * path belongs to or finds the tests for the current file or build target
-   */
-  def debugDiscovery(
-      params: DebugDiscoveryParams
-  )(implicit ec: ExecutionContext): Future[b.DebugSessionParams] = {
-    val runTypeO = RunType.fromString(params.runType)
-    val pathOpt = Option(params.path).map(_.toAbsolutePath)
-    val buildTargetO = pathOpt.flatMap(buildTargets.inverseSources(_)).orElse {
-      Option(params.buildTarget)
-        .flatMap(buildTargets.findByDisplayName)
-        .map(_.getId())
-    }
-
-    lazy val mainClasses = (bti: BuildTargetIdentifier) =>
-      buildTargetClasses.classesOf(bti).mainClasses
-
-    lazy val testClasses = (bti: BuildTargetIdentifier) =>
-      buildTargetClasses.classesOf(bti).testClasses
-
-    val result: Future[DebugSessionParams] =
-      (runTypeO, buildTargetO, pathOpt) match {
-        case (_, Some(buildTarget), _)
-            if buildClient.buildHasErrors(buildTarget) =>
-          Future.failed(WorkspaceErrorsException)
-        case (_, None, Some(path)) =>
-          Future.failed(BuildTargetNotFoundForPathException(path))
-        case (None, _, _) =>
-          Future.failed(RunType.UnknownRunTypeException(params.runType))
-        case (Some(Run), target, _) =>
-          val targetIds = target match {
-            case None => buildTargets.allBuildTargetIds
-            case Some(value) => List(value)
-          }
-          val requestedMain = Option(params.mainClass)
-          val targetToMainClasses = targetIds
-            .map { target =>
-              target ->
-                mainClasses(target).values.toList.filter(cls =>
-                  requestedMain.isEmpty || requestedMain.contains(
-                    cls.getClassName()
-                  )
-                )
-
-            }
-            .filter { case (_, mains) => mains.nonEmpty }
-            .toMap
-          if (targetToMainClasses.nonEmpty)
-            verifyMain(
-              targetToMainClasses,
-              params,
-            )
-          else
-            Future.failed(
-              MainClassException(
-                params,
-                targetIds.nonEmpty,
-                buildTargets.all.map(_.getDisplayName).toSeq,
-              )
-            )
-        case (Some(RunOrTestFile), Some(target), _) =>
-          resolveInFile(
-            target,
-            mainClasses(target),
-            testClasses(target),
-            params,
-          )
-        case (Some(TestFile), Some(target), path)
-            if testClasses(target).isEmpty =>
-          Future.failed(
-            NoTestsFoundException("file", path.toString())
-          )
-        case (Some(TestTarget), Some(target), _)
-            if testClasses(target).isEmpty =>
-          Future.failed(
-            NoTestsFoundException("build target", displayName(target))
-          )
-        case (Some(TestTarget), None, _) =>
-          Future.failed(NoBuildTargetSpecified)
-        case (Some(TestFile), Some(target), Some(path)) =>
-          semanticdbs()
-            .textDocument(path)
-            .documentIncludingStale
-            .fold[Future[Seq[BuildTargetClasses.FullyQualifiedClassName]]] {
-              Future.failed(SemanticDbNotFoundException)
-            } { textDocument =>
-              Future {
-                for {
-                  symbolInfo <- textDocument.symbols
-                  symbol = symbolInfo.symbol
-                  testSymbolInfo <- testClasses(target).get(symbol)
-                } yield testSymbolInfo.fullyQualifiedName
-              }
-            }
-            .map { tests =>
-              val params = new b.DebugSessionParams(
-                singletonList(target)
-              )
-              params.setDataKind(
-                b.TestParamsDataKind.SCALA_TEST_SUITES
-              )
-              params.setData(tests.asJava.toJson)
-              params
-            }
-        case (Some(TestTarget), Some(target), _) =>
-          Future {
-            val params = new b.DebugSessionParams(
-              singletonList(target)
-            )
-            params.setDataKind(b.TestParamsDataKind.SCALA_TEST_SUITES)
-            params.setData(
-              testClasses(target).values
-                .map(_.fullyQualifiedName)
-                .toList
-                .asJava
-                .toJson
-            )
-            params
-          }
-        case (Some(tpe @ (TestFile | RunOrTestFile)), _, None) =>
-          Future.failed(UndefinedPathException(tpe))
-
-      }
-
-    result.failed.foreach(reportErrors)
-    result
-  }
-
   def findMainClassAndItsBuildTarget(
       params: DebugUnresolvedMainClassParams
   ): Try[List[(ScalaMainClass, b.BuildTarget)]] =
@@ -840,8 +481,9 @@ class DebugProvider(
           )
         }
 
-        val env = Option(params.env).toList.flatMap(createEnvList)
+        val env = Option(params.env).toList.flatMap(DebugProvider.createEnvList)
         createMainParams(
+          workspace,
           clazz,
           target.getId(),
           Option(params.args),
@@ -883,29 +525,30 @@ class DebugProvider(
             "test",
           )
         }
-        val env = Option(params.env).toList.flatMap(createEnvList)
+        val env = Option(params.env).toList.flatMap(DebugProvider.createEnvList)
 
-        envFromFile(Option(params.envFile)).map { envFromFile =>
-          val jvmOpts =
-            JvmOpts.fromWorkspaceOrEnvForTest(workspace).getOrElse(Nil)
-          val scalaTestSuite = new b.ScalaTestSuites(
-            List(
-              new b.ScalaTestSuiteSelection(params.testClass, Nil.asJava)
-            ).asJava,
-            Option(params.jvmOptions)
-              .map(jvmOpts ++ _.asScala)
-              .getOrElse(jvmOpts)
-              .asJava,
-            (envFromFile ::: env).asJava,
-          )
-          val debugParams = new b.DebugSessionParams(
-            singletonList(target.getId())
-          )
-          debugParams.setDataKind(
-            b.TestParamsDataKind.SCALA_TEST_SUITES_SELECTION
-          )
-          debugParams.setData(scalaTestSuite.toJson)
-          debugParams
+        DebugProvider.envFromFile(workspace, Option(params.envFile)).map {
+          envFromFile =>
+            val jvmOpts =
+              JvmOpts.fromWorkspaceOrEnvForTest(workspace).getOrElse(Nil)
+            val scalaTestSuite = new b.ScalaTestSuites(
+              List(
+                new b.ScalaTestSuiteSelection(params.testClass, Nil.asJava)
+              ).asJava,
+              Option(params.jvmOptions)
+                .map(jvmOpts ++ _.asScala)
+                .getOrElse(jvmOpts)
+                .asJava,
+              (envFromFile ::: env).asJava,
+            )
+            val debugParams = new b.DebugSessionParams(
+              singletonList(target.getId())
+            )
+            debugParams.setDataKind(
+              b.TestParamsDataKind.SCALA_TEST_SUITES_SELECTION
+            )
+            debugParams.setData(scalaTestSuite.toJson)
+            debugParams
         }
       // should not really happen due to
       // `findMainClassAndItsBuildTarget` succeeding with non-empty list
@@ -1116,6 +759,47 @@ class DebugProvider(
 
 object DebugProvider {
 
+  def createEnvList(env: ju.Map[String, String]) = {
+    env.asScala.map { case (key, value) =>
+      s"$key=$value"
+    }.toList
+  }
+
+  def envFromFile(
+      workspace: AbsolutePath,
+      envFile: Option[String],
+  )(implicit ec: ExecutionContext): Future[List[String]] =
+    envFile
+      .map { file =>
+        val path = AbsolutePath(file)(workspace)
+        DotEnvFileParser
+          .parse(path)
+          .map(_.map { case (key, value) => s"$key=$value" }.toList)
+      }
+      .getOrElse(Future.successful(List.empty))
+
+  def createMainParams(
+      workspace: AbsolutePath,
+      main: ScalaMainClass,
+      target: BuildTargetIdentifier,
+      args: Option[ju.List[String]],
+      jvmOptions: Option[ju.List[String]],
+      env: List[String],
+      envFile: Option[String],
+  )(implicit ec: ExecutionContext): Future[DebugSessionParams] = {
+    main.setArguments(args.getOrElse(ju.Collections.emptyList()))
+    main.setJvmOptions(
+      jvmOptions.getOrElse(ju.Collections.emptyList())
+    )
+    envFromFile(workspace, envFile).map { envFromFile =>
+      main.setEnvironmentVariables((envFromFile ::: env).asJava)
+      val params = new b.DebugSessionParams(singletonList(target))
+      params.setDataKind(b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS)
+      params.setData(main.toJson)
+      params
+    }
+  }
+
   private def exceptionOrder(t: Throwable): Int = t match {
     /* Validation errors, should shown first as they are relevant for each build target.
      */
@@ -1134,68 +818,6 @@ object DebugProvider {
     case _: NoClassFoundException => 7
     case _: BuildTargetNotFoundException => 8
     case _ => 9
-  }
-
-  /**
-   * Given an occurence and a text document return the symbol of a main method
-   * that could be defined using the Scala 3 @main annotation.
-   *
-   * @param occurrence The symbol occurence you're checking against the document.
-   * @param textDocument The document of the current file.
-   * @return Possible symbol name of main.
-   */
-  def mainFromAnnotation(
-      occurrence: SymbolOccurrence,
-      textDocument: TextDocument,
-  ): Option[String] = {
-    if (occurrence.symbol == "scala/main#") {
-      occurrence.range match {
-        case Some(range) =>
-          val closestOccurence = textDocument.occurrences.minBy { occ =>
-            occ.range
-              .filter { rng =>
-                occ.symbol != "scala/main#" &&
-                rng.endLine - range.endLine >= 0 &&
-                rng.endCharacter - rng.startCharacter > 0
-              }
-              .map(rng =>
-                (
-                  rng.endLine - range.endLine,
-                  rng.endCharacter - range.endCharacter,
-                )
-              )
-              .getOrElse((Int.MaxValue, Int.MaxValue))
-          }
-          dropSourceFromToplevelSymbol(closestOccurence.symbol)
-
-        case None => None
-      }
-    } else {
-      None
-    }
-
-  }
-
-  /**
-   * Converts Scala3 sorceToplevelSymbol into a plain one that corresponds to class name.
-   * From `3.1.0` plain names were removed from occurrences because they are synthetic.
-   * Example:
-   *   `foo/Foo$package.mainMethod().` -> `foo/mainMethod#`
-   */
-  private def dropSourceFromToplevelSymbol(symbol: String): Option[String] = {
-    Symbol(symbol) match {
-      case GlobalSymbol(
-            GlobalSymbol(
-              owner,
-              Descriptor.Term(_),
-            ),
-            Descriptor.Method(name, _),
-          ) =>
-        val converted = GlobalSymbol(owner, Descriptor.Term(name))
-        Some(converted.value)
-      case _ =>
-        None
-    }
   }
 
   case object WorkspaceErrorsException

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DiscoveryFailures.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DiscoveryFailures.scala
@@ -1,0 +1,70 @@
+package scala.meta.internal.metals.debug
+
+import scala.meta.internal.metals.config.RunType.RunType
+import scala.meta.io.AbsolutePath
+
+object DiscoveryFailures {
+
+  case class BuildTargetNotFoundException(
+      buildTargetName: String,
+      candidates: Seq[String],
+  ) extends Exception(
+        s"Build target not found: $buildTargetName, candidates:\n${candidates.mkString("\n")}"
+      )
+
+  object NothingToRun
+      extends Exception(
+        "There is nothing to run in the workspace"
+      )
+
+  case class ClassNotFoundInBuildTargetException(
+      className: String,
+      buildTarget: String,
+  ) extends Exception(
+        s"Class '$className' not found in build target '${buildTarget}'"
+      )
+
+  case class NoMainClassFoundException(
+      className: String
+  ) extends Exception(
+        s"Class '$className' not found in any build target"
+      )
+
+  case class BuildTargetNotFoundForPathException(path: AbsolutePath)
+      extends Exception(
+        s"No build target could be found for the path: ${path.toString()}"
+      )
+  case class BuildTargetContainsNoMainException(buildTargetName: String)
+      extends Exception(
+        s"No main could be found in build target: $buildTargetName"
+      )
+  case class NoTestsFoundException(
+      testType: String,
+      name: String,
+  ) extends Exception(
+        s"No tests could be found in ${testType}: $name"
+      )
+
+  case object NoBuildTargetSpecified
+      extends Exception(
+        s"No build target was specified."
+      )
+
+  case object WorkspaceErrorsException
+      extends Exception(
+        s"Cannot run class, since the workspace has errors."
+      )
+
+  case class UndefinedPathException(runType: RunType)
+      extends Exception(
+        s"Cannot run since the $runType required a path to be defined."
+      )
+  case object NoRunOptionException
+      extends Exception(
+        s"There is nothing to run or test in the current file."
+      )
+  case object SemanticDbNotFoundException
+      extends Exception(
+        "Build misconfiguration. No semanticdb can be found for you file, please check the doctor."
+      )
+}

--- a/tests/unit/src/test/scala/tests/DebugDiscoverySuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugDiscoverySuite.scala
@@ -5,13 +5,9 @@ import java.util.concurrent.TimeUnit
 import scala.meta.internal.metals.DebugDiscoveryParams
 import scala.meta.internal.metals.JsonParser._
 import scala.meta.internal.metals.ServerCommands
-import scala.meta.internal.metals.debug.BuildTargetContainsNoMainException
-import scala.meta.internal.metals.debug.DebugProvider
-import scala.meta.internal.metals.debug.DebugProvider.SemanticDbNotFoundException
-import scala.meta.internal.metals.debug.DebugProvider.WorkspaceErrorsException
+import scala.meta.internal.metals.debug.DiscoveryFailures._
 import scala.meta.internal.metals.debug.DotEnvFileParser.InvalidEnvFileException
 import scala.meta.internal.metals.debug.ExtendedScalaMainClass
-import scala.meta.internal.metals.debug.NoTestsFoundException
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.DebugSessionParams
@@ -199,7 +195,7 @@ class DebugDiscoverySuite
         .recover { case e: ResponseErrorException => e.getMessage }
     } yield assertNoDiff(
       result.toString(),
-      DebugProvider.NoRunOptionException.getMessage(),
+      NoRunOptionException.getMessage(),
     )
   }
 

--- a/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
@@ -11,7 +11,7 @@ import scala.meta.internal.metals.DebugUnresolvedMainClassParams
 import scala.meta.internal.metals.DebugUnresolvedTestClassParams
 import scala.meta.internal.metals.JsonParser._
 import scala.meta.internal.metals.MetalsEnrichments._
-import scala.meta.internal.metals.debug.DebugProvider.WorkspaceErrorsException
+import scala.meta.internal.metals.debug.DiscoveryFailures._
 
 import ch.epfl.scala.bsp4j.DebugSessionParamsDataKind
 import ch.epfl.scala.bsp4j.ScalaMainClass


### PR DESCRIPTION
Previously, it was not possible to get a command to run if one only input the main class name. Now it works the same as a discovery of main class to run within a file.

Fixes https://github.com/scalameta/metals/issues/6239