### PR TITLE
feat: completions respect backticks at defn site

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/mtags/KeywordWrapper.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/mtags/KeywordWrapper.scala
@@ -49,12 +49,14 @@ trait KeywordWrapper {
   final def backtickWrap(
       s: String,
       exclusions: Set[String] = Set.empty,
-      wrapOperators: Boolean = false
+      wrapOperators: Boolean = false,
+      wrapUnconditionally: Boolean = false
   ): String = {
-    if (exclusions.contains(s)) s
+    if (exclusions.contains(s) && !wrapUnconditionally) s
     else if (s.isEmpty) "``"
     else if (s(0) == '`' && s.last == '`') s
-    else if (needsBacktick(s, wrapOperators)) "" + ('`') + s + '`'
+    else if (needsBacktick(s, wrapOperators) || wrapUnconditionally)
+      "" + ('`') + s + '`'
     else s
   }
 }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -102,8 +102,17 @@ class CompletionProvider(
 
     val items = sorted.iterator.zipWithIndex.map { case (member, idx) =>
       params.checkCanceled()
+      val definitionSiteHasBackticks = {
+        val defnNameStart = member.sym.pos.focus
+        defnNameStart.isDefined && defnNameStart.source.content
+          .lift(defnNameStart.start)
+          .contains('`')
+      }
       val symbolName = member.symNameDropLocal.decoded
-      val simpleIdent = Identifier.backtickWrap(symbolName)
+      val simpleIdent = Identifier.backtickWrap(
+        symbolName,
+        wrapUnconditionally = definitionSiteHasBackticks
+      )
       val ident =
         member match {
           case _: WorkspaceMember | _: WorkspaceImplicitMember |

--- a/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
@@ -87,9 +87,7 @@ class CompletionBacktickSuite extends BaseCompletionSuite {
        |  spaced@@
        |}
        |""".stripMargin,
-    // NOTE(olafur) expected output is not backticked because the compiler symbol does not
-    // distinguish if the symbol was defined with backticks in source.
-    """spaced: Int
+    """`spaced`: Int
       |""".stripMargin,
     filterText = ""
   )
@@ -204,4 +202,20 @@ class CompletionBacktickSuite extends BaseCompletionSuite {
        |""".stripMargin
   )
 
+  check(
+    "preserve-backticks",
+    """|trait Foo {
+       |  def withoutBackticks: Unit
+       |  def `withUnecessaryBackticks`: Unit
+       |  def `with necessary backticks`: Unit
+       |
+       |  with@@
+       |}
+       |""".stripMargin,
+    """|`with necessary backticks`: Unit
+       |`withUnecessaryBackticks`: Unit
+       |withoutBackticks: Unit
+       |""".stripMargin,
+    topLines = Some(3)
+  )
 }


### PR DESCRIPTION
Completions will try to include backticks if they were present at the definition site (in addition to ensuring there are backticks when they are essential).

Closes https://github.com/scalameta/metals-feature-requests/issues/426