### PR TITLE
feat: add inlay hints for byname parameters

### DIFF
--- a/metals-bench/src/main/scala/bench/InlayHintsBench.scala
+++ b/metals-bench/src/main/scala/bench/InlayHintsBench.scala
@@ -94,6 +94,7 @@ class InlayHintsBench extends PcBenchmark {
         true,
         true,
         true,
+        true,
         false,
       )
       pc.inlayHints(pcParams).get().asScala.toList

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -646,6 +646,7 @@ class Compilers(
         implicitParameters = options.implicitArguments,
         implicitConversions = options.implicitConversions,
         typeParameters = options.typeParameters,
+        byNameParameters = options.byNameParameters,
         hintsInPatternMatch = options.hintsInPatternMatch,
       )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/InlayHintsOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InlayHintsOptions.scala
@@ -10,6 +10,8 @@ case class InlayHintsOptions(options: Map[InlayHintsOption, Boolean])
     options.getOrElse(InlayHintsOption.ImplicitArguments, false)
   def typeParameters: Boolean =
     options.getOrElse(InlayHintsOption.TypeParameters, false)
+  def byNameParameters: Boolean =
+    options.getOrElse(InlayHintsOption.ByNameParameters, false)
   def hintsInPatternMatch: Boolean =
     options.getOrElse(InlayHintsOption.HintsInPatternMatch, false)
   def areSyntheticsEnabled: Boolean = options.exists(_._2)
@@ -22,6 +24,7 @@ object InlayHintsOptions {
       InlayHintsOption.ImplicitConversions -> true,
       InlayHintsOption.ImplicitArguments -> true,
       InlayHintsOption.TypeParameters -> true,
+      InlayHintsOption.ByNameParameters -> true,
       InlayHintsOption.HintsInPatternMatch -> true,
     )
   )
