### PR TITLE
improvement: Properly set minimum Bloop version instead of using current

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BloopServers.scala
@@ -531,4 +531,6 @@ object BloopServers {
   }
 
   def defaultBloopVersion = BloopRifleConfig.defaultVersion
+
+  def minimumBloopVersion = "2.0.17"
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
@@ -528,7 +528,7 @@ class ConnectionProvider(
         if (!notification.isDismissed) {
           val messageParams = IncompatibleBloopVersion.params(
             bspServerVersion,
-            BuildInfo.bloopVersion,
+            BloopServers.minimumBloopVersion,
             isChangedInSettings = userConfig.bloopVersion != None,
           )
           languageClient

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/ProblemResolver.scala
@@ -5,7 +5,6 @@ import scala.concurrent.ExecutionContext
 
 import scala.meta.internal.bsp.BspSession
 import scala.meta.internal.metals.BloopServers
-import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.JavaInfo
 import scala.meta.internal.metals.JavaTarget
 import scala.meta.internal.metals.JdkSources
@@ -31,7 +30,7 @@ class ProblemResolver(
       case Some(bspSession) =>
         bspSession.main.name == BloopServers.name && !SemVer
           .isCompatibleVersion(
-            BuildInfo.bloopVersion,
+            BloopServers.minimumBloopVersion,
             bspSession.main.version,
           )
       case None =>

--- a/metals/src/main/scala/scala/meta/internal/metals/doctor/ScalaProblem.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/doctor/ScalaProblem.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.metals.doctor
 
+import scala.meta.internal.metals.BloopServers
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.ScalaVersions
 import scala.meta.io.AbsolutePath
@@ -62,7 +63,7 @@ case class SemanticDBDisabled(
 ) extends ScalaProblem {
   override def message: String = {
     if (unsupportedBloopVersion) {
-      s"""|The installed Bloop server version is $bloopVersion while Metals requires at least Bloop version ${BuildInfo.bloopVersion},
+      s"""|The installed Bloop server version is $bloopVersion while Metals requires at least Bloop version ${BloopServers.minimumBloopVersion},
           |To fix this problem please update your Bloop server.""".stripMargin
     } else if (
       ScalaVersions.isSupportedAtReleaseMomentScalaVersion(scalaVersion)


### PR DESCRIPTION
This will avoid hard to understand messages for the users. This isn't really useful to show.