### PR TITLE
improvement: avoid atomic double touch if not needed

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ChosenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ChosenBuildTool.scala
@@ -13,21 +13,23 @@ class ChosenBuildTool(conn: () => Connection) {
     )
 
   def selectedBuildTool(): Option[String] = {
-    val selected = currentTool
-      .get()
-      .orElse(
-        conn()
+    currentTool.get() match {
+      case selected @ Some(_) =>
+        selected
+      case None =>
+        val selected = conn()
           .query(
             "select * from chosen_build_tool LIMIT 1;"
           )(_ => ()) { _.getString("build_tool") }
           .headOption
-      )
-    selected.flatMap(toolName =>
-      currentTool.updateAndGet {
-        case None => Some(toolName)
-        case some => some
-      }
-    )
+
+        selected.flatMap(toolName =>
+          currentTool.updateAndGet {
+            case None => Some(toolName)
+            case some => some
+          }
+        )
+    }
   }
 
   def chooseBuildTool(buildTool: String): Int = synchronized {


### PR DESCRIPTION
When researching https://github.com/scalameta/metals/issues/6950#issuecomment-2489515847

I found that this atomic it is touched twice, even it just attempts to write the value it obtained already. That doesn't seem right.
With this fix, if the atomic has a value it will take a faster path out.