### PR TITLE
bugfix: Remove jrtClassPathCAches to try fix -release issues

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/CompilerConfiguration.scala
@@ -422,36 +422,16 @@ class CompilerConfiguration(
 
       releaseVersion match {
         // https://github.com/scala/bug/issues/13045
-        case Some(version)
-            if version < 17 && scalaTarget.scalaBinaryVersion == "2.13" =>
+        case Some(version) =>
           /* Filter out -target: and -Xtarget: options, since they are not relevant and
            * might interfere with -release option */
           val filterOutTarget = scalacOptions.filterNot(opt =>
             opt.startsWith("-target:") || opt.startsWith("-Xtarget:")
           )
           filterOutTarget ++ List("-release", version.toString())
-        case _ if scalaTarget.scalaBinaryVersion == "2.13" =>
-          removeReleaseOptions(scalacOptions)
         case _ =>
           scalacOptions
       }
-    }
-  }
-
-  private def isHigherThan17(version: String) =
-    Try(version.toInt).toOption.exists(_ >= 17)
-
-  private def removeReleaseOptions(options: Seq[String]): Seq[String] = {
-    options match {
-      case "-release" :: version :: tail if isHigherThan17(version) =>
-        removeReleaseOptions(tail)
-      case opt :: tail
-          if opt.startsWith("-release") && isHigherThan17(
-            opt.stripPrefix("-release:")
-          ) =>
-        removeReleaseOptions(tail)
-      case head :: tail => head +: removeReleaseOptions(tail)
-      case Nil => options
     }
   }
 

--- a/mtags/src/main/scala-2.11/scala/meta/internal/pc/JrtClasspathCompat.scala
+++ b/mtags/src/main/scala-2.11/scala/meta/internal/pc/JrtClasspathCompat.scala
@@ -1,0 +1,9 @@
+package scala.meta.internal.pc
+
+import java.util.logging.Logger
+
+object JrtClasspathCompat {
+
+  def clearJrtClassPathCaches(logger: Logger): Boolean = false
+
+}

--- a/mtags/src/main/scala-2.12/scala/meta/internal/pc/JrtClasspathCompat.scala
+++ b/mtags/src/main/scala-2.12/scala/meta/internal/pc/JrtClasspathCompat.scala
@@ -1,0 +1,9 @@
+package scala.meta.internal.pc
+
+import java.util.logging.Logger
+
+object JrtClasspathCompat {
+
+  def clearJrtClassPathCaches(logger: Logger): Boolean = true
+
+}

--- a/mtags/src/main/scala-2.13/scala/meta/internal/pc/JrtClasspathCompat.scala
+++ b/mtags/src/main/scala-2.13/scala/meta/internal/pc/JrtClasspathCompat.scala
@@ -1,0 +1,111 @@
+package scala.meta.internal.pc
+
+import java.io.Closeable
+import java.util.logging.Logger
+
+import scala.tools.nsc.classpath.CtSymClassPath
+import scala.tools.nsc.classpath.FileBasedCache
+import scala.tools.nsc.classpath.JrtClassPath
+import scala.tools.nsc.util.ClassPath
+
+object JrtClasspathCompat {
+
+  /**
+   * It seems that sometimes the JrtClassPath or CtSymClassPath caches get corrupted
+   * and since it's an object it never gets removed or cleared even when restarting
+   * the compiler..
+   *
+   * This should help in those cases, we'll test it on snapshot versions and maybe
+   * backport to scala itself if it proves to be useful.
+   *
+   * @return true if the caches were cleared, false otherwise if any reflection failed
+   */
+  def clearJrtClassPathCaches(logger: Logger): Boolean = {
+    try {
+      val jrtClassPathClass = JrtClassPath.getClass()
+      val jrtClassPathCacheField =
+        jrtClassPathClass.getDeclaredField("jrtClassPathCache")
+      jrtClassPathCacheField.setAccessible(true)
+      val jrtClassPathCache =
+        jrtClassPathCacheField.get(null).asInstanceOf[FileBasedCache[_, _]]
+
+      closeAllFileSystems(jrtClassPathCache, logger)
+      jrtClassPathCache.clear()
+
+      val ctSymClassPathCacheField =
+        jrtClassPathClass.getDeclaredField("ctSymClassPathCache")
+      ctSymClassPathCacheField.setAccessible(true)
+      val ctSymClassPathCache = ctSymClassPathCacheField
+        .get(null)
+        .asInstanceOf[FileBasedCache[_, _]]
+
+      closeAllFileSystems(ctSymClassPathCache, logger)
+      ctSymClassPathCache.clear()
+
+      true
+    } catch {
+      case e: Exception =>
+        logger.warning(
+          s"Failed to clear JrtClassPath caches: ${e.getMessage}"
+        )
+        false
+    }
+  }
+
+  /**
+   * Make sure to close all the FileBasedCache instances. It uses reflection to
+   * access the private fields of the FileBasedCache class. This might fail,
+   * but  the only issue should be that a filesystem is not closed.
+   */
+  private def closeAllFileSystems(
+      cache: FileBasedCache[_, _],
+      logger: Logger
+  ): Unit = {
+    try {
+      // Accessing: private val cache = collection.mutable.Map.empty[(K, Seq[Path]), Entry]
+      val cacheClass = cache.getClass
+      val innerCacheField = cacheClass.getDeclaredField(
+        "scala$tools$nsc$classpath$FileBasedCache$$cache"
+      )
+      innerCacheField.setAccessible(true)
+      val innerCache =
+        innerCacheField.get(cache).asInstanceOf[collection.mutable.Map[_, _]]
+
+      /**
+       * Version before Scala 2.13.15 didn't have the close method on the JrtClassPath
+       * and CtSymClassPath classes. So we need to run reflection to access FileSystem
+       * and close it ourselves.
+       */
+      def closeFileSystem(
+          cls: Class[_],
+          clsPath: ClassPath,
+          fieldName: String
+      ): Unit = {
+        val fs = cls.getDeclaredField(fieldName)
+        fs.setAccessible(true)
+        fs.get(clsPath).asInstanceOf[Closeable].close()
+      }
+
+      innerCache.synchronized {
+        innerCache.values.foreach { entry =>
+          // Entry class: case class Entry(k: K, stamps: Seq[Stamp], t: T)
+          val value = entry.getClass().getDeclaredField("t")
+          value.setAccessible(true)
+          value.get(entry) match {
+            case jrtClassPath: JrtClassPath =>
+              closeFileSystem(jrtClassPath.getClass(), jrtClassPath, "fs")
+            case ctClasspath: CtSymClassPath =>
+              closeFileSystem(ctClasspath.getClass(), ctClasspath, "fileSystem")
+            case _ => // ignore other values since they do not cache anything
+          }
+        }
+      }
+    } catch {
+      case e: Throwable =>
+        logger.warning(
+          s"Failed to close JrtClassPath or CtSymClassPath cache entries: ${e.getMessage}"
+        )
+        throw e
+    }
+  }
+}

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaPresentationCompiler.scala
@@ -14,6 +14,7 @@ import java.{util => ju}
 import scala.collection.Seq
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
+import scala.reflect.internal.FatalError
 import scala.reflect.io.VirtualDirectory
 import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.StoreReporter
