### PR TITLE
bugfix: fix `typeDefinition` on backticked identifier

### DIFF
--- a/tests/cross/src/test/scala/tests/typedef/TypeDefinitionSuite.scala
+++ b/tests/cross/src/test/scala/tests/typedef/TypeDefinitionSuite.scala
@@ -395,4 +395,39 @@ class TypeDefinitionSuite extends BasePcDefinitionSuite {
        |""".stripMargin
   )
 
+  check(
+    "backticked identifier",
+    """|
+       |class Main {
+       |  def `Foo /*scala/Int# Int.scala*/@@ Bar` = 1 + 2
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "whitespace",
+    """|
+       |class Main {
+       |  def x = 1 @@ + 2
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "delimiters-1",
+    """|
+       |class Main {
+       |  def x = (1 )@@ + 2
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "delimiters-2",
+    """|
+       |class Main {
+       |  def x = (1 @@) + 2
+       |}
+       |""".stripMargin
+  )
 }

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -375,7 +375,9 @@ class DefinitionLspSuite
       _ = client.messageRequests.clear()
       _ <- server.didOpen("Main.scala")
       _ = server.workspaceDefinitions // trigger definition
-      _ <- server.didOpen("scala/package.scala")
+      // println should be found in Predef.scala
+      _ <- server.didOpen("scala/Predef.scala")
+      // toArray should be found in IterableOnce.scala
       _ <- server.didOpen("scala/collection/IterableOnce.scala")
       _ = assertNoDiff(
         client.workspaceMessageRequests,


### PR DESCRIPTION
One of the short-circuiting conditions in the type definition logic was a bit too broad, leading to `typeDefinition` not returning a result if the position queried happened to precede a space in an identifier (see the test that was added).