### PR TITLE
Fixed issue where oldPath wasn't using OS specific spelling for Path/PATH

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JdkSources.scala
@@ -63,14 +63,14 @@ object JdkSources {
       )
       .collectFirst {
         case (javaHome, javaBin) if javaHome.exists && javaBin.exists =>
-          val oldPath = System.getenv().getOrDefault("PATH", "")
+          val variableName = if (Properties.isWin) "Path" else "PATH"
+          val oldPath = System.getenv().getOrDefault(variableName, "")
           val newPath =
             if (oldPath.isEmpty()) javaBin.toString()
             else {
               val sep = if (Properties.isWin) ";" else ":"
               s"$javaBin$sep$oldPath"
             }
-          val variableName = if (Properties.isWin) "Path" else "PATH"
           Map(
             "JAVA_HOME" -> javaHome.toString(),
             variableName -> newPath


### PR DESCRIPTION
For Windows users oldPath would always return as an empty string. This is because we're using "PATH" instead of "Path". Being's that would always return as an empty string, the newPath would always be the javaBin string. When storing in the map, we used the OS specific Path/PATH but with the wrong information.