### PR TITLE
improvement: don't fail on `shortType`

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/PcQueryContext.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/PcQueryContext.scala
@@ -1,0 +1,32 @@
+package scala.meta.internal.metals
+
+import scala.meta.internal.mtags.CommonMtagsEnrichments._
+import scala.meta.internal.pc.CompilerThrowable
+import scala.meta.pc.VirtualFileParams
+
+case class PcQueryContext(
+    params: Option[VirtualFileParams],
+    additionalReportingData: () => String
+)(implicit rc: ReportContext) {
+  def report(name: String, e: Throwable, additionalInfo: String): Unit = {
+    val error = CompilerThrowable.trimStackTrace(e)
+    val report =
+      Report(
+        name,
+        s"""|occurred in the presentation compiler.
+            |
+            |$additionalInfo
+            |
+            |action parameters:
+            |${params.map(_.printed()).getOrElse("<NONE>")}
+            |
+            |presentation compiler configuration:
+            |${additionalReportingData()}
+            |
+            |""".stripMargin,
+        error,
+        path = params.map(_.uri())
+      )
+    rc.unsanitized.create(report)
+  }
+}

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.pc
 import scala.collection.mutable
 
 import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.PcQueryContext
 import scala.meta.pc.AutoImportsResult
 import scala.meta.pc.OffsetParams
 
