### PR TITLE
improvement: Index toplevel members from dependencies

### DIFF
--- a/metals/src/main/resources/db/migration/V7__Toplevel_members.sql
+++ b/metals/src/main/resources/db/migration/V7__Toplevel_members.sql
@@ -1,0 +1,17 @@
+-- Toplevel member information, e.g. symbol: "a/Foo#Bar#", range: "1:5-1:8"
+create table toplevel_members(
+  symbol varchar not null,
+  start_line int not null,
+  start_character int not null,
+  end_line int not null,
+  end_character int not null,
+  path varchar not null,
+  kind int not null,
+  jar int,
+  foreign key (jar) references indexed_jar (id) on delete cascade
+);
+
+create index toplevel_members_jar on toplevel_members(jar);
+
+alter table indexed_jar
+add toplevel_members_indexed bit;

--- a/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/implementation/ImplementationProvider.scala
@@ -85,7 +85,7 @@ final class ImplementationProvider(
   }
 
   def addTypeHierarchy(results: List[IndexingResult]): Unit = for {
-    IndexingResult(path, _, overrides) <- results
+    IndexingResult(path, _, overrides, _) <- results
     (overridesSymbol, overriddenSymbols) <- overrides
     overridden <- overriddenSymbols
   } addTypeHierarchyElement(path, overridesSymbol, overridden)

--- a/metals/src/main/scala/scala/meta/internal/metals/SqlSharedIndices.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SqlSharedIndices.scala
@@ -21,5 +21,5 @@ class SqlSharedIndices
       migrations = "/shared-db/migration",
     ) {
 
-  val jvmTypeHierarchy: JarTypeHierarchy = new JarTypeHierarchy(() => connect)
+  val jvmTypeHierarchy: JarIndexingInfo = new JarIndexingInfo(() => connect)
 }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/GlobalSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/GlobalSymbolIndex.scala
