### PR TITLE
improvement: Do not return the full formatting

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FormattingProvider.scala
@@ -154,7 +154,7 @@ final class FormattingProvider(
       path: AbsolutePath,
       projectRoot: AbsolutePath,
       token: CancelChecker,
-  ): Future[Either[String, Option[String]]] = {
+  ): Future[Either[String, List[l.TextEdit]]] = {
     reset(token)
     val input = path.toInputFromBuffers(buffers)
 
@@ -195,10 +195,19 @@ final class FormattingProvider(
           Left(s"Formatting error: ${e.getMessage}")
       }
     }
+    def fullDocumentFormat(config: AbsolutePath) = {
+      val fullDocumentRange =
+        Position.Range(input, 0, input.chars.length).toLsp
+      formatWithConfig(config).map { formatted =>
+        formatted.map { text =>
+          new l.TextEdit(fullDocumentRange, text)
+        }.toList
+      }
+    }
 
     scalafmtConf(projectRoot) match {
       case Some(config) =>
-        Future.successful(formatWithConfig(config))
+        Future.successful(fullDocumentFormat(config))
       case None =>
         // No config found, use default config
         val defaultConfig = projectRoot.resolve(Directories.hiddenScalafmt)
@@ -217,7 +226,7 @@ final class FormattingProvider(
               )
           }
         }
-        Future.successful(formatWithConfig(defaultConfig))
+        Future.successful(fullDocumentFormat(defaultConfig))
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
@@ -49,8 +49,10 @@ import io.modelcontextprotocol.spec.McpSchema.Tool
 import io.undertow.Undertow
 import io.undertow.servlet.Servlets
 import io.undertow.servlet.api.InstanceHandle
+import org.eclipse.lsp4j.ApplyWorkspaceEditParams
 import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.MessageType
+import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.services.LanguageClient
 import reactor.core.publisher.Mono
 
