### PR TITLE
chore: Add standalone metal MCP server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -507,6 +507,15 @@ lazy val metals = project
   .dependsOn(mtags, `mtags-java`)
   .enablePlugins(BuildInfoPlugin)
 
+lazy val `metals-mcp` = project
+  .in(file("metals-mcp"))
+  .settings(
+    sharedSettings,
+    moduleName := "metals-mcp",
+    Compile / mainClass := Some("scala.meta.metals.McpMain"),
+  )
+  .dependsOn(metals)
+
 lazy val `sbt-metals` = project
   .settings(
     buildInfoPackage := "scala.meta.internal.sbtmetals",
@@ -779,7 +788,7 @@ lazy val slow = project
       .dependsOn(`sbt-metals` / publishLocal, publishBinaryMtags)
       .value,
   )
-  .dependsOn(unit)
+  .dependsOn(unit, `metals-mcp`)
 
 lazy val bench = project
   .in(file("metals-bench"))

--- a/metals-mcp/src/main/scala/scala/meta/internal/metals/mcp/McpLanguageClient.scala
+++ b/metals-mcp/src/main/scala/scala/meta/internal/metals/mcp/McpLanguageClient.scala
@@ -1,0 +1,260 @@
+package scala.meta.internal.metals.mcp
+
+import java.util.concurrent.CompletableFuture
+import java.{util => ju}
+
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.TextEdits
+import scala.meta.internal.metals.clients.language.MetalsInputBoxParams
+import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.clients.language.MetalsQuickPickParams
+import scala.meta.internal.metals.clients.language.MetalsStatusParams
+import scala.meta.internal.metals.clients.language.RawMetalsInputBoxResult
+import scala.meta.internal.metals.clients.language.RawMetalsQuickPickResult
+import scala.meta.internal.tvp.TreeViewDidChangeParams
+import scala.meta.io.AbsolutePath
+
+import org.eclipse.lsp4j.ApplyWorkspaceEditParams
+import org.eclipse.lsp4j.ApplyWorkspaceEditResponse
+import org.eclipse.lsp4j.ConfigurationParams
+import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.MessageActionItem
+import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.MessageType
+import org.eclipse.lsp4j.ProgressParams
+import org.eclipse.lsp4j.PublishDiagnosticsParams
+import org.eclipse.lsp4j.RegistrationParams
+import org.eclipse.lsp4j.ShowDocumentParams
+import org.eclipse.lsp4j.ShowDocumentResult
+import org.eclipse.lsp4j.ShowMessageRequestParams
+import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j.UnregistrationParams
+import org.eclipse.lsp4j.WorkDoneProgressCreateParams
+import org.eclipse.lsp4j.WorkspaceFolder
+
+/**
+ * An implementation of MetalsLanguageClient for standalone MCP mode.
+ *
+ * This client is used when running Metals as a standalone MCP server without
+ * an LSP client connection. It logs messages to scribe instead of sending them
+ * to a client, and handles workspace edits by writing directly to files.
+ *
+ * @param workspace The workspace root path, used for resolving file paths
+ */
+class McpLanguageClient(workspace: AbsolutePath) extends MetalsLanguageClient {
+
+  override def telemetryEvent(value: Object): Unit = {
+    scribe.debug(s"[MCP Telemetry] $value")
+  }
+
+  override def publishDiagnostics(
+      diagnostics: PublishDiagnosticsParams
+  ): Unit = {
+    // diagnotics are server via the compile request
+  }
+
+  override def showMessage(message: MessageParams): Unit = {
+    val level = message.getType match {
+      case MessageType.Error => "ERROR"
+      case MessageType.Warning => "WARN"
+      case MessageType.Info => "INFO"
+      case MessageType.Log => "DEBUG"
+      case _ => "INFO"
+    }
+    scribe.info(s"[MCP $level] ${message.getMessage}")
+  }
+
+  override def showMessageRequest(
+      request: ShowMessageRequestParams
+  ): CompletableFuture[MessageActionItem] = {
+
+    if (request.getMessage.contains("workspace detected")) {
+      CompletableFuture.completedFuture(Messages.ImportBuild.yes)
+    } else {
+      scribe.error(s"[MCP Request not handled] ${request.getMessage}")
+      // Return null to indicate no selection (as there's no user to interact with)
+      CompletableFuture.completedFuture(null)
+    }
+  }
+
+  override def logMessage(message: MessageParams): Unit = {
+    message.getType match {
+      case MessageType.Error => scribe.error(s"[MCP Log] ${message.getMessage}")
+      case MessageType.Warning =>
+        scribe.warn(s"[MCP Log] ${message.getMessage}")
+      case MessageType.Info => scribe.info(s"[MCP Log] ${message.getMessage}")
+      case _ => scribe.debug(s"[MCP Log] ${message.getMessage}")
+    }
+  }
+
+  /**
+   * Apply workspace edits by writing directly to files.
+   *
+   * In standalone MCP mode, we don't have an LSP client to apply edits,
+   * so we write changes directly to the filesystem.
+   */
+  override def applyEdit(
+      params: ApplyWorkspaceEditParams
+  ): CompletableFuture[ApplyWorkspaceEditResponse] = {
+    val edit = params.getEdit
+    val response = new ApplyWorkspaceEditResponse(true)
+
+    def updateFile(path: AbsolutePath, textEdits: ju.List[TextEdit]): Unit = {
+      val content = path.readText
+      val currentContent =
+        TextEdits.applyEdits(content, textEdits.asScala.toList)
+      path.writeText(currentContent)
+
+      scribe.debug(
+        s"[MCP Edit] Applied ${textEdits.size} versioned edit(s) to $path"
+      )
+    }
+
+    try {
+      // Handle document changes
+      val changes = Option(edit.getChanges)
+      changes.foreach { changesMap =>
+        changesMap.forEach { (uri, textEdits) =>
+          val path = uri.toAbsolutePath
+          if (path.exists) {
+            updateFile(path, textEdits)
+          }
+        }
+      }
+
+      // Handle document changes (versioned)
+      val documentChanges = Option(edit.getDocumentChanges)
+      documentChanges.foreach { changes =>
+        changes.forEach { change =>
+          if (change.isLeft) {
+            val textDocEdit = change.getLeft
+            val uri = textDocEdit.getTextDocument.getUri
+            val path = uri.toAbsolutePath
+
+            if (path.exists) {
+              val textEdits = textDocEdit.getEdits
+              updateFile(path, textEdits)
+            }
+          }
+        }
+      }
+
+    } catch {
+      case e: Exception =>
+        scribe.error(s"[MCP Edit] Failed to apply edits: ${e.getMessage}", e)
+        response.setApplied(false)
+        response.setFailureReason(e.getMessage)
+    }
+
+    CompletableFuture.completedFuture(response)
+  }
+
+  override def metalsTreeViewDidChange(
+      params: TreeViewDidChangeParams
+  ): Unit = {
+    scribe.debug(s"[MCP TreeView] Changed: ${params.nodes.length} nodes")
+  }
+
+  // Status bar - log to scribe
+  override def metalsStatus(params: MetalsStatusParams): Unit = {
+    if (params.text != null && params.text.nonEmpty) {
+      scribe.info(s"[MCP Status] ${params.text}")
+    }
+  }
+
+  // Execute client command - no-op,
+  override def metalsExecuteClientCommand(
+      params: ExecuteCommandParams
+  ): Unit = {
+    scribe.debug(s"[MCP Command] ${params.getCommand}")
+  }
+
+  // Refresh model - no-op
+  override def refreshModel(): CompletableFuture[Unit] = {
+    CompletableFuture.completedFuture(())
+  }
+
+  // Input box - return cancelled (no user interaction)
+  override def rawMetalsInputBox(
+      params: MetalsInputBoxParams
+  ): CompletableFuture[RawMetalsInputBoxResult] = {
+    scribe.debug(s"[MCP InputBox] ${params.prompt}")
+    CompletableFuture.completedFuture(RawMetalsInputBoxResult(cancelled = true))
+  }
+
+  // Quick pick - return cancelled (no user interaction)
+  override def rawMetalsQuickPick(
+      params: MetalsQuickPickParams
+  ): CompletableFuture[RawMetalsQuickPickResult] = {
+    scribe.debug(s"[MCP QuickPick] ${params.placeHolder}")
+    CompletableFuture.completedFuture(
+      RawMetalsQuickPickResult(cancelled = true)
+    )
+  }
+
+  // Progress - log to scribe
+  override def createProgress(
+      params: WorkDoneProgressCreateParams
+  ): CompletableFuture[Void] = {
+    CompletableFuture.completedFuture(null)
+  }
+
+  override def notifyProgress(params: ProgressParams): Unit = {
+    // Progress notifications are logged at debug level
+    scribe.debug(s"[MCP Progress] ${params.getToken}")
+  }
+
+  // Registration - no-op
+  override def registerCapability(
+      params: RegistrationParams
+  ): CompletableFuture[Void] = {
+    CompletableFuture.completedFuture(null)
+  }
+
+  override def unregisterCapability(
+      params: UnregistrationParams
+  ): CompletableFuture[Void] = {
+    CompletableFuture.completedFuture(null)
+  }
+
+  // Configuration - return empty
+  override def configuration(
+      params: ConfigurationParams
+  ): CompletableFuture[java.util.List[Object]] = {
+    CompletableFuture.completedFuture(java.util.Collections.emptyList())
+  }
+
+  // Workspace folders - return workspace
+  override def workspaceFolders()
+      : CompletableFuture[java.util.List[WorkspaceFolder]] = {
+    val folder =
+      new WorkspaceFolder(workspace.toURI.toString, workspace.filename)
+    CompletableFuture.completedFuture(
+      java.util.Collections.singletonList(folder)
+    )
+  }
+
+  // Show document - no-op
+  override def showDocument(
+      params: ShowDocumentParams
+  ): CompletableFuture[ShowDocumentResult] = {
+    scribe.debug(s"[MCP ShowDocument] ${params.getUri}")
+    CompletableFuture.completedFuture(new ShowDocumentResult(false))
+  }
+
+  // Semantic tokens refresh - no-op
+  override def refreshSemanticTokens(): CompletableFuture[Void] = {
+    CompletableFuture.completedFuture(null)
+  }
+
+  // Inlay hints refresh - no-op
+  override def refreshInlayHints(): CompletableFuture[Void] = {
+    CompletableFuture.completedFuture(null)
+  }
+
+  // Code lens refresh - no-op
+  override def refreshCodeLenses(): CompletableFuture[Void] = {
+    CompletableFuture.completedFuture(null)
+  }
+}

