### PR TITLE
chore: Use Scala 2.13 in test in unit module

### DIFF
--- a/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
+++ b/tests/unit/src/test/scala/tests/FindTextInDependencyJarsSuite.scala
@@ -29,7 +29,7 @@ class FindTextInDependencyJarsSuite
         s"""/metals.json
            |{
            |  "a": {
-           |    "scalaVersion": "${V.scala212}",
+           |    "scalaVersion": "${V.scala213}",
            |    "libraryDependencies": ["com.typesafe.akka::akka-actor-typed:2.6.16"]
            |  }
            |}
@@ -48,16 +48,16 @@ class FindTextInDependencyJarsSuite
       assertLocations(
         akkaLocations,
         s"""|
-            |akka-actor_2.12-${akkaVersion}.jar/reference.conf:96:3: info: result
+            |akka-actor_2.13-${akkaVersion}.jar/reference.conf:96:3: info: result
             |  jvm-shutdown-hooks = on
             |  ^^^^^^^^^^^^^^^^^^
-            |akka-actor_2.12-${akkaVersion}.jar/reference.conf:1178:41: info: result
+            |akka-actor_2.13-${akkaVersion}.jar/reference.conf:1178:41: info: result
             |    # This property is related to `akka.jvm-shutdown-hooks` above.
             |                                        ^^^^^^^^^^^^^^^^^^
-            |akka-actor_2.12-${akkaVersion}-sources.jar/reference.conf:96:3: info: result
+            |akka-actor_2.13-${akkaVersion}-sources.jar/reference.conf:96:3: info: result
             |  jvm-shutdown-hooks = on
             |  ^^^^^^^^^^^^^^^^^^
-            |akka-actor_2.12-${akkaVersion}-sources.jar/reference.conf:1178:41: info: result
+            |akka-actor_2.13-${akkaVersion}-sources.jar/reference.conf:1178:41: info: result
             |    # This property is related to `akka.jvm-shutdown-hooks` above.
             |                                        ^^^^^^^^^^^^^^^^^^
             |""".stripMargin,
@@ -67,6 +67,7 @@ class FindTextInDependencyJarsSuite
         jdkLocations, {
           val line =
             if (isJava24) 1545
+            else if (isJava21 && !isMacOS && !isWindows) 1476
             else if (isJava21) 1487
             else if (
               SemVer.isCompatibleVersion(

--- a/tests/unit/src/test/scala/tests/FormattingLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/FormattingLspSuite.scala
@@ -468,10 +468,10 @@ class FormattingLspSuite extends BaseLspSuite("formatting") {
         s"""|/metals.json
             |{
             |  "a": {
-            |     "scalaVersion": "${V.scala212}"
+            |     "scalaVersion": "${V.scala213}"
             |  },
             |  "b": {
-            |     "scalaVersion": "${V.scala212}",
+            |     "scalaVersion": "${V.scala213}",
             |     "scalacOptions": ["-Xsource:3"],
             |     "sbtVersion": "1.6.0-RC2"
             |  }
@@ -488,7 +488,7 @@ class FormattingLspSuite extends BaseLspSuite("formatting") {
       _ = assertNoDiff(
         server.textContents(".scalafmt.conf"),
         s"""|version = "${V.scalafmtVersion}"
-            |runner.dialect = scala212
+            |runner.dialect = scala213
             |""".stripMargin,
       )
 


### PR DESCRIPTION
Scala 2.12 is not published for those tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test configurations and expectations to target Scala 2.13, including formatting/dialect expectations and dependency reference updates to match the newer Scala version.
  * Aligned test outputs for Java-version-specific line mappings so diagnostics remain stable across platform variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->