### PR TITLE
Add `resolve-stacktrace-location` LSP command

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1390,6 +1390,9 @@ abstract class MetalsLspService(
   def analyzeStackTrace(content: String): Option[ExecuteCommandParams] =
     stacktraceAnalyzer.analyzeCommand(content)
 
+  def resolveStacktraceLocation(stacktraceLine: String): Option[Location] =
+    stacktraceAnalyzer.resolveStacktraceLocationCommand(stacktraceLine)
+
   def findBuildTargetByDisplayName(target: String): Option[b.BuildTarget] =
     buildTargets.findByDisplayName(target)
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -451,6 +451,18 @@ object ServerCommands {
     "[string], where the string is a stacktrace.",
   )
 
+  val ResolveStacktraceLocation = new ParametrizedCommand[String](
+    "resolve-stacktrace-location",
+    "Resolve stacktrace location",
+    """|Resolves a single line of a stacktrace to its source location.
+       |
+       |Returns a Location object containing the URI and line number of the 
+       |source file where the stacktrace line originated, if it can be resolved
+       |to a location in the workspace.
+       |""".stripMargin,
+    "[string], where the string is a single line from a stacktrace.",
+  )
+
   val MetalsPaste = new ParametrizedCommand[MetalsPasteParams](
     "metals-did-paste",
     "Add needed import statements after paste",
@@ -748,6 +760,7 @@ object ServerCommands {
   def all: List[BaseCommand] =
     List(
       AnalyzeStacktrace,
+      ResolveStacktraceLocation,
       BspSwitch,
       ConnectBuildServer,
       CancelCompile,

--- a/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StacktraceAnalyzer.scala
@@ -26,6 +26,12 @@ class StacktraceAnalyzer(
     analyzeStackTrace(stacktrace)
   }
 
+  def resolveStacktraceLocationCommand(
+      stacktraceLine: String
+  ): Option[l.Location] = {
+    workspaceFileLocationFromLine(stacktraceLine)
+  }
+
   def isStackTraceFile(path: AbsolutePath): Boolean =
     path == workspace.resolve(Directories.stacktrace)
 

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -1128,6 +1128,16 @@ class WorkspaceLspService(
           scribe.debug(s"Executing AnalyzeStacktrace ${command}")
         }.asJavaObject
 
+      case ServerCommands.ResolveStacktraceLocation(stacktraceLine) =>
+        Future {
+          // Getting the service for focused document and first one otherwise
+          val service =
+            focusedDocument.get().map(getServiceFor).getOrElse(fallbackService)
+          val location = service.resolveStacktraceLocation(stacktraceLine)
+          scribe.debug(s"Resolved stacktrace location: ${location}")
+          location.orNull
+        }.asJavaObject
+
       case ServerCommands.GotoSuperMethod(textDocumentPositionParams) =>
         getServiceFor(textDocumentPositionParams.getTextDocument().getUri())
           .gotoSupermethod(textDocumentPositionParams)

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -94,6 +94,7 @@ object TestGroups {
       "tests.ScalafmtConfigSuite", "tests.DocumentSymbolScala2Suite",
       "tests.StacktraceParseSuite", "tests.WorksheetDependencySourcesSuite",
       "tests.DefinitionScala2Suite", "tests.AnalyzeStacktraceLspSuite",
+      "tests.ResolveStacktraceLocationLspSuite",
       "tests.codeactions.ExtractRenameMemberLspSuite",
       "tests.debug.DotEnvFileParserSuite", "tests.SemanticdbScala3Suite",
       "tests.troubleshoot.ProblemResolverSuite", "tests.BspBuildChangedSuite",

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -833,6 +833,10 @@ final case class TestingServer(
     )
   }
 
+  def resolveStacktraceLocation(stacktraceLine: String): Option[l.Location] = {
+    server.stacktraceAnalyzer.resolveStacktraceLocationCommand(stacktraceLine)
+  }
+
   def exportEvaluation(filename: String): Option[String] = {
     val path = toPath(filename)
     Await.result(server.worksheetProvider.copyWorksheetOutput(path), 5.minutes)

--- a/tests/unit/src/test/scala/tests/ResolveStacktraceLocationLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/ResolveStacktraceLocationLspSuite.scala
@@ -1,0 +1,155 @@
+package tests
+
+import scala.meta.internal.metals.{BuildInfo => V}
+
+import munit.TestOptions
+
+class ResolveStacktraceLocationLspSuite
+    extends BaseAnalyzeStacktraceSuite("resolve-stacktrace-location") {
+
+  def checkLocation(
+      name: TestOptions,
+      code: String,
+      stacktraceLine: String,
+      expectedLine: Int,
+      filename: String = "Main.scala",
+      scalaVersion: String = V.scala213,
+      dependency: String = "",
+  )(implicit loc: munit.Location): Unit = {
+    test(name) {
+      cleanWorkspace()
+      for {
+        _ <- initialize(
+          s"""
+             |/metals.json
+             |{ 
+             |  "a": { 
+             |    "scalaVersion": "$scalaVersion",
+             |    "libraryDependencies": [ $dependency ]
+             |   }
+             |}
+             |/a/src/main/scala/a/$filename
+             |$code
+             |""".stripMargin
+        )
+        // Don't call server.didOpen - just initialize the workspace
+        location = server.resolveStacktraceLocation(stacktraceLine)
+        _ = {
+          location match {
+            case Some(loc) =>
+              val actualLine = loc.getRange().getStart().getLine()
+              assertEquals(
+                actualLine,
+                expectedLine,
+                s"Expected line $expectedLine but got $actualLine",
+              )
+              assert(
+                loc.getUri().contains(filename),
+                s"Expected URI to contain $filename but got ${loc.getUri()}",
+              )
+            case None =>
+              fail(
+                s"Expected location but got None for stacktrace line: $stacktraceLine"
+              )
+          }
+        }
+      } yield ()
+    }
+  }
+
+  def checkNone(
+      name: TestOptions,
+      stacktraceLine: String,
+      code: String = defaultCode,
+      filename: String = "Main.scala",
+      scalaVersion: String = V.scala213,
+  )(implicit loc: munit.Location): Unit = {
+    test(name) {
+      cleanWorkspace()
+      for {
+        _ <- initialize(
+          s"""
+             |/metals.json
+             |{ 
+             |  "a": { 
+             |    "scalaVersion": "$scalaVersion"
+             |   }
+             |}
+             |/a/src/main/scala/a/$filename
+             |$code
+             |""".stripMargin
+        )
+        location = server.resolveStacktraceLocation(stacktraceLine)
+        _ = assertEquals(
+          location,
+          None,
+          s"Expected None but got $location for stacktrace line: $stacktraceLine",
+        )
+      } yield ()
+    }
+  }
+
+  private lazy val defaultCode: String =
+    """|package a.b
+       |
+       |object Main {
+       |  def main(args: Array[String]): Unit = {
+       |    new ClassError().raise
+       |  }
+       |}
+       |
+       |class ClassError {
+       |  def raise: ClassConstrError = {
+       |    ObjectError.raise
+       |  }
+       |}
+       |
+       |object ObjectError {
+       |  def raise: ClassConstrError = {
+       |    new ClassConstrError()
+       |  }
+       |}
+       |
+       |class ClassConstrError {
+       |  val a = 3
+       |  throw new Exception("error")
+       |  val b = 4
+       |}
+       |""".stripMargin
+
+  checkLocation(
+    "simple-method-call",
+    defaultCode,
+    "\tat a.b.ClassError.raise(Main.scala:11)",
+    expectedLine = 10, // 0-indexed, so line 11 in stacktrace = line 10 in LSP
+  )
+
+  checkLocation(
+    "object-method-call",
+    defaultCode,
+    "\tat a.b.ObjectError$.raise(Main.scala:16)",
+    expectedLine = 15,
+  )
+
+  checkLocation(
+    "constructor-error",
+    defaultCode,
+    "\tat a.b.ClassConstrError.<init>(Main.scala:23)",
+    expectedLine = 22,
+  )
+
+  checkNone(
+    "invalid-stacktrace-line",
+    "invalid stacktrace line format",
+  )
+
+  checkNone(
+    "external-library-location",
+    "\tat java.lang.Thread.run(Thread.java:748)",
+  )
+
+  checkNone(
+    "non-existent-method",
+    "\tat a.b.NonExistent.method(Main.scala:5)",
+  )
+}


### PR DESCRIPTION
Add new LSP command that resolves single stacktrace lines directly to Location objects. Uses existing workspaceFileLocationFromLine logic and filters to workspace files only.

Includes test suite covering various stacktrace formats.

Usage:
```json
{
  "command": "resolve-stacktrace-location",
  "arguments": ["at com.example.Class.method(File.scala:42)"]
}
```

Returns: Location object with URI and line number, or null if unresolvable.

```json
{
  "range": {
    "end": {
      "character": 0,
      "line": 10
    },
    "start": {
      "character": 0,
      "line": 10
    }
  },
  "uri": "file:///path/to/Foo.scala"
}
```

I use this in Acme with [`acme-lsp`](https://github.com/cptaffe/acme-lsp/tree/feat/exec) and plumber to open the relevant file at the offending line when right clicking on a stack trace anywhere in the editor. The [plumbing rule](https://9fans.github.io/plan9port/man/man7/plumb.html) looks like:

```
# Scala stack traces
type	is	text
data	matches	'([a-z0-9_\.]+\.[A-Z0-9\$_][A-Za-z0-9\$_]*\.[a-z\$][A-Za-z0-9\$_]*\([A-Z0-9\$_][A-Za-z0-9\$_]*\.scala:([0-9]+)\))'
plumb	start rc -c 'plumb `{L exec -s metals resolve-stacktrace-location ''"at '$1'"'' | jq -r ''.uri | sub("^file:(//)?/"; "/")'' }':$2

```

The functionality mimics what [`jdtls`](https://github.com/eclipse-jdtls/eclipse.jdt.ls) provides with `java.project.resolveStackTraceLocation`.