### PR TITLE
fix: MCP test tool runs properly if `verbose` argument is not provided

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
@@ -333,7 +333,9 @@ class MetalsMcpServer(
         val optPath = arguments
           .getOptAs[String]("testFile")
           .map(path => AbsolutePath(Path.of(path))(projectPath))
-        val printOnlyErrorsAndSummary = arguments.getAs[Boolean]("verbose")
+        val printOnlyErrorsAndSummary = arguments
+          .getOptAs[Boolean]("verbose")
+          .getOrElse(false)
         val result = mcpTestRunner.runTests(
           testClass,
           optPath,


### PR DESCRIPTION
Fixes #7469 