### PR TITLE
improvement: Fall back to current Scala version in unit tests

### DIFF
--- a/tests/slow/src/test/scala/tests/feature/CrossReferenceSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CrossReferenceSuite.scala
@@ -2,11 +2,15 @@ package tests.feature
 
 import scala.concurrent.Future
 
+import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.{BuildInfo => V}
 
 import tests.BaseRangesSuite
 
 class CrossReferenceSuite extends BaseRangesSuite("cross-reference-suite") {
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(fallbackScalaVersion = Some(V.scala3))
 
   check(
     "references-scala3",

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -6,6 +6,7 @@ import scala.concurrent.Promise
 import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ServerCommands
+import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.{BuildInfo => V}
 
 import org.eclipse.lsp4j.MessageActionItem
@@ -13,6 +14,11 @@ import org.eclipse.lsp4j.MessageActionItem
 abstract class BaseAmmoniteSuite(scalaVersion: String)
     extends BaseLspSuite(s"ammonite-$scalaVersion")
     with ScriptsAssertions {
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(
+      fallbackScalaVersion = Some(scalaVersion)
+    )
 
   override def munitIgnore: Boolean =
     !isValidScalaVersionForEnv(scalaVersion)

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -36,7 +36,8 @@ abstract class BaseLspSuite(
 ) extends BaseSuite {
   MetalsLogger.updateDefaultFormat()
   def icons: Icons = Icons.default
-  def userConfig: UserConfiguration = UserConfiguration()
+  def userConfig: UserConfiguration =
+    UserConfiguration(fallbackScalaVersion = Some(BuildInfo.scalaVersion))
   def serverConfig: MetalsServerConfig = MetalsServerConfig.default
   def time: Time = Time.system
   implicit val ex: ExecutionContextExecutorService =

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -22,7 +22,12 @@ abstract class BaseWorksheetLspSuite(
     )
 
   override def userConfig: UserConfiguration =
-    super.userConfig.copy(worksheetScreenWidth = 40, worksheetCancelTimeout = 1)
+    super.userConfig.copy(
+      worksheetScreenWidth = 40,
+      worksheetCancelTimeout = 1,
+      fallbackScalaVersion = Some(scalaVersion),
+    )
+
   override def munitIgnore: Boolean = !isValidScalaVersionForEnv(scalaVersion)
 
   def versionSpecificCodeToValidate: String = ""

--- a/tests/unit/src/test/scala/tests/FileWatcherLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/FileWatcherLspSuite.scala
@@ -10,6 +10,7 @@ import scala.meta.internal.metals.RecursivelyDelete
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams
 import org.eclipse.lsp4j.FileChangeType
 import org.eclipse.lsp4j.FileEvent
+
 class FileWatcherLspSuite extends BaseLspSuite("file-watcher") {
 
   override protected def initializationOptions: Option[InitializationOptions] =

--- a/tests/unit/src/test/scala/tests/SingleFileSuite.scala
+++ b/tests/unit/src/test/scala/tests/SingleFileSuite.scala
@@ -5,27 +5,29 @@ class SingleFileSuite extends BaseCompletionLspSuite("workspaceFolderSuite") {
   test("basic") {
     cleanWorkspace()
     val newFileContent =
-      """|/A.scala
-         |case class MyObjectA() {
-         |  val <<foo@@>>: String = "aaa"
-         |  val j = <<foo>> + "a"
-         |}
-         |""".stripMargin
+      s"""|//> using scala ${BuildInfo.scalaVersion}
+          |case class MyObjectA() {
+          |  val <<foo@@>>: String = "aaa"
+          |  val j = <<foo>> + "a"
+          |}
+          |""".stripMargin
 
     writeLayout(
-      """|/A.scala
-         |case class MyObjectA() {
-         |  val i: Int = "aaa"
-         |}
-         |""".stripMargin
+      s"""|/A.scala
+          |//> using scala ${BuildInfo.scalaVersion}
+          |case class MyObjectA() {
+          |  val i: Int = "aaa"
+          |}
+          |""".stripMargin
     )
     for {
       _ <- initialize(Map.empty[String, String], expectError = false)
       _ <- server.didOpen("A.scala")
       _ = assertNoDiff(
         server.client.workspaceDiagnostics,
-        """|A.scala:2:16: error: Found:    ("aaa" : String)
-           |Required: Int
+        """|A.scala:3:16: error: type mismatch;
+           | found   : String("aaa")
+           | required: Int
            |  val i: Int = "aaa"
            |               ^^^^^
            |""".stripMargin,


### PR DESCRIPTION
Thanks to this we should get less timeouts as we will not try to resolve Scala 3, which will not be available anyway.