### PR TITLE
fix: show implicit param when it is an apply

### DIFF
--- a/tests/slow/src/test/scala/tests/feature/InlayHintsLspScala3Suite.scala
+++ b/tests/slow/src/test/scala/tests/feature/InlayHintsLspScala3Suite.scala
@@ -1,0 +1,38 @@
+package tests.feature
+
+import scala.meta.internal.metals.BuildInfo
+
+import tests.BaseInlayHintsLspSuite
+
+class InlayHintsLspScala3Suite
+    extends BaseInlayHintsLspSuite(
+      "inlayHints-scala3",
+      BuildInfo.scala3,
+    ) {
+
+  check(
+    "i6379",
+    expected =
+      """|import cats.Applicative
+         |import cats.data.Validated
+         |import cats.data.ValidatedNec
+         |import cats.implicits._
+         |import cats.syntax.all._
+         |
+         |class A {
+         |  type Validated[A] = ValidatedNec[Nothing, A]
+         |
+         |  val a = implicitly[Applicative[Validated]]/*(using catsDataApplicativeErrorForValidated<<cats/data/ValidatedInstances#catsDataApplicativeErrorForValidated().>>)*/.pure(1)
+         |}
+         |""".stripMargin,
+    dependencies = List("org.typelevel::cats-core:2.10.0"),
+    config = Some(
+      """|"inferredTypes": {"enable":false},
+         |"implicitConversions": {"enable":false},
+         |"implicitArguments": {"enable":true},
+         |"typeParameters": {"enable":false},
+         |"hintsInPatternMatch": {"enable":false}
+         |""".stripMargin
+    ),
+  )
+}


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/6379

This wasn't printed before, because the implicit arg is an apply in itself with another implicit arg. I assumed we only want to print the most external implicit arg.