--- a/metals-mcp/src/main/scala/scala/meta/internal/metals/mcp/StandaloneMcpService.scala
+++ b/metals-mcp/src/main/scala/scala/meta/internal/metals/mcp/StandaloneMcpService.scala
@@ -1,0 +1,168 @@
+package scala.meta.internal.metals.mcp
+
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContextExecutorService
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.util.control.NonFatal
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals._
+import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
+import scala.meta.internal.metals.doctor.HeadDoctor
+import scala.meta.io.AbsolutePath
+
+/**
+ * Standalone MCP service that initializes Metals components for MCP server mode
+ * without requiring an LSP client connection.
+ *
+ * This service provides a lightweight way to run Metals as a standalone MCP server,
+ * enabling AI agents and tools to interact with Scala projects directly.
+ *
+ * @param workspace The workspace root path
+ * @param port Optional port for HTTP transport
+ * @param transport Transport type (HTTP or stdio, reserved for future use)
+ * @param scheduledExecutor Scheduled executor for background tasks
+ */
+class StandaloneMcpService(
+    workspace: AbsolutePath,
+    port: Option[Int],
+    scheduledExecutor: ScheduledExecutorService,
+)(implicit ec: ExecutionContextExecutorService)
+    extends Cancelable {
+  port match {
+    case Some(port) =>
+      McpConfig.writeConfig(port, workspace.filename, workspace, NoClient)
+    case None =>
+    // random port will be assigned by the system
+  }
+
+  private val cancelables = new MutableCancelable()
+  private val isCancelled = new AtomicBoolean(false)
+
+  private val time: Time = Time.system
+
+  private val clientConfig: ClientConfiguration = ClientConfiguration(
+    MetalsServerConfig.default
+  )
+
+  private val mcpClient = new ConfiguredLanguageClient(
+    new McpLanguageClient(workspace),
+    clientConfig,
+    None,
+  )
+
+  private val statusBar: StatusBar = new StatusBar(mcpClient, time)
+
+  private val timerProvider: TimerProvider = new TimerProvider(time)
+
+  private val workDoneProgress: WorkDoneProgress =
+    new WorkDoneProgress(mcpClient, time)
+
+  private val headDoctor = new HeadDoctor(
+    () => List.empty,
+    () => Future.successful(None),
+    clientConfig,
+    mcpClient,
+    isHttpEnabled = false,
+  )
+
+  private lazy val moduleStatus: ModuleStatus =
+    new ModuleStatus(
+      mcpClient,
+      () => None,
+      (path) => projectMetalsLspService,
+      clientConfig.icons(),
+    )
+
+  private val bspStatus = new BspStatus(
+    mcpClient,
+    isBspStatusProvider = false,
+  )
+
+  lazy val projectMetalsLspService = new ProjectMetalsLspService(
+    ec,
+    scheduledExecutor,
+    MetalsServerInputs.productionConfiguration,
+    mcpClient,
+    StandaloneMcpService.defaultInitializeParams,
+    clientConfig,
+    statusBar,
+    () => None,
+    timerProvider,
+    () => (),
+    workspace,
+    None,
+    headDoctor,
+    bspStatus,
+    workDoneProgress,
+    maxScalaCliServers = 3,
+    moduleStatus,
+  )
+
+  /**
+   * Run the MCP server. This blocks until shutdown.
+   */
+  def startAndBlock(): Unit = {
+    start()
+    // Block until shutdown signal
+    synchronized {
+      while (!isCancelled.get()) {
+        try {
+          wait(1000)
+        } catch {
+          case _: InterruptedException =>
+            isCancelled.set(true)
+        }
+      }
+    }
+  }
+
+  def start(): Unit = {
+    scribe.info("Starting MCP server...")
+    Await.result(projectMetalsLspService.initialized(), 10.minutes)
+    Await.result(projectMetalsLspService.startMcpServer(), 2.minutes)
+    cancelables.add(projectMetalsLspService)
+
+    scribe.info("MCP server started successfully")
+  }
+
+  override def cancel(): Unit = {
+    if (isCancelled.compareAndSet(false, true)) {
+      scribe.info("Cancelling standalone MCP service...")
+      try {
+        cancelables.cancel()
+      } catch {
+        case NonFatal(e) =>
+          scribe.warn("Error cancelling services", e)
+      }
+      // Wake up the startAndBlock() method
+      synchronized {
+        notifyAll()
+      }
+
+      scribe.info("Standalone MCP service cancelled")
+    }
+  }
+
+}
+
+object StandaloneMcpService {
+  import org.eclipse.lsp4j.InitializeParams
+  import org.eclipse.lsp4j.ClientCapabilities
+  import org.eclipse.lsp4j.ClientInfo
+
+  // Default initialize params for standalone mode
+  val defaultInitializeParams: InitializeParams = {
+    val params = new InitializeParams()
+    params.setCapabilities(new ClientCapabilities())
+    val clientInfo = new ClientInfo()
+    clientInfo.setName("metals-mcp-standalone")
+    clientInfo.setVersion(BuildInfo.metalsVersion)
+    params.setClientInfo(clientInfo)
+    params
+  }
+}

