### PR TITLE
bugfix: Take into account space in sbtopts

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/SbtOpts.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SbtOpts.scala
@@ -52,6 +52,8 @@ object SbtOpts {
         Some(noGlobalOpts)
       else if (sbtToJdkOpts.exists { case (k, _) => opt.startsWith(k) })
         processOptWithArg(opt)
+      else if (opt.contains(" "))
+        process(opt.split("\\s+").toList)
       else if (opt.startsWith("-J"))
         Some(opt.substring(2))
       else if (opt.startsWith("-D"))

--- a/tests/unit/src/test/scala/tests/SbtOptsSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtOptsSuite.scala
@@ -25,6 +25,7 @@ class SbtOptsSuite extends BaseSuite {
       |-sbt-dir /some/where/else/sbt
       |-ivy /some/where/ivy
       |-jvm-debug 4711
+      |-J-Xmx5G -J-XX:+UseG1GC
       |
     """.stripMargin,
     """
@@ -32,6 +33,8 @@ class SbtOptsSuite extends BaseSuite {
       |-Dsbt.global.base=/some/where/else/sbt
       |-Dsbt.ivy.home=/some/where/ivy
       |-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=4711
+      |-Xmx5G
+      |-XX:+UseG1GC
     """.stripMargin,
   )
 


### PR DESCRIPTION
I couldn't find any information about how .sbtopts should look like, but splitting on space should be ok. Especially that with spaces this doesn't work -> https://github.com/sbt/sbt/issues/7333

Fixes https://github.com/scalameta/metals/issues/6858