### PR TITLE
bugfix: Don't show run code lense when using Main class and worksheets

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -96,12 +96,15 @@ final class RunTestCodeLens(
       // most of the bsp servers such as bloop and sbt might not support it.
     } yield requestJvmEnvironment(buildTargetId, isJVM).map { _ =>
       val classes = buildTargetClasses.classesOf(buildTargetId)
-      val syntheticLenses = syntheticCodeLenses(
-        textDocument,
-        buildTargetId,
-        classes,
-        isJVM,
-      )
+      val syntheticLenses =
+        if (!path.isWorksheet)
+          syntheticCodeLenses(
+            textDocument,
+            buildTargetId,
+            classes,
+            isJVM,
+          )
+        else Nil
       val regularLenses =
         codeLenses(
           textDocument,


### PR DESCRIPTION
It happens if we have no package Main class and a worksheet next to it.

This is pretty minor edge case and doesn't break anything, but we should not show run/debug lenses for worksheets as it will run a different clas.