### PR TITLE
improvement: Ignore single failing file

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
@@ -41,7 +41,7 @@ final class OnDemandSymbolIndex(
   private def getOrCreateBucket(dialect: Dialect): SymbolIndexBucket =
     dialectBuckets.getOrElseUpdate(
       dialect,
-      SymbolIndexBucket.empty(dialect, mtags, toIndexSource)
+      SymbolIndexBucket.empty(dialect, mtags, toIndexSource, onError)
     )
 
   override def definition(symbol: Symbol): Option[SymbolDefinition] = {


### PR DESCRIPTION
One file failing to tokenize should not cause the entire jar to not be tokenized.

This was prompted by /doobie/free/kleisliinterpreter.scala which was ended in the middle inside the sources.

Fixes https://github.com/scalameta/metals/issues/6717