### PR TITLE
feat: read the Mill version from YAML frontmatter of the buildfile

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -65,7 +65,9 @@ case class MillBuildTool(
 
   private val yamlMillVersionPattern = "//[|] +mill-version: +([^ ]+) *$".r
 
-  def readMillVersionYamlFrontmatter(file: AbsolutePath): Option[String] =
+  private def readMillVersionYamlFrontmatter(
+      file: AbsolutePath
+  ): Option[String] =
     file match {
       case f if f.isFile =>
         Files

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -2,13 +2,13 @@ package scala.meta.internal.builds
 import java.nio.file.Files
 import java.nio.file.Path
 
+import scala.jdk.CollectionConverters._
 import scala.util.Properties
 
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
-import scala.jdk.CollectionConverters._
 
 case class MillBuildTool(
     userConfig: () => UserConfiguration,

--- a/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MillBuildTool.scala
@@ -63,7 +63,7 @@ case class MillBuildTool(
 
   }
 
-  private val usingMillVersionPattern = "//[|] +mill-version: +([^ ]+) *$".r
+  private val yamlMillVersionPattern = "//[|] +mill-version: +([^ ]+) *$".r
 
   def readMillVersionYamlFrontmatter(file: AbsolutePath): Option[String] =
     file match {
@@ -72,7 +72,7 @@ case class MillBuildTool(
           .readAllLines(f.toNIO)
           .asScala
           .takeWhile(_.startsWith("//|"))
-          .collectFirst { case usingMillVersionPattern(version) =>
+          .collectFirst { case yamlMillVersionPattern(version) =>
             version
           }
       case _ => None

--- a/tests/unit/src/test/scala/tests/MillVersionSuite.scala
+++ b/tests/unit/src/test/scala/tests/MillVersionSuite.scala
@@ -41,6 +41,13 @@ class MillVersionSuite extends BaseSuite {
   )
 
   check(
+    """|build.mill
+       |//| mill-version: 0.13.0-M1-jvm
+       |""".stripMargin,
+    "0.13.0-M1",
+  )
+
+  check(
     """|mill
        |#!/usr/bin/env sh
        |


### PR DESCRIPTION
With Mill 0.13/1.0, Mill support YAML frontmatter to configure the preferred Mill version.

```scala
//| mill-version: 1.0.0
```

This pull request add support for reading the Mill version from the YAML frontmatter in the main build script.

This change maintains the following precedence rules:

1. if exists, read `.mill-version`
2. if exists, read `.config/mill-version`
3. if exists, read YAML frontmatter of `build.mill`
4. if exists, read YAML frontmatter of `build.mill.scala`
5. if exists, read YAML frontmatter of `build.sc`
6. if exists, parse the `DEFAULT_MILL_VERSION` attribute from a local `mill` script

(Steps 3-5 are newly added in this PR.)

Additional, the `-jvm` suffix is stripped from the version, since it is used to denote, that Mill should not attempt to use a native launcher.

The automated unit tests checking proper version parsing was extended to cover the YAML parsing accordingly.

