### PR TITLE
bugfix: Don't use connection name as an ID

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ Global / onLoad ~= { old =>
         prePush,
         """#!/bin/sh
           |set -eux
-          |bin/scalafmt --diff --diff-branch databricks
+          |bin/scalafmt --diff --diff-branch main-v2
           |git diff --exit-code
           |""".stripMargin.getBytes(),
       )

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildTargets.scala
@@ -331,7 +331,7 @@ final class BuildTargets private (
     )
     val params = new InverseSourcesParams(identifier)
     val connections =
-      data.fromIterators(_.idToConnection.values.toIterator).distinct
+      data.fromIterators(_.targetToConnectionId.values.toIterator).distinct
     val queries = connections.map { connection =>
       connection
         .buildTargetInverseSources(params)
@@ -672,9 +672,7 @@ final class BuildTargets private (
   def buildServerOf(
       id: BuildTargetIdentifier
   ): Option[BuildServerConnection] =
-    data.fromOptions(d =>
-      d.targetToConnectionId.get(id).flatMap(d.idToConnection.get)
-    )
+    data.fromOptions(d => d.targetToConnectionId.get(id))
 
   def addData(data: TargetData): Unit =
     dataLock.synchronized {

--- a/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
@@ -399,7 +399,7 @@ class ConnectionProvider(
           case None => Future.successful(None)
           case Some(session) =>
             bspSession = None
-            mainBuildTargetsData.resetConnections(List.empty, List.empty)
+            mainBuildTargetsData.resetConnections(List.empty)
             session.shutdown().map(_ => Some(session.main.name))
         }
         _ <-
@@ -427,13 +427,12 @@ class ConnectionProvider(
           session.importBuilds(progress)
         }
         _ = {
-          val connections = bspBuilds.map(_.connection)
           val idToConnection = bspBuilds.flatMap { bspBuild =>
             val targets =
               bspBuild.build.workspaceBuildTargets.getTargets().asScala
-            targets.map(t => (t.getId(), bspBuild.connection.name))
+            targets.map(t => (t.getId(), bspBuild.connection))
           }
-          mainBuildTargetsData.resetConnections(connections, idToConnection)
+          mainBuildTargetsData.resetConnections(idToConnection)
           saveProjectReferencesInfo(bspBuilds)
         }
         _ = compilers.cancel()

--- a/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ammonite/Ammonite.scala
@@ -107,7 +107,7 @@ final class Ammonite(
             val workspace0 = workspace()
             val targets = build0.workspaceBuildTargets.getTargets.asScala
             val connections =
-              targets.iterator.map(_.getId).map((_, conn.name)).toList
+              targets.iterator.map(_.getId).map((_, conn)).toList
             for {
               target <- targets
               classDirUriOpt = build0.scalacOptions.getItems.asScala
@@ -128,7 +128,7 @@ final class Ammonite(
                 new Ammonite.AmmoniteMappedSource(AbsolutePath(scalaPath))
               buildTargetsData.addMappedSource(scPath, mapped)
             }
-            buildTargetsData.resetConnections(List(conn), connections)
+            buildTargetsData.resetConnections(connections)
           }
           _ <- indexWorkspace()
           toCompile = buffers.open.toSeq.filter(_.isAmmoniteScript)

--- a/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/scalacli/ScalaCli.scala
@@ -124,8 +124,8 @@ class ScalaCli(
           if (state.compareAndSet(st, st.copy(importedBuild = build0))) {
             val targets = build0.workspaceBuildTargets.getTargets.asScala
             val connections =
-              targets.iterator.map(_.getId).map((_, st.connection.name)).toList
-            buildTargetsData.resetConnections(List(st.connection), connections)
+              targets.iterator.map(_.getId).map((_, st.connection)).toList
+            buildTargetsData.resetConnections(connections)
 
             for {
               _ <- indexWorkspace()


### PR DESCRIPTION
Previously, we would get multiple connections with the same ID, since Bloop starts multiple connections for meta builds.

Now, I reverted the additional mapping since it doesn't seem to be used.