### PR TITLE
bugfix: Don't search for stacktrace line if at word is not present

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
@@ -264,10 +264,13 @@ private[debug] final class DebugProxy(
       client.consume(response)
     case message @ ErrorOutputNotification(output) =>
       initialized.trySuccess(())
-      val analyzedMessage = stackTraceAnalyzer
-        .fileLocationFromLine(output.getOutput())
-        .map(DebugProtocol.stacktraceOutputResponse(output, _))
-        .getOrElse(message)
+      val analyzedMessage =
+        if (output.getOutput().contains("at "))
+          stackTraceAnalyzer
+            .fileLocationFromLine(output.getOutput())
+            .map(DebugProtocol.stacktraceOutputResponse(output, _))
+            .getOrElse(message)
+        else message
       client.consume(analyzedMessage)
 
     case message @ OutputNotification(output) if stripColor =>


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/6553