### PR TITLE
improvement: Forward all LSP data from BSP

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -331,13 +331,15 @@ final class Diagnostics(
             )
             // Scala 3 sets the diagnostic code to -1 for NoExplanation Messages. Ideally
             // this will change and we won't need this check in the future, but for now
-            // let's not forward them.
+            // let's not forward them, since they are not valid for all clients.
             val isScala3NoExplanationDiag = d.getCode() != null && d
               .getCode()
               .isLeft() && d.getCode().getLeft() == "-1"
             if (!isScala3NoExplanationDiag) ld.setCode(d.getCode())
 
             ld.setTags(d.getTags())
+            ld.setRelatedInformation(d.getRelatedInformation)
+            ld.setCodeDescription(d.getCodeDescription())
             adjustedDiagnosticData(d, edit).map(newData => ld.setData(newData))
             ld
           }


### PR DESCRIPTION
I am not sure actually why we were creating a new diagnostic, but we should not need to and any time anything new is added we will automatically support it.

I don't think the new fields are supported yet, but anyway this should be a simple fix.

Related to https://github.com/scalameta/metals-feature-requests/issues/424