### PR TITLE
improvement: Add message on timeout and remove warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -172,6 +172,7 @@ def lintingOptions(scalaVersion: String) = {
     "-Wconf:src=*.TreeViewProvider.scala&msg=parameter params in method (children|parent) is never used:silent",
     "-Wconf:src=*.InheritanceContext.scala&msg=parameter ec in method getLocations is never used:silent",
     "-Wconf:src=*.CompilerWrapper.scala&msg=parameter params in method compiler is never used:silent",
+    "-Wconf:src=*.MetalsLanguageClient.scala&msg=parameter params in method showMessageRequest is never used:silent",
     // silence "The outer reference in this type test cannot be checked at run time."
     "-Wconf:src=.*(CompletionProvider|ArgCompletions|Completions|Keywords|IndentOnPaste).scala&msg=The outer reference:silent",
   )

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildToolSelector.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildToolSelector.scala
@@ -94,8 +94,7 @@ final class BuildToolSelector(
         defaultTo = () => {
           languageClient.showMessage(
             Messages.NewBuildToolDetected.notificationParams(
-              newBuildTool.executableName,
-              currentBuildTool.executableName,
+              newBuildTool.executableName
             )
           )
           Messages.NewBuildToolDetected.dontSwitch

--- a/metals/src/main/scala/scala/meta/internal/metals/GithubNewIssueUrlCreator.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/GithubNewIssueUrlCreator.scala
@@ -7,6 +7,7 @@ import scala.util.Properties
 
 import scala.meta.internal.bsp.BspResolvedResult
 import scala.meta.internal.bsp.BspSession
+import scala.meta.internal.bsp.RegenerateBspConfig
 import scala.meta.internal.bsp.ResolvedBloop
 import scala.meta.internal.bsp.ResolvedBspOne
 import scala.meta.internal.bsp.ResolvedMultiple
@@ -99,7 +100,8 @@ class GithubNewIssueUrlCreator(
                 s"Disconnected: ${details.getName()}"
               case ResolvedMultiple(_, details) =>
                 s"Disconnected: Multiple Found ${details.map(_.getName()).mkString("; ")}"
-              case ResolvedNone => s"Disconnected: None Found"
+              case ResolvedNone => "Disconnected: None Found"
+              case RegenerateBspConfig => "Regenerate bsp config"
             }
           }
         buildServer

--- a/metals/src/main/scala/scala/meta/internal/metals/JarSourcesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/JarSourcesProvider.scala
@@ -148,7 +148,7 @@ object JarSourcesProvider {
       .addClassifiers(Classifier.sources)
       .future()
       .map(_.map(_.toPath()).toList)
-      .withTimeout(1, TimeUnit.MINUTES)
+      .withTimeout(1, TimeUnit.MINUTES, Some("fetching the dependency sources"))
   }
 
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Messages.scala
@@ -377,8 +377,7 @@ object Messages {
     val switch = new MessageActionItem("yes")
     val dontSwitch = new MessageActionItem("no")
     def notificationParams(
-        newBuildTool: String,
-        currentBuildTool: String,
+        newBuildTool: String
     ): MessageParams = {
       new MessageParams(
         MessageType.Info,

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -653,7 +653,11 @@ case class ScalafixProvider(
                 tables.dismissedNotifications.ScalafixConfAmend.dismissForever()
               case _ =>
             }
-            .withTimeout(15, ju.concurrent.TimeUnit.SECONDS)
+            .withTimeout(
+              15,
+              ju.concurrent.TimeUnit.SECONDS,
+              Some("amending the scalafix config"),
+            )
             .map(_ => confFile)
         }).getOrElse(Future.successful(confFile))
       case _ => Future.successful(confFile)

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -1453,7 +1453,6 @@ class WorkspaceLspService(
         languageClient.underlying,
         () => server.reload(),
         clientConfig.icons(),
-        clientConfig,
       )
       render = () => newClient.renderHtml
       completeCommand = e => newClient.completeCommand(e)

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/ConfiguredLanguageClient.scala
@@ -154,7 +154,7 @@ final class ConfiguredLanguageClient(
             },
           )
         )
