### PR TITLE
improvement: Only show symbol import if static method exists

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImportsProvider.scala
@@ -55,9 +55,14 @@ final class AutoImportsProvider(
     def correctInTreeContext(sym: Symbol) = lastVisitedParentTrees match {
       case (_: Ident) :: (sel: Select) :: _ =>
         sym.info.members.exists(_.name == sel.name)
-      case (_: Ident) :: (_: Apply) :: _ =>
-        sym.info.members.exists(_.name == nme.apply)
-      case _ => true
+      case (_: Ident) :: (_: Apply) :: _ if !sym.isMethod =>
+        def applyInObject =
+          sym.companionModule.info.members.exists(_.name == nme.apply)
+        def applyInClass = sym.info.members.exists(_.name == nme.apply)
+        applyInClass || applyInObject
+
+      case _ =>
+        true
     }
 
     def namePos: l.Range =

--- a/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
@@ -12,6 +12,62 @@ class AutoImportsSuite extends BaseAutoImportsSuite {
        |}
        |""".stripMargin,
     """|scala.concurrent
+       |""".stripMargin
+  )
+  check(
+    "basic-apply",
+    """|object A {
+       |  <<Future>>(2)
+       |}
+       |""".stripMargin,
+    """|scala.concurrent
+       |""".stripMargin
+  )
+
+  check(
+    "basic-apply-wrong",
+    """|object A {
+       |  new <<Future>>(2)
+       |}
+       |""".stripMargin,
+    """|scala.concurrent
+       |java.util.concurrent
+       |""".stripMargin,
+    compat = Map(
+      "2.11" ->
+        """|scala.concurrent
+           |scala.concurrent.impl
+           |java.util.concurrent
+           |""".stripMargin
+    )
+  )
+
+  check(
+    "basic-fuzzy",
+    """|object A {
+       |  <<Future>>.thisMethodDoesntExist(2)
+       |}
+       |""".stripMargin,
+    """|scala.concurrent
+       |java.util.concurrent
+       |""".stripMargin,
+    compat = Map(
+      "2.11" ->
+        """|scala.concurrent
+           |scala.concurrent.impl
+           |java.util.concurrent
+           |""".stripMargin
+    )
+  )
+
+  check(
+    "typed-simple",
+    """|object A {
+       |  import scala.concurrent.Promise
+       |  val fut: <<Future>> = Promise[Unit]().future
+       |}
+       |""".stripMargin,
+    """|scala.concurrent
        |java.util.concurrent
        |""".stripMargin,
     compat = Map(

--- a/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/AutoImportsSuite.scala
@@ -14,6 +14,7 @@ class AutoImportsSuite extends BaseAutoImportsSuite {
     """|scala.concurrent
        |""".stripMargin
   )
+
   check(
     "basic-apply",
     """|object A {
@@ -21,6 +22,32 @@ class AutoImportsSuite extends BaseAutoImportsSuite {
        |}
        |""".stripMargin,
     """|scala.concurrent
+       |""".stripMargin,
+    compat = Map(
+      "2.11" ->
+        """|scala.concurrent
+           |scala.concurrent.impl
+           |""".stripMargin
+    )
+  )
+
+  check(
+    "basic-function-apply",
+    """|
+       |object ForgeFor{
+       |  def importMe(): Int = ???
+       |}
+       |object ForgeFor2{
+       |  case class importMe()
+       |}
+       |
+       |
+       |object test2 { 
+       |  <<importMe>>()
+       |}
+       |""".stripMargin,
+    """|ForgeFor
+       |ForgeFor2
        |""".stripMargin
   )
 

--- a/tests/slow/src/test/scala/tests/scalacli/ScalaCliActionsSuite.scala
+++ b/tests/slow/src/test/scala/tests/scalacli/ScalaCliActionsSuite.scala
@@ -128,7 +128,6 @@ class ScalaCliActionsSuite
         |}
         |""".stripMargin,
     s"""|${ImportMissingSymbol.title("Future", "scala.concurrent")}
-        |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
         |${CreateNewSymbol.title("Future")}
         |""".stripMargin,
     s"""|//> using scala "${BuildInfo.scala213}"
@@ -156,7 +155,6 @@ class ScalaCliActionsSuite
         |}
         |""".stripMargin,
     s"""|${ImportMissingSymbol.title("Future", "scala.concurrent")}
-        |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
         |${CreateNewSymbol.title("Future")}
         |""".stripMargin,
     s"""|#!/usr/bin/env -S scala-cli shebang

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -2,7 +2,6 @@ package tests.codeactions
 
 import scala.meta.internal.metals.codeactions.ConvertToNamedArguments
 import scala.meta.internal.metals.codeactions.CreateNewSymbol
-import scala.meta.internal.metals.codeactions.ExtractMethodCodeAction
 import scala.meta.internal.metals.codeactions.ImportMissingSymbol
 
 class ImportMissingSymbolLspSuite
@@ -17,7 +16,6 @@ class ImportMissingSymbolLspSuite
        |}
        |""".stripMargin,
     s"""|${ImportMissingSymbol.title("Future", "scala.concurrent")}
-        |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
         |${CreateNewSymbol.title("Future")}
         |""".stripMargin,
     """|package a
@@ -39,7 +37,6 @@ class ImportMissingSymbolLspSuite
        |}
        |""".stripMargin,
     s"""|${ImportMissingSymbol.title("Future", "scala.concurrent")}
-        |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
         |${CreateNewSymbol.title("Future")}
         |""".stripMargin,
     """|package a
@@ -80,7 +77,7 @@ class ImportMissingSymbolLspSuite
     """|package a
        |
        |object A {
-       |  val f = <<Future.successful(Instant.now)>>
+       |  val f = <<new Future(Instant.now)>>
        |  val b = ListBuffer.newBuilder[Int]
        |}
        |""".stripMargin,
@@ -89,15 +86,13 @@ class ImportMissingSymbolLspSuite
         |${ImportMissingSymbol.title("Instant", "java.time")}
         |${CreateNewSymbol.title("Future")}
         |${CreateNewSymbol.title("Instant")}
-        |${ExtractMethodCodeAction.title("object `A`")}
-        |${ConvertToNamedArguments.title("successful(...)")}
         |""".stripMargin,
     """|package a
        |
        |import scala.concurrent.Future
        |
        |object A {
-       |  val f = Future.successful(Instant.now)
+       |  val f = new Future(Instant.now)
        |  val b = ListBuffer.newBuilder[Int]
        |}
        |""".stripMargin,
@@ -141,7 +136,8 @@ class ImportMissingSymbolLspSuite
     """|package a
        |
        |object A {
-       |  val f = <<Future.successful(Instant.now)
+       |  <<val f: Future[Int] = ???
+       |  val i = Instant.now
        |  val a = "  " + "  " + "  "
        |  val b = ListBuffer.newBuilder[Int]>>
        |}
@@ -154,7 +150,6 @@ class ImportMissingSymbolLspSuite
         |${CreateNewSymbol.title("Future")}
         |${CreateNewSymbol.title("Instant")}
         |${CreateNewSymbol.title("ListBuffer")}
-        |${ConvertToNamedArguments.title("successful(...)")}
         |""".stripMargin,
     """|package a
        |
@@ -162,7 +157,8 @@ class ImportMissingSymbolLspSuite
        |import scala.collection.mutable.ListBuffer
        |
        |object A {
-       |  val f = Future.successful(Instant.now)
+       |  val f: Future[Int] = ???
+       |  val i = Instant.now
        |  val a = "  " + "  " + "  "
        |  val b = ListBuffer.newBuilder[Int]
        |}
@@ -175,9 +171,10 @@ class ImportMissingSymbolLspSuite
     """|package a
        |
        |object A {
-       |  val f = <<Future.successful(Instant.now)
+       |  <<val f: Future[Int] = ???
+       |  val i = Instant.now
        |  val b = ListBuffer.newBuilder[Int]
-       |  val t = Future.successful(ListBuffer.empty)>>
+       |  val t: Future[ListBuffer] = ???>>
        |}
        |""".stripMargin,
     s"""|${ImportMissingSymbol.allSymbolsTitle}
@@ -188,7 +185,6 @@ class ImportMissingSymbolLspSuite
         |${CreateNewSymbol.title("Future")}
         |${CreateNewSymbol.title("Instant")}
         |${CreateNewSymbol.title("ListBuffer")}
-        |${ConvertToNamedArguments.title("successful(...)")}
         |""".stripMargin,
     """|package a
        |
@@ -196,9 +192,10 @@ class ImportMissingSymbolLspSuite
        |import scala.collection.mutable.ListBuffer
        |
        |object A {
-       |  val f = Future.successful(Instant.now)
+       |  val f: Future[Int] = ???
+       |  val i = Instant.now
        |  val b = ListBuffer.newBuilder[Int]
-       |  val t = Future.successful(ListBuffer.empty)
+       |  val t: Future[ListBuffer] = ???
        |}
        |""".stripMargin,
     expectNoDiagnostics = false,


### PR DESCRIPTION
For now it's a small improvement, I tried some other cases, but for example if we have rhs that we want to check the type for it's currently impossible when the lhs type is not imported. 

Inserting the import and rechecking would be too costly in the auto imports context unfortunately.