@@ -87,7 +87,8 @@ trait GlobalSymbolIndex {
    */
   def addSourceJar(
       jar: AbsolutePath,
-      dialect: Dialect
+      dialect: Dialect,
+      reindex: Boolean = false
   ): List[IndexingResult]
 
   /**
@@ -126,5 +127,6 @@ case class SymbolDefinition(
 case class IndexingResult(
     path: AbsolutePath,
     topLevels: List[String],
-    overrides: List[(String, List[OverriddenSymbol])]
+    overrides: List[(String, List[OverriddenSymbol])],
+    toplevelMembers: List[ToplevelMember]
 )

--- a/mtags/src/main/scala/scala/meta/internal/mtags/Mtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/Mtags.scala
@@ -49,11 +49,15 @@ final class Mtags(implicit rc: ReportContext) {
     }
   }
 
-  def indexWithOverrides(
+  def extendedIndexing(
       path: AbsolutePath,
       dialect: Dialect = dialects.Scala213,
       includeMembers: Boolean = false
-  ): (TextDocument, MtagsIndexer.AllOverrides) = {
+  ): (
+      TextDocument,
+      MtagsIndexer.AllOverrides,
+      MtagsIndexer.AllToplevelMembers
+  ) = {
     val input = path.toInput
     val language = input.toLanguage
     if (language.isJava || language.isScala) {
@@ -74,8 +78,9 @@ final class Mtags(implicit rc: ReportContext) {
           mtags.index()
         )
       val overrides = mtags.overrides()
-      (doc, overrides)
-    } else (TextDocument(), Nil)
+      val toplevelMembers = mtags.toplevelMembers()
+      (doc, overrides, toplevelMembers)
+    } else (TextDocument(), Nil, Nil)
   }
 
   def topLevelSymbols(
@@ -163,14 +168,18 @@ object Mtags {
     new Mtags().toplevels(path, dialect)
   }
 
-  def indexWithOverrides(
+  def extendedIndexing(
       path: AbsolutePath,
       dialect: Dialect = dialects.Scala213,
       includeMembers: Boolean = false
   )(implicit
       rc: ReportContext = new EmptyReportContext()
-  ): (TextDocument, MtagsIndexer.AllOverrides) = {
-    new Mtags().indexWithOverrides(path, dialect, includeMembers)
+  ): (
+      TextDocument,
+      MtagsIndexer.AllOverrides,
+      MtagsIndexer.AllToplevelMembers
+  ) = {
+    new Mtags().extendedIndexing(path, dialect, includeMembers)
   }
 
   def topLevelSymbols(

--- a/mtags/src/main/scala/scala/meta/internal/mtags/MtagsIndexer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/MtagsIndexer.scala
@@ -17,6 +17,7 @@ trait MtagsIndexer {
   def input: Input.VirtualFile
   // should only be called after `index`/`indexRoot`
   def overrides(): MtagsIndexer.AllOverrides = Nil
+  def toplevelMembers(): MtagsIndexer.AllToplevelMembers = Nil
   def index(): s.TextDocument = {
     indexRoot()
     s.TextDocument(
@@ -177,4 +178,5 @@ trait MtagsIndexer {
 
 object MtagsIndexer {
   type AllOverrides = List[(String, List[OverriddenSymbol])]
+  type AllToplevelMembers = List[ToplevelMember]
 }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/OnDemandSymbolIndex.scala
@@ -76,13 +76,14 @@ final class OnDemandSymbolIndex(
   // all non-trivial toplevel Scala symbols.
   override def addSourceJar(
       jar: AbsolutePath,
-      dialect: Dialect
+      dialect: Dialect,
+      reindex: Boolean = false
   ): List[IndexingResult] =
     tryRun(
       jar,
       List.empty, {
         try {
-          getOrCreateBucket(dialect).addSourceJar(jar)
+          getOrCreateBucket(dialect).addSourceJar(jar, reindex)
         } catch {
           case e: ZipError =>
             onError(new IndexingExceptions.InvalidJarException(jar, e))

--- a/mtags/src/main/scala/scala/meta/internal/mtags/ToplevelMember.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/ToplevelMember.scala
@@ -1,0 +1,18 @@
+package scala.meta.internal.mtags
+
+import scala.meta.internal.semanticdb.Range
+import scala.meta.internal.semanticdb.SymbolInformation
+
+/**
+ * Represents a toplevel member in a source file such as `type A = String` in a package or package object.
+ * These toplevel members will be indexed in the database.
+ *
+ * @param symbol The symbol of the toplevel member.
+ * @param range The range of the toplevel member in the source file.
+ * @param kind The kind of the toplevel member.
+ */
+case class ToplevelMember(
+    symbol: String,
+    range: Range,
+    kind: SymbolInformation.Kind
+)

--- a/tests/mtest/src/main/scala/tests/DelegatingGlobalSymbolIndex.scala
+++ b/tests/mtest/src/main/scala/tests/DelegatingGlobalSymbolIndex.scala
@@ -31,9 +31,10 @@ class DelegatingGlobalSymbolIndex(
   }
   def addSourceJar(
       jar: AbsolutePath,
-      dialect: Dialect
+      dialect: Dialect,
+      reindex: Boolean = false
   ): List[mtags.IndexingResult] = {
-    underlying.addSourceJar(jar, dialect)
+    underlying.addSourceJar(jar, dialect, reindex)
   }
 
   def addSourceDirectory(

--- a/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/CompletionCrossLspSuite.scala
@@ -44,7 +44,7 @@ class CompletionCrossLspSuite
         """|DefaultSerializable - scala.collection.generic
            |NotSerializableException - java.io
            |Serializable  a
-           |Serializable - java.io
+           |Serializable - scala.package = Serializable
            |SerializablePermission - java.io
            |""".stripMargin,
       )

--- a/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
@@ -612,4 +612,101 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
       )
     } yield ()
   }
