### PR TITLE
docs: Add release notes for Metals 1.6.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
     id: version
     attributes:
       label: Version of Metals
-      placeholder: v1.6.5
+      placeholder: v1.6.6
     validations:
       required: true
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 Global / resolvers += "scala-nightlies" at
   "https://repo.scala-lang.org/artifactory/maven-nightlies"
 
-def localSnapshotVersion = "1.6.6-SNAPSHOT"
-def latestReleaseVersion = "1.6.5"
+def localSnapshotVersion = "1.6.7-SNAPSHOT"
+def latestReleaseVersion = "1.6.6"
 def isCI = System.getenv("CI") != null
 def isTest = System.getenv("METALS_TEST") != null
 

--- a/docs/build-tools/bloop.md
+++ b/docs/build-tools/bloop.md
@@ -12,7 +12,7 @@ To manually tell Metals to connect with Bloop, run the "Connect to build server"
 (id: `build.connect`) command. In VS Code, open the "Command palette"
 (`Cmd + Shift + P`) and search "connect to build server".
 
-![Import connect to build server command](https://github.com/scalameta/gh-pages-images/metals/bloop/mIR0WTe.png?raw=true)
+![Import connect to build server command](https://github.com/scalameta/gh-pages-images/metals/bloop/mIR0WTe.png)
 
 In case of any issues, it's also possible to restart a running Bloop server
 using the `Restart Bloop server` command (id: `build-restart`).

--- a/docs/build-tools/sbt.md
+++ b/docs/build-tools/sbt.md
@@ -10,7 +10,7 @@ Metals out-of-the-box.
 
 ```
 
-![Import build](https://github.com/scalameta/gh-pages-images/blob/master/metals/sbt/t5RJ3q6.png?raw=true)
+![Import build](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/sbt/t5RJ3q6.png)
 
 The Automatic build import process for sbt happens through
 [Bloop](https://scalacenter.github.io/bloop/), a build server for Scala. Bloop

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -63,7 +63,7 @@ To avoid repetition, common utilities of presentation compilers are in `mtags-sh
 Below diagram shows project structure and dependencies among modules. Note that
 `default-<suffix>` is a [default root project](https://www.scala-sbt.org/1.x/docs/Multi-Project.html#Default+root+project)
 created implicitly by sbt.
-![Projects diagram](https://github.com/scalameta/gh-pages-images/blob/master/metals/getting-started/oIhXd5l.png?raw=true)
+![Projects diagram](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/getting-started/oIhXd5l.png)
 
 ## Related projects
 
@@ -188,11 +188,11 @@ Then you can attach IDE with opened Metals repository to the debugged instance:
 
   Then pick such a defined configuration and run debug.
 
-  ![Attach debugger](https://github.com/scalameta/gh-pages-images/blob/master/metals/getting-started/ySAo6Um.png?raw=true)
+  ![Attach debugger](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/getting-started/ySAo6Um.png)
 
 - IntelliJ - Select Attach to the process and pick proper process from the list
 
-  ![Attach to the process](https://github.com/scalameta/gh-pages-images/blob/master/metals/getting-started/lHSl57l.png?raw=true)
+  ![Attach to the process](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/getting-started/lHSl57l.png)
 
 ## Unit tests
 
@@ -282,7 +282,7 @@ Next, update the "Server version" setting under preferences to point to the
 version you published locally via `sbt publishLocal`. You'll notice that version has the format
 `<version>-SNAPSHOT`.
 
-![Metals server version setting](https://github.com/scalameta/gh-pages-images/blob/master/metals/getting-started/ogVWI1t.png?raw=true)
+![Metals server version setting](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/getting-started/ogVWI1t.png)
 
 When you make changes in the Metals Scala codebase
 

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -67,7 +67,7 @@ explanation and examples.
 If you want to add images to the release notes, you can add them to the separate
 folder in the `gh-pages-images` repository and reference them in the release
 notes using the
-`![image-name](https://github.com/scalameta/gh-pages-images/blob/master/metals/<release-name>/image-name.gif?raw=true)`
+`![image-name](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/<release-name>/image-name.gif)`
 format.
 
 ### Update Metals version

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -6,7 +6,7 @@ title: Emacs
 Metals works in Emacs thanks to the
 [`lsp-mode`](https://github.com/emacs-lsp/lsp-mode) package (another option is the [Eglot](#eglot) package).
 
-![Emacs demo](https://github.com/scalameta/gh-pages-images/blob/master/metals/emacs/KJQLMZ7.gif?raw=true)
+![Emacs demo](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/emacs/KJQLMZ7.gif)
 
 ```scala mdoc:requirements
 
@@ -177,14 +177,14 @@ The above shall become unnecessary once [this issue](https://github.com/emacs-ls
 
 To manually trigger a build import, run `M-x lsp-metals-build-import`.
 
-![Import build command](https://github.com/scalameta/gh-pages-images/blob/master/metals/emacs/SvGXJDK.png?raw=true)
+![Import build command](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/emacs/SvGXJDK.png)
 
 ## Run doctor
 
 Run `M-x lsp-metals-doctor-run` to troubleshoot potential configuration problems
 in your build.
 
-![Run doctor command](https://github.com/scalameta/gh-pages-images/blob/master/metals/emacs/yelm0jd.png?raw=true)
+![Run doctor command](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/emacs/yelm0jd.png)
 
 ### eglot
 

--- a/docs/editors/helix.md
+++ b/docs/editors/helix.md
@@ -4,7 +4,7 @@ sidebar_label: Helix
 title: Helix
 ---
 
-![helix demo](https://github.com/scalameta/gh-pages-images/blob/master/metals/helix/b0sETIY.gif?raw=true)
+![helix demo](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/helix/b0sETIY.gif)
 
 ```scala mdoc:requirements
 

--- a/docs/editors/overview.md
+++ b/docs/editors/overview.md
@@ -326,7 +326,7 @@ pattern matches and more.
 
 See the expression type and symbol signature under the cursor.
 
-![](https://github.com/scalameta/gh-pages-images/blob/master/metals/overview/2MfQvsM.gif?raw=true)
+![Hover](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/overview/2MfQvsM.gif)
 
 - **Expression type**: shows the non-generic type of the highlighted expression.
 - **Symbol signature**: shows the generic signature of symbol under the cursor
@@ -336,7 +336,7 @@ See the expression type and symbol signature under the cursor.
 
 View a method signature and method overloads as you fill in the arguments.
 
-![](https://github.com/scalameta/gh-pages-images/blob/master/metals/overview/DAWIrHu.gif?raw=true)
+![Signature help](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/overview/DAWIrHu.gif)
 
 ## Find references
 
@@ -377,7 +377,7 @@ Fuzzy search a symbol in the workspace of library dependencies by its name.
 - Queries ending with a dot `.` list nested symbols.
 - Queries containing a semicolon `;` search library dependencies.
 
-![Fuzzy symbol search example](https://github.com/scalameta/gh-pages-images/blob/master/metals/overview/w5yrK1w.gif?raw=true)
+![Fuzzy symbol search example](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/overview/w5yrK1w.gif)
 
 ## Formatting
 
@@ -393,13 +393,13 @@ https://scalameta.org/scalafmt/docs/configuration.html.
 
 Fold ranges such as large multi-line expressions, import groups and comments.
 
-![](https://camo.githubusercontent.com/3fdd7ae28907ac61c0a1ac5fdc07d085245957aa/68747470733a2f2f692e696d6775722e636f6d2f667149554a54472e676966)
+![Code folding](https://camo.githubusercontent.com/3fdd7ae28907ac61c0a1ac5fdc07d085245957aa/68747470733a2f2f692e696d6775722e636f6d2f667149554a54472e676966)
 
 ## Document highlight
 
 Highlight references to the same symbol in the open file.
 
-![](https://github.com/scalameta/gh-pages-images/blob/master/metals/overview/0uhc9P5.gif?raw=true)
+![Document highlight](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/overview/0uhc9P5.gif)
 
 ## Package explorer
 
@@ -413,7 +413,7 @@ tree representation of tests. Although it was implemented in order to use Visual
 Studio Code's
 [Testing API](https://code.visualstudio.com/api/extension-guides/testing). The
 Test Explorer API is editor agnostic and can be used by other editors than just
-VS Code. ![test-explorer](https://github.com/scalameta/gh-pages-images/blob/master/metals/overview/Z3VtS0O.gif?raw=true)
+VS Code. ![test-explorer](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/overview/Z3VtS0O.gif)
 
 Work on the Test Explorer is still in progress and the feature has some known
 limitations:

--- a/docs/editors/sublime.md
+++ b/docs/editors/sublime.md
@@ -6,7 +6,7 @@ title: Sublime Text
 Metals works with Sublime Text (build 4000 or later) thanks to the
 [sublimelsp/LSP](https://github.com/sublimelsp/LSP) and [scalameta/metals-sublime](https://github.com/scalameta/metals-sublime) plugins.
 
-![Sublime Text demo](https://github.com/scalameta/gh-pages-images/blob/master/metals/sublime/vJKP0T3.gif?raw=true)
+![Sublime Text demo](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/sublime/vJKP0T3.gif)
 
 ```scala mdoc:requirements
 
@@ -40,7 +40,7 @@ definition.
 
 ## Importing a build
 
-![Build Import](https://github.com/scalameta/gh-pages-images/blob/master/metals/sublime/eUk30Zy.png?raw=true)
+![Build Import](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/sublime/eUk30Zy.png)
 
 Open Sublime in the base directory of your Scala project and it will then prompt you to import the build as long as you're using one of the [supported build tools](https://scalameta.org/metals/docs/build-tools/overview.html). Click "Import build" to start the installation step.
 
@@ -55,7 +55,7 @@ workspace. The exact time depends on the complexity of the build and if the libr
 For more detailed information about what is happening behind the scenes during
 `sbt bloopInstall` run `lsp toggle server panel` in the command palette. You can optionally add key binding for this command.
 
-![Server logs](https://github.com/scalameta/gh-pages-images/blob/master/metals/sublime/PilER2E.png?raw=true)
+![Server logs](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/sublime/PilER2E.png)
 
 Once the import step completes, compilation starts for your open `*.scala`
 files. Once the sources have compiled successfully, you can navigate the
@@ -66,17 +66,17 @@ sources with "Goto definition" by pressing `F12`.
 The default key binding is `shift+F12`. If you use vim-bindings, you need to be
 in insert-mode.
 
-![Find references](https://github.com/scalameta/gh-pages-images/blob/master/metals/sublime/BJDkczD.gif?raw=true)
+![Find references](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/sublime/BJDkczD.gif)
 
 ## Goto symbol in workspace
 
 You can search for symbols in your dependency source using the command palette.
 
-![workspace symbols](https://github.com/scalameta/gh-pages-images/blob/master/metals/sublime/8X0XNi2.gif?raw=true)
+![workspace symbols](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/sublime/8X0XNi2.gif)
 
 ## Manually trigger build import
 
-![Import build command](https://github.com/scalameta/gh-pages-images/blob/master/metals/sublime/LViPc95.png?raw=true)
+![Import build command](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/sublime/LViPc95.png)
 
 You can optionally register a key binding for the command.
 
@@ -107,7 +107,7 @@ set following setting in the "Preferences > Preferences: LSP Settings":
 }
 ```
 
-![Symbol references in the popup](https://github.com/scalameta/gh-pages-images/blob/master/metals/sublime/7tSiEfX.gif?raw=true
+![Symbol references in the popup](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/sublime/7tSiEfX.gif
 )
 
 ### Additional key mappings 
@@ -128,7 +128,7 @@ definition.
   }
 ]
 ```
-![Add key mapping for formatting document via scalafmt](https://github.com/scalameta/gh-pages-images/blob/master/metals/sublime/wVjC1Ij.gif?raw=true)
+![Add key mapping for formatting document via scalafmt](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/sublime/wVjC1Ij.gif)
 
 
 ### Add key mapping for Goto symbol in workspace
@@ -163,7 +163,7 @@ Open "Preferences > Key Binding" and add:
 ```
 
 
-![Import after Enter key was hit](https://github.com/scalameta/gh-pages-images/blob/master/metals/sublime/RDYx9mB.gif?raw=true)
+![Import after Enter key was hit](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/sublime/RDYx9mB.gif)
 
 ## Using latest Metals SNAPSHOT
 

--- a/docs/editors/vim.md
+++ b/docs/editors/vim.md
@@ -4,7 +4,7 @@ sidebar_label: Vim
 title: Vim
 ---
 
-![nvim-metals demo](https://github.com/scalameta/gh-pages-images/blob/master/metals/vim/BglIFli.gif?raw=true)
+![nvim-metals demo](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vim/BglIFli.gif)
 
 While Metals works with most LSP clients for [Vim](https://www.vim.org/) and
 [Neovim](https://neovim.io/), we recommend using the dedicated Neovim plugin to

--- a/docs/editors/vscode.md
+++ b/docs/editors/vscode.md
@@ -18,7 +18,7 @@ by clicking on this badge
 [![Install Metals extension](https://img.shields.io/badge/metals-vscode-blue.png)](vscode:extension/scalameta.metals)
 or via the VS Code editor:
 
-![install stable version](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/Qew0fNH.png?raw=true)
+![install stable version](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/Qew0fNH.png)
 
 Next, open a directory containing your Scala code. The extension activates when
 the main directory contains `build.sbt` or `build.sc` file, a Scala file is
@@ -32,14 +32,14 @@ with [SNAPSHOT](#SNAPSHOT) releases of Metals server. Using pre-release versions
 may result in less stable experience and it is not intented for beginners.
 Pre-release versions follow `major.minor.PATCH` versioning.
 
-![Install the pre-release extension](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/CzOTleE.png?raw=true)
+![Install the pre-release extension](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/CzOTleE.png)
 
 ```scala mdoc:editor:vscode
 Update the "Sbt Script" setting to use a custom `sbt` script instead of the
 default Metals launcher if you need further customizations like reading environment
 variables.
 
-![Sbt Launcher](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/NuwEBe4.png?raw=true)
+![Sbt Launcher](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/NuwEBe4.png)
 ```
 
 ```scala mdoc:command-palette:vscode
@@ -79,7 +79,7 @@ variable, if the variable is not set is falls to using the Metals's JDK.
 - `Java Home` - path to project's JDK's Home. Note: this setting isn't respected
   for `Bazel`.
 
-![Java Home setting](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/sKrPKk2.png?raw=true)
+![Java Home setting](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/sKrPKk2.png)
 
 Note: Project's JDK version should be greater or equal to Metals's server JDK
 version for features like completions to work correctly.
@@ -143,15 +143,15 @@ to take effect.
 Run the "Explorer: Focus on Outline View" command to open the symbol outline for
 the current file in the sidebar.
 
-![Document Symbols Outline](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/T0kVJsr.gif?raw=true)
+![Document Symbols Outline](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/T0kVJsr.gif)
 
 Run the "Open Symbol in File" command to search for a symbol in the current file
 without opening the sidebar.
 
-![Document Symbols Command](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/0PJ4brd.png?raw=true)
+![Document Symbols Command](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/0PJ4brd.png)
 
 As you type, the symbol outline is also visible at the top of the file.
-![Document Symbols Outline](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/L217n4q.png?raw=true)
+![Document Symbols Outline](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/L217n4q.png)
 
 ```scala mdoc:parent-lenses:vscode
 
@@ -187,7 +187,7 @@ project's modules. From this panel it's possible to
 - run/debug test
 - navigate to test's definition.
 
-![test-explorer](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/Z3VtS0O.gif?raw=true)
+![test-explorer](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/Z3VtS0O.gif)
 
 ```scala mdoc:test-frameworks
 
@@ -196,11 +196,11 @@ project's modules. From this panel it's possible to
 If you encounter an error, create an
 [issue](https://github.com/scalameta/metals/issues).
 
-![test-explorer](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/Z3VtS0O.gif?raw=true)
+![test-explorer](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/Z3VtS0O.gif)
 
 ### via code lenses
 
-![lenses](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/5nTnrcS.png?raw=true)
+![lenses](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/5nTnrcS.png)
 
 For each main or test class Metals shows two code lenses `run | debug` or
 `test | test debug`, which show up above the definition as a kind of virtual
@@ -332,26 +332,26 @@ nativeConfig ~= { c =>
 
 ## On type formatting for multiline string formatting
 
-![on-type](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/a0O2vCs.gif?raw=true)
+![on-type](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/a0O2vCs.gif)
 
 To properly support adding `|` in multiline strings we are using the
 `onTypeFormatting` method. The functionality is enabled by default, but you can
 disable/enable `onTypeFormatting` inside Visual Studio Code settings by checking
 `Editor: Format On Type`:
 
-![on-type-setting](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/s6nT9rC.png?raw=true)
+![on-type-setting](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/s6nT9rC.png)
 
 ## Formatting on paste for multiline strings
 
 Whenever text is paste into a multiline string with `|` it will be properly
 formatted by Metals:
 
-![format-on-paste](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/fF0XWYC.gif?raw=true)
+![format-on-paste](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/fF0XWYC.gif)
 
 This feature is enabled by default. If you need to disable/enable formatting on
 paste in Visual Studio Code you can check the `Editor: Format On Paste` setting:
 
-![format-on-paste-setting](https://github.com/scalameta/gh-pages-images/blob/master/metals/vscode/rMrk27F.png?raw=true)
+![format-on-paste-setting](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/vscode/rMrk27F.png)
 
 ```scala mdoc:worksheet:vscode
 

--- a/docs/features/scripts.md
+++ b/docs/features/scripts.md
@@ -10,7 +10,7 @@ not `*.worksheet.sc` or a build server has not already started for it, users
 will be prompted to use [Scala CLI](https://scala-cli.virtuslab.org/) to power
 the script.
 
-![scala-cli](https://github.com/scalameta/gh-pages-images/blob/master/metals/scripts/ghR1Src.gif?raw=true)
+![scala-cli](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/scripts/ghR1Src.gif)
 
 Scripts are usually used for smaller programs and the main difference is that
 statements can be put on top level without a need for additional objects or

--- a/docs/integrations/new-editor.md
+++ b/docs/integrations/new-editor.md
@@ -651,7 +651,7 @@ Metals has an optional web interface that can be used to trigger server commands
 and respond to server requests. This interface is not intended for regular
 users, it exists only to help editor plugin authors integrate with Metals.
 
-![Metals http client](https://github.com/scalameta/gh-pages-images/blob/master/metals/new-editor/t5RJ3q6.png?raw=true)
+![Metals http client](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/new-editor/t5RJ3q6.png)
 
 The server is enabled by passing the `-Dmetals.http=on` system property. The
 server runs by default at [`http://localhost:5031`](http://localhost:5031/).
@@ -694,7 +694,7 @@ In general, Metals uses status notifications to update the user about ongoing
 events in the server such as batch compilation in the build server or when a
 successful connection was established with the build server.
 
-![Metals status bar](https://github.com/scalameta/gh-pages-images/blob/master/metals/new-editor/XX9CLRH.gif?raw=true)
+![Metals status bar](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/new-editor/XX9CLRH.gif)
 
 The "🚀 Imported build" and "🔄 Compiling explorer" messages at the bottom of
 the window are `metals/status` notifications.
@@ -725,7 +725,7 @@ The Metals did focus notification is sent from the client to the server when the
 editor changes focus to a new text document. Unlike `textDocument/didOpen`, the
 did focus notification is sent even when the text document is already open.
 
-![Metals did focus](https://github.com/scalameta/gh-pages-images/blob/master/metals/new-editor/XjTtAZK.gif?raw=true)
+![Metals did focus](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/new-editor/XjTtAZK.gif)
 
 Observe that the compilation error appears as soon as `UserTest.scala` is
 focused even if the text document was already open before. The LSP

--- a/docs/integrations/test-explorer.md
+++ b/docs/integrations/test-explorer.md
@@ -35,15 +35,15 @@ Both run and debug under the hood use BSP's debug request.
 
 ### Running and debugging
 
-Following diagram ([source](https://github.com/scalacenter/bloop/blob/12bdc7f97cc3970d3e22a8b513f4b609c813f0a7/docs/assets/dap-example-metals.png)) represents what communication between language client, language server and build server. ![](https://raw.githubusercontent.com/scalacenter/bloop/master/docs/assets/dap-example-metals.png)
+Following diagram ([source](https://github.com/scalacenter/bloop/blob/12bdc7f97cc3970d3e22a8b513f4b609c813f0a7/docs/assets/dap-example-metals.png)) represents what communication between language client, language server and build server. ![Debugging diagram](https://raw.githubusercontent.com/scalacenter/bloop/master/docs/assets/dap-example-metals.png)
 
 The current implementation of TE is a better version of code lenses, with more user friendly UX provided by the VSCode.
 
 ### Getting and analyzing results
 
 After test run was finished TE analyzes execution results and sets proper statutes for each test included in run.
-![](https://github.com/scalameta/gh-pages-images/blob/master/metals/test-explorer/vop095s.png?raw=true)
-![](https://github.com/scalameta/gh-pages-images/blob/master/metals/test-explorer/TLhwEtG.png?raw=true)
+![Test Explorer results](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/test-explorer/vop095s.png)
+![Test Explorer results](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/test-explorer/TLhwEtG.png)
 
 Such detailed information is available thanks to the [sbt-test-interface](https://github.com/sbt/test-interface) which abstracts over test framework internals, most important classes are: [Event](https://github.com/sbt/test-interface/blob/17a94641942546e21f4c6b300a3360be2d2888f6/src/main/java/sbt/testing/Event.java) and [Status](https://github.com/sbt/test-interface/blob/17a94641942546e21f4c6b300a3360be2d2888f6/src/main/java/sbt/testing/Status.java) which are used in the [sbt.ForkMain](https://github.com/sbt/sbt/blob/50c3cf10825bae3e89af11b3a2c9741e6d98add5/testing/agent/src/main/java/sbt/ForkMain.java). Almost all of build servers (if not all of them) uses `ForkMain` and `sbt-test-interface` to offload testing.
 

--- a/docs/integrations/tree-view-protocol.md
+++ b/docs/integrations/tree-view-protocol.md
@@ -14,7 +14,7 @@ One "tree view" represents the root of a tree along with all of its descendent
 tree nodes. Multiple tree views can be displayed at the same time in an editor
 client.
 
-![Example tree views](https://github.com/scalameta/gh-pages-images/blob/master/metals/tree-view-protocol/FRWL3Aq.png?raw=true)
+![Example tree views](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/tree-view-protocol/FRWL3Aq.png)
 
 A tree view is uniquely identified by a `viewId: string` field in other data
 structures.

--- a/docs/troubleshooting/faq.md
+++ b/docs/troubleshooting/faq.md
@@ -17,7 +17,7 @@ additional parameter for starting Metals server.
 
 ## I'm using Scala 2.13.x but doctor shows me `*-build` and `*-build-build` at 2.12.x
 
-![build-build-doctor](https://github.com/scalameta/gh-pages-images/blob/master/metals/faq/mgnRXse.png?raw=true)
+![build-build-doctor](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/faq/mgnRXse.png)
 
 When using sbt and Metals you get completions and hovers in your sbt build
 files. This is done by extra BSP connections with Bloop. So your build is
@@ -34,7 +34,7 @@ see this in the Doctor since sbt does not yet have sbt file support._
 
 ## Why do I see this popup about Bloop when I upgrade?
 
-![update-bloop](https://github.com/scalameta/gh-pages-images/blob/master/metals/faq/0rtoIxy.png?raw=true)
+![update-bloop](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/faq/0rtoIxy.png)
 
 Sometimes when you update to the latest version of Metals you will see this
 popup. Remember that [Bloop](https://scalacenter.github.io/bloop/) runs in the
@@ -87,11 +87,11 @@ Worksheet code is entirely wrapped in a class (`class MdocApp`). The class wrapp
 
 If worksheet evaluation times out, you can also increase the timeout by setting `-Dmetals.worksheet-timeout=<number of seconds>` server property:
 
-![worksheet-timeout](https://github.com/scalameta/gh-pages-images/blob/master/metals/faq/v2GEanF.png?raw=true)
+![worksheet-timeout](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/faq/v2GEanF.png)
 
 ## Why do I get a warning to save my file when I try to organize imports?
 
-![organize-imports-warning](https://github.com/scalameta/gh-pages-images/blob/master/metals/faq/g8d82bV.png?raw=true)
+![organize-imports-warning](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/faq/g8d82bV.png)
 
 You'll currently see this if you try to use your editor action to organize
 imports. You'll also see this if you use the following setting in VS Code.

--- a/metals-docs/src/main/scala/docs/Image.scala
+++ b/metals-docs/src/main/scala/docs/Image.scala
@@ -3,18 +3,18 @@ package docs
 object Image {
   val all: Map[String, Map[String, String]] = Map(
     "vscode" -> Map(
-      "importBuild" -> "https://github.com/scalameta/gh-pages-images/blob/master/metals/Image/0VqZWay.png?raw=true",
-      "importChanges" -> "https://github.com/scalameta/gh-pages-images/blob/master/metals/Image/72kdZkL.png?raw=true",
-      "importCommand" -> "https://github.com/scalameta/gh-pages-images/blob/master/metals/Image/QHLKt8u.png?raw=true",
-      "runDoctor" -> "https://github.com/scalameta/gh-pages-images/blob/master/metals/Image/K02g0UM.png?raw=true",
+      "importBuild" -> "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/Image/0VqZWay.png",
+      "importChanges" -> "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/Image/72kdZkL.png",
+      "importCommand" -> "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/Image/QHLKt8u.png",
+      "runDoctor" -> "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/Image/K02g0UM.png",
     ),
     "vim" -> Map(
-      "importBuild" -> "https://github.com/scalameta/gh-pages-images/blob/master/metals/Image/1EyQPTC.png?raw=true",
-      "importChanges" -> "https://github.com/scalameta/gh-pages-images/blob/master/metals/Image/iocTVb6.png?raw=true",
+      "importBuild" -> "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/Image/1EyQPTC.png",
+      "importChanges" -> "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/Image/iocTVb6.png",
     ),
     "emacs" -> Map(
-      "importBuild" -> "https://github.com/scalameta/gh-pages-images/blob/master/metals/Image/UdwMQFk.png?raw=true",
-      "importChanges" -> "https://github.com/scalameta/gh-pages-images/blob/master/metals/Image/UFK0p8i.png?raw=true",
+      "importBuild" -> "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/Image/UdwMQFk.png",
+      "importChanges" -> "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/Image/UFK0p8i.png",
     ),
   )
   def importBuild(editor: String): String =

--- a/website/blog/2019-01-22-bloom-filters.md
+++ b/website/blog/2019-01-22-bloom-filters.md
@@ -354,7 +354,7 @@ bottle-neck appears to be starting the file watcher and parsing all `*.scala`
 and `*.java` sources in the workspace. The following flamegraph shows a detailed
 breakdown of what goes on during indexing.
 
-![Akka indexing flamegraph](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-01-22-bloom-filters/Xhr1wXp.jpg?raw=true)(https://geirsson.com/assets/metals-akka-initialize.svg)
+![Akka indexing flamegraph](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-01-22-bloom-filters/Xhr1wXp.jpg)(https://geirsson.com/assets/metals-akka-initialize.svg)
 
 > Click on image to interactively explore the flamegraph.
 
@@ -371,7 +371,7 @@ the distribution is different for how long each indexing task takes. Prisma has
 fewer sources (80k lines of Scala code, no Java) and a larger number of library
 dependencies compared to Akka.
 
-![Prisma indexing flamegraph](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-01-22-bloom-filters/JR3SNx6.jpg?raw=true)(https://geirsson.com/assets/metals-prisma-initialize.svg)
+![Prisma indexing flamegraph](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-01-22-bloom-filters/JR3SNx6.jpg)(https://geirsson.com/assets/metals-prisma-initialize.svg)
 
 > Click on image to interactively explore the flamegraph.
 
@@ -411,4 +411,4 @@ installation instructions here
 https://scalameta.org/metals/docs/editors/overview.html.
 
 The indexer is working when the status bar says `Indexing⠋`
-![Indexing status bar](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-01-22-bloom-filters/6VLPu9c.gif?raw=true)
+![Indexing status bar](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-01-22-bloom-filters/6VLPu9c.gif)

--- a/website/blog/2019-01-24-tin.md
+++ b/website/blog/2019-01-24-tin.md
@@ -36,7 +36,7 @@ Previously, Metals only published compile errors from the build on file save.
 Now, a syntax error is also published as you type making it easier to catch
 common errors like unclosed string literals and missing parentheses.
 
-![Syntax errors as you type](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-01-24-tin/2nzeSQv.gif?raw=true)
+![Syntax errors as you type](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-01-24-tin/2nzeSQv.gif)
 
 This change has an additional benefit in editors like Vim where compile errors
 would previously disappear if you for example inserted a newline above an error.
@@ -57,7 +57,7 @@ The status bar now includes information which individual build targets are being
 compiled along with a percentage estimate for how much remains of the
 compilation.
 
-![Detailed compile progress](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-01-24-tin/fbQysxW.gif?raw=true)
+![Detailed compile progress](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-01-24-tin/fbQysxW.gif)
 
 ### Cascade compile command
 
@@ -66,7 +66,7 @@ targets in the workspace. For example, if you have made changes in the main
 sources of you project you can run cascade compile to trigger compilation in the
 test sources.
 
-![Cascade compile](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-01-24-tin/EbKPn6g.png?raw=true)
+![Cascade compile](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-01-24-tin/EbKPn6g.png)
 
 ### Formatting with Scalafmt
 
@@ -185,7 +185,7 @@ without using the HTTP server.
 
 It's now possible to manually trigger a build import from the command palette.
 
-![Import build command](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-01-24-tin/LViPc95.png?raw=true)
+![Import build command](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-01-24-tin/LViPc95.png)
 
 See
 [manually trigger build import](https://scalameta.org/metals/docs/editors/sublime#manually-trigger-build-import)

--- a/website/blog/2019-04-12-mercury.md
+++ b/website/blog/2019-04-12-mercury.md
@@ -44,7 +44,7 @@ generate exhaustive pattern matches and more.
 It's now possible to see the expression type and symbol signature under the
 cursor.
 
-![](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-04-12-mercury/2MfQvsM.gif?raw=true)
+![Hover](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-04-12-mercury/2MfQvsM.gif)
 
 - **Expression type**: shows the non-generic type of the highlighted expression.
 - **Symbol signature**: shows the generic signature of symbol under the cursor
@@ -55,14 +55,14 @@ cursor.
 It's now possible to view a method signature and overloads as you fill in
 arguments.
 
-![](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-04-12-mercury/DAWIrHu.gif?raw=true)
+![Signature help](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-04-12-mercury/DAWIrHu.gif)
 
 ## Code folding
 
 It's now possible to fold ranges such as large expressions, import groups and
 comments.
 
-![](https://camo.githubusercontent.com/3fdd7ae28907ac61c0a1ac5fdc07d085245957aa/68747470733a2f2f692e696d6775722e636f6d2f667149554a54472e676966)
+![Code folding](https://camo.githubusercontent.com/3fdd7ae28907ac61c0a1ac5fdc07d085245957aa/68747470733a2f2f692e696d6775722e636f6d2f667149554a54472e676966)
 
 Big thanks to [@marek1840](https://github.com/marek1840) for contributing this
 feature!
@@ -71,7 +71,7 @@ feature!
 
 It's now possible to highlight references to the same symbol in the open file.
 
-![](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-04-12-mercury/0uhc9P5.gif?raw=true)
+![Document highlight](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-04-12-mercury/0uhc9P5.gif)
 
 Big thanks to [@tgodzik](https://github.com/tgodzik) for contributing this
 feature!
@@ -87,7 +87,7 @@ semicolon character `;`. For example:
   workspace contains 0 results
 - queries "Future;" or ";Future" or "Fut;ure": workspace + library dependencies.
 
-![](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-04-12-mercury/w5yrK1w.gif?raw=true)
+![Fuzzy symbol search](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-04-12-mercury/w5yrK1w.gif)
 
 This change improves the quality for the search results since most often you
 want to navigate to symbols defined in the workspace. A nice side-effect is that
@@ -105,7 +105,7 @@ successfully compiled in the build tool. Now, you can use goto definition for
 symbols that you just typed even if the source file hasn't been saved or
 contains type errors.
 
-![](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-04-12-mercury/63PYPhX.gif?raw=true)
+![Goto definition](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-04-12-mercury/63PYPhX.gif)
 
 ## Standalone Scala files outside a build tool
 

--- a/website/blog/2019-06-28-thorium.md
+++ b/website/blog/2019-06-28-thorium.md
@@ -89,7 +89,7 @@ Metals can now run on Java 11! To use Java 11 instead of Java 8, point the
 The VS Code extension will continue to use Java 8 by default, update the "Java
 Home" setting to use Java 11 instead.
 
-![](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-06-28-thorium/F5djfzt.png?raw=true)
+![JDK 11 support](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-06-28-thorium/F5djfzt.png)
 
 To obtain the Java 11 home on macOS, use the following command:
 
@@ -122,7 +122,7 @@ Previously, nothing happened when invoking "goto definition" on the symbol
 definition itself. Now, Metals falls back to "find references" in this
 situation.
 
-![Fallback](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-06-28-thorium/BT3h0FJ.gif?raw=true)
+![Fallback](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-06-28-thorium/BT3h0FJ.gif)
 
 Big thanks to [@tanishiking](https://github.com/tanishiking) for contributing
 this new feature!

--- a/website/blog/2019-09-02-thorium.md
+++ b/website/blog/2019-09-02-thorium.md
@@ -54,13 +54,13 @@ relative path between the new source file and source root. This is done using
 applyWorkspaceEdit method, which causes the change to be done in editor and this
 can easily be rewerted like any other change you would type.
 
-![add-package](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-09-02-thorium/6V9gHnM.gif?raw=true)
+![add-package](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-09-02-thorium/6V9gHnM.gif)
 
 We also added support for package objects. Whenever you create `package.scala`
 file, we will automatically create the barebone definition of the package
 object.
 
-![package-object](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-09-02-thorium/CfF0cdE.gif?raw=true)
+![package-object](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-09-02-thorium/CfF0cdE.gif)
 
 There is still some work to be done about moving files between packages, which
 will be addressed in the next release.
@@ -74,7 +74,7 @@ We finally managed to properly support adding `|` in multiline strings using the
 `onTypeFormatting` method. Previous implementation was very naive and often
 added pipes in wrong places.
 
-![pipes](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-09-02-thorium/iXGYOf0.gif?raw=true)
+![pipes](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-09-02-thorium/iXGYOf0.gif)
 
 To enable the functionality you need to enable `onTypeFormatting` inside your
 editor if it's not enabled by default.
@@ -82,7 +82,7 @@ editor if it's not enabled by default.
 In Visual Studio Code this needs to be done in settings by checking
 `Editor: Format On Type`:
 
-![on-type](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-09-02-thorium/4eVvSP5.gif?raw=true)
+![on-type](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-09-02-thorium/4eVvSP5.gif)
 
 You will also need the newest version of the Visual Studio Code plugin.
 

--- a/website/blog/2019-09-12-thorium.md
+++ b/website/blog/2019-09-12-thorium.md
@@ -31,7 +31,7 @@ Whenever we invoke a method and try completions inside the brackets there is an
 additional option to allow Metals to deduce what should be filled for each
 parameter.
 
-![auto-fill](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-09-12-thorium/8pCiMqE.gif?raw=true)
+![auto-fill](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-09-12-thorium/8pCiMqE.gif)
 
 This algorithm checks if there exists a value in scope with the same type as the
 parameters' and then works according to the rules below:
@@ -50,7 +50,7 @@ auto-filled parameters and choose or replace the auto-filled values.
 Leveraging the work that went into the previous feature, we were also able to
 provide additional support for concrete values in named parameter completions.
 
-![deduce](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-09-12-thorium/m11xixy.gif?raw=true)
+![deduce](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-09-12-thorium/m11xixy.gif)
 
 We generate completion item for each value that fits the type of the parameter.
 

--- a/website/blog/2019-09-23-thorium.md
+++ b/website/blog/2019-09-23-thorium.md
@@ -35,12 +35,12 @@ available to use with Metals!
 Whenever text is pasted into a multiline string with `|` it will be properly
 formatted by Metals:
 
-![format-on-paste](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-09-23-thorium/yJLAIxQ.gif?raw=true)
+![format-on-paste](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-09-23-thorium/yJLAIxQ.gif)
 
 To enable this feature you need to enable formatting on paste in your editor of
 choice. In Visual Studio Code it can be done via modifying a checkbox:
 
-![format-on-paste](https://github.com/scalameta/gh-pages-images/blob/master/metals/2019-09-23-thorium/OaBxwer.png?raw=true)
+![format-on-paste](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2019-09-23-thorium/OaBxwer.png)
 
 ## Fixes for autofill feature
 

--- a/website/blog/2020-01-10-cobalt.md
+++ b/website/blog/2020-01-10-cobalt.md
@@ -88,7 +88,7 @@ Metals now implements the textDocument/implementations LSP endpoint, which
 enables all supported editors to display a list of all implementations of
 abstract classes or members.
 
-![implementations](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-01-10-cobalt/rke6iny.gif?raw=true)
+![implementations](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-01-10-cobalt/rke6iny.gif)
 
 Finding implementations also works for symbols outside of the workspace, at the
 price of a small performance penalty for the first invocation.
@@ -113,7 +113,7 @@ Thanks to the implementation of the `Go to implementations` feature, we were
 able to work on a proper rename for any workspace symbol that will rename all
 occurrences of a symbol even if that symbol is a part of a class hierarchy.
 
-![rename](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-01-10-cobalt/QHaJCr0.gif?raw=true)
+![rename](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-01-10-cobalt/QHaJCr0.gif)
 
 There are a couple of cases in which rename might behave differently based on
 the particular symbol being renamed:
@@ -166,7 +166,7 @@ Visual Studio Code and coc-metals.
 
 Visual Studio Code:
 
-![worksheet](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-01-10-cobalt/8c1NkIx.gif?raw=true)
+![worksheet](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-01-10-cobalt/8c1NkIx.gif)
 
 The other way worksheets are implemented for all other editors that don't
 support the `Decoration extension` is using workspace/applyEdits and comments

--- a/website/blog/2020-05-04-lithium.md
+++ b/website/blog/2020-05-04-lithium.md
@@ -99,7 +99,7 @@ use to fix their workspace as well as added two new commands:
 - `Restart Bloop server` - restart the Bloop build server, which should help
   with the cases where compilation would hang.
 
-  ![reworked-tree-view](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-05-04-lithium/PERfNqt.png?raw=true)
+  ![reworked-tree-view](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-05-04-lithium/PERfNqt.png)
 
 Even if those commands help, do not hesitate to report any issues. We are also
 monitoring the situation ourselves and investigating all problems encountered.
@@ -112,7 +112,7 @@ and bug fixes to the project. Thanks to her, we can now easily enter a newline
 inside a single line string and that string will be correctly split with an
 additional `+`.
 
-![split-line](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-05-04-lithium/uhF0MOx.gif?raw=true)
+![split-line](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-05-04-lithium/uhF0MOx.gif)
 
 ## Code action to import all missing symbols
 
@@ -122,7 +122,7 @@ the ability to import everything in bulk for every unambiguous import available.
 Unambiguous in this case meaning that there is only one possible import to
 choose from.
 
-![import-all](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-05-04-lithium/mmzgJs7.gif?raw=true)
+![import-all](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-05-04-lithium/mmzgJs7.gif)
 
 ## Miscellaneous improvements
 

--- a/website/blog/2020-07-01-lithium.md
+++ b/website/blog/2020-07-01-lithium.md
@@ -132,7 +132,7 @@ Thanks to the efforts of [olafurpg](https://github.com/olafurpg) in
 to import dependencies directly inside of their Scala worksheet with completions
 and diagnostics working right from the start.
 
-![worksheet-imports](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-07-01-lithium/qXgdNWM.gif?raw=true)
+![worksheet-imports](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-07-01-lithium/qXgdNWM.gif)
 
 You can add them using the following syntax:
 
@@ -189,7 +189,7 @@ strings. Firstly, thanks to [mlachkar](https://github.com/mlachkar) we now
 automatically add `stripMargin` method invocation when using newline in a
 multiline string if that string uses `|` and has no existing `stripMargin`:
 
-![strip-margin](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-07-01-lithium/Z2Q1glN.gif?raw=true)
+![strip-margin](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-07-01-lithium/Z2Q1glN.gif)
 
 This behaviour can be disabled in Metals settings using
 `metals.enableStripMarginOnTypeFormatting`.
@@ -198,7 +198,7 @@ Another useful improvement coming from [colineto](https://github.com/colineto)
 is a new code action that can easily convert single string into the traditional
 multiline string with `|` and `stripMargin` at the end:
 
-![new-action](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-07-01-lithium/5ohRcl9.gif?raw=true)
+![new-action](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-07-01-lithium/5ohRcl9.gif)
 
 ## Multiple workspace build tools selection
 
@@ -211,7 +211,7 @@ An example situation where this is needed is when you have a project with both a
 definition. Previously if both were detected, it was automatically considered an
 Sbt workspace, however now it's possible to choose.
 
-![multiple-build-tool](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-07-01-lithium/pAgZK7u.gif?raw=true)
+![multiple-build-tool](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-07-01-lithium/pAgZK7u.gif)
 
 In case of multiple build tools in single workspace you can see which one was
 used to import project in 'Metals Doctor' view. If you choose the wrong one, or

--- a/website/blog/2020-07-15-lithium.md
+++ b/website/blog/2020-07-15-lithium.md
@@ -56,7 +56,7 @@ reset it:
 
 - via a new button available in the doctor (Visual Studio Code):
 
-![doctor](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-07-15-lithium/Vz3vMpA.png?raw=true)
+![doctor](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-07-15-lithium/Vz3vMpA.png)
 
 - using a new command `metals.reset-choice` (other editors):
 

--- a/website/blog/2020-07-23-configuring-a-client.md
+++ b/website/blog/2020-07-23-configuring-a-client.md
@@ -95,7 +95,7 @@ containing the definition of the method or symbol or display the full method
 hierarchy allowing you to choose where to go.
 
 Here is an example of what this looks like in Vim:
-![Super Method Hierarchy](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-07-23-configuring-a-client/rEvhzG1.png?raw=true)
+![Super Method Hierarchy](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-07-23-configuring-a-client/rEvhzG1.png)
 
 This feature is actually turned off by default since in very large code bases
 you may experience a lag. So if a user wanted to turn this on, it wouldn't be a

--- a/website/blog/2020-08-19-lithium.md
+++ b/website/blog/2020-08-19-lithium.md
@@ -73,7 +73,7 @@ supported worksheets.
 This is a great place for anyone to experiment with Scala 3 and see what is
 coming around the corner!
 
-![worksheet-sample](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-08-19-lithium/DZvz3Le.gif?raw=true)
+![worksheet-sample](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-08-19-lithium/DZvz3Le.gif)
 
 ## Running main classes from dependencies
 

--- a/website/blog/2020-09-21-lithium.md
+++ b/website/blog/2020-09-21-lithium.md
@@ -63,7 +63,7 @@ The only thing users need to do is copy the stack trace and run the
 web view, where it will be possible for users to navigate the files that are
 included in the exception.
 
-![stacktrace-vscode](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-09-21-lithium/WBU4hvT.gif?raw=true)
+![stacktrace-vscode](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-09-21-lithium/WBU4hvT.gif)
 
 ### coc-metals
 

--- a/website/blog/2020-11-06-sbt-BSP-support.md
+++ b/website/blog/2020-11-06-sbt-BSP-support.md
@@ -34,7 +34,7 @@ editor to abstract over various programming languages by a shared way to
 communicate to a language server, BSP allows IDE's to abstract over various
 build servers. A typical example of this can be illustrated like so:
 
-![LSP BSP example](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-11-06-sbt-BSP-support/0RRUDlU.png?raw=true)
+![LSP BSP example](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-11-06-sbt-BSP-support/0RRUDlU.png)
 
 You have your editor (Emacs) communicating with Metals via LSP, and then Metals
 communicating with a BSP server (Bloop) via BSP. This communication over BSP can
@@ -115,7 +115,7 @@ like this:
 
 ### `metals.generate-bsp-config`
 
-![generate-bsp-config](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-11-06-sbt-BSP-support/kBNbtzI.gif?raw=true)
+![generate-bsp-config](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-11-06-sbt-BSP-support/kBNbtzI.gif)
 
 ### `.bsp/sbt.json` already exists
 
@@ -125,7 +125,7 @@ and choose sbt. For example, using `coc-metals`, it looks like this:
 
 ### `metals.bsp-switch`
 
-![bsp-switch](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-11-06-sbt-BSP-support/6tY2ofL.gif?raw=true)
+![bsp-switch](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-11-06-sbt-BSP-support/6tY2ofL.gif)
 
 ### Switching back to Bloop
 
@@ -139,7 +139,7 @@ Doctor.
 
 ### Doctor reset
 
-![Doctor](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-11-06-sbt-BSP-support/YEGfEGB.png?raw=true)
+![Doctor](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-11-06-sbt-BSP-support/YEGfEGB.png)
 
 ## Conclusion
 

--- a/website/blog/2020-11-10-lithium.md
+++ b/website/blog/2020-11-10-lithium.md
@@ -62,7 +62,7 @@ automatically organize imports. We are happy to announce, that thanks to
 [Scalafix](https://github.com/scalacenter/scalafix) and Metals, this new feature
 is now available via an `Organize imports` code action.
 
-![imports](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-11-10-lithium/8YBdjjC.gif?raw=true)
+![imports](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-11-10-lithium/8YBdjjC.gif)
 
 Depending on the editor this code action can be invoked differently, please
 consult your specific editor's documentation. For example in Visual Studio Code
@@ -134,12 +134,12 @@ release, users can use two new options when looking through their code:
 - `metals.showImplicitArguments` will enable users to see implicit parameters
   within their code:
 
-![params](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-11-10-lithium/vAvM7YV.png?raw=true)
+![params](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-11-10-lithium/vAvM7YV.png)
 
 - `metals.showInferredType` will enable users to see inferred type for any
   generic methods they are using:
 
-![types](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-11-10-lithium/K3QrUd2.png?raw=true)
+![types](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-11-10-lithium/K3QrUd2.png)
 
 Both new options are disabled by default, since they add a great number of
 information, which might not be necessary for all users. Full name with package

--- a/website/blog/2020-11-20-lithium.md
+++ b/website/blog/2020-11-20-lithium.md
@@ -63,7 +63,7 @@ users to quickly peek at the additional information about their code and then
 turn it back off. All these commands can be bound to a shortcut to further
 improve the user experience.
 
-![implicits](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-11-20-lithium/k6GRgue.gif?raw=true)
+![implicits](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-11-20-lithium/k6GRgue.gif)
 
 Any editor that allows for quickly changing these settings will also benefit
 from this change, as the file's decorations are refreshed instantly upon
@@ -77,7 +77,7 @@ Previously, it was possible to navigate a stacktrace using the
 turns out, we can reuse the same mechanism to show file links in the
 `Debug Console` in Visual Studio code:
 
-![navigate-stacktrace](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-11-20-lithium/qeitymN.gif?raw=true)
+![navigate-stacktrace](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-11-20-lithium/qeitymN.gif)
 
 This was achieved by adding additional information to the output already sent to
 the editor, so this additional file links should also be reused by any other DAP

--- a/website/blog/2020-12-19-lithium.md
+++ b/website/blog/2020-12-19-lithium.md
@@ -55,7 +55,7 @@ be able to export their evaluated worksheets using a new command,
 `copy-worksheet-output`, or `Metals: Copy worksheet output` in Visual Studio
 Code.
 
-![worksheet-export](https://github.com/scalameta/gh-pages-images/blob/master/metals/2020-12-19-lithium/PQmT2i3.gif?raw=true)
+![worksheet-export](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2020-12-19-lithium/PQmT2i3.gif)
 
 When using this command existing statements will be copied to your clipboard
 along with their evaluations included as comments below them. This will allow

--- a/website/blog/2021-02-02-metals-retro-part1.md
+++ b/website/blog/2021-02-02-metals-retro-part1.md
@@ -3,7 +3,7 @@ authors: ckipp
 title: A Metals Retrospective (Part 1)
 ---
 
-![metals-banner](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-02-02-metals-retro-part1/FYZXteD.png?raw=true)
+![metals-banner](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-02-02-metals-retro-part1/FYZXteD.png)
 
 At the end of 2020 the Metals team sent out a survey to gather input from our
 users in hopes to get a better picture of who you are, what you want out of
@@ -23,7 +23,7 @@ this to be a 2 part series. You can expect the following:
 
 ## Editor Support
 
-![editor-results](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-02-02-metals-retro-part1/w67gMGW.png?raw=true)
+![editor-results](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-02-02-metals-retro-part1/w67gMGW.png)
 
 Surprising no one, VS Code came out on top for editors with the most desire for
 Metals support. Our
@@ -142,8 +142,8 @@ communication open with pretty impressive response times if you ever get stuck.
 Here are the results about where people go for question about Metals and also
 where they get their news about Metals.
 
-![metals info](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-02-02-metals-retro-part1/6Ijm9Bv.png?raw=true)
-![metals help](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-02-02-metals-retro-part1/2Qysoqe.png?raw=true)
+![metals info](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-02-02-metals-retro-part1/6Ijm9Bv.png)
+![metals help](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-02-02-metals-retro-part1/2Qysoqe.png)
 
 Apart from the places that we had listed in the survey, the place mentioned the
 most for where people hear about Metals related news was

--- a/website/blog/2021-02-24-tungsten.md
+++ b/website/blog/2021-02-24-tungsten.md
@@ -105,7 +105,7 @@ for(i <- 0 to 10)`
 The decoration is based on the information produced during the compilation, so
 anything new will first need to be compiled to have the type shown.
 
-![type-decorations](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-02-24-tungsten/NHzB0M6.png?raw=true)
+![type-decorations](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-02-24-tungsten/NHzB0M6.png)
 
 This feature can easily be controlled by the previously available
 `metals.showInferredType` setting and will currently work for clients that allow
@@ -125,7 +125,7 @@ What it means is that this new feature will work even in some more problematic
 cases when the file is not yet compiled or in files where type decorations are
 not yet supported, like in worksheets.
 
-![inferred-type](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-02-24-tungsten/ZT36mH7.gif?raw=true)
+![inferred-type](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-02-24-tungsten/ZT36mH7.gif)
 
 There might be still some work to do when it comes to some more complicated
 types, but it should work perfectly well for most daily use cases. Please do

--- a/website/blog/2021-05-17-tungsten.md
+++ b/website/blog/2021-05-17-tungsten.md
@@ -59,7 +59,7 @@ multiple definitions in the source file. This works for classes, traits, enums,
 and objects. The code action will not show if the definition we are extracting
 is or extends a `sealed` definition.
 
-![gif1](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-05-17-tungsten/dKKkLcL.gif?raw=true)
+![gif1](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-05-17-tungsten/dKKkLcL.gif)
 
 The extraction happens via a code action on the definition's name, it will also
 extract any relevant package definition, imports, and, if available, the
@@ -71,7 +71,7 @@ It is also now possible when there is only a single definition in a file that
 doesn't have the same name as the definition, to quickly rename the file
 according to its content.
 
-![gif2](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-05-17-tungsten/pUADnMn.gif?raw=true)
+![gif2](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-05-17-tungsten/pUADnMn.gif)
 
 ## [Scala 3] Auto imports in completions and code actions
 

--- a/website/blog/2021-07-14-tungsten.md
+++ b/website/blog/2021-07-14-tungsten.md
@@ -87,7 +87,7 @@ We're hard at work ensuring that the same feature-set for Scala 2 is available
 for Scala 3. This release adds support for the `Insert Inferred Type` code
 action.
 
-![gif2](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-07-14-tungsten/GJGFOOy.gif?raw=true)
+![gif2](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-07-14-tungsten/GJGFOOy.gif)
 
 In addition to other small fixes, it's worth mentioning that the
 `Go to Definition` functionality was improved so that in situations where there
@@ -110,7 +110,7 @@ works from within your dependency sources to include references from all
 workspace sources. Previously, it included only local occurrences in the
 dependency source file.
 
-![gif3](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-07-14-tungsten/myHPDjP.gif?raw=true)
+![gif3](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-07-14-tungsten/myHPDjP.gif)
 
 ## Miscellaneous
 

--- a/website/blog/2021-09-06-tungsten.md
+++ b/website/blog/2021-09-06-tungsten.md
@@ -67,7 +67,7 @@ block irrelevant of whether it has braces or not. A number of improvements has
 also been done to make sure the cursor ends up on the correct indentation level
 upon writing a newline.
 
-![indentation](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-09-06-tungsten/TVewmY7.gif?raw=true)
+![indentation](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-09-06-tungsten/TVewmY7.gif)
 
 If you encounter any issues, please don't hesitate to report them since the
 functionality is new and there might be some edge cases where it doesn't work.
@@ -90,7 +90,7 @@ other particular situations, which might be automated, via the the Metals's
 Thanks to [kpodsiad](https://github.com/kpodsiad) it's now possible to
 automatically rewrite lambdas with `_ match` expressions to partial functions:
 
-![partial-func](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-09-06-tungsten/Ffm4RXZ.gif?raw=true)
+![partial-func](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-09-06-tungsten/Ffm4RXZ.gif)
 
 ### Replace () with {} in functions and vice versa
 
@@ -98,7 +98,7 @@ It's quite often that in Scala we might want to change to a simple lambda to a
 multiline one or vice versa. This has previously been a manual chore, but now
 whenever possible you can do it via a code action:
 
-![replace](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-09-06-tungsten/DTylGT9.gif?raw=true)
+![replace](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-09-06-tungsten/DTylGT9.gif)
 
 ## Allow organize imports on unsaved code
 

--- a/website/blog/2021-10-26-tungsten.md
+++ b/website/blog/2021-10-26-tungsten.md
@@ -69,7 +69,7 @@ Since expression evaluation is a complex feature there might still be some bugs
 that we didn't account for, so do not hesitate to report anything that doesn't
 look right.
 
-![evaluator](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-10-26-tungsten/1b17Vtm.gif?raw=true)
+![evaluator](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-10-26-tungsten/1b17Vtm.gif)
 
 _Editors support_: every client that implements DAP
 
@@ -105,7 +105,7 @@ The full list of commands:
 In VS Code you can notice that there is a new `Metals Analyze Source` submenu in
 file pop-up menu that provides a list of all these commands.
 
-![analyze](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-10-26-tungsten/6tGSvuI.gif?raw=true)
+![analyze](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-10-26-tungsten/6tGSvuI.gif)
 
 _Editors support_: VS Code, nvim-metals
 
@@ -115,7 +115,7 @@ This release also introduces another helpful feature, it's possible now to do
 text search through files in classpath jars and source-jars. Thanks to
 [@ Z1kkurat](https://github.com/Z1kkurat) for his contribution!
 
-![find-in-jars](https://github.com/scalameta/gh-pages-images/blob/master/metals/2021-10-26-tungsten/o1Drd12.gif?raw=true)
+![find-in-jars](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2021-10-26-tungsten/o1Drd12.gif)
 
 _Editors support_: VS Code, nvim-metals
 

--- a/website/blog/2022-01-12-aluminium.md
+++ b/website/blog/2022-01-12-aluminium.md
@@ -67,7 +67,7 @@ possible to decompile class files using Lee Benfield's
 CFR decompiles class files to java, which is much more readable than using
 `javap`.
 
-![cfr](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-01-12-aluminium/exDFGyT.gif?raw=true)
+![cfr](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-01-12-aluminium/exDFGyT.gif)
 
 In the future this might help in go to definition for jars that do not have a
 corresponding source jar, which is what Metals uses today.
@@ -181,7 +181,7 @@ Lenses. The new UI adds a testing view, which shows all test suites declared in
 project's modules. From this panel it's also possible to run/debug test or to
 navigate to test's definition.
 
-![test-explorer](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-01-12-aluminium/Z3VtS0O.gif?raw=true)
+![test-explorer](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-01-12-aluminium/Z3VtS0O.gif)
 
 Code Lenses are still the default in other editors and can be brought back by
 setting `"metals.testUserInterface": "Code Lenses"`
@@ -200,7 +200,7 @@ limitation was mostly due to the lack of proper UI options in different editors.
 Recently, we've managed to work around it by using command links that can be
 rendered in the hover and will bring the user to the right definition.
 
-![synthetic-def](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-01-12-aluminium/YyHVmLX.gif?raw=true)
+![synthetic-def](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-01-12-aluminium/YyHVmLX.gif)
 
 Editor support: Visual Studio Code, Sublime Text
 
@@ -212,7 +212,7 @@ targets. Currently the biggest missing piece is interactive compiler that would
 allow us to properly support features such as completions, hover or signature
 help.
 
-![java](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-01-12-aluminium/SJvLTRL.gif?raw=true)
+![java](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-01-12-aluminium/SJvLTRL.gif)
 
 This was possible thanks to using the Java semanticdb plugin included in
 [lsif Java project](https://github.com/sourcegraph/lsif-java) from

--- a/website/blog/2022-03-08-aluminium.md
+++ b/website/blog/2022-03-08-aluminium.md
@@ -84,7 +84,7 @@ in one view information such as:
 - projects classpath
 - and many more
 
-![display-build-target-info](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-03-08-aluminium/XGyJEsl.gif?raw=true)
+![display-build-target-info](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-03-08-aluminium/XGyJEsl.gif)
 
 ## [vscode] View source jar files as virtual docs
 
@@ -99,7 +99,7 @@ Together with Metals tab, this feature could be used to browse through your
 dependencies' sources. Just run the `Metals: Reveal Active File in Side Bar`
 command and browse through both dependencies and source code seamlessly.
 
-![virtual-docs-navigation](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-03-08-aluminium/HsuW8Hn.gif?raw=true)
+![virtual-docs-navigation](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-03-08-aluminium/HsuW8Hn.gif)
 
 Currently, `Metals: Reveal Active File in Side Bar` works only for Scala 2.
 
@@ -108,7 +108,7 @@ Currently, `Metals: Reveal Active File in Side Bar` works only for Scala 2.
 Completion suggestions for different Scala keywords now work with most of the
 Scala 3 keywords. This includes for example `given` and `enum`, it should also
 work even if defining things in toplevel without a wrapping class or object.
-![keyword-completions](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-03-08-aluminium/4BUxCDK.gif?raw=true)
+![keyword-completions](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-03-08-aluminium/4BUxCDK.gif)
 
 Another improvement for Scala 3 completions is better support for showing scope
 completions, when writing in an empty line. Previously, we would not show
@@ -135,7 +135,7 @@ JUnit4.
 Currently, this feature **only works when using Bloop as your build server**,
 but in a future release there will be support added for sbt as well.
 
-![test-explorer-single-tests](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-03-08-aluminium/FbgSTGr.gif?raw=true)
+![test-explorer-single-tests](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-03-08-aluminium/FbgSTGr.gif)
 
 ## [vscode] Add mirror setting to help coursier set up
 
@@ -147,7 +147,7 @@ repo1.maven.org.
 Thanks to [tgodzik](https://github.com/tgodzik)'s work from now on it's possible
 to define `metals.coursierMirror` property.
 
-![coursier-mirror](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-03-08-aluminium/iLB079M.png?raw=true)
+![coursier-mirror](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-03-08-aluminium/iLB079M.png)
 
 More information about mirrors can be found at
 [coursier documentation](https://get-coursier.io/blog/#mirrors).

--- a/website/blog/2022-04-26-aluminium.md
+++ b/website/blog/2022-04-26-aluminium.md
@@ -52,7 +52,7 @@ give Metals a try!
 - Create companion object code action
 - Add status bar when starting a debug session
 - Ensure the "no run or test" message is shown to user.
-- Show better unnaply signatures
+- Show better unapply signatures
 - Provide an easier way to configure bloop settings
 - Better MUnit support in Test Explorer
 - Better sbt BSP integration
@@ -71,7 +71,7 @@ currently:
 - displays the compilation status of project
 - allows to navigate to the build target info for each target
 
-![new-doctor-view](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-04-26-aluminium/ByzzlM8.png?raw=true)
+![new-doctor-view](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-04-26-aluminium/ByzzlM8.png)
 
 ## Create companion object code action
 
@@ -79,7 +79,7 @@ Thanks to the efforts of [zmerr](https://github.com/zmerr), Metals offers a new
 code action - `Create companion object`. As its name suggests, it can be used to
 automatically create a companion object for the given class, trait or enum.
 
-![create-companion-object-code-action](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-04-26-aluminium/HW5rr5f.gif?raw=true) Theme:
+![create-companion-object-code-action](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-04-26-aluminium/HW5rr5f.gif) Theme:
 [One Dark Pro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme)
 
 ## Add status bar when starting a debug session
@@ -94,18 +94,18 @@ Until now, the user had no idea what is happening because Metals didn't show any
 progress indicator. [ckipp01](https://github.com/ckipp01) addressed this problem
 and added a status bar for each of the steps.
 
-![start-debug-session-status-bar](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-04-26-aluminium/qh7Jzdy.gif?raw=true) Theme:
+![start-debug-session-status-bar](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-04-26-aluminium/qh7Jzdy.gif) Theme:
 [One Dark Pro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme)
 
 ## Ensure the "no run or test" message is shown to user.
 
 There is a command `Run main class or tests in current file` which is a
 convenient way, as name suggests, of running main class:
-![run-main](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-04-26-aluminium/rShZ8L3.gif?raw=true) Theme:
+![run-main](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-04-26-aluminium/rShZ8L3.gif) Theme:
 [One Dark Pro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme)
 
 or running tests in the current file:
-![run-tests](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-04-26-aluminium/BtbOubC.gif?raw=true) Theme:
+![run-tests](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-04-26-aluminium/BtbOubC.gif) Theme:
 [One Dark Pro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme)
 
 It is also possible to just press `F5` in file and Metals will execute main
@@ -114,15 +114,15 @@ class or run tests in the current file if no run configuration is defined.
 However, this command was silently failing when there was no class or test to
 run in the file. This is no longer the case, now Metals will display proper
 error message in this scenario.
-![no-class-to-run](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-04-26-aluminium/xda3ApF.gif?raw=true) Theme:
+![no-class-to-run](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-04-26-aluminium/xda3ApF.gif) Theme:
 [One Dark Pro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme)
 
-## Show better unnaply signatures
+## Show better unapply signatures
 
-Previously, when pattern matching Metals was showing real `unnaply` method
+Previously, when pattern matching Metals was showing real `unapply` method
 signature, which wasn't very useful. Now, Metals properly uses unapply result
 type to show what types can be matched on.
-![unnaply-signatures](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-04-26-aluminium/Gzg11YT.png?raw=true) Theme:
+![unapply-signatures](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-04-26-aluminium/Gzg11YT.png) Theme:
 [One Dark Pro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme)
 
 ## Provide an easier way to configure bloop settings
@@ -135,7 +135,7 @@ Each modification of `Bloop Jvm Properties` settings will try to update that
 global file if possible. In case of manually configured settings, Metals will
 inform user about it and ask for their action.
 
-![update-bloop-settings](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-04-26-aluminium/Xz2gO0h.gif?raw=true) Theme:
+![update-bloop-settings](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-04-26-aluminium/Xz2gO0h.gif) Theme:
 [One Dark Pro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme)
 
 ## Better MUnit support in Test Explorer
@@ -144,7 +144,7 @@ Disclaimer: **this works only when Bloop is a build server**
 
 Test Explorer in Metals is now able to detect some single test cases for
 [MUnit](https://scalameta.org/munit/) test framework.
-![munit-single-tests](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-04-26-aluminium/QQMLy6M.png?raw=true) Theme:
+![munit-single-tests](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-04-26-aluminium/QQMLy6M.png) Theme:
 [One Dark Pro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme)
 
 More information about current MUnit support status can be found at this

--- a/website/blog/2022-06-03-aluminium.md
+++ b/website/blog/2022-06-03-aluminium.md
@@ -56,7 +56,7 @@ Metals shows the scaladoc on hover for Scala3 projects. (Before this release,
 Metals was unable to show the scaladoc for the symbols from third-party
 modules).
 
-![override-completion](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-06-03-aluminium/Go3sMxy.gif?raw=true)
+![override-completion](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-06-03-aluminium/Go3sMxy.gif)
 
 ## [Scala3] Show scaladoc on hover for Scala 3 project
 
@@ -64,7 +64,7 @@ Previously, scaladocs were missing for a lot of classes and methods in Scala 3,
 especially for the symbols from third-party modules. From this release, Metals
 will always show the scaladoc on hover for Scala3 projects.
 
-![hover-scala3](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-06-03-aluminium/Svzq5DD.png?raw=true)
+![hover-scala3](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-06-03-aluminium/Svzq5DD.png)
 
 ### [Scala3] Support `completionItem/resolve`
 
@@ -73,7 +73,7 @@ information when moving through the list of suggested completions. It will show
 documentation, proper parameter names for Java methods, and default values for
 Scala 3 methods. Now, this is also available for use in Scala 3.
 
-![completion-item-resolve](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-06-03-aluminium/Tz6AOsx.gif?raw=true)
+![completion-item-resolve](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-06-03-aluminium/Tz6AOsx.gif)
 
 ## Show parent scaladoc if implementation is returning empty
 
@@ -109,7 +109,7 @@ usages of those helper methods and display them in Test Explorer.
 
 This feature is available for Bloop and SBT 1.7.0-M2 or later.
 
-![MUnit-helper-methods](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-06-03-aluminium/GGRDpXA.gif?raw=true)
+![MUnit-helper-methods](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-06-03-aluminium/GGRDpXA.gif)
 
 ## Support Cats Effect stacktraces in stacktrace analyzer
 
@@ -120,7 +120,7 @@ Now, Stacktrace Analyzer is able to recognize CE's stacktraces and provide link
 to location in code. Say no to tedious debugging when you have only stacktrace
 from the logs!
 
-![cats-effect-stacktraces](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-06-03-aluminium/5fMvcYd.gif?raw=true)
+![cats-effect-stacktraces](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-06-03-aluminium/5fMvcYd.gif)
 
 ## Improve implement all completion and code action
 
@@ -134,7 +134,7 @@ Sometimes, it wasn't clear which code would be affected by
 [rewrite to braces/parenthesis](https://scalameta.org/metals/blog/2021/09/06/tungsten#replace--with--in-functions-and-vice-versa)
 code action. Now, code action's description contains name of the function/method
 which will be affected by executing action.
-![rewrite-braces-parens](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-06-03-aluminium/SkHolsJ.gif?raw=true) Theme:
+![rewrite-braces-parens](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-06-03-aluminium/SkHolsJ.gif) Theme:
 [One Dark Pro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme)
 
 ## Automatically setup java home for the Bloop build server

--- a/website/blog/2022-07-04-aluminium.md
+++ b/website/blog/2022-07-04-aluminium.md
@@ -82,11 +82,11 @@ Metals settings. This could result in two possible notifications:
 
 - Metals changing Java version:
 
-![metals-java-home](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-07-04-aluminium/BH8AS5c.png?raw=true)
+![metals-java-home](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-07-04-aluminium/BH8AS5c.png)
 
 - Metals detecting an existing Bloop Java configuration:
 
-![metals-java-home-existing](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-07-04-aluminium/PCyyNVT.png?raw=true)
+![metals-java-home-existing](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-07-04-aluminium/PCyyNVT.png)
 
 However, this caused a couple of issues:
 
@@ -128,7 +128,7 @@ release you should be able to apply all currently defined
 By default it's bound to `alt` + `ctrl` + `shift` + `o` shortcut in Visual
 Studio Code.
 
-![scalafix-run](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-07-04-aluminium/DLe5sYT.gif?raw=true)
+![scalafix-run](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-07-04-aluminium/DLe5sYT.gif)
 
 One major drawback of the current approach is that we are unable to run some of
 the custom rules. Only the default rules and the contributed Hygiene rules are
@@ -156,7 +156,7 @@ concrete class, you could only see the completion to override particular
 members. However, you needed to add those members one by one. Now you'll see a
 code action to implement all the members at once.
 
-![implement-all](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-07-04-aluminium/foU3oHL.gif?raw=true)
+![implement-all](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-07-04-aluminium/foU3oHL.gif)
 
 Great work by [tanishiking](https://github.com/tanishiking).
 
@@ -167,7 +167,7 @@ would be the name of the method. With snippets we can now add additional `()`
 with cursor ending in or after the parenthesis depending on whether the method
 accepts parameters.
 
-![snippets](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-07-04-aluminium/QEbPSTd.gif?raw=true)
+![snippets](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-07-04-aluminium/QEbPSTd.gif)
 
 For editors that do not support snippets the previous behaviour is preserved.
 
@@ -177,7 +177,7 @@ A file name completion feature has been available only in the Scala 2 project,
 but thanks to the effort by [riiswa](https://github.com/riiswa), Metals 0.11.7
 will complete class name based on the enclosing file, in Scala3!
 
-![filename-completion](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-07-04-aluminium/f10pnJ6.gif?raw=true)
+![filename-completion](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-07-04-aluminium/f10pnJ6.gif)
 
 ## [Scala 3] Expression evaluation for debugger.
 
@@ -187,7 +187,7 @@ however it was still missing for Scala 3. Thanks to the main work by
 bug fixes by [adpi2](https://github.com/adpi2) it is now possible to to evaluate
 your code on breakpoints in the Scala 3 code.
 
-![debug](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-07-04-aluminium/jYs7QdM.gif?raw=true)
+![debug](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-07-04-aluminium/jYs7QdM.gif)
 
 It was added in the previous 0.11.6 version of Metals, however it was still not
 working correctly enough to promote it. Currently, it should be working
@@ -205,7 +205,7 @@ it's sometimes hard to tell which arguments match which parameters at a glance.
 In this situation you may want to make them named arguments. Now you will be
 able to automatically convert all those arguments into named arguments.
 
-![convert-to-named-vscode](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-07-04-aluminium/SiUYUSY.gif?raw=true)
+![convert-to-named-vscode](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-07-04-aluminium/SiUYUSY.gif)
 
 We'd like to thank [@camgraff](https://github.com/camgraff) for
 [implementing this feature](https://github.com/scalameta/metals/pull/3971) 🥳
@@ -220,7 +220,7 @@ This is purely a syntactic sugar which gives us an ability to offer a code
 action to automatically convert any chain of the mentioned methods with a for
 comprehensions.
 
-![for-comp](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-07-04-aluminium/MOZLYi0.gif?raw=true)
+![for-comp](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-07-04-aluminium/MOZLYi0.gif)
 
 There is currently one known issue with two separate chains being inside one
 another, which might cause unexpected issues. Please report any other issues you

--- a/website/blog/2022-08-10-aluminium.md
+++ b/website/blog/2022-08-10-aluminium.md
@@ -65,7 +65,7 @@ it. But, this was time-consuming and not always beginner friendly.
 Now, Metals provides auto-completion for extension methods and automatically
 imports them!
 
-![extension-methods](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-08-10-aluminium/EAbVHeH.gif?raw=true)
+![extension-methods](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-08-10-aluminium/EAbVHeH.gif)
 
 ## [Scala 3] Convert to Named Parameters code action
 
@@ -74,7 +74,7 @@ imports them!
 Thanks to the contribution by [@jkciesluk](https://github.com/jkciesluk), this
 feature is now available for Scala 3!
 
-![convert-to-named](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-08-10-aluminium/9i7MWoQ.gif?raw=true)
+![convert-to-named](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-08-10-aluminium/9i7MWoQ.gif)
 
 ## [Scala 3] Scaladoc completion
 
@@ -82,7 +82,7 @@ Metals now supports offering Scaladoc completions in Scala 3. When typing `/**`
 you get an option to auto-complete a scaladoc template for methods, classes,
 etc.!
 
-![scala-doc-completion](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-08-10-aluminium/MEJUXr3.gif?raw=true)
+![scala-doc-completion](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-08-10-aluminium/MEJUXr3.gif)
 
 ## [Scala 3] Completions in string interpolation
 
@@ -92,7 +92,7 @@ possible to get an automatic conversion to string interpolation when typing
 `$value`, as well as automatic wrapping in `{}` when accessing members of such
 value.
 
-![scala3-interpolation](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-08-10-aluminium/EyFKpiv.gif?raw=true)
+![scala3-interpolation](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-08-10-aluminium/EyFKpiv.gif)
 
 ## [Scala 2] Automatically import types in string interpolations
 
@@ -103,7 +103,7 @@ something from another package, you would need to do it manually.
 This problem is now resolved. Users can easily get such symbols automatically
 imported, which creates a seamless workflow.
 
-![scala2-inteprolation](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-08-10-aluminium/cCWTQnj.gif?raw=true)
+![scala2-inteprolation](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-08-10-aluminium/cCWTQnj.gif)
 
 The feature is also being worked on for Scala 3.
 

--- a/website/blog/2022-10-06-aluminium.md
+++ b/website/blog/2022-10-06-aluminium.md
@@ -68,7 +68,7 @@ returned type of the body of a function and in that case any adjustments had to
 be made manually. Now, whenever the compiler shows type mismatch error Metals
 should be able to adjust the type for you automatically.
 
-![adjust-type](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-10-06-aluminium/R7z7JNf.gif?raw=true)
+![adjust-type](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-10-06-aluminium/R7z7JNf.gif)
 
 As this feature is quite new and might still require some tinkering, please
 report any issues you find.
@@ -92,7 +92,7 @@ Thanks to [alexarchambault](https://github.com/alexarchambault), who is also
 leading the effort on ScalaCLI, Metals now supports ScalaCLI scripts along with
 the Ammonite ones.
 
-![scala-cli](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-10-06-aluminium/ghR1Src.gif?raw=true)
+![scala-cli](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-10-06-aluminium/ghR1Src.gif)
 
 Whenever, Metals will be opened on a file with `*.sc` extension (but not
 `*.worksheet.sc`), users will be prompted to choose which tool they want to use
@@ -121,7 +121,7 @@ something from another package, you would need to do it manually.
 This problem is now resolved. Users can easily get such symbols automatically
 imported, which creates a seamless more workflow.
 
-![auto-import](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-10-06-aluminium/COKtciq.gif?raw=true)
+![auto-import](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-10-06-aluminium/COKtciq.gif)
 
 These completions will also allow you to automatically import extension methods.
 
@@ -135,7 +135,7 @@ fill in all the arguments of the current method using the symbol in scope or
 with `???` if no symbols match. Users can later tabulate over the different
 proposal to adjust them.
 
-![auto-fill](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-10-06-aluminium/tZTKnSw.gif?raw=true)
+![auto-fill](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-10-06-aluminium/tZTKnSw.gif)
 
 The feature was already available for Scala 2.
 
@@ -169,7 +169,7 @@ presentation compiler already used in such features as hovers or completions.
 Thanks to this change document highlight should work even if your code doesn't
 compile.
 
-![document-highlight](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-10-06-aluminium/0uhc9P5.gif?raw=true)
+![document-highlight](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-10-06-aluminium/0uhc9P5.gif)
 
 This should also make it easier for us to fix any issue that might pop up and it
 has already improved support for locally defined classes.
@@ -182,7 +182,7 @@ exhaustive completion with all of them. This was previously not available for
 Scala 3, but thanks to ([jkciesluk](https://github.com/jkciesluk)) users can now
 benefit from this feature in their Scala 3 codebases.
 
-![exhaustive](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-10-06-aluminium/6wynpRq.gif?raw=true)
+![exhaustive](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-10-06-aluminium/6wynpRq.gif)
 
 The Scala 3 version will additionally work with the Scala enums as well as offer
 completions for simple cases with one possible type, which might be useful to
@@ -196,7 +196,7 @@ is the possibility to extract arbitrary parts of code into a separate function.
 It will also add any values unavailable in the selected scope as parameters in
 the new function.
 
-![extract-method](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-10-06-aluminium/VMXLKPg.gif?raw=true)
+![extract-method](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-10-06-aluminium/VMXLKPg.gif)
 
 The code action will currently not turn any methods or classes into parameters
 even if they is not available in the scope into which the code is being
@@ -214,7 +214,7 @@ import $$ivy.`io.circe::circe-core:0.14.2`
 which will bring in the `circe-core` dependency. Starting in this version it
 will be possible to auto complete group ids, artifact names and their versions.
 
-![import-dep](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-10-06-aluminium/TWgIIVp.gif?raw=true)
+![import-dep](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-10-06-aluminium/TWgIIVp.gif)
 
 Thanks to [LaurenceWarne](https://github.com/LaurenceWarne) for the great
 feature!
@@ -229,7 +229,7 @@ This release brings about
 which is an LSP feature that enables users to see which method are invoked in a
 current method or which methods invoke the current one.
 
-![call-hierarchy-dep](https://github.com/scalameta/gh-pages-images/blob/master/metals/2022-10-06-aluminium/1lTYFmu.gif?raw=true)
+![call-hierarchy-dep](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2022-10-06-aluminium/1lTYFmu.gif)
 
 This non trivial feature was brought to you by
 [riiswa](https://github.com/riiswa), thanks for the great work!

--- a/website/blog/2023-01-02-aluminium.md
+++ b/website/blog/2023-01-02-aluminium.md
@@ -125,7 +125,7 @@ The first experiment within that area was done by
 you will see a warning whenever a library has a newer version available and
 you'll have a quick fix suggested via code action.
 
-![actionable](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-01-02-aluminium/3D9WcQb.gif?raw=true) These warnings can be disabled
+![actionable](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-01-02-aluminium/3D9WcQb.gif) These warnings can be disabled
 within ScalaCLi using:
 
 ```
@@ -166,7 +166,7 @@ always easy and convenient to do that. From now on Metals also allows users to
 use the `go to type definition` feature within all the supported editors. User
 will be able to go directly to the type of a particular symbol.
 
-![type-def](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-01-02-aluminium/t77kB1S.gif?raw=true)
+![type-def](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-01-02-aluminium/t77kB1S.gif)
 
 This feature might work a bit differently depending on the symbol you are
 checking:
@@ -190,7 +190,7 @@ Java command to run within the code lenses, that can be used by the editors. It
 currently works with VS Code and it will run main classes within the task
 terminal.
 
-![run-main](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-01-02-aluminium/tXfSSj7.gif?raw=true)
+![run-main](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-01-02-aluminium/tXfSSj7.gif)
 
 In next release, we also plan to use the same mechanism for running main classes
 from all the other places. We also want to make tests runnable without the
@@ -207,7 +207,7 @@ which can't be used outside the current file.
 Metals will now allow users to rename any local code irrelevant of whether the
 workspace was compiled or not.
 
-![rename-local](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-01-02-aluminium/EEKchJB.gif?raw=true)
+![rename-local](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-01-02-aluminium/EEKchJB.gif)
 
 When renaming symbols that might be use outside the current file the previous
 limitations will apply.
@@ -217,7 +217,7 @@ limitations will apply.
 Thanks to [lwronski](https://github.com/lwronski) it's now possible to run and
 debug scripts when using Scala CLI.
 
-![script-debug](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-01-02-aluminium/bwfoEFY.gif?raw=true)
+![script-debug](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-01-02-aluminium/bwfoEFY.gif)
 
 For running scripts without debugging we will also provide the possibility of
 using the explicit Java command to run from code lenses.

--- a/website/blog/2023-03-02-aluminium.md
+++ b/website/blog/2023-03-02-aluminium.md
@@ -118,7 +118,7 @@ symbols. For example:
 will make vars red and values light blue while also crossing out any deprecated
 methods or classes.
 
-![semantic-tokens](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-03-02-aluminium/vkllczg.png?raw=true)
+![semantic-tokens](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-03-02-aluminium/vkllczg.png)
 
 For setting up semantic tokens in editors other than VS Code please consult the
 relevant documentation.
@@ -132,13 +132,13 @@ the same file. This works in two ways:
 
 - if inlining at a reference we will only replace the current value reference
 
-![replace-one](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-03-02-aluminium/yLuM079.gif?raw=true)
+![replace-one](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-03-02-aluminium/yLuM079.gif)
 
 - if inlining at the definition we will try to replace all the references and
   remove the definition if the definition cannot be accessed from outside the
   current file
 
-![replace-all](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-03-02-aluminium/LdlSQsB.gif?raw=true)
+![replace-all](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-03-02-aluminium/LdlSQsB.gif)
 
 ## Expanded workspace symbol search to include fields
 
@@ -149,7 +149,7 @@ convenient. This release adds the ability to also search for method, types or
 values within the workspace. This will not work for dependencies in order to not
 increase indexes used by Metals too much.
 
-![search](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-03-02-aluminium/YQCinNz.gif?raw=true)
+![search](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-03-02-aluminium/YQCinNz.gif)
 
 Another great contribution from [kasiaMarek](https://github.com/kasiaMarek)!
 

--- a/website/blog/2023-04-21-aluminium.md
+++ b/website/blog/2023-04-21-aluminium.md
@@ -80,15 +80,15 @@ ones to your GitHub issue. Invoking the `Metals: Zip reports` command will
 create a zip of all the incognito that reports can also be included in the
 issue.
 
-![Reports](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-04-21-aluminium/wBwFjpZ.gif?raw=true)
-![Zip reports](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-04-21-aluminium/YN3U3N9.gif?raw=true)
+![Reports](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-04-21-aluminium/wBwFjpZ.gif)
+![Zip reports](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-04-21-aluminium/YN3U3N9.gif)
 
 ## New code action for converting dependencies from sbt to scala-cli compliant ones
 
 New code action for scala-cli `using (dep | lib | plugin)` directives, which
 allows to convert dependencies from sbt style to scala-cli compliant ones.
 
-![Convert dependency](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-04-21-aluminium/G9W7Nox.gif?raw=true)
+![Convert dependency](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-04-21-aluminium/G9W7Nox.gif)
 
 A great contribution by [majk-p](https://github.com/majk-p).
 

--- a/website/blog/2023-07-17-workspace-folders.md
+++ b/website/blog/2023-07-17-workspace-folders.md
@@ -58,7 +58,7 @@ To load multiple projects into a single workspace you can simply open one of the
 projects and add the other one using `File > Add Folder to Workspace` and then
 choosing the correct folder.
 
-![add-workspace-folder](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-07-17-workspace-folders/LTYrx9V.gif?raw=true)
+![add-workspace-folder](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-07-17-workspace-folders/LTYrx9V.gif)
 
 Now you have two projects loaded side by side, so you can easily see both and
 switch between them. All of the current metals functionality accommodates
@@ -67,14 +67,14 @@ biggest changes will be visible in the places where information from the whole
 workspace is collected, like workspace symbol search, test explorer, or metals
 doctor.
 
-![multi-root-tests](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-07-17-workspace-folders/zWmmsC2.gif?raw=true)
+![multi-root-tests](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-07-17-workspace-folders/zWmmsC2.gif)
 
 The target project for a command is usually chosen based on the currently opened
 file. E.g. if you run `Switch build server` the command it will be executed for
 the project in focus. If no project is in focus the editor will explicitly ask
 for which project the command should be executed.
 
-![target-folder](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-07-17-workspace-folders/tV7K822.gif?raw=true)
+![target-folder](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-07-17-workspace-folders/tV7K822.gif)
 
 Finally, logs can still be found in the `.metals/metals.log` in the root of each
 project. Note, that for the time being all information is logged to all opened
@@ -91,7 +91,7 @@ the
 [`vim.lsp.buf.add_workspace_folder()`](https://neovim.io/doc/user/lsp.html#vim.lsp.buf.add_workspace_folder())
 function to add the folder containing the file you're in as another root.
 
-![add_workspace_folder](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-07-17-workspace-folders/E8iriR9.gif?raw=true)
+![add_workspace_folder](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-07-17-workspace-folders/E8iriR9.gif)
 
 To make this easier, you can also just create a mapping to use.
 
@@ -102,13 +102,13 @@ vim.keymap.set("n", "<leader>awf", vim.lsp.buf.add_workspace_folder)
 To verify that this has worked correctly you should be able to now see both
 workspaces reflected in your Metals Doctor.
 
-![nvim-metals doctor](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-07-17-workspace-folders/2u48wDK.gif?raw=true)
+![nvim-metals doctor](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-07-17-workspace-folders/2u48wDK.gif)
 
 You should also see that some commands, like the
 [`vim.lsp.buf.workspace_symbol()`](https://neovim.io/doc/user/lsp.html#vim.lsp.buf.workspace_symbol())
 now show results from all the added workspaces.
 
-![workspace_symbols](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-07-17-workspace-folders/RczJIcp.gif?raw=true)
+![workspace_symbols](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-07-17-workspace-folders/RczJIcp.gif)
 
 ## Changes for the clients
 

--- a/website/blog/2023-07-19-silver.md
+++ b/website/blog/2023-07-19-silver.md
@@ -98,7 +98,7 @@ time look into Java source and figure out what's going on there. This will not
 provide an experience of a full Java language server, but it will provide some
 basic functionality that will make it easier to work with Java sources.
 
-![java-hover](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-07-19-silver/mp1BKse.gif?raw=true)
+![java-hover](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-07-19-silver/mp1BKse.gif)
 
 Please let us know about any issues! This is a new feature and we expect that it
 might take some time to get it ironed out.

--- a/website/blog/2023-08-28-silver.md
+++ b/website/blog/2023-08-28-silver.md
@@ -58,7 +58,7 @@ and further improvements by [tgodzik](https://github.com/tgodzik), you will be
 able to get completions in Java files. It should make working with Java sources
 easier, though Metals will not strive to be a full Java language server.
 
-![java-completion](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-08-28-silver/wLlh7ig.gif?raw=true)
+![java-completion](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-08-28-silver/wLlh7ig.gif)
 
 ## Liveness monitor
 
@@ -67,7 +67,7 @@ the build server stopped responding. Thanks to
 [kasiaMarek](https://github.com/kasiaMarek) Metals will now monitor the state of
 the build server and notify the user if it becomes unresponsive.
 
-![not-responsive](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-08-28-silver/R2T5x3t.png?raw=true)
+![not-responsive](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-08-28-silver/R2T5x3t.png)
 
 Dismissing the notification will dismiss it for the current connection.
 
@@ -81,7 +81,7 @@ This release also brings in multiple fixes connected to enums:
 
 This great work was done by [kasiaMarek](https://github.com/kasiaMarek)
 
-![enum](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-08-28-silver/tZrSDYC.gif?raw=true)
+![enum](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-08-28-silver/tZrSDYC.gif)
 
 ## Semantic highlighting
 

--- a/website/blog/2023-10-17-silver.md
+++ b/website/blog/2023-10-17-silver.md
@@ -94,7 +94,7 @@ Thanks to [Tomasz Godzik](https://github.com/tgodzik) now we have run code lens
 when using Mill build server. As a reminder, it's possible to start using it by
 running `Metals: Switch build server` command for a Mill project.
 
-![mill-run-lens](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-10-17-silver/5drObNP.gif?raw=true)
+![mill-run-lens](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-10-17-silver/5drObNP.gif)
 
 ## Convert single line comments to multiline
 
@@ -102,7 +102,7 @@ Thanks to [Kasper Kondzielski](https://github.com/ghostbuster91) we have a new
 code action that converts a block of single line comments into a multiline
 comment.
 
-![convert-to-multiline](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-10-17-silver/tu3B25s.gif?raw=true)
+![convert-to-multiline](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-10-17-silver/tu3B25s.gif)
 
 ## Detect project root
 

--- a/website/blog/2023-12-12-bismuth.md
+++ b/website/blog/2023-12-12-bismuth.md
@@ -61,7 +61,7 @@ synthetic decorations such as inferred types or implicit conversions. This was
 not ideal as it meant that the information was not always up to date and could
 be inconsistent with the current state of code.
 
-![synthetics](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-12-12-bismuth/td11vRH.gif?raw=true)
+![synthetics](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-12-12-bismuth/td11vRH.gif)
 
 To fix that [jkciesluk](https://github.com/jkciesluk) switched to using the
 presentation compiler for this information. This means that each time code
@@ -86,13 +86,13 @@ indexing in case of jars and semanticdb for local workspace files. This means
 that Scala 3 is fully supported and this has been the last big feature missing
 for full parity between Scala 2 and 3.
 
-![tree-view](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-12-12-bismuth/Vun4kJh.gif?raw=true)
+![tree-view](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-12-12-bismuth/Vun4kJh.gif)
 
 All the existing features should now work for Scala 3 as well. This includes the
 reveal command which allows to quickly reveal the current file in the tree view
 including inside jars.
 
-![tree-view-reveal](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-12-12-bismuth/xW0W3I3.gif?raw=true) Additionally, we improved
+![tree-view-reveal](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-12-12-bismuth/xW0W3I3.gif) Additionally, we improved
 icons used by the tree view. They will now use the default VS Code icons for the
 most part, which should make them more consistent with the rest of the editor.
 
@@ -103,7 +103,7 @@ of a form `[[name.name.ClassName]]`. Thanks to
 [kasiaMarek](https://github.com/kasiaMarek) Metals will now allow you to
 navigate to the target of the link via normal go to definition.
 
-![scaladoc-def](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-12-12-bismuth/TYNMCEm.gif?raw=true)
+![scaladoc-def](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-12-12-bismuth/TYNMCEm.gif)
 
 To learn more about linking in scaladoc check out the
 [Scala documentation](https://docs.scala-lang.org/scala3/guides/scaladoc/linking.html)
@@ -121,7 +121,7 @@ To help with that we added a new setting `metals.customProjectRoot` that allows
 you to specify the root directory for your project. This setting is available in
 the settings UI and can be set to a path relative to the workspace root.
 
-![custom-root](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-12-12-bismuth/sgr1j1T.png?raw=true)
+![custom-root](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-12-12-bismuth/sgr1j1T.png)
 
 Another amazing feature from [kasiaMarek](https://github.com/kasiaMarek)
 
@@ -137,7 +137,7 @@ bar item that will show the number of errors in the build server. This will be
 shown only if there are any errors and will be hidden once the reports connected
 to them are removed.
 
-![bsp-status](https://github.com/scalameta/gh-pages-images/blob/master/metals/2023-12-12-bismuth/Kdn2347.gif?raw=true)
+![bsp-status](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2023-12-12-bismuth/Kdn2347.gif)
 
 ## Add back unintentionally removed support for 2.11.x
 

--- a/website/blog/2024-02-07-bismuth.md
+++ b/website/blog/2024-02-07-bismuth.md
@@ -70,10 +70,10 @@ by [jkciesluk](https://github.com/jkciesluk), with
 [tgodzik](https://github.com/tgodzik) contributing additional improvements to
 the area.
 
-![bazel completions](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-02-07-bismuth/HGwKygN.gif?raw=true) _Completions in a Bazel
+![bazel completions](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-02-07-bismuth/HGwKygN.gif) _Completions in a Bazel
 project._
 
-![bazel go to definitions](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-02-07-bismuth/ELWMVfa.gif?raw=true) _Hover and go to
+![bazel go to definitions](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-02-07-bismuth/ELWMVfa.gif) _Hover and go to
 definition in a Bazel project._
 
 You can get the slightly more advanced features working by enabling
@@ -107,13 +107,13 @@ Simply add the following content to your build:
   )
   ```
 
-![bazel add semanticdb](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-02-07-bismuth/2mj9QLP.gif?raw=true) _Adding SemanticDB to a
+![bazel add semanticdb](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-02-07-bismuth/2mj9QLP.gif) _Adding SemanticDB to a
 Bazel project._
 
 Enabling SemanticDB in your Bazel project will allow you to use such features as
 go to references.
 
-![bazel go to references](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-02-07-bismuth/SwNQOIf.gif?raw=true) _Go to references in
+![bazel go to references](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-02-07-bismuth/SwNQOIf.gif) _Go to references in
 a Bazel project._
 
 You can read more about Metals current support for Bazel and setting it up in
@@ -127,7 +127,7 @@ can run your code using `native` and `js` platforms straight from the editor.
 Just click on the `run` code lens or trigger debug run in any other way
 appropriate for your editor of choice.
 
-![run native](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-02-07-bismuth/TTX3crM.gif?raw=true) _Running a Scala Native program
+![run native](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-02-07-bismuth/TTX3crM.gif) _Running a Scala Native program
 using code lenses._
 
 ## Metals view for uncompiled changes
@@ -139,7 +139,7 @@ The feature was further improved by [tgodzik](https://github.com/tgodzik), and
 now the information about workspace symbols is updated as you write, instead of
 on compile as before.
 
-![tree view update](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-02-07-bismuth/whEjhZ0.gif?raw=true) _Tree view updating while
+![tree view update](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-02-07-bismuth/whEjhZ0.gif) _Tree view updating while
 typing._
 
 ## LSP Progress support

--- a/website/blog/2024-04-15-thalium.md
+++ b/website/blog/2024-04-15-thalium.md
@@ -115,7 +115,7 @@ like usual code, you can navigate to definition and get proper hovers. It will
 also allow all editors to support decorations without implementing the
 additional extension to the protocol.
 
-![inlay-hints](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-04-15-thalium/G6H2aPr.gif?raw=true)
+![inlay-hints](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-04-15-thalium/G6H2aPr.gif)
 
 Additionally, together with inlay hints we reworked all the decoration settings
 to be included in a single object and two new ones were added:
@@ -144,7 +144,7 @@ Another great new feature done by [jkciesluk](https://github.com/jkciesluk)
 enables users to get a suggestion that will complete a pattern match with all
 types within a union type.
 
-![union](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-04-15-thalium/yY2TvSk.gif?raw=true)
+![union](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-04-15-thalium/yY2TvSk.gif)
 
 ## Debugger improvements
 
@@ -188,7 +188,7 @@ dependencies as Metals didn't index type hierarchy. Thanks to
 Scala and Java files with an exception of JDK to avoid additional cost of
 indexing it in every workspace. The latter will be fixed later on.
 
-![implementations](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-04-15-thalium/JarfZHE.gif?raw=true)
+![implementations](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-04-15-thalium/JarfZHE.gif)
 
 As with inlay hints, this feature will not work when using older deprecated
 Scala 2 versions and some of the older Scala 3 3.3.x and 3.4.x versions.
@@ -200,7 +200,7 @@ adding support for completions of old style extension methods that were declared
 within implicit classes. This will work similar to extensions method completions
 for Scala 3.
 
-![implicit](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-04-15-thalium/pLt8GF2.gif?raw=true)
+![implicit](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-04-15-thalium/pLt8GF2.gif)
 
 ## Plugin author changes
 

--- a/website/blog/2024-06-19-thallium.md
+++ b/website/blog/2024-06-19-thallium.md
@@ -68,7 +68,7 @@ build target (module).
 Further work is being done on a similar approach for Scala 3, which should be
 available in one of the upcoming releases.
 
-![broken-code](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-06-19-thallium/ZBwWGTK.gif?raw=true) _Completions on not compiling
+![broken-code](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-06-19-thallium/ZBwWGTK.gif) _Completions on not compiling
 code_
 
 ## Use presentation compiler as fallback for references search
@@ -79,7 +79,7 @@ fail to find references for code that didn't compile. Now if SemanticDB
 information is missing or outdated Metals will fallback to using presentation
 compiler for reference search for all the files this concerns.
 
-![uncompiled-go-to-ref](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-06-19-thallium/tI43rhl.gif?raw=true) _Find references on
+![uncompiled-go-to-ref](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-06-19-thallium/tI43rhl.gif) _Find references on
 non-compiling code_
 
 ## Allow to override debug server startup timeout

--- a/website/blog/2024-07-12-thallium.md
+++ b/website/blog/2024-07-12-thallium.md
@@ -59,7 +59,7 @@ In this version of Metals we added a central database that can be found under
 the `.metals` directory in user home, which contains shared indexes of JDK
 sources thus avoiding a need to index them more than once on any given machine.
 
-![jdk-sources](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-07-12-thallium/lTMmhD8.gif?raw=true)
+![jdk-sources](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-07-12-thallium/lTMmhD8.gif)
 
 This great improvement was added by [kasiaMarek](https://github.com/kasiaMarek)
 
@@ -79,7 +79,7 @@ In this version of Metals [kasiaMarek](https://github.com/kasiaMarek) added
 support for value completions where union types are unions of specific literal
 types. If used together with intersection types it will still work as expected.
 
-![example](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-07-12-thallium/FKrytqC.png?raw=true)
+![example](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-07-12-thallium/FKrytqC.png)
 
 The feature will work on latest LTS and Next Scala versions as it required some
 work upstream in the compiler itself.

--- a/website/blog/2024-07-24-thallium.md
+++ b/website/blog/2024-07-24-thallium.md
@@ -66,7 +66,7 @@ frequency, so the symbols more often referenced in project appear higher on the
 list of completions. This cool feature was added by
 [Temurlock](https://github.com/Temurlock).
 
-![sort-by-freq](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-07-24-thallium/lAOeVCZ.gif?raw=true)
+![sort-by-freq](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-07-24-thallium/lAOeVCZ.gif)
 
 # Miscellaneous
 

--- a/website/blog/2024-12-16-palladium.md
+++ b/website/blog/2024-12-16-palladium.md
@@ -58,11 +58,11 @@ case we offer to create a method instead.
 
 This will work both when the symbol is used as a parameter:
 
-![first-example](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-12-16-palladium/9fWQ3Yg.gif?raw=true)
+![first-example](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-12-16-palladium/9fWQ3Yg.gif)
 
 as well as a standalone function call:
 
-![second-example](https://github.com/scalameta/gh-pages-images/blob/master/metals/2024-12-16-palladium/gizIjBB.gif?raw=true)
+![second-example](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2024-12-16-palladium/gizIjBB.gif)
 
 The feature has only been implemented for Scala 2 for the time being and there
 might be still some unsupported cases.

--- a/website/blog/2025-03-26-strontium.md
+++ b/website/blog/2025-03-26-strontium.md
@@ -71,7 +71,7 @@ location of the test failure was not shown, only the start of the test case.
 Now, we will correctly show the exact location of the test failure, which should
 make it easier to navigate to the failing test.
 
-![test-loc](https://github.com/scalameta/gh-pages-images/blob/master/metals/2025-03-26-strontium/JuIES78.gif?raw=true)
+![test-loc](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2025-03-26-strontium/JuIES78.gif)
 
 ## Convert sbt style deps on paste in for scala-cli
 
@@ -80,7 +80,7 @@ you paste into a Scala CLI file after `//> using dep` will be automatically
 converted to Scala CLI style dependencies. This was previously only supported in
 a code action, but turns out to be useful enough to apply the rewrite automatically on paste.
 
-![paste-dep](https://github.com/scalameta/gh-pages-images/blob/master/metals/2025-03-26-strontium/6BNvmmO.gif?raw=true)
+![paste-dep](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2025-03-26-strontium/6BNvmmO.gif)
 
 ## Add test cases discovery for TestNG
 

--- a/website/blog/2025-07-31-osmium.md
+++ b/website/blog/2025-07-31-osmium.md
@@ -52,7 +52,7 @@ give Metals a try!
 
 Thanks to [Mensh1kov](https://github.com/Mensh1kov) Metals now supports highlighting SQL queries in the editor when `sql` or `fr` interpolated strings are used.
 
-![sql-highlighting](https://github.com/scalameta/gh-pages-images/blob/master/metals/2025-07-31-osmium/sql-highlighting.gif?raw=true)
+![sql-highlighting](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2025-07-31-osmium/sql-highlighting.gif)
 
 ## Model Context Protocol Improvements
 

--- a/website/blog/2025-10-16-osmium.md
+++ b/website/blog/2025-10-16-osmium.md
@@ -152,7 +152,7 @@ a new paste command that allows to automatically add imports when copying
 between files. This command is enabled by default in Scala files within VS Code
 and requires the origin to be filed when adding in other editors.
 
-![paste-import](https://github.com/scalameta/gh-pages-images/blob/master/metals/2025-10-16-osmium/on-paste.gif?raw=true)
+![paste-import](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2025-10-16-osmium/on-paste.gif)
 
 The change will currently only work for Scala 2, some further work is needed to
 add support for Scala 3.
@@ -166,7 +166,7 @@ closest main or test to the cursor.
 This new command is available in Visual Studio Code via `metals.run-closest` in
 the command palette and can be assigned to a new shortcut.
 
-![run-closest](https://github.com/scalameta/gh-pages-images/blob/master/metals/2025-10-16-osmium/run-closest.gif?raw=true)
+![run-closest](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2025-10-16-osmium/run-closest.gif)
 
 ## Testing: Test discovery for Bazel
 

--- a/website/blog/2026-03-03-osmium.md
+++ b/website/blog/2026-03-03-osmium.md
@@ -1,0 +1,449 @@
+---
+authors: tgodzik
+title: Metals v1.6.6 - Osmium
+---
+
+We're happy to announce the release of Metals v1.6.6, which brings a standalone
+MCP server for AI-powered workflows, support for Play's Twirl templates, easier
+access to compiler explain output, and an option to shut down the build server
+when closing your editor.
+
+<table>
+<tbody>
+  <tr>
+    <td>Commits since last release</td>
+    <td align="center">72</td>
+  </tr>
+  <tr>
+    <td>Merged PRs</td>
+    <td align="center">72</td>
+  </tr>
+    <tr>
+    <td>Contributors</td>
+    <td align="center">8</td>
+  </tr>
+  <tr>
+    <td>Closed issues</td>
+    <td align="center">14</td>
+  </tr>
+  <tr>
+    <td>New features</td>
+    <td align="center">5</td>
+  </tr>
+</tbody>
+</table>
+
+For full details:
+[https://github.com/scalameta/metals/milestone/85?closed=1](https://github.com/scalameta/metals/milestone/85?closed=1)
+
+Metals is a language server for Scala that works with VS Code, Cursor, Vim,
+Emacs, Zed, Helix and Sublime Text. Metals is developed at the
+[Scala Center](https://scala.epfl.ch/) and [VirtusLab](https://virtuslab.com)
+with the help from contributors from the community.
+
+## TL;DR
+
+Check out [https://scalameta.org/metals/](https://scalameta.org/metals/), and
+give Metals a try!
+
+- [Allow users to get the output of -explain](#allow-users-to-get-the-output-of--explain)
+- [Standalone MCP server](#standalone-mcp-server)
+- [Add an option to shutdown Bloop build server](#add-an-option-to-shutdown-bloop-build-server)
+- [Support for Play's Twirl templates](#support-for-plays-twirl-templates)
+- [New File Improvements](#new-file-improvements)
+
+## Allow users to get the output of -explain
+
+When the Scala compiler suggests using the `-explain` option to get more
+detailed error messages, it isn't exactly easy to do so. You would have to change
+your build configuration, which might require rebuilding the entire project.
+
+Metals now offers two ways to access explain output:
+
+- **With virtual documents support**: When your editor supports virtual
+  documents, Metals replaces the code description with a link that invokes a
+  command to get diagnostics from the presentation compiler with `-explain`
+  enabled.
+
+![explain-diagnostic](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2026-03-03-osmium/explain.gif)
+
+- **Without virtual documents**: If your editor doesn't support virtual
+  documents, Metals shows a code action that, when invoked, creates a new
+  document in the `.metals/explained-diagnostics` directory with the full
+  diagnostic output from `-explain`. Some editors might not open the new file
+  automatically.
+
+![explain-diagnostic2](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2026-03-03-osmium/explain-action.gif)
+
+## Standalone MCP server
+
+Metals now includes a standalone MCP (Model Context Protocol) server that can
+run independently of your editor. This allows AI-powered tools like Cursor,
+Claude Code, or other MCP clients to interact with your Scala project without
+needing the full Metals language server running inside an IDE.
+
+The standalone server runs over HTTP and automatically imports the workspace
+when a project is detected. Several improvements make it easier to configure:
+
+```bash
+A standalone MCP (Model Context Protocol) server for Scala projects.
+
+Usage:
+  metals-mcp --workspace <path> [options]
+
+Options:
+  --workspace <path>      Path to the Scala project (required)
+  --port <number>         HTTP port to listen on (default: auto-assign)
+  --transport <type>      Transport type: http (default) or stdio (reserved for future use)
+  --client <name>         Client to generate config for: Visual Studio Code, Visual Studio Code - Insiders, VSCodium, vscode, VSCodium - Insiders, Kilo, kilo, Cursor, cursor, claude, Claude Code, claude-code
+  --<key> [value]         UserConfiguration override. Use kebab-case (e.g. --java-home /path, --bloop-version 1.4.0).
+                          For boolean options, value is optional: omit for true, or use --key true/false.
+  --help, -h              Show this help message
+  --version, -v           Show version information
+
+Examples:
+  # Start MCP server for a project
+  metals-mcp --workspace /path/to/project
+
+  # Start with specific port
+  metals-mcp --workspace /path/to/project --port 8080
+
+  # Override Java home and enable default BSP to build tool (boolean, omit = true)
+  metals-mcp --workspace /path/to/project --java-home /path/to/jdk --default-bsp-to-build-tool
+
+  # Generate config for Cursor editor
+  metals-mcp --workspace /path/to/project --client Cursor
+
+```
+
+- **Client configuration**: When you specify `--client` (e.g.
+  `--client cursor`), Metals generates the appropriate MCP configuration for
+  supported clients, making setup straightforward for command-line tools.
+- **User configuration in CLI**: You can pass Metals configuration options
+  directly via the command line using `--<key> <value>` syntax, including nested
+  keys and boolean flags. This lets you customize the MCP server behavior
+  independently of your editor.
+
+You should be able to install the standalone MCP server using the following
+command:
+
+```bash
+cs install metals-mcp
+```
+
+## Add an option to shutdown Bloop build server
+
+A long-standing request was to terminate the Bloop process when closing the
+editor, so you don't end up with leftover build server processes running in the
+background if you didn't need it anymore.
+
+Metals now provides the `build-disconnect-and-shutdown` LSP command. When
+invoked, it disconnects from the build server and shuts it down so the process
+exits. Visual Studio Code will use this command if you set the
+`metals.shutdownBloopOnEditorClose` configuration option to `true`. It will try
+to track the number of open VS Code instances and only exit if there are no more
+open instances.
+
+It's important to note that this doesn't work with any other BSP server other
+than Bloop.
+
+Thanks to [thomasGuerin3](https://github.com/thomasGuerin3) for implementing
+this feature!
+
+## Support for Play's Twirl templates
+
+Metals now has LSP support for Play Framework's Twirl template files
+(`.scala.html`, `.scala.txt`, `.scala.xml`, `.scala.js`). This work was done as
+part of Google Summer of Code 2025.
+
+The IDE features for Twirl templates include:
+
+- **Hover**: See documentation and type information when hovering over symbols
+- **Completions**: Get code completions for Scala expressions within templates
+- **Go to definition**: Navigate from template code to Scala definitions
+- **Auto-import**: Automatically add imports when using completions
+- **Rename**: Rename symbols with proper updates across the template
+- **Document highlighting**: See all occurrences of the symbol currently under
+  the cursor in a single file
+
+![twirl](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2026-03-03-osmium/twirl.gif)
+
+Metals compiles Twirl templates in-memory and maps positions between the
+template source and the generated Scala code, so all these features should work
+correctly within the template syntax.
+
+Thanks to [ajafri2001](https://github.com/ajafri2001) for implementing this
+feature and to [zielinsky](https://github.com/zielinsky) for finishing the work!
+
+## New File Improvements
+
+When using "New Scala File" or "New Java File" commands, Metals will now
+automatically strip extensions from the file name if they are provided.
+Additionally, there is a new type of new file which will take the current copied
+snippet and insert it into the new file with the suggested name.
+
+![new-file](https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/2026-03-03-osmium/new-file.gif)
+
+As this requires access to the clipboard, it's only available in the Visual
+Studio Code extension, which implements the new clipboard API.
+
+## Miscellaneous
+
+- fix: reduce presentation compiler memory usage (#6967)
+  [krrish175-byte](https://github.com/krrish175-byte)
+- improvement: Properly set minimum Bloop version instead of using newest to
+  avoid unnecessary bloop server restart messages
+  [tgodzik](https://github.com/tgodzik)
+- feat(mcp): Add smart fallback and module parameter for inspect, get-docs,
+  get-usages [li-nkSN](https://github.com/li-nkSN)
+- fix: Recompile worksheet on changes even if didFocus is not supported
+  [krrish175-byte](https://github.com/krrish175-byte)
+- improvement: Add message on timeouts to simplify debugging for users
+  [tgodzik](https://github.com/tgodzik)
+- bugfix: Make sure that cs or coursier is a coursier binary
+  [tgodzik](https://github.com/tgodzik)
+- improvement: Add KiloCodeEditor client configuration
+  [cheleb](https://github.com/cheleb)
+
+## Contributors
+
+Big thanks to everybody who contributed to this release or reported an issue!
+
+```bash
+$ git shortlog -sn --no-merges v1.6.5..v1.6.6
+    28	scalameta-bot
+    23	Tomasz Godzik
+     7	dependabot[bot]
+     2	Krrish Biswas
+     1	Olivier NOUGUIER
+     1	Prince
+     1	li-nkSN
+     1	thomasGuerin3
+```
+
+## Merged PRs
+
+## [v1.6.6](https://github.com/scalameta/metals/tree/v1.6.6) (2026-02-27)
+
+[Full Changelog](https://github.com/scalameta/metals/compare/v1.6.5...v1.6.6)
+
+**Merged pull requests:**
+
+- build(deps): Update mcp, mcp-json-jackson2 from 0.18.1 to 1.0.0
+  [\#8215](https://github.com/scalameta/metals/pull/8215)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): bump actions/upload-artifact from 6 to 7 in the github-actions
+  [\#8219](https://github.com/scalameta/metals/pull/8219)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): bump the npm-dependencies group in /website with 2 updates
+  [\#8220](https://github.com/scalameta/metals/pull/8220)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): Update flyway-core from 12.0.2 to 12.0.3
+  [\#8221](https://github.com/scalameta/metals/pull/8221)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update sbt, scripted-plugin from 1.12.3 to 1.12.5
+  [\#8222](https://github.com/scalameta/metals/pull/8222)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update munit from 1.2.2 to 1.2.3
+  [\#8223](https://github.com/scalameta/metals/pull/8223)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update cli_3, scala-cli-bsp from 1.12.2 to 1.12.3 commit-count:1
+  [\#8224](https://github.com/scalameta/metals/pull/8224)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- improvement: Improve the UX of new file provider
+  [\#8209](https://github.com/scalameta/metals/pull/8209)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update sbt-scalafix, scalafix-interfaces from 0.14.5 to 0.14.6
+  [\#8212](https://github.com/scalameta/metals/pull/8212)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update protobuf-java from 4.33.5 to 4.34.0
+  [\#8214](https://github.com/scalameta/metals/pull/8214)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update jackson-databind from 2.21.0 to 2.21.1
+  [\#8213](https://github.com/scalameta/metals/pull/8213)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- chore: Test Scala 3.8.2
+  [\#8208](https://github.com/scalameta/metals/pull/8208)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update flyway-core from 12.0.1 to 12.0.2
+  [\#8207](https://github.com/scalameta/metals/pull/8207)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- improvement: Allow specifying UserConfiguration in CLI
+  [\#8206](https://github.com/scalameta/metals/pull/8206)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update sbt-mima-plugin from 1.1.4 to 1.1.5
+  [\#8204](https://github.com/scalameta/metals/pull/8204)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update mcp, mcp-json-jackson2 from 0.17.2 to 0.18.1
+  [\#8205](https://github.com/scalameta/metals/pull/8205)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- improvement: Add KiloCodeEditor client configuration
+  [\#8196](https://github.com/scalameta/metals/pull/8196)
+  ([cheleb](https://github.com/cheleb))
+- Twirl support in metals
+  [\#7751](https://github.com/scalameta/metals/pull/7751)
+  ([ajafri2001](https://github.com/ajafri2001))
+- build(deps): Update scalameta, semanticdb-metap, ... from 4.14.7 to 4.15.2
+  [\#8202](https://github.com/scalameta/metals/pull/8202)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- chore: Bump Scala to 3.8.2-RC3
+  [\#8203](https://github.com/scalameta/metals/pull/8203)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update org.eclipse.lsp4j, ... from 0.24.0 to 1.0.0
+  [\#8192](https://github.com/scalameta/metals/pull/8192)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update ujson from 4.4.2 to 4.4.3
+  [\#8200](https://github.com/scalameta/metals/pull/8200)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update sbt, scripted-plugin from 1.12.2 to 1.12.3
+  [\#8201](https://github.com/scalameta/metals/pull/8201)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- feat(server): add build-disconnect-and-shutdown command
+  [\#8162](https://github.com/scalameta/metals/pull/8162)
+  ([thomasGuerin3](https://github.com/thomasGuerin3))
+- build(deps): bump qs from 6.14.1 to 6.14.2 in /website
+  [\#8190](https://github.com/scalameta/metals/pull/8190)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- bugfix: Make sure that cs or coursier is a coursier binary
+  [\#8191](https://github.com/scalameta/metals/pull/8191)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update scalafmt-core, scalafmt-dynamic from 3.10.6 to 3.10.7
+  [\#8194](https://github.com/scalameta/metals/pull/8194)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update flyway-core from 12.0.0 to 12.0.1
+  [\#8193](https://github.com/scalameta/metals/pull/8193)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- improvement: Log normally when started as http mcp server
+  [\#8197](https://github.com/scalameta/metals/pull/8197)
+  ([tgodzik](https://github.com/tgodzik))
+- improvement: Generate configuration for client when --client is supplied
+  [\#8184](https://github.com/scalameta/metals/pull/8184)
+  ([tgodzik](https://github.com/tgodzik))
+- ci: Use coursier cache and make it reuse between jobs
+  [\#8189](https://github.com/scalameta/metals/pull/8189)
+  ([tgodzik](https://github.com/tgodzik))
+- chore: Test Metals on 3.8.2-RC2
+  [\#8188](https://github.com/scalameta/metals/pull/8188)
+  ([tgodzik](https://github.com/tgodzik))
+- improvement: Reduce the number of tests and split sbt tests into two groups
+  [\#8186](https://github.com/scalameta/metals/pull/8186)
+  ([tgodzik](https://github.com/tgodzik))
+- improvement: Add more shards and drop running macOS tests
+  [\#8185](https://github.com/scalameta/metals/pull/8185)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): bump the npm-dependencies group in /website with 2 updates
+  [\#8182](https://github.com/scalameta/metals/pull/8182)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- chore: Group dependabot PRs
+  [\#8180](https://github.com/scalameta/metals/pull/8180)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update cli_3, scala-cli-bsp from 1.12.1 to 1.12.2
+  [\#8178](https://github.com/scalameta/metals/pull/8178)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update mill-contrib-testng from 1.1.1 to 1.1.2
+  [\#8177](https://github.com/scalameta/metals/pull/8177)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- improvement: Adjust messages about mcp server
+  [\#8175](https://github.com/scalameta/metals/pull/8175)
+  ([tgodzik](https://github.com/tgodzik))
+- improvement: Add message on timeout and remove warnings
+  [\#8176](https://github.com/scalameta/metals/pull/8176)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update cli_3, scala-cli-bsp from 1.12.0 to 1.12.1
+  [\#8173](https://github.com/scalameta/metals/pull/8173)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update sbt, scripted-plugin from 1.12.1 to 1.12.2
+  [\#8171](https://github.com/scalameta/metals/pull/8171)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): bump webpack from 5.96.1 to 5.105.0 in /website in the
+  npm_and_yarn group across 1 directory
+  [\#8174](https://github.com/scalameta/metals/pull/8174)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): Update scalameta, semanticdb-metap, ... from 4.14.5 to 4.14.7
+  [\#8172](https://github.com/scalameta/metals/pull/8172)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- chore: Add standalone metal MCP server
+  [\#8156](https://github.com/scalameta/metals/pull/8156)
+  ([tgodzik](https://github.com/tgodzik))
+- chore: Update mill and mill scripts
+  [\#8170](https://github.com/scalameta/metals/pull/8170)
+  ([tgodzik](https://github.com/tgodzik))
+- chore: Bump Bloop and Bazel BSP
+  [\#8169](https://github.com/scalameta/metals/pull/8169)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): bump react from 19.2.3 to 19.2.4 in /website
+  [\#8159](https://github.com/scalameta/metals/pull/8159)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): Update munit from 1.2.0 to 1.2.2
+  [\#8166](https://github.com/scalameta/metals/pull/8166)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update requests from 0.9.2 to 0.9.3
+  [\#8164](https://github.com/scalameta/metals/pull/8164)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- chore: Use Scala 2.13 in test in unit module
+  [\#8168](https://github.com/scalameta/metals/pull/8168)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update os-lib from 0.11.7 to 0.11.8
+  [\#8163](https://github.com/scalameta/metals/pull/8163)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update flyway-core from 11.20.3 to 12.0.0
+  [\#8165](https://github.com/scalameta/metals/pull/8165)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update scalafmt-core, scalafmt-dynamic from 3.10.4 to 3.10.6
+  [\#8167](https://github.com/scalameta/metals/pull/8167)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps-dev): bump @types/node from 25.0.3 to 25.1.0 in /website
+  [\#8160](https://github.com/scalameta/metals/pull/8160)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): bump @easyops-cn/docusaurus-search-local from 0.52.2 to 0.52.3 in
+  /website [\#8161](https://github.com/scalameta/metals/pull/8161)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- build(deps): Update mill-contrib-testng from 1.0.6 to 1.1.0
+  [\#8148](https://github.com/scalameta/metals/pull/8148)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update protobuf-java from 4.33.4 to 4.33.5
+  [\#8147](https://github.com/scalameta/metals/pull/8147)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update os-lib from 0.11.6 to 0.11.7
+  [\#8149](https://github.com/scalameta/metals/pull/8149)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update flyway-core from 11.20.2 to 11.20.3
+  [\#8150](https://github.com/scalameta/metals/pull/8150)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- build(deps): Update sbt, scripted-plugin from 1.12.0 to 1.12.1
+  [\#8151](https://github.com/scalameta/metals/pull/8151)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- fix: Recompile worksheet on changes even if didFocus is not supported
+  [\#8141](https://github.com/scalameta/metals/pull/8141)
+  ([krrish175-byte](https://github.com/krrish175-byte))
+- feat(mcp): Add smart fallback and module parameter for inspect, get-d…
+  [\#8125](https://github.com/scalameta/metals/pull/8125)
+  ([li-nkSN](https://github.com/li-nkSN))
+- bugfix: Fix test failure on Windows
+  [\#8143](https://github.com/scalameta/metals/pull/8143)
+  ([tgodzik](https://github.com/tgodzik))
+- test: Add mcp test for running testng suites
+  [\#8140](https://github.com/scalameta/metals/pull/8140)
+  ([tgodzik](https://github.com/tgodzik))
+- feature: Allow users to get the output of -explain
+  [\#8088](https://github.com/scalameta/metals/pull/8088)
+  ([tgodzik](https://github.com/tgodzik))
+- improvement: Properly set minimum Bloop version instead of using current
+  [\#8137](https://github.com/scalameta/metals/pull/8137)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): Update mcp, mcp-json-jackson2 from 0.17.1 to 0.17.2
+  [\#8135](https://github.com/scalameta/metals/pull/8135)
+  ([scalameta-bot](https://github.com/scalameta-bot))
+- chore: Test newest Next 3.8.1
+  [\#8134](https://github.com/scalameta/metals/pull/8134)
+  ([tgodzik](https://github.com/tgodzik))
+- build(deps): bump lodash from 4.17.21 to 4.17.23 in /website in the
+  npm_and_yarn group across 1 directory
+  [\#8133](https://github.com/scalameta/metals/pull/8133)
+  ([dependabot[bot]](https://github.com/dependabot[bot]))
+- fix: reduce presentation compiler memory usage (#6967)
+  [\#8124](https://github.com/scalameta/metals/pull/8124)
+  ([krrish175-byte](https://github.com/krrish175-byte))
+- docs: Add release notes for Metals 1.6.5
+  [\#8129](https://github.com/scalameta/metals/pull/8129)
+  ([tgodzik](https://github.com/tgodzik))

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -36,14 +36,14 @@ const Features = (props) => {
     {
       title: "Simple installation",
       content: "Open a directory, import your build and start coding.",
-      image: "https://github.com/scalameta/gh-pages-images/blob/master/metals/index/L5CurFG.png?raw=true",
+      image: "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/index/L5CurFG.png",
       imageAlign: "left",
     },
     {
       title: "Accurate diagnostics",
       content:
         "Compile on file save and see errors from the build tool directly inside the editor. No more switching focus to the console.",
-      image: "https://github.com/scalameta/gh-pages-images/blob/master/metals/index/JYLQGrc.gif?raw=true",
+      image: "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/index/JYLQGrc.gif",
       imageAlign: "right",
     },
     {
@@ -59,7 +59,7 @@ const Features = (props) => {
       title: "Goto definition",
       content:
         "Jump to symbol definitions in your project sources and Scala/Java library dependencies.",
-      image: "https://github.com/scalameta/gh-pages-images/blob/master/metals/index/bCIhFof.gif?raw=true",
+      image: "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/index/bCIhFof.gif",
       imageAlign: "right",
     },
     {
@@ -73,14 +73,14 @@ const Features = (props) => {
     {
       title: "Hover (aka. type at point)",
       content: "See the expression type and symbol signature under the cursor.",
-      image: "https://github.com/scalameta/gh-pages-images/blob/master/metals/index/2MfQvsM.gif?raw=true",
+      image: "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/index/2MfQvsM.gif",
       imageAlign: "right",
     },
     {
       title: "Signature help (aka. parameter hints)",
       content:
         "View a method signature and method overloads as you fill in the arguments.",
-      image: "https://github.com/scalameta/gh-pages-images/blob/master/metals/index/DAWIrHu.gif?raw=true",
+      image: "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/index/DAWIrHu.gif",
       imageAlign: "left",
     },
     {
@@ -93,7 +93,7 @@ const Features = (props) => {
     {
       title: "Fuzzy symbol search",
       content: "Search for symbols in the workspace or library dependencies.",
-      image: "https://github.com/scalameta/gh-pages-images/blob/master/metals/index/w5yrK1w.gif?raw=true",
+      image: "https://raw.githubusercontent.com/scalameta/gh-pages-images/main/metals/index/w5yrK1w.gif",
       imageAlign: "left",
     },
   ];


### PR DESCRIPTION
I plan to release on Tuesday.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped release versions (stable and snapshot) to the new release line.
  * Updated bug report template Metals version placeholder.

* **Documentation**
  * Updated many image links across docs, website, and blog posts to main/raw GitHub paths.
  * Published Metals v1.6.6 (Osmium) release notes describing new features and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->