### PR TITLE
feature: Add scalafix imports rules for completions, quickfix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -226,7 +226,8 @@ lazy val interfaces = project
     ),
     crossPaths := false,
     libraryDependencies ++= List(
-      V.lsp4j
+      V.lsp4j,
+      "ch.epfl.scala" % "scalafix-interfaces" % V.scalafix,
     ),
     javacOptions := Seq("--release", "8"),
     crossVersion := CrossVersion.disabled,

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -10,6 +10,11 @@ import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
 import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions
 import org.eclipse.lsp4j.FileSystemWatcher
 import org.eclipse.lsp4j.jsonrpc.messages.Either
+import metaconfig._
+import metaconfig.generic._
+import scala.reflect.ClassTag
+import scala.meta.Importer
+import scala.util.matching.Regex
 
 object Configs {
 
@@ -115,5 +120,4 @@ object Configs {
       )
     }
   }
-
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -444,6 +444,7 @@ abstract class MetalsLspService(
       sourceMapper,
       worksheetProvider,
       () => referencesProvider,
+      () => scalafixProvider,
     )
   )
 

--- a/metals/src/main/scala/scala/meta/internal/metals/PresentationCompilerClassLoader.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/PresentationCompilerClassLoader.scala
@@ -15,6 +15,7 @@ class PresentationCompilerClassLoader(parent: ClassLoader)
       name.startsWith("org.eclipse.lsp4j") ||
         name.startsWith("com.google.gson") ||
         name.startsWith("scala.meta.pc") ||
+        name.startsWith("scalafix") ||
         name.startsWith("javax")
     if (isShared) {
       parent.loadClass(name)

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -574,12 +574,13 @@ case class ScalafixProvider(
     }
   }
 
