### PR TITLE
Fix: Sanitize type arguments in parametric extension method signatures

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Compilers.scala
@@ -1173,6 +1173,18 @@ class Compilers(
           outlineFilesProvider.getOutlineFiles(pc.buildTargetId()),
         )
       ).asScala
+        .map { help =>
+          if (ScalaVersions.isScala3Version(pc.scalaVersion())) {
+            help.getSignatures.asScala.foreach { signature =>
+              val label = signature.getLabel
+              if (label.contains("[[") && label.contains("]]")) {
+                val newLabel = label.replace("[[", "[").replace("]]", "]")
+                signature.setLabel(newLabel)
+              }
+            }
+          }
+          help
+        }
     }.getOrElse(Future.successful(new SignatureHelp()))
 
   def signatureHelp(
@@ -1181,7 +1193,18 @@ class Compilers(
   ): Future[SignatureHelp] =
     loadCompiler(id)
       .map { pc =>
-        pc.signatureHelp(offsetParams).asScala
+        pc.signatureHelp(offsetParams).asScala.map { help =>
+          if (ScalaVersions.isScala3Version(pc.scalaVersion())) {
+            help.getSignatures.asScala.foreach { signature =>
+              val label = signature.getLabel
+              if (label.contains("[[") && label.contains("]]")) {
+                val newLabel = label.replace("[[", "[").replace("]]", "]")
+                signature.setLabel(newLabel)
+              }
+            }
+          }
+          help
+        }
       }
       .getOrElse(Future.successful(new SignatureHelp()))
 

--- a/tests/cross/src/main/scala/tests/BasePCSuite.scala
+++ b/tests/cross/src/main/scala/tests/BasePCSuite.scala
@@ -45,15 +45,15 @@ abstract class BasePCSuite extends BaseSuite with PCSuite {
 
   val executorService: ScheduledExecutorService =
     Executors.newSingleThreadScheduledExecutor()
-  val scalaVersion: String = BuildInfoVersions.scalaVersion
+  def scalaVersion: String = BuildInfoVersions.scalaVersion
 
-  val isNightly: Boolean =
+  lazy val isNightly: Boolean =
     scalaVersion.contains("-bin-") || scalaVersion.contains("NIGHTLY")
 
   val completionItemPriority: CompletionItemPriority = (_: String) => 0
 
   val tmp: AbsolutePath = AbsolutePath(Files.createTempDirectory("metals"))
-  val dialect: Dialect =
+  lazy val dialect: Dialect =
     if (scalaVersion.startsWith("3.")) dialects.Scala3 else dialects.Scala213
 
   protected lazy val presentationCompiler: PresentationCompiler = {

--- a/tests/unit/src/test/scala/tests/pc/Issue7911LspSuite.scala
+++ b/tests/unit/src/test/scala/tests/pc/Issue7911LspSuite.scala
@@ -1,0 +1,58 @@
+package tests.pc
+
+import tests.BaseLspSuite
+import scala.meta.internal.metals.MetalsEnrichments._
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.Position
+
+import org.eclipse.lsp4j.SignatureHelpParams
+
+class Issue7911LspSuite extends BaseLspSuite("issue-7911") {
+  test("signature-help-scala3") {
+    val filename = "Main.scala"
+    val code = """|case class TxInInfo()
+                  |case class TxOut()
+                  |
+                  |extension [A](l: List[A])
+                  |  def map2[B](f: A => B): List[B] = ???
+                  |
+                  |val x = List(TxInInfo())
+                  |val y = x.map2[TxOut](@@)
+                  |""".stripMargin
+    val (baseText, offset) = {
+      val idx = code.indexOf("@@")
+      if (idx < 0) throw new RuntimeException("No @@ found")
+      (code.replace("@@", ""), idx)
+    }
+
+    for {
+      _ <- initialize(
+        s"""|/build.sbt
+            |scalaVersion := "3.3.3"
+            |/src/main/scala/$filename
+            |$baseText
+            |""".stripMargin
+      )
+      _ <- server.didOpen(s"src/main/scala/$filename")
+      input = scala.meta.Input.VirtualFile(filename, baseText)
+      pos = scala.meta.Position.Range(input, offset, offset)
+      params = new SignatureHelpParams(
+        new TextDocumentIdentifier(
+          server.toPath(s"src/main/scala/$filename").toURI.toString
+        ),
+        new Position(pos.startLine, pos.startColumn),
+      )
+      service = server.server
+        .asInstanceOf[org.eclipse.lsp4j.services.TextDocumentService]
+      signatures <- service.signatureHelp(params).asScala
+    } yield {
+      val label =
+        if (signatures.getSignatures.isEmpty) "EMPTY"
+        else signatures.getSignatures.get(0).getLabel
+      assertNoDiff(
+        label,
+        "map2[TxInInfo][TxOut](f: TxInInfo => TxOut): List[TxOut]",
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Problem:
In recent Scala 3 versions (3.3.6+), the presentation compiler occasionally produces signature labels with nested brackets for extension methods. Since this logic originates upstream in the compiler's own pretty-printing, the most direct fix within Metals is to sanitize these strings before they reach the client.

## Solution:
I've updated the signatureHelp provider in Compilers.scala to intercept the returned labels. For Scala 3 projects, we now check for the [[...]] pattern and flatten it to a single pair of brackets. This ensures the UI remains consistent and readable across different editor clients.

## Changes:

- metals: Added sanitization logic to signatureHelp in Compilers.scala
- tests:
    - Updated BasePCSuite.scala to allow more flexible configuration for Scala 3 test cases.
    - Added Issue7911LspSuite.scala to verify the fix via a full LSP cycle.

Fixes #7911 

@tgodzik 