### PR TITLE
fix: colliding pattern and scope completions

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -362,19 +362,20 @@ class CompletionProvider(
     val isIgnored = mutable.Set.empty[Symbol]
     val buf = List.newBuilder[Member]
     def visit(head: Member): Boolean = {
-      val id =
-        if (head.sym.isClass || head.sym.isModule) {
-          head.sym.fullName
-        } else {
-          head match {
-            case o: OverrideDefMember =>
-              o.label
-            case named: NamedArgMember =>
-              s"named-${semanticdbSymbol(named.sym)}"
-            case _ =>
-              semanticdbSymbol(head.sym)
+      val id = head match {
+        case o: OverrideDefMember =>
+          o.label
+        case named: NamedArgMember =>
+          s"named-${semanticdbSymbol(named.sym)}"
+        case pattern: CasePatternMember =>
+          s"case-pattern-${semanticdbSymbol(pattern.sym)}"
+        case _ =>
+          if (head.sym.isClass || head.sym.isModule) {
+            head.sym.fullName
+          } else {
+            semanticdbSymbol(head.sym)
           }
-        }
+      }
 
       def isIgnoredWorkspace: Boolean =
         head.isInstanceOf[WorkspaceMember] &&

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -598,10 +598,12 @@ class MetalsGlobal(
                 case Descriptor.None =>
                   Nil
                 case Descriptor.Type(value) =>
-                  val member = owner.info.decl(TypeName(value).encode) :: Nil
-                  if (sym.isJava)
-                    owner.info.decl(TermName(value).encode) :: member
-                  else member
+                  val members =
+                    if (sym.isJava)
+                      owner.info.decl(TermName(value).encode) :: Nil
+                    else Nil
+                  // Put the type ahead of the Java-induced term for `inverseSemanticdbSymbol`
+                  owner.info.decl(TypeName(value).encode) :: members
                 case Descriptor.Term(value) =>
                   owner.info.decl(TermName(value).encode) :: Nil
                 case Descriptor.Package(value) =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -78,6 +78,25 @@ trait Completions { this: MetalsGlobal =>
       val commitCharacter: Option[String] = None
   ) extends ScopeMember(sym, NoType, true, EmptyTree)
 
+  class CasePatternMember(
+      override val filterText: String,
+      override val edit: l.TextEdit,
+      sym: Symbol,
+      override val label: Option[String] = None,
+      override val detail: Option[String] = None,
+      override val command: Option[String] = None,
+      override val additionalTextEdits: List[l.TextEdit] = Nil
+  ) extends TextEditMember(
+        filterText,
+        edit,
+        sym,
+        label,
+        detail,
+        command,
+        additionalTextEdits,
+        None
+      )
+
   val packageSymbols: mutable.Map[String, Option[Symbol]] =
     mutable.Map.empty[String, Option[Symbol]]
   def packageSymbolFromString(symbol: String): Option[Symbol] =

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -910,4 +910,24 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin
   )
 
+  check(
+    "underscore-and-object",
+    """package myPackage1 {
+      |  class MyClass
+      |  object MyClass {
+      |    val TheValue = new MyClass
+      |  }
+      |}
+      |object Test {
+      |  val x = myPackage1.MyClass.TheValue
+      |  x match {
+      |    case My@@
+      |  }
+      |}
+      |""".stripMargin,
+    """_: MyClass myPackage1
+      |MyClass - myPackage1
+      |""".stripMargin
+  )
+
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionPatternSuite.scala
@@ -85,8 +85,8 @@ class CompletionPatternSuite extends BaseCompletionSuite {
       |    case abc @ @@ =>
       |  }
       |}""".stripMargin,
-    """|None scala
-       |Some(value) scala
+    """|Some(value) scala
+       |None scala
        |""".stripMargin,
     topLines = Some(2)
   )
@@ -111,7 +111,7 @@ class CompletionPatternSuite extends BaseCompletionSuite {
       |    case _: @@ =>
       |  }
       |}""".stripMargin,
-    """|None scala
+    """|Some[_] scala
        |""".stripMargin,
     compat = Map(
       "3" ->
@@ -141,7 +141,7 @@ class CompletionPatternSuite extends BaseCompletionSuite {
       |    case ab: @@ =>
       |  }
       |}""".stripMargin,
-    """|None scala
+    """|Some[_] scala
        |""".stripMargin,
     compat = Map(
       "3" ->

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -1028,9 +1028,13 @@ class CompletionSuite extends BaseCompletionSuite {
         |}
         |""".stripMargin,
     """|Some(value) scala
+       |Some scala
        |""".stripMargin,
     compat = Map(
-      "2.11" -> "Some(x) scala",
+      "2.11" ->
+        """|Some(x) scala
+           |Some scala
+           |""".stripMargin,
       "3" ->
         """|Some(value) scala
            |Some scala
@@ -1060,11 +1064,11 @@ class CompletionSuite extends BaseCompletionSuite {
     "adt",
     s"""|object Main {
         |  Option(1) match {
-        |    case No@@
+        |    case Non@@
         |}
         |""".stripMargin,
     """|None scala
-       |NoManifest scala.reflect
+       |NonFatal - scala.util.control
        |""".stripMargin,
     topLines = Some(2)
   )


### PR DESCRIPTION
This ensures that scope-based completions show up in a pattern context, even if the symbol to complete is the same as the one underlying a pattern completion (see the `underscore-and-object` test added)

This is achieved by putting case pattern completions in a new completion member with its own dedup-ing `id`.

Although it turned out to not matter in this specific case, also fixed `inverseSemanticdbSymbol` incorrectly returning an object symbol for some class symbols. That tweak on its own didn't affect any test output.

fixes #7291