### PR TITLE
bugfix: Exclude comma if included in symbol range

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -188,16 +188,15 @@ object V {
   def deprecatedScalaVersions =
     deprecatedScala2Versions ++ deprecatedScala3Versions
 
-  val quickPublishScalaVersions =
-    Set(
-      bazelScalaVersion,
-      scala211,
-      sbtScala,
-      scala212,
-      ammonite212Version,
-      scala213,
-      ammonite213Version,
-      scala3,
-      ammonite3Version,
-    ).toList ++ scala3RC.toList
+  val quickPublishScalaVersions = Set(
+    bazelScalaVersion,
+    scala211,
+    sbtScala,
+    scala212,
+    ammonite212Version,
+    scala213,
+    ammonite213Version,
+    scala3,
+    ammonite3Version,
+  ).toList ++ scala3RC.toList
 }

--- a/tests/slow/src/test/scala/tests/feature/RenameCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/RenameCrossLspSuite.scala
@@ -65,4 +65,31 @@ class RenameCrossLspSuite extends BaseRenameLspSuite("rename-cross") {
     scalaVersion = Some(V.scala3),
   )
 
+  renamed(
+    "ends-comma",
+    """|/a/src/main/scala/a/Main.scala
+       |package a
+       |object main {
+       |  def myMethod(
+       |      s1: String,
+       |      s2: String,
+       |      s3: String,
+       |      s4: String,
+       |  ) = s1 ++ s2 ++ s3 ++ s4
+       |
+       |  val word1 = "hello"
+       |  val <<word2>> = "world"
+       |
+       |  myMethod(
+       |    word1,
+       |    <<word2>>,
+       |    s3 = word1,
+       |    s4 = <<word2>>,
+       |  )
+       |}
+       |""".stripMargin,
+    newName = "NewSymbol",
+    scalaVersion = Some(V.scala3),
+  )
+
 }


### PR DESCRIPTION
Some previous versions of Scala 3 would included the final comma in a parameters list, this should help out with that case.

Versions from 3.5.2 and onwards work correctly.

I also reworked the tests to try and rename in each place a symbol is expected, which should catch more errors and need less test cases. I will follow up with changes to RenameLspSuite

Related to https://github.com/scalameta/metals/issues/6795