### PR TITLE
fix: correct autoImportBuilds config key name

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -495,7 +495,7 @@ object UserConfiguration {
            |about incremental compilation in Zinc.""".stripMargin,
       ),
       UserConfigurationOption(
-        "auto-import-build",
+        "auto-import-builds",
         "off",
         "all",
         "Import build when changes detected without prompting",

--- a/website/blog/2024-04-15-thalium.md
+++ b/website/blog/2024-04-15-thalium.md
@@ -89,7 +89,7 @@ This means we have two settings for Java:
 
 Thanks to [keirlawson](http://github.com/keirlawson) it's now possible to make
 Metals automatically import any workspace. This takes a shape of a new setting
-`metals.autoImportBuild` which has three options:
+`metals.autoImportBuilds` which has three options:
 
 - `off` - users will always be asked whether they want to import their workspace
   either initially or after changes.


### PR DESCRIPTION
## Problem

The `UserConfigurationOption` for auto-import builds was defined with key `"auto-import-build"` (without 's'), but the parsing code and serialization both use the plural form `"auto-import-builds"`. This inconsistency caused the generated documentation to show the wrong key name (`autoImportBuild` instead of `autoImportBuilds`).

## Changes

1. Updated the `UserConfigurationOption` key from `"auto-import-build"` to `"auto-import-builds"` in `UserConfiguration.scala`
2. Fixed the blog post reference in `2024-04-15-thalium.md` to use `metals.autoImportBuilds`
