### PR TITLE
chore: Report if target root is missing

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FileSystemSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FileSystemSemanticdbs.scala
@@ -45,6 +45,8 @@ final class FileSystemSemanticdbs(
           javaRoot orElse buildTargets.scalaTargetRoot(buildTarget)
         }
       } yield {
+        if (!targetroot.exists)
+          scribe.warn(s"Target root $targetroot does not exist")
         val optScalaVersion =
           if (file.toLanguage.isJava) None
           else buildTargets.scalaTarget(buildTarget).map(_.scalaVersion)


### PR DESCRIPTION
I noticed it happening in a bazel project for a couple of targets. This is most likely a bug in Bazel BSP, but digging into that could take a while, so to make sure that this will show up properly I added a log statement.