### PR TITLE
refactor: Use codeAction interface for most code actions

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ConvertToNamedArguments.scala
@@ -28,10 +28,6 @@ class ConvertToNamedArguments(
   import ConvertToNamedArguments._
   override val kind: String = l.CodeActionKind.RefactorRewrite
 
-  override val maybeCodeActionId: Option[String] = Some(
-    "ConvertToNamedArguments"
-  )
-
   override type CommandData = ServerCommands.ConvertToNamedArgsRequest
 
   override def command: Option[ActionCommand] = Some(

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractMethodCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ExtractMethodCodeAction.scala
@@ -32,10 +32,6 @@ class ExtractMethodCodeAction(
   )
   override def kind: String = l.CodeActionKind.RefactorExtract
 
-  override val maybeCodeActionId: Option[String] = Some(
-    "ExtractMethod"
-  )
-
   override def handleCommand(
       data: ServerCommands.ExtractMethodParams,
       token: CancelToken,

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImplementAbstractMembers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImplementAbstractMembers.scala
@@ -15,10 +15,6 @@ class ImplementAbstractMembers(compilers: Compilers) extends CodeAction {
 
   override def kind: String = l.CodeActionKind.QuickFix
 
-  override val maybeCodeActionId: Option[String] = Some(
-    "ImplementAbstractMembers"
-  )
-
   override def contribute(
       params: l.CodeActionParams,
       token: CancelToken,

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
@@ -18,10 +18,6 @@ class ImportMissingSymbol(compilers: Compilers, buildTargets: BuildTargets)
 
   override def kind: String = l.CodeActionKind.QuickFix
 
-  override val maybeCodeActionId: Option[String] = Some(
-    "ImportMissingSymbol"
-  )
-
   override def contribute(
       params: l.CodeActionParams,
       token: CancelToken,

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/InlineValueCodeAction.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/InlineValueCodeAction.scala
@@ -32,10 +32,6 @@ class InlineValueCodeAction(
 
   override def kind: String = l.CodeActionKind.RefactorInline
 
-  override val maybeCodeActionId: Option[String] = Some(
-    "InlineValue"
-  )
-
   override def contribute(params: l.CodeActionParams, token: CancelToken)(
       implicit ec: ExecutionContext
   ): Future[Seq[l.CodeAction]] = Future {

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/InsertInferredType.scala
@@ -33,10 +33,6 @@ class InsertInferredType(
   import InsertInferredType._
   override def kind: String = l.CodeActionKind.QuickFix
 
-  override val maybeCodeActionId: Option[String] = Some(
-    "InsertInferredType"
-  )
-
   override def handleCommand(
       textDocumentParams: l.TextDocumentPositionParams,
       token: CancelToken,

--- a/mtags-interfaces/src/main/java/scala/meta/pc/CodeActionId.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/CodeActionId.java
@@ -1,0 +1,14 @@
+package scala.meta.pc;
+
+/**
+ * All known code action Ids, this is not a complete list, new code actions might
+ * be added by clients, which is why this is not an enum
+ */
+public class CodeActionId {
+  public static final String ConvertToNamedArguments = "ConvertToNamedArguments";
+  public static final String ExtractMethod = "ExtractMethod";
+  public static final String ImplementAbstractMembers = "ImplementAbstractMembers";
+  public static final String ImportMissingSymbol = "ImportMissingSymbol";
+  public static final String InlineValue = "InlineValue";
+  public static final String InsertInferredType = "InsertInferredType";
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -114,8 +114,20 @@ public abstract class PresentationCompiler {
 
 	/**
 	 * Execute the given code action
+	 * 
+	 * @deprecated Please use the code action with optional data.
 	 */
-	public CompletableFuture<List<TextEdit>> codeAction(OffsetParams params, String codeActionId, Object codeActionPayload) {
+	@Deprecated(since = "1.4.1")
+	public CompletableFuture<List<TextEdit>> codeAction(OffsetParams params, String codeActionId,
+			Object codeActionPayload) {
+		return codeAction(params, codeActionId, Optional.of(codeActionPayload));
+	}
+
+	/**
+	 * Execute the given code action
+	 */
+	public <T> CompletableFuture<List<TextEdit>> codeAction(OffsetParams params, String codeActionId,
+			Optional<T> codeActionPayload) {
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
@@ -123,14 +135,7 @@ public abstract class PresentationCompiler {
 	 * Returns the list of code actions supported by the current presentation compiler.
 	 */
 	public List<String> supportedCodeActions() {
-		return Arrays.asList(
-			"ConvertToNamedArguments",
-			"ExtractMethod",
-			"ImplementAbstractMembers",
-			"ImportMissingSymbol",
-			"InlineValue",
-			"InsertInferredType"
-		);
+		return Arrays.asList();
 	}
 
 	/**
@@ -294,7 +299,6 @@ public abstract class PresentationCompiler {
 	 * Provide workspace root for features like ammonite script $file completions.
 	 */
 	public abstract PresentationCompiler withWorkspace(Path workspace);
-
 
 	/**
 	 * Provide CompletionItemPriority for additional sorting completion items.


### PR DESCRIPTION
I think we were still not perfect with the interfaces, some changes I did:
- I changed the default value to empty, which now makes it easy to see which methods migrated to the new interface method.
- removed maybeCodeActionId from code actions that we know can be handled otherwise
- added a CodeActionId class to gather all known classes once we agree on adding soemthing, can still be implemented separately

This added some duplication, since for older Scala version we need to use the older methods, but anything new should now be quite easy to handle.

So not so useful for older things, but still it's good to migrate to new codeAction interface.

@KacperFKorban What do you think?