### PR TITLE
Suggest open diagnotics for debug compile errors

### DIFF
--- a/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DebugProtocolSuite.scala
@@ -426,7 +426,17 @@ class DebugProtocolSuite
           }
     } yield assertNoDiff(
       result.toString(),
-      WorkspaceErrorsException.getMessage(),
+      """
+        |ShowMessageRequestParams [
+        |  actions = SeqWrapper (
+        |    MessageActionItem [
+        |      title = "View Problems"
+        |    ]
+        |  )
+        |  type = Error
+        |  message = "Cannot launch due to compile errors."
+        |]
+      """.stripMargin,
     )
   }
 


### PR DESCRIPTION
Show client error message and suggest opening diagnostics view when trying to debug a workspace with compile errors.

Meant to be released in conjunction with https://github.com/scalameta/metals-vscode/pull/1601