### PR TITLE
bugfix: Don't start mtags with full classpath

### DIFF
--- a/metals-bench/src/main/scala/bench/PcBenchmark.scala
+++ b/metals-bench/src/main/scala/bench/PcBenchmark.scala
@@ -71,7 +71,7 @@ abstract class PcBenchmark {
     val pc = MtagsResolver.default().resolve(version) match {
       case Some(MtagsBinaries.BuildIn) => new ScalaPresentationCompiler()
       case Some(artifacts: MtagsBinaries.Artifacts) =>
-        embedded.presentationCompiler(artifacts, classpath)
+        embedded.presentationCompiler(artifacts)
       case _ =>
         throw new RuntimeException(
           s"Forgot to release scala version: $version ?"

--- a/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
@@ -162,7 +162,13 @@ class CompilerConfiguration(
     protected def newCompiler(classpath: Seq[Path]): PresentationCompiler = {
       val name = scalaTarget.scalac.getTarget().getUri
       val options = enrichWithReleaseOption(scalaTarget)
-      fromMtags(mtags, options, classpath ++ additionalClasspath, name, search)
+      fromMtags(
+        mtags,
+        options,
+        classpath ++ additionalClasspath,
+        name,
+        search,
+      )
         .withBuildTargetName(scalaTarget.displayName)
     }
 
@@ -253,7 +259,7 @@ class CompilerConfiguration(
     val pc = mtags match {
       case MtagsBinaries.BuildIn => new ScalaPresentationCompiler()
       case artifacts: MtagsBinaries.Artifacts =>
-        embedded.presentationCompiler(artifacts, classpathSeq)
+        embedded.presentationCompiler(artifacts)
     }
 
     val filteredOptions = plugins.filterSupportedOptions(options)

--- a/tests/unit/src/main/scala/tests/TestScala3Compiler.scala
+++ b/tests/unit/src/main/scala/tests/TestScala3Compiler.scala
@@ -27,7 +27,7 @@ object TestScala3Compiler {
         val status = new WorkDoneProgress(client, time)(ec)
         val embedded = new Embedded(status)
         val pc = embedded
-          .presentationCompiler(mtags, mtags.jars)
+          .presentationCompiler(mtags)
           .newInstance(
             name,
             input.classpath.entries.map(_.toNIO).asJava,


### PR DESCRIPTION
I think this was done by mistake in https://github.com/scalameta/metals/pull/2417 but very rarely caused any issues.

Previous to that PR we would only get Scala jars from ScalaBuildTarget.getJars method and after we would use the full classpath.

This never happened in the latest Scala version as we would just start mtags via new ScalaPresentationCompiler and it would happen randomly for some other versions.

Now, since we always use mtags artifacts they always contain the needed Scala jars (unless there would be a custom platform) so there is no need to add anything more.

This might have caused https://github.com/scalameta/metals/issues/5272