### PR TITLE
improvement: deduplicate file indexing in classfile symbol search

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSymbolProvider.scala
@@ -8,7 +8,6 @@ import scala.collection.concurrent.TrieMap
 import scala.util.control.NonFatal
 
 import scala.meta.internal.mtags.GlobalSymbolIndex
-import scala.meta.internal.mtags.SymbolDefinition
 import scala.meta.internal.pc.InterruptException
 import scala.meta.io.AbsolutePath
 import scala.meta.pc.CancelToken
@@ -246,18 +245,18 @@ final class WorkspaceSymbolProvider(
   }
 
   class PreferredScalaVersionOrdering(preferredScalaVersions: Set[String])
-      extends Ordering[SymbolDefinition] {
+      extends Ordering[AbsolutePath] {
     private def pathMatchesPreferred(path: AbsolutePath) =
       buildTargets
         .possibleScalaVersions(path)
         .exists(preferredScalaVersions(_))
 
-    private def pathLength(symbolDef: SymbolDefinition) =
-      symbolDef.path.toURI.toString().length()
+    private def pathLength(path: AbsolutePath) =
+      path.toURI.toString().length()
 
-    override def compare(x: SymbolDefinition, y: SymbolDefinition): Int = {
-      val xVersionMatches = pathMatchesPreferred(x.path)
-      val yVersionMatches = pathMatchesPreferred(y.path)
+    override def compare(x: AbsolutePath, y: AbsolutePath): Int = {
+      val xVersionMatches = pathMatchesPreferred(x)
+      val yVersionMatches = pathMatchesPreferred(y)
 
       if (xVersionMatches && !yVersionMatches) -1
       else if (yVersionMatches && !xVersionMatches) 1
@@ -266,7 +265,7 @@ final class WorkspaceSymbolProvider(
   }
 
   object SymbolDefinitionOrdering {
-    def fromOptPath(path: Option[AbsolutePath]): Ordering[SymbolDefinition] = {
+    def fromOptPath(path: Option[AbsolutePath]): Ordering[AbsolutePath] = {
       path.toList.flatMap(buildTargets.possibleScalaVersions(_)) match {
         case Nil => DefaultSymbolDefinitionOrdering
         case preferredScalaVersions =>

--- a/mtags/src/main/scala/scala/meta/internal/mtags/GlobalSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/GlobalSymbolIndex.scala
@@ -98,6 +98,16 @@ trait GlobalSymbolIndex {
       dialect: Dialect
   ): List[IndexingResult]
 
+  /**
+   * Get files for top level symbol
+   *
+   * @param topLevelSymbol
+   * @return List of files that contain the top level symbol and dialect used in the file
+   */
+  def findFileForToplevel(
+      topLevelSymbol: mtags.Symbol
+  ): List[(AbsolutePath, Dialect)]
+
 }
 
 case class SymbolDefinition(

--- a/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
@@ -144,6 +144,12 @@ final class OnDemandSymbolIndex(
       .sortBy(d => (!d.isExact, d.dialect != dialects.Scala3))
   }
 
+  def findFileForToplevel(
+      topLevelSymbol: Symbol
+  ): List[(AbsolutePath, Dialect)] = {
+    dialectBuckets.values.flatMap(_.findFileForToplevel(topLevelSymbol)).toList
+  }
+
 }
 
 object OnDemandSymbolIndex {

--- a/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/SymbolIndexBucket.scala
@@ -173,6 +173,18 @@ class SymbolIndexBucket(
     }
   }
 
+  def findFileForToplevel(
+      topLevelSymbol: Symbol
+  ): List[(AbsolutePath, Dialect)] = {
+    toplevels
+      .get(topLevelSymbol.toString())
+      .map(_.toList)
+      .orElse(loadFromSourceJars(trivialPaths(topLevelSymbol)))
+      .orElse(loadFromSourceJars(modulePaths(topLevelSymbol)))
+      .getOrElse(Nil)
+      .map(x => (x, dialect))
+  }
+
   def query(symbol: Symbol): List[SymbolDefinition] =
     query0(symbol, symbol)
 

--- a/tests/mtest/src/main/scala/tests/DelegatingGlobalSymbolIndex.scala
+++ b/tests/mtest/src/main/scala/tests/DelegatingGlobalSymbolIndex.scala
@@ -42,4 +42,9 @@ class DelegatingGlobalSymbolIndex(
   ): List[mtags.IndexingResult] = {
     underlying.addSourceDirectory(dir, dialect)
   }
+
+  def findFileForToplevel(
+      topLevelSymbol: mtags.Symbol
+  ): List[(AbsolutePath, Dialect)] =
+    underlying.findFileForToplevel(topLevelSymbol)
 }


### PR DESCRIPTION
In `WorkspaceSearchVisitor` we used `definition` to find the source file for the class file. This unnecessarily causes an indexing of that file. Since we use toplevel symbol for that search anyway, now we just look for the path in indexes avoiding unnecessary steps.