### PR TITLE
improvement: Add relevant methods from Metals v2

### DIFF
--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompiler.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
 
 /**
  * The public API of the presentation compiler.
@@ -273,6 +274,10 @@ public abstract class PresentationCompiler {
 		return this;
 	};
 
+	public PresentationCompiler withProgressBars(ProgressBars progressBars) {
+		return this;
+	}
+
 	/**
 	 * Provide a SymbolSearch to extract docstrings, java parameter names and Scala
 	 * default parameter values.
@@ -302,6 +307,10 @@ public abstract class PresentationCompiler {
 	 * Provide workspace root for features like ammonite script $file completions.
 	 */
 	public abstract PresentationCompiler withWorkspace(Path workspace);
+
+	public PresentationCompiler withSemanticdbFileManager(SemanticdbFileManager semanticdbFileManager) {
+		return this;
+	}
 
 	/**
 	 * Provide CompletionItemPriority for additional sorting completion items.
@@ -333,24 +342,26 @@ public abstract class PresentationCompiler {
 	public abstract PresentationCompiler newInstance(String buildTargetIdentifier, List<Path> classpath,
 			List<String> options);
 
-	// =============================
-	// Intentionally missing methods
-	// =============================
-
-	// Metals uses diagnostics from the build. It is not on the roadmap to publish
-	// diagnostics
-	// from the presentation compiler because they are unreliable, especially for
-	// long-running
-	// compiler instances.
-	// def diagnostics(): List[Diagnostics]
-
-	// The presentation compiler does not have enough information to implement it
-	// standalone.
-	// def definition(params: OffsetParams): List[Location]
-
-	// The presentation compiler does not have enough information to implement it
-	// standalone.
-	// def references(params: OffsetParams): List[Location]
+	/**
+	 * Construct a new presentation compiler with the given parameters.
+	 *
+	 * @param buildTargetIdentifier the build target containing this source file.
+	 *                              This is needed for
+	 *                              {@link #completionItemResolve(CompletionItem, String)}.
+	 * @param classpath             the classpath of this build target.
+	 * @param options               the compiler flags for the new compiler.
+	 *                              Important, it is recommended to disable all
+	 *                              compiler plugins excluding
+	 *                              org.scalamacros:paradise, kind-projector and
+	 *                              better-monadic-for.
+	 * @param sourcePath            A supplier that returns the source path for this
+	 *                              build target, used by the PC to locate types
+	 *                              that have not been built yet.
+	 */
+	public PresentationCompiler newInstance(String buildTargetIdentifier, List<Path> classpath, List<String> options,
+			Supplier<List<Path>> sourcePath) {
+		return newInstance(buildTargetIdentifier, classpath, options);
+	}
 
 	// ==============================================
 	// Internal methods - not intended for public use

--- a/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/PresentationCompilerConfig.java
@@ -7,6 +7,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 /**
  * Configuration options used by the Metals presentation compiler.
  */
@@ -52,6 +55,16 @@ public interface PresentationCompilerConfig {
 		Ascii,
 		/** Render as "🔼". */
 		Unicode
+	}
+
+	/** Strategy for placing Scala imports when auto-importing symbols. */
+	enum ScalaImportsPlacement {
+		/** Append imports at the end of the import block. */
+		APPEND_LAST,
+		/**
+		 * Place imports intelligently based on prefix matching and alphabetical order.
+		 */
+		SMART
 	}
 
 	/**
@@ -133,4 +146,24 @@ public interface PresentationCompilerConfig {
 		return ContentType.MARKDOWN;
 	}
 
+	default boolean emitDiagnostics() {
+		return false;
+	}
+
+	default Path workspaceRoot() {
+		return Paths.get(System.getProperty("user.dir"));
+	}
+
+	/** Returns the mode of the source path to use. */
+	default SourcePathMode sourcePathMode() {
+		return SourcePathMode.PRUNED;
+	}
+
+	default boolean shouldRunRefchecks() {
+		return false;
+	}
+	/** Returns the Scala import placement strategy. */
+	default ScalaImportsPlacement scalaImportsPlacement() {
+		return ScalaImportsPlacement.APPEND_LAST;
+	}
 }

