### PR TITLE
chore: Test Metals with Scala 3.8.3

### DIFF
--- a/project/V.scala
+++ b/project/V.scala
@@ -13,7 +13,7 @@ object V {
 
   val scala3ForSBT2 = "3.7.4"
 
-  val latestScala3Next = "3.8.2"
+  val latestScala3Next = "3.8.3"
 
   // When you can add to removedScalaVersions in MtagsResolver.scala with the last released version
   val sbtScala = "2.12.20"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Scala 3 "next" compiler reference from 3.8.2 to 3.8.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->