@@ -575,7 +576,7 @@ case class ScalaPresentationCompiler(
 
   override def buildTargetId(): String = buildTargetIdentifier
 
-  def newCompiler(): MetalsGlobal = {
+  def newCompiler(withClearedCaches: Boolean = false): MetalsGlobal = {
     val classpath = this.classpath.mkString(File.pathSeparator)
     val vd = new VirtualDirectory("(memory)", None)
     val settings = new Settings
@@ -600,15 +601,31 @@ case class ScalaPresentationCompiler(
     if (unprocessed.nonEmpty || !isSuccess) {
       logger.warning(s"Unknown compiler options: ${unprocessed.mkString(", ")}")
     }
-    new MetalsGlobal(
-      settings,
-      new StoreReporter,
-      search,
-      buildTargetIdentifier,
-      config,
-      folderPath,
-      completionItemPriority
-    )
+    try {
+      new MetalsGlobal(
+        settings,
+        new StoreReporter,
+        search,
+        buildTargetIdentifier,
+        config,
+        folderPath,
+        completionItemPriority
+      )
+    } catch {
+      case e: FatalError
+          if scalaVersion.startsWith("2.13") && !withClearedCaches =>
+        val cleared = JrtClasspathCompat.clearJrtClassPathCaches(logger)
+        if (cleared) {
+          logger.warning(
+            s"Cleared JrtClassPath caches, to try and fix `${e.getMessage()}`"
+          )
+          newCompiler(withClearedCaches = true)
+        } else {
+          throw e
+        }
+      case e: FatalError =>
+        throw e
+    }
   }
 
   // ================

--- a/tests/cross/src/test/scala/tests/pc/Release8CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/Release8CompletionSuite.scala
@@ -2,6 +2,9 @@ package tests.pc
 
 import java.nio.file.Path
 
+import scala.meta.internal.pc.JrtClasspathCompat
+import scala.meta.internal.pc.ScalaPresentationCompiler
+
 import tests.BaseCompletionSuite
 
 class Release8CompletionSuite extends BaseCompletionSuite {
@@ -65,4 +68,15 @@ class Release8CompletionSuite extends BaseCompletionSuite {
     )
   )
 
+  test("clear-jrt-class-path-caches") {
+    presentationCompiler match {
+      case pc: ScalaPresentationCompiler =>
+        assert(
+          JrtClasspathCompat.clearJrtClassPathCaches(pc.logger),
+          "Failed to clear JrtClassPath caches"
+        )
+      case _ =>
+        fail("presentationCompiler is not a ScalaPresentationCompiler")
+    }
+  }
 }


### PR DESCRIPTION
I can't find the actual problem where it happens unfortunately, so this is my best guess on what can help. This might anyway be needed for older Scala 2.13 versions, but we could try to fix it in later.

I will continue trying to reproduce.