### PR TITLE
chore: Update mill and mill scripts

### DIFF
--- a/metals/src/main/resources/mill
+++ b/metals/src/main/resources/mill
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -z "${DEFAULT_MILL_VERSION}" ] ; then DEFAULT_MILL_VERSION="SNAPSHOT"; fi
+if [ -z "${DEFAULT_MILL_VERSION}" ] ; then DEFAULT_MILL_VERSION="1.1.1"; fi
 
 if [ -z "${GITHUB_RELEASE_CDN}" ] ; then GITHUB_RELEASE_CDN=""; fi
 
@@ -54,49 +54,67 @@ if [ -z "${MILL_FINAL_DOWNLOAD_FOLDER}" ] ; then MILL_FINAL_DOWNLOAD_FOLDER="${M
 
 MILL_NATIVE_SUFFIX="-native"
 MILL_JVM_SUFFIX="-jvm"
-FULL_MILL_VERSION=$MILL_VERSION
 ARTIFACT_SUFFIX=""
-set_artifact_suffix(){
-  if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" = "Linux" ]; then
+
+# Check if GLIBC version is at least the required version
+# Returns 0 (true) if GLIBC >= required version, 1 (false) otherwise
+check_glibc_version() {
+  required_version="2.39"
+  required_major=$(echo "$required_version" | cut -d. -f1)
+  required_minor=$(echo "$required_version" | cut -d. -f2)
+  # Get GLIBC version from ldd --version (first line contains version like "ldd (GNU libc) 2.31")
+  glibc_version=$(ldd --version 2>/dev/null | head -n 1 | grep -oE '[0-9]+\.[0-9]+$' || echo "")
+  if [ -z "$glibc_version" ]; then
+    # If we can't determine GLIBC version, assume it's too old
+    return 1
+  fi
+  glibc_major=$(echo "$glibc_version" | cut -d. -f1)
+  glibc_minor=$(echo "$glibc_version" | cut -d. -f2)
+  if [ "$glibc_major" -gt "$required_major" ]; then
+    return 0
+  elif [ "$glibc_major" -eq "$required_major" ] && [ "$glibc_minor" -ge "$required_minor" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+set_artifact_suffix() {
+  if [ "$(uname -s 2>/dev/null | cut -c 1-5)" = "Linux" ]; then
+    # Native binaries require new enough GLIBC; fall back to JVM launcher if older
+    if ! check_glibc_version; then
+      return
+    fi
     if [ "$(uname -m)" = "aarch64" ]; then ARTIFACT_SUFFIX="-native-linux-aarch64"
     else ARTIFACT_SUFFIX="-native-linux-amd64"; fi
   elif [ "$(uname)" = "Darwin" ]; then
     if [ "$(uname -m)" = "arm64" ]; then ARTIFACT_SUFFIX="-native-mac-aarch64"
     else ARTIFACT_SUFFIX="-native-mac-amd64"; fi
   else
-     echo "This native mill launcher supports only Linux and macOS." 1>&2
-     exit 1
+    echo "This native mill launcher supports only Linux and macOS." 1>&2
+    exit 1
   fi
 }
 
 case "$MILL_VERSION" in
-    *"$MILL_NATIVE_SUFFIX")
-  MILL_VERSION=${MILL_VERSION%"$MILL_NATIVE_SUFFIX"}
-  set_artifact_suffix
-  ;;
+  *"$MILL_NATIVE_SUFFIX")
+    MILL_VERSION=${MILL_VERSION%"$MILL_NATIVE_SUFFIX"}
+    set_artifact_suffix
+    ;;
 
-    *"$MILL_JVM_SUFFIX")
+  *"$MILL_JVM_SUFFIX")
     MILL_VERSION=${MILL_VERSION%"$MILL_JVM_SUFFIX"}
-  ;;
+    ;;
 
-    *)
-  case "$MILL_VERSION" in
-    0.1.*) ;;
-    0.2.*) ;;
-    0.3.*) ;;
-    0.4.*) ;;
-    0.5.*) ;;
-    0.6.*) ;;
-    0.7.*) ;;
-    0.8.*) ;;
-    0.9.*) ;;
-    0.10.*) ;;
-    0.11.*) ;;
-    0.12.*) ;;
-    *)
-      set_artifact_suffix
-  esac
-  ;;
+  *)
+    case "$MILL_VERSION" in
+      0.1.* | 0.2.* | 0.3.* | 0.4.* | 0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.* | 0.12.*)
+        ;;
+      *)
+        set_artifact_suffix
+        ;;
+    esac
+    ;;
 esac
 
 MILL="${MILL_FINAL_DOWNLOAD_FOLDER}/$MILL_VERSION$ARTIFACT_SUFFIX"
