### PR TITLE
fix: add alternative vscode editor names

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpConfig.scala
@@ -87,7 +87,7 @@ object McpConfig {
 }
 
 case class Editor(
-    name: String,
+    names: List[String],
     settingsPath: String,
     serverField: String,
     additionalProperties: List[(String, String)],
@@ -95,7 +95,12 @@ case class Editor(
 
 object VSCodeEditor
     extends Editor(
-      name = "Visual Studio Code",
+      names = List(
+        "Visual Studio Code",
+        "Visual Studio Code - Insiders",
+        "VSCodium",
+        "VSCodium - Insiders",
+      ),
       settingsPath = ".vscode/",
       serverField = "servers",
       additionalProperties = List(
@@ -105,7 +110,7 @@ object VSCodeEditor
 
 object CursorEditor
     extends Editor(
-      name = "Cursor",
+      names = List("Cursor"),
       settingsPath = ".cursor/",
       serverField = "mcpServers",
       additionalProperties = Nil,

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
@@ -176,7 +176,7 @@ class MetalsMcpServer(
     val deployment = manager.addDeployment(servletDeployment)
     deployment.deploy()
 
-    val editor = Editor.allEditors.find(_.name == editorName)
+    val editor = Editor.allEditors.find(_.names.contains(editorName))
     val configPort =
       editor.flatMap(e => McpConfig.readPort(projectPath, projectName, e))
     val undertowServer = Undertow


### PR DESCRIPTION
Brought up on Discord, config for VSCode MCP should also be created for other VSCodium distribution and insider versions.