### PR TITLE
fix: don't remove non-existent entries from classpath

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -1065,7 +1065,6 @@ object MetalsEnrichments
     def toAbsoluteClasspath: Iterator[AbsolutePath] = {
       classpath.iterator
         .map(_.toAbsolutePath)
-        .filter(p => Files.exists(p.toNIO))
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -424,7 +424,7 @@ abstract class MetalsLspService(
     )
   )
 
-  protected val compilers: Compilers = register(
+  val compilers: Compilers = register(
     new Compilers(
       folder,
       clientConfig,

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -124,6 +124,9 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
   var quickPickHandler: MetalsQuickPickParams => RawMetalsQuickPickResult = {
     (_: MetalsQuickPickParams) => RawMetalsQuickPickResult(cancelled = true)
   }
+  var onMetalsStatus: MetalsStatusParams => Unit = { (_: MetalsStatusParams) =>
+    ()
+  }
 
   private val refreshCount = new AtomicInteger
   var refreshModelHandler: Int => Unit = (_) => ()
@@ -425,7 +428,7 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
 
   override def metalsStatus(params: MetalsStatusParams): Unit = {
     statusParams.add(params)
-
+    onMetalsStatus(params)
   }
 
   override def createProgress(


### PR DESCRIPTION
I run into this issue in https://github.com/scalameta/metals/pull/7440 with Mill tests.

If presentation compiler was before compilation finished and `<...>.dest` folder was created,
these entries would be removed from the classpath leading to incorrect classpath passed to the presentation compiler.