### PR TITLE
improvement: add CompileTarget server command

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1308,6 +1308,9 @@ abstract class MetalsLspService(
 
   def cleanCompile(): Future[Unit] = compilations.recompileAll()
 
+  def compileTarget(target: b.BuildTargetIdentifier): Future[b.CompileResult] =
+    compilations.compileTarget(target)
+
   def cancelCompile(): Future[Unit] = Future {
     // We keep this in here to provide a way for clients that aren't work done progress cancel providers
     // to be able to cancel a long-running worksheet evaluation by canceling compilation.

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -270,6 +270,18 @@ object ServerCommands {
        |""".stripMargin,
   )
 
+  val CompileTarget = new ParametrizedCommand[b.BuildTargetIdentifier](
+    "compile-target",
+    "CompileTarget",
+    """|Compile the currently open file.
+       |
+       |Can be used as an explicit command in order
+       |to force compilation to start and finish e.g. before executing a codeLens.
+       |Returns CompileResult with field 'statusCode' being 1 for success, 2 for errors or 3 for compile cancelled.
+       |""".stripMargin,
+    "BuildTargetIdentifier",
+  )
+
   val CancelCompile = new Command(
     "compile-cancel",
     "Cancel compilation",
@@ -735,6 +747,7 @@ object ServerCommands {
       CancelCompile,
       CascadeCompile,
       CleanCompile,
+      CompileTarget,
       CopyWorksheetOutput,
       DiscoverMainClasses,
       DiscoverTestSuites,

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -930,6 +930,14 @@ class WorkspaceLspService(
           _.cleanCompile(),
           ServerCommands.CleanCompile.title,
         ).asJavaObject
+      case ServerCommands.CompileTarget(target) =>
+        onCurrentFolder(
+          _.compileTarget(target),
+          ServerCommands.CompileTarget.title,
+          false,
+          () =>
+            null, // shouldn't happen, but json null is fine as a default here
+        ).liftToLspError.asJavaObject
       case ServerCommands.CancelCompile() =>
         foreachSeqIncludeFallback(_.cancelCompile(), ignoreValue = true)
       case ServerCommands.PresentationCompilerRestart() =>


### PR DESCRIPTION
This allows clients to force compilation and await completion in order to mitigate races against compilation.


This is required for this metals-vscode PR: https://github.com/scalameta/metals-vscode/pull/1607