### PR TITLE
bugfix: Include jvm properties from build server when running from MCP

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -50,6 +50,7 @@ import scala.meta.internal.metals.debug.DiscoveryFailures._
 import scala.meta.internal.metals.debug.server.AttachRemoteDebugAdapter
 import scala.meta.internal.metals.debug.server.DebugLogger
 import scala.meta.internal.metals.debug.server.DebugeeParamsCreator
+import scala.meta.internal.metals.debug.server.DebugeeProject
 import scala.meta.internal.metals.debug.server.Discovered
 import scala.meta.internal.metals.debug.server.MainClassDebugAdapter
 import scala.meta.internal.metals.debug.server.MetalsDebugToolsResolver
@@ -410,26 +411,22 @@ class DebugProvider(
       }
     }
 
-  /**
-   * JVM flags for in-Metals test runs ([[TestSuiteDebugAdapter]], MCP `runTests`):
-   * workspace / env-based options from [[JvmOpts.fromWorkspaceOrEnvForTest]] (e.g. `.test-jvmopts`,
-   * `TEST_JVM_OPTS`, filtered `.jvmopts`) plus `buildTarget/jvmTestEnvironment` from the BSP server
-   * (e.g. sbt `Test / javaOptions`).
-   */
-  def scalaTestJvmOptionsForLocalRun(
+  def jvmTestEnvironment(
       buildTargetId: BuildTargetIdentifier
-  )(implicit ec: ExecutionContext): Future[List[String]] = {
-    val workspaceOpts =
-      JvmOpts.fromWorkspaceOrEnvForTest(workspace).getOrElse(Nil)
-    buildTargetClasses.jvmRunEnvironment(buildTargetId, isTests = true).map {
-      envOpt =>
-        val bspOpts = envOpt
-          .flatMap(env => Option(env.getJvmOptions()))
-          .map(_.asScala.toList)
-          .getOrElse(Nil)
-        (workspaceOpts ++ bspOpts).distinct
-    }
-  }
+  ): Future[Option[b.JvmEnvironmentItem]] =
+    buildTargetClasses.jvmRunEnvironment(buildTargetId, isTests = true)
+
+  def createDebugeeProjectForTests(
+      id: BuildTargetIdentifier,
+      cancelPromise: Promise[Unit],
+      jvmTestEnvironment: Future[Option[b.JvmEnvironmentItem]],
+  ): Either[String, Future[DebugeeProject]] =
+    debugConfigCreator.create(
+      id,
+      cancelPromise,
+      isTests = true,
+      Some(jvmTestEnvironment),
+    )
 
   def discoverTests(
       id: BuildTargetIdentifier,
@@ -820,6 +817,38 @@ class DebugProvider(
 }
 
 object DebugProvider {
+
+  /**
+   * JVM options and environment variables for in-Metals ScalaTest runs, merged from workspace
+   * discovery ([[JvmOpts.fromWorkspaceOrEnvForTest]]) and BSP `buildTarget/jvmTestEnvironment`.
+   */
+  final case class ScalaTestLocalRunSettings(
+      jvmOptions: List[String],
+      environmentVariables: Map[String, String],
+  ) {
+    def environmentVariablesAsStrings: List[String] =
+      environmentVariables.map { case (k, v) => s"$k=$v" }.toList
+  }
+
+  def scalaTestLocalRunSettings(
+      workspace: AbsolutePath,
+      envItem: Option[b.JvmEnvironmentItem],
+  ): ScalaTestLocalRunSettings = {
+    val workspaceOpts =
+      JvmOpts.fromWorkspaceOrEnvForTest(workspace).getOrElse(Nil)
+    val bspJvmOpts = envItem
+      .flatMap(env => Option(env.getJvmOptions()))
+      .map(_.asScala.toList)
+      .getOrElse(Nil)
+    val envVars = envItem
+      .flatMap(env => Option(env.getEnvironmentVariables()))
+      .map(_.asScala.toMap)
+      .getOrElse(Map.empty)
+    ScalaTestLocalRunSettings(
+      (workspaceOpts ++ bspJvmOpts).distinct,
+      envVars,
+    )
+  }
 
   def createEnvList(env: ju.Map[String, String]): List[String] = {
     env.asScala.map { case (key, value) =>

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -410,6 +410,27 @@ class DebugProvider(
       }
     }
 
+  /**
+   * JVM flags for in-Metals test runs ([[TestSuiteDebugAdapter]], MCP `runTests`):
+   * workspace / env-based options from [[JvmOpts.fromWorkspaceOrEnvForTest]] (e.g. `.test-jvmopts`,
+   * `TEST_JVM_OPTS`, filtered `.jvmopts`) plus `buildTarget/jvmTestEnvironment` from the BSP server
+   * (e.g. sbt `Test / javaOptions`).
+   */
+  def scalaTestJvmOptionsForLocalRun(
+      buildTargetId: BuildTargetIdentifier
+  )(implicit ec: ExecutionContext): Future[List[String]] = {
+    val workspaceOpts =
+      JvmOpts.fromWorkspaceOrEnvForTest(workspace).getOrElse(Nil)
+    buildTargetClasses.jvmRunEnvironment(buildTargetId, isTests = true).map {
+      envOpt =>
+        val bspOpts = envOpt
+          .flatMap(env => Option(env.getJvmOptions()))
+          .map(_.asScala.toList)
+          .getOrElse(Nil)
+        (workspaceOpts ++ bspOpts).distinct
+    }
+  }
+
   def discoverTests(
       id: BuildTargetIdentifier,
       testClasses: b.ScalaTestSuites,

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/server/DebugeeParamsCreator.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/server/DebugeeParamsCreator.scala
@@ -28,7 +28,7 @@ class DebugeeParamsCreator(buildTargetClasses: BuildTargetClasses) {
 
   /**
    * @param isTests whether the build target is a test target
-   * @param jvmRunEnvironmentOverride when set, this future is used instead of calling
+   * @param jvmRunEnvironmentFuture when set, this future is used instead of calling
    *        `buildTarget/jvmTestEnvironment` or `buildTarget/jvmRunEnvironment` again
    *        (for example after the same future was used to assemble ScalaTest JVM options and env).
    */
@@ -36,8 +36,7 @@ class DebugeeParamsCreator(buildTargetClasses: BuildTargetClasses) {
       id: BuildTargetIdentifier,
       cancelPromise: Promise[Unit],
       isTests: Boolean,
-      jvmRunEnvironmentOverride: Option[Future[Option[JvmEnvironmentItem]]] =
-        None,
+      jvmRunEnvironmentFuture: Option[Future[Option[JvmEnvironmentItem]]] = None,
   )(implicit ec: ExecutionContext): Either[String, Future[DebugeeProject]] = {
     for {
       target <- buildTargets
@@ -63,14 +62,13 @@ class DebugeeParamsCreator(buildTargetClasses: BuildTargetClasses) {
       val includedInLibsOrModules =
         debugLibs.map(_.absolutePath).toSet ++ modules.map(_.absolutePath).toSet
 
-      val jvmRunEnvFuture = jvmRunEnvironmentOverride.getOrElse(
-        buildTargetClasses.jvmRunEnvironment(id, isTests = isTests)
-      )
       for {
         classpathString <- buildTargets
           .targetClasspath(id, cancelPromise)
           .getOrElse(Future.successful(Nil))
-        jvmRunEnv <- jvmRunEnvFuture
+        jvmRunEnv <- jvmRunEnvironmentFuture.getOrElse(
+          buildTargetClasses.jvmRunEnvironment(id, isTests = isTests)
+        )
       } yield {
 
         val classpath = classpathString.map(_.toAbsolutePath)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/server/DebugeeParamsCreator.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/server/DebugeeParamsCreator.scala
@@ -13,6 +13,7 @@ import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import ch.epfl.scala.bsp4j.JvmEnvironmentItem
 import ch.epfl.scala.bsp4j.MavenDependencyModule
 import ch.epfl.scala.debugadapter.Library
 import ch.epfl.scala.debugadapter.Module
@@ -25,11 +26,18 @@ import ch.epfl.scala.debugadapter.UnmanagedEntry
 class DebugeeParamsCreator(buildTargetClasses: BuildTargetClasses) {
   val buildTargets = buildTargetClasses.buildTargets
 
-  /** @param isTests whether the build target is a test target */
+  /**
+   * @param isTests whether the build target is a test target
+   * @param jvmRunEnvironmentOverride when set, this future is used instead of calling
+   *        `buildTarget/jvmTestEnvironment` or `buildTarget/jvmRunEnvironment` again
+   *        (for example after the same future was used to assemble ScalaTest JVM options and env).
+   */
   def create(
       id: BuildTargetIdentifier,
       cancelPromise: Promise[Unit],
       isTests: Boolean,
+      jvmRunEnvironmentOverride: Option[Future[Option[JvmEnvironmentItem]]] =
+        None,
   )(implicit ec: ExecutionContext): Either[String, Future[DebugeeProject]] = {
     for {
       target <- buildTargets
@@ -55,11 +63,14 @@ class DebugeeParamsCreator(buildTargetClasses: BuildTargetClasses) {
       val includedInLibsOrModules =
         debugLibs.map(_.absolutePath).toSet ++ modules.map(_.absolutePath).toSet
 
+      val jvmRunEnvFuture = jvmRunEnvironmentOverride.getOrElse(
+        buildTargetClasses.jvmRunEnvironment(id, isTests = isTests)
+      )
       for {
         classpathString <- buildTargets
           .targetClasspath(id, cancelPromise)
           .getOrElse(Future.successful(Nil))
-        jvmRunEnv <- buildTargetClasses.jvmRunEnvironment(id, isTests = isTests)
+        jvmRunEnv <- jvmRunEnvFuture
       } yield {
 
         val classpath = classpathString.map(_.toAbsolutePath)

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
@@ -46,33 +46,34 @@ class McpTestRunner(
       id <- buildTargets
         .inverseSources(path)
         .toRight(s"Could not find build target for $path")
-      projectInfo <- debugProvider.debugConfigCreator.create(
+      jvmTestEnv = debugProvider.jvmTestEnvironment(id)
+      projectFut <- debugProvider.createDebugeeProjectForTests(
         id,
         cancelPromise,
-        isTests = true,
+        jvmTestEnv,
       )
     } yield {
-      debugProvider.scalaTestJvmOptionsForLocalRun(id).flatMap { jvmOpts =>
-        val testSuites = new b.ScalaTestSuites(
+      for {
+        env <- jvmTestEnv
+        settings = DebugProvider.scalaTestLocalRunSettings(workspace, env)
+        testSuites = new b.ScalaTestSuites(
           List(testSelection).asJava,
-          jvmOpts.asJava,
-          Nil.asJava,
+          settings.jvmOptions.asJava,
+          settings.environmentVariablesAsStrings.asJava,
         )
-        for {
-          discovered <- debugProvider.discoverTests(id, testSuites)
-          project <- projectInfo
-          adapter = new TestSuiteDebugAdapter(
-            workspace,
-            testSuites,
-            project,
-            userConfig().javaHome,
-            discovered,
-            isDebug = false,
-          )
-          listener = new McpDebuggeeListener(verbose)
-          _ <- adapter.run(listener).future
-        } yield listener.result
-      }
+        discovered <- debugProvider.discoverTests(id, testSuites)
+        project <- projectFut
+        listener = new McpDebuggeeListener(verbose)
+        adapter = new TestSuiteDebugAdapter(
+          workspace,
+          testSuites,
+          project,
+          userConfig().javaHome,
+          discovered,
+          isDebug = false,
+        )
+        _ <- adapter.run(listener).future
+      } yield listener.result
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
@@ -38,11 +38,6 @@ class McpTestRunner(
       case None =>
         new b.ScalaTestSuiteSelection(testClass, Nil.asJava)
     }
-    val testSuites = new b.ScalaTestSuites(
-      List(testSelection).asJava,
-      Nil.asJava,
-      Nil.asJava,
-    )
     val cancelPromise = Promise[Unit]()
     for {
       path <- optPath
@@ -57,20 +52,27 @@ class McpTestRunner(
         isTests = true,
       )
     } yield {
-      for {
-        discovered <- debugProvider.discoverTests(id, testSuites)
-        project <- projectInfo
-        adapter = new TestSuiteDebugAdapter(
-          workspace,
-          testSuites,
-          project,
-          userConfig().javaHome,
-          discovered,
-          isDebug = false,
+      debugProvider.scalaTestJvmOptionsForLocalRun(id).flatMap { jvmOpts =>
+        val testSuites = new b.ScalaTestSuites(
+          List(testSelection).asJava,
+          jvmOpts.asJava,
+          Nil.asJava,
         )
-        listener = new McpDebuggeeListener(verbose)
-        _ <- adapter.run(listener).future
-      } yield listener.result
+        for {
+          discovered <- debugProvider.discoverTests(id, testSuites)
+          project <- projectInfo
+          adapter = new TestSuiteDebugAdapter(
+            workspace,
+            testSuites,
+            project,
+            userConfig().javaHome,
+            discovered,
+            isDebug = false,
+          )
+          listener = new McpDebuggeeListener(verbose)
+          _ <- adapter.run(listener).future
+        } yield listener.result
+      }
     }
   }
 

--- a/tests/unit/src/test/scala/tests/mcp/McpRunTestSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpRunTestSuite.scala
@@ -97,6 +97,56 @@ class McpRunTestSuite extends BaseLspSuite("mcp-test") {
     } yield ()
   }
 
+  // Regression for https://github.com/scalameta/metals/issues/8305 — MCP test runs
+  // must pass workspace `.test-jvmopts` into the forked test JVM (alongside BSP options).
+  test("mcp-run-tests-respects-test-jvmopts", maxRetry = 3) {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""
+           |/metals.json
+           |{
+           |  "a": {
+           |    "libraryDependencies" : ["org.scalameta::munit:1.0.0-M4"]
+           |  }
+           |}
+           |/.test-jvmopts
+           |-Dmetals.issue8305.jvmopts=from-test-jvmopts
+           |/a/src/test/scala/a/JvmOptsMcpSuite.scala
+           |package a
+           |
+           |class JvmOptsMcpSuite extends munit.FunSuite {
+           |  test("sees -D from .test-jvmopts in forked mcp test jvm") {
+           |    assertEquals(
+           |      System.getProperty("metals.issue8305.jvmopts"),
+           |      "from-test-jvmopts",
+           |    )
+           |  }
+           |}
+           |
+           |""".stripMargin
+      )
+      _ <- server.didOpen("a/src/test/scala/a/JvmOptsMcpSuite.scala")
+      _ = assertNoDiagnostics()
+      _ <- server.server.indexingPromise.future
+      path = server.toPath("a/src/test/scala/a/JvmOptsMcpSuite.scala")
+      result <- server.headServer.mcpTestRunner
+        .runTests(
+          "a.JvmOptsMcpSuite",
+          Some(path),
+          None,
+          verbose = false,
+        ) match {
+        case Right(value) => value
+        case Left(error) => throw new RuntimeException(error)
+      }
+      _ = assert(
+        result.contains("1 tests, 1 passed, 0 failed"),
+        s"Expected munit to pass when forked JVM receives -D from .test-jvmopts; got:\n$result",
+      )
+    } yield ()
+  }
+
   test("zio-test", maxRetry = 3) {
     cleanWorkspace()
     for {


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/8305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test execution now respects per-target JVM options and environment variables by merging workspace and build-provided settings so forked test processes run with the intended JVM flags and env vars.

* **Tests**
  * Added a test that verifies the test runner forwards workspace JVM options into the forked test JVM.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->