### PR TITLE
improvement: Return only last version in find-dep tool

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/MetalsMcpServer.scala
@@ -954,14 +954,14 @@ class MetalsMcpServer(
             completed = coursierComplete.complete(depString)
             if completed.nonEmpty
           } yield {
-            val completedOrLast =
-              if (key == FindDepKey.version && version.contains("latest"))
-                completed.headOption.toSeq
-              else completed
-            McpMessages.FindDep.dependencyReturnMessage(
-              key,
-              completedOrLast.distinct,
-            )
+            if (key == FindDepKey.version)
+              McpMessages.FindDep.versionMessage(completed.headOption)
+            else
+              McpMessages.FindDep.dependencyReturnMessage(
+                key,
+                completed.distinct,
+              )
+
           }
         }.headOption
           .getOrElse(McpMessages.FindDep.noCompletionsFound)
@@ -1427,6 +1427,12 @@ object MetalsMcpServer {
 object McpMessages {
 
   object FindDep {
+
+    def versionMessage(completed: Option[String]): String = {
+      s"""|Latest version found: ${completed.getOrElse("none")}
+          |""".stripMargin
+    }
+
     def dependencyReturnMessage(
         key: String,
         completed: Seq[String],

--- a/tests/unit/src/test/scala/tests/mcp/McpServerLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpServerLspSuite.scala
@@ -70,16 +70,7 @@ class McpServerLspSuite extends BaseLspSuite("mcp-server") with McpTestUtils {
       _ = assertNoDiff(
         resultNameVersion.mkString("\n"),
         McpMessages.FindDep
-          .dependencyReturnMessage("version", Seq("4.10.2", "4.10.1", "4.10.0")),
-      )
-      resultNameVersion2 <- client.findDep(
-        "org.scalameta",
-        Some("parsers_2.13"),
-        None,
-      )
-      _ = assert(
-        resultNameVersion2.head.contains(", 4.13.0,"),
-        s"Expected to contain version 4.13.0, got ${resultNameVersion2.mkString("\n")}",
+          .versionMessage(Some("4.10.2")),
       )
       _ <- client.shutdown()
     } yield ()


### PR DESCRIPTION
Latest version is usually what we want anyway and we waste context otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency search now shows a single, most-relevant version option and provides a clearer version-specific message, while other dependency fields continue to present distinct completion options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->