### PR TITLE
bugfix: Publish interfaces and  mtagsShared for JDK 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -214,7 +214,6 @@ publish / skip := true
 
 lazy val interfaces = project
   .in(file("mtags-interfaces"))
-  .settings(sharedJavacOptions)
   .settings(
     moduleName := "mtags-interfaces",
     autoScalaLibrary := false,
@@ -226,6 +225,7 @@ lazy val interfaces = project
     libraryDependencies ++= List(
       V.lsp4j
     ),
+    javacOptions := Seq("--release", "8"),
     crossVersion := CrossVersion.disabled,
     Compile / doc / javacOptions ++= List(
       "-tag",
@@ -241,6 +241,14 @@ lazy val mtagsShared = project
     crossTarget := target.value / s"scala-${scalaVersion.value}",
     // Dotty depends on Scala 2.13 for compatibility guarantees for from-source compilation.
     crossScalaVersions := V.supportedScalaVersions,
+    scalacOptions --= crossSetting(
+      scalaVersion.value,
+      if213 = List("-target:17"),
+    ),
+    scalacOptions ++= crossSetting(
+      scalaVersion.value,
+      if213 = List("-target:8"),
+    ),
     crossVersion := CrossVersion.full,
     Compile / packageSrc / publishArtifact := true,
     Compile / scalacOptions ++= {

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -114,10 +114,10 @@ public abstract class PresentationCompiler {
 
 	/**
 	 * Execute the given code action
-	 * 
+	 * @since 1.4.1
 	 * @deprecated Please use the code action with optional data.
 	 */
-	@Deprecated(since = "1.4.1")
+	@Deprecated
 	public CompletableFuture<List<TextEdit>> codeAction(OffsetParams params, String codeActionId,
 			Object codeActionPayload) {
 		return codeAction(params, codeActionId, Optional.of(codeActionPayload));


### PR DESCRIPTION
This is needed by the Scala 3 compiler.