### PR TITLE
bugfix: fix incorrect `excludedPackages` on startup

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -182,6 +182,7 @@ abstract class MetalsLspService(
   protected val savedFiles = new ActiveFiles(time)
   protected val recentlyOpenedFiles = new ActiveFiles(time)
 
+  @volatile
   var excludedPackageHandler: ExcludedPackagesHandler =
     ExcludedPackagesHandler.default
 
@@ -692,6 +693,9 @@ abstract class MetalsLspService(
   def setUserConfig(newConfig: UserConfiguration): UserConfiguration = {
     val old = userConfig
     userConfig = newConfig
+    excludedPackageHandler = ExcludedPackagesHandler.fromUserConfiguration(
+      userConfig.excludedPackages.getOrElse(Nil)
+    )
     userConfigPromise.trySuccess(())
     old
   }
@@ -699,9 +703,6 @@ abstract class MetalsLspService(
   def onUserConfigUpdate(newConfig: UserConfiguration): Future[Unit] = {
     val old = setUserConfig(newConfig)
     if (userConfig.excludedPackages != old.excludedPackages) {
-      excludedPackageHandler = ExcludedPackagesHandler.fromUserConfiguration(
-        userConfig.excludedPackages.getOrElse(Nil)
-      )
       workspaceSymbols.indexClasspath()
     }
 


### PR DESCRIPTION
On the original `initialized` message, we call `setUserConfig` to set the configuration gotten from `workspace/configuration`, but we weren't updating `excludedPackageHandler`. That would lead to the original config of `excludedPackages` being basically ignored.

The buggy behaviour might be masked depending on whether `initialized` or `workspace/didChangeConfiguration` set settings first. Those messages get sent by the LSP client in quick succession, so it is a toss up which reaches the config code first.

  - if `workspace/didChangeConfiguration` logic got there first, it would update the `excludedPackageHandler` and correct behaviour would be observed

  - if `initialized` logic got there first, it would update the config, but not the `excludedPackageHandler`, which would mean when the other message did arrive it would think it was a no-op for excluded packages and do nothing

Also marked the `excludedPackages` as `@volatile` since it is going to be written and read to from a variety of different threads.