### PR TITLE
Respect LSP build target no-ide tag

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ImportedBuild.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ImportedBuild.scala
@@ -121,7 +121,8 @@ object ImportedBuild {
     val targets = workspaceBuildTargets.getTargets.asScala.toList
     val scalaJavaTargets = targets.filter { target =>
       val langIds = target.getLanguageIds.asScala.toList
-      langIds.contains("scala") || langIds.contains("java")
+      val isNoIde = target.getTags().contains("no-ide")
+      !isNoIde && (langIds.contains("scala") || langIds.contains("java"))
     }
     workspaceBuildTargets.setTargets(scalaJavaTargets.asJava)
     workspaceBuildTargets


### PR DESCRIPTION
https://github.com/scalameta/metals/issues/7218

Metals was ignoring BuildTargets tagged with `no-ide`, in this PR, a new filtering criteria was added to filter out BuildTargets tagged with `no-ide` from the list of targets to be imported.

**Before** 
![Image](https://github.com/user-attachments/assets/4a2b3165-d699-43a9-b0ca-64e2110dbfb7)

**After** 
![Image](https://github.com/user-attachments/assets/677ebfbe-9165-403c-af4b-9d7a62171e49)