### PR TITLE
bugfix: Only detect 100% sure test names

### DIFF
--- a/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/TestSuitesProviderSuite.scala
@@ -285,6 +285,7 @@ class TestSuitesProviderSuite extends BaseLspSuite("testSuitesFinderSuite") {
         |      println(name)
         |      assertEquals(n1, n2)
         |    }
+        |  test("test1" + "test2") {}
         |}
         |""".stripMargin,
     List("app/src/main/scala/a/b/c/MunitTestSuite.scala"),


### PR DESCRIPTION
Previously, we would treat any string literal inside the apply of a test function as a name of such function, but each test name can actually be any kind of expression, so we would not detect the correc tname always.

Now, we only detect names of tests if they are of an expected format, either simple string, select or a tag.

Fixes https://github.com/scalameta/metals/issues/6617