### PR TITLE
bugfix: Fix issue with uri is wrongly sent for watching

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -16,13 +16,13 @@ object Configs {
   final case class GlobSyntaxConfig(value: String) {
     import GlobSyntaxConfig._
     def isUri: Boolean = this == uri
-    def isVscode: Boolean = this == vscode
+    def isPath: Boolean = this == path
     def registrationOptions(
         workspace: AbsolutePath
     ): DidChangeWatchedFilesRegistrationOptions = {
       val root: String =
-        if (isVscode) workspace.toString()
-        else workspace.toURI.toString.stripSuffix("/")
+        if (isUri) workspace.toURI.toString.stripSuffix("/")
+        else workspace.toString()
       new DidChangeWatchedFilesRegistrationOptions(
         (List(
           new FileSystemWatcher(Either.forLeft(s"$root/*.sbt")),
@@ -58,14 +58,17 @@ object Configs {
 
   object GlobSyntaxConfig {
     def uri = new GlobSyntaxConfig("uri")
-    def vscode = new GlobSyntaxConfig("vscode")
+    def path = new GlobSyntaxConfig("vscode")
     def default =
       new GlobSyntaxConfig(
-        System.getProperty("metals.glob-syntax", uri.value)
+        // Default to plain path globs (LSP 3.17); URI-prefixed patterns break strict
+        // clients (e.g. Neovim 0.12). Override with -Dmetals.glob-syntax=uri if needed.
+        System.getProperty("metals.glob-syntax", path.value)
       )
     def fromString(value: String): Option[GlobSyntaxConfig] =
       value match {
-        case "vscode" => Some(vscode)
+        case "vscode" => Some(path)
+        case "path" => Some(path)
         case "uri" => Some(uri)
         case _ => None
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsServerConfig.scala
@@ -222,7 +222,7 @@ object MetalsServerConfig {
       case MetalsClientType.vscode =>
         base.copy(
           icons = Icons.vscode,
-          globSyntax = GlobSyntaxConfig.vscode,
+          globSyntax = GlobSyntaxConfig.path,
           compilers = base.compilers.copy(
             _parameterHintsCommand =
               Some("editor.action.triggerParameterHints"),


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/8292



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Changes

- Updated default glob syntax mode for file pattern matching in projects, changing from URI to Path mode
- Simplified glob syntax configuration naming from VSCode to Path for improved clarity and consistency
- Maintained full backward compatibility with existing glob pattern matching options including both Path and URI modes for flexible workspace configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->