### PR TITLE
Improvement: Support for scalatest feature specs

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
@@ -119,12 +119,14 @@ object ScalatestTestFinder {
         namePrefix: String,
     ): List[TestCaseEntry] =
       stats.flatMap {
-        // format: off
-        //
-        case Term.Apply(appl @ Term.Apply(Term.Name(opName), Lit.String(scenarioName) :: _), _)
-          if AnyFeatureSpec.leafMethods.contains(opName) =>
-        // format: on
-          val testname = s"$namePrefix $scenarioName"
+        case Term.Apply(
+              appl @ Term.Apply(
+                Term.Name(opName),
+                Lit.String(scenarioName) :: _,
+              ),
+              _,
+            ) if AnyFeatureSpec.leafMethods.contains(opName) =>
+          val testname = s"Feature: $namePrefix Scenario: $scenarioName"
           TestCaseEntry(testname, appl.pos.toLsp.toLocation(path.toURI)) :: Nil
 
         case _ =>

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
@@ -294,6 +294,7 @@ object ScalatestStyle {
       AnyFunSpec,
       AnyWordSpec,
       AnyFreeSpec,
+      AnyFeatureSpec,
     )
 
   val baseSymbols: Set[String] = styles.flatMap(_.symbols).toSet
@@ -358,16 +359,16 @@ object ScalatestStyle {
 
   case object AnyFeatureSpec extends ScalatestStyle {
     val symbols: Set[String] = Set(
-      "org/scalatest/freespec/AnyFeatureSpec#",
-      "org/scalatest/freespec/AnyFeatureSpecLike#",
-      "org/scalatest/freespec/AsyncFeatureSpec#",
-      "org/scalatest/freespec/AsyncFeatureSpecLike#",
-      "org/scalatest/freespec/FixtureAnyFeatureSpec#",
-      "org/scalatest/freespec/FixtureAnyFeatureSpecLike#",
-      "org/scalatest/freespec/FixtureAsyncFeatureSpec#",
-      "org/scalatest/freespec/FixtureAsyncFeatureSpecLike#",
+      "org/scalatest/featurespec/AnyFeatureSpec#",
+      "org/scalatest/featurespec/AnyFeatureSpecLike#",
+      "org/scalatest/featurespec/AsyncFeatureSpec#",
+      "org/scalatest/featurespec/AsyncFeatureSpecLike#",
+      "org/scalatest/featurespec/FixtureAnyFeatureSpec#",
+      "org/scalatest/featurespec/FixtureAnyFeatureSpecLike#",
+      "org/scalatest/featurespec/FixtureAsyncFeatureSpec#",
+      "org/scalatest/featurespec/FixtureAsyncFeatureSpecLike#",
     )
-    override val intermediateMethods: Set[String] = Set("Feature", "feature")
-    override val leafMethods: Set[String] = Set("Scenario", "scenario")
+    override val intermediateMethods: Set[String] = Set("Feature")
+    override val leafMethods: Set[String] = Set("Scenario")
   }
 }

--- a/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
@@ -348,7 +348,7 @@ class ScalatestFinderSuite extends FunSuite {
     "any-async-feature-spec",
     """|import org.scalatest.featurespec.AsyncFeatureSpecLike
        |
-       |class FeatureSpec extends AsyncFeatureSpecLike {
+       |class AsyncFeatureSpec extends AsyncFeatureSpecLike {
        |  Feature("A test feature") {
        |    Scenario("A test scenario") {
        |      assert(1 + 1 == 2)
@@ -359,7 +359,7 @@ class ScalatestFinderSuite extends FunSuite {
        |  }
        |}
        |""".stripMargin,
-    FullyQualifiedName("FeatureSpec"),
+    FullyQualifiedName("AsyncFeatureSpec"),
     Set(
       ("A test feature A test scenario", QuickRange(4, 4, 4, 31)),
       ("A test feature Another test scenario", QuickRange(7, 4, 7, 37)),

--- a/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
@@ -338,8 +338,14 @@ class ScalatestFinderSuite extends FunSuite {
        |""".stripMargin,
     FullyQualifiedName("FeatureSpec"),
     Set(
-      ("A test feature A test scenario", QuickRange(4, 4, 4, 31)),
-      ("A test feature Another test scenario", QuickRange(7, 4, 7, 37)),
+      (
+        "Feature: A test feature Scenario: A test scenario",
+        QuickRange(4, 4, 4, 31),
+      ),
+      (
+        "Feature: A test feature Scenario: Another test scenario",
+        QuickRange(7, 4, 7, 37),
+      ),
     ),
     ScalatestStyle.AnyFeatureSpec,
   )
@@ -361,8 +367,14 @@ class ScalatestFinderSuite extends FunSuite {
        |""".stripMargin,
     FullyQualifiedName("AsyncFeatureSpec"),
     Set(
-      ("A test feature A test scenario", QuickRange(4, 4, 4, 31)),
-      ("A test feature Another test scenario", QuickRange(7, 4, 7, 37)),
+      (
+        "Feature: A test feature Scenario: A test scenario",
+        QuickRange(4, 4, 4, 31),
+      ),
+      (
+        "Feature: A test feature Scenario: Another test scenario",
+        QuickRange(7, 4, 7, 37),
+      ),
     ),
     ScalatestStyle.AnyFeatureSpec,
   )

--- a/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
@@ -344,6 +344,29 @@ class ScalatestFinderSuite extends FunSuite {
     ScalatestStyle.AnyFeatureSpec,
   )
 
+  check(
+    "any-async-feature-spec",
+    """|import org.scalatest.featurespec.AsyncFeatureSpecLike
+       |
+       |class FeatureSpec extends AsyncFeatureSpecLike {
+       |  Feature("A test feature") {
+       |    Scenario("A test scenario") {
+       |      assert(1 + 1 == 2)
+       |    }
+       |    Scenario("Another test scenario") {
+       |      assert(2 + 2 == 5)
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+    FullyQualifiedName("FeatureSpec"),
+    Set(
+      ("A test feature A test scenario", QuickRange(4, 4, 4, 31)),
+      ("A test feature Another test scenario", QuickRange(7, 4, 7, 37)),
+    ),
+    ScalatestStyle.AnyFeatureSpec,
+  )
+
   def check(
       name: TestOptions,
       sourceText: String,

--- a/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
@@ -321,6 +321,29 @@ class ScalatestFinderSuite extends FunSuite {
     ScalatestStyle.AnyPropSpec,
   )
 
+  check(
+    "any-feature-spec",
+    """|import org.scalatest.featurespec.AnyFeatureSpec
+       |
+       |class FeatureSpec extends AnyFeatureSpec {
+       |  Feature("A test feature") {
+       |    Scenario("A test scenario") {
+       |      assert(1 + 1 == 2)
+       |    }
+       |    Scenario("Another test scenario") {
+       |      assert(2 + 2 == 5)
+       |    }
+       |  }
+       |}
+       |""".stripMargin,
+    FullyQualifiedName("FeatureSpec"),
+    Set(
+      ("A test feature A test scenario", QuickRange(4, 4, 4, 31)),
+      ("A test feature Another test scenario", QuickRange(7, 4, 7, 37)),
+    ),
+    ScalatestStyle.AnyFeatureSpec,
+  )
+
   def check(
       name: TestOptions,
       sourceText: String,


### PR DESCRIPTION
I'm back again with more updates to the Scalatest Finder. This time I am adding support for Feature specs. 

Let me know if you need any changes to this, I've tried to copy the existing pattern. 