### PR TITLE
bugfix: Readd build tool when missing

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ChosenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ChosenBuildTool.scala
@@ -41,6 +41,7 @@ class ChosenBuildTool(conn: () => Connection) {
   }
 
   def reset(): Unit = {
+    currentTool.set(None)
     conn().update("delete from chosen_build_tool;") { _ => () }
   }
 }

--- a/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/sbt/SbtBloopLspSuite.scala
@@ -670,6 +670,38 @@ class SbtBloopLspSuite
 
   }
 
+  test("sbt-file-after-reset") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/build.sbt
+            |scalaVersion := "$scalaVersion"
+         """.stripMargin
+      )
+      hoverRes <- assertHoverAtPos("build.sbt", 0, 2)
+      expectedHoverRes =
+        """|```scala
+           |val scalaVersion: SettingKey[String]
+           |```
+           |```range
+           |scalaVersion
+           |```""".stripMargin
+      _ = assertNoDiff(hoverRes, expectedHoverRes)
+      _ = server.headServer.tables.buildTool.reset()
+      _ = assert(server.headServer.tables.buildTool.selectedBuildTool().isEmpty)
+      _ <- server.executeCommand(ServerCommands.ConnectBuildServer)
+      hoverRes <- assertHoverAtPos("build.sbt", 0, 2)
+      expectedHoverRes =
+        """|```scala
+           |val scalaVersion: SettingKey[String]
+           |```
+           |```range
+           |scalaVersion
+           |```""".stripMargin
+      _ = assertNoDiff(hoverRes, expectedHoverRes)
+    } yield ()
+  }
+
   test("scala-file-hover") {
     cleanWorkspace()
     for {

--- a/tests/unit/src/test/scala/tests/BillLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/BillLspSuite.scala
@@ -204,6 +204,7 @@ class BillLspSuite extends BaseLspSuite("bill") {
       _ = assertNoDiff(
         client.workspaceMessageRequests,
         List(
+          Messages.ChooseBuildTool.message,
           Messages.BspSwitch.message,
           Messages.CheckDoctor.allProjectsMisconfigured,
         ).mkString("\n"),


### PR DESCRIPTION
It seems if anyone removed their .metals directory, but left everything else, we would never set the used build tools again. This meant that when we check for sbt, we wouldn't get any result and we wouldn't support build.sbt file.

Now, if build tool is missing we requery it.