@@ -33,6 +36,7 @@ object InlayHintsOption {
   case object ImplicitConversions extends InlayHintsOption
   case object ImplicitArguments extends InlayHintsOption
   case object TypeParameters extends InlayHintsOption
+  case object ByNameParameters extends InlayHintsOption
   case object HintsInPatternMatch extends InlayHintsOption
   def unapply(value: String): Option[InlayHintsOption] =
     StringCase.kebabToCamel(value) match {
@@ -40,6 +44,7 @@ object InlayHintsOption {
       case "implicitConversions" => Some(ImplicitConversions)
       case "implicitArguments" => Some(ImplicitArguments)
       case "typeParameters" => Some(TypeParameters)
+      case "byNameParameters" => Some(ByNameParameters)
       case "hintsInPatternMatch" => Some(HintsInPatternMatch)
       case _ => None
     }

--- a/mtags-interfaces/src/main/java/scala/meta/pc/InlayHintsParams.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/InlayHintsParams.java
@@ -25,6 +25,13 @@ public interface InlayHintsParams extends RangeParams {
   boolean implicitParameters();
 
   /**
+   * Response should contain decorations for by name parameters.
+   */
+  default boolean byNameParameters() {
+    return false;
+  }
+
+  /**
    * Response should contain decorations for implicit conversions.
    */
   boolean implicitConversions();

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/CompilerInlayHintsParams.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/CompilerInlayHintsParams.scala
@@ -12,6 +12,7 @@ case class CompilerInlayHintsParams(
     inferredTypes: Boolean,
     typeParameters: Boolean,
     implicitParameters: Boolean,
+    override val byNameParameters: Boolean,
     implicitConversions: Boolean,
     override val hintsInPatternMatch: Boolean
 ) extends InlayHintsParams {
@@ -27,7 +28,8 @@ case class CompilerInlayHintsParams(
       inferredTypes = inferredTypes,
       typeParameters = typeParameters,
       implicitConversions = implicitConversions,
-      implicitParameters = implicitParameters
+      implicitParameters = implicitParameters,
+      byNameParameters = byNameParameters
     )
   }
 

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/CompilerSyntheticDecorationsParams.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/CompilerSyntheticDecorationsParams.scala
@@ -11,6 +11,7 @@ case class CompilerSyntheticDecorationsParams(
     inferredTypes: Boolean,
     typeParameters: Boolean,
     implicitParameters: Boolean,
+    byNameParameters: Boolean,
     implicitConversions: Boolean
 ) extends SyntheticDecorationsParams {
   override def uri(): URI = virtualFileParams.uri

--- a/tests/cross/src/main/scala/tests/BaseInlayHintsSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseInlayHintsSuite.scala
@@ -36,6 +36,7 @@ class BaseInlayHintsSuite extends BasePCSuite {
         true,
         true,
         true,
+        true,
         hintsInPatternMatch
       )
 

--- a/tests/cross/src/test/scala/tests/pc/InlayHintsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InlayHintsSuite.scala
@@ -544,17 +544,17 @@ class InlayHintsSuite extends BaseInlayHintsSuite {
        |class DemoSpec {
        |  import ScalatestMock._
        |
-       |  /*StringTestOps<<(6:17)>>(*/"foo"/*)*/ should {
-       |    /*StringTestOps<<(6:17)>>(*/"checkThing1"/*)*/ in {
+       |  /*StringTestOps<<(6:17)>>(*/"foo"/*)*/ should {/*=> */
+       |    /*StringTestOps<<(6:17)>>(*/"checkThing1"/*)*/ in {/*=> */
        |      checkThing1[String]/*(instancesString<<(10:15)>>)*/
        |    }/*(here<<(5:15)>>)*/
-       |    /*StringTestOps<<(6:17)>>(*/"checkThing2"/*)*/ in {
+       |    /*StringTestOps<<(6:17)>>(*/"checkThing2"/*)*/ in {/*=> */
        |      checkThing2[String]/*(instancesString<<(10:15)>>, instancesString<<(10:15)>>)*/
        |    }/*(here<<(5:15)>>)*/
        |  }/*(subjectRegistrationFunction<<(3:15)>>)*/
        |
-       |  /*StringTestOps<<(6:17)>>(*/"bar"/*)*/ should {
-       |    /*StringTestOps<<(6:17)>>(*/"checkThing1"/*)*/ in {
+       |  /*StringTestOps<<(6:17)>>(*/"bar"/*)*/ should {/*=> */
+       |    /*StringTestOps<<(6:17)>>(*/"checkThing1"/*)*/ in {/*=> */
        |      checkThing1[String]/*(instancesString<<(10:15)>>)*/
        |    }/*(here<<(5:15)>>)*/
        |  }/*(subjectRegistrationFunction<<(3:15)>>)*/
@@ -1064,4 +1064,58 @@ class InlayHintsSuite extends BaseInlayHintsSuite {
        |""".stripMargin
   )
 
+  check(
+    "by-name-regular",
+    """|object Main{
+       |  def foo(x: => Int, y: Int, z: => Int)(w: Int, v: => Int): Unit = ()
+       |  foo(1, 2, 3)(4, 5)
+       |}
+       |""".stripMargin,
+    """|object Main{
+       |  def foo(x: => Int, y: Int, z: => Int)(w: Int, v: => Int): Unit = ()
+       |  foo(/*=> */1, 2, /*=> */3)(4, /*=> */5)
+       |}
+       |""".stripMargin
+  )
+
+  check(
+    "by-name-block",
+    """|object Main{
+       |  def Future[A](arg: => A): A = arg
+       |
+       |  Future(1 + 2)
+       |  Future {
+       |    1 + 2
+       |  }
+       |  Future {
+       |    val x = 1
+       |    val y = 2
+       |    x + y
+       |  }
+       |  Some(Option(2).getOrElse {
+       |    List(1,2)
+       |      .headOption
+       |  })
+       |}
+       |""".stripMargin,
+    """|package `by-name-block`
+       |object Main{
+       |  def Future[A](arg: => A): A = arg
+       |
+       |  Future/*[Int<<scala/Int#>>]*/(/*=> */1 + 2)
+       |  Future/*[Int<<scala/Int#>>]*/ {/*=> */
+       |    1 + 2
+       |  }
+       |  Future/*[Int<<scala/Int#>>]*/ {/*=> */
+       |    val x/*: Int<<scala/Int#>>*/ = 1
+       |    val y/*: Int<<scala/Int#>>*/ = 2
+       |    x + y
+       |  }
+       |  Some/*[Any<<scala/Any#>>]*/(Option/*[Int<<scala/Int#>>]*/(2).getOrElse/*[Any<<scala/Any#>>]*/ {/*=> */
+       |    List/*[Int<<scala/Int#>>]*/(1,2)
+       |      .headOption
+       |  })
+       |}
+       |""".stripMargin
+  )
 }

--- a/tests/unit/src/main/scala/tests/BaseInlayHintsExpectSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseInlayHintsExpectSuite.scala
@@ -34,6 +34,7 @@ abstract class BaseInlayHintsExpectSuite(
             true,
             true,
             true,
+            true,
           )
           val inlayHints =
             compiler


### PR DESCRIPTION
This adds `=>` hints for function parameters that are passed by name.
The common case of block by-name arguments moves the `=>` to occur right
after the opening brace instead of before the entire argument.

Implements <https://github.com/scalameta/metals-feature-requests/issues/377>