### PR TITLE
bugfix: Fix signature help issue if .tpe is null

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/SignatureHelpProvider.scala
@@ -171,7 +171,11 @@ class SignatureHelpProvider(val compiler: MetalsGlobal)(implicit
           o.info
             .member(compiler.nme.apply)
             .safeAlternatives
-            .map(alt => alt -> qual.tpe.memberType(alt))
+            .flatMap { alt =>
+              val tpe = qual.tpe
+              if (tpe == null) None
+              else Some(alt -> tpe.memberType(alt))
+            }
         case o: ClassSymbol =>
           o.info
             .member(compiler.termNames.CONSTRUCTOR)


### PR DESCRIPTION
Fixes scalameta/metals#7608