### PR TITLE
bugfix: Retry deleting Bloop folders

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BloopDir.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopDir.scala
@@ -1,13 +1,26 @@
 package scala.meta.internal.metals
 
+import scala.util.control.NonFatal
+
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
 
 object BloopDir {
+
+  private def deleteWithRetry(f: AbsolutePath, retry: Int = 3): Unit = try {
+    f.deleteRecursively()
+  } catch {
+    case NonFatal(e) =>
+      if (retry > 0) deleteWithRetry(f, retry - 1)
+      else throw e
+  }
+
   def clear(workspace: AbsolutePath): Unit = {
     val bloopDir = workspace.resolve(".bloop")
     bloopDir.list.foreach { f =>
-      if (f.exists && f.isDirectory) f.deleteRecursively()
+      if (f.exists && f.isDirectory) {
+        deleteWithRetry(f)
+      }
     }
     val remainingDirs =
       bloopDir.list.filter(f => f.exists && f.isDirectory).toList


### PR DESCRIPTION
It seems there is a race when shutting down and some directories are also being deleted by Bloop. The retry should be enough to help out.

Fixes https://github.com/scalameta/metals/issues/6612