### PR TITLE
Explicitly add AutoValueProcessor in turbine build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -292,6 +292,10 @@ lazy val turbine = project
       "com.google.auto.value" % "auto-value-annotations" % "1.11.1",
       "com.google.protobuf" % "protobuf-java" % V.protobuf,
     ),
+    Compile / javacOptions ++= Seq(
+      "-processor",
+      "com.google.auto.value.processor.AutoValueProcessor",
+    ),
     (Compile / PB.targets) :=
       Seq(PB.gens.java(V.protobuf) -> (Compile / sourceManaged).value),
   )


### PR DESCRIPTION
Build fails on Windows if I don't add the processor explicitly.