### PR TITLE
improvement: if no binary version in jar path try using build target info

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -396,7 +396,8 @@ final class ImplementationProvider(
   }
 
   private def semanticdbForJarFile(fileSource: AbsolutePath) = {
-    val dialect = ScalaVersions.dialectForDependencyJar(fileSource.filename)
+    val dialect =
+      ScalaVersions.dialectForDependencyJar(fileSource, buildTargets)
     FileIO.slurp(fileSource, StandardCharsets.UTF_8)
     val textDocument = Mtags.index(fileSource, dialect)
     textDocument

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -415,7 +415,7 @@ case class Indexer(indexProviders: IndexProviders)(implicit rc: ReportContext) {
       case Right(zip) =>
         scribe.debug(s"Indexing JDK sources from $zip")
         usedJars += zip
-        val dialect = ScalaVersions.dialectForDependencyJar(zip.filename)
+        val dialect = ScalaVersions.dialectForDependencyJar(zip, buildTargets)
         sharedIndices.jvmTypeHierarchy.getTypeHierarchy(zip) match {
           case Some(overrides) =>
             definitionIndex.addIndexedSourceJar(zip, Nil, dialect)
@@ -540,7 +540,7 @@ case class Indexer(indexProviders: IndexProviders)(implicit rc: ReportContext) {
    * @param path JAR path
    */
   private def addSourceJarSymbols(path: AbsolutePath): Unit = {
-    val dialect = ScalaVersions.dialectForDependencyJar(path.filename)
+    val dialect = ScalaVersions.dialectForDependencyJar(path, buildTargets)
     tables.jarSymbols.getTopLevels(path) match {
       case Some(toplevels) =>
         tables.jarSymbols.getTypeHierarchy(path) match {

--- a/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StandaloneSymbolSearch.scala
@@ -44,7 +44,10 @@ class StandaloneSymbolSearch(
 
   private val index = OnDemandSymbolIndex.empty()
   sources.foreach(s =>
-    index.addSourceJar(s, ScalaVersions.dialectForDependencyJar(s.filename))
+    index.addSourceJar(
+      s,
+      ScalaVersions.dialectForDependencyJar(s, buildTargets),
+    )
   )
 
   private val docs = new Docstrings(index)

--- a/metals/src/main/scala/scala/meta/internal/metals/TargetData.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/TargetData.scala
@@ -206,9 +206,10 @@ final class TargetData {
     }
   }
 
-  def findSourceJarOf(
+  def findConnectedArtifact(
       jar: AbsolutePath,
       targetId: Option[BuildTargetIdentifier],
+      classifier: String = "sources",
   ): Option[AbsolutePath] = {
     val jarUri = jar.toURI.toString()
     def depModules: Iterator[MavenDependencyModule] = targetId match {
@@ -228,10 +229,10 @@ final class TargetData {
       module <- depModules
       artifacts = module.getArtifacts().asScala
       if artifacts.exists(artifact => isUriEqual(artifact.getUri(), jarUri))
-      sourceJar <- artifacts.find(_.getClassifier() == "sources")
-      sourceJarPath = sourceJar.getUri().toAbsolutePath
-      if sourceJarPath.exists
-    } yield sourceJarPath
+      foundJar <- artifacts.find(_.getClassifier() == classifier)
+      foundJarPath = foundJar.getUri().toAbsolutePath
+      if foundJarPath.exists
+    } yield foundJarPath
     allFound.headOption
   }
 

--- a/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/tvp/MetalsTreeViewProvider.scala
@@ -132,9 +132,8 @@ class MetalsTreeViewProvider(
     val dialect =
       if (path.isJarFileSystem) {
         path.jarPath
-          .map { p =>
-            ScalaVersions.dialectForDependencyJar(p.filename)
-          }
+          .flatMap(p => ScalaVersions.scalaBinaryVersionFromJarName(p.filename))
+          .map(ScalaVersions.dialectForScalaVersion(_, includeSource3 = true))
           .getOrElse(dialects.Scala3)
       } else dialectFromWorkspace
     val input = path.toInput
@@ -264,7 +263,7 @@ class FolderTreeViewProvider(
     valueTooltip = _.toString,
     toplevels = () => buildTargets.allSourceJars.filter(_.exists),
     loadSymbols = (path, symbol) => {
-      val dialect = ScalaVersions.dialectForDependencyJar(path.filename)
+      val dialect = ScalaVersions.dialectForDependencyJar(path, buildTargets)
       classpath.jarSymbols(path, symbol, dialect)
     },
     toplevelIcon = "package",

--- a/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
+++ b/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
@@ -81,7 +81,11 @@ object MetalsTestEnrichments {
       }
       libraries.foreach(
         _.sources.entries.foreach { s =>
-          val dialect = ScalaVersions.dialectForDependencyJar(s.filename)
+          val version = ScalaVersions
+            .scalaBinaryVersionFromJarName(s.filename)
+            .getOrElse("2.13")
+          val dialect =
+            ScalaVersions.dialectForScalaVersion(version, includeSource3 = true)
           wsp.index.addSourceJar(s, dialect)
         }
       )

--- a/tests/unit/src/test/scala/tests/DefinitionSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionSuite.scala
@@ -45,9 +45,15 @@ abstract class DefinitionSuiteBase(
     // Step 2. Index dependency sources
     index.addSourceJar(JdkSources().right.get, dialect)
     input.dependencySources.entries.foreach { jar =>
+      val scalaVersion = ScalaVersions
+        .scalaBinaryVersionFromJarName(jar.filename)
+        .getOrElse("2.13")
       index.addSourceJar(
         jar,
-        ScalaVersions.dialectForDependencyJar(jar.filename),
+        ScalaVersions.dialectForScalaVersion(
+          scalaVersion,
+          includeSource3 = true,
+        ),
       )
     }
 

--- a/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaVersionsSuite.scala
@@ -316,7 +316,7 @@ class ScalaVersionsSuite extends BaseSuite {
   checkJar("tested-3.0-sources.jar", "2.13")
 
   def checkJar(jar: String, expected: String): Unit = test(jar) {
-    val out = ScalaVersions.scalaBinaryVersionFromJarName(jar)
+    val out = ScalaVersions.scalaBinaryVersionFromJarName(jar).getOrElse("2.13")
     assertEquals(out, expected, jar)
   }
 


### PR DESCRIPTION
For jars if no scala version included in the path, fallback to using scala version from build target before defaulting to "2.13".

resolves: https://github.com/scalameta/metals/issues/6693