### PR TITLE
bugfix: Use the current version when publishing docs

### DIFF
--- a/metals-docs/src/main/scala/docs/Snapshot.scala
+++ b/metals-docs/src/main/scala/docs/Snapshot.scala
@@ -32,7 +32,12 @@ object Snapshot {
   ): Snapshot = {
     if (System.getenv("CI") != null) {
       try {
-        fetchLatest(useSnapshot, binaryVersion)
+        // There is no way to query for snapshots currently
+        if (useSnapshot) {
+          Snapshot(BuildInfo.metalsVersion, LocalDateTime.now())
+        } else {
+          fetchLatest(useSnapshot, binaryVersion)
+        }
       } catch {
         case NonFatal(e) if retry > 0 =>
           scribe.error(


### PR DESCRIPTION
Quoting sonatype:

```
Due to a bug with the underlying service we rely on to provide SNAPSHOT hosting, we've had to temporarily remove browse access for SNAPSHOT releases. This is related to an outage we've experienced in early June 2025. You should still be able to publish and consume SNAPSHOT releases as usual, but you cannot browse them via the UI. Please let us know if you encounter any issues.
```