### PR TITLE
improvement: Specifically choose which targets to compile

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -68,17 +68,25 @@ final class Compilations(
 
   def previouslyCompiled: Iterable[b.BuildTargetIdentifier] = lastCompile
 
-  def compilationFinished(targets: Seq[BuildTargetIdentifier]): Future[Unit] =
+  def compilationFinished(
+      targets: Seq[BuildTargetIdentifier],
+      compileInverseDependencies: Boolean,
+  ): Future[Unit] =
     if (currentlyCompiling.isEmpty) {
       Future(())
-    } else {
+    } else if (compileInverseDependencies) {
       cascadeCompile(targets)
+    } else {
+      compileTargets(targets)
     }
 
   def compilationFinished(
-      source: AbsolutePath
+      source: AbsolutePath,
+      compileInverseDependencies: Boolean,
   ): Future[Unit] =
-    expand(source).flatMap(targets => compilationFinished(targets.toSeq))
+    expand(source).flatMap(targets =>
+      compilationFinished(targets.toSeq, compileInverseDependencies)
+    )
 
   def compileTarget(
       target: b.BuildTargetIdentifier


### PR DESCRIPTION
Previously, we would wait for full compilation for debugger and scalafix, however that is not needed, we only need to compile the current target in that case.

Now, we specify it explicitly.

The change is really small, ignore whitespaces option will show it.