### PR TITLE
fix: Add correct indexing of external libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 Global / resolvers += "scala-integration" at
   "https://scala-ci.typesafe.com/artifactory/scala-integration/"
 
-def localSnapshotVersion = "1.6.3-SNAPSHOT"
+def localSnapshotVersion = "1.6.4-SNAPSHOT"
 def isCI = System.getenv("CI") != null
 def isTest = System.getenv("METALS_TEST") != null
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 Global / resolvers += "scala-integration" at
   "https://scala-ci.typesafe.com/artifactory/scala-integration/"
 
-def localSnapshotVersion = "1.6.4-SNAPSHOT"
+def localSnapshotVersion = "1.6.3-SNAPSHOT"
 def isCI = System.getenv("CI") != null
 def isTest = System.getenv("METALS_TEST") != null
 

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -24,6 +24,7 @@ import scala.meta.internal.semanticdb.Scala._
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.{bsp4j => b}
+import com.google.gson.JsonObject
 import org.eclipse.lsp4j.Position
 
 // todo https://github.com/scalameta/metals/issues/4788
@@ -192,6 +193,10 @@ case class Indexer(indexProviders: IndexProviders)(implicit rc: ReportContext) {
         usedJars ++= indexJdkSources(
           buildTool.data,
           buildTool.importedBuild.dependencySources,
+        )
+        usedJars ++= indexDependencyModules(
+          buildTool.data,
+          buildTool.importedBuild.dependencyModules,
         )
         usedJars ++= indexDependencySources(
           buildTool.data,
@@ -362,6 +367,61 @@ case class Indexer(indexProviders: IndexProviders)(implicit rc: ReportContext) {
         )
       )
     } finally threadPool.shutdown()
