### PR TITLE
improvement: Use bootstrapped compiler always

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MtagsResolver.scala
@@ -114,7 +114,7 @@ object MtagsResolver {
     )(implicit ec: ExecutionContext): Option[MtagsBinaries] = {
       if (hasStablePresentationCompiler(scalaVersion))
         resolve(
-          scalaVersion,
+          scalaVersion.stripSuffix("-nonbootstrapped"),
           original = None,
           resolveType = ResolveType.StablePC,
         )


### PR DESCRIPTION
The compiler doesn't publish presentation compiler for nonbootstrapped version, but it should work fine with bootstrapped one. It's mainly needed in scaladoc.