### PR TITLE
fix: blocking user requests in connect

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -85,6 +85,7 @@ class BspConnector(
       workspace: AbsolutePath,
       userConfiguration: () => UserConfiguration,
       shellRunner: ShellRunner,
+      createSession: () => Unit
   )(implicit ec: ExecutionContext): Future[Option[BspSession]] = {
     val projectRoot = buildTool
       .map(_.projectRoot)
@@ -207,13 +208,9 @@ class BspConnector(
               )
             _ = tables.buildServers.chooseServer(item.getName())
             _ = optSetBuildTool(item.getName())
-            conn <- bspServers.newServer(
-              projectRoot,
-              bspTraceRoot,
-              item,
-              bspStatusOpt,
-            )
-          } yield Some(conn)
+          } yield createSession()
+
+          Future.successful(None)
       }
     }
 

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -24,19 +24,19 @@ import scala.meta.internal.metals.StatusBar
 import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.scalacli.ScalaCli
 import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BspConnectionDetails
 import com.google.common.collect.ImmutableList
-import org.eclipse.lsp4j.services.LanguageClient
 
 class BspConnector(
     bloopServers: BloopServers,
     bspServers: BspServers,
     buildTools: BuildTools,
-    client: LanguageClient,
+    client: ConfiguredLanguageClient,
     tables: Tables,
     userConfig: () => UserConfiguration,
     statusBar: StatusBar,

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -85,7 +85,7 @@ class BspConnector(
       workspace: AbsolutePath,
       userConfiguration: () => UserConfiguration,
       shellRunner: ShellRunner,
-      createSession: () => Unit
+      createSession: () => Unit,
   )(implicit ec: ExecutionContext): Future[Option[BspSession]] = {
     val projectRoot = buildTool
       .map(_.projectRoot)

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -27,7 +27,7 @@ import scala.meta.internal.metals.SocketConnection
 import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.WorkDoneProgress
-import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.mtags.MD5
 import scala.meta.internal.mtags.URIEncoderDecoder
 import scala.meta.internal.process.SystemProcess
@@ -44,7 +44,7 @@ import com.google.gson.Gson
 final class BspServers(
     mainWorkspace: AbsolutePath,
     charset: Charset,
-    client: MetalsLanguageClient,
+    client: ConfiguredLanguageClient,
     buildClient: MetalsBuildClient,
     tables: Tables,
     bspGlobalInstallDirectories: List[AbsolutePath],

--- a/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
@@ -4,15 +4,11 @@ import java.util.concurrent.TimeUnit
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.concurrent.Promise
 
 import scala.meta.internal.builds.Digest.Status
 import scala.meta.internal.metals.BuildInfo
-import scala.meta.internal.metals.CancelSwitch
 import scala.meta.internal.metals.CancelableFuture
 import scala.meta.internal.metals.Confirmation
-import scala.meta.internal.metals.Interruptable
-import scala.meta.internal.metals.Interruptable._
 import scala.meta.internal.metals.Messages._
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.Tables
@@ -20,6 +16,7 @@ import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.process.ExitCodes
 import scala.meta.io.AbsolutePath
+import scala.meta.internal.bsp.BuildChange
 
 /**
  * Runs `sbt/gradle/mill/mvn bloopInstall` processes.
@@ -40,7 +37,7 @@ final class BloopInstall(
 
   override def toString: String = s"BloopInstall($workspace)"
 
-  def runUnconditionally(
+  def run(
       buildTool: BloopInstallProvider
   ): CancelableFuture[WorkspaceLoadedStatus] = {
     buildTool.bloopInstall(
@@ -117,36 +114,36 @@ final class BloopInstall(
   def runIfApproved(
       buildTool: BloopInstallProvider,
       digest: String,
-  ): CancelableFuture[WorkspaceLoadedStatus] =
+      bloopInstall: () => Future[BuildChange]
+  ): Future[BuildChange] =
     synchronized {
       oldInstallResult(digest) match {
         case Some(result)
             if result != WorkspaceLoadedStatus.Duplicate(Status.Requested) =>
           scribe.info(s"skipping build import with status '${result.name}'")
-          CancelableFuture.successful(result)
+          Future.successful(BuildChange.None)
         case _ =>
           if (userConfig().shouldAutoImportNewProject) {
-            runUnconditionally(buildTool)
+            bloopInstall()
           } else {
             scribe.debug("Awaiting user response...")
-            implicit val cancelSwitch = CancelSwitch(Promise[Unit]())
             (for {
               userResponse <- requestImport(
                 buildTools,
                 buildTool,
                 languageClient,
                 digest,
-              ).withInterrupt
+              )
               installResult <- {
                 if (userResponse.isYes) {
-                  runUnconditionally(buildTool).withInterrupt
+                  bloopInstall()
                 } else {
                   // Don't spam the user with requests during rapid build changes.
                   notification.dismiss(2, TimeUnit.MINUTES)
-                  Interruptable.successful(WorkspaceLoadedStatus.Rejected)
+                  Future.successful(BuildChange.None)
                 }
               }
-            } yield installResult).toCancellable
+            } yield installResult)
           }
       }
     }

--- a/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import scala.meta.internal.bsp.BuildChange
 import scala.meta.internal.builds.Digest.Status
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.CancelableFuture
@@ -16,7 +17,6 @@ import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
 import scala.meta.internal.process.ExitCodes
 import scala.meta.io.AbsolutePath
-import scala.meta.internal.bsp.BuildChange
 
 /**
  * Runs `sbt/gradle/mill/mvn bloopInstall` processes.

--- a/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BloopInstall.scala
@@ -114,7 +114,7 @@ final class BloopInstall(
   def runIfApproved(
       buildTool: BloopInstallProvider,
       digest: String,
-      bloopInstall: () => Future[BuildChange]
+      bloopInstall: () => Future[BuildChange],
   ): Future[BuildChange] =
     synchronized {
       oldInstallResult(digest) match {

--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -3,8 +3,6 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Properties
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
@@ -280,10 +278,6 @@ case class SbtBuildTool(
             case _ =>
               promise.trySuccess(())
               Future.successful(())
-          }
-          .withTimeout(15, TimeUnit.SECONDS)
-          .recover { case _: TimeoutException =>
-            Future.successful(())
           }
       future.onComplete(promise.tryComplete(_))
       promise.future

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -11,8 +11,6 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.attribute.PosixFilePermissions
 import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.annotation.tailrec
@@ -274,15 +272,13 @@ final class BloopServers(
             Option(res) match {
               case Some(item) if item == OldBloopVersionRunning.yes =>
                 killOldBloop()
+              case Some(Messages.missedByUser) =>
+                languageClient.showMessage(
+                  OldBloopVersionRunning.killingBloopParams()
+                )
+                killOldBloop()
               case _ =>
             }
-          }
-          .withTimeout(15, TimeUnit.SECONDS)
-          .recover { case _: TimeoutException =>
-            languageClient.showMessage(
-              OldBloopVersionRunning.killingBloopParams()
-            )
-            killOldBloop()
           }
     }
   } catch {

--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -268,11 +268,12 @@ final class BloopServers(
           .showMessageRequest(
             OldBloopVersionRunning.params(),
             ConnectionProvider.ConnectRequestCancelationGroup,
-            throw MetalsCancelException
+            throw MetalsCancelException,
           )
           .map { res =>
             Option(res) match {
-              case Some(item) if item == OldBloopVersionRunning.yes => killOldBloop()
+              case Some(item) if item == OldBloopVersionRunning.yes =>
+                killOldBloop()
               case _ =>
             }
           }

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -20,7 +20,6 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
-import scala.util.Failure
 import scala.util.Success
 
 import scala.meta.internal.bsp.ConnectionBspStatus
@@ -477,11 +476,6 @@ class BuildServerConnection private (
               connection
             case _ =>
               connection
-          }
-          .withTimeout(10, TimeUnit.SECONDS)
-          .transformWith {
-            case Failure(_: TimeoutException) => connection
-            case t => Future.fromTry(t)
           }
       } else {
         connection

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -20,6 +20,7 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
+import scala.util.Failure
 import scala.util.Success
 
 import scala.meta.internal.bsp.ConnectionBspStatus
@@ -471,6 +472,11 @@ class BuildServerConnection private (
             connection
           case _ =>
             connection
+        }
+        .withTimeout(10, TimeUnit.SECONDS)
+        .transformWith {
+          case Failure(_: TimeoutException) => connection
+          case t => Future.fromTry(t)
         }
       } else {
         connection

--- a/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
@@ -530,7 +530,7 @@ class ConnectionProvider(
             isChangedInSettings = userConfig.bloopVersion != None,
           )
           languageClient.showMessageRequest(messageParams).asScala.foreach {
-            case action if action == IncompatibleBloopVersion.shutdown => // C
+            case action if action == IncompatibleBloopVersion.shutdown =>
               connect(new CreateSession(true))
             case action if action == IncompatibleBloopVersion.dismissForever =>
               notification.dismissForever()

--- a/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
@@ -162,7 +162,7 @@ class ConnectionProvider(
               buildTool
             ) && buildTool.isBloopInstallProvider =>
         def runInstall() = connect(new BloopInstallAndConnect(buildTool))
-        if(forceImport) runInstall()
+        if (forceImport) runInstall()
         else {
           bloopInstall.runIfApproved(buildTool, digest, runInstall)
         }
@@ -347,7 +347,9 @@ class ConnectionProvider(
         currentRequest.foreach(ongoing =>
           if (request.cancelCompare(ongoing.request) == TakeOver) {
             ongoing.cancel()
-            languageClient.cancelRequest(ConnectionProvider.ConnectRequestCancelationGroup)
+            languageClient.cancelRequest(
+              ConnectionProvider.ConnectRequestCancelationGroup
+            )
           }
         )
         info
@@ -660,7 +662,7 @@ class ConnectionProvider(
     }
 
     private def bloopInstallAndConnect(
-        buildTool: BloopInstallProvider,
+        buildTool: BloopInstallProvider
     )(implicit cancelSwitch: CancelSwitch): Interruptable[BuildChange] = {
       for {
         result <- bloopInstall.run(buildTool).withInterrupt
@@ -787,7 +789,7 @@ case class GenerateBspConfigAndConnect(
   def cancelCompare(other: ConnectRequest): ConflictBehaviour = TakeOver
 }
 case class BloopInstallAndConnect(
-    buildTool: BloopInstallProvider,
+    buildTool: BloopInstallProvider
 ) extends ConnectRequest {
   def cancelCompare(other: ConnectRequest): ConflictBehaviour =
     other match {

--- a/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
@@ -570,7 +570,6 @@ class ConnectionProvider(
               folder,
               () => userConfig,
               shellRunner,
-              () => createSession(shutdownServer),
             )
           }
           .withInterrupt

--- a/metals/src/main/scala/scala/meta/internal/metals/IndexProviders.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/IndexProviders.scala
@@ -7,7 +7,7 @@ import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.Promise
 
 import scala.meta.internal.implementation.ImplementationProvider
-import scala.meta.internal.metals.clients.language.DelegatingLanguageClient
+import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.metals.watcher.FileWatcher
 import scala.meta.internal.mtags.OnDemandSymbolIndex
@@ -16,7 +16,7 @@ import scala.meta.io.AbsolutePath
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 
 trait IndexProviders {
-  def languageClient: DelegatingLanguageClient
+  def languageClient: ConfiguredLanguageClient
   def executionContext: ExecutionContextExecutorService
   def tables: Tables
   def statusBar: StatusBar

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -419,6 +419,13 @@ object Messages {
       )
       params
     }
+
+    def killingBloopParams(): MessageParams = {
+      val params = new MessageParams()
+      params.setMessage("No response, killing old Bloop server.")
+      params.setType(MessageType.Warning)
+      params
+    }
   }
 
   object BloopVersionChange {

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -1098,6 +1098,8 @@ object Messages {
     }
   }
 
+  val missedByUser = new MessageActionItem("Missed by user")
+
 }
 
 object FileOutOfScalaCliBspScope {

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
@@ -110,7 +110,9 @@ final class ConfiguredLanguageClient(
   def showMessageRequest(
       params: ShowMessageRequestParams,
       cancelationGroup: String,
-      cancelValue: => MessageActionItem = new MessageActionItem("Missed by user"),
+      cancelValue: => MessageActionItem = new MessageActionItem(
+        "Missed by user"
+      ),
   ): Future[MessageActionItem] = {
     val promise = Promise[Unit]()
     // put promise into cancellation map
@@ -124,7 +126,7 @@ final class ConfiguredLanguageClient(
 
     // call client
     val result = showMessageRequest(params)
-    val future = 
+    val future =
       Future.firstCompletedOf(
         List(
           result.asScala,
@@ -135,9 +137,12 @@ final class ConfiguredLanguageClient(
         )
       )
 
-    future.onComplete{ _ =>
+    future.onComplete { _ =>
       // remove promise from cancellation map
-      requestMap.computeIfPresent(cancelationGroup, (_, promises) => promises - promise)
+      requestMap.computeIfPresent(
+        cancelationGroup,
+        (_, promises) => promises - promise,
+      )
     }
 
     future

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -38,7 +38,7 @@ import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.TargetData
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.WorkDoneProgress
-import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.scalacli.ScalaCli.ScalaCliCommand
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
@@ -56,7 +56,7 @@ class ScalaCli(
     diagnostics: () => Diagnostics,
     tables: Tables,
     buildClient: () => MetalsBuildClient,
-    languageClient: MetalsLanguageClient,
+    languageClient: ConfiguredLanguageClient,
     config: () => MetalsServerConfig,
     userConfig: () => UserConfiguration,
     cliCommand: ScalaCliCommand,

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCliServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCliServers.scala
@@ -23,7 +23,7 @@ import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.TargetData
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.WorkDoneProgress
-import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.scalacli.ScalaCli.ScalaCliCommand
 import scala.meta.internal.metals.{BuildInfo => V}
 import scala.meta.internal.process.SystemProcess
@@ -40,7 +40,7 @@ class ScalaCliServers(
     diagnostics: () => Diagnostics,
     tables: Tables,
     buildClient: () => MetalsBuildClient,
-    languageClient: MetalsLanguageClient,
+    languageClient: ConfiguredLanguageClient,
     config: () => MetalsServerConfig,
     userConfig: () => UserConfiguration,
     parseTreesAndPublishDiags: Seq[AbsolutePath] => Future[Unit],

--- a/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
@@ -16,6 +16,7 @@ import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.DebugSessionParamsDataKind
 import ch.epfl.scala.bsp4j.ScalaMainClass
+import org.eclipse.lsp4j.MessageActionItem
 import scribe.LogRecord
 import scribe.Logger
 import scribe.output.LogOutput
@@ -27,7 +28,6 @@ import tests.SbtBuildLayout
 import tests.SbtServerInitializer
 import tests.ScriptsAssertions
 import tests.TestSemanticTokens
-import org.eclipse.lsp4j.MessageActionItem
 
 /**
  * Basic suite to ensure that a connection to sbt server can be made.


### PR DESCRIPTION
fixes: https://github.com/scalameta/metals/issues/7509

This PR fixes blocking behaviour of waiting for user request inside of connect. The following fixes and improvements were implemented:
 - when possible extracted requests to user from `connect`, or don't wait for their result (only callback)
 - when impossible, add timeout and implement a cancel strategy, so a "stronger" connect request can cancel the previous.