### PR TITLE
feat: introduce a format-file MCP tool

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -273,6 +273,7 @@ class ProjectMetalsLspService(
             languageClient,
             connectionProvider,
             scalaVersionSelector,
+            formattingProvider,
           )
         ).run()
     }.recover { case e: Exception =>

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
@@ -19,6 +19,7 @@ import scala.meta.internal.metals.Cancelable
 import scala.meta.internal.metals.Compilations
 import scala.meta.internal.metals.ConnectionProvider
 import scala.meta.internal.metals.Diagnostics
+import scala.meta.internal.metals.FormattingProvider
 import scala.meta.internal.metals.JsonParser.XtensionSerializableToJson
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MutableCancelable
@@ -66,6 +67,7 @@ class MetalsMcpServer(
     languageClient: LanguageClient,
     connectionProvider: ConnectionProvider,
     scalaVersionSelector: ScalaVersionSelector,
+    formattingProvider: FormattingProvider,
 )(implicit
     ec: ExecutionContext
 ) extends Cancelable {
@@ -123,6 +125,7 @@ class MetalsMcpServer(
     asyncServer.addTool(importBuildTool()).subscribe()
     asyncServer.addTool(createFindDepTool()).subscribe()
     asyncServer.addTool(createListModulesTool()).subscribe()
+    asyncServer.addTool(createFormatTool()).subscribe()
 
     // Log server initialization
     asyncServer.loggingNotification(
@@ -776,6 +779,74 @@ class MetalsMcpServer(
             false,
           )
         }.toMono
+      },
+    )
+  }
+
+  private def createFormatTool(): AsyncToolSpecification = {
+    val schema =
+      """|{
+         |  "type": "object",
+         |  "properties": {
+         |    "fileInFocus": {
+         |      "type": "string",
+         |      "description": "The file to format, if empty we will try to detect file in focus"
+         |    }
+         |  }
+         |}""".stripMargin
+    new AsyncToolSpecification(
+      new Tool(
+        "format-file",
+        "Format a Scala file and return the formatted text",
+        schema,
+      ),
+      withErrorHandling { (_, arguments) =>
+        val path = arguments.getFileInFocus
+        if (path.exists && path.isScalaFilename) {
+          // Use the existing FormattingProvider
+          val cancelChecker = new org.eclipse.lsp4j.jsonrpc.CancelChecker {
+            override def isCanceled(): Boolean = false
+            override def checkCanceled(): Unit = ()
+          }
+
+          formattingProvider
+            .format(path, projectPath, cancelChecker)
+            .map { textEdits =>
+              if (textEdits.isEmpty) {
+                new CallToolResult(
+                  createContent("File is already properly formatted."),
+                  false,
+                )
+              } else {
+                // Return the formatted text from the first (and likely only) TextEdit
+                val formattedText = textEdits.get(0).getNewText
+                new CallToolResult(
+                  createContent(formattedText),
+                  false,
+                )
+              }
+            }
+            .recover { case exception: Exception =>
+              new CallToolResult(
+                createContent(
+                  s"Error formatting file: ${exception.getMessage}"
+                ),
+                true,
+              )
+            }
+            .toMono
+        } else {
+          Future
+            .successful(
+              new CallToolResult(
+                createContent(
+                  s"Error: File not found or not a Scala file: $path"
+                ),
+                true,
+              )
+            )
+            .toMono
+        }
       },
     )
   }

--- a/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
+++ b/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
@@ -72,4 +72,10 @@ class TestMcpClient(url: String, val port: Int)(implicit ec: ExecutionContext) {
     val params = objectMapper.createObjectNode()
     callTool("list-modules", params).map(_.mkString)
   }
+
+  def format(filePath: String): Future[String] = {
+    val params = objectMapper.createObjectNode()
+    params.put("fileInFocus", filePath)
+    callTool("format-file", params).map(_.mkString)
+  }
 }

