### PR TITLE
bugfix: Make sure to choose the best import option

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
@@ -174,7 +174,7 @@ class ImportMissingSymbol(compilers: Compilers, buildTargets: BuildTargets)
                * suggest it.
                */
               val minimalImportsSet =
-                actions.foldLeft(actions.head.map(_.getTitle()).toSet) {
+                actions.tail.foldLeft(actions.head.map(_.getTitle()).toSet) {
                   case (actions, action) =>
                     actions.intersect(action.map(_.getTitle()).toSet)
                 }

--- a/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/CreateNewSymbolLspSuite.scala
@@ -28,9 +28,9 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
        |
        |case class School(name: String, location: <<Location>>)
        |""".stripMargin,
-    s"""|${ImportMissingSymbol.title("Location", "javax.tools.JavaFileManager")}
+    s"""|${ImportMissingSymbol.title("Location", "javax.xml.stream")}${additionalLocation}
+        |${ImportMissingSymbol.title("Location", "javax.tools.JavaFileManager")}
         |${ImportMissingSymbol.title("Location", docToolName)}
-        |${ImportMissingSymbol.title("Location", "javax.xml.stream")}${additionalLocation}
         |${CreateNewSymbol.title("Location")}""".stripMargin,
     selectedActionIndex = if (isJava21) 4 else 3,
     pickedKind = "scala-case-class",
@@ -113,9 +113,9 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
        |
        |case class School(name: String, location: <<Location>>)
        |""".stripMargin,
-    s"""|${ImportMissingSymbol.title("Location", "javax.tools.JavaFileManager")}
+    s"""|${ImportMissingSymbol.title("Location", "javax.xml.stream")}${additionalLocation}
+        |${ImportMissingSymbol.title("Location", "javax.tools.JavaFileManager")}
         |${ImportMissingSymbol.title("Location", docToolName)}
-        |${ImportMissingSymbol.title("Location", "javax.xml.stream")}${additionalLocation}
         |${CreateNewSymbol.title("Location")}""".stripMargin,
     selectedActionIndex = if (isJava21) 4 else 3,
     pickedKind = "scala-trait",
@@ -134,9 +134,9 @@ class CreateNewSymbolLspSuite extends BaseCodeActionLspSuite("createNew") {
        |
        |<<case class School(name: Missing, location: Location)>>
        |""".stripMargin,
-    s"""|${ImportMissingSymbol.title("Location", "javax.tools.JavaFileManager")}
+    s"""|${ImportMissingSymbol.title("Location", "javax.xml.stream")}${additionalLocation}
+        |${ImportMissingSymbol.title("Location", "javax.tools.JavaFileManager")}
         |${ImportMissingSymbol.title("Location", docToolName)}
-        |${ImportMissingSymbol.title("Location", "javax.xml.stream")}${additionalLocation}
         |${CreateNewSymbol.title("Missing")}
         |${CreateNewSymbol.title("Location")}
         |${ExtractRenameMember.renameFileAsClassTitle(fileName = "A.scala", memberName = "School")}

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -29,6 +29,64 @@ class ImportMissingSymbolLspSuite
   )
 
   check(
+    "all-mixed",
+    """|package a
+       |
+       |object A {
+       |  <<val f = Future.successful(2)
+       |  val t: Future[Unit] = Promise[Unit]().future>>
+       |}
+       |""".stripMargin,
+    s"""|${ImportMissingSymbol.allSymbolsTitle}
+        |${ImportMissingSymbol.title("Future", "scala.concurrent")}
+        |${ImportMissingSymbol.title("Promise", "scala.concurrent")}
+        |${ImportMissingSymbol.title("Promise", "scala.concurrent.impl")}
+        |${CreateNewSymbol.title("Future")}
+        |${CreateNewSymbol.title("Promise")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.concurrent.Future
+       |
+       |object A {
+       |  val f = Future.successful(2)
+       |  val t: Future[Unit] = Promise[Unit]().future
+       |}
+       |""".stripMargin,
+    expectNoDiagnostics = false,
+  )
+
+  check(
+    "all-mixed-rename",
+    """|package a
+       |
+       |import scala.{concurrent => cu}
+       |
+       |object A {
+       |  <<val f = Future.successful(2)
+       |  val t: Future[Unit] = Promise[Unit]().future>>
+       |}
+       |""".stripMargin,
+    s"""|${ImportMissingSymbol.allSymbolsTitle}
+        |${ImportMissingSymbol.title("Future", "scala.concurrent")}
+        |${ImportMissingSymbol.title("Promise", "scala.concurrent")}
+        |${ImportMissingSymbol.title("Promise", "scala.concurrent.impl")}
+        |${CreateNewSymbol.title("Future")}
+        |${CreateNewSymbol.title("Promise")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.{concurrent => cu}
+       |
+       |object A {
+       |  val f = cu.Future.successful(2)
+       |  val t: cu.Future[Unit] = Promise[Unit]().future
+       |}
+       |""".stripMargin,
+    expectNoDiagnostics = false,
+  )
+
+  check(
     "enclosed-range",
     """|package a
        |
@@ -81,7 +139,8 @@ class ImportMissingSymbolLspSuite
        |  val b = ListBuffer.newBuilder[Int]
        |}
        |""".stripMargin,
-    s"""|${ImportMissingSymbol.title("Future", "scala.concurrent")}
+    s"""|${ImportMissingSymbol.allSymbolsTitle}
+        |${ImportMissingSymbol.title("Future", "scala.concurrent")}
         |${ImportMissingSymbol.title("Future", "java.util.concurrent")}
         |${ImportMissingSymbol.title("Instant", "java.time")}
         |${CreateNewSymbol.title("Future")}
@@ -97,6 +156,7 @@ class ImportMissingSymbolLspSuite
        |}
        |""".stripMargin,
     expectNoDiagnostics = false,
+    selectedActionIndex = 1,
   )
 
   check(


### PR DESCRIPTION
When importing symbols in a range it might turn out we are able to get a better suggestions in a certain spot in the file.

For example if we know that one object has a specific method while the other doesn't.

This means that this import is better for the entire file since it's more concrete.

Previously, we would still show all options, but now search for the shortest action choice for each missing symbol.