### PR TITLE
bugfix: Remove stale top level symbols from current run

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/MetalsGlobal.scala
@@ -27,6 +27,7 @@ import scala.{meta => m}
 
 import scala.meta.XtensionSyntax
 import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.mtags.Chars
 import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.semanticdb.scalac.SemanticdbOps
 import scala.meta.pc.CompletionItemPriority
@@ -85,7 +86,6 @@ class MetalsGlobal(
   val fullyCompiled: mutable.Set[String] = mutable.Set.empty[String]
 
   val compileUnitsCache = new CompileUnitsCache(5)
-
   def didChange(uri: URI): Unit = {
     compileUnitsCache.didChange(uri)
   }
@@ -754,8 +754,18 @@ class MetalsGlobal(
             richUnit.source.content
           ) && (isOutline || fullyCompiled(filename)) && !forceNew =>
         value
-      case _ =>
+      case maybeOldUnit =>
         unitOfFile(richUnit.source.file) = richUnit
+
+        maybeOldUnit.foreach { _ =>
+          currentRun.symSource.foreach { case (sym, _) =>
+            // otherwise we seem to be getting stale symbol completions for toplevels
+            if (sym.owner.hasPackageFlag && sym.isStale) {
+              sym.owner.info.decls unlink sym
+            }
+          }
+        }
+
         if (!isOutline) {
           fullyCompiled += filename
         } else {
@@ -961,6 +971,11 @@ class MetalsGlobal(
       sym.pos.isRange &&
         unitOfFile.get(sym.pos.source.file).exists { unit =>
           if (unit.source ne sym.pos.source) {
+            def continuesIdentifier = {
+              val next =
+                unit.source.content(sym.pos.point + sym.decodedName.length())
+              Chars.isIdentifierPart(next)
+            }
             // HACK(olafur) Check if the position of the symbol in the old
             // source points to the symbol's name in the new source file. There
             // are cases where the same class definition has two different
@@ -968,7 +983,8 @@ class MetalsGlobal(
             // `knownDirectSubClasses` returns the version of the class symbol
             // while `Context.lookupSymbol` returns the new version of the class
             // symbol.
-            !unit.source.content.startsWith(sym.decodedName, sym.pos.point)
+            !unit.source.content
+              .startsWith(sym.decodedName, sym.pos.point) || continuesIdentifier
           } else {
             false
           }

--- a/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
+++ b/tests/cross/src/main/scala/tests/BaseCompletionSuite.scala
@@ -20,9 +20,10 @@ abstract class BaseCompletionSuite extends BasePCSuite {
   private def cancelToken: CancelToken = EmptyCancelToken
 
   private def resolvedCompletions(
-      params: CompilerOffsetParams
+      params: CompilerOffsetParams,
+      restart: Boolean
   ): CompletionList = {
-    presentationCompiler.restart()
+    if (restart) presentationCompiler.restart()
     val result = presentationCompiler.complete(params).get()
     val newItems = result.getItems.asScala.map { item =>
       item.data
@@ -36,9 +37,10 @@ abstract class BaseCompletionSuite extends BasePCSuite {
   }
 
   // NOTE: this filters out things from `java.lang.classfile` which was added in JDK 22
-  private def getItems(
+  protected def getItems(
       original: String,
-      filename: String = "A.scala"
+      filename: String = "A.scala",
+      restart: Boolean = true
   ): Seq[CompletionItem] = {
     val (code, offset) = params(original, filename)
     val result = resolvedCompletions(
@@ -47,7 +49,8 @@ abstract class BaseCompletionSuite extends BasePCSuite {
         code,
         offset,
         cancelToken
-      )
+      ),
+      restart
     )
     result.getItems.asScala
       .filterNot(item => item.getLabel().contains("- java.lang.classfile"))

--- a/tests/cross/src/test/scala/tests/pc/CompilerStaleSymSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompilerStaleSymSuite.scala
@@ -1,0 +1,73 @@
+package tests.pc
+
+import munit.TestOptions
+import tests.BaseCompletionSuite
+
+class CompilerStaleSymSuite extends BaseCompletionSuite {
+
+  checkRenamedTopelevel(
+    "multiple-requests",
+    "Metals",
+    (contents, max) => contents.replace(s"object Metals", s"object Metals$max"),
+    s"""|B example
+        |Metals123456789 example
+        |""".stripMargin
+  )
+
+  checkRenamedTopelevel(
+    "multiple-requests-backtick",
+    "`M Metals M`",
+    (contents, max) => contents.replace(s"Metals M", s"Metals M "),
+    s"""|B example
+        |`M Metals M         ` example
+        |""".stripMargin
+  )
+
+  def checkRenamedTopelevel(
+      name: TestOptions,
+      toRename: String,
+      renameFunc: (String, Int) => String,
+      expected: String
+  ): Unit = test(name) {
+    val file1 = "A.scala"
+    val file2 = "B.scala"
+    val baseFile = s"""|package example
+                       |object $toRename {
+                       |  val x = 1
+                       |  x@@
+                       |}""".stripMargin
+    def loop(fileContents: String, max: Int = 9): Unit = {
+      getItems(
+        fileContents,
+        file1,
+        restart = false
+      )
+
+      if (max > 0) {
+        loop(
+          renameFunc(fileContents, max),
+          max - 1
+        )
+      }
+
+    }
+
+    loop(baseFile)
+
+    val items = getItems(
+      s"""|package example
+          |object B {
+          |  val x = 1
+          |  example.@@
+          |}""".stripMargin,
+      file2,
+      restart = false
+    )
+    assertNoDiff(
+      items.map(_.getLabel).mkString("\n"),
+      expected
+    )
+
+  }
+
+}


### PR DESCRIPTION
Normally, symbols are invalidated between runs, but we seem to be always at runId = 1, which means no symbols are invalidated.

To fix that, when updating compilation unit I go over old top level symbols and invalidate if they are stale. I also had to fix the isStale check, which would accept stale Symbol
s such as prefixes of the current symbol.

Fixes https://github.com/scalameta/metals/issues/7587