### PR TITLE
bugfix: Default to 0 if minor or patch are missing, log warning

### DIFF
--- a/mtags-shared/src/main/scala/scala/meta/internal/semver/SemVer.scala
+++ b/mtags-shared/src/main/scala/scala/meta/internal/semver/SemVer.scala
@@ -1,8 +1,12 @@
 package scala.meta.internal.semver
 
+import java.util.logging.Logger
+
 import scala.util.Try
 
 object SemVer {
+
+  private val logger: Logger = Logger.getLogger(getClass.getName)
 
   case class Version(
       major: Int,
@@ -48,8 +52,19 @@ object SemVer {
   object Version {
     def fromString(version: String): Version = {
       val parts = version.split("\\.|-")
-      val Array(major, minor, patch) =
-        parts.take(3).map(tryToInt)
+      val parsed = parts.take(3).map(p => Try(p.toInt).toOption)
+      val (major, minor, patch) =
+        parsed match {
+          case Array(Some(major), Some(minor), Some(patch)) =>
+            (major, minor, patch)
+          case Array(Some(major), Some(minor), _*) =>
+            (major, minor, 0)
+          case Array(Some(major), _*) =>
+            (major, 0, 0)
+          case _ =>
+            logger.warning(s"Version $version is invalid.")
+            throw new IllegalArgumentException(s"Version $version is invalid")
+        }
       val (rc, milestone) = parts
         .lift(3)
         .map { v =>


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/8229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Version parsing tolerates incomplete or malformed semantic version strings by defaulting missing components to 0 and reducing parse failures.
  * Warning-level diagnostics are emitted when components are missing or non-numeric to surface fallbacks and aid troubleshooting.
  * Clearly invalid version formats are rejected with an error while providing warnings to help identify issues.

* **Chores**
  * No changes to public API or exported signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->