--- a/mtags-interfaces/src/main/java/scala/meta/pc/ProgressBars.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/ProgressBars.java
@@ -1,0 +1,106 @@
+package scala.meta.pc;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public abstract class ProgressBars {
+
+  public interface ProgressBar {
+    public String title();
+
+    public String message();
+
+    public long progress();
+
+    public long total();
+
+    public void updateProgress(long progress, long total);
+
+    public void updateMessage(String message);
+  }
+
+  public static class ProgressTimeout {
+    public final Duration duration;
+    public final Runnable onTimeout;
+
+    public ProgressTimeout(Duration duration, Runnable onTimeout) {
+      this.duration = duration;
+      this.onTimeout = onTimeout;
+    }
+  }
+
+  public static class StartProgressBarParams {
+    public final String title;
+    public boolean progressEnabled = false;
+    public boolean timerEnabled = true;
+    public Optional<Runnable> onCancel = Optional.empty();
+    public Optional<ProgressTimeout> timeout = Optional.empty();
+
+    public StartProgressBarParams(String title) {
+      this.title = title;
+    }
+
+    public StartProgressBarParams withProgress(boolean value) {
+      this.progressEnabled = value;
+      return this;
+    }
+
+    public StartProgressBarParams withTimer(boolean value) {
+      this.timerEnabled = value;
+      return this;
+    }
+
+    public StartProgressBarParams withCancelHandler(Runnable onCancel) {
+      this.onCancel = Optional.of(onCancel);
+      return this;
+    }
+
+    public StartProgressBarParams withTimeout(ProgressTimeout timeout) {
+      this.timeout = Optional.of(timeout);
+      return this;
+    }
+  }
+
+  public abstract ProgressBar start(StartProgressBarParams params);
+
+  public abstract void end(ProgressBar progressBar);
+
+  private static final ProgressBar EMPTY_PROGRESS_BAR =
+      new ProgressBar() {
+        @Override
+        public String title() {
+          return "";
+        }
+
+        @Override
+        public String message() {
+          return "";
+        }
+
+        @Override
+        public long progress() {
+          return 0;
+        }
+
+        @Override
+        public long total() {
+          return 0;
+        }
+
+        @Override
+        public void updateProgress(long progress, long total) {}
+
+        @Override
+        public void updateMessage(String message) {}
+      };
+  public static final ProgressBars EMPTY =
+      new ProgressBars() {
+        @Override
+        public ProgressBar start(StartProgressBarParams params) {
+          return EMPTY_PROGRESS_BAR;
+        }
+
+        @Override
+        public void end(ProgressBar progressBar) {}
+      };
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/SemanticdbFileManager.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/SemanticdbFileManager.java
@@ -1,0 +1,14 @@
+package scala.meta.pc;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+public interface SemanticdbFileManager {
+  default Map<String, Set<Path>> listAllPackages() {
+    return Collections.emptyMap();
+  }
+
+  public static final SemanticdbFileManager EMPTY = new SemanticdbFileManager() {};
+}

--- a/mtags-interfaces/src/main/java/scala/meta/pc/SourcePathMode.java
+++ b/mtags-interfaces/src/main/java/scala/meta/pc/SourcePathMode.java
@@ -1,0 +1,23 @@
+package scala.meta.pc;
+
+public enum SourcePathMode {
+  /** Do not use the source path. */
+  DISABLED,
+  /** Use the source path with complete source code. */
+  FULL,
+  /**
+   * Use the source path with pruned source code (field and method bodies removed whenever
+   * possible).
+   */
+  PRUNED,
+
+  /**
+   * Use the full source path from the MBT-based symbol index. Used for the fallback Scala
+   * presentation compiler.
+   */
+  MBT;
+
+  public boolean shouldPrune() {
+    return this == PRUNED || this == MBT;
+  }
+}


### PR DESCRIPTION
We can then use these added method in the Scala 3 presentation compiler and implement source path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced presentation compiler configuration with defaults for diagnostics, workspace root, source-path handling, refchecks, and Scala import placement.
  * Added a progress-bar framework with start/end, timeout and cancel support plus a safe no-op default.
  * New source-path modes (DISABLED, FULL, PRUNED, MBT) to control source discovery behavior.
  * Added semanticdb file manager integration for improved package listing and tooling support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->