### PR TITLE
fix: include `inline` when printing param names

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/printer/MetalsPrinter.scala
@@ -403,7 +403,8 @@ class MetalsPrinter(
         else if includeDefaultParam == MetalsPrinter.IncludeDefaultParam.ResolveLater && isDefaultParam
         then " = ..."
         else "" // includeDefaultParam == Never or !isDefaultParam
-      s"$keywordName: ${paramTypeString}$default"
+      val inline = if(param.is(Flags.Inline)) "inline " else ""
+      s"$inline$keywordName: ${paramTypeString}$default"
     end if
   end paramLabel
 

--- a/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
@@ -99,7 +99,13 @@ class CancelCompletionSuite extends BaseCompletionSuite {
     """.stripMargin,
     """|assert(assertion: Boolean): Unit
        |assert(assertion: Boolean, message: => Any): Unit
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "3" ->
+        """|assert(inline assertion: Boolean): Unit
+           |assert(inline assertion: Boolean, inline message: => Any): Unit
+           |""".stripMargin
+    )
   )
 
   /**

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -870,7 +870,13 @@ class CompletionArgSuite extends BaseCompletionSuite {
     """|aaa = : Int
        |assert(assertion: Boolean): Unit
        |""".stripMargin,
-    topLines = Some(2)
+    topLines = Some(2),
+    compat = Map(
+      "3" ->
+        """|aaa = : Int
+           |assert(inline assertion: Boolean): Unit
+           |""".stripMargin
+    )
   )
 
   check(
@@ -885,7 +891,13 @@ class CompletionArgSuite extends BaseCompletionSuite {
     """|aaa = : Int
        |assert(assertion: Boolean): Unit
        |""".stripMargin,
-    topLines = Some(2)
+    topLines = Some(2),
+    compat = Map(
+      "3" ->
+        """|aaa = : Int
+           |assert(inline assertion: Boolean): Unit
+           |""".stripMargin
+    )
   )
 
   check(
@@ -998,7 +1010,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |""".stripMargin,
     """|aaa = : Int
        |abb = : Option[Int]
-       |assert(assertion: Boolean): Unit
+       |assert(inline assertion: Boolean): Unit
        |""".stripMargin,
     topLines = Some(3)
   )
@@ -1012,7 +1024,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |""".stripMargin,
     """|aaa = : Int
        |abb = : Option[Int]
-       |assert(assertion: Boolean): Unit
+       |assert(inline assertion: Boolean): Unit
        |""".stripMargin,
     topLines = Some(3)
   )
@@ -1033,7 +1045,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |""".stripMargin,
     """|aaa = : Int
        |abb = : Option[Int]
-       |assert(assertion: Boolean): Unit
+       |assert(inline assertion: Boolean): Unit
        |""".stripMargin,
     topLines = Some(3)
   )
@@ -1051,7 +1063,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |""".stripMargin,
     """|abb = : Option[Int]
        |acc = : List[Int]
-       |assert(assertion: Boolean): Unit
+       |assert(inline assertion: Boolean): Unit
        |""".stripMargin,
     topLines = Some(3)
   )

--- a/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/Scala3CodeActionLspSuite.scala
@@ -687,6 +687,56 @@ class Scala3CodeActionLspSuite
     ),
   )
 
+  check(
+    "lose-inline",
+    """|package a
+       |
+       |trait Hello:
+       |  extension (inline rb: Int) inline def hello: Unit
+       |
+       |object <<X>> extends Hello
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |${ExtractRenameMember.title("object", "X")}
+        |""".stripMargin,
+    """|package a
+       |
+       |trait Hello:
+       |  extension (inline rb: Int) inline def hello: Unit
+       |
+       |object X extends Hello {
+       |
+       |  extension (inline rb: Int) override inline def hello: Unit = ???
+       |
+       |}
+       |""".stripMargin,
+  )
+
+  check(
+    "lose-inline-2",
+    """|package a
+       |
+       |trait Hello:
+       |  inline def hello(inline i: Int): Unit
+       |
+       |object <<X>> extends Hello
+       |""".stripMargin,
+    s"""|${ImplementAbstractMembers.title}
+        |${ExtractRenameMember.title("object", "X")}
+        |""".stripMargin,
+    """|package a
+       |
+       |trait Hello:
+       |  inline def hello(inline i: Int): Unit
+       |
+       |object X extends Hello {
+       |
+       |  override inline def hello(inline i: Int): Unit = ???
+       |
+       |}
+       |""".stripMargin,
+  )
+
   private def getPath(name: String) = s"a/src/main/scala/a/$name"
 
   def checkExtractedMember(


### PR DESCRIPTION
fixes: https://github.com/scalameta/metals/issues/6292