### PR TITLE
fix: correctly auto import when there is a renamed symbol with the same name in scope

### DIFF
--- a/mtags/src/main/scala-3/scala/meta/internal/pc/IndexedContext.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/IndexedContext.scala
@@ -37,8 +37,8 @@ sealed trait IndexedContext:
       // when all the conflicting symbols came from an old version of the file
       case Some(symbols) if symbols.nonEmpty && symbols.forall(_.isStale) =>
         Result.Missing
-      case Some(_) => Result.Conflict
-      case None => Result.Missing
+      case Some(symbols) if symbols.exists(rename(_).isEmpty) => Result.Conflict
+      case _ => Result.Missing
   end lookupSym
 
   final def hasRename(sym: Symbol, as: String): Boolean =

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/Completions.scala
@@ -591,8 +591,12 @@ class Completions(
           then
             indexedContext.lookupSym(sym) match
               case IndexedContext.Result.InScope =>
+                val name =
+                  indexedContext.rename(sym) match
+                    case Some(rename) => rename
+                    case None => sym.decodedName
                 visit(
-                  CompletionValue.Scope(sym.decodedName, sym, findSuffix(sym))
+                  CompletionValue.Scope(name, sym, findSuffix(sym))
                 )
               case _ =>
                 completionsWithSuffix(

--- a/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
@@ -367,6 +367,37 @@ class AutoImportsSuite extends BaseAutoImportsSuite {
     )
   )
 
+  checkEdit(
+    "i6477".tag(IgnoreScala2),
+    """|package a
+       |import a.b.SomeClass as SC
+       |
+       |package b {
+       |  class SomeClass
+       |}
+       |package c {
+       |  class SomeClass
+       |}
+       |
+       |val bar: SC = ???
+       |val foo: <<SomeClass>> = ???
+       |""".stripMargin,
+    """|package a
+       |import a.b.SomeClass as SC
+       |import a.c.SomeClass
+       |
+       |package b {
+       |  class SomeClass
+       |}
+       |package c {
+       |  class SomeClass
+       |}
+       |
+       |val bar: SC = ???
+       |val foo: SomeClass = ???
+       |""".stripMargin
+  )
+
   private def ammoniteWrapper(code: String): String =
     // Vaguely looks like a scala file that Ammonite generates
     // from a sc file.

--- a/tests/cross/src/test/scala/tests/pc/CompletionScala3Suite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionScala3Suite.scala
@@ -104,4 +104,68 @@ class CompletionScala3Suite extends BaseCompletionSuite {
        |SetOps scala.collection
        |""".stripMargin
   )
+
+  checkEdit(
+    "i6477-1",
+    """|package a
+       |import a.b.SomeClass as SC
+       |
+       |package b {
+       |  class SomeClass
+       |}
+       |package c {
+       |  class SomeClass
+       |}
+       |
+       |val bar: SC = ???
+       |val foo: SomeClass@@
+       |""".stripMargin,
+    """|package a
+       |import a.b.SomeClass as SC
+       |
+       |package b {
+       |  class SomeClass
+       |}
+       |package c {
+       |  class SomeClass
+       |}
+       |
+       |val bar: SC = ???
+       |val foo: SC
+       |""".stripMargin,
+    assertSingleItem = false
+  )
+
+  checkEdit(
+    "i6477-2",
+    """|package a
+       |import a.b.SomeClass as SC
+       |
+       |package b {
+       |  class SomeClass
+       |}
+       |package c {
+       |  class SomeClass
+       |}
+       |
+       |val bar: SC = ???
+       |val foo: SomeClass@@
+       |""".stripMargin,
+    """|package a
+       |import a.b.SomeClass as SC
+       |import a.c.SomeClass
+       |
+       |package b {
+       |  class SomeClass
+       |}
+       |package c {
+       |  class SomeClass
+       |}
+       |
+       |val bar: SC = ???
+       |val foo: SomeClass
+       |""".stripMargin,
+    assertSingleItem = false,
+    itemIndex = 1
+  )
 }


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/6477