### PR TITLE
feat: handle `% "provided"` on pasting sbt-style deps

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/DependencyConverter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/DependencyConverter.scala
@@ -17,7 +17,7 @@ object DependencyConverter {
     }
     scalaCliDependencyIdentifier <- rest match {
       case Nil => Some(dependencyIdentifierLike)
-      case "%" :: TestConfig(_) :: Nil => Some("test.dep")
+      case List("%", Scope(dep)) => Some(dep)
       case _ => None
     }
   } yield {
@@ -43,9 +43,13 @@ object DependencyConverter {
   }
 
   /** @see https://www.scala-sbt.org/1.x/docs/Library-Dependencies.html#Per-configuration+dependencies */
-  private object TestConfig {
+  private object Scope {
+    private val dependencyScope = Map(
+      "test" -> "test.dep",
+      "provided" -> "compileOnly.dep",
+    )
     def unapply(scope: String): Option[String] =
-      Option.when(scope.toLowerCase.replace("\"", "") == "test")(scope)
+      dependencyScope.get(scope.toLowerCase.replace("\"", ""))
   }
 
   case class ReplacementSuggestion(

--- a/tests/unit/src/test/scala/tests/rangeFormatting/ScalaCliDependencyRangeFormatter.scala
+++ b/tests/unit/src/test/scala/tests/rangeFormatting/ScalaCliDependencyRangeFormatter.scala
@@ -66,6 +66,21 @@ class ScalaCliDependencyRangeFormatterPastingSuite
   )
 
   check(
+    "change-no-dep-format-provided-configuration",
+    s"""
+       |//> using @@
+       |object Main {
+       |  println("hello")
+       |}""".stripMargin,
+    s"""|"com.github.dwickern" %% "scala-nameof" % "4.0.0" % "provided"""".stripMargin,
+    s"""
+       |//> using compileOnly.dep com.github.dwickern::scala-nameof:4.0.0
+       |object Main {
+       |  println("hello")
+       |}""".stripMargin,
+  )
+
+  check(
     "change-no-dep-format-within-existing-deps",
     s"""
        |//> using dep com.lihaoyi::utest::0.7.10


### PR DESCRIPTION
see:
- https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope
- https://scala-cli.virtuslab.org/docs/commands/compile/#compile-only-dependencies