### PR TITLE
Update fuzzy matcher logic to allow for slightly more forgiving matching

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/CompletionProvider.scala
@@ -557,8 +557,13 @@ class CompletionProvider(
       }
       val isTypeMember = kind == CompletionListKind.Type
       params.checkCanceled()
+
+      val query = completions.name.toString
+      val queryStartsWithLowercase = query.headOption.forall(_.isLower)
       val matchingResults = completions.matchingResults { entered => name =>
         if (isTypeMember) CompletionFuzzy.matchesSubCharacters(entered, name)
+        else if (queryStartsWithLowercase)
+          CompletionFuzzy.matches(entered, name, forgivingFirstChar = true)
         else CompletionFuzzy.matches(entered, name)
       }
 
@@ -571,7 +576,6 @@ class CompletionProvider(
         completions,
         latestParentTrees
       )
-      val query = completions.name.toString
       val items = filterInteresting(
         matchingResults,
         kind,

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseInsensitiveSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseInsensitiveSuite.scala
@@ -1,0 +1,81 @@
+package tests.pc
+
+import tests.BaseCompletionSuite
+
+class CompletionCaseInsensitiveSuite extends BaseCompletionSuite {
+
+  check(
+    "use case insensitive comparison for first character of query",
+    """
+      |object A {
+      | def test(longNameYouWillNotRemember: Long): Unit = {
+      |   val foo = nam@@
+      | }
+      |}""".stripMargin,
+    """longNameYouWillNotRemember: Long
+      |deprecatedName scala
+      |""".stripMargin
+  )
+
+  check(
+    "use case insensitive comparison for first character of query at the beginning of the symbol",
+    """
+      |object A {
+      | def test(longNameYouWillNotRemember: Long): Unit = {
+      |   val foo = lon@@
+      | }
+      |}""".stripMargin,
+    """longNameYouWillNotRemember: Long
+      |long2Long(x: Long): lang.Long
+      |longArrayOps(xs: Array[Long]): ArrayOps[Long]
+      |longWrapper(x: Long): RichLong
+      |wrapLongArray(xs: Array[Long]): ArraySeq.ofLong
+      |""".stripMargin,
+    compat = Map(
+      "2.12" ->
+        """longNameYouWillNotRemember: Long
+          |long2Long(x: Long): lang.Long
+          |longArrayOps(xs: Array[Long]): ArrayOps.ofLong
+          |longWrapper(x: Long): RichLong
+          |wrapLongArray(xs: Array[Long]): WrappedArray[Long]
+          |readLong(): Long
+          |""".stripMargin
+    )
+  )
+
+  check(
+    "use case insensitive comparison for first character of query, correctly narrow result using later uppercase in query",
+    """
+      |object A {
+      | def test(longNameYouWillNotRemember: Long): Unit = {
+      |   val foo = namY@@
+      | }
+      |}""".stripMargin,
+    """longNameYouWillNotRemember: Long
+      |""".stripMargin
+  )
+
+  check(
+    "use case insensitive comparison for first character of query, correctly narrow result using uppercase not directly following matched segment",
+    """
+      |object A {
+      | def test(longNameYouWillNotRemember: Long): Unit = {
+      |   val foo = namRem@@
+      | }
+      |}""".stripMargin,
+    """longNameYouWillNotRemember: Long
+      |""".stripMargin
+  )
+
+  check(
+    "lower case query should still only match for segments, so 'ill' should not bring up the long name",
+    """
+      |object A {
+      | def test(longNameYouWillNotRemember: Long): Unit = {
+      |   val foo = ill@@
+      | }
+      |}""".stripMargin,
+    ""
+  )
+
+}

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseInsensitiveSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseInsensitiveSuite.scala
@@ -32,6 +32,14 @@ class CompletionCaseInsensitiveSuite extends BaseCompletionSuite {
       |wrapLongArray(xs: Array[Long]): ArraySeq.ofLong
       |""".stripMargin,
     compat = Map(
+      "2.11" ->
+        """|longNameYouWillNotRemember: Long
+           |long2Long(x: Long): lang.Long
+           |longArrayOps(xs: Array[Long]): ArrayOps[Long]
+           |longWrapper(x: Long): RichLong
+           |wrapLongArray(xs: Array[Long]): WrappedArray[Long]
+           |readLong(): Long
+           |""".stripMargin,
       "2.12" ->
         """longNameYouWillNotRemember: Long
           |long2Long(x: Long): lang.Long

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -285,10 +285,19 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |case Some(value) => scala
        |case (exhaustive) Option[A] (2 cases)
        |""".stripMargin,
-    compat = Map("3" -> """|case None => scala
-                           |case Some(value) => scala
-                           |case (exhaustive) Option[Int] (2 cases)
-                           |""".stripMargin)
+    compat = Map(
+      "2.12" ->
+        """|case None => scala
+           |case Some(value) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |case (exhaustive) Option[A] (2 cases)
+           |""".stripMargin,
+      "3" ->
+        """|case None => scala
+           |case Some(value) => scala
+           |case (exhaustive) Option[Int] (2 cases)
+           |""".stripMargin
+    )
   )
 
   check(
@@ -302,7 +311,14 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """|case None => scala
        |case Some(value) => scala
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "2.12" ->
+        """|case None => scala
+           |case Some(value) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |""".stripMargin
+    )
   )
 
   check(
@@ -316,7 +332,14 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """|case None => scala
        |case Some(value) => scala
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "2.12" ->
+        """|case None => scala
+           |case Some(value) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |""".stripMargin
+    )
   )
 
   check(
@@ -331,10 +354,18 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |case Some(value) => scala
        |case (exhaustive) Option[A] (2 cases)
        |""".stripMargin,
-    compat = Map("3" -> """|case None => scala
-                           |case Some(value) => scala
-                           |case (exhaustive) Option[Int] (2 cases)
-                           |""".stripMargin)
+    compat = Map(
+      "2.12" ->
+        """|case None => scala
+           |case Some(value) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |case (exhaustive) Option[A] (2 cases)
+           |""".stripMargin,
+      "3" -> """|case None => scala
+                |case Some(value) => scala
+                |case (exhaustive) Option[Int] (2 cases)
+                |""".stripMargin
+    )
   )
 
   check(
@@ -349,10 +380,18 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |case Some(value) => scala
        |case (exhaustive) Option[A] (2 cases)
        |""".stripMargin,
-    compat = Map("3" -> """|case None => scala
-                           |case Some(value) => scala
-                           |case (exhaustive) Option[Int] (2 cases)
-                           |""".stripMargin)
+    compat = Map(
+      "2.12" ->
+        """|case None => scala
+           |case Some(value) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |case (exhaustive) Option[A] (2 cases)
+           |""".stripMargin,
+      "3" -> """|case None => scala
+                |case Some(value) => scala
+                |case (exhaustive) Option[Int] (2 cases)
+                |""".stripMargin
+    )
   )
 
   check(
@@ -366,7 +405,14 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """|case None => scala
        |case Some(value) => scala
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "2.12" ->
+        """|case None => scala
+           |case Some(value) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |""".stripMargin
+    )
   )
 
   check(
@@ -380,7 +426,14 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |}""".stripMargin,
     """|case None => scala
        |case Some(value) => scala
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "2.12" ->
+        """|case None => scala
+           |case Some(value) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |""".stripMargin
+    )
   )
 
   check(
@@ -782,7 +835,12 @@ class CompletionCaseSuite extends BaseCompletionSuite {
       |  }
       |}""".stripMargin,
     """|case
