### PR TITLE
improvement: Run mtags check parallel and set maximum timeout

### DIFF
--- a/metals-docs/src/main/scala/docs/RequirementsModifier.scala
+++ b/metals-docs/src/main/scala/docs/RequirementsModifier.scala
@@ -1,5 +1,7 @@
 package docs
 
+import scala.concurrent.duration._
+
 import scala.meta.inputs.Input
 import scala.meta.metals.SupportedScalaVersions
 
@@ -43,7 +45,7 @@ class RequirementsModifier extends SupportedScalaVersions with StringModifier {
        |
        |**Scala 2.13, 2.12, 2.11 and Scala 3**. Metals supports these Scala versions:
        |
-       |${supportedVersionsString(Snapshot.latest("releases", "2.13").version)}
+       |${supportedVersionsString(Snapshot.latest("releases", "2.13").version, 5.minutes)}
        |
        |Note that 2.11.x support is deprecated and it will be removed in future releases.
        |It's recommended to upgrade to Scala 2.12 or Scala 2.13

--- a/metals/src/main/scala/scala/meta/metals/Main.scala
+++ b/metals/src/main/scala/scala/meta/metals/Main.scala
@@ -3,6 +3,7 @@ package scala.meta.metals
 import java.util.concurrent.Executors
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 import scala.meta.internal.metals.BuildInfo
@@ -29,7 +30,7 @@ object Main extends SupportedScalaVersions {
       println(
         s"""|metals ${BuildInfo.metalsVersion}
             |
-            |${supportedVersionsString(BuildInfo.metalsVersion)}
+            |${supportedVersionsString(BuildInfo.metalsVersion, 15.seconds)}
             |""".stripMargin
       )
       sys.exit(0)

--- a/tests/unit/src/test/scala/tests/SupportedScalaSuite.scala
+++ b/tests/unit/src/test/scala/tests/SupportedScalaSuite.scala
@@ -1,12 +1,14 @@
 package tests
 
+import scala.concurrent.duration._
+
 import scala.meta.metals.Main
 
 class SupportedScalaSuite extends BaseSuite {
 
   test("released-version") {
     assertNoDiff(
-      Main.supportedVersionsString("1.2.0"),
+      Main.supportedVersionsString("1.2.0", 5.minutes),
       """|- Scala 2.11:
          |   2.11.12
          |
@@ -30,7 +32,7 @@ class SupportedScalaSuite extends BaseSuite {
 
   test("snapshot-version") {
     assertNoDiff(
-      Main.supportedVersionsString("0.11.10+90-55f285b7-SNAPSHOT"),
+      Main.supportedVersionsString("0.11.10+90-55f285b7-SNAPSHOT", 5.minutes),
       """|- Scala 2.11:
          |   2.11.12
          |


### PR DESCRIPTION
Previously, we would check mtags links one by one, which would be slow as there are a number of online requests.

Now, we run all the requests parallel and also use a timeout, which will print defaults.

```
~ metals --version
Checking available versions on https://oss.sonatype.org/content/repositories/snapshots/org/scalameta/

metals 1.3.1+39-99831afc-SNAPSHOT

 - Scala 2.11:
   2.11.12

 - Scala 2.12:
   2.12.12, 2.12.13, 2.12.14, 2.12.15, 2.12.16, 2.12.17, 2.12.18, 2.12.19

 - Scala 2.13:
   2.13.7, 2.13.8, 2.13.9, 2.13.10, 2.13.11, 2.13.12, 2.13.13, 2.13.14

 - Scala 3:
   3.3.1, 3.2.2, 3.3.2, 3.1.3, 3.3.3

Scala 3 versions from 3.3.4 are automatically supported by Metals.

Any older Scala versions will no longer get bugfixes, but should still
work properly with newest Metals.

```

Fixes https://github.com/scalameta/metals/issues/6426