--- a/tests/unit/src/test/scala/tests/mcp/McpFormatLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpFormatLspSuite.scala
@@ -1,0 +1,235 @@
+package tests.mcp
+
+import scala.meta.internal.metals.{BuildInfo => V}
+
+import tests.BaseLspSuite
+
+class McpFormatLspSuite extends BaseLspSuite("mcp-format") with McpTestUtils {
+
+  test("format-file - with scalafmt config") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |/.scalafmt.conf
+           |version = "${V.scalafmtVersion}"
+           |runner.dialect = scala213
+           |maxColumn = 40
+           |/a/src/main/scala/com/example/Formatting.scala
+           |package com.example
+           |
+           |object Formatting{def main(args:Array[String]):Unit=println("needs formatting")}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/com/example/Formatting.scala")
+      client <- startMcpServer()
+      formatted <- client.format(
+        server.workspace
+          .resolve("a/src/main/scala/com/example/Formatting.scala")
+          .toString
+      )
+      _ = assert(
+        formatted.contains("object Formatting {"),
+        s"Expected formatted output to contain proper spacing, got: $formatted",
+      )
+      _ = assert(
+        formatted.contains("def main(args: Array[String]): Unit ="),
+        s"Expected formatted output to contain proper spacing, got: $formatted",
+      )
+      _ = assert(
+        formatted.contains("println(\"needs formatting\")"),
+        s"Expected formatted output with proper spacing, got: $formatted",
+      )
+      _ <- client.shutdown()
+    } yield ()
+  }
+
+  test("format-file - without scalafmt config") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |/a/src/main/scala/com/example/Formatting.scala
+           |package com.example
+           |
+           |object Formatting{def main(args:Array[String]):Unit=println("needs formatting")}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/com/example/Formatting.scala")
+      client <- startMcpServer()
+      result <- client.format(
+        server.workspace
+          .resolve("a/src/main/scala/com/example/Formatting.scala")
+          .toString
+      )
+      // Without scalafmt config, may not format or may say already formatted
+      _ = assert(
+        result.contains("File is already properly formatted.") || result
+          .contains("object Formatting"),
+        s"Expected either 'already formatted' message or formatted code, got: $result",
+      )
+      _ <- client.shutdown()
+    } yield ()
+  }
+
+  test("format-file - already properly formatted") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |/.scalafmt.conf
+           |version = "${V.scalafmtVersion}"
+           |runner.dialect = scala213
+           |/a/src/main/scala/com/example/Formatting.scala
+           |package com.example
+           |
+           |object Formatting {
+           |  def main(args: Array[String]): Unit = println("already formatted")
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/com/example/Formatting.scala")
+      client <- startMcpServer()
+      result <- client.format(
+        server.workspace
+          .resolve("a/src/main/scala/com/example/Formatting.scala")
+          .toString
+      )
+      _ = assertNoDiff(
+        result,
+        "File is already properly formatted.",
+      )
+      _ <- client.shutdown()
+    } yield ()
+  }
+
+  test("format-file - non-existent file") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |""".stripMargin
+      )
+      client <- startMcpServer()
+      result <- client.format(
+        server.workspace
+          .resolve("a/src/main/scala/com/example/NonExistent.scala")
+          .toString
+      )
+      _ = assert(
+        result.contains("Error: File not found or not a Scala file"),
+        s"Expected error message for non-existent file, got: $result",
+      )
+      _ <- client.shutdown()
+    } yield ()
+  }
+
+  test("format-file - non-Scala file") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |/a/src/main/java/com/example/JavaFile.java
+           |package com.example;
+           |
+           |public class JavaFile {
+           |    public static void main(String[] args) {
+           |        System.out.println("Java file");
+           |    }
+           |}
+           |""".stripMargin
+      )
+      client <- startMcpServer()
+      result <- client.format(
+        server.workspace
+          .resolve("a/src/main/java/com/example/JavaFile.java")
+          .toString
+      )
+      _ = assert(
+        result.contains("Error: File not found or not a Scala file"),
+        s"Expected error message for Java file, got: $result",
+      )
+      _ <- client.shutdown()
+    } yield ()
+  }
+
+  test("format-file - with custom scalafmt config location") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |/.scala-build/.scalafmt.conf
+           |version = "${V.scalafmtVersion}"
+           |runner.dialect = scala213
+           |style = IntelliJ
+           |/a/src/main/scala/com/example/Formatting.scala
+           |package com.example
+           |
+           |object Formatting{def main(args:Array[String]):Unit=println("needs formatting")}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/com/example/Formatting.scala")
+      client <- startMcpServer()
+      formatted <- client.format(
+        server.workspace
+          .resolve("a/src/main/scala/com/example/Formatting.scala")
+          .toString
+      )
+      _ = assert(
+        formatted.contains("object Formatting {"),
+        s"Expected formatted output with scala-build config, got: $formatted",
+      )
+      _ = assert(
+        formatted.contains("def main(args: Array[String]): Unit ="),
+        s"Expected formatted output with scala-build config, got: $formatted",
+      )
+      _ <- client.shutdown()
+    } yield ()
+  }
+
+  test("format-file - with syntax errors") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |/.scalafmt.conf
+           |version = "${V.scalafmtVersion}"
+           |runner.dialect = scala213
+           |/a/src/main/scala/com/example/Formatting.scala
+           |package com.example
+           |
+           |object Formatting{def main(args:Array[String]):Unit=println("syntax error" }
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/com/example/Formatting.scala")
+      client <- startMcpServer()
+      result <- client.format(
+        server.workspace
+          .resolve("a/src/main/scala/com/example/Formatting.scala")
+          .toString
+      )
+      // With syntax errors, scalafmt may return error, formatted code, or "already formatted"
+      _ = assert(
+        result.contains("Error formatting file") ||
+          result.contains("object Formatting") ||
+          result.contains("File is already properly formatted."),
+        s"Expected error message, code content, or 'already formatted', got: $result",
+      )
+      _ <- client.shutdown()
+    } yield ()
+  }
+}


### PR DESCRIPTION
The specific use-case I have for this is that when using claude code
you're allowed to define tools as hooks. So when you make edits to a
file you can run a hook after it. Often this is something like
formatting. While we can call scalafmt directly I thought it'd be nice
to just add this as another tool as everything is mostly there already.
