### PR TITLE
feat: Produce diagnostics for errors in sbt files

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
@@ -18,6 +18,7 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.parsing.BloopDiagnosticsParser
 import scala.meta.internal.process.ExitCodes
 import scala.meta.io.AbsolutePath
 
@@ -66,6 +67,11 @@ final class BloopInstall(
       javaHome: Option[String],
   ): CancelableFuture[WorkspaceLoadedStatus] = {
     persistChecksumStatus(Status.Started, buildTool)
+    val buffer = scala.collection.mutable.ArrayBuffer.empty[String]
+    val errorHandler = (x: String) => {
+      buffer.append(x)
+      scribe.error(x)
+    }
     val processFuture = shellRunner
       .run(
         s"${buildTool.executableName} bloopInstall",
@@ -80,11 +86,18 @@ final class BloopInstall(
           "METALS_ENABLED" -> "true",
           "SCALAMETA_VERSION" -> BuildInfo.semanticdbVersion,
         ) ++ sys.env,
+        processErr = errorHandler,
       )
       .map {
         case ExitCodes.Success => WorkspaceLoadedStatus.Installed
         case ExitCodes.Cancel => WorkspaceLoadedStatus.Cancelled
         case result => WorkspaceLoadedStatus.Failed(result)
+      }
+      .map { value =>
+        BloopDiagnosticsParser
+          .getDiagnosticsFromErrors(buffer.toArray)
+          .foreach(languageClient.publishDiagnostics)
+        value
       }
     processFuture.future.foreach { result =>
       try result.toChecksumStatus.foreach(persistChecksumStatus(_, buildTool))

--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -65,6 +65,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
 import org.eclipse.lsp4j.{Position => LspPosition}
 import org.eclipse.lsp4j.{Range => LspRange}
 import org.eclipse.lsp4j.{debug => d}
+import org.eclipse.lsp4j.DiagnosticSeverity
 
 /**
  * Manages lifecycle for presentation compilers in all build targets.
@@ -260,15 +261,39 @@ class Compilers(
           AdjustedLspData.default,
         )
 
+        val (prependedLinesSize, modifiedText) = Option
+          .when(path.isSbt)(
+            buildTargets
+              .sbtAutoImports(path)
+          )
+          .flatten
+          .fold((0, input.value))(imports =>
+            (
+              imports.size,
+              SbtBuildTool.prependAutoImports(input.value, imports),
+            )
+          )
+
         outlineFilesProvider.didChange(pc.buildTargetId(), path)
 
         for {
           ds <-
             pc
               .didChange(
-                CompilerVirtualFileParams(path.toNIO.toUri(), input.value)
+                CompilerVirtualFileParams(path.toNIO.toUri, modifiedText)
               )
               .asScala
+              .map(diagnosticsList => {
+                diagnosticsList.forEach(diagnostic => {
+                  val range = diagnostic.getRange
+                  val start = range.getStart
+                  val end = range.getEnd
+                  start.setLine(start.getLine - prependedLinesSize)
+                  end.setLine(end.getLine - prependedLinesSize)
+                  diagnostic.setSeverity(DiagnosticSeverity.Error)
+                })
+                diagnosticsList
+              })
         } yield {
           ds.asScala.map(adjust.adjustDiagnostic).toList
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -187,6 +187,7 @@ final class Diagnostics(
       path: AbsolutePath,
       diagnostics: Seq[Diagnostic],
       isReset: Boolean,
+      useFreshDiagnostics: Boolean = true,
   ): Unit = {
     val isSamePathAsLastDiagnostic = path == lastPublished.get()
     lastPublished.set(path)
@@ -212,7 +213,7 @@ final class Diagnostics(
     // Notification N: [1, ..., N]
     if (isReset || !isSamePathAsLastDiagnostic) {
       publishDiagnosticsBuffer()
-      publishDiagnostics(path, queue)
+      publishDiagnostics(path, queue, useFreshDiagnostics)
     } else {
       diagnosticsBuffer.add(path)
     }
@@ -276,13 +277,16 @@ final class Diagnostics(
   private def publishDiagnostics(
       path: AbsolutePath,
       queue: ju.Queue[Diagnostic],
+      useFreshDiagnostics: Boolean = true,
   ): Unit = {
     if (!path.isFile) return didDelete(path)
     val uri = path.toURI.toString
     val all = new ju.ArrayList[Diagnostic](queue.size() + 1)
     for {
       diagnostic <- queue.asScala
-      freshDiagnostic <- toFreshDiagnostic(path, diagnostic)
+      freshDiagnostic <-
+        if (useFreshDiagnostics) toFreshDiagnostic(path, diagnostic)
+        else Some(diagnostic)
     } {
       all.add(freshDiagnostic)
     }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -818,10 +818,18 @@ abstract class MetalsLspService(
       case Some(change) =>
         val path = params.getTextDocument.getUri.toAbsolutePath
         buffers.put(path, change.getText)
-        diagnostics.didChange(path)
-        compilers.didChange(path)
+        val didChangeDiagnostics = compilers.didChange(path)
+        val result = didChangeDiagnostics.map(r =>
+          diagnostics.onPublishDiagnostics(
+            path,
+            r,
+            isReset = true,
+            useFreshDiagnostics = false,
+          )
+        )
         referencesProvider.didChange(path, change.getText)
         parseTrees(path).asJava
+        result.asJavaUnit
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/parsing/BloopDiagnosticsParser.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/BloopDiagnosticsParser.scala
@@ -1,0 +1,74 @@
+package scala.meta.internal.parsing
+
+import org.eclipse.lsp4j.{
+  Diagnostic,
+  DiagnosticSeverity,
+  Position,
+  PublishDiagnosticsParams,
+  Range,
+}
+
+import java.nio.file.Paths
+import scala.jdk.CollectionConverters.SeqHasAsJava
+
+case class FileDiagnostic(filepath: String, diagnostic: Diagnostic)
+
+object BloopDiagnosticsParser {
+  def getDiagnosticsFromErrors(
+      errorLines: Array[String]
+  ): Iterable[PublishDiagnosticsParams] = {
+    errorLines
+      .foldLeft(List.empty[Vector[String]]) { case (accumulator, element) =>
+        if (element.startsWith("/")) {
+          accumulator.prepended(Vector(element))
+        } else {
+          accumulator
+            .drop(1)
+            .prepended(
+              accumulator.headOption.fold(Vector(element))(_.prepended(element))
+            )
+        }
+      }
+      .flatMap(errorsR => {
+        val errors = errorsR.reverse
+        for {
+          head <- errors.headOption
+          split = head.split(":", 3)
+          filepath <- split.headOption
+          line1 <- split.lift(1).flatMap(_.toIntOption)
+          line0 = line1 - 1
+          errorText <- split.lift(2).map(_.strip())
+          uriFilepath = Paths.get(filepath).toUri
+
+          pointerIndex = errors.indexWhere(
+            """^\s*\^""".r.findPrefixOf(_).isDefined
+          )
+          (string, errorTextEnriched) =
+            if (pointerIndex != -1)
+              (
+                errors(pointerIndex),
+                (errorText +: errors.slice(1, pointerIndex + 1)).mkString("\n"),
+              )
+            else ("", errorText)
+          startIndex = string.indexOf('^').max(0)
+
+          positionStart = new Position(line0, startIndex)
+          positionEnd = new Position(line0, Integer.MAX_VALUE)
+          range = new Range(positionStart, positionEnd)
+          diagnostic = new Diagnostic(
+            range,
+            errorTextEnriched,
+            DiagnosticSeverity.Error,
+            uriFilepath.toString,
+          )
+        } yield FileDiagnostic(uriFilepath.toString, diagnostic)
+      })
+      .groupBy(_.filepath)
+      .map { case (uriFilepath, diagnostics) =>
+        new PublishDiagnosticsParams(
+          uriFilepath,
+          diagnostics.map(_.diagnostic).asJava,
+        )
+      }
+  }
+}

--- a/mtags/src/main/scala-2.11/scala/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.11/scala/meta/internal/pc/Compat.scala
@@ -2,6 +2,7 @@ package scala.meta.internal.pc
 
 import scala.tools.nsc.reporters.Reporter
 import scala.tools.nsc.reporters.StoreReporter
+import scala.tools.nsc.Settings
 
 import scala.meta.pc.OutlineFiles
 
@@ -17,6 +18,9 @@ trait Compat { this: MetalsGlobal =>
       case s: StoreReporter => Some(s)
       case _ => None
     }
+
+  def storeReporterConstructor(settings: Settings): StoreReporter =
+    new StoreReporter
 
   def isAliasCompletion(m: Member): Boolean = false
 

--- a/mtags/src/main/scala-2.12/scala/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.12/scala/meta/internal/pc/Compat.scala
@@ -8,6 +8,7 @@ import scala.tools.nsc.reporters.StoreReporter
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.pc.OutlineFiles
 import scala.meta.pc.VirtualFileParams
+import scala.tools.nsc.Settings
 
 trait Compat { this: MetalsGlobal =>
   def metalsFunctionArgTypes(tpe: Type): List[Type] =
@@ -18,6 +19,9 @@ trait Compat { this: MetalsGlobal =>
       case s: StoreReporter => Some(s)
       case _ => None
     }
+
+  def storeReporterConstructor(settings: Settings): StoreReporter =
+    new StoreReporter(settings)
 
   def isAliasCompletion(m: Member): Boolean = false
 

--- a/mtags/src/main/scala-2.13/scala/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.13/scala/meta/internal/pc/Compat.scala
@@ -8,6 +8,7 @@ import scala.tools.nsc.reporters.StoreReporter
 import scala.meta.internal.jdk.CollectionConverters._
 import scala.meta.pc.OutlineFiles
 import scala.meta.pc.VirtualFileParams
+import scala.tools.nsc.Settings
 
 trait Compat { this: MetalsGlobal =>
   def metalsFunctionArgTypes(tpe: Type): List[Type] =
@@ -20,6 +21,8 @@ trait Compat { this: MetalsGlobal =>
       case s: StoreReporter => Some(s)
       case _ => None
     }
+  def storeReporterConstructor(settings: Settings): StoreReporter =
+    new StoreReporter(settings)
 
   def isAliasCompletion(m: Member): Boolean = m match {
     case tm: TypeMember => tm.aliasInfo.nonEmpty

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -45,15 +45,20 @@ import scala.meta.pc.reports.EmptyReportContext
 import scala.meta.pc.reports.ReportContext
 import scala.meta.pc.{PcSymbolInformation => IPcSymbolInformation}
 
-import org.eclipse.lsp4j.CompletionItem
-import org.eclipse.lsp4j.CompletionList
-import org.eclipse.lsp4j.Diagnostic
-import org.eclipse.lsp4j.DocumentHighlight
-import org.eclipse.lsp4j.InlayHint
-import org.eclipse.lsp4j.Range
-import org.eclipse.lsp4j.SelectionRange
-import org.eclipse.lsp4j.SignatureHelp
-import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j.{
+  CompletionItem,
+  CompletionList,
+  Diagnostic,
+  DocumentHighlight,
+  InlayHint,
+  Position,
+  Range,
+  SelectionRange,
+  SignatureHelp,
+  TextEdit
+}
+
+import scala.reflect.internal.util.RangePosition
 
 case class ScalaPresentationCompiler(
     buildTargetIdentifier: String = "",
@@ -168,10 +173,51 @@ case class ScalaPresentationCompiler(
     )
   }
 
+  private def collectDiagnosticsPC(
+      pc: CompilerWrapper[StoreReporter, MetalsGlobal],
+      params: VirtualFileParams
+  ): ju.List[Diagnostic] = {
+    val unit = new TypeCheckCompilationUnit(pc.compiler(params), params)
+    val infos = unit.getInfos
+    infos
+      .flatMap(info =>
+        info.pos match {
+          case range: RangePosition =>
+            val source = range.source
+
+            val lineStart = source.offsetToLine(range.start)
+            val characterStart = range.start - source.lineToOffset(lineStart)
+
+            val lineEnd = source.offsetToLine(range.end)
+            val characterEnd = range.end - source.lineToOffset(lineEnd)
+
+            Some(
+              new Diagnostic(
+                new Range(
+                  new Position(lineStart, characterStart),
+                  new Position(lineEnd, characterEnd)
+                ),
+                info.msg
+              )
+            )
+          case _ => None
+        }
+      )
+      .toList
+      .asJava
+  }
+
   override def didChange(
       params: VirtualFileParams
   ): CompletableFuture[ju.List[Diagnostic]] = {
-    CompletableFuture.completedFuture(Nil.asJava)
+    if (params.uri().toAbsolutePath.isSbt) {
+      compilerAccess.withNonInterruptableCompiler(
+        List.empty[Diagnostic].asJava,
+        params.token
+      )(collectDiagnosticsPC(_, params))(params.toQueryContext)
+    } else {
+      CompletableFuture.completedFuture(List.empty.asJava)
+    }
   }
 
   def didClose(uri: URI): Unit = {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/TypeCheckCompilationUnit.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/TypeCheckCompilationUnit.scala
@@ -1,0 +1,33 @@
+package scala.meta.internal.pc
+
+import scala.meta.pc.{OffsetParams, VirtualFileParams}
+
+class TypeCheckCompilationUnit(
+    val compiler: MetalsGlobal,
+    val params: VirtualFileParams
+) {
+  import compiler._
+  val unit: RichCompilationUnit = addCompilationUnit(
+    code = params.text(),
+    filename = params.uri().toString,
+    cursor = None
+  )
+  val offset: Int = params match {
+    case p: OffsetParams => p.offset()
+    case _: VirtualFileParams => 0
+  }
+  val pos: Position = unit.position(offset)
+  lazy val text = unit.source.content
+
+  private val previousReporter = reporter
+
+  private val console = storeReporterConstructor(settings)
+  reporter = console
+  typeCheck(unit)
+
+  reporter = previousReporter
+
+  def getInfos = {
+    console.infos.toSet
+  }
+}

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -240,10 +240,13 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
   def workspaceMessageRequests: String = {
     messageRequests.asScala.mkString("\n")
   }
-  def pathDiagnostics(filename: String): String = {
-    pathDiagnostics(toPath(filename))
+  def pathDiagnostics(
+      filename: String,
+      formatMessage: Boolean = true,
+  ): String = {
+    pathDiagnostics(toPath(filename), formatMessage)
   }
-  def pathDiagnostics(path: AbsolutePath): String = {
+  def pathDiagnostics(path: AbsolutePath, formatMessage: Boolean): String = {
     val isDeleted = !path.isFile
     val diags = diagnostics.getOrElse(path, Nil).sortBy(_.getRange)
     val relpath =
@@ -259,7 +262,8 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
       }
     val sb = new StringBuilder
     diags.foreach { diag =>
-      val message = diag.formatMessage(input)
+      val message =
+        if (formatMessage) diag.formatMessage(input) else diag.getMessage
       sb.append(message).append("\n")
     }
     sb.toString()
@@ -275,7 +279,7 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
   }
   def workspaceDiagnostics: String = {
     val paths = diagnostics.keys.toList.sortBy(_.toURI.toString)
-    paths.map(pathDiagnostics).mkString
+    paths.map(pathDiagnostics(_, formatMessage = true)).mkString
   }
 
   override def registerCapability(


### PR DESCRIPTION
This PR introduces enhanced diagnostics for .sbt files:
1. After bloopInstall, by parsing error message from sbt
![bloopInstall_example](https://github.com/user-attachments/assets/e0121226-67c1-4680-bbb2-0e769fea6903)

2. After any change to .sbt files, by using presentation compiler in didChange callback
![PC_example-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/86378aab-270c-45ac-8821-2055a02a8006)
