### PR TITLE
feat: Forward credentials to Bloop process

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -118,11 +118,8 @@ final class BspServers(
       // Convert credential-related system properties to environment variables
       // This helps BSP servers (like sbt) access custom repository credentials
       val credentialEnvVars = sys.props.collect {
-        case (key, value)
-            if key.startsWith("sbt.boot.credentials") ||
-              key.startsWith("sbt.credentials") ||
-              key.contains("repository.credentials") =>
-          key.toUpperCase.replace(".", "_").replace("-", "_") -> value
+        case (key, value) if key == "coursier.credentials" =>
+          "COURSIER_CREDENTIALS" -> value
       }
 
       val allVariables =


### PR DESCRIPTION
### Problem
Metals fails to fetch build dependencies from custom repositories because environment variables (like Coursier credentials, Artifactory tokens, or custom repository URLs) are not passed to the BSP server process.

### Solution
Added a new `bsp-environment-variables` configuration option that allows users to specify environment variables to pass to the BSP server.

### Usage
```
json
{
  "metals.bsp-environment-variables": {
    "ARTIFACTORY_HOST": "my.artifactory.com",
    "ARTIFACTORY_USER": "user",
    "ARTIFACTORY_TOKEN": "token",
    "COURSIER_REPOSITORIES": "https://my.repo.com/maven"
  }
}
```

### Closing issue

closes #7785 