### PR TITLE
bugfix: Don't hang on ProjectDirs

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsProjectDirectories.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsProjectDirectories.scala
@@ -1,0 +1,43 @@
+package scala.meta.internal.metals
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import dev.dirs.ProjectDirectories
+
+object MetalsProjectDirectories {
+
+  def from(qualifier: String, organization: String, application: String)(
+      implicit ec: ExecutionContext
+  ): Option[ProjectDirectories] =
+    wrap { () =>
+      ProjectDirectories.from(qualifier, organization, application)
+    }
+
+  def fromPath(path: String)(implicit
+      ec: ExecutionContext
+  ): Option[ProjectDirectories] =
+    wrap { () =>
+      ProjectDirectories.fromPath(path)
+    }
+
+  private def wrap(
+      f: () => ProjectDirectories
+  )(implicit ec: ExecutionContext): Option[ProjectDirectories] = {
+    Try {
+      val dirs = Future { f() }
+      Await.result(dirs, 10.seconds)
+
+    } match {
+      case Failure(exception) =>
+        scribe.error("Failed to get project directories", exception)
+        None
+      case Success(value) => Some(value)
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerInputs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerInputs.scala
@@ -3,6 +3,8 @@ package scala.meta.internal.metals
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 
+import scala.concurrent.ExecutionContext
+
 import scala.meta.internal.bsp.BspServers
 import scala.meta.internal.metals.Buffers
 import scala.meta.internal.metals.ClasspathSearch
@@ -69,7 +71,8 @@ object MetalsServerInputs {
       time = Time.system,
       initialServerConfig = MetalsServerConfig.default,
       initialUserConfig = UserConfiguration.default,
-      bspGlobalDirectories = BspServers.globalInstallDirectories,
+      bspGlobalDirectories =
+        BspServers.globalInstallDirectories(ExecutionContext.global),
       mtagsResolver = MtagsResolver.default(),
       onStartCompilation = () => (),
       redirectSystemOut = true,

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
@@ -354,7 +354,7 @@ private[debug] object DebugProxy {
       workspace: AbsolutePath,
       endpoint: RemoteEndpoint,
       name: String,
-  ): RemoteEndpoint =
+  )(implicit ec: ExecutionContext): RemoteEndpoint =
     Trace.setupTracePrinter(name, workspace) match {
       case Some(trace) => new EndpointLogger(endpoint, trace)
       case None => endpoint

--- a/metals/src/main/scala/scala/meta/metals/Main.scala
+++ b/metals/src/main/scala/scala/meta/metals/Main.scala
@@ -37,10 +37,10 @@ object Main extends SupportedScalaVersions {
     }
     val systemIn = System.in
     val systemOut = System.out
-    MetalsLogger.redirectSystemOut(Trace.metalsLog)
-    val tracePrinter = Trace.setupTracePrinter("LSP")
     val exec = Executors.newCachedThreadPool()
     val ec = ExecutionContext.fromExecutorService(exec)
+    MetalsLogger.redirectSystemOut(Trace.metalsLog(ec))
+    val tracePrinter = Trace.setupTracePrinter("LSP")(ec)
     val sh = Executors.newSingleThreadScheduledExecutor()
     val server = new MetalsLanguageServer(ec, sh)
     try {

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -123,5 +123,4 @@ object TestGroups {
       "tests.ServerLivenessMonitorSuite", "tests.ResetWorkspaceLspSuite",
       "tests.ToplevelWithInnerScala3Suite"),
   )
-
 }

--- a/tests/slow/src/main/scala/tests/scalacli/BaseScalaCLIActionSuite.scala
+++ b/tests/slow/src/main/scala/tests/scalacli/BaseScalaCLIActionSuite.scala
@@ -97,7 +97,7 @@ class BaseScalaCLIActionSuite(name: String)
       expectError,
       filterAction,
       overrideLayout = layout,
-      retryAction,
+      retryAction = retryAction,
     )
   }
 }

--- a/tests/slow/src/main/scala/tests/scalacli/BaseScalaCLIActionSuite.scala
+++ b/tests/slow/src/main/scala/tests/scalacli/BaseScalaCLIActionSuite.scala
@@ -66,7 +66,6 @@ class BaseScalaCLIActionSuite(name: String)
       changeFile: String => String = identity,
       expectError: Boolean = false,
       filterAction: CodeAction => Boolean = _ => true,
-      retryAction: Int = 0,
   )(implicit loc: Location): Unit = {
 
     val path = toPath(fileName)
@@ -97,7 +96,6 @@ class BaseScalaCLIActionSuite(name: String)
       expectError,
       filterAction,
       overrideLayout = layout,
-      retryAction = retryAction,
     )
   }
 }

--- a/tests/slow/src/test/scala/tests/scalacli/ScalaCliActionsSuite.scala
+++ b/tests/slow/src/test/scala/tests/scalacli/ScalaCliActionsSuite.scala
@@ -53,8 +53,6 @@ class ScalaCliActionsSuite
     scalaCliOptions = List("--actions", "-S", scalaVersion),
     expectNoDiagnostics = false,
     selectedActionIndex = 1,
-    // Scala CLI doesn't publish everything with the normal diagnostics, but later
-    retryAction = 5,
   )
 
   checkScalaCLI(
@@ -85,8 +83,6 @@ class ScalaCliActionsSuite
     scalaCliOptions = List("--actions", "-S", scalaVersion),
     expectNoDiagnostics = false,
     selectedActionIndex = 1,
-    // Scala CLI doesn't publish everything with the normal diagnostics, but later
-    retryAction = 5,
   )
 
   checkNoActionScalaCLI(

--- a/tests/unit/src/main/scala/tests/Library.scala
+++ b/tests/unit/src/main/scala/tests/Library.scala
@@ -87,7 +87,7 @@ object Library {
     val fetch = Fetch
       .create()
       .withMainArtifacts()
-      .withClassifiers(Set("sources", "_").asJava)
+      .addClassifiers("sources")
       .withDependencies(
         deps: _*
       )

--- a/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -141,6 +141,7 @@ abstract class BaseCodeActionLspSuite(
           case _: Throwable if expectError => Future.successful(Nil)
         }
     }
+
     test(name) {
       cleanWorkspace()
       for {


### PR DESCRIPTION
It seems in rare scenarios it's possible that the method ProjectDirs.from will hang. To fix that I wrapped it in a Future and added some fallbacks.

Not sure if this will fix everything, but that's my best try.

Should help with https://github.com/scalameta/metals/issues/6762