### PR TITLE
fix: by-max on empty

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -253,7 +253,7 @@ final class BuildTargets private (
   ): Option[BuildTargetIdentifier] = {
     val buildTargets = sourceBuildTargets(source)
     val orSbtBuildTarget =
-      buildTargets.getOrElse(sbtBuildScalaTarget(source).toIterable)
+      buildTargets.getOrElse(sbtBuildScalaTarget(source).toIterable).toSeq
     if (orSbtBuildTarget.isEmpty) {
       tables
         .flatMap(_.dependencySources.getBuildTarget(source))


### PR DESCRIPTION
fixes: https://github.com/scalameta/metals/actions/runs/10003222130/job/27649766803#step:4:1457

It seems `sourceBuildTargets` returns something mutable.