### PR TITLE
feat(server): add build-disconnect-and-shutdown command

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -42,6 +42,13 @@ object ServerCommands {
     """Unconditionally cancel existing build server connection without reconnecting""",
   )
 
+  val DisconnectBuildServerAndShutdown = new Command(
+    "build-disconnect-and-shutdown",
+    "Disconnect from build server and shut it down",
+    """|Disconnect from the build server and shut it down so that its process exits.
+       |Use when closing the editor if you want no leftover Bloop (or other build server) process.""".stripMargin,
+  )
+
   val RestartBuildServer = new Command(
     "build-restart",
     "Restart build server",
@@ -835,6 +842,7 @@ object ServerCommands {
       ScalafixRunOnly,
       DecodeFile,
       DisconnectBuildServer,
+      DisconnectBuildServerAndShutdown,
       ListBuildTargets,
       ScanWorkspaceSources,
       StartDebugAdapter,

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -885,6 +885,11 @@ class WorkspaceLspService(
           _.connect(Disconnect(shutdownBuildServer = false)).ignoreValue,
           ServerCommands.DisconnectBuildServer.title,
         ).asJavaObject
+      case ServerCommands.DisconnectBuildServerAndShutdown() =>
+        onCurrentFolder(
+          _.connect(Disconnect(shutdownBuildServer = true)).ignoreValue,
+          ServerCommands.DisconnectBuildServerAndShutdown.title,
+        ).asJavaObject
       case ServerCommands.DecodeFile(uri) =>
         getServiceForOpt(uri)
           .orElse(currentFolder)


### PR DESCRIPTION
## Summary

Adds one LSP command so that editors can disconnect from the build server and optionally shut it down when closing the editor or workspace. This addresses the long-standing feature request to terminate the Bloop (or other BSP) process when the editor is closed.

Closes scalameta/metals-feature-requests#129 (reference: https://github.com/scalameta/metals-feature-requests/issues/129).

## New command

- **`build-disconnect-and-shutdown`** – Disconnect and shut down the build server so its process exits. Intended for use when closing the editor so there are no leftover Bloop/sbt BSP processes.

## Implementation notes

- Server commands are defined in `ServerCommands.scala` and executed in `WorkspaceLspService.scala`.
- Disconnect/shutdown logic lives in `ConnectionProvider.disconnect(shutdownBuildServer)` and reuses existing BSP session shutdown; when `shutdownBuildServer` is true, Bloop is stopped via `BloopServers.shutdownServer()` and sbt BSP via `SbtBuildTool.shutdownBspServer`.
- Editors (e.g. VS Code) can call these commands on window/workspace close; the metals-vscode side will be implemented separately to expose this behavior to users (See metals-vscode PR : https://github.com/scalameta/metals-vscode/pull/1838)

## Testing

- Unit test `reconnect-after-disconnect-and-shutdown` added in `BillLspSuite`, mirroring the existing `reconnect-manual` test for `DisconnectBuildServer`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to disconnect from the build server and shut it down, allowing users to cleanly terminate leftover build server processes when closing the editor.

* **Improvements**
  * Shutdown now properly signals the build server so reconnection initializes a fresh session, avoiding stale background processes and ensuring reliable reconnect behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->