### PR TITLE
improvement: Improve the UX of new file provider

### DIFF
--- a/metals-mcp/src/main/scala/scala/meta/internal/metals/mcp/McpLanguageClient.scala
+++ b/metals-mcp/src/main/scala/scala/meta/internal/metals/mcp/McpLanguageClient.scala
@@ -12,6 +12,7 @@ import scala.meta.internal.metals.clients.language.MetalsQuickPickParams
 import scala.meta.internal.metals.clients.language.MetalsStatusParams
 import scala.meta.internal.metals.clients.language.RawMetalsInputBoxResult
 import scala.meta.internal.metals.clients.language.RawMetalsQuickPickResult
+import scala.meta.internal.metals.clients.language.RawMetalsReadClipboardResult
 import scala.meta.internal.tvp.TreeViewDidChangeParams
 import scala.meta.io.AbsolutePath
 
@@ -43,6 +44,13 @@ import org.eclipse.lsp4j.WorkspaceFolder
  * @param workspace The workspace root path, used for resolving file paths
  */
 class McpLanguageClient(workspace: AbsolutePath) extends MetalsLanguageClient {
+
+  override def rawMetalsReadClipboard()
+      : CompletableFuture[RawMetalsReadClipboardResult] = {
+    CompletableFuture.completedFuture(
+      RawMetalsReadClipboardResult(value = null)
+    )
+  }
 
   override def telemetryEvent(value: Object): Unit = {
     scribe.debug(s"[MCP Telemetry] $value")

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -112,6 +112,13 @@ final class ClientConfiguration(
       false,
     )
 
+  def isReadClipboardProvider(): Boolean =
+    extract(
+      initializationOptions.readClipboardProvider,
+      experimentalCapabilities.readClipboardProvider,
+      false,
+    )
+
   def isOpenFilesOnRenameProvider(): Boolean =
     extract(
       initializationOptions.openFilesOnRenameProvider,

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientExperimentalCapabilities.scala
@@ -23,6 +23,7 @@ final case class ClientExperimentalCapabilities(
     inputBoxProvider: Option[Boolean],
     openFilesOnRenameProvider: Option[Boolean],
     quickPickProvider: Option[Boolean],
+    readClipboardProvider: Option[Boolean],
     statusBarProvider: Option[String],
     treeViewProvider: Option[Boolean],
 ) {
@@ -36,6 +37,7 @@ final case class ClientExperimentalCapabilities(
 object ClientExperimentalCapabilities {
   import scala.meta.internal.metals.JsonParser._
   val Default: ClientExperimentalCapabilities = ClientExperimentalCapabilities(
+    None,
     None,
     None,
     None,
@@ -79,6 +81,7 @@ object ClientExperimentalCapabilities {
       openFilesOnRenameProvider =
         jsonObj.getBooleanOption("openFilesOnRenameProvider"),
       quickPickProvider = jsonObj.getBooleanOption("quickPickProvider"),
+      readClipboardProvider = jsonObj.getBooleanOption("readClipboardProvider"),
       statusBarProvider = jsonObj.getStringOption("statusBarProvider"),
       treeViewProvider = jsonObj.getBooleanOption("treeViewProvider"),
     )

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -37,6 +37,7 @@ import org.eclipse.{lsp4j => l}
  * `*                    https://code.visualstudio.com/api/extension-guides/virtual-documents
  * @param openFilesOnRenameProvider whether or not the client supports opening files on rename.
  * @param quickPickProvider if the client implements `metals/quickPick`.
+ * @param readClipboardProvider if the client implements `metals/readClipboard` (e.g. for "New Scala File > From clipboard").
  * @param renameFileThreshold amount of files that should be opened during rename if client
  *                            is a `openFilesOnRenameProvider`.
  * @param statusBarProvider if the client implements `metals/status`.
@@ -70,6 +71,7 @@ final case class InitializationOptions(
     isVirtualDocumentSupported: Option[Boolean],
     openFilesOnRenameProvider: Option[Boolean],
     quickPickProvider: Option[Boolean],
+    readClipboardProvider: Option[Boolean],
     renameFileThreshold: Option[Int],
     statusBarProvider: Option[String],
     treeViewProvider: Option[Boolean],
@@ -99,6 +101,7 @@ object InitializationOptions {
 
   val Default: InitializationOptions = InitializationOptions(
     CompilerInitializationOptions.default,
+    None,
     None,
     None,
     None,
@@ -171,6 +174,7 @@ object InitializationOptions {
       openFilesOnRenameProvider =
         jsonObj.getBooleanOption("openFilesOnRenameProvider"),
       quickPickProvider = jsonObj.getBooleanOption("quickPickProvider"),
+      readClipboardProvider = jsonObj.getBooleanOption("readClipboardProvider"),
       renameFileThreshold = jsonObj.getIntOption("renameFileThreshold"),
       statusBarProvider = jsonObj.getStringOption("statusBarProvider"),
       treeViewProvider = jsonObj.getBooleanOption("treeViewProvider"),

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -476,6 +476,7 @@ abstract class MetalsLspService(
     packageProvider,
     scalaVersionSelector,
     clientConfig.icons(),
+    clientConfig.isReadClipboardProvider(),
     onCreate = path => {
       onCreate(path)
       onChange(List(path))

--- a/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ServerCommands.scala
@@ -609,6 +609,7 @@ object ServerCommands {
         |The currently allowed Scala file types that can be passed in are:
         |
         | - ${NewFileTypes.ScalaFile.id} (${NewFileTypes.ScalaFile.label})
+        | - ${NewFileTypes.FromClipboard.id} (${NewFileTypes.FromClipboard.label})
         | - ${NewFileTypes.Class.id} (${NewFileTypes.Class.label})
         | - ${NewFileTypes.CaseClass.id} (${NewFileTypes.CaseClass.label})
         | - ${NewFileTypes.Enum.id} (${NewFileTypes.Enum.label})

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/DelegatingLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/DelegatingLanguageClient.scala
@@ -90,6 +90,11 @@ class DelegatingLanguageClient(var underlying: MetalsLanguageClient)
     underlying.rawMetalsInputBox(params)
   }
 
+  override def rawMetalsReadClipboard()
+      : CompletableFuture[RawMetalsReadClipboardResult] = {
+    underlying.rawMetalsReadClipboard()
+  }
+
   override def rawMetalsQuickPick(
       params: MetalsQuickPickParams
   ): CompletableFuture[RawMetalsQuickPickResult] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/MetalsLanguageClient.scala
@@ -69,6 +69,15 @@ trait MetalsLanguageClient extends LanguageClient with TreeViewClient {
     }
 
   /**
+   * Returns the current clipboard content. Used by "New Scala File > From clipboard".
+   * Clients that support this should set readClipboardProvider in InitializationOptions.
+   * @return clipboard text, or null if not available / not supported.
+   */
+  @JsonRequest("metals/readClipboard")
+  private[clients] def rawMetalsReadClipboard()
+      : CompletableFuture[RawMetalsReadClipboardResult]
+
+  /**
    * Opens an menu to ask the user to pick one of the suggested options. This method is used to deal with gson and existing extension protocol.
    * @return the user provided pick.
    */
@@ -76,6 +85,11 @@ trait MetalsLanguageClient extends LanguageClient with TreeViewClient {
   private[clients] def rawMetalsQuickPick(
       params: MetalsQuickPickParams
   ): CompletableFuture[RawMetalsQuickPickResult]
+
+  final def metalsReadClipboard(): CompletableFuture[Option[String]] =
+    rawMetalsReadClipboard().thenApply { result =>
+      Option(result.value).filter(_.nonEmpty)
+    }
 
   /**
    * Opens an menu to ask the user to pick one of the suggested options.
@@ -117,6 +131,10 @@ case class RawMetalsInputBoxResult(
     @Nullable value: String = null,
     @Nullable cancelled: java.lang.Boolean = null,
 )
+case class RawMetalsReadClipboardResult(
+    @Nullable value: String = null
+)
+
 case class RawMetalsQuickPickResult(
     // value=null when cancelled=true
     @Nullable itemId: String = null,

--- a/metals/src/main/scala/scala/meta/internal/metals/clients/language/NoopLanguageClient.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/clients/language/NoopLanguageClient.scala
@@ -43,6 +43,12 @@ abstract class NoopLanguageClient extends MetalsLanguageClient {
   ): CompletableFuture[RawMetalsInputBoxResult] = {
     CompletableFuture.completedFuture(RawMetalsInputBoxResult(cancelled = true))
   }
+  override def rawMetalsReadClipboard()
+      : CompletableFuture[RawMetalsReadClipboardResult] = {
+    CompletableFuture.completedFuture(
+      RawMetalsReadClipboardResult(value = null)
+    )
+  }
   override def rawMetalsQuickPick(
       params: MetalsQuickPickParams
   ): CompletableFuture[RawMetalsQuickPickResult] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileProvider.scala
@@ -32,6 +32,7 @@ class NewFileProvider(
     packageProvider: PackageProvider,
     selector: ScalaVersionSelector,
     icons: Icons,
+    isReadClipboardProvider: Boolean,
     onCreate: AbsolutePath => Future[Unit],
 )(implicit
     ec: ExecutionContext
@@ -92,33 +93,67 @@ class NewFileProvider(
   ) = {
     fileType match {
       case kind @ (Class | CaseClass | Object | Trait | Enum) =>
-        getName(kind, name)
+        getName(kind, name, None)
           .mapOption(
             createClass(directory, _, kind, ".scala")
           )
       case kind @ (JavaClass | JavaEnum | JavaInterface | JavaRecord) =>
-        getName(kind, name)
+        getName(kind, name, None)
           .mapOption(
             createClass(directory, _, kind, ".java")
           )
       case ScalaFile =>
-        getName(ScalaFile, name).mapOption(
+        getName(ScalaFile, name, None).mapOption(
           createEmptyFileWithPackage(directory, _)
         )
       case Worksheet =>
-        getName(Worksheet, name)
+        getName(Worksheet, name, None)
           .mapOption(
             createEmptyFile(directory, _, ".worksheet.sc")
           )
       case ScalaScript =>
-        getName(ScalaScript, name)
+        getName(ScalaScript, name, None)
           .mapOption(
             createEmptyFile(directory, _, ".sc")
           )
+      case FromClipboard =>
+        createFromClipboard(directory, name)
       case PackageObject =>
         createPackageObject(directory).liftOption
     }
   }
+
+  /** Suggests a filename from Scala snippet content (first class/object/trait/enum name). */
+  private def suggestNameFromScalaContent(content: String): String = {
+    val pattern =
+      """(?m)^\s*(?:(?:sealed|final|implicit|abstract)\s+)*(?:case\s+)?(?:class|object|trait|enum)\s+([A-Za-z_][A-Za-z0-9_]*)""".r
+    pattern.findFirstMatchIn(content).map(_.group(1)).getOrElse("Snippet")
+  }
+
+  private def createFromClipboard(
+      directory: AbsolutePath,
+      name: Option[String],
+  ): Future[Option[(AbsolutePath, Range)]] =
+    client.metalsReadClipboard().asScala.flatMap {
+      case Some(content) if content.trim.nonEmpty =>
+        val suggestedName = suggestNameFromScalaContent(content)
+        getName(FromClipboard, name, Some(suggestedName))
+          .mapOption { fileName =>
+            val path =
+              directory.resolve(fileNameWithExtension(fileName, ".scala"))
+            val text = packageProvider
+              .packageStatement(path)
+              .map(_.fileContent)
+              .getOrElse("") + content.trim + "\n"
+            createFileAndWriteText(path, NewFileTemplate.fromContent(text))
+          }
+      case _ =>
+        client.showMessage(
+          MessageType.Info,
+          "Clipboard is empty or not supported by this client.",
+        )
+        Future.successful(None)
+    }
 
   private def askForKind(
       kinds: List[NewFileType]
@@ -137,7 +172,7 @@ class NewFileProvider(
   private def askForScalaKind(
       isScala3: Boolean
   ): Future[Option[NewFileType]] = {
-    val allFileTypes = List(
+    val baseTypes = List(
       ScalaFile,
       Class,
       CaseClass,
@@ -147,8 +182,10 @@ class NewFileProvider(
       Worksheet,
       ScalaScript,
     )
+    val withClipboard =
+      if (isReadClipboardProvider) FromClipboard +: baseTypes else baseTypes
     val withEnum =
-      if (isScala3) allFileTypes :+ Enum else allFileTypes
+      if (isScala3) withClipboard :+ Enum else withClipboard
     askForKind(withEnum)
   }
 
@@ -164,10 +201,16 @@ class NewFileProvider(
     askForKind(withRecord)
   }
 
-  private def askForName(kind: String): Future[Option[String]] = {
+  private def askForName(
+      kind: String,
+      value: Option[String],
+  ): Future[Option[String]] = {
     client
       .metalsInputBox(
-        MetalsInputBoxParams(prompt = NewScalaFile.enterNameMessage(kind))
+        MetalsInputBoxParams(
+          prompt = NewScalaFile.enterNameMessage(kind),
+          value = value.orNull,
+        )
       )
       .asScala
       .mapOptionInside(_.value)
@@ -176,12 +219,17 @@ class NewFileProvider(
   private def getName(
       kind: NewFileType,
       name: Option[String],
+      suggestedValue: Option[String],
   ): Future[Option[String]] = {
     name match {
       case Some(v) if v.trim.length > 0 => Future.successful(name)
-      case _ => askForName(kind.label)
+      case _ => askForName(kind.label, suggestedValue)
     }
   }
+
+  /** Avoids double extension when user types "Foo.scala" or "Foo.java". */
+  private def fileNameWithExtension(name: String, ext: String): String =
+    if (name.endsWith(ext)) name else name + ext
 
   private def createClass(
       directory: AbsolutePath,
@@ -189,11 +237,10 @@ class NewFileProvider(
       kind: NewFileType,
       ext: String,
   ): Future[(AbsolutePath, Range)] = {
-    val path = directory.resolve(name + ext)
-    // name can be actually be "foo/Name", where "foo" is a folder to create
-    val className = Identifier.backtickWrap(
-      directory.resolve(name).filename
-    )
+    val fileName = fileNameWithExtension(name, ext)
+    val path = directory.resolve(fileName)
+    // name can be "foo/Name" or "Foo.scala"; use path filename without ext for template
+    val className = Identifier.backtickWrap(path.filename.stripSuffix(ext))
     val template = kind match {
       case CaseClass => caseClassTemplate(className)
       case Enum => enumTemplate(className)
@@ -213,7 +260,7 @@ class NewFileProvider(
       directory: AbsolutePath,
       name: String,
   ): Future[(AbsolutePath, Range)] = {
-    val path = directory.resolve(name + ".scala")
+    val path = directory.resolve(fileNameWithExtension(name, ".scala"))
     val pkg = packageProvider
       .packageStatement(path)
       .map(_.fileContent)
@@ -240,7 +287,7 @@ class NewFileProvider(
       name: String,
       extension: String,
   ): Future[(AbsolutePath, Range)] = {
-    val path = directory.resolve(name + extension)
+    val path = directory.resolve(fileNameWithExtension(name, extension))
     createFileAndWriteText(path, NewFileTemplate.empty)
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileTemplate.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileTemplate.scala
@@ -39,4 +39,8 @@ object NewFileTemplate {
   }
 
   def empty = new NewFileTemplate(cursorMarker)
+
+  /** Template from raw content with cursor at end (e.g. for paste-from-clipboard). */
+  def fromContent(content: String): NewFileTemplate =
+    NewFileTemplate(content + cursorMarker)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileTypes.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/newScalaFile/NewFileTypes.scala
@@ -16,6 +16,12 @@ object NewFileTypes {
     override val label: String = "Empty file"
   }
 
+  case object FromClipboard extends NewFileType {
+    override val id: String = "scala-file-from-clipboard"
+    override val syntax: Option[String] = None
+    override val label: String = "From clipboard"
+  }
+
   case object Class extends NewFileType {
     override val id: String = "scala-class"
     override val syntax: Option[String] = Some("class")
@@ -96,6 +102,7 @@ object NewFileTypes {
       case Object.id => Some(Object)
       case Trait.id => Some(Trait)
       case ScalaFile.id => Some(ScalaFile)
+      case FromClipboard.id => Some(FromClipboard)
       case PackageObject.id => Some(PackageObject)
       case Worksheet.id => Some(Worksheet)
       case ScalaScript.id => Some(ScalaScript)

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -30,6 +30,7 @@ import scala.meta.internal.metals.clients.language.MetalsStatusParams
 import scala.meta.internal.metals.clients.language.NoopLanguageClient
 import scala.meta.internal.metals.clients.language.RawMetalsInputBoxResult
 import scala.meta.internal.metals.clients.language.RawMetalsQuickPickResult
+import scala.meta.internal.metals.clients.language.RawMetalsReadClipboardResult
 import scala.meta.internal.metals.clients.language.StatusType
 import scala.meta.internal.tvp.TreeViewDidChangeParams
 import scala.meta.io.AbsolutePath
@@ -141,6 +142,9 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
   }
   var quickPickHandler: MetalsQuickPickParams => RawMetalsQuickPickResult = {
     (_: MetalsQuickPickParams) => RawMetalsQuickPickResult(cancelled = true)
+  }
+  var readClipboardHandler: () => RawMetalsReadClipboardResult = { () =>
+    RawMetalsReadClipboardResult(value = null)
   }
   var onMetalsStatus: MetalsStatusParams => Unit = { (_: MetalsStatusParams) =>
     ()
@@ -497,6 +501,11 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
       messageRequests.addLast(params.prompt)
       inputBoxHandler(params)
     }
+  }
+
+  override def rawMetalsReadClipboard()
+      : CompletableFuture[RawMetalsReadClipboardResult] = {
+    CompletableFuture.completedFuture(readClipboardHandler())
   }
 
   override def rawMetalsQuickPick(

--- a/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/NewFileLspSuite.scala
@@ -13,6 +13,7 @@ import scala.meta.internal.metals.RecursivelyDelete
 import scala.meta.internal.metals.ServerCommands
 import scala.meta.internal.metals.clients.language.MetalsInputBoxParams
 import scala.meta.internal.metals.clients.language.RawMetalsInputBoxResult
+import scala.meta.internal.metals.clients.language.RawMetalsReadClipboardResult
 import scala.meta.internal.metals.newScalaFile.NewFileTypes._
 import scala.meta.internal.metals.{BuildInfo => V}
 
@@ -23,7 +24,12 @@ import org.eclipse.lsp4j.ShowMessageRequestParams
 class NewFileLspSuite extends BaseLspSuite("new-file") {
 
   override protected def initializationOptions: Option[InitializationOptions] =
-    Some(InitializationOptions.Default.copy(inputBoxProvider = Some(true)))
+    Some(
+      InitializationOptions.Default.copy(
+        inputBoxProvider = Some(true),
+        readClipboardProvider = Some(true),
+      )
+    )
 
   checkScala("new-worksheet-picked")(
     directory = Some("a/src/main/scala/"),
@@ -356,6 +362,54 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
                           |""".stripMargin,
   )
 
+  checkScala("empty-file-name-with-extension")(
+    directory = Some("a/src/main/scala/foo"),
+    fileType = Right(ScalaFile),
+    fileName = Right("Foo.scala"),
+    expectedFilePath = "a/src/main/scala/foo/Foo.scala",
+    expectedContent = s"""|package foo
+                          |
+                          |
+                          |""".stripMargin,
+  )
+
+  checkScala("new-class-name-with-extension")(
+    directory = Some("a/src/main/scala/foo/"),
+    fileType = Right(Class),
+    fileName = Right("Bar.scala"),
+    expectedFilePath = "a/src/main/scala/foo/Bar.scala",
+    expectedContent = s"""|package foo
+                          |
+                          |class Bar {
+                          |$indent
+                          |}
+                          |""".stripMargin,
+  )
+
+  checkScala("new-file-from-clipboard")(
+    directory = Some("a/src/main/scala/foo/"),
+    fileType = Right(FromClipboard),
+    fileName = Right("Demo"),
+    expectedFilePath = "a/src/main/scala/foo/Demo.scala",
+    expectedContent = """|package foo
+                         |
+                         |object Demo { def x = 1 }
+                         |""".stripMargin,
+    expectedSnippet = Some("object Demo { def x = 1 }"),
+  )
+
+  checkScala("new-file-from-clipboard2")(
+    directory = Some("a/src/main/scala/foo/"),
+    fileType = Right(FromClipboard),
+    fileName = Right("Demo2"),
+    expectedFilePath = "a/src/main/scala/foo/Demo2.scala",
+    expectedContent = """|package foo
+                         |
+                         |sealed trait Demo2 { def x = 1 }
+                         |""".stripMargin,
+    expectedSnippet = Some("sealed trait Demo2 { def x = 1 }"),
+  )
+
   checkScala("new-class-infer-base-package")(
     directory = Some("a/src/main/scala/foo/bar"),
     fileType = Right(Class),
@@ -573,6 +627,7 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
       existingFiles: String = "",
       expectedException: List[Class[_]] = Nil,
       scalaVersion: Option[String] = None,
+      expectedSnippet: Option[String] = None,
   )(implicit loc: Location): Unit = check(testName)(
     directory,
     fileType,
@@ -583,6 +638,7 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
     existingFiles,
     expectedException,
     scalaVersion,
+    expectedSnippet,
   )
 
   /**
@@ -599,6 +655,7 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
       existingFiles: String,
       expectedException: List[Class[_]],
       scalaVersion: Option[String],
+      expectedSnippet: Option[String] = None,
   )(implicit loc: Location): Unit =
     test(testName) {
       val localScalaVersion = scalaVersion.getOrElse(V.scala213)
@@ -618,6 +675,14 @@ class NewFileLspSuite extends BaseLspSuite("new-file") {
         fileType match {
           case Left(providedType) => providedType.label
           case Right(pickedType) =>
+            expectedSnippet match {
+              case Some(snippet) if pickedType == FromClipboard =>
+                client.readClipboardHandler = () =>
+                  RawMetalsReadClipboardResult(
+                    value = snippet
+                  )
+              case _ =>
+            }
             client.showMessageRequestHandler = { params =>
               if (isSelectTheKindOfFile(params)) {
                 params.getActions().asScala.find(_.getTitle() == pickedType.id)


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/8210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "From clipboard" option for creating new Scala files when enabled in client settings. Users can paste clipboard content to create files, with automatic filename suggestions derived from the snippet and improved extension handling.
* **Documentation**
  * Updated new-file help text to list "From clipboard" as an available Scala file type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->