### PR TITLE
improvement: Don't show bazel navigation issue always

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -276,9 +276,6 @@ object Messages {
     def multipleProblemsDetected: String =
       s"Multiple problems detected in your build."
 
-    def bazelNavigation: String =
-      "Global rename and references for Bazel projects is not supported yet."
-
     val misconfiguredTestFrameworks: String =
       "Test Explorer won't work due to mis-configuration." + moreInfo
 

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/Doctor.scala
@@ -250,7 +250,9 @@ final class Doctor(
         DoctorExplanation.CompilationStatus.toJson(allTargetsInfo),
         DoctorExplanation.Diagnostics.toJson(allTargetsInfo),
         DoctorExplanation.Interactive.toJson(allTargetsInfo),
-        DoctorExplanation.SemanticDB.toJson(allTargetsInfo),
+        DoctorExplanation
+          .SemanticDB(problemResolver.isBazelBsp)
+          .toJson(allTargetsInfo),
         DoctorExplanation.Debugging.toJson(allTargetsInfo),
         DoctorExplanation.JavaSupport.toJson(allTargetsInfo),
       )
@@ -427,7 +429,9 @@ final class Doctor(
       DoctorExplanation.CompilationStatus.toHtml(html, allTargetsInfo)
       DoctorExplanation.Diagnostics.toHtml(html, allTargetsInfo)
       DoctorExplanation.Interactive.toHtml(html, allTargetsInfo)
-      DoctorExplanation.SemanticDB.toHtml(html, allTargetsInfo)
+      DoctorExplanation
+        .SemanticDB(problemResolver.isBazelBsp)
+        .toHtml(html, allTargetsInfo)
       DoctorExplanation.Debugging.toHtml(html, allTargetsInfo)
       DoctorExplanation.JavaSupport.toHtml(html, allTargetsInfo)
 

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/DoctorExplanation.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/DoctorExplanation.scala
@@ -144,13 +144,19 @@ object DoctorExplanation {
       allTargetsInfo.exists(_.interactiveStatus.isCorrect == false)
   }
 
-  case object SemanticDB extends DoctorExplanation {
+  case class SemanticDB(isBazelBsp: Boolean) extends DoctorExplanation {
     val title =
       "Semanticdb features (references, renames, go to implementation):"
     val correctMessage: String =
       s"${Icons.unicode.check} - build tool automatically creating needed semanticdb files"
+
+    private val additionalBazelMessage =
+      if (isBazelBsp)
+        ", you might need to enable enable_semanticdb flag in scala_toolchain."
+      else ""
+
     val incorrectMessage: String =
-      s"""|${Icons.unicode.alert} - semanticdb index files not present currently
+      s"""|${Icons.unicode.alert} - semanticdb index files not present currently$additionalBazelMessage
           |${Icons.unicode.error} - semanticdb index not being produced""".stripMargin
 
     def show(allTargetsInfo: Seq[DoctorTargetInfo]): Boolean =

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
@@ -158,12 +158,6 @@ class ProblemResolver(
         None
       }
 
-    val bazelSemanticdbMessage = if (isBazelBsp) {
-      Some(Messages.CheckDoctor.bazelNavigation)
-    } else {
-      None
-    }
-
     val allMessages = List(
       deprecatedMessage,
       deprecatedRemovedMessage,
@@ -174,7 +168,6 @@ class ProblemResolver(
       unsupportedSbtMessage,
       futureSbtMessage,
       semanticdbMessage,
-      bazelSemanticdbMessage,
     ).flatten ++ javaIssues
 
     def scalaVersionsMessages = List(
@@ -337,7 +330,7 @@ class ProblemResolver(
     else isWrongJavaRelease(javaTarget)
   }
 
-  private def isBazelBsp = currentBuildServer().exists(_.main.isBazel)
+  def isBazelBsp: Boolean = currentBuildServer().exists(_.main.isBazel)
 
   private def isWrongJavaRelease(
       javaTarget: JavaTarget

--- a/tests/slow/src/test/scala/tests/bazel/BazelLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelLspSuite.scala
@@ -47,8 +47,7 @@ class BazelLspSuite
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          importMessage,
-          bazelNavigationMessage,
+          importMessage
         ).mkString("\n"),
       )
       _ = assert(bazelBspConfig.exists)
@@ -128,10 +127,7 @@ class BazelLspSuite
            |""".stripMargin,
       )
     } yield {
-      assertNoDiff(
-        client.workspaceMessageRequests,
-        bazelNavigationMessage,
-      )
+      assertEmpty(client.workspaceMessageRequests)
       assert(bazelBspConfig.exists)
       server.assertBuildServerConnection()
     }
@@ -197,8 +193,7 @@ class BazelLspSuite
       assertNoDiff(
         client.workspaceMessageRequests,
         List(
-          bazelNavigationMessage,
-          Messages.ResetWorkspace.message,
+          Messages.ResetWorkspace.message
         ).mkString("\n"),
       )
       assert(bazelBspConfig.exists)

--- a/tests/unit/src/main/scala/tests/BaseImportSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseImportSuite.scala
@@ -23,9 +23,6 @@ abstract class BaseImportSuite(
   def progressMessage: String =
     s"${buildTool.executableName} bloopInstall"
 
-  def bazelNavigationMessage: String =
-    CheckDoctor.bazelNavigation
-
   def currentDigest(workspace: AbsolutePath): Option[String]
 
   def currentChecksum(): String =


### PR DESCRIPTION
It's not possible to see if a user has semanticdb enabled in Bazel, so instead we already show if the semanticdb is currently present. This makes the warning message sometimes invalid, so instead I added further explanation to the doctor.