### PR TITLE
fix: generate auto-imports for more pattern completions

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -963,9 +963,25 @@ class MetalsGlobal(
       } else {
         other.dealiased == sym.dealiased ||
         other.companion == sym.dealiased ||
-        semanticdbSymbol(other.dealiased) == semanticdbSymbol(sym.dealiased)
+        semanticdbSymbol(other.dealiased) == semanticdbSymbol(sym.dealiased) ||
+        isScalaPackageObjectReexport(other)
       }
     }
+
+    /**
+     * Check if the symbol is a `scala.*` `val` re-export of `other`
+     *
+     * @param other
+     * @return
+     */
+    private def isScalaPackageObjectReexport(other: Symbol): Boolean =
+      sym.tpe match {
+        case NullaryMethodType(resultType: SingleType) =>
+          sym.isDefinedInPackage && sym.isStable &&
+          sym.effectiveOwner.name.toTermName == termNames.scala_ &&
+          resultType =:= other.tpe
+        case _ => false
+      }
 
     def snippetCursor: String =
       sym.paramss match {

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -165,8 +165,6 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |""".stripMargin
   )
 
-  // TODO: `Left` has conflicting name in Scope, we should fix it so the result is the same as for scala 2
-  // Issue: https://github.com/scalameta/metals/issues/4368
   check(
     "sealed-conflict",
     """
@@ -858,6 +856,58 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     ""
+  )
+
+  checkEdit(
+    "underscore-autoimport",
+    """
+      |object Outer {
+      |  class Cls
+      |}
+      |object A {
+      |  val t: Outer.Cls = ???
+      |  t match {
+      |    case@@
+      |  }
+      |}""".stripMargin,
+    """
+      |import Outer.Cls
+      |
+      |object Outer {
+      |  class Cls
+      |}
+      |object A {
+      |  val t: Outer.Cls = ???
+      |  t match {
+      |    case _: Cls => $0
+      |  }
+      |}""".stripMargin
+  )
+
+  checkEdit(
+    "case-class-autoimport",
+    """
+      |object Outer {
+      |  case class Cls(i: Int)
+      |}
+      |object A {
+      |  val t: Outer.Cls = ???
+      |  t match {
+      |    case@@
+      |  }
+      |}""".stripMargin,
+    """
+      |import Outer.Cls
+      |
+      |object Outer {
+      |  case class Cls(i: Int)
+      |}
+      |object A {
+      |  val t: Outer.Cls = ???
+      |  t match {
+      |    case Cls(i) => $0
+      |  }
+      |}""".stripMargin
   )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -440,14 +440,7 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
         """|to(end: Int): scala.collection.immutable.Range.Inclusive
            |   ^^^^^^^^
            |to(end: Int, step: Int): scala.collection.immutable.Range.Inclusive
-           |""".stripMargin,
-      "2.11" -> """|^^^^^^
-                   |to(end: Int): immutable.Range.Inclusive
-                   |to(end: Int, step: Int): immutable.Range.Inclusive
-                   |to(end: T): NumericRange.Inclusive[T]
-                   |to(end: T): Range.Partial[T,NumericRange[T]]
-                   |to(end: T, step: T): NumericRange.Inclusive[T]
-                   |""".stripMargin
+           |""".stripMargin
     )
   )
 


### PR DESCRIPTION
This tweaks the case-completion logic to always take auto-imports into account. The auto-import logic was present for known direct subclasses, but not for some other cases. Now, they all get handled uniformly.

The only hair in the soup is that extra work needs to go in to

     def myList: List[Int]
     myList match {
       case N@@   // want `case Nil =>`, not `case immutable.Nil =>`
     }

Reason here is that the `Nil` variant is completing with `scala.collection.immutable.Nil`, while only `scala.Nil` is in scope. The `scala.*` package re-exports are narrowly worked around since they probably would occur frequently.