### PR TITLE
Java PC: hide non‑static members in class context (Fixes #6356)

### DIFF
--- a/tests/javapc/src/test/scala/pc/CompletionMemberSelectSuite.scala
+++ b/tests/javapc/src/test/scala/pc/CompletionMemberSelectSuite.scala
@@ -157,10 +157,30 @@ class CompletionMemberSelectSuite extends BaseJavaCompletionSuite {
       |  }
       |}
       |""".stripMargin,
-    """|cleanStack()
-       |clone()
-       |""".stripMargin,
+    "",
     // let's make sure we don't get any <clinit> method
     filterText = Some("cl"),
+  )
+
+  check(
+    "only-static-members-select",
+    """
+      |class TestStaticMethods {
+      |  public static String hello(){
+      |        return "hello";
+      |    }
+      |
+      |    public String nonStaticHello(){
+      |        return "nonStatic";
+      |    }
+      |
+      |    public static void main(String[] args) {
+      |        TestStaticMethods.@@
+      |    }
+      |}
+      |""".stripMargin,
+    """|hello()
+       |main(java.lang.String[] args)
+       |""".stripMargin,
   )
 }


### PR DESCRIPTION
Summary
Hide non‑static members from completion when invoked on a class (not an instance). Fixes #6356.

Problem
When completing after a class name, non‑static members were suggested, which is incorrect for Java and caused noisy/invalid completions.