### PR TITLE
improvement: Reduce the number of tests and split sbt tests into two groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
         type:
           [
             gradle-mac,
-            sbt,
+            sbt-1,
+            sbt-2,
             maven,
             gradle,
             scalacli,
@@ -91,18 +92,27 @@ jobs:
             name: Gradle MacOS integration
             os: macOS-latest
             java: "17"
-          - type: sbt
+          - type: sbt-1
             command: |
               bin/test.sh +sbt-metals/publishLocal
               bin/test.sh 'slow/testOnly -- tests.sbt.*'
-            name: Sbt integration
+            name: Sbt integration 1/2
             os: ubuntu-latest
             java: "17"
+            shard: 1
+          - type: sbt-2
+            command: |
+              bin/test.sh +sbt-metals/publishLocal
+              bin/test.sh 'slow/testOnly -- tests.sbt.*'
+            name: Sbt integration 2/2
+            os: ubuntu-latest
+            java: "17"
+            shard: 2
           - type: sbt-metals jdk8
             command: bin/test.sh sbt-metals/scripted
-            name: Sbt-metals/scripted jdk11
+            name: sbt-metals/scripted jdk17
             os: ubuntu-latest
-            java: "11"
+            java: "17"
           - type: sbt-metals Sbt 2
             command: bin/test.sh '++3.x; sbt-metals/scripted'
             name: sbt-metals/scripted (Sbt 2)
@@ -183,6 +193,7 @@ jobs:
           ${{ matrix.command }}
         env:
           METALS_TEST: true
+          TEST_SHARD: ${{ matrix.shard }}
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
       - name: Upload test reports

--- a/project/TestGroups.scala
+++ b/project/TestGroups.scala
@@ -143,4 +143,20 @@ object TestGroups {
     .grouped(Math.ceil(allTests.length.toDouble / numberOfShards).toInt)
     .map(_.toSet)
     .toList
+
+  val sbtTests = List(
+    "tests.sbt.ActivePlatformsSuite", "tests.sbt.CancelCompileSuite",
+    "tests.sbt.SbtBloopLspSuite", "tests.sbt.SbtBreakpointDapSuite",
+    "tests.sbt.SbtCrossDebugSuite", "tests.sbt.SbtEvaluationDapSuite",
+    "tests.sbt.SbtServerSuite", "tests.sbt.SbtStackFrameDapSuite",
+    "tests.sbt.SbtStepDapSuite", "tests.sbt.WorkspaceFolderSuite",
+  )
+
+  val sbtNumberOfShards = 2
+
+  val sbtTestGroups: List[Set[String]] = sbtTests
+    .grouped(Math.ceil(sbtTests.length.toDouble / numberOfShards).toInt)
+    .map(_.toSet)
+    .toList
+
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs two parallel sbt integration shards (shard-aware matrix) and propagates shard metadata into integration and unit steps for targeted execution.
  * Scripted tests updated to require JDK 17.

* **Tests**
  * SBT/Bloop tests reorganized: added sbt-focused 2-shard test grouping and consolidated many checks into a single comprehensive LSP feature suite.
  * Test expectations updated for newer Scala/SBT configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->