### PR TITLE
docs: Add release notes for 1.6.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
     id: version
     attributes:
       label: Version of Metals
-      placeholder: v1.6.1
+      placeholder: v1.6.2
     validations:
       required: true
 

--- a/.github/workflows/mtags-auto-release.yml
+++ b/.github/workflows/mtags-auto-release.yml
@@ -8,14 +8,14 @@ on:
       metals_version:
         description: "Metals Version"
         required: true
-        default: "v1.6.1"
+        default: "v1.6.2"
       metals_ref:
         description: "Tag/branch-name from which run release"
         required: true
         # If you update this line after release
         #   just put the tag name (`v*.*.*`) here as in `metals_version.value` above.
         # Don't be confused if this value contains `*.*.*_mtags_release`
-        default: "v1.6.1"
+        default: "v1.6.2"
 jobs:
   test_and_release:
     runs-on: ubuntu-latest

--- a/bin/merged_prs.scala
+++ b/bin/merged_prs.scala
@@ -14,7 +14,7 @@ import org.kohsuke.github.GHIssueState
 import java.text.SimpleDateFormat
 import java.util.Date
 
-val codename = "Strontium"
+val codename = "Osmium"
 
 @main
 def main(

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 Global / resolvers += "scala-integration" at
   "https://scala-ci.typesafe.com/artifactory/scala-integration/"
 
-def localSnapshotVersion = "1.6.2-SNAPSHOT"
+def localSnapshotVersion = "1.6.3-SNAPSHOT"
 def isCI = System.getenv("CI") != null
 def isTest = System.getenv("METALS_TEST") != null
 

--- a/website/blog/2025-08-09-osmium.md
+++ b/website/blog/2025-08-09-osmium.md
@@ -1,0 +1,156 @@
+---
+authors: tgodzik
+title: Metals v1.6.2 - Osmium
+---
+
+We're happy to announce the release of Metals v1.6.2, which is mainly a bugfix release.
+
+<table>
+<tbody>
+  <tr>
+    <td>Commits since last release</td>
+    <td align="center">28</td>
+  </tr>
+  <tr>
+    <td>Merged PRs</td>
+    <td align="center">28</td>
+  </tr>
+    <tr>
+    <td>Contributors</td>
+    <td align="center">5</td>
+  </tr>
+  <tr>
+    <td>Closed issues</td>
+    <td align="center">1</td>
+  </tr>
+  <tr>
+    <td>New features</td>
+    <td align="center">0</td>
+  </tr>
+</tbody>
+</table>
+
+For full details: [https://github.com/scalameta/metals/milestone/81?closed=1](https://github.com/scalameta/metals/milestone/81?closed=1)
+
+Metals is a language server for Scala that works with VS Code, Vim, Emacs, Zed,
+Helix and Sublime Text. Metals is developed at the
+[Scala Center](https://scala.epfl.ch/) and [VirtusLab](https://virtuslab.com)
+with the help from contributors from the community.
+
+## TL;DR
+
+Check out [https://scalameta.org/metals/](https://scalameta.org/metals/), and
+give Metals a try!
+
+## Miscellaneous
+
+- improvement: Also include SQL interpolation [tgodzik](https://github.com/tgodzik)
+- bugfix: Remove jrtClassPathCAches to try fix -release issues [tgodzik](https://github.com/tgodzik)
+- improvement: Enable Scala3Future dialect support (capture checking, better modularity) [Odomontois](https://github.com/Odomontois)
+- bugfix: Don't show error message when scalafix was invoked from quickfix [tgodzik](https://github.com/tgodzik)
+
+## Contributors
+
+Big thanks to everybody who contributed to this release or reported an issue!
+
+```
+$ git shortlog -sn --no-merges v1.6.1..v1.6.2
+    12	Tomasz Godzik
+    11	scalameta-bot
+     3	dependabot[bot]
+     1	Odomontois
+     1	Zieliński Patryk
+```
+
+## Merged PRs
+
+## [v1.6.2](https://github.com/scalameta/metals/tree/v1.6.2) (2025-08-09)
+
+[Full Changelog](https://github.com/scalameta/metals/compare/v1.6.1...v1.6.2)
+
+**Merged pull requests:**
+
+- bugfix: Don't show error message when scalafix was invoked from quickfix
+  [\#7708](https://github.com/scalameta/metals/pull/7708)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update sbt, scripted-plugin from 1.11.3 to 1.11.4
+  [\#7705](https://github.com/scalameta/metals/pull/7705)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update cli_3, scala-cli-bsp from 1.8.4 to 1.8.5
+  [\#7706](https://github.com/scalameta/metals/pull/7706)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update scala-debug-adapter from 4.2.7 to 4.2.8
+  [\#7702](https://github.com/scalameta/metals/pull/7702)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update mill-contrib-testng from 1.0.2 to 1.0.3
+  [\#7703](https://github.com/scalameta/metals/pull/7703)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update mcp from 0.11.0 to 0.11.1
+  [\#7704](https://github.com/scalameta/metals/pull/7704)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- Enable Scala3Future dialect support (capture checking, better modularity)
+  [\#7692](https://github.com/scalameta/metals/pull/7692)
+  ([Odomontois](https://github.com/Odomontois))
+- bugfix: Add snasphot repository for Scala 3.4.x
+  [\#7695](https://github.com/scalameta/metals/pull/7695)
+  ([tgodzik](https://github.com/tgodzik))
+- update: Bump Bazel BSP to 4.0.1
+  [\#7698](https://github.com/scalameta/metals/pull/7698)
+  ([tgodzik](https://github.com/tgodzik))
+- bugfix: Remove jrtClassPathCAches to try fix -release issues
+  [\#7697](https://github.com/scalameta/metals/pull/7697)
+  ([tgodzik](https://github.com/tgodzik))
+- bugfix: Update Bloop to 2.0.13
+  [\#7696](https://github.com/scalameta/metals/pull/7696)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update mcp from 0.10.0 to 0.11.0
+  [\#7679](https://github.com/scalameta/metals/pull/7679)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- chore: Fix issues if Bloop start timeouts
+  [\#7694](https://github.com/scalameta/metals/pull/7694)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update flyway-core from 11.10.4 to 11.10.5
+  [\#7680](https://github.com/scalameta/metals/pull/7680)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- bugfix: Fix currently failing tests for querying versions supported by a snapshot
+  [\#7693](https://github.com/scalameta/metals/pull/7693)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): bump react from 19.1.0 to 19.1.1 in /website
+  [\#7682](https://github.com/scalameta/metals/pull/7682)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): bump @docusaurus/plugin-client-redirects from 3.8.0 to 3.8.1 in /website
+  [\#7683](https://github.com/scalameta/metals/pull/7683)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- improvement: Also include SQL interpolation
+  [\#7690](https://github.com/scalameta/metals/pull/7690)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps-dev): bump @types/node from 24.0.8 to 24.1.0 in /website
+  [\#7684](https://github.com/scalameta/metals/pull/7684)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): Update os-lib from 0.11.4 to 0.11.5
+  [\#7678](https://github.com/scalameta/metals/pull/7678)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update scalameta, semanticdb-metap, ... from 4.13.8 to 4.13.9
+  [\#7689](https://github.com/scalameta/metals/pull/7689)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- fix: change workspace information format when using 'metals.open-new-github-issue' (#7669)
+  [\#7688](https://github.com/scalameta/metals/pull/7688)
+  ([zielinsky](https://github.com/zielinsky))
+- chore: Remove no longer used snapshots to avoid timeouts
+  [\#7686](https://github.com/scalameta/metals/pull/7686)
+  ([tgodzik](https://github.com/tgodzik))
+- docs: Add note about x-ray mode
+  [\#7687](https://github.com/scalameta/metals/pull/7687)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update mill-contrib-testng from 1.0.1 to 1.0.2
+  [\#7677](https://github.com/scalameta/metals/pull/7677)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update github-api from 1.327 to 1.329
+  [\#7681](https://github.com/scalameta/metals/pull/7681)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- chore: Remove no longer needed workaround
+  [\#7676](https://github.com/scalameta/metals/pull/7676)
+  ([tgodzik](https://github.com/tgodzik))
+- chore: [skip-ci] Add release notes for Metals 1.6.1
+  [\#7670](https://github.com/scalameta/metals/pull/7670)
+  ([tgodzik](https://github.com/tgodzik))


### PR DESCRIPTION
skip-ci

Mainly updating Bloop, which has an issue in the previous release