### PR TITLE
feat: Set unused tag for unused diagnostics

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DiagnosticCodes.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DiagnosticCodes.scala
@@ -1,0 +1,23 @@
+package scala.meta.internal.metals
+
+import scala.meta.internal.mtags.CommonMtagsEnrichments._
+
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+
+/**
+ * This file contains known and useful (from metals perspective) diagnostic codes.
+ * Diagnostic codes are defined in scala3 compiler, but since metals can refernce multiple scala compiler versions at runtime,
+ * we cannot have a compile-time dependency on the original definition.
+ *
+ * See https://github.com/scala/scala3/blob/3fdb2923f83acd2ef8910c9f71a394c46be4e268/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala for more codes
+ */
+object DiagnosticCodes {
+  val Unused: Int = 198
+
+  def isEqual(lspCode: Either[String, Integer], other: Int): Boolean = {
+    lspCode.asScala match {
+      case Left(strCode) => strCode == other.toString()
+      case Right(intCode) => intCode == other
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -148,7 +148,7 @@ final class Diagnostics(
         if (path.isFile)
       } yield onPublishDiagnostics(
         path,
-        params.getDiagnostics().asScala.map(_.toLsp).toSeq,
+        diagnostics,
         params.getReset(),
       )
 
@@ -295,12 +295,12 @@ final class Diagnostics(
             // Scala 3 sets the diagnostic code to -1 for NoExplanation Messages. Ideally
             // this will change and we won't need this check in the future, but for now
             // let's not forward them.
-            if (
-              d.getCode() != null && d
-                .getCode()
-                .isLeft() && d.getCode().getLeft() != "-1"
-            )
-              ld.setCode(d.getCode())
+            val isScala3NoExplanationDiag = d.getCode() != null && d
+              .getCode()
+              .isLeft() && d.getCode().getLeft() == "-1"
+            if (!isScala3NoExplanationDiag) ld.setCode(d.getCode())
+
+            ld.setTags(d.getTags())
             adjustedDiagnosticData(d, edit).map(newData => ld.setData(newData))
             ld
           }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -938,9 +938,13 @@ object MetalsEnrichments
         diag.getSeverity.toLsp,
         if (diag.getSource == null) "scalac" else diag.getSource,
       )
-      if (diag.getCode() != null) {
+      Option(diag.getCode()).foreach { code =>
         ld.setCode(diag.getCode())
+        if (DiagnosticCodes.isEqual(code, DiagnosticCodes.Unused)) {
+          ld.setTags(java.util.List.of(l.DiagnosticTag.Unnecessary))
+        }
       }
+
       ld.setData(diag.getData)
       ld
     }


### PR DESCRIPTION
~waiting for: https://github.com/scala/scala3/pull/19780~

For now this will only work for scala3 as scala2 does not emit errorCodes. 
Regex based support for this feature in scala2 will be added as a follow-up. 

cc @rochala 