### PR TITLE
fix: change project ref setting to support VSCode workspace folder reload

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DelegateSetting.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DelegateSetting.scala
@@ -1,28 +1,51 @@
 package scala.meta.internal.metals
 
+import scala.util.Try
+
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
 
+import ujson.Value
+
 object DelegateSetting {
-  private val settingName = "delegate"
+  val delegateSetting = "delegate"
+  private val projectRefSetting = "project-ref"
 
-  def writeDeleteSetting(
+  def writeProjectRef(
       folder: AbsolutePath,
-      servicePath: AbsolutePath,
+      projectRefs: List[AbsolutePath],
   ): Unit = {
-    val relPath = servicePath.toRelative(folder)
-    val jsonText = ujson.Obj(settingName -> relPath.toString()).toString()
+    val relPath = projectRefs.map(_.toRelative(folder))
+    val jsonText =
+      ujson.Obj(projectRefSetting -> relPath.map(_.toString())).toString()
     folder.resolve(Directories.metalsSettings).writeText(jsonText)
-
   }
 
-  def readDeleteSetting(folder: AbsolutePath): Option[AbsolutePath] =
+  def readProjectRefs(folder: AbsolutePath): List[AbsolutePath] = {
     for {
-      text <- folder.resolve(Directories.metalsSettings).readTextOpt
-      json = ujson.read(text)
-      relPath <- json(settingName).strOpt
-      path = folder.resolve(relPath).dealias
+      setting <- getSetting(folder, projectRefSetting).toList
+      ref <- setting.arrOpt.getOrElse(Nil)
+      pathStr <- ref.strOpt
+      path = folder.resolve(pathStr).dealias
       if path.exists
     } yield path
+  }
+
+  def readDeleteSetting(root: AbsolutePath): Option[AbsolutePath] =
+    for {
+      setting <- getSetting(root, delegateSetting)
+      relPath <- setting.strOpt
+      path = root.resolve(relPath).dealias
+      if path.exists
+    } yield path
+
+  private def getSetting(
+      root: AbsolutePath,
+      settingName: String,
+  ): Option[Value] =
+    for {
+      text <- root.resolve(Directories.metalsSettings).readTextOpt
+      setting <- Try(ujson.read(text)(settingName)).toOption
+    } yield setting
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1422,26 +1422,6 @@ abstract class MetalsLspService(
         }
     }
 
-  protected def importBuild(session: BspSession): Future[Unit] = {
-    val importedBuilds0 = timerProvider.timed("Imported build") {
-      session.importBuilds()
-    }
-    for {
-      bspBuilds <- workDoneProgress.trackFuture(
-        Messages.importingBuild,
-        importedBuilds0,
-      )
-      _ = {
-        val idToConnection = bspBuilds.flatMap { bspBuild =>
-          val targets =
-            bspBuild.build.workspaceBuildTargets.getTargets().asScala
-          targets.map(t => (t.getId(), bspBuild.connection))
-        }
-        mainBuildTargetsData.resetConnections(idToConnection)
-      }
-    } yield compilers.cancel()
-  }
-
   val buildClient: ForwardingMetalsBuildClient =
     new ForwardingMetalsBuildClient(
       languageClient,

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -1359,6 +1359,9 @@ class Folder(
   lazy val optDelegatePath: Option[AbsolutePath] =
     DelegateSetting.readDeleteSetting(path)
 
+  def projectReferences: List[AbsolutePath] =
+    DelegateSetting.readProjectRefs(path)
+
   def nameOrUri: String = visibleName.getOrElse(path.toString())
 }
 


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/6497

I think this is still rarely used so maybe we can just delete the old setting? We can also leave a transition period.