### PR TITLE
feat: show organize imports failure as status bar notification

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -160,7 +160,6 @@ case class ScalafixProvider(
                   level = "warn",
                   show = true,
                   tooltip = fullMsg,
-                  durationMs = 5000L,
                 )
                 scribe.warn(
                   fullMsg

--- a/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/StatusBar.scala
@@ -92,11 +92,9 @@ final class StatusBar(
     def priority: Long = timer.elapsedNanos
     def isRecent: Boolean = timer.elapsedSeconds < 3
     def formattedMessage: String = params.text
-    def isOutdated: Boolean = {
-      val duration = Option(params.durationMs).map(_ / 1000).getOrElse(10L)
-      timer.elapsedSeconds > duration ||
-      firstShow.exists(_.elapsedSeconds > 5)
-    }
+    def isOutdated: Boolean =
+      timer.elapsedSeconds > 10 ||
+        firstShow.exists(_.elapsedSeconds > 5)
     def isStale: Boolean = (firstShow.isDefined && !isRecent) || isOutdated
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsLanguageClient.scala
@@ -125,7 +125,6 @@ case class RawMetalsQuickPickResult(
  * @param command optional command that the client should trigger when the user clicks on
  *                the status bar item.
  * @param statusType is this a bsp or metals status.
- * @param durationMs optional duration in milliseconds for how long the status message should be displayed.
  */
 case class MetalsStatusParams(
     text: String,
@@ -137,7 +136,6 @@ case class MetalsStatusParams(
     @Nullable metalsCommand: MetalsCommand = null,
     @Nullable commandTooltip: String = null,
     @Nullable statusType: String = StatusType.metals.toString(),
-    @Nullable durationMs: java.lang.Long = null,
 ) {
 
   def logMessage(icons: Icons): String = {


### PR DESCRIPTION
# Fixes #7759
This PR improves the user experience for organize imports failures by displaying a warning in the status bar instead of a pop-up dialog.
## Key changes include
- When organizing imports fails, the warning is now shown in the status bar rather than as a modal pop-up. This makes the notification less intrusive and annoying.