### PR TITLE
bugfix: Add missing type to array in MCP schema

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
@@ -949,6 +949,9 @@ class MetalsMcpServer(
         |    },
         |    "targets": {
         |      "type": "array",
+        |      "items": {
+        |        "type": "string"
+        |      },
         |      "description": "The targets to run the rule on, if empty will run on the last focused target"
         |    },
         |    "sampleCode": {


### PR DESCRIPTION
**Summary**
Copilot Agent Mode rejects the Metals MCP tool `generate-scalafix-rule` due to an invalid JSON Schema:

```
Failed to validate tool mcp_hello-world-m_generate-scalafix-rule: Error: tool parameters array type must have items.
```

The tool’s `inputSchema.properties.targets` is `"type": "array"` but lacks an `"items"` schema, causing Copilot’s validation to fail and agent mode to break.

**Steps to Reproduce**

1. `sbt new scala/scala3.g8`
2. `code .`
3. Start Metals MCP server and enable Copilot Agent Mode
4. Observe Copilot error

**Evidence**

* mcp.trace.json excerpt:

```json
{
  "name": "generate-scalafix-rule",
  "description": "Generate a scalafix rule and run it on the current project.",
  "inputSchema": {
    "type": "object",
    "properties": {
      "ruleImplementation": { "type": "string", "description": "The implementation of the scalafix rule to run, this should contain the actual scalafix rule implementation." },
      "description": { "type": "string", "description": "The description of the scalafix rule to run for later MCP invocations." },
      "targets": {
        "type": "array",
        "description": "The targets to run the rule on, if empty will run on the last focused target"
        // Missing "items": { ... }
      },
      "sampleCode": { "type": "string", "description": "Sample code that we are trying to match in the rule, if nothing was matched an error will be returned with the structure of this sample." },
      "fileToRunOn": { "type": "string", "description": "File to run it all, if empty will run on all files in given targets" }
    },
    "required": ["description", "ruleImplementation"]
  }
}

```