### PR TITLE
Finer grained accessibility check for  auto-imports

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -58,7 +58,8 @@ final class AutoImportsProvider(
       sym.name.dropLocal.decoded == name
 
     symbols.result().collect {
-      case sym if isExactMatch(sym, name) =>
+      case sym
+          if isExactMatch(sym, name) && context.isAccessible(sym, sym.info) =>
         val pkg = sym.owner.fullName
         val edits = importPosition match {
           // if we are in import section just specify full name

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/WorkspaceSymbolSearch.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/WorkspaceSymbolSearch.scala
@@ -153,7 +153,7 @@ trait WorkspaceSymbolSearch { compiler: MetalsGlobal =>
 
       var added = 0
       for {
-        sym <- loadSymbolFromClassfile(top)
+        sym <- loadSymbolFromClassfile(top, context)
         if context.lookupSymbol(sym.name, _ => true).symbol != sym
       } {
         if (visitMember(sym)) {
@@ -183,13 +183,11 @@ trait WorkspaceSymbolSearch { compiler: MetalsGlobal =>
   }
 
   private def loadSymbolFromClassfile(
-      classfile: SymbolSearchCandidate
+      classfile: SymbolSearchCandidate,
+      context: Context
   ): List[Symbol] = {
     def isAccessible(sym: Symbol): Boolean = {
-      sym != NoSymbol && {
-        sym.info // needed to fill complete symbol
-        sym.isPublic
-      }
+      context.isAccessible(sym, sym.info)
     }
     try {
       classfile match {

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompilerSearchVisitor.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompilerSearchVisitor.scala
@@ -28,7 +28,7 @@ class CompilerSearchVisitor(
     owner.isStatic && owner.isPublic
 
   private def isAccessible(sym: Symbol): Boolean = try
-    sym != NoSymbol && sym.isPublic && sym.isStatic ||
+    (sym != NoSymbol && sym.isAccessibleFrom(ctx.owner.info) && sym.isStatic) ||
       isAccessibleImplicitClass(sym)
   catch
     case err: AssertionError =>

--- a/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSnippetSuite.scala
@@ -185,7 +185,6 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
            |ArrayDequeOps[$0]
            |ArrayDeque
            |ArrayDeque
-           |ArrayDequeOps
            |""".stripMargin
     )
   )
@@ -472,11 +471,16 @@ class CompletionSnippetSuite extends BaseCompletionSuite {
        |WindowEvent -  java.awt.event
        |""".stripMargin,
     compat = Map(
-      ">=2.13.0" -> """|Widget -  example
-                       |Window -  java.awt
-                       |WindowPeer -  java.awt.peer
-                       |WithFilter -  scala.collection
-                       |""".stripMargin
+      "2.13" -> """|Widget -  example
+                   |Window -  java.awt
+                   |WindowPeer -  java.awt.peer
+                   |WithFilter -  scala.collection
+                   |""".stripMargin,
+      "3" -> """|Widget -  example
+                |Window -  java.awt
+                |WindowPeer -  java.awt.peer
+                |WithFilter($0) - [A](p: A => Boolean, xs: Array[A]): WithFilter[A]
+                |""".stripMargin
     ),
     includeDetail = true,
     topLines = Some(4)

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -360,18 +360,16 @@ class CompletionSuite extends BaseCompletionSuite {
        |PKIXCertPathBuilderResult - java.security.cert
        |""".stripMargin,
     compat = Map(
-      "2" ->
-        """|ProcessBuilder java.lang
-           |ProcessBuilder - scala.sys.process
-           |CertPathBuilder - java.security.cert
-           |CertPathBuilderSpi - java.security.cert
-           |ProcessBuilderImpl - scala.sys.process
-           |CertPathBuilderResult - java.security.cert
-           |PKIXBuilderParameters - java.security.cert
-           |PooledConnectionBuilder - javax.sql
-           |CertPathBuilderException - java.security.cert
-           |PKIXCertPathBuilderResult - java.security.cert
-           |""".stripMargin
+      "3" -> """|ProcessBuilder java.lang
+                |ProcessBuilder - scala.sys.process
+                |CertPathBuilder - java.security.cert
+                |CertPathBuilderSpi - java.security.cert
+                |CertPathBuilderResult - java.security.cert
+                |PKIXBuilderParameters - java.security.cert
+                |PooledConnectionBuilder - javax.sql
+                |CertPathBuilderException - java.security.cert
+                |PKIXCertPathBuilderResult - java.security.cert
+                |""".stripMargin
     )
   )
 

--- a/tests/cross/src/test/scala/tests/pc/ShadowingCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/ShadowingCompletionSuite.scala
@@ -27,7 +27,12 @@ class ShadowingCompletionSuite extends BaseCompletionSuite {
        |ListBuffer - scala.collection.mutable
        |""".stripMargin,
     compat = Map(
-      "2" -> "ListBuffer - scala.collection.mutable"
+      "2" -> "ListBuffer - scala.collection.mutable",
+      "3" -> """|ListBuffer[A](elems: A*): CC[A]
+                |ListBuffer(i: Int): A
+                |ListBuffer - scala.collection.mutable
+                |ListBuffer - coursierapi.shaded.scala.collection.mutable
+                |""".stripMargin
     )
   )
 }

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -285,4 +285,93 @@ class ImportMissingSymbolLspSuite
        |}
        |""".stripMargin,
   )
+
+  check(
+    "i6732-happy",
+    s"""|package example.a {
+        |  private [example] object A {
+        |    val foo = "foo"
+        |  }
+        |}
+        |package example.b {
+        |  object B {
+        |    val bar = <<A>>.foo
+        |  }
+        |}
+        |""".stripMargin,
+    s"""|${ImportMissingSymbol.title("A", "example.a")}
+        |${CreateNewSymbol.title("A")}
+        |""".stripMargin,
+    s"""|package example.a {
+        |  private [example] object A {
+        |    val foo = "foo"
+        |  }
+        |}
+        |package example.b {
+        |
+        |  import _root_.example.a.A
+        |  object B {
+        |    val bar = A.foo
+        |  }
+        |}
+        |""".stripMargin,
+  )
+
+  check(
+    "i6732-negative (private)",
+    s"""|package example.a {
+        |  private object A {
+        |    val foo = "foo"
+        |  }
+        |}
+        |package example.b {
+        |  object B {
+        |    val bar = <<A>>
+        |  }
+        |}
+        |""".stripMargin,
+    "",
+    s"""|package example.a {
+        |  private object A {
+        |    val foo = "foo"
+        |  }
+        |}
+        |package example.b {
+        |  object B {
+        |    val bar = A
+        |  }
+        |}
+        |""".stripMargin,
+    expectNoDiagnostics = false,
+    filterAction = _.getTitle() == ImportMissingSymbol.title("A", "example.a"),
+  )
+
+  check(
+    "i6732-negative (private with out of path access boundary)",
+    s"""|package exampleA.a {
+        |  private [exampleA] object A {
+        |    val foo = "foo"
+        |  }
+        |}
+        |package exampleB.b {
+        |  object B {
+        |    val bar = <<A>>
+        |  }
+        |}
+        |""".stripMargin,
+    "",
+    s"""|package exampleA.a {
+        |  private [exampleA] object A {
+        |    val foo = "foo"
+        |  }
+        |}
+        |package exampleB.b {
+        |  object B {
+        |    val bar = A
+        |  }
+        |}
+        |""".stripMargin,
+    expectNoDiagnostics = false,
+    filterAction = _.getTitle() == ImportMissingSymbol.title("A", "example.a"),
+  )
 }


### PR DESCRIPTION
closes #6732 

## TODOs
- [x] Share "is accessible" logic between filtering for `searchOutline` and `SymbolSearch#search` for Scala 2
- [x]  Implement refined filtering for Scala 3