### PR TITLE
improvement: Show crashes more visibly for the user

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -286,6 +286,7 @@ abstract class MetalsLspService(
       () => bspSession,
       tables,
       connectionBspStatus,
+      diagnostics,
     )
 
   val workspaceSymbols: WorkspaceSymbolProvider =

--- a/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
@@ -277,7 +277,7 @@ class SbtBloopLspSuite
       _ = client.importBuildChanges = ImportBuildChanges.yes
       _ <- server.didChange("build.sbt") { text =>
         s"""$text
-           |libraryDependencies += "com.lihaoyi" %% "sourcecode" % "0.1.4"
+           |libraryDependencies += "com.lihaoyi" %% "sourcecode" % "0.4.4"
            |""".stripMargin
       }
       _ <- server.didSave("build.sbt")

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -300,7 +300,9 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
   }
   def workspaceDiagnostics: String = {
     val paths = diagnostics.keys.toList
-      .filter(f => f.isScalaOrJava || f.extension == "conf")
+      .filter(f =>
+        f.isScalaOrJava || f.extension == "conf" || f.extension == "md"
+      )
       .sortBy(_.toURI.toString)
     paths.map(pathDiagnostics).mkString
   }


### PR DESCRIPTION
Previously, we would only show it in the build server status, which might not always be visible to the user.

Now, we show a new diagnotic pointing to the actual error report. It will get removed when the next compilation runs.

Fixes https://github.com/scalameta/metals-feature-requests/issues/316