### PR TITLE
feat: add in `testName` to the test tool

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
@@ -29,12 +29,17 @@ class McpTestRunner(
   def runTests(
       testClass: String,
       optPath: Option[AbsolutePath],
+      testName: Option[String],
       verbose: Boolean,
   ): Either[String, Future[String]] = {
-    val testSuites = new b.ScalaTestSuites(
-      List(
+    val testSelection = testName match {
+      case Some(name) =>
+        new b.ScalaTestSuiteSelection(testClass, List(name).asJava)
+      case None =>
         new b.ScalaTestSuiteSelection(testClass, Nil.asJava)
-      ).asJava,
+    }
+    val testSuites = new b.ScalaTestSuites(
+      List(testSelection).asJava,
       Nil.asJava,
       Nil.asJava,
     )

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
@@ -408,6 +408,10 @@ class MetalsMcpServer(
          |      "type": "string",
          |      "description": "Fully qualified name of the test class to run"
          |    },
+         |    "testName": {
+         |      "type": "string",
+         |      "description": "Name of the specific test to run within the test class, if empty runs all tests in the class"
+         |    },
          |    "verbose": {
          |      "type": "boolean",
          |      "description": "Print all output from the test suite, otherwise prints only errors and summary",
@@ -423,12 +427,14 @@ class MetalsMcpServer(
         val optPath = arguments
           .getOptAs[String]("testFile")
           .map(path => AbsolutePath(Path.of(path))(projectPath))
+        val testName = arguments.getOptAs[String]("testName")
         val printOnlyErrorsAndSummary = arguments
           .getOptAs[Boolean]("verbose")
           .getOrElse(false)
         val result = mcpTestRunner.runTests(
           testClass,
           optPath,
+          testName,
           printOnlyErrorsAndSummary,
         )
         (result match {

--- a/tests/unit/src/test/scala/tests/mcp/McpRunTestSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpRunTestSuite.scala
@@ -44,7 +44,12 @@ class McpRunTestSuite extends BaseLspSuite("mcp-test") {
 
       // Test with explicit path and verbose output
       res1 <- server.headServer.mcpTestRunner
-        .runTests("a.b.MunitTestSuite", Some(path), verbose = true) match {
+        .runTests(
+          "a.b.MunitTestSuite",
+          Some(path),
+          None,
+          verbose = true,
+        ) match {
         case Right(value) => value
         case Left(error) => throw new RuntimeException(error)
       }
@@ -54,13 +59,41 @@ class McpRunTestSuite extends BaseLspSuite("mcp-test") {
 
       // Test without path and non-verbose output
       res2 <- server.headServer.mcpTestRunner
-        .runTests("a.b.MunitTestSuite", None, verbose = false) match {
+        .runTests("a.b.MunitTestSuite", None, None, verbose = false) match {
         case Right(value) => value
         case Left(error) => throw new RuntimeException(error)
       }
       _ = assert(res2.contains("2 tests, 1 passed, 1 failed"), res2)
       // Non-verbose prints only errors and summary
       _ = assert(!res2.contains("Some string"), res2)
+
+      // Test running a single test that passes
+      res3 <- server.headServer.mcpTestRunner
+        .runTests(
+          "a.b.MunitTestSuite",
+          Some(path),
+          Some("test1"),
+          verbose = false,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      _ = assert(res3.contains("test1"), s"Should contain test1: $res3")
+      _ = assert(res3.contains("2 tests, 1 passed, 0 failed, 1 skipped"), res3)
+
+      // Test running a single test that fails
+      res4 <- server.headServer.mcpTestRunner
+        .runTests(
+          "a.b.MunitTestSuite",
+          Some(path),
+          Some("test2"),
+          verbose = false,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      _ = assert(res4.contains("test2"), s"Should contain test2: $res4")
+      _ = assert(res4.contains("2 tests, 0 passed, 1 failed, 1 skipped"), res4)
     } yield ()
   }
 
@@ -104,7 +137,7 @@ class McpRunTestSuite extends BaseLspSuite("mcp-test") {
 
       // Test ZIO test execution - runs all tests in the suite
       result <- server.headServer.mcpTestRunner
-        .runTests("a.ZioTestSuite", Some(path), verbose = false) match {
+        .runTests("a.ZioTestSuite", Some(path), None, verbose = false) match {
         case Right(value) => value
         case Left(error) => throw new RuntimeException(error)
       }
@@ -116,6 +149,147 @@ class McpRunTestSuite extends BaseLspSuite("mcp-test") {
       _ = assert(
         result.contains("test two"),
         s"ZIO test result should contain 'test two': '$result'",
+      )
+
+      // Test running a single ZIO test
+      singleResult <- server.headServer.mcpTestRunner
+        .runTests(
+          "a.ZioTestSuite",
+          Some(path),
+          Some("test one"),
+          verbose = false,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      _ = assert(
+        singleResult.nonEmpty,
+        s"Single ZIO test returned empty result: '$singleResult'",
+      )
+      _ = assert(
+        singleResult.contains("test one"),
+        s"Single ZIO test result should contain 'test one': '$singleResult'",
+      )
+      // ZIO test framework doesn't seem to support individual test selection properly yet
+      // So we just verify the test ran and contains our target test
+    } yield ()
+  }
+
+  test("individual-test-execution", maxRetry = 3) {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "libraryDependencies" : ["org.scalameta::munit:1.0.0-M4"]
+           |  }
+           |}
+           |/a/src/test/scala/a/IndividualTestSuite.scala
+           |package a
+           |
+           |class IndividualTestSuite extends munit.FunSuite {
+           |  test("passing test") {
+           |    assert(1 == 1)
+           |  }
+           |
+           |  test("failing test") {
+           |    assert(1 == 2)
+           |  }
+           |
+           |  test("another passing test") {
+           |    assert(true)
+           |  }
+           |}
+           |
+           |""".stripMargin
+      )
+      _ <- server.didOpen(
+        "a/src/test/scala/a/IndividualTestSuite.scala"
+      )
+      _ = assertNoDiagnostics()
+      _ <- server.server.indexingPromise.future
+      path = server.toPath("a/src/test/scala/a/IndividualTestSuite.scala")
+
+      // Test running all tests
+      allResult <- server.headServer.mcpTestRunner
+        .runTests(
+          "a.IndividualTestSuite",
+          Some(path),
+          None,
+          verbose = false,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      _ = assert(
+        allResult.contains("3 tests, 2 passed, 1 failed"),
+        s"All tests result: $allResult",
+      )
+
+      // Test running only the passing test
+      passingResult <- server.headServer.mcpTestRunner
+        .runTests(
+          "a.IndividualTestSuite",
+          Some(path),
+          Some("passing test"),
+          verbose = false,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      _ = assert(
+        passingResult.contains("passing test"),
+        s"Should contain 'passing test': $passingResult",
+      )
+      _ = assert(
+        passingResult.contains("3 tests, 1 passed, 0 failed, 2 skipped"),
+        s"Should have 1 passed: $passingResult",
+      )
+      _ = assert(
+        !passingResult.contains("failing test failed"),
+        s"Should not show 'failing test' as failed: $passingResult",
+      )
+
+      // Test running only the failing test
+      failingResult <- server.headServer.mcpTestRunner
+        .runTests(
+          "a.IndividualTestSuite",
+          Some(path),
+          Some("failing test"),
+          verbose = false,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      _ = assert(
+        failingResult.contains("failing test"),
+        s"Should contain 'failing test': $failingResult",
+      )
+      _ = assert(
+        failingResult.contains("3 tests, 0 passed, 1 failed, 2 skipped"),
+        s"Should have 1 failed: $failingResult",
+      )
+      _ = assert(
+        !failingResult.contains("passing test passed"),
+        s"Should not show 'passing test' as passed: $failingResult",
+      )
+
+      // Test running a non-existent test
+      nonExistentResult <- server.headServer.mcpTestRunner
+        .runTests(
+          "a.IndividualTestSuite",
+          Some(path),
+          Some("non-existent test"),
+          verbose = false,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      _ = assert(
+        nonExistentResult.contains("3 tests, 0 passed, 0 failed, 3 skipped"),
+        s"Non-existent test should skip all tests: $nonExistentResult",
       )
     } yield ()
   }


### PR DESCRIPTION
I've seen claude do this a few times with sbt where it uses --z to
target a specific test that it knows it testing what i needs, not a
whole suite. I thought it'd be nice for the test tool to also be used
for this. So not not only can you pass in the testFile, but also the
testName in that file.
