### PR TITLE
docs: Simplify install instructions

### DIFF
--- a/website/blog/2026-03-03-osmium.md
+++ b/website/blog/2026-03-03-osmium.md
@@ -128,10 +128,8 @@ You should be able to install the standalone MCP server using the following
 command:
 
 ```bash
-cs bootstrap org.scalameta:metals-mcp_2.13:1.6.6 -o metals-mcp
+cs install metals-mcp
 ```
-
-This will create an executable `metals-mcp` in your current directory.
 
 ## Add an option to shutdown Bloop build server
 


### PR DESCRIPTION
We managed to release apps, so metals-mcp is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified MCP server installation instructions with a more direct command.
  * Removed outdated installation notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->