### PR TITLE
improvement: Further heuristic improvements

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/mtags/KeywordWrapper.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/mtags/KeywordWrapper.scala
@@ -11,9 +11,12 @@ trait KeywordWrapper {
 
   def keywords: Set[String]
 
-  final def needsBacktick(s: String): Boolean = {
+  final def needsBacktick(
+      s: String,
+      wrapOperators: Boolean = false
+  ): Boolean = {
     val chunks = s.split("_", -1)
-    def validOperator(c: Char) = {
+    def validOperator(c: Char) = !wrapOperators && {
       c.getType == Character.MATH_SYMBOL ||
       c.getType == Character.OTHER_SYMBOL ||
       "!#%&*+-/:<=>?@\\^|~".contains(c)
@@ -45,12 +48,13 @@ trait KeywordWrapper {
 
   final def backtickWrap(
       s: String,
-      exclusions: Set[String] = Set.empty
+      exclusions: Set[String] = Set.empty,
+      wrapOperators: Boolean = false
   ): String = {
     if (exclusions.contains(s)) s
     else if (s.isEmpty) "``"
     else if (s(0) == '`' && s.last == '`') s
-    else if (needsBacktick(s)) "" + ('`') + s + '`'
+    else if (needsBacktick(s, wrapOperators)) "" + ('`') + s + '`'
     else s
   }
 }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/Symbol.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/Symbol.scala
@@ -161,7 +161,8 @@ object Symbol {
       case ((prefix, insideObject), next) =>
         val name = keywordWrapper.backtickWrap(
           next.replace("\\", ""),
-          Set("this", "package")
+          Set("this", "package"),
+          wrapOperators = true
         )
         if (prefix.isEmpty())
           (name, /*insideObject =*/ name.find(_.isLetter).exists(_.isUpper))


### PR DESCRIPTION
Couple of related improvements:
- escape operators, they are escaped for semanticdb symbols ( otherwise ??? will not be found)
- add standard Scala imports (needed for scala.Predef.`???`().)
- also try and guess method with (). ending
- check if the returned symbol is exactly the same as we were looking for (could not reproduce it 100% the same as I encountered in the wild, but it's close enough)