### PR TITLE
feat(mcp): add configurable instructions path for AI agents

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -285,6 +285,7 @@ class ProjectMetalsLspService(
             scalaVersionSelector,
             formattingProvider,
             scalafixLlmRuleProvider,
+            userConfig.mcpInstructionsPath,
           )
         ).run()
     }.recover { case e: Exception =>

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -60,6 +60,7 @@ case class UserConfiguration(
     defaultShell: Option[String] = None,
     startMcpServer: Boolean = false,
     mcpClient: Option[String] = None,
+    mcpInstructionsPath: Option[String] = None,
 ) {
 
   override def toString(): String = {
@@ -542,6 +543,16 @@ object UserConfiguration {
            |and it will still generate the one matching your editor if it's also supported.
            |""".stripMargin,
       ),
+      UserConfigurationOption(
+        "mcp-instructions-path",
+        """empty string `""`.""",
+        """"docs/mcp-instructions.md"""",
+        "MCP Instructions Markdown file path",
+        """|Optional path to a Markdown file containing instructions for MCP clients.
+           |These instructions will be sent to AI agents during MCP server initialization.
+           |Should be a relative path from the workspace root.
+           |""".stripMargin,
+      ),
     )
 
   def fromJson(
@@ -826,6 +837,8 @@ object UserConfiguration {
 
     val mcpClient = getStringKey("mcp-client")
 
+    val mcpInstructionsPath = getStringKey("mcp-instructions-path")
+
     if (errors.isEmpty) {
       Right(
         UserConfiguration(
@@ -861,6 +874,7 @@ object UserConfiguration {
           defaultShell,
           startMcpServer,
           mcpClient,
+          mcpInstructionsPath,
         )
       )
     } else {

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -393,4 +393,47 @@ class UserConfigurationSuite extends BaseSuite {
       )
     )
   }
+
+  checkOK(
+    "mcp-instructions-path",
+    """
+      |{
+      |  "mcp-instructions-path": "docs/mcp-instructions.md"
+      |}
+    """.stripMargin,
+  ) { obtained =>
+    assert(obtained.mcpInstructionsPath == Some("docs/mcp-instructions.md"))
+  }
+
+  checkOK(
+    "mcp-instructions-path-empty",
+    """
+      |{
+      |  "mcp-instructions-path": ""
+      |}
+    """.stripMargin,
+  ) { obtained =>
+    assert(obtained.mcpInstructionsPath == None)
+  }
+
+  checkOK(
+    "mcp-instructions-path-default",
+    """
+      |{
+      |}
+    """.stripMargin,
+  ) { obtained =>
+    assert(obtained.mcpInstructionsPath == None)
+  }
+
+  checkOK(
+    "mcp-instructions-path-sys-prop",
+    """
+      |{
+      |}
+    """.stripMargin,
+    Map("metals.mcp-instructions-path" -> "system/path.md"),
+  ) { obtained =>
+    assert(obtained.mcpInstructionsPath == Some("system/path.md"))
+  }
 }


### PR DESCRIPTION
Introduce the ability to provide custom instructions to AI agents through a configurable Markdown file path. This enables project-specific guidance for AI agents using the MCP server.

## Key changes

- Add metals.mcpInstructionsPath configuration option to UserConfiguration
- Pass instructions path from ProjectMetalsLspService to MCP server
- Implement file loading logic in MetalsMcpServer with error handling
- Add comprehensive test coverage for configuration scenarios

## Configuration

VS Code example:
```json
  {
    "metals.mcpInstructionsPath": "METALS.md"
  }
```

The path is relative to the workspace root. The implementation gracefully handles missing files with warnings and operates without instructions if the file cannot be read.

## Verification

Tested with MCP Inspector v0.16.5 confirming the instructions are correctly transmitted in the initialize response:

<img width="2560" height="1440" alt="Screenshot 2025-09-04 at 1 14 07" src="https://github.com/user-attachments/assets/fbc19654-db38-4458-9f2c-b20d88ed10d1" />

The screenshot shows:
- Successful connection to Metals MCP server at http://localhost:60296/sse
- Initialize response containing the instructions field with METALS.md content
- Instructions properly formatted and transmitted to the client

## Testing

- ✅ All UserConfigurationSuite tests pass (22 tests)
- ✅ Scalafmt verification completed
- ✅ Manual verification with MCP Inspector
- ✅ Integration tested with Claude Code extension

## Benefits

- Project teams can define custom AI agent guidelines - Teams can maintain project-specific instructions for AI agents
- Instructions are maintained separately from code - Documentation lives in Markdown files, making it easy to update
- Supports workspace-specific AI agent behavior - Different projects can have different AI guidance

## Related issues

- scalameta/metals-feature-requests#439 (MCP Resources feature)
- scalameta/metals-feature-requests#440 (MCP Prompts feature)
- Builds on #7390 (initial MCP support)

## Contributing guidelines

I have read and followed:
- https://github.com/scalameta/metals/blob/main/CONTRIBUTING.md - Followed the coding standards, ran tests, and used scalafmt
- https://github.com/scalameta/.github/blob/main/CODE_OF_CONDUCT.md - Committed to maintaining a welcoming and inclusive environment

## Note

This is my first contribution to Metals. I've followed existing patterns and conventions to the best of my ability. Open to feedback and happy to make adjustments as needed.