### PR TITLE
chore: Freeze bloop plugin for versions of sbt lower than 1.5.8

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -206,6 +206,8 @@ case class SbtBuildTool(
         // from 1.4.6 Bloop is not compatible with sbt < 1.3.0
         if (SemVer.isLaterVersion(version, "1.3.0"))
           "1.4.6"
+        else if (SemVer.isLaterVersion(version, "1.5.0"))
+          "2.0.2"
         else userConfig().currentBloopVersion
 
       val plugin = bloopPluginDetails(pluginVersion)


### PR DESCRIPTION
The upcoming version of Bloop will be using sbt 1.5.8 as a baseline with some keys only added in 1.5.x version.