### PR TITLE
improvement: thresholds for folding regions

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -255,6 +255,7 @@ abstract class MetalsLspService(
     trees,
     buffers,
     foldOnlyLines = initializeParams.foldOnlyLines,
+    clientConfig.initialConfig.foldingRageMinimumSpan,
   )
 
   protected val diagnostics: Diagnostics = new Diagnostics(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -121,6 +121,11 @@ final case class MetalsServerConfig(
       "metals.enable-best-effort",
       default = false,
     ),
+    foldingRageMinimumSpan: Int =
+      Option(System.getProperty("metals.folding-range-minimum-span"))
+        .filter(_.forall(Character.isDigit(_)))
+        .map(_.toInt)
+        .getOrElse(3),
 ) {
   override def toString: String =
     List[String](
@@ -144,6 +149,7 @@ final case class MetalsServerConfig(
       s"worksheet-timeout=$worksheetTimeout",
       s"debug-server-start-timeout=$debugServerStartTimeout",
       s"enable-best-effort=$enableBestEffort",
+      s"folding-range-minimum-span=$foldingRageMinimumSpan",
     ).mkString("MetalsServerConfig(\n  ", ",\n  ", "\n)")
 }
 object MetalsServerConfig {

--- a/metals/src/main/scala/scala/meta/internal/parsing/JavaFoldingRangeExtractor.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/JavaFoldingRangeExtractor.scala
@@ -20,7 +20,6 @@ import org.eclipse.lsp4j.FoldingRange
 import org.eclipse.lsp4j.FoldingRangeKind
 
 final object JavaFoldingRangeExtractor {
-  private val spanThreshold = 2
 
   private case class Range(
       startPos: Long,
@@ -165,6 +164,7 @@ final object JavaFoldingRangeExtractor {
       text: String,
       path: AbsolutePath,
       foldOnlyLines: Boolean,
+      spanThreshold: Int,
   ): List[FoldingRange] = {
     getTrees(text, path) match {
       case Some((trees, root)) =>

--- a/tests/unit/src/test/resources/foldingRange-scala3-foldLineOnly/expect/Main.java
+++ b/tests/unit/src/test/resources/foldingRange-scala3-foldLineOnly/expect/Main.java
@@ -23,6 +23,7 @@ public class Main >>region>>{
 
     abstract class A >>region>>{
         abstract void hello();
+        abstract void hello2();
     }<<region<<
 
     abstract class B extends A >>region>>{
@@ -41,13 +42,13 @@ public class Main >>region>>{
             return "asssd";
         }<<region<<
 
-        void openingCommentInStr() >>region>>{
+        void openingCommentInStr() {
             System.out.println("/* ignore");
-        }<<region<<
+        }
 
-        void closingCommentInStr() >>region>>{
+        void closingCommentInStr() {
             System.out.println("*/ ignore");
-        }<<region<<
+        }
 
         void handleLineWithBlockAndCode() >>region>>{
             if (true) >>region>>{

--- a/tests/unit/src/test/resources/foldingRange-scala3-foldLineOnly/expect/i6938.scala
+++ b/tests/unit/src/test/resources/foldingRange-scala3-foldLineOnly/expect/i6938.scala
@@ -1,0 +1,28 @@
+def xd =>>region>>
+  val t =
+    1 + 2
+
+  t match
+    case 3 => println("ok")
+    case _ => println("ko")<<region<<
+end xd
+
+
+def xd2 =>>region>>
+  val t = 1 + 2
+
+  t match>>region>>
+    case 3 =>
+      println("ok")
+    case _ => println("ko")<<region<<<<region<<
+end xd2
+
+def xd3 =>>region>>
+  val t =
+    1 + 2
+
+  t match>>region>>
+    case 3 =>
+        println("ok")
+    case _ => println("ko")<<region<<<<region<<
+end xd3

--- a/tests/unit/src/test/resources/foldingRange-scala3-foldLineOnly/input/Main.java
+++ b/tests/unit/src/test/resources/foldingRange-scala3-foldLineOnly/input/Main.java
@@ -23,6 +23,7 @@ public class Main {
 
     abstract class A {
         abstract void hello();
+        abstract void hello2();
     }
 
     abstract class B extends A {

--- a/tests/unit/src/test/resources/foldingRange-scala3-foldLineOnly/input/i6938.scala
+++ b/tests/unit/src/test/resources/foldingRange-scala3-foldLineOnly/input/i6938.scala
@@ -1,0 +1,28 @@
+def xd =
+  val t =
+    1 + 2
+
+  t match
+    case 3 => println("ok")
+    case _ => println("ko")
+end xd
+
+
+def xd2 =
+  val t = 1 + 2
+
+  t match
+    case 3 =>
+      println("ok")
+    case _ => println("ko")
+end xd2
+
+def xd3 =
+  val t =
+    1 + 2
+
+  t match
+    case 3 =>
+        println("ok")
+    case _ => println("ko")
+end xd3

--- a/tests/unit/src/test/resources/foldingRange-scala3/expect/BlockWithNoBraces.scala
+++ b/tests/unit/src/test/resources/foldingRange-scala3/expect/BlockWithNoBraces.scala
@@ -43,7 +43,7 @@ def fooNested(): Unit =>>region>>
 
 def fooWithMatch(): Unit =>>region>>
   def bar(): Unit =>>region>>
-    ??? match
+    ??? match>>region>>
       case 1 =>>>region>>
         ???
         ???
@@ -56,7 +56,7 @@ def fooWithMatch(): Unit =>>region>>
           case 6 => ???<<region<<
         ???
         ???
-        ???<<region<<<<region<<
+        ???<<region<<<<region<<<<region<<
   ???
   ???
   ???

--- a/tests/unit/src/test/resources/foldingRange/expect/Blocks.scala
+++ b/tests/unit/src/test/resources/foldingRange/expect/Blocks.scala
@@ -19,20 +19,20 @@ class A >>region>>{
 
   def chain =>>region>> Seq(1).map{
     x =>
-    x + 1
+    >>region>>x + 1
      + 1
      + 1
      + 1
      + 1
      + 1
-     + 1
+     + 1<<region<<
   }.map>>region>>{
-    _ + 1
+    >>region>>_ + 1
     + 1
     + 1
     + 1
     + 1
-    + 1
+    + 1<<region<<
   }<<region<<<<region<<
 
   def chain =>>region>> Seq(1).map(

--- a/tests/unit/src/test/resources/foldingRange/expect/ForLoop.scala
+++ b/tests/unit/src/test/resources/foldingRange/expect/ForLoop.scala
@@ -7,14 +7,14 @@ class A >>region>>{
     }<<region<<
 
   def noSpacing =>>region>>
-    for>>region>>{
+    for{
       x <- ???
-    }<<region<<{
+    }>>region>>{
       ???
       ???
       ???
       ???
-    }<<region<<
+    }<<region<<<<region<<
 
   def why =>>region>>
     for

--- a/tests/unit/src/test/resources/foldingRange/expect/ForYield.scala
+++ b/tests/unit/src/test/resources/foldingRange/expect/ForYield.scala
@@ -9,11 +9,11 @@ class A >>region>>{
   def noSpacing =>>region>>
     for{
       x <- ???
-    }yield{
+    }yield>>region>>{
       ???
       ???
       ???
-    }<<region<<
+    }<<region<<<<region<<
 
   def why =>>region>>
     for

--- a/tests/unit/src/test/resources/foldingRange/expect/Literals.scala
+++ b/tests/unit/src/test/resources/foldingRange/expect/Literals.scala
@@ -1,13 +1,13 @@
 class A>>region>>{
   val multilineString =>>region>>
-    """
+    """>>region>>
       |
       |
       |
       |
       |
       |
-    """.stripMargin<<region<<
+    """<<region<<.stripMargin<<region<<
 
   val b = ???
 }<<region<<

--- a/tests/unit/src/test/resources/foldingRange/expect/Main.java
+++ b/tests/unit/src/test/resources/foldingRange/expect/Main.java
@@ -23,6 +23,7 @@ public class Main >>region>>{
 
     abstract class A >>region>>{
         abstract void hello();
+        abstract void aaa();
     }<<region<<
 
     abstract class B extends A >>region>>{
@@ -41,13 +42,13 @@ public class Main >>region>>{
             return "asssd";
         }<<region<<
 
-        void openingCommentInStr() >>region>>{
+        void openingCommentInStr() {
             System.out.println("/* ignore");
-        }<<region<<
+        }
 
-        void closingCommentInStr() >>region>>{
+        void closingCommentInStr() {
             System.out.println("*/ ignore");
-        }<<region<<
+        }
 
         void handleLineWithBlockAndCode() >>region>>{
             if (true) >>region>>{

--- a/tests/unit/src/test/resources/foldingRange/expect/PartialFunctionCases.scala
+++ b/tests/unit/src/test/resources/foldingRange/expect/PartialFunctionCases.scala
@@ -1,7 +1,7 @@
 class A >>region>>{
   val tryCatch =>>region>>
     try ???
-    catch {
+    catch >>region>>{
       case 0 =>
       case 1 => println()
       case 2 =>>>region>>
@@ -12,7 +12,7 @@ class A >>region>>{
       case 3 =>
         println()
       case _ => println()
-    }<<region<<
+    }<<region<<<<region<<
 
   val patternMatching =>>region>> ??? match {
     case 0 =>

--- a/tests/unit/src/test/resources/foldingRange/expect/Try.scala
+++ b/tests/unit/src/test/resources/foldingRange/expect/Try.scala
@@ -1,7 +1,7 @@
 class A>>region>>{
   val shortExpr =>>region>>
     try ???
-    catch {
+    catch >>region>>{
       case 0 =>
       case 1 => println()
       case 2 =>>>region>>
@@ -12,7 +12,7 @@ class A>>region>>{
       case 3 =>
         println()
       case _ => println()
-    }<<region<<
+    }<<region<<<<region<<
 
   val aTry =>>region>>
     try >>region>>{

--- a/tests/unit/src/test/resources/foldingRange/input/Main.java
+++ b/tests/unit/src/test/resources/foldingRange/input/Main.java
@@ -23,6 +23,7 @@ public class Main {
 
     abstract class A {
         abstract void hello();
+        abstract void aaa();
     }
 
     abstract class B extends A {

--- a/tests/unit/src/test/scala/tests/FoldingRangeSuite.scala
+++ b/tests/unit/src/test/scala/tests/FoldingRangeSuite.scala
@@ -19,7 +19,7 @@ abstract class FoldingRangeSuite(
 ) extends DirectoryExpectSuite(s"$directory/expect") {
   private val (buffers, trees) = TreeUtils.getTrees(scalaVersion)
   private val foldingRangeProvider =
-    new FoldingRangeProvider(trees, buffers, lineFoldingOnly)
+    new FoldingRangeProvider(trees, buffers, lineFoldingOnly, 3)
 
   override def testCases(): List[ExpectTestCase] = {
     val inputDirectory = AbsolutePath(testResourceDirectory)


### PR DESCRIPTION
- don't merge region with parent when if parent too small without it
- allow to configure folding region threshold using server properties
- make threshold work consistently

resolves: https://github.com/scalameta/metals/issues/6938