### PR TITLE
fix(tests): support method call syntax for behavior.of in AnyFlatSpec

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ScalatestTestFinder.scala
@@ -218,6 +218,13 @@ object ScalatestTestFinder {
           (acc, Some(newPrefix))
         // format: on
 
+        // behavior.of("An empty Set") - alternative style for behavior of "An empty Set"
+        case Term.Apply(
+              Term.Select(Term.Name("behavior"), Term.Name("of")),
+              List(Lit.String(newPrefix)),
+            ) =>
+          (acc, Some(newPrefix))
+
         // format: off
         // "An empty Set" should "have size 0" in { ... }
         case Term.ApplyInfix(appl @ Term.ApplyInfix(Lit.String(newPrefix), Term.Name(infixOp), _, List(Lit.String(right))), _: Term.Name, _, _) =>

--- a/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
+++ b/tests/unit/src/test/scala/tests/testProvider/ScalatestFinderSuite.scala
@@ -211,6 +211,50 @@ class ScalatestFinderSuite extends FunSuite {
   )
 
   check(
+    "any-flat-spec-with-behavior-dot-of",
+    """|import org.scalatest.flatspec.AnyFlatSpec
+       |
+       |class FlatSpec extends AnyFlatSpec {
+       |  behavior.of("An empty Set")
+       |
+       |  it should "have size 0" in {
+       |    assert(Set.empty.size == 0)
+       |  }
+       |
+       |  it should "produce NoSuchElementException when head is invoked" in {
+       |    assertThrows[NoSuchElementException] {
+       |      Set.empty.head
+       |    }
+       |  }
+       |
+       |  ignore should "have size 1" in {
+       |    assert(Set.empty.size == 1)
+       |  }
+       |
+       |  behavior of "Non-empty Set"
+       |
+       |  it should "have size greater than 0" in {
+       |    assert(Set(1).size > 0)
+       |  }
+       |}
+       |""".stripMargin,
+    FullyQualifiedName("FlatSpec"),
+    Set(
+      ("An empty Set should have size 1", QuickRange(15, 2, 15, 29)),
+      (
+        "An empty Set should produce NoSuchElementException when head is invoked",
+        QuickRange(9, 2, 9, 65),
+      ),
+      ("An empty Set should have size 0", QuickRange(5, 2, 5, 25)),
+      (
+        "Non-empty Set should have size greater than 0",
+        QuickRange(21, 2, 21, 38),
+      ),
+    ),
+    ScalatestStyle.AnyFlatSpec,
+  )
+
+  check(
     "any-fun-spec",
     """|import org.scalatest.funspec.AnyFunSpec
        |


### PR DESCRIPTION
## Descript

Handle both infix and method call syntax for 'behavior of' in AnyFlatSpec discovery logic.

Previously, only 'Term.ApplyInfix' was matched, causing test prefixes to be lost when 'behavior.of("...")' was encountered. This led to mismatched test names in the Test Explorer, especially in Scala 3 environments where infix notation might be desugared or formatted differently.

## Testing

Added a regression test 'any-flat-spec-with-behavior-dot-of' in ScalatestFinderSuite to verify the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test discovery to recognize the alternative FlatSpec `behavior.of("...")` syntax so tests using that form are correctly found and runnable.

* **Tests**
  * Added unit tests covering the `behavior.of(...)` FlatSpec variant to validate discovery and range expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->