### PR TITLE
bugfix: Fix issues when we would rename more symbols

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -865,6 +865,10 @@ class MetalsGlobal(
   }
 
   implicit class XtensionSymbolMetals(sym: Symbol) {
+    def isLocallyDefined: Boolean =
+      sym.ownersIterator
+        .drop(1)
+        .exists(owner => owner.isMethod || owner.isAnonymousFunction)
     def foreachKnownDirectSubClass(fn: Symbol => Unit): Unit = {
       // NOTE(olafur) The logic in this method is fairly involved because `knownDirectSubClasses`
       // returns a lot of redundant and unrelevant symbols in long-running sessions. For example,

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcRenameProvider.scala
@@ -25,10 +25,7 @@ class PcRenameProvider(
   def canRenameSymbol(sym: Symbol): Boolean = {
     val name = sym.decodedName.toString
     def sameName = soughtSymbolNames(name)
-    def isLocal =
-      sym.ownersIterator
-        .drop(1)
-        .exists(owner => owner.isMethod || owner.isAnonymousFunction)
+    def isLocal = sym.isLocallyDefined
 
     // this also works for worksheets, since they are wrapped in `method main`
     (!sym.isMethod || !forbiddenMethods(name)) && isLocal && sameName

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/WithCompilationUnit.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/WithCompilationUnit.scala
@@ -47,12 +47,19 @@ class WithCompilationUnit(
         val info =
           if (sym.owner.isClass) sym.owner.info
           else sym.owner.owner.info
-        Set(
-          sym,
-          info.member(sym.getterName),
-          info.member(sym.setterName),
-          info.member(sym.localName)
-        ) ++ constructorParam(sym) ++ sym.allOverriddenSymbols.toSet
+        val additionalSymbols =
+          Set(
+            info.member(sym.getterName),
+            info.member(sym.setterName),
+            info.member(sym.localName)
+          )
+        // check if the symbol is actually getter/setter/local value, otherwise we should not show it
+        val base =
+          if (additionalSymbols(sym))
+            additionalSymbols + sym
+          else
+            Set(sym)
+        base ++ constructorParam(sym) ++ sym.allOverriddenSymbols.toSet
       } else Set(sym)
     all.filter(s => s != NoSymbol && !s.isError)
   }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -17,7 +17,6 @@ import scala.meta.internal.pc.IdentifierComparator
 import scala.meta.internal.pc.InterpolationSplice
 import scala.meta.internal.pc.MemberOrdering
 import scala.meta.internal.pc.MetalsGlobal
-import scala.meta.internal.semanticdb.Scala._
 
 import org.eclipse.{lsp4j => l}
 
@@ -355,7 +354,7 @@ trait Completions { this: MetalsGlobal =>
     else Nil
   }
   def dealiasedValForwarder(sym: Symbol): List[Symbol] = {
-    if (sym.isValue && sym.hasRawInfo && !semanticdbSymbol(sym).isLocal) {
+    if (sym.isValue && sym.hasRawInfo && !sym.isLocallyDefined) {
       sym.rawInfo match {
         case SingleType(_, dealias) if dealias.isModule =>
           dealias :: dealias.companion :: Nil


### PR DESCRIPTION
toSemanticdb method is not thread safe and could cause multiple local symbols to have the same local name assigned. I removed usage of it from collectors since it seems it wasn't needed. ~I also added synchronized, since otherwise we can have weird issues all over the place. We should also try not to use it.~ I removed that, I think most other usages do not have the same issue. We could remove more usages of semanticdb method later if needed