### PR TITLE
fix: don't look for overshadow conflicts for symbols not in the scope

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/InlineValueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InlineValueSuite.scala
@@ -300,6 +300,23 @@ class InlineValueSuite extends BaseCodeActionSuite with CommonMtagsEnrichments {
        |}""".stripMargin
   )
 
+  checkEdit(
+    "i6924",
+    """|object O {
+       |  def test(n: Int) = {
+       |    val isOne = n == 1
+       |    <<i>>sOne
+       |  }
+       |}
+       |""".stripMargin,
+    """|object O {
+       |  def test(n: Int) = {
+       |    n == 1
+       |  }
+       |}
+       |""".stripMargin
+  )
+
   checkError(
     "scoping-packages",
     """|package a


### PR DESCRIPTION
fixes: #6924

### Before:
We search for overshadowed symbols before performing inline - names, which would refer to different symbol after inline, by looking at symbols available in the new scope.

### Problem:
For symbol `scala/Int#==()` , conflicting `scala/Any#==()` was found.

### Now:
Since symbols for `methods` and `values` on a class/type instance that is not an owner of the inlined method are not in the scope, we don't check them for conflicts.