### PR TITLE
Fix typed-glob-search to handle JSON string symbolType parameter with fallback

### DIFF
--- a/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
+++ b/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
@@ -112,4 +112,26 @@ class TestMcpClient(url: String, val port: Int)(implicit ec: ExecutionContext) {
     filePath.foreach(path => params.put("fileToRunOn", path))
     callTool("run-scalafix-rule", params).map(_.mkString)
   }
+
+  def typedGlobSearch(
+      query: String,
+      symbolTypes: List[String],
+  ): Future[String] = {
+    val params = objectMapper.createObjectNode()
+    params.put("query", query)
+    val symbolTypeArray = objectMapper.createArrayNode()
+    symbolTypes.foreach(symbolTypeArray.add)
+    params.set("symbolType", symbolTypeArray)
+    callTool("typed-glob-search", params).map(_.mkString)
+  }
+
+  def typedGlobSearch(
+      query: String,
+      symbolTypes: String,
+  ): Future[String] = {
+    val params = objectMapper.createObjectNode()
+    params.put("query", query)
+    params.put("symbolType", symbolTypes)
+    callTool("typed-glob-search", params).map(_.mkString)
+  }
 }


### PR DESCRIPTION
Support both JSON array and JSON string formats for symbolType parameter
Add InvalidSymbolTypeException for better error messages

Fixes https://github.com/scalameta/metals/issues/7735