### PR TITLE
Add `$` as a trigger character

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -1180,7 +1180,7 @@ class WorkspaceLspService(
         capabilities.setCompletionProvider(
           new lsp4j.CompletionOptions(
             clientConfig.isCompletionItemResolve(),
-            List(".", "*").asJava,
+            List(".", "*", "$").asJava,
           )
         )
         capabilities.setCallHierarchyProvider(true)


### PR DESCRIPTION
This makes string interpolation completions much more discoverable and I haven't yet found any bad outcome for this.

At least in VS code

  * With default settings, `s"Hello $|"` with cursor at `|` triggers a completion

  * With (non-default) `"editor.quickSuggestions.strings": true`, `"Hello $|"` with cursor at `|` triggers a completion (and thanks to the interpolation logic, that completion will add in the `s` string interpolation context)