### PR TITLE
fix: signature help inside annotation trees

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -56,17 +56,27 @@ class SignatureHelpProvider(val compiler: MetalsGlobal)(implicit
           true
       })
     override def traverse(tree: Tree): Unit = {
-      if (tree.pos.includes(pos)) {
-        tree match {
-          case Apply(qual, _) if isValidQualifier(qual) =>
-            last = tree
-          case TypeApply(qual, _) if isValidQualifier(qual) =>
-            last = tree
-          case AppliedTypeTree(qual, _) if isValidQualifier(qual) =>
-            last = tree
-          case _ =>
-        }
-        super.traverse(tree)
+
+      // Position of annotation tree is outside of `tree.pos` so must be checked separately
+      val annotationTrees = tree match {
+        case annotatable: MemberDef => annotatable.mods.annotations
+        case _ => Nil
+      }
+
+      (tree :: annotationTrees).find(_.pos.includes(pos)) match {
+        case Some(found) =>
+          found match {
+            case Apply(qual, _) if isValidQualifier(qual) =>
+              last = found
+            case TypeApply(qual, _) if isValidQualifier(qual) =>
+              last = found
+            case AppliedTypeTree(qual, _) if isValidQualifier(qual) =>
+              last = found
+            case _ =>
+          }
+          super.traverse(found)
+
+        case None =>
       }
     }
   }

--- a/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/SignatureHelpSuite.scala
@@ -1176,4 +1176,49 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite {
        |""".stripMargin
   )
 
+  check(
+    "class-annotation-constructor",
+    """
+      |class AnAnnotation(i: Int, j: Int) extends annotation.StaticAnnotation
+      |
+      |@AnAnnotation(123, 4@@56)
+      |class Bar
+      |""".stripMargin,
+    """<init>(i: Int, j: Int): AnAnnotation
+      |               ^^^^^^
+      |""".stripMargin
+  )
+
+  check(
+    "field-annotation-constructor",
+    """
+      |class AnAnnotation(i: Int, j: Int) extends annotation.StaticAnnotation
+      |
+      |class Bar {
+      |  @AnAnnotation(123@@, 456)
+      |  def bar = "foo"
+      |}
+      |""".stripMargin,
+    """<init>(i: Int, j: Int): AnAnnotation
+      |               ^^^^^^
+      |""".stripMargin
+  )
+
+  check(
+    "annotation-subtree",
+    """
+      |object Helper {
+      |  def func(i: Int, b: Boolean): Int = ???
+      |}
+      |
+      |class AnAnnotation(i: Int, j: Int) extends annotation.StaticAnnotation
+      |
+      |@AnAnnotation(Helper.func(1, @@true), 3)
+      |class Bar
+      |""".stripMargin,
+    """func(i: Int, b: Boolean): Int
+      |             ^^^^^^^^^^
+      |""".stripMargin
+  )
+
 }


### PR DESCRIPTION
Signature help was never triggering anywhere in annotations (top-level as well as in nested apply calls).

It turns out that the reason was just that the `tree: Tree` position does not extend to also include the position of the annotations on it.