### PR TITLE
bugfix #6950:respect customProjectRoot in BspConnector

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -86,7 +86,11 @@ class BspConnector(
       userConfiguration: () => UserConfiguration,
       shellRunner: ShellRunner,
   )(implicit ec: ExecutionContext): Future[Option[BspSession]] = {
-    val projectRoot = buildTool.map(_.projectRoot).getOrElse(workspace)
+    val projectRoot = buildTool
+      .map(_.projectRoot)
+      .orElse(userConfiguration().getCustomProjectRoot(workspace))
+      .getOrElse(workspace)
+
     def connect(
         projectRoot: AbsolutePath,
         bspTraceRoot: AbsolutePath,


### PR DESCRIPTION
When choosing a default folder to start a BSP connection and failing to obtain one from the build tool, respect customProjectRoot setting before defaulting to workspace.

Fixes https://github.com/scalameta/metals/issues/6950

So the the proposal mentioned [here](https://github.com/scalameta/metals/issues/6950#issuecomment-2489515847) doesn't fly, because it seem like it never gets to writing the build tool.

Yet, I figured that the user settings are available where the Bloop-default folder is decided. So at that point, respecting the setting (if configured) seems only fair.

(I verified with a local build that indeed solves the problem)
