### PR TITLE
bugfix: Use metals Java versions as default

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -182,9 +182,9 @@ final class BloopServers(
   }
 
   private def metalsJavaHome(userConfiguration: UserConfiguration) =
-    userConfiguration.javaHome
+    sys.props
+      .get("java.home")
       .orElse(sys.env.get("JAVA_HOME"))
-      .orElse(sys.props.get("java.home"))
 
   private lazy val bloopLogger: BloopRifleLogger = new BloopRifleLogger {
     def info(msg: => String): Unit = scribe.info(msg)


### PR DESCRIPTION
~~Some distributions seem to require this to work, so it's safer to include it by default.~~

I reworked it, since the problem was actually different, we used wrong Java home, which might have been older.
