### PR TITLE
prefer `.bazelproject` as the Bazel BSP root

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
@@ -88,7 +88,9 @@ object BazelBuildTool {
   )
 
   private def hasProjectView(dir: AbsolutePath): Option[AbsolutePath] =
-    dir.list.find(_.filename.endsWith(".bazelproject"))
+    Some(dir.resolve(".bazelproject"))
+      .filter(_.isFile)
+      .orElse(dir.list.find(_.filename.endsWith(".bazelproject")))
 
   val fallbackProjectView: String = {
     """|targets:


### PR DESCRIPTION
Noticed that in a monorepo Metals Bazel import was working for some people and not others. It turns out that we have some secondary files with the `.bazelproject` suffix and depending on the order of the directory listing, you would get either the right `.bazelproject` file or else some `.personal.bazelproject` file (incidentally imported from that first `.bazelprojct`).

Logic to go looking for anything with a `.bazelproject` suffix is reasonable, but it should probably still prefer a file literally called `.bazelproject` if it exists.