### PR TITLE
improvement: Don't require a name when generating a scalafix rule

### DIFF
--- a/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
+++ b/tests/unit/src/main/scala/tests/mcp/McpTestClient.scala
@@ -88,13 +88,11 @@ class TestMcpClient(url: String, val port: Int)(implicit ec: ExecutionContext) {
   }
 
   def generateScalafixRule(
-      ruleName: String,
       ruleImplementation: String,
       ruleDescription: String,
       sampleCode: Option[String] = None,
   ): Future[String] = {
     val params = objectMapper.createObjectNode()
-    params.put("ruleName", ruleName)
     params.put("ruleImplementation", ruleImplementation)
     params.put("description", ruleDescription)
     sampleCode.foreach(code => params.put("sampleCode", code))

--- a/tests/unit/src/test/scala/tests/mcp/McpServerLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpServerLspSuite.scala
@@ -6,6 +6,7 @@ import scala.meta.internal.metals.mcp.McpMessages
 import scala.meta.internal.metals.mcp.NoClient
 import scala.meta.internal.metals.mcp.SymbolType
 
+import munit.Location
 import tests.BaseLspSuite
 
 class McpServerLspSuite extends BaseLspSuite("mcp-server") with McpTestUtils {
@@ -107,100 +108,144 @@ class McpServerLspSuite extends BaseLspSuite("mcp-server") with McpTestUtils {
     } yield ()
   }
 
-  test("run-scalafix-rule") {
-    cleanWorkspace()
-    val initial =
-      """|package com.example
-         |
-         |object Hello { 
-         |  val str = "John"
-         |  def main(args: Array[String]): Unit = println(str)
-         |}
-         |""".stripMargin
-    val expectedResult =
-      """|package com.example
-         |
-         |object Hello { 
-         |  val str = "Johnatan"
-         |  def main(args: Array[String]): Unit = println(str)
-         |}
-         |""".stripMargin
-    for {
-      _ <- initialize(
-        s"""
-           |/metals.json
-           |{"a": {}}
-           |/a/src/main/scala/com/example/Hello.scala
-           |$initial
-           |""".stripMargin
-      )
-      _ <- server.didOpen("a/src/main/scala/com/example/Hello.scala")
-      client <- startMcpServer()
-      result <- client.generateScalafixRule(
-        "ReplaceJohnWithJohnatan",
-        """|
-           |package fix
+  def checkScalafixRule(
+      testName: String,
+      input: String,
+      expectedMessage: String,
+      expectedRules: String,
+  )(implicit loc: Location): Unit = {
+    test(testName) {
+      cleanWorkspace()
+      val initial =
+        """|package com.example
            |
-           |import scalafix.v1._
-           |import scala.meta._
-           |
-           |class ReplaceJohnWithJohnatan extends SemanticRule("ReplaceJohnWithJohnatan") {
-           |  override def fix(implicit doc: SemanticDocument): Patch = {
-           |    doc.tree.collect {
-           |      case lit @ Lit.String(value) if value.contains("John") =>
-           |        val newValue = value.replace("John", "\"Johnatan\"")
-           |        Patch.replaceTree(lit, newValue)
-           |    }.asPatch
-           |  }
+           |object Hello { 
+           |  val str = "John"
+           |  def main(args: Array[String]): Unit = println(str)
            |}
+           |""".stripMargin
+      val expectedResult =
+        """|package com.example
            |
-           |""".stripMargin,
-        "Replaces John with Johnatan",
-      )
-      _ = assertNoDiff(
-        result,
-        """|Created and ran Scalafix rule ReplaceJohnWithJohnatan successfully
-           |""".stripMargin,
-      )
-      _ = assertNoDiff(
-        server.buffers
-          .get(workspace.resolve("a/src/main/scala/com/example/Hello.scala"))
-          .get,
-        expectedResult,
-      )
-      // Test listing scalafix rules after creating one
-      rules <- client.listScalafixRules()
-      _ = assertNoDiff(
-        rules,
-        """|Available scalafix rules:
-           |- ExplicitResultTypes: Inserts type annotations for inferred public members.
-           |- OrganizeImports: Organize import statements, used for source.organizeImports code action
-           |- ProcedureSyntax: Replaces deprecated Scala 2.x procedure syntax with explicit ': Unit ='
-           |- RedundantSyntax: Removes redundant syntax such as `final` modifiers on an object
-           |- RemoveUnused: Removes unused imports and terms that reported by the compiler under -Wunused
-           |- ReplaceJohnWithJohnatan: Replaces John with Johnatan
-           |""".stripMargin,
-      )
-      _ <- server.didChange("a/src/main/scala/com/example/Hello.scala") {
-        _.replace("Johnatan", "John")
-      }
-      _ <- server.didSave("a/src/main/scala/com/example/Hello.scala")
-      _ = assertNoDiff(
-        server.buffers
-          .get(workspace.resolve("a/src/main/scala/com/example/Hello.scala"))
-          .get,
-        initial,
-      )
-      _ <- client.runScalafixRule("ReplaceJohnWithJohnatan")
-      _ = assertNoDiff(
-        server.buffers
-          .get(workspace.resolve("a/src/main/scala/com/example/Hello.scala"))
-          .get,
-        expectedResult,
-      )
-      _ <- client.shutdown()
-    } yield ()
+           |object Hello { 
+           |  val str = "Johnatan"
+           |  def main(args: Array[String]): Unit = println(str)
+           |}
+           |""".stripMargin
+      for {
+        _ <- initialize(
+          s"""
+             |/metals.json
+             |{"a": {}}
+             |/a/src/main/scala/com/example/Hello.scala
+             |$initial
+             |""".stripMargin
+        )
+        _ <- server.didOpen("a/src/main/scala/com/example/Hello.scala")
+        client <- startMcpServer()
+        result <- client.generateScalafixRule(
+          input,
+          "Replaces John with Johnatan",
+        )
+        _ = assertNoDiff(
+          result,
+          expectedMessage,
+        )
+        _ = assertNoDiff(
+          server.buffers
+            .get(workspace.resolve("a/src/main/scala/com/example/Hello.scala"))
+            .get,
+          expectedResult,
+        )
+        // Test listing scalafix rules after creating one
+        rules <- client.listScalafixRules()
+        _ = assertNoDiff(
+          rules,
+          expectedRules,
+        )
+        _ <- server.didChange("a/src/main/scala/com/example/Hello.scala") {
+          _.replace("Johnatan", "John")
+        }
+        _ <- server.didSave("a/src/main/scala/com/example/Hello.scala")
+        _ = assertNoDiff(
+          server.buffers
+            .get(workspace.resolve("a/src/main/scala/com/example/Hello.scala"))
+            .get,
+          initial,
+        )
+        _ <- client.runScalafixRule("ReplaceJohnWithJohnatan")
+        _ = assertNoDiff(
+          server.buffers
+            .get(workspace.resolve("a/src/main/scala/com/example/Hello.scala"))
+            .get,
+          expectedResult,
+        )
+        _ <- client.shutdown()
+      } yield ()
+    }
   }
+
+  checkScalafixRule(
+    "replace-john-with-johnatan-simple",
+    """|
+       |package fix
+       |
+       |import scalafix.v1._
+       |import scala.meta._
+       |
+       |class ReplaceJohnWithJohnatan extends SemanticRule("ReplaceJohnWithJohnatan") {
+       |  override def fix(implicit doc: SemanticDocument): Patch = {
+       |    doc.tree.collect {
+       |      case lit @ Lit.String(value) if value.contains("John") =>
+       |        val newValue = value.replace("John", "\"Johnatan\"")
+       |        Patch.replaceTree(lit, newValue)
+       |    }.asPatch
+       |  }
+       |}
+       |
+       |""".stripMargin,
+    """|Created and ran Scalafix rule ReplaceJohnWithJohnatan successfully
+       |""".stripMargin,
+    """|Available scalafix rules:
+       |- ExplicitResultTypes: Inserts type annotations for inferred public members.
+       |- OrganizeImports: Organize import statements, used for source.organizeImports code action
+       |- ProcedureSyntax: Replaces deprecated Scala 2.x procedure syntax with explicit ': Unit ='
+       |- RedundantSyntax: Removes redundant syntax such as `final` modifiers on an object
+       |- RemoveUnused: Removes unused imports and terms that reported by the compiler under -Wunused
+       |- ReplaceJohnWithJohnatan: Replaces John with Johnatan
+       |""".stripMargin,
+  )
+
+  checkScalafixRule(
+    "replace-john-with-johnatan-mismatch",
+    """|
+       |package fix
+       |
+       |import scalafix.v1._
+       |import scala.meta._
+       |
+       |class ReplacerClass extends SemanticRule("Replacer") {
+       |  override def fix(implicit doc: SemanticDocument): Patch = {
+       |    doc.tree.collect {
+       |      case lit @ Lit.String(value) if value.contains("John") =>
+       |        val newValue = value.replace("John", "\"Johnatan\"")
+       |        Patch.replaceTree(lit, newValue)
+       |    }.asPatch
+       |  }
+       |}
+       |
+       |""".stripMargin,
+    """|Created and ran Scalafix rule Replacer successfully
+       |""".stripMargin,
+    """|Available scalafix rules:
+       |- ExplicitResultTypes: Inserts type annotations for inferred public members.
+       |- OrganizeImports: Organize import statements, used for source.organizeImports code action
+       |- ProcedureSyntax: Replaces deprecated Scala 2.x procedure syntax with explicit ': Unit ='
+       |- RedundantSyntax: Removes redundant syntax such as `final` modifiers on an object
+       |- RemoveUnused: Removes unused imports and terms that reported by the compiler under -Wunused
+       |- Replacer: Replaces John with Johnatan
+       |""".stripMargin,
+  )
 
   test("list-scalafix-rules") {
     cleanWorkspace()
@@ -252,7 +297,6 @@ class McpServerLspSuite extends BaseLspSuite("mcp-server") with McpTestUtils {
       client <- startMcpServer()
       // Test with no rules present
       result <- client.generateScalafixRule(
-        "ReplaceJohnWithJohnatan",
         """|
            |package fix
            |


### PR DESCRIPTION
This easily led to mismatches with LLMs, which would have a different name and classname. We can just easily get that information from the soruces.