### PR TITLE
bugfix: don't propose inaccessible named arg defaults

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/ArgCompletions.scala
@@ -126,7 +126,8 @@ trait ArgCompletions { this: MetalsGlobal =>
       completions match {
         case members: CompletionResult.ScopeMembers
             if paramType != definitions.AnyTpe =>
-          members.results
+          members
+            .matchingResults(_ => _ => true)
             .collect {
               case mem
                   if mem.sym.tpe <:< paramType && notNothingOrNull(

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -1290,4 +1290,26 @@ class CompletionArgSuite extends BaseCompletionSuite {
     topLines = Some(1)
   )
 
+  check(
+    "inaccessible-defaults",
+    """|package object A {
+       |  private[A] val somePackagePrivStr = "foo"
+       |  private val somePrivStr = "foo"
+       |  val somePubStr = "bar"
+       |}
+       |package B {
+       |  import A._
+       |  object Testing {
+       |    def foo(arg: String): Unit = ()
+       |    foo(@@)
+       |  }
+       |}
+       |""".stripMargin,
+    """|arg = : String
+       |arg = somePubStr : String
+       |somePubStr: String
+       |""".stripMargin,
+    topLines = Some(3)
+  )
+
 }


### PR DESCRIPTION
Directly accessing `CompletionResult.ScopeMembers.results` bypasses accessibility and similar checks. Going through `matchingResults` ensures we get the same validation we'd get in other scope-based completion contexts.

Before this patch, the newly added test would propose the invalid completion

    foo(arg = somePackagePrivStr)