### PR TITLE
improvement: Don't add release flag for versions from 17

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
@@ -396,15 +396,37 @@ class CompilerConfiguration(
         } yield jvmVersion.major
 
       releaseVersion match {
-        case Some(version) =>
+        // https://github.com/scala/bug/issues/13045
+        case Some(version)
+            if version < 17 && scalaTarget.scalaBinaryVersion == "2.13" =>
           /* Filter out -target: and -Xtarget: options, since they are not relevant and
            * might interfere with -release option */
           val filterOutTarget = scalacOptions.filterNot(opt =>
             opt.startsWith("-target:") || opt.startsWith("-Xtarget:")
           )
           filterOutTarget ++ List("-release", version.toString())
-        case _ => scalacOptions
+        case _ if scalaTarget.scalaBinaryVersion == "2.13" =>
+          removeReleaseOptions(scalacOptions)
+        case _ =>
+          scalacOptions
       }
+    }
+  }
+
+  private def isHigherThan17(version: String) =
+    Try(version.toInt).toOption.exists(_ >= 17)
+
+  private def removeReleaseOptions(options: Seq[String]): Seq[String] = {
+    options match {
+      case "-release" :: version :: tail if isHigherThan17(version) =>
+        removeReleaseOptions(tail)
+      case opt :: tail
+          if opt.startsWith("-release") && isHigherThan17(
+            opt.stripPrefix("-release:")
+          ) =>
+        removeReleaseOptions(tail)
+      case head :: tail => head +: removeReleaseOptions(tail)
+      case Nil => options
     }
   }
 


### PR DESCRIPTION
I noticed some issues with Scala 2.13.15 and I am not sure how to work around it. This can be worked around if the user needs it as Metals does work with 17 and up. 

I have not noticed the same issues with JDK <17

For reference:
- https://github.com/scala/bug/issues/13045
- https://github.com/scalameta/metals/issues/5272