### PR TITLE
improvement: Show actual Scala versions supported by Metals

### DIFF
--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -132,7 +132,7 @@ primary	git@github.com:scalameta/metals.git (push)
   - https://github.com/scalameta/metals-vscode:
     - generate metals website with `sbt docs/run`
     - open `website/target/docs/editors/vscode.md` and copy everything from
-      "Requirements" over to the scalameta/metals-vscode README
+      "Installation" over to the scalameta/metals-vscode README
       - remove "Using latest SNAPSHOT" section, this table is only up-to-date on
         the website
     - check or update `enum` values of `fallbackScalaVersion` property in

--- a/metals-docs/src/main/scala/docs/RequirementsModifier.scala
+++ b/metals-docs/src/main/scala/docs/RequirementsModifier.scala
@@ -1,30 +1,22 @@
 package docs
 
 import scala.meta.inputs.Input
-import scala.meta.internal.metals.BuildInfo
-import scala.meta.internal.metals.ScalaVersions
-import scala.meta.internal.semver.SemVer
+import scala.meta.metals.SupportedScalaVersions
 
 import mdoc.Reporter
 import mdoc.StringModifier
 
-class RequirementsModifier extends StringModifier {
+class RequirementsModifier extends SupportedScalaVersions with StringModifier {
   override val name: String = "requirements"
 
-  def supportedScalaVersions: String = {
-    val grouped = BuildInfo.supportedScalaVersions.groupBy { version =>
-      if (ScalaVersions.isScala3Version(version)) "3"
-      else ScalaVersions.scalaBinaryVersionFromFullVersion(version)
-    }
-
-    grouped
-      .map { case (binary, versions) =>
-        val versionString =
-          versions.sortWith(SemVer.isLaterVersion).reverse.mkString(", ")
-        s"""| - **Scala $binary**:
-            |   $versionString""".stripMargin
-      }
-      .mkString("\n\n")
+  override protected def formatSingle(
+      major: String,
+      versions: Seq[String],
+  ): String = {
+    s"""| - **Scala ${major}**:
+        |   ${versions.mkString(", ")}
+        |
+        |""".stripMargin
   }
 
   override def process(
@@ -51,7 +43,7 @@ class RequirementsModifier extends StringModifier {
        |
        |**Scala 2.13, 2.12, 2.11 and Scala 3**. Metals supports these Scala versions:
        |
-       |$supportedScalaVersions
+       |${supportedVersionsString(Snapshot.latest("releases", "2.13").version)}
        |
        |Note that 2.11.x support is deprecated and it will be removed in future releases.
        |It's recommended to upgrade to Scala 2.12 or Scala 2.13

--- a/metals/src/main/scala/scala/meta/metals/Main.scala
+++ b/metals/src/main/scala/scala/meta/metals/Main.scala
@@ -6,38 +6,32 @@ import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 
 import scala.meta.internal.metals.BuildInfo
-import scala.meta.internal.metals.ScalaVersions
 import scala.meta.internal.metals.Trace
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.metals.logging.MetalsLogger
 
 import org.eclipse.lsp4j.jsonrpc.Launcher
 
-object Main {
+object Main extends SupportedScalaVersions {
+
+  override protected def formatSingle(
+      major: String,
+      versions: Seq[String],
+  ): String = {
+
+    s"""| - Scala ${major}:
+        |   ${versions.mkString(", ")}
+        |
+        |""".stripMargin
+  }
   def main(args: Array[String]): Unit = {
     if (args.exists(Set("-v", "--version", "-version"))) {
-      val supportedScala2Versions =
-        BuildInfo.supportedScala2Versions
-          .groupBy(ScalaVersions.scalaBinaryVersionFromFullVersion)
-          .toSeq
-          .sortBy(_._1)
-          .map { case (_, versions) => versions.mkString(", ") }
-          .mkString("\n#       ")
-
-      val supportedScala3Versions =
-        BuildInfo.supportedScala3Versions.sorted.mkString(", ")
-
       println(
         s"""|metals ${BuildInfo.metalsVersion}
             |
-            |# Note:
-            |#   Supported Scala versions:
-            |#     Scala 3: $supportedScala3Versions
-            |#     Scala 2:
-            |#       $supportedScala2Versions
+            |${supportedVersionsString(BuildInfo.metalsVersion)}
             |""".stripMargin
       )
-
       sys.exit(0)
     }
     val systemIn = System.in

--- a/metals/src/main/scala/scala/meta/metals/SupportedScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/metals/SupportedScalaVersions.scala
@@ -1,0 +1,103 @@
+package scala.meta.metals
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import scala.util.control.NonFatal
+
+import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.semver.SemVer
+
+import org.jsoup.Jsoup
+
+abstract class SupportedScalaVersions {
+
+  def supportedVersionsString(version: String): String = {
+    findAllSupported(version).getOrElse(
+      formatVersions(BuildInfo.supportedScalaVersions)
+    )
+  }
+
+  private def findAllSupported(metalsVersion: String) = {
+    if (metalsVersion.contains("SNAPSHOT")) {
+      supportedInMetals(
+        "https://oss.sonatype.org/content/repositories/snapshots/org/scalameta/",
+        metalsVersion,
+      )
+    } else {
+      supportedInMetals(
+        "https://repo1.maven.org/maven2/org/scalameta/",
+        metalsVersion,
+      )
+    }
+  }
+
+  private def supportedInMetals(
+      url: String,
+      metalsVersion: String,
+  ): Option[String] =
+    try {
+
+      val allScalametaArtifacts = Jsoup.connect(url).get
+
+      val allMdocs = allScalametaArtifacts
+        .select("a")
+        .asScala
+        .filter { a =>
+          val name = a.text()
+          name.contains("mtags_")
+        }
+
+      // find all supported Scala versions for this metals version
+      val allSupportedScala = allMdocs.iterator
+        .filter { mdocLink =>
+          // let's not check nightly Scala versions
+          if (mdocLink.text().contains("NIGHTLY")) false
+          else {
+            val link = mdocLink.attr("href")
+            val mtagsLink = if (link.startsWith("http")) link else url + link
+            Try {
+              Jsoup.connect(mtagsLink + metalsVersion).get
+            } match {
+              case Success(_) => true
+              case Failure(_) => false
+            }
+
+          }
+        }
+        .map(_.text().stripPrefix("mtags_").stripSuffix("/"))
+
+      val template = formatVersions(allSupportedScala.toList)
+
+      Some(
+        s"""|$template
+            |Scala 3 versions from 3.3.4 are automatically supported by Metals.
+            |
+            |Any older Scala versions will no longer get bugfixes, but should still
+            |work properly with newest Metals. 
+            |""".stripMargin
+      )
+    } catch {
+      case NonFatal(t) =>
+        scribe.error("Could not check supported Scala versions", t)
+        None
+    }
+
+  protected def formatSingle(major: String, versions: Seq[String]): String
+
+  private def formatVersions(versions: Seq[String]) = {
+    versions.toList
+      .map(SemVer.Version.fromString)
+      .groupBy { version =>
+        if (version.major == 2) version.major.toString + "." + version.minor
+        else version.major.toString()
+      }
+      .toList
+      .sortBy(_._1)
+      .map { case (major, vers) =>
+        formatSingle(major, vers.sortBy(_.patch).map(_.toString()))
+      }
+      .mkString("")
+  }
+}

--- a/tests/unit/src/test/scala/tests/SupportedScalaSuite.scala
+++ b/tests/unit/src/test/scala/tests/SupportedScalaSuite.scala
@@ -1,0 +1,54 @@
+package tests
+
+import scala.meta.metals.Main
+
+class SupportedScalaSuite extends BaseSuite {
+
+  test("released-version") {
+    assertNoDiff(
+      Main.supportedVersionsString("1.2.0"),
+      """|- Scala 2.11:
+         |   2.11.12
+         |
+         | - Scala 2.12:
+         |   2.12.11, 2.12.12, 2.12.13, 2.12.14, 2.12.15, 2.12.16, 2.12.17, 2.12.18, 2.12.19
+         |
+         | - Scala 2.13:
+         |   2.13.5, 2.13.6, 2.13.7, 2.13.8, 2.13.9, 2.13.10, 2.13.11, 2.13.12, 2.13.13
+         |
+         | - Scala 3:
+         |   3.1.0, 3.2.0, 3.3.0, 3.1.1, 3.2.1, 3.3.1, 3.1.2, 3.2.2, 3.3.2-RC1, 3.3.2-RC3, 3.1.3
+         |
+         |
+         |Scala 3 versions from 3.3.4 are automatically supported by Metals.
+         |
+         |Any older Scala versions will no longer get bugfixes, but should still
+         |work properly with newest Metals.
+         |""".stripMargin,
+    )
+  }
+
+  test("snapshot-version") {
+    assertNoDiff(
+      Main.supportedVersionsString("0.11.10+90-55f285b7-SNAPSHOT"),
+      """|- Scala 2.11:
+         |   2.11.12
+         |
+         | - Scala 2.12:
+         |   2.12.10, 2.12.11, 2.12.12, 2.12.13, 2.12.14, 2.12.15, 2.12.16, 2.12.17
+         |
+         | - Scala 2.13:
+         |   2.13.3, 2.13.4, 2.13.5, 2.13.6, 2.13.7, 2.13.8, 2.13.9, 2.13.10
+         |
+         | - Scala 3:
+         |   3.1.0, 3.2.0, 3.3.0-RC1, 3.3.0-RC2, 3.1.1, 3.2.1, 3.0.2, 3.1.2, 3.2.2-RC2, 3.2.2, 3.1.3
+         |
+         |
+         |Scala 3 versions from 3.3.4 are automatically supported by Metals.
+         |
+         |Any older Scala versions will no longer get bugfixes, but should still
+         |work properly with newest Metals.
+         |""".stripMargin,
+    )
+  }
+}


### PR DESCRIPTION
This will check maven central for stable releases and sonatype snapshots for snapshot ones.

There are two way new mechanism for checking supported Scala will be used:
- `metals --versions` which will show all supported versions for the current server
- in the docs, where we will show support for the latest stable version. It will get updated after any back publish of Scala version when the website is updated after any PR.

Supersedes https://github.com/scalameta/metals/pull/4606