### PR TITLE
bugfix: Filter out invalid multiline comment fold ranges

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/parsing/FoldingRangeExtractor.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/FoldingRangeExtractor.scala
@@ -142,13 +142,14 @@ final class FoldingRangeExtractor(
           range.setStartCharacter(first.pos.startColumn)
           range.setEndCharacter(last.pos.endColumn)
 
-          if (isLineComment(last)) {
-            if (range.getStartLine < range.getEndLine) { // one line comment should not be folded
+          if (range.getStartLine < range.getEndLine) { // one line comment should not be folded
+            if (isLineComment(last)) {
               ranges.addAsIs(Comment, range)
+            } else {
+              ranges.add(Comment, range)
             }
-          } else {
-            ranges.add(Comment, range)
           }
+
         case _ =>
       }
     }


### PR DESCRIPTION
For a file that looks like this:
```scala
val foo = 0

/** This is a one-line scaladoc comment */
val bar = 0

/** This is a multi-line scaladoc comment. This is a multi-line scaladoc
  * comment.
  */
val baz = 0
```
Metals responds to the LSP `textDocument/foldingRange` query with:
```
{
  { endCharacter = 42, endLine = 1, kind = "comment", startCharacter = 0, startLine = 2 },
  { endCharacter = 4, endLine = 6, kind = "comment", startCharacter = 0, startLine = 5 },
},
```
There is one invalid range with startLine 2 and endLine 1. VS Code filters it out, but other LSP clients might run into errors if they are not defensively programmed to ignore invalid ranges. For some reason the code in `meta/internal/parsing/FoldingRangeExtractor.scala` that checks `range.getStartLine < range.getEndLine` is only applied to line comments, not scaladoc comments. This is fixed by moving that check to cover both comment types. We then get a correct response of
```
{
  { endCharacter = 4, endLine = 6, kind = "comment", startCharacter = 0, startLine = 5 } 
}
```