### PR TITLE
bugfix: Fix navigation in mill projects for Java

### DIFF
--- a/tests/slow/src/test/scala/tests/mill/MillServerSuite.scala
+++ b/tests/slow/src/test/scala/tests/mill/MillServerSuite.scala
@@ -115,6 +115,89 @@ class MillServerSuite
     }
   }
 
+  test("java-1.0.0") {
+    cleanWorkspace()
+
+    val fileContent =
+      """|
+         |package foo;
+         |
+         |import net.sourceforge.argparse4j.ArgumentParsers;
+         |import net.sourceforge.argparse4j.inf.Argume@@ntParser;
+         |import net.sourceforge.argparse4j.inf.Namespace;
+         |import org.thymeleaf.TemplateEngine;
+         |import org.thymeleaf.context.Context;
+         |
+         |public class Foo {
+         |  public static String generateHtml(String text) {
+         |    Context context = new Context();
+         |    context.setVariable("text", text);
+         |    return new TemplateEngine().process("<h1 th:text=\"${text}\"></h1>", context);
+         |  }
+         |
+         |  public static void main(String[] args) {
+         |    ArgumentParser parser = ArgumentParsers.newFor("template")
+         |        .build()
+         |        .defaultHelp(true)
+         |        .description("Inserts text into a HTML template");
+         |
+         |    parser.addArgument("-t", "--text").required(true).help("text to insert");
+         |
+         |    Namespace ns = null;
+         |    try {
+         |      ns = parser.parseArgs(args);
+         |    } catch (Exception e) {
+         |      System.out.println(e.getMessage());
+         |      System.exit(1);
+         |    }
+         |
+         |    System.out.println(generateHtml(ns.getString("text")));
+         |  }
+         |}
+         |""".stripMargin
+
+    for {
+      _ <- initialize(
+        s"""|
+            |/build.mill
+            |//| mill-version: ${V.millVersion}
+            |//// SNIPPET:BUILD
+            |package build
+            |import mill.*, javalib.*
+            |
+            |object foo extends JavaModule {
+            |  def mvnDeps = Seq(
+            |    mvn"net.sourceforge.argparse4j:argparse4j:0.9.0",
+            |    mvn"org.thymeleaf:thymeleaf:3.1.1.RELEASE"
+            |  )
+            |
+            |  object test extends JavaTests, TestModule.Junit4 {
+            |    def mvnDeps = Seq(
+            |      mvn"com.google.guava:guava:33.3.0-jre"
+            |    )
+            |  }
+            |}
+            |
+            |/foo/src/foo/Foo.java
+            |${fileContent.replace("@@", "")}
+            |""".stripMargin
+      )
+      _ <- server.didOpen("foo/src/foo/Foo.java")
+      _ <- server.didSave("foo/src/foo/Foo.java")
+      definition <- server.definition(
+        "foo/src/foo/Foo.java",
+        fileContent,
+        workspace,
+      )
+      _ = assert(
+        definition
+          .map(_.getUri())
+          .mkString("\n")
+          .contains("net/sourceforge/argparse4j/inf/ArgumentParser.java")
+      )
+    } yield ()
+  }
+
   test("too-old") {
     writeLayout(MillBuildLayout("", V.scala213, testDep = None, preBspVersion))
     for {


### PR DESCRIPTION
Mill 1.0.6 seems to add a full path to semanticdb files instead of a relative one.

Fixes https://github.com/scalameta/metals/issues/7913