### PR TITLE
improvement: Allow specifying UserConfiguration in CLI

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -98,7 +98,6 @@ case class UserConfiguration(
       optStringField("millScript", millScript),
       optStringField("scalafmtConfigPath", scalafmtConfigPath),
       optStringField("scalafixConfigPath", scalafixConfigPath),
-      optStringField("scalafixConfigPath", scalafixConfigPath),
       mapField("symbolPrefixes", symbolPrefixes),
       Some(("worksheetScreenWidth", worksheetScreenWidth)),
       Some(("worksheetCancelTimeout", worksheetCancelTimeout)),
@@ -268,6 +267,14 @@ object UserConfiguration {
           |""".stripMargin,
       ),
       UserConfigurationOption(
+        "scalafix-rules-dependencies",
+        """`[]`""",
+        """["com.github.liancheng::organize-imports:0.6.0"]""",
+        "Scalafix rules dependencies",
+        """Optional list of Scalafix rules dependencies to use for running `scalafix --rules`.""",
+        isArray = true,
+      ),
+      UserConfigurationOption(
         "excluded-packages",
         """`[]`.""",
         """["akka.actor.typed.javadsl"]""",
@@ -289,11 +296,15 @@ object UserConfiguration {
             |["--sun"]
             |```
             |""".stripMargin,
+        isArray = true,
       ),
       UserConfigurationOption(
-        "bloop-sbt-already-installed", "false", "false",
+        "bloop-sbt-already-installed",
+        "false",
+        "false",
         "Don't generate Bloop plugin file for sbt",
         "If true, Metals will not generate `metals.sbt` files under the assumption that sbt-bloop is already manually installed in the sbt build. Build import will fail with a 'not valid command bloopInstall' error in case Bloop is not manually installed in the build when using this option.",
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "bloop-version",
@@ -311,6 +322,7 @@ object UserConfiguration {
         """|Optional list of JVM properties to pass along to the Bloop server.
            |Please follow this guide for the format https://scalacenter.github.io/bloop/docs/server-reference#global-settings-for-the-server"
            |""".stripMargin,
+        isArray = true,
       ),
       UserConfigurationOption(
         "super-method-lenses-enabled",
@@ -321,6 +333,7 @@ object UserConfiguration {
            |Disabled lenses are not calculated for opened documents which might speed up document processing.
            |
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "inlay-hints.inferred-types.enable",
@@ -331,6 +344,7 @@ object UserConfiguration {
            |displayed either as additional decorations if they are supported by the editor or
            |shown in the hover.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "inlay-hints.named-parameters.enable",
@@ -341,6 +355,7 @@ object UserConfiguration {
            |displayed either as additional decorations if they are supported by the editor or 
            |shown in the hover.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "inlay-hints.by-name-parameters.enable",
@@ -351,6 +366,7 @@ object UserConfiguration {
            |displayed either as additional '=>' decorations if they are supported by the editor or 
            |shown in the hover.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "inlay-hints.implicit-arguments.enable",
@@ -361,6 +377,7 @@ object UserConfiguration {
            |displayed either as additional decorations if they are supported by the editor or 
            |shown in the hover.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "inlay-hints.implicit-conversions.enable",
@@ -371,6 +388,7 @@ object UserConfiguration {
            |displayed either as additional decorations if they are supported by the editor or 
            |shown in the hover.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "inlay-hints.type-parameters.enable",
@@ -381,6 +399,7 @@ object UserConfiguration {
            |displayed either as additional decorations if they are supported by the editor or
            |shown in the hover.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "inlay-hints.hints-in-pattern-match.enable",
@@ -391,6 +410,7 @@ object UserConfiguration {
            |displayed either as additional decorations if they are supported by the editor or
            |shown in the hover.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "inlay-hints.hints-x-ray-mode.enable",
@@ -400,6 +420,7 @@ object UserConfiguration {
         """|When this option is enabled, each method/attribute call in a multi-line chain will get
            | its own type annotation.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "inlay-hints.closing-labels.enable",
@@ -409,6 +430,7 @@ object UserConfiguration {
         """|When this option is enabled, each method/class/object definition that uses braces syntax,
            | will get a closing label hint next to the closing brace with the name of the definition.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "enable-semantic-highlighting",
@@ -418,6 +440,7 @@ object UserConfiguration {
         """|When this option is enabled, Metals will provide semantic tokens for clients that support it.
            |The feature should work within all supported files extensions aside from Java.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "enable-indent-on-paste",
@@ -427,6 +450,7 @@ object UserConfiguration {
         """|When this option is enabled, when a snippet is pasted into a Scala file, Metals will
            |try to adjust the indentation to that of the current cursor.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "fallback-scala-version",
@@ -493,6 +517,7 @@ object UserConfiguration {
         """|If a build server supports it (for example Bloop or Scala CLI), setting it to true
            |will make the logs contain all the possible debugging information including
            |about incremental compilation in Zinc.""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "auto-import-builds",
@@ -521,6 +546,7 @@ object UserConfiguration {
         """|If your build tool can also serve as a build server,
            |default to using it instead of Bloop.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "enable-best-effort",
@@ -530,6 +556,7 @@ object UserConfiguration {
         """|When using Scala 3, use best effort compilation to improve Metals 
            |correctness when the workspace doesn't compile.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "default-shell",
@@ -549,6 +576,7 @@ object UserConfiguration {
         "Start MCP server",
         """|If Metals should start the MCP (SSE) server, that an AI agent can connect to.
            |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "mcp-client",

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfigurationOption.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfigurationOption.scala
@@ -11,7 +11,14 @@ case class UserConfigurationOption(
     example: String,
     title: String,
     description: String,
+    isBoolean: Boolean = false,
+    isArray: Boolean = false,
 ) {
+  assert(
+    !(isArray && isBoolean),
+    "isArray and isBoolean cannot be true at the same time",
+  )
+
   def headerID: String = {
     title.toLowerCase().replace(' ', '-').replace("'", " ")
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI configuration overrides at runtime (nested keys, lists, boolean-flag shorthand) with validation and error reporting.
  * Start MCP with an optional initial user configuration supplied at launch; runtime overrides are applied.
  * New user-config option for scalafix rules dependencies; many options now expose array or boolean semantics.

* **Bug Fixes**
  * Removed duplicated entry in user-configuration string output.

* **Documentation**
  * Help text expanded to document CLI override syntax and boolean behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->