### PR TITLE
Add RawPresentationCompiler interface

### DIFF
--- a/mtags-interfaces/src/main/java/scala/meta/pc/RawPresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/RawPresentationCompiler.java
@@ -1,0 +1,264 @@
+package scala.meta.pc;
+
+import scala.meta.pc.reports.ReportContext;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.CompletionTriggerKind;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.InlayHint;
+import org.eclipse.lsp4j.SelectionRange;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The raw public API of the presentation compiler that does not handle synchronisation.
+ * Scala compiler can't run concurrent code at that point, so we need to enforce sequential, single threaded execution.
+ * It has to be implemented by the consumer of this API.
+ *
+ * This API should remain binary compatible
+ */
+public abstract class RawPresentationCompiler {
+
+	// ==============================
+	// Language Server Protocol APIs.
+	// ==============================
+
+	/**
+	 * Returns token informations from presentation compiler.
+	 *
+	 */
+	public abstract List<Node> semanticTokens(VirtualFileParams params);
+
+	/**
+	 * Returns code completions for the given source position.
+	 *
+	 * The returned completion items are incomplete meaning they may not contain
+	 * available information such as documentation or the detail signature may have
+	 * `x$1` parameter names for Java methods. It's recommended to call
+	 * {@link #completionItemResolve(CompletionItem, String)} before displaying the
+	 * `detail` and `documentation` fields to the user.
+	 *
+	 * @implNote supports cancellation.
+	 */
+	public abstract CompletionList complete(OffsetParams params, CompletionTriggerKind completionTriggerKind);
+
+	/**
+	 * Returns a fully resolved completion item with defined fields such as
+	 * `documentation` and `details` populated.
+	 *
+	 * @implNote does not support cancellation.
+	 */
+	public abstract CompletionItem completionItemResolve(CompletionItem item, String symbol);
+
+	/**
+	 * Returns the parameter hints at the given source position.
+	 *
+	 * @implNote supports cancellation.
+	 */
+	public abstract SignatureHelp signatureHelp(OffsetParams params);
+
+	/**
+	 * Returns the type of the expression at the given position along with the
+	 * symbol of the referenced symbol.
+	 */
+	public abstract Optional<HoverSignature> hover(OffsetParams params);
+
+	/**
+	 * Checks if the symbol at given position can be renamed using presentation
+	 * compiler. Returns Some(range) if symbol is defined inside a method or the
+	 * file is a worksheet, None otherwise
+	 */
+	public abstract Optional<Range> prepareRename(OffsetParams params);
+
+	/**
+	 * Renames the symbol at given position and all of its occurrences to `name`. If
+	 * symbol can't be renamed using presentation compiler (prepareRename returns
+	 * None), returns empty list.
+	 */
+	public abstract List<TextEdit> rename(OffsetParams params, String name);
+
+	/**
+	 * Returns the definition of the symbol at the given position.
+	 */
+	public abstract DefinitionResult definition(OffsetParams params);
+
+	/**
+	 * Returns location of the expression's type definition at the given position.
+	 */
+	public abstract DefinitionResult typeDefinition(OffsetParams params);
+
+	/**
+	 * Returns the occurrences of the symbol under the current position in the
+	 * entire file.
+	 */
+	public abstract List<DocumentHighlight> documentHighlight(OffsetParams params);
+
+	/**
+	 * Returns the references of the symbol under the current position in the target files.
+	 */
+	public abstract List<ReferencesResult> references(ReferencesRequest params);
+
+	/**
+	 * Execute the given code action
+	 */
+	public abstract <T> List<TextEdit> codeAction(OffsetParams params, String codeActionId,
+			Optional<T> codeActionPayload);
+
+	/**
+	 * Returns the list of code actions supported by the current presentation compiler.
+	 */
+	public abstract List<String> supportedCodeActions();
+
+	/**
+	 * Return decoded and pretty printed TASTy content for .scala or .tasty file.
+	 *
+	 */
+	public abstract String getTasty(URI targetUri, boolean isHttpEnabled);
+
+	/**
+	 * Return the necessary imports for a symbol at the given position.
+	 */
+	public abstract List<AutoImportsResult> autoImports(String name, OffsetParams params,
+			Boolean isExtension);
+
+	/**
+	 * Return the missing implements and imports for the symbol at the given
+	 * position.
+	 */
+	public abstract List<TextEdit> implementAbstractMembers(OffsetParams params);
+
+	/**
+	 * Return the missing implements and imports for the symbol at the given
+	 * position.
+	 */
+	public abstract List<TextEdit> insertInferredType(OffsetParams params);
+
+	/**
+	 * Return the text edits for inlining a value.
+	 */
+	public abstract List<TextEdit> inlineValue(OffsetParams params);
+
+	/**
+	 * Extract method in selected range
+	 *
+	 * @param range         range to extract from
+	 * @param extractionPos position in file to extract to
+	 */
+	public abstract List<TextEdit> extractMethod(RangeParams range, OffsetParams extractionPos);
+
+	/**
+	 * Return named arguments for the apply method that encloses the given position.
+	 * May fail with a DisplayableException.
+	 */
+	public abstract List<TextEdit> convertToNamedArguments(OffsetParams params,
+			List<Integer> argIndices);
+
+	/**
+	 * The text contents of the given file changed.
+	 */
+	public abstract List<Diagnostic> didChange(VirtualFileParams params);
+
+	/**
+	 * Returns decorations for missing type adnotations, inferred type parameters,
+	 * implicit parameters and conversions.
+	 */
+	public abstract List<InlayHint> inlayHints(InlayHintsParams params);
+
+	public abstract Optional<PcSymbolInformation> info(String symbol);
+
+	/**
+	 * File was closed.
+	 */
+	public abstract void didClose(URI uri);
+
+	/**
+	 * Returns the Protobuf byte array representation of a SemanticDB
+	 * <code>TextDocument</code> for the given source.
+	 */
+	public abstract byte[] semanticdbTextDocument(URI filename, String code);
+
+	/**
+	 * Returns the Protobuf byte array representation of a SemanticDB
+	 * <code>TextDocument</code> for the given source.
+	 */
+	public abstract byte[] semanticdbTextDocument(VirtualFileParams params);
+
+	/**
+	 * Return the selections ranges for the given positions.
+	 */
+	public abstract List<SelectionRange> selectionRange(List<OffsetParams> params);
+
+	// =================================
+	// Configuration and lifecycle APIs.
+	// =================================
+
+	/**
+	 * Set logger level for reports.
+	 */
+	public abstract RawPresentationCompiler withReportsLoggerLevel(String level);
+
+	/**
+	 * Set build target name.
+	 */
+	public abstract RawPresentationCompiler withBuildTargetName(String buildTargetName);
+
+	/**
+	 * Provide a SymbolSearch to extract docstrings, java parameter names and Scala
+	 * default parameter values.
+	 */
+	public abstract RawPresentationCompiler withSearch(SymbolSearch search);
+
+	/**
+	 * Provide custom configuration for features like signature help and
+	 * completions.
+	 */
+	public abstract RawPresentationCompiler withConfiguration(PresentationCompilerConfig config);
+
+	/**
+	 * Provide workspace root for features like ammonite script $file completions.
+	 */
+	public abstract RawPresentationCompiler withWorkspace(Path workspace);
+
+	/**
+	 * Provide CompletionItemPriority for additional sorting completion items.
+	 */
+	public abstract RawPresentationCompiler withCompletionItemPriority(CompletionItemPriority priority);
+
+	/**
+	 * Provide a reporting context for reporting errors.
+	 */
+	public abstract RawPresentationCompiler withReportContext(ReportContext reportContext);
+
+	/**
+	 * Construct a new presentation compiler with the given parameters.
+	 *
+	 * @param buildTargetIdentifier the build target containing this source file.
+	 *                              This is needed for
+	 *                              {@link #completionItemResolve(CompletionItem, String)}.
+	 * @param classpath             the classpath of this build target.
+	 * @param options               the compiler flags for the new compiler.
+	 *                              Important, it is recommended to disable all
+	 *                              compiler plugins excluding
+	 *                              org.scalamacros:paradise, kind-projector and
+	 *                              better-monadic-for.
+	 */
+	public abstract RawPresentationCompiler newInstance(String buildTargetIdentifier, List<Path> classpath,
+			List<String> options);
+
+	/**
+	 * Scala version for the current presentation compiler
+	 */
+	public abstract String scalaVersion();
+
+	public abstract String buildTargetId();
+
+}


### PR DESCRIPTION
`RawPresentationCompiler` is a direct, unsafe way to access presentation compiler interface.

It is up to the consumer to guarantee thread safety and sequential request processing.
The main story behind the need for such interface is that some servers may use custom runtime which will simplify presentation compiler usage and make it more performant. Currently there is no real way to specify the Thread that will be used to compute this, and on top of that we're creating a custom single threaded executor for each presentation compiler (each module has its own instance, so you can have even 20 or 30 of them).

The proposed implementation will be submitted in another PR directly in Scala 3 repository. At the moment of writing it is:


<details>
  <summary>Implementation proposal</summary>

```scala
package dotty.tools.pc

import java.io.File
import java.net.URI
import java.nio.file.Path
import java.util.Optional
import java.util.concurrent.CompletableFuture
import java.util.concurrent.ExecutorService
import java.util.concurrent.ScheduledExecutorService
import java.util as ju

import scala.concurrent.ExecutionContext
import scala.concurrent.ExecutionContextExecutor
import scala.jdk.CollectionConverters._
import scala.language.unsafeNulls
import scala.meta.internal.metals.CompilerVirtualFileParams
import scala.meta.internal.metals.EmptyCancelToken
import scala.meta.pc.reports.EmptyReportContext
import scala.meta.internal.metals.PcQueryContext
import scala.meta.pc.reports.ReportContext
import scala.meta.internal.metals.ReportLevel
import scala.meta.internal.mtags.CommonMtagsEnrichments.*
import scala.meta.internal.pc.CompilerAccess
import scala.meta.internal.pc.DefinitionResultImpl
import scala.meta.internal.pc.EmptyCompletionList
import scala.meta.internal.pc.EmptySymbolSearch
import scala.meta.internal.pc.PresentationCompilerConfigImpl
import scala.meta.pc.*
import scala.meta.pc.{PcSymbolInformation as IPcSymbolInformation}

import dotty.tools.dotc.reporting.StoreReporter
import dotty.tools.pc.completions.CompletionProvider
import dotty.tools.pc.InferExpectedType
import dotty.tools.pc.completions.OverrideCompletions
import dotty.tools.pc.buildinfo.BuildInfo
import dotty.tools.pc.SymbolInformationProvider
import dotty.tools.dotc.interactive.InteractiveDriver

import org.eclipse.lsp4j.DocumentHighlight
import org.eclipse.lsp4j.TextEdit
import org.eclipse.lsp4j as l


case class RawScalaPresentationCompiler(
    buildTargetIdentifier: String = "",
    buildTargetName: Option[String] = None,
    classpath: Seq[Path] = Nil,
    options: List[String] = Nil,
    search: SymbolSearch = EmptySymbolSearch,
    config: PresentationCompilerConfig = PresentationCompilerConfigImpl(),
    folderPath: Option[Path] = None,
    reportsLevel: ReportLevel = ReportLevel.Info,
    completionItemPriority: CompletionItemPriority = (_: String) => 0,
    reportContext: ReportContext = EmptyReportContext()
) extends RawPresentationCompiler:

  given ReportContext = reportContext

  override def supportedCodeActions(): ju.List[String] = List(
     CodeActionId.ConvertToNamedArguments,
     CodeActionId.ImplementAbstractMembers,
     CodeActionId.ExtractMethod,
     CodeActionId.InlineValue,
     CodeActionId.InsertInferredType,
     PcConvertToNamedLambdaParameters.codeActionId
   ).asJava

  val scalaVersion = BuildInfo.scalaVersion

  private val forbiddenOptions = Set("-print-lines", "-print-tasty") // -no-indent ?
  private val forbiddenDoubleOptions = Set.empty[String]

  val driverSettings =
    val implicitSuggestionTimeout = List("-Ximport-suggestion-timeout", "0")
    val defaultFlags = List("-color:never")
    val filteredOptions = removeDoubleOptions(options.filterNot(forbiddenOptions))

    filteredOptions ::: defaultFlags ::: implicitSuggestionTimeout ::: "-classpath" :: classpath
      .mkString(File.pathSeparator) :: Nil

  lazy val driver: InteractiveDriver = CachingDriver(driverSettings)

  override def codeAction[T](
    params: OffsetParams,
    codeActionId: String,
    codeActionPayload: Optional[T]
   ): ju.List[TextEdit] =
     (codeActionId, codeActionPayload.asScala) match
        case (
              CodeActionId.ConvertToNamedArguments,
              Some(argIndices: ju.List[_])
            ) =>
          val payload =
            argIndices.asScala.collect {

        case i: Integer => i.toInt }.toSet
          convertToNamedArguments(params, payload)
        case (CodeActionId.ImplementAbstractMembers, _) =>
          implementAbstractMembers(params)
        case (CodeActionId.InsertInferredType, _) =>
          insertInferredType(params)
        case (CodeActionId.InlineValue, _) =>
          inlineValue(params)
        case (CodeActionId.ExtractMethod, Some(extractionPos: OffsetParams)) =>
          params match {
            case range: RangeParams =>
              extractMethod(range, extractionPos)
            case _ => throw new IllegalArgumentException(s"Expected range parameters")
          }
        case (PcConvertToNamedLambdaParameters.codeActionId, _) =>
          PcConvertToNamedLambdaParameters(driver, params).convertToNamedLambdaParameters
        case (id, _) => throw new IllegalArgumentException(s"Unsupported action id $id")

  override def withCompletionItemPriority(
    priority: CompletionItemPriority
  ): RawPresentationCompiler =
    copy(completionItemPriority = priority)

  override def withBuildTargetName(buildTargetName: String): RawPresentationCompiler =
    copy(buildTargetName = Some(buildTargetName))

  override def withReportsLoggerLevel(level: String): RawPresentationCompiler =
    copy(reportsLevel = ReportLevel.fromString(level))

  private def removeDoubleOptions(options: List[String]): List[String] =
    options match
      case head :: _ :: tail if forbiddenDoubleOptions(head) =>
        removeDoubleOptions(tail)
      case head :: tail => head :: removeDoubleOptions(tail)
      case Nil => options

  override def semanticTokens(
      params: VirtualFileParams
  ): ju.List[Node] =
    new PcSemanticTokensProvider(driver, params).provide().asJava

  override def inlayHints(
      params: InlayHintsParams
  ): ju.List[l.InlayHint] =
    new PcInlayHintsProvider(driver, params, search)
      .provide()
      .asJava

  override def getTasty(
      targetUri: URI,
      isHttpEnabled: Boolean
  ): String =
    TastyUtils.getTasty(targetUri, isHttpEnabled)

  def complete(params: OffsetParams, completionTriggerKind: l.CompletionTriggerKind): l.CompletionList =
    new CompletionProvider(
      search,
      driver,
      () => InteractiveDriver(driverSettings),
      params,
      config,
      buildTargetIdentifier,
      folderPath,
      completionItemPriority
    ).completions()

  def definition(params: OffsetParams): DefinitionResult =
    PcDefinitionProvider(driver, params, search).definitions()

  override def typeDefinition(
      params: OffsetParams
  ): DefinitionResult =
    PcDefinitionProvider(driver, params, search).typeDefinitions()

  def documentHighlight(
      params: OffsetParams
  ): ju.List[DocumentHighlight] =
    PcDocumentHighlightProvider(driver, params).highlights.asJava

  override def references(
      params: ReferencesRequest
  ): ju.List[ReferencesResult] =
    PcReferencesProvider(driver, params)
      .references()
      .asJava

  def inferExpectedType(params: OffsetParams): ju.Optional[String] =
    new InferExpectedType(search, driver, params).infer().asJava

  def diagnosticsForDebuggingPurposes(): ju.List[String] = List[String]().asJava

  override def info(
      symbol: String
  ): Optional[IPcSymbolInformation] =
    SymbolInformationProvider(using driver.currentCtx)
      .info(symbol)
      .map(_.asJava)
      .asJava

  def semanticdbTextDocument(
      filename: URI,
      code: String
  ): Array[Byte] =
    val virtualFile = CompilerVirtualFileParams(filename, code)
    val provider = SemanticdbTextDocumentProvider(driver, folderPath)
    provider.textDocument(filename, code)

  def completionItemResolve(
      item: l.CompletionItem,
      symbol: String
  ): l.CompletionItem =
    CompletionItemResolver.resolve(item, symbol, search, config)(using driver.currentCtx) // FIX ME

  def autoImports(
      name: String,
      params: scala.meta.pc.OffsetParams,
      isExtension: java.lang.Boolean
  ): ju.List[scala.meta.pc.AutoImportsResult] =
    new AutoImportsProvider(
      search,
      driver,
      name,
      params,
      config,
      buildTargetIdentifier
    )
      .autoImports(isExtension)
      .asJava

  def implementAbstractMembers(
      params: OffsetParams
  ): ju.List[l.TextEdit] =
    OverrideCompletions.implementAllAt(
      params,
      driver,
      search,
      config
    )

  override def insertInferredType(
      params: OffsetParams
  ): ju.List[l.TextEdit] =
    new InferredTypeProvider(params, driver, config, search)
      .inferredTypeEdits()
      .asJava

  override def inlineValue(
      params: OffsetParams
  ): ju.List[l.TextEdit] =
    new PcInlineValueProvider(driver, params).getInlineTextEdits() match
      case Right(edits: List[TextEdit]) => edits.asJava
      case Left(error: String) => throw new DisplayableException(error)
  end inlineValue

  override def extractMethod(
      range: RangeParams,
      extractionPos: OffsetParams
  ): ju.List[l.TextEdit] =
    new ExtractMethodProvider(
      range,
      extractionPos,
      driver,
      search,
      options.contains("-no-indent"),
    )
      .extractMethod()
      .asJava
  end extractMethod

  override def convertToNamedArguments(
      params: OffsetParams,
      argIndices: ju.List[Integer]
  ): ju.List[l.TextEdit] =
    convertToNamedArguments(params, argIndices.asScala.toSet.map(_.toInt))

  def convertToNamedArguments(
      params: OffsetParams,
      argIndices: Set[Int]
  ): ju.List[l.TextEdit] =
    new ConvertToNamedArgumentsProvider(
      driver,
      params,
      argIndices
    ).convertToNamedArguments match
      case Left(error: String) => throw new DisplayableException(error)
      case Right(edits: List[l.TextEdit]) => edits.asJava
  end convertToNamedArguments

  override def selectionRange(
      params: ju.List[OffsetParams]
  ): ju.List[l.SelectionRange] =
    new SelectionRangeProvider(
      driver,
      params,
    ).selectionRange().asJava
  end selectionRange

  def hover(
      params: OffsetParams
  ): ju.Optional[HoverSignature] =
    HoverProvider.hover(params, driver, search, config.hoverContentType())
  end hover

  def prepareRename(
      params: OffsetParams
  ): ju.Optional[l.Range] =
    PcRenameProvider(driver, params, None).prepareRename().asJava

  def rename(
      params: OffsetParams,
      name: String
  ): ju.List[l.TextEdit] =
    PcRenameProvider(driver, params, Some(name)).rename().asJava

  def newInstance(
      buildTargetIdentifier: String,
      classpath: ju.List[Path],
      options: ju.List[String]
  ): RawPresentationCompiler =
    copy(
      buildTargetIdentifier = buildTargetIdentifier,
      classpath = classpath.asScala.toSeq,
      options = options.asScala.toList
    )

  def signatureHelp(params: OffsetParams): l.SignatureHelp =
    SignatureHelpProvider.signatureHelp(driver, params, search)

  override def didChange(params: VirtualFileParams): ju.List[l.Diagnostic] =
    new DiagnosticProvider(driver, params).diagnostics().asJava

  override def didClose(uri: URI): Unit =
    driver.close(uri)

  override def semanticdbTextDocument(params: VirtualFileParams): Array[Byte] =
    semanticdbTextDocument(params.uri, params.text)

  override def buildTargetId(): String = buildTargetIdentifier

  override def withConfiguration(
      config: PresentationCompilerConfig
  ): RawPresentationCompiler =
    copy(config = config)

  def withSearch(search: SymbolSearch): RawPresentationCompiler =
    copy(search = search)

  override def withReportContext(reportContext: ReportContext): RawPresentationCompiler =
    copy(reportContext = reportContext)

  def withWorkspace(workspace: Path): RawPresentationCompiler =
    copy(folderPath = Some(workspace))

  def additionalReportData() =
    s"""|Scala version: $scalaVersion
        |Classpath:
        |${classpath
          .map(path => s"$path [${if path.exists then "exists" else "missing"} ]")
          .mkString(", ")}
        |Options:
        |${options.mkString(" ")}
        |""".stripMargin

  extension (params: VirtualFileParams)
    def toQueryContext = PcQueryContext(Some(params), additionalReportData)

  def emptyQueryContext = PcQueryContext(None, additionalReportData)

end RawScalaPresentationCompiler
```

</details>

*Sidenote - Ideally I would implement it without any use of lsp4j, but whole PresentationCompiler is already implemented with that interface in mind so I left it as it is.*