### PR TITLE
Add metals-extract module for dependency extraction from build tools

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -541,6 +541,31 @@ lazy val `mtags-java` = project
   .configure(JavaPcSettings.settings(sharedSettings))
   .dependsOn(interfaces, mtagsShared, `semanticdb-javac`, turbine)
 
+lazy val `metals-extract` = project
+  .in(file("metals-extract"))
+  .settings(
+    sharedSettings,
+    moduleName := "metals-extract",
+    Compile / run / fork := true,
+    Compile / mainClass := Some("scala.meta.metals.extract.MbtExtract"),
+    libraryDependencies ++= List(
+      // Maven Artifact Resolver (Eclipse Aether) for Maven dependency extraction
+      "org.apache.maven.resolver" % "maven-resolver-api" % "1.9.22",
+      "org.apache.maven.resolver" % "maven-resolver-impl" % "1.9.22",
+      "org.apache.maven.resolver" % "maven-resolver-connector-basic" % "1.9.22",
+      "org.apache.maven.resolver" % "maven-resolver-transport-file" % "1.9.22",
+      "org.apache.maven.resolver" % "maven-resolver-transport-http" % "1.9.22",
+      "org.apache.maven" % "maven-resolver-provider" % "3.9.9",
+      "org.apache.maven" % "maven-model" % "3.9.9",
+      // Gradle Tooling API for Gradle dependency extraction
+      "org.gradle" % "gradle-tooling-api" % "8.5",
+      // JSON parsing for Bazel maven_install.json
+      "com.google.code.gson" % "gson" % "2.11.0",
+    ),
+    // Gradle Tooling API requires the Gradle repository
+    resolvers += "Gradle Releases" at "https://repo.gradle.org/gradle/libs-releases/",
+  )
+
 lazy val metals = project
   .settings(
     sharedSettings,

--- a/metals-extract/src/main/scala/scala/meta/metals/extract/BazelExtractor.scala
+++ b/metals-extract/src/main/scala/scala/meta/metals/extract/BazelExtractor.scala
@@ -1,0 +1,679 @@
+package scala.meta.metals.extract
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.nio.file.Files
+import java.nio.file.Path
+
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+import com.google.gson.Gson
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+
+/**
+ * Extracts dependencies from Bazel projects using rules_jvm_external.
+ *
+ * This extractor parses the maven_install.json file that rules_jvm_external
+ * generates to pin Maven dependencies. It also locates the actual JAR files
+ * in the Bazel output base.
+ */
+object BazelExtractor {
+
+  private val gson = new Gson()
+
+  def extract(
+      projectDir: Path,
+      verbose: Boolean
+  ): Either[String, Seq[DependencyModule]] = {
+    // Find all maven_install.json files
+    val mavenInstallPaths = findAllMavenInstallJson(projectDir, verbose)
+
+    if (mavenInstallPaths.isEmpty) {
+      return Left(
+        "No maven_install.json found. Make sure rules_jvm_external is configured and pinned."
+      )
+    }
+
+    Try {
+      // Get the Bazel output base for locating JAR files
+      val outputBase = getBazelOutputBase(projectDir, verbose)
+
+      // Extract from all maven_install files and merge results
+      val allModules = mavenInstallPaths.flatMap { path =>
+        if (verbose) println(s"Processing: $path")
+        val content = Files.readString(path)
+        val json = gson.fromJson(content, classOf[JsonObject])
+        extractArtifacts(json, outputBase, projectDir, verbose)
+      }
+
+      // Deduplicate by id, preferring entries with sources
+      allModules
+        .groupBy(_.id)
+        .values
+        .map { modules =>
+          modules.maxBy(m => if (m.sources.isDefined) 1 else 0)
+        }
+        .toSeq
+        .sortBy(_.id)
+    }.toEither.left.map(e => s"Bazel extraction failed: ${e.getMessage}")
+  }
+
+  /**
+   * Find all maven_install.json files in various possible locations.
+   * Also searches for patterns like maven_install_*.json, *_maven_install.json
+   */
+  private def findAllMavenInstallJson(projectDir: Path, verbose: Boolean): Seq[Path] = {
+    val candidates = Seq(
+      // Standard location
+      projectDir.resolve("maven_install.json"),
+      // Bzlmod repository rule output (common pattern)
+      projectDir.resolve("third_party/maven_install.json"),
+      // Some projects put it in a subdirectory
+      projectDir.resolve("dependencies/maven_install.json"),
+      // Compatibility subdirectory
+      projectDir.resolve("compatibility/maven_install.json")
+    )
+
+    // Search for maven_install*.json or *maven*install*.json patterns in project root
+    val patternMatches = Try {
+      Files.list(projectDir).iterator().asScala.filter { path =>
+        val name = path.getFileName.toString.toLowerCase
+        name.endsWith(".json") && name.contains("maven") && name.contains("install")
+      }.toSeq
+    }.getOrElse(Seq.empty)
+
+    // Also check for Bzlmod-style external repository structure
+    val bzlmodCandidates = Try {
+      val external = getBazelOutputBase(projectDir, verbose)
+        .map(_.resolve("external"))
+
+      external.toSeq.flatMap { extDir =>
+        if (Files.exists(extDir)) {
+          Files.list(extDir).iterator().asScala.flatMap { repoDir =>
+            val name = repoDir.getFileName.toString
+            if (name.contains("maven") || name.contains("jvm_external")) {
+              Seq(
+                repoDir.resolve("maven_install.json"),
+                repoDir.resolve("pin.json")
+              )
+            } else Seq.empty
+          }.toSeq
+        } else Seq.empty
+      }
+    }.getOrElse(Seq.empty)
+
+    val allCandidates = (candidates ++ patternMatches ++ bzlmodCandidates).distinct.filter(Files.exists(_))
+
+    if (verbose) {
+      println("Found maven_install.json files:")
+      allCandidates.foreach(p => println(s"  - $p"))
+    }
+
+    allCandidates
+  }
+
+  /**
+   * Get Bazel output base directory using `bazel info output_base`.
+   */
+  private def getBazelOutputBase(projectDir: Path, verbose: Boolean): Option[Path] = {
+    Try {
+      val process = new ProcessBuilder("bazel", "info", "output_base")
+        .directory(projectDir.toFile)
+        .redirectErrorStream(true)
+        .start()
+
+      val reader = new BufferedReader(new InputStreamReader(process.getInputStream))
+      val output = reader.readLine()
+      reader.close()
+      process.waitFor()
+
+      if (output != null && !output.isEmpty) {
+        val path = Path.of(output.trim)
+        if (verbose) println(s"Bazel output base: $path")
+        Some(path)
+      } else {
+        None
+      }
+    }.toOption.flatten
+  }
+
+  /**
+   * Extract artifacts from maven_install.json.
+   *
+   * Supports two formats:
+   *
+   * New format (rules_jvm_external v5+):
+   * {
+   *   "artifacts": {
+   *     "com.google.guava:guava": {
+   *       "version": "31.1-jre",
+   *       "shasums": { "jar": "...", "sources": "..." }
+   *     }
+   *   }
+   * }
+   *
+   * Legacy format (rules_jvm_external v4 and earlier):
+   * {
+   *   "dependency_tree": {
+   *     "dependencies": [
+   *       { "coord": "com.google.guava:guava:31.1-jre", "file": "v1/https/..." }
+   *     ]
+   *   }
+   * }
+   */
+  private def extractArtifacts(
+      json: JsonObject,
+      outputBase: Option[Path],
+      projectDir: Path,
+      verbose: Boolean
+  ): Seq[DependencyModule] = {
+    val repositoryName = detectRepositoryName(json)
+    if (verbose) println(s"Using repository name: $repositoryName")
+    val externalDir = outputBase.map(_.resolve("external"))
+
+    // Try new format first (artifacts key at root)
+    val artifactsObj = Option(json.getAsJsonObject("artifacts"))
+    if (artifactsObj.isDefined) {
+      return extractFromNewFormat(artifactsObj.get, repositoryName, externalDir, projectDir, verbose)
+    }
+
+    // Try legacy format (dependency_tree.dependencies array)
+    val dependencyTree = Option(json.getAsJsonObject("dependency_tree"))
+    dependencyTree.flatMap { dt =>
+      Option(dt.getAsJsonArray("dependencies"))
+    } match {
+      case Some(deps) =>
+        if (verbose) println("Using legacy dependency_tree format")
+        extractFromLegacyFormat(deps, repositoryName, externalDir, projectDir, verbose)
+      case None =>
+        if (verbose) println("No 'artifacts' or 'dependency_tree.dependencies' found in maven_install.json")
+        Seq.empty
+    }
+  }
+
+  /**
+   * Extract from new format: { "artifacts": { "group:artifact": { "version": "..." } } }
+   */
+  private def extractFromNewFormat(
+      artifacts: JsonObject,
+      repositoryName: String,
+      externalDir: Option[Path],
+      projectDir: Path,
+      verbose: Boolean
+  ): Seq[DependencyModule] = {
+    artifacts.entrySet().asScala.toSeq.flatMap { entry =>
+      val coordKey = entry.getKey // e.g., "com.google.guava:guava"
+      val artifactInfo = entry.getValue
+
+      Try {
+        parseArtifact(
+          coordKey,
+          artifactInfo,
+          repositoryName,
+          externalDir,
+          projectDir,
+          verbose
+        )
+      }.toOption.flatten
+    }
+  }
+
+  /**
+   * Extract from legacy format: { "dependency_tree": { "dependencies": [...] } }
+   */
+  private def extractFromLegacyFormat(
+      dependencies: com.google.gson.JsonArray,
+      repositoryName: String,
+      externalDir: Option[Path],
+      projectDir: Path,
+      verbose: Boolean
+  ): Seq[DependencyModule] = {
+    val deps = dependencies.iterator().asScala.toSeq
+
+    // Group by base coordinate to pair JARs with sources
+    val jarDeps = deps.filter { elem =>
+      if (!elem.isJsonObject) false
+      else {
+        val coord = Option(elem.getAsJsonObject.get("coord")).map(_.getAsString).getOrElse("")
+        !coord.contains(":jar:sources:") && !coord.contains("-sources.")
+      }
+    }
+
+    jarDeps.flatMap { elem =>
+      parseLegacyDependency(elem, deps, repositoryName, externalDir, projectDir, verbose)
+    }
+  }
+
+  private def parseLegacyDependency(
+      elem: JsonElement,
+      allDeps: Seq[JsonElement],
+      repositoryName: String,
+      externalDir: Option[Path],
+      projectDir: Path,
+      verbose: Boolean
+  ): Option[DependencyModule] = {
+    Try {
+      val obj = elem.getAsJsonObject
+      val coord = obj.get("coord").getAsString // e.g., "com.google.guava:guava:31.1-jre"
+      val file = Option(obj.get("file")).map(_.getAsString)
+      val url = Option(obj.get("url")).map(_.getAsString)
+
+      // Parse coordinate: group:artifact:version
+      val parts = coord.split(":")
+      if (parts.length < 3) return None
+
+      val (groupId, artifactId, version) = (parts(0), parts(1), parts(2))
+
+      if (version.contains("SNAPSHOT")) {
+        if (verbose) println(s"  Skipping SNAPSHOT: $coord")
+        return None
+      }
+
+      val id = s"$groupId:$artifactId:$version"
+      val groupPath = groupId.replace('.', '/')
+      val jarName = s"$artifactId-$version.jar"
+
+      // Find JAR path - try local paths first
+      val jarPath = file.flatMap { f =>
+        findJarFromLegacyPath(f, repositoryName, externalDir, projectDir)
+      }.orElse {
+        findJarPath(groupId, artifactId, version, repositoryName, externalDir, projectDir, verbose)
+      }.orElse {
+        // Download from URL if available and not found locally
+        url.flatMap { u =>
+          downloadToM2Cache(u, groupPath, artifactId, version, jarName, verbose)
+        }
+      }
+
+      jarPath.map { jar =>
+        // Look for corresponding sources in the dependencies array
+        val sourcesCoord = s"$groupId:$artifactId:jar:sources:$version"
+        val sourcesEntry = allDeps.find { e =>
+          e.isJsonObject &&
+          Option(e.getAsJsonObject.get("coord")).map(_.getAsString).contains(sourcesCoord)
+        }
+
+        val sourcesFile = sourcesEntry.flatMap { e =>
+          Option(e.getAsJsonObject.get("file")).map(_.getAsString)
+        }
+        val sourcesUrl = sourcesEntry.flatMap { e =>
+          Option(e.getAsJsonObject.get("url")).map(_.getAsString)
+        }
+
+        val sourcesJarName = s"$artifactId-$version-sources.jar"
+        val sourcesPath = sourcesFile.flatMap { f =>
+          findJarFromLegacyPath(f, repositoryName, externalDir, projectDir)
+        }.orElse {
+          findSourcesPath(groupId, artifactId, version, repositoryName, externalDir, projectDir, verbose)
+        }.orElse {
+          // Download sources from URL if available
+          sourcesUrl.flatMap { u =>
+            downloadToM2Cache(u, groupPath, artifactId, version, sourcesJarName, verbose)
+          }
+        }
+
+        DependencyModule(id = id, jar = jar, sources = sourcesPath)
+      }
+    }.toOption.flatten
+  }
+
+  /**
+   * Download a JAR from URL to the local Maven cache.
+   */
+  private def downloadToM2Cache(
+      url: String,
+      groupPath: String,
+      artifactId: String,
+      version: String,
+      jarName: String,
+      verbose: Boolean
+  ): Option[String] = {
+    Try {
+      val m2Dir = Path.of(
+        System.getProperty("user.home"),
+        ".m2",
+        "repository",
+        groupPath,
+        artifactId,
+        version
+      )
+      val targetPath = m2Dir.resolve(jarName)
+
+      // Check if already exists
+      if (Files.exists(targetPath)) {
+        return Some(targetPath.toString)
+      }
+
+      if (verbose) println(s"  Downloading: $url")
+
+      // Create directory
+      Files.createDirectories(m2Dir)
+
+      // Download file
+      val connection = new java.net.URL(url).openConnection()
+      connection.setConnectTimeout(10000)
+      connection.setReadTimeout(30000)
+
+      val in = connection.getInputStream
+      try {
+        Files.copy(in, targetPath)
+        if (verbose) println(s"  Downloaded to: $targetPath")
+        Some(targetPath.toString)
+      } finally {
+        in.close()
+      }
+    }.toOption.flatten
+  }
+
+  /**
+   * Find JAR from legacy format's "file" path.
+   * The file path is like: v1/https/repo1.maven.org/maven2/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar
+   */
+  private def findJarFromLegacyPath(
+      filePath: String,
+      repositoryName: String,
+      externalDir: Option[Path],
+      projectDir: Path
+  ): Option[String] = {
+    // Try direct path in external directory with repository name prefix
+    val patterns = Seq(
+      s"$repositoryName/$filePath",
+      s"maven/$filePath",
+      filePath
+    )
+
+    val jarFromExternal = externalDir.flatMap { extDir =>
+      patterns.map(p => extDir.resolve(p)).find(Files.exists(_))
+    }
+
+    if (jarFromExternal.isDefined) return jarFromExternal.map(_.toString)
+
+    // Try bazel-<project>/external symlink
+    val bazelProjectPath = Try {
+      val bazelLink = projectDir.resolve(s"bazel-${projectDir.getFileName}")
+      if (Files.exists(bazelLink)) {
+        val extDir = bazelLink.resolve("external")
+        if (Files.exists(extDir)) Some(extDir) else None
+      } else None
+    }.getOrElse(None)
+
+    bazelProjectPath.flatMap { extDir =>
+      patterns.map(p => extDir.resolve(p)).find(Files.exists(_))
+    }.map(_.toString)
+  }
+
+  /**
+   * Detect the repository name from maven_install.json.
+   * It's typically "maven" but can be customized.
+   */
+  private def detectRepositoryName(json: JsonObject): String = {
+    // Try to find it in the JSON metadata
+    Option(json.get("__AUTOGENERATED_FILE_DO_NOT_MODIFY_THIS_FILE_MANUALLY"))
+      .orElse(Option(json.get("version")))
+      .map(_ => "maven") // Default to "maven"
+      .getOrElse("maven")
+  }
+
+  private def parseArtifact(
+      coordKey: String,
+      artifactInfo: JsonElement,
+      repositoryName: String,
+      externalDir: Option[Path],
+      projectDir: Path,
+      verbose: Boolean
+  ): Option[DependencyModule] = {
+    if (!artifactInfo.isJsonObject) return None
+
+    val info = artifactInfo.getAsJsonObject
+
+    // Get version
+    val version = Option(info.get("version"))
+      .filter(_.isJsonPrimitive)
+      .map(_.getAsString)
+
+    version.flatMap { v =>
+      if (v.contains("SNAPSHOT")) {
+        if (verbose) println(s"  Skipping SNAPSHOT: $coordKey:$v")
+        return None
+      }
+
+      val parts = coordKey.split(":")
+      if (parts.length != 2) return None
+
+      val (groupId, artifactId) = (parts(0), parts(1))
+      val id = s"$groupId:$artifactId:$v"
+
+      // Find JAR file path
+      val jarPath = findJarPath(groupId, artifactId, v, repositoryName, externalDir, projectDir, verbose)
+
+      jarPath.map { jar =>
+        val sourcesPath = findSourcesPath(groupId, artifactId, v, repositoryName, externalDir, projectDir, verbose)
+
+        DependencyModule(
+          id = id,
+          jar = jar,
+          sources = sourcesPath
+        )
+      }
+    }
+  }
+
+  /**
+   * Find the JAR file in the Bazel external directory.
+   *
+   * Bazel stores external dependencies in different patterns:
+   *
+   * Bzlmod mode (Bazel 6+):
+   *   {output_base}/external/rules_jvm_external~{version}~maven~{artifact_dir}_{version}/file/v1/{group_path}/{artifact}/{version}/{artifact}-{version}.jar
+   *   Example: rules_jvm_external~6.2~maven~com_google_guava_guava_32_1_3_android/file/v1/com/google/guava/guava/32.1.3-android/guava-32.1.3-android.jar
+   *
+   * WORKSPACE mode:
+   *   {output_base}/external/maven/v1/https/repo1.maven.org/maven2/{group_path}/{artifact}/{version}/{artifact}-{version}.jar
+   */
+  private def findJarPath(
+      groupId: String,
+      artifactId: String,
+      version: String,
+      repositoryName: String,
+      externalDir: Option[Path],
+      projectDir: Path,
+      verbose: Boolean
+  ): Option[String] = {
+    val groupPath = groupId.replace('.', '/')
+    val jarName = s"$artifactId-$version.jar"
+
+    // Build Bzlmod-style directory name: com.google.guava:guava:32.1.3-android -> com_google_guava_guava_32_1_3_android
+    val bzlmodArtifactDir = toBzlmodArtifactDir(groupId, artifactId, version)
+
+    // Try Bzlmod patterns first
+    val jarFromBzlmod = externalDir.flatMap { extDir =>
+      findBzlmodJar(extDir, bzlmodArtifactDir, groupPath, artifactId, version, jarName, verbose)
+    }
+
+    if (jarFromBzlmod.isDefined) return jarFromBzlmod.map(_.toString)
+
+    // Try WORKSPACE patterns
+    val workspacePatterns = Seq(
+      s"$repositoryName/v1/https/repo1.maven.org/maven2/$groupPath/$artifactId/$version/$jarName",
+      s"maven/v1/https/repo1.maven.org/maven2/$groupPath/$artifactId/$version/$jarName",
+      s"maven/$groupPath/$artifactId/$version/$jarName"
+    )
+
+    val jarFromWorkspace = externalDir.flatMap { extDir =>
+      workspacePatterns.map(p => extDir.resolve(p)).find(Files.exists(_))
+    }
+
+    if (jarFromWorkspace.isDefined) return jarFromWorkspace.map(_.toString)
+
+    // Try bazel-<project>/external symlink
+    val bazelProjectPath = Try {
+      val bazelLink = projectDir.resolve(s"bazel-${projectDir.getFileName}")
+      if (Files.exists(bazelLink)) {
+        val extDir = bazelLink.resolve("external")
+        if (Files.exists(extDir)) Some(extDir) else None
+      } else None
+    }.getOrElse(None)
+
+    val jarFromBazelProject = bazelProjectPath.flatMap { extDir =>
+      findBzlmodJar(extDir, bzlmodArtifactDir, groupPath, artifactId, version, jarName, verbose)
+        .orElse(workspacePatterns.map(p => extDir.resolve(p)).find(Files.exists(_)))
+    }
+
+    if (jarFromBazelProject.isDefined) return jarFromBazelProject.map(_.toString)
+
+    // Fall back to local Maven cache
+    val m2Path = Path.of(
+      System.getProperty("user.home"),
+      ".m2",
+      "repository",
+      groupPath,
+      artifactId,
+      version,
+      jarName
+    )
+
+    if (Files.exists(m2Path)) Some(m2Path.toString) else None
+  }
+
+  /**
+   * Convert artifact coordinates to Bzlmod directory name format.
+   * Example: com.google.guava:guava:32.1.3-android -> com_google_guava_guava_32_1_3_android
+   */
+  private def toBzlmodArtifactDir(groupId: String, artifactId: String, version: String): String = {
+    val sanitize = (s: String) => s.replace('.', '_').replace('-', '_').replace(':', '_')
+    s"${sanitize(groupId)}_${sanitize(artifactId)}_${sanitize(version)}"
+  }
+
+  /**
+   * Find JAR in Bzlmod external directory by scanning for rules_jvm_external prefix.
+   *
+   * Supports multiple Bazel versions:
+   * - Bazel 7.x: rules_jvm_external~{version}~maven~{artifactDir}
+   * - Bazel 8.x: rules_jvm_external++maven+{artifactDir}
+   */
+  private def findBzlmodJar(
+      extDir: Path,
+      artifactDir: String,
+      groupPath: String,
+      artifactId: String,
+      version: String,
+      jarName: String,
+      verbose: Boolean
+  ): Option[Path] = {
+    Try {
+      val entries = Files.list(extDir).iterator().asScala.toSeq
+
+      // Look for directory matching Bazel 7.x pattern: rules_jvm_external~{version}~maven~{artifactDir}
+      val bazel7Dir = entries.find { entry =>
+        val name = entry.getFileName.toString
+        name.startsWith("rules_jvm_external~") &&
+        name.contains("~maven~") &&
+        name.endsWith(s"~$artifactDir")
+      }
+
+      // Look for directory matching Bazel 8.x pattern: rules_jvm_external++maven+{artifactDir}
+      val bazel8Dir = entries.find { entry =>
+        val name = entry.getFileName.toString
+        name.startsWith("rules_jvm_external++maven+") &&
+        name.endsWith(s"+$artifactDir")
+      }
+
+      val matchingDir = bazel7Dir.orElse(bazel8Dir)
+
+      matchingDir.flatMap { dir =>
+        val jarPath = dir.resolve(s"file/v1/$groupPath/$artifactId/$version/$jarName")
+        if (Files.exists(jarPath)) {
+          if (verbose) println(s"  Found Bzlmod JAR: $jarPath")
+          Some(jarPath)
+        } else {
+          // Also try without the nested path (some artifacts are directly in the directory)
+          val altJarPath = dir.resolve(s"file/$jarName")
+          if (Files.exists(altJarPath)) {
+            if (verbose) println(s"  Found Bzlmod JAR (alt): $altJarPath")
+            Some(altJarPath)
+          } else {
+            None
+          }
+        }
+      }
+    }.getOrElse(None)
+  }
+
+  /**
+   * Find the sources JAR file.
+   */
+  private def findSourcesPath(
+      groupId: String,
+      artifactId: String,
+      version: String,
+      repositoryName: String,
+      externalDir: Option[Path],
+      projectDir: Path,
+      verbose: Boolean
+  ): Option[String] = {
+    val groupPath = groupId.replace('.', '/')
+    val sourcesJarName = s"$artifactId-$version-sources.jar"
+
+    // Build Bzlmod-style directory name for sources: group_artifact_jar_sources_version
+    val bzlmodSourcesDir = toBzlmodSourcesDir(groupId, artifactId, version)
+
+    // Try Bzlmod patterns first
+    val sourcesFromBzlmod = externalDir.flatMap { extDir =>
+      findBzlmodJar(extDir, bzlmodSourcesDir, groupPath, artifactId, version, sourcesJarName, verbose)
+    }
+
+    if (sourcesFromBzlmod.isDefined) return sourcesFromBzlmod.map(_.toString)
+
+    // Try WORKSPACE patterns
+    val workspacePatterns = Seq(
+      s"$repositoryName/v1/https/repo1.maven.org/maven2/$groupPath/$artifactId/$version/$sourcesJarName",
+      s"maven/v1/https/repo1.maven.org/maven2/$groupPath/$artifactId/$version/$sourcesJarName"
+    )
+
+    val sourcesFromWorkspace = externalDir.flatMap { extDir =>
+      workspacePatterns.map(p => extDir.resolve(p)).find(Files.exists(_))
+    }
+
+    if (sourcesFromWorkspace.isDefined) return sourcesFromWorkspace.map(_.toString)
+
+    // Try bazel-<project>/external symlink
+    val bazelProjectPath = Try {
+      val bazelLink = projectDir.resolve(s"bazel-${projectDir.getFileName}")
+      if (Files.exists(bazelLink)) {
+        val extDir = bazelLink.resolve("external")
+        if (Files.exists(extDir)) Some(extDir) else None
+      } else None
+    }.getOrElse(None)
+
+    val sourcesFromBazelProject = bazelProjectPath.flatMap { extDir =>
+      findBzlmodJar(extDir, bzlmodSourcesDir, groupPath, artifactId, version, sourcesJarName, verbose)
+        .orElse(workspacePatterns.map(p => extDir.resolve(p)).find(Files.exists(_)))
+    }
+
+    if (sourcesFromBazelProject.isDefined) return sourcesFromBazelProject.map(_.toString)
+
+    // Fall back to local Maven cache
+    val m2Path = Path.of(
+      System.getProperty("user.home"),
+      ".m2",
+      "repository",
+      groupPath,
+      artifactId,
+      version,
+      sourcesJarName
+    )
+
+    if (Files.exists(m2Path)) Some(m2Path.toString) else None
+  }
+
+  /**
+   * Convert artifact coordinates to Bzlmod sources directory name format.
+   * Example: com.google.guava:guava:32.1.3-android -> com_google_guava_guava_jar_sources_32_1_3_android
+   */
+  private def toBzlmodSourcesDir(groupId: String, artifactId: String, version: String): String = {
+    val sanitize = (s: String) => s.replace('.', '_').replace('-', '_').replace(':', '_')
+    s"${sanitize(groupId)}_${sanitize(artifactId)}_jar_sources_${sanitize(version)}"
+  }
+}

--- a/metals-extract/src/main/scala/scala/meta/metals/extract/GradleExtractor.scala
+++ b/metals-extract/src/main/scala/scala/meta/metals/extract/GradleExtractor.scala
@@ -1,0 +1,158 @@
+package scala.meta.metals.extract
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+import scala.util.Using
+
+import org.gradle.tooling.GradleConnector
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.model.eclipse.EclipseProject
+
+/**
+ * Extracts dependencies from Gradle projects using the Gradle Tooling API.
+ */
+object GradleExtractor {
+
+  def extract(
+      projectDir: Path,
+      resolveSources: Boolean,
+      verbose: Boolean
+  ): Either[String, Seq[DependencyModule]] = {
+    val hasBuildGradle = Files.exists(projectDir.resolve("build.gradle")) ||
+      Files.exists(projectDir.resolve("build.gradle.kts"))
+
+    if (!hasBuildGradle) {
+      return Left(s"No build.gradle or build.gradle.kts found in $projectDir")
+    }
+
+    Try {
+      val connector = GradleConnector.newConnector()
+        .forProjectDirectory(projectDir.toFile)
+
+      // Use gradle wrapper if available
+      val gradlewPath = projectDir.resolve("gradlew")
+      if (Files.exists(gradlewPath)) {
+        if (verbose) println("Using Gradle wrapper")
+        // GradleConnector will automatically detect and use the wrapper
+      }
+
+      Using.resource(connector.connect()) { connection =>
+        extractFromConnection(connection, resolveSources, verbose)
+      }
+    }.toEither.left.map(e => s"Gradle extraction failed: ${e.getMessage}")
+  }
+
+  private def extractFromConnection(
+      connection: ProjectConnection,
+      resolveSources: Boolean,
+      verbose: Boolean
+  ): Seq[DependencyModule] = {
+    // Use EclipseProject model which gives us classpath entries with source attachments
+    val eclipseProject = connection.getModel(classOf[EclipseProject])
+
+    val modules = collectFromProject(eclipseProject, resolveSources, verbose, Set.empty)
+
+    // Remove duplicates by id
+    modules.distinctBy(_.id)
+  }
+
+  private def collectFromProject(
+      project: EclipseProject,
+      resolveSources: Boolean,
+      verbose: Boolean,
+      visited: Set[String]
+  ): Seq[DependencyModule] = {
+    val projectPath = project.getProjectDirectory.getAbsolutePath
+
+    if (visited.contains(projectPath)) {
+      return Seq.empty
+    }
+
+    if (verbose) {
+      println(s"Processing Gradle project: ${project.getName}")
+    }
+
+    val newVisited = visited + projectPath
+
+    // Get classpath entries from this project
+    val entries = project.getClasspath.asScala.toSeq
+
+    val modules = entries.flatMap { entry =>
+      Option(entry.getGradleModuleVersion).flatMap { moduleVersion =>
+        val group = moduleVersion.getGroup
+        val name = moduleVersion.getName
+        val version = moduleVersion.getVersion
+
+        // Skip entries without proper coordinates or SNAPSHOT versions
+        if (group == null || name == null || version == null) {
+          None
+        } else if (version.contains("SNAPSHOT")) {
+          if (verbose) println(s"  Skipping SNAPSHOT: $group:$name:$version")
+          None
+        } else {
+          val jarFile = entry.getFile
+          if (jarFile != null && jarFile.exists()) {
+            val sourcesPath = if (resolveSources) {
+              Option(entry.getSource).map(_.getAbsolutePath).orElse {
+                // Try to find sources in sibling hash directories (Gradle cache structure)
+                findSourcesInGradleCache(jarFile, verbose)
+              }
+            } else None
+
+            Some(DependencyModule(
+              id = s"$group:$name:$version",
+              jar = jarFile.getAbsolutePath,
+              sources = sourcesPath
+            ))
+          } else {
+            None
+          }
+        }
+      }
+    }
+
+    // Recursively process child projects
+    val childModules = project.getChildren.asScala.toSeq.flatMap { child =>
+      collectFromProject(child, resolveSources, verbose, newVisited)
+    }
+
+    modules ++ childModules
+  }
+
+  /**
+   * Gradle cache structure:
+   * ~/.gradle/caches/modules-2/files-2.1/group/name/version/HASH/artifact.jar
+   *
+   * Sources are typically in a sibling hash directory with -sources.jar suffix.
+   */
+  private def findSourcesInGradleCache(
+      jarFile: File,
+      @annotation.nowarn("msg=never used") verbose: Boolean
+  ): Option[String] = {
+    val parent = jarFile.getParentFile // HASH directory
+    if (parent == null) return None
+
+    val versionDir = parent.getParentFile // version directory
+    if (versionDir == null) return None
+
+    // Look through all hash directories at the same level
+    val hashDirs = versionDir.listFiles()
+    if (hashDirs == null) return None
+
+    val sourcesJar = hashDirs.toSeq.flatMap { hashDir =>
+      if (hashDir.isDirectory) {
+        hashDir.listFiles().toSeq.filter { f =>
+          f.getName.endsWith("-sources.jar")
+        }
+      } else {
+        Seq.empty
+      }
+    }.headOption
+
+    sourcesJar.map(_.getAbsolutePath)
+  }
+}

--- a/metals-extract/src/main/scala/scala/meta/metals/extract/MavenExtractor.scala
+++ b/metals-extract/src/main/scala/scala/meta/metals/extract/MavenExtractor.scala
@@ -1,0 +1,418 @@
+package scala.meta.metals.extract
+
+import java.io.FileReader
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.{ArrayList => JArrayList}
+import java.util.{List => JList}
+
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+import scala.util.Using
+
+import org.apache.maven.model.{Dependency => MavenDependency}
+import org.apache.maven.model.Model
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils
+import org.eclipse.aether.RepositorySystem
+import org.eclipse.aether.RepositorySystemSession
+import org.eclipse.aether.artifact.Artifact
+import org.eclipse.aether.artifact.DefaultArtifact
+import org.eclipse.aether.collection.CollectRequest
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory
+import org.eclipse.aether.graph.{Dependency => AetherDependency}
+import org.eclipse.aether.repository.LocalRepository
+import org.eclipse.aether.repository.RemoteRepository
+import org.eclipse.aether.resolution.ArtifactRequest
+import org.eclipse.aether.resolution.ArtifactResult
+import org.eclipse.aether.resolution.DependencyRequest
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory
+import org.eclipse.aether.spi.connector.transport.TransporterFactory
+import org.eclipse.aether.transport.file.FileTransporterFactory
+import org.eclipse.aether.transport.http.HttpTransporterFactory
+import org.eclipse.aether.util.artifact.SubArtifact
+
+/**
+ * Extracts dependencies from Maven projects using the Maven Artifact Resolver API (Eclipse Aether).
+ */
+object MavenExtractor {
+
+  private val m2Repo: Path = {
+    val m2RepoEnv = sys.env.get("M2_REPO")
+    m2RepoEnv match {
+      case Some(path) => Path.of(path)
+      case None => Path.of(System.getProperty("user.home"), ".m2", "repository")
+    }
+  }
+
+  def extract(
+      projectDir: Path,
+      resolveSources: Boolean,
+      verbose: Boolean
+  ): Either[String, Seq[DependencyModule]] = {
+    val pomFile = projectDir.resolve("pom.xml")
+
+    if (!Files.exists(pomFile)) {
+      return Left(s"pom.xml not found in $projectDir")
+    }
+
+    Try {
+      val model = readPom(pomFile)
+      val repoSystem = newRepositorySystem()
+      val session = newSession(repoSystem)
+
+      // Collect all dependencies from the model
+      val dependencies = collectDependencies(model, projectDir, verbose)
+
+      if (verbose) {
+        println(s"Found ${dependencies.size} direct dependencies")
+      }
+
+      // Create repository list (Maven Central + any configured repos)
+      val repositories = getRepositories(model)
+
+      // Resolve all dependencies transitively
+      val resolved = resolveDependencies(repoSystem, session, dependencies, repositories, verbose)
+
+      if (verbose) {
+        println(s"Resolved ${resolved.size} total artifacts (including transitive)")
+      }
+
+      // Convert to DependencyModule format
+      val modules = resolved.flatMap { artifactResult =>
+        val artifact = artifactResult.getArtifact
+        if (artifact != null && artifact.getFile != null) {
+          val jarPath = artifact.getFile.getAbsolutePath
+
+          // Skip SNAPSHOT versions
+          if (artifact.getVersion.contains("SNAPSHOT")) {
+            if (verbose) println(s"  Skipping SNAPSHOT: ${artifact}")
+            None
+          } else {
+            val sourcesPath = if (resolveSources) {
+              resolveSourcesJar(repoSystem, session, artifact, repositories, verbose)
+            } else None
+
+            Some(DependencyModule(
+              id = s"${artifact.getGroupId}:${artifact.getArtifactId}:${artifact.getVersion}",
+              jar = jarPath,
+              sources = sourcesPath
+            ))
+          }
+        } else {
+          None
+        }
+      }.distinctBy(_.id)
+
+      modules
+    }.toEither.left.map(e => s"Maven extraction failed: ${e.getMessage}")
+  }
+
+  private def readPom(pomFile: Path): Model = {
+    Using.resource(new FileReader(pomFile.toFile)) { reader =>
+      new MavenXpp3Reader().read(reader)
+    }
+  }
+
+  private def newRepositorySystem(): RepositorySystem = {
+    val locator = MavenRepositorySystemUtils.newServiceLocator()
+    locator.addService(classOf[RepositoryConnectorFactory], classOf[BasicRepositoryConnectorFactory])
+    locator.addService(classOf[TransporterFactory], classOf[FileTransporterFactory])
+    locator.addService(classOf[TransporterFactory], classOf[HttpTransporterFactory])
+    locator.getService(classOf[RepositorySystem])
+  }
+
+  private def newSession(system: RepositorySystem): RepositorySystemSession = {
+    val session = MavenRepositorySystemUtils.newSession()
+    val localRepo = new LocalRepository(m2Repo.toFile)
+    session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepo))
+    session
+  }
+
+  private def collectDependencies(model: Model, projectDir: Path, verbose: Boolean): Seq[AetherDependency] = {
+    // Get managed dependencies from dependencyManagement (including from parent)
+    val managedVersions = collectManagedVersions(model, projectDir, verbose)
+
+    // First, collect all Maven model dependencies from this POM and parent POMs
+    val directMavenDeps = collectMavenDependencies(model, projectDir, verbose)
+
+    // Also collect dependencies from all submodules (for multi-module projects)
+    val moduleDeps = collectModuleDependencies(model, projectDir, managedVersions, verbose)
+
+    // Convert direct Maven dependencies to Aether dependencies
+    val directAetherDeps = directMavenDeps.flatMap { mavenDep =>
+      convertToAetherDependency(mavenDep, managedVersions, model, verbose)
+    }
+
+    // Combine and deduplicate
+    (directAetherDeps ++ moduleDeps).distinctBy(d => (d.getArtifact.getGroupId, d.getArtifact.getArtifactId))
+  }
+
+  private def collectManagedVersions(model: Model, projectDir: Path, verbose: Boolean): Map[(String, String), String] = {
+    // Get managed versions from parent POM first
+    val parentManagedVersions = Option(model.getParent).flatMap { parent =>
+      val relativePath = Option(parent.getRelativePath).getOrElse("../pom.xml")
+      val parentPomPath = projectDir.resolve(relativePath)
+      if (Files.exists(parentPomPath)) {
+        Try(readPom(parentPomPath)).toOption.map { parentModel =>
+          collectManagedVersions(parentModel, parentPomPath.getParent, verbose)
+        }
+      } else {
+        None
+      }
+    }.getOrElse(Map.empty)
+
+    // Get managed dependencies from this model's dependencyManagement
+    val localManagedDeps = Option(model.getDependencyManagement)
+      .flatMap(dm => Option(dm.getDependencies))
+      .map(_.asScala.toSeq)
+      .getOrElse(Seq.empty)
+
+    val localManagedVersions: Map[(String, String), String] = localManagedDeps.map { d =>
+      (d.getGroupId, d.getArtifactId) -> d.getVersion
+    }.toMap
+
+    // Local versions override parent versions
+    parentManagedVersions ++ localManagedVersions
+  }
+
+  private def collectModuleDependencies(
+      model: Model,
+      projectDir: Path,
+      managedVersions: Map[(String, String), String],
+      verbose: Boolean
+  ): Seq[AetherDependency] = {
+    // Collect properties from parent chain for resolution
+    val parentProperties = collectProperties(model, projectDir)
+
+    val modules = Option(model.getModules).map(_.asScala.toSeq).getOrElse(Seq.empty)
+
+    if (modules.nonEmpty && verbose) {
+      println(s"Processing ${modules.size} submodules...")
+    }
+
+    modules.flatMap { modulePath =>
+      val modulePomPath = projectDir.resolve(modulePath).resolve("pom.xml")
+      if (Files.exists(modulePomPath)) {
+        Try {
+          if (verbose) println(s"  Reading module: $modulePath")
+          val moduleModel = readPom(modulePomPath)
+          val moduleDir = modulePomPath.getParent
+
+          // Recursively collect from this module (including its submodules)
+          val moduleManagedVersions = collectManagedVersions(moduleModel, moduleDir, verbose) ++ managedVersions
+          val moduleMavenDeps = collectMavenDependencies(moduleModel, moduleDir, verbose)
+
+          // Merge properties from parent into module for resolution
+          val moduleProperties = parentProperties ++ collectProperties(moduleModel, moduleDir)
+
+          val moduleAetherDeps = moduleMavenDeps.flatMap { mavenDep =>
+            convertToAetherDependencyWithProps(mavenDep, moduleManagedVersions, moduleModel, moduleProperties, verbose)
+          }
+
+          // Also process nested modules
+          val nestedDeps = collectModuleDependencies(moduleModel, moduleDir, moduleManagedVersions, verbose)
+
+          moduleAetherDeps ++ nestedDeps
+        }.recover { case e =>
+          if (verbose) println(s"  Warning: Failed to read module $modulePath: ${e.getMessage}")
+          Seq.empty[AetherDependency]
+        }.get
+      } else {
+        if (verbose) println(s"  Warning: Module pom.xml not found: $modulePomPath")
+        Seq.empty
+      }
+    }
+  }
+
+  private def collectProperties(model: Model, projectDir: Path): Map[String, String] = {
+    // Get properties from parent first
+    val parentProps = Option(model.getParent).flatMap { parent =>
+      val relativePath = Option(parent.getRelativePath).getOrElse("../pom.xml")
+      val parentPomPath = projectDir.resolve(relativePath)
+      if (Files.exists(parentPomPath)) {
+        Try(readPom(parentPomPath)).toOption.map { parentModel =>
+          collectProperties(parentModel, parentPomPath.getParent)
+        }
+      } else {
+        None
+      }
+    }.getOrElse(Map.empty)
+
+    // Get local properties
+    val localProps = Option(model.getProperties).map { props =>
+      props.stringPropertyNames().asScala.map(k => k -> props.getProperty(k)).toMap
+    }.getOrElse(Map.empty)
+
+    // Add built-in properties
+    val builtinProps = Map(
+      "project.version" -> Option(model.getVersion).getOrElse(""),
+      "project.groupId" -> Option(model.getGroupId).getOrElse(""),
+      "project.artifactId" -> Option(model.getArtifactId).getOrElse("")
+    ).filter(_._2.nonEmpty)
+
+    parentProps ++ localProps ++ builtinProps
+  }
+
+  private def collectMavenDependencies(model: Model, projectDir: Path, verbose: Boolean): Seq[MavenDependency] = {
+    // Handle parent POM if present
+    val parentDeps = Option(model.getParent).flatMap { parent =>
+      val relativePath = Option(parent.getRelativePath).getOrElse("../pom.xml")
+      val parentPomPath = projectDir.resolve(relativePath)
+      if (Files.exists(parentPomPath)) {
+        if (verbose) println(s"Reading parent POM from $parentPomPath")
+        Try(readPom(parentPomPath)).toOption.map { parentModel =>
+          collectMavenDependencies(parentModel, parentPomPath.getParent, verbose)
+        }
+      } else {
+        None
+      }
+    }.getOrElse(Seq.empty)
+
+    // Get dependencies from this model
+    val directDeps: Seq[MavenDependency] = Option(model.getDependencies)
+      .map(_.asScala.toSeq)
+      .getOrElse(Seq.empty)
+
+    parentDeps ++ directDeps
+  }
+
+  private def convertToAetherDependency(
+      mavenDep: MavenDependency,
+      managedVersions: Map[(String, String), String],
+      model: Model,
+      verbose: Boolean
+  ): Option[AetherDependency] = {
+    val properties = collectProperties(model, Path.of("."))
+    convertToAetherDependencyWithProps(mavenDep, managedVersions, model, properties, verbose)
+  }
+
+  private def convertToAetherDependencyWithProps(
+      mavenDep: MavenDependency,
+      managedVersions: Map[(String, String), String],
+      @annotation.nowarn("msg=never used") model: Model,
+      properties: Map[String, String],
+      verbose: Boolean
+  ): Option[AetherDependency] = {
+    // Skip test and provided scope by default
+    val scope = Option(mavenDep.getScope).getOrElse("compile")
+    if (scope == "test" || scope == "provided" || scope == "system") {
+      return None
+    }
+
+    val version = Option(mavenDep.getVersion)
+      .orElse(managedVersions.get((mavenDep.getGroupId, mavenDep.getArtifactId)))
+      .getOrElse {
+        if (verbose) println(s"  Warning: No version for ${mavenDep.getGroupId}:${mavenDep.getArtifactId}")
+        return None
+      }
+
+    // Handle property placeholders like ${project.version} using collected properties
+    val resolvedVersion = resolvePropertiesWithMap(version, properties)
+
+    if (resolvedVersion.startsWith("$")) {
+      if (verbose) println(s"  Warning: Unresolved property in version: $resolvedVersion")
+      return None
+    }
+
+    val classifier = Option(mavenDep.getClassifier).filter(_.nonEmpty)
+    val packaging = Option(mavenDep.getType).getOrElse("jar")
+
+    val artifact = classifier match {
+      case Some(c) =>
+        new DefaultArtifact(mavenDep.getGroupId, mavenDep.getArtifactId, c, packaging, resolvedVersion)
+      case None =>
+        new DefaultArtifact(mavenDep.getGroupId, mavenDep.getArtifactId, packaging, resolvedVersion)
+    }
+
+    Some(new AetherDependency(artifact, scope))
+  }
+
+  private def resolvePropertiesWithMap(value: String, properties: Map[String, String]): String = {
+    val propertyPattern = """\$\{([^}]+)\}""".r
+    propertyPattern.replaceAllIn(value, { m =>
+      val propName = m.group(1)
+      properties.getOrElse(propName, s"$${$propName}")
+    })
+  }
+
+  private def getRepositories(model: Model): JList[RemoteRepository] = {
+    val repos = new JArrayList[RemoteRepository]()
+
+    // Always include Maven Central
+    repos.add(new RemoteRepository.Builder(
+      "central", "default", "https://repo1.maven.org/maven2/"
+    ).build())
+
+    // Add repositories defined in the POM
+    Option(model.getRepositories).foreach { modelRepos =>
+      modelRepos.asScala.foreach { repo =>
+        repos.add(new RemoteRepository.Builder(
+          repo.getId, "default", repo.getUrl
+        ).build())
+      }
+    }
+
+    repos
+  }
+
+  private def resolveDependencies(
+      system: RepositorySystem,
+      session: RepositorySystemSession,
+      dependencies: Seq[AetherDependency],
+      repositories: JList[RemoteRepository],
+      verbose: Boolean
+  ): Seq[ArtifactResult] = {
+    if (dependencies.isEmpty) {
+      return Seq.empty
+    }
+
+    val collectRequest = new CollectRequest()
+    dependencies.foreach(d => collectRequest.addDependency(d))
+    collectRequest.setRepositories(repositories)
+
+    val dependencyRequest = new DependencyRequest(collectRequest, null)
+
+    try {
+      val result = system.resolveDependencies(session, dependencyRequest)
+      result.getArtifactResults.asScala.toSeq
+    } catch {
+      case e: Exception =>
+        if (verbose) {
+          println(s"  Warning: Some dependencies could not be resolved: ${e.getMessage}")
+        }
+        // Try to resolve individually to get partial results
+        dependencies.flatMap { dep =>
+          Try {
+            val request = new ArtifactRequest(dep.getArtifact, repositories, null)
+            system.resolveArtifact(session, request)
+          }.toOption
+        }
+    }
+  }
+
+  private def resolveSourcesJar(
+      system: RepositorySystem,
+      session: RepositorySystemSession,
+      artifact: Artifact,
+      repositories: JList[RemoteRepository],
+      verbose: Boolean
+  ): Option[String] = {
+    val sourcesArtifact = new SubArtifact(artifact, "sources", "jar")
+    val request = new ArtifactRequest(sourcesArtifact, repositories, null)
+
+    Try {
+      val result = system.resolveArtifact(session, request)
+      if (result.getArtifact != null && result.getArtifact.getFile != null) {
+        Some(result.getArtifact.getFile.getAbsolutePath)
+      } else {
+        None
+      }
+    }.getOrElse {
+      if (verbose) {
+        println(s"  No sources jar for ${artifact.getGroupId}:${artifact.getArtifactId}:${artifact.getVersion}")
+      }
+      None
+    }
+  }
+}

