### PR TITLE
bugfix: Log message by default

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBarConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBarConfig.scala
@@ -18,6 +18,6 @@ object StatusBarConfig {
     )
   def bspDefault =
     new StatusBarConfig(
-      System.getProperty("metals.bsp-status-bar", "show-message")
+      System.getProperty("metals.bsp-status-bar", "log-message")
     )
 }

--- a/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ServerLivenessMonitorLspSuite.scala
@@ -7,6 +7,7 @@ import scala.meta.internal.metals.Icons
 import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.StatusBarConfig
 
 import bill.Bill
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
@@ -18,6 +19,7 @@ class ServerLivenessMonitorLspSuite extends BaseLspSuite("liveness-monitor") {
     MetalsServerConfig.default.copy(
       metalsToIdleTime = Duration("3m"),
       pingInterval = pingInterval,
+      bspStatusBar = StatusBarConfig.showMessage,
     )
 
   test("handle-not-responding-server") {


### PR DESCRIPTION
Turns out it was actually set in a totally different place, which I haven't realized.

Fixes https://github.com/scalameta/metals/issues/6988