### PR TITLE
fix: uri in mcp inspect for Scala 3

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -236,6 +236,7 @@ class ProjectMetalsLspService(
       referencesProvider,
       scalaVersionSelector,
       mcpSearch,
+      folder,
     )
 
   lazy val mcpTestRunner =

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpQueryEngine.scala
@@ -30,6 +30,7 @@ class McpQueryEngine(
     referenceProvider: ReferenceProvider,
     scalaVersionSelector: ScalaVersionSelector,
     mcpSearch: McpSymbolSearch,
+    workspace: AbsolutePath,
 )(implicit ec: ExecutionContext) {
   private val mcpDefinitionProvider =
     new McpSymbolProvider(scalaVersionSelector, mcpSearch)
@@ -76,7 +77,12 @@ class McpQueryEngine(
       symbol <- mcpDefinitionProvider
         .symbols(fqcn, Some(path))
         .distinctBy(_.symbolType)
-    } yield McpInspectProvider.inspect(compilers, symbol, buildTarget)
+    } yield McpInspectProvider.inspect(
+      compilers,
+      workspace,
+      symbol,
+      buildTarget,
+    )
 
     Future.sequence(results).map(_.flatten)
   }


### PR DESCRIPTION
Previously `inspect` would fail for Scala 3.
```Scala
java.base/java.nio.file.Path.of(Path.java:199)
	java.base/java.nio.file.Paths.get(Paths.java:98)
	dotty.tools.dotc.util.SourceFile$.virtual(SourceFile.scala:232)
	dotty.tools.pc.SignatureHelpProvider$.signatureHelp(SignatureHelpProvider.scala:30)
	dotty.tools.pc.ScalaPresentationCompiler.signatureHelp$$anonfun$1(ScalaPresentationCompiler.scala:479)
```