--- a/metals-extract/src/main/scala/scala/meta/metals/extract/MbtExtract.scala
+++ b/metals-extract/src/main/scala/scala/meta/metals/extract/MbtExtract.scala
@@ -1,0 +1,271 @@
+package scala.meta.metals.extract
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import scala.util.Try
+
+/**
+ * CLI entry point for metals-extract.
+ *
+ * Extracts dependency information from Maven, Gradle, or Bazel projects
+ * and writes it to .metals/mbt.json for use with Metals.
+ *
+ * Usage:
+ *   metals-extract [options] [project-dir]
+ *
+ * Options:
+ *   --maven       Force Maven extraction
+ *   --gradle      Force Gradle extraction
+ *   --bazel       Force Bazel extraction
+ *   --output      Output file (default: .metals/mbt.json)
+ *   --sources     Also resolve source jars (slower)
+ *   --help        Show help message
+ */
+object MbtExtract {
+
+  case class Config(
+      projectDir: Path = Paths.get(".").toAbsolutePath.normalize,
+      outputFile: Option[Path] = None,
+      forceBuildTool: Option[BuildTool] = None,
+      resolveSources: Boolean = true,
+      verbose: Boolean = false,
+      scalaVersion: Option[String] = None // e.g. "2.12", "2.13", "3"
+  )
+
+  sealed trait BuildTool
+  object BuildTool {
+    case object Maven extends BuildTool
+    case object Gradle extends BuildTool
+    case object Bazel extends BuildTool
+  }
+
+  def main(args: Array[String]): Unit = {
+    parseArgs(args.toList) match {
+      case Left(error) =>
+        System.err.println(s"Error: $error")
+        System.err.println("Use --help for usage information")
+        System.exit(1)
+      case Right(None) =>
+        // Help was printed
+        System.exit(0)
+      case Right(Some(config)) =>
+        run(config) match {
+          case Left(error) =>
+            System.err.println(s"Error: $error")
+            System.exit(1)
+          case Right(count) =>
+            println(s"Successfully extracted $count dependencies to ${outputPath(config)}")
+        }
+    }
+  }
+
+  def run(config: Config): Either[String, Int] = {
+    val projectDir = config.projectDir
+
+    if (!Files.isDirectory(projectDir)) {
+      return Left(s"Project directory does not exist: $projectDir")
+    }
+
+    val buildTool = config.forceBuildTool.getOrElse(detectBuildTool(projectDir))
+
+    val result: Either[String, Seq[DependencyModule]] = buildTool match {
+      case BuildTool.Maven =>
+        println("Extracting dependencies from Maven project...")
+        MavenExtractor.extract(projectDir, config.resolveSources, config.verbose)
+      case BuildTool.Gradle =>
+        println("Extracting dependencies from Gradle project...")
+        GradleExtractor.extract(projectDir, config.resolveSources, config.verbose)
+      case BuildTool.Bazel =>
+        println("Extracting dependencies from Bazel project...")
+        BazelExtractor.extract(projectDir, config.verbose)
+    }
+
+    result.flatMap { modules =>
+      val filtered = filterByScalaVersion(modules, config.scalaVersion)
+      writeOutput(config, filtered)
+    }
+  }
+
+  /**
+   * Filter dependencies by Scala version suffix.
+   * If scalaVersion is None, returns all modules.
+   * If scalaVersion is Some("2.13"), filters out artifacts ending with _2.12 or _3
+   */
+  private def filterByScalaVersion(
+      modules: Seq[DependencyModule],
+      scalaVersion: Option[String]
+  ): Seq[DependencyModule] = {
+    scalaVersion match {
+      case None => modules
+      case Some(version) =>
+        // Suffixes to exclude based on target version
+        val excludeSuffixes = version match {
+          case v if v.startsWith("2.12") => Seq("_2.13", "_3")
+          case v if v.startsWith("2.13") => Seq("_2.12", "_3")
+          case v if v.startsWith("3") => Seq("_2.12", "_2.13")
+          case _ => Seq.empty
+        }
+
+        modules.filter { m =>
+          val artifactId = m.id.split(":").lift(1).getOrElse("")
+          // Check if this artifact has a Scala version suffix
+          val hasScalaSuffix = artifactId.matches(".*_\\d+(\\.\\d+)?$") ||
+            artifactId.matches(".*_3$")
+
+          if (!hasScalaSuffix) {
+            // No Scala suffix, keep it (Java library)
+            true
+          } else {
+            // Has Scala suffix, check if it matches target or should be excluded
+            !excludeSuffixes.exists(suffix => artifactId.endsWith(suffix))
+          }
+        }
+    }
+  }
+
+  private def detectBuildTool(projectDir: Path): BuildTool = {
+    val hasMaven = Files.exists(projectDir.resolve("pom.xml"))
+    val hasGradle = Files.exists(projectDir.resolve("build.gradle")) ||
+      Files.exists(projectDir.resolve("build.gradle.kts"))
+    val hasBazel = Files.exists(projectDir.resolve("WORKSPACE")) ||
+      Files.exists(projectDir.resolve("WORKSPACE.bazel")) ||
+      Files.exists(projectDir.resolve("MODULE.bazel"))
+
+    (hasMaven, hasGradle, hasBazel) match {
+      case (true, false, false) => BuildTool.Maven
+      case (false, true, false) => BuildTool.Gradle
+      case (false, false, true) => BuildTool.Bazel
+      case (true, true, _) =>
+        System.err.println("Warning: Both Maven and Gradle detected, using Maven")
+        BuildTool.Maven
+      case (_, _, true) if hasMaven || hasGradle =>
+        System.err.println("Warning: Bazel detected alongside Maven/Gradle, using Bazel")
+        BuildTool.Bazel
+      case _ =>
+        System.err.println("Warning: No build tool detected, trying Maven")
+        BuildTool.Maven
+    }
+  }
+
+  private def outputPath(config: Config): Path = {
+    config.outputFile.getOrElse(config.projectDir.resolve(".metals/mbt.json"))
+  }
+
+  private def writeOutput(config: Config, modules: Seq[DependencyModule]): Either[String, Int] = {
+    val output = outputPath(config)
+    Try {
+      Files.createDirectories(output.getParent)
+      val mbtBuild = MbtBuild(modules)
+      val json = mbtBuild.toJson
+      Files.writeString(output, json)
+      modules.size
+    }.toEither.left.map(e => s"Failed to write output: ${e.getMessage}")
+  }
+
+  private def parseArgs(args: List[String]): Either[String, Option[Config]] = {
+    def loop(args: List[String], config: Config): Either[String, Option[Config]] = {
+      args match {
+        case Nil => Right(Some(config))
+        case "--help" :: _ =>
+          printHelp()
+          Right(None)
+        case "--maven" :: rest =>
+          loop(rest, config.copy(forceBuildTool = Some(BuildTool.Maven)))
+        case "--gradle" :: rest =>
+          loop(rest, config.copy(forceBuildTool = Some(BuildTool.Gradle)))
+        case "--bazel" :: rest =>
+          loop(rest, config.copy(forceBuildTool = Some(BuildTool.Bazel)))
+        case "--output" :: path :: rest =>
+          loop(rest, config.copy(outputFile = Some(Paths.get(path))))
+        case "--cwd" :: path :: rest =>
+          val projectPath = Paths.get(path).toAbsolutePath.normalize
+          loop(rest, config.copy(projectDir = projectPath))
+        case "-C" :: path :: rest =>
+          val projectPath = Paths.get(path).toAbsolutePath.normalize
+          loop(rest, config.copy(projectDir = projectPath))
+        case "--sources" :: rest =>
+          loop(rest, config.copy(resolveSources = true))
+        case "--no-sources" :: rest =>
+          loop(rest, config.copy(resolveSources = false))
+        case "--verbose" :: rest =>
+          loop(rest, config.copy(verbose = true))
+        case "-v" :: rest =>
+          loop(rest, config.copy(verbose = true))
+        case "--scala-version" :: version :: rest =>
+          loop(rest, config.copy(scalaVersion = Some(version)))
+        case path :: rest if !path.startsWith("-") =>
+          val projectPath = Paths.get(path).toAbsolutePath.normalize
+          loop(rest, config.copy(projectDir = projectPath))
+        case unknown :: _ =>
+          Left(s"Unknown option: $unknown")
+      }
+    }
+    loop(args, Config())
+  }
+
+  private def printHelp(): Unit = {
+    println("""metals-extract - Extract dependency information for Metals
+              |
+              |Usage: metals-extract [options] [project-dir]
+              |
+              |Options:
+              |  --cwd, -C <path>       Set project directory (alternative to positional arg)
+              |  --maven                Force Maven extraction (even if Gradle/Bazel files exist)
+              |  --gradle               Force Gradle extraction (even if Maven/Bazel files exist)
+              |  --bazel                Force Bazel extraction (even if Maven/Gradle files exist)
+              |  --output <path>        Output file (default: <project>/.metals/mbt.json)
+              |  --sources              Resolve source jars (default: enabled)
+              |  --no-sources           Skip resolving source jars (faster)
+              |  --scala-version <ver>  Filter by Scala version (2.12, 2.13, or 3)
+              |  --verbose, -v          Enable verbose output
+              |  --help                 Show this help message
+              |
+              |Auto-detection:
+              |  - pom.xml present                       -> Maven
+              |  - build.gradle(.kts) present            -> Gradle
+              |  - WORKSPACE(.bazel) or MODULE.bazel     -> Bazel
+              |
+              |Examples:
+              |  metals-extract                          # Extract from current directory
+              |  metals-extract /path/to/project         # Extract from specified directory
+              |  metals-extract --scala-version 2.13     # Filter to Scala 2.13 artifacts only
+              |  metals-extract --bazel --scala-version 3  # Bazel project, Scala 3 only
+              |  metals-extract --no-sources             # Skip source jar resolution
+              |""".stripMargin)
+  }
+}
+
+/**
+ * Represents a single dependency module with its coordinates and file paths.
+ */
+case class DependencyModule(
+    id: String, // e.g. "com.google.guava:guava:30.0-jre"
+    jar: String, // absolute path to jar
+    sources: Option[String] = None // absolute path to sources jar
+)
+
+/**
+ * The mbt.json format that Metals reads.
+ */
+case class MbtBuild(dependencyModules: Seq[DependencyModule]) {
+  def toJson: String = {
+    val modulesJson = dependencyModules.map { m =>
+      val sourcesField = m.sources match {
+        case Some(s) => s""", "sources": "${escapeJson(s)}""""
+        case None => ""
+      }
+      s"""    { "id": "${escapeJson(m.id)}", "jar": "${escapeJson(m.jar)}"$sourcesField }"""
+    }
+    s"""{
+       |  "dependencyModules": [
+       |${modulesJson.mkString(",\n")}
+       |  ]
+       |}""".stripMargin
+  }
+
+  private def escapeJson(s: String): String = {
+    s.replace("\\", "\\\\").replace("\"", "\\\"")
+  }
+}