-       |""".stripMargin
+       |""".stripMargin,
+    compat = Map(
+      "2.12" ->
+        """|case
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]""".stripMargin
+    )
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseSuite.scala
@@ -286,6 +286,12 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |case (exhaustive) Option[A] (2 cases)
        |""".stripMargin,
     compat = Map(
+      "2.11" ->
+        """|case None => scala
+           |case Some(x) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |case (exhaustive) Option[A] (2 cases)
+           |""".stripMargin,
       "2.12" ->
         """|case None => scala
            |case Some(value) => scala
@@ -313,6 +319,11 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |case Some(value) => scala
        |""".stripMargin,
     compat = Map(
+      "2.11" ->
+        """|case None => scala
+           |case Some(x) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |""".stripMargin,
       "2.12" ->
         """|case None => scala
            |case Some(value) => scala
@@ -334,6 +345,11 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |case Some(value) => scala
        |""".stripMargin,
     compat = Map(
+      "2.11" ->
+        """|case None => scala
+           |case Some(x) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |""".stripMargin,
       "2.12" ->
         """|case None => scala
            |case Some(value) => scala
@@ -355,6 +371,12 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |case (exhaustive) Option[A] (2 cases)
        |""".stripMargin,
     compat = Map(
+      "2.11" ->
+        """|case None => scala
+           |case Some(x) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |case (exhaustive) Option[A] (2 cases)
+           |""".stripMargin,
       "2.12" ->
         """|case None => scala
            |case Some(value) => scala
@@ -381,6 +403,12 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |case (exhaustive) Option[A] (2 cases)
        |""".stripMargin,
     compat = Map(
+      "2.11" ->
+        """|case None => scala
+           |case Some(x) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |case (exhaustive) Option[A] (2 cases)
+           |""".stripMargin,
       "2.12" ->
         """|case None => scala
            |case Some(value) => scala
