### PR TITLE
fix(`DotEnvFileParser`): empty values or nonquoted values with comment

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
@@ -12,26 +12,30 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
 
 object DotEnvFileParser {
-  // DotEnv file regex adapted from the following projects:
-  //  - https://github.com/mefellows/sbt-dotenv
-  //  - https://github.com/bkeepers/dotenv
+  // DotEnv file regex adapted from the following project: https://github.com/Philippus/sbt-dotenv
   val LineRegex: Regex =
-    """(?xms)
-    ^                         # start of line
-    \s*                       # leading whitespace
-    (?:export\s+)?            # optional export
-    ([a-zA-Z_]+[a-zA-Z0-9_]*) # key
-    (?:\s*=\s*|\s*\:\s*)      # separator (= or :)
-    (                         # value capture group
-      '(?:\\'|[^'])*'         # single quoted value or
-      |
-      "(?:\\"|[^"])*"         # double quoted value or
-      |
-      [^\r\n]*                # unquoted value    
-    )
-    \s*                       # trailing whitespace
-    (?:\#[^\n]*)?                 # optional comment
-    $                         # end of line
+      """(?xms)
+      (?:^|\A)           # start of line
+      \s*                # leading whitespace
+      (?:export\s+)?     # export (optional)
+      (                  # start variable name (captured)
+        [a-zA-Z_]          # single alphabetic or underscore character
+        [a-zA-Z0-9_]*    # zero or more alphnumeric, underscore
+      )                  # end variable name (captured)
+      (?:\s*[=:]\s*?)       # assignment with whitespace
+      (                  # start variable value (captured)
+        '(?:\\'|[^'])*'    # single quoted variable
+        |                  # or
+        "(?:\\"|[^"])*"    # double quoted variable
+        |                  # or
+        [^\#\r\n]*         # unquoted variable
+      )                  # end variable value (captured)
+      \s*                # trailing whitespace
+      (?:                # start trailing comment (optional)
+        \#                 # begin comment
+        (?:(?!$).)*        # any character up to end-of-line
+      )?                 # end trailing comment (optional)
+      (?:$|\z)           # end of line
   """.r
 
   def parse(

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DotEnvFileParser.scala
@@ -14,28 +14,28 @@ import scala.meta.io.AbsolutePath
 object DotEnvFileParser {
   // DotEnv file regex adapted from the following project: https://github.com/Philippus/sbt-dotenv
   val LineRegex: Regex =
-      """(?xms)
-      (?:^|\A)           # start of line
-      \s*                # leading whitespace
-      (?:export\s+)?     # export (optional)
-      (                  # start variable name (captured)
-        [a-zA-Z_]          # single alphabetic or underscore character
-        [a-zA-Z0-9_]*    # zero or more alphnumeric, underscore
-      )                  # end variable name (captured)
-      (?:\s*[=:]\s*?)       # assignment with whitespace
-      (                  # start variable value (captured)
-        '(?:\\'|[^'])*'    # single quoted variable
-        |                  # or
-        "(?:\\"|[^"])*"    # double quoted variable
-        |                  # or
-        [^\#\r\n]*         # unquoted variable
-      )                  # end variable value (captured)
-      \s*                # trailing whitespace
-      (?:                # start trailing comment (optional)
-        \#                 # begin comment
-        (?:(?!$).)*        # any character up to end-of-line
-      )?                 # end trailing comment (optional)
-      (?:$|\z)           # end of line
+    """(?xms)
+        (?:^|\A)           # start of line
+        \s*                # leading whitespace
+        (?:export\s+)?     # export (optional)
+        (                  # start variable name (captured)
+          [a-zA-Z_]          # single alphabetic or underscore character
+          [a-zA-Z0-9_]*    # zero or more alphnumeric, underscore
+        )                  # end variable name (captured)
+        (?:\s*[=:]\s*?)       # assignment with whitespace
+        (                  # start variable value (captured)
+          '(?:\\'|[^'])*'    # single quoted variable
+          |                  # or
+          "(?:\\"|[^"])*"    # double quoted variable
+          |                  # or
+          [^\#\r\n]*         # unquoted variable
+        )                  # end variable value (captured)
+        \s*                # trailing whitespace
+        (?:                # start trailing comment (optional)
+          \#                 # begin comment
+          (?:(?!$).)*        # any character up to end-of-line
+        )?                 # end trailing comment (optional)
+        (?:$|\z)           # end of line
   """.r
 
   def parse(

--- a/tests/unit/src/test/scala/tests/debug/DotEnvFileParserSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/DotEnvFileParserSuite.scala
@@ -11,6 +11,10 @@ class DotEnvFileParserSuite extends BaseSuite {
     assertDiffEqual(parse("KEY="), Map("KEY" -> ""))
   }
 
+  test("parse empty values and do not spill over to next line") {
+    assertDiffEqual(parse("KEY=\nKEY2=value"), Map("KEY" -> "", "KEY2" -> "value"))
+  }
+
   test("parse values separated by :") {
     assertDiffEqual(parse("KEY:value"), keyValue)
   }
@@ -81,11 +85,8 @@ class DotEnvFileParserSuite extends BaseSuite {
     assertDiffEqual(parse(" \nKEY=value"), keyValue)
   }
 
-  test("allow # and spaces in unquoted values") {
-    assertDiffEqual(
-      parse("KEY=v a l u e # not a comment"),
-      Map("KEY" -> "v a l u e # not a comment"),
-    )
+  test("ignore inline comments after unquoted values") {
+    assertDiffEqual(parse("KEY=value # comment"), keyValue)
   }
 
   test("ignore inline comments after single quoted values") {

--- a/tests/unit/src/test/scala/tests/debug/DotEnvFileParserSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/DotEnvFileParserSuite.scala
@@ -12,7 +12,10 @@ class DotEnvFileParserSuite extends BaseSuite {
   }
 
   test("parse empty values and do not spill over to next line") {
-    assertDiffEqual(parse("KEY=\nKEY2=value"), Map("KEY" -> "", "KEY2" -> "value"))
+    assertDiffEqual(
+      parse("KEY=\nKEY2=value"),
+      Map("KEY" -> "", "KEY2" -> "value"),
+    )
   }
 
   test("parse values separated by :") {


### PR DESCRIPTION
During our trial of transition from IntelliJ to Metals, we discovered that some environment variables from our usual dotenv file (`envFile` in launch.json) were wrongly parsed, particularly as follows:

```bash
# Case 1. Empty value spills the result in backward
A=
B=value
# Expected result: Map("A" -> "", "B" -> "value")
# Actual result: Map("A" -> "B=value")

# Case 2. Comments are retained after unquoted values
LEVEL=WARN # this is noisy
# Expected result: Map("LEVEL" -> "WARN")
# Actual result: Map("LEVEL" -> "WARN # This is noisy")
```

Case 1 is trivially a bug. Case 2 is less obvious since it's actually tested against the current output in the test suite, but I believe the test is wrong given that it's parsed into the expected result well in bash, IntelliJ, and the recent `sbt-dotenv`.

This PR updates `DotEnvFileParser.LineRegex` to [that of the latest revision](https://github.com/Philippus/sbt-dotenv/blob/0210db3e3ec6242a4a108b4d3933c298ec64a368/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala#L132-L154) in [sbt-dotenv](https://github.com/Philippus/sbt-dotenv). Some parts of the regex are modified to retain ability to parse some dialects in the test suite, but not fully:
- Added support for `KEY : value` form: this is outright non-conforming in POSIX shells but at the same time a popular dialect.
- Removed support for `K.E.Y=value` and `K-E-Y=value` form: the latest `sbt-dotenv` supports these dialects but the test suite explicitly demands to ignore them.