### PR TITLE
improvement: when logging error report creation use `warning` instead  of `severe`

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/ReportContext.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/ReportContext.scala
@@ -156,7 +156,7 @@ class StdReporter(
           path
         }
         if (!ifVerbose) {
-          logger.severe(
+          logger.warning(
             s"${report.shortSummary} (full report at: $pathToReport)"
           )
         }


### PR DESCRIPTION
Logging error report creation with `severe` makes users feel like something broke badly, where in most cases it only points to a single operation issue, that doesn't affect overall Metals's performance.