### PR TITLE
sbt-metals: publish for & test against 2.0.0-M4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
             os: ubuntu-latest
             java: "11"
           - type: sbt-metals Sbt 2
-            command: bin/test.sh '++3.6.2; sbt-metals/scripted'
+            command: bin/test.sh '++3.x; sbt-metals/scripted'
             name: sbt-metals/scripted (Sbt 2)
             os: ubuntu-latest
             java: "21"

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -28,6 +28,7 @@ project.excludeFilters = [
 fileOverride {
   "glob:**/sbt-metals/**" {
     runner.dialect = scala212source3
+    rewrite.scala3.convertToNewSyntax = yes
   },
   "glob:**/scala-3*/**" {
     runner.dialect = scala3

--- a/build.sbt
+++ b/build.sbt
@@ -518,12 +518,6 @@ lazy val `sbt-metals` = project
         case _ => "2.0.0-M4"
       }
     },
-    scalacOptions ++= {
-      scalaBinaryVersion.value match {
-        case "2.12" => "-Xsource:3" :: Nil
-        case _ => Nil
-      }
-    },
   )
   .settings(sharedScalacOptions)
   .enablePlugins(BuildInfoPlugin, SbtPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -515,7 +515,7 @@ lazy val `sbt-metals` = project
     (pluginCrossBuild / sbtVersion) := {
       scalaBinaryVersion.value match {
         case "2.12" => "1.5.8"
-        case _ => "2.0.0-M3"
+        case _ => "2.0.0-M4"
       }
     },
     scalacOptions ++= {

--- a/project/V.scala
+++ b/project/V.scala
@@ -6,7 +6,7 @@ object V {
   val scala212 = "2.12.20"
   val scala213 = "2.13.16"
   val scala3 = "3.3.5"
-  val scala3ForSBT2 = "3.6.2"
+  val scala3ForSBT2 = "3.6.4"
   val latestScala3Next = "3.6.4"
 
   // When you can add to removedScalaVersions in MtagsResolver.scala with the last released version

--- a/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
+++ b/sbt-metals/src/main/scala/scala/meta/metals/MetalsPlugin.scala
@@ -1,10 +1,10 @@
 package metals
 
 import java.nio.file.Paths
-import java.{util => ju}
+import java.util as ju
 
 import scala.io.Source
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Properties
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -12,8 +12,8 @@ import scala.util.control.NonFatal
 import scala.meta.internal.sbtmetals.BuildInfo
 
 import sbt.Keys
-import sbt.Keys._
-import sbt._
+import sbt.Keys.*
+import sbt.*
 import sbt.internal.inc.ScalaInstance
 import sbt.plugins.SemanticdbPlugin
 
@@ -25,9 +25,9 @@ object MetalsPlugin extends AutoPlugin {
     lazy val javaSemanticdbEnabled =
       settingKey[Boolean]("Enables SemanticDB Javac plugin")
   }
-  import autoImport._
+  import autoImport.*
 
-  override lazy val projectSettings: Seq[Def.Setting[_]] = Def.settings(
+  override lazy val projectSettings: Seq[Def.Setting[?]] = Def.settings(
     Keys.semanticdbVersion := {
       if (requiresSemanticdb.value && !isScala3.value)
         BuildInfo.lastSupportedSemanticdb.getOrElse(

--- a/sbt-metals/src/sbt-test/sbt-metals/semanticdb/build.sbt
+++ b/sbt-metals/src/sbt-test/sbt-metals/semanticdb/build.sbt
@@ -75,15 +75,11 @@ def assertSemanticdbForScala2 = Def.task {
 
   assert(enabled, s"semanticdb is disabled in ${project.id}/${config.id}")
   assertPlugin(sOptions, s"semanticdb-scalac", sv, BuildInfo.semanticdbVersion)
-
-  // currently option added twice for test scope
-  if (!sbtVersion.value.startsWith("2") && !config.name.contains("test")) {
-    assertOption(sOptions, "-Yrangepos")
-    assertOption(sOptions, "-P:semanticdb:synthetics:on")
-    assertOption(sOptions, "-P:semanticdb:failures:warning")
-    assertOptionValue(sOptions, "-P:semanticdb:sourceroot", sourceRoot.toString)
-    assertOptionValue(sOptions, "-P:semanticdb:targetroot", targetRoot.toString)
-  }
+  assertOption(sOptions, "-Yrangepos")
+  assertOption(sOptions, "-P:semanticdb:synthetics:on")
+  assertOption(sOptions, "-P:semanticdb:failures:warning")
+  assertOptionValue(sOptions, "-P:semanticdb:sourceroot", sourceRoot.toString)
+  assertOptionValue(sOptions, "-P:semanticdb:targetroot", targetRoot.toString)
 
   assert(
     jOptions.exists(_.startsWith("-Xplugin:semanticdb")),
@@ -102,17 +98,8 @@ def assertSemanticdbForScala3 = Def.taskDyn {
         val project = thisProject.value
         val config = configuration.value
         assert(enabled, s"semanticdb is disabled in ${project.id}/${config.id}")
-        // currently option added twice for test scope
-        if (
-          !sbtVersion.value.startsWith("2") && !config.name.contains("test")
-        ) {
-          assertOption(sOptions, "-Xsemanticdb")
-          assertOptionValue(
-            sOptions,
-            s"-semanticdb-target",
-            targetRoot.toString,
-          )
-        }
+        assertOption(sOptions, "-Xsemanticdb")
+        assertOptionValue(sOptions, s"-semanticdb-target", targetRoot.toString)
       }
   }
 }

--- a/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
@@ -182,7 +182,7 @@ class SbtServerSuite
     for {
       _ <- initialize(
         s"""|/project/build.properties
-            |sbt.version=2.0.0-M3
+            |sbt.version=2.0.0-M4
             |/build.sbt
             |
             |scalaVersion := "$scalaVersion"


### PR DESCRIPTION
Follows https://github.com/scalameta/metals/pull/7045

- https://github.com/sbt/sbt/issues/7956 was fixed
- Bloop is [still not cross-built](https://github.com/scalacenter/bloop/issues/2455) so sbt BSP must be used
- https://github.com/scalacenter/scala-debug-adapter cannot be re-enabled, it's still not cross-built
