### PR TITLE
improvement: don't run `compileAndLookForNewReferences `

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/AdjustLspData.scala
@@ -55,11 +55,20 @@ trait AdjustLspData {
     new Location(location.getUri(), adjustRange(location.getRange()))
 
   def adjustReferencesResult(
-      referencesResult: pc.ReferencesResult
+      referencesResult: pc.ReferencesResult,
+      additionalAdjust: AdjustRange,
+      text: String,
   ): ReferencesResult =
     new ReferencesResult(
       referencesResult.symbol,
-      referencesResult.locations().asScala.map(adjustLocation).toList,
+      referencesResult
+        .locations()
+        .asScala
+        .flatMap(loc =>
+          additionalAdjust(loc, text, referencesResult.symbol)
+            .map(adjustLocation)
+        )
+        .toList,
     )
 
   def adjustLocations(

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -762,7 +762,7 @@ class Compilers(
       searchFiles: List[AbsolutePath],
       includeDefinition: Boolean,
       symbol: String,
-      additionalAdjust: AdjustRange
+      additionalAdjust: AdjustRange,
   ): Future[List[ReferencesResult]] = {
     // we filter only Scala files, since `references` for Java are not implemented
     val filteredFiles = searchFiles.filter(_.isScala)
@@ -784,7 +784,14 @@ class Compilers(
             compiler
               .references(requestParams)
               .asScala
-              .map(_.asScala.map(adjust.adjustReferencesResult(_, additionalAdjust, input.text)).toList)
+              .map(
+                _.asScala
+                  .map(
+                    adjust
+                      .adjustReferencesResult(_, additionalAdjust, input.text)
+                  )
+                  .toList
+              )
           }
         }
           .getOrElse(Nil)

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -733,6 +733,7 @@ class Compilers(
   def references(
       params: ReferenceParams,
       token: CancelToken,
+      additionalAdjust: AdjustRange,
   ): Future[List[ReferencesResult]] = {
     withPCAndAdjustLsp(params) { case (pc, pos, adjust) =>
       val requestParams = new internal.pc.PcReferencesRequest(
@@ -742,7 +743,17 @@ class Compilers(
       )
       pc.references(requestParams)
         .asScala
-        .map(_.asScala.map(adjust.adjustReferencesResult).toList)
+        .map(
+          _.asScala
+            .map(
+              adjust.adjustReferencesResult(
+                _,
+                additionalAdjust,
+                requestParams.file.text(),
+              )
+            )
+            .toList
+        )
     }
   }.getOrElse(Future.successful(Nil))
 
@@ -751,6 +762,7 @@ class Compilers(
       searchFiles: List[AbsolutePath],
       includeDefinition: Boolean,
       symbol: String,
+      additionalAdjust: AdjustRange
   ): Future[List[ReferencesResult]] = {
     // we filter only Scala files, since `references` for Java are not implemented
     val filteredFiles = searchFiles.filter(_.isScala)
@@ -772,7 +784,7 @@ class Compilers(
             compiler
               .references(requestParams)
               .asScala
-              .map(_.asScala.map(adjust.adjustReferencesResult).toList)
+              .map(_.asScala.map(adjust.adjustReferencesResult(_, additionalAdjust, input.text)).toList)
           }
         }
           .getOrElse(Nil)

--- a/metals/src/main/scala/scala/meta/internal/metals/IdentifierIndex.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/IdentifierIndex.scala
@@ -59,4 +59,13 @@ object IdentifierIndex {
       id: BuildTargetIdentifier,
       bloom: BloomFilter[CharSequence],
   )
+
+  case class IndexEntryWithStaleInfo(
+      id: BuildTargetIdentifier,
+      bloom: BloomFilter[CharSequence],
+      isStale: Boolean,
+  ) {
+    def asStale: IndexEntryWithStaleInfo =
+      IndexEntryWithStaleInfo(id, bloom, isStale = true)
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/IdentifierIndex.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/IdentifierIndex.scala
@@ -60,12 +60,12 @@ object IdentifierIndex {
       bloom: BloomFilter[CharSequence],
   )
 
-  case class IndexEntryWithStaleInfo(
+  case class MaybeStaleIndexEntry(
       id: BuildTargetIdentifier,
       bloom: BloomFilter[CharSequence],
       isStale: Boolean,
   ) {
-    def asStale: IndexEntryWithStaleInfo =
-      IndexEntryWithStaleInfo(id, bloom, isStale = true)
+    def asStale: MaybeStaleIndexEntry =
+      MaybeStaleIndexEntry(id, bloom, isStale = true)
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -53,7 +53,7 @@ final class ReferenceProvider(
       .inverseSources(file)
       .map(id => identifierIndex.addIdentifiers(file, id, set))
 
-  def indexIdentifiers(
+  def didChange(
       path: AbsolutePath,
       text: String,
   ): Future[Unit] = Future {
@@ -61,6 +61,7 @@ final class ReferenceProvider(
       val dialect = scalaVersionSelector.getDialect(path)
       val set = identifierIndex.collectIdentifiers(text, dialect)
       identifierIndex.addIdentifiers(path, id, set)
+      index.remove(path.toNIO)
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -45,7 +45,8 @@ final class ReferenceProvider(
     scalaVersionSelector: ScalaVersionSelector,
 )(implicit ec: ExecutionContext)
     extends SemanticdbFeatureProvider {
-  val index: TrieMap[Path, IdentifierIndex.IndexEntry] = TrieMap.empty
+  val index: TrieMap[Path, IdentifierIndex.IndexEntryWithStaleInfo] =
+    TrieMap.empty
   val identifierIndex: IdentifierIndex = new IdentifierIndex
 
   def addIdentifiers(file: AbsolutePath, set: Iterable[String]): Unit =
@@ -61,7 +62,10 @@ final class ReferenceProvider(
       val dialect = scalaVersionSelector.getDialect(path)
       val set = identifierIndex.collectIdentifiers(text, dialect)
       identifierIndex.addIdentifiers(path, id, set)
-      index.remove(path.toNIO)
+      index.updateWith(path.toNIO) {
+        case Some(entry) if !entry.isStale => Some(entry.asStale)
+        case optEntry => optEntry
+      }
     }
   }
 
@@ -83,7 +87,8 @@ final class ReferenceProvider(
         0.01,
       )
 
-      val entry = IdentifierIndex.IndexEntry(id, bloom)
+      val entry =
+        IdentifierIndex.IndexEntryWithStaleInfo(id, bloom, isStale = false)
       index(file.toNIO) = entry
       docs.documents.foreach { d =>
         d.occurrences.foreach { o =>
@@ -145,7 +150,7 @@ final class ReferenceProvider(
       includeSynthetics: Synthetic => Boolean = _ => true,
   )(implicit report: ReportContext): Future[List[ReferencesResult]] = {
     val source = params.getTextDocument.getUri.toAbsolutePath
-    semanticdbs().textDocument(source).documentIncludingStale match {
+    semanticdbs().textDocument(source).toOption match {
       case Some(doc) =>
         val results: List[ResolvedSymbolOccurrence] = {
           val posOccurrences =
@@ -213,7 +218,8 @@ final class ReferenceProvider(
             source,
             results.flatMap(_.occurrence).map(_.symbol),
             params.getContext().isIncludeDeclaration(),
-            path => !index.contains(path.toNIO),
+            path => !index.get(path.toNIO).exists(!_.isStale),
+            findRealRange,
           )
 
         Future
@@ -228,7 +234,7 @@ final class ReferenceProvider(
           )
       case None =>
         scribe.debug(s"No semanticdb for $source")
-        pcReferences(source, params).map(
+        pcReferences(source, params, findRealRange).map(
           _.groupBy(_.symbol)
             .collect { case (symbol, refs) =>
               ReferencesResult(symbol, refs.flatMap(_.locations))
@@ -331,14 +337,17 @@ final class ReferenceProvider(
   private def pcReferences(
       path: AbsolutePath,
       params: ReferenceParams,
+      adjustLocation: AdjustRange,
   ): Future[List[ReferencesResult]] = {
-    compilers.references(params, EmptyCancelToken).flatMap { foundRefs =>
-      pcReferences(
-        path,
-        foundRefs.map(_.symbol),
-        includeDeclaration = params.getContext().isIncludeDeclaration(),
-        filterTargetFiles = _ != path,
-      ).map(_ ++ foundRefs)
+    compilers.references(params, EmptyCancelToken, adjustLocation).flatMap {
+      foundRefs =>
+        pcReferences(
+          path,
+          foundRefs.map(_.symbol),
+          includeDeclaration = params.getContext().isIncludeDeclaration(),
+          filterTargetFiles = _ != path,
+          adjustLocation,
+        ).map(_ ++ foundRefs)
     }
   }
 
@@ -347,6 +356,7 @@ final class ReferenceProvider(
       symbols: List[String],
       includeDeclaration: Boolean,
       filterTargetFiles: AbsolutePath => Boolean,
+      adjustLocation: AdjustRange,
   ): Future[List[ReferencesResult]] = {
     val visited = mutable.Set[AbsolutePath]()
     val results = for {
@@ -370,6 +380,7 @@ final class ReferenceProvider(
           searchFiles,
           includeDeclaration,
           symbol,
+          adjustLocation,
         )
     }
     val maxPcsNumber = Runtime.getRuntime().availableProcessors() / 2
@@ -415,6 +426,7 @@ final class ReferenceProvider(
   private def pathsFor(
       buildTargetSet: Set[BuildTargetIdentifier],
       isSymbol: Set[String],
+      includeStale: Boolean,
   ): Iterator[AbsolutePath] = {
     if (buildTargetSet.isEmpty) Iterator.empty
     else {
@@ -423,6 +435,7 @@ final class ReferenceProvider(
       val visited = scala.collection.mutable.Set.empty[AbsolutePath]
       val result = for {
         (path, entry) <- index.iterator
+        if includeStale || !entry.isStale || path.filename.isJavaFilename
         if allowedBuildTargets(entry.id) &&
           isSymbol.exists(entry.bloom.mightContain)
         sourcePath = AbsolutePath(path)
@@ -464,7 +477,11 @@ final class ReferenceProvider(
       }
 
     val result = for {
-      sourcePath <- pathsFor(definitionBuildTargets, isSymbol)
+      sourcePath <- pathsFor(
+        definitionBuildTargets,
+        isSymbol,
+        includeStale = false,
+      )
       semanticdb <-
         semanticdbs()
           .textDocument(sourcePath)
@@ -507,7 +524,9 @@ final class ReferenceProvider(
   )(implicit ec: ExecutionContext): Future[Set[AbsolutePath]] = {
     buildTargets
       .inverseSourcesBspAll(source)
-      .map(buildTargets => pathsFor(buildTargets.toSet, isSymbol).toSet)
+      .map(buildTargets =>
+        pathsFor(buildTargets.toSet, isSymbol, includeStale = true).toSet
+      )
   }
 
   private def references(
@@ -525,7 +544,7 @@ final class ReferenceProvider(
     val isLocal = occ.symbol.isLocal
     if (isLocal)
       compilers
-        .references(params, EmptyCancelToken)
+        .references(params, EmptyCancelToken, findRealRange)
         .map(_.flatMap(_.locations))
     else {
       /* search local in the following cases:
@@ -620,16 +639,8 @@ final class ReferenceProvider(
       range <- synthetic.range.toList
     } add(range)
 
-    buf.result().toSeq.sortWith(sortByLocationPosition)
+    buf.result().toSeq
   }
-
-  private def sortByLocationPosition(l1: Location, l2: Location): Boolean = {
-    l1.getRange.getStart.getLine < l2.getRange.getStart.getLine
-  }
-
-  private val noAdjustRange: AdjustRange =
-    (range: s.Range, _: String, _: String) => Some(range)
-  type AdjustRange = (s.Range, String, String) => Option[s.Range]
 
 }
 
@@ -747,4 +758,38 @@ object SyntheticPackageObject {
   val regex: Regex = "/.*[$]package[.]".r
   def unapply(str: String): Option[String] =
     Option.when(regex.matches(str))(str)
+}
+
+trait AdjustRange {
+  def apply(range: s.Range, text: String, symbol: String): Option[s.Range]
+  def apply(loc: Location, text: String, symbol: String): Option[Location] = {
+    val semRange = s.Range(
+      loc.getRange().getStart().getLine(),
+      loc.getRange().getStart().getCharacter(),
+      loc.getRange().getEnd().getLine(),
+      loc.getRange().getEnd().getCharacter(),
+    )
+    for (adjusted <- apply(semRange, text, symbol)) yield {
+      loc.setRange(adjusted.toLsp)
+      loc
+    }
+  }
+}
+
+object noAdjustRange extends AdjustRange {
+  def apply(range: s.Range, text: String, symbol: String): Option[s.Range] =
+    Some(range)
+  override def apply(
+      loc: Location,
+      text: String,
+      symbol: String,
+  ): Option[Location] = Some(loc)
+}
+
+object AdjustRange {
+  def apply(adjust: (s.Range, String, String) => Option[s.Range]): AdjustRange =
+    new AdjustRange {
+      def apply(range: s.Range, text: String, symbol: String): Option[s.Range] =
+        adjust(range, text, symbol)
+    }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -45,7 +45,7 @@ final class ReferenceProvider(
     scalaVersionSelector: ScalaVersionSelector,
 )(implicit ec: ExecutionContext)
     extends SemanticdbFeatureProvider {
-  val index: TrieMap[Path, IdentifierIndex.IndexEntryWithStaleInfo] =
+  val index: TrieMap[Path, IdentifierIndex.MaybeStaleIndexEntry] =
     TrieMap.empty
   val identifierIndex: IdentifierIndex = new IdentifierIndex
 
@@ -88,7 +88,7 @@ final class ReferenceProvider(
       )
 
       val entry =
-        IdentifierIndex.IndexEntryWithStaleInfo(id, bloom, isStale = false)
+        IdentifierIndex.MaybeStaleIndexEntry(id, bloom, isStale = false)
       index(file.toNIO) = entry
       docs.documents.foreach { d =>
         d.occurrences.foreach { o =>

--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/SymbolInfo.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/SymbolInfo.scala
@@ -1,0 +1,38 @@
+package scala.meta.internal.pc
+
+object SymbolInfo {
+  type IsClass = Boolean
+  def getPartsFromSymbol(symbol: String): SymbolParts = {
+    val index = symbol.lastIndexOf("/")
+    val pkgString = symbol.take(index + 1)
+
+    def loop(
+        symbol: String,
+        acc: List[(String, Boolean)]
+    ): List[(String, Boolean)] =
+      if (symbol.isEmpty()) acc.reverse
+      else {
+        val newSymbol = symbol.takeWhile(c => c != '.' && c != '#')
+        val rest = symbol.drop(newSymbol.size)
+        loop(rest.drop(1), (newSymbol, rest.headOption.exists(_ == '#')) :: acc)
+      }
+
+    val (toNames, rest) = {
+      val withoutPackage = symbol.drop(index + 1)
+      val i = withoutPackage.indexOf('(')
+      if (i < 0) (withoutPackage, "")
+      else withoutPackage.splitAt(i)
+    }
+    val paramName =
+      Some(rest.dropWhile(_ != '.').drop(2).dropRight(1)).filter(_.nonEmpty)
+    val names = loop(toNames, List.empty)
+
+    SymbolParts(pkgString, names, paramName)
+  }
+
+  case class SymbolParts(
+      packagePart: String,
+      names: List[(String, IsClass)],
+      paramName: Option[String]
+  )
+}

--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -245,7 +245,7 @@ trait MtagsEnrichments extends ScalametaCommonEnrichments {
       lazy val backtickedSetter =
         text(pos.start) == '`' && text.length > pos.end + 4 && text
           .slice(pos.end + 1, pos.end + 4)
-          .mkString == "_=`"
+          .mkString == backtickedSetterEnding
       val isOldNameBackticked = text(pos.start) == '`' &&
         (text(pos.end - 1) != '`' || pos.start == (pos.end - 1)) &&
         text(pos.end + 1) == '`'
@@ -258,6 +258,8 @@ trait MtagsEnrichments extends ScalametaCommonEnrichments {
       else (pos, false)
     }
   }
+
+  private val backtickedSetterEnding = "_=`"
 
   implicit class XtensionRangeParameters(pos: RangeParams) {
     def encloses(other: Position): Boolean =

--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -242,11 +242,17 @@ trait MtagsEnrichments extends ScalametaCommonEnrichments {
         text(pos.end - 1) == '`' &&
         pos.start != (pos.end - 1) // for one character names, e.g. `c`
       //                                                    start-^^-end
+      lazy val backtickedSetter =
+        text(pos.start) == '`' && text.length > pos.end + 4 && text
+          .slice(pos.end + 1, pos.end + 4)
+          .mkString == "_=`"
       val isOldNameBackticked = text(pos.start) == '`' &&
         (text(pos.end - 1) != '`' || pos.start == (pos.end - 1)) &&
         text(pos.end + 1) == '`'
       if (isBackticked && forRename)
         (pos.withStart(pos.start + 1).withEnd(pos.end - 1), true)
+      else if (backtickedSetter)
+        (pos.withStart(pos.start + 1).withEnd(pos.end + 1), false)
       else if (isOldNameBackticked) // pos
         (pos.withEnd(pos.end + 2), false)
       else (pos, false)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -790,9 +790,18 @@ class MetalsGlobal(
      * Returns the position of the name/identifier of this select.
      */
     def namePosition: Position = {
-      val start = sel.pos.point
-      val end = start + sel.name.getterName.decoded.trim.length()
-      Position.range(sel.pos.source, start, start, end)
+      sel match {
+        case Select(qualifier: Select, name)
+            if (name == nme.apply || name == nme.unapply) && sel.pos.point == qualifier.pos.point =>
+          qualifier.namePosition
+        case Select(qualifier: Ident, name)
+            if (name == nme.apply || name == nme.unapply) && sel.pos.point == qualifier.pos.point =>
+          qualifier.pos
+        case _ =>
+          val start = sel.pos.point
+          val end = start + sel.name.getterName.decoded.trim.length()
+          Position.range(sel.pos.source, start, start, end)
+      }
     }
 
   }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcReferencesProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcReferencesProvider.scala
@@ -25,9 +25,9 @@ trait PcReferencesProvider {
     val (pos, _) = toAdjust.adjust(text)
     tree match {
       case t: DefTree if !includeDefinition =>
-        (compiler.semanticdbSymbol(t.symbol), None)
+        (compiler.semanticdbSymbol(sym.getOrElse(t.symbol)), None)
       case t =>
-        (compiler.semanticdbSymbol(t.symbol), Some(pos.toLsp))
+        (compiler.semanticdbSymbol(sym.getOrElse(t.symbol)), Some(pos.toLsp))
     }
   }
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/SymbolInformationProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/SymbolInformationProvider.scala
@@ -113,7 +113,7 @@ object SymbolProvider:
         case Nil => owners
 
     val pkgSym =
-      if info.packagePart == "_empty_" then requiredPackage(nme.EMPTY_PACKAGE)
+      if info.packagePart == "_empty_/" then requiredPackage(nme.EMPTY_PACKAGE)
       else requiredPackage(normalizePackage(info.packagePart))
     val found = loop(List(pkgSym), info.names)
     info.paramName match

--- a/tests/slow/src/test/scala/tests/feature/PcReferencesLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/PcReferencesLspSuite.scala
@@ -119,41 +119,39 @@ class PcReferencesLspSuite
       scalaVersion,
       useGoToDef = true,
     )
+
+    check(
+       s"apply-test_$scalaVersion",
+       """|/a/src/main/scala/Defn.scala
+          |package a
+          |class O(v: Int) { }
+          |object O {
+          |  def <<app@@ly>>() = new O(1)
+          |}
+          |/a/src/main/scala/Main.scala
+          |package a
+          |object Main {
+          |  val g = <<O>>()
+          |}
+          |""".stripMargin,
+       scalaVersion,
+     )
+
+     check(
+       s"constructor_$scalaVersion",
+       """|/a/src/main/scala/Defn.scala
+          |package a
+          |case class Name(<<val@@ue>>: String)
+          |
+          |/a/src/main/scala/Main.scala
+          |package a
+          |object Main {
+          |  val name2 = new Name(<<value>> = "44")
+          |}
+          |""".stripMargin,
+       scalaVersion,
+     )
   }
-
-  check(
-    s"apply-test_${metals.BuildInfo.scala3}",
-    """|/a/src/main/scala/Defn.scala
-       |package a
-       |class O(v: Int) { }
-       |object O {
-       |  def <<app@@ly>>() = new O(1)
-       |}
-       |/a/src/main/scala/Main.scala
-       |package a
-       |object Main {
-       |  val g = <<O>>()
-       |}
-       |""".stripMargin,
-    metals.BuildInfo.scala3,
-  )
-
-  check(
-    s"apply-test_${metals.BuildInfo.scala213}",
-    """|/a/src/main/scala/Defn.scala
-       |package a
-       |class O(v: Int) { }
-       |object O {
-       |  def <<app@@ly>>() = new O(1)
-       |}
-       |/a/src/main/scala/Main.scala
-       |package a
-       |object Main {
-       |  val g = <<O()
-       |}>>
-       |""".stripMargin,
-    metals.BuildInfo.scala213,
-  )
 
   def check(
       name: TestOptions,

--- a/tests/slow/src/test/scala/tests/feature/PcReferencesLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/PcReferencesLspSuite.scala
@@ -121,36 +121,36 @@ class PcReferencesLspSuite
     )
 
     check(
-       s"apply-test_$scalaVersion",
-       """|/a/src/main/scala/Defn.scala
-          |package a
-          |class O(v: Int) { }
-          |object O {
-          |  def <<app@@ly>>() = new O(1)
-          |}
-          |/a/src/main/scala/Main.scala
-          |package a
-          |object Main {
-          |  val g = <<O>>()
-          |}
-          |""".stripMargin,
-       scalaVersion,
-     )
+      s"apply-test_$scalaVersion",
+      """|/a/src/main/scala/Defn.scala
+         |package a
+         |class O(v: Int) { }
+         |object O {
+         |  def <<app@@ly>>() = new O(1)
+         |}
+         |/a/src/main/scala/Main.scala
+         |package a
+         |object Main {
+         |  val g = <<O>>()
+         |}
+         |""".stripMargin,
+      scalaVersion,
+    )
 
-     check(
-       s"constructor_$scalaVersion",
-       """|/a/src/main/scala/Defn.scala
-          |package a
-          |case class Name(<<val@@ue>>: String)
-          |
-          |/a/src/main/scala/Main.scala
-          |package a
-          |object Main {
-          |  val name2 = new Name(<<value>> = "44")
-          |}
-          |""".stripMargin,
-       scalaVersion,
-     )
+    check(
+      s"constructor_$scalaVersion",
+      """|/a/src/main/scala/Defn.scala
+         |package a
+         |case class Name(<<val@@ue>>: String)
+         |
+         |/a/src/main/scala/Main.scala
+         |package a
+         |object Main {
+         |  val name2 = new Name(<<value>> = "44")
+         |}
+         |""".stripMargin,
+      scalaVersion,
+    )
   }
 
   def check(

--- a/tests/slow/src/test/scala/tests/feature/RenameCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/RenameCrossLspSuite.scala
@@ -48,4 +48,21 @@ class RenameCrossLspSuite extends BaseRenameLspSuite("rename-cross") {
     scalaVersion = Some(V.scala3),
   )
 
+  renamed(
+    "variable-explicit2",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object Main {
+       |  var <<v5>> = false
+       |
+       |  def f5: Boolean = {
+       |    `<<v@@5>>_=`(true)
+       |    <<v5>> == true
+       |  }
+       |}
+       |""".stripMargin,
+    newName = "NewSymbol",
+    scalaVersion = Some(V.scala3),
+  )
+
 }


### PR DESCRIPTION
Previously we would run recompile for inverse build targets after `go to references` to find if there are no new references. This would cause a lot of recompilations in presence of compilation errors. Since now we use `pc` as fallback for finding references we can use it always for files that have stale semanticdb.

resolves: https://github.com/scalameta/metals/issues/6348

Since now a lot more tests use `pc` for references this showed a few issues with that. The fixes probably have to also be migrated to Scala 3 pc.