### PR TITLE
bugfix: don't prefix scope completions from supertype

### DIFF
--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -2069,4 +2069,26 @@ class CompletionSuite extends BaseCompletionSuite {
     assertSingleItem = false
   )
 
+  check(
+    "overloaded-no-prefix",
+    """|trait Foo {
+       |  def overloaded(i: Int): Unit
+       |  def overloaded(s: String): Unit
+       |}
+       |trait Bar extends Foo {
+       |  val bar = overlo@@
+       |}
+       |""".stripMargin,
+    """|overloaded(i: Int): Unit
+       |overloaded(s: String): Unit
+       |""".stripMargin,
+    topLines = Some(2),
+    compat = Map {
+      "3" ->
+        """|overloaded(s: String): Unit
+           |overloaded(i: Int): Unit
+           |""".stripMargin
+    }
+  )
+
 }


### PR DESCRIPTION
In the added test case, the previous behaviour would've been to complete to `Foo.overloaded` instead of just `overloaded`. This was because the effective owner of `overloaded` was `Foo` instead of `Bar`. Since those were not the same symbol, the logic for determining the prefix would incorrectly add a `Foo` prefix to the completion.

By augumenting the equality check to be a subtyping check, we ensure that we don't add prefixes to completions coming from supertype scopes.