### PR TITLE
Use fallback mtags and presentation compiler implementations in 2.12

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
@@ -54,14 +54,20 @@ class CompilerConfiguration(
       classpath: Seq[Path],
       referenceCounter: CompletionItemPriority,
   ) extends MtagsPresentationCompiler {
+    private val resolvedMtags = mtagsResolver.resolve(scalaVersion)
+
     private val mtags =
-      mtagsResolver.resolve(scalaVersion).getOrElse(MtagsBinaries.BuildIn)
+      resolvedMtags.getOrElse(MtagsBinaries.BuildIn)
+
+    private val classPathExtension =
+      if (resolvedMtags.nonEmpty) Embedded.scalaLibrary(scalaVersion)
+      else Embedded.scalaLibrary(MtagsBinaries.BuildIn.scalaVersion)
 
     val standalone: PresentationCompiler =
       fromMtags(
         mtags,
         options = Nil,
-        classpath ++ Embedded.scalaLibrary(scalaVersion),
+        classpath ++ classPathExtension,
         "default",
         symbolSearch,
         referenceCounter,

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -1206,7 +1206,8 @@ class Compilers(
             if (path.isScalaFilename) fallbackCompiler else javaFallbackCompiler
           Some(fallback)
         case Some(value) =>
-          if (path.isScalaFilename) loadCompiler(value)
+          if (path.isScalaFilename)
+            Some(loadCompiler(value).getOrElse(fallbackCompiler))
           else if (path.isJavaFilename && forceScala)
             loadCompiler(value)
               .orElse(Some(loadJavaCompiler(value)))


### PR DESCRIPTION
Co-authored with @migoilee @rajcspsg on Scala Tooling Spree

Resolves https://github.com/scalameta/metals/issues/7378