-        .withTimeout(15, TimeUnit.SECONDS)
+        .withTimeout(15, TimeUnit.SECONDS, Some("sending showMessageRequest"))
         .recover { case _: TimeoutException =>
           result.cancel(false)
           Messages.missedByUser

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsHttpClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsHttpClient.scala
@@ -47,7 +47,6 @@ final class MetalsHttpClient(
     initial: MetalsLanguageClient,
     triggerReload: () => Unit,
     icons: Icons,
-    clientConfig: ClientConfiguration,
 )(implicit ec: ExecutionContext)
     extends DelegatingLanguageClient(initial) {
 

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -260,7 +260,11 @@ class DebugProvider(
             clientConfig.initialConfig.debugServerStartTimeout
 
           conn
-            .withTimeout(startupTimeout, TimeUnit.SECONDS)
+            .withTimeout(
+              startupTimeout,
+              TimeUnit.SECONDS,
+              Some("starting the debug sessions"),
+            )
             .recover { case exception =>
               connectedToServer.tryFailure(exception)
               cancelPromise.trySuccess(())

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProxy.scala
@@ -192,7 +192,11 @@ private[debug] final class DebugProxy(
           response.setResult(responseArgs.toJson)
           client.consume(response)
         }
-        .withTimeout(5, TimeUnit.SECONDS)
+        .withTimeout(
+          5,
+          TimeUnit.SECONDS,
+          Some("completing the completions request"),
+        )
 
     case HotCodeReplace(req) =>
       scribe.info("Hot code replace triggered")

--- a/metals/src/main/scala/scala/meta/internal/metals/utils/FutureWithTimeout.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/utils/FutureWithTimeout.scala
@@ -42,6 +42,7 @@ object FutureWithTimeout {
     def withOnTimeout(
         withTimeout: Future[(T, FiniteDuration)],
         duration: FiniteDuration,
+        reason: Option[String],
     ): Future[(T, FiniteDuration)] = {
       withTimeout.transformWith {
         case Success(res) => Future.successful(res)
@@ -54,7 +55,11 @@ object FutureWithTimeout {
                 cancelable.cancel()
                 Future.failed(e)
               case FutureWithTimeout.Wait =>
-                withOnTimeout(request.withTimeout(duration * 3), duration * 3)
+                withOnTimeout(
+                  request.withTimeout(duration * 3, reason),
+                  duration * 3,
+                  reason,
+                )
               case FutureWithTimeout.Dismiss => request
             }
           } yield res
@@ -62,7 +67,11 @@ object FutureWithTimeout {
       }
     }
 
-    withOnTimeout(request.withTimeout(duration), duration)
+    withOnTimeout(
+      request.withTimeout(duration, reason = None),
+      duration,
+      reason = None,
+    )
 
     CancelableFuture(result.future, cancelable)
   }

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Debugger.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/Debugger.scala
@@ -187,8 +187,14 @@ final class Debugger(server: RemoteServer)(implicit ec: ExecutionContext) {
   }
 
   def shutdown(timeout: Int = 20): Future[Unit] = {
-    server.listening.withTimeout(timeout, TimeUnit.SECONDS).andThen { case _ =>
-      server.cancel()
-    }
+    server.listening
+      .withTimeout(
+        timeout,
+        TimeUnit.SECONDS,
+        Some("shutting down the debugger"),
+      )
+      .andThen { case _ =>
+        server.cancel()
+      }
   }
 }

--- a/tests/unit/src/main/scala/scala/meta/internal/metals/debug/RemoteServer.scala
+++ b/tests/unit/src/main/scala/scala/meta/internal/metals/debug/RemoteServer.scala
@@ -206,7 +206,13 @@ private[debug] final class RemoteServer(
       }
     }
 
-    response.onTimeout(90, TimeUnit.SECONDS)(logTimeout(endpoint)).asJava
+    response
+      .onTimeout(
+        90,
+        TimeUnit.SECONDS,
+        Some(s"waiting for a response to $endpoint request"),
+      )(logTimeout(endpoint))
+      .asJava
   }
 
   private def logTimeout(endpoint: String): Unit = {

--- a/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseWorksheetLspSuite.scala
@@ -227,7 +227,7 @@ abstract class BaseWorksheetLspSuite(
            |""".stripMargin
       )
       _ <- server.didOpen("a/src/main/scala/Main.worksheet.sc")
-      _ <- cancelled.future.withTimeout(10.seconds)
+      _ <- cancelled.future.withTimeout(10.seconds, reason = None)
       _ = client.onWorkDoneProgressStart = (_, _) => {}
       _ <- server.didChange("a/src/main/scala/Main.worksheet.sc")(
         _.replace("Stream", "// Stream")

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -1146,7 +1146,7 @@ final case class TestingServer(
       .codeLens(params)
       .asScala
       .map(_.asScala)
-      .withTimeout(10, util.concurrent.TimeUnit.SECONDS)
+      .withTimeout(10, util.concurrent.TimeUnit.SECONDS, reason = None)
       .recover { _ =>
         scribe.info(s"Timeout for fetching lenses reached for $filename")
         Nil
@@ -1181,7 +1181,7 @@ final case class TestingServer(
           if (lenses.size >= minExpectedLenses) Future.successful(lenses)
           else codeLenses.future
         }
-        .withTimeout(60, util.concurrent.TimeUnit.SECONDS)
+        .withTimeout(60, util.concurrent.TimeUnit.SECONDS, reason = None)
     } yield lenses.toList
   }
 

--- a/tests/unit/src/test/scala/tests/UnsupportedDebuggingLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/UnsupportedDebuggingLspSuite.scala
@@ -34,7 +34,7 @@ class UnsupportedDebuggingLspSuite
       codeLenses <-
         server
           .codeLensesText("a/src/main/scala/Main.scala")(maxRetries = 3)
-          .withTimeout(5, TimeUnit.SECONDS)
+          .withTimeout(5, TimeUnit.SECONDS, reason = None)
           .transform(Success(_))
     } yield {
       codeLenses match {


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/7997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced timeout diagnostics with descriptive messages for improved error troubleshooting and debugging information during operations.

* **Chores**
  * Improved notification handling for newly detected build tools.
  * Added support for BSP configuration regeneration in error reporting.
  * Streamlined internal HTTP client configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->