--- a/metals-mcp/src/main/scala/scala/meta/metals/McpMain.scala
+++ b/metals-mcp/src/main/scala/scala/meta/metals/McpMain.scala
@@ -1,0 +1,185 @@
+package scala.meta.metals
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.Executors
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutorService
+import scala.util.control.NonFatal
+
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.logging.MetalsLogger
+import scala.meta.internal.metals.mcp.StandaloneMcpService
+import scala.meta.io.AbsolutePath
+
+/**
+ * Entry point for standalone MCP server mode.
+ *
+ * This allows Metals to run as a standalone MCP (Model Context Protocol) server
+ * without requiring an LSP client connection, enabling AI agents and tools to
+ * interact with Scala projects directly via MCP.
+ *
+ * Usage:
+ *   metals-mcp --workspace /path/to/project [--port <number>] [--transport <stdio|http>]
+ */
+object McpMain {
+
+  sealed trait Transport
+  object Transport {
+    case object Http extends Transport
+    case object Stdio extends Transport
+
+    def fromString(s: String): Option[Transport] = s.toLowerCase match {
+      case "http" => Some(Http)
+      case "stdio" => Some(Stdio)
+      case _ => None
+    }
+  }
+
+  case class Config(
+      workspace: Option[AbsolutePath] = None,
+      port: Option[Int] = None,
+      transport: Transport = Transport.Http,
+  )
+
+  def main(args: Array[String]): Unit = {
+    parseArgs(args.toList) match {
+      case Left(error) =>
+        System.err.println(s"Error: $error")
+        printUsage()
+        sys.exit(1)
+
+      case Right(config) if config.workspace.isEmpty =>
+        System.err.println("Error: --workspace is required")
+        printUsage()
+        sys.exit(1)
+
+      case Right(config) =>
+        runServer(config)
+    }
+  }
+
+  private def parseArgs(args: List[String]): Either[String, Config] = {
+    def parse(
+        remaining: List[String],
+        config: Config,
+    ): Either[String, Config] = {
+      remaining match {
+        case Nil => Right(config)
+
+        case ("--help" | "-h") :: _ =>
+          printUsage()
+          sys.exit(0)
+
+        case ("--version" | "-v") :: _ =>
+          println(s"metals-mcp ${BuildInfo.metalsVersion}")
+          sys.exit(0)
+
+        case "--workspace" :: path :: rest =>
+          val absPath = AbsolutePath(Path.of(path).toAbsolutePath)
+          if (!Files.isDirectory(absPath.toNIO)) {
+            Left(s"Workspace path does not exist or is not a directory: $path")
+          } else {
+            parse(rest, config.copy(workspace = Some(absPath)))
+          }
+
+        case "--port" :: portStr :: rest =>
+          portStr.toIntOption match {
+            case Some(port) if port > 0 && port < 65536 =>
+              parse(rest, config.copy(port = Some(port)))
+            case _ =>
+              Left(s"Invalid port number: $portStr")
+          }
+
+        case "--transport" :: transportStr :: rest =>
+          Transport.fromString(transportStr) match {
+            case Some(transport) =>
+              parse(rest, config.copy(transport = transport))
+            case None =>
+              Left(
+                s"Invalid transport: $transportStr. Valid options: http, stdio"
+              )
+          }
+
+        case unknown :: _ =>
+          Left(s"Unknown argument: $unknown")
+      }
+    }
+
+    parse(args, Config())
+  }
+
+  private def printUsage(): Unit = {
+    println(
+      s"""
+         |Metals MCP Server ${BuildInfo.metalsVersion}
+         |
+         |A standalone MCP (Model Context Protocol) server for Scala projects.
+         |
+         |Usage:
+         |  metals-mcp --workspace <path> [options]
+         |
+         |Options:
+         |  --workspace <path>      Path to the Scala project (required)
+         |  --port <number>         HTTP port to listen on (default: auto-assign)
+         |  --transport <type>      Transport type: http (default) or stdio (reserved for future use)
+         |  --help, -h              Show this help message
+         |  --version, -v           Show version information
+         |
+         |Examples:
+         |  # Start MCP server for a project
+         |  metals-mcp --workspace /path/to/project
+         |
+         |  # Start with specific port
+         |  metals-mcp --workspace /path/to/project --port 8080
+         |
+         |  # Start in stdio mode for direct process integration
+         |  metals-mcp --workspace /path/to/project --transport stdio
+         |
+         |""".stripMargin
+    )
+  }
+
+  private def runServer(config: Config): Unit = {
+    val workspace = config.workspace.get
+    val exec = Executors.newCachedThreadPool()
+    implicit val ec: ExecutionContextExecutorService =
+      ExecutionContext.fromExecutorService(exec)
+    val sh = Executors.newSingleThreadScheduledExecutor()
+    val metalsLog = workspace.resolve(".metals/metals.log")
+    MetalsLogger.redirectSystemOut(metalsLog)
+
+    scribe.info(
+      s"Starting Metals MCP server ${BuildInfo.metalsVersion} for workspace: $workspace"
+    )
+    scribe.info(s"Transport: ${config.transport}")
+
+    val service = new StandaloneMcpService(
+      workspace,
+      config.port,
+      sh,
+    )(ec)
+
+    Runtime.getRuntime.addShutdownHook(new Thread(() => {
+      scribe.info("Shutting down Metals MCP server...")
+      try {
+        service.cancel()
+        ec.shutdown()
+        sh.shutdown()
+      } catch {
+        case NonFatal(e) =>
+          scribe.error("Error during shutdown", e)
+      }
+    }))
+
+    try {
+      service.startAndBlock()
+    } catch {
+      case NonFatal(e) =>
+        scribe.error("Fatal error in MCP server", e)
+        e.printStackTrace(System.err)
+        sys.exit(1)
+    }
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -130,7 +130,7 @@ abstract class MetalsLspService(
   ThreadPools.discardRejectedRunnables("MetalsLanguageServer.sh", sh)
   ThreadPools.discardRejectedRunnables("MetalsLanguageServer.ec", ec)
 
-  def getVisibleName: String = folderVisibleName.getOrElse(folder.toString())
+  def getVisibleName: String = folderVisibleName.getOrElse(folder.filename)
 
   protected val cancelables = new MutableCancelable()
   val isCancelled = new AtomicBoolean(false)

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -130,7 +130,7 @@ class WorkspaceLspService(
 
   private val languageClient = {
     val languageClient =
-      new ConfiguredLanguageClient(client, clientConfig, this)
+      new ConfiguredLanguageClient(client, clientConfig, Some(this))
     // Set the language client so that we can forward log messages to the client
     LanguageClientLogger.languageClient = Some(languageClient)
     cancelables.add(() => languageClient.shutdown())

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
@@ -39,7 +39,7 @@ import org.eclipse.lsp4j.WorkDoneProgressCreateParams
 final class ConfiguredLanguageClient(
     initial: MetalsLanguageClient,
     clientConfig: ClientConfiguration,
-    service: WorkspaceLspService,
+    service: Option[WorkspaceLspService],
 )(implicit ec: ExecutionContext)
     extends DelegatingLanguageClient(initial) {
 
@@ -95,10 +95,12 @@ final class ConfiguredLanguageClient(
             case `action` =>
               val execCommandParams =
                 new ExecuteCommandParams(params.command, List.empty.asJava)
-              if (ServerCommands.allIds.contains(params.command)) {
-                service.executeCommand(execCommandParams)
-              } else {
-                underlying.metalsExecuteClientCommand(execCommandParams)
+              service match {
+                case Some(service)
+                    if ServerCommands.allIds.contains(params.command) =>
+                  service.executeCommand(execCommandParams)
+                case _ =>
+                  underlying.metalsExecuteClientCommand(execCommandParams)
               }
             case _ =>
           }

--- a/tests/slow/src/test/scala/tests/feature/StandaloneMcpSuite.scala
+++ b/tests/slow/src/test/scala/tests/feature/StandaloneMcpSuite.scala
@@ -1,0 +1,116 @@
+package tests.feature
+
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutorService
+import scala.util.control.NonFatal
+
+import scala.meta.internal.metals.RecursivelyDelete
+import scala.meta.internal.metals.mcp.StandaloneMcpService
+import scala.meta.internal.metals.{BuildInfo => V}
+
+import tests.BaseLspSuite
+import tests.FileLayout
+import tests.SbtBuildLayout
+import tests.mcp.TestMcpClient
+
+/**
+ * Integration tests for standalone MCP server mode.
+ *
+ * These tests verify that the standalone MCP server can initialize and
+ * provide MCP functionality without requiring an LSP client connection.
+ */
+class StandaloneMcpSuite extends BaseLspSuite("standalone-metals-suite") {
+
+  implicit val ec: ExecutionContextExecutorService =
+    ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
+
+  private val scheduledExecutor =
+    Executors.newSingleThreadScheduledExecutor()
+
+  private val portToUse: Int = {
+    val socket = new java.net.ServerSocket(0)
+    val port = socket.getLocalPort()
+    socket.close()
+    port
+  }
+
+  override def afterAll(): Unit = {
+    ec.shutdown()
+    scheduledExecutor.shutdown()
+    try {
+      if (!ec.awaitTermination(5, TimeUnit.SECONDS)) {
+        ec.shutdownNow()
+      }
+      if (!scheduledExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+        scheduledExecutor.shutdownNow()
+      }
+    } catch {
+      case _: InterruptedException =>
+        ec.shutdownNow()
+        scheduledExecutor.shutdownNow()
+    }
+  }
+
+  test("standalone-mcp-service-initialization") {
+    val layout = SbtBuildLayout(
+      """|/a/src/main/scala/com/example/Hello.scala
+         |package com.example
+         |
+         |object Hello {
+         |  def main(args: Array[String]): Unit = {
+         |    println("Hello, World!")
+         |  }
+         |}
+         |""".stripMargin,
+      V.scala213,
+    )
+    val workspace = createWorkspace("standalone-metals")
+    FileLayout.fromString(layout, workspace)
+    val service = new StandaloneMcpService(
+      workspace = workspace,
+      port = Some(portToUse),
+      scheduledExecutor = scheduledExecutor,
+    )
+
+    // Test that service can be initialized (start() awaits MCP server readiness)
+    service.start()
+    val client =
+      new TestMcpClient(s"http://localhost:$portToUse", portToUse)
+
+    for {
+      _ <- client.initialize()
+      modules <- client.listModules()
+      _ <- client.shutdown()
+      _ = service.cancel()
+    } yield {
+
+      service.cancel()
+      try {
+        RecursivelyDelete(workspace)
+      } catch {
+        case NonFatal(_) =>
+      }
+      val preambule = modules.linesIterator.take(1).toList.head
+      val modulesList =
+        modules.linesIterator.drop(1).toList.sorted.mkString("\n")
+
+      assertNoDiff(
+        s"$preambule\n$modulesList",
+        """|Available modules (build targets):
+           |- a
+           |- a-test
+           |- b
+           |- b-test
+           |- standalone-metals
+           |- standalone-metals-build
+           |- standalone-metals-test
+           |""".stripMargin,
+      )
+    }
+
+  }
+
+}

--- a/tests/unit/src/main/scala/tests/ResourceOperations.scala
+++ b/tests/unit/src/main/scala/tests/ResourceOperations.scala
@@ -39,12 +39,9 @@ class ResourceOperations(buffers: Buffers) {
     val options: Option[CreateFileOptions] = Option(operation.getOptions)
 
     val overwrite =
-      options
-        .map(opt => opt.getOverwrite: Boolean)
-        .getOrElse(false)
-    val ignoreIfExists = options
-      .map(opt => opt.getIgnoreIfExists: Boolean)
-      .getOrElse(true.booleanValue())
+      options.flatMap(opt => Option(opt.getOverwrite)).contains(true)
+    val ignoreIfExists =
+      options.flatMap(opt => Option(opt.getIgnoreIfExists)).contains(true)
 
     val path = uri.toAbsolutePath
     val fileExists = path.exists
@@ -63,12 +60,10 @@ class ResourceOperations(buffers: Buffers) {
     val newUri = operation.getNewUri
     val options: Option[RenameFileOptions] = Option(operation.getOptions)
 
-    val overwrite = options
-      .map(opt => opt.getOverwrite: Boolean)
-      .getOrElse(false)
-    val ignoreIfExists = options
-      .map(opt => opt.getOverwrite: Boolean)
-      .getOrElse(false)
+    val overwrite =
+      options.flatMap(opt => Option(opt.getOverwrite)).contains(true)
+    val ignoreIfExists =
+      options.flatMap(opt => Option(opt.getIgnoreIfExists)).contains(true)
 
     val oldPath = oldUri.toAbsolutePath
     val newPath = newUri.toAbsolutePath


### PR DESCRIPTION
Currently, only http type only, but we can work on stdio later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standalone MCP server mode with CLI (workspace, port, transport, help, version); defaults to HTTP.
  * Headless MCP client that applies workspace edits to files and routes output to logs.

* **Tests**
  * Integration suite validating standalone MCP startup, module discovery, lifecycle, and cleanup.

* **Refactor**
  * Client wiring updated to accept an optional service wrapper for command handling.

* **Bug Fixes**
  * File-operation option handling adjusted (overwrite/ignoreIfExists defaults corrected).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->