### PR TITLE
Make Metals look for `./mill` and `./mill.bat` files when identifying Mill projects

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -97,7 +97,9 @@ final class BuildTools(
     path.resolve("build.mill").isFile ||
       path.resolve("build.mill.yaml").isFile ||
       path.resolve("build.mill.scala").isFile ||
-      path.resolve("build.sc").isFile
+      path.resolve("build.sc").isFile ||
+      path.resolve("mill").isFile ||
+      path.resolve("mill.bat").isFile
   )
   def isMill: Boolean = millProject.isDefined
   def isMillBsp(path: AbsolutePath): Boolean =

--- a/tests/unit/src/test/scala/tests/DetectionSuite.scala
+++ b/tests/unit/src/test/scala/tests/DetectionSuite.scala
@@ -194,6 +194,81 @@ class DetectionSuite extends BaseSuite {
   )
 
   /**
+   * ------------ Mill ------------*
+   */
+  def checkNotMill(name: String, layout: String)(implicit
+      loc: Location
+  ): Unit = {
+    checkMill(name, layout, isTrue = false)
+  }
+  def checkMill(
+      name: String,
+      layout: String,
+      isTrue: Boolean = true,
+  )(implicit loc: Location): Unit = {
+    test(s"mill-$name") {
+      check(
+        layout,
+        p => BuildTools.default(p).isMill,
+        isTrue,
+      )
+    }
+  }
+
+  checkMill(
+    "build.sc",
+    """|/build.sc
+       |import mill._
+       |""".stripMargin,
+  )
+
+  checkMill(
+    "build.mill",
+    """|/build.mill
+       |package build
+       |import mill._
+       |""".stripMargin,
+  )
+
+  checkMill(
+    "build.mill.yaml",
+    """|/build.mill.yaml
+       |mill-version: 0.12.0
+       |""".stripMargin,
+  )
+
+  checkMill(
+    "build.mill.scala",
+    """|/build.mill.scala
+       |package build
+       |import mill._
+       |""".stripMargin,
+  )
+
+  checkMill(
+    "mill-script",
+    """|/mill
+       |#!/usr/bin/env sh
+       |DEFAULT_MILL_VERSION=0.12.0
+       |""".stripMargin,
+  )
+
+  checkMill(
+    "mill.bat-script",
+    """|/mill.bat
+       |@echo off
+       |set DEFAULT_MILL_VERSION=0.12.0
+       |""".stripMargin,
+  )
+
+  checkNotMill(
+    "sbt-only",
+    """|/build.sbt
+       |lazy val a = project
+       |""".stripMargin,
+  )
+
+  /**
    * ------------ Multiple Build Files ------------*
    */
   def checkMulti(name: String, layout: String, isTrue: Boolean = true)(implicit


### PR DESCRIPTION
The upcoming Mill 1.1.0 has [Single-File Scripts](https://mill-build.org/mill/scalalib/script.html) that can be run even in the absence of a `build.mill` file, so we should no longer assume that a Mill build will have a root `build.mill` especially for smaller codebases that may just be a bunch of scripts. 

This PR makes Metals check for `./mill` and `./mill.bat` files as well to identify such projects as Mill builds and allow support for Mill scripts even in the absence of `build.mill` or `build.mill.yaml`