@@ -407,6 +435,11 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |case Some(value) => scala
        |""".stripMargin,
     compat = Map(
+      "2.11" ->
+        """|case None => scala
+           |case Some(x) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |""".stripMargin,
       "2.12" ->
         """|case None => scala
            |case Some(value) => scala
@@ -428,6 +461,11 @@ class CompletionCaseSuite extends BaseCompletionSuite {
        |case Some(value) => scala
        |""".stripMargin,
     compat = Map(
+      "2.11" ->
+        """|case None => scala
+           |case Some(x) => scala
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]
+           |""".stripMargin,
       "2.12" ->
         """|case None => scala
            |case Some(value) => scala
@@ -837,6 +875,9 @@ class CompletionCaseSuite extends BaseCompletionSuite {
     """|case
        |""".stripMargin,
     compat = Map(
+      "2.11" ->
+        """|case
+           |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]""".stripMargin,
       "2.12" ->
         """|case
            |fallbackStringCanBuildFrom[T]: CanBuildFrom[String,T,IndexedSeq[T]]""".stripMargin

--- a/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionIssueSuite.scala
@@ -277,7 +277,8 @@ class CompletionIssueSuite extends BaseCompletionSuite {
        |      ???
        |    }
        |}
-       |""".stripMargin
+       |""".stripMargin,
+    assertSingleItem = false
   )
 
   // We shouldn't get exhaustive completions for AbsolutePath

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -956,7 +956,14 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
        |override def overTop: Int
        |""".stripMargin,
     includeDetail = false,
-    topLines = Some(3)
+    topLines = Some(3),
+    compat = Map(
+      "2.11" ->
+        """|overTop: Int
+           |override def overTop: Int
+           |override def equals(obj: Any): Boolean
+           |""".stripMargin
+    )
   )
 
   checkEdit(
@@ -997,6 +1004,11 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
     includeDetail = false,
     topLines = Some(3),
     compat = Map(
+      "2.11" ->
+        """|override def hello1: Int
+           |override val hello2: Int
+           |override def equals(obj: Any): Boolean
+           |""".stripMargin,
       "3" ->
         """|override def hello1: Int
            |override val hello2: Int

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -952,10 +952,11 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|overTop: Int
+       |deprecatedOverriding scala
        |override def overTop: Int
        |""".stripMargin,
     includeDetail = false,
-    topLines = Some(2)
+    topLines = Some(3)
   )
 
   checkEdit(
@@ -989,11 +990,12 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
        |   overr@@
        |}
        |""".stripMargin,
-    """|override def hello1: Int
+    """|deprecatedOverriding scala
+       |override def hello1: Int
        |override val hello2: Int
        |""".stripMargin,
     includeDetail = false,
-    topLines = Some(2),
+    topLines = Some(3),
     compat = Map(
       "3" ->
         """|override def hello1: Int


### PR DESCRIPTION
This pr aims to resolve https://github.com/scalameta/metals-feature-requests/issues/249

I'm adding an updated version of the current fuzzy matching logic, which treats the first character of the query specially. When a query starts with a lowercase character the forgiving rule is selected in the CompletionProvider.

I wanted the new forgiving matcher to have a very similar feel like the current one, ideally have as little change as possible in the expected results for any existing query, while supporting a more forgiving approach to matching described in the issue above.
The logic I came up with was to give special treatment to the first character of the query. The first character also matches upper case characters. There are some exceptions to this. Symbols which themselves are starting with an upper case letter are not going to be matched in a forgiving way. We also don't want to match lower case characters later in a symbol only because of the forgiving rule. This is best explained with a couple of examples:
 - the query "fiStr" would match "input**Fi**le**Str**eam" without any problems
 -  the query "inStr" would not match "InputFileStream" because the symbol starts with an uppercase. I came up with this rule to cleanup the results I was getting in some tests. For example without this rule in the CompletionKeywordSuite for "val-template" I was getting:
 ```
value: Int
ClassValue java.lang
SafeVarargs java.lang
ScopedValue java.lang
ValueOf scala
val
var
varargs - scala.annotation
override def equals(x$1: Object): Boolean
override def hashCode(): Int
override def finalize(): Unit
```
 - the query "leStr" would not match "inputFileStream" because we don't want to match lower case letters which became accessible only because of the forgiving first letter. This is to avoid confusing results, and keeping the spirit of the original matcher.

As alternatives to the above I also considered:
- Using matchesSubCharacters for queries which are all lowercase. But that gave results which in my opinion where a bit too random for short queries.
- Using case insensitive substring matching, but In my opinion this goes too far away from the spirit of the original matcher, and one looses the ability to quickly narrow down results by typing an upcoming upper case character.