### PR TITLE
refactor: pass report context to the presentation compiler

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BSPErrorHandler.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BSPErrorHandler.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.builds
 
 import java.security.MessageDigest
+import java.util.Optional
 
 import scala.meta.internal.bsp.BspSession
 import scala.meta.internal.bsp.ConnectionBspStatus
@@ -19,7 +20,7 @@ class BspErrorHandler(
   def onError(message: String): Unit = {
     if (shouldShowBspError) {
       for {
-        report <- createReport(message)
+        report <- createReport(message).asScala
         if !tables.dismissedNotifications.BspErrors.isDismissed
       } bspStatus.showError(message, report)
     } else logError(message)
@@ -35,15 +36,15 @@ class BspErrorHandler(
     val digest = MessageDigest.getInstance("MD5").digest(message.getBytes)
     val id = BaseEncoding.base64().encode(digest)
     val sanitized = reportContext.bloop.sanitize(message)
-    reportContext.bloop.create(
+    reportContext.bloop.create(() =>
       Report(
         sanitized.trimTo(20),
         s"""|### Bloop error:
             |
             |$message""".stripMargin,
         shortSummary = sanitized.trimTo(100),
-        path = None,
-        id = Some(id),
+        path = Optional.empty(),
+        id = Optional.of(id),
       )
     )
   }

--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.implementation
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
+import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -179,16 +180,17 @@ final class ImplementationProvider(
               .toSet
 
         if (sourceFiles.isEmpty) {
-          rc.unsanitized.create(
-            Report(
-              "missing-definition",
-              s"""|Missing definition symbol for:
-                  |$dealisedSymbol
-                  |""".stripMargin,
-              s"missing def: $dealisedSymbol",
-              Some(source.toURI),
+          rc.unsanitized()
+            .create(() =>
+              Report(
+                "missing-definition",
+                s"""|Missing definition symbol for:
+                    |$dealisedSymbol
+                    |""".stripMargin,
+                s"missing def: $dealisedSymbol",
+                path = Optional.of(source.toURI),
+              )
             )
-          )
         }
 
         val isWorkspaceSymbol =

--- a/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
@@ -296,6 +296,7 @@ class CompilerConfiguration(
       .withWorkspace(workspace.toNIO)
       .withScheduledExecutorService(sh)
       .withReportsLoggerLevel(MetalsServerConfig.default.loglevel)
+      .withReportContext(rc)
       .withConfiguration {
         val options =
           InitializationOptions.from(initializeParams).compilerOptions
@@ -370,7 +371,7 @@ class CompilerConfiguration(
               |""".stripMargin,
           error,
         )
-      rc.unsanitized.create(report)
+      rc.unsanitized().create(() => report)
       EmptySymbolSearch
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala
@@ -152,7 +152,7 @@ final class DefinitionProvider(
           }
       }
     } yield {
-      reportBuilder.build().foreach(rc.unsanitized.create(_))
+      reportBuilder.build().foreach(r => rc.unsanitized().create(() => r))
       result
     }
   }
@@ -614,10 +614,8 @@ class DefinitionProviderReportBuilder(
                 |${params.printed(buffers)}
                 |""".stripMargin,
             s"empty definition using pc, found symbol in pc: ${compilerDefn.querySymbol}",
-            path = Some(path.toURI),
-            id = querySymbol.orElse(
-              Some(s"${path.toURI}:${params.getPosition().getLine()}")
-            ),
+            path = ju.Optional.of(path.toURI),
+            id = querySymbol.map(s => s"${path.toURI}:$s").asJava,
             error = error,
           )
         )

--- a/metals/src/main/scala/scala/meta/internal/metals/InlayHintResolveProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InlayHintResolveProvider.scala
@@ -42,7 +42,8 @@ final class InlayHintResolveProvider(
       case Right(labelParts) => labelParts
       case Left(error) =>
         scribe.warn(s"Failed to resolve inlay hint: $error")
-        rc.unsanitized.create(report(inlayHint, error), ifVerbose = true)
+        rc.unsanitized()
+          .create(() => report(inlayHint, error), /* ifVerbose = */ true)
         Future.successful(inlayHint)
     }
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/LoggerContext.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/LoggerContext.scala
@@ -3,17 +3,18 @@ package scala.meta.internal.metals
 import java.lang
 import java.nio.file.Path
 import java.util.Optional
+import java.util.function.Supplier
 
 import scala.meta.internal.metals.utils.TimestampedFile
-import scala.meta.pc.reports.LazyReport
+import scala.meta.pc.reports.Report
 
 object LoggerReporter extends Reporter {
 
   override def create(
-      lazyReport: LazyReport,
+      lazyReport: Supplier[Report],
       ifVerbose: lang.Boolean,
   ): Optional[Path] = {
-    val report = lazyReport.create()
+    val report = lazyReport.get()
     scribe.info(
       s"Report ${report.name}: ${report.fullText( /* withIdAndSummary = */ false)}"
     )

--- a/metals/src/main/scala/scala/meta/internal/metals/LoggerContext.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/LoggerContext.scala
@@ -1,18 +1,26 @@
 package scala.meta.internal.metals
 
+import java.lang
 import java.nio.file.Path
+import java.util.Optional
 
 import scala.meta.internal.metals.utils.TimestampedFile
+import scala.meta.pc.reports.LazyReport
 
 object LoggerReporter extends Reporter {
 
-  override def name: String = "logger-report"
-  override def create(report: => Report, ifVerbose: Boolean): Option[Path] = {
+  override def create(
+      lazyReport: LazyReport,
+      ifVerbose: lang.Boolean,
+  ): Optional[Path] = {
+    val report = lazyReport.create()
     scribe.info(
-      s"Report ${report.name}: ${report.fullText(withIdAndSummary = false)}"
+      s"Report ${report.name}: ${report.fullText( /* withIdAndSummary = */ false)}"
     )
-    None
+    Optional.empty()
   }
+
+  override def name: String = "logger-report"
 
   override def cleanUpOldReports(maxReportsNumber: Int): List[TimestampedFile] =
     List()

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -760,14 +760,16 @@ object MetalsEnrichments
         Some(toAbsolutePath)
       } catch {
         case NonFatal(error) =>
-          reports.incognito.create(
-            Report(
-              "absolute-path",
-              s"""|Uri: $value
-                  |""".stripMargin,
-              error,
+          reports
+            .incognito()
+            .create(() =>
+              Report(
+                "absolute-path",
+                s"""|Uri: $value
+                    |""".stripMargin,
+                error,
+              )
             )
-          )
           None
       }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1687,7 +1687,7 @@ abstract class MetalsLspService(
         case e: IndexingExceptions.PathIndexingException =>
           scribe.error(s"issues while parsing: ${e.path}", e.getCause)
         case e: IndexingExceptions.InvalidSymbolException =>
-          reports.incognito.create(
+          reports.incognito.create(() =>
             Report(
               "invalid-symbol",
               s"""Symbol: ${e.symbol}""".stripMargin,

--- a/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReferenceProvider.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.metals
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
+import java.util.Optional
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.concurrent.TrieMap
@@ -226,21 +227,24 @@ final class ReferenceProvider(
                 scribe.debug(
                   s"No references found, index size ${index.size}\n" + fileInIndex
                 )
-                report.unsanitized.create(
-                  Report(
-                    "empty-references",
-                    index
-                      .map { case (path, entry) =>
-                        s"$path -> ${entry.bloom.approximateElementCount()}"
-                      }
-                      .mkString("\n"),
-                    s"Could not find any locations for ${result.occurrence}, printing index state",
-                    Some(source.toURI),
-                    Some(
-                      source.toString() + ":" + result.occurrence.getOrElse("")
-                    ),
+                report
+                  .unsanitized()
+                  .create(() =>
+                    Report(
+                      "empty-references",
+                      index
+                        .map { case (path, entry) =>
+                          s"$path -> ${entry.bloom.approximateElementCount()}"
+                        }
+                        .mkString("\n"),
+                      s"Could not find any locations for ${result.occurrence}, printing index state",
+                      path = Optional.of(source.toURI),
+                      id = Optional.of(
+                        source.toString() + ":" + result.occurrence
+                          .getOrElse("")
+                      ),
+                    )
                   )
-                )
               }
               ReferencesResult(occurrence.symbol, locations)
             }

--- a/metals/src/main/scala/scala/meta/internal/metals/ReportContext.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ReportContext.scala
@@ -8,6 +8,7 @@ import java.nio.file.Paths
 import java.util.Optional
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
+import java.util.function.Supplier
 import java.util.logging.Logger
 
 import scala.util.Try
@@ -131,7 +132,7 @@ class StdReporter(
   }
 
   override def create(
-      lazyReport: jreports.LazyReport,
+      lazyReport: Supplier[jreports.Report],
       ifVerbose: lang.Boolean,
   ): Optional[Path] =
     if (ifVerbose && !level.isVerbose) Optional.empty()
@@ -141,7 +142,7 @@ class StdReporter(
           readInIds()
         }
 
-        val report = lazyReport.create()
+        val report = lazyReport.get()
         val sanitizedId = report.id().asScala.map(sanitize)
         val path = reportPath(report)
 
@@ -219,7 +220,7 @@ object EmptyReporter extends Reporter {
     Nil
 
   override def create(
-      report: jreports.LazyReport,
+      report: Supplier[jreports.Report],
       ifVerbose: lang.Boolean,
   ): Optional[Path] =
     Optional.empty()

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -466,7 +466,7 @@ case class ScalafixProvider(
                   |""".stripMargin,
               serviceError,
             )
-          rc.incognito.create(report)
+          rc.incognito().create(() => report)
           if (shouldRetry) {
             rulesClassloaderCache.remove(scalafixRulesKey)
             scalafixEvaluate(

--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
@@ -1,5 +1,7 @@
 package scala.meta.internal.metals
 
+import java.util.Optional
+
 import scala.annotation.switch
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
@@ -94,15 +96,16 @@ object SemanticTokensProvider {
     } else {
       val tokens = Try(getTokens(isScala3, params.text())) match {
         case Failure(t) =>
-          rc.unsanitized.create(
-            Report(
-              "semantic-tokens-provider",
-              params.text(),
-              s"Could not find semantic tokens for: ${params.uri()}",
-              Some(params.uri()),
-              error = Some(t),
+          rc.unsanitized()
+            .create(() =>
+              Report(
+                "semantic-tokens-provider",
+                params.text(),
+                s"Could not find semantic tokens for: ${params.uri()}",
+                path = Optional.of(params.uri()),
+                error = Some(t),
+              )
             )
-          )
           /* Try to get tokens from trees as a fallback to avoid
            * things being unhighlighted too often.
            */

--- a/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/Trees.scala
@@ -1,5 +1,7 @@
 package scala.meta.internal.parsing
 
+import java.util.Optional
+
 import scala.collection.concurrent.TrieMap
 import scala.reflect.ClassTag
 
@@ -183,14 +185,16 @@ final class Trees(
     } catch {
       // if the parsers breaks we should not throw the exception further
       case _: StackOverflowError =>
-        val newPathCopy = reports.unsanitized.create(
-          Report(
-            s"stackoverflow_${path.filename}",
-            text,
-            s"Stack overflow in ${path.filename}",
-            path = Some(path.toURI),
+        val newPathCopy = reports
+          .unsanitized()
+          .create(() =>
+            Report(
+              s"stackoverflow_${path.filename}",
+              text,
+              s"Stack overflow in ${path.filename}",
+              path = Optional.of(path.toURI),
+            )
           )
-        )
         val message =
           s"Could not parse $path, saved the current snapshot to ${newPathCopy}"
         scribe.warn(message)

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -1,5 +1,7 @@
 package scala.meta.pc;
 
+import scala.meta.pc.reports.ReportContext;
+
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.DocumentHighlight;
@@ -305,6 +307,13 @@ public abstract class PresentationCompiler {
 	 * Provide CompletionItemPriority for additional sorting completion items.
 	 */
 	public PresentationCompiler withCompletionItemPriority(CompletionItemPriority priority) {
+		return this;
+	}
+
+	/**
+	 * Provide a reporting context for reporting errors.
+	 */
+	public PresentationCompiler withReportContext(ReportContext reportContext) {
 		return this;
 	}
 

--- a/mtags-interfaces/src/main/java/scala/meta/pc/reports/EmptyReportContext.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/reports/EmptyReportContext.java
@@ -1,0 +1,20 @@
+package scala.meta.pc.reports;
+
+public class EmptyReportContext implements ReportContext {
+  private final Reporter emptyReporter = new EmptyReporter();
+  @Override
+  public Reporter unsanitized() {
+    return emptyReporter;
+  }
+
+  @Override
+  public Reporter incognito() {
+    return emptyReporter;
+  }
+
+  @Override
+  public Reporter bloop() {
+    return emptyReporter;
+  }
+  
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/reports/EmptyReporter.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/reports/EmptyReporter.java
@@ -2,10 +2,11 @@ package scala.meta.pc.reports;
 
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public class EmptyReporter implements Reporter {
   @Override
-  public Optional<Path> create(LazyReport report, Boolean ifVerbose) {
+  public Optional<Path> create(Supplier<Report> report, Boolean ifVerbose) {
     return Optional.empty();
   }
 }

--- a/mtags-interfaces/src/main/java/scala/meta/pc/reports/EmptyReporter.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/reports/EmptyReporter.java
@@ -1,0 +1,11 @@
+package scala.meta.pc.reports;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class EmptyReporter implements Reporter {
+  @Override
+  public Optional<Path> create(LazyReport report, Boolean ifVerbose) {
+    return Optional.empty();
+  }
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/reports/LazyReport.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/reports/LazyReport.java
@@ -1,5 +1,0 @@
-package scala.meta.pc.reports;
-
-public interface LazyReport {
-  Report create();
-}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/reports/LazyReport.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/reports/LazyReport.java
@@ -1,0 +1,5 @@
+package scala.meta.pc.reports;
+
+public interface LazyReport {
+  Report create();
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/reports/Report.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/reports/Report.java
@@ -1,0 +1,11 @@
+package scala.meta.pc.reports;
+import java.util.Optional;
+import java.net.URI;
+
+public interface Report {
+    String name();
+    String shortSummary();
+    Optional<URI> path();
+    Optional<String> id();
+    String fullText(boolean withIdAndSummary);
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/reports/ReportContext.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/reports/ReportContext.java
@@ -1,0 +1,7 @@
+package scala.meta.pc.reports;
+
+public interface ReportContext {
+  Reporter unsanitized();
+  Reporter incognito();
+  Reporter bloop();
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/reports/Reporter.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/reports/Reporter.java
@@ -2,10 +2,11 @@ package scala.meta.pc.reports;
 
 import java.util.Optional;
 import java.nio.file.Path;
+import java.util.function.Supplier;
 
 public interface Reporter {
-   Optional<Path> create(LazyReport report, Boolean ifVerbose);
-   default Optional<Path> create(LazyReport report) {
+   Optional<Path> create(Supplier<Report> report, Boolean ifVerbose);
+   default Optional<Path> create(Supplier<Report>  report) {
       return create(report, Boolean.FALSE);
    }
 }

--- a/mtags-interfaces/src/main/java/scala/meta/pc/reports/Reporter.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/reports/Reporter.java
@@ -1,0 +1,11 @@
+package scala.meta.pc.reports;
+
+import java.util.Optional;
+import java.nio.file.Path;
+
+public interface Reporter {
+   Optional<Path> create(LazyReport report, Boolean ifVerbose);
+   default Optional<Path> create(LazyReport report) {
+      return create(report, Boolean.FALSE);
+   }
+}

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/PcQueryContext.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/PcQueryContext.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.metals
 import scala.meta.internal.mtags.CommonMtagsEnrichments._
 import scala.meta.internal.pc.CompilerThrowable
 import scala.meta.pc.VirtualFileParams
+import scala.meta.pc.reports.ReportContext
 
 case class PcQueryContext(
     params: Option[VirtualFileParams],
@@ -27,6 +28,6 @@ case class PcQueryContext(
         error,
         path = params.map(_.uri())
       )
-    rc.unsanitized.create(report)
+    rc.unsanitized().create(() => report)
   }
 }

--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/Report.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/Report.scala
@@ -1,0 +1,102 @@
+package scala.meta.internal.metals
+
+import java.net.URI
+import java.util.Optional
+
+import scala.meta.internal.mtags.CommonMtagsEnrichments._
+import scala.meta.internal.mtags.MD5
+import scala.meta.pc.{reports => jreports}
+
+case class Report(
+    name: String,
+    text: String,
+    shortSummary: String,
+    path: Optional[URI] = Optional.empty(),
+    id: Optional[String] = Optional.empty(),
+    error: Option[Throwable] = None
+) extends jreports.Report {
+
+  def extend(moreInfo: String): Report =
+    this.copy(
+      text = s"""|${this.text}
+                 |$moreInfo"""".stripMargin
+    )
+
+  def fullText(withIdAndSummary: Boolean): String = {
+    val sb = new StringBuilder
+    if (withIdAndSummary) {
+      id.asScala
+        .orElse(
+          error.map(error =>
+            MD5.compute(s"${name}:${error.getStackTrace().mkString("\n")}")
+          )
+        )
+        .foreach(id => sb.append(s"${Report.idPrefix}$id\n"))
+    }
+    path.asScala.foreach(path => sb.append(s"$path\n"))
+    error match {
+      case Some(error) =>
+        sb.append(
+          s"""|### $error
+              |
+              |$text
+              |
+              |#### Error stacktrace:
+              |
+              |```
+              |${error.getStackTrace().mkString("\n\t")}
+              |```
+              |""".stripMargin
+        )
+      case None => sb.append(s"$text\n")
+    }
+    if (withIdAndSummary)
+      sb.append(s"""|${Report.summaryTitle}
+                    |
+                    |$shortSummary""".stripMargin)
+    sb.result()
+  }
+}
+
+object Report {
+
+  def apply(
+      name: String,
+      text: String,
+      error: Throwable,
+      path: Option[URI]
+  ): Report =
+    Report(
+      name,
+      text,
+      shortSummary = error.toString(),
+      path = path.asJava,
+      error = Some(error)
+    )
+
+  def apply(name: String, text: String, error: Throwable): Report =
+    Report(name, text, error, path = None)
+
+  val idPrefix = "error id: "
+  val summaryTitle = "#### Short summary: "
+}
+
+sealed trait ReportLevel {
+  def isVerbose: Boolean
+}
+
+object ReportLevel {
+  case object Info extends ReportLevel {
+    def isVerbose = false
+  }
+
+  case object Debug extends ReportLevel {
+    def isVerbose = true
+  }
+
+  def fromString(level: String): ReportLevel =
+    level match {
+      case "debug" => Debug
+      case _ => Info
+    }
+}

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
@@ -1,16 +1,18 @@
 package scala.meta.internal.pc
 
+import java.util.Optional
+
 import scala.reflect.internal.util.Position
 import scala.reflect.internal.{Flags => gf}
 
 import scala.meta.internal.metals.PcQueryContext
 import scala.meta.internal.metals.Report
-import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.pc.ContentType
 import scala.meta.pc.HoverSignature
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.RangeParams
+import scala.meta.pc.reports.ReportContext
 
 class HoverProvider(
     val compiler: MetalsGlobal,
@@ -76,8 +78,8 @@ class HoverProvider(
             |```
             |""".stripMargin,
         s"empty hover in $fileName",
-        id = Some(s"$fileName::$posId"),
-        path = Some(fileName)
+        id = Optional.of(s"$fileName::$posId"),
+        path = Optional.of(fileName)
       )
     }
 
@@ -305,7 +307,9 @@ class HoverProvider(
       }
 
     if (result.isEmpty) {
-      report.foreach(reportContext.unsanitized.create(_, ifVerbose = true))
+      report.foreach(r =>
+        reportContext.unsanitized().create(() => r, /*ifVerbose = true*/ true)
+      )
     }
     result
   }

--- a/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/Docstrings.scala
@@ -25,6 +25,7 @@ import scala.meta.pc.ContentType.MARKDOWN
 import scala.meta.pc.ContentType.PLAINTEXT
 import scala.meta.pc.ParentSymbols
 import scala.meta.pc.SymbolDocumentation
+import scala.meta.pc.reports.ReportContext
 
 /**
  * Implementation of the `documentation(symbol: String): Option[SymbolDocumentation]` method in `SymbolSearch`.

--- a/mtags/src/main/scala/scala/meta/internal/metals/JavadocIndexer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JavadocIndexer.scala
@@ -16,6 +16,7 @@ import scala.meta.pc.ContentType
 import scala.meta.pc.ContentType.MARKDOWN
 import scala.meta.pc.ContentType.PLAINTEXT
 import scala.meta.pc.SymbolDocumentation
+import scala.meta.pc.reports.ReportContext
 
 import com.thoughtworks.qdox.model.JavaAnnotatedElement
 import com.thoughtworks.qdox.model.JavaClass

--- a/mtags/src/main/scala/scala/meta/internal/metals/SemanticdbDefinition.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/SemanticdbDefinition.scala
@@ -13,6 +13,7 @@ import scala.meta.internal.semanticdb.SymbolInformation
 import scala.meta.internal.semanticdb.SymbolOccurrence
 import scala.meta.internal.tokenizers.UnexpectedInputEndException
 import scala.meta.internal.{semanticdb => s}
+import scala.meta.pc.reports.ReportContext
 import scala.meta.tokenizers.TokenizeException
 
 import org.eclipse.{lsp4j => l}

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.mtags
 import java.io.StringReader
 import java.net.URI
 import java.util.Comparator
+import java.util.Optional
 
 import scala.util.control.NonFatal
 
@@ -12,11 +13,11 @@ import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.CompilerRangeParamsUtils
 import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.metals.Report
-import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 import scala.meta.internal.semanticdb.Language
 import scala.meta.internal.semanticdb.SymbolInformation.Kind
 import scala.meta.internal.semanticdb.SymbolInformation.Property
+import scala.meta.pc.reports.ReportContext
 
 import com.thoughtworks.qdox._
 import com.thoughtworks.qdox.model.JavaClass
@@ -246,17 +247,18 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
         else virtualFile.path
       }
 
-      rc.unsanitized.create(
-        new Report(
-          name = "qdox-error",
-          text = s"""|error in qdox parser$content
-                     |""".stripMargin,
-          error = Some(e),
-          path = Some(new URI(virtualFile.path)),
-          shortSummary = s"QDox $errorName in $shortFileName",
-          id = Some(virtualFile.path)
+      rc.unsanitized()
+        .create(() =>
+          new Report(
+            name = "qdox-error",
+            text = s"""|error in qdox parser$content
+                       |""".stripMargin,
+            error = Some(e),
+            path = Optional.of(new URI(virtualFile.path)),
+            shortSummary = s"QDox $errorName in $shortFileName",
+            id = Optional.of(virtualFile.path)
+          )
         )
-      )
     } catch {
       case NonFatal(_) =>
     }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaToplevelMtags.scala
@@ -1,19 +1,19 @@
 package scala.meta.internal.mtags
 
 import java.nio.file.Paths
+import java.util.Optional
 
 import scala.annotation.tailrec
-import scala.util.Try
 import scala.util.control.NonFatal
 
 import scala.meta.dialects
 import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import scala.meta.internal.metals.Report
-import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.semanticdb.Language
 import scala.meta.internal.semanticdb.SymbolInformation
 import scala.meta.internal.tokenizers.CharArrayReader
+import scala.meta.pc.reports.ReportContext
 
 class JavaToplevelMtags(
     val input: Input.VirtualFile,
@@ -43,20 +43,21 @@ class JavaToplevelMtags(
       }
     } catch {
       case NonFatal(e) =>
-        rc.unsanitized.create(
-          new Report(
-            s"failed-idex-java",
-            s"""|Java indexer failed with and exception.
-                |```Java
-                |${input.text}
-                |```
-                |""".stripMargin,
-            s"Java indexer failed with and exception.",
-            path = Try(Paths.get(input.path).toUri()).toOption,
-            id = Some(input.path),
-            error = Some(e)
+        rc.unsanitized()
+          .create(() =>
+            new Report(
+              s"failed-idex-java",
+              s"""|Java indexer failed with and exception.
+                  |```Java
+                  |${input.text}
+                  |```
+                  |""".stripMargin,
+              s"Java indexer failed with and exception.",
+              path = Optional.of(Paths.get(input.path).toUri()),
+              id = Optional.of(input.path),
+              error = Some(e)
+            )
           )
-        )
     }
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/Mtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/Mtags.scala
@@ -3,13 +3,13 @@ package scala.meta.internal.mtags
 import scala.meta.Dialect
 import scala.meta.dialects
 import scala.meta.inputs.Input
-import scala.meta.internal.metals.EmptyReportContext
-import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 import scala.meta.internal.semanticdb.Language
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.semanticdb.TextDocument
 import scala.meta.io.AbsolutePath
+import scala.meta.pc.reports.EmptyReportContext
+import scala.meta.pc.reports.ReportContext
 
 final class Mtags(implicit rc: ReportContext) {
   def totalLinesOfCode: Long = javaLines + scalaLines
@@ -125,7 +125,7 @@ final class Mtags(implicit rc: ReportContext) {
 }
 object Mtags {
   def index(path: AbsolutePath, dialect: Dialect)(implicit
-      rc: ReportContext = EmptyReportContext
+      rc: ReportContext = new EmptyReportContext()
   ): TextDocument = {
     new Mtags().index(path.toLanguage, path, dialect)
   }
@@ -144,7 +144,7 @@ object Mtags {
       input: Input.VirtualFile,
       dialect: Dialect,
       includeMembers: Boolean = true
-  )(implicit rc: ReportContext = EmptyReportContext): TextDocument =
+  )(implicit rc: ReportContext = new EmptyReportContext()): TextDocument =
     input.toLanguage match {
       case Language.JAVA =>
         new JavaMtags(input, includeMembers = true).index()
@@ -159,7 +159,7 @@ object Mtags {
   def toplevels(
       path: AbsolutePath,
       dialect: Dialect = dialects.Scala213
-  )(implicit rc: ReportContext = EmptyReportContext): TextDocument = {
+  )(implicit rc: ReportContext = new EmptyReportContext()): TextDocument = {
     new Mtags().toplevels(path, dialect)
   }
 
@@ -168,7 +168,7 @@ object Mtags {
       dialect: Dialect = dialects.Scala213,
       includeMembers: Boolean = false
   )(implicit
-      rc: ReportContext = EmptyReportContext
+      rc: ReportContext = new EmptyReportContext()
   ): (TextDocument, MtagsIndexer.AllOverrides) = {
     new Mtags().indexWithOverrides(path, dialect, includeMembers)
   }
@@ -176,7 +176,7 @@ object Mtags {
   def topLevelSymbols(
       path: AbsolutePath,
       dialect: Dialect = dialects.Scala213
-  )(implicit rc: ReportContext = EmptyReportContext): List[String] = {
+  )(implicit rc: ReportContext = new EmptyReportContext()): List[String] = {
     new Mtags().topLevelSymbols(path, dialect)
   }
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
@@ -9,8 +9,8 @@ import scala.util.control.NonFatal
 import scala.meta.Dialect
 import scala.meta.dialects
 import scala.meta.internal.io.{ListFiles => _}
-import scala.meta.internal.metals.ReportContext
 import scala.meta.io.AbsolutePath
+import scala.meta.pc.reports.ReportContext
 
 /**
  * An implementation of GlobalSymbolIndex with fast indexing and low memory usage.

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
@@ -1,16 +1,15 @@
 package scala.meta.internal.mtags
 
 import java.nio.file.Paths
+import java.util.Optional
 
 import scala.annotation.tailrec
-import scala.util.Try
 
 import scala.meta.Dialect
 import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import scala.meta.internal.inputs._
 import scala.meta.internal.metals.Report
-import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 import scala.meta.internal.semanticdb.Language
 import scala.meta.internal.semanticdb.Scala
@@ -21,6 +20,7 @@ import scala.meta.internal.tokenizers.LegacyScanner
 import scala.meta.internal.tokenizers.LegacyToken
 import scala.meta.internal.tokenizers.LegacyToken._
 import scala.meta.internal.tokenizers.LegacyTokenData
+import scala.meta.pc.reports.ReportContext
 import scala.meta.tokenizers.TokenizeException
 
 final class Identifier(val name: String, val pos: Position) {
@@ -1168,15 +1168,16 @@ class ScalaToplevelMtags(
     curr.token >= WHITESPACE_LF && curr.token < WHITESPACE_END
 
   def reportError(expected: String): Unit = {
-    rc.incognito.create(
-      Report(
-        "scala-toplevel-mtags",
-        failMessage(expected),
-        s"expected $expected; obtained $currentToken",
-        id = Some(s"""${input.path}:${newPosition}"""),
-        path = Try(Paths.get(input.path).toUri()).toOption
+    rc.incognito()
+      .create(() =>
+        Report(
+          "scala-toplevel-mtags",
+          failMessage(expected),
+          s"expected $expected; obtained $currentToken",
+          id = Optional.of(s"""${input.path}:${newPosition}"""),
+          path = Optional.of(Paths.get(input.path).toUri())
+        )
       )
-    )
   }
 
   def failMessage(expected: String): String = {

--- a/tests/mtest/src/main/scala/tests/DelegatingGlobalSymbolIndex.scala
+++ b/tests/mtest/src/main/scala/tests/DelegatingGlobalSymbolIndex.scala
@@ -1,19 +1,19 @@
 package tests
 
 import scala.meta.Dialect
-import scala.meta.internal.metals.EmptyReportContext
 import scala.meta.internal.mtags
 import scala.meta.internal.mtags.GlobalSymbolIndex
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.mtags.SymbolDefinition
 import scala.meta.io.AbsolutePath
+import scala.meta.pc.reports.EmptyReportContext
 
 /**
  * Symbol index that delegates all methods to an underlying implementation
  */
 class DelegatingGlobalSymbolIndex(
     var underlying: OnDemandSymbolIndex =
-      OnDemandSymbolIndex.empty()(EmptyReportContext)
+      OnDemandSymbolIndex.empty()(new EmptyReportContext())
 ) extends GlobalSymbolIndex {
 
   def definitions(symbol: mtags.Symbol): List[SymbolDefinition] =

--- a/tests/mtest/src/main/scala/tests/PCSuite.scala
+++ b/tests/mtest/src/main/scala/tests/PCSuite.scala
@@ -10,11 +10,11 @@ import scala.meta.Dialect
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.internal.metals.ClasspathSearch
 import scala.meta.internal.metals.Docstrings
-import scala.meta.internal.metals.EmptyReportContext
 import scala.meta.internal.metals.ExcludedPackagesHandler
 import scala.meta.internal.metals.JdkSources
-import scala.meta.internal.metals.ReportContext
 import scala.meta.io.AbsolutePath
+import scala.meta.pc.reports.EmptyReportContext
+import scala.meta.pc.reports.ReportContext
 
 import coursierapi.Fetch
 import coursierapi.Repository
@@ -51,7 +51,9 @@ trait PCSuite {
 
   protected def search(
       myclasspath: Seq[Path]
-  )(implicit rc: ReportContext = EmptyReportContext): TestingSymbolSearch = {
+  )(implicit
+      rc: ReportContext = new EmptyReportContext()
+  ): TestingSymbolSearch = {
     new TestingSymbolSearch(
       ClasspathSearch
         .fromClasspath(myclasspath, ExcludedPackagesHandler.default),

--- a/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
+++ b/tests/mtest/src/main/scala/tests/TestingSymbolSearch.scala
@@ -6,8 +6,6 @@ import java.{util => ju}
 
 import scala.meta.internal.metals.ClasspathSearch
 import scala.meta.internal.metals.Docstrings
-import scala.meta.internal.metals.EmptyReportContext
-import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.metals.WorkspaceSymbolInformation
 import scala.meta.internal.metals.WorkspaceSymbolQuery
 import scala.meta.internal.mtags.GlobalSymbolIndex
@@ -20,6 +18,8 @@ import scala.meta.pc.ParentSymbols
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 import scala.meta.pc.SymbolSearchVisitor
+import scala.meta.pc.reports.EmptyReportContext
+import scala.meta.pc.reports.ReportContext
 
 import org.eclipse.lsp4j.Location
 
@@ -30,11 +30,12 @@ import org.eclipse.lsp4j.Location
  */
 class TestingSymbolSearch(
     classpath: ClasspathSearch = ClasspathSearch.empty,
-    docs: Docstrings = Docstrings.empty(EmptyReportContext),
+    docs: Docstrings = Docstrings.empty(new EmptyReportContext()),
     workspace: TestingWorkspaceSearch =
-      TestingWorkspaceSearch.empty(EmptyReportContext),
-    index: GlobalSymbolIndex = OnDemandSymbolIndex.empty()(EmptyReportContext)
-)(implicit rc: ReportContext = EmptyReportContext)
+      TestingWorkspaceSearch.empty(new EmptyReportContext()),
+    index: GlobalSymbolIndex =
+      OnDemandSymbolIndex.empty()(new EmptyReportContext())
+)(implicit rc: ReportContext = new EmptyReportContext())
     extends SymbolSearch {
 
   override def documentation(

--- a/tests/mtest/src/main/scala/tests/TestingWorkspaceSearch.scala
+++ b/tests/mtest/src/main/scala/tests/TestingWorkspaceSearch.scala
@@ -6,21 +6,23 @@ import scala.collection.mutable
 
 import scala.meta.Dialect
 import scala.meta.inputs.Input
-import scala.meta.internal.metals.EmptyReportContext
-import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.metals.SemanticdbDefinition
 import scala.meta.internal.metals.WorkspaceSymbolInformation
 import scala.meta.internal.metals.WorkspaceSymbolQuery
 import scala.meta.internal.mtags.ScalametaCommonEnrichments.XtensionWorkspaceSymbolQuery
 import scala.meta.pc.SymbolSearchVisitor
+import scala.meta.pc.reports.EmptyReportContext
+import scala.meta.pc.reports.ReportContext
 
 object TestingWorkspaceSearch {
   def empty(implicit
-      rc: ReportContext = EmptyReportContext
+      rc: ReportContext = new EmptyReportContext()
   ): TestingWorkspaceSearch = new TestingWorkspaceSearch
 }
 
-class TestingWorkspaceSearch(implicit rc: ReportContext = EmptyReportContext) {
+class TestingWorkspaceSearch(implicit
+    rc: ReportContext = new EmptyReportContext()
+) {
   val inputs: mutable.Map[String, (String, Dialect)] =
     mutable.Map.empty[String, (String, Dialect)]
   def search(


### PR DESCRIPTION
Previously: we would create a new report context in the presentation compiler.
After this PR: report context is passed to the presentation compiler from outside. This has to benefits:
  1. Sharing an instance of report context, means that we can track data in memory, e.g. how many reports for a specific file were created (needed for: https://github.com/scalameta/metals/issues/7384). Alternatively we could add ask pc about this, which might be error prone if pc was killed.
  2. We can add actions unavailable in pc to report context, e.g. sending a notification to the client.