### PR TITLE
fix: use uri from params in pc for location

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -119,9 +119,7 @@ final class DefinitionProvider(
           .definition(path, params, isScala3)
           .orElse(fallback.search(path, params.getPosition(), isScala3))
           .getOrElse(definition)
-      } else {
-        definition
-      }
+      } else definition
     }
   }
 

--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -102,12 +102,6 @@ object MtagsEnrichments extends ScalametaCommonEnrichments:
     def focusAt(point: Int): SourcePosition =
       pos.withSpan(pos.span.withPoint(point).focus)
 
-    def toLocation: Option[l.Location] =
-      for
-        uri <- InteractiveDriver.toUriOption(pos.source)
-        range <- if pos.exists then Some(pos.toLsp) else None
-      yield new l.Location(uri.toString, range)
-
     def encloses(other: SourcePosition): Boolean =
       pos.start <= other.start && pos.end >= other.end
 

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -128,13 +128,13 @@ class PcDefinitionProvider(
             defs.headOption match
               case Some(srcTree) =>
                 val pos = srcTree.namePos
-                pos.toLocation match
-                  case None => DefinitionResultImpl.empty
-                  case Some(loc) =>
-                    DefinitionResultImpl(
-                      SemanticdbSymbols.symbolName(sym),
-                      List(loc).asJava,
-                    )
+                if pos.exists then
+                  val loc = new Location(params.uri().toString(), pos.toLsp)
+                  DefinitionResultImpl(
+                    SemanticdbSymbols.symbolName(sym),
+                    List(loc).asJava,
+                  )
+                else DefinitionResultImpl.empty
               case None =>
                 alternative(sym) match
                   case Some(alt) => findDefsForSymbol(alt)


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/6680

We use presentation compiler to find the definition of this symbol. (This happens also if using semanticdb the found symbol isn't exactly as expected). Since this is a jar `InteractiveDriver.toUriOption(pos.source)` did not return correct full uri but only `/com/monovore/decline/opts.scala`.