### PR TITLE
improvement: Make including detail in completion label configurable

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -200,6 +200,9 @@ object InitializationOptions {
       isSignatureHelpDocumentationEnabled = compilerObj.flatMap(
         _.getBooleanOption("isSignatureHelpDocumentationEnabled")
       ),
+      isDetailIncludedInLabel = compilerObj.flatMap(
+        _.getBooleanOption("isDetailIncludedInLabel")
+      ),
       overrideDefFormat = compilerObj.flatMap(
         _.getStringOption("overrideDefFormat")
       ),
@@ -210,7 +213,6 @@ object InitializationOptions {
         compilerObj.flatMap(_.getBooleanOption("snippetAutoIndent")),
     )
   }
-
 }
 
 sealed trait CommandHTMLFormat {

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -225,7 +225,8 @@ object MetalsServerConfig {
         base.copy(
           executeClientCommand = ExecuteClientCommandConfig.on,
           compilers = base.compilers.copy(
-            snippetAutoIndent = false
+            snippetAutoIndent = false,
+            isDetailIncludedInLabel = false,
           ),
         )
       case _ =>

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -97,6 +97,13 @@ public interface PresentationCompilerConfig {
 	boolean isCompletionSnippetsEnabled();
 
 	/**
+	 * Returns true if the completion's description should be included in the label.
+	 */
+	default boolean isDetailIncludedInLabel() {
+		return true;
+	}
+
+	/**
 	 * The maximum delay for requests to respond.
 	 *
 	 * After the given delay, every request to completions/hover/signatureHelp is

--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/CompilerInitializationOptions.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/CompilerInitializationOptions.scala
@@ -16,6 +16,8 @@ package scala.meta.internal.pc
  * @param isHoverDocumentationEnabled whether to include docstrings in a `textDocument/hover`.
  * @param isSignatureHelpDocumentationEnabled whether the `SignatureHelp.documentation` field
  *                                            should be populated.
+ * @param isDetailIncludedInLabel whether the completion's description should be included in the
+ *                                label.
  * @param overrideDefFormat whether the override should include a unicode icon or only ascii.
  * @param parameterHintsCommand command identifier to trigger parameter hints.
  * @param snippetAutoIndent whether the client defaults to adding the indentation of the reference
@@ -28,6 +30,7 @@ case class CompilerInitializationOptions(
     isCompletionItemResolve: Option[Boolean],
     isHoverDocumentationEnabled: Option[Boolean],
     isSignatureHelpDocumentationEnabled: Option[Boolean],
+    isDetailIncludedInLabel: Option[Boolean],
     overrideDefFormat: Option[String],
     parameterHintsCommand: Option[String],
     snippetAutoIndent: Option[Boolean]
@@ -36,6 +39,7 @@ case class CompilerInitializationOptions(
 object CompilerInitializationOptions {
   def default: CompilerInitializationOptions =
     CompilerInitializationOptions(
+      None,
       None,
       None,
       None,

--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/PresentationCompilerConfigImpl.scala
@@ -22,6 +22,7 @@ case class PresentationCompilerConfigImpl(
     snippetAutoIndent: Boolean = true,
     isSignatureHelpDocumentationEnabled: Boolean = true,
     isCompletionSnippetsEnabled: Boolean = true,
+    override val isDetailIncludedInLabel: Boolean = true,
     isCompletionItemResolve: Boolean = true,
     _isStripMarginOnTypeFormattingEnabled: () => Boolean = () => true,
     timeoutDelay: Long = 20,
@@ -71,6 +72,9 @@ case class PresentationCompilerConfigImpl(
         ),
       isCompletionItemResolve = options.isCompletionItemResolve.getOrElse(
         this.isCompletionItemResolve
+      ),
+      isDetailIncludedInLabel = options.isDetailIncludedInLabel.getOrElse(
+        this.isDetailIncludedInLabel
       ),
       _parameterHintsCommand = options.parameterHintsCommand.orElse(
         this._parameterHintsCommand

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -111,7 +111,9 @@ class CompletionProvider(
       }
 
       def labelWithSig =
-        if (member.sym.isMethod || member.sym.isValue) {
+        if (
+          compiler.metalsConfig.isDetailIncludedInLabel && (member.sym.isMethod || member.sym.isValue)
+        ) {
           ident + detail
         } else {
           ident

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -110,9 +110,10 @@ class CompletionProvider(
         case _ => detailString(member, history)
       }
 
+      val includeDetailInLabel = compiler.metalsConfig.isDetailIncludedInLabel
       def labelWithSig =
         if (
-          compiler.metalsConfig.isDetailIncludedInLabel && (member.sym.isMethod || member.sym.isValue)
+          includeDetailInLabel && (member.sym.isMethod || member.sym.isValue)
         ) {
           ident + detail
         } else {
@@ -130,7 +131,7 @@ class CompletionProvider(
           o.label.getOrElse(labelWithSig)
         case _: WorkspaceImplicitMember =>
           s"$labelWithSig (implicit)"
-        case o: WorkspaceMember =>
+        case o: WorkspaceMember if includeDetailInLabel =>
           s"$ident - ${o.sym.owner.fullName}"
         case _ => labelWithSig
       }

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/completions/CompletionProvider.scala
@@ -162,7 +162,11 @@ class CompletionProvider(
     // related issue https://github.com/lampepfl/dotty/issues/11941
     lazy val kind: CompletionItemKind = completion.completionItemKind
     val description = completion.description(printer)
-    val label = completion.labelWithDescription(printer)
+    val label =
+      if config.isDetailIncludedInLabel then
+        completion.labelWithDescription(printer)
+      else
+        completion.label
     val ident = completion.insertText.getOrElse(completion.label)
 
     def mkItem(

--- a/tests/cross/src/test/scala/tests/pc/CompletionWithoutDetailsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWithoutDetailsSuite.scala
@@ -19,28 +19,60 @@ class CompletionWithoutDetailsSuite extends BaseCompletionSuite {
       |  Lis@@
       |}""".stripMargin,
     """|List
-       |List - java.awt
-       |List - java.util
-       |JList - javax.swing
-       |ListUI - javax.swing.plaf
+       |List
+       |List
+       |JList
+       |ListUI
        |""".stripMargin,
     compat = Map(
       "2.13" ->
         """|List
            |LazyList
-           |List - java.awt
-           |List - java.util
-           |JList - javax.swing
+           |List
+           |List
+           |JList
            |""".stripMargin,
       "3" ->
         """|List
-           |List - java.awt
-           |List - java.util
-           |List - scala.collection.immutable
-           |List[A](elems: A*): CC[A]
+           |List
+           |List
+           |List
+           |List
            |""".stripMargin
     ),
     includeDetail = false,
+    topLines = Some(5)
+  )
+
+  check(
+    "scope-detail",
+    """
+      |object A {
+      |  Lis@@
+      |}""".stripMargin,
+    """|List scala.collection.immutable
+       |List java.awt
+       |List java.util
+       |JList javax.swing
+       |ListUI javax.swing.plaf
+       |""".stripMargin,
+    compat = Map(
+      "2.13" ->
+        """|List scala.collection.immutable
+           |LazyList scala.collection.immutable
+           |List java.awt
+           |List java.util
+           |JList javax.swing
+           |""".stripMargin,
+      "3" ->
+        """|List scala.collection.immutable
+           |List java.awt
+           |List java.util
+           |List scala.collection.immutable
+           |List[A](elems: A*): CC[A]
+           |""".stripMargin
+    ),
+    includeDetail = true,
     topLines = Some(5)
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionWithoutDetailsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWithoutDetailsSuite.scala
@@ -1,0 +1,119 @@
+package tests.pc
+
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
+import scala.meta.pc.PresentationCompilerConfig
+
+import tests.BaseCompletionSuite
+
+class CompletionWithoutDetailsSuite extends BaseCompletionSuite {
+
+  override def config: PresentationCompilerConfig =
+    PresentationCompilerConfigImpl().copy(
+      isDetailIncludedInLabel = false
+    )
+
+  check(
+    "scope",
+    """
+      |object A {
+      |  Lis@@
+      |}""".stripMargin,
+    """|List
+       |List - java.awt
+       |List - java.util
+       |JList - javax.swing
+       |ListUI - javax.swing.plaf
+       |""".stripMargin,
+    compat = Map(
+      "2.13" ->
+        """|List
+           |LazyList
+           |List - java.awt
+           |List - java.util
+           |JList - javax.swing
+           |""".stripMargin,
+      "3" ->
+        """|List
+           |List - java.awt
+           |List - java.util
+           |List - scala.collection.immutable
+           |List[A](elems: A*): CC[A]
+           |""".stripMargin
+    ),
+    includeDetail = false,
+    topLines = Some(5)
+  )
+
+  check(
+    "member",
+    """
+      |object A {
+      |  List.emp@@
+      |}""".stripMargin,
+    """
+      |empty
+      |""".stripMargin,
+    includeDetail = false
+  )
+
+  check(
+    "extension",
+    """
+      |object A {
+      |  "".stripSu@@
+      |}""".stripMargin,
+    """|stripSuffix
+       |""".stripMargin,
+    includeDetail = false
+  )
+
+  check(
+    "tparam",
+    """
+      |class Foo[A] {
+      |  def identity[B >: A](a: B): B = a
+      |}
+      |object Foo {
+      |  new Foo[Int].ident@@
+      |}""".stripMargin,
+    """|identity
+       |""".stripMargin,
+    includeDetail = false
+  )
+
+  check(
+    "tparam1",
+    """
+      |class Foo[A] {
+      |  def identity(a: A): A = a
+      |}
+      |object Foo {
+      |  new Foo[Int].ident@@
+      |}""".stripMargin,
+    """|identity
+       |""".stripMargin,
+    includeDetail = false
+  )
+
+  check(
+    "tparam2",
+    """
+      |object A {
+      |  Map.empty[Int, String].getOrEl@@
+      |}
+      |""".stripMargin,
+    """|getOrElse
+       |""".stripMargin,
+    includeDetail = false
+  )
+
+  check(
+    "pkg",
+    """
+      |import scala.collection.conc@@
+      |""".stripMargin,
+    """|concurrent
+       |""".stripMargin,
+    includeDetail = false
+  )
+}


### PR DESCRIPTION
Some LSP clients (such as Emacs using Eglot and Corfu) use the label field to insert a completion if `completionItem/resolve` has not returned by the time the completion is selected. Including the contents of the detail property in the label causes it to be included in the file itself in these clients. To remedy this, we define a `isDetailIncludedInLabel` option under `compilerOptions` to make this behaviour toggleable. We also disable this behaviour by default in Emacs, since this is where the undesirable behaviour was located.

TODO:
- [x] Figure out why option is ignored in Scala 3.3.4 projects
- [ ] Testing (unsure what tests should be added - please let me know where they should go)

Fixes #6849.