### PR TITLE
bugfix: Remove jrtClassPathCAches to try fix -release issues

### DIFF
--- a/mtags/src/main/scala-2.11/scala/meta/internal/pc/JrtClasspathCompat.scala
+++ b/mtags/src/main/scala-2.11/scala/meta/internal/pc/JrtClasspathCompat.scala
@@ -1,0 +1,9 @@
+package scala.meta.internal.pc
+
+import java.util.logging.Logger
+
+object JrtClasspathCompat {
+
+  def clearJrtClassPathCaches(logger: Logger): Boolean = false
+
+}

--- a/mtags/src/main/scala-2.12/scala/meta/internal/pc/JrtClasspathCompat.scala
+++ b/mtags/src/main/scala-2.12/scala/meta/internal/pc/JrtClasspathCompat.scala
@@ -1,0 +1,9 @@
+package scala.meta.internal.pc
+
+import java.util.logging.Logger
+
+object JrtClasspathCompat {
+
+  def clearJrtClassPathCaches(logger: Logger): Boolean = true
+
+}

--- a/mtags/src/main/scala-2.13/scala/meta/internal/pc/JrtClasspathCompat.scala
+++ b/mtags/src/main/scala-2.13/scala/meta/internal/pc/JrtClasspathCompat.scala
@@ -1,0 +1,47 @@
+package scala.meta.internal.pc
+
+import java.util.logging.Logger
+
+import scala.tools.nsc.classpath.FileBasedCache
+import scala.tools.nsc.classpath.JrtClassPath
+
+object JrtClasspathCompat {
+
+  /**
+   * It seems that sometimes the JrtClassPath or CtSymClassPath caches get corrupted
+   * and since it's an object it never gets removed or cleared even when restarting
+   * the compiler.
+   *
+   * @return true if the caches were cleared, false otherwise if any reflection failed
+   */
+  def clearJrtClassPathCaches(logger: Logger): Boolean = {
+    try {
+      val jrtClassPathClass = JrtClassPath.getClass()
+      val jrtClassPathCacheField =
+        jrtClassPathClass.getDeclaredField("jrtClassPathCache")
+      jrtClassPathCacheField.setAccessible(true)
+      val jrtClassPathCache =
+        jrtClassPathCacheField.get(null).asInstanceOf[FileBasedCache[_, _]]
+
+      jrtClassPathCache.clear()
+
+      val ctSymClassPathCacheField =
+        jrtClassPathClass.getDeclaredField("ctSymClassPathCache")
+      ctSymClassPathCacheField.setAccessible(true)
+      val ctSymClassPathCache = ctSymClassPathCacheField
+        .get(null)
+        .asInstanceOf[FileBasedCache[_, _]]
+
+      ctSymClassPathCache.clear()
+
+      true
+    } catch {
+      case e: Exception =>
+        logger.warning(
+          s"Failed to clear JrtClassPath caches: ${e.getMessage}"
+        )
+        false
+    }
+  }
+
+}

--- a/tests/cross/src/test/scala/tests/pc/Release8CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/Release8CompletionSuite.scala
@@ -2,6 +2,9 @@ package tests.pc
 
 import java.nio.file.Path
 
+import scala.meta.internal.pc.JrtClasspathCompat
+import scala.meta.internal.pc.ScalaPresentationCompiler
+
 import tests.BaseCompletionSuite
 
 class Release8CompletionSuite extends BaseCompletionSuite {
@@ -65,4 +68,15 @@ class Release8CompletionSuite extends BaseCompletionSuite {
     )
   )
 
+  test("clear-jrt-class-path-caches") {
+    presentationCompiler match {
+      case pc: ScalaPresentationCompiler =>
+        assert(
+          JrtClasspathCompat.clearJrtClassPathCaches(pc.logger),
+          "Failed to clear JrtClassPath caches"
+        )
+      case _ =>
+        fail("presentationCompiler is not a ScalaPresentationCompiler")
+    }
+  }
 }


### PR DESCRIPTION
I can't find the actual problem where it happens unfortunately, so this is my best guess on what can help. This might anyway be needed for older Scala 2.13 versions, but we could try to fix it in later.

I tested this with the debugger and clearing the cache actually fixed things.

Another try at https://github.com/scalameta/metals/issues/5272