### PR TITLE
feat: convert string to interpolation on `${`

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -1244,7 +1244,10 @@ class WorkspaceLspService(
         capabilities.setRenameProvider(renameOptions)
         capabilities.setDocumentHighlightProvider(true)
         capabilities.setDocumentOnTypeFormattingProvider(
-          new lsp4j.DocumentOnTypeFormattingOptions("\n", List("\"").asJava)
+          new lsp4j.DocumentOnTypeFormattingOptions(
+            "\n",
+            List("\"", "{").asJava,
+          )
         )
         capabilities.setDocumentRangeFormattingProvider(
           initialServerConfig.allowMultilineStringFormatting

--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/InterpolateStringContext.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/InterpolateStringContext.scala
@@ -1,0 +1,69 @@
+package scala.meta.internal.metals.formatting
+
+import scala.meta
+
+import scala.meta.inputs.Position
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.tokens.Token
+
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.TextEdit
+
+/**
+ * Formatter that automatically converts a string literal to an interpolation
+ * when an interpolation `${}` marker is added in the literal.
+ */
+object InterpolateStringContext extends OnTypeFormatter {
+
+  override def contribute(
+      params: OnTypeFormatterParams
+  ): Option[List[TextEdit]] = {
+    params.triggerChar.head match {
+      case '{' => contributeInterpolationContext(params)
+      case _ => None
+    }
+  }
+
+  private def contributeInterpolationContext(
+      params: OnTypeFormatterParams
+  ): Option[List[TextEdit]] = {
+    val range = new Range(params.position, params.position)
+    params.tokens
+      .getOrElse(Nil)
+      .collectFirst {
+        case lit: Token.Constant.String if lit.pos.toLsp.encloses(range) =>
+          convertStringToInterpolation(
+            lit.pos,
+            params.sourceText,
+            params.startPos.start,
+          )
+      }
+      .flatten
+  }
+
+  private def convertStringToInterpolation(
+      stringLitPos: meta.Position,
+      sourceText: String,
+      cursorPos: Int,
+  ): Option[List[TextEdit]] = {
+    val expectedDollarPos = cursorPos - 2
+    val input = stringLitPos.input
+    if (
+      expectedDollarPos >= 0 && cursorPos < sourceText.length() && sourceText
+        .substring(expectedDollarPos, cursorPos + 1) == "${}"
+    ) {
+      def insertTextEdit(offset: Int, text: String): TextEdit =
+        new TextEdit(Position.Range(input, offset, offset).toLsp, text)
+
+      val interpolationContextEdit = insertTextEdit(stringLitPos.start, "s")
+      val dollarEdits = (stringLitPos.start to stringLitPos.end)
+        .filter(i => sourceText.charAt(i) == '$' && i != expectedDollarPos)
+        .map(insertTextEdit(_, "$"))
+        .toList
+
+      Some(interpolationContextEdit :: dollarEdits.toList)
+    } else {
+      None
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/MultilineString.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/MultilineString.scala
@@ -353,6 +353,7 @@ case class MultilineString(userConfig: () => UserConfiguration)
     params.triggerChar.head match {
       case '"' => contributeQuotes(params)
       case '\n' => contributeNewline(params)
+      case _ => None
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/formatting/OnTypeFormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/formatting/OnTypeFormattingProvider.scala
@@ -38,7 +38,8 @@ class OnTypeFormattingProvider(
 
   // The order of which this is important to know which will first return the Edits
   val formatters: List[OnTypeFormatter] = List(
-    MultilineString(userConfig)
+    MultilineString(userConfig),
+    InterpolateStringContext,
   )
 
   def format(

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -952,6 +952,7 @@ final case class TestingServer(
       query: String,
       expected: String,
       autoIndent: String,
+      autoInserted: String,
       triggerChar: String,
       root: AbsolutePath = workspace,
   )(implicit loc: munit.Location): Future[Unit] = {
@@ -961,6 +962,7 @@ final case class TestingServer(
         query,
         root,
         autoIndent,
+        autoInserted,
         triggerChar,
       )
       multiline <- fullServer.onTypeFormatting(params).asScala
@@ -1262,6 +1264,7 @@ final case class TestingServer(
       original: String,
       root: AbsolutePath,
       autoIndent: String,
+      autoInserted: String,
       triggerChar: String,
   ): Future[(String, DocumentOnTypeFormattingParams)] = {
     positionFromString(
@@ -1269,11 +1272,14 @@ final case class TestingServer(
       original,
       root,
       replaceWith =
-        if (triggerChar == "\n") triggerChar + autoIndent else triggerChar,
+        if (triggerChar == "\n") triggerChar + autoIndent
+        else triggerChar + autoInserted,
     ) { case (text, textId, start) =>
       if (triggerChar == "\n") {
         start.setLine(start.getLine() + 1) // + newline
         start.setCharacter(autoIndent.size)
+      } else {
+        start.setCharacter(start.getCharacter() + autoInserted.length)
       }
       val params = new DocumentOnTypeFormattingParams(
         textId,

--- a/tests/unit/src/test/scala/tests/formatting/OnTypeFormattingSuite.scala
+++ b/tests/unit/src/test/scala/tests/formatting/OnTypeFormattingSuite.scala
@@ -612,11 +612,58 @@ class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
        |}""".stripMargin,
   )
 
+  check(
+    "vscode-add-missing-interp-string-context",
+    """
+      |object Main {
+      |  val str = "not yet interp $@@"
+      |}""".stripMargin,
+    """
+      |object Main {
+      |  val str = s"not yet interp ${}"
+      |}""".stripMargin,
+    triggerCharacter = "{",
+    autoInserted = "}",
+  )
+
+  check(
+    "vscode-escape-existing-dollar-in-string-interp",
+    """
+      |object Main {
+      |  val str = "not yet $interp $@@"
+      |}""".stripMargin,
+    """
+      |object Main {
+      |  val str = s"not yet $$interp ${}"
+      |}""".stripMargin,
+    triggerCharacter = "{",
+    autoInserted = "}",
+  )
+
+  check(
+    "vscode-multi-line-string-interp",
+    """
+      |object Main {
+      |  val str = '''not ${} yet interp
+      |              |and multiline $@@
+      |              |$content'''.stripMargin
+      |}""".stripMargin,
+    """
+      |object Main {
+      |  val str = s'''not $${} yet interp
+      |              |and multiline ${}
+      |              |$$content'''.stripMargin
+      |}""".stripMargin,
+    triggerCharacter = "{",
+    autoInserted = "}",
+  )
+
   def check(
       name: TestOptions,
       testCase: String,
       expectedCase: String,
       autoIndent: String = indent,
+      autoInserted: String = "",
       triggerCharacter: String = "\n",
       stripMarginEnabled: Boolean = true,
       additionalRequests: TestingServer => Future[Unit] = _ => Future.unit,
@@ -652,6 +699,7 @@ class OnTypeFormattingSuite extends BaseLspSuite("onTypeFormatting") {
           testCode,
           expected,
           autoIndent,
+          autoInserted,
           triggerCharacter,
         )
       } yield ()


### PR DESCRIPTION
Add an on-type formatter that looks for what looks like a string interpolation argument `${}` inside of a string and then converts the string into an interpolation.

Closes https://github.com/scalameta/metals-feature-requests/issues/425