### PR TITLE
feat: code action to remove invalid imports

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
@@ -28,7 +28,8 @@ object ScalacDiagnostic {
   }
 
   object SymbolNotFound {
-    private val regex = """(n|N)ot found: (value|type)?\s?(\w+)(\s|\S)*""".r
+    private val regex =
+      """(n|N)ot found: (value|type|object)?\s?(\w+)(\s|\S)*""".r
     def unapply(d: l.Diagnostic): Option[String] =
       d.getMessage().trim() match {
         case regex(_, _, name, _) => Some(name)
@@ -96,6 +97,15 @@ object ScalacDiagnostic {
     def unapply(d: l.Diagnostic): Option[String] =
       d.getMessage().trim() match {
         case regex() => Some(d.getMessage())
+        case _ => None
+      }
+  }
+
+  object ObjectNotAMemberOfPackage {
+    private val regex = """(?s)object (.+) is not a member of package.*""".r
+    def unapply(d: l.Diagnostic): Option[String] =
+      d.getMessage().trim() match {
+        case regex(name) => Some(name)
         case _ => None
       }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/CodeActionProvider.scala
@@ -47,6 +47,8 @@ final class CodeActionProvider(
     new MillifyDependencyCodeAction(buffers),
     new MillifyScalaCliDependencyCodeAction(buffers),
     new ConvertCommentCodeAction(buffers),
+    new RemoveInvalidImportQuickFix(trees, buildTargets),
+    new SourceRemoveInvalidImports(trees, buildTargets, diagnostics),
   )
 
   def actionsForParams(params: l.CodeActionParams): List[CodeAction] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
@@ -47,13 +47,7 @@ sealed abstract class ImportMissingSymbol(
     val uri = params.getTextDocument().getUri()
     val file = uri.toAbsolutePath
     lazy val isScala3 =
-      (for {
-        buildId <- buildTargets.inverseSources(file)
-        target <- buildTargets.scalaTarget(buildId)
-        isScala3 = ScalaVersions.isScala3Version(
-          target.scalaInfo.getScalaVersion()
-        )
-      } yield isScala3).getOrElse(false)
+      buildTargets.scalaVersion(file).exists(ScalaVersions.isScala3Version)
 
     def getChanges(codeAction: l.CodeAction): IterableOnce[l.TextEdit] =
       codeAction
@@ -304,7 +298,7 @@ class SourceAddMissingImports(
 }
 
 object SourceAddMissingImports {
-  final val kind: String = l.CodeActionKind.Source
+  final val kind: String = l.CodeActionKind.Source + ".addMissingImports"
   final val title: String =
     "Add all missing imports that are unambiguous for the entire file"
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/RemoveInvalidImport.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/RemoveInvalidImport.scala
@@ -1,0 +1,415 @@
+package scala.meta.internal.metals.codeactions
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.Import
+import scala.meta.Importee
+import scala.meta.Importer
+import scala.meta.Tree
+import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.Diagnostics
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.metals.ScalacDiagnostic
+import scala.meta.internal.metals.codeactions.CodeAction
+import scala.meta.internal.metals.codeactions.CodeActionBuilder
+import scala.meta.internal.parsing.Trees
+import scala.meta.pc.CancelToken
+
+import org.eclipse.{lsp4j => l}
+
+// Cuts out invalid subsets of or whole imports
+sealed abstract class RemoveInvalidImport(
+    trees: Trees,
+    buildTargets: BuildTargets,
+) extends CodeAction {
+  protected def allImportsTitle: String
+
+  protected def isRemoveAllSourceAction: Boolean
+
+  protected def getDiagnostics(params: l.CodeActionParams): Seq[l.Diagnostic]
+
+  protected def getRange(params: l.CodeActionParams): l.Range
+
+  override def contribute(params: l.CodeActionParams, token: CancelToken)(
+      implicit ec: ExecutionContext
+  ): Future[Seq[l.CodeAction]] = {
+    val file = params.getTextDocument().getUri().toAbsolutePath
+    val range = getRange(params)
+    lazy val isScala3 =
+      buildTargets.scalaVersion(file).exists(ScalaVersions.isScala3Version)
+
+    def relevantDiagRange(diag: l.Diagnostic): Boolean =
+      isRemoveAllSourceAction || range.overlapsWith(diag.getRange())
+
+    val sortedActions = getDiagnostics(params)
+      .collect {
+        case diag @ ScalacDiagnostic.SymbolNotFound(name)
+            if relevantDiagRange(diag) =>
+          diag.getRange() -> name
+        case diag @ ScalacDiagnostic.ObjectNotAMemberOfPackage(name)
+            if !isScala3 && relevantDiagRange(diag) =>
+          diag.getRange() -> name
+        case diag @ ScalacDiagnostic.NotAMember(name)
+            if isScala3 && relevantDiagRange(diag) =>
+          diag.getRange() -> name
+      }
+      .sortBy { case (diagRange, _) =>
+        diagRange.getStart().getLine() -> diagRange.getStart().getCharacter()
+      }
+
+    lazy val imports = trees.findAllInRange[Import](file, range).toList
+
+    val codeActions = if (sortedActions.isEmpty || imports.isEmpty) {
+      // Optimization: fast-exit path
+      Nil
+    } else {
+      val importsAndDiags =
+        groupDiagnosticsByTree(sortedActions.toList, imports)
+      val (caseByCaseRemovals, fullRemovals) = importsAndDiags.map {
+        case (imprt, diags) =>
+          val (caseByCase, aggregate) = removeInvalidFromImport(imprt, diags)
+          caseByCase.map { case (title, edits) =>
+            title -> edits.toLspRanges(imprt, true)
+          } -> aggregate.toLspRanges(imprt, true)
+      }.unzip
+
+      // Actions for removing each bad import individually
+      val removeSingleImportActions = caseByCaseRemovals.flatten.map {
+        case (title, removalRanges) =>
+          CodeActionBuilder.build(
+            title = title,
+            kind = this.kind,
+            changes = List(file -> removalRanges.map(new l.TextEdit(_, ""))),
+          )
+      }
+
+      // Action (possibly empty) for removing all bad imports at once
+      val removeAllImportsAction = if (removeSingleImportActions.lengthIs > 0) {
+        Seq(
+          CodeActionBuilder.build(
+            title = allImportsTitle,
+            kind = this.kind,
+            changes =
+              List(file -> fullRemovals.flatten.map(new l.TextEdit(_, ""))),
+          )
+        )
+      } else {
+        Nil
+      }
+
+      if (isRemoveAllSourceAction) removeAllImportsAction
+      else if (removeSingleImportActions.lengthIs == 1)
+        removeSingleImportActions
+      else removeAllImportsAction ++ removeSingleImportActions
+    }
+    Future.successful(codeActions)
+  }
+
+  private sealed trait RemovalEdit {
+
+    /**
+     * Turn the removal edit into a concrete set of ranges to remove
+     *
+     * @param tree for which AST node is this removal?
+     * @param trimTrailingNewline trim trailing whitespace if tree is fully removed
+     * @return ranges to remove
+     */
+    def toLspRanges(
+        tree: Tree,
+        trimTrailingNewline: Boolean,
+    ): Seq[l.Range] = {
+      this match {
+        case RemovalEdit.EntireTree =>
+          val pos = tree.pos
+          val range = pos.toLsp
+
+          // If there is a newline right after the tree, include that in the range
+          if (
+            trimTrailingNewline && pos.input.chars.lift(pos.end).contains('\n')
+          ) {
+            val end = range.getEnd()
+            range.setEnd(new l.Position(end.getLine() + 1, 0))
+          }
+          Seq(range)
+        case RemovalEdit.Parts(parts) =>
+          parts
+      }
+    }
+  }
+  private object RemovalEdit {
+    case object EntireTree extends RemovalEdit
+    case class Parts(parts: Seq[l.Range]) extends RemovalEdit
+
+    val Empty: Parts = Parts(Seq.empty)
+
+    /**
+     * Given a sequence of elements and the removals applied to each of them, build up the removal
+     * for the entire sequence.
+     *
+     * This handles a couple details
+     *
+     *   - dropping ranges _between_ elements when at least one element was removed.
+     *     Ex: removing `bar` from `{foo, bar, baz}` should be `{foo, baz}`, not `{foo, , baz}`
+     *
+     *   - dropping the entire range if every component was dropped
+     *     Ex: removing `foo` and `bar` from `{foo, baz}` should drop the entire seq
+     *
+     * @param orderedElements ordered elements of the seq and the removal edit to them
+     * @return removal edit for the seq as a whole
+     */
+    def fromSeqEdits(
+        orderedElements: Iterator[(Tree, RemovalEdit)]
+    ): RemovalEdit = {
+
+      var seqIsFullyRemoved = true
+      val removalRanges = Seq.newBuilder[l.Range]
+      def addRemovalRanges(ranges: Seq[l.Range]) =
+        for (range <- ranges; if !range.isOffset && !range.isNone) {
+          removalRanges += range
+        }
+
+      // If the previous entry was removed, Left(range of pending removal).
+      // If the previous entry was present, Right(previous tree)
+      var runningRemovalOrPrev: Either[l.Range, Tree] =
+        orderedElements.next() match {
+          case (firstElement, RemovalEdit.EntireTree) =>
+            Left(firstElement.pos.toLsp)
+          case (firstElement, RemovalEdit.Parts(parts)) =>
+            seqIsFullyRemoved = false
+            addRemovalRanges(parts)
+            Right(firstElement)
+        }
+
+      for ((element, removeEdit) <- orderedElements) {
+        (removeEdit, runningRemovalOrPrev) match {
+          case (RemovalEdit.EntireTree, Left(runningRemoval)) =>
+            val newRunningRemoval =
+              new l.Range(runningRemoval.getStart(), element.pos.toLsp.getEnd())
+            runningRemovalOrPrev = Left(newRunningRemoval)
+
+          case (RemovalEdit.EntireTree, Right(prevTree)) =>
+            val runningRemoval = new l.Range(
+              prevTree.pos.toLsp.getEnd(),
+              element.pos.toLsp.getEnd(),
+            )
+            runningRemovalOrPrev = Left(runningRemoval)
+
+          case (RemovalEdit.Parts(parts), Left(runningRemoval)) =>
+            addRemovalRanges(Seq(if (seqIsFullyRemoved) {
+              new l.Range(runningRemoval.getStart, element.pos.toLsp.getStart())
+            } else {
+              runningRemoval
+            }))
+            seqIsFullyRemoved = false
+            addRemovalRanges(parts)
+            runningRemovalOrPrev = Right(element)
+
+          case (RemovalEdit.Parts(parts), Right(_)) =>
+            seqIsFullyRemoved = false
+            addRemovalRanges(parts)
+            runningRemovalOrPrev = Right(element)
+        }
+      }
+
+      if (seqIsFullyRemoved) {
+        RemovalEdit.EntireTree
+      } else {
+        runningRemovalOrPrev match {
+          case Left(runningRemoval) => addRemovalRanges(Seq(runningRemoval))
+          case Right(_) => ()
+        }
+        RemovalEdit.Parts(removalRanges.result())
+      }
+    }
+  }
+
+  // Possibly remove invalid importee
+  private def removeInvalidFromImportee(
+      importee: Importee,
+      diags: Seq[(l.Range, String)],
+  ): Option[(String, RemovalEdit)] = {
+    val nameOpt = importee match {
+      case Importee.Name(name) => Some(name)
+      case Importee.Rename(name, _) => Some(name)
+      case Importee.Unimport(name) => Some(name)
+      case Importee.Wildcard() | Importee.Given(_) | Importee.GivenAll() => None
+    }
+    nameOpt.flatMap { name =>
+      if (diags.contains(name.pos.toLsp -> name.value)) {
+        Some(RemoveInvalidImport.title(name.value) -> RemovalEdit.EntireTree)
+      } else {
+        None
+      }
+    }
+  }
+
+  // Remove invalid elements from importer
+  // Return (all possible individual removals, result of removing everything)
+  private def removeInvalidFromImporter(
+      importer: Importer,
+      diags: List[(l.Range, String)],
+  ): (Seq[(String, RemovalEdit)], RemovalEdit) = {
+
+    // Found error in the `ref` (ex: `bar` being invalid in `import foo.bar.baz.Quz`)
+    val diagInRef = diags.headOption.filter { case (r, _) =>
+      importer.ref.pos.encloses(r)
+    }
+
+    diagInRef match {
+      case Some((_, invalidName)) =>
+        (Seq(
+          RemoveInvalidImport.title(invalidName) -> RemovalEdit.EntireTree
+        ) -> RemovalEdit.EntireTree)
+      case None =>
+        val importees = importer.importees
+        val importeeEdits = groupDiagnosticsByTree(diags, importees)
+          .map { case (importee, diags) =>
+            removeInvalidFromImportee(importee, diags)
+          }
+
+        val caseByCase = importeeEdits.zipWithIndex
+          .collect { case ((Some(removal), idx)) => removal -> idx }
+          .map { case ((title, removal), index) =>
+            title -> RemovalEdit.fromSeqEdits(
+              importees.iterator.zipWithIndex.map { case (tree, treeIndex) =>
+                tree -> (if (treeIndex == index) removal
+                         else RemovalEdit.Empty)
+              }
+            )
+          }
+        val aggregate = RemovalEdit.fromSeqEdits(
+          importees.zip(importeeEdits).iterator.map {
+            case (importee, editOpt) =>
+              importee -> editOpt.fold[RemovalEdit](RemovalEdit.Empty)(_._2)
+          }
+        )
+        caseByCase -> aggregate
+    }
+  }
+
+  // Remove invalid elements from import
+  // Return (all possible individual removals, result of removing everything)
+  private def removeInvalidFromImport(
+      imprt: Import,
+      diags: List[(l.Range, String)],
+  ): (Seq[(String, RemovalEdit)], RemovalEdit) = {
+
+    val importers = imprt.importers
+    val (caseByCaseImporterEdits, allEdits) =
+      groupDiagnosticsByTree(diags, importers).map { case (importer, diags) =>
+        removeInvalidFromImporter(importer, diags)
+      }.unzip
+
+    val caseByCase = caseByCaseImporterEdits.zipWithIndex
+      .flatMap { case (removals, index) =>
+        removals.map { case (title, removal) =>
+          title -> RemovalEdit.fromSeqEdits(
+            importers.iterator.zipWithIndex.map { case (tree, treeIndex) =>
+              tree -> (if (treeIndex == index) removal else RemovalEdit.Empty)
+            }
+          )
+        }
+      }
+    val aggregate = RemovalEdit.fromSeqEdits(
+      importers.zip(allEdits).iterator
+    )
+
+    caseByCase -> aggregate
+  }
+
+  /**
+   * Group diags associated with ranges up along the subtrees containing them
+   *
+   * Pre-condition: diags and trees are both sorted by start of range
+   * Post-condition: output list is sorted by trees and diag groups are also sorted
+   * Post-condition: add trees are in the output (though some diags may be dropped)
+   */
+  private def groupDiagnosticsByTree[T <: Tree](
+      diags: List[(l.Range, String)],
+      trees: List[T],
+  ): List[(T, List[(l.Range, String)])] = {
+    val diagnosticsByTree = List.newBuilder[(T, List[(l.Range, String)])]
+    var remainingDiags = diags
+
+    for (tree <- trees) {
+      val treeRange = tree.pos.toLsp
+      val (thisTree, newRemainingDiags) = remainingDiags.span {
+        case (diagRange, _) =>
+          diagRange.getStart() <= treeRange.getEnd
+      }
+      val diagsForTree = thisTree.filter { case (diagRange, _) =>
+        treeRange.encloses(diagRange)
+      }
+      diagnosticsByTree += tree -> diagsForTree
+      remainingDiags = newRemainingDiags
+    }
+
+    diagnosticsByTree.result()
+  }
+}
+
+object RemoveInvalidImport {
+  def title(name: String): String =
+    s"Remove invalid import of '$name'"
+}
+
+class RemoveInvalidImportQuickFix(
+    trees: Trees,
+    buildTargets: BuildTargets,
+) extends RemoveInvalidImport(trees, buildTargets) {
+
+  override protected def getDiagnostics(
+      params: l.CodeActionParams
+  ): Seq[l.Diagnostic] =
+    params.getContext().getDiagnostics().asScala.toSeq
+
+  override protected def getRange(params: l.CodeActionParams): l.Range =
+    params.getRange()
+
+  override val kind: String = l.CodeActionKind.QuickFix
+
+  override protected val allImportsTitle: String =
+    RemoveInvalidImportQuickFix.allImportsTitle
+
+  override protected def isRemoveAllSourceAction: Boolean = false
+}
+
+object RemoveInvalidImportQuickFix {
+  val allImportsTitle = "Remove all invalid imports"
+}
+
+class SourceRemoveInvalidImports(
+    trees: Trees,
+    buildTargets: BuildTargets,
+    diagnostics: Diagnostics,
+) extends RemoveInvalidImport(trees, buildTargets) {
+
+  override protected def getDiagnostics(
+      params: l.CodeActionParams
+  ): Seq[l.Diagnostic] = {
+    val uri = params.getTextDocument().getUri()
+    val file = uri.toAbsolutePath
+    this.diagnostics.getFileDiagnostics(file).toSeq
+  }
+
+  override protected def getRange(params: l.CodeActionParams): l.Range = {
+    val uri = params.getTextDocument().getUri()
+    val file = uri.toAbsolutePath
+    this.trees.get(file).fold(new l.Range())(_.pos.toLsp)
+  }
+
+  override val kind: String = SourceRemoveInvalidImports.kind
+
+  override protected val allImportsTitle: String =
+    SourceRemoveInvalidImports.title
+
+  override protected def isRemoveAllSourceAction: Boolean = true
+}
+
+object SourceRemoveInvalidImports {
+  val title = "Remove all invalid imports for the entire file"
+
+  val kind: String = l.CodeActionKind.Source + ".removeInvalidImports"
+}

--- a/mtags-shared/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/mtags/CommonMtagsEnrichments.scala
@@ -137,6 +137,9 @@ trait CommonMtagsEnrichments {
       pos.getLine() < 0 &&
         pos.getCharacter() < 0
 
+    def <=(other: l.Position): Boolean =
+      pos.getLine < other.getLine ||
+        (pos.getLine == other.getLine && pos.getCharacter <= other.getCharacter)
   }
 
   implicit class XtensionLspRange(range: l.Range) {
@@ -147,17 +150,8 @@ trait CommonMtagsEnrichments {
       range.getStart().isNone &&
         range.getEnd().isNone
 
-    def encloses(position: l.Position): Boolean = {
-      val startsBeforeOrAt =
-        range.getStart.getLine < position.getLine ||
-          (range.getStart.getLine == position.getLine &&
-            range.getStart.getCharacter <= position.getCharacter)
-      val endsAtOrAfter =
-        range.getEnd.getLine > position.getLine ||
-          (range.getEnd.getLine == position.getLine &&
-            range.getEnd.getCharacter >= position.getCharacter)
-      startsBeforeOrAt && endsAtOrAfter
-    }
+    def encloses(position: l.Position): Boolean =
+      range.getStart <= position && position <= range.getEnd
 
     def encloses(other: l.Range): Boolean =
       encloses(other.getStart) && encloses(other.getEnd)

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -5,7 +5,6 @@ import scala.meta.internal.metals.codeactions.CreateNewSymbol
 import scala.meta.internal.metals.codeactions.ImportMissingSymbol
 import scala.meta.internal.metals.codeactions.ImportMissingSymbolQuickFix
 import scala.meta.internal.metals.codeactions.SourceAddMissingImports
-import scala.meta.internal.metals.codeactions.SourceOrganizeImports
 
 import org.eclipse.lsp4j.CodeActionKind
 
@@ -473,7 +472,6 @@ class ImportMissingSymbolLspSuite
        |}
        |""".stripMargin,
     s"""|${SourceAddMissingImports.title}
-        |${SourceOrganizeImports.title} (disabled)
         |""".stripMargin,
     """|package a
        |
@@ -496,7 +494,6 @@ class ImportMissingSymbolLspSuite
        |}
        |""".stripMargin,
     s"""|${SourceAddMissingImports.title}
-        |${SourceOrganizeImports.title} (disabled)
         |""".stripMargin,
     """|package a
        |

--- a/tests/unit/src/test/scala/tests/codeactions/RemoveInvalidImportLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/RemoveInvalidImportLspSuite.scala
@@ -1,0 +1,523 @@
+package tests.codeactions
+
+import scala.meta.internal.metals.codeactions.RemoveInvalidImport
+import scala.meta.internal.metals.codeactions.RemoveInvalidImportQuickFix
+import scala.meta.internal.metals.codeactions.SourceRemoveInvalidImports
+
+import org.eclipse.{lsp4j => l}
+
+class RemoveInvalidImportLspSuite
+    extends BaseCodeActionLspSuite("removeInvalidSymbol") {
+
+  // ---------------------------------------------------------------------------
+  // Tests for RemoveInvalidImportQuickFix (CodeActionKind.QuickFix)
+  // These tests verify the existing behavior for manual import resolution
+  // ---------------------------------------------------------------------------
+
+  check(
+    "entire-import-1-fix",
+    """|package a
+       |
+       |<<import scala.collection.Seq
+       |import scala.collection.DoesntExist>>
+       |
+       |object A
+       |""".stripMargin,
+    s"""|${RemoveInvalidImport.title("DoesntExist")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.Seq
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(l.CodeActionKind.QuickFix),
+  )
+
+  check(
+    "entire-import-2-fix",
+    """|package a
+       |
+       |<<import scala.collection.Seq
+       |import scala.collection.doesntExist.List>>
+       |
+       |object A
+       |""".stripMargin,
+    s"""|${RemoveInvalidImport.title("doesntExist")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.Seq
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(l.CodeActionKind.QuickFix),
+  )
+
+  check(
+    "entire-import-3-fix",
+    """|package a
+       |
+       |<<import scala.collection.Seq
+       |import scala.collection.doesntExist.{List, LazyList}>>
+       |
+       |object A
+       |""".stripMargin,
+    s"""|${RemoveInvalidImport.title("doesntExist")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.Seq
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(l.CodeActionKind.QuickFix),
+  )
+
+  check(
+    "in-importer-1-fix",
+    """|package a
+       |
+       |<<import scala.doesntExist.Baz, scala.collection.Seq>>
+       |
+       |object A
+       |""".stripMargin,
+    s"""|${RemoveInvalidImport.title("doesntExist")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.Seq
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(l.CodeActionKind.QuickFix),
+  )
+
+  check(
+    "in-importer-2-fix",
+    """|package a
+       |
+       |<<import scala.collection.Seq, scala.doesntExist.Baz>>
+       |
+       |object A
+       |""".stripMargin,
+    s"""|${RemoveInvalidImport.title("doesntExist")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.Seq
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(l.CodeActionKind.QuickFix),
+  )
+
+  check(
+    "in-importer-3-fix",
+    """|package a
+       |
+       |<<import scala.collection.DoesntExist, scala.doesntExist.Baz>>
+       |
+       |object A
+       |""".stripMargin,
+    s"""|${RemoveInvalidImportQuickFix.allImportsTitle}
+        |${RemoveInvalidImport.title("DoesntExist")}
+        |${RemoveInvalidImport.title("doesntExist")}
+        |""".stripMargin,
+    """|package a
+       |
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(l.CodeActionKind.QuickFix),
+  )
+
+  check(
+    "in-importer-4-fix",
+    """|package a
+       |
+       |import scala.collection.{DoesntExist1, <<DoesntExist2}, scala.doesn>>tExist.Baz
+       |
+       |object A
+       |""".stripMargin,
+    s"""|${RemoveInvalidImportQuickFix.allImportsTitle}
+        |${RemoveInvalidImport.title("DoesntExist2")}
+        |${RemoveInvalidImport.title("doesntExist")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.{DoesntExist1}
+       |
+       |object A
+       |""".stripMargin,
+    expectNoDiagnostics = false,
+    kind = List(l.CodeActionKind.QuickFix),
+  )
+
+  check(
+    "in-selector-1-fix",
+    """|package a
+       |
+       |<<import scala.collection.{DoesntExist, Seq, IndexedSeq}>>
+       |
+       |object A
+       |""".stripMargin,
+    s"""|${RemoveInvalidImport.title("DoesntExist")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.{Seq, IndexedSeq}
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(l.CodeActionKind.QuickFix),
+  )
+
+  check(
+    "in-selector-2-fix",
+    """|package a
+       |
+       |<<import scala.collection.{Seq, DoesntExist, IndexedSeq}>>
+       |
+       |object A
+       |""".stripMargin,
+    s"""|${RemoveInvalidImport.title("DoesntExist")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.{Seq, IndexedSeq}
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(l.CodeActionKind.QuickFix),
+  )
+
+  check(
+    "in-selector-3-fix",
+    """|package a
+       |
+       |<<import scala.collection.{Seq, IndexedSeq, DoesntExist}>>
+       |
+       |object A
+       |""".stripMargin,
+    s"""|${RemoveInvalidImport.title("DoesntExist")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.{Seq, IndexedSeq}
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(l.CodeActionKind.QuickFix),
+  )
+
+  check(
+    "in-selector-4-fix",
+    """|package a
+       |
+       |<<import scala.collection.{DoesntExist1, DoesntExist2}>>
+       |
+       |object A
+       |""".stripMargin,
+    s"""|${RemoveInvalidImportQuickFix.allImportsTitle}
+        |${RemoveInvalidImport.title("DoesntExist1")}
+        |${RemoveInvalidImport.title("DoesntExist2")}
+        |""".stripMargin,
+    """|package a
+       |
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(l.CodeActionKind.QuickFix),
+  )
+
+  check(
+    "in-selector-5-fix",
+    """|package a
+       |
+       |import scala.<<collection.{DoesntExist1>>, DoesntExist2}
+       |
+       |object A
+       |""".stripMargin,
+    s"""|${RemoveInvalidImport.title("DoesntExist1")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.{DoesntExist2}
+       |
+       |object A
+       |""".stripMargin,
+    expectNoDiagnostics = false,
+    kind = List(l.CodeActionKind.QuickFix),
+  )
+
+  check(
+    "involved1-fix",
+    """|package a
+       |<<
+       |import scala.sys.doesntExit.other
+       |import scala.collection.{DoesntExist1, AbstractSet, DoesntExist2}, scala.collection.DoesntExist3, scala.foo.DoesntExist4
+       |import doesnt.exist
+       |import _root_.scala.concurrent.Future
+       |>>
+       |object A
+       |""".stripMargin,
+    s"""|${RemoveInvalidImportQuickFix.allImportsTitle}
+        |${RemoveInvalidImport.title("doesntExit")}
+        |${RemoveInvalidImport.title("DoesntExist1")}
+        |${RemoveInvalidImport.title("DoesntExist2")}
+        |${RemoveInvalidImport.title("DoesntExist3")}
+        |${RemoveInvalidImport.title("foo")}
+        |${RemoveInvalidImport.title("doesnt")}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.{AbstractSet}
+       |import _root_.scala.concurrent.Future
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(l.CodeActionKind.QuickFix),
+    filterAction = action => action.getTitle().contains("invalid import"),
+  )
+
+  // ---------------------------------------------------------------------------
+  // Tests for SourceRemoveInvalidImports (CodeActionKind.Source)
+  // These tests verify the existing behavior for manual import resolution
+  // ---------------------------------------------------------------------------
+
+  check(
+    "entire-import-1-source",
+    """|package a
+       |
+       |import scala.collection.Seq
+       |import scala.collection.DoesntExist
+       |
+       |object <<A>>
+       |""".stripMargin,
+    s"""|${SourceRemoveInvalidImports.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.Seq
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(SourceRemoveInvalidImports.kind),
+  )
+
+  check(
+    "entire-import-2-source",
+    """|package a
+       |
+       |import scala.collection.Seq
+       |import scala.collection.doesntExist.List
+       |
+       |object <<A>>
+       |""".stripMargin,
+    s"""|${SourceRemoveInvalidImports.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.Seq
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(SourceRemoveInvalidImports.kind),
+  )
+
+  check(
+    "entire-import-3-source",
+    """|package a
+       |
+       |import scala.collection.Seq
+       |import scala.collection.doesntExist.{List, LazyList}
+       |
+       |object <<A>>
+       |""".stripMargin,
+    s"""|${SourceRemoveInvalidImports.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.Seq
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(SourceRemoveInvalidImports.kind),
+  )
+
+  check(
+    "in-importer-1-source",
+    """|package a
+       |
+       |import scala.doesntExist.Baz, scala.collection.Seq
+       |
+       |object <<A>>
+       |""".stripMargin,
+    s"""|${SourceRemoveInvalidImports.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.Seq
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(SourceRemoveInvalidImports.kind),
+  )
+
+  check(
+    "in-importer-2-source",
+    """|package a
+       |
+       |import scala.collection.Seq, scala.doesntExist.Baz
+       |
+       |object <<A>>
+       |""".stripMargin,
+    s"""|${SourceRemoveInvalidImports.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.Seq
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(SourceRemoveInvalidImports.kind),
+  )
+
+  check(
+    "in-importer-3-source",
+    """|package a
+       |
+       |import scala.collection.DoesntExist, scala.doesntExist.Baz
+       |
+       |object <<A>>
+       |""".stripMargin,
+    s"""|${SourceRemoveInvalidImports.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(SourceRemoveInvalidImports.kind),
+  )
+
+  check(
+    "in-selector-1-source",
+    """|package a
+       |
+       |import scala.collection.{DoesntExist, Seq, IndexedSeq}
+       |
+       |object <<A>>
+       |""".stripMargin,
+    s"""|${SourceRemoveInvalidImports.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.{Seq, IndexedSeq}
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(SourceRemoveInvalidImports.kind),
+  )
+
+  check(
+    "in-selector-2-source",
+    """|package a
+       |
+       |import scala.collection.{Seq, DoesntExist, IndexedSeq}
+       |
+       |object <<A>>
+       |""".stripMargin,
+    s"""|${SourceRemoveInvalidImports.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.{Seq, IndexedSeq}
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(SourceRemoveInvalidImports.kind),
+  )
+
+  check(
+    "in-selector-3-source",
+    """|package a
+       |
+       |import scala.collection.{Seq, IndexedSeq, DoesntExist}
+       |
+       |object <<A>>
+       |""".stripMargin,
+    s"""|${SourceRemoveInvalidImports.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.{Seq, IndexedSeq}
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(SourceRemoveInvalidImports.kind),
+  )
+
+  check(
+    "in-selector-4-source",
+    """|package a
+       |
+       |import scala.collection.{DoesntExist1, DoesntExist2}
+       |
+       |object <<A>>
+       |""".stripMargin,
+    s"""|${SourceRemoveInvalidImports.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(SourceRemoveInvalidImports.kind),
+  )
+
+  check(
+    "involved1-source",
+    """|package a
+       |
+       |import scala.sys.doesntExit.other
+       |import scala.collection.{DoesntExist1, AbstractSet, DoesntExist2}, scala.collection.DoesntExist3, scala.foo.DoesntExist4
+       |import doesnt.exist
+       |import _root_.scala.concurrent.Future
+       |
+       |object <<A>>
+       |""".stripMargin,
+    s"""|${SourceRemoveInvalidImports.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.{AbstractSet}
+       |import _root_.scala.concurrent.Future
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(SourceRemoveInvalidImports.kind),
+  )
+
+  // After 2.13.17, `DoesntExist2 => other` should also be removed
+  check(
+    "renames",
+    """|package a
+       |
+       |import scala.collection.{DoesntExist1, AbstractSet, DoesntExist2 => other}
+       |
+       |object <<A>>
+       |""".stripMargin,
+    s"""|${SourceRemoveInvalidImports.title}
+        |""".stripMargin,
+    """|package a
+       |
+       |import scala.collection.{AbstractSet, DoesntExist2 => other}
+       |
+       |object A
+       |""".stripMargin,
+    kind = List(SourceRemoveInvalidImports.kind),
+    expectNoDiagnostics = false,
+  )
+}


### PR DESCRIPTION
Add a new code action to faciliate removing invalid imports (or invalid parts inside of them). Note that this is only as good as the spans of the errors around the imports. For instance, since Scala 2.12 does not have <https://github.com/scala/scala/pull/10868>, some quickfixes will be missing there.

Implements <https://github.com/scalameta/metals-feature-requests/issues/431>