### PR TITLE
fix: filter out invalid <empty> package imports from quickfix actions

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ImportMissingSymbol.scala
@@ -241,6 +241,11 @@ class ImportMissingSymbolQuickFix(
   override protected val allSymbolsTitle: String =
     ImportMissingSymbol.allSymbolsTitle
   override protected def isImportAllSourceAction: Boolean = false
+  override protected def filterImportActions(
+      allActions: Seq[l.CodeAction]
+  ): Seq[l.CodeAction] = {
+    allActions.filter(!_.getTitle().endsWith("from package '<empty>'"))
+  }
 }
 
 object ImportMissingSymbolQuickFix {

--- a/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ImportMissingSymbolLspSuite.scala
@@ -458,6 +458,18 @@ class ImportMissingSymbolLspSuite
     kind = List(ImportMissingSymbolQuickFix.kind),
   )
 
+  checkActionsOnly(
+    "i7777 (<empty> package)",
+    s"""|package a
+        |object Foo {
+        |  <<Bar>>
+        |}
+        |/a/src/main/scala/Bar.scala
+        |object Bar {}
+        |""".stripMargin,
+    s"${CreateNewSymbol.title("Bar")}",
+  )
+
   // ---------------------------------------------------------------------------
   // Tests for SourceAddMissingImports (source.addMissingImports)
   // These tests verify the auto-import behavior that only imports unambiguous symbols


### PR DESCRIPTION
# Fixes #7777 
This PR introduces improved handling of import quickfix suggestions in Metals by filtering out invalid import actions that reference the <empty> package.
## Key changes include:
- The quickfix logic now filters out code actions that would import symbols from the `<empty>` package.
- A dedicated test has been added to ensure that these invalid import actions are not suggested.
- A new `checkActionsOnly` method has been introduced in `BaseCodeActionLspSuite.scala` to allow tests to assert which code actions are available without executing any of them.