### PR TITLE
bugfix: completion in args in generic method w/ default args

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -21,8 +21,10 @@ trait ArgCompletions { this: MetalsGlobal =>
     val funPos = apply.fun.pos
     val method: Tree = typedTreeAt(funPos) match {
       // Functions calls with default arguments expand into this form
-      case Apply(Block(defParams, app @ (_: Apply | _: Select)), _)
-          if defParams.forall(p => p.isInstanceOf[ValDef]) =>
+      case Apply(
+            Block(defParams, app @ (_: Apply | _: Select | _: TypeApply)),
+            _
+          ) if defParams.forall(p => p.isInstanceOf[ValDef]) =>
         app
       case New(c) => c
       case t => t

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -376,6 +376,29 @@ class CompletionArgSuite extends BaseCompletionSuite {
     topLines = Some(3)
   )
 
+  check(
+    "default-args8",
+    """|trait Foo {
+       |  def bar[A](fst: A, snd: Int, thd: Int = 23)
+       |}
+       |object Main {
+       |  def foo: Foo = ???
+       |  foo.bar(123, @@)
+       |}
+       |""".stripMargin,
+    """|snd = : Int
+       |thd = : Int
+       |""".stripMargin,
+    topLines = Some(2),
+    compat = Map(
+      // TODO: this isn't right, we should see `snd = : Int` here as well
+      ">=3.3.1" ->
+        """|thd = : Int
+           |Main `default-args8`
+           |""".stripMargin
+    )
+  )
+
   checkSnippet( // see: https://github.com/scalameta/metals/issues/2400
     "explicit-dollar",
     """


### PR DESCRIPTION
Previous behaviour would throw an exception, leading to no completions. This is just another unaccounted way in which methods with default args can be desugared.