### PR TITLE
chore: Bump eclipse jdt and remove excludes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -429,70 +429,7 @@ lazy val metals = project
       "ch.epfl.scala" %% "scala-debug-adapter" % V.debugAdapter,
       // for finding paths of global log/cache directories
       "dev.dirs" % "directories" % "26",
-      // for Java formatting
-      "org.eclipse.jdt" % "org.eclipse.jdt.core" % "3.25.0" exclude ("*", "*"),
-      "org.eclipse.platform" % "org.eclipse.ant.core" % "3.5.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.compare.core" % "3.6.600" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.commands" % "3.9.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.contenttype" % "3.7.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.expressions" % "3.6.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.filesystem" % "1.7.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.jobs" % "3.10.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.resources" % "3.13.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.runtime" % "3.16.0" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.variables" % "3.4.600" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.equinox.app" % "1.4.300" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.equinox.common" % "3.10.600" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.equinox.preferences" % "3.7.600" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.equinox.registry" % "3.8.600" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.osgi" % "3.15.0" exclude ("*", "*"),
-      "org.eclipse.platform" % "org.eclipse.team.core" % "3.8.700" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.text" % "3.9.0" exclude ("*", "*"),
+      "org.eclipse.jdt" % "org.eclipse.jdt.core" % "3.25.0",
       // ==================
       // Scala dependencies
       // ==================


### PR DESCRIPTION
The excludes are no longer needed because we already compile on JDK 11+