@@ -104,11 +122,11 @@ MILL="${MILL_FINAL_DOWNLOAD_FOLDER}/$MILL_VERSION$ARTIFACT_SUFFIX"
 # If not already downloaded, download it
 if [ ! -s "${MILL}" ] || [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
   case $MILL_VERSION in
-    0.0.* | 0.1.* | 0.2.* | 0.3.* | 0.4.* )
+    0.0.* | 0.1.* | 0.2.* | 0.3.* | 0.4.*)
       MILL_DOWNLOAD_SUFFIX=""
       MILL_DOWNLOAD_FROM_MAVEN=0
       ;;
-    0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.0-M* )
+    0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.0-M*)
       MILL_DOWNLOAD_SUFFIX="-assembly"
       MILL_DOWNLOAD_FROM_MAVEN=0
       ;;
@@ -118,13 +136,13 @@ if [ ! -s "${MILL}" ] || [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
       ;;
   esac
   case $MILL_VERSION in
-    0.12.0 | 0.12.1 | 0.12.2 | 0.12.3 | 0.12.4 | 0.12.5 | 0.12.6 | 0.12.7 | 0.12.8 | 0.12.9 | 0.12.10 | 0.12.11 )
+    0.12.0 | 0.12.1 | 0.12.2 | 0.12.3 | 0.12.4 | 0.12.5 | 0.12.6 | 0.12.7 | 0.12.8 | 0.12.9 | 0.12.10 | 0.12.11)
       MILL_DOWNLOAD_EXT="jar"
       ;;
-    0.12.* )
+    0.12.*)
       MILL_DOWNLOAD_EXT="exe"
       ;;
-    0.* )
+    0.*)
       MILL_DOWNLOAD_EXT="jar"
       ;;
     *)
@@ -145,8 +163,8 @@ if [ ! -s "${MILL}" ] || [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
 
 
   if [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
-    echo $MILL_DOWNLOAD_URL
-    echo $MILL
+    echo "$MILL_DOWNLOAD_URL"
+    echo "$MILL"
     exit 0
   fi
 
@@ -163,7 +181,7 @@ if [ ! -s "${MILL}" ] || [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
 fi
 
 MILL_FIRST_ARG=""
-if [ "$1" = "--bsp" ] || [ "${1#"-i"}" != "$1" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--no-daemon" ] || [ "$1" = "--repl" ] || [ "$1" = "--help" ] ; then
+if [ "$1" = "--bsp" ] || [ "${1#"-i"}" != "$1" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--no-daemon" ] || [ "$1" = "--help" ] ; then
   # Need to preserve the first position of those listed options
   MILL_FIRST_ARG=$1
   shift

--- a/metals/src/main/resources/mill.bat
+++ b/metals/src/main/resources/mill.bat
@@ -2,7 +2,7 @@
 
 setlocal enabledelayedexpansion
 
-if [!DEFAULT_MILL_VERSION!]==[] ( set "DEFAULT_MILL_VERSION=SNAPSHOT" )
+if [!DEFAULT_MILL_VERSION!]==[] ( set "DEFAULT_MILL_VERSION=1.1.1" )
 
 if [!MILL_GITHUB_RELEASE_CDN!]==[] ( set "MILL_GITHUB_RELEASE_CDN=" )
 
@@ -93,6 +93,7 @@ rem without bat file extension, cmd doesn't seem to be able to run it
 
 set "MILL_NATIVE_SUFFIX=-native"
 set "MILL_JVM_SUFFIX=-jvm"
+set "MILL_FULL_VERSION=%MILL_VERSION%"
 set "MILL_DOWNLOAD_EXT=.bat"
 set "ARTIFACT_SUFFIX="
 REM Check if MILL_VERSION contains MILL_NATIVE_SUFFIX
@@ -139,7 +140,7 @@ if !errorlevel! equ 0 (
     )
 )
 
-set MILL=%MILL_FINAL_DOWNLOAD_FOLDER%\!MILL_VERSION!!MILL_DOWNLOAD_EXT!
+set MILL=%MILL_FINAL_DOWNLOAD_FOLDER%\!MILL_FULL_VERSION!!MILL_DOWNLOAD_EXT!
 
 set MILL_RESOLVE_DOWNLOAD=
 
@@ -275,12 +276,8 @@ if [%~1%]==[--bsp] (
         if [%~1%]==[--no-daemon] (
           set MILL_FIRST_ARG=%1%
         ) else (
-          if [%~1%]==[--repl] (
+          if [%~1%]==[--help] (
             set MILL_FIRST_ARG=%1%
-          ) else (
-            if [%~1%]==[--help] (
-              set MILL_FIRST_ARG=%1%
-            )
           )
         )
       )

--- a/project/V.scala
+++ b/project/V.scala
@@ -57,7 +57,7 @@ object V {
 
   val mavenBloop = "2.0.3"
 
-  val mill = "1.1.0"
+  val mill = "1.1.1"
 
   val mdoc = "2.8.2"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Mill version to 1.1.1 (previously SNAPSHOT)
  * Native artifacts on Linux systems now require GLIBC 2.39 or newer
  * Removed support for the --repl command-line option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->