@@ -864,7 +866,7 @@ class MetalsMcpServer(
     new AsyncToolSpecification(
       new Tool(
         "format-file",
-        "Format a Scala file and return the formatted text",
+        "Format a Scala file and use LSP to apply the changes. If LSP client is not available, it will be done in the background",
         schema,
       ),
       withErrorHandling { (_, arguments) =>
@@ -877,22 +879,39 @@ class MetalsMcpServer(
 
           formattingProvider
             .formatForMcp(path, projectPath, cancelChecker)
-            .map {
+            .flatMap {
               case Left(errorMessage) =>
-                new CallToolResult(
-                  createContent(errorMessage),
-                  true,
+                Future.successful(
+                  new CallToolResult(
+                    createContent(errorMessage),
+                    true,
+                  )
                 )
-              case Right(None) =>
-                new CallToolResult(
-                  createContent("File is already properly formatted."),
-                  false,
+              case Right(Nil) =>
+                Future.successful(
+                  new CallToolResult(
+                    createContent("File is already properly formatted."),
+                    false,
+                  )
                 )
-              case Right(Some(formattedText)) =>
-                new CallToolResult(
-                  createContent(formattedText),
-                  false,
-                )
+              case Right(formattedText) =>
+                languageClient
+                  .applyEdit(
+                    new ApplyWorkspaceEditParams(
+                      new WorkspaceEdit(
+                        Map(
+                          path.toURI.toString -> formattedText.asJava
+                        ).asJava
+                      )
+                    )
+                  )
+                  .asScala
+                  .map { _ =>
+                    new CallToolResult(
+                      createContent(s"$path was formatted"),
+                      false,
+                    )
+                  }
             }
             .toMono
         } else {

--- a/tests/unit/src/test/scala/tests/mcp/McpFormatLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpFormatLspSuite.scala
@@ -6,7 +6,7 @@ import tests.BaseLspSuite
 
 class McpFormatLspSuite extends BaseLspSuite("mcp-format") with McpTestUtils {
 
-  test("format-file - with scalafmt config") {
+  test("with-scalafmt-config") {
     cleanWorkspace()
     for {
       _ <- initialize(
@@ -32,8 +32,14 @@ class McpFormatLspSuite extends BaseLspSuite("mcp-format") with McpTestUtils {
       )
       _ = assertNoDiff(
         formatted,
-        s"""
-           |package com.example
+        s"${server.workspace.resolve("a/src/main/scala/com/example/Formatting.scala")} was formatted",
+      )
+      fileContenxt = server.buffers
+        .get(workspace.resolve("a/src/main/scala/com/example/Formatting.scala"))
+        .mkString
+      _ = assertNoDiff(
+        fileContenxt,
+        """|package com.example
            |
            |object Formatting {
            |  def main(args: Array[String]): Unit =
@@ -45,7 +51,7 @@ class McpFormatLspSuite extends BaseLspSuite("mcp-format") with McpTestUtils {
     } yield ()
   }
 
-  test("format-file - without scalafmt config") {
+  test("without-scalafmt-config") {
     cleanWorkspace()
     for {
       _ <- initialize(
@@ -67,18 +73,25 @@ class McpFormatLspSuite extends BaseLspSuite("mcp-format") with McpTestUtils {
       )
       _ = assertNoDiff(
         result,
-        """package com.example
-          |
-          |object Formatting {
-          |  def main(args: Array[String]): Unit = println("needs formatting")
-          |}
-          |""".stripMargin,
+        s"${server.workspace.resolve("a/src/main/scala/com/example/Formatting.scala")} was formatted",
+      )
+      fileContenxt = server.buffers
+        .get(workspace.resolve("a/src/main/scala/com/example/Formatting.scala"))
+        .mkString
+      _ = assertNoDiff(
+        fileContenxt,
+        """|package com.example
+           |
+           |object Formatting {
+           |  def main(args: Array[String]): Unit = println("needs formatting")
+           |}
+           |""".stripMargin,
       )
       _ <- client.shutdown()
     } yield ()
   }
 
-  test("format-file - already properly formatted") {
+  test("already-properly-formatted") {
     cleanWorkspace()
     for {
       _ <- initialize(
@@ -111,7 +124,7 @@ class McpFormatLspSuite extends BaseLspSuite("mcp-format") with McpTestUtils {
     } yield ()
   }
 
-  test("format-file - non-existent file") {
+  test("non-existent-file") {
     cleanWorkspace()
     for {
       _ <- initialize(
@@ -134,7 +147,7 @@ class McpFormatLspSuite extends BaseLspSuite("mcp-format") with McpTestUtils {
     } yield ()
   }
 
-  test("format-file - non-Scala file") {
+  test("non-scala-file") {
     cleanWorkspace()
     for {
       _ <- initialize(
@@ -165,7 +178,7 @@ class McpFormatLspSuite extends BaseLspSuite("mcp-format") with McpTestUtils {
     } yield ()
   }
 
-  test("format-file - with custom scalafmt config location") {
+  test("with-custom-scalafmt-config-location") {
     cleanWorkspace()
     for {
       _ <- initialize(
@@ -191,8 +204,14 @@ class McpFormatLspSuite extends BaseLspSuite("mcp-format") with McpTestUtils {
       )
       _ = assertNoDiff(
         formatted,
-        s"""
-           |package com.example
+        s"${server.workspace.resolve("a/src/main/scala/com/example/Formatting.scala")} was formatted",
+      )
+      fileContenxt = server.buffers
+        .get(workspace.resolve("a/src/main/scala/com/example/Formatting.scala"))
+        .mkString
+      _ = assertNoDiff(
+        fileContenxt,
+        """|package com.example
            |
            |object Formatting {
            |  def main(args: Array[String]): Unit = println("needs formatting")
@@ -203,7 +222,7 @@ class McpFormatLspSuite extends BaseLspSuite("mcp-format") with McpTestUtils {
     } yield ()
   }
 
-  test("format-file - with syntax errors") {
+  test("with-syntax-errors") {
     cleanWorkspace()
     for {
       _ <- initialize(


### PR DESCRIPTION
If we return the full string, this gets added to LLM context and it might not even apply the correct formatting.

This might not work for the standalone client, but there is no way of knowing if we have a "fake" client.