### PR TITLE
chore: Check name when renaming

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
@@ -12,7 +12,7 @@ class PcRenameProvider(
 ) extends WithSymbolSearchCollector[l.TextEdit](compiler, params) {
   import compiler._
   private val forbiddenMethods =
-    Set("equals", "hashCode", "unapply", "unary_!", "!")
+    Set("equals", "hashCode", "unapply", "apply", "<init>", "unary_!", "!")
 
   private val soughtSymbolNames = soughtSymbols match {
     case Some((symbols, _)) =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
@@ -14,15 +14,26 @@ class PcRenameProvider(
   private val forbiddenMethods =
     Set("equals", "hashCode", "unapply", "unary_!", "!")
 
-  def canRenameSymbol(sym: Symbol): Boolean = {
-    (!sym.isMethod || !forbiddenMethods(sym.decodedName)) &&
-    (sym.ownersIterator
-      .drop(1)
-      .exists(owner =>
-        owner.isMethod || owner.isAnonymousFunction
-      )) // this also works for worksheets, since they are wrapped in `method main`
-
+  private val soughtSymbolNames = soughtSymbols match {
+    case Some((symbols, _)) =>
+      symbols
+        .filterNot(_.isErroneous)
+        .map(symbol => symbol.decodedName.toString)
+    case None => Set.empty[String]
   }
+
+  def canRenameSymbol(sym: Symbol): Boolean = {
+    val name = sym.decodedName.toString
+    def sameName = soughtSymbolNames(name)
+    def isLocal =
+      sym.ownersIterator
+        .drop(1)
+        .exists(owner => owner.isMethod || owner.isAnonymousFunction)
+
+    // this also works for worksheets, since they are wrapped in `method main`
+    (!sym.isMethod || !forbiddenMethods(name)) && isLocal && sameName
+  }
+
   def prepareRename(
   ): Option[l.Range] = {
     soughtSymbols.flatMap { case (symbols, pos) =>

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/PcRenameProvider.scala
@@ -17,7 +17,7 @@ final class PcRenameProvider(
     name: Option[String],
 ) extends WithSymbolSearchCollector[l.TextEdit](driver, params):
   private val forbiddenMethods =
-    Set("equals", "hashCode", "unapply", "unary_!", "!")
+    Set("equals", "hashCode", "unapply", "apply", "<init>", "unary_!", "!")
 
   private val soughtSymbolNames = soughtSymbols match
     case Some((symbols, _)) =>
@@ -26,14 +26,14 @@ final class PcRenameProvider(
 
   def canRenameSymbol(sym: Symbol)(using Context): Boolean =
     val decodedName = sym.decodedName
-    def isNotForbiddenMethod =
-      !sym.is(Method) || !forbiddenMethods(decodedName)
+    def isForbiddenMethod =
+      sym.is(Method) && forbiddenMethods(decodedName)
 
     def local = sym.ownersIterator.drop(1).exists(ow => ow.is(Method))
 
     def isInWorksheet = sym.source.path.isWorksheet
 
-    isNotForbiddenMethod && (local || isInWorksheet) && soughtSymbolNames(
+    !isForbiddenMethod && (local || isInWorksheet) && soughtSymbolNames(
       decodedName
     )
 

--- a/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/PcRenameSuite.scala
@@ -41,6 +41,32 @@ class PcRenameSuite extends BasePcRenameSuite {
   )
 
   check(
+    "apply-rename",
+    """|object B{
+       |  def locally = {
+       |    object A{ def app@@ly(a: Int) = ??? }
+       |    A(123)
+       |    A.apply(123)
+       |  }
+       |}  
+       |""".stripMargin,
+    wrap = false
+  )
+
+  check(
+    "constructor-rename",
+    """|object B{
+       |  def locally = {
+       |    class A(a : String){ def th@@is(a: Int) = this(a.toString) }
+       |    A(123)
+       |    A.apply(123)
+       |  }
+       |}  
+       |""".stripMargin,
+    wrap = false
+  )
+
+  check(
     "generics",
     """|trait S1[X] { def <<torename>>(p: X): String = "" }
        |trait T1[Z] extends S1[Z] { override def <<torename>>(p: Z): String = super.<<torename>>(p) }


### PR DESCRIPTION
I noticed that sometimes rename worked on symbols not within the local scope and these checks should help.