### PR TITLE
improvement: Adjust messages about mcp server

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.metals.mcp
 
-import java.io.PrintWriter
 import java.net.InetSocketAddress
 import java.nio.file.Path
 import java.util.Arrays
@@ -27,7 +26,6 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MutableCancelable
 import scala.meta.internal.metals.ScalaVersionSelector
 import scala.meta.internal.metals.ScalaVersions
-import scala.meta.internal.metals.Trace
 import scala.meta.internal.metals.mcp.McpPrinter._
 import scala.meta.internal.metals.mcp.McpQueryEngine
 import scala.meta.internal.metals.mcp.SymbolType
@@ -80,9 +78,6 @@ class MetalsMcpServer(
 
   private val client =
     Client.allClients.find(_.names.contains(clientName)).getOrElse(NoClient)
-
-  val tracePrinter: Option[PrintWriter] =
-    Trace.setupTracePrinter("mcp", projectPath)
 
   private val objectMapper = new ObjectMapper()
 
@@ -206,7 +201,9 @@ class MetalsMcpServer(
       )
     )
 
-    scribe.info(s"Metals MCP server started on port: $port.")
+    scribe.info(
+      s"To connect to Metals MCP server use `http` transport type and url: http://localhost:$port/mcp."
+    )
 
     cancelable.add(() => undertowServer.stop())
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the startup notification message for the Metals MCP server to provide explicit instructions for establishing connections using HTTP transport on localhost, significantly improving user guidance and clarity.
  * Removed the internal trace printing functionality to streamline the server's runtime operations and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->