### PR TITLE
bugfix: Don't use unsafe alternatives method which can throw

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -618,7 +618,7 @@ class MetalsGlobal(
                 case Descriptor.Method(value, _) =>
                   owner.info
                     .decl(TermName(value).encode)
-                    .alternatives
+                    .safeAlternatives
                     .iterator
                     .filter(sym => semanticdbSymbol(sym) == s)
                     .toList
@@ -868,6 +868,18 @@ class MetalsGlobal(
   }
 
   implicit class XtensionSymbolMetals(sym: Symbol) {
+
+    def safeAlternatives: List[Symbol] = {
+      if (sym == NoSymbol) Nil
+      else {
+        sym.info match {
+          case overloadedType: OverloadedType => overloadedType.alternatives
+          case _ if sym.isOverloaded => Nil
+          case _ => sym.alternatives
+        }
+      }
+    }
+
     def isLocallyDefined: Boolean =
       sym.ownersIterator
         .drop(1)

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala
@@ -130,7 +130,7 @@ class PcDefinitionProvider(val compiler: MetalsGlobal, params: OffsetParams) {
       val adjusted = namePos.adjust(unit.source.content)._1
       List(new Location(params.uri().toString(), adjusted.toLsp))
     } else {
-      symbol.alternatives
+      symbol.safeAlternatives
         .map(semanticdbSymbol)
         .sorted
         .flatMap { sym =>

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -160,12 +160,12 @@ class SignatureHelpProvider(val compiler: MetalsGlobal)(implicit
         case o: ModuleSymbol =>
           o.info
             .member(compiler.nme.apply)
-            .alternatives
+            .safeAlternatives
             .map(alt => alt -> qual.tpe.memberType(alt))
         case o: ClassSymbol =>
           o.info
             .member(compiler.termNames.CONSTRUCTOR)
-            .alternatives
+            .safeAlternatives
             .map(alt => alt -> alt.tpe)
         case m: MethodSymbol if !m.isLocalToBlock =>
           val recieverTpe = qual match {
@@ -174,10 +174,10 @@ class SignatureHelpProvider(val compiler: MetalsGlobal)(implicit
           }
           recieverTpe
             .member(symbol.name)
-            .alternatives
+            .safeAlternatives
             .map(alt => alt -> recieverTpe.memberType(alt))
         case _ =>
-          symbol.alternatives.map(alt => alt -> alt.tpe)
+          symbol.safeAlternatives.map(alt => alt -> alt.tpe)
       }
 
     def nonOverload: Symbol =

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -837,7 +837,7 @@ trait Completions { this: MetalsGlobal =>
       definitions.PredefModule,
       TermName("valueOf")
     )
-  ).flatMap(_.alternatives)
+  ).flatMap(_.safeAlternatives)
 
   lazy val renameConfig: collection.Map[Symbol, Name] =
     metalsConfig


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/7453

alternatives makes a case on OverloadedType, which seems to fail sometimes