### PR TITLE
fix: don't show byname hints for defaulted args

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcInlayHintsProvider.scala
@@ -436,6 +436,7 @@ final class PcInlayHintsProvider(
                 .zip(params)
                 .collect { case (tree, param) if param.isByNameParam => tree }
                 .map(tree => tree.pos)
+                .filter(_.isRange) // filter out default arguments
             })
           case _ => None
         }

--- a/tests/cross/src/test/scala/tests/pc/InlayHintsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/InlayHintsSuite.scala
@@ -1118,4 +1118,23 @@ class InlayHintsSuite extends BaseInlayHintsSuite {
        |}
        |""".stripMargin
   )
+
+  check(
+    "by-name-default-arguments",
+    """|object Main{
+       |  def foo(a: => Int = 1 + 2) = ()
+       |
+       |  foo()
+       |  foo(4 + 2)
+       |}
+       |""".stripMargin,
+    """|package `by-name-default-arguments`
+       |object Main{
+       |  def foo(a: => Int = 1 + 2)/*: Unit<<scala/Unit#>>*/ = ()
+       |
+       |  foo()
+       |  foo(/*=> */4 + 2)
+       |}
+       |""".stripMargin
+  )
 }


### PR DESCRIPTION
This makes sure we don't display an extra `=> ` for default byname arguments which the user never wrote. Ideally we would have a better way to check for default arguments, but it looks like like scalac only fairly recently added an annotation info to indicate that an apply argument is defaulted. Checking for an empty position is a fallback that should work on old versions as well.