### PR TITLE
chore: Bump mdoc to 2.6.5

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -37,7 +37,7 @@ object V {
   val lsp4jV = "0.24.0"
   val mavenBloop = "2.0.1"
   val mill = "0.12.8"
-  val mdoc = "2.6.4"
+  val mdoc = "2.6.5"
   val munit = "1.1.0"
   val pprint = "0.7.3"
   val sbtBloop = bloop


### PR DESCRIPTION
Also fixes https://github.com/scalameta/metals/issues/7286