### PR TITLE
docs: Upgrade Docusaurus to Version 3.6.0

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -136,21 +136,7 @@ export default {
       }
     }
   },
-  webpack: {
-    jsLoader: (isServer) => ({
-      loader: "swc-loader",
-      options: {
-        jsc: {
-          parser: {
-            syntax: "typescript",
-            tsx: true,
-          },
-          target: "es2020",
-        },
-        module: {
-          type: isServer ? "commonjs" : "es6",
-        },
-      },
-    }),
-  }
+  "future": {
+    "experimental_faster": true,
+  },
 } satisfies Config

--- a/website/package.json
+++ b/website/package.json
@@ -11,14 +11,13 @@
     "@types/node": "^22.8.6"
   },
   "dependencies": {
-    "@docusaurus/core": "3.5.2",
-    "@docusaurus/plugin-client-redirects": "3.5.2",
-    "@docusaurus/preset-classic": "3.5.2",
+    "@docusaurus/core": "3.6.0",
+    "@docusaurus/faster": "3.6.0",
+    "@docusaurus/plugin-client-redirects": "3.6.0",
+    "@docusaurus/preset-classic": "3.6.0",
     "@easyops-cn/docusaurus-search-local": "0.45.0",
-    "@swc/core": "^1.7.42",
     "clsx": "^2.1.1",
     "react": "^18.3.1",
-    "react-dom": "^18.2.0",
-    "swc-loader": "^0.2.6"
+    "react-dom": "^18.2.0"
   }
 }


### PR DESCRIPTION
This PR updates Docusaurus to version 3.6.0, introducing many build tool improvements.

For details: https://docusaurus.io/blog/releases/3.6