### PR TITLE
feat: add scalafix diagnostics

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -86,7 +86,7 @@ final class Diagnostics(
     }
 
   def reset(): Unit = {
-    val keys = diagnostics.keys ++ scalafixDiagnostics.keys
+    val keys = (diagnostics.keySet ++ scalafixDiagnostics.keySet).toSet
     diagnostics.clear()
     scalafixDiagnostics.clear()
     scalafixSnapshots.clear()

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -57,6 +57,8 @@ final class Diagnostics(
     TrieMap.empty[AbsolutePath, ju.Queue[DiagnosticWithOrigin]]
   private val syntaxError =
     TrieMap.empty[AbsolutePath, Diagnostic]
+  private val scalafixDiagnostics =
+    TrieMap.empty[AbsolutePath, List[Diagnostic]]
   private val snapshots =
     TrieMap.empty[AbsolutePath, Input.VirtualFile]
   private val lastPublished =
@@ -84,6 +86,7 @@ final class Diagnostics(
   def reset(): Unit = {
     val keys = diagnostics.keys
     diagnostics.clear()
+    scalafixDiagnostics.clear()
     keys.foreach { key => publishDiagnostics(key) }
   }
 
@@ -160,6 +163,7 @@ final class Diagnostics(
       diagnostics.remove(path).toList.flatMap(_.asScala) ++
         syntaxError.remove(path)
     } else syntaxError.remove(path).toList
+    scalafixDiagnostics.remove(path)
     diags match {
       case Nil =>
         () // Do nothing, there was no previous error.
@@ -171,6 +175,7 @@ final class Diagnostics(
   def didDelete(path: AbsolutePath): Unit = {
     diagnostics.remove(path)
     syntaxError.remove(path)
+    scalafixDiagnostics.remove(path)
     languageClient.publishDiagnostics(
       new PublishDiagnosticsParams(
         path.toURI.toString(),
@@ -307,6 +312,15 @@ final class Diagnostics(
       .toList
   }
 
+  def onScalafixLint(path: AbsolutePath, diags: List[Diagnostic]): Unit = {
+    if (diags.nonEmpty) {
+      scalafixDiagnostics(path) = diags
+    } else {
+      scalafixDiagnostics.remove(path)
+    }
+    publishDiagnostics(path)
+  }
+
   def hasSyntaxError(path: AbsolutePath): Boolean =
     syntaxError.contains(path)
 
@@ -359,6 +373,9 @@ final class Diagnostics(
       if !isDuplicate && !isSameMessage
     } {
       all.add(d)
+    }
+    for (scalafixDiag <- scalafixDiagnostics.getOrElse(path, Nil)) {
+      all.add(scalafixDiag)
     }
     languageClient.publishDiagnostics(new PublishDiagnosticsParams(uri, all))
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -59,8 +59,6 @@ final class Diagnostics(
     TrieMap.empty[AbsolutePath, Diagnostic]
   private val scalafixDiagnostics =
     TrieMap.empty[AbsolutePath, List[Diagnostic]]
-  private val scalafixSnapshots =
-    TrieMap.empty[AbsolutePath, Input.VirtualFile]
   private val snapshots =
     TrieMap.empty[AbsolutePath, Input.VirtualFile]
   private val lastPublished =
@@ -89,7 +87,6 @@ final class Diagnostics(
     val keys = diagnostics.keys ++ scalafixDiagnostics.keys
     diagnostics.clear()
     scalafixDiagnostics.clear()
-    scalafixSnapshots.clear()
     keys.foreach { key => publishDiagnostics(key) }
   }
 
@@ -166,7 +163,7 @@ final class Diagnostics(
       diagnostics.remove(path).toList.flatMap(_.asScala) ++
         syntaxError.remove(path)
     } else syntaxError.remove(path).toList
-    scalafixSnapshots.remove(path)
+
     val hadScalafixDiags = scalafixDiagnostics.remove(path).isDefined
     if (diags.nonEmpty || hadScalafixDiags) {
       publishDiagnostics(path)
@@ -177,7 +174,7 @@ final class Diagnostics(
     diagnostics.remove(path)
     syntaxError.remove(path)
     scalafixDiagnostics.remove(path)
-    scalafixSnapshots.remove(path)
+
     languageClient.publishDiagnostics(
       new PublishDiagnosticsParams(
         path.toURI.toString(),
@@ -314,18 +311,11 @@ final class Diagnostics(
       .toList
   }
 
-  def onScalafixLint(
-      path: AbsolutePath,
-      diags: List[Diagnostic],
-      snapshot: Option[Input.VirtualFile] = None,
-  ): Unit = {
-    if (diags.nonEmpty) {
+  def onScalafixLint(path: AbsolutePath, diags: List[Diagnostic]): Unit = {
+    if (diags.nonEmpty)
       scalafixDiagnostics(path) = diags
-      snapshot.foreach(scalafixSnapshots(path) = _)
-    } else {
+    else
       scalafixDiagnostics.remove(path)
-      scalafixSnapshots.remove(path)
-    }
     publishDiagnostics(path)
   }
 
@@ -382,17 +372,8 @@ final class Diagnostics(
     } {
       all.add(d)
     }
-    for {
-      scalafixDiag <- scalafixDiagnostics.getOrElse(path, Nil)
-      freshDiag <- toFreshDiagnostic(
-        path,
-        scalafixDiag,
-        snapshot = scalafixSnapshots.get(path),
-        fallbackToNearest = true,
-      )
-    } {
-      all.add(freshDiag)
-    }
+    for (scalafixDiag <- scalafixDiagnostics.getOrElse(path, Nil))
+      all.add(scalafixDiag)
     languageClient.publishDiagnostics(new PublishDiagnosticsParams(uri, all))
   }
 
@@ -406,15 +387,8 @@ final class Diagnostics(
       path: AbsolutePath,
       d: Diagnostic,
       fallbackToNearest: Boolean = true,
-  ): Option[Diagnostic] =
-    toFreshDiagnostic(path, d, snapshots.get(path), fallbackToNearest)
-
-  private def toFreshDiagnostic(
-      path: AbsolutePath,
-      d: Diagnostic,
-      snapshot: Option[Input.VirtualFile],
-      fallbackToNearest: Boolean,
   ): Option[Diagnostic] = {
+    val snapshot = snapshots.get(path)
     snapshot match {
       case Some(snapshot) =>
         val edit =

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -86,7 +86,7 @@ final class Diagnostics(
     }
 
   def reset(): Unit = {
-    val keys = (diagnostics.keySet ++ scalafixDiagnostics.keySet).toSet
+    val keys = diagnostics.keys ++ scalafixDiagnostics.keys
     diagnostics.clear()
     scalafixDiagnostics.clear()
     scalafixSnapshots.clear()

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -314,10 +314,14 @@ final class Diagnostics(
       .toList
   }
 
-  def onScalafixLint(path: AbsolutePath, diags: List[Diagnostic]): Unit = {
+  def onScalafixLint(
+      path: AbsolutePath,
+      diags: List[Diagnostic],
+      snapshot: Option[Input.VirtualFile] = None,
+  ): Unit = {
     if (diags.nonEmpty) {
       scalafixDiagnostics(path) = diags
-      scalafixSnapshots(path) = path.toInput
+      snapshot.foreach(scalafixSnapshots(path) = _)
     } else {
       scalafixDiagnostics.remove(path)
       scalafixSnapshots.remove(path)

--- a/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Diagnostics.scala
@@ -59,6 +59,8 @@ final class Diagnostics(
     TrieMap.empty[AbsolutePath, Diagnostic]
   private val scalafixDiagnostics =
     TrieMap.empty[AbsolutePath, List[Diagnostic]]
+  private val scalafixSnapshots =
+    TrieMap.empty[AbsolutePath, Input.VirtualFile]
   private val snapshots =
     TrieMap.empty[AbsolutePath, Input.VirtualFile]
   private val lastPublished =
@@ -84,9 +86,10 @@ final class Diagnostics(
     }
 
   def reset(): Unit = {
-    val keys = diagnostics.keys
+    val keys = diagnostics.keys ++ scalafixDiagnostics.keys
     diagnostics.clear()
     scalafixDiagnostics.clear()
+    scalafixSnapshots.clear()
     keys.foreach { key => publishDiagnostics(key) }
   }
 
@@ -163,12 +166,10 @@ final class Diagnostics(
       diagnostics.remove(path).toList.flatMap(_.asScala) ++
         syntaxError.remove(path)
     } else syntaxError.remove(path).toList
-    scalafixDiagnostics.remove(path)
-    diags match {
-      case Nil =>
-        () // Do nothing, there was no previous error.
-      case _ =>
-        publishDiagnostics(path) // Remove old syntax error.
+    scalafixSnapshots.remove(path)
+    val hadScalafixDiags = scalafixDiagnostics.remove(path).isDefined
+    if (diags.nonEmpty || hadScalafixDiags) {
+      publishDiagnostics(path)
     }
   }
 
@@ -176,6 +177,7 @@ final class Diagnostics(
     diagnostics.remove(path)
     syntaxError.remove(path)
     scalafixDiagnostics.remove(path)
+    scalafixSnapshots.remove(path)
     languageClient.publishDiagnostics(
       new PublishDiagnosticsParams(
         path.toURI.toString(),
@@ -315,8 +317,10 @@ final class Diagnostics(
   def onScalafixLint(path: AbsolutePath, diags: List[Diagnostic]): Unit = {
     if (diags.nonEmpty) {
       scalafixDiagnostics(path) = diags
+      scalafixSnapshots(path) = path.toInput
     } else {
       scalafixDiagnostics.remove(path)
+      scalafixSnapshots.remove(path)
     }
     publishDiagnostics(path)
   }
@@ -374,8 +378,16 @@ final class Diagnostics(
     } {
       all.add(d)
     }
-    for (scalafixDiag <- scalafixDiagnostics.getOrElse(path, Nil)) {
-      all.add(scalafixDiag)
+    for {
+      scalafixDiag <- scalafixDiagnostics.getOrElse(path, Nil)
+      freshDiag <- toFreshDiagnostic(
+        path,
+        scalafixDiag,
+        snapshot = scalafixSnapshots.get(path),
+        fallbackToNearest = true,
+      )
+    } {
+      all.add(freshDiag)
     }
     languageClient.publishDiagnostics(new PublishDiagnosticsParams(uri, all))
   }
@@ -390,8 +402,15 @@ final class Diagnostics(
       path: AbsolutePath,
       d: Diagnostic,
       fallbackToNearest: Boolean = true,
+  ): Option[Diagnostic] =
+    toFreshDiagnostic(path, d, snapshots.get(path), fallbackToNearest)
+
+  private def toFreshDiagnostic(
+      path: AbsolutePath,
+      d: Diagnostic,
+      snapshot: Option[Input.VirtualFile],
+      fallbackToNearest: Boolean,
   ): Option[Diagnostic] = {
-    val snapshot = snapshots.get(path)
     snapshot match {
       case Some(snapshot) =>
         val edit =

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -886,12 +886,28 @@ abstract class MetalsLspService(
           onChange(List(path)),
         )
       )
-      .ignoreValue
+      .flatMap(_ => runScalafixLint(path))
       .asJava
   }
 
   protected def didCompileTarget(report: CompileReport): Unit = {
     compilers.didCompile(report)
+  }
+
+  private def runScalafixLint(path: AbsolutePath): Future[Unit] = {
+    if (!userConfig.scalafixLintEnabled || !path.isScalaFilename)
+      return Future.successful(())
+    val result = for {
+      target <- buildTargets.inverseSources(path)
+      scalaTarget <- buildTargets.scalaTarget(target)
+    } yield {
+      scalafixProvider
+        .runLintDiagnostics(path, scalaTarget)
+        .map { diags =>
+          diagnostics.onScalafixLint(path, diags)
+        }
+    }
+    result.getOrElse(Future.successful(()))
   }
 
   def didChangeWatchedFiles(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -895,8 +895,10 @@ abstract class MetalsLspService(
   }
 
   private def runScalafixLint(path: AbsolutePath): Future[Unit] = {
-    if (!userConfig.scalafixLintEnabled || !path.isScalaFilename)
+    if (!userConfig.scalafixLintEnabled || !path.isScalaFilename) {
+      diagnostics.onScalafixLint(path, Nil)
       return Future.successful(())
+    }
     val result = for {
       target <- buildTargets.inverseSources(path)
       scalaTarget <- buildTargets.scalaTarget(target)
@@ -907,7 +909,10 @@ abstract class MetalsLspService(
           diagnostics.onScalafixLint(path, diags)
         }
     }
-    result.getOrElse(Future.successful(()))
+    result.getOrElse {
+      diagnostics.onScalafixLint(path, Nil)
+      Future.successful(())
+    }
   }
 
   def didChangeWatchedFiles(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -517,12 +517,28 @@ abstract class MetalsLspService(
     symbolHierarchyOps,
   )
 
+  protected val scalafixProvider: ScalafixProvider = ScalafixProvider(
+    buffers,
+    () => userConfig,
+    folder,
+    workDoneProgress,
+    compilations,
+    languageClient,
+    buildTargets,
+    interactiveSemanticdbs,
+    tables,
+    buildHasErrors,
+    diagnostics,
+    statusBar,
+  )
+
   val semanticDBIndexer: SemanticdbIndexer = new SemanticdbIndexer(
     List(
       referencesProvider,
       implementationProvider,
       testProvider,
       buildTargetClasses,
+      scalafixProvider,
     ),
     buildTargets,
     folder,
@@ -564,20 +580,6 @@ abstract class MetalsLspService(
 
   def buildHasErrors(path: scala.meta.io.AbsolutePath): Boolean =
     buildClient.buildHasErrors(path)
-
-  protected val scalafixProvider: ScalafixProvider = ScalafixProvider(
-    buffers,
-    () => userConfig,
-    folder,
-    workDoneProgress,
-    compilations,
-    languageClient,
-    buildTargets,
-    interactiveSemanticdbs,
-    tables,
-    buildHasErrors,
-    statusBar,
-  )
 
   protected val codeActionProvider: CodeActionProvider = new CodeActionProvider(
     compilers,
@@ -886,33 +888,12 @@ abstract class MetalsLspService(
           onChange(List(path)),
         )
       )
-      .flatMap(_ => runScalafixLint(path))
+      .map(_ => ())
       .asJava
   }
 
   protected def didCompileTarget(report: CompileReport): Unit = {
     compilers.didCompile(report)
-  }
-
-  private def runScalafixLint(path: AbsolutePath): Future[Unit] = {
-    if (!userConfig.scalafixLintEnabled || !path.isScalaFilename) {
-      diagnostics.onScalafixLint(path, Nil)
-      return Future.successful(())
-    }
-    val result = for {
-      target <- buildTargets.inverseSources(path)
-      scalaTarget <- buildTargets.scalaTarget(target)
-    } yield {
-      scalafixProvider
-        .runLintDiagnostics(path, scalaTarget)
-        .map { diags =>
-          diagnostics.onScalafixLint(path, diags)
-        }
-    }
-    result.getOrElse {
-      diagnostics.onScalafixLint(path, Nil)
-      Future.successful(())
-    }
   }
 
   def didChangeWatchedFiles(

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -888,7 +888,7 @@ abstract class MetalsLspService(
           onChange(List(path)),
         )
       )
-      .map(_ => ())
+      .ignoreValue
       .asJava
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -62,39 +62,30 @@ case class ScalafixProvider(
   private val scalafixCache = TrieMap.empty[ScalaVersion, Scalafix]
   private val rulesClassloaderCache =
     TrieMap.empty[ScalafixRulesClasspathKey, URLClassLoader]
-  private val lintedFiles = TrieMap.empty[AbsolutePath, Unit]
   private val lintVersions = TrieMap.empty[AbsolutePath, AtomicLong]
 
   override def onChange(docs: TextDocuments, path: AbsolutePath): Unit = {
     if (!userConfig().scalafixLintEnabled || !path.isScalaFilename) {
-      if (lintedFiles.contains(path)) clearLintDiagnostics(path)
+      clearLintDiagnostics(path)
       return
     }
 
     val version = lintVersions
       .getOrElseUpdate(path, new AtomicLong(0))
       .incrementAndGet()
-    val snapshot = path.toInput
 
     runLintDiagnosticsForPath(path).foreach { diags =>
       val currentVersion = lintVersions.get(path).map(_.get()).getOrElse(0L)
-      if (version == currentVersion) {
-        if (diags.nonEmpty) lintedFiles.put(path, ())
-        else lintedFiles.remove(path)
-        diagnostics.onScalafixLint(path, diags, Some(snapshot))
-      }
+      if (version == currentVersion)
+        diagnostics.onScalafixLint(path, diags)
     }
   }
 
   override def onDelete(path: AbsolutePath): Unit =
     clearLintDiagnostics(path)
 
-  override def reset(): Unit = {
-    val files = lintedFiles.keys.toList
-    lintedFiles.clear()
+  override def reset(): Unit =
     lintVersions.clear()
-    files.foreach(path => diagnostics.onScalafixLint(path, Nil))
-  }
 
   private def runLintDiagnosticsForPath(
       path: AbsolutePath
@@ -113,7 +104,6 @@ case class ScalafixProvider(
   }
 
   private def clearLintDiagnostics(path: AbsolutePath): Unit = {
-    lintedFiles.remove(path)
     lintVersions.remove(path)
     diagnostics.onScalafixLint(path, Nil)
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -252,9 +252,7 @@ case class ScalafixProvider(
     val severity = diag.severity() match {
       case ScalafixSeverity.INFO => l.DiagnosticSeverity.Information
       case ScalafixSeverity.WARNING => l.DiagnosticSeverity.Warning
-      case ScalafixSeverity.ERROR =>
-        if (userConfig().scalafixLintCapSeverity) l.DiagnosticSeverity.Warning
-        else l.DiagnosticSeverity.Error
+      case ScalafixSeverity.ERROR => l.DiagnosticSeverity.Warning
     }
 
     val range = diag.position().asScala match {

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -5,7 +5,6 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
-import java.util.concurrent.atomic.AtomicLong
 import java.{util => ju}
 
 import scala.collection.concurrent.TrieMap
@@ -62,30 +61,23 @@ case class ScalafixProvider(
   private val scalafixCache = TrieMap.empty[ScalaVersion, Scalafix]
   private val rulesClassloaderCache =
     TrieMap.empty[ScalafixRulesClasspathKey, URLClassLoader]
-  private val lintVersions = TrieMap.empty[AbsolutePath, AtomicLong]
 
   override def onChange(docs: TextDocuments, path: AbsolutePath): Unit = {
-    if (!userConfig().scalafixLintEnabled || !path.isScalaFilename) {
-      clearLintDiagnostics(path)
-      return
-    }
-
-    val version = lintVersions
-      .getOrElseUpdate(path, new AtomicLong(0))
-      .incrementAndGet()
-
-    runLintDiagnosticsForPath(path).foreach { diags =>
-      val currentVersion = lintVersions.get(path).map(_.get()).getOrElse(0L)
-      if (version == currentVersion)
-        diagnostics.onScalafixLint(path, diags)
+    if (path.isScalaFilename) {
+      if (!userConfig().scalafixLintEnabled) {
+        clearLintDiagnostics(path)
+      } else {
+        runLintDiagnosticsForPath(path).foreach { diags =>
+          diagnostics.onScalafixLint(path, diags)
+        }
+      }
     }
   }
 
   override def onDelete(path: AbsolutePath): Unit =
     clearLintDiagnostics(path)
 
-  override def reset(): Unit =
-    lintVersions.clear()
+  override def reset(): Unit = ()
 
   private def runLintDiagnosticsForPath(
       path: AbsolutePath
@@ -104,7 +96,6 @@ case class ScalafixProvider(
   }
 
   private def clearLintDiagnostics(path: AbsolutePath): Unit = {
-    lintVersions.remove(path)
     diagnostics.onScalafixLint(path, Nil)
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -34,9 +34,11 @@ import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.MessageType
 import org.eclipse.{lsp4j => l}
 import scalafix.interfaces.Scalafix
+import scalafix.interfaces.ScalafixDiagnostic
 import scalafix.interfaces.ScalafixEvaluation
 import scalafix.interfaces.ScalafixException
 import scalafix.interfaces.ScalafixFileEvaluationError
+import scalafix.interfaces.ScalafixSeverity
 import scalafix.internal.interfaces.ScalafixCoursier
 import scalafix.internal.interfaces.ScalafixInterfacesClassloader
 
@@ -242,6 +244,74 @@ case class ScalafixProvider(
             }
           }
       }
+  }
+
+  private def convertToLspDiagnostic(
+      diag: ScalafixDiagnostic
+  ): l.Diagnostic = {
+    val severity = diag.severity() match {
+      case ScalafixSeverity.INFO => l.DiagnosticSeverity.Information
+      case ScalafixSeverity.WARNING => l.DiagnosticSeverity.Warning
+      case ScalafixSeverity.ERROR =>
+        if (userConfig().scalafixLintCapSeverity) l.DiagnosticSeverity.Warning
+        else l.DiagnosticSeverity.Error
+    }
+
+    val range = diag.position().asScala match {
+      case Some(pos) =>
+        new l.Range(
+          new l.Position(pos.startLine(), pos.startColumn()),
+          new l.Position(pos.endLine(), pos.endColumn()),
+        )
+      case None =>
+        new l.Range(new l.Position(0, 0), new l.Position(0, 0))
+    }
+
+    val message = {
+      val explanation = diag.explanation()
+      if (explanation != null && explanation.nonEmpty)
+        s"${diag.message()}\n${explanation}"
+      else diag.message()
+    }
+
+    val lspDiag = new l.Diagnostic(range, message, severity, "scalafix")
+    diag.lintID().asScala.foreach { lintId =>
+      lspDiag.setCode(s"${lintId.ruleName()}.${lintId.categoryID()}")
+    }
+    lspDiag
+  }
+
+  def runLintDiagnostics(
+      file: AbsolutePath,
+      scalaTarget: ScalaTarget,
+  ): Future[List[l.Diagnostic]] = {
+    val rules = rulesFromScalafixConf().toList
+    if (rules.isEmpty) return Future.successful(Nil)
+
+    val fromDisk = file.toInput
+    scalafixEvaluate(
+      file,
+      scalaTarget,
+      fromDisk.value,
+      produceSemanticdb = false,
+      rules,
+      suggestConfigAmend = false,
+    ).map { results =>
+      if (scalafixSucceded(results)) {
+        results
+          .getFileEvaluations()
+          .headOption
+          .map { fileEval =>
+            fileEval.getDiagnostics().toList.map(convertToLspDiagnostic)
+          }
+          .getOrElse(Nil)
+      } else {
+        Nil
+      }
+    }.recover { case NonFatal(e) =>
+      scribe.warn(s"Scalafix lint failed for $file: ${e.getMessage}")
+      Nil
+    }
   }
 
   private def createTemporarySemanticdb(

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -53,12 +53,58 @@ case class ScalafixProvider(
     interactive: InteractiveSemanticdbs,
     tables: Tables,
     buildHasErrors: AbsolutePath => Boolean,
+    diagnostics: Diagnostics,
     statusBar: StatusBar,
-)(implicit ec: ExecutionContext, rc: ReportContext) {
+)(implicit ec: ExecutionContext, rc: ReportContext)
+    extends SemanticdbFeatureProvider {
   import ScalafixProvider._
   private val scalafixCache = TrieMap.empty[ScalaVersion, Scalafix]
   private val rulesClassloaderCache =
     TrieMap.empty[ScalafixRulesClasspathKey, URLClassLoader]
+  private val lintedFiles = TrieMap.empty[AbsolutePath, Unit]
+
+  override def onChange(docs: TextDocuments, path: AbsolutePath): Unit = {
+    if (!userConfig().scalafixLintEnabled || !path.isScalaFilename) {
+      clearLintDiagnostics(path)
+      return
+    }
+
+    runLintDiagnosticsForPath(path).foreach { diags =>
+      if (diags.nonEmpty) lintedFiles.put(path, ())
+      else lintedFiles.remove(path)
+      diagnostics.onScalafixLint(path, diags)
+    }
+  }
+
+  override def onDelete(path: AbsolutePath): Unit =
+    clearLintDiagnostics(path)
+
+  override def reset(): Unit = {
+    val files = lintedFiles.keys.toList
+    lintedFiles.clear()
+    files.foreach(path => diagnostics.onScalafixLint(path, Nil))
+  }
+
+  private def runLintDiagnosticsForPath(
+      path: AbsolutePath
+  ): Future[List[l.Diagnostic]] = {
+    val result = for {
+      target <- buildTargets.inverseSources(path)
+      scalaTarget <- buildTargets.scalaTarget(target)
+    } yield runLintDiagnostics(path, scalaTarget)
+
+    result.getOrElse {
+      scribe.warn(
+        s"Skipping Scalafix lint diagnostics for $path: no Scala build target found"
+      )
+      Future.successful(Nil)
+    }
+  }
+
+  private def clearLintDiagnostics(path: AbsolutePath): Unit = {
+    lintedFiles.remove(path)
+    diagnostics.onScalafixLint(path, Nil)
+  }
 
   def runAllRules(file: AbsolutePath): Future[List[l.TextEdit]] = {
     val definedRules = rulesFromScalafixConf()
@@ -303,6 +349,11 @@ case class ScalafixProvider(
             fileEval.getDiagnostics().toList.map(convertToLspDiagnostic)
           }
           .getOrElse(Nil)
+      } else if (hasStaleOrMissingSemanticdb(results)) {
+        scribe.warn(
+          s"Skipping Scalafix lint diagnostics for $file: missing or stale semanticdb"
+        )
+        Nil
       } else {
         Nil
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalafixProvider.scala
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
+import java.util.concurrent.atomic.AtomicLong
 import java.{util => ju}
 
 import scala.collection.concurrent.TrieMap
@@ -62,17 +63,26 @@ case class ScalafixProvider(
   private val rulesClassloaderCache =
     TrieMap.empty[ScalafixRulesClasspathKey, URLClassLoader]
   private val lintedFiles = TrieMap.empty[AbsolutePath, Unit]
+  private val lintVersions = TrieMap.empty[AbsolutePath, AtomicLong]
 
   override def onChange(docs: TextDocuments, path: AbsolutePath): Unit = {
     if (!userConfig().scalafixLintEnabled || !path.isScalaFilename) {
-      clearLintDiagnostics(path)
+      if (lintedFiles.contains(path)) clearLintDiagnostics(path)
       return
     }
 
+    val version = lintVersions
+      .getOrElseUpdate(path, new AtomicLong(0))
+      .incrementAndGet()
+    val snapshot = path.toInput
+
     runLintDiagnosticsForPath(path).foreach { diags =>
-      if (diags.nonEmpty) lintedFiles.put(path, ())
-      else lintedFiles.remove(path)
-      diagnostics.onScalafixLint(path, diags)
+      val currentVersion = lintVersions.get(path).map(_.get()).getOrElse(0L)
+      if (version == currentVersion) {
+        if (diags.nonEmpty) lintedFiles.put(path, ())
+        else lintedFiles.remove(path)
+        diagnostics.onScalafixLint(path, diags, Some(snapshot))
+      }
     }
   }
 
@@ -82,6 +92,7 @@ case class ScalafixProvider(
   override def reset(): Unit = {
     val files = lintedFiles.keys.toList
     lintedFiles.clear()
+    lintVersions.clear()
     files.foreach(path => diagnostics.onScalafixLint(path, Nil))
   }
 
@@ -103,6 +114,7 @@ case class ScalafixProvider(
 
   private def clearLintDiagnostics(path: AbsolutePath): Unit = {
     lintedFiles.remove(path)
+    lintVersions.remove(path)
     diagnostics.onScalafixLint(path, Nil)
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -52,7 +52,6 @@ case class UserConfiguration(
     javaFormatConfig: Option[JavaFormatConfig] = None,
     scalafixRulesDependencies: List[String] = Nil,
     scalafixLintEnabled: Boolean = false,
-    scalafixLintCapSeverity: Boolean = false,
     customProjectRoot: Option[String] = None,
     verboseCompilation: Boolean = false,
     automaticImportBuild: AutoImportBuildKind = AutoImportBuildKind.Off,
@@ -135,7 +134,6 @@ case class UserConfiguration(
         Some(scalafixRulesDependencies),
       ),
       Some(("scalafixLintEnabled", scalafixLintEnabled)),
-      Some(("scalafixLintCapSeverity", scalafixLintCapSeverity)),
       optStringField("customProjectRoot", customProjectRoot),
       Some(("verboseCompilation", verboseCompilation)),
       Some(
@@ -289,17 +287,6 @@ object UserConfiguration {
         """When enabled, Scalafix rules from `.scalafix.conf` will be run after each
           |successful compilation and lint diagnostics will be published alongside
           |compiler diagnostics. Only lint diagnostics are shown; no code rewrites are applied.
-          |""".stripMargin,
-        isBoolean = true,
-      ),
-      UserConfigurationOption(
-        "scalafix-lint-cap-severity",
-        "false",
-        "true",
-        "Cap Scalafix lint severity to warning",
-        """When enabled, Scalafix lint diagnostics will never be shown as errors,
-          |only as warnings at most. This is useful since Scalafix errors can be confusing
-          |as the code still compiles successfully.
           |""".stripMargin,
         isBoolean = true,
       ),
@@ -890,9 +877,6 @@ object UserConfiguration {
     val scalafixLintEnabled =
       getBooleanKey("scalafix-lint-enabled").getOrElse(false)
 
-    val scalafixLintCapSeverity =
-      getBooleanKey("scalafix-lint-cap-severity").getOrElse(false)
-
     val customProjectRoot = getStringKey("custom-project-root")
     val verboseCompilation =
       getBooleanKey("verbose-compilation").getOrElse(false)
@@ -954,7 +938,6 @@ object UserConfiguration {
           javaFormatConfig,
           scalafixRulesDependencies,
           scalafixLintEnabled,
-          scalafixLintCapSeverity,
           customProjectRoot,
           verboseCompilation,
           autoImportBuilds,

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -284,8 +284,8 @@ object UserConfiguration {
         "false",
         "false",
         "Enable Scalafix lint diagnostics",
-        """When enabled, Scalafix rules from `.scalafix.conf` will be run after each
-          |successful compilation and lint diagnostics will be published alongside
+        """When enabled, Scalafix rules from `.scalafix.conf` will be run on
+          |semanticdb updates and lint diagnostics will be published alongside
           |compiler diagnostics. Only lint diagnostics are shown; no code rewrites are applied.
           |""".stripMargin,
         isBoolean = true,

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -51,6 +51,8 @@ case class UserConfiguration(
     testUserInterface: TestUserInterfaceKind = TestUserInterfaceKind.CodeLenses,
     javaFormatConfig: Option[JavaFormatConfig] = None,
     scalafixRulesDependencies: List[String] = Nil,
+    scalafixLintEnabled: Boolean = false,
+    scalafixLintCapSeverity: Boolean = false,
     customProjectRoot: Option[String] = None,
     verboseCompilation: Boolean = false,
     automaticImportBuild: AutoImportBuildKind = AutoImportBuildKind.Off,
@@ -132,6 +134,8 @@ case class UserConfiguration(
         "scalafixRulesDependencies",
         Some(scalafixRulesDependencies),
       ),
+      Some(("scalafixLintEnabled", scalafixLintEnabled)),
+      Some(("scalafixLintCapSeverity", scalafixLintCapSeverity)),
       optStringField("customProjectRoot", customProjectRoot),
       Some(("verboseCompilation", verboseCompilation)),
       Some(
@@ -276,6 +280,28 @@ object UserConfiguration {
         "Scalafix rules dependencies",
         """Optional list of Scalafix rules dependencies to use for running `scalafix --rules`.""",
         isArray = true,
+      ),
+      UserConfigurationOption(
+        "scalafix-lint-enabled",
+        "false",
+        "false",
+        "Enable Scalafix lint diagnostics",
+        """When enabled, Scalafix rules from `.scalafix.conf` will be run after each
+          |successful compilation and lint diagnostics will be published alongside
+          |compiler diagnostics. Only lint diagnostics are shown; no code rewrites are applied.
+          |""".stripMargin,
+        isBoolean = true,
+      ),
+      UserConfigurationOption(
+        "scalafix-lint-cap-severity",
+        "false",
+        "true",
+        "Cap Scalafix lint severity to warning",
+        """When enabled, Scalafix lint diagnostics will never be shown as errors,
+          |only as warnings at most. This is useful since Scalafix errors can be confusing
+          |as the code still compiles successfully.
+          |""".stripMargin,
+        isBoolean = true,
       ),
       UserConfigurationOption(
         "excluded-packages",
@@ -861,6 +887,12 @@ object UserConfiguration {
     val scalafixRulesDependencies =
       getStringListKey("scalafix-rules-dependencies").getOrElse(Nil)
 
+    val scalafixLintEnabled =
+      getBooleanKey("scalafix-lint-enabled").getOrElse(false)
+
+    val scalafixLintCapSeverity =
+      getBooleanKey("scalafix-lint-cap-severity").getOrElse(false)
+
     val customProjectRoot = getStringKey("custom-project-root")
     val verboseCompilation =
       getBooleanKey("verbose-compilation").getOrElse(false)
@@ -921,6 +953,8 @@ object UserConfiguration {
           disableTestCodeLenses,
           javaFormatConfig,
           scalafixRulesDependencies,
+          scalafixLintEnabled,
+          scalafixLintCapSeverity,
           customProjectRoot,
           verboseCompilation,
           autoImportBuilds,

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -152,6 +152,8 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
 
   private val refreshCount = new AtomicInteger
   var refreshModelHandler: Int => Unit = (_) => ()
+  private val diagnosticsPromises =
+    TrieMap.empty[AbsolutePath, (Promise[Unit], Seq[Diagnostic] => Boolean)]
 
   val testExplorerUpdates: Promise[List[JsonObject]] =
     Promise[List[JsonObject]]()
@@ -343,6 +345,21 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
     diagnosticsCount
       .getOrElseUpdate(path, new AtomicInteger())
       .incrementAndGet()
+    diagnosticsPromises.get(path).foreach { case (promise, condition) =>
+      if (condition(params.getDiagnostics.asScala.toSeq)) {
+        diagnosticsPromises.remove(path)
+        promise.trySuccess(())
+      }
+    }
+  }
+
+  def nextDiagnosticsFor(
+      path: AbsolutePath,
+      condition: Seq[Diagnostic] => Boolean = _ => true,
+  ): Future[Unit] = {
+    val promise = Promise[Unit]()
+    diagnosticsPromises(path) = (promise, condition)
+    promise.future
   }
   override def showMessage(params: MessageParams): Unit = {
     showMessageHandler(params)

--- a/tests/unit/src/main/scala/tests/TestingClient.scala
+++ b/tests/unit/src/main/scala/tests/TestingClient.scala
@@ -358,7 +358,12 @@ class TestingClient(workspace: AbsolutePath, val buffers: Buffers)
       condition: Seq[Diagnostic] => Boolean = _ => true,
   ): Future[Unit] = {
     val promise = Promise[Unit]()
-    diagnosticsPromises(path) = (promise, condition)
+    diagnosticsPromises.put(path, (promise, condition)).foreach {
+      case (oldPromise, _) =>
+        oldPromise.tryFailure(
+          new Exception("Replaced by a newer nextDiagnosticsFor call")
+        )
+    }
     promise.future
   }
   override def showMessage(params: MessageParams): Unit = {

--- a/tests/unit/src/main/scala/tests/TestingServer.scala
+++ b/tests/unit/src/main/scala/tests/TestingServer.scala
@@ -700,6 +700,16 @@ final case class TestingServer(
 
   def waitFor(millis: Long): Future[Unit] = Future { Thread.sleep(millis) }
 
+  def awaitNextDiagnostics(
+      filename: String,
+      condition: Seq[l.Diagnostic] => Boolean = _ => true,
+  ): Future[Unit] = {
+    val path = toPath(filename)
+    client
+      .nextDiagnosticsFor(path, condition)
+      .withTimeout(30, util.concurrent.TimeUnit.SECONDS, reason = None)
+  }
+
   /**
    * @param target the build target to debug, like "myproject.test"
    * @param kind one of the constants in [[ch.epfl.scala.bsp4j.TestParamsDataKind]] or [[ch.epfl.scala.bsp4j.DebugSessionParamsDataKind]].

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -322,6 +322,8 @@ class UserConfigurationSuite extends BaseSuite {
           |    "rule1",
           |    "rule2"
           |  ],
+          |  "scalafixLintEnabled": false,
+          |  "scalafixLintCapSeverity": false,
           |  "testUserInterface": "test explorer",
           |  "bloopVersion": "1.2.3",
           |  "fallbackScalaVersion": "3.2.1",
@@ -371,6 +373,8 @@ class UserConfigurationSuite extends BaseSuite {
           |scalafmt-config-path                         string                         ""              Scalafmt config path
           |scalafix-config-path                         string                         ""              Scalafix config path
           |scalafix-rules-dependencies                  array                          []              Scalafix rules dependencies
+          |scalafix-lint-enabled                        boolean                        false           Enable Scalafix lint diagnostics
+          |scalafix-lint-cap-severity                   boolean                        false           Cap Scalafix lint severity to warning
           |excluded-packages                            array                          []              Excluded Packages
           |bloop-sbt-already-installed                  boolean                        false           Don't generate Bloop plugin file for sbt
           |bloop-version                                string                         $bloopVersionPadded Version of Bloop

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -287,7 +287,6 @@ class UserConfigurationSuite extends BaseSuite {
       json,
       s"""|{
           |  "enableIndentOnPaste": true,
-          |  "customProjectRoot": "customs",
           |  "millScript": "mill",
           |  "javaFormat": {
           |    "eclipseConfigPath": "$fakePathString",
@@ -307,6 +306,8 @@ class UserConfigurationSuite extends BaseSuite {
           |  "scalafixConfigPath": "$fakePathString",
           |  "superMethodLensesEnabled": true,
           |  "startMcpServer": false,
+          |  "customProjectRoot": "customs",
+          |  "scalafixLintEnabled": false,
           |  "bloopSbtAlreadyInstalled": true,
           |  "symbolPrefixes": {
           |    "java/util/": "hello."
@@ -322,7 +323,6 @@ class UserConfigurationSuite extends BaseSuite {
           |    "rule1",
           |    "rule2"
           |  ],
-          |  "scalafixLintEnabled": false,
           |  "testUserInterface": "test explorer",
           |  "bloopVersion": "1.2.3",
           |  "fallbackScalaVersion": "3.2.1",

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -323,7 +323,6 @@ class UserConfigurationSuite extends BaseSuite {
           |    "rule2"
           |  ],
           |  "scalafixLintEnabled": false,
-          |  "scalafixLintCapSeverity": false,
           |  "testUserInterface": "test explorer",
           |  "bloopVersion": "1.2.3",
           |  "fallbackScalaVersion": "3.2.1",
@@ -374,7 +373,6 @@ class UserConfigurationSuite extends BaseSuite {
           |scalafix-config-path                         string                         ""              Scalafix config path
           |scalafix-rules-dependencies                  array                          []              Scalafix rules dependencies
           |scalafix-lint-enabled                        boolean                        false           Enable Scalafix lint diagnostics
-          |scalafix-lint-cap-severity                   boolean                        false           Cap Scalafix lint severity to warning
           |excluded-packages                            array                          []              Excluded Packages
           |bloop-sbt-already-installed                  boolean                        false           Don't generate Bloop plugin file for sbt
           |bloop-version                                string                         $bloopVersionPadded Version of Bloop

--- a/tests/unit/src/test/scala/tests/scalafix/ScalafixLintDiagnosticsSuite.scala
+++ b/tests/unit/src/test/scala/tests/scalafix/ScalafixLintDiagnosticsSuite.scala
@@ -11,6 +11,13 @@ class ScalafixLintDiagnosticsSuite
   override def userConfig: UserConfiguration =
     super.userConfig.copy(scalafixLintEnabled = true)
 
+  private val mainFile = "a/src/main/scala/Main.scala"
+
+  private def hasScalafixDiag(
+      diags: Seq[org.eclipse.lsp4j.Diagnostic]
+  ): Boolean =
+    diags.exists(d => d.getSource == "scalafix")
+
   private def scalafixInitPayload(mainScalaContent: String): String =
     s"""/metals.json
        |{"a":{"scalaVersion": "${V.scala213}"}}
@@ -34,8 +41,13 @@ class ScalafixLintDiagnosticsSuite
              |""".stripMargin
         )
       )
-      _ <- server.didOpen("a/src/main/scala/Main.scala")
-      _ <- server.didSave("a/src/main/scala/Main.scala")
+      _ <- server.didOpen(mainFile)
+      diagnosticsPromise = server.awaitNextDiagnostics(
+        mainFile,
+        hasScalafixDiag,
+      )
+      _ <- server.didSave(mainFile)
+      _ <- diagnosticsPromise
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|a/src/main/scala/Main.scala:2:3: warning: mutable state should be avoided
@@ -57,8 +69,13 @@ class ScalafixLintDiagnosticsSuite
              |""".stripMargin
         )
       )
-      _ <- server.didOpen("a/src/main/scala/Main.scala")
-      _ <- server.didSave("a/src/main/scala/Main.scala")
+      _ <- server.didOpen(mainFile)
+      diagnosticsPromise = server.awaitNextDiagnostics(
+        mainFile,
+        hasScalafixDiag,
+      )
+      _ <- server.didSave(mainFile)
+      _ <- diagnosticsPromise
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|a/src/main/scala/Main.scala:2:3: warning: mutable state should be avoided
@@ -66,13 +83,18 @@ class ScalafixLintDiagnosticsSuite
            |  ^^^
            |""".stripMargin,
       )
-      _ <- server.didChange("a/src/main/scala/Main.scala") { _ =>
+      _ <- server.didChange(mainFile) { _ =>
         """|object Main {
            |  val x = 1
            |}
            |""".stripMargin
       }
-      _ <- server.didSave("a/src/main/scala/Main.scala")
+      clearedPromise = server.awaitNextDiagnostics(
+        mainFile,
+        !hasScalafixDiag(_),
+      )
+      _ <- server.didSave(mainFile)
+      _ <- clearedPromise
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         "",
@@ -97,8 +119,13 @@ class ScalafixLintDiagnosticsSuite
              |""".stripMargin
         )
       )
-      _ <- server.didOpen("a/src/main/scala/Main.scala")
-      _ <- server.didSave("a/src/main/scala/Main.scala")
+      _ <- server.didOpen(mainFile)
+      diagnosticsPromise = server.awaitNextDiagnostics(
+        mainFile,
+        hasScalafixDiag,
+      )
+      _ <- server.didSave(mainFile)
+      _ <- diagnosticsPromise
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         """|a/src/main/scala/Main.scala:5:3: warning: mutable state should be avoided

--- a/tests/unit/src/test/scala/tests/scalafix/ScalafixLintDiagnosticsSuite.scala
+++ b/tests/unit/src/test/scala/tests/scalafix/ScalafixLintDiagnosticsSuite.scala
@@ -32,7 +32,7 @@ class ScalafixLintDiagnosticsSuite
       _ <- server.didSave("a/src/main/scala/Main.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
-        """|a/src/main/scala/Main.scala:2:3: error: mutable state should be avoided
+        """|a/src/main/scala/Main.scala:2:3: warning: mutable state should be avoided
            |  var x = 1
            |  ^^^
            |""".stripMargin,
@@ -61,7 +61,7 @@ class ScalafixLintDiagnosticsSuite
       _ <- server.didSave("a/src/main/scala/Main.scala")
       _ = assertNoDiff(
         client.workspaceDiagnostics,
-        """|a/src/main/scala/Main.scala:2:3: error: mutable state should be avoided
+        """|a/src/main/scala/Main.scala:2:3: warning: mutable state should be avoided
            |  var x = 1
            |  ^^^
            |""".stripMargin,
@@ -76,6 +76,45 @@ class ScalafixLintDiagnosticsSuite
       _ = assertNoDiff(
         client.workspaceDiagnostics,
         "",
+      )
+    } yield ()
+  }
+
+  test("lint-with-compiler-warnings") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""/metals.json
+           |{"a":{"scalaVersion": "${V.scala213}"}}
+           |/.scalafix.conf
+           |rules = [
+           |  DisableSyntax
+           |]
+           |DisableSyntax.noVars = true
+           |/a/src/main/scala/Main.scala
+           |sealed trait Animal
+           |case class Dog(name: String) extends Animal
+           |case class Cat(name: String) extends Animal
+           |object Main {
+           |  var x = 1
+           |  def greet(a: Animal): String = a match {
+           |    case Dog(n) => n
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      _ <- server.didSave("a/src/main/scala/Main.scala")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|a/src/main/scala/Main.scala:5:3: warning: mutable state should be avoided
+           |  var x = 1
+           |  ^^^
+           |a/src/main/scala/Main.scala:6:34: warning: match may not be exhaustive.
+           |It would fail on the following input: Cat(_)
+           |  def greet(a: Animal): String = a match {
+           |                                 ^
+           |""".stripMargin,
       )
     } yield ()
   }

--- a/tests/unit/src/test/scala/tests/scalafix/ScalafixLintDiagnosticsSuite.scala
+++ b/tests/unit/src/test/scala/tests/scalafix/ScalafixLintDiagnosticsSuite.scala
@@ -1,0 +1,83 @@
+package tests.scalafix
+
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.{BuildInfo => V}
+
+import tests.BaseLspSuite
+
+class ScalafixLintDiagnosticsSuite
+    extends BaseLspSuite("scalafix-lint-diagnostics") {
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(scalafixLintEnabled = true)
+
+  test("lint-diagnostics-published") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""/metals.json
+           |{"a":{"scalaVersion": "${V.scala213}"}}
+           |/.scalafix.conf
+           |rules = [
+           |  DisableSyntax
+           |]
+           |DisableSyntax.noVars = true
+           |/a/src/main/scala/Main.scala
+           |object Main {
+           |  var x = 1
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      _ <- server.didSave("a/src/main/scala/Main.scala")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|a/src/main/scala/Main.scala:2:3: error: mutable state should be avoided
+           |  var x = 1
+           |  ^^^
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("lint-diagnostics-cleared-on-fix") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""/metals.json
+           |{"a":{"scalaVersion": "${V.scala213}"}}
+           |/.scalafix.conf
+           |rules = [
+           |  DisableSyntax
+           |]
+           |DisableSyntax.noVars = true
+           |/a/src/main/scala/Main.scala
+           |object Main {
+           |  var x = 1
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/main/scala/Main.scala")
+      _ <- server.didSave("a/src/main/scala/Main.scala")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        """|a/src/main/scala/Main.scala:2:3: error: mutable state should be avoided
+           |  var x = 1
+           |  ^^^
+           |""".stripMargin,
+      )
+      _ <- server.didChange("a/src/main/scala/Main.scala") { _ =>
+        """|object Main {
+           |  val x = 1
+           |}
+           |""".stripMargin
+      }
+      _ <- server.didSave("a/src/main/scala/Main.scala")
+      _ = assertNoDiff(
+        client.workspaceDiagnostics,
+        "",
+      )
+    } yield ()
+  }
+
+}

--- a/tests/unit/src/test/scala/tests/scalafix/ScalafixLintDiagnosticsSuite.scala
+++ b/tests/unit/src/test/scala/tests/scalafix/ScalafixLintDiagnosticsSuite.scala
@@ -11,22 +11,28 @@ class ScalafixLintDiagnosticsSuite
   override def userConfig: UserConfiguration =
     super.userConfig.copy(scalafixLintEnabled = true)
 
+  private def scalafixInitPayload(mainScalaContent: String): String =
+    s"""/metals.json
+       |{"a":{"scalaVersion": "${V.scala213}"}}
+       |/.scalafix.conf
+       |rules = [
+       |  DisableSyntax
+       |]
+       |DisableSyntax.noVars = true
+       |/a/src/main/scala/Main.scala
+       |$mainScalaContent
+       |""".stripMargin
+
   test("lint-diagnostics-published") {
     cleanWorkspace()
     for {
       _ <- initialize(
-        s"""/metals.json
-           |{"a":{"scalaVersion": "${V.scala213}"}}
-           |/.scalafix.conf
-           |rules = [
-           |  DisableSyntax
-           |]
-           |DisableSyntax.noVars = true
-           |/a/src/main/scala/Main.scala
-           |object Main {
-           |  var x = 1
-           |}
-           |""".stripMargin
+        scalafixInitPayload(
+          """|object Main {
+             |  var x = 1
+             |}
+             |""".stripMargin
+        )
       )
       _ <- server.didOpen("a/src/main/scala/Main.scala")
       _ <- server.didSave("a/src/main/scala/Main.scala")
@@ -44,18 +50,12 @@ class ScalafixLintDiagnosticsSuite
     cleanWorkspace()
     for {
       _ <- initialize(
-        s"""/metals.json
-           |{"a":{"scalaVersion": "${V.scala213}"}}
-           |/.scalafix.conf
-           |rules = [
-           |  DisableSyntax
-           |]
-           |DisableSyntax.noVars = true
-           |/a/src/main/scala/Main.scala
-           |object Main {
-           |  var x = 1
-           |}
-           |""".stripMargin
+        scalafixInitPayload(
+          """|object Main {
+             |  var x = 1
+             |}
+             |""".stripMargin
+        )
       )
       _ <- server.didOpen("a/src/main/scala/Main.scala")
       _ <- server.didSave("a/src/main/scala/Main.scala")
@@ -84,24 +84,18 @@ class ScalafixLintDiagnosticsSuite
     cleanWorkspace()
     for {
       _ <- initialize(
-        s"""/metals.json
-           |{"a":{"scalaVersion": "${V.scala213}"}}
-           |/.scalafix.conf
-           |rules = [
-           |  DisableSyntax
-           |]
-           |DisableSyntax.noVars = true
-           |/a/src/main/scala/Main.scala
-           |sealed trait Animal
-           |case class Dog(name: String) extends Animal
-           |case class Cat(name: String) extends Animal
-           |object Main {
-           |  var x = 1
-           |  def greet(a: Animal): String = a match {
-           |    case Dog(n) => n
-           |  }
-           |}
-           |""".stripMargin
+        scalafixInitPayload(
+          """|sealed trait Animal
+             |case class Dog(name: String) extends Animal
+             |case class Cat(name: String) extends Animal
+             |object Main {
+             |  var x = 1
+             |  def greet(a: Animal): String = a match {
+             |    case Dog(n) => n
+             |  }
+             |}
+             |""".stripMargin
+        )
       )
       _ <- server.didOpen("a/src/main/scala/Main.scala")
       _ <- server.didSave("a/src/main/scala/Main.scala")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scalafix lint diagnostics are shown in the editor and merged with other diagnostics; they publish on edit/save and are cleared on fix, file deletion, or reset.
  * New user option: scalafix-lint-enabled (boolean, default: false).

* **Tests**
  * Added end-to-end tests validating lint diagnostics publish/clear behavior and coexistence with compiler warnings.
  * Added test helpers to await and synchronize on next diagnostics for a file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->