### PR TITLE
improvement: Move jdt dependencies outside of build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -430,24 +430,69 @@ lazy val metals = project
       // for finding paths of global log/cache directories
       "dev.dirs" % "directories" % "26",
       // for Java formatting
-      "org.eclipse.jdt" % "org.eclipse.jdt.core" % "3.25.0" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.ant.core" % "3.5.500" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.compare.core" % "3.6.600" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.core.commands" % "3.9.500" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.core.contenttype" % "3.7.500" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.core.expressions" % "3.6.500" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.core.filesystem" % "1.7.500" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.core.jobs" % "3.10.500" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.core.resources" % "3.13.500" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.core.runtime" % "3.16.0" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.core.variables" % "3.4.600" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.equinox.app" % "1.4.300" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.equinox.common" % "3.10.600" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.equinox.preferences" % "3.7.600" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.equinox.registry" % "3.8.600" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.osgi" % "3.15.0" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.team.core" % "3.8.700" intransitive (),
-      "org.eclipse.platform" % "org.eclipse.text" % "3.9.0" intransitive (),
+      "org.eclipse.jdt" % "org.eclipse.jdt.core" % "3.25.0" exclude ("*", "*"),
+      "org.eclipse.platform" % "org.eclipse.ant.core" % "3.5.500" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.compare.core" % "3.6.600" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.core.commands" % "3.9.500" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.core.contenttype" % "3.7.500" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.core.expressions" % "3.6.500" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.core.filesystem" % "1.7.500" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.core.jobs" % "3.10.500" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.core.resources" % "3.13.500" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.core.runtime" % "3.16.0" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.core.variables" % "3.4.600" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.equinox.app" % "1.4.300" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.equinox.common" % "3.10.600" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.equinox.preferences" % "3.7.600" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.equinox.registry" % "3.8.600" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.osgi" % "3.15.0" exclude ("*", "*"),
+      "org.eclipse.platform" % "org.eclipse.team.core" % "3.8.700" exclude (
+        "*",
+        "*",
+      ),
+      "org.eclipse.platform" % "org.eclipse.text" % "3.9.0" exclude ("*", "*"),
       // ==================
       // Scala dependencies
       // ==================

--- a/build.sbt
+++ b/build.sbt
@@ -400,6 +400,8 @@ lazy val metals = project
     sharedSettings,
     Compile / run / fork := true,
     Compile / mainClass := Some("scala.meta.metals.Main"),
+    // for Java formatting
+    libraryDependencies ++= V.eclipseJdt,
     // As a general rule of thumb, we try to keep Scala dependencies to a minimum.
     libraryDependencies ++= List(
       // =================
@@ -429,70 +431,6 @@ lazy val metals = project
       "ch.epfl.scala" %% "scala-debug-adapter" % V.debugAdapter,
       // for finding paths of global log/cache directories
       "dev.dirs" % "directories" % "26",
-      // for Java formatting
-      "org.eclipse.jdt" % "org.eclipse.jdt.core" % "3.25.0" exclude ("*", "*"),
-      "org.eclipse.platform" % "org.eclipse.ant.core" % "3.5.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.compare.core" % "3.6.600" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.commands" % "3.9.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.contenttype" % "3.7.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.expressions" % "3.6.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.filesystem" % "1.7.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.jobs" % "3.10.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.resources" % "3.13.500" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.runtime" % "3.16.0" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.core.variables" % "3.4.600" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.equinox.app" % "1.4.300" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.equinox.common" % "3.10.600" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.equinox.preferences" % "3.7.600" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.equinox.registry" % "3.8.600" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.osgi" % "3.15.0" exclude ("*", "*"),
-      "org.eclipse.platform" % "org.eclipse.team.core" % "3.8.700" exclude (
-        "*",
-        "*",
-      ),
-      "org.eclipse.platform" % "org.eclipse.text" % "3.9.0" exclude ("*", "*"),
       // ==================
       // Scala dependencies
       // ==================

--- a/project/V.scala
+++ b/project/V.scala
@@ -52,6 +52,72 @@ object V {
   val lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % lsp4jV
   val dap4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j.debug" % lsp4jV
 
+  val eclipseJdt = Seq(
+    "org.eclipse.jdt" % "org.eclipse.jdt.core" % "3.25.0" exclude ("*", "*"),
+    "org.eclipse.platform" % "org.eclipse.ant.core" % "3.5.500" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.compare.core" % "3.6.600" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.core.commands" % "3.9.500" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.core.contenttype" % "3.7.500" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.core.expressions" % "3.6.500" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.core.filesystem" % "1.7.500" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.core.jobs" % "3.10.500" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.core.resources" % "3.13.500" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.core.runtime" % "3.16.0" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.core.variables" % "3.4.600" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.equinox.app" % "1.4.300" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.equinox.common" % "3.10.600" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.equinox.preferences" % "3.7.600" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.equinox.registry" % "3.8.600" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.osgi" % "3.15.0" exclude ("*", "*"),
+    "org.eclipse.platform" % "org.eclipse.team.core" % "3.8.700" exclude (
+      "*",
+      "*",
+    ),
+    "org.eclipse.platform" % "org.eclipse.text" % "3.9.0" exclude ("*", "*"),
+  )
+
   def semanticdb(scalaVersion: String) =
     SemanticDbSupport.last.getOrElse(scalaVersion, scalameta)
 


### PR DESCRIPTION

Turns out sbt reports a bunch of warnings in this case and there is no other way to deal with it :/