### PR TITLE
improvement: add additional ScalaTest WordSpec types

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
@@ -299,6 +299,12 @@ object ScalatestStyle {
     val symbols: Set[String] = Set(
       "org/scalatest/wordspec/AnyWordSpec#",
       "org/scalatest/wordspec/AnyWordSpecLike#",
+      "org/scalatest/wordspec/AsyncWordSpec#",
+      "org/scalatest/wordspec/AsyncWordSpecLike#",
+      "org/scalatest/wordspec/FixtureAnyWordSpec#",
+      "org/scalatest/wordspec/FixtureAnyWordSpecLike#",
+      "org/scalatest/wordspec/FixtureAsyncWordSpec#",
+      "org/scalatest/wordspec/FixtureAsyncWordSpecLike#",
     )
     override val intermediateMethods: Set[String] =
       Set("when", "should", "must", "can", "which")

--- a/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
@@ -90,6 +90,84 @@ class ScalatestFinderSuite extends FunSuite {
   )
 
   check(
+    "async-word-spec",
+    """|class AsyncSetSpec extends AsyncWordSpec {
+       |
+       |  "A Set" when {
+       |    "empty" should {
+       |      "have size 0" in {
+       |        assert(Set.empty.size == 0)
+       |      }
+       |
+       |      "produce NoSuchElementException when head is invoked" in {
+       |        assertThrows[NoSuchElementException] {
+       |          Set.empty.head
+       |        }
+       |      }
+       |
+       |      "have size 1" ignore {
+       |        assert(Set.empty.size == 1)
+       |      }
+       |
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+    FullyQualifiedName("AsyncSetSpec"),
+    Set(
+      ("A Set when empty should have size 0", QuickRange(4, 6, 4, 19)),
+      (
+        "A Set when empty should produce NoSuchElementException when head is invoked",
+        QuickRange(8, 6, 8, 59),
+      ),
+      ( // this is ignored test
+        "A Set when empty should have size 1",
+        QuickRange(14, 6, 14, 19),
+      ),
+    ),
+    ScalatestStyle.AnyWordSpec,
+  )
+
+  check(
+    "fixture-async-word-spec",
+    """|class FixtureAsyncSetSpec extends FixtureAsyncWordSpec {
+       |
+       |  "A Set" when {
+       |    "empty" should {
+       |      "have size 0" in {
+       |        assert(Set.empty.size == 0)
+       |      }
+       |
+       |      "produce NoSuchElementException when head is invoked" in {
+       |        assertThrows[NoSuchElementException] {
+       |          Set.empty.head
+       |        }
+       |      }
+       |
+       |      "have size 1" ignore {
+       |        assert(Set.empty.size == 1)
+       |      }
+       |
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+    FullyQualifiedName("FixtureAsyncSetSpec"),
+    Set(
+      ("A Set when empty should have size 0", QuickRange(4, 6, 4, 19)),
+      (
+        "A Set when empty should produce NoSuchElementException when head is invoked",
+        QuickRange(8, 6, 8, 59),
+      ),
+      ( // this is ignored test
+        "A Set when empty should have size 1",
+        QuickRange(14, 6, 14, 19),
+      ),
+    ),
+    ScalatestStyle.AnyWordSpec,
+  )
+
+  check(
     "any-flat-spec",
     """|import org.scalatest.flatspec.AnyFlatSpec
        |


### PR DESCRIPTION
When using metals I found that many of my test suites would not pick up the individual test cases. After some debugging I figured out that they extend different traits and while they are the same as AnyWordSpec in structure they do not directly extend it or AnyWordSpecLike. 

I have added the additional WordSpec types that exist in the current ScalaTest so that test cases get correctly picked up. 