### PR TITLE
support testing on Scala 2 PR validation snapshots

### DIFF
--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -34,8 +34,16 @@ abstract class BasePCSuite extends BaseSuite with PCSuite {
       "https://scala-ci.typesafe.com/artifactory/scala-integration/"
     )
 
+  val scalaPRValidationRepo: MavenRepository =
+    MavenRepository.of(
+      "https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/"
+    )
+
   override val allRepos: Seq[Repository] =
-    Repository.defaults().asScala.toSeq :+ scalaNightlyRepo
+    Repository
+      .defaults()
+      .asScala
+      .toSeq :+ scalaNightlyRepo :+ scalaPRValidationRepo
 
   val executorService: ScheduledExecutorService =
     Executors.newSingleThreadScheduledExecutor()


### PR DESCRIPTION
this makes it possible to test metals with an unmerged Scala 2 PR, such as (but not only) in the context of the Scala 2 community build

this came up today over at https://github.com/scala/scala/pull/10986#discussion_r1941511604