### PR TITLE
fix: prefer latter fully qualified name parts when building trigrams for fuzzy search

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/TrigramSubstrings.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/TrigramSubstrings.scala
@@ -17,10 +17,11 @@ object TrigramSubstrings {
    * Iterate over all possible substrings of length 3 for the given string.
    */
   def foreach(
-      string: String,
+      inString: String,
       f: String => Unit,
       maxResults: Int = DefaultMaxTrigrams
   ): Unit = {
+    val string = inString.reverse
     val N = string.length
     val arr = new Array[Char](3)
     var max = maxResults
@@ -31,9 +32,9 @@ object TrigramSubstrings {
       while (j < N && isNotDone) {
         var k = j + 1
         while (k < N && isNotDone) {
-          arr(0) = string.charAt(i)
+          arr(2) = string.charAt(i)
           arr(1) = string.charAt(j)
-          arr(2) = string.charAt(k)
+          arr(0) = string.charAt(k)
           f(new String(arr))
           max -= 1
           k += 1

--- a/tests/slow/src/test/scala/tests/feature/ImportMissingSymbolCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/ImportMissingSymbolCrossLspSuite.scala
@@ -168,4 +168,33 @@ class ImportMissingSymbolCrossLspSuite
     scalacOptions = List("-explain"),
   )
 
+  check(
+    "i6475",
+    """|package com.scalaFakePackage.test.latestCommentByItem.domain.projection.latestCommentByItemView
+       |package subscriber {
+       |  class CreateLatestCommentByItemSubscriber
+       |}
+       |package a {
+       |  object O {
+       |    val g: <<CreateLatestCommentByItemSubscriber>> = ???
+       |  }
+       |}
+       |""".stripMargin,
+    s"""|${ImportMissingSymbol.title("CreateLatestCommentByItemSubscriber", "com.scalaFakePackage.test.latestCommentByItem.domain.projection.latestCommentByItemView.subscriber")}
+        |${CreateNewSymbol.title("CreateLatestCommentByItemSubscriber")}""".stripMargin,
+    """|package com.scalaFakePackage.test.latestCommentByItem.domain.projection.latestCommentByItemView
+       |
+       |import com.scalaFakePackage.test.latestCommentByItem.domain.projection.latestCommentByItemView.subscriber.CreateLatestCommentByItemSubscriber
+       |package subscriber {
+       |  class CreateLatestCommentByItemSubscriber
+       |}
+       |package a {
+       |  object O {
+       |    val g: CreateLatestCommentByItemSubscriber = ???
+       |  }
+       |}
+       |""".stripMargin,
+    scalaVersion = "3.3.3",
+  )
+
 }

--- a/tests/unit/src/test/scala/tests/TrigramSubstringsSuite.scala
+++ b/tests/unit/src/test/scala/tests/TrigramSubstringsSuite.scala
@@ -26,10 +26,10 @@ class TrigramSubstringsSuite extends BaseSuite {
   check(
     "abcd",
     """
-      |abc
-      |abd
-      |acd
       |bcd
+      |acd
+      |abd
+      |abc
       |""".stripMargin,
   )
 


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/6475