### PR TITLE
improvement: Allow first letter to be lower case

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/metals/Fuzzy.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/metals/Fuzzy.scala
@@ -331,9 +331,12 @@ class Fuzzy {
         val qChar = query.charAt(queryPos)
         val sChar = symbol.charAt(symbolPos)
         if (
-          queryPos == queryStartIdx && // we are at the first letter of the query string
-          symbolStartCharIsLower && // the first letter of the symbol is lowercase. (we expect the user to remember classes)
-          qChar.toUpper == sChar // therefore we check if it matches the upper case character
+          // we are at the first letter of the query string
+          queryPos == queryStartIdx &&
+          // accept symbols starting with the same letter as the query if query is lower case
+          ((symbolStartCharIsLower && qChar.toUpper == sChar) ||
+            // if it's a start of both avoid, we match most forgiving
+            (symbolPos == symbolStartIdx && qChar.toLower == sChar.toLower))
         ) {
           loop(queryPos + 1, queryPos, symbolPos + 1, symbolPos)
         } else if (

--- a/mtags-shared/src/main/scala/scala/meta/internal/pc/MemberOrdering.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/pc/MemberOrdering.scala
@@ -8,10 +8,10 @@ object MemberOrdering {
   val IsNotLocalByBlock: Int = 1 << 26
   val IsNotDefinedInFile: Int = 1 << 25
   val IsNotTypeInTypePos: Int = 1 << 24
-  val IsNotGetter: Int = 1 << 23
+  val IsNotPublic: Int = 1 << 23
   val IsPackage: Int = 1 << 22
   val IsNotCaseAccessor: Int = 1 << 21
-  val IsNotPublic: Int = 1 << 20
+  val IsNotGetter: Int = 1 << 20
   val IsSynthetic: Int = 1 << 19
   val IsDeprecated: Int = 1 << 18
   val IsEvilMethod: Int = 1 << 17 // example: clone() and finalize()

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/Completions.scala
@@ -187,7 +187,7 @@ trait Completions { this: MetalsGlobal =>
     // accessors of case class members are more relevant
     if (!sym.isCaseAccessor) relevance |= IsNotCaseAccessor
     // public symbols are more relevant
-    if (!sym.isPublic) relevance |= IsNotCaseAccessor
+    if (!sym.isPublic && !sym.hasGetter) relevance |= IsNotPublic
     // synthetic symbols are less relevant (e.g. `copy` on case classes)
     if (sym.isSynthetic) relevance |= IsSynthetic
     if (sym.isDeprecated) relevance |= IsDeprecated
@@ -228,10 +228,11 @@ trait Completions { this: MetalsGlobal =>
       def fuzzyScore(o: Member): Int = {
         fuzzyCache.getOrElseUpdate(
           o.sym, {
-            val name = o.sym.name.toString().toLowerCase()
+            val name = o.sym.name.toString()
             if (name.startsWith(queryLower)) 0
-            else if (name.toLowerCase().contains(queryLower)) 1
-            else 2
+            else if (name.startsWith(query)) 1
+            else if (name.toLowerCase().contains(queryLower)) 2
+            else 3
           }
         )
       }

--- a/mtags/src/main/scala-2/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
+++ b/mtags/src/main/scala-2/scala/meta/internal/pc/completions/InterpolatorCompletions.scala
@@ -52,7 +52,11 @@ trait InterpolatorCompletions { this: MetalsGlobal =>
 
     override def contribute: List[Member] = {
       metalsTypeMembers(ident.pos).collect {
-        case m if CompletionFuzzy.matches(query, m.sym.name) =>
+        case m
+            if !m.sym.isConstructor && CompletionFuzzy.matches(
+              query,
+              m.sym.name
+            ) =>
           val edit = new l.TextEdit(pos, newText(m.sym))
           // for VS Code we need to include the entire `ident.member`
           val filterText = ident.name.decoded + "." + m.sym.getterName.decoded

--- a/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CancelCompletionSuite.scala
@@ -84,7 +84,6 @@ class CancelCompletionSuite extends BaseCompletionSuite {
         getExpected(expected, compat, scalaVersion)
       val obtained = completion.getItems.asScala
         .map(_.getLabel)
-        .sorted
         .mkString("\n")
       assertNoDiff(obtained, expectedCompat)
     }
@@ -99,13 +98,8 @@ class CancelCompletionSuite extends BaseCompletionSuite {
     """.stripMargin,
     """|assert(assertion: Boolean): Unit
        |assert(assertion: Boolean, message: => Any): Unit
-       |""".stripMargin,
-    compat = Map(
-      "3" ->
-        """|assert(inline assertion: Boolean): Unit
-           |assert(inline assertion: Boolean, inline message: => Any): Unit
-           |""".stripMargin
-    )
+       |AssertionError
+       |""".stripMargin
   )
 
   /**

--- a/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionArgSuite.scala
@@ -507,6 +507,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
     """|`type` = : Int
        |`type` = number : Int
        |`type` = number2 : Int
+       |TypeNotPresentException java.lang
        |""".stripMargin,
     topLines = Some(5)
   )
@@ -534,7 +535,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |  ___
         |}
         |""".stripMargin,
-    "foo(auto@@)",
+    "foo(autof@@)",
     "foo(argument = ${1:number}, other = ${2:hello})"
   )
 
@@ -552,7 +553,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |  ___
         |}
         |""".stripMargin,
-    "foo(auto@@)",
+    "foo(autof@@)",
     "foo(animal = ${1:dog}, furniture = ${2:chair})"
   )
 
@@ -566,7 +567,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |  ___
         |}
         |""".stripMargin,
-    "foo(auto@@)",
+    "foo(autof@@)",
     "foo(argument = ${1|???,argument,number|}, other = ${2:hello})"
   )
 
@@ -580,7 +581,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |  ___
         |}
         |""".stripMargin,
-    "foo(auto@@)",
+    "foo(autof@@)",
     "foo(argument = ${1:number}, other = ${2:???}, isTrue = ${3:???}, opt = ${4:???})"
   )
 
@@ -595,7 +596,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |  ___
         |}
         |""".stripMargin,
-    "foo(auto@@)",
+    "foo(autof@@)",
     "foo(argument = ${1|???,list4,list3|}, other = ${2|???,list2,list1|})",
     compat = Map(
       "3" -> "foo(argument = ${1|???,list3,list4|}, other = ${2|???,list1,list2|})"
@@ -611,7 +612,7 @@ class CompletionArgSuite extends BaseCompletionSuite {
         |  ___
         |}
         |""".stripMargin,
-    "f(auto@@)",
+    "f(autof@@)",
     "f(a = ${1|???,str1,str|}, b = ${2|???,str1,str|}, `type` = ${3|???,str1,str|})",
     compat = Map(
       "3" -> "f(a = ${1|???,str,str1|}, b = ${2|???,str,str1|}, `type` = ${3|???,str,str1|})"
@@ -876,10 +877,11 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |value = value : Int
        |""".stripMargin,
     compat = Map(
-      "3" ->
-        """|value = : Int
+      "2.13" ->
+        """|value: Int
+           |value = : Int
            |value = value : Int
-           |value: Int
+           |ValueOf scala
            |""".stripMargin
     ),
     topLines = Some(4)
@@ -908,15 +910,10 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|aaa = : Int
+       |AnyRef: Specializable
        |assert(assertion: Boolean): Unit
        |""".stripMargin,
-    topLines = Some(2),
-    compat = Map(
-      "3" ->
-        """|aaa = : Int
-           |assert(inline assertion: Boolean): Unit
-           |""".stripMargin
-    )
+    topLines = Some(3)
   )
 
   check(
@@ -929,15 +926,9 @@ class CompletionArgSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|aaa = : Int
-       |assert(assertion: Boolean): Unit
+       |AnyRef: Specializable
        |""".stripMargin,
-    topLines = Some(2),
-    compat = Map(
-      "3" ->
-        """|aaa = : Int
-           |assert(inline assertion: Boolean): Unit
-           |""".stripMargin
-    )
+    topLines = Some(2)
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionBacktickSuite.scala
@@ -66,18 +66,15 @@ class CompletionBacktickSuite extends BaseCompletionSuite {
   )
 
   check(
-    "named-arg".tag(IgnoreScala3),
+    "named-arg",
     """|object Main {
        |  def foo(`type`: Int) = 42
        |  foo(type@@)
        |}
        |""".stripMargin,
-    """`type` = : Int
-      |""".stripMargin,
-    filterText = "type",
-    compat = Map(
-      "3" -> ""
-    )
+    """|`type` = : Int
+       |TypeNotPresentException java.lang
+       |""".stripMargin
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionCaseInsensitiveSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionCaseInsensitiveSuite.scala
@@ -25,18 +25,22 @@ class CompletionCaseInsensitiveSuite extends BaseCompletionSuite {
       |   val foo = lon@@
       | }
       |}""".stripMargin,
-    """longNameYouWillNotRemember: Long
-      |long2Long(x: Long): lang.Long
-      |longArrayOps(xs: Array[Long]): ArrayOps[Long]
-      |longWrapper(x: Long): RichLong
-      |wrapLongArray(xs: Array[Long]): ArraySeq.ofLong
-      |""".stripMargin,
+    """|longNameYouWillNotRemember: Long
+       |long2Long(x: Long): lang.Long
+       |longArrayOps(xs: Array[Long]): ArrayOps[Long]
+       |longWrapper(x: Long): RichLong
+       |Long scala
+       |Long2long(x: lang.Long): Long
+       |wrapLongArray(xs: Array[Long]): ArraySeq.ofLong
+       |""".stripMargin,
     compat = Map(
       "2.11" ->
         """|longNameYouWillNotRemember: Long
            |long2Long(x: Long): lang.Long
            |longArrayOps(xs: Array[Long]): ArrayOps[Long]
            |longWrapper(x: Long): RichLong
+           |Long scala
+           |Long2long(x: lang.Long): Long
            |wrapLongArray(xs: Array[Long]): WrappedArray[Long]
            |readLong(): Long
            |""".stripMargin,
@@ -45,6 +49,8 @@ class CompletionCaseInsensitiveSuite extends BaseCompletionSuite {
           |long2Long(x: Long): lang.Long
           |longArrayOps(xs: Array[Long]): ArrayOps.ofLong
           |longWrapper(x: Long): RichLong
+          |Long scala
+          |Long2long(x: lang.Long): Long
           |wrapLongArray(xs: Array[Long]): WrappedArray[Long]
           |readLong(): Long
           |""".stripMargin
@@ -76,14 +82,65 @@ class CompletionCaseInsensitiveSuite extends BaseCompletionSuite {
   )
 
   check(
-    "lower case query should still only match for segments, so 'ill' should not bring up the long name",
+    "lower case query should still only match for segments, so 'ill' should only bring up the long name starting with 'ill'",
     """
       |object A {
       | def test(longNameYouWillNotRemember: Long): Unit = {
       |   val foo = ill@@
       | }
       |}""".stripMargin,
-    ""
+    """|IllegalAccessError java.lang
+       |IllegalAccessException java.lang
+       |IllegalArgumentException java.lang
+       |IllegalCallerException java.lang
+       |IllegalMonitorStateException java.lang
+       |IllegalStateException java.lang
+       |IllegalThreadStateException java.lang
+       |""".stripMargin
+  )
+
+  check(
+    "case-backticked",
+    """package kase
+      |class SomeModel {
+      |  def `Sentence Case Metric` = ...
+      |  def `Sentence Case Metric (12m Average)` = `Sentence Case Metric`.rollingAvg(12.months)
+      |  def `Sentence Case Metric (6m Average)` = `Sentence Case Metric`.rollingAvg(6.months)
+      |  def `Aggregated Sentence Case Metric` = sente@@
+      |}""".stripMargin,
+    """|`Sentence Case Metric`: Null
+       |`Sentence Case Metric (6m Average)`: Any
+       |""".stripMargin
+  )
+
+  check(
+    "case-backticked2",
+    """package kase
+      |class SomeModel {
+      |  def `Sentence Case Metric` = ...
+      |  def `Sentence Case Metric (12m Average)` = `Sentence Case Metric`.rollingAvg(12.months)
+      |  def `Sentence Case Metric (6m Average)` = `Sentence Case Metric`.rollingAvg(6.months)
+      |  def `Aggregated Sentence Case Metric` = SenteCa@@
+      |}""".stripMargin,
+    """|`Aggregated Sentence Case Metric`: Any
+       |`Sentence Case Metric`: Null
+       |`Sentence Case Metric (6m Average)`: Any
+       |""".stripMargin
+  )
+
+  /* This doesn't match because we expect the substring to be continuous, otherwise we might match too much results.
+   * We can match non continuous substring only if they start with Capital letter.
+   */
+  check(
+    "case-backticked3",
+    """package kase
+      |class SomeModel {
+      |  def `Sentence Case Metric` = ...
+      |  def `Sentence Case Metric (12m Average)` = `Sentence Case Metric`.rollingAvg(12.months)
+      |  def `Sentence Case Metric (6m Average)` = `Sentence Case Metric`.rollingAvg(6.months)
+      |  def `Aggregated Sentence Case Metric` = sente12@@
+      |}""".stripMargin,
+    """|""".stripMargin
   )
 
 }

--- a/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionDocSuite.scala
@@ -284,69 +284,6 @@ class CompletionDocSuite extends BaseCompletionSuite {
         |Iterator scala.collection
         |""".stripMargin
 
-  def iteratorAndSpecificIterableFactoryDocs213(
-      withLinearSeqIterator: Boolean = true
-  ): String = {
-    val linearSeqIteratorDocs =
-      if (withLinearSeqIterator) {
-        "\n" +
-          """|> A specialized Iterator for LinearSeqs that is lazy enough for Stream and LazyList. This is accomplished by not
-             |evaluating the tail after returning the current head.
-             |LinearSeqIterator scala.collection""".stripMargin
-      } else {
-        ""
-      }
-    s"""|$iteratorDocs213> Explicit instantiation of the `Iterator` trait to reduce class file size in subclasses.
-        |AbstractIterator scala.collection
-        |> Buffered iterators are iterators which provide a method `head`
-        | that inspects the next element without discarding it.
-        |BufferedIterator scala.collection$linearSeqIteratorDocs
-        |> Base trait for companion objects of collections that require an implicit `ClassTag`.
-        |
-        |**Type Parameters**
-        |- `CC`: Collection type constructor (e.g. `ArraySeq`)
-        |ClassTagIterableFactory scala.collection
-        |> Base trait for companion objects of collections that require an implicit evidence.
-        |
-        |**Type Parameters**
-        |- `CC`: Collection type constructor (e.g. `ArraySeq`)
-        |- `Ev`: Unary type constructor for the implicit evidence required for an element type
-        |           (typically `Ordering` or `ClassTag`)
-        |EvidenceIterableFactory scala.collection
-        |> This trait provides default implementations for the factory methods `fromSpecific` and
-        |`newSpecificBuilder` that need to be refined when implementing a collection type that refines
-        |the `CC` and `C` type parameters. It is used for collections that have an additional constraint,
-        |expressed by the `evidenceIterableFactory` method.
-        |
-        |The default implementations in this trait can be used in the common case when `CC[A]` is the
-        |same as `C`.
-        |EvidenceIterableFactoryDefaults scala.collection
-        |> Base trait for companion objects of unconstrained collection types that may require
-        |multiple traversals of a source collection to build a target collection `CC`.
-        |
-        |
-        |**Type Parameters**
-        |- `CC`: Collection type constructor (e.g. `List`)
-        |IterableFactory scala.collection
-        |> This trait provides default implementations for the factory methods `fromSpecific` and
-        |`newSpecificBuilder` that need to be refined when implementing a collection type that refines
-        |the `CC` and `C` type parameters.
-        |
-        |The default implementations in this trait can be used in the common case when `CC[A]` is the
-        |same as `C`.
-        |IterableFactoryDefaults scala.collection
-        |> Base trait for companion objects of collections that require an implicit `Ordering`.
-        |
-        |**Type Parameters**
-        |- `CC`: Collection type constructor (e.g. `SortedSet`)
-        |SortedIterableFactory scala.collection
-        |> **Type Parameters**
-        |- `A`: Type of elements (e.g. `Int`, `Boolean`, etc.)
-        |- `C`: Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
-        |SpecificIterableFactory scala.collection
-        |""".stripMargin
-  }
-
   check(
     "scala4",
     """
@@ -398,10 +335,56 @@ class CompletionDocSuite extends BaseCompletionSuite {
     includeDocs = true,
     compat = Map(
       // LinearSeqIterator should actually not be added since it's private and it's fixed in 2.13.5
-      "2.13" -> iteratorAndSpecificIterableFactoryDocs213(
-        withLinearSeqIterator = false
-      ),
-      "3" -> iteratorDocs213
+      "2.13" ->
+        s"""|$iteratorDocs213> Explicit instantiation of the `Iterator` trait to reduce class file size in subclasses.
+            |AbstractIterator scala.collection
+            |> Buffered iterators are iterators which provide a method `head`
+            | that inspects the next element without discarding it.
+            |BufferedIterator scala.collection
+            |> Base trait for companion objects of collections that require an implicit `ClassTag`.
+            |
+            |**Type Parameters**
+            |- `CC`: Collection type constructor (e.g. `ArraySeq`)
+            |ClassTagIterableFactory scala.collection
+            |> Base trait for companion objects of collections that require an implicit evidence.
+            |
+            |**Type Parameters**
+            |- `CC`: Collection type constructor (e.g. `ArraySeq`)
+            |- `Ev`: Unary type constructor for the implicit evidence required for an element type
+            |           (typically `Ordering` or `ClassTag`)
+            |EvidenceIterableFactory scala.collection
+            |> This trait provides default implementations for the factory methods `fromSpecific` and
+            |`newSpecificBuilder` that need to be refined when implementing a collection type that refines
+            |the `CC` and `C` type parameters. It is used for collections that have an additional constraint,
+            |expressed by the `evidenceIterableFactory` method.
+            |
+            |The default implementations in this trait can be used in the common case when `CC[A]` is the
+            |same as `C`.
+            |EvidenceIterableFactoryDefaults scala.collection
+            |> Base trait for companion objects of unconstrained collection types that may require
+            |multiple traversals of a source collection to build a target collection `CC`.
+            |
+            |
+            |**Type Parameters**
+            |- `CC`: Collection type constructor (e.g. `List`)
+            |IterableFactory scala.collection
+            |> This trait provides default implementations for the factory methods `fromSpecific` and
+            |`newSpecificBuilder` that need to be refined when implementing a collection type that refines
+            |the `CC` and `C` type parameters.
+            |
+            |The default implementations in this trait can be used in the common case when `CC[A]` is the
+            |same as `C`.
+            |IterableFactoryDefaults scala.collection
+            |> Base trait for companion objects of collections that require an implicit `Ordering`.
+            |
+            |**Type Parameters**
+            |- `CC`: Collection type constructor (e.g. `SortedSet`)
+            |SortedIterableFactory scala.collection
+            |> **Type Parameters**
+            |- `A`: Type of elements (e.g. `Int`, `Boolean`, etc.)
+            |- `C`: Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
+            |SpecificIterableFactory scala.collection
+            |""".stripMargin
     )
   )
 

--- a/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionKeywordSuite.scala
@@ -208,17 +208,11 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
         """|value: Int
            |val
            |var
+           |ValueOf scala
            |varargs - scala.annotation
            |override def equals(x$1: Object): Boolean
            |override def hashCode(): Int
            |override def finalize(): Unit
-           |""".stripMargin,
-      "3" ->
-        """|value: Int
-           |val
-           |var
-           |varargs(): varargs
-           |varargs - scala.annotation
            |""".stripMargin
     )
   )
@@ -234,37 +228,22 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |  }
       |}
       |""".stripMargin,
-    """|val
+    """|
+       |val
        |var
+       |ValueOf scala
        |varargs - scala.annotation
        |""".stripMargin,
     compat = Map(
-      "3" -> """|val
-                |var
-                |varargs(): varargs
-                |varargs - scala.annotation
-                |""".stripMargin
+      "2.12" -> """|val
+                   |var
+                   |varargs - scala.annotation
+                   |""".stripMargin,
+      "2.11" -> """|val
+                   |var
+                   |varargs - scala.annotation
+                   |""".stripMargin
     )
-  )
-
-  check(
-    "given-def",
-    """
-      |package foo
-      |
-      |object A {
-      |  def someMethod = {
-      |    gi@@
-      |  }
-      |}
-      |""".stripMargin,
-    """|given (commit: '')
-       |""".stripMargin,
-    includeCommitCharacter = true,
-    compat = Map(
-      "2" -> ""
-    ),
-    topLines = Some(5)
   )
 
   check(
@@ -279,12 +258,16 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |}
       |""".stripMargin,
     """|value: Int
+       |ValueOf scala
        |varargs - scala.annotation
        |""".stripMargin,
     compat = Map(
-      "3" -> """|value: Int
-                |varargs(): varargs
-                |varargs - scala.annotation""".stripMargin
+      "2.12" ->
+        """|value: Int
+           |varargs - scala.annotation""".stripMargin,
+      "2.11" ->
+        """|value: Int
+           |varargs - scala.annotation""".stripMargin
     )
   )
 
@@ -424,8 +407,8 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
       |  typ@@
       |}
     """.stripMargin,
-    """type
-    """.stripMargin
+    """|TypeNotPresentException java.lang
+       |type""".stripMargin
   )
 
   check(
@@ -442,7 +425,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite {
     """.stripMargin,
     // NOTE(olafur) `type` is technically valid in blocks but they're not completed
     // to reduce noise (we do the same for class, object, trait).
-    ""
+    "TypeNotPresentException java.lang"
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionOverrideSuite.scala
@@ -952,14 +952,16 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
        |}
        |""".stripMargin,
     """|overTop: Int
+       |Override
        |deprecatedOverriding scala
        |override def overTop: Int
        |""".stripMargin,
     includeDetail = false,
-    topLines = Some(3),
+    topLines = Some(4),
     compat = Map(
       "2.11" ->
         """|overTop: Int
+           |Override
            |override def overTop: Int
            |override def equals(obj: Any): Boolean
            |""".stripMargin
@@ -997,15 +999,17 @@ class CompletionOverrideSuite extends BaseCompletionSuite {
        |   overr@@
        |}
        |""".stripMargin,
-    """|deprecatedOverriding scala
+    """|Override
+       |deprecatedOverriding scala
        |override def hello1: Int
        |override val hello2: Int
        |""".stripMargin,
     includeDetail = false,
-    topLines = Some(3),
+    topLines = Some(4),
     compat = Map(
       "2.11" ->
-        """|override def hello1: Int
+        """|Override
+           |override def hello1: Int
            |override val hello2: Int
            |override def equals(obj: Any): Boolean
            |""".stripMargin,

--- a/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionSuite.scala
@@ -25,13 +25,6 @@ class CompletionSuite extends BaseCompletionSuite {
            |List - java.awt
            |List - java.util
            |JList - javax.swing
-           |""".stripMargin,
-      "3" ->
-        """|List scala.collection.immutable
-           |List - java.awt
-           |List - java.util
-           |List - scala.collection.immutable
-           |List[A](elems: A*): CC[A]
            |""".stripMargin
     ),
     topLines = Some(5)
@@ -472,18 +465,7 @@ class CompletionSuite extends BaseCompletionSuite {
                    |AsJavaLongConsumer - scala.jdk.FunctionWrappers
                    |FromJavaBiConsumer - scala.jdk.FunctionWrappers
                    |FromJavaIntConsumer - scala.jdk.FunctionWrappers
-                   |""".stripMargin,
-      "3" -> """|AsJavaConverters - scala.collection.convert
-                |JavaConverters - scala.collection
-                |JavaConversions - scala.concurrent
-                |AsJavaConsumer - scala.jdk.FunctionWrappers
-                |FromJavaConsumer - scala.jdk.FunctionWrappers
-                |AsJavaBiConsumer - scala.jdk.FunctionWrappers
-                |AsJavaIntConsumer - scala.jdk.FunctionWrappers
-                |AsJavaLongConsumer - scala.jdk.FunctionWrappers
-                |FromJavaBiConsumer - scala.jdk.FunctionWrappers
-                |FromJavaIntConsumer - scala.jdk.FunctionWrappers
-                |""".stripMargin
+                   |""".stripMargin
     )
   )
 
@@ -1581,13 +1563,9 @@ class CompletionSuite extends BaseCompletionSuite {
         |  scala@@
         |}
         |""".stripMargin,
-    """|scala `<root>`
-       |""".stripMargin,
-    compat = Map(
-      "2" ->
-        """|scala _root_
-           |""".stripMargin
-    )
+    """|ScalaReflectionException scala
+       |scala _root_
+       |""".stripMargin
   )
 
   check(

--- a/tests/cross/src/test/scala/tests/pc/CompletionWithoutDetailsSuite.scala
+++ b/tests/cross/src/test/scala/tests/pc/CompletionWithoutDetailsSuite.scala
@@ -31,13 +31,6 @@ class CompletionWithoutDetailsSuite extends BaseCompletionSuite {
            |List
            |List
            |JList
-           |""".stripMargin,
-      "3" ->
-        """|List
-           |List
-           |List
-           |List
-           |List
            |""".stripMargin
     ),
     includeDetail = false,
@@ -63,13 +56,6 @@ class CompletionWithoutDetailsSuite extends BaseCompletionSuite {
            |List java.awt
            |List java.util
            |JList javax.swing
-           |""".stripMargin,
-      "3" ->
-        """|List scala.collection.immutable
-           |List java.awt
-           |List java.util
-           |List scala.collection.immutable
-           |List[A](elems: A*): CC[A]
            |""".stripMargin
     ),
     includeDetail = true,

--- a/tests/unit/src/test/scala/tests/FuzzySuite.scala
+++ b/tests/unit/src/test/scala/tests/FuzzySuite.scala
@@ -70,8 +70,8 @@ class FuzzySuite extends BaseSuite {
 
   // Basic first character case-insensitive matching
   checkForgiving("name", "name", true)
-  checkForgiving("name", "Name", false)
-  checkForgiving("Name", "name", false)
+  checkForgiving("name", "Name", true)
+  checkForgiving("Name", "name", true)
   checkForgiving("Name", "Name", true)
   checkForgiving("xame", "Name", false)
 
@@ -82,6 +82,13 @@ class FuzzySuite extends BaseSuite {
   checkForgiving("namYo", "LongNameYouCouldForget", false)
   checkForgiving("NAMYO", "longNameYouCouldForget", false)
   checkForgiving("ameYo", "longNameYouCouldForget", false)
+  checkForgiving(
+    "sen",
+    "Sentence Case Metric (12m Average)",
+    true,
+  )
+  checkForgiving("va", "ClassValue", false)
+  checkForgiving("va", "java", false)
 
   checkForgiving("_name", "_Name", false)
   checkForgiving("na1", "name1", true)

--- a/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
+++ b/tests/unit/src/test/scala/tests/debug/CompletionDapSuite.scala
@@ -184,9 +184,9 @@ class CompletionDapSuite
     "single-dot",
     expression = "Main.@@",
     expectedCompletions = """|name: Option[String]
-                             |args: Array[String]
                              |executionStart: Long
                              |main(args: Array[String]): Unit
+                             |delayedInit(body: => Unit): Unit
                              |""".stripMargin,
     expectedEdit = "Main.name",
     topLines = Some(4),


### PR DESCRIPTION
The intention here is to make the completions even more forgiving when user forgot that the variable started with a capital letter and wrote lower case instead. The new completions should mostly got to the end aside from cases with our custom completions (keyword and override completions might go later, but not sure if we should change it here)

Should fix https://github.com/scalameta/metals-feature-requests/issues/445

@harpocrates any cases that we should also account for?