### PR TITLE
fix: use alternative with stripped synthetic `filename$package.`

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/ProxySymbolDocumentation.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/ProxySymbolDocumentation.scala
@@ -1,0 +1,18 @@
+package scala.meta.internal.metals
+
+import java.util
+import java.util.Collections
+
+import scala.meta.pc.SymbolDocumentation
+
+case class ProxySymbolDocumentation(orginalSymbol: String)
+    extends SymbolDocumentation {
+  override def symbol(): String = ""
+  override def displayName(): String = ""
+  override def docstring(): String = ""
+  override def defaultValue(): String = ""
+  override def typeParameters(): util.List[SymbolDocumentation] =
+    Collections.emptyList()
+  override def parameters(): util.List[SymbolDocumentation] =
+    Collections.emptyList()
+}

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionItemResolver.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionItemResolver.scala
@@ -75,7 +75,7 @@ class CompletionItemResolver(
       }
     } else {
       val companionDoc = docs(companion)
-      if (companionDoc.isEmpty) gsymDoc
+      if (companionDoc.isEmpty || companionDoc == gsymDoc) gsymDoc
       else if (gsymDoc.isEmpty) companionDoc
       else {
         List(

--- a/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -230,9 +230,10 @@ object MtagsEnrichments extends ScalametaCommonEnrichments:
     def stripBackticks: String = s.stripPrefix("`").stripSuffix("`")
 
   extension (search: SymbolSearch)
-    def symbolDocumentation(symbol: Symbol, contentType: ContentType = ContentType.MARKDOWN)(using
-        Context
-    ): Option[SymbolDocumentation] =
+    def symbolDocumentation(
+      symbol: Symbol,
+      contentType: ContentType = ContentType.MARKDOWN
+    )(using Context): Option[SymbolDocumentation] =
       def toSemanticdbSymbol(symbol: Symbol) =
         SemanticdbSymbols.symbolName(
           if !symbol.is(JavaDefined) && symbol.isPrimaryConstructor then

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionItemResolver.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/CompletionItemResolver.scala
@@ -71,7 +71,7 @@ object CompletionItemResolver extends ItemResolver:
       else gsymDoc
     else
       val companionDoc = docs(companion)
-      if companionDoc.isEmpty then gsymDoc
+      if companionDoc.isEmpty || companionDoc == gsymDoc then gsymDoc
       else if gsymDoc.isEmpty then companionDoc
       else
         List(

--- a/mtags/src/main/scala/scala/meta/internal/mtags/DefinitionAlternatives.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/DefinitionAlternatives.scala
@@ -3,20 +3,21 @@ package scala.meta.internal.mtags
 import scala.meta.internal.semanticdb.Scala._
 
 object DefinitionAlternatives {
+
   /**
    * Returns a list of fallback symbols that can act instead of given symbol.
    */
   def apply(symbol: Symbol): List[Symbol] = {
-      List(
-        stripSyntheticPackageObjectFromObject(symbol),
-        caseClassCompanionToType(symbol),
-        caseClassApplyOrCopy(symbol),
-        caseClassApplyOrCopyParams(symbol),
-        initParamToValue(symbol),
-        varGetter(symbol),
-        methodOwner(symbol),
-        objectInsteadOfAny(symbol)
-      ).flatten
+    List(
+      stripSyntheticPackageObjectFromObject(symbol),
+      caseClassCompanionToType(symbol),
+      caseClassApplyOrCopy(symbol),
+      caseClassApplyOrCopyParams(symbol),
+      initParamToValue(symbol),
+      varGetter(symbol),
+      methodOwner(symbol),
+      objectInsteadOfAny(symbol)
+    ).flatten
   }
 
   object GlobalSymbol {
@@ -26,7 +27,9 @@ object DefinitionAlternatives {
       Some(sym.owner -> sym.value.desc)
   }
 
-  private def stripSyntheticPackageObjectFromObject(symbol: Symbol): Option[Symbol] = {
+  private def stripSyntheticPackageObjectFromObject(
+      symbol: Symbol
+  ): Option[Symbol] = {
     val toplevel = symbol.toplevel
     Option(toplevel).flatMap {
       case GlobalSymbol(owner, Descriptor.Term(pkgName))

--- a/mtags/src/main/scala/scala/meta/internal/mtags/DefinitionAlternatives.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/DefinitionAlternatives.scala
@@ -1,17 +1,14 @@
 package scala.meta.internal.mtags
 
-import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.semanticdb.Scala._
 
 object DefinitionAlternatives {
-  type ValidateLocation = SymbolLocation => Boolean
-
   /**
    * Returns a list of fallback symbols that can act instead of given symbol.
    */
-  def apply(symbol: Symbol): List[(Symbol, Option[ValidateLocation])] = {
-    stripSyntheticPackageObjectFromObject(symbol).toList ++
+  def apply(symbol: Symbol): List[Symbol] = {
       List(
+        stripSyntheticPackageObjectFromObject(symbol),
         caseClassCompanionToType(symbol),
         caseClassApplyOrCopy(symbol),
         caseClassApplyOrCopyParams(symbol),
@@ -19,7 +16,7 @@ object DefinitionAlternatives {
         varGetter(symbol),
         methodOwner(symbol),
         objectInsteadOfAny(symbol)
-      ).flatten.map((_, None))
+      ).flatten
   }
 
   object GlobalSymbol {
@@ -29,23 +26,15 @@ object DefinitionAlternatives {
       Some(sym.owner -> sym.value.desc)
   }
 
-  private def stripSyntheticPackageObjectFromObject(
-      symbol: Symbol
-  ): Option[(Symbol, Option[ValidateLocation])] = {
+  private def stripSyntheticPackageObjectFromObject(symbol: Symbol): Option[Symbol] = {
     val toplevel = symbol.toplevel
     Option(toplevel).flatMap {
       case GlobalSymbol(owner, Descriptor.Term(pkgName))
           if pkgName.endsWith("$package") =>
         val newSymbol =
           Symbol(s"${owner.value}${symbol.value.stripPrefix(toplevel.value)}")
-        if (newSymbol.toplevel.isTerm) {
-          Some(
-            (
-              newSymbol,
-              Some(loc => s"${loc.path.scalaFileName}$$package" == pkgName)
-            )
-          )
-        } else None
+        if (newSymbol.toplevel.isTerm) Some(newSymbol)
+        else None
       case _ => None
     }
   }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalametaCommonEnrichments.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalametaCommonEnrichments.scala
@@ -363,6 +363,9 @@ trait ScalametaCommonEnrichments extends CommonMtagsEnrichments {
 
     def filename: String = path.toNIO.filename
 
+    def scalaFileName: String =
+      path.filename.stripSuffix(".scala").stripSuffix(".sc")
+
     def toIdeallyRelativeURI(sourceItemOpt: Option[AbsolutePath]): String =
       sourceItemOpt match {
         case Some(sourceItem) =>

--- a/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
@@ -12,7 +12,6 @@ import scala.meta.Dialect
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.io.PlatformFileIO
-import scala.meta.internal.mtags.DefinitionAlternatives.ValidateLocation
 import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.{semanticdb => s}
@@ -191,8 +190,7 @@ class SymbolIndexBucket(
    */
   private def query0(
       querySymbol: Symbol,
-      symbol: Symbol,
-      validate: Option[ValidateLocation] = None
+      symbol: Symbol
   ): List[SymbolDefinition] = {
 
     removeOldEntries(symbol)
@@ -226,27 +224,21 @@ class SymbolIndexBucket(
     if (!definitions.contains(symbol.value)) {
       // Fallback 3: guess related symbols from the enclosing class.
       DefinitionAlternatives(symbol)
-        .flatMap { case (alternative, validate) =>
-          query0(querySymbol, alternative, validate)
-        }
+        .flatMap { case (alternative) => query0(querySymbol, alternative) }
     } else {
       definitions
         .get(symbol.value)
         .map { paths =>
-          paths.flatMap { location =>
-            if (validate.forall(_(location))) {
-              Some(
-                SymbolDefinition(
-                  querySymbol = querySymbol,
-                  definitionSymbol = symbol,
-                  path = location.path,
-                  dialect = dialect,
-                  range = location.range,
-                  kind = None,
-                  properties = 0
-                )
-              )
-            } else None
+          paths.map { location =>
+            SymbolDefinition(
+              querySymbol = querySymbol,
+              definitionSymbol = symbol,
+              path = location.path,
+              dialect = dialect,
+              range = location.range,
+              kind = None,
+              properties = 0
+            )
           }.toList
         }
         .getOrElse(List.empty)

--- a/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
@@ -223,8 +223,7 @@ class SymbolIndexBucket(
     }
     if (!definitions.contains(symbol.value)) {
       // Fallback 3: guess related symbols from the enclosing class.
-      DefinitionAlternatives(symbol)
-        .flatMap { case (alternative) => query0(querySymbol, alternative) }
+      DefinitionAlternatives(symbol).flatMap(query0(querySymbol, _))
     } else {
       definitions
         .get(symbol.value)

--- a/tests/cross/src/main/scala/tests/pc/BaseHoverSuite.scala
+++ b/tests/cross/src/main/scala/tests/pc/BaseHoverSuite.scala
@@ -24,9 +24,11 @@ abstract class BaseHoverSuite
       expected: String,
       includeRange: Boolean = false,
       automaticPackage: Boolean = true,
-      compat: Map[String, String] = Map.empty
+      compat: Map[String, String] = Map.empty,
+      repeat: Int = 1
   )(implicit loc: Location): Unit = {
     test(testOpt) {
+      assert(repeat > 0)
       val filename = "Hover.scala"
       val pkg = scala.meta.Term.Name(testOpt.name).syntax
       val noRange = original
@@ -42,10 +44,14 @@ abstract class BaseHoverSuite
       } else {
         CompilerRangeParams(Paths.get(filename).toUri(), code, so, eo)
       }
-      val hover = presentationCompiler
-        .hover(pcParams)
-        .get()
-        .asScala
+      val hover = (0 to repeat)
+        .map(_ =>
+          presentationCompiler
+            .hover(pcParams)
+            .get()
+            .asScala
+        )
+        .last
         .map(_.toLsp())
       val obtained: String = renderAsString(code, hover, includeRange)
       assertNoDiff(

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -595,4 +595,20 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
        |""".stripMargin
   )
 
+  check(
+    "i6852",
+    """
+      |type Foo = String
+      |
+      |/** some doc */
+      |object Foo:
+      |  /** doc doc */
+      |  val fo@@o = ""
+      |""".stripMargin,
+    """|```scala
+       |val foo: String
+       |```
+       |doc doc""".stripMargin
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverScala3TypeSuite.scala
@@ -608,7 +608,8 @@ class HoverScala3TypeSuite extends BaseHoverSuite {
     """|```scala
        |val foo: String
        |```
-       |doc doc""".stripMargin
+       |doc doc""".stripMargin,
+    repeat = 2
   )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -520,7 +520,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
       |
       |
     """.stripMargin,
-    """|apply(viewId: String, nodeUri: String, label: String, command: String = ..., icon: String = ..., tooltip: String = ..., collapseState: String = ...): TreeViewNode
+    """|apply(viewId: String, nodeUri: String, label: String, command: String = null, icon: String = null, tooltip: String = null, collapseState: String = null): TreeViewNode
        |      ^^^^^^^^^^^^^^
        |""".stripMargin,
     compat = Map(


### PR DESCRIPTION
fixes: #6852

### Root cause of the problem
A toplevel object that is a companion for a top-level type has a synthetic parent - `filename$package`. This is not reflected by Metals symbol indexer (`ScalaMtags`).  It would be problematic, since the the type definition might be after the object definition

#### Example
For this code:
```demo.scala
// demo.scala
object Foo
type Foo = String
```
Symbols in compiler and what is in semanticDB is
```
_empty_/demo$package.Foo#
_empty_/demo$package.Foo.
```
Where Metals symbol indexer produces:
```
_empty_/demo$package.Foo#
_empty_/Foo.
```

### Solution
  1. Add symbols with `filename$package` to alternatives in definition search
  2. When searching for docstring fallback to docs from found definition symbol
