### PR TITLE
remove mtags backpublishing adhoc code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,32 +19,16 @@ jobs:
           java-version: 17
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
-      - name: Publish
-        run: |
-          COMMAND="ci-release"
-          UPDATE_DOCS=true
-          if [[ $GITHUB_REF == "refs/tags"* ]] && [[ $GITHUB_REF_NAME == "mtags_v"* ]]; then
-            METALS_VERSION=$(echo $GITHUB_REF_NAME | cut -d "_" -f2 | cut -c2-)
-            SCALA_VERSION=$(echo $GITHUB_REF_NAME | cut -d "_" -f3)
-            if [ ! -z $METALS_VERSION ] && [ ! -z $SCALA_VERSION ]; then
-              export CI_RELEASE="++$SCALA_VERSION! mtags/publishSigned; mtagsShared/publishSigned"
-              UPDATE_DOCS=false
-              COMMAND="; set ThisBuild/version :=\"$METALS_VERSION\"; $COMMAND"
-            else
-              echo 'Invalid tag name for mtags. Expected: mtags_v${existing-metals-release}_${scala-version}'
-              exit 1
-            fi
-          fi
-          sbt "$COMMAND"
-          if [ "$UPDATE_DOCS" = true ]; then
-            sbt docs/docusaurusPublishGhpages
-          fi
+      - name: Publish to Sonatype
+        run: sbt ci-release
         env:
-          GIT_USER: scalameta@scalameta.org
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      - name: Publish Documentation
+        if: ${{ !contains(github.ref_name, '@') }}
+        run: sbt docs/docusaurusPublishGhpages
+        env:
+          GIT_USER: scalameta@scalameta.org
           GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
-          GITHUB_TOKEN: ${{ secrets.PUSH_TAG_GH_TOKEN }}
-          GH_TOKEN: ${{ secrets.PUSH_TAG_GH_TOKEN }}


### PR DESCRIPTION
Follows https://github.com/scalameta/metals/pull/7342#issuecomment-2757053512 & https://github.com/scalameta/metals/pull/7340#issuecomment-2757033907

See https://eed3si9n.com/tag-based-back-publishing-with-sbt/.

For example, to publish mtags v1.3.5 against 2.13.16, we should now push the tag `v1.3.5@2.13.16@mtags/publishSigned@mtagsShared/publishSigned`.