### PR TITLE
bugfix: Don't preemptively load scalafix

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -172,7 +172,6 @@ final case class Indexer(
         timerProvider.timedThunk("indexed workspace", onlyIf = true) {
           try indexWorkspace(check)
           finally {
-            scalafixProvider().load()
             indexingPromise().trySuccess(())
           }
         }


### PR DESCRIPTION
I haven't managed to figure out why exactly scalafix is failing, but it seems organize imports would not work in Metals if we loaded scalafix eagerly. My guess is that we would somehow get two different classloaders somewhere, but I can't figure out where.