### PR TITLE
fix: indexer bug around type members

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ScalaToplevelMtags.scala
@@ -803,7 +803,7 @@ class ScalaToplevelMtags(
             isAfterEq: Boolean = false
         ): Option[String] = {
           curr.token match {
-            case SEMI => name
+            case SEMI | RBRACE => name
             case _ if isNewline | isDone => name
             case EQUALS =>
               scanner.mtagsNextToken()

--- a/tests/input/src/main/scala/example/TypeMembers.scala
+++ b/tests/input/src/main/scala/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+package example
+
+trait TypeMembers { type TypeMember }
+
+object AfterTrait

--- a/tests/unit/src/test/resources/definition-scala3/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/definition-scala3/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+package example
+
+trait TypeMembers/*TypeMembers.scala*/ { type TypeMember/*TypeMembers.scala*/ }
+
+object AfterTrait/*TypeMembers.scala*/

--- a/tests/unit/src/test/resources/definition/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/definition/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+package example
+
+trait TypeMembers/*TypeMembers.scala*/ { type TypeMember/*TypeMembers.scala*/ }
+
+object AfterTrait/*TypeMembers.scala*/

--- a/tests/unit/src/test/resources/documentSymbol-scala3/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/documentSymbol-scala3/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+/*example(Package):5*/package example
+
+/*example.TypeMembers(Interface):3*/trait TypeMembers { /*example.TypeMembers#TypeMember(TypeParameter):3*/type TypeMember }
+
+/*example.AfterTrait(Module):5*/object AfterTrait

--- a/tests/unit/src/test/resources/documentSymbol/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/documentSymbol/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+/*example(Package):5*/package example
+
+/*example.TypeMembers(Interface):3*/trait TypeMembers { /*example.TypeMembers#TypeMember(TypeParameter):3*/type TypeMember }
+
+/*example.AfterTrait(Module):5*/object AfterTrait

--- a/tests/unit/src/test/resources/expect/toplevels-scala3.expect
+++ b/tests/unit/src/test/resources/expect/toplevels-scala3.expect
@@ -46,6 +46,8 @@ example/ToplevelImplicit.scala -> example/ToplevelImplicit$package.Xtension#
 example/ToplevelImplicit.scala -> example/ToplevelImplicit$package.XtensionAnyVal#
 example/TryCatch.scala -> example/TryCatch#
 example/TypeEnum.scala -> example/TypeEnum#
+example/TypeMembers.scala -> example/AfterTrait.
+example/TypeMembers.scala -> example/TypeMembers#
 example/TypeParameters.scala -> example/TypeParameters#
 example/VarArgs.scala -> example/VarArgs#
 example/Vars.scala -> example/Vars.

--- a/tests/unit/src/test/resources/expect/toplevels.expect
+++ b/tests/unit/src/test/resources/expect/toplevels.expect
@@ -27,6 +27,8 @@ example/ReflectiveInvocation.scala -> example/ReflectiveInvocation#
 example/Scalalib.scala -> example/Scalalib#
 example/StructuralTypes.scala -> example/StructuralTypes.
 example/TryCatch.scala -> example/TryCatch#
+example/TypeMembers.scala -> example/AfterTrait.
+example/TypeMembers.scala -> example/TypeMembers#
 example/TypeParameters.scala -> example/TypeParameters#
 example/VarArgs.scala -> example/VarArgs#
 example/Vars.scala -> example/Vars.

--- a/tests/unit/src/test/resources/inlayHints/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/inlayHints/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+package example
+
+trait TypeMembers { type TypeMember }
+
+object AfterTrait

--- a/tests/unit/src/test/resources/inlayHints3/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/inlayHints3/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+package example
+
+trait TypeMembers { type TypeMember }
+
+object AfterTrait

--- a/tests/unit/src/test/resources/mtags-scala3/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/mtags-scala3/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+package example
+
+trait TypeMembers/*example.TypeMembers#*/ { type TypeMember/*example.TypeMembers#TypeMember#*/ }
+
+object AfterTrait/*example.AfterTrait.*/

--- a/tests/unit/src/test/resources/mtags/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/mtags/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+package example
+
+trait TypeMembers/*example.TypeMembers#*/ { type TypeMember/*example.TypeMembers#TypeMember#*/ }
+
+object AfterTrait/*example.AfterTrait.*/

--- a/tests/unit/src/test/resources/semanticTokens/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/semanticTokens/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+<<package>>/*keyword*/ <<example>>/*namespace*/
+
+<<trait>>/*keyword*/ <<TypeMembers>>/*interface,abstract*/ { <<type>>/*keyword*/ <<TypeMember>>/*type,declaration,abstract*/ }
+
+<<object>>/*keyword*/ <<AfterTrait>>/*class*/

--- a/tests/unit/src/test/resources/semanticTokens3/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/semanticTokens3/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+<<package>>/*keyword*/ <<example>>/*namespace*/
+
+<<trait>>/*keyword*/ <<TypeMembers>>/*interface,abstract*/ { <<type>>/*keyword*/ <<TypeMember>>/*type,definition,abstract*/ }
+
+<<object>>/*keyword*/ <<AfterTrait>>/*class*/

--- a/tests/unit/src/test/resources/semanticdb-scala3/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/semanticdb-scala3/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+package example
+
+trait TypeMembers/*example.TypeMembers#*/ { type TypeMember/*example.TypeMembers#TypeMember#*/ }
+
+object AfterTrait/*example.AfterTrait.*/

--- a/tests/unit/src/test/resources/semanticdb/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/semanticdb/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+package example
+
+trait TypeMembers/*example.TypeMembers#*/ { type TypeMember/*example.TypeMembers#TypeMember#*/ }
+
+object AfterTrait/*example.AfterTrait.*/

--- a/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner-scala3/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+package example
+
+trait TypeMembers/*example.TypeMembers#*/ { type TypeMember }
+
+object AfterTrait/*example.AfterTrait.*/

--- a/tests/unit/src/test/resources/toplevel-with-inner/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/toplevel-with-inner/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+package example
+
+trait TypeMembers/*example.TypeMembers#*/ { type TypeMember }
+
+object AfterTrait/*example.AfterTrait.*/

--- a/tests/unit/src/test/resources/workspace-symbol/example/TypeMembers.scala
+++ b/tests/unit/src/test/resources/workspace-symbol/example/TypeMembers.scala
@@ -1,0 +1,5 @@
+package example
+
+trait TypeMembers/*example.TypeMembers#*/ { type TypeMember/*example.TypeMembers#TypeMember#*/ }
+
+object AfterTrait/*example.AfterTrait.*/

--- a/tests/unit/src/test/scala/tests/SaveExpect.scala
+++ b/tests/unit/src/test/scala/tests/SaveExpect.scala
@@ -11,6 +11,8 @@ object SaveExpect {
       new MtagsScala3Suite,
       new ToplevelsScala2Suite,
       new ToplevelsScala3Suite,
+      new ToplevelWithInnerScala2Suite,
+      new ToplevelWithInnerScala3Suite,
       new DocumentSymbolScala2Suite,
       new DocumentSymbolScala3Suite,
       new FoldingRangeScala2Suite,


### PR DESCRIPTION
When a `type A` member was immediately followed by a closing brace (closing a surrounding scope), the indexer would swallow the closing brace while scanning the member. This would cause the rest of the file to be interpreted as though that closing brace was missing.

Fixes #7475