### PR TITLE
bugfix: Always require _ to calculate scala version from jar

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaVersions.scala
@@ -147,7 +147,7 @@ class ScalaVersions(
   }
 
   private val scalaVersionRegex =
-    "(_)?(\\d)(\\.\\d{1,2})?(\\.\\d(-(RC|M)\\d)?)?".r
+    raw"(_)(\d)(\.\d{1,2})?(\.\d(-(RC|M)\d)?)?".r
 
   /**
    * Extract scala binary version from dependency jar name.
@@ -178,7 +178,7 @@ class ScalaVersions(
       .sortBy(_._2)(Ordering.Boolean.reverse)
       .headOption
       .map { case (version, _) => scalaBinaryVersionFromFullVersion(version) }
-      .getOrElse(scala213)
+      .getOrElse("2.13")
   }
 
   def dialectForDependencyJar(filename: String): Dialect =

--- a/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
@@ -303,24 +303,21 @@ class ScalaVersionsSuite extends BaseSuite {
     )
   }
 
-  test("from-jar-name") {
-    val expected =
-      List(
-        ("smth-library_2.13-21.2.0-sources.jar", "2.13"),
-        (
-          "scala3-compiler_3-3.0.1-RC2-bin-20210310-4af1386-NIGHTLY-sources.jar",
-          "3",
-        ),
-        ("scala3-library_3-3.1.0-RC1.jar", "3"),
-        ("scala-library-2.13.1.jar", "2.13"),
-        ("cool4.4_2.13-3.0.jar", "2.13"),
-        ("scala3-library_3-3.0.0-sources.jar", "3"),
-        ("munit_3-0.7.29-sources.jar", "3"),
-      )
-    expected.foreach { case (jar, version) =>
-      val out = ScalaVersions.scalaBinaryVersionFromJarName(jar)
-      assertEquals(out, version, jar)
-    }
+  checkJar("smth-library_2.13-21.2.0-sources.jar", "2.13")
+  checkJar(
+    "scala3-compiler_3-3.0.1-RC2-bin-20210310-4af1386-NIGHTLY-sources.jar",
+    "3",
+  )
+  checkJar("scala3-library_3-3.1.0-RC1.jar", "3")
+  checkJar("scala-library-2.13.1.jar", "2.13")
+  checkJar("cool4.4_2.13-3.0.jar", "2.13")
+  checkJar("scala3-library_3-3.0.0-sources.jar", "3")
+  checkJar("munit_3-0.7.29-sources.jar", "3")
+  checkJar("tested-3.0-sources.jar", "2.13")
+
+  def checkJar(jar: String, expected: String): Unit = test(jar) {
+    val out = ScalaVersions.scalaBinaryVersionFromJarName(jar)
+    assertEquals(out, expected, jar)
   }
 
   def scalaVersions(supportedScalaVersions: String*): ScalaVersions = {


### PR DESCRIPTION
Previously, we would identify any jar with 3.0 as Scala 3. Now we require _ as is always added to scala libraries

Fixes https://github.com/scalameta/metals/issues/6533