### PR TITLE
feat: discovery main classes in dependencies

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -37,6 +37,7 @@ import scala.meta.internal.metals.codelenses.RunTestCodeLens
 import scala.meta.internal.metals.codelenses.SuperMethodCodeLens
 import scala.meta.internal.metals.codelenses.WorksheetCodeLens
 import scala.meta.internal.metals.debug.BuildTargetClasses
+import scala.meta.internal.metals.debug.BuildTargetClassesFinder
 import scala.meta.internal.metals.debug.DebugDiscovery
 import scala.meta.internal.metals.debug.DebugProvider
 import scala.meta.internal.metals.doctor.Doctor
@@ -1420,6 +1421,13 @@ abstract class MetalsLspService(
       moduleStatus,
     )
 
+  protected val buildTargetClassesFinder: BuildTargetClassesFinder =
+    new BuildTargetClassesFinder(
+      buildTargets,
+      buildTargetClasses,
+      definitionIndex,
+    )
+
   protected val debugDiscovery: DebugDiscovery = new DebugDiscovery(
     buildTargetClasses,
     buildTargets,
@@ -1428,6 +1436,7 @@ abstract class MetalsLspService(
     semanticdbs,
     () => userConfig,
     folder,
+    buildTargetClassesFinder,
   )
 
   protected val debugProvider: DebugProvider = register(
@@ -1438,7 +1447,7 @@ abstract class MetalsLspService(
       compilations,
       languageClient,
       buildClient,
-      definitionIndex,
+      buildTargetClassesFinder,
       stacktraceAnalyzer,
       clientConfig,
       compilers,

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugDiscovery.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugDiscovery.scala
@@ -41,6 +41,7 @@ class DebugDiscovery(
     semanticdbs: () => Semanticdbs,
     userConfig: () => UserConfiguration,
     workspace: AbsolutePath,
+    buildTargetClassesFinder: BuildTargetClassesFinder,
 )(implicit ec: ExecutionContext) {
 
   private def mainClasses(bti: b.BuildTargetIdentifier) =
@@ -62,17 +63,6 @@ class DebugDiscovery(
   }
 
   import DebugDiscovery._
-
-  private def findMainClass(
-      targetId: b.BuildTargetIdentifier,
-      mains: Set[String],
-  ): List[b.ScalaMainClass] = {
-    mainClasses(targetId).values.toList.filter(cls =>
-      mains.contains(
-        cls.getClassName()
-      )
-    )
-  }
 
   private def validate(
       params: DebugDiscoveryParams
@@ -114,39 +104,33 @@ class DebugDiscovery(
           case Some(value) => List(value)
         }
         Option(params.mainClass) match {
-          case Some(main)
-              if targetIds
-                .exists(id => findMainClass(id, Set(main)).nonEmpty) =>
-            Success(ValidRunType.Run(targetIds, Set(main)))
           case Some(main) =>
-            target match {
-              case None => Failure(NoMainClassFoundException(main))
-              case Some(targetId) =>
-                Failure(
-                  ClassNotFoundInBuildTargetException(
-                    main,
-                    displayName(targetId),
-                  )
-                )
-            }
-          case None if targetIds.exists(id => mainClasses(id).nonEmpty) =>
-            Success(
-              ValidRunType.Run(
-                targetIds,
-                targetIds
-                  .map(mainClasses(_).values.map(_.getClassName()))
-                  .flatten
-                  .toSet,
+            buildTargetClassesFinder
+              .findMainClassAndItsBuildTarget(
+                main,
+                buildTarget.map(displayName),
               )
-            )
+              .map(found =>
+                ValidRunType.Run(found.map { case (mainClass, target) =>
+                  target.getId() -> mainClass
+                })
+              )
+
           case None =>
-            target match {
-              case None =>
-                Failure(NothingToRun)
-              case Some(targetId) =>
-                Failure(
-                  BuildTargetContainsNoMainException(displayName(targetId))
-                )
+            val classes = targetIds
+              .flatMap(id => mainClasses(id).values.map(id -> _))
+              .toList
+            if (classes.isEmpty) {
+              target match {
+                case None =>
+                  Failure(NothingToRun)
+                case Some(targetId) =>
+                  Failure(
+                    BuildTargetContainsNoMainException(displayName(targetId))
+                  )
+              }
+            } else {
+              Success(ValidRunType.Run(classes))
             }
         }
       case (Some(RunOrTestFile), Some(target), Some(path)) =>
@@ -170,8 +154,8 @@ class DebugDiscovery(
     val validated = Future.fromTry(validate(params))
 
     validated.flatMap {
-      case ValidRunType.Run(targetIds, mains) =>
-        run(params, targetIds, mains)
+      case ValidRunType.Run(classes) =>
+        run(params, classes)
       case ValidRunType.RunOrTestFile(target, path) =>
         runOrTestFile(target, params, path)
       case ValidRunType.TestFile(target, path) =>
@@ -183,13 +167,10 @@ class DebugDiscovery(
 
   private def run(
       params: DebugDiscoveryParams,
-      targetIds: Seq[b.BuildTargetIdentifier],
-      mains: Set[String],
+      classes: List[(b.BuildTargetIdentifier, b.ScalaMainClass)],
   ): Future[b.DebugSessionParams] = {
-    val targetToMainClasses = targetIds
-      .map(target => target -> findMainClass(target, mains))
-      .filter { case (_, mains) => mains.nonEmpty }
-      .toMap
+    val targetToMainClasses =
+      classes.groupBy(_._1).view.mapValues(_.map(_._2)).toMap
     findMainToRun(
       targetToMainClasses,
       params,
@@ -447,7 +428,7 @@ object DebugDiscovery {
 
     sealed trait Value
 
-    case class Run(targets: Seq[b.BuildTargetIdentifier], mains: Set[String])
+    case class Run(classes: List[(b.BuildTargetIdentifier, b.ScalaMainClass)])
         extends Value
     case class RunOrTestFile(
         target: b.BuildTargetIdentifier,

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -55,7 +55,6 @@ import scala.meta.internal.metals.debug.server.MetalsDebugToolsResolver
 import scala.meta.internal.metals.debug.server.MetalsDebuggee
 import scala.meta.internal.metals.debug.server.TestSuiteDebugAdapter
 import scala.meta.internal.metals.testProvider.TestSuitesProvider
-import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.io.AbsolutePath
 
 import bloop.config.Config
@@ -80,7 +79,7 @@ class DebugProvider(
     compilations: Compilations,
     languageClient: MetalsLanguageClient,
     buildClient: MetalsBuildClient,
-    index: OnDemandSymbolIndex,
+    buildTargetClassesFinder: BuildTargetClassesFinder,
     stacktraceAnalyzer: StacktraceAnalyzer,
     clientConfig: ClientConfiguration,
     compilers: Compilers,
@@ -119,12 +118,6 @@ class DebugProvider(
     if (runner != null) runner.cancel()
     debugSessions.cancel()
   }
-
-  lazy val buildTargetClassesFinder = new BuildTargetClassesFinder(
-    buildTargets,
-    buildTargetClasses,
-    index,
-  )
 
   def start(
       parameters: b.DebugSessionParams

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DiscoveryFailures.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DiscoveryFailures.scala
@@ -21,13 +21,13 @@ object DiscoveryFailures {
       className: String,
       buildTarget: String,
   ) extends Exception(
-        s"Main class '$className' not found in build target '${buildTarget}' (not considering dependencies)"
+        s"Main class '$className' not found in build target '${buildTarget}'"
       )
 
   case class NoMainClassFoundException(
       className: String
   ) extends Exception(
-        s"Main class '$className' not found in any build target (not considering dependencies)"
+        s"Main class '$className' not found in any build target"
       )
 
   case class BuildTargetNotFoundForPathException(path: AbsolutePath)

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -36,6 +36,7 @@ import scala.meta.internal.metals.ClasspathSearch
 import scala.meta.internal.metals.ClientCommands
 import scala.meta.internal.metals.Command
 import scala.meta.internal.metals.Debug
+import scala.meta.internal.metals.DebugDiscoveryParams
 import scala.meta.internal.metals.DebugSession
 import scala.meta.internal.metals.DebugUnresolvedMainClassParams
 import scala.meta.internal.metals.DecoderResponse
@@ -327,6 +328,13 @@ final case class TestingServer(
   ): Future[DecoderResponse] = {
     executeCommand(ServerCommands.DecodeFile, uri)
       .asInstanceOf[Future[DecoderResponse]]
+  }
+
+  def executeDiscoverMainClassesCommand(
+      params: DebugDiscoveryParams
+  ): Future[b.DebugSessionParams] = {
+    executeCommand(ServerCommands.DiscoverMainClasses, params)
+      .asInstanceOf[Future[b.DebugSessionParams]]
   }
 
   def assertSuperMethodHierarchy(


### PR DESCRIPTION
This updates `discovery-jvm-run-command` to match the existing debug discovery logic fallback of looking in dependencies when a main class was specified but not found in the build target itself.

One net outcome: making a "run" launch config in VS code will now uniformly launch the class _not_ in the debug console, regardless of whether the main class is in a dependency or in the target. (Relatedly, [this change][0] to `metals-vscode` is probably no longer as important)

[0]: https://github.com/scalameta/metals-vscode/pull/1597