### PR TITLE
refactor: add support for claude

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -266,7 +266,9 @@ class ProjectMetalsLspService(
             diagnostics,
             buildTargets,
             mcpTestRunner,
-            initializeParams.getClientInfo().getName(),
+            userConfig.mcpClient.getOrElse(
+              initializeParams.getClientInfo().getName()
+            ),
             getVisibleName,
             languageClient,
             connectionProvider,

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -59,6 +59,7 @@ case class UserConfiguration(
     enableBestEffort: Boolean = false,
     defaultShell: Option[String] = None,
     startMcpServer: Boolean = false,
+    mcpClient: Option[String] = None,
 ) {
 
   override def toString(): String = {
@@ -156,6 +157,7 @@ case class UserConfiguration(
           startMcpServer,
         )
       ),
+      optStringField("mcpClient", mcpClient),
     ).flatten.toMap.asJava
     val gson = new GsonBuilder().setPrettyPrinting().create()
     gson.toJson(fields).toString()
@@ -518,6 +520,19 @@ object UserConfiguration {
         """|If Metals should start the MCP (SSE) server, that an AI agent can connect to.
            |""".stripMargin,
       ),
+      UserConfigurationOption(
+        "mcp-client",
+        """empty string `""`.""",
+        "claude",
+        "MCP Client Name",
+        """|This is used in situations where the client you're using doesn't match the editor
+           |you're using or you also want an extra config generated, which is what Metals will
+           |default to. For example if you use claude code cli in your terminal while you have
+           |Metals running you would set this to "claude".
+           |NOTE: This will generate an extra config if Metals supports the client you are passing in
+           |and it will still generate the one matching your editor if it's also supported.
+           |""".stripMargin,
+      ),
     )
 
   def fromJson(
@@ -796,6 +811,9 @@ object UserConfiguration {
       getBooleanKey("enable-best-effort").getOrElse(false)
 
     val startMcpServer = getBooleanKey("start-mcp-server").getOrElse(false)
+
+    val mcpClient = getStringKey("mcp-client")
+
     if (errors.isEmpty) {
       Right(
         UserConfiguration(
@@ -830,6 +848,7 @@ object UserConfiguration {
           enableBestEffort,
           defaultShell,
           startMcpServer,
+          mcpClient,
         )
       )
     } else {

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
@@ -61,7 +61,7 @@ class MetalsMcpServer(
     diagnostics: Diagnostics,
     buildTargets: BuildTargets,
     mcpTestRunner: McpTestRunner,
-    editorName: String,
+    clientName: String,
     projectName: String,
     languageClient: LanguageClient,
     connectionProvider: ConnectionProvider,
@@ -158,9 +158,10 @@ class MetalsMcpServer(
     val deployment = manager.addDeployment(servletDeployment)
     deployment.deploy()
 
-    val editor =
-      Editor.allEditors.find(_.names.contains(editorName)).getOrElse(NoEditor)
-    val configPort = McpConfig.readPort(projectPath, projectName, editor)
+    val client =
+      Client.allClients.find(_.names.contains(clientName)).getOrElse(NoClient)
+
+    val configPort = McpConfig.readPort(projectPath, projectName, client)
     val undertowServer = Undertow
       .builder()
       .addHttpListener(configPort.getOrElse(0), "localhost")
@@ -173,7 +174,7 @@ class MetalsMcpServer(
       listenerInfo.get(0).getAddress().asInstanceOf[InetSocketAddress].getPort()
 
     if (!configPort.isDefined) {
-      McpConfig.writeConfig(port, projectName, projectPath, editor)
+      McpConfig.writeConfig(port, projectName, projectPath, client)
     }
 
     languageClient.showMessage(

--- a/tests/unit/src/test/scala/tests/mcp/McpConfigSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpConfigSuite.scala
@@ -4,8 +4,9 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.mcp.Claude
+import scala.meta.internal.metals.mcp.Client
 import scala.meta.internal.metals.mcp.CursorEditor
-import scala.meta.internal.metals.mcp.Editor
 import scala.meta.internal.metals.mcp.McpConfig
 import scala.meta.internal.metals.mcp.VSCodeEditor
 import scala.meta.io.AbsolutePath
@@ -20,11 +21,16 @@ class McpConfigSuite extends BaseSuite {
       port: Int,
       projectName: String,
       expected: String,
-      editor: Editor = CursorEditor,
+      client: Client = CursorEditor,
   ): Unit = {
     test(name) {
       val obtained =
-        McpConfig.createConfig(inputConfig, port, projectName, editor)
+        McpConfig.createConfig(
+          inputConfig,
+          port,
+          client.serverEntry.getOrElse(projectName + "-metals"),
+          client,
+        )
       assertNoDiff(obtained, expected)
     }
   }
@@ -56,7 +62,7 @@ class McpConfigSuite extends BaseSuite {
       |    }
       |  }
       |}""".stripMargin,
-    editor = VSCodeEditor,
+    client = VSCodeEditor,
   )
 
   check(
@@ -71,6 +77,22 @@ class McpConfigSuite extends BaseSuite {
       |    }
       |  }
       |}""".stripMargin,
+  )
+
+  check(
+    "new-config-claude",
+    "{ }",
+    1234,
+    "test-project",
+    """{
+      |  "mcpServers": {
+      |    "metals": {
+      |      "url": "http://localhost:1234/sse",
+      |      "type": "sse"
+      |    }
+      |  }
+      |}""".stripMargin,
+    client = Claude,
   )
 
   check(

--- a/tests/unit/src/test/scala/tests/mcp/McpPortConfigSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpPortConfigSuite.scala
@@ -5,7 +5,7 @@ import scala.util.Random
 
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.mcp.McpConfig
-import scala.meta.internal.metals.mcp.NoEditor
+import scala.meta.internal.metals.mcp.NoClient
 
 import org.eclipse.lsp4j.MessageParams
 import tests.BaseLspSuite
@@ -31,7 +31,7 @@ class McpPortConfigSuite extends BaseLspSuite("mcp-port-config") {
            |""".stripMargin
       )
     } yield {
-      val port = McpConfig.readPort(workspace, "root", NoEditor)
+      val port = McpConfig.readPort(workspace, "root", NoClient)
       assert(port.isDefined)
     }
   }
@@ -40,7 +40,7 @@ class McpPortConfigSuite extends BaseLspSuite("mcp-port-config") {
     cleanWorkspace()
 
     val port = Random.nextInt(55535) + 10000
-    McpConfig.writeConfig(port, "root", workspace, NoEditor)
+    McpConfig.writeConfig(port, "root", workspace, NoClient)
 
     val waitForMessage = Promise[Unit]
     client.showMessageHandler = {


### PR DESCRIPTION
This PR also sort of switches the wording around from being editor focused to client focused allowing for other future configurations to be there for other types of clients, like CLIs. This also introduces a new user configuration option `mcpClient` that a user can manually pass in a client irregardless of what editor they are working in. This is the workflow that I use locally setting this to `claude` and then getting my config (project scoped) automatically generated so that when I start `claude` everything just works.

You can see a video of this working [here](https://imgur.com/a/D3aPsuE).
