### PR TITLE
bugfix: Set semanticdb version correctly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ def crossSetting[A](
 logo := Welcome.logo
 usefulTasks := Welcome.tasks
 
-ThisBuild / scalafixScalaBinaryVersion := scalaBinaryVersion.value
+ThisBuild / semanticdbVersion := V.semanticdb(scalaVersion.value)
 
 inThisBuild(
   List(


### PR DESCRIPTION
Should fix https://github.com/scalameta/metals/issues/6694

I am not super sure why this doesn't actually break for me or the CI, but anyway this should work correctly now.