### PR TITLE
improve error messages when no main classes can be found

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -848,10 +848,20 @@ class WorkspaceLspService(
                   }
               }(_ => true)
               .flatMap { mains =>
-                mains.headOption.fold(
+                mains.fold(
                   Future.failed[DebugSessionParams](
-                    DiscoveryFailures
-                      .NoMainClassFoundException(unresolvedParams.mainClass)
+                    Option(unresolvedParams.buildTarget)
+                      .map(buildTarget =>
+                        DiscoveryFailures
+                          .ClassNotFoundInBuildTargetException(
+                            unresolvedParams.mainClass,
+                            buildTarget,
+                          )
+                      )
+                      .getOrElse(
+                        DiscoveryFailures
+                          .NoMainClassFoundException(unresolvedParams.mainClass)
+                      )
                   )
                 )(Future.successful(_))
               }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DiscoveryFailures.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DiscoveryFailures.scala
@@ -21,13 +21,13 @@ object DiscoveryFailures {
       className: String,
       buildTarget: String,
   ) extends Exception(
-        s"Class '$className' not found in build target '${buildTarget}'"
+        s"Main class '$className' not found in build target '${buildTarget}' (not considering dependencies)"
       )
 
   case class NoMainClassFoundException(
       className: String
   ) extends Exception(
-        s"Class '$className' not found in any build target"
+        s"Main class '$className' not found in any build target (not considering dependencies)"
       )
 
   case class BuildTargetNotFoundForPathException(path: AbsolutePath)


### PR DESCRIPTION
This improves the error message for main classes discovery in a way that would have helped us in a problem we encountered. The old error message said:

`a.b.c.OurClass not found in any build target`

The new one says

`Main class '$className' not found in build target '${buildTarget}' (not considering dependencies)`

Giving away that the code actually did not ignore the build target we provided, only considered main classes, but not from dependencies. We tried to run a main class from a dependency, but it wasn't immediately clear why it didn't work.