### PR TITLE
fix: change workspace symbol search to include extension methods

### DIFF
--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -7,6 +7,7 @@ import scala.concurrent.Future
 import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.Messages
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.{BuildInfo => V}
 
 import org.eclipse.lsp4j.SymbolInformation
 import org.eclipse.lsp4j.WorkspaceSymbolParams
@@ -395,6 +396,33 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
         """|scala.<:<
            |scala.<:<
            |""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("extension-symbol") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": { "scalaVersion": "${V.latestScala3Next}" }
+           |}
+           |/a/src/main/scala/a/A.scala
+           |package a
+           |
+           |object A {
+           |  extension (i: Int) {
+           |    def foobar: Int = i + 1
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/A.scala")
+      _ = assertNoDiff(
+        server.workspaceSymbol("foobar"),
+        "a.A.foobar",
       )
     } yield ()
   }


### PR DESCRIPTION
# Fixes #7766
This PR updates the workspace symbol search logic in `WorkspaceSymbolProvider` to correctly include extension methods defined in the project.
## Key changes include
- Extension methods from `inWorkspaceMethods` are now iterated and matched alongside regular symbols during workspace symbol search.
## As a result
- "Search symbol in workspace" now finds extension methods.