### PR TITLE
bugfix: Revert timeout, the default is 1 hour.

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
@@ -3,7 +3,6 @@ package scala.meta.internal.metals.mcp
 import java.io.PrintWriter
 import java.net.InetSocketAddress
 import java.nio.file.Path
-import java.time.Duration
 import java.util.Arrays
 import java.util.function.BiFunction
 import java.util.{List => JList}
@@ -111,7 +110,6 @@ class MetalsMcpServer(
       .async(servlet)
       .serverInfo("scala-mcp-server", "0.1.0")
       .capabilities(capabilities)
-      .requestTimeout(Duration.ofMinutes(1))
       .build()
 
     cancelable.add(() => asyncServer.close())

--- a/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
+++ b/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
@@ -1,5 +1,7 @@
 package tests.mcp
 
+import java.time.Duration
+
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -17,7 +19,8 @@ import io.modelcontextprotocol.spec.McpSchema.TextContent
 class TestMcpClient(url: String, val port: Int)(implicit ec: ExecutionContext) {
   private val objectMapper = new ObjectMapper()
   private val transport = new HttpClientSseClientTransport(url)
-  private val client = McpClient.async(transport).build()
+  private val client =
+    McpClient.async(transport).requestTimeout(Duration.ofMinutes(5)).build()
 
   private def callTool(
       toolName: String,


### PR DESCRIPTION
Instead we should change the timeout for the TestClient, which fails on MacOS currently. :