### PR TITLE
Consider build.mill and build.mill.scala when calculating Mill digest

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/MillDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillDigest.scala
@@ -20,8 +20,10 @@ object MillDigest extends Digestable {
       imported.forall(script => analyzeBuildScript(script)) && Digest
         .digestFile(file, digest)
     }
-    val buildFile = workspace.resolve("build.sc")
-    analyzeBuildScript(buildFile)
+    List("build.sc", "build.mill", "build.mill.scala").exists{ fileName =>
+      val file = workspace.resolve("build.sc")
+      analyzeBuildScript(file)
+    }
   }
 
   private case class ImportLinesAcc(


### PR DESCRIPTION
When I added a dependency in `build.mill`, it skipped reimporting the build with "Skipping reload with status 'Installed'".  
I traced the code and this is is my best guess for a fix.  
First time working on Metals btw. :)