### PR TITLE
fix: pass the environment variables from the BSP server when running tests

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -77,7 +77,9 @@ final class RunTestCodeLens(
         isJvm: Boolean,
     ): Future[Unit] = {
       if (isJvm)
-        buildTargetClasses.jvmRunEnvironment(buildTargetId).map(_ => ())
+        buildTargetClasses
+          .jvmRunEnvironment(buildTargetId, isTests = true)
+          .map(_ => ())
       else
         Future.unit
     }
@@ -335,7 +337,7 @@ final class RunTestCodeLens(
       if (!isJVM) (main.toJson, false)
       else
         buildTargetClasses
-          .jvmRunEnvironmentSync(target)
+          .jvmRunEnvironmentSync(target, isTests = true)
           .zip(javaBinary) match {
           case None =>
             (main.toJson, false)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugDiscovery.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugDiscovery.scala
@@ -358,7 +358,7 @@ class DebugDiscovery(
               )
               .orElse(userConfig().usedJavaBinary)
             buildTargetClasses
-              .jvmRunEnvironment(params.getTargets().get(0))
+              .jvmRunEnvironment(params.getTargets().get(0), isTests = false)
               .map { envItem =>
                 val updatedData = envItem.zip(javaBinary) match {
                   case None =>

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -336,7 +336,11 @@ class DebugProvider(
           case b.DebugSessionParamsDataKind.SCALA_MAIN_CLASS =>
             for {
               id <- buildTarget
-              projectInfo <- debugConfigCreator.create(id, cancelPromise)
+              projectInfo <- debugConfigCreator.create(
+                id,
+                cancelPromise,
+                isTests = false,
+              )
               scalaMainClass <- params.asScalaMainClass()
             } yield projectInfo.map(
               new MainClassDebugAdapter(
@@ -350,7 +354,11 @@ class DebugProvider(
               b.TestParamsDataKind.SCALA_TEST_SUITES) =>
             for {
               id <- buildTarget
-              projectInfo <- debugConfigCreator.create(id, cancelPromise)
+              projectInfo <- debugConfigCreator.create(
+                id,
+                cancelPromise,
+                isTests = true,
+              )
               testSuites <- params.asScalaTestSuites()
             } yield {
               for {

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/server/TestSuiteDebugAdapter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/server/TestSuiteDebugAdapter.scala
@@ -124,7 +124,16 @@ class TestSuiteDebugAdapter(
     }
     val handler = new LoggingEventHandler(listener)
     val jvmOptions = testClasses.getJvmOptions.asScala.toList
-    val envOptions = testClasses.getEnvironmentVariables().asScala.toList
+    val testClassesEnvOptions =
+      testClasses.getEnvironmentVariables().asScala.toList
+    val buildServerEnvOptions = project.environmentVariables.iterator.map {
+      case (k, v) => s"$k=$v"
+    }.toList
+    val envOptions = testClassesEnvOptions ++ buildServerEnvOptions
+    scribe.info(
+      s"""|Environment variables for the test suite: 
+          |  ${envOptions.mkString("\n  ")}""".stripMargin
+    )
 
     scribe.debug("Starting forked test execution...")
     val resolvedSuites = suites(frameworks.toSeq)

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
@@ -46,7 +46,11 @@ class McpTestRunner(
       id <- buildTargets
         .inverseSources(path)
         .toRight(s"Could not find build target for $path")
-      projectInfo <- debugProvider.debugConfigCreator.create(id, cancelPromise)
+      projectInfo <- debugProvider.debugConfigCreator.create(
+        id,
+        cancelPromise,
+        isTests = true,
+      )
     } yield {
       for {
         discovered <- debugProvider.discoverTests(id, testSuites)
@@ -59,9 +63,9 @@ class McpTestRunner(
           discovered,
           isDebug = false,
         )
-        listner = new McpDebuggeeListener(verbose)
-        _ <- adapter.run(listner).future
-      } yield listner.result
+        listener = new McpDebuggeeListener(verbose)
+        _ <- adapter.run(listener).future
+      } yield listener.result
     }
   }
 

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -688,6 +688,11 @@ final case class TestingServer(
 
   def waitFor(millis: Long): Future[Unit] = Future { Thread.sleep(millis) }
 
+  /**
+   * @param target the build target to debug, like "myproject.test"
+   * @param kind one of the constants in [[ch.epfl.scala.bsp4j.TestParamsDataKind]] or [[ch.epfl.scala.bsp4j.DebugSessionParamsDataKind]].
+   * @param parameter the parameter to pass to the debug adapter, for example an instance of [[scala.meta.internal.metals.ScalaTestSuites]].
+   */
   def startDebugging(
       target: String,
       kind: String,
@@ -758,6 +763,7 @@ final case class TestingServer(
     fullServer.didFocus(toPath(filename).toURI.toString).asScala
   }
 
+  /** Saves the file to disk and sends `didSave` notification to the server. */
   def didSave(filename: String): Future[Unit] = {
     Debug.printEnclosing(filename)
     val abspath = toPath(filename)


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/mill/issues/5039.

Metals has two code paths for running tests, one where the build server provides debugging support and another where it does not. Mill does not provide the debug support.

Now Metals correctly:
- invokes either `buildTarget/jvmRunEnvironment` or `buildTarget/jvmTestEnvironment` BSP commands.
- actually uses the environment variables from those (previously only the classpath was used)