### PR TITLE
fix: don't change focused file on `didOpen` if client is a `didFocusProvider`

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -731,10 +731,11 @@ abstract class MetalsLspService(
     // In some cases like peeking definition didOpen might be followed up by close
     // and we would lose the notion of the focused document
     recentlyOpenedFiles.add(path)
+
     val prevBuildTarget = focusedDocumentBuildTarget.getAndUpdate { current =>
-      buildTargets
-        .inverseSources(path)
-        .getOrElse(current)
+      val shouldUpdate = !clientConfig.isDidFocusProvider() || current == null
+      if (shouldUpdate) buildTargets.inverseSources(path).getOrElse(current)
+      else current
     }
 
     // Update md5 fingerprint from file contents on disk

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -390,7 +390,8 @@ class WorkspaceLspService(
     focusedDocument.get().foreach(recentlyFocusedFiles.add)
     val uri = params.getTextDocument.getUri
     val path = uri.toAbsolutePath
-    setFocusedDocument(Some(path))
+    if (!clientConfig.isDidFocusProvider() || focusedDocument.get().isEmpty)
+      setFocusedDocument(Some(path))
     val service = getServiceForOpt(path)
       .orElse {
         if (path.filename.isScalaOrJavaFilename) {
@@ -418,7 +419,9 @@ class WorkspaceLspService(
 
   override def didClose(params: DidCloseTextDocumentParams): Unit = {
     val path = params.getTextDocument.getUri.toAbsolutePath
-    if (focusedDocument.get().contains(path)) {
+    if (
+      !clientConfig.isDidFocusProvider() && focusedDocument.get().contains(path)
+    ) {
       setFocusedDocument(recentlyFocusedFiles.pollRecent())
     }
     getServiceFor(params.getTextDocument().getUri()).didClose(params)


### PR DESCRIPTION
On actions like `rename` VSCode can in the background open a file, change it, save and close the file. In that time the document in focus does not change. For VSCode only `didFocusTextDocument` should trigger focus text document change.

Side note: there already was such a fix: https://github.com/scalameta/metals/pull/2501/