+  }
+
+  private def indexDependencyModules(
+      data: TargetData,
+      dependencyModules: b.DependencyModulesResult,
+  ): Set[AbsolutePath] = {
+    val usedJars = mutable.HashSet.empty[AbsolutePath]
+    val isVisited = new ju.HashSet[String]()
+
+    for {
+      item <- dependencyModules.getItems.asScala
+      module <- item.getModules.asScala
+      if module.getData != null
+      uri <- module.getData
+        .asInstanceOf[JsonObject]
+        .get("artifacts")
+        .getAsJsonArray
+        .asScala
+        .filter(_.getAsJsonObject.has("classifier"))
+        .map(_.getAsJsonObject.get("uri").getAsString)
+        .toList
+    } {
+      val absolutePath = uri.toAbsolutePath
+      data.addDependencySource(absolutePath, item.getTarget)
+
+      if (!isVisited.contains(uri)) {
+        isVisited.add(uri)
+        try {
+          if (absolutePath.isJar && absolutePath.exists) {
+            usedJars += absolutePath
+            addSourceJarSymbols(absolutePath)
+          } else if (absolutePath.isDirectory) {
+            val dialect = buildTargets
+              .scalaTarget(item.getTarget)
+              .map(scalaTarget =>
+                ScalaVersions.dialectForScalaVersion(
+                  scalaTarget.scalaVersion,
+                  includeSource3 = true,
+                )
+              )
+              .getOrElse(Scala213)
+            definitionIndex.addSourceDirectory(absolutePath, dialect)
+          } else {
+            scribe.warn(
+              s"unexpected dependency with absolute path: $absolutePath"
+            )
+          }
+        } catch {
+          case NonFatal(e) =>
+            scribe.error(s"error processing $uri", e)
+        }
+      }
+    }
+
+    usedJars.toSet
   }
 
   private def indexDependencySources(

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -380,14 +380,17 @@ case class Indexer(indexProviders: IndexProviders)(implicit rc: ReportContext) {
       item <- dependencyModules.getItems.asScala
       module <- item.getModules.asScala
       if module.getData != null
-      uri <- module.getData
-        .asInstanceOf[JsonObject]
-        .get("artifacts")
-        .getAsJsonArray
-        .asScala
-        .filter(_.getAsJsonObject.has("classifier"))
-        .map(_.getAsJsonObject.get("uri").getAsString)
-        .toList
+      uri <- module.getData match {
+        case jsonObject: JsonObject =>
+          jsonObject
+            .get("artifacts")
+            .getAsJsonArray
+            .asScala
+            .filter(_.getAsJsonObject.has("classifier"))
+            .map(_.getAsJsonObject.get("uri").getAsString)
+            .toList
+        case _ => Nil
+      }
     } {
       val absolutePath = uri.toAbsolutePath
       data.addDependencySource(absolutePath, item.getTarget)

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -370,34 +370,33 @@ case class Indexer(indexProviders: IndexProviders)(implicit rc: ReportContext) {
   }
 
   private def processDependencyPath(
-     path: AbsolutePath,
-     target: b.BuildTargetIdentifier,
-     usedJars: mutable.HashSet[AbsolutePath],
-   ): Unit = {
-      try {
-        if (path.isJar && path.exists) {
-          usedJars += path
-          addSourceJarSymbols(path)
-        } else if (path.isDirectory) {
-          val dialect = buildTargets
-            .scalaTarget(target)
-            .map(scalaTarget =>
-              ScalaVersions.dialectForScalaVersion(
-                scalaTarget.scalaVersion,
-                includeSource3 = true,
-              )
+      path: AbsolutePath,
+      target: b.BuildTargetIdentifier,
+      usedJars: mutable.HashSet[AbsolutePath],
+  ): Unit = {
+    try {
+      if (path.isJar && path.exists) {
+        usedJars += path
+        addSourceJarSymbols(path)
+      } else if (path.isDirectory) {
+        val dialect = buildTargets
+          .scalaTarget(target)
+          .map(scalaTarget =>
+            ScalaVersions.dialectForScalaVersion(
+              scalaTarget.scalaVersion,
+              includeSource3 = true,
             )
-            .getOrElse(Scala213)
-          definitionIndex.addSourceDirectory(path, dialect)
-        } else {
-          scribe.warn(s"unexpected dependency with absolute path: $path")
-        }
-      } catch {
-        case NonFatal(e) =>
-          scribe.error(s"Error processing $path", e)
+          )
+          .getOrElse(Scala213)
+        definitionIndex.addSourceDirectory(path, dialect)
+      } else {
+        scribe.warn(s"unexpected dependency with absolute path: $path")
       }
+    } catch {
+      case NonFatal(e) =>
+        scribe.error(s"Error processing $path", e)
+    }
   }
-
 
   private def indexDependencyModules(
       data: TargetData,
@@ -415,9 +414,7 @@ case class Indexer(indexProviders: IndexProviders)(implicit rc: ReportContext) {
           Option(jsonObject.get("artifacts")) match {
             case Some(artifactsElement) if artifactsElement.isJsonArray =>
               try {
-                artifactsElement
-                  .getAsJsonArray
-                  .asScala
+                artifactsElement.getAsJsonArray.asScala
                   .filter(element =>
                     element.isJsonObject &&
                       element.getAsJsonObject.has("classifier")
@@ -426,7 +423,9 @@ case class Indexer(indexProviders: IndexProviders)(implicit rc: ReportContext) {
                   .toList
               } catch {
                 case NonFatal(e) =>
-                  scribe.warn(s"Error processing artifacts array: ${e.getMessage}")
+                  scribe.warn(
+                    s"Error processing artifacts array: ${e.getMessage}"
+                  )
                   Nil
               }
             case _ => Nil
@@ -437,8 +436,8 @@ case class Indexer(indexProviders: IndexProviders)(implicit rc: ReportContext) {
       _ = data.addDependencySource(absolutePath, item.getTarget)
       if !isVisited.contains(uri)
     } {
-        isVisited.add(uri)
-        processDependencyPath(absolutePath, item.getTarget, usedJars)
+      isVisited.add(uri)
+      processDependencyPath(absolutePath, item.getTarget, usedJars)
     }
 
     usedJars.toSet

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -243,7 +243,7 @@ class DefinitionLspSuite
     } yield ()
   }
 
-  test("goto-definition-into-dependency-sources-list") {
+  test("goto-definition-into-dependency-sources") {
     cleanWorkspace()
     for {
       _ <- initialize(
@@ -272,44 +272,29 @@ class DefinitionLspSuite
         "Li@@st(1, 2, 3)",
         workspace,
       )
-
-      _ = assert(listDefinition.nonEmpty)
-      _ = assert(listDefinition.head.getUri.contains("scala-library"))
-    } yield ()
-  }
-
-  test("goto-definition-into-dependency-sources-list-map") {
-    cleanWorkspace()
-    for {
-      _ <- initialize(
-        s"""|/metals.json
-            |{
-            |  "a": {
-            |    "scalaVersion": "${V.latestScala3Next}",
-            |    "libraryDependencies": [
-            |      "org.scala-lang:scala3-library_3:${V.latestScala3Next}"
-            |    ]
-            |  }
-            |}
-            |/a/src/main/scala/Main.scala
-            |package example
-            |object Main {
-            |  val list = List(1, 2, 3)
-            |  list.map(identity)
-            |}
-            |""".stripMargin
-      )
-      _ <- server.didOpen("a/src/main/scala/Main.scala")
-      _ = server.workspaceDefinitions
-
-      listDefinition <- server.definition(
+      mapDefinition <- server.definition(
         "a/src/main/scala/Main.scala",
         "list.ma@@p(identity)",
         workspace,
       )
 
-      _ = assert(listDefinition.nonEmpty)
-      _ = assert(listDefinition.head.getUri.contains("scala-library"))
+      _ = assert(
+        listDefinition.nonEmpty,
+        s"Expected a definition location for 'List', but got an empty result.",
+      )
+      _ = assert(
+        listDefinition.head.getUri.contains("scala-library"),
+        s"Expected List definition URI to contain 'scala-library', but was: ${listDefinition.head.getUri}",
+      )
+      _ = assert(
+        mapDefinition.nonEmpty,
+        s"Expected a definition location for 'map', but got an empty result.",
+      )
+      _ = assert(
+        mapDefinition.head.getUri.contains("scala-library"),
+        s"Expected map definition URI to contain 'scala-library', but was: ${mapDefinition.head.getUri}",
+      )
+
     } yield ()
   }
 

--- a/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/DefinitionLspSuite.scala
@@ -243,6 +243,76 @@ class DefinitionLspSuite
     } yield ()
   }
 
+  test("goto-definition-into-dependency-sources-list") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {
+            |    "scalaVersion": "${V.latestScala3Next}",
+            |    "libraryDependencies": [
+            |      "org.scala-lang:scala3-library_3:${V.latestScala3Next}"
+            |    ]
+            |  }
+            |}
+            |/a/src/main/scala/Main.scala
+            |package example
+            |object Main {
+            |  val list = List(1, 2, 3)
+            |  list.map(identity)
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      _ = server.workspaceDefinitions
+
+      listDefinition <- server.definition(
+        "a/src/main/scala/Main.scala",
+        "Li@@st(1, 2, 3)",
+        workspace,
+      )
+
+      _ = assert(listDefinition.nonEmpty)
+      _ = assert(listDefinition.head.getUri.contains("scala-library"))
+    } yield ()
+  }
+
+  test("goto-definition-into-dependency-sources-list-map") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/metals.json
+            |{
+            |  "a": {
+            |    "scalaVersion": "${V.latestScala3Next}",
+            |    "libraryDependencies": [
+            |      "org.scala-lang:scala3-library_3:${V.latestScala3Next}"
+            |    ]
+            |  }
+            |}
+            |/a/src/main/scala/Main.scala
+            |package example
+            |object Main {
+            |  val list = List(1, 2, 3)
+            |  list.map(identity)
+            |}
+            |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      _ = server.workspaceDefinitions
+
+      listDefinition <- server.definition(
+        "a/src/main/scala/Main.scala",
+        "list.ma@@p(identity)",
+        workspace,
+      )
+
+      _ = assert(listDefinition.nonEmpty)
+      _ = assert(listDefinition.head.getUri.contains("scala-library"))
+    } yield ()
+  }
+
   test("stale") {
     for {
       _ <- initialize(


### PR DESCRIPTION
Previously, external libraries were collected, but not used during indexing. This change should enable `go to definition` operations on external libraries.