### PR TITLE
Update coursier to 2.1.25-M17 and coursier-interface to 1.0.29-M2

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -21,7 +21,7 @@ object V {
   val coursier = "2.1.25-M17"
   // changing coursier interfaces version may be not binary compatible.
   // After each update of coursier interfaces, remember to bump the version in dotty repository.
-  val coursierInterfaces = "1.0.28"
+  val coursierInterfaces = "1.0.29-M2"
   val debugAdapter = "4.2.8"
   val genyVersion = "1.0.0"
   val gitter8Version = "0.17.0"


### PR DESCRIPTION
This should address issues seen on Windows ARM64.