### PR TITLE
improvement: make `inlayHints/resolve` not depend on focused document

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -606,7 +606,8 @@ class Compilers(
                 else InlayHintKind.Parameter
               hint.setKind(kind)
               hint.setData(
-                internal.pc.InlayHints.toData(params.uri(), List(Left("")))
+                internal.pc.InlayHints
+                  .toData(params.uri().toString(), List(Left("")))
               )
               hint
             }
@@ -624,7 +625,10 @@ class Compilers(
           }
           .map { hint =>
             hint.setPosition(adjust.adjustPos(hint.getPosition()))
-            hint
+            InlayHintCompat.maybeFixInlayHintData(
+              hint,
+              params.getTextDocument().getUri(),
+            )
           }
           .asJava
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -605,7 +605,9 @@ class Compilers(
                 if (d.kind() <= 2) InlayHintKind.Type
                 else InlayHintKind.Parameter
               hint.setKind(kind)
-              hint.setData(Array(""))
+              hint.setData(
+                internal.pc.InlayHints.toData(params.uri(), List(Left("")))
+              )
               hint
             }
           )

--- a/metals/src/main/scala/scala/meta/internal/metals/InlayHintResolveProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InlayHintResolveProvider.scala
@@ -110,3 +110,27 @@ final class InlayHintResolveProvider(
   }
 
 }
+
+object InlayHintCompat {
+  private def parseData(
+      data: Array[Any]
+  ): List[Either[String, l.Position]] =
+    data.map {
+      case data: l.Position => Right(data)
+      case data: String => Left(data)
+    }.toList
+
+  // for compatibility with old inlay hint data
+  def maybeFixInlayHintData(hint: InlayHint, uri: String): InlayHint = {
+    if (hint.getData.isInstanceOf[Array[_]]) {
+      try {
+        val labelParts = parseData(hint.getData.asInstanceOf[Array[Any]])
+        hint.setData(InlayHints.toData(uri, labelParts))
+      } catch {
+        case e: Throwable =>
+          scribe.warn(s"Failed to fix inlay hint data: $e")
+      }
+    }
+    hint
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/InlayHintResolveProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InlayHintResolveProvider.scala
@@ -25,9 +25,7 @@ final class InlayHintResolveProvider(
     try {
       val (uri, labelParts) =
         InlayHints.fromData(inlayHint.getData().asInstanceOf[JsonElement])
-      pprint.log(uri)
       val path = uri.toAbsolutePath
-      pprint.log(labelParts)
       resolve(inlayHint, getLabelParts(inlayHint).zip(labelParts), path, token)
     } catch {
       case error: Throwable =>

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1022,13 +1022,10 @@ abstract class MetalsLspService(
 
   def inlayHintResolve(
       inlayHint: InlayHint
-  ): CompletableFuture[InlayHint] = {
+  ): CompletableFuture[InlayHint] =
     CancelTokens.future { token =>
-      focusedDocument
-        .map(path => inlayHintResolveProvider.resolve(inlayHint, path, token))
-        .getOrElse(Future.successful(inlayHint))
+      inlayHintResolveProvider.resolve(inlayHint, token)
     }
-  }
 
   override def documentHighlights(
       params: TextDocumentPositionParams

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
@@ -36,7 +36,9 @@ final class PcInlayHintsProvider(
 
   def provide(): List[InlayHint] =
     treesInRange()
-      .flatMap(tpdTree => traverse(InlayHints.empty, tpdTree).result())
+      .flatMap(tpdTree =>
+        traverse(InlayHints.empty(params.uri()), tpdTree).result()
+      )
 
   private def adjustPos(pos: Position): Position =
     pos.adjust(text)._1

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcInlayHintsProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcInlayHintsProvider.scala
@@ -55,7 +55,7 @@ class PcInlayHintsProvider(
       .headOption
       .getOrElse(unit.tpdTree)
       .enclosedChildren(pos.span)
-      .flatMap(tpdTree => deepFolder(InlayHints.empty, tpdTree).result())
+      .flatMap(tpdTree => deepFolder(InlayHints.empty(params.uri()), tpdTree).result())
 
   private def adjustPos(pos: SourcePosition): SourcePosition =
     pos.adjust(text)._1

--- a/tests/unit/src/main/scala/tests/BaseInlayHintsExpectSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseInlayHintsExpectSuite.scala
@@ -3,6 +3,7 @@ package tests
 import scala.meta.internal.metals.CompilerInlayHintsParams
 import scala.meta.internal.metals.CompilerRangeParams
 import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.internal.metals.InlayHintCompat
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.pc.PresentationCompiler
 
@@ -35,7 +36,15 @@ abstract class BaseInlayHintsExpectSuite(
             true,
           )
           val inlayHints =
-            compiler.inlayHints(pcParams).get().asScala.toList
+            compiler
+              .inlayHints(pcParams)
+              .get()
+              .asScala
+              .toList
+              .map(
+                InlayHintCompat
+                  .maybeFixInlayHintData(_, file.file.toURI.toString())
+              )
           TestInlayHints.applyInlayHints(file.code, inlayHints)
         },
       )


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/6968