### PR TITLE
docs: Update docs

### DIFF
--- a/docs/editors/vscode.md
+++ b/docs/editors/vscode.md
@@ -138,6 +138,13 @@ to take effect.
 
 ```
 
+To have the Bloop server shut down when you close VS Code, enable the
+`metals.shutdownBloopOnEditorClose` setting (machine-scoped). Bloop is only shut
+down when the **last** VS Code window that had Metals open is closed; with
+multiple windows open, it keeps running until the last one closes. See
+[metals-feature-requests#129](https://github.com/scalameta/metals-feature-requests/issues/129)
+for more context.
+
 ## Show document symbols
 
 Run the "Explorer: Focus on Outline View" command to open the symbol outline for

--- a/website/blog/2026-03-03-osmium.md
+++ b/website/blog/2026-03-03-osmium.md
@@ -128,8 +128,10 @@ You should be able to install the standalone MCP server using the following
 command:
 
 ```bash
-cs install metals-mcp
+cs bootstrap org.scalameta:metals-mcp_2.13:1.6.6 -o metals-mcp
 ```
+
+This will create an executable `metals-mcp` in your current directory.
 
 ## Add an option to shutdown Bloop build server
 


### PR DESCRIPTION
Releasing apps doesn't seem to work currently and we missed one doc change from upstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated VS Code editor documentation with clarification on Bloop shutdown behavior and machine-scoped configuration details when closing VS Code
  * Updated standalone MCP server installation instructions with a revised installation command and information about where the executable is created

<!-- end of auto-generated comment: release notes by coderabbit.ai -->