### PR TITLE
fix: don't create `semanticdb` next to user sources for single files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/ScalaCliBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ScalaCliBuildTool.scala
@@ -22,7 +22,7 @@ case class ScalaCliBuildTool(
     with VersionRecommendation {
 
   lazy val runScalaCliCommand: Option[Seq[String]] =
-    ScalaCli.localScalaCli(userConfig())
+    ScalaCli.localScalaCli(userConfig()).map(_.command)
 
   override def generateBspConfig(
       workspace: AbsolutePath,


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/6508

This is the case where paths totally don't match and compiler panics and creates `semanticdb` next to the sources. Adding `--semanticdb-sourceroot` flag will cause it create it in the correct place for `.scala` files.

However, we don't actually use semanticdb for single files anyway, since the paths will still be broken for scripts. Maybe instead of `--semanticdb-sourceroot`, we could have a flag that stops semanticdb from being produced all together?
CC: @tgodzik @Gedochao
