### PR TITLE
feature: Add MCP tool to generate and run scalafix rules

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Directories.scala
@@ -30,6 +30,8 @@ object Directories {
     RelativePath(".bsp")
   def metalsSettings: RelativePath =
     RelativePath(".metals").resolve("settings.json")
+  def rules: RelativePath =
+    RelativePath(".metals").resolve("rules")
 
   val stacktraceFilename = "stacktrace.scala"
   val dependenciesName = "dependencies"

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -27,6 +27,7 @@ import scala.meta.internal.metals.mcp.McpQueryEngine
 import scala.meta.internal.metals.mcp.McpSymbolSearch
 import scala.meta.internal.metals.mcp.McpTestRunner
 import scala.meta.internal.metals.mcp.MetalsMcpServer
+import scala.meta.internal.metals.mcp.ScalafixLlmRuleProvider
 import scala.meta.internal.metals.watcher.FileWatcherEvent
 import scala.meta.internal.metals.watcher.FileWatcherEvent.EventType
 import scala.meta.internal.metals.watcher.ProjectFileWatcher
@@ -254,6 +255,14 @@ class ProjectMetalsLspService(
       mcpSearch,
     )
 
+  val scalafixLlmRuleProvider = new ScalafixLlmRuleProvider(
+    folder,
+    scalafixProvider,
+    () => userConfig,
+    languageClient,
+    buildTargets,
+  )
+
   def startMcpServer(): Future[Unit] =
     Future {
       if (!isMcpServerRunning.getAndSet(true))
@@ -274,6 +283,7 @@ class ProjectMetalsLspService(
             connectionProvider,
             scalaVersionSelector,
             formattingProvider,
+            scalafixLlmRuleProvider,
           )
         ).run()
     }.recover { case e: Exception =>

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -261,6 +261,7 @@ class ProjectMetalsLspService(
     () => userConfig,
     languageClient,
     buildTargets,
+    scalaVersionSelector,
   )
 
   def startMcpServer(): Future[Unit] =

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -117,7 +117,7 @@ case class ScalafixProvider(
     val inBuffers = file.toInputFromBuffers(buffers)
 
     additionalDeps.foreach { case (ruleName, dep) =>
-      scribe.info(s"Running rule $ruleName with dep $dep")
+      scribe.debug(s"Running rule $ruleName with dep $dep")
     }
 
     compilations

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -70,6 +70,28 @@ case class ScalafixProvider(
     rulesFut.flatMap(runRules(file, _))
   }
 
+  def runRuleFromDep(
+      file: AbsolutePath,
+      ruleName: String,
+      ruleDep: Dependency,
+  ): Future[List[l.TextEdit]] = {
+    val scalaTarget = buildTargets.inverseSources(file)
+    scalaTarget
+      .flatMap(buildId => buildTargets.scalaTarget(buildId))
+      .map { scalaTarget =>
+        val additionalDeps = Map(
+          ruleName -> Dependency.of(ruleDep)
+        )
+        runScalafixRules(
+          file,
+          scalaTarget,
+          List(ruleName),
+          additionalDeps,
+        )
+      }
+      .getOrElse(Future.successful(Nil))
+  }
+
   def organizeImports(
       file: AbsolutePath,
       scalaTarget: ScalaTarget,
@@ -87,11 +109,16 @@ case class ScalafixProvider(
       file: AbsolutePath,
       scalaTarget: ScalaTarget,
       rules: List[String],
+      additionalDeps: Map[String, Dependency] = Map.empty,
       retried: Boolean = false,
       silent: Boolean = false,
   ): Future[List[l.TextEdit]] = {
     val fromDisk = file.toInput
     val inBuffers = file.toInputFromBuffers(buffers)
+
+    additionalDeps.foreach { case (ruleName, dep) =>
+      scribe.info(s"Running rule $ruleName with dep $dep")
+    }
 
     compilations
       .compilationFinished(file, compileInverseDependencies = false)
@@ -103,6 +130,7 @@ case class ScalafixProvider(
             inBuffers.value,
             retried || isUnsaved(inBuffers.text, fromDisk.text),
             rules,
+            additionalDeps = additionalDeps,
           )
 
         scalafixEvaluation
@@ -135,6 +163,8 @@ case class ScalafixProvider(
               Future.successful(Nil)
             case results if !scalafixSucceded(results) =>
               val scalafixError = getMessageErrorFromScalafix(results)
+              scribe.error(file.toString, scalafixError)
+              scribe.error(additionalDeps.toString)
               val exception = ScalafixRunException(scalafixError)
               if (!silent) {
                 if (
@@ -360,6 +390,7 @@ case class ScalafixProvider(
       rules: List[String],
       suggestConfigAmend: Boolean = true,
       shouldRetry: Boolean = true,
+      additionalDeps: Map[String, Dependency] = Map.empty,
   ): Future[ScalafixEvaluation] = {
     val isScala3 = ScalaVersions.isScala3Version(scalaTarget.scalaVersion)
     val isSource3 = scalaTarget.scalac.getOptions().contains("-Xsource:3")
@@ -396,6 +427,7 @@ case class ScalafixProvider(
         scalaVersion,
         userConfig(),
         rules,
+        additionalDeps,
       )
     // It seems that Scalafix ignores the targetroot parameter and searches the classpath
     // Prepend targetroot to make sure that it's picked up first always
@@ -727,9 +759,16 @@ object ScalafixProvider {
         scalaVersion: String,
         userConfig: UserConfiguration,
         rules: List[String],
+        additionalDeps: Map[String, Dependency],
     ): ScalafixRulesClasspathKey = {
       val rulesClasspath =
-        rulesDependencies(scalaVersion, scalaBinaryVersion, userConfig, rules)
+        rulesDependencies(
+          scalaVersion,
+          scalaBinaryVersion,
+          userConfig,
+          rules,
+          additionalDeps,
+        )
       ScalafixRulesClasspathKey(scalaBinaryVersion, rulesClasspath)
     }
   }
@@ -742,6 +781,7 @@ object ScalafixProvider {
       scalaBinaryVersion: String,
       userConfig: UserConfiguration,
       rules: List[String],
+      additionalDeps: Map[String, Dependency],
   ): Set[Dependency] = {
     val fromSettings =
       userConfig.scalafixRulesDependencies.flatMap { dependencyString =>
@@ -758,7 +798,7 @@ object ScalafixProvider {
             Some(dep)
         }
       }
-    val builtInRuleDeps = builtInRules(scalaBinaryVersion)
+    val builtInRuleDeps = builtInRules(scalaBinaryVersion) ++ additionalDeps
 
     val allDeps = fromSettings ++ rules.flatMap(builtInRuleDeps.get)
     // only get newest versions for each dependency

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/ScalafixLlmRuleProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/ScalafixLlmRuleProvider.scala
@@ -6,6 +6,7 @@ import scala.concurrent.Future
 
 import scala.meta.internal.builds.ShellRunner
 import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.Directories
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.ScalaVersions
 import scala.meta.internal.metals.ScalafixProvider
@@ -25,7 +26,7 @@ class ScalafixLlmRuleProvider(
     metalsClient: MetalsLanguageClient,
     buildTargets: BuildTargets,
 )(implicit ec: ExecutionContext) {
-  private val rulesDirectory = workspace.resolve(".metals/rules")
+  private val rulesDirectory = workspace.resolve(Directories.rules)
 
   private def layout(
       ruleName: String,
@@ -68,7 +69,6 @@ class ScalafixLlmRuleProvider(
     scribe.debug(s"Wrote the rule to $rulesFile")
     rulesFile.writeText(ruleContents)
 
-    // TODO does semantic rule need a different file?
     val metadataFile =
       ruleDir.resolve(s"resources/META-INF/services/scalafix.v1.Rule")
     metadataFile.writeText(s"$ruleNameToUse")
@@ -183,4 +183,17 @@ class ScalafixLlmRuleProvider(
     Future.sequence(all.toList).map(_ => ())
   }
 
+}
+
+object ScalafixLlmRuleProvider {
+  // Curated list of rules that LLMs can use
+  def curatedRules : Map[String, String] = {
+    Map(
+      "ExplicitResultTypes" -> "Inserts type annotations for inferred public members.",
+      "OrganizeImports" -> "Organize import statements, used for source.organizeImports code action",
+      "RemoveUnused" -> "Removes unused imports and terms that reported by the compiler under -Wunused",
+      "ProcedureSyntax" -> "Replaces deprecated Scala 2.x procedure syntax with explicit ': Unit ='",
+      "RedundantSyntax" -> "Removes redundant syntax such as `final` modifiers on an object",
+    )
+  }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/ScalafixLlmRuleProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/ScalafixLlmRuleProvider.scala
@@ -1,0 +1,186 @@
+package scala.meta.internal.metals.mcp
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import scala.meta.internal.builds.ShellRunner
+import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ScalaVersions
+import scala.meta.internal.metals.ScalafixProvider
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.scalacli.ScalaCli
+import scala.meta.io.AbsolutePath
+
+import coursierapi.Dependency
+import org.eclipse.lsp4j.ApplyWorkspaceEditParams
+import org.eclipse.lsp4j.WorkspaceEdit
+
+class ScalafixLlmRuleProvider(
+    workspace: AbsolutePath,
+    scalafixProvider: ScalafixProvider,
+    userConfig: () => UserConfiguration,
+    metalsClient: MetalsLanguageClient,
+    buildTargets: BuildTargets,
+)(implicit ec: ExecutionContext) {
+  private val rulesDirectory = workspace.resolve(".metals/rules")
+
+  private def layout(
+      ruleName: String,
+      scalaVersion: String,
+      ruleImplementation: String,
+  ): String =
+    s"""|
+        |//> using scala $scalaVersion
+        |//> using dep "ch.epfl.scala:scalafix-core_2.13:0.14.3"
+        |//> using publish.organization "com.github.metals"
+        |//> using publish.name "$ruleName"
+        |//> using publish.version "0.1.0-SNAPSHOT"
+        |//> using test.resourceDir ./resources
+        |
+        |$ruleImplementation
+        |
+        |""".stripMargin
+
+  private def publishRule(
+      ruleName: String,
+      scalaVersion: String,
+      ruleImplementation: String,
+      description: String,
+  ): Either[String, Dependency] = {
+    val ruleContents = layout(ruleName, scalaVersion, ruleImplementation)
+    import scala.meta._
+    val checkPackage = ruleContents.parse[Source] match {
+      case Parsed.Success(source) => source
+      case Parsed.Error(pos, message, details) =>
+        throw details
+    }
+    val ruleNameToUse = checkPackage match {
+      case Source(List(Pkg(name, _))) => name.syntax + "." + ruleName
+      case otherwise =>
+        scribe.debug(s"No package found in rule: ${otherwise.syntax}")
+        ruleName
+    }
+    val ruleDir = rulesDirectory.resolve(ruleName)
+    val rulesFile = ruleDir.resolve(s"$ruleName.scala")
+    scribe.debug(s"Wrote the rule to $rulesFile")
+    rulesFile.writeText(ruleContents)
+
+    // TODO does semantic rule need a different file?
+    val metadataFile =
+      ruleDir.resolve(s"resources/META-INF/services/scalafix.v1.Rule")
+    metadataFile.writeText(s"$ruleNameToUse")
+    scribe.debug(s"Wrote the rule definition to $metadataFile")
+    val readmeFile = ruleDir.resolve("README.md")
+    val binaryVersion =
+      ScalaVersions.scalaBinaryVersionFromFullVersion(scalaVersion)
+    val scalaCli =
+      ScalaCli.localScalaCli(userConfig()).getOrElse(ScalaCli.jvmBased())
+
+    scribe.info(
+      s"Publishing rule with command: ${scalaCli.command.toList ++ List("publish", "local", ruleDir.toString())}"
+    )
+    val errorReporting = new StringBuilder()
+    val result = ShellRunner.runSync(
+      scalaCli.command.toList ++ List("publish", "local", ruleDir.toString()),
+      workspace,
+      redirectErrorOutput = false,
+      processErr = { err =>
+        scribe.error(err)
+        errorReporting.append(err + "\n")
+      },
+    )
+    result match {
+      case Some(_) =>
+        readmeFile.writeText(description)
+        Right(
+          Dependency.of(
+            s"com.github.metals",
+            s"${ruleName}_$binaryVersion",
+            "0.1.0-SNAPSHOT",
+          )
+        )
+      case None =>
+        readmeFile.deleteIfExists()
+        Left(s"Error publishing rule: ${errorReporting.toString()}")
+
+    }
+  }
+
+  def runOnAllTargets(
+      ruleName: String,
+      ruleImplementation: String,
+      description: String,
+  ): Either[String, Future[Unit]] = {
+    val publishedBuffer = TrieMap.empty[String, Dependency]
+    val allTargets =
+      buildTargets.allBuildTargetIds.map(buildTargets.scalaTarget).collect {
+        case Some(scalaTarget) if !scalaTarget.isSbt => scalaTarget
+      }
+    val allScalaVersions = allTargets.map(_.scalaVersion).toSet
+    def loop(scalaVersions: List[String]): Either[String, Future[Unit]] =
+      scalaVersions match {
+        case scalaVersion :: next =>
+          publishRule(
+            ruleName,
+            scalaVersion,
+            ruleImplementation,
+            description,
+          ) match {
+            case Left(value) => Left(value)
+            case Right(value) =>
+              publishedBuffer.put(scalaVersion, value)
+              loop(next)
+          }
+        case Nil => Right(Future.unit)
+      }
+    loop(allScalaVersions.toList) match {
+      case Left(value) => Left(value)
+      case Right(value) =>
+        val allFutures = allTargets.iterator.map { scalaTarget =>
+          val sources = buildTargets.buildTargetSources(scalaTarget.id).toList
+          runScalafixRule(
+            ruleName,
+            sources,
+            publishedBuffer.getOrElse(
+              scalaTarget.scalaVersion,
+              throw new RuntimeException(
+                s"No published rule for ${scalaTarget.scalaVersion}"
+              ),
+            ),
+          )
+        }
+        Right(Future.sequence(allFutures.toList).map(_ => ()))
+    }
+  }
+
+  private def runScalafixRule(
+      ruleName: String,
+      sources: List[AbsolutePath],
+      publishedRule: Dependency,
+  ): Future[Unit] = {
+    val all =
+      sources.filter(file => file.filename.isScala).map { file =>
+        scalafixProvider
+          .runRuleFromDep(
+            file,
+            ruleName,
+            publishedRule,
+          )
+          .flatMap { edits =>
+            val changes = Map(file.toURI.toString -> edits.asJava).asJava
+            metalsClient
+              .applyEdit(
+                new ApplyWorkspaceEditParams(
+                  new WorkspaceEdit(changes)
+                )
+              )
+              .asScala
+          }
+      }
+    Future.sequence(all.toList).map(_ => ())
+  }
+
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -317,6 +317,17 @@ object ScalaCli {
     ) extends ConnectionState
   }
 
+  def jvmBased(): ScalaCliCommand = {
+    val cp = ScalaCli.scalaCliClassPath()
+    val command = Seq(
+      ScalaCli.javaCommand,
+      "-cp",
+      cp.mkString(File.pathSeparator),
+      ScalaCli.scalaCliMainClass,
+    )
+    ScalaCliCommand(command, Version(BuildInfo.scalaCliVersion))
+  }
+
   def localScalaCli(userConfig: UserConfiguration): Option[ScalaCliCommand] = {
 
     def readFully(is: InputStream): Array[Byte] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCliServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCliServers.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.metals.scalacli
 
-import java.io.File
 import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicReference
 
@@ -25,11 +24,8 @@ import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.WorkDoneProgress
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.scalacli.ScalaCli.ScalaCliCommand
-import scala.meta.internal.metals.{BuildInfo => V}
 import scala.meta.internal.process.SystemProcess
 import scala.meta.io.AbsolutePath
-
-import coursier.core.Version
 
 class ScalaCliServers(
     compilers: () => Compilers,
@@ -94,19 +90,8 @@ class ScalaCliServers(
       scribe.warn(
         s"scala-cli >= ${ScalaCli.minVersion} not found in PATH, fetching and starting a JVM-based Scala CLI"
       )
-      jvmBased()
+      ScalaCli.jvmBased()
     }
-  }
-
-  def jvmBased(): ScalaCliCommand = {
-    val cp = ScalaCli.scalaCliClassPath()
-    val command = Seq(
-      ScalaCli.javaCommand,
-      "-cp",
-      cp.mkString(File.pathSeparator),
-      ScalaCli.scalaCliMainClass,
-    )
-    ScalaCliCommand(command, Version(V.scalaCliVersion))
   }
 
   def lastImportedBuilds: List[(ImportedBuild, TargetData)] =

--- a/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
+++ b/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
@@ -83,4 +83,14 @@ class TestMcpClient(url: String, val port: Int)(implicit ec: ExecutionContext) {
     params.put("fileInFocus", filePath)
     callTool("format-file", params).map(_.mkString)
   }
+
+  def runScalafixRule(
+      ruleName: String,
+      ruleImplementation: String,
+  ): Future[String] = {
+    val params = objectMapper.createObjectNode()
+    params.put("ruleName", ruleName)
+    params.put("ruleImplementation", ruleImplementation)
+    callTool("run-scalafix-rule", params).map(_.mkString)
+  }
 }

--- a/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
+++ b/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
@@ -84,18 +84,30 @@ class TestMcpClient(url: String, val port: Int)(implicit ec: ExecutionContext) {
     callTool("format-file", params).map(_.mkString)
   }
 
-  def runScalafixRule(
+  def generateScalafixRule(
       ruleName: String,
       ruleImplementation: String,
+      ruleDescription: String,
   ): Future[String] = {
     val params = objectMapper.createObjectNode()
     params.put("ruleName", ruleName)
     params.put("ruleImplementation", ruleImplementation)
-    callTool("run-scalafix-rule", params).map(_.mkString)
+    params.put("description", ruleDescription)
+    callTool("generate-scalafix-rule", params).map(_.mkString)
   }
 
   def listScalafixRules(): Future[String] = {
     val params = objectMapper.createObjectNode()
     callTool("list-scalafix-rules", params).map(_.mkString)
+  }
+
+  def runScalafixRule(
+      ruleName: String,
+      filePath: Option[String] = None,
+  ): Future[String] = {
+    val params = objectMapper.createObjectNode()
+    params.put("ruleName", ruleName)
+    filePath.foreach(path => params.put("fileToRunOn", path))
+    callTool("run-scalafix-rule", params).map(_.mkString)
   }
 }

--- a/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
+++ b/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
@@ -88,11 +88,13 @@ class TestMcpClient(url: String, val port: Int)(implicit ec: ExecutionContext) {
       ruleName: String,
       ruleImplementation: String,
       ruleDescription: String,
+      sampleCode: Option[String] = None,
   ): Future[String] = {
     val params = objectMapper.createObjectNode()
     params.put("ruleName", ruleName)
     params.put("ruleImplementation", ruleImplementation)
     params.put("description", ruleDescription)
+    sampleCode.foreach(code => params.put("sampleCode", code))
     callTool("generate-scalafix-rule", params).map(_.mkString)
   }
 

--- a/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
+++ b/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
@@ -93,4 +93,9 @@ class TestMcpClient(url: String, val port: Int)(implicit ec: ExecutionContext) {
     params.put("ruleImplementation", ruleImplementation)
     callTool("run-scalafix-rule", params).map(_.mkString)
   }
+
+  def listScalafixRules(): Future[String] = {
+    val params = objectMapper.createObjectNode()
+    callTool("list-scalafix-rules", params).map(_.mkString)
+  }
 }

--- a/tests/unit/src/test/scala/tests/mcp/McpServerLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpServerLspSuite.scala
@@ -157,6 +157,37 @@ class McpServerLspSuite extends BaseLspSuite("mcp-server") with McpTestUtils {
            |}
            |""".stripMargin,
       )
+      // Test listing scalafix rules after creating one
+      rules <- client.listScalafixRules()
+      _ = assert(
+        rules.contains("ReplaceJohnWithJohnatan"),
+        s"Expected rules to contain ReplaceJohnWithJohnatan, got: $rules",
+      )
+      _ <- client.shutdown()
+    } yield ()
+  }
+
+  test("list-scalafix-rules") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{"a": {}}
+           |/a/src/main/scala/com/example/Hello.scala
+           |package com.example
+           |
+           |object Hello { def main(args: Array[String]): Unit = println("Hello") }
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/com/example/Hello.scala")
+      client <- startMcpServer()
+      // Test with no rules present
+      noRulesResult <- client.listScalafixRules()
+      _ = assertNoDiff(
+        noRulesResult,
+        McpMessages.ListScalafixRules.noRulesFound,
+      )
       _ <- client.shutdown()
     } yield ()
   }


### PR DESCRIPTION
The intention is to do large scal refactorings even in larger codebase without the need to create a large context.