### PR TITLE
fix: ignore implicit apply for signature help

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -47,7 +47,7 @@ class SignatureHelpProvider(val compiler: MetalsGlobal)(implicit
       last
     }
     def isValidQualifier(qual: Tree): Boolean =
-      !qual.pos.includes(pos) && (qual match {
+      !qual.pos.includes(pos) && qual.pos.isRange && (qual match {
         // Ignore synthetic TupleN constructors from tuple syntax.
         case Select(ident @ Ident(TermName("scala")), TermName(tuple))
             if tuple.startsWith("Tuple") && ident.pos == qual.pos =>

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -1159,4 +1159,21 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
        |""".stripMargin
   )
 
+  check(
+    "implicit-conversions",
+    """
+      |class Foo
+      |class Bar
+      |object Baz {
+      |  implicit def foo2bar(foo: Foo): Bar = ???
+      |
+      |  def takesBar(bar: Bar) = ()
+      |  takesBar(new Fo@@o)
+      |}
+      |""".stripMargin,
+    """|takesBar(bar: Bar): Unit
+       |         ^^^^^^^^
+       |""".stripMargin
+  )
+
 }


### PR DESCRIPTION
Previously, signature help at an argument where an implicit conversion is wrapping the argument would produce no results.