+
+  test("zio-type-members") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""/metals.json
+           |{
+           |  "a": { 
+           |    "scalaVersion": "${V.scala213}",
+           |    "libraryDependencies": ["dev.zio::zio:2.1.20"]
+           |  }
+           |}
+           |/a/src/main/scala/a/Main.scala
+           |package a
+           |object Main {
+           |  // @@
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      _ = assertNoDiagnostics()
+      _ <- assertCompletion(
+        "  def test: UIO@@",
+        """|UIO - zio.package [+A] = UIO
+           |URIO - zio.package [-R, +A] = URIO
+           |UncheckedIOException - java.io
+           |UnlessZIO - zio.ZIO
+           |UnlessZIODiscard - zio.ZIO
+           |""".stripMargin,
+        filename = Some("a/src/main/scala/a/Main.scala"),
+      )
+    } yield ()
+  }
+
+  test("non-reachable-type-members") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""/metals.json
+           |{
+           |  "a": { 
+           |    "scalaVersion": "${V.scala213}",
+           |    "libraryDependencies": ["dev.zio::zio:2.1.20"]
+           |  },
+           |  "b": { 
+           |    "scalaVersion": "${V.scala213}"
+           |  }
+           |}
+           |/b/src/main/scala/b/Main.scala
+           |package b
+           |object Main {
+           |  // @@
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("b/src/main/scala/b/Main.scala")
+      _ = assertNoDiagnostics()
+      _ <- assertCompletion(
+        "  def test: UIO@@",
+        """|UncheckedIOException - java.io
+           |""".stripMargin,
+        filename = Some("b/src/main/scala/b/Main.scala"),
+      )
+    } yield ()
+  }
+
+  test("local-type-members") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""/metals.json
+           |{
+           |  "a": { 
+           |    "scalaVersion": "${V.scala213}"
+           |  }
+           |}
+           |/a/src/main/scala/a/b/package.scala
+           |package object b {
+           |  type MyList[A] = List[A]
+           |}
+           |/a/src/main/scala/a/Main.scala
+           |package a
+           |object Main {
+           |  // @@
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/Main.scala")
+      _ = assertNoDiagnostics()
+      _ <- assertCompletion(
+        "  def test: My@@",
+        """|MyList - b.package [A] = MyList
+           |""".stripMargin,
+        filename = Some("a/src/main/scala/a/Main.scala"),
+      )
+    } yield ()
+  }
 }

--- a/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/ScalaToplevelSuite.scala
@@ -153,6 +153,7 @@ class ScalaToplevelSuite extends BaseToplevelSuite {
       "z/",
       "z/Test$package.",
       "z/Test$package.X#",
+      "type z/Test$package.X#",
     ),
     mode = All,
   )
@@ -622,7 +623,7 @@ class ScalaToplevelSuite extends BaseToplevelSuite {
     // than to change symbols emitted by `ScalaTopLevelMtags`,
     // since the object could be placed before type definition.
     List("s/", "s/Test$package.", "s/Test$package.Cow# -> Long", "s/Cow.",
-      "s/Cow.apply()."),
+      "s/Cow.apply().", "type s/Test$package.Cow#"),
     dialect = dialects.Scala3,
     mode = All,
   )
@@ -694,7 +695,8 @@ class ScalaToplevelSuite extends BaseToplevelSuite {
        |    a
        |class Bar
        |""".stripMargin,
-    List("a/", "a/Bar#", "a/Test$package."),
+    List("a/", "a/Bar#", "a/Test$package.", "type a/Test$package.A#",
+      "type a/Test$package.Elem#", "type a/Test$package.W#"),
     dialect = dialects.Scala3,
     mode = ToplevelWithInner,
   )
@@ -796,6 +798,38 @@ class ScalaToplevelSuite extends BaseToplevelSuite {
        |""".stripMargin,
     List("a/", "a/A# -> B", "a/B#"),
     mode = All,
+  )
+
+  check(
+    "package-members",
+    """|package a
+       |package object b{
+       |  type A = Int
+       |  type B = String
+       |}
+       |""".stripMargin,
+    List(
+      "a/",
+      "a/b/package.",
+      "type a/b/package.A#",
+      "type a/b/package.B#",
+    ),
+    mode = ToplevelWithInner,
+  )
+
+  check(
+    "package-members-scala3",
+    """|package a
+       |type A = Int
+       |opaque type B = String
+       |""".stripMargin,
+    List(
+      "a/",
+      "a/Test$package.",
+      "type a/Test$package.A#",
+      "type a/Test$package.B#",
+    ),
+    mode = ToplevelWithInner,
   )
 
   check(


### PR DESCRIPTION
This should not add too much to memory usage, even with zio library added, there was around 20 toplevel types.

Fixes https://github.com/scalameta/metals-feature-requests/issues/378

Update: I changed it a bit to mean toplevel members, so that we can include toplevel extension methods etc.