### PR TITLE
bugfix: Disable best effort compilation by default

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -612,7 +612,12 @@ object BuildServerConnection {
           Cancelable(() => listening.cancel(false))
         val result =
           try {
-            BuildServerConnection.initialize(projectRoot, server, serverName)
+            BuildServerConnection.initialize(
+              projectRoot,
+              server,
+              serverName,
+              config,
+            )
           } catch {
             case e: TimeoutException =>
               conn.cancelables.foreach(_.cancel())
@@ -705,12 +710,13 @@ object BuildServerConnection {
       workspace: AbsolutePath,
       server: MetalsBuildServer,
       serverName: String,
+      config: MetalsServerConfig,
   ): InitializeBuildResult = {
     val extraParams = BspExtraBuildParams(
       BuildInfo.javaSemanticdbVersion,
       BuildInfo.scalametaVersion,
       BuildInfo.supportedScala2Versions.asJava,
-      true,
+      config.enableBestEffort,
     )
 
     val capabilities = new BuildClientCapabilities(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -120,6 +120,10 @@ final case class MetalsServerConfig(
         .filter(_.forall(Character.isDigit(_)))
         .map(_.toInt)
         .getOrElse(60),
+    enableBestEffort: Boolean = MetalsServerConfig.binaryOption(
+      "metals.enable-best-effort",
+      default = false,
+    ),
 ) {
   override def toString: String =
     List[String](
@@ -143,6 +147,7 @@ final case class MetalsServerConfig(
       s"build-server-ping-interval=${pingInterval}",
       s"worksheet-timeout=$worksheetTimeout",
       s"debug-server-start-timeout=$debugServerStartTimeout",
+      s"enable-best-effort=$enableBestEffort",
     ).mkString("MetalsServerConfig(\n  ", ",\n  ", "\n)")
 }
 object MetalsServerConfig {

--- a/tests/unit/src/test/scala/tests/best-effort/BestEffortCompilationSuite.scala
+++ b/tests/unit/src/test/scala/tests/best-effort/BestEffortCompilationSuite.scala
@@ -1,10 +1,15 @@
 package tests.`best-effort`
 
+import scala.meta.internal.metals.MetalsServerConfig
+
 import tests.BaseNonCompilingLspSuite
 
 class BestEffortCompilationSuite
     extends BaseNonCompilingLspSuite("best-effort-compilation") {
   val scalaVersion = "3.5.0-RC1"
+
+  override def serverConfig: MetalsServerConfig =
+    super.serverConfig.copy(enableBestEffort = true)
 
   override val scalaVersionConfig = s"\"scalaVersion\": \"${scalaVersion}\""
   override val saveAfterChanges: Boolean = true


### PR DESCRIPTION
Looks like sometimes best effort artifacts are being produced despite the fact that compilation finished successfully. I think this actually causes downstream module to fail the compilation.

I've put it into server config mostly because I don't really want users to have to tinker with that. Once it works it should be enabled always.

Helps with https://github.com/scalameta/metals/issues/6628