### PR TITLE
bugfix: Make sure we don't throw when reading workspace files

### DIFF
--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -734,7 +734,9 @@ final case class TestingServer(
       val workspaceFiles =
         nonTarget.flatMap(_.listRecursive.filter(_.isScalaOrJava).toList)
       val usesSystemExit =
-        workspaceFiles.exists(_.text.contains("System.exit(0)"))
+        workspaceFiles.exists(
+          _.readTextOpt.exists(_.contains("System.exit(0)"))
+        )
       if (!usesSystemExit)
         throw new RuntimeException(
           "All debug test for main classes should have `System.exit(0)`"


### PR DESCRIPTION
It seems sometimes we would read mill files which got removed

Found in https://github.com/scalameta/metals/actions/runs/15924363494/job/44918150008