### PR TITLE
bugfix: Don't include target option for PC

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
@@ -353,7 +353,12 @@ class CompilerConfiguration(
 
       releaseVersion match {
         case Some(version) =>
-          scalacOptions ++ List("-release", version.toString())
+          /* Filter out -target: and -Xtarget: options, since they are not relevant and
+           * might interfere with -release option */
+          val filterOutTarget = scalacOptions.filter(opt =>
+            opt.startsWith("-target:") || opt.startsWith("-Xtarget:")
+          )
+          filterOutTarget ++ List("-release", version.toString())
         case _ => scalacOptions
       }
     }


### PR DESCRIPTION
It's not important for presentation compiler and causes a warning when wrongly paired with release option. It's easier to just ingore it.