### PR TITLE
bugfix: fix Scala 2 NPE in implicit inlay hints

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
@@ -200,7 +200,7 @@ final class PcInlayHintsProvider(
         if (t.symbol != null) labelPart(t.symbol, t.symbol.decodedName)
         else if (t.tpe != null)
           LabelPart(s"(?$treeLabel: ${t.tpe.toLongString})")
-        else LabelPart(s"(?$treeLabel: ?)")
+        else LabelPart(s"(?$treeLabel: ???)")
 
       @tailrec
       def recurseImplicitArgs(

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
@@ -196,6 +196,12 @@ final class PcInlayHintsProvider(
     }
 
     def partsFromImplicitArgs(trees: List[Tree]): List[LabelPart] = {
+      def safeLabel(t: Tree, treeLabel: String) =
+        if (t.symbol != null) labelPart(t.symbol, t.symbol.decodedName)
+        else if (t.tpe != null)
+          LabelPart(s"(?$treeLabel: ${t.tpe.toLongString})")
+        else LabelPart(s"(?$treeLabel: ?)")
+
       @tailrec
       def recurseImplicitArgs(
           currentArgs: List[Tree],
@@ -243,7 +249,7 @@ final class PcInlayHintsProvider(
                     LabelPart(", ") :: label :: parts
                   )
               case Apply(fun, args) =>
-                val applyLabel = labelPart(fun.symbol, fun.symbol.decodedName)
+                val applyLabel = safeLabel(fun, "apply")
                 recurseImplicitArgs(
                   args,
                   remainingArgs :: remainingArgsLists,
@@ -251,16 +257,18 @@ final class PcInlayHintsProvider(
                 )
               case t @ Function(vparams, body) =>
                 val funLabels =
-                  if (t.symbol.isSynthetic)
-                    reversedLabelPartsFromParams(vparams)
-                  else List(labelPart(t.symbol, t.symbol.decodedName))
+                  if (t.symbol != null)
+                    if (t.symbol.isSynthetic)
+                      reversedLabelPartsFromParams(vparams)
+                    else List(labelPart(t.symbol, t.symbol.decodedName))
+                  else safeLabel(t, "function") :: Nil
                 recurseImplicitArgs(
                   List(body),
                   remainingArgs :: remainingArgsLists,
                   LabelPart(" => ") :: funLabels ::: parts
                 )
               case t if t.isTerm =>
-                val termLabel = labelPart(t.symbol, t.symbol.decodedName)
+                val termLabel = safeLabel(t, "term")
                 if (remainingArgs.isEmpty)
                   recurseImplicitArgs(
                     remainingArgs,
@@ -281,6 +289,7 @@ final class PcInlayHintsProvider(
                 )
             }
         }
+
       (LabelPart(")") :: recurseImplicitArgs(
         trees,
         Nil,

--- a/tests/cross/src/test/scala/tests/pc/InlayHintsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InlayHintsSuite.scala
@@ -7,7 +7,7 @@ class InlayHintsSuite extends BaseInlayHintsSuite {
 
   override def extraDependencies(scalaVersion: String): Seq[Dependency] = {
     val scalaBinaryVersion = createBinaryVersion(scalaVersion)
-    if (isScala3Version(scalaVersion) || scalaVersion.startsWith("2.11")) {
+    if (scalaVersion.startsWith("2.11")) {
       Seq.empty
     } else {
       Seq(

--- a/tests/cross/src/test/scala/tests/pc/InlayHintsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InlayHintsSuite.scala
@@ -1,8 +1,20 @@
 package tests.pc
 
+import coursierapi.Dependency
 import tests.BaseInlayHintsSuite
 
 class InlayHintsSuite extends BaseInlayHintsSuite {
+
+  override def extraDependencies(scalaVersion: String): Seq[Dependency] = {
+    val scalaBinaryVersion = createBinaryVersion(scalaVersion)
+    if (isScala3Version(scalaVersion) || scalaVersion.startsWith("2.11")) {
+      Seq.empty
+    } else {
+      Seq(
+        Dependency.of("com.chuusai", s"shapeless_$scalaBinaryVersion", "2.3.12")
+      )
+    }
+  }
 
   check(
     "local",
@@ -1023,6 +1035,20 @@ class InlayHintsSuite extends BaseInlayHintsSuite {
                 |}
                 |""".stripMargin
     )
+  )
+
+  check(
+    "implicit-fn-shapeless".tag(IgnoreScala211),
+    """|object Main{
+       |  import shapeless.Generic
+       |  Generic[(String, Int)]
+       |}
+       |""".stripMargin,
+    """|object Main{
+       |  import shapeless.Generic
+       |  Generic[(String, Int)]/*(instance<<shapeless/Generic.instance().>>((x0$1: Tuple2<<scala/Tuple2#>>) => (?term: String :: Int :: shapeless.HNil)), (x0$2: ::<<shapeless/`::`#>>) => (?term: (String, Int)))))*/
+       |}
+       |""".stripMargin
   )
 
   check(


### PR DESCRIPTION
I've added safety null checks for cases where symbol information could be missing (triggered for example by shapeless Generic macros).

I default to showing the type of the tree or, if that is missing too, just a static placeholder.

I've also added a test that uses Shapeless to verify the fix. (Unfortunately I wasn't able to reproduce the bug any other way.)