### PR TITLE
improvement: Make sure we always have correct projectview file

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspSession.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspSession.scala
@@ -44,6 +44,8 @@ case class BspSession(
 
   def workspaceReload(): Future[List[Object]] =
     Future.sequence(connections.map(conn => conn.workspaceReload()))
+
+  def canReloadWorkspace: Boolean = connections.forall(_.canReloadWorkspace)
 }
 
 object BspSession {

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTool.scala
@@ -27,6 +27,8 @@ trait BuildTool {
     }
   }
 
+  def ensurePrerequisites(workspace: AbsolutePath): Unit = {}
+
   protected def digest(workspace: AbsolutePath): Option[String]
 
   protected lazy val tempDir: Path = {

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -112,6 +112,9 @@ class BuildServerConnection private (
   def supportsLazyClasspathResolution: Boolean =
     capabilities.getJvmCompileClasspathProvider()
 
+  def canReloadWorkspace: Boolean =
+    capabilities.getCanReload()
+
   def supportsLanguage(id: String): Boolean =
     Option(capabilities.getCompileProvider())
       .exists(_.getLanguageIds().contains(id)) ||

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -92,8 +92,11 @@ final case class Indexer(
     def reloadAndIndex(session: BspSession): Future[BuildChange] = {
       workspaceReload().persistChecksumStatus(Status.Started, buildTool)
 
+      buildTool.ensurePrerequisites(workspaceFolder)
       buildTool match {
         case _: BspOnly =>
+          reconnectToBuildServer()
+        case _ if !session.canReloadWorkspace =>
           reconnectToBuildServer()
         case _ =>
           session

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -308,8 +308,9 @@ class ProjectMetalsLspService(
           found.digest,
           importBuild,
           reconnectToBuildServer = () =>
-            if (!isConnecting.get()) quickConnectToBuildServer()
-            else {
+            if (!isConnecting.get()) {
+              quickConnectToBuildServer()
+            } else {
               scribe.warn("Cannot reload build session, still connecting...")
               Future.successful(BuildChange.None)
             },


### PR DESCRIPTION
Previously, it was possible that the file would get delete and recreated by Bazel BSP automatically. In that case it will end up empty and no targets would be imported,

Now, we make sure that it's not possible to have empty projectview be it because of  Bazel BSP or because of user changes,