### PR TITLE
Avoid NPE when no severity is supplied in PublishDiagnosticsParams.Diagnostic

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -971,7 +971,8 @@ object MetalsEnrichments
       val ld = new l.Diagnostic(
         diag.getRange.toLsp,
         fansi.Str(diag.getMessage, ErrorMode.Strip).plainText,
-        diag.getSeverity.toLsp,
+        if (diag.getSeverity == null) l.DiagnosticSeverity.Warning
+        else diag.getSeverity.toLsp,
         if (diag.getSource == null) "scalac" else diag.getSource,
       )
       Option(diag.getCode()).foreach { code =>


### PR DESCRIPTION
Per spec https://build-server-protocol.github.io/docs/specification#diagnostic:
```
  /** The diagnostic's severity. Can be omitted. If omitted it is up to the
   * client to interpret diagnostics as error, warning, info or hint. */
  severity?: DiagnosticSeverity;
```

Defaulting to warn