### PR TITLE
bugfix: Don't fail on broken pipe

### DIFF
--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/TestDebugger.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/TestDebugger.scala
@@ -144,7 +144,10 @@ final class TestDebugger(
       case Category.STDERR =>
         val output = event.getOutput()
         // This might sometimes be printed in the JVM, but does not cause any actual issues
-        if (!output.contains("Picked up JAVA_TOOL_OPTIONS"))
+        if (
+          !output.contains("Picked up JAVA_TOOL_OPTIONS") ||
+          output.contains("transport error 202: send failed: Broken pipe")
+        )
           fail(new IllegalStateException(output))
       case _ =>
       // ignore


### PR DESCRIPTION
It seems it might sometimes fail when disconnecting, but that is not a huge deal

It happened in multiple recent PRs and it seems only flaky, not really reproducible