### PR TITLE
allow backpublishing with sbt-ci-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     branches: [main]
-    tags: ["*"]
+    tags: ["**"]
 concurrency:
   group: release-${{ github.ref }}
 jobs:


### PR DESCRIPTION
https://eed3si9n.com/back-publishing-actually/#sbt-pgp-231-is-back-published-to-sbt-200-m3

I attempted to backpublish https://github.com/scalameta/metals/pull/7340 via https://github.com/scalameta/metals/releases/tag/v1.5.2%403.x%40sbt-metals%2FpublishSigned%23sbt2.0.0-M4, but the github action did not start.