### PR TITLE
improvement: Check all references at the same time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,8 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
+        with:
+          sbt-runner-version: 1.10.3
       - name: ${{ matrix.command }}
         run: ${{ matrix.command }}
         env:

--- a/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
+++ b/tests/unit/src/main/scala/tests/MetalsTestEnrichments.scala
@@ -3,6 +3,8 @@ package tests
 import java.nio.file.Files
 
 import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.{meta => m}
 
 import scala.meta.dialects
@@ -53,6 +55,13 @@ object MetalsTestEnrichments {
       ),
     )(EmptyReportContext)
   }
+
+  def orderly(lst: Iterable[() => Future[Unit]])(implicit
+      ec: ExecutionContext
+  ): Future[Unit] =
+    lst.foldLeft(Future.unit) { case (acc, next) =>
+      acc.flatMap(_ => next())
+    }
 
   implicit class XtensionTestAbsolutePath(path: AbsolutePath) {
     def text: String = Files.readAllLines(path.toNIO).asScala.mkString("\n")

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -75,7 +75,7 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
        |package a
        |
        |object Main{
-       |  def <<hel@@lo>>() = println("Hello world")
+       |  def <<hello>>() = println("Hello world")
        |  <<hello>>()
        |  <<hello>>()
        |  <<hello>>()
@@ -87,22 +87,6 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
   check(
     "companion-object",
     """|/Main.scala
-       |case class <<Rend@@erTile>>(
-       |    lowBits: Int,
-       |    highBits: Int,
-       |    // 2 bits
-       |    attrBits: Int
-       |)
-       |
-       |object <<RenderTile>>{
-       |  val zero = <<RenderTile>>(0, 0, 0)
-       |}
-       |""".stripMargin,
-  )
-
-  check(
-    "companion-class",
-    """|/Main.scala
        |case class <<RenderTile>>(
        |    lowBits: Int,
        |    highBits: Int,
@@ -110,7 +94,7 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
        |    attrBits: Int
        |)
        |
-       |object <<Rende@@rTile>>{
+       |object <<RenderTile>>{
        |  val zero = <<RenderTile>>(0, 0, 0)
        |}
        |""".stripMargin,
@@ -372,7 +356,7 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
     "ordering",
     """|/a/src/main/scala/a/Main.scala
        |package a
-       |trait <<A@@A>>
+       |trait <<AA>>
        |/a/src/main/scala/a/Other.scala
        |package a
        |trait BB extends <<AA>>
@@ -384,7 +368,7 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
   check(
     "worksheet",
     """|/a/src/main/scala/a/Main.worksheet.sc
-       |trait <<A@@A>>
+       |trait <<AA>>
        |trait BB extends <<AA>>
        |trait CC extends <<AA>>
        |trait DD extends <<AA>>
@@ -400,7 +384,7 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
        |}
        |/a/src/main/scala/a/Other.scala
        |object Other {
-       |  val mb = new <<M@@ain>>("b")
+       |  val mb = new <<Main>>("b")
        |}
        |""".stripMargin,
   )
@@ -410,7 +394,7 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
     """|/a/src/main/scala/a/Main.scala
        |case class <<Main>>(name: String)
        |object F {
-       |  val ma = <<Ma@@in>>("a")
+       |  val ma = <<Main>>("a")
        |}
        |/a/src/main/scala/a/Other.scala
        |object Other {
@@ -425,7 +409,7 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
        |case class Name(<<value>>: String)
        |
        |object Main {
-       |  val name2 = new Name(<<va@@lue>> = "44")
+       |  val name2 = new Name(<<value>> = "44")
        |}
        |""".stripMargin,
   )


### PR DESCRIPTION
We should check if references find the same amount of references when invoked at each occurrence. This will avoid having to write multiple tests differing in just @@ and make sure that the references are found reliably.