### PR TITLE
fix: Bazel docs specify wrong extension for projectview.bazelproject

### DIFF
--- a/docs/build-tools/bazel.md
+++ b/docs/build-tools/bazel.md
@@ -20,7 +20,7 @@ The first time you open Metals in a new Bazel workspace you will be prompted to
 import the build. Select "Import Build" to start the automatic installation.
 This will create all the needed files, this includes:
 
-- `projectview.bazel`
+- `projectview.bazelproject`
 
 This file contains the default settings configured so that Metals can work with
 Bazel without a hitch. By default it will work for all targets in the workspace,


### PR DESCRIPTION
## Problem

The current docs at https://scalameta.org/metals/docs/build-tools/bazel/ mention that Metals will generate a `projectview.bazel` file. But these configurations are required to have a `.bazelproject` suffix according to the implementation. So I believe this is simply a typo. Later in the same page, the `.bsp` configuration links to a `projectview.bazelproject` file.

So I believe this is a typo or a historical name that is no longer accurate.

## Solution

Update the md to use the proper suffix.