### PR TITLE
bugfix: Set Bloop plugin version to 2.0.10 for pre 1.9.0

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -238,6 +238,8 @@ case class SbtBuildTool(
           "1.4.6"
         else if (SemVer.isLaterVersion(version, "1.5.0"))
           "2.0.2"
+        else if (SemVer.isLaterVersion(version, "1.9.0"))
+          "2.0.10"
         else userConfig().currentBloopVersion
 
       val plugin = bloopPluginDetails(pluginVersion)


### PR DESCRIPTION
We can no longer publish the old pattern that was used by versions of plugins published pre 1.9.0.

This should be msotly fine, no real changes in the plugin since that version.