### PR TITLE
bugfix: Fix infinite indexing

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaToplevelMtags.scala
@@ -168,6 +168,10 @@ class JavaToplevelMtags(
     @tailrec
     def quotedLiteral(quote: Char): Token = {
       reader.nextChar()
+
+      if (reader.endCharOffset >= reader.buf.length)
+        throw new RuntimeException("Broken file, quote doesn't end.")
+
       reader.ch match {
         case `quote` => Token.Literal
         case '\\' =>

--- a/tests/unit/src/test/scala/tests/JavaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaToplevelSuite.scala
@@ -67,6 +67,17 @@ class JavaToplevelSuite extends BaseToplevelSuite {
   )
 
   check(
+    "broken",
+    """|package dot.enum;
+       |
+       |public class Abc {
+       |  public static final String REFERRER_ORIGIN_HOST = "audit.example.org.apache.hadoop.shaded.org.;
+       |}
+       |""".stripMargin,
+    List("dot/enum/Abc#"),
+  )
+
+  check(
     "extends",
     """|package dot.example;
        |


### PR DESCRIPTION
Turns out one lbirary released broken source without ending quote and this caused the infinite indexing.

Fixes https://github.com/scalameta/metals/issues/6418