### PR TITLE
refactor: Don't try to download artifacts in ProblemResolverSuite

### DIFF
--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -56,7 +56,7 @@ abstract class BaseLspSuite(
   protected def useVirtualDocuments = useVirtualDocs
 
   protected def mtagsResolver: MtagsResolver =
-    new TestMtagsResolver
+    new TestMtagsResolver(checkCoursier = true)
 
   override def afterAll(): Unit = {
     if (server != null) {

--- a/tests/unit/src/main/scala/tests/TestScala3Compiler.scala
+++ b/tests/unit/src/main/scala/tests/TestScala3Compiler.scala
@@ -19,7 +19,7 @@ object TestScala3Compiler {
   def compiler(name: String, input: InputProperties)(implicit
       ec: ExecutionContext
   ): Option[PresentationCompiler] = {
-    val resolver = new TestMtagsResolver()
+    val resolver = new TestMtagsResolver(checkCoursier = true)
     resolver.resolve(V.scala3) match {
       case Some(mtags: MtagsBinaries.Artifacts) =>
         val time = new FakeTime

--- a/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
+++ b/tests/unit/src/test/scala/tests/troubleshoot/ProblemResolverSuite.scala
@@ -228,7 +228,7 @@ class ProblemResolverSuite extends FunSuite {
 
       val problemResolver = new ProblemResolver(
         AbsolutePath(workspace),
-        new TestMtagsResolver,
+        new TestMtagsResolver(checkCoursier = false),
         () => None,
         () => javaHome,
         () => isTestExplorerProvider,


### PR DESCRIPTION
The tests often timeout if coursier with retries is involved and besides mtags are not published aside from 2.13.x so this will always fail.