### PR TITLE
fix: encode build target names to include in report file name

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/metals/EncoderDecoder.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/metals/EncoderDecoder.scala
@@ -1,0 +1,46 @@
+package scala.meta.internal.mtags
+
+class EncoderDecoder(escapeChar: Char, unsafeChars: Set[Char]) {
+
+  protected val toEscape: Map[Char, String] =
+    unsafeChars
+      .map(char => char -> (escapeChar + char.toHexString))
+      .toMap
+
+  protected val toDecode: Map[String, Char] =
+    toEscape.map { case (k, v) => v -> k }
+
+  def encode(args: String): String = {
+    args.flatMap { char =>
+      toEscape.getOrElse(char, char.toString())
+    }
+  }
+
+  def decode(args: String): String = {
+    val it = args.iterator
+    var ch: Char = 'a'
+    val buffer = new StringBuilder()
+    while (it.hasNext) {
+      ch = it.next()
+      if (ch == escapeChar) {
+        if (it.hasNext) {
+          val first = it.next()
+          if (it.hasNext) {
+            val second = it.next()
+            val value = s"$escapeChar$first$second"
+            buffer.append(toDecode.getOrElse(value.toLowerCase(), value))
+          } else {
+            buffer.append(escapeChar.toString())
+            buffer.append(first)
+          }
+        } else {
+          buffer.append(ch)
+        }
+
+      } else {
+        buffer.append(ch)
+      }
+    }
+    buffer.toString()
+  }
+}

--- a/mtags/src/main/scala-2/scala/meta/internal/metals/URIEncoderDecoder.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/metals/URIEncoderDecoder.scala
@@ -1,49 +1,11 @@
 package scala.meta.internal.mtags
 
-object URIEncoderDecoder {
-
-  // Some encoding schemes encode `:` (although not the first one as that indicates scheme).
-  // Currently Metals doesn't encode `:` but does decode it
-  private val toEscape: Map[Char, String] =
-    Set('"', '<', '>', '&', '\'', '[', ']', '{', '}', ' ', '+')
-      .map(char => char -> ("%" + char.toHexString))
-      .toMap
-
-  private val toDecode: Map[String, Char] = toEscape.map { case (k, v) =>
-    v -> k
+object URIEncoderDecoder
+    extends EncoderDecoder(
+      '%',
+      Set('"', '<', '>', '&', '\'', '[', ']', '{', '}', ' ', '+')
+    ) {
+  override protected val toDecode: Map[String, Char] = toEscape.map {
+    case (k, v) => v -> k
   } + ("%3a" -> ':')
-
-  def encode(args: String): String = {
-    args.flatMap { char =>
-      toEscape.getOrElse(char, char.toString())
-    }
-  }
-
-  def decode(args: String): String = {
-    val it = args.iterator
-    var ch: Char = 'a'
-    val buffer = new StringBuilder()
-    while (it.hasNext) {
-      ch = it.next()
-      if (ch == '%') {
-        if (it.hasNext) {
-          val first = it.next()
-          if (it.hasNext) {
-            val second = it.next()
-            val value = s"%$first$second"
-            buffer.append(toDecode.getOrElse(value.toLowerCase(), value))
-          } else {
-            buffer.append("%")
-            buffer.append(first)
-          }
-        } else {
-          buffer.append(ch)
-        }
-
-      } else {
-        buffer.append(ch)
-      }
-    }
-    buffer.toString()
-  }
 }


### PR DESCRIPTION
For build target `@//:calculator`, previously we would create:
<img width="649" alt="Screenshot 2025-05-27 at 10 02 27" src="https://github.com/user-attachments/assets/d91db64e-fd6a-45fb-bdec-709c5764d989" />

Now we encode any unsafe chars:
<img width="620" alt="Screenshot 2025-05-27 at 10 24 24" src="https://github.com/user-attachments/assets/aa996021-5f61-4f39-b85c-a90fa0c9f65d" />
