### PR TITLE
bugfix: Use default bloop properties if provided empty array

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -333,8 +333,8 @@ final class BloopServers(
       )
 
     userConfig.flatMap(_.bloopJvmProperties) match {
-      case None => config
-      case Some(opts) => config.copy(javaOpts = opts)
+      case Some(opts) if opts.nonEmpty => config.copy(javaOpts = opts)
+      case _ => config
     }
   }
 


### PR DESCRIPTION
Empty array is a default value, so this would start Bloop with no options as default.