### PR TITLE
fix(hover): allow hover on whitespace inside backtick identifiers

### DIFF
--- a/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/mtags/MtagsEnrichments.scala
@@ -64,6 +64,25 @@ trait MtagsEnrichments extends ScalametaCommonEnrichments {
         case _ => false
       })
     }
+
+    def isWithinBackticks: Boolean = {
+      val text = params.text()
+      val offset = params.offset()
+
+      if (offset < 0 || offset >= text.length) return false
+      if (!text.charAt(offset).isWhitespace) return false
+
+      val lineStart = text.lastIndexOf('\n', offset) + 1
+      val lineEnd = text.indexOf('\n', offset) match {
+        case -1 => text.length
+        case end => end
+      }
+
+      val beforeBacktick = text.lastIndexBetween('`', lineStart, offset - 1)
+      val afterBacktick = text.indexBetween('`', offset + 1, lineEnd)
+
+      beforeBacktick >= lineStart && afterBacktick >= 0
+    }
   }
   implicit class XtensionIterableOps[T](lst: Iterable[T]) {
     def distinctBy[B](fn: T => B): List[T] = {
@@ -201,6 +220,16 @@ trait MtagsEnrichments extends ScalametaCommonEnrichments {
         index -= 1
       }
       if (index < safeLowerBound) -1 else index
+    }
+    def indexBetween(
+        char: Char,
+        lowerBound: Int,
+        upperBound: Int
+    ): Int = {
+      val safeUpperBound = Math.min(value.length, upperBound)
+      var i = lowerBound
+      while (i < safeUpperBound && value(i) != char) i += 1
+      if (i < safeUpperBound) i else -1
     }
   }
 

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/HoverProvider.scala
@@ -24,7 +24,9 @@ class HoverProvider(
   def hover(): Option[HoverSignature] = params match {
     case range: RangeParams =>
       range.trimWhitespaceInRange.flatMap(hoverOffset)
-    case _ if params.isWhitespace && params.prevIsWhitespaceOrDelimeter => None
+    case _
+        if params.isWhitespace && params.prevIsWhitespaceOrDelimeter && !params.isWithinBackticks =>
+      None
     case _ => hoverOffset(params)
   }
 

--- a/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDefnSuite.scala
@@ -277,4 +277,13 @@ class HoverDefnSuite extends BaseHoverSuite {
        |""".stripMargin,
     "val foo: Int".hover
   )
+
+  check(
+    "backticked",
+    """|object A {
+       |  <<val `foo @@ bar` = 123>>
+       |}
+       |""".stripMargin,
+    "val `foo  bar`: Int".hover
+  )
 }


### PR DESCRIPTION
# Fixes #7581
## Problem
Previously, Metals did not provide hover information when the cursor was placed on whitespace inside a backtick identifier, such as `foo  bar`. This was due to an early return in the hover logic that checked whether the character was whitespace and whether it was preceded by whitespace or a delimiter.
```scala
def hover(): Option[HoverSignature] = params match {
    case range: RangeParams =>
      range.trimWhitespaceInRange.flatMap(hoverOffset)
    case _ if params.isWhitespace && params.prevIsWhitespaceOrDelimeter => // `foo @@ bar` met both conditions
      None
    case _ => hoverOffset(params)
  }
```
## Solution
This PR introduces a new method, `isWithinBackticks`. This method efficiently checks whether the cursor is currently on whitespace that is inside a backtick identifier, by searching for backtick characters within the current line and ensuring the cursor is between them. The hover logic is updated to allow hover requests on whitespace only if isWithinBackticks returns true, thus enabling hover for backtick identifiers with spaces while still skipping hover on regular whitespace between tokens.
## Performance Considerations
I am aware that any additional string scanning could introduce performance overhead, especially with very long lines. I have benchmarked this implementation and did not observe any significant overhead in practical scenarios, even with long lines. However, I am open to suggestions for further optimization or alternative approaches.