### PR TITLE
fix: Don't pass `--best-effort` flag for bazel

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilations.scala
@@ -265,7 +265,7 @@ final class Compilations(
       userConfiguration().verboseCompilation && (connection.isBloop || connection.isScalaCLI)
     ) {
       params.setArguments(List("--verbose", "--best-effort").asJava)
-    } else { params.setArguments(List("--best-effort").asJava) }
+    } else if (!connection.isBazel) { params.setArguments(List("--best-effort").asJava) }
     targets.foreach { target =>
       isCompiling(target) = true
     }


### PR DESCRIPTION
`--best-effort` is not a valid `bazel build` flag