### PR TITLE
bugfix: Make sure Bloop is always properly restarted

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -83,7 +83,7 @@ class BspConnector(
   def connect(
       buildTool: Option[BuildTool],
       workspace: AbsolutePath,
-      userConfiguration: UserConfiguration,
+      userConfiguration: () => UserConfiguration,
       shellRunner: ShellRunner,
   )(implicit ec: ExecutionContext): Future[Option[BspSession]] = {
     val projectRoot = buildTool.map(_.projectRoot).getOrElse(workspace)
@@ -118,7 +118,7 @@ class BspConnector(
             .getOrElse(Future.successful(()))
           val connectionF =
             for {
-              _ <- SbtBuildTool(projectRoot, () => userConfiguration)
+              _ <- SbtBuildTool(projectRoot, userConfiguration)
                 .ensureCorrectJavaVersion(
                   shellRunner,
                   projectRoot,

--- a/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
@@ -477,7 +477,7 @@ class ConnectionProvider(
           bspConnector.connect(
             buildToolProvider.buildTool,
             folder,
-            userConfig,
+            () => userConfig,
             shellRunner,
           )
         }

--- a/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Embedded.scala
@@ -293,7 +293,7 @@ object Embedded {
 
   def downloadDependency(
       dep: Dependency,
-      scalaVersion: Option[String],
+      scalaVersion: Option[String] = None,
       classfiers: Seq[String] = Seq.empty,
       resolution: Option[ResolutionParams] = None,
   ): List[Path] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -662,13 +662,13 @@ class ProjectMetalsLspService(
               session.version,
               userConfig.bloopVersion.nonEmpty,
               old.bloopVersion.isDefined,
-              () => connect(CreateSession()),
+              () => connect(CreateSession(shutdownBuildServer = true)),
             )
             .flatMap { _ =>
               bloopServers.checkPropertiesChanged(
                 old,
                 newConfig,
-                () => connect(CreateSession()),
+                () => connect(CreateSession(shutdownBuildServer = true)),
               )
             }
             .flatMap { _ =>


### PR DESCRIPTION
Previously, a version from before an update would be used for restarting in some cases or when multiple metals servers where run (the other server than the current one would sometimes be quicker to reconnect and use its old version)

Now, we always take the latest version from the settings.

I also added a few minor fixes around that.