### PR TITLE
Infer base package in `PackageProvider`

### DIFF
--- a/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
@@ -356,6 +356,24 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
                           |""".stripMargin,
   )
 
+  checkScala("new-class-infer-base-package")(
+    directory = Some("a/src/main/scala/foo/bar"),
+    fileType = Right(Class),
+    fileName = Right("Baz"),
+    expectedFilePath = "a/src/main/scala/foo/bar/Baz.scala",
+    expectedContent = s"""|package org.someorg.foo.bar
+                          |
+                          |class Baz {
+                          |$indent
+                          |}
+                          |""".stripMargin,
+    existingFiles = """|/a/src/main/scala/foo/Qux.scala
+                       |package org.someorg.foo
+                       |
+                       |class Qux
+                       |""".stripMargin,
+  )
+
   checkJava("new-java-class")(
     directory = Some("a/src/main/java/foo/"),
     fileType = Right(JavaClass),

--- a/tests/unit/src/test/scala/tests/RenameFilesLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/RenameFilesLspSuite.scala
@@ -896,6 +896,25 @@ class RenameFilesLspSuite extends BaseRenameFilesLspSuite("rename_files") {
     expectedRenames = Map.empty,
   )
 
+  renamed(
+    "infer-base-package",
+    s"""|/$prefix/C/Sun.scala
+        |package org.someorg.<<C>>
+        |
+        |class Sun
+        |/$prefix/C/Moon.scala
+        |package org.someorg.C
+        |
+        |import org.someorg.<<C>>.Sun
+        |object Moon {
+        | val o = new Sun()
+        |}
+        |""".stripMargin,
+    fileRenames = Map(s"$prefix/C/Sun.scala" -> s"$prefix/C/D/Sun.scala"),
+    expectedRenames = Map("C" -> "C.D"),
+    sourcesAreCompiled = true,
+  )
+
   /* Cases that are not yet supported */
 
   renamed(


### PR DESCRIPTION
This tweaks the package inference logic in `PackageProvider` to support the case where the directory structure is missing a common prefix of the package structure.

Implements scalameta/metals-feature-requests#414