### PR TITLE
improvement: Don't sent text on didSave

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -872,9 +872,6 @@ abstract class MetalsLspService(
   ): CompletableFuture[Unit] = {
     val path = params.getTextDocument.getUri.toAbsolutePath
     savedFiles.add(path)
-    // read file from disk, we only remove files from buffers on didClose.
-    val text = path.toInput.text
-    buffers.put(path, text)
     Future
       .sequence(
         List(

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -1215,7 +1215,10 @@ class WorkspaceLspService(
 
         val textDocumentSyncOptions = new lsp4j.TextDocumentSyncOptions
         textDocumentSyncOptions.setChange(lsp4j.TextDocumentSyncKind.Full)
-        textDocumentSyncOptions.setSave(new lsp4j.SaveOptions(true))
+        // We don't use the text at all.
+        textDocumentSyncOptions.setSave(
+          new lsp4j.SaveOptions( /* includeText = */ false)
+        )
         textDocumentSyncOptions.setOpenClose(true)
 
         val scalaFilesPattern = new lsp4j.FileOperationPattern("**/*.scala")

--- a/tests/slow/src/test/scala/tests/bazel/BazelLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelLspSuite.scala
@@ -55,13 +55,13 @@ class BazelLspSuite
       _ = assertStatus(_.isInstalled)
       _ = assertNoDiff(client.workspaceDiagnostics, "")
       _ <- server.didChange("WORKSPACE")(_ + "\n# comment")
-      _ <- server.didSave("WORKSPACE")(identity)
+      _ <- server.didSave("WORKSPACE")
       // Comment changes do not trigger "re-import project" request
       _ = assertNoDiff(client.workspaceMessageRequests, "")
       _ <- server.didChange("Hello.scala") { text =>
         text.replace("def hello: String", "def hello: Int")
       }
-      _ <- server.didSave("Hello.scala")(identity)
+      _ <- server.didSave("Hello.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|Hello.scala:4:20: error: type mismatch;
@@ -78,7 +78,7 @@ class BazelLspSuite
       }
       _ = assertNoDiff(client.workspaceMessageRequests, "")
       _ = client.generateBspAndConnect = GenerateBspAndConnect.yes
-      _ <- server.didSave(s"BUILD")(identity)
+      _ <- server.didSave(s"BUILD")
     } yield {
       assertNoDiff(
         client.workspaceMessageRequests,
@@ -105,7 +105,7 @@ class BazelLspSuite
       _ <- server.didChange(s"BUILD") { text =>
         text.replace("\"hello\"", "\"hello1\"")
       }
-      _ <- server.didSave(s"BUILD")(identity)
+      _ <- server.didSave(s"BUILD")
       _ = assertNoDiff(client.workspaceMessageRequests, "")
       _ = server.headServer.connectionProvider.buildServerPromise = Promise()
       _ <- server.executeCommand(ServerCommands.GenerateBspConfig)
@@ -114,7 +114,7 @@ class BazelLspSuite
       _ <- server.didChange("Hello.scala") { text =>
         text.replace("def hello: String", "def hello: Int")
       }
-      _ <- server.didSave("Hello.scala")(identity)
+      _ <- server.didSave("Hello.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|Hello.scala:4:20: error: type mismatch;
@@ -158,7 +158,7 @@ class BazelLspSuite
       _ <- server.didChange(s"BUILD") { text =>
         text.replace("\"hello\"", "\"hello1\"")
       }
-      _ <- server.didSave(s"BUILD")(identity)
+      _ <- server.didSave(s"BUILD")
       _ = assertNoDiff(client.workspaceMessageRequests, "")
       _ = server.headServer.connectionProvider.buildServerPromise = Promise()
       _ <- server.executeCommand(ServerCommands.ImportBuild)
@@ -209,7 +209,7 @@ class BazelLspSuite
       )
       _ <- server.didOpen("Hello.scala")
       _ <- server.didOpen("Main.scala")
-      _ <- server.didSave("Main.scala")(identity)
+      _ <- server.didSave("Main.scala")
       references <- server.references("Hello.scala", "hello")
       _ = assertNoDiff(
         references,
@@ -251,7 +251,7 @@ class BazelLspSuite
            |}
            |""".stripMargin
       }
-      _ <- server.didSave("Hello.scala")(identity)
+      _ <- server.didSave("Hello.scala")
       _ = assertNoDiff(
         server.client.workspaceDiagnostics,
         """|Hello.scala:11:3: warning: match may not be exhaustive.
@@ -269,7 +269,7 @@ class BazelLspSuite
             |class Additional
             |""".stripMargin
       }
-      _ <- server.didSave("Hello.scala")(identity)
+      _ <- server.didSave("Hello.scala")
       _ = assertNoDiff(
         server.client.workspaceDiagnostics,
         """|Hello.scala:11:3: warning: match may not be exhaustive.
@@ -315,7 +315,7 @@ class BazelLspSuite
       _ <- server.didChange("Hello.scala") { text =>
         text.replace("def hello: String", "def hello: Int")
       }
-      _ <- server.didSave("Hello.scala")(identity)
+      _ <- server.didSave("Hello.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|Hello.scala:4:20: error: type mismatch;
@@ -353,7 +353,7 @@ class BazelLspSuite
       _ <- server.didChange("Hello.scala") { text =>
         text.replace("def hello: String", "def hello: Int")
       }
-      _ <- server.didSave("Hello.scala")(identity)
+      _ <- server.didSave("Hello.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|Hello.scala:4:20: error: type mismatch;
@@ -367,12 +367,14 @@ class BazelLspSuite
       )
       _ = client.messageRequests.clear()
       _ <- server.didOpen("Hello.scala")
-      _ <- server.didSave("Hello.scala") { text =>
+      _ <- server.didChange("Hello.scala") { text =>
         text.replace("def hello: Int", "def hello: String")
       }
+      _ <- server.didSave("Hello.scala")
       _ = assertNoDiagnostics()
       _ <- server.didOpen("projectview.bazelproject")
-      _ <- server.didSave("projectview.bazelproject")(_ => "")
+      _ <- server.didChange("projectview.bazelproject")(_ => "")
+      _ <- server.didSave("projectview.bazelproject")
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         ImportBuildChanges.params("bazel").getMessage(),

--- a/tests/slow/src/test/scala/tests/bazel/BazelLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelLspSuite.scala
@@ -234,7 +234,7 @@ class BazelLspSuite
         BazelBuildLayout(workspaceLayout, V.bazelScalaVersion, bazelVersion)
       )
       _ <- server.didOpen("Hello.scala")
-      _ <- server.didSave("Hello.scala") { _ =>
+      _ <- server.didChange("Hello.scala") { _ =>
         """|package examples.scala3
            |
            |sealed trait A
@@ -251,6 +251,7 @@ class BazelLspSuite
            |}
            |""".stripMargin
       }
+      _ <- server.didSave("Hello.scala")(identity)
       _ = assertNoDiff(
         server.client.workspaceDiagnostics,
         """|Hello.scala:11:3: warning: match may not be exhaustive.
@@ -262,12 +263,13 @@ class BazelLspSuite
            |""".stripMargin,
       )
       // warnings should not disappear after updating
-      _ <- server.didSave("Hello.scala") { text =>
+      _ <- server.didChange("Hello.scala") { text =>
         s"""|$text
             |
             |class Additional
             |""".stripMargin
       }
+      _ <- server.didSave("Hello.scala")(identity)
       _ = assertNoDiff(
         server.client.workspaceDiagnostics,
         """|Hello.scala:11:3: warning: match may not be exhaustive.

--- a/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/AmmoniteSuite.scala
@@ -20,7 +20,7 @@ class Ammonite213Suite extends tests.BaseAmmoniteSuite(V.ammonite213) {
            |""".stripMargin
       )
       _ <- server.didOpen("main.sc")
-      _ <- server.didSave("main.sc")(identity)
+      _ <- server.didSave("main.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
 
       groupCompletionList <- server.completion(
@@ -52,7 +52,7 @@ class Ammonite212Suite extends tests.BaseAmmoniteSuite(V.ammonite212) {
            |""".stripMargin
       )
       _ <- server.didOpen("main.sc")
-      _ <- server.didSave("main.sc")(identity)
+      _ <- server.didSave("main.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
     } yield {
       assertEmpty(client.workspaceErrorShowMessages)

--- a/tests/slow/src/test/scala/tests/feature/MultipleBuildFilesLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/MultipleBuildFilesLspSuite.scala
@@ -53,7 +53,7 @@ class MultipleBuildFilesLspSuite
         text + "\nversion := \"1.0.0\"\n"
       }
       _ = assertNoDiff(client.workspaceMessageRequests, "")
-      _ <- server.didSave("build.sbt")(identity)
+      _ <- server.didSave("build.sbt")
     } yield {
       assertNoDiff(
         client.workspaceMessageRequests,

--- a/tests/slow/src/test/scala/tests/feature/SyntaxErrorLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/SyntaxErrorLspSuite.scala
@@ -76,7 +76,8 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
       _ = assertNoDiff(client.workspaceDiagnostics, "")
       _ <- server.didOpen("Main.scala")
       _ <- server.didOpen("project/plugins.sbt")
-      _ <- server.didSave("Main.scala")(_ => "object A\n")
+      _ <- server.didChange("Main.scala")(_ => "object A\n")
+      _ <- server.didSave("Main.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|project/plugins.sbt:1:8: error: `identifier` expected but `object` found
@@ -84,7 +85,8 @@ class SyntaxErrorLspSuite extends BaseLspSuite("syntax-error") {
            |       ^^^^^^
            |""".stripMargin,
       )
-      _ <- server.didSave("project/plugins.sbt")(_ => "lazy val x = 1\n")
+      _ <- server.didChange("project/plugins.sbt")(_ => "lazy val x = 1\n")
+      _ <- server.didSave("project/plugins.sbt")
       _ = assertNoDiff(client.workspaceDiagnostics, "")
     } yield ()
   }

--- a/tests/slow/src/test/scala/tests/gradle/GradleLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/gradle/GradleLspSuite.scala
@@ -50,7 +50,7 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
       _ = assertStatus(_.isInstalled)
       _ <- server.didChange("build.gradle")(_ + "\n// comment")
       _ = assertNoDiff(client.workspaceMessageRequests, "")
-      _ <- server.didSave("build.gradle")(identity)
+      _ <- server.didSave("build.gradle")
       // Comment changes do not trigger "re-import project" request
       _ = assertNoDiff(client.workspaceMessageRequests, "")
       _ <- server.didChange("build.gradle") { text =>
@@ -58,7 +58,7 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
       }
       _ = assertNoDiff(client.workspaceMessageRequests, "")
       _ = client.importBuildChanges = ImportBuildChanges.yes
-      _ <- server.didSave("build.gradle")(identity)
+      _ <- server.didSave("build.gradle")
     } yield {
       assertNoDiff(
         client.workspaceMessageRequests,
@@ -97,7 +97,7 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
         workspace.resolve("inner"),
       )
       _ <- server.didOpen("inner/src/main/scala/A.scala")
-      _ <- server.didSave("inner/src/main/scala/A.scala")(identity)
+      _ <- server.didSave("inner/src/main/scala/A.scala")
       _ = assertNoDiff(
         client.pathDiagnostics("inner/src/main/scala/A.scala"),
         """|inner/src/main/scala/A.scala:2:18: error: type mismatch;
@@ -148,14 +148,14 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
       _ = assertStatus(_.isInstalled)
       _ <- server.didChange("build.gradle")(_ + "\n// comment")
       _ = assertNoDiff(client.workspaceMessageRequests, "")
-      _ <- server.didSave("build.gradle")(identity)
+      _ <- server.didSave("build.gradle")
       // Comment changes do not trigger "re-import project" request
       _ = assertNoDiff(client.workspaceMessageRequests, "")
       _ <- server.didChange("build.gradle") { text =>
         text + "\ndef version = \"1.0.0\"\n"
       }
       _ = assertNoDiff(client.workspaceMessageRequests, "")
-      _ <- server.didSave("build.gradle")(identity)
+      _ <- server.didSave("build.gradle")
     } yield {
       assertNoDiff(
         client.workspaceMessageRequests,
@@ -196,7 +196,7 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
       )
       _ = client.messageRequests.clear()
       _ = assertStatus(_.isInstalled)
-      _ <- server.didSave("src/main/java/a/Main.java")(identity)
+      _ <- server.didSave("src/main/java/a/Main.java")
       debugger <- server.startDebugging(
         javaOnlyTestName,
         DebugSessionParamsDataKind.SCALA_MAIN_CLASS,
@@ -301,19 +301,21 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
       _ <- server.didOpen("src/main/scala/reload/Main.scala")
       _ = assertNoDiff(client.workspaceDiagnostics, "")
       _ = client.importBuildChanges = ImportBuildChanges.yes
-      _ <- server.didSave("build.gradle") { text =>
+      _ <- server.didChange("build.gradle") { text =>
         s"""$text
            |dependencies {
            |    implementation 'com.lihaoyi:sourcecode_2.12:0.1.4'
            |}
            |""".stripMargin
       }
+      _ <- server.didSave("build.gradle")
       _ <-
         server
-          .didSave("src/main/scala/reload/Main.scala") { text =>
+          .didChange("src/main/scala/reload/Main.scala") { text =>
             text.replaceAll("\"", "")
           }
           .recover { case e => scribe.error("compile", e) }
+      _ <- server.didSave("src/main/scala/reload/Main.scala")
       _ = assertNoDiff(client.workspaceDiagnostics, "")
     } yield ()
   }
@@ -339,7 +341,7 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
       )
       _ = assertStatus(!_.isInstalled)
       _ = client.messageRequests.clear()
-      _ <- server.didSave("build.gradle") { _ =>
+      _ <- server.didChange("build.gradle") { _ =>
         s"""|plugins {
             |    id 'scala'
             |}
@@ -351,6 +353,7 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
             |}
             |""".stripMargin
       }
+      _ <- server.didSave("build.gradle")
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         importBuildMessage,
@@ -528,7 +531,7 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
         "rootProject.name = 'new-name'\n"
       )
       _ = client.importBuildChanges = ImportBuildChanges.yes
-      _ <- server.didSave("inner/settings.gradle")(identity)
+      _ <- server.didSave("inner/settings.gradle")
       _ = assert(
         server.server.buildTargets.all
           .exists(_.getDisplayName() == "new-name"),

--- a/tests/slow/src/test/scala/tests/maven/MavenLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/maven/MavenLspSuite.scala
@@ -46,7 +46,7 @@ class MavenLspSuite extends BaseImportSuite("maven-import") {
           .replace("<!--URL-->", "<!--Your comment--><!--MARKER-->")
       )
       _ = assertNoDiff(client.workspaceMessageRequests, "")
-      _ <- server.didSave("pom.xml")(identity)
+      _ <- server.didSave("pom.xml")
       // Comment changes do not trigger "re-import project" request
       _ = assertNoDiff(client.workspaceMessageRequests, "")
       _ <- server.didChange("pom.xml") { _ =>
@@ -54,7 +54,7 @@ class MavenLspSuite extends BaseImportSuite("maven-import") {
       }
       _ = assertNoDiff(client.workspaceMessageRequests, "")
       _ = client.importBuildChanges = ImportBuildChanges.yes
-      _ <- server.didSave("pom.xml")(identity)
+      _ <- server.didSave("pom.xml")
     } yield {
       assertNoDiff(
         client.workspaceMessageRequests,
@@ -146,7 +146,7 @@ class MavenLspSuite extends BaseImportSuite("maven-import") {
       _ <- server.didOpen("src/main/scala/reload/Main.scala")
       _ = assertNoDiff(client.workspaceDiagnostics, "")
       _ = client.importBuildChanges = ImportBuildChanges.yes
-      _ <- server.didSave("pom.xml") { text =>
+      _ <- server.didChange("pom.xml") { text =>
         text.replace(
           "<!--DEPENDENCY-->",
           s"""
@@ -158,12 +158,16 @@ class MavenLspSuite extends BaseImportSuite("maven-import") {
              |""".stripMargin,
         )
       }
+      _ <- server.didSave("pom.xml")
       _ <-
         server
-          .didSave("src/main/scala/reload/Main.scala") { text =>
+          .didChange("src/main/scala/reload/Main.scala") { text =>
             text.replaceAll("\"", "")
           }
           .recover { case e => scribe.error("compile", e) }
+      _ <-
+        server
+          .didSave("src/main/scala/reload/Main.scala")
       _ = assertNoDiff(client.workspaceDiagnostics, "")
     } yield ()
   }
@@ -197,7 +201,8 @@ class MavenLspSuite extends BaseImportSuite("maven-import") {
       )
       _ = assertStatus(!_.isInstalled)
       _ = client.messageRequests.clear()
-      _ <- server.didSave("pom.xml")(_ => defaultPom)
+      _ <- server.didChange("pom.xml")(_ => defaultPom)
+      _ <- server.didSave("pom.xml")
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         importBuildMessage,

--- a/tests/slow/src/test/scala/tests/mill/MillDebugDiscoverySuite.scala
+++ b/tests/slow/src/test/scala/tests/mill/MillDebugDiscoverySuite.scala
@@ -61,11 +61,11 @@ class MillDebugDiscoverySuite
           )
         )
         _ <- server.didOpen("a/src/Main.scala")
-        _ <- server.didSave("a/src/Main.scala")(
-          identity
+        _ <- server.didSave(
+          "a/src/Main.scala"
         ) // making sure it gets compiled to the correct destination
         _ <- server.didOpen(barPath)
-        _ <- server.didSave(barPath)(identity)
+        _ <- server.didSave(barPath)
         _ <- server.waitFor(TimeUnit.SECONDS.toMillis(10))
         debugger <- server.startDebuggingUnresolved(
           new DebugDiscoveryParams(
@@ -108,7 +108,7 @@ class MillDebugDiscoverySuite
           )
         )
         _ <- server.didOpen(fooPath)
-        _ <- server.didSave(fooPath)(identity)
+        _ <- server.didSave(fooPath)
         _ <- server.waitFor(TimeUnit.SECONDS.toMillis(10))
         debugger <- server.startDebugging(
           "a.test",
@@ -148,7 +148,7 @@ class MillDebugDiscoverySuite
         )
       )
       _ <- server.didOpen(fooPath)
-      _ <- server.didSave(fooPath)(identity)
+      _ <- server.didSave(fooPath)
       _ <- server.waitFor(TimeUnit.SECONDS.toMillis(10))
       debugger <- server.startDebugging(
         "a.test",

--- a/tests/slow/src/test/scala/tests/mill/MillServerCodeLensSuite.scala
+++ b/tests/slow/src/test/scala/tests/mill/MillServerCodeLensSuite.scala
@@ -41,7 +41,7 @@ class MillServerCodeLensSuite
       _ <- server.initialized()
       _ <- server.executeCommand(ServerCommands.GenerateBspConfig)
       _ <- server.didOpen("a/src/Main.scala")
-      _ <- server.didSave("a/src/Main.scala")(identity)
+      _ <- server.didSave("a/src/Main.scala")
       _ = assertNoDiagnostics()
       _ <- assertCodeLenses(
         "a/src/Main.scala",

--- a/tests/slow/src/test/scala/tests/sbt/WorkspaceFolderSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/WorkspaceFolderSuite.scala
@@ -107,9 +107,7 @@ class WorkspaceFolderSuite extends BaseImportSuite("sbt-workspace-suite") {
                 |}
                 |""".stripMargin
       )
-      _ <- server.didSave(s"$libraryFolder/src/main/scala/example/A.scala")(
-        identity
-      )
+      _ <- server.didSave(s"$libraryFolder/src/main/scala/example/A.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|library-folder/src/main/scala/example/A.scala:3:19: error: type mismatch;

--- a/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
+++ b/tests/slow/src/test/scala/tests/scalacli/ScalaCliSuite.scala
@@ -417,7 +417,7 @@ class ScalaCliSuite extends BaseScalaCliSuite("3.3.3") {
       )
       _ = client.switchBuildTool = Messages.NewBuildToolDetected.switch
       _ = client.importBuild = Messages.ImportBuild.yes
-      _ <- server.didSave("build.sbt")(identity)
+      _ <- server.didSave("build.sbt")
       _ = assert(
         server.server.tables.buildTool.selectedBuildTool().contains("sbt")
       )
@@ -502,11 +502,12 @@ class ScalaCliSuite extends BaseScalaCliSuite("3.3.3") {
            |            ^^
            |""".stripMargin,
       )
-      _ <- server.didSave("Main.scala") { text =>
+      _ <- server.didChange("Main.scala") { text =>
         text.replace("// >", "//>")
       }
+      _ <- server.didSave("Main.scala")
       // cause another compilation to wait on workspace reload, the previous gets cancelled
-      _ <- server.didSave("Main.scala")(identity)
+      _ <- server.didSave("Main.scala")
       _ = assertEquals(
         server.client.workspaceDiagnostics,
         "",

--- a/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseAmmoniteSuite.scala
@@ -64,7 +64,7 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
            |""".stripMargin
       )
       _ <- server.didOpen("main.sc")
-      _ <- server.didSave("main.sc")(identity)
+      _ <- server.didSave("main.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
 
       // via Ammonite-generated Semantic DB
@@ -136,7 +136,7 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
       )
       _ <- server.didOpen("main.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
-      _ <- server.didSave("main.sc")(identity)
+      _ <- server.didSave("main.sc")
       _ = assertNoDiagnostics()
       _ <- server.didOpen("build.sc")
       _ = assertNoDiagnostics()
@@ -168,9 +168,10 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
         server.client.workspaceShowMessages,
         s"Error importing Scala script ${workspace.resolve("main.sc")}. See the logs for more details.",
       )
-      _ <- server.didSave("main.sc") { text =>
+      _ <- server.didChange("main.sc") { text =>
         text.replace(fakeScalaVersion, scalaVersion)
       }
+      _ <- server.didSave("main.sc")
       _ <- server.server.indexingPromise.future
       targets <- server.executeCommand(ServerCommands.ListBuildTargets)
       _ = assertEquals(
@@ -210,7 +211,7 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
            |""".stripMargin
       )
       _ <- server.didOpen("main.sc")
-      _ <- server.didSave("main.sc")(identity)
+      _ <- server.didSave("main.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
 
       expectedHoverRes = """```scala
@@ -230,15 +231,17 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
         }
         promise
       }
-      _ <- server.didSave("main.sc") { _ =>
+      _ <- server.didChange("main.sc") { _ =>
         s""" // scala $scalaVersion
            |import $$ivy.`com.github.alexarchambault::case-app:2.0.0-M16`
            |import caseapp.CaseApp
            |""".stripMargin
       }
+      _ <- server.didSave("main.sc")
       // wait for Ammonite build targets to be reloaded
       _ <- refreshedPromise.future
-      _ <- server.didSave("main.sc") { text => text + "\nval a = 1" }
+      _ <- server.didChange("main.sc") { text => text + "\nval a = 1" }
+      _ <- server.didSave("main.sc")
       // Hover on class defined in dependency loaded after the re-index.
       // Fails if interactive compilers were not properly discarded prior
       // to re-indexing.
@@ -289,11 +292,11 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
       _ <- server.didOpen("b/others/Script.sc")
       _ <- server.didOpen("b/notThis.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
-      _ <- server.didSave("b/otherMain.sc")(identity)
-      _ <- server.didSave("b/other.sc")(identity)
-      _ <- server.didSave("b/otherScript.sc")(identity)
-      _ <- server.didSave("b/others/Script.sc")(identity)
-      _ <- server.didSave("b/notThis.sc")(identity)
+      _ <- server.didSave("b/otherMain.sc")
+      _ <- server.didSave("b/other.sc")
+      _ <- server.didSave("b/otherScript.sc")
+      _ <- server.didSave("b/others/Script.sc")
+      _ <- server.didSave("b/notThis.sc")
       expectedCompletionList = """|other.sc
                                   |otherScript.sc
                                   |others""".stripMargin
@@ -328,8 +331,8 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
       _ <- server.didOpen("foo.sc")
       _ <- server.didOpen("foos/Script.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
-      _ <- server.didSave("foo.sc")(identity)
-      _ <- server.didSave("foos/Script.sc")(identity)
+      _ <- server.didSave("foo.sc")
+      _ <- server.didSave("foos/Script.sc")
 
       expectedCompletionList = "Script.sc"
       completionList <- server.completion(
@@ -370,7 +373,7 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
            |""".stripMargin
       )
       _ <- server.didOpen("main.sc")
-      _ <- server.didSave("main.sc")(identity)
+      _ <- server.didSave("main.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
 
       expectedCompletionList = """noSpaces: String
@@ -404,7 +407,7 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
            |""".stripMargin
       )
       _ <- server.didOpen("main.sc")
-      _ <- server.didSave("main.sc")(identity)
+      _ <- server.didSave("main.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
       completionList <- server.completion("main.sc", "test.a@@")
       _ = assert(completionList.startsWith("aaa: Int\n"))
@@ -464,7 +467,7 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
            |""".stripMargin
       )
       _ <- server.didOpen("errored.sc")
-      _ <- server.didSave("errored.sc")(identity)
+      _ <- server.didSave("errored.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
 
       diagnostics = server.client.pathDiagnostics("errored.sc")
@@ -514,7 +517,7 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
            |""".stripMargin
       )
       _ <- server.didOpen("main.sc")
-      _ <- server.didSave("main.sc")(identity)
+      _ <- server.didSave("main.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
 
       // via Ammonite-generated Semantic DB
@@ -634,7 +637,7 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
            |""".stripMargin
       )
       _ <- server.didOpen("main.sc")
-      _ <- server.didSave("main.sc")(identity)
+      _ <- server.didSave("main.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
 
       groupExpectedCompletionList =
@@ -725,7 +728,7 @@ abstract class BaseAmmoniteSuite(scalaVersion: String)
           |""".stripMargin
       )
       _ <- server.didOpen("main.sc")
-      _ <- server.didSave("main.sc")(identity)
+      _ <- server.didSave("main.sc")
       _ <- server.executeCommand(ServerCommands.StartAmmoniteBuildServer)
       _ <- server.assertSemanticHighlight(
         "main.sc",

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -420,7 +420,8 @@ abstract class BaseWorksheetLspSuite(
       _ <- server.didChange("a/src/main/scala/a/Util.scala")(
         _.replace("n + 1", "n + 2")
       )
-      _ <- server.didSave("a/src/main/scala/a/Main.worksheet.sc")
+      _ <- server.didSave("a/src/main/scala/a/Util.scala")
+      _ <- server.didFocus("a/src/main/scala/a/Main.worksheet.sc")
       _ <- server.assertInlayHints(
         "a/src/main/scala/a/Main.worksheet.sc",
         """

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -59,7 +59,7 @@ abstract class BaseWorksheetLspSuite(
              |""".stripMargin
         )
         _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
-        _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
+        _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")
         identity <- server.completion(
           "a/src/main/scala/foo/Main.worksheet.sc",
           "identity@@",
@@ -227,12 +227,14 @@ abstract class BaseWorksheetLspSuite(
       _ <- server.didOpen("a/src/main/scala/Main.worksheet.sc")
       _ <- cancelled.future.withTimeout(10.seconds)
       _ = client.onWorkDoneProgressStart = (_, _) => {}
-      _ <- server.didSave("a/src/main/scala/Main.worksheet.sc")(
+      _ <- server.didChange("a/src/main/scala/Main.worksheet.sc")(
         _.replace("Stream", "// Stream")
       )
-      _ <- server.didSave("a/src/main/scala/Main.worksheet.sc")(
+      _ <- server.didSave("a/src/main/scala/Main.worksheet.sc")
+      _ <- server.didChange("a/src/main/scala/Main.worksheet.sc")(
         _.replace("42", "43")
       )
+      _ <- server.didSave("a/src/main/scala/Main.worksheet.sc")
       _ <- server.assertInlayHints(
         "a/src/main/scala/Main.worksheet.sc",
         """|
@@ -415,10 +417,10 @@ abstract class BaseWorksheetLspSuite(
           |a.Util.increase(1)/* // : Int = 2*/
           |""".stripMargin,
       )
-      _ <- server.didSave("a/src/main/scala/a/Util.scala")(
+      _ <- server.didChange("a/src/main/scala/a/Util.scala")(
         _.replace("n + 1", "n + 2")
       )
-      _ <- server.didSave("a/src/main/scala/a/Main.worksheet.sc")(identity)
+      _ <- server.didSave("a/src/main/scala/a/Main.worksheet.sc")
       _ <- server.assertInlayHints(
         "a/src/main/scala/a/Main.worksheet.sc",
         """
@@ -684,7 +686,7 @@ abstract class BaseWorksheetLspSuite(
            |""".stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
-      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
+      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")
       export = server.exportEvaluation(
         "a/src/main/scala/foo/Main.worksheet.sc"
       )
@@ -728,12 +730,13 @@ abstract class BaseWorksheetLspSuite(
           )
         ),
       )
-      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(
+      _ <- server.didChange("a/src/main/scala/foo/Main.worksheet.sc")(
         _.replace(
           "Hi(1, 2, 3)",
           "Hi(7, 8, 9)",
         )
       )
+      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")
       export = server.exportEvaluation(
         "a/src/main/scala/foo/Main.worksheet.sc"
       )
@@ -879,7 +882,7 @@ abstract class BaseWorksheetLspSuite(
              |""".stripMargin
         )
         _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
-        _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
+        _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")
         codeActions <-
           server
             .assertCodeAction(
@@ -897,9 +900,7 @@ abstract class BaseWorksheetLspSuite(
               Nil,
             )
         _ <- client.applyCodeAction(0, codeActions, server)
-        _ <- server.didSave(path) { _ =>
-          server.bufferContents(path)
-        }
+        _ <- server.didSave(path)
         // Assert if indentation is correct. See `AutoImports.renderImport`
         _ = assertNoDiff(
           server.bufferContents(path),
@@ -965,7 +966,7 @@ abstract class BaseWorksheetLspSuite(
           |""".stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
-      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
+      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")
       _ <- server.assertSemanticHighlight(
         "a/src/main/scala/foo/Main.worksheet.sc",
         expected,
@@ -1002,7 +1003,7 @@ abstract class BaseWorksheetLspSuite(
           |""".stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
-      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
+      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")
       _ <- server.assertSemanticHighlight(
         "a/src/main/scala/foo/Main.worksheet.sc",
         expected,

--- a/tests/unit/src/main/scala/tests/JavaHomeChangeTest.scala
+++ b/tests/unit/src/main/scala/tests/JavaHomeChangeTest.scala
@@ -58,13 +58,13 @@ trait JavaHomeChangeTest { self: BaseLspSuite =>
         _ <- server.didOpen("a/src/main/scala/a/A.scala")
         _ = assertNoDiagnostics()
         _ <- server.didChange("a/src/main/scala/a/A.scala")(_ => java11Code)
-        _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
+        _ <- server.didSave("a/src/main/scala/a/A.scala")
         _ = assertNoDiagnostics()
         _ <- server.server.onUserConfigUpdate(
           userConfig.copy(javaHome = Some(pathToJava11))
         )
         _ <- server.didChange("a/src/main/scala/a/A.scala")(_ => java17Code)
-        _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
+        _ <- server.didSave("a/src/main/scala/a/A.scala")
         _ = assertNoDiff(
           client.workspaceDiagnostics,
           errorMessage,

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -787,6 +787,7 @@ final case class TestingServer(
     val abspath = toPath(filename)
     val oldText = abspath.toInputFromBuffers(buffers).text
     val newText = fn(oldText)
+    buffers.put(abspath, newText)
     didChange(filename, newText)
   }
 

--- a/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/codeactions/BaseCodeActionLspSuite.scala
@@ -163,12 +163,13 @@ abstract class BaseCodeActionLspSuite(
         )
         codeActions <- assertCodeAction(retryAction)
         _ <- client.applyCodeAction(selectedActionIndex, codeActions, server)
-        _ <- server.didSave(newPath) { _ =>
+        _ <- server.didChange(newPath) { _ =>
           if (newPath != path)
             server.toPath(newPath).readText
           else
             server.bufferContents(newPath)
         }
+        _ <- server.didSave(newPath)
         _ = assertNoDiff(server.bufferContents(newPath), actualExpectedCode)
         _ = if (expectNoDiagnostics) assertNoDiagnostics() else ()
         _ = extraOperations

--- a/tests/unit/src/test/scala/tests/BaseNonCompilingLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BaseNonCompilingLspSuite.scala
@@ -47,7 +47,7 @@ abstract class BaseNonCompilingLspSuite(name: String)
         }
       _ <-
         if (saveAfterChanges)
-          server.didSave("a/src/main/scala/b/B.scala")(identity)
+          server.didSave("a/src/main/scala/b/B.scala")
         else Future.unit
       _ <- assertCompletion(
         "b.UniqueObject.completeThisUniqueNa@@",
@@ -77,7 +77,7 @@ abstract class BaseNonCompilingLspSuite(name: String)
         }
       _ <-
         if (saveAfterChanges)
-          server.didSave("a/src/main/scala/b/B.scala")(identity)
+          server.didSave("a/src/main/scala/b/B.scala")
         else Future.unit
       _ <- assertCompletion(
         "b.UniqueObjectOther.completeThisUniqueNa@@",
@@ -105,9 +105,10 @@ abstract class BaseNonCompilingLspSuite(name: String)
                    |}
                    |""".stripMargin
       input = newText.replace("<<", "").replace(">>", "")
-      _ <- server.didSave("a/src/main/scala/a/A.scala") { _ =>
+      _ <- server.didChange("a/src/main/scala/a/A.scala") { _ =>
         newText.replace("<<", "").replace(">>", "")
       }
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ <-
         server
           .assertCodeAction(
@@ -119,9 +120,10 @@ abstract class BaseNonCompilingLspSuite(name: String)
             kind = Nil,
           )
       // make sure that the now change UniqueObject is not suggested
-      _ <- server.didSave("a/src/main/scala/a/A.scala") { _ =>
+      _ <- server.didChange("a/src/main/scala/a/A.scala") { _ =>
         input.replace("UniqueObjectOther", "UniqueObject")
       }
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ <-
         server
           .assertCodeAction(
@@ -355,7 +357,7 @@ abstract class BaseNonCompilingLspSuite(name: String)
            |}
            |""".stripMargin
       }
-      _ <- server.didSave("a/src/main/scala/b/B.scala")(identity)
+      _ <- server.didSave("a/src/main/scala/b/B.scala")
       // check if the change name is picked up despite the file not compiling
       newText = """|package a
                    |
@@ -366,7 +368,7 @@ abstract class BaseNonCompilingLspSuite(name: String)
                    |""".stripMargin
       input = newText.replace("<<", "").replace(">>", "")
       _ <- server.didChange("a/src/main/scala/a/A.scala")(_ => input)
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ <-
         server
           .assertCodeAction(

--- a/tests/unit/src/test/scala/tests/BillLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BillLspSuite.scala
@@ -38,7 +38,8 @@ class BillLspSuite extends BaseLspSuite("bill") {
           |               ^^
         """.stripMargin,
       )
-      _ <- server.didSave("src/com/App.scala")(_ => "object App")
+      _ <- server.didChange("src/com/App.scala")(_ => "object App")
+      _ <- server.didSave("src/com/App.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         "",
@@ -156,7 +157,8 @@ class BillLspSuite extends BaseLspSuite("bill") {
           |               ^^
         """.stripMargin,
       )
-      _ <- server.didSave("src/com/App.scala")(_ => "object App")
+      _ <- server.didChange("src/com/App.scala")(_ => "object App")
+      _ <- server.didSave("src/com/App.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         "",

--- a/tests/unit/src/test/scala/tests/BuildServerConnectionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BuildServerConnectionLspSuite.scala
@@ -26,9 +26,10 @@ class BuildServerConnectionLspSuite
       _ = server.server.bspSession.get.cancel()
       _ = assertNoDiagnostics()
       _ <- server.executeCommand(ServerCommands.ConnectBuildServer)
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(
+      _ <- server.didChange("a/src/main/scala/a/A.scala")(
         _.replace("val n = 42", "val n: String = 42")
       )
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|a/src/main/scala/a/A.scala:3:19: error: type mismatch;

--- a/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
@@ -229,9 +229,10 @@ class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
           |}
           |""".stripMargin,
       )
-      _ <- server.didSave("a/src/main/scala/Main.scala")(text =>
+      _ <- server.didChange("a/src/main/scala/Main.scala")(text =>
         text.replace("object Main", "class Main")
       )
+      _ <- server.didSave("a/src/main/scala/Main.scala")
       _ <- assertNoCodeLenses("a/src/main/scala/Main.scala")
 
     } yield ()

--- a/tests/unit/src/test/scala/tests/CompilersLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompilersLspSuite.scala
@@ -44,9 +44,17 @@ class CompilersLspSuite extends BaseCompletionLspSuite("compilers") {
         count,
       )
       _ <-
-        server.didSave("b/src/main/scala/b/B.scala")(_ => "package b; object B")
+        server.didChange("b/src/main/scala/b/B.scala")(_ =>
+          "package b; object B"
+        )
       _ <-
-        server.didSave("a/src/main/scala/a/A.scala")(_ => "package a; class A")
+        server.didSave("b/src/main/scala/b/B.scala")
+      _ <-
+        server.didChange("a/src/main/scala/a/A.scala")(_ =>
+          "package a; class A"
+        )
+      _ <-
+        server.didSave("a/src/main/scala/a/A.scala")
       _ = assertNoDiagnostics()
       countAfter = server.server.loadedPresentationCompilerCount()
       _ = assertEquals(

--- a/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
@@ -369,7 +369,7 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
           |}
           |""".stripMargin
       )
-      _ <- server.didSave("a/src/main/java/a/B.java")(identity)
+      _ <- server.didSave("a/src/main/java/a/B.java")
       _ <- assertCompletion(
         "a.n@@",
         """|name java.lang.String
@@ -409,7 +409,7 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
            |}
            |""".stripMargin
       )
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ <- assertCompletion(
         "  val k = Qu@@",
         """|QuadCurve2D - java.awt.geom
@@ -459,7 +459,7 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
            |}
            |""".stripMargin
       )
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ <- assertCompletion(
         "  Fut@@",
         """
@@ -511,7 +511,7 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
            |}
            |""".stripMargin
       )
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ <- assertCompletion(
         "  Fut@@",
         """
@@ -528,16 +528,17 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
           |""".stripMargin,
         saveCompletionOrder = true,
       )
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(_ =>
+      _ <- server.didChange("a/src/main/scala/a/A.scala")(_ =>
         """|package a
            |
            |object A {
            |}""".stripMargin
       )
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
 
       // add scala Future reference in other file
       _ = assertNoDiagnostics()
-      _ <- server.didSave("a/src/main/scala/a/B.scala")(_ =>
+      _ <- server.didChange("a/src/main/scala/a/B.scala")(_ =>
         """|package a
            |import scala.concurrent.Future
            |object E {
@@ -545,6 +546,7 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
            |}
            |""".stripMargin
       )
+      _ <- server.didSave("a/src/main/scala/a/B.scala")
       _ = assertNoDiagnostics()
       _ <- server.didChange("a/src/main/scala/a/A.scala")(_ =>
         """|package a
@@ -554,7 +556,7 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
            |}
            |""".stripMargin
       )
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
 
       // check that completions changed
       _ <- assertCompletion(

--- a/tests/unit/src/test/scala/tests/DebugDiscoverySuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugDiscoverySuite.scala
@@ -168,7 +168,7 @@ class DebugDiscoverySuite
            |""".stripMargin
       )
       _ <- server.didOpen(fooPath)
-      _ <- server.didSave(fooPath)(identity)
+      _ <- server.didSave(fooPath)
       _ <- server.waitFor(TimeUnit.SECONDS.toMillis(10))
       debugger <- server.startDebuggingUnresolved(
         new DebugDiscoveryParams(
@@ -380,7 +380,7 @@ class DebugDiscoverySuite
            |""".stripMargin
       )
       _ <- server.didOpen(mainPath)
-      _ <- server.didSave(mainPath)(identity)
+      _ <- server.didSave(mainPath)
       _ <- server.waitFor(TimeUnit.SECONDS.toMillis(10))
       result <- server
         .startDebuggingUnresolved(
@@ -414,7 +414,7 @@ class DebugDiscoverySuite
            |""".stripMargin
       )
       _ <- server.didOpen(fooPath)
-      _ <- server.didSave(fooPath)(identity)
+      _ <- server.didSave(fooPath)
       _ <- server.waitFor(TimeUnit.SECONDS.toMillis(10))
       debugger <- server.startDebuggingUnresolved(
         new DebugDiscoveryParams(
@@ -452,7 +452,7 @@ class DebugDiscoverySuite
            |""".stripMargin
       )
       _ <- server.didOpen(barPath)
-      _ <- server.didSave(barPath)(identity)
+      _ <- server.didSave(barPath)
       _ <- server.waitFor(TimeUnit.SECONDS.toMillis(10))
       debugger <- server.startDebuggingUnresolved(
         new DebugDiscoveryParams(
@@ -516,7 +516,7 @@ class DebugDiscoverySuite
            |""".stripMargin
       )
       _ <- server.didOpen(fooPath)
-      _ <- server.didSave(fooPath)(identity)
+      _ <- server.didSave(fooPath)
       _ <- server.waitFor(TimeUnit.SECONDS.toMillis(10))
       _ = cleanCompileCache("a")
       result <- server

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -266,9 +266,10 @@ class DefinitionLspSuite
            |}
         """.stripMargin,
       )
-      _ <- server.didSave("a/src/main/scala/a/Main.scala")(
+      _ <- server.didChange("a/src/main/scala/a/Main.scala")(
         _.replace("max(1, 2)", "max")
       )
+      _ <- server.didSave("a/src/main/scala/a/Main.scala")
       _ = assertNoDiff(
         server.workspaceDefinitions,
         """|/a/src/main/scala/a/Main.scala

--- a/tests/unit/src/test/scala/tests/DiagnosticsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DiagnosticsLspSuite.scala
@@ -355,9 +355,10 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
            |               ^^
            |""".stripMargin,
       )
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(
+      _ <- server.didChange("a/src/main/scala/a/A.scala")(
         _.replace("val n: Int = \"\"", "val n: Int = \" ")
       )
+      _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|a/src/main/scala/a/A.scala:2:16: error: unclosed string literal

--- a/tests/unit/src/test/scala/tests/DiagnosticsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DiagnosticsLspSuite.scala
@@ -107,9 +107,10 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
            |""".stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/Main.scala")
-      _ <- server.didSave("a/src/main/scala/Main.scala")(
+      _ <- server.didChange("a/src/main/scala/Main.scala")(
         _.replace("val a = 2", "val a = 1\n  val a = 2")
       )
+      _ <- server.didSave("a/src/main/scala/Main.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         // Duplicate diagnostics are expected, the scala compiler reports them.
@@ -121,9 +122,10 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
            |      ^^^^^
            |""".stripMargin,
       )
-      _ <- server.didSave("a/src/main/scala/Main.scala")(
+      _ <- server.didChange("a/src/main/scala/Main.scala")(
         _.replace("val a = 1\n  ", "")
       )
+      _ <- server.didSave("a/src/main/scala/Main.scala")
       // FIXME: https://github.com/scalacenter/bloop/issues/785
       _ = assertNoDiff(client.workspaceDiagnostics, "")
     } yield ()
@@ -257,9 +259,10 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
       )
       _ <- server.executeCommand(ServerCommands.DisconnectBuildServer)
       _ = assertNoDiagnostics()
-      _ <- server.didSave("a/src/main/scala/a/B.scala")(
+      _ <- server.didChange("a/src/main/scala/a/B.scala")(
         _.replace("String", "Int")
       )
+      _ <- server.didSave("a/src/main/scala/a/B.scala")
       _ <- server.didClose("a/src/main/scala/a/B.scala")
       _ <- server.didOpen("a/src/main/scala/a/A.scala")
       _ <- server.executeCommand(ServerCommands.ConnectBuildServer)
@@ -295,7 +298,7 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
            |""".stripMargin,
       )
       _ = Files.delete(server.toPath("a/src/main/scala/a/B.scala").toNIO)
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ = assertNoDiagnostics()
     } yield ()
   }
@@ -358,7 +361,7 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
       _ <- server.didChange("a/src/main/scala/a/A.scala")(
         _.replace("val n: Int = \"\"", "val n: Int = \" ")
       )
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|a/src/main/scala/a/A.scala:2:16: error: unclosed string literal
@@ -388,7 +391,7 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
       _ <- server.didOpen(B.path)
       _ = assertNoDiagnostics()
       _ <- server.didChange(B.path) { _ => B.content("String", "1") }
-      _ <- server.didSave(B.path)(identity)
+      _ <- server.didSave(B.path)
       _ = assertNoDiff(
         client.pathDiagnostics(B.path),
         """|b/src/main/scala/b/B.scala:4:19: error: type mismatch;
@@ -405,7 +408,7 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
       )
       _ <- server.didOpen(A.path)
       _ <- server.didChange(A.path) { _ => A.content("String", "1") }
-      _ <- server.didSave(A.path)(identity)
+      _ <- server.didSave(A.path)
       _ = assertNoDiff(
         client.pathDiagnostics(A.path),
         """|a/src/main/scala/a/A.scala:4:19: error: type mismatch;
@@ -419,7 +422,7 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
       _ = assertNoDiff(client.pathDiagnostics(B.path), "")
 
       _ <- server.didChange(A.path) { _ => A.content("String", "\"aa\"") }
-      _ <- server.didSave(A.path)(identity)
+      _ <- server.didSave(A.path)
       _ = assertNoDiff(client.pathDiagnostics(A.path), "")
 
       // we want the diagnostics for B to appear
@@ -435,7 +438,7 @@ class DiagnosticsLspSuite extends BaseLspSuite("diagnostics") {
 
       _ <- server.didOpen(B.path)
       _ <- server.didChange(B.path) { _ => B.content("String", "\"aa\"") }
-      _ <- server.didSave(B.path)(identity)
+      _ <- server.didSave(B.path)
       _ = assertNoDiagnostics()
 
     } yield ()

--- a/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
@@ -185,9 +185,10 @@ class DidFocusWhileCompilingLspSuite
            |""".stripMargin
       }
       _ = fakeTime.elapseSeconds(10)
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(
+      _ <- server.didChange("a/src/main/scala/a/A.scala")(
         _.replace("1", "\"\"")
       )
+      _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         xMismatch,

--- a/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DidFocusLspSuite.scala
@@ -58,9 +58,10 @@ class DidFocusLspSuite extends BaseLspSuite("did-focus") {
       // fake delete the diagnostic to see that `c` won't get recompiled
       _ = client.diagnostics(server.toPath("c/src/main/scala/c/C.scala")) =
         Seq.empty
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(
+      _ <- server.didChange("a/src/main/scala/a/A.scala")(
         _.replace("val x = 1", "val x = \"string\"")
       )
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ = fakeTime.elapseSeconds(10)
       _ = assertNoDiagnostics()
       didCompile <- server.didFocus("a/src/main/scala/a/A2.scala")
@@ -113,9 +114,10 @@ class DidFocusLspSuite extends BaseLspSuite("did-focus") {
       _ = assertNoDiagnostics()
       _ = fakeTime.elapseSeconds(10)
       _ <- server.didFocus("b/src/main/scala/b/B.scala")
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(
+      _ <- server.didChange("a/src/main/scala/a/A.scala")(
         _.replace("val x = 1", "val x = \"string\"")
       )
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ = fakeTime.elapseSeconds(10)
       _ = assertNoDiff(
         client.workspaceDiagnostics,
@@ -188,21 +190,23 @@ class DidFocusWhileCompilingLspSuite
       _ <- server.didChange("a/src/main/scala/a/A.scala")(
         _.replace("1", "\"\"")
       )
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         xMismatch,
       )
-      _ <- server.didSave("b/src/main/scala/b/B.scala")(
+      _ <- server.didChange("b/src/main/scala/b/B.scala")(
         _.replace("2", "\"\"")
       )
+      _ <- server.didSave("b/src/main/scala/b/B.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         xMismatch,
       )
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(
+      _ <- server.didChange("a/src/main/scala/a/A.scala")(
         _.replace("Int", "String")
       )
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|b/src/main/scala/b/B.scala:3:16: error: type mismatch;

--- a/tests/unit/src/test/scala/tests/FingerprintsLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/FingerprintsLspSuite.scala
@@ -33,12 +33,14 @@ class FingerprintsLspSuite extends BaseLspSuite("fingerprints") {
       _ <- server.executeCommand(ServerCommands.CascadeCompile)
       _ = assertNoDiff(client.workspaceDiagnostics, "")
       _ = server.assertReferenceDefinitionBijection()
-      _ <- server.didSave("a/src/main/scala/a/Names.scala")(text =>
+      _ <- server.didChange("a/src/main/scala/a/Names.scala")(text =>
         text.replace("+ surname", "+ surname2")
       )
-      _ <- server.didSave("a/src/main/scala/a/Adresses.scala")(text =>
+      _ <- server.didSave("a/src/main/scala/a/Names.scala")
+      _ <- server.didChange("a/src/main/scala/a/Adresses.scala")(text =>
         text.replace("+ number", "+ number2")
       )
+      _ <- server.didSave("a/src/main/scala/a/Adresses.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|a/src/main/scala/a/Adresses.scala:5:44: error: not found: value number2

--- a/tests/unit/src/test/scala/tests/HoverLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/HoverLspSuite.scala
@@ -116,7 +116,7 @@ class HoverLspSuite extends BaseLspSuite("hover-") with TestHovers {
           |}
         """.stripMargin
       )
-      _ <- server.didSave("a/src/main/scala/a/Def.scala")(s => s) // index docs
+      _ <- server.didSave("a/src/main/scala/a/Def.scala") // index docs
       _ <- server.assertHover(
         "a/src/main/scala/a/Main.scala",
         """
@@ -148,7 +148,7 @@ class HoverLspSuite extends BaseLspSuite("hover-") with TestHovers {
           |}
         """.stripMargin
       )
-      _ <- server.didSave("a/src/main/scala/a/Def.scala")(s => s)
+      _ <- server.didSave("a/src/main/scala/a/Def.scala")
       _ <- server.assertHover(
         "a/src/main/scala/a/Main.scala",
         """
@@ -162,9 +162,10 @@ class HoverLspSuite extends BaseLspSuite("hover-") with TestHovers {
            |test
            |""".stripMargin.hover,
       )
-      _ <- server.didSave("a/src/main/scala/a/Def.scala")(s =>
+      _ <- server.didChange("a/src/main/scala/a/Def.scala")(s =>
         s.replace("test", "test2")
       )
+      _ <- server.didSave("a/src/main/scala/a/Def.scala")
       _ <- server.assertHover(
         "a/src/main/scala/a/Main.scala",
         """

--- a/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ReferenceLspSuite.scala
@@ -496,7 +496,7 @@ class ReferenceLspSuite extends BaseRangesSuite("reference") {
            |}
            |""".stripMargin
       )
-      _ <- server.didSave("moduleB/src/main/scala/Main.scala")(identity)
+      _ <- server.didSave("moduleB/src/main/scala/Main.scala")
       _ <- server.didOpen("root/src/main/scala/Main.scala")
       _ <- server.didChange("root/src/main/scala/Main.scala")(_ =>
         """|import a.Person

--- a/tests/unit/src/test/scala/tests/ResetWorkspaceLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ResetWorkspaceLspSuite.scala
@@ -53,9 +53,10 @@ class ResetWorkspaceLspSuite extends BaseLspSuite(s"reset-workspace") {
         client.workspaceShowMessages,
         "",
       )
-      _ <- server.didSave("a/src/main/scala/b/B.scala")(
+      _ <- server.didChange("a/src/main/scala/b/B.scala")(
         _.replaceAll("val x: Int = 42", "val x: String = 42")
       )
+      _ <- server.didSave("a/src/main/scala/b/B.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|a/src/main/scala/b/B.scala:4:19: error: type mismatch;

--- a/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
@@ -283,7 +283,7 @@ class SemanticTokensLspSuite extends BaseLspSuite("SemanticTokens") {
       )
       _ <- server.didOpen("a/src/main/scala/a/Main.scala")
       _ <- server.didChange("a/src/main/scala/a/Main.scala")(_ => fileContent)
-      _ <- server.didSave("a/src/main/scala/a/Main.scala")(identity)
+      _ <- server.didSave("a/src/main/scala/a/Main.scala")
       _ <- server.didOpen("a/src/main/scala/a/OtherFile.scala")
       // triggers outline compile on `Main.scala`
       _ <- server.assertSemanticHighlight(

--- a/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
@@ -40,12 +40,13 @@ class ServerLivenessMonitorLspSuite extends BaseLspSuite("liveness-monitor") {
       )
       _ <- server.didOpen("src/com/App.scala")
       _ = Thread.sleep(sleepTime)
-      _ <- server.didSave("src/com/App.scala")(str => s"""|$str
-                                                          |
-                                                          |object O {
-                                                          | def i: Int = 3
-                                                          |}
-                                                          |""".stripMargin)
+      _ <- server.didChange("src/com/App.scala")(str => s"""|$str
+                                                            |
+                                                            |object O {
+                                                            | def i: Int = 3
+                                                            |}
+                                                            |""".stripMargin)
+      _ <- server.didSave("src/com/App.scala")
       _ = Thread.sleep(sleepTime)
       _ = assertNoDiff(
         server.client.workspaceMessageRequests,

--- a/tests/unit/src/test/scala/tests/StatusBarLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/StatusBarLspSuite.scala
@@ -16,9 +16,10 @@ class StatusBarLspSuite extends BaseLspSuite("status-bar") {
           |}
         """.stripMargin
       )
-      _ <- server.didSave("a/src/main/scala/A.scala") { text =>
+      _ <- server.didChange("a/src/main/scala/A.scala") { text =>
         text.replace("A", "AA")
       }
+      _ <- server.didSave("a/src/main/scala/A.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         "",
@@ -28,18 +29,20 @@ class StatusBarLspSuite extends BaseLspSuite("status-bar") {
         server.statusBarHistory,
         s"${icons.check}Compiled a",
       )
-      _ <- server.didSave("a/src/main/scala/A.scala")(
+      _ <- server.didChange("a/src/main/scala/A.scala")(
         _.replaceFirst("val x = 42", "val x: String = 42")
       )
+      _ <- server.didSave("a/src/main/scala/A.scala")
       _ = assertNotEmpty(client.workspaceDiagnostics)
       // Failed compilation is always reported in the status bar.
       _ = assertContains(
         server.statusBarHistory,
         s"${icons.alert}Compiled a",
       )
-      _ <- server.didSave("a/src/main/scala/A.scala")(
+      _ <- server.didChange("a/src/main/scala/A.scala")(
         _.replaceFirst("val x: String = 42", "val x: Long = 42")
       )
+      _ <- server.didSave("a/src/main/scala/A.scala")
       // Successful compilation is reported in the status bar when following a failed compilation.
       _ = assertContains(
         server.statusBarHistory,

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -118,7 +118,7 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
             |""".stripMargin,
       )
       _ <- server.didOpen("a/src/main/scala/a/Zero.scala")
-      _ <- server.didSave("a/src/main/scala/a/Zero.scala")(identity)
+      _ <- server.didSave("a/src/main/scala/a/Zero.scala")
       _ <- server.treeViewVisibilityDidChange(
         TreeViewProvider.Project,
         isVisible = true,
@@ -173,9 +173,10 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
            |c symbol-variable
            |""".stripMargin,
       )
-      _ <- server.didSave("a/src/main/scala/a/Zero.scala") { text =>
+      _ <- server.didChange("a/src/main/scala/a/Zero.scala") { text =>
         text.replace("val a = 1", "val a = 1\nval b = 1.0")
       }
+      _ <- server.didSave("a/src/main/scala/a/Zero.scala")
       _ = assertEquals(
         server.client.workspaceTreeViewChanges,
         s"metalsPackages projects-$folder:${server.buildTarget("a")}!/_root_/",
@@ -191,9 +192,10 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
         s"projects-$folder:${server.buildTarget("a")}!/_root_/",
         isCollapsed = true,
       )
-      _ <- server.didSave("a/src/main/scala/a/Zero.scala") { text =>
+      _ <- server.didChange("a/src/main/scala/a/Zero.scala") { text =>
         text.replace("val a = 1", "val a = 1\nval c = 1.0")
       }
+      _ <- server.didSave("a/src/main/scala/a/Zero.scala")
       _ = assertEmpty(
         server.client.workspaceTreeViewChanges
       )

--- a/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/TreeViewLspSuite.scala
@@ -176,7 +176,6 @@ class TreeViewLspSuite extends BaseLspSuite("tree-view") {
       _ <- server.didChange("a/src/main/scala/a/Zero.scala") { text =>
         text.replace("val a = 1", "val a = 1\nval b = 1.0")
       }
-      _ <- server.didSave("a/src/main/scala/a/Zero.scala")
       _ = assertEquals(
         server.client.workspaceTreeViewChanges,
         s"metalsPackages projects-$folder:${server.buildTarget("a")}!/_root_/",

--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -51,9 +51,10 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
         server.workspaceSymbol("a.b.PazQux"),
         "a.b.PazQux",
       )
-      _ <- server.didSave("a/src/main/scala/a/B.scala")(
+      _ <- server.didChange("a/src/main/scala/a/B.scala")(
         _.replace("class B", "  class HaddockBax")
       )
+      _ <- server.didSave("a/src/main/scala/a/B.scala")
       _ = assertNoDiff(
         server.workspaceSymbol("Had"),
         "a.HaddockBax",
@@ -297,7 +298,7 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
         Files.move(before, after)
       }
       _ <- server.didOpen("a/src/main/scala/a/After.scala")
-      _ <- server.didSave("a/src/main/scala/a/After.scala")(identity)
+      _ <- server.didSave("a/src/main/scala/a/After.scala")
       _ = assertNoDiagnostics()
       _ = assertNoDiff(
         server.workspaceSymbol("MyObjectSymbol", includeFilename = true),

--- a/tests/unit/src/test/scala/tests/bestEffort/BestEffortCompilationSuite.scala
+++ b/tests/unit/src/test/scala/tests/bestEffort/BestEffortCompilationSuite.scala
@@ -191,7 +191,7 @@ class BestEffortCompilationSuite
             |}
             |""".stripMargin
       }
-      _ <- server.didSave("b/src/main/scala/b/B.scala")(identity)
+      _ <- server.didSave("b/src/main/scala/b/B.scala")
       _ <- assertCompletion(
         "BCustom@@",
         """|BCustomChangedObject <empty>
@@ -264,7 +264,7 @@ class BestEffortCompilationSuite
             |    unseal.pos  // error
             |""".stripMargin
       }
-      _ <- server.didSave("b/src/main/scala/b/B.scala")(identity)
+      _ <- server.didSave("b/src/main/scala/b/B.scala")
       _ <- server.didChange("a/src/main/scala/a/A.scala") { _ =>
         """|object A:
            |  B.completionBar
@@ -273,7 +273,7 @@ class BestEffortCompilationSuite
            |  B.completionAdded // should not errored out, as now we do not recompile A.scala
            |""".stripMargin
       }
-      _ <- server.didSave("a/src/main/scala/a/A.scala")(identity)
+      _ <- server.didSave("a/src/main/scala/a/A.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|a/src/main/scala/a/A.scala:4:3: error: value completionUnknown is not a member of object B

--- a/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
@@ -159,7 +159,7 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
           }
           client.applyCodeAction(selectedActionIndex, codeActions, server)
         }
-        _ <- server.didSave(path)(identity)
+        _ <- server.didSave(path)
         _ = if (expectNoDiagnostics) assertNoDiagnostics() else ()
         _ = {
           val (path, content) = newFile

--- a/tests/unit/src/test/scala/tests/codeactions/ImplementAbstractMembersLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImplementAbstractMembersLspSuite.scala
@@ -269,10 +269,11 @@ class ImplementAbstractMembersLspSuite
     for {
       _ <- initialize(fullInput)
       _ <- server.didOpen(path)
-      _ <- server.didSave(path)(_ => """|package a
-                                        |
-                                        |object Impl extends Service
-                                        |""".stripMargin)
+      _ <- server.didChange(path)(_ => """|package a
+                                          |
+                                          |object Impl extends Service
+                                          |""".stripMargin)
+      _ <- server.didSave(path)
       codeActions <-
         server
           .assertCodeAction(

--- a/tests/unit/src/test/scala/tests/scalafix/ScalafixProviderLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/scalafix/ScalafixProviderLspSuite.scala
@@ -94,12 +94,13 @@ class ScalafixProviderLspSuite extends BaseLspSuite("scalafix-provider") {
            |""".stripMargin,
       )
       // add a new rule to scalafix configuration
-      _ <- server.didSave(".scalafix.conf") { old =>
+      _ <- server.didChange(".scalafix.conf") { old =>
         old.replace(
           "ExplicitResultTypes,",
           "ExplicitResultTypes,\n  ProcedureSyntax,",
         )
       }
+      _ <- server.didSave(".scalafix.conf")
       // execute the scalafix command again
       _ <- server.executeCommand(
         ServerCommands.RunScalafix,
@@ -222,12 +223,13 @@ class ScalafixProviderLspSuite extends BaseLspSuite("scalafix-provider") {
           |}
           |""".stripMargin
       )
-      _ <- server.didSave(".scalafix.conf") { old =>
+      _ <- server.didChange(".scalafix.conf") { old =>
         old.replace(
           "ExplicitResultTypes,",
           "ExplicitResultTypes,\n   \"class:fix.Examplescalafixrule_v1\",",
         )
       }
+      _ <- server.didSave(".scalafix.conf")
       _ <- server.executeCommand(
         ServerCommands.RunScalafix,
         textParams,

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetInfiniteLoopSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetInfiniteLoopSuite.scala
@@ -58,7 +58,7 @@ class WorksheetInfiniteLoopSuite
       _ <- server.didChange("a/src/main/scala/foo/Main.worksheet.sc")(_ =>
         "val a = 1"
       )
-      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
+      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")
       _ <- server.assertInlayHints(
         "a/src/main/scala/Main.worksheet.sc",
         """|val a = 1/* // : Int = 1*/

--- a/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/worksheets/WorksheetLspSuite.scala
@@ -35,7 +35,7 @@ class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala213) {
              |""".stripMargin
         )
         _ <- server.didOpen(path)
-        _ <- server.didSave(path)(identity)
+        _ <- server.didSave(path)
         identity <- server.completion(
           path,
           "htmlFile.render@@",
@@ -182,7 +182,7 @@ class WorksheetLspSuite extends tests.BaseWorksheetLspSuite(V.scala213) {
            |""".stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/foo/Main.worksheet.sc")
-      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")(identity)
+      _ <- server.didSave("a/src/main/scala/foo/Main.worksheet.sc")
       _ = assertNoDiagnostics()
     } yield ()
   }


### PR DESCRIPTION
Previously, we would have clients send us full text on didSave, which was never used.

Now, we removed that option.

I also removed reading the file from disk to buffers since that file should already be up to date form didChanged