### PR TITLE
fix: add backticks in hover output when needed

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
@@ -278,10 +278,11 @@ class HoverProvider(
         )
         val name =
           if (symbol.isConstructor) "this"
-          else symbol.name.decoded
-        val flags = List(symbolFlagString(symbol), keyword, name)
-          .filterNot(_.isEmpty)
-          .mkString(" ")
+          else Identifier.backtickWrap(symbol.name.decoded)
+        val flags =
+          List(symbolFlagString(symbol), keyword, name)
+            .filterNot(_.isEmpty)
+            .mkString(" ")
         val prettyType =
           metalsToLongString(tpe.widen.finalResultType.map(_.dealias), history)
         val macroSuffix =

--- a/tests/unit/src/test/scala/tests/HoverLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/HoverLspSuite.scala
@@ -296,4 +296,25 @@ class HoverLspSuite extends BaseLspSuite("hover-") with TestHovers {
     } yield ()
   }
 
+  test("backticked-name".tag(FlakyWindows)) {
+    for {
+      _ <- initialize(
+        """/metals.json
+          |{"a":{}}
+        """.stripMargin
+      )
+      _ <- server.assertHover(
+        "a/src/main/scala/a/Main.scala",
+        """
+          |object Main {
+          |  def `foo ba@@r baz` = 123
+          |}""".stripMargin,
+        """|```scala
+           |def `foo bar baz`: Int
+           |```
+           |""".stripMargin.hover,
+      )
+    } yield ()
+  }
+
 }


### PR DESCRIPTION
Identifiers that need backticks should have the hover code-snippet signature preview render with those backticks.