### PR TITLE
fix: publish empty scaladoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -198,7 +198,7 @@ val sharedScalacOptions = List(
 )
 
 val sharedSettings = sharedJavacOptions ++ sharedScalacOptions ++ List(
-  Compile / packageDoc / publishArtifact := false,
+  Compile / doc / sources := Seq.empty,
   libraryDependencies ++= crossSetting(
     scalaVersion.value,
     if2 = List(


### PR DESCRIPTION
It seems this commit: https://github.com/scalameta/metals/pull/7105/commits/2c9cf5e988c5d6c8dc95939441427f90ef922b63 
broke release https://github.com/scalameta/metals/actions/runs/12948583151/job/36117533530, since sonatype requires javadoc.

This PR doesn't simply revert the change but makes an empty scaladoc for all modules (previously only that was the case for mtags).