### PR TITLE
chore: move mill test to newest mill version

### DIFF
--- a/tests/slow/src/test/scala/tests/mill/MillLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/mill/MillLspSuite.scala
@@ -141,8 +141,6 @@ class MillLspSuite extends BaseImportSuite("mill-import") {
            |  def scalaVersion = "${V.scala213}"
            |  def scalacOptions = Seq("-Xfatal-warnings", "-Ywarn-unused")
            |}
-           |/.mill-version
-           |${V.millVersion}
            |/foo/src/Warning.scala
            |import scala.concurrent.Future // unused
            |object Warning
@@ -164,7 +162,11 @@ class MillLspSuite extends BaseImportSuite("mill-import") {
       // we should still have references despite fatal warning
       refs <- server.workspaceReferences()
       _ = assertNoDiff(
-        refs.references.map(_.symbol).sorted.mkString("\n"),
+        refs.references
+          .withFilter(_.location.getUri().endsWith("Warning.scala"))
+          .map(_.symbol)
+          .sorted
+          .mkString("\n"),
         """|_empty_/A.
            |_empty_/A.B.
            |_empty_/Warning.


### PR DESCRIPTION
Since `0.11.8` there is also a build target for mill build (after import to bloop). Find references, shows references between user created `build.sc` and generated `build.sc`.