### PR TITLE
update scala-debug-adapter and sbt-jdi-tools

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -385,7 +385,7 @@ object SbtBuildTool {
         "This plugin makes sure that the JDI tools are in the sbt classpath.",
         "JDI tools are used by the debug adapter server.",
       ),
-      s""""org.scala-debugger" % "sbt-jdi-tools" % "${BuildInfo.sbtJdiToolsVersion}"""",
+      s""""com.github.sbt" % "sbt-jdi-tools" % "${BuildInfo.sbtJdiToolsVersion}"""",
       resolver = None,
     )
 

--- a/project/V.scala
+++ b/project/V.scala
@@ -26,7 +26,7 @@ object V {
   // changing coursier interfaces version may be not binary compatible.
   // After each update of coursier interfaces, remember to bump the version in dotty repository.
   val coursierInterfaces = "1.0.27"
-  val debugAdapter = "4.2.1"
+  val debugAdapter = "4.2.2"
   val genyVersion = "1.0.0"
   val gitter8Version = "0.17.0"
   val gradleBloop = "1.6.2"
@@ -41,7 +41,7 @@ object V {
   val munit = "1.0.4"
   val pprint = "0.7.3"
   val sbtBloop = bloop
-  val sbtJdiTools = "1.1.1"
+  val sbtJdiTools = "1.2.0"
   val scalaCli = "1.5.4"
   val scalafix = "0.14.0"
   val scalafmt = "3.7.15"


### PR DESCRIPTION
Fix #7115

Also sbt-jdi-tools is now published with correct Maven pattern