### PR TITLE
fix: Filter out internal package objects from workspace symbol search

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSearchVisitor.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceSearchVisitor.scala
@@ -106,6 +106,9 @@ class WorkspaceSearchVisitor(
       range: l.Range,
   ): Int = {
     val (desc, owner) = DescriptorParser(symbol)
+    if (desc.name.value.endsWith("$package")) {
+      return 0
+    }
     fromWorkspace.add(
       new l.SymbolInformation(
         desc.name.value,
@@ -139,12 +142,16 @@ class WorkspaceSearchVisitor(
         includeMembers = false,
       ) { semanticDefn =>
         if (query.matches(semanticDefn.info)) {
-          val adjustedPath =
-            if (saveClassFileToDisk) path.toFileOnDisk(workspace)
-            else path
-          val uri = adjustedPath.toURI.toString
-          fromClasspath.add(semanticDefn.toLsp(uri))
-          isHit = true
+          val (desc, _) = DescriptorParser(semanticDefn.info.symbol)
+          if (!desc.name.value.endsWith("$package")) {
+
+            val adjustedPath =
+              if (saveClassFileToDisk) path.toFileOnDisk(workspace)
+              else path
+            val uri = adjustedPath.toURI.toString
+            fromClasspath.add(semanticDefn.toLsp(uri))
+            isHit = true
+          }
         }
       }
     }

--- a/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/WorkspaceSymbolLspSuite.scala
@@ -427,4 +427,25 @@ class WorkspaceSymbolLspSuite extends BaseLspSuite("workspace-symbol") {
       )
     } yield ()
   }
+  test("scala3-toplevel-package") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": { "scalaVersion": "${V.scala3}" }
+           |}
+           |/a/src/main/scala/a/MyFile.scala
+           |package a
+           |def foo = 1
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/a/MyFile.scala")
+      _ = assertNoDiff(
+        server.workspaceSymbol("MyFile"),
+        "",
+      )
+    } yield ()
+  }
 }


### PR DESCRIPTION
## Summary
Fixes an issue where internal artifacts, such as `$package` symbols generated by Scala 3 top-level definitions or package objects, were appearing in workspace symbol search results. These symbols are implementation details and not useful for users.

Fixes #7040

## Changes
- **WorkspaceSearchVisitor**: Updated `visitWorkspaceSymbol` and `expandClassfile` to explicitly filter out symbols ending in `$package` from both workspace and classpath searches.
- **Tests**: Added a regression test (`scala3-toplevel-package`) in `WorkspaceSymbolLspSuite` to verify that searching for a file with top-level definitions does not return the internal `$package` symbol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace symbol search to exclude package-level synthetic symbols from results, ensuring cleaner and more relevant search outcomes when looking up symbols in your workspace.

* **Tests**
  * Added test coverage for Scala 3 top-level package symbol handling to verify correct behavior in workspace symbol lookups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->