### PR TITLE
fix(mcp): ensure you use serverEntry if it exists to read the port

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpConfig.scala
@@ -54,7 +54,6 @@ object McpConfig {
             configFile.writeText(gson.toJson(value))
           }
       }
-
     }
   }
 
@@ -141,7 +140,9 @@ object McpConfig {
         JsonParser.parseString(configInput).getAsJsonObject()
       ).toOption
       mcpServers <- config.getObjectOption(editor.serverField)
-      serverConfig <- mcpServers.getObjectOption(s"$projectName-metals")
+      serverConfig <- mcpServers.getObjectOption(
+        editor.serverEntry.getOrElse(s"$projectName-metals")
+      )
       url <- serverConfig.getStringOption("url")
       port <- Try(url.stripSuffix("/sse").split(":").last.toInt).toOption
     } yield port

--- a/tests/unit/src/test/scala/tests/mcp/McpConfigSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpConfigSuite.scala
@@ -242,6 +242,21 @@ class McpConfigSuite extends BaseSuite {
     )
   }
 
+  test("getPort - Claude client uses serverEntry") {
+    val config = """{
+      "mcpServers": {
+        "metals": {
+          "url": "http://localhost:8080/sse"
+        }
+      }
+    }"""
+
+    assertEquals(
+      McpConfig.getPort(config, "test-project", Claude),
+      Some(8080),
+    )
+  }
+
   test("deleteConfig - preserves other entries") {
     val workspace = Files.createTempDirectory("metals-mcp-test")
     val projectPath = AbsolutePath(workspace)


### PR DESCRIPTION
This is what was going wrong with claude. Since we use the `serverEntry`
for `claude` it wasn't finding the key correctly and therefore not
seeing the port that already existed.


Fixes #7627
