### PR TITLE
Refactor `validateWorkspace` to handle missing custom `scalafmtConfigPath` gracefully and log warning

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -435,7 +435,7 @@ final class FormattingProvider(
     configpath.orElse(default)
   }
 
-  def getTextFromBuffers(conf: AbsolutePath): Option[String] = {
+  private def getTextFromBuffers(conf: AbsolutePath): Option[String] = {
     Try(conf.toInputFromBuffers(buffers).text) match {
       case Success(text) =>
         Some(text)

--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -16,9 +16,9 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
-import scala.util.Try
 import scala.util.Failure
 import scala.util.Success
+import scala.util.Try
 
 import scala.meta._
 import scala.meta.internal.io.FileIO


### PR DESCRIPTION
### PR Overview

This PR refactors the `validateWorkspace` function to gracefully handle missing `scalafmtConfigPath` files. Previously, this scenario would result in uncaught exceptions. 

#### Example Logs
```console
2024.12.31 11:48:07 ERROR Failed to connect with build server, no functionality will work.
java.nio.file.NoSuchFileException: {dir}/akka-quickstart-scala/.my_scalafmt.conf
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218)
	at java.nio.file.Files.newByteChannel(Files.java:380)
	at java.nio.file.Files.newByteChannel(Files.java:432)
	at java.nio.file.Files.readAllBytes(Files.java:3288)
	at scala.meta.internal.io.PlatformFileIO$.slurp(PlatformFileIO.scala:42)
	at scala.meta.internal.io.FileIO$.slurp(FileIO.scala:18)
	at scala.meta.internal.mtags.ScalametaCommonEnrichments$XtensionAbsolutePath.toInput(ScalametaCommonEnrichments.scala:445)
	at scala.meta.internal.metals.MetalsEnrichments$XtensionAbsolutePathBuffers.toInputFromBuffers(MetalsEnrichments.scala:621)
	at scala.meta.internal.metals.FormattingProvider.validateWorkspace(FormattingProvider.scala:408)
```

The refactor:
- Wraps `.toInputFromBuffers` in a `Try` to catch errors.
- Logs a warning when custom `scalafmtConfigPath` is missing.
- Returns `None` instead of throwing exceptions, improving stability and providing clear feedback.

### Key Changes
- Added handling for missing `scalafmtConfigPath`.
- Refactored `validateWorkspace` to use a safer text extraction approach.

### Rationale
Improves robustness and user experience by ensuring the absence of `scalafmtConfigPath` is handled gracefully with logging instead of crashes.

Stemmed from [discussion](https://github.com/scalameta/nvim-metals/discussions/678) in `nvim-metals` (logs included): 

