### PR TITLE
docs: Fix links to Typescript code

### DIFF
--- a/docs/integrations/debug-adapter-protocol.md
+++ b/docs/integrations/debug-adapter-protocol.md
@@ -151,9 +151,10 @@ your own without DAP.
 No matter which method you use, you still need to connect the debug adapter
 extension specific to you editor using the aforementioned URI and let it drive
 the run/debug session. For reference, take a look at the
-[vscode implementation](https://github.com/scalameta/metals-vscode/blob/master/src/scalaDebugger.ts)
+[vscode implementation](https://github.com/scalameta/metals-vscode/blob/main/packages/metals-vscode/src/debugger/scalaDebugger.ts)
+
 and how it is
-[wired up together](https://github.com/scalameta/metals-vscode/blob/master/src/extension.ts#L356)
+[wired up together](https://github.com/scalameta/metals-vscode/blob/main/packages/metals-vscode/src/extension.ts)
 
 ## Supported Testing Frameworks
 


### PR DESCRIPTION
I'm not sure, what the line number 356 in `extension.ts` used to show.
If someone happens to know, I could link to the exact line as well.