### PR TITLE
Enable Scala3Future dialect support (capture checking, better modularity)

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalaTarget.scala
@@ -2,12 +2,15 @@ package scala.meta.internal.metals
 
 import scala.util.Success
 import scala.util.Try
+import scala.util.matching.Regex
 
 import scala.meta.Dialect
 import scala.meta.dialects._
 import scala.meta.internal.builds.BazelBuildTool
 import scala.meta.internal.builds.MillBuildTool
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ScalaTarget.ExperimentalSyntaxRegex
+import scala.meta.internal.metals.ScalaTarget.KindProjectorRegex
 import scala.meta.internal.semver.SemVer
 import scala.meta.io.AbsolutePath
 
@@ -17,11 +20,6 @@ import ch.epfl.scala.bsp4j.JvmBuildTarget
 import ch.epfl.scala.bsp4j.ScalaBuildTarget
 import ch.epfl.scala.bsp4j.ScalaPlatform
 import ch.epfl.scala.bsp4j.ScalacOptionsItem
-import scala.util.matching.Regex
-import scala.meta.internal.metals.ScalaTarget.{
-  KindProjectorRegex,
-  ExperimentalSyntaxRegex,
-}
 
 case class ScalaTarget(
     info: BuildTarget,


### PR DESCRIPTION
Follow up scalameta/metals-feature-requests#438
The language mode is triggered by scalacOptions

- [language:experimental.captureChecking](https://docs.scala-lang.org/scala3/reference/experimental/cc.html)
- [language:experimental.modularity](https://docs.scala-lang.org/scala3/reference/experimental/modularity.html)
- [language:experimental.into](https://docs.scala-lang.org/scala3/reference/experimental/into.html)