### PR TITLE
Disable OrganizeImports commands if they are not available

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionBuilder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionBuilder.scala
@@ -16,6 +16,7 @@ object CodeActionBuilder {
       documentChanges: List[DocumentChange] = Nil,
       command: Option[l.Command] = None,
       diagnostics: List[l.Diagnostic] = Nil,
+      disabledReason: Option[String] = None,
   ): l.CodeAction = {
     val codeAction = new l.CodeAction()
     codeAction.setTitle(title)
@@ -41,6 +42,9 @@ object CodeActionBuilder {
 
     codeAction.setEdit(workspaceEdits)
     command.foreach(codeAction.setCommand)
+    disabledReason.foreach(reason =>
+      codeAction.setDisabled(new l.CodeActionDisabled(reason))
+    )
     codeAction.setDiagnostics(diagnostics.asJava)
     codeAction
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
@@ -36,7 +36,6 @@ final class CodeActionProvider(
       scalafixProvider,
       buildTargets,
       diagnostics,
-      languageClient,
     ),
     new OrganizeImportsQuickFix(
       scalafixProvider,

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/OrganizeImports.scala
@@ -43,7 +43,7 @@ sealed abstract class OrganizeImports(
               title = this.title,
               kind = this.kind,
               disabledReason =
-                Some("Can not organize imports if file has error"),
+                Some("Cannot organize imports if the file has an error"),
             )
           )
         )

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1406,8 +1406,13 @@ final case class TestingServer(
         .asScala
         .map(_.asScala.filter(filterAction))
     } yield (
-      codeActions.toList,
-      codeActions.map(_.getTitle()).mkString("\n"),
+      codeActions.toList.filter(_.getDisabled() == null),
+      codeActions
+        .map(a =>
+          a.getTitle() +
+            Option(a.getDisabled()).fold("")(_ => " (disabled)")
+        )
+        .mkString("\n"),
     )
 
   def assertSemanticHighlight(

--- a/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/OrganizeImportsLspSuite.scala
@@ -286,7 +286,7 @@ class OrganizeImportsLspSuite
        |  val a: Int = "no one wants unused imports"
        |}
        |""".stripMargin,
-    "", // This should give back no code action
+    s"${SourceOrganizeImports.title} (disabled)",
     """|package a
        |
        |import java.time.Instant


### PR DESCRIPTION
Rather than having Metals show a warning message, leave it to the client to decide on what to do with the reason for why they are disabled, and if/how it should be displayed.

Fixes https://github.com/scalameta/metals-zed/issues/14

Then it looks like this in VS Code:
![organize-imports-disabled-vscode](https://github.com/user-attachments/assets/41a6cac2-bf63-4fdf-80f3-6d5b5637f7a4)
