### PR TITLE
fix: pc functions for multiline strings in worksheets in scala 3

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/worksheets/WorksheetProvider.scala
@@ -498,9 +498,8 @@ object WorksheetProvider {
       originInput: Input.VirtualFile
   ): Option[(Input.VirtualFile, AdjustLspData)] = {
     val ident = "  "
-    val withOuter = s"""|object worksheet{
-                        |$ident${originInput.value.replace("\n", "\n" + ident)}
-                        |}""".stripMargin
+    val withOuter =
+      s"""object worksheet{\n$ident${originInput.value.replace("\n", "\n" + ident)}\n}"""
     val modifiedInput =
       originInput.copy(value = withOuter)
     val adjustLspData = AdjustedLspData.create(


### PR DESCRIPTION
Since we didn't put synthetic `|` on every new line, `.stripMargin` was stripping `|` from the actual code.

resolves: https://github.com/scalameta/metals/issues/6361