### PR TITLE
bugfix: Use latest stable mill version

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -35,7 +35,7 @@ object V {
   val kindProjector = "0.13.3"
   val lsp4jV = "0.23.1"
   val mavenBloop = "2.0.0"
-  val mill = "0.11.7"
+  val mill = "0.11.8"
   val mdoc = "2.5.2"
   val munit = "1.0.0"
   val pprint = "0.7.3"

--- a/tests/slow/src/test/scala/tests/mill/MillServerCodeLensSuite.scala
+++ b/tests/slow/src/test/scala/tests/mill/MillServerCodeLensSuite.scala
@@ -1,6 +1,7 @@
 package tests.mill
 
 import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.metals.debug.MUnit
 import scala.meta.internal.metals.{BuildInfo => V}
 
 import tests.BaseCodeLensLspSuite
@@ -31,8 +32,7 @@ class MillServerCodeLensSuite
            |class Foo extends munit.FunSuite {}
            |""".stripMargin,
         V.scala3,
-        V.millVersion,
-        includeMunit = true,
+        testDep = Some(MUnit),
       )
     )
 

--- a/tests/slow/src/test/scala/tests/mill/MillServerSuite.scala
+++ b/tests/slow/src/test/scala/tests/mill/MillServerSuite.scala
@@ -65,7 +65,7 @@ class MillServerSuite
       )
 
   test("too-old") {
-    writeLayout(MillBuildLayout("", V.scala213, preBspVersion))
+    writeLayout(MillBuildLayout("", V.scala213, testDep = None, preBspVersion))
     for {
       _ <- server.initialize()
       _ <- server.initialized()
@@ -93,7 +93,7 @@ class MillServerSuite
   private def testGenerationAndConnection(version: String) = {
     test(s"generate-and-connect-$version") {
       def millBspConfig = workspace.resolve(".bsp/mill-bsp.json")
-      writeLayout(MillBuildLayout("", V.scala213, version))
+      writeLayout(MillBuildLayout("", V.scala213, testDep = None, version))
       for {
         _ <- server.initialize()
         _ <- server.initialized()

--- a/tests/unit/src/main/scala/tests/BuildServerLayout.scala
+++ b/tests/unit/src/main/scala/tests/BuildServerLayout.scala
@@ -61,6 +61,7 @@ object MillBuildLayout extends BuildToolLayout {
       sourceLayout: String,
       scalaVersion: String,
       testDep: Option[TestFramework],
+      millVersion: String = V.millVersion,
   ): String = {
     val optDepModule =
       testDep.map {
@@ -84,7 +85,9 @@ object MillBuildLayout extends BuildToolLayout {
         case _ => ""
       }
 
-    s"""|/build.sc
+    s"""|/.mill-version
+        |$millVersion
+        |/build.sc
         |import mill._, scalalib._
         |
         |object a extends ScalaModule {
@@ -95,21 +98,20 @@ object MillBuildLayout extends BuildToolLayout {
         |""".stripMargin
   }
 
-  def apply(
-      sourceLayout: String,
-      scalaVersion: String,
-      millVersion: String,
-      includeMunit: Boolean = false,
-  ): String =
-    s"""|/.mill-version
-        |$millVersion
-        |${apply(sourceLayout, scalaVersion)}
-        |${apply(
-         sourceLayout,
-         scalaVersion,
-         if (includeMunit) Some(MUnit) else None,
-       )}
-        |""".stripMargin
+  // def apply(
+  //     sourceLayout: String,
+  //     scalaVersion: String,
+  //     millVersion: String,
+  //     includeMunit: Boolean = false,
+  // ): String =
+  //   s"""|${apply(sourceLayout, scalaVersion)}
+  //       |${apply(
+  //        sourceLayout,
+  //        scalaVersion,
+  //        if (includeMunit) Some(MUnit) else None,
+  //        millVersion,
+  //      )}
+  //       |""".stripMargin
 }
 
 object BazelBuildLayout extends BuildToolLayout {


### PR DESCRIPTION
Looks like using latest might be causing some issues, especially mtags not being resolved and causing a lag in the tests.