### PR TITLE
bugfix: completion of args in method w/ default args

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -20,7 +20,8 @@ trait ArgCompletions { this: MetalsGlobal =>
       pos.withStart(ident.pos.start).withEnd(pos.start).toLsp
     val funPos = apply.fun.pos
     val method: Tree = typedTreeAt(funPos) match {
-      case Apply(Block(defParams, app: Apply), _)
+      // Functions calls with default arguments expand into this form
+      case Apply(Block(defParams, app @ (_: Apply | _: Select)), _)
           if defParams.forall(p => p.isInstanceOf[ValDef]) =>
         app
       case New(c) => c

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -359,6 +359,23 @@ class CompletionArgSuite extends BaseCompletionSuite {
     topLines = Some(2)
   )
 
+  check(
+    "default-args7",
+    """|trait Foo {
+       |  def bar(fst: String = null, snd: Int = 3 + 2, thd: Int = 23)
+       |}
+       |object Main {
+       |  def foo: Foo = ???
+       |  foo.bar(@@)
+       |}
+       |""".stripMargin,
+    """|fst = : String
+       |snd = : Int
+       |thd = : Int
+       |""".stripMargin,
+    topLines = Some(3)
+  )
+
   checkSnippet( // see: https://github.com/scalameta/metals/issues/2400
     "explicit-dollar",
     """


### PR DESCRIPTION
This case used to throw an exception, leading to no completions (and a crash report). Looks like just another unaccounted for variation of how method calls with default arguments are desugard by the presentation compiler.

Fixes #7088