### PR TITLE
chore: Send enabled rules in initialize params

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
@@ -61,7 +61,7 @@ case class BazelBuildTool(
     workspace.list.find(_.filename.endsWith(".bazelproject")) match {
       // project view cannot be empty, so we need to create a fallback
       case Some(path) if path.readText.trim.isEmpty =>
-        path.writeText(BazelBuildTool.fallbackProjectView(projectRoot))
+        path.writeText(BazelBuildTool.fallbackProjectView)
       case _ =>
     }
   }
@@ -103,19 +103,18 @@ object BazelBuildTool {
       .filter(_.isFile)
       .orElse(dir.list.find(_.filename.endsWith(".bazelproject")))
 
-  def fallbackProjectView(projectRoot: AbsolutePath): String = {
+  def enabledRules(projectRoot: AbsolutePath): List[String] = {
     val scalaRules = getScalaRulesName(projectRoot)
+    List(scalaRules, "rules_java", "rules_jvm")
+  }
+
+  def fallbackProjectView: String = {
     s"""|targets:
         |    //...
         |
         |build_manual_targets: false
         |
         |derive_targets_from_directories: false
-        |
-        |enabled_rules:
-        |    $scalaRules
-        |    rules_java
-        |    rules_jvm
         |
         |""".stripMargin
   }
@@ -132,19 +131,14 @@ object BazelBuildTool {
     existingProjectView(projectRoot) match {
       // if project view is empty nothing will work, since no targets are specified
       case Some(projectView) if projectView.readText.trim().isEmpty =>
-        projectView.writeText(fallbackProjectView(projectRoot))
+        projectView.writeText(fallbackProjectView)
         List("-p", projectView.toRelative(projectRoot).toString())
       case Some(projectView) =>
         List("-p", projectView.toRelative(projectRoot).toString())
       case None =>
-        val scalaRules = getScalaRulesName(projectRoot)
         List(
           "-t",
           "//...",
-          "-enabled-rules",
-          scalaRules,
-          "rules_java",
-          "rules_jvm",
         )
     }
   }

--- a/tests/slow/src/test/scala/tests/bazel/BazelLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelLspSuite.scala
@@ -364,7 +364,7 @@ class BazelLspSuite
       _ <- server.didOpen("Hello.scala")
       _ = assertNoDiff(
         projectview.readText,
-        BazelBuildTool.fallbackProjectView(workspace),
+        BazelBuildTool.fallbackProjectView,
       )
       _ <- server.didChange("Hello.scala") { text =>
         text.replace("def hello: String", "def hello: Int")
@@ -397,7 +397,7 @@ class BazelLspSuite
       )
       _ = assertNoDiff(
         projectview.readText,
-        BazelBuildTool.fallbackProjectView(workspace),
+        BazelBuildTool.fallbackProjectView,
       )
     } yield ()
   }
@@ -454,11 +454,6 @@ class BazelLspSuite
            |allow_manual_targets_sync: false
            |
            |derive_targets_from_directories: false
-           |
-           |enabled_rules:
-           |    rules_scala
-           |    rules_java
-           |    rules_jvm
            |
            |""".stripMargin,
       )


### PR DESCRIPTION
This way we avoid conflicts with .projectview from the main bazel branch (which might also have more functionality that is currently handled)