-  private def getScalafix(
+  def getScalafix(
       scalaVersion: ScalaVersion
   ): Future[Scalafix] = Future {
     scalafixCache.getOrElseUpdate(
       scalaVersion, {
         workDoneProgress.trackBlocking("Downloading scalafix") {
+          scribe.info(s"GET SCALAFIX")
           val scalafix =
             if (scalaVersion.startsWith("2.11")) scala211Fallback
             else
@@ -633,6 +634,7 @@ case class ScalafixProvider(
             Embedded.rulesClasspath(
               rulesDependencies.toList ++ organizeImportRule
             )
+          scribe.info(s"RULE CLASSLOADER: ${paths}")
           val classloader = Embedded.toClassLoader(
             Classpath(paths.map(AbsolutePath(_))),
             scalafixClassLoader,
@@ -712,6 +714,9 @@ object ScalafixProvider {
       userConfig: UserConfiguration,
       rules: List[String],
   ): Set[Dependency] = {
+    scribe.info(
+      s"here is scalafixRulesDependencies: ${userConfig.scalafixRulesDependencies}"
+    )
     val fromSettings =
       userConfig.scalafixRulesDependencies.flatMap { dependencyString =>
         Try {

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
+import scalafix.interfaces.imports.OrganizeImportsDirect;
 /**
  * The public API of the presentation compiler.
  *
@@ -305,6 +306,10 @@ public abstract class PresentationCompiler {
 	 * Provide CompletionItemPriority for additional sorting completion items.
 	 */
 	public PresentationCompiler withCompletionItemPriority(CompletionItemPriority priority) {
+		return this;
+	}
+
+	public PresentationCompiler withOrganizeImports(OrganizeImportsDirect organize) {
 		return this;
 	}
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/AutoImports.scala
@@ -52,11 +52,13 @@ trait AutoImports { this: MetalsGlobal =>
               .lastOption
             val padTop = lastImportOpt.isEmpty
             val lastImportOrPkg = lastImportOpt.getOrElse(pkg.pid)
-            new AutoImportPosition(
-              pos.source.lineToOffset(lastImportOrPkg.pos.focusEnd.line),
-              text,
-              padTop
-            )
+            val aipos =
+              new AutoImportPosition(
+                pos.source.lineToOffset(lastImportOrPkg.pos.focusEnd.line),
+                text,
+                padTop
+              )
+            aipos
           }
 
         def forScript(isAmmonite: Boolean) = {

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/InferredMethodProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/InferredMethodProvider.scala
@@ -10,6 +10,7 @@ import scala.meta.internal.metals.PcQueryContext
 import scala.meta.pc.OffsetParams
 
 import org.eclipse.lsp4j.TextEdit
+import scalafix.interfaces.imports.OrganizeImportsDirect
 
 /**
  * Tries to calculate edits needed to create a method that will fix missing symbol
@@ -144,7 +145,11 @@ final class InferredMethodProvider(
       // existing symbols in scope, so we just do nothing
       Nil
     case Some(importPosition) =>
-      history.autoImports(pos, importPosition)
+      history.autoImports(
+        pos,
+        importPosition,
+        OrganizeImportsDirect.noopInstance()
+      )
   }
 
   private def prettyType(tpe: Type) =

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/InferredTypeProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/InferredTypeProvider.scala
@@ -8,6 +8,7 @@ import scala.meta.tokens.{Token => T}
 
 import org.eclipse.lsp4j.TextEdit
 import org.eclipse.{lsp4j => l}
+import scalafix.interfaces.imports.OrganizeImportsDirect
 
 /**
  * Tries to calculate edits needed to insert the inferred type annotation
@@ -66,7 +67,11 @@ final class InferredTypeProvider(
         // existing symbols in scope, so we just do nothing
         Nil
       case Some(importPosition) =>
-        history.autoImports(pos, importPosition)
+        history.autoImports(
+          pos,
+          importPosition,
+          OrganizeImportsDirect.noopInstance()
+        )
     }
 
     def prettyType(tpe: Type) =

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -31,6 +31,8 @@ import scala.meta.pc.PresentationCompilerConfig
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.SymbolSearch
 
+import scalafix.interfaces.imports.OrganizeImportsDirect
+
 import org.eclipse.{lsp4j => l}
 
 class MetalsGlobal(
@@ -40,7 +42,8 @@ class MetalsGlobal(
     val buildTargetIdentifier: String,
     val metalsConfig: PresentationCompilerConfig,
     val workspace: Option[Path],
-    val completionItemPriority: CompletionItemPriority
+    val completionItemPriority: CompletionItemPriority,
+    val orgImports: OrganizeImportsDirect
 ) extends Global(settings, reporter)
     with completions.Completions
     with completions.AmmoniteFileCompletions

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/OverrideCompletions.scala
@@ -12,6 +12,7 @@ import scala.meta.internal.pc.MetalsGlobal
 import scala.meta.pc.PresentationCompilerConfig.OverrideDefFormat
 
 import org.eclipse.{lsp4j => l}
+import scalafix.interfaces.imports.OrganizeImportsDirect
 
 trait OverrideCompletions { this: MetalsGlobal =>
 
@@ -289,7 +290,8 @@ trait OverrideCompletions { this: MetalsGlobal =>
             importContext,
             autoImport.offset,
             autoImport.indent,
-            autoImport.padTop
+            autoImport.padTop,
+            OrganizeImportsDirect.noopInstance()
           ),
           details
         )

--- a/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
+++ b/mtags/src/main/scala-3/scala/meta/internal/pc/AutoImports.scala
@@ -137,6 +137,7 @@ object AutoImports:
    * @param indexedContext A context of the position where the autoImport is invoked
    * @param renames A function that returns the name of the given symbol which is renamed on import statement.
    */
+
   class AutoImportsGenerator(
       val pos: SourcePosition,
       importPosition: AutoImportPosition,

--- a/project/V.scala
+++ b/project/V.scala
@@ -44,7 +44,7 @@ object V {
   val sbtBloop = bloop
   val sbtJdiTools = "1.2.0"
   val scalaCli = "1.6.2"
-  val scalafix = "0.14.2"
+  val scalafix = "0.13.0+206-fbeb3345+20250518-1627-SNAPSHOT"
   val scalafmt = "3.7.15"
   val scalameta = "4.13.1.1"
   val scribe = "3.16.0"


### PR DESCRIPTION
This PR introduces support for scalafix imports' rules when using completions and quickfix
![demo](https://github.com/user-attachments/assets/55698bb4-6308-4fd7-be30-e473db274f04)

Motivation
Improve UX reducing manual efforts for passing linter checks in CI.

Have questions about idea in general and implementation methods.
With @dos65 [modify](https://github.com/scalacenter/scalafix/compare/main...dos65:scalafix:org-imports-ide) scalafix codebase to support suggested functionality
