### PR TITLE
bugfix: Don't connect to Bloop even if bsp json file is missing

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspConnector.scala
@@ -54,25 +54,29 @@ class BspConnector(
    * workspace can support Bloop, it will also resolve Bloop.
    */
   def resolve(buildTool: Option[BuildTool]): BspResolvedResult = {
-    resolveExplicit().getOrElse {
-      if (buildTool.exists(_.isBloopInstallProvider) || buildTools.isBloop)
+    tables.buildServers.selectedServer() match {
+      case None
+          if buildTool.exists(_.isBloopInstallProvider) || buildTools.isBloop =>
         ResolvedBloop
-      else bspServers.resolve()
+      case None => bspServers.resolve()
+      case Some(selected) if selected == BloopServers.name =>
+        ResolvedBloop
+      case Some(selected) =>
+        resolveExplicit(selected).getOrElse(RegenerateBspConfig)
     }
   }
 
-  private def resolveExplicit(): Option[BspResolvedResult] = {
-    tables.buildServers.selectedServer().flatMap { sel =>
-      if (sel == BloopServers.name) Some(ResolvedBloop)
-      else
-        bspServers
-          .findAvailableServers()
-          .find(buildServer =>
-            (ScalaCli.names(buildServer.getName()) && ScalaCli.names(sel)) ||
-              buildServer.getName == sel
-          )
-          .map(ResolvedBspOne.apply)
-    }
+  private def resolveExplicit(
+      selectedServer: String
+  ): Option[BspResolvedResult] = {
+    bspServers
+      .findAvailableServers()
+      .find(buildServer =>
+        (ScalaCli.names(buildServer.getName()) &&
+          ScalaCli.names(selectedServer)) ||
+          buildServer.getName == selectedServer
+      )
+      .map(ResolvedBspOne.apply)
   }
 
   /**
@@ -219,6 +223,33 @@ class BspConnector(
               bspStatusOpt,
             )
           } yield Some(conn)
+        case RegenerateBspConfig =>
+          buildTool match {
+            case Some(bsp: BuildServerProvider) =>
+              scribe.info(
+                s"Regenerating ${bsp.buildServerName} json config since it was missing."
+              )
+              bsp
+                .generateBspConfig(
+                  workspace,
+                  args => bspConfigGenerator.runUnconditionally(bsp, args),
+                  statusBar,
+                )
+                .future
+                .flatMap { _ =>
+                  connect(
+                    projectRoot,
+                    bspTraceRoot,
+                    addLivenessMonitor,
+                    regeneratedConfig = true,
+                  )
+                }
+            case _ =>
+              scribe.error(
+                s"Cannot regenerate json config for build tool since no build server capable tool is available."
+              )
+              Future.successful(None)
+          }
       }
     }
 

--- a/metals/src/main/scala/scala/meta/internal/bsp/BspResolvedResult.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspResolvedResult.scala
@@ -9,6 +9,7 @@ import ch.epfl.scala.bsp4j.BspConnectionDetails
  */
 sealed trait BspResolvedResult extends Product with Serializable
 case object ResolvedNone extends BspResolvedResult
+case object RegenerateBspConfig extends BspResolvedResult
 case object ResolvedBloop extends BspResolvedResult
 case class ResolvedBspOne(details: BspConnectionDetails)
     extends BspResolvedResult

--- a/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtServerSuite.scala
@@ -6,6 +6,7 @@ import scala.concurrent.Promise
 import scala.meta.internal.builds.SbtBuildTool
 import scala.meta.internal.builds.SbtDigest
 import scala.meta.internal.metals.CreateSession
+import scala.meta.internal.metals.Disconnect
 import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.Messages.ImportBuildChanges
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -666,6 +667,50 @@ class SbtServerSuite
             "build.sbt" -> buildSbtBase,
           ),
         )
+
+    } yield ()
+  }
+
+  test("no-fallback-to-bloop") {
+    cleanWorkspace()
+    val sbtBspConfig = workspace.resolve(".bsp/sbt.json")
+
+    for {
+      _ <- initialize(
+        s"""|/project/build.properties
+            |sbt.version=${V.sbtVersion}
+            |/build.sbt
+            |${SbtBuildLayout.commonSbtSettings}
+            |scalaVersion := "${V.scala213}"
+            |val a = project.in(file("a"))
+            |/a/src/main/scala/a/A.scala
+            |package a
+            |object A {
+            | val a = 1
+            |}
+            |""".stripMargin
+      )
+      _ = assert(
+        sbtBspConfig.exists,
+        "sbt.json should exist after initialization",
+      )
+      _ = assert(
+        server.server.bspSession.get.main.isSbt,
+        "Should be connected to sbt",
+      )
+      _ <- server.headServer.connect(Disconnect(shutdownBuildServer = true))
+      _ = assert(server.server.bspSession.isEmpty, "Should be disconnected")
+      _ = {
+        assert(sbtBspConfig.exists, "sbt.json should exist before removal")
+        sbtBspConfig.delete()
+        assert(!sbtBspConfig.exists, "sbt.json should be deleted")
+      }
+      _ <- server.headServer.connect(CreateSession(shutdownBuildServer = false))
+      _ = server.server.bspSession match {
+        case Some(session) if session.main.isSbt =>
+        case otherwise =>
+          fail(s"Should be connected to sbt, but got $otherwise")
+      }
 
     } yield ()
   }


### PR DESCRIPTION
Previously, even if we selected a server and .bsp entry was missing we would fallback to Bloop. Now, we will try to regenerate bsp config.