### PR TITLE
fix: use server command for doctor run in status bar

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/ConnectionBspStatus.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/ConnectionBspStatus.scala
@@ -8,6 +8,7 @@ import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ReportContext
+import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.clients.language.MetalsStatusParams
 import scala.meta.internal.metals.clients.language.StatusType
 import scala.meta.io.AbsolutePath
@@ -139,7 +140,7 @@ object ConnectionBspStatus {
       "warn",
       show = true,
       tooltip = message.trimTo(TOOLTIP_MAX_LENGTH),
-      command = ClientCommands.RunDoctor.id,
+      command = ServerCommands.RunDoctor.id,
       commandTooltip = "Open doctor.",
     ).withStatusType(StatusType.bsp)
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Warnings.scala
@@ -43,7 +43,7 @@ final class ProjectWarnings(
         statusBar.addMessage(
           MetalsStatusParams(
             s"${icons.alert}Build misconfiguration",
-            command = ClientCommands.RunDoctor.id,
+            command = ServerCommands.RunDoctor.id,
           )
         )
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -21,7 +21,6 @@ import scala.util.control.NonFatal
 import scala.meta.internal.metals.BuildServerConnection
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.Cancelable
-import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.ClientConfiguration
 import scala.meta.internal.metals.Compilations
 import scala.meta.internal.metals.Compilers
@@ -38,6 +37,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MutableCancelable
 import scala.meta.internal.metals.ScalaTestSuites
 import scala.meta.internal.metals.ScalaTestSuitesDebugRequest
+import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.SourceMapper
 import scala.meta.internal.metals.StacktraceAnalyzer
 import scala.meta.internal.metals.StatusBar
@@ -803,7 +803,7 @@ class DebugProvider(
         MetalsStatusParams(
           text = s"${clientConfig.icons.alert}Build misconfiguration",
           tooltip = e.getMessage(),
-          command = ClientCommands.RunDoctor.id,
+          command = ServerCommands.RunDoctor.id,
         )
       )
     case _ =>


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/6387

For clients that do not support status bar `showMessageRequest` is used, and the appropriate command is executed on option chosen:
https://github.com/scalameta/metals/blob/0c8159200e7da4a1792e017e0f3f99c052f0950a/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala#L60-L82

Previously:
We'd use client command `metals-doctor-run` for running doctor in status bar. When status bar not supported this command would be send with empty args to client, which caused https://github.com/scalameta/metals/issues/6387.

Now:
We use server command `doctor-run` instead. If status bar not supported the command will be executed on the server without clients involvement.

@ckipp01 Will this change cause issues for nvim?