### PR TITLE
feat: infer dependency identifier on pasting sbt-style dependencies

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/ScalaCliDependencyRangeFormatter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/ScalaCliDependencyRangeFormatter.scala
@@ -17,11 +17,15 @@ object ScalaCliDependencyRangeFormatter extends RangeFormatter {
       range.endPos.end,
     )
     DependencyConverter
-      .convertSbtToMillStyleIfPossible(
-        line
-      )
+      .convertSbtToMillStyleIfPossible(line)
       .map(converted =>
-        new l.TextEdit(range.range, converted.millStyleDependency)
+        new l.TextEdit(
+          new l.Range(
+            new l.Position(range.startPos.startLine, 0),
+            new l.Position(range.startPos.startLine, line.length),
+          ),
+          converted.replacementDirective.replace("\"", ""),
+        )
       )
       .map(List(_))
 

--- a/tests/unit/src/test/scala/tests/rangeFormatting/ScalaCliDependencyRangeFormatter.scala
+++ b/tests/unit/src/test/scala/tests/rangeFormatting/ScalaCliDependencyRangeFormatter.scala
@@ -36,6 +36,25 @@ class ScalaCliDependencyRangeFormatterPastingSuite
   )
 
   check(
+    "change-no-dep-format-within-existing-deps",
+    s"""
+       |//> using dep com.lihaoyi::utest::0.7.10
+       |//> using @@
+       |//> using dep com.lihaoyi::pprint::0.6.6
+       |object Main {
+       |  println("hello")
+       |}""".stripMargin,
+    s"""|"org.scalameta" %% "munit" % "0.7.26"""".stripMargin,
+    s"""
+       |//> using dep com.lihaoyi::utest::0.7.10
+       |//> using dep org.scalameta::munit:0.7.26
+       |//> using dep com.lihaoyi::pprint::0.6.6
+       |object Main {
+       |  println("hello")
+       |}""".stripMargin,
+  )
+
+  check(
     "change-dep-format-within-existing-deps",
     s"""
        |//> using dep com.lihaoyi::utest::0.7.10


### PR DESCRIPTION
part 3 of sbt style identifier to scala-cli conversion (part 1: #7176, part 2: #7333)

defaults to `dep`
