### PR TITLE
bugfix: Run close when stopping the presentation compiler

### DIFF
--- a/mtags/src/main/scala-2.11/scala/meta/internal/pc/Compat.scala
+++ b/mtags/src/main/scala-2.11/scala/meta/internal/pc/Compat.scala
@@ -4,8 +4,11 @@ import scala.tools.nsc.reporters.Reporter
 import scala.tools.nsc.reporters.StoreReporter
 
 import scala.meta.pc.OutlineFiles
+import java.io.Closeable
 
-trait Compat { this: MetalsGlobal =>
+trait Compat { this: MetalsGlobal with Closeable =>
+  override def close(): Unit = {}
+
   def metalsFunctionArgTypes(tpe: Type): List[Type] = {
     val dealiased = tpe.dealiasWiden
     if (definitions.isFunctionTypeDirect(dealiased)) dealiased.typeArgs.init

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -1,7 +1,9 @@
 package scala.meta.internal.pc
 
+import java.io.Closeable
 import java.nio.file.Path
 import java.util
+import java.util.logging.Level
 import java.util.logging.Logger
 import java.{util => ju}
 
@@ -63,8 +65,14 @@ class MetalsGlobal(
     with GlobalProxy
     with AutoImports
     with Keywords
-    with WorkspaceSymbolSearch { compiler =>
+    with WorkspaceSymbolSearch
+    with Closeable { compiler =>
   hijackPresentationCompilerThread()
+
+  override def close(): Unit = {
+    super.close()
+    logger.log(Level.FINE, "Restarting compiler and clearing caches.")
+  }
 
   val logger: Logger = Logger.getLogger(classOf[MetalsGlobal].getName)
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaCompilerAccess.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/ScalaCompilerAccess.scala
@@ -30,6 +30,7 @@ class ScalaCompilerWrapper(global: MetalsGlobal)
 
   override def askShutdown(): Unit = {
     global.askShutdown()
+    global.close()
   }
 
   override def isAlive(): Boolean = {


### PR DESCRIPTION
Alternative solution to https://github.com/scalameta/metals/pull/7541/files

Looks like running close should purge those caches as well, but we didn't run it before.