@@ -12,7 +13,7 @@ final class AutoImportsProvider(
     val compiler: MetalsGlobal,
     name: String,
     params: OffsetParams
-) {
+)(implicit queryInfo: PcQueryContext) {
   import compiler._
 
   def autoImports(): List[AutoImportsResult] = {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -7,6 +7,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 
 import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.PcQueryContext
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.SymbolSearch
@@ -21,7 +22,7 @@ import org.eclipse.{lsp4j => l}
 class CompletionProvider(
     val compiler: MetalsGlobal,
     params: OffsetParams
-) {
+)(implicit val queryInfo: PcQueryContext) {
   import compiler._
 
   private def cursorName: String = {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ExtractMethodProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ExtractMethodProvider.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.pc
 
+import scala.meta.internal.metals.PcQueryContext
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.RangeParams
@@ -10,7 +11,8 @@ final class ExtractMethodProvider(
     val compiler: MetalsGlobal,
     range: RangeParams,
     extractionPos: OffsetParams
-) extends ExtractMethodUtils {
+)(implicit queryInfo: PcQueryContext)
+    extends ExtractMethodUtils {
   import compiler._
   def extractMethod: List[l.TextEdit] = {
     val text = range.text()

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.pc
 import scala.reflect.internal.util.Position
 import scala.reflect.internal.{Flags => gf}
 
+import scala.meta.internal.metals.PcQueryContext
 import scala.meta.internal.metals.Report
 import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.mtags.MtagsEnrichments._
@@ -15,9 +16,7 @@ class HoverProvider(
     val compiler: MetalsGlobal,
     params: OffsetParams,
     contentType: ContentType
-)(implicit
-    reportContext: ReportContext
-) {
+)(implicit reportContext: ReportContext, queryInfo: PcQueryContext) {
   import compiler._
 
   def hover(): Option[HoverSignature] = params match {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/InferredMethodProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/InferredMethodProvider.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.pc
 
 import scala.annotation.tailrec
 
+import scala.meta.internal.metals.PcQueryContext
 import scala.meta.pc.OffsetParams
 
 import org.eclipse.lsp4j.TextEdit
@@ -22,7 +23,7 @@ import org.eclipse.lsp4j.TextEdit
 final class InferredMethodProvider(
     val compiler: MetalsGlobal,
     params: OffsetParams
-) {
+)(implicit queryInfo: PcQueryContext) {
   import compiler._
   val unit: RichCompilationUnit = addCompilationUnit(
     code = params.text(),

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/InferredTypeProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/InferredTypeProvider.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.pc
 
 import scala.meta._
+import scala.meta.internal.metals.PcQueryContext
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.OffsetParams
 import scala.meta.tokens.{Token => T}
@@ -27,7 +28,7 @@ import org.eclipse.{lsp4j => l}
 final class InferredTypeProvider(
     val compiler: MetalsGlobal,
     params: OffsetParams
-) {
+)(implicit queryInfo: PcQueryContext) {
   import compiler._
 
   case class AdjustTypeOpts(

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -306,84 +306,101 @@ class MetalsGlobal(
    * with fully qualified names. This method strips out package prefixes to shorten the names while
    * making sure to not convert two different symbols into same short name.
    */
-  def shortType(longType: Type, history: ShortenedNames): Type = {
-    val isVisited = mutable.Set.empty[(Type, Option[ShortName])]
-    val cached = new ju.HashMap[(Type, Option[ShortName]), Type]()
-    def loop(tpe: Type, name: Option[ShortName]): Type = {
-      val key = tpe -> name
-      // NOTE(olafur) Prevent infinite recursion, see https://github.com/scalameta/metals/issues/749
-      if (isVisited(key)) return cached.getOrDefault(key, tpe)
-      isVisited += key
-      val result = tpe match {
-        case TypeRef(pre, sym, args) =>
-          def shortSymbol = {
-            // workaround for Tuple1 (which is incorrectly printed by Scala 2 compiler)
-            def isTuple1 = sym == definitions.TupleClass(1)
-            /* If it's an alias type we want to prevent dealiasing it
+  def shortType(longType: Type, history: ShortenedNames): Type =
+    try {
+      val isVisited = mutable.Set.empty[(Type, Option[ShortName])]
+      val cached = new ju.HashMap[(Type, Option[ShortName]), Type]()
+      def loop(tpe: Type, name: Option[ShortName]): Type = {
+        val key = tpe -> name
+        // NOTE(olafur) Prevent infinite recursion, see https://github.com/scalameta/metals/issues/749
+        if (isVisited(key)) return cached.getOrDefault(key, tpe)
+        isVisited += key
+        val result = tpe match {
+          case TypeRef(pre, sym, args) =>
+            def shortSymbol = {
+              // workaround for Tuple1 (which is incorrectly printed by Scala 2 compiler)
+              def isTuple1 = sym == definitions.TupleClass(1)
+              /* If it's an alias type we want to prevent dealiasing it
                AnyRef should stay to be dropped if neded later on since it's
                not an important class.
-             */
-            if ((sym.isAliasType && sym != definitions.AnyRefClass) || isTuple1)
-              backtickify(sym.newErrorSymbol(sym.name).updateInfo(sym.info))
-            else backtickify(sym)
-          }
-          if (history.isSymbolInScope(sym, pre)) {
-            TypeRef(
-              NoPrefix,
-              shortSymbol,
-              args.map(arg => loop(arg, None))
-            )
-          } else {
-            val ownerSymbol = pre.termSymbol
-            def hasConflictingMembersInScope =
-              history.lookupSymbol(sym.name).exists {
-                case _: LookupSucceeded => true
-                case _ => false
+               */
+              if (
+                (sym.isAliasType && sym != definitions.AnyRefClass) || isTuple1
+              )
+                backtickify(sym.newErrorSymbol(sym.name).updateInfo(sym.info))
+              else backtickify(sym)
+            }
+            if (history.isSymbolInScope(sym, pre)) {
+              TypeRef(
+                NoPrefix,
+                shortSymbol,
+                args.map(arg => loop(arg, None))
+              )
+            } else {
+              val ownerSymbol = pre.termSymbol
+              def hasConflictingMembersInScope =
+                history.lookupSymbol(sym.name).exists {
+                  case _: LookupSucceeded => true
+                  case _ => false
+                }
+
+              def canRename(rename: Name, ownerSym: Symbol): Boolean = {
+                val shouldRenamePrefix =
+                  !metalsConfig.isDefaultSymbolPrefixes || hasConflictingMembersInScope
+
+                if (shouldRenamePrefix) {
+                  val existingRename = history.rename(ownerSym)
+                  existingRename.isEmpty && history.tryShortenName(
+                    ShortName(rename, ownerSymbol)
+                  )
+                } else false
               }
 
-            def canRename(rename: Name, ownerSym: Symbol): Boolean = {
-              val shouldRenamePrefix =
-                !metalsConfig.isDefaultSymbolPrefixes || hasConflictingMembersInScope
-
-              if (shouldRenamePrefix) {
-                val existingRename = history.rename(ownerSym)
-                existingRename.isEmpty && history.tryShortenName(
-                  ShortName(rename, ownerSymbol)
-                )
-              } else false
-            }
-
-            history.config.get(ownerSymbol) match {
-              case Some(rename) if canRename(rename, ownerSymbol) =>
-                TypeRef(
-                  SingleType(
-                    NoPrefix,
-                    sym.newErrorSymbol(rename)
-                  ),
-                  shortSymbol,
-                  args.map(arg => loop(arg, None))
-                )
-              case _ =>
-                history.rename(sym) match {
-                  case Some(rename) =>
-                    TypeRef(
+              history.config.get(ownerSymbol) match {
+                case Some(rename) if canRename(rename, ownerSymbol) =>
+                  TypeRef(
+                    SingleType(
                       NoPrefix,
-                      sym.newErrorSymbol(rename),
-                      args.map(arg => loop(arg, None))
-                    )
-                  case _ =>
-                    if (
-                      sym.isAliasType &&
-                      (sym.isAbstract ||
-                        sym.overrides.lastOption.exists(_.isAbstract))
-                    ) {
+                      sym.newErrorSymbol(rename)
+                    ),
+                    shortSymbol,
+                    args.map(arg => loop(arg, None))
+                  )
+                case _ =>
+                  history.rename(sym) match {
+                    case Some(rename) =>
+                      TypeRef(
+                        NoPrefix,
+                        sym.newErrorSymbol(rename),
+                        args.map(arg => loop(arg, None))
+                      )
+                    case _ =>
+                      if (
+                        sym.isAliasType &&
+                        (sym.isAbstract ||
+                          sym.overrides.lastOption.exists(_.isAbstract))
+                      ) {
 
-                      // Always dealias abstract type aliases but leave concrete aliases alone.
-                      // trait Generic { type Repr /* dealias */ }
-                      // type Catcher[T] = PartialFunction[Throwable, T] // no dealias
-                      loop(tpe.dealias, name)
-                    } else if (history.owners(pre.typeSymbol)) {
-                      if (history.nameResolvesToSymbol(sym.name, sym)) {
+                        // Always dealias abstract type aliases but leave concrete aliases alone.
+                        // trait Generic { type Repr /* dealias */ }
+                        // type Catcher[T] = PartialFunction[Throwable, T] // no dealias
+                        loop(tpe.dealias, name)
+                      } else if (history.owners(pre.typeSymbol)) {
+                        if (history.nameResolvesToSymbol(sym.name, sym)) {
+                          TypeRef(
+                            NoPrefix,
+                            shortSymbol,
+                            args.map(arg => loop(arg, None))
+                          )
+                        } else {
+                          TypeRef(
+                            ThisType(pre.typeSymbol),
+                            shortSymbol,
+                            args.map(arg => loop(arg, None))
+                          )
+                        }
+                      } else if (sym.isMethod && sym.safeOwner.isImplicit) {
+                        history.tryShortenName(ShortName(sym.safeOwner))
                         TypeRef(
                           NoPrefix,
                           shortSymbol,
@@ -391,153 +408,143 @@ class MetalsGlobal(
                         )
                       } else {
                         TypeRef(
-                          ThisType(pre.typeSymbol),
+                          loop(pre, Some(ShortName(sym))),
                           shortSymbol,
                           args.map(arg => loop(arg, None))
                         )
                       }
-                    } else if (sym.isMethod && sym.safeOwner.isImplicit) {
-                      history.tryShortenName(ShortName(sym.safeOwner))
-                      TypeRef(
-                        NoPrefix,
-                        shortSymbol,
-                        args.map(arg => loop(arg, None))
-                      )
-                    } else {
-                      TypeRef(
-                        loop(pre, Some(ShortName(sym))),
-                        shortSymbol,
-                        args.map(arg => loop(arg, None))
-                      )
-                    }
-                }
-            }
-          }
-        case SingleType(pre, sym) =>
-          def backtickifiedSymbol = backtickify(sym)
-          if (sym.hasPackageFlag || sym.isPackageObjectOrClass) {
-            val dotSyntaxFriendlyName = name.map { name0 =>
-              if (name0.symbol.isStatic) name0
-              else {
-                // Use the prefix rather than the real owner to maximize the
-                // chances of shortening the reference: when `name` is directly
-                // nested in a non-statically addressable type (class or trait),
-                // its original owner is that type (requiring a type projection
-                // to reference it) while the prefix is its concrete owner value
-                // (for which the dot syntax works).
-                // https://docs.scala-lang.org/tour/inner-classes.html
-                // https://danielwestheide.com/blog/the-neophytes-guide-to-scala-part-13-path-dependent-types/
-                ShortName(name0.symbol.cloneSymbol(sym))
+                  }
               }
             }
-            if (history.tryShortenName(dotSyntaxFriendlyName)) NoPrefix
-            else SingleType(pre, backtickifiedSymbol)
-          } else {
-            if (history.isSymbolInScope(sym, pre))
-              SingleType(NoPrefix, backtickifiedSymbol)
-            else {
-              pre match {
-                case ThisType(psym) if history.isSymbolInScope(psym, pre) =>
-                  SingleType(NoPrefix, backtickifiedSymbol)
-                case _ =>
-                  SingleType(
-                    loop(pre, Some(ShortName(sym))),
-                    backtickifiedSymbol
-                  )
-              }
-            }
-          }
-        case ThisType(sym) =>
-          val owners = sym.ownerChain
-          // to make sure we always use renamed package
-          // what is saved in renames is actually companion module of a package
-          val renamedOwnerIndex =
-            owners.indexWhere(s => history.rename(s.companionModule).nonEmpty)
-          if (renamedOwnerIndex < 0 && history.tryShortenName(name)) NoPrefix
-          else {
-            val prefix =
-              if (renamedOwnerIndex < 0)
-                owners.indexWhere { owner =>
-                  owner.owner != definitions.ScalaPackageClass &&
-                  history.tryShortenName(
-                    Some(ShortName(owner.name, owner))
-                  )
+          case SingleType(pre, sym) =>
+            def backtickifiedSymbol = backtickify(sym)
+            if (sym.hasPackageFlag || sym.isPackageObjectOrClass) {
+              val dotSyntaxFriendlyName = name.map { name0 =>
+                if (name0.symbol.isStatic) name0
+                else {
+                  // Use the prefix rather than the real owner to maximize the
+                  // chances of shortening the reference: when `name` is directly
+                  // nested in a non-statically addressable type (class or trait),
+                  // its original owner is that type (requiring a type projection
+                  // to reference it) while the prefix is its concrete owner value
+                  // (for which the dot syntax works).
+                  // https://docs.scala-lang.org/tour/inner-classes.html
+                  // https://danielwestheide.com/blog/the-neophytes-guide-to-scala-part-13-path-dependent-types/
+                  ShortName(name0.symbol.cloneSymbol(sym))
                 }
-              else renamedOwnerIndex
-            if (prefix < 0) {
-              SingleType(
-                NoPrefix,
-                sym.newErrorSymbol(TypeName(history.fullname(sym)))
-              )
+              }
+              if (history.tryShortenName(dotSyntaxFriendlyName)) NoPrefix
+              else SingleType(pre, backtickifiedSymbol)
             } else {
-              val names = owners
-                .take(prefix + 1)
-                .reverse
-                .map(s =>
-                  m.Term.Name(
-                    history
-                      .rename(s.companionModule)
-                      .map(_.toString())
-                      .getOrElse(s.nameSyntax)
-                  )
-                )
-              val ref = names.tail.foldLeft(names.head: m.Term.Ref) {
-                case (qual, name) => m.Term.Select(qual, name)
+              if (history.isSymbolInScope(sym, pre))
+                SingleType(NoPrefix, backtickifiedSymbol)
+              else {
+                pre match {
+                  case ThisType(psym) if history.isSymbolInScope(psym, pre) =>
+                    SingleType(NoPrefix, backtickifiedSymbol)
+                  case _ =>
+                    SingleType(
+                      loop(pre, Some(ShortName(sym))),
+                      backtickifiedSymbol
+                    )
+                }
               }
-              SingleType(
-                NoPrefix,
-                sym.newErrorSymbol(TypeName(ref.syntax))
-              )
             }
-          }
-        case ConstantType(Constant(sym: TermSymbol))
-            if sym.hasFlag(gf.JAVA_ENUM) =>
-          loop(SingleType(sym.owner.thisPrefix, sym), None)
-        case ConstantType(Constant(tpe: Type)) =>
-          ConstantType(Constant(loop(tpe, None)))
-        case SuperType(thistpe, supertpe) =>
-          SuperType(loop(thistpe, None), loop(supertpe, None))
-        case RefinedType(parents, decls) =>
-          RefinedType(parents.map(parent => loop(parent, None)), decls)
-        case AnnotatedType(annotations, underlying) =>
-          AnnotatedType(annotations, loop(underlying, None))
-        case ExistentialType(quantified, underlying) =>
-          ExistentialType(
-            quantified.map(sym => sym.setInfo(loop(sym.info, None))),
-            loop(underlying, None)
-          )
-        case PolyType(typeParams, resultType) =>
-          resultType.map(t => loop(t, None)) match {
-            // [x] => F[x] is not printable in the code, we need to use just `F`
-            case TypeRef(_, sym, args)
-                if typeParams == args.map(_.typeSymbol) =>
-              TypeRef(
-                NoPrefix,
-                sym.newErrorSymbol(sym.name),
-                Nil
-              )
-            case otherType =>
-              PolyType(typeParams, otherType)
-          }
-        case NullaryMethodType(resultType) =>
-          loop(resultType, None)
-        case TypeBounds(lo, hi) =>
-          TypeBounds(loop(lo, None), loop(hi, None))
-        case MethodType(params, resultType) =>
-          MethodType(params, loop(resultType, None))
-        case ErrorType =>
-          definitions.AnyTpe
-        case t => t
+          case ThisType(sym) =>
+            val owners = sym.ownerChain
+            // to make sure we always use renamed package
+            // what is saved in renames is actually companion module of a package
+            val renamedOwnerIndex =
+              owners.indexWhere(s => history.rename(s.companionModule).nonEmpty)
+            if (renamedOwnerIndex < 0 && history.tryShortenName(name)) NoPrefix
+            else {
+              val prefix =
+                if (renamedOwnerIndex < 0)
+                  owners.indexWhere { owner =>
+                    owner.owner != definitions.ScalaPackageClass &&
+                    history.tryShortenName(
+                      Some(ShortName(owner.name, owner))
+                    )
+                  }
+                else renamedOwnerIndex
+              if (prefix < 0) {
+                SingleType(
+                  NoPrefix,
+                  sym.newErrorSymbol(TypeName(history.fullname(sym)))
+                )
+              } else {
+                val names = owners
+                  .take(prefix + 1)
+                  .reverse
+                  .map(s =>
+                    m.Term.Name(
+                      history
+                        .rename(s.companionModule)
+                        .map(_.toString())
+                        .getOrElse(s.nameSyntax)
+                    )
+                  )
+                val ref = names.tail.foldLeft(names.head: m.Term.Ref) {
+                  case (qual, name) => m.Term.Select(qual, name)
+                }
+                SingleType(
+                  NoPrefix,
+                  sym.newErrorSymbol(TypeName(ref.syntax))
+                )
+              }
+            }
+          case ConstantType(Constant(sym: TermSymbol))
+              if sym.hasFlag(gf.JAVA_ENUM) =>
+            loop(SingleType(sym.owner.thisPrefix, sym), None)
+          case ConstantType(Constant(tpe: Type)) =>
+            ConstantType(Constant(loop(tpe, None)))
+          case SuperType(thistpe, supertpe) =>
+            SuperType(loop(thistpe, None), loop(supertpe, None))
+          case RefinedType(parents, decls) =>
+            RefinedType(parents.map(parent => loop(parent, None)), decls)
+          case AnnotatedType(annotations, underlying) =>
+            AnnotatedType(annotations, loop(underlying, None))
+          case ExistentialType(quantified, underlying) =>
+            ExistentialType(
+              quantified.map(sym => sym.setInfo(loop(sym.info, None))),
+              loop(underlying, None)
+            )
+          case PolyType(typeParams, resultType) =>
+            resultType.map(t => loop(t, None)) match {
+              // [x] => F[x] is not printable in the code, we need to use just `F`
+              case TypeRef(_, sym, args)
+                  if typeParams == args.map(_.typeSymbol) =>
+                TypeRef(
+                  NoPrefix,
+                  sym.newErrorSymbol(sym.name),
+                  Nil
+                )
+              case otherType =>
+                PolyType(typeParams, otherType)
+            }
+          case NullaryMethodType(resultType) =>
+            loop(resultType, None)
+          case TypeBounds(lo, hi) =>
+            TypeBounds(loop(lo, None), loop(hi, None))
+          case MethodType(params, resultType) =>
+            MethodType(params, loop(resultType, None))
+          case ErrorType =>
+            definitions.AnyTpe
+          case t => t
+        }
+        cached.putIfAbsent(key, result)
+        result
       }
-      cached.putIfAbsent(key, result)
-      result
-    }
 
-    longType match {
-      case ThisType(_) => longType
-      case _ => loop(longType, None)
+      longType match {
+        case ThisType(_) => longType
+        case _ => loop(longType, None)
+      }
+    } catch {
+      case NonFatal(e) =>
+        logger.warning(s"Failed to shorten type $longType: $e")
+        longType
     }
-  }
 
   /**
    * Custom `Type.toLongString` that shortens fully qualified package prefixes.
@@ -1164,5 +1171,4 @@ class MetalsGlobal(
       }
     }
   }
-
 }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -306,7 +306,9 @@ class MetalsGlobal(
    * with fully qualified names. This method strips out package prefixes to shorten the names while
    * making sure to not convert two different symbols into same short name.
    */
-  def shortType(longType: Type, history: ShortenedNames): Type =
+  def shortType(longType: Type, history: ShortenedNames)(implicit
+      queryInfo: m.internal.metals.PcQueryContext
+  ): Type =
     try {
       val isVisited = mutable.Set.empty[(Type, Option[ShortName])]
       val cached = new ju.HashMap[(Type, Option[ShortName]), Type]()
@@ -542,14 +544,20 @@ class MetalsGlobal(
       }
     } catch {
       case NonFatal(e) =>
-        logger.warning(s"Failed to shorten type $longType: $e")
+        queryInfo.report(
+          "shorten-type",
+          e,
+          s"Failed to shorten type $longType"
+        )
         longType
     }
 
   /**
    * Custom `Type.toLongString` that shortens fully qualified package prefixes.
    */
-  def metalsToLongString(tpe: Type, history: ShortenedNames): String = {
+  def metalsToLongString(tpe: Type, history: ShortenedNames)(implicit
+      queryInfo: m.internal.metals.PcQueryContext
+  ): String = {
     shortType(tpe, history).toLongString
   }
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.pc
 
 import scala.annotation.tailrec
 
+import scala.meta.internal.metals.PcQueryContext
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.InlayHintsParams
 
@@ -11,7 +12,7 @@ import org.eclipse.lsp4j.InlayHintKind
 final class PcInlayHintsProvider(
     protected val compiler: MetalsGlobal,
     val params: InlayHintsParams
-) {
+)(implicit queryInfo: PcQueryContext) {
   import compiler._
   val unit: RichCompilationUnit = addCompilationUnit(
     code = params.text(),

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaCompilerAccess.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaCompilerAccess.scala
@@ -7,7 +7,6 @@ import scala.tools.nsc.interactive.ShutdownReq
 import scala.tools.nsc.reporters.StoreReporter
 import scala.util.control.NonFatal
 
-import scala.meta.internal.metals.ReportContext
 import scala.meta.pc.PresentationCompilerConfig
 import scala.meta.pc.VirtualFileParams
 
@@ -50,15 +49,13 @@ class ScalaCompilerWrapper(global: MetalsGlobal)
 class ScalaCompilerAccess(
     config: PresentationCompilerConfig,
     sh: Option[ScheduledExecutorService],
-    newCompiler: () => ScalaCompilerWrapper,
-    additionalReportingData: () => String
-)(implicit ec: ExecutionContextExecutor, rc: ReportContext)
+    newCompiler: () => ScalaCompilerWrapper
+)(implicit ec: ExecutionContextExecutor)
     extends CompilerAccess[StoreReporter, MetalsGlobal](
       config,
       sh,
       newCompiler,
-      shouldResetJobQueue = false,
-      additionalReportingData
+      shouldResetJobQueue = false
     ) {
 
   def newReporter = new StoreReporter

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.pc
 
 import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.PcQueryContext
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.OffsetParams
 
@@ -8,7 +9,9 @@ import org.eclipse.lsp4j.ParameterInformation
 import org.eclipse.lsp4j.SignatureHelp
 import org.eclipse.lsp4j.SignatureInformation
 
-class SignatureHelpProvider(val compiler: MetalsGlobal) {
+class SignatureHelpProvider(val compiler: MetalsGlobal)(implicit
+    queryInfo: PcQueryContext
+) {
   import compiler._
 
   def signatureHelp(

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/Signatures.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/Signatures.scala
@@ -5,6 +5,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
 import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.PcQueryContext
 import scala.meta.pc
 import scala.meta.pc.SymbolDocumentation
 
@@ -44,7 +45,7 @@ trait Signatures { compiler: MetalsGlobal =>
         pos: Position,
         scope: Context,
         importPosition: AutoImportPosition
-    ): (String, List[l.TextEdit]) = {
+    )(implicit queryInfo: PcQueryContext): (String, List[l.TextEdit]) = {
       val history = new ShortenedNames(
         lookupSymbol = name => {
           val companion =
@@ -66,7 +67,7 @@ trait Signatures { compiler: MetalsGlobal =>
         pos: Position,
         scope: Context,
         importPosition: AutoImportPosition
-    ): (String, List[l.TextEdit]) = {
+    )(implicit queryInfo: PcQueryContext): (String, List[l.TextEdit]) = {
       if (scope.symbolIsInScope(sym)) (Identifier(sym.name), Nil)
       else if (!scope.nameIsInScope(sym.name)) {
         val startPos = pos.withPoint(importPosition.offset).focus
@@ -289,7 +290,7 @@ trait Signatures { compiler: MetalsGlobal =>
       includeDocs: Boolean,
       includeDefaultParam: Boolean = true,
       printLongType: Boolean = true
-  ) {
+  )(implicit queryInfo: PcQueryContext) {
     private val info: Option[SymbolDocumentation] =
       if (includeDocs) {
         symbolDocumentation(gsym)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/MatchCaseCompletions.scala
@@ -7,6 +7,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
 import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.metals.PcQueryContext
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.pc.CompletionFuzzy
 import scala.meta.internal.pc.Identifier
@@ -39,7 +40,8 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
       patternOnly: Option[String] = None,
       hasBind: Boolean = false,
       includeExhaustive: Option[NewLineOptions] = None
-  ) extends CompletionPosition {
+  )(implicit queryInfo: PcQueryContext)
+      extends CompletionPosition {
     val context: Context = doLocateContext(pos)
     val parents: Parents = selector match {
       case EmptyTree =>
@@ -254,7 +256,8 @@ trait MatchCaseCompletions { this: MetalsGlobal =>
       pos: Position,
       source: URI,
       text: String
-  ) extends CompletionPosition {
+  )(implicit queryInfo: PcQueryContext)
+      extends CompletionPosition {
     private def subclassesForType(tpe: Type): List[Symbol] = {
       if (tpe.typeSymbol.isRefinementClass) {
         val RefinedType(parents, _) = tpe

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/Scala3CompilerAccess.scala
@@ -13,7 +13,6 @@ class Scala3CompilerAccess(
     config: PresentationCompilerConfig,
     sh: Option[ScheduledExecutorService],
     newCompiler: () => Scala3CompilerWrapper,
-    additionalReportingData: () => String,
 )(using ec: ExecutionContextExecutor, rc: ReportContext)
     extends CompilerAccess[StoreReporter, MetalsDriver](
       config,
@@ -23,7 +22,6 @@ class Scala3CompilerAccess(
        * Otherwise it will block indefinetely in case of infinite loops.
        */
       shouldResetJobQueue = true,
-      additionalReportingData,
     ):
 
   def newReporter = new StoreReporter(null)


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/7091

I added `PcQueryContext` class, so it can be implicitly passed between pc methods. This way we can easily create and error report with all the context information from any place in the presentation compiler.