### PR DESCRIPTION
Previously, users had to install Bun and run the mbt-extract.ts script to extract build data. This commit introduces a new alternative to create `mbt.json`, a Scala CLI using more official APIs:
- Maven Artifact Resolver API (Eclipse Aether) for Maven projects
- Gradle Tooling API for Gradle projects
- Parses maven_install.json for Bazel projects (bazel query/aspects for full support)

Implements extractors for Maven, Gradle, and Bazel projects that generate mbt.json files containing dependency information for Metals.

MavenExtractor features:
- Uses Maven Artifact Resolver API (Eclipse Aether)
- Support for parent POM inheritance
- Support for multi-module projects (recursive submodule processing)
- DependencyManagement version resolution
- Property placeholder resolution (${project.version}, etc.)
- Transitive dependency resolution
- Skips test, provided, and system scope dependencies
- Uses ~/.m2/repository (or M2_REPO env var) as local cache
- Supports custom repositories defined in pom.xml

GradleExtractor features:
- Uses Gradle Tooling API with EclipseProject model
- Support for build.gradle and build.gradle.kts
- Auto-detects and uses Gradle wrapper when available
- Recursively processes child projects in multi-project builds
- Finds sources JARs in Gradle cache structure
- Deduplicates dependencies by artifact ID

BazelExtractor features:
- Support for Bazel 7.x Bzlmod naming (~ separators)
- Support for Bazel 8.x Bzlmod naming (++ and + separators)
- Support for legacy dependency_tree format (rules_jvm_external v4)
- Support for WORKSPACE mode
- Process ALL maven_install*.json files and merge results
- Download missing JARs from Maven Central using URLs in JSON
- Fallback to .m2 cache when Bazel JARs not found

CLI options:
- --scala-version <ver>  Filter by Scala version (2.12, 2.13, or 3) Excludes artifacts with non-matching Scala suffixes (_2.12, _2.13, _3)

Tested against:
- bazel-bsp: 100 deps (Bazel 7.0.2)
- rules_jvm_external/bzlmod: 66 deps (Bazel 8.3.1)
- salesforce/rules_spring: 183 deps (Bazel 7.4.1)
- linafx/digital-assets: 322 deps with --scala-version 2.13
- ValdemarGr/mezel: 23 deps with --scala-version 2.13