### PR TITLE
bugfix: Metals `SqlSharedIndices.scala` XDG path violation

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/SqlSharedIndices.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SqlSharedIndices.scala
@@ -2,12 +2,25 @@ package scala.meta.internal.metals
 
 import java.nio.file.Paths
 
+import scala.util.Properties
+
 import scala.meta.io.AbsolutePath
+
+object MetalsDirectories {
+  def getMetalsDirectory: AbsolutePath = {
+    if (Properties.isLinux) {
+      Option(System.getenv("XDG_DATA_HOME"))
+        .map(xdg => Paths.get(xdg, "metals"))
+        .getOrElse(Paths.get(sys.props("user.home"), ".local", "share", "metals"))
+    } else {
+      Paths.get(sys.props("user.home"), ".metals")
+    }
+  }.toAbsolutePath
+}
 
 class SqlSharedIndices
     extends H2ConnectionProvider(
-      directory =
-        AbsolutePath(Paths.get(sys.props("user.home"))).resolve(".metals"),
+      directory = MetalsDirectories.getMetalsDirectory,
       name = "metals-shared",
       migrations = "/shared-db/migration",
     ) {

--- a/metals/src/main/scala/scala/meta/internal/metals/SqlSharedIndices.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SqlSharedIndices.scala
@@ -2,20 +2,16 @@ package scala.meta.internal.metals
 
 import java.nio.file.Paths
 
-import scala.util.Properties
-
 import scala.meta.io.AbsolutePath
 
+import dev.dirs.ProjectDirectories
+
 object MetalsDirectories {
+  private val projectDirectories = ProjectDirectories.from(null, null, "metals")
+
   def getMetalsDirectory: AbsolutePath = {
-    if (Properties.isLinux) {
-      Option(System.getenv("XDG_DATA_HOME"))
-        .map(xdg => Paths.get(xdg, "metals"))
-        .getOrElse(Paths.get(sys.props("user.home"), ".local", "share", "metals"))
-    } else {
-      Paths.get(sys.props("user.home"), ".metals")
-    }
-  }.toAbsolutePath
+    AbsolutePath(Paths.get(projectDirectories.dataDir))
+  }
 }
 
 class SqlSharedIndices


### PR DESCRIPTION
see #6801
It can be easily modified to fit specific project requirements, but the main idea is to follow the XDG Base Directory Specification, which Metals already does in most places except for this `SqlSharedIndices` class.

Update: I have used directories-jvm in the updated version, which was already present in the project. The SQL shared indices will be preserved across different platforms.

_NOTES: maybe `MetalsProjectDirectories` should be used instead of `ProjectDirectories`, see [bugfix: Don't hang on ProjectDirs](https://github.com/scalameta/metals/pull/6763/commits/6c2cbd07f50e8adb9d67512dbf75c6509b8416bb#diff-9eb2283d351d794e495756c6ec5effb0efa2c9740d86f7fa45dd6fa415ddff0e)_

![image](https://github.com/user-attachments/assets/4061bf5e-f806-495e-93c3-0270ae112a37)
