### PR TITLE
fix: always start scala-cli if no build tool

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -428,7 +428,6 @@ class ProjectMetalsLspService(
     if (
       !buildTools.isAutoConnectable()
       && buildTools.loadSupported().isEmpty
-      && (folder.isScalaProject() || focusedDocument().exists(_.isScala))
     ) {
       scalaCli.setupIDE(folder)
     } else Future.successful(())


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/6283

We don't need to check here if it is a scala project, it has to be for `ProjectMetalsLspService` to be created.