### PR TITLE
chore: Add support for Scala 3.3.4-RC1

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
@@ -81,7 +81,7 @@ object MtagsResolver {
 
   class Default extends MtagsResolver {
 
-    private val firstScala3PCVersion = "3.3.4"
+    private val firstScala3PCVersion = "3.3.4-RC1"
     private val states =
       new ConcurrentHashMap[String, State]()
 


### PR DESCRIPTION
I totally forgot that the current state is from 3.3.4 full versions and we count 3.3.4-RC1 as being before it.

Will release separate for the last two metals versions