### PR TITLE
Presentation Compiler is now loaded with correct classloader

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/PresentationCompilerClassLoader.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/PresentationCompilerClassLoader.scala
@@ -9,7 +9,7 @@ package scala.meta.internal.metals
  * method signatures of the `PresentationCompiler` class.
  */
 class PresentationCompilerClassLoader(parent: ClassLoader)
-    extends ClassLoader(null) {
+    extends ClassLoader(ClassLoader.getSystemClassLoader().getParent()) {
   override def findClass(name: String): Class[_] = {
     val isShared =
       name.startsWith("org.eclipse.lsp4j") ||

--- a/tests/unit/src/test/scala/tests/ClassloaderModulesSupport.scala
+++ b/tests/unit/src/test/scala/tests/ClassloaderModulesSupport.scala
@@ -1,0 +1,56 @@
+package tests
+
+import scala.meta.internal.metals.BuildInfo
+
+class ClassloaderModulesSupport
+    extends BaseLspSuite("classloader-modules-")
+    with TestHovers {
+
+  test("basic") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""/metals.json
+           |{
+           |  "a": { "scalaVersion": "${BuildInfo.scala3}" },
+           |  "b": { "dependsOn": ["a"], "scalaVersion": "${BuildInfo.scala3}" }
+           |}
+           |
+           |/a/src/main/scala/a/A.scala
+           |package a
+           |
+           |import scala.quoted._
+           |
+           |object MacroImpl:
+           |  transparent inline def make = $${ makeImpl }
+           |
+           |  private def makeImpl(using Quotes): Expr[Unit] =
+           |    Class.forName("java.sql.Driver")
+           |    '{()}
+           |
+           |/b/src/main/scala/b/B.scala
+           |package b
+           |
+           |object B:
+           |  a.MacroImpl.make
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ <- server.didOpen("b/src/main/scala/b/B.scala")
+      _ = assertNoDiagnostics()
+      _ <- server.assertHover(
+        "b/src/main/scala/b/B.scala",
+        """
+          |/b/src/main/scala/b/B.scala
+          |package b
+          |
+          |object B:
+          |  a.MacroImpl.ma@@ke
+          |""".stripMargin,
+        """|
+           |inline transparent def make: Unit
+           |""".stripMargin.hover,
+      )
+    } yield ()
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/6494
Fixes https://github.com/scala/scala3/issues/20560
 
We've found that classloader used to load presentation compiler is defined as follows:
```scala
package scala.meta.internal.metals

/**
 * ClassLoader that is used to reflectively invoke presentation compiler APIs.
 *
 * The presentation compiler APIs are compiled against exact Scala versions of the compiler
 * while Metals only runs in a single Scala version. In order to communicate between Metals and the
 * reflectively loaded compiler, this classloader shares a subset of Java classes that appear in
 * method signatures of the `PresentationCompiler` class.
 */
class PresentationCompilerClassLoader(parent: ClassLoader)
    extends ClassLoader(null) {
  override def findClass(name: String): Class[_] = {
    val isShared =
      name.startsWith("org.eclipse.lsp4j") ||
        name.startsWith("com.google.gson") ||
        name.startsWith("scala.meta.pc") ||
        name.startsWith("javax")
    if (isShared) {
      parent.loadClass(name)
    } else {
      throw new ClassNotFoundException(name)
    }
  }
}
```

and it is used as a parent classloader:

```scala
  private def newPresentationCompilerClassLoader(
      mtags: MtagsBinaries.Artifacts
  ): URLClassLoader = {
    val allJars = mtags.jars.iterator
    val allURLs = allJars.map(_.toUri.toURL).toArray
    // Share classloader for a subset of types.
    val parent =
      new PresentationCompilerClassLoader(this.getClass.getClassLoader)
    new URLClassLoader(allURLs, parent)
  }
```

This approach won't work on java 9+ 
More information here: https://github.com/scala/scala3/pull/11658/files