### PR TITLE
fix & feat: improvements in selection ranges

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -814,7 +814,10 @@ class MetalsGlobal(
         if (defn.symbol.isPackageObject) defn.symbol.enclosingPackageClass.name
         else defn.name
       val start = defn.pos.point
-      val end = start + name.dropLocal.decoded.length()
+      val decoded = name.dropLocal.decoded
+      val hasBackticks = defn.pos.source.content.lift(start).contains('`')
+      val backtickLen = if (hasBackticks) 2 else 0
+      val end = start + decoded.length() + backtickLen
       Position.range(defn.pos.source, start, start, end)
     }
   }

--- a/tests/cross/src/test/scala/tests/pc/SelectionRangeSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SelectionRangeSuite.scala
@@ -218,4 +218,56 @@ class SelectionRangeSuite extends BaseSelectionRangeSuite {
       """object Main extends App { >>region>>def foo[Type <: T1, B](hi: Int, b: Int, c:Int) = ???<<region<< }""".stripMargin
     )
   )
+
+  check(
+    "def - lhs",
+    """
+    object Main extends App { def `foo ba@@r` = ??? }
+    """.stripMargin,
+    List(
+      """object Main extends App { def >>region>>`foo bar`<<region<< = ??? }""".stripMargin,
+      """object Main extends App { >>region>>def `foo bar` = ???<<region<< }""".stripMargin
+    )
+  )
+
+  check(
+    "expr - apply",
+    """
+    object Main extends App { def foo = bar.baz(1, math.floor(p@@i), 2) }
+    """.stripMargin,
+    List(
+      """object Main extends App { def foo = bar.baz(1, math.floor(>>region>>pi<<region<<), 2) }""",
+      """object Main extends App { def foo = bar.baz(1, >>region>>math.floor(pi)<<region<<, 2) }""",
+      """object Main extends App { def foo = bar.baz(>>region>>1, math.floor(pi), 2<<region<<) }""",
+      """object Main extends App { def foo = >>region>>bar.baz(1, math.floor(pi), 2)<<region<< }""",
+      """object Main extends App { >>region>>def foo = bar.baz(1, math.floor(pi), 2)<<region<< }"""
+    )
+  )
+
+  check(
+    "expr - backticked",
+    """
+    object Main extends App { def foo = `foo ba@@r` + 1 }
+    """.stripMargin,
+    List(
+      """object Main extends App { def foo = >>region>>`foo bar`<<region<< + 1 }""",
+      """object Main extends App { def foo = >>region>>`foo bar` +<<region<< 1 }""",
+      """object Main extends App { def foo = >>region>>`foo bar` + 1<<region<< }""",
+      """object Main extends App { >>region>>def foo = `foo bar` + 1<<region<< }"""
+    )
+  )
+
+  check(
+    "type - apply",
+    """
+    object Main extends App { def foo: Tuple3[Int, List[In@@t], Double] = ??? }
+    """.stripMargin,
+    List(
+      """object Main extends App { def foo: Tuple3[Int, List[>>region>>Int<<region<<], Double] = ??? }""",
+      """object Main extends App { def foo: Tuple3[Int, >>region>>List[Int]<<region<<, Double] = ??? }""",
+      """object Main extends App { def foo: Tuple3[>>region>>Int, List[Int], Double<<region<<] = ??? }""",
+      """object Main extends App { def foo: >>region>>Tuple3[Int, List[Int], Double]<<region<< = ??? }""",
+      """object Main extends App { >>region>>def foo: Tuple3[Int, List[Int], Double] = ???<<region<< }"""
+    )
+  )
 }


### PR DESCRIPTION
Fixed #7398 by switching away from using anonymous subclasses of `SelectionRange`. Also tweaked a number of existing selection ranges:

  - function application and type application lists now get their own selection range for the list (if it has length > 1)

  - LHS name of a def now has its own selection range