### PR TITLE
deps: Update to sbt 2.0.0-RC6

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -44,7 +44,7 @@ object V {
   val scalameta = "4.13.10"
   val scribe = "3.17.0"
   val qdox = "2.2.0"
-  val sbt2Version = "2.0.0-RC5"
+  val sbt2Version = "2.0.0-RC6"
 
   val guava = "com.google.guava" % "guava" % "33.5.0-jre"
   val lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % lsp4jV


### PR DESCRIPTION
sbt 2.0.0-RC5 broke bincompat, so please update to 2.0.0-RC6.
See https://github.com/sbt/sbt/releases/tag/v2.0.0-RC6
