### PR TITLE
chore: Don't recalculate build tools every time

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BuildToolSelector.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildToolSelector.scala
@@ -57,7 +57,8 @@ final class BuildToolSelector(
   ): Future[Boolean] = {
     languageClient
       .showMessageRequest(
-        Messages.NewBuildToolDetected.params(newBuildTool, currentBuildTool)
+        Messages.NewBuildToolDetected
+          .params(newBuildTool.executableName, currentBuildTool.executableName)
       )
       .asScala
       .map {

--- a/metals/src/main/scala/scala/meta/internal/builds/ScalaCliBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ScalaCliBuildTool.scala
@@ -13,7 +13,7 @@ import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.scalacli.ScalaCli
 import scala.meta.io.AbsolutePath
 
-class ScalaCliBuildTool(
+case class ScalaCliBuildTool(
     val workspaceVersion: Option[String],
     val projectRoot: AbsolutePath,
     userConfig: () => UserConfiguration,

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -231,12 +231,12 @@ object Messages {
     val switch = new MessageActionItem("yes")
     val dontSwitch = new MessageActionItem("no")
     def params(
-        newBuildTool: BuildTool,
-        currentBuildTool: BuildTool,
+        newBuildTool: String,
+        currentBuildTool: String,
     ): ShowMessageRequestParams = {
       val params = new ShowMessageRequestParams()
       params.setMessage(
-        s"""|Would you like to switch from the current build tool (${currentBuildTool.executableName}) to newly detected ${newBuildTool.executableName}?
+        s"""|Would you like to switch from the current build tool (${currentBuildTool}) to newly detected ${newBuildTool}?
             |This action will also reset build server choice.
             |""".stripMargin
       )

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -390,7 +390,7 @@ class ProjectMetalsLspService(
   def maybeSetupScalaCli(): Future[Unit] = {
     if (
       !buildTools.isAutoConnectable()
-      && buildTools.loadSupported.isEmpty
+      && buildTools.loadSupported().isEmpty
       && (folder.isScalaProject() || focusedDocument().exists(_.isScala))
     ) {
       scalaCli.setupIDE(folder)
@@ -767,7 +767,7 @@ class ProjectMetalsLspService(
   protected def buildTool: Option[BuildTool] =
     for {
       name <- tables.buildTool.selectedBuildTool()
-      buildTool <- buildTools.loadSupported.find(_.executableName == name)
+      buildTool <- buildTools.current().find(_.executableName == name)
       found <- isCompatibleVersion(buildTool) match {
         case BuildTool.Found(bt, _) => Some(bt)
         case _ => None
@@ -792,7 +792,7 @@ class ProjectMetalsLspService(
   }
 
   def supportedBuildTool(): Future[Option[BuildTool.Found]] = {
-    buildTools.loadSupported match {
+    buildTools.loadSupported() match {
       case Nil => {
         if (!buildTools.isAutoConnectable()) {
           warnings.noBuildTool()
@@ -1299,9 +1299,9 @@ class ProjectMetalsLspService(
   override def check(): Unit = {
     super.check()
     buildTools
-      .loadSupported()
+      .current()
       .map(_.projectRoot)
-      .distinct match {
+      .toList match {
       case Nil => formattingProvider.validateWorkspace(folder)
       case paths =>
         paths.foreach(

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
@@ -141,7 +141,7 @@ final class Doctor(
       case FallbackService => None
       case projectService: ProjectService =>
         val isExplicitChoice =
-          projectService.buildTools.loadSupported().length > 1
+          projectService.buildTools.current().size > 1
         tables.buildTool.selectedBuildTool().map { value =>
           (s"Build definition is coming from ${value}.", isExplicitChoice)
         }

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -337,7 +337,10 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
       val buildTools = BuildTools.default().allAvailable
       buildTools.exists(newBuildTool =>
         buildTools.exists(oldBuildTool =>
-          NewBuildToolDetected.params(newBuildTool, oldBuildTool) == params
+          NewBuildToolDetected.params(
+            newBuildTool.executableName,
+            oldBuildTool.executableName,
+          ) == params
         )
       )
     }


### PR DESCRIPTION
Since we already cache a list of build tools and that is actually updated on build related changes then it's better to use current whenever possible

Fixes https://github.com/scalameta/metals/issues/6459