### PR TITLE
bugfix: Java toplevel indexer skips text blocks (JDK 25 HtmlConfiguration)

### DIFF
--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaToplevelMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaToplevelMtags.scala
@@ -169,18 +169,52 @@ class JavaToplevelMtags(
   private def fetchToken: Token = {
 
     @tailrec
-    def quotedLiteral(quote: Char): Token = {
-      reader.nextChar()
-
+    def quotedLiteralFromCurrent(quote: Char): Token = {
       if (reader.endCharOffset >= reader.buf.length)
         throw new RuntimeException("Broken file, quote doesn't end.")
-
       reader.ch match {
-        case `quote` => Token.Literal
+        case `quote` =>
+          Token.Literal
         case '\\' =>
           reader.nextChar()
-          quotedLiteral(quote)
-        case _ => quotedLiteral(quote)
+          reader.ch match {
+            case `quote` =>
+              reader.nextChar()
+            case '\\' =>
+              reader.nextChar()
+            case _ =>
+          }
+          quotedLiteralFromCurrent(quote)
+        case _ =>
+          reader.nextChar()
+          quotedLiteralFromCurrent(quote)
+      }
+    }
+
+    def quotedLiteral(quote: Char): Token = {
+      reader.nextChar()
+      quotedLiteralFromCurrent(quote)
+    }
+
+    /**
+     * Skip until the closing `"""` of a Java text block (JLS 3.10.6). On return, [[reader.ch]] is
+     * the third `"` of the closing delimiter (same convention as [[quotedLiteralFromCurrent]]).
+     */
+    @tailrec
+    def skipTextBlockUntilClosingDelimiter(): Unit = {
+      if (reader.ch == Chars.SU || reader.endCharOffset >= reader.buf.length) ()
+      else if (
+        reader.ch == '"' &&
+        reader.endCharOffset < reader.buf.length &&
+        reader.buf(reader.endCharOffset) == '"' &&
+        reader.endCharOffset + 1 < reader.buf.length &&
+        reader.buf(reader.endCharOffset + 1) == '"'
+      ) {
+        reader.nextChar()
+        reader.nextChar()
+      } else {
+        reader.nextChar()
+        skipTextBlockUntilClosingDelimiter()
       }
     }
 
@@ -227,7 +261,20 @@ class JavaToplevelMtags(
         case ']' => (Token.RBracket, false)
         case '<' => (Token.LessThan, false)
         case '>' => (Token.GreaterThan, false)
-        case '"' => (quotedLiteral('"'), false)
+        case '"' =>
+          reader.nextChar()
+          if (
+            reader.ch == '"' &&
+            reader.endCharOffset < reader.buf.length &&
+            reader.buf(reader.endCharOffset) == '"'
+          ) {
+            reader.nextChar()
+            reader.nextChar()
+            skipTextBlockUntilClosingDelimiter()
+            (Token.Literal, false)
+          } else {
+            (quotedLiteralFromCurrent('"'), false)
+          }
         case '\'' => (quotedLiteral('\''), false)
         case '/' =>
           reader.nextChar()

--- a/tests/unit/src/test/scala/tests/BaseToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/BaseToplevelSuite.scala
@@ -4,7 +4,10 @@ import java.nio.file.Files
 
 import scala.meta.Dialect
 import scala.meta.dialects
+import scala.meta.internal.metals.EmptyReporter
 import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ReportContext
+import scala.meta.internal.metals.Reporter
 import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.ResolvedOverriddenSymbol
 import scala.meta.internal.mtags.ToplevelMember
@@ -24,8 +27,10 @@ abstract class BaseToplevelSuite extends BaseSuite {
       expected: List[String],
       mode: Mode = Toplevel,
       dialect: Dialect = dialects.Scala3,
+      errorExpected: Boolean = false,
   )(implicit location: munit.Location): Unit = {
     test(options) {
+      implicit val testReportContext = new TestReportContext()
       if (!allowedModes(mode)) {
         throw new Exception(s"Mode $mode is not allowed.")
       }
@@ -68,6 +73,11 @@ abstract class BaseToplevelSuite extends BaseSuite {
         obtained.sorted.mkString("\n"),
         expected.sorted.mkString("\n"),
       )
+      if (!errorExpected)
+        assert(
+          !testReportContext.wasErrorReported(),
+          "Error should not be reported",
+        )
     }
   }
 
@@ -78,6 +88,25 @@ abstract class BaseToplevelSuite extends BaseSuite {
     assertNoDiff(obtained.sorted.mkString("\n"), expected.sorted.mkString("\n"))
   }
 
+  class TestReportContext extends ReportContext {
+    def wasErrorReported(): Boolean = wasReported
+    private var wasReported = false
+    override def unsanitized(): Reporter = {
+      wasReported = true
+      EmptyReporter
+    }
+
+    override def incognito(): Reporter = {
+      wasReported = true
+      EmptyReporter
+    }
+
+    override def bloop(): Reporter = {
+      wasReported = true
+      EmptyReporter
+    }
+
+  }
   sealed trait Mode
   // includeInnerClasses = false
   // includeMembers = false

--- a/tests/unit/src/test/scala/tests/JavaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaToplevelSuite.scala
@@ -3,7 +3,41 @@ package tests
 class JavaToplevelSuite extends BaseToplevelSuite {
 
   override def filename: String = "Test.java"
-  override def allowedModes: Set[Mode] = Set(Toplevel, ToplevelWithInner)
+  override def allowedModes: Set[Mode] = Set(All, Toplevel, ToplevelWithInner)
+
+  check(
+    "text-block-with-embedded-quotes-i8293",
+    s"""|package sample;
+        |
+        |public class HtmlConfiguration {
+        |  void m() {
+        |    String s = ${"\"\"\""}
+        |    ["']${"\"\"\""};
+        |    
+        |  }
+        |  class InnerClass {}
+        |}
+        |""".stripMargin,
+    List(
+      "sample/",
+      "sample/HtmlConfiguration#",
+      "sample/HtmlConfiguration#InnerClass#",
+    ),
+    mode = ToplevelWithInner,
+  )
+
+  check(
+    "multiple-slashes",
+    s"""|package sample;
+        |
+        |public class HtmlConfiguration {
+        |  void m() {
+        |    String s = "\\\\\\\\"
+        |  }
+        |}
+        |""".stripMargin,
+    List("sample/HtmlConfiguration#"),
+  )
 
   check(
     "base",
@@ -75,6 +109,7 @@ class JavaToplevelSuite extends BaseToplevelSuite {
        |}
        |""".stripMargin,
     List("dot/enum/Abc#"),
+    errorExpected = true,
   )
 
   check(


### PR DESCRIPTION
JDK 25 source uses Java text blocks (""") for regex strings. The tokenizer treated the third quote as starting an ordinary string, so an unescaped " inside the block (e.g. ["']) closed the string early and left backslashes as unexpected tokens.

Detect opening """ and skip until the closing """ before resuming tokenization.

Another issue was connect with \\ mixed with ", now should be handled properly as well.

Fixes scalameta/metals#8293.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved parsing of Java text block literals so multi-line string delimiters and their contents are correctly recognized and skipped.

* **Tests**
  * Expanded unit tests for Java text block scenarios, including escaped characters and multi-part outputs.
  * Test harness enhanced to assert reporting/errors more precisely during checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->