### PR TITLE
fix: index top level with inner when apply with `{ }` in method

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
@@ -983,6 +983,9 @@ class ScalaToplevelMtags(
       !isDone &&
       (curr.token match {
         case SEMI => false
+        case LBRACE =>
+          acceptBalancedDelimeters(LBRACE, RBRACE)
+          true
         case _ => !isNewline
       })
     ) {

--- a/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
@@ -765,4 +765,23 @@ class ScalaToplevelSuite extends BaseToplevelSuite {
     dialect = dialects.Scala3,
     mode = All,
   )
+
+  check(
+    "i6712",
+    """"
+      |package a
+      |
+      |trait Strict
+      |
+      |object FormData {
+      |  def apply() = Strict {
+      |    _ => true
+      |  }
+      |  case class Strict(i: Unit => Boolean)
+      |}
+      |
+      |""".stripMargin,
+    List("a/", "a/FormData.", "a/Strict#", "a/FormData.Strict#"),
+    mode = ToplevelWithInner,
+  )
 }


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/6712