### PR TITLE
feat: convert sbt style deps on paste in for scala-cli test.dep

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/DependencyConverter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/DependencyConverter.scala
@@ -26,7 +26,7 @@ object DependencyConverter {
       case _ => None
     }
 
-  private val dependencyIdentifiers = Set("dep", "lib", "plugin")
+  private val dependencyIdentifiers = Set("dep", "test.dep", "lib", "plugin")
   private val sbtDependencyDelimiters = Set("%", "%%", "%%%")
 
   case class ReplacementSuggestion(

--- a/tests/unit/src/test/scala/tests/rangeFormatting/ScalaCliDependencyRangeFormatter.scala
+++ b/tests/unit/src/test/scala/tests/rangeFormatting/ScalaCliDependencyRangeFormatter.scala
@@ -21,6 +21,21 @@ class ScalaCliDependencyRangeFormatterPastingSuite
   )
 
   check(
+    "change-test-dep-format-on-paste",
+    s"""
+       |//> using test.dep @@
+       |object Main {
+       |  println("hello")
+       |}""".stripMargin,
+    s"""|"org.scalameta" %% "munit" % "0.7.26"""".stripMargin,
+    s"""
+       |//> using test.dep org.scalameta::munit:0.7.26
+       |object Main {
+       |  println("hello")
+       |}""".stripMargin,
+  )
+
+  check(
     "change-dep-format-within-existing-deps",
     s"""
        |//> using dep com.lihaoyi::utest::0.7.10


### PR DESCRIPTION
https://github.com/scalameta/metals/pull/7176 was not working for `test.dep`.

see: https://scala-cli.virtuslab.org/docs/guides/introduction/dependencies#test-dependencies