### PR TITLE
bugfix: Calculate indent and insert position before retrying infering…

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/InferredMethodProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/InferredMethodProvider.scala
@@ -247,15 +247,15 @@ final class InferredMethodProvider(
         params.token(),
         params.outlineFiles()
       )
+    val insertRange = insertPosition().toLsp
+    val ident = "\n" + " " * insertRange.getStart().getCharacter()
 
     val inferredTypeProvider = new InferredMethodProvider(compiler, newParams)
     inferredTypeProvider.inferredMethodEdits() match {
       case right @ Right(List(edit)) =>
-        val range = untyped.pos.toLsp
-        range.setEnd(range.getStart())
-        edit.setRange(range)
-        val indent = indentation(params.text(), untyped.pos.start - 1)
-        edit.setNewText(edit.getNewText() + indent)
+        insertRange.setEnd(insertRange.getStart())
+        edit.setRange(insertRange)
+        edit.setNewText(edit.getNewText().trim() + ident)
         right
       case otherwise => otherwise
     }

--- a/tests/cross/src/test/scala/tests/pc/InsertInferredMethodSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InsertInferredMethodSuite.scala
@@ -318,8 +318,8 @@ class InsertInferredMethodSuite extends BaseCodeActionSuite {
        |
        |""".stripMargin,
     """|trait Main {
+       |  def otherMethod(arg0: (Int, Int, Int)) = ???
        |  def main() = {
-       |    def otherMethod(arg0: (Int, Int, Int)) = ???
        |    List((1, 2, 3)).filter(_ => true).map(otherMethod)
        |  }
        |}
@@ -337,9 +337,28 @@ class InsertInferredMethodSuite extends BaseCodeActionSuite {
        |
        |""".stripMargin,
     """|trait Main {
+       |  def otherMethod(arg0: (Int, Int, Int)) = ???
+       |  def main() = {
+       |    List((1, 2, 3)).map(otherMethod)
+       |  }
+       |}
+       |""".stripMargin
+  )
+
+  checkEdit(
+    "lambda-def-complex-type-list",
+    """|
+       |trait Main {
+       |  def main() = {
+       |    val res = List((1, 2, 3)).map(<<otherMethod>>)
+       |  }
+       |}
+       |
+       |""".stripMargin,
+    """|trait Main {
        |  def main() = {
        |    def otherMethod(arg0: (Int, Int, Int)) = ???
-       |    List((1, 2, 3)).map(otherMethod)
+       |    val res = List((1, 2, 3)).map(otherMethod)
        |  }
        |}
        |""".stripMargin


### PR DESCRIPTION
… method

Previously, we would get the position and indent in the modified tree which would not make sense in terms of the original tree,