### PR TITLE
fix: SQL syntax highlighting

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/SemanticTokensProvider.scala
@@ -154,9 +154,9 @@ object SemanticTokensProvider {
   ): ((List[Integer], List[Node], Line), Boolean, Option[SQLToken]) = tk match {
     case Token.Interpolation.Id(id) if acceptedSQLInterpolations(id) =>
       (handleToken(tk, nodesIterator, isScala3, delta), true, None)
-    case Token.Interpolation.Part(value) if isSQLInterpolator =>
+    case part @ Token.Interpolation.Part(_) if isSQLInterpolator =>
       val buffer = ListBuffer.empty[Integer]
-      val sqlTokens = SQLTokenizer.tokenize(value, lastSQLToken)
+      val sqlTokens = SQLTokenizer.tokenize(part.text, lastSQLToken)
 
       val (delta0, lastToken0) =
         sqlTokens.foldLeft((delta, Option.empty[SQLToken])) {

--- a/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/SemanticTokensLspSuite.scala
@@ -290,6 +290,30 @@ class SemanticTokensLspSuite extends BaseLspSuite("SemanticTokens") {
     libraryDependencies = List("org.tpolecat::doobie-core:1.0.0-RC2"),
   )
 
+  check(
+    "doobie-postgresql-cast-operators",
+    s"""|<<import>>/*keyword*/ <<doobie>>/*namespace*/.<<implicits>>/*class*/.<<_>>/*variable,readonly*/
+        |
+        |<<object>>/*keyword*/ <<SQL>>/*class*/ {
+        |  <<val>>/*keyword*/ <<query>>/*variable,definition,readonly*/ = <<fr>>/*keyword*/<<\"\"\">>/*string*/<<SELECT>>/*keyword*/
+        |    <<jsonb_path_query>>/*function*/(<<entry>>/*variable*/, <<'dateRange'>>/*string*/)<<::>>/*operator*/<<TEXT>>/*keyword*/<<::>>/*operator*/<<DATE>>/*keyword*/ <<as>>/*keyword*/ <<from_date>>/*variable*/
+        |    <<FROM>>/*keyword*/ <<subq0>>/*variable*/<<\"\"\">>/*string*/
+        |}
+        |""".stripMargin,
+    libraryDependencies = List("org.tpolecat::doobie-core:1.0.0-RC2"),
+  )
+
+  check(
+    "doobie-sql-with-dollar-escape",
+    s"""|<<import>>/*keyword*/ <<doobie>>/*namespace*/.<<implicits>>/*class*/.<<_>>/*variable,readonly*/
+        |
+        |<<object>>/*keyword*/ <<SQL>>/*class*/ {
+        |  <<val>>/*keyword*/ <<query>>/*variable,definition,readonly*/ = <<fr>>/*keyword*/<<\">>/*string*/<<SELECT>>/*keyword*/ <<'$$$$.path'>>/*string*/<<::>>/*operator*/<<TEXT>>/*keyword*/ <<FROM>>/*keyword*/ <<t>>/*variable*/<<\">>/*string*/
+        |}
+        |""".stripMargin,
+    libraryDependencies = List("org.tpolecat::doobie-core:1.0.0-RC2"),
+  )
+
   test("new-changes") {
     val expected =
       """|<<package>>/*keyword*/ <<a>>/*namespace*/


### PR DESCRIPTION
## Summary
  - Fix SQL syntax highlighting for PostgreSQL :: cast and ->> JSON operators
  - Fix token position alignment when $$ escape sequences are present in SQL interpolators
  - Support identifiers with digits (e.g. subq0)
#### Fixes #7700 
## Before
<img width="908" height="223" alt="image" src="https://github.com/user-attachments/assets/014db28b-e9e7-472a-9b04-460c01a63f81" />

## After
<img width="904" height="229" alt="image" src="https://github.com/user-attachments/assets/68072c29-543a-40e8-88aa-366aeddb7c75" />
