### PR TITLE
improvement: Treat MBT as a separate built in build server

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -23,12 +23,15 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.MetalsProjectDirectories
 import scala.meta.internal.metals.MetalsServerConfig
 import scala.meta.internal.metals.QuietInputStream
+import scala.meta.internal.metals.ScalaVersionSelector
 import scala.meta.internal.metals.SocketConnection
 import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.TaskProgress
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.WorkDoneProgress
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.mbt.MbtBuild
+import scala.meta.internal.metals.mbt.MbtBuildServer
 import scala.meta.internal.mtags.MD5
 import scala.meta.internal.mtags.URIEncoderDecoder
 import scala.meta.internal.process.SystemProcess
@@ -51,7 +54,9 @@ final class BspServers(
     bspGlobalInstallDirectories: List[AbsolutePath],
     config: MetalsServerConfig,
     userConfig: () => UserConfiguration,
+    mbtBuild: () => MbtBuild,
     workDoneProgress: WorkDoneProgress,
+    scalaVersionSelector: ScalaVersionSelector,
 )(implicit ec: ExecutionContextExecutorService) {
   private def customProjectRoot =
     userConfig().getCustomProjectRoot(mainWorkspace)
@@ -156,29 +161,46 @@ final class BspServers(
         )
       }
     }
-
-    BuildServerConnection.fromSockets(
-      projectDirectory,
-      bspTraceRoot,
-      buildClient,
-      client,
-      newConnection,
-      tables.dismissedNotifications.ReconnectBsp,
-      tables.dismissedNotifications.RequestTimeout,
-      config,
-      details.getName(),
-      bspStatusOpt,
-      workDoneProgress = workDoneProgress,
-    )
+    if (MbtBuildServer.isMbtServer(details.getName())) {
+      MbtBuildServer.newServer(
+        projectDirectory,
+        buildClient,
+        client,
+        config,
+        tables.dismissedNotifications.RequestTimeout,
+        tables.dismissedNotifications.ReconnectBsp,
+        bspStatusOpt,
+        mbtBuild,
+        workDoneProgress,
+        scalaVersionSelector,
+      )
+    } else {
+      BuildServerConnection.fromSockets(
+        projectDirectory,
+        bspTraceRoot,
+        buildClient,
+        client,
+        newConnection,
+        tables.dismissedNotifications.RequestTimeout,
+        tables.dismissedNotifications.ReconnectBsp,
+        config,
+        details.getName(),
+        bspStatusOpt,
+        workDoneProgress = workDoneProgress,
+      )
+    }
   }
 
   /**
    * Returns a list of BspConnectionDetails from reading the .bsp/
    *  entries. Notes that this will not return Bloop even though it
    *  may be a server in the current workspace
+   *
+   *  Additionally, also returns the MBT server details if the mbt.json build file is not empty.
    */
   def findAvailableServers(): List[BspConnectionDetails] =
-    findJsonFiles().flatMap(readInBspConfig(_, charset))
+    (findJsonFiles().flatMap(readInBspConfig(_, charset)) :::
+      Option.when(!mbtBuild().isEmpty)(MbtBuildServer.details).toList)
 
   private def findJsonFiles(): List[AbsolutePath] = {
     val buf = List.newBuilder[AbsolutePath]

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -52,6 +52,7 @@ final class BuildTools(
       maybeProjectRoot: Option[AbsolutePath] = None
   ): Boolean = {
     maybeProjectRoot.map(isBloop).getOrElse(isBloop) ||
+    isMbt ||
     (isBsp && all.isEmpty) ||
     (isBsp && explicitChoiceMade()) ||
     (isBsp && userConfig().preferredBuildServer.isDefined)
@@ -66,6 +67,7 @@ final class BuildTools(
     ) ||
     bspGlobalDirectories.exists(hasJsonFile)
   }
+  def isMbt: Boolean = workspace.resolve(".metals/mbt.json").isFile
   private def hasJsonFile(dir: AbsolutePath): Boolean = {
     dir.list.exists(_.extension == "json")
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
@@ -89,7 +89,9 @@ class ConnectionProvider(
     bspGlobalDirectories,
     clientConfig.initialConfig,
     () => userConfig,
+    mbtBuild,
     workDoneProgress,
+    scalaVersionSelector,
   )
 
   val bspConnector: BspConnector = new BspConnector(
@@ -137,16 +139,29 @@ class ConnectionProvider(
               connect(CreateSession(), progress)
             else slowConnectToBuildServer(forceImport = false, progress)
           _ <-
-            if (
-              bspSession.isEmpty && !mbtBuild().dependencyModules
-                .isEmpty()
-            )
+            if (bspSession.isEmpty && !mbtBuild().isEmpty)
               connect(Index(check), progress)
             else Future.unit
         } yield buildServerPromise.trySuccess(()),
       metricName = Some("initialize_build_server"),
     )
   }
+
+  def reloadCurrentSession(): Future[Unit] =
+    bspSession match {
+      case Some(session) if session.canReloadWorkspace =>
+        workDoneProgress.trackProgressFuture(
+          "Sync",
+          progress =>
+            for {
+              _ <- session.workspaceReload()
+              _ <- connect(new ImportBuildAndIndex(session), progress)
+            } yield (),
+          metricName = Some("reload_build_server"),
+        )
+      case _ =>
+        fullConnect()
+    }
 
   private def isBspAvailable(buildTool: BuildTool) =
     buildTool.isBspGenerated(folder) || bspGlobalDirectories.exists(

--- a/metals/src/main/scala/scala/meta/internal/metals/FallbackClasspaths.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/FallbackClasspaths.scala
@@ -129,7 +129,7 @@ class FallbackClasspaths(
       return Nil
     }
     val build = mbtBuild()
-    build.dependencyModules.asScala.iterator.map(_.jarPath).toSeq
+    build.getDependencyModules.asScala.iterator.flatMap(_.jarPath).toSeq
   }
 
   private def guessClasspath(): Seq[Path] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -22,6 +22,7 @@ import scala.meta.internal.metals.Indexer.BackgroundJob
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.SemanticdbDefinition
 import scala.meta.internal.metals.mbt.MbtBuild
+import scala.meta.internal.metals.mbt.MbtBuildServer
 import scala.meta.internal.metals.mbt.OnDidChangeSymbolsParams
 import scala.meta.internal.mtags.DependencyModule
 import scala.meta.internal.mtags.IndexingResult
@@ -114,6 +115,12 @@ case class Indexer(indexProviders: IndexProviders, mbtBuild: () => MbtBuild)(
       resetService()
     }
     val allBuildTargetsData = buildData()
+    // If the user didn't select MBT, we still want the fallbacks to work properly
+    val shouldFallbackToFileMbt =
+      (indexProviders.userConfig.fallbackClasspath.isMbt || bspSession.isEmpty) &&
+        !bspSession.exists(session =>
+          MbtBuildServer.isMbtServer(session.main.name)
+        )
     for (buildTool <- allBuildTargetsData)
       timerProvider.timedThunk(
         s"updated ${buildTool.name} build targets",
@@ -138,11 +145,9 @@ case class Indexer(indexProviders: IndexProviders, mbtBuild: () => MbtBuild)(
         data.addDependencyModules(
           importedBuild.dependencyModules
         )
-        if (
-          indexProviders.userConfig.fallbackClasspath.isMbt || bspSession.isEmpty
-        ) {
+        if (shouldFallbackToFileMbt) {
           val build = MbtBuild.fromWorkspace(indexProviders.folder)
-          data.addDependencyModules(build.asBsp)
+          data.addDependencyModules(build.asBspModules)
         }
 
         // Fallback compilers can possibly use the jars from the build target data, so we trigger a restart
@@ -239,11 +244,9 @@ case class Indexer(indexProviders: IndexProviders, mbtBuild: () => MbtBuild)(
             progress,
           )
         }
-        if (
-          indexProviders.userConfig.fallbackClasspath.isMbt || bspSession.isEmpty
-        ) {
+        if (shouldFallbackToFileMbt) {
           val build = MbtBuild.fromWorkspace(indexProviders.folder)
-          indexDependencyModules(build.asBsp, progress)
+          indexDependencyModules(build.asBspModules, progress)
         }
         usedJars ++= indexDependencySources(
           buildTool.data,

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -202,7 +202,7 @@ abstract class MetalsLspService(
 
   def containsJar(path: AbsolutePath): Boolean = {
     buildTargets.inverseSources(path).nonEmpty ||
-    mbtBuild.dependencyModules.asScala.exists(_.jarPath.equals(path))
+    mbtBuild.getDependencyModules.asScala.exists(_.jarPath.equals(path))
   }
   val buildTargetClasses =
     new BuildTargetClasses(buildTargets)
@@ -301,6 +301,14 @@ abstract class MetalsLspService(
       tables,
       connectionBspStatus,
     )
+
+  /**
+   * When `.metals/mbt.json` changes and the active BSP connection is the
+   * built-in MBT server, subclasses reconnect so imported build metadata
+   * refreshes.
+   */
+  protected def reconnectAfterMbtJsonChange(): Future[Unit] =
+    Future.successful(())
 
   private val sleeper: Sleeper =
     new Sleeper.ScheduledExecutorServiceSleeper(sh)
@@ -1095,14 +1103,15 @@ abstract class MetalsLspService(
       onDelete(event.getUri().toAbsolutePath)
     )
     val paths = changeAndCreateEvents.map(_.getUri().toAbsolutePath)
-    futures += Future {
-      paths.find(path => path.filename == "mbt.json") match {
-        case Some(mbtJsonPath) =>
+    futures += (paths.find(_.filename == "mbt.json") match {
+      case Some(mbtJsonPath) =>
+        Future {
           mbtBuild = MbtBuild.fromFile(mbtJsonPath.toNIO)
           compilers.clearFallbackCompilerCache()
-        case None =>
-      }
-    }.ignoreValue
+        }.flatMap(_ => reconnectAfterMbtJsonChange())
+      case None =>
+        Future.successful(())
+    })
     futures += onChange(paths)
     Future.sequence(futures.result()).ignoreValue
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -25,6 +25,7 @@ import scala.meta.internal.metals.ammonite.Ammonite
 import scala.meta.internal.metals.clients.language.ConfiguredLanguageClient
 import scala.meta.internal.metals.doctor.HeadDoctor
 import scala.meta.internal.metals.doctor.MetalsServiceInfo
+import scala.meta.internal.metals.mbt.MbtBuildServer
 import scala.meta.internal.metals.watcher.FileWatcher
 import scala.meta.internal.metals.watcher.FileWatcherEvent
 import scala.meta.internal.metals.watcher.FileWatcherEvent.EventType
@@ -193,6 +194,11 @@ class ProjectMetalsLspService(
     syncStatusReporter,
     () => mbtBuild,
   )
+
+  override protected def reconnectAfterMbtJsonChange(): Future[Unit] =
+    if (bspSession.exists(s => MbtBuildServer.isMbtServer(s.main.name)))
+      connectionProvider.reloadCurrentSession()
+    else Future.successful(())
 
   protected val onBuildChanged: BatchedFunction[AbsolutePath, Unit] =
     BatchedFunction.fromFuture[AbsolutePath, Unit](

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuild.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuild.scala
@@ -1,78 +1,151 @@
 package scala.meta.internal.metals.mbt
 
-import java.net.URI
+import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.ArrayList
+import java.util.LinkedHashMap
 import java.{util => ju}
 import javax.annotation.Nullable
 
-import scala.jdk.CollectionConverters._
-
-import scala.meta.internal.mtags
+import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.io.AbsolutePath
 
 import ch.epfl.scala.bsp4j
-import com.google.gson.Gson
 
 case class MbtBuild(
-    var dependencyModules: ju.List[MbtDependencyModule]
+    @Nullable dependencyModules: ju.List[MbtDependencyModule],
+    @Nullable namespaces: ju.Map[String, MbtNamespace],
 ) {
-  def asBsp: bsp4j.DependencyModulesResult =
+
+  def getDependencyModules(): ju.List[MbtDependencyModule] =
+    if (this.dependencyModules != null) this.dependencyModules
+    else ju.Collections.emptyList()
+
+  def getNamespaces: ju.Map[String, MbtNamespace] =
+    if (this.namespaces != null) this.namespaces else ju.Collections.emptyMap()
+
+  def isEmpty: Boolean =
+    (dependencyModules == null || dependencyModules.isEmpty) &&
+      (namespaces == null || namespaces.isEmpty)
+
+  def asBspModules: bsp4j.DependencyModulesResult =
     new bsp4j.DependencyModulesResult(
-      List(
-        new bsp4j.DependencyModulesItem(
-          new bsp4j.BuildTargetIdentifier("mbt.json"),
-          dependencyModules.asScala
-            .map(m => {
-              val module = new bsp4j.DependencyModule(m.id, m.version)
-              val artifacts =
-                new ArrayList[bsp4j.MavenDependencyModuleArtifact]()
-              artifacts.add(
-                new bsp4j.MavenDependencyModuleArtifact(m.jarUriString)
-              )
-              if (m.sources != null) {
-                val sources =
-                  new bsp4j.MavenDependencyModuleArtifact(
-                    m.sourcesUriString.get
-                  )
-                sources.setClassifier("sources")
-                artifacts.add(sources)
-              }
-              module.setDataKind(bsp4j.DependencyModuleDataKind.MAVEN)
-              module.setData(
-                new bsp4j.MavenDependencyModule(
-                  m.organization,
-                  m.name,
-                  m.version,
-                  artifacts,
+      mbtTargets
+        .filter(_.dependencyModules.nonEmpty)
+        .map { target =>
+          new bsp4j.DependencyModulesItem(
+            target.id,
+            target.dependencyModules.map(_.asBsp).asJava,
+          )
+        }
+        .asJava
+    )
+
+  def mbtTargets: Seq[MbtTarget] =
+    if (getNamespaces.isEmpty) {
+      Option
+        .when(!getDependencyModules().isEmpty) {
+          MbtTarget(
+            name = MbtBuild.LegacyTargetName,
+            id = new bsp4j.BuildTargetIdentifier(MbtBuild.LegacyTargetName),
+            sources = Nil,
+            globMatchers = Nil,
+            compilerOptions = Nil,
+            dependencyModules = dependencyModules.asScala.toSeq,
+          )
+        }
+        .toSeq
+    } else {
+      val knownNamespaces = getNamespaces.keySet.asScala.toSet
+      getNamespaces.asScala.toSeq.map { case (name, namespace) =>
+        val dependsOnIds =
+          namespace.getDependsOn.asScala.toSeq.distinct.flatMap { depName =>
+            if (knownNamespaces.contains(depName)) {
+              Some(
+                new bsp4j.BuildTargetIdentifier(
+                  MbtBuild.namespaceTargetId(depName)
                 )
               )
-              module
-            })
-            .asJava,
+            } else {
+              scribe.warn(
+                s"mbt-build: namespace '$name' dependsOn unknown namespace '$depName'."
+              )
+              None
+            }
+          }
+        val globPatterns = namespace.getSources.asScala.toSeq.filter(isGlob)
+        val (validNsModules, invalidNsModules) =
+          namespace.getDependencyModules.asScala.partition(_.isValid)
+        invalidNsModules.foreach { module =>
+          scribe.warn(
+            s"mbt-build: ignoring invalid dependency module ID '${module.id}' in namespace '$name'. Expected format: 'organization:name:version'."
+          )
+        }
+        MbtTarget(
+          name = name,
+          id =
+            new bsp4j.BuildTargetIdentifier(MbtBuild.namespaceTargetId(name)),
+          sources = namespace.getSources.asScala.toSeq
+            .filterNot(isGlob),
+          globMatchers = globPatterns.map(pattern =>
+            MbtGlobMatcher(
+              pattern = pattern,
+              prefix = globPrefix(pattern),
+              matcher = FileSystems.getDefault.getPathMatcher(
+                "glob:" + globPatternForMatcher(pattern)
+              ),
+            )
+          ),
+          compilerOptions = namespace.getCompilerOptions.asScala.toSeq,
+          dependencyModules = validNsModules.toSeq,
+          scalaVersion = Option(namespace.scalaVersion),
+          javaHome = Option(namespace.javaHome),
+          dependsOn = dependsOnIds,
         )
-      ).asJava
-    )
-  def asMtags: Seq[mtags.DependencyModule] =
-    dependencyModules.asScala.iterator
-      .map(module =>
-        mtags.DependencyModule(
-          mtags
-            .MavenCoordinates(module.organization, module.name, module.version),
-          AbsolutePath(module.jar),
-          Option(module.sources).map(AbsolutePath(_)),
-        )
-      )
+      }
+    }
+
+  private def isGlob(pattern: String): Boolean = {
+    val n = normalizeSlashes(pattern)
+    n.exists(c => c == '*' || c == '?' || c == '[' || c == '{')
+  }
+
+  private def normalizeSlashes(s: String): String =
+    s.trim.replace('\\', '/')
+
+  /** Leading `./` is stripped so matchers align with workspace-relative paths. */
+  private def globPatternForMatcher(pattern: String): String = {
+    val n = normalizeSlashes(pattern)
+    if (n.startsWith("./")) n.substring(2) else n
+  }
+
+  private def globPrefix(pattern: String): Option[Path] = {
+    val literalSegments = globPatternForMatcher(pattern)
+      .split('/')
       .toSeq
+      .filter(_.nonEmpty)
+      .takeWhile(segment => !isGlob(segment))
+    literalSegments match {
+      case head +: tail => Some(Paths.get(head, tail: _*))
+      case _ => None
+    }
+  }
 }
 
 object MbtBuild {
-  val gson = new Gson()
-  def empty: MbtBuild = MbtBuild(ju.Collections.emptyList())
+  private val gson = new com.google.gson.Gson()
+  val LegacyTargetName = "default"
+
+  def empty: MbtBuild =
+    MbtBuild(
+      ju.Collections.emptyList(),
+      new LinkedHashMap[String, MbtNamespace](),
+    )
+
   def fromWorkspace(workspace: AbsolutePath): MbtBuild =
     fromFile(workspace.resolve(".metals/mbt.json").toNIO)
+
   def fromFile(file: Path): MbtBuild = try {
     if (!Files.isRegularFile(file)) {
       return MbtBuild.empty
@@ -80,7 +153,7 @@ object MbtBuild {
     val text = Files.readString(file)
     val build = gson.fromJson(text, classOf[MbtBuild])
     val (validModules, invalidModules) =
-      build.dependencyModules.asScala.partition(_.isValid)
+      build.getDependencyModules.asScala.partition(_.isValid)
     invalidModules.foreach { module =>
       scribe.warn(
         s"mbt-build: ignoring invalid dependency module ID '${module.id}'. Expected format: 'organization:name:version'."
@@ -92,23 +165,9 @@ object MbtBuild {
       scribe.warn(s"Failed to parse MBT build from JSON file '$file'", e)
       MbtBuild.empty
   }
-}
-case class MbtDependencyModule(
-    var id: String, // e.g. "com.google.guava:guava:30.0-jre"
-    var jar: String,
-    @Nullable var sources: String = null,
-) {
-  def jarPath: Path = Paths.get(jar)
-  def jarUri: URI = Paths.get(jar).toUri
-  def jarUriString: String = jarUri.toString
-  def sourcesUri: Option[URI] = Option(sources).map(Paths.get(_).toUri)
-  def sourcesUriString: Option[String] = sourcesUri.map(_.toString)
-  private def idParts: Array[String] = id.split(":", 3)
-  def isValid: Boolean = idParts.length == 3
-  def organization: String =
-    idParts.lift(0).getOrElse(s"INVALID_ORGANIZATION=$id")
-  def name: String =
-    idParts.lift(1).getOrElse(s"INVALID_NAME=$id")
-  def version: String =
-    idParts.lift(2).getOrElse(s"INVALID_VERSION=$id")
+
+  def namespaceTargetId(name: String): String = {
+    s"mbt://namespace/$name"
+  }
+
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuild.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuild.scala
@@ -4,7 +4,6 @@ import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.LinkedHashMap
 import java.{util => ju}
 import javax.annotation.Nullable
 
@@ -19,15 +18,14 @@ case class MbtBuild(
 ) {
 
   def getDependencyModules(): ju.List[MbtDependencyModule] =
-    if (this.dependencyModules != null) this.dependencyModules
-    else ju.Collections.emptyList()
+    Option(this.dependencyModules).getOrElse(ju.Collections.emptyList())
 
   def getNamespaces: ju.Map[String, MbtNamespace] =
-    if (this.namespaces != null) this.namespaces else ju.Collections.emptyMap()
+    Option(this.namespaces).getOrElse(ju.Collections.emptyMap())
 
   def isEmpty: Boolean =
-    (dependencyModules == null || dependencyModules.isEmpty) &&
-      (namespaces == null || namespaces.isEmpty)
+    Option(this.dependencyModules).forall(_.isEmpty) &&
+      Option(this.namespaces).forall(_.isEmpty)
 
   def asBspModules: bsp4j.DependencyModulesResult =
     new bsp4j.DependencyModulesResult(
@@ -140,7 +138,7 @@ object MbtBuild {
   def empty: MbtBuild =
     MbtBuild(
       ju.Collections.emptyList(),
-      new LinkedHashMap[String, MbtNamespace](),
+      new ju.LinkedHashMap[String, MbtNamespace](),
     )
 
   def fromWorkspace(workspace: AbsolutePath): MbtBuild =

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
@@ -164,13 +164,13 @@ final class MbtBuildServer(
   ): CompletableFuture[InitializeBuildResult] =
     CompletableFuture.completedFuture {
       val capabilities = new BuildServerCapabilities
-      capabilities.setCompileProvider(
-        new CompileProvider(List("scala", "java").asJava)
-      )
       capabilities.setCanReload(true)
       capabilities.setDependencySourcesProvider(true)
       capabilities.setDependencyModulesProvider(true)
       capabilities.setInverseSourcesProvider(true)
+      capabilities.setCompileProvider(
+        new CompileProvider(List("scala", "java").asJava)
+      )
       capabilities.setResourcesProvider(false)
       capabilities.setJvmCompileClasspathProvider(true)
       new InitializeBuildResult(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
@@ -1,0 +1,490 @@
+package scala.meta.internal.metals.mbt
+
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.net.URI
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.build.bsp.WrappedSourcesResult
+import scala.collection.mutable
+import scala.concurrent.ExecutionContextExecutorService
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.jdk.CollectionConverters._
+
+import scala.meta.internal.bsp.ConnectionBspStatus
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.BuildServerConnection
+import scala.meta.internal.metals.Cancelable
+import scala.meta.internal.metals.ClosableOutputStream
+import scala.meta.internal.metals.DismissedNotifications
+import scala.meta.internal.metals.MetalsBuildClient
+import scala.meta.internal.metals.MetalsBuildServer
+import scala.meta.internal.metals.MetalsEnrichments.XtensionAbsolutePathBuffers
+import scala.meta.internal.metals.MetalsServerConfig
+import scala.meta.internal.metals.QuietInputStream
+import scala.meta.internal.metals.ScalaVersionSelector
+import scala.meta.internal.metals.SocketConnection
+import scala.meta.internal.metals.WorkDoneProgress
+import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.io.AbsolutePath
+
+import ch.epfl.scala.bsp4j.BspConnectionDetails
+import ch.epfl.scala.bsp4j.BuildClient
+import ch.epfl.scala.bsp4j.BuildServerCapabilities
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import ch.epfl.scala.bsp4j.CleanCacheParams
+import ch.epfl.scala.bsp4j.CleanCacheResult
+import ch.epfl.scala.bsp4j.CompileParams
+import ch.epfl.scala.bsp4j.CompileProvider
+import ch.epfl.scala.bsp4j.CompileResult
+import ch.epfl.scala.bsp4j.DebugSessionAddress
+import ch.epfl.scala.bsp4j.DebugSessionParams
+import ch.epfl.scala.bsp4j.DependencyModulesParams
+import ch.epfl.scala.bsp4j.DependencyModulesResult
+import ch.epfl.scala.bsp4j.DependencySourcesParams
+import ch.epfl.scala.bsp4j.DependencySourcesResult
+import ch.epfl.scala.bsp4j.InitializeBuildParams
+import ch.epfl.scala.bsp4j.InitializeBuildResult
+import ch.epfl.scala.bsp4j.InverseSourcesParams
+import ch.epfl.scala.bsp4j.InverseSourcesResult
+import ch.epfl.scala.bsp4j.JavacOptionsParams
+import ch.epfl.scala.bsp4j.JavacOptionsResult
+import ch.epfl.scala.bsp4j.JvmCompileClasspathItem
+import ch.epfl.scala.bsp4j.JvmCompileClasspathParams
+import ch.epfl.scala.bsp4j.JvmCompileClasspathResult
+import ch.epfl.scala.bsp4j.JvmRunEnvironmentParams
+import ch.epfl.scala.bsp4j.JvmRunEnvironmentResult
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentParams
+import ch.epfl.scala.bsp4j.JvmTestEnvironmentResult
+import ch.epfl.scala.bsp4j.OutputPathsParams
+import ch.epfl.scala.bsp4j.OutputPathsResult
+import ch.epfl.scala.bsp4j.ReadParams
+import ch.epfl.scala.bsp4j.ResourcesParams
+import ch.epfl.scala.bsp4j.ResourcesResult
+import ch.epfl.scala.bsp4j.RunParams
+import ch.epfl.scala.bsp4j.RunResult
+import ch.epfl.scala.bsp4j.ScalaMainClassesParams
+import ch.epfl.scala.bsp4j.ScalaMainClassesResult
+import ch.epfl.scala.bsp4j.ScalaTestClassesParams
+import ch.epfl.scala.bsp4j.ScalaTestClassesResult
+import ch.epfl.scala.bsp4j.ScalacOptionsParams
+import ch.epfl.scala.bsp4j.ScalacOptionsResult
+import ch.epfl.scala.bsp4j.SourcesParams
+import ch.epfl.scala.bsp4j.SourcesResult
+import ch.epfl.scala.bsp4j.StatusCode
+import ch.epfl.scala.bsp4j.TestParams
+import ch.epfl.scala.bsp4j.TestResult
+import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult
+import org.eclipse.lsp4j.jsonrpc.Launcher
+
+final class MbtBuildServer(
+    workspace: AbsolutePath,
+    build: () => MbtBuild,
+    scalaVersionSelector: ScalaVersionSelector,
+) extends MetalsBuildServer {
+
+  private val buildClient = new AtomicReference[BuildClient]()
+  private val importedBuild =
+    new AtomicReference[Seq[MbtTarget]](build().mbtTargets)
+
+  def onConnectWithClient(client: BuildClient): Unit =
+    buildClient.set(client)
+
+  private def importedBuildTargets: Seq[MbtTarget] = importedBuild.get()
+
+  private def shouldScanGlobDirectory(
+      relativeDirectory: Path,
+      targets: Seq[MbtTarget],
+  ): Boolean =
+    targets.exists(_.shouldScanGlobDirectory(relativeDirectory))
+
+  private def globbedSourceFiles(
+      targets: Seq[MbtTarget]
+  ): Map[BuildTargetIdentifier, Seq[AbsolutePath]] = {
+    val targetsWithGlobs = targets.filter(_.globMatchers.nonEmpty)
+    if (targetsWithGlobs.isEmpty) Map.empty
+    else {
+      val matchedFiles =
+        mutable.LinkedHashMap.empty[
+          BuildTargetIdentifier,
+          mutable.LinkedHashSet[AbsolutePath],
+        ]
+      Files.walkFileTree(
+        workspace.toNIO,
+        new SimpleFileVisitor[Path] {
+          override def preVisitDirectory(
+              dir: Path,
+              attrs: BasicFileAttributes,
+          ): FileVisitResult = {
+            val relativeDirectory =
+              if (dir == workspace.toNIO) Paths.get("")
+              else workspace.toNIO.relativize(dir)
+            if (shouldScanGlobDirectory(relativeDirectory, targetsWithGlobs))
+              FileVisitResult.CONTINUE
+            else FileVisitResult.SKIP_SUBTREE
+          }
+
+          override def visitFile(
+              path: Path,
+              attrs: BasicFileAttributes,
+          ): FileVisitResult = {
+            val file = AbsolutePath(path)
+            if (attrs.isRegularFile && file.isScalaOrJava) {
+              val relativePath = workspace.toNIO.relativize(path)
+              targetsWithGlobs.foreach { target =>
+                if (
+                  !target.containsStableSource(workspace, file) &&
+                  target.globMatchers.exists(_.matcher.matches(relativePath))
+                ) {
+                  matchedFiles
+                    .getOrElseUpdate(target.id, mutable.LinkedHashSet.empty)
+                    .add(file)
+                }
+              }
+            }
+            FileVisitResult.CONTINUE
+          }
+        },
+      )
+      matchedFiles.view.mapValues(_.toSeq).toMap
+    }
+  }
+  override def onRunReadStdin(params: ReadParams): Unit = ()
+
+  override def buildInitialize(
+      params: InitializeBuildParams
+  ): CompletableFuture[InitializeBuildResult] =
+    CompletableFuture.completedFuture {
+      val capabilities = new BuildServerCapabilities
+      capabilities.setCompileProvider(
+        new CompileProvider(List("scala", "java").asJava)
+      )
+      capabilities.setCanReload(true)
+      capabilities.setDependencySourcesProvider(true)
+      capabilities.setDependencyModulesProvider(true)
+      capabilities.setInverseSourcesProvider(true)
+      capabilities.setResourcesProvider(false)
+      capabilities.setJvmCompileClasspathProvider(true)
+      new InitializeBuildResult(
+        MbtBuildServer.name,
+        BuildInfo.metalsVersion,
+        BuildInfo.bspVersion,
+        capabilities,
+      )
+    }
+
+  override def onBuildInitialized(): Unit = ()
+
+  override def buildShutdown(): CompletableFuture[AnyRef] =
+    CompletableFuture.completedFuture(null)
+
+  override def onBuildExit(): Unit = ()
+
+  override def workspaceReload(): CompletableFuture[Object] = {
+    importedBuild.set(build().mbtTargets)
+    CompletableFuture.completedFuture(null)
+  }
+
+  override def workspaceBuildTargets()
+      : CompletableFuture[WorkspaceBuildTargetsResult] =
+    CompletableFuture.completedFuture(
+      new WorkspaceBuildTargetsResult(
+        importedBuildTargets
+          .map(_.buildTarget(workspace, scalaVersionSelector))
+          .asJava
+      )
+    )
+
+  override def buildTargetSources(
+      params: SourcesParams
+  ): CompletableFuture[SourcesResult] = {
+    val requestedTargets = params.getTargets.asScala.toSet
+    val targets = importedBuildTargets.filter(t => requestedTargets(t.id))
+    val globbedSources = globbedSourceFiles(targets)
+    CompletableFuture.completedFuture(
+      new SourcesResult(
+        targets
+          .map(target =>
+            target.sourcesItem(
+              workspace,
+              globbedSources.getOrElse(target.id, Nil),
+            )
+          )
+          .asJava
+      )
+    )
+  }
+  override def buildTargetInverseSources(
+      params: InverseSourcesParams
+  ): CompletableFuture[InverseSourcesResult] =
+    CompletableFuture.completedFuture {
+      val path =
+        AbsolutePath(Paths.get(URI.create(params.getTextDocument.getUri)))
+      new InverseSourcesResult(
+        importedBuildTargets
+          .filter(_.containsSource(workspace, path))
+          .map(_.id)
+          .asJava
+      )
+    }
+
+  override def buildTargetDependencySources(
+      params: DependencySourcesParams
+  ): CompletableFuture[DependencySourcesResult] = {
+    val requestedTargets = params.getTargets.asScala.toSet
+    CompletableFuture.completedFuture(
+      new DependencySourcesResult(
+        importedBuildTargets
+          .filter(t => requestedTargets(t.id))
+          .map(_.dependencySourcesItem)
+          .asJava
+      )
+    )
+  }
+
+  override def buildTargetResources(
+      params: ResourcesParams
+  ): CompletableFuture[ResourcesResult] =
+    CompletableFuture.failedFuture(
+      new UnsupportedOperationException(
+        "MBT build server does not support 'buildTarget/resources'."
+      )
+    )
+
+  override def buildTargetOutputPaths(
+      params: OutputPathsParams
+  ): CompletableFuture[OutputPathsResult] =
+    CompletableFuture.failedFuture(
+      new UnsupportedOperationException(
+        "MBT build server does not support 'buildTarget/outputPaths'."
+      )
+    )
+
+  override def buildTargetCompile(
+      params: CompileParams
+  ): CompletableFuture[CompileResult] =
+    CompletableFuture.completedFuture(new CompileResult(StatusCode.OK))
+
+  override def buildTargetTest(
+      params: TestParams
+  ): CompletableFuture[TestResult] =
+    CompletableFuture.failedFuture(
+      new UnsupportedOperationException(
+        "MBT build server does not support 'buildTarget/test'."
+      )
+    )
+
+  override def buildTargetRun(
+      params: RunParams
+  ): CompletableFuture[RunResult] =
+    CompletableFuture.failedFuture(
+      new UnsupportedOperationException(
+        "MBT build server does not support 'buildTarget/run'."
+      )
+    )
+
+  override def buildTargetCleanCache(
+      params: CleanCacheParams
+  ): CompletableFuture[CleanCacheResult] =
+    CompletableFuture.completedFuture {
+      val result = new CleanCacheResult(false)
+      result.setMessage("MBT build server is read-only.")
+      result
+    }
+
+  override def buildTargetScalacOptions(
+      params: ScalacOptionsParams
+  ): CompletableFuture[ScalacOptionsResult] = {
+    val requestedTargets = params.getTargets.asScala.toSet
+    CompletableFuture.completedFuture(
+      new ScalacOptionsResult(
+        importedBuildTargets
+          .filter(t => requestedTargets(t.id))
+          .map(_.scalacOptionsItem(workspace))
+          .asJava
+      )
+    )
+  }
+
+  override def buildTargetJavacOptions(
+      params: JavacOptionsParams
+  ): CompletableFuture[JavacOptionsResult] = {
+    val requestedTargets = params.getTargets.asScala.toSet
+    CompletableFuture.completedFuture(
+      new JavacOptionsResult(
+        importedBuildTargets
+          .filter(t => requestedTargets(t.id))
+          .map(_.javacOptionsItem(workspace))
+          .asJava
+      )
+    )
+  }
+
+  override def buildTargetScalaMainClasses(
+      params: ScalaMainClassesParams
+  ): CompletableFuture[ScalaMainClassesResult] =
+    CompletableFuture.completedFuture(
+      new ScalaMainClassesResult(List.empty.asJava)
+    )
+
+  override def buildTargetScalaTestClasses(
+      params: ScalaTestClassesParams
+  ): CompletableFuture[ScalaTestClassesResult] =
+    CompletableFuture.completedFuture(
+      new ScalaTestClassesResult(List.empty.asJava)
+    )
+
+  override def buildTargetDependencyModules(
+      params: DependencyModulesParams
+  ): CompletableFuture[DependencyModulesResult] = {
+    val requestedTargets = params.getTargets.asScala.toSet
+    CompletableFuture.completedFuture(
+      new DependencyModulesResult(
+        importedBuildTargets
+          .filter(t => requestedTargets(t.id))
+          .map(_.dependencyModulesItem)
+          .asJava
+      )
+    )
+  }
+
+  override def buildTargetJvmCompileClasspath(
+      params: JvmCompileClasspathParams
+  ): CompletableFuture[JvmCompileClasspathResult] = {
+    val requestedTargets = params.getTargets.asScala.toSet
+    CompletableFuture.completedFuture {
+      new JvmCompileClasspathResult(
+        importedBuildTargets
+          .filter(t => requestedTargets(t.id))
+          .map(_.javacOptionsItem(workspace))
+          .map { item =>
+            new JvmCompileClasspathItem(
+              item.getTarget,
+              item.getClasspath,
+            )
+          }
+          .asJava
+      )
+    }
+  }
+
+  override def debugSessionStart(
+      params: DebugSessionParams
+  ): CompletableFuture[DebugSessionAddress] =
+    CompletableFuture.failedFuture(
+      new UnsupportedOperationException(
+        "MBT build server does not support debug sessions."
+      )
+    )
+
+  override def buildTargetJvmRunEnvironment(
+      params: JvmRunEnvironmentParams
+  ): CompletableFuture[JvmRunEnvironmentResult] =
+    CompletableFuture.completedFuture(
+      new JvmRunEnvironmentResult(List.empty.asJava)
+    )
+
+  override def buildTargetJvmTestEnvironment(
+      params: JvmTestEnvironmentParams
+  ): CompletableFuture[JvmTestEnvironmentResult] =
+    CompletableFuture.completedFuture(
+      new JvmTestEnvironmentResult(List.empty.asJava)
+    )
+
+  override def buildTargetWrappedSources(
+      params: scala.build.bsp.WrappedSourcesParams
+  ): CompletableFuture[scala.build.bsp.WrappedSourcesResult] =
+    CompletableFuture.completedFuture(
+      new WrappedSourcesResult(List.empty.asJava)
+    )
+}
+
+object MbtBuildServer {
+  val name = "MBT"
+
+  def details: BspConnectionDetails =
+    new BspConnectionDetails(
+      name,
+      List.empty[String].asJava,
+      BuildInfo.metalsVersion,
+      BuildInfo.bspVersion,
+      List("scala", "java").asJava,
+    )
+
+  def isMbtServer(name: String): Boolean =
+    name == MbtBuildServer.name
+
+  def newServer(
+      workspace: AbsolutePath,
+      buildClient: MetalsBuildClient,
+      languageClient: MetalsLanguageClient,
+      config: MetalsServerConfig,
+      requestTimeOutNotification: DismissedNotifications#Notification,
+      reconnectNotification: DismissedNotifications#Notification,
+      bspStatusOpt: Option[ConnectionBspStatus],
+      mbtBuild: () => MbtBuild,
+      workDoneProgress: WorkDoneProgress,
+      scalaVersionSelector: ScalaVersionSelector,
+  )(implicit
+      ec: ExecutionContextExecutorService
+  ): Future[BuildServerConnection] = {
+    def connect(): Future[SocketConnection] = Future.successful {
+      val clientInput = new PipedInputStream()
+      val serverOutput = new PipedOutputStream(clientInput)
+      val serverInput = new PipedInputStream()
+      val clientOutput = new PipedOutputStream(serverInput)
+      val finished = Promise[Unit]()
+      val server = new MbtBuildServer(workspace, mbtBuild, scalaVersionSelector)
+      val serverLauncher = new Launcher.Builder[BuildClient]()
+        .setInput(serverInput)
+        .setOutput(serverOutput)
+        .setLocalService(server)
+        .setRemoteInterface(classOf[BuildClient])
+        .setExecutorService(ec)
+        .create()
+      server.onConnectWithClient(serverLauncher.getRemoteProxy)
+      val listening = serverLauncher.startListening()
+      Future {
+        listening.get()
+        ()
+      }.onComplete(finished.tryComplete)
+      val cancel = Cancelable { () =>
+        listening.cancel(false)
+        clientOutput.close()
+        clientInput.close()
+        serverInput.close()
+        serverOutput.close()
+        finished.trySuccess(())
+      }
+      SocketConnection(
+        name,
+        new ClosableOutputStream(clientOutput, s"$name output stream"),
+        new QuietInputStream(clientInput, s"$name input stream"),
+        List(cancel),
+        finished,
+      )
+    }
+
+    BuildServerConnection.fromSockets(
+      workspace,
+      workspace.resolve(".metals").resolve("bsp.trace"),
+      buildClient,
+      languageClient,
+      connect,
+      requestTimeOutNotification,
+      reconnectNotification,
+      config,
+      name,
+      bspStatusOpt,
+      workDoneProgress = workDoneProgress,
+    )
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuildServer.scala
@@ -39,6 +39,8 @@ import scala.meta.io.AbsolutePath
 import ch.epfl.scala.bsp4j.BspConnectionDetails
 import ch.epfl.scala.bsp4j.BuildClient
 import ch.epfl.scala.bsp4j.BuildServerCapabilities
+import ch.epfl.scala.bsp4j.BuildTargetEvent
+import ch.epfl.scala.bsp4j.BuildTargetEventKind
 import ch.epfl.scala.bsp4j.BuildTargetIdentifier
 import ch.epfl.scala.bsp4j.CleanCacheParams
 import ch.epfl.scala.bsp4j.CleanCacheResult
@@ -51,6 +53,7 @@ import ch.epfl.scala.bsp4j.DependencyModulesParams
 import ch.epfl.scala.bsp4j.DependencyModulesResult
 import ch.epfl.scala.bsp4j.DependencySourcesParams
 import ch.epfl.scala.bsp4j.DependencySourcesResult
+import ch.epfl.scala.bsp4j.DidChangeBuildTarget
 import ch.epfl.scala.bsp4j.InitializeBuildParams
 import ch.epfl.scala.bsp4j.InitializeBuildResult
 import ch.epfl.scala.bsp4j.InverseSourcesParams
@@ -189,7 +192,18 @@ final class MbtBuildServer(
   override def onBuildExit(): Unit = ()
 
   override def workspaceReload(): CompletableFuture[Object] = {
-    importedBuild.set(build().mbtTargets)
+    val newTargets = build().mbtTargets
+    importedBuild.set(newTargets)
+    Option(buildClient.get()).foreach { client =>
+      val events = newTargets.map { target =>
+        val event = new BuildTargetEvent(target.id)
+        event.setKind(BuildTargetEventKind.CHANGED)
+        event
+      }
+      client.onBuildTargetDidChange(
+        new DidChangeBuildTarget(events.asJava)
+      )
+    }
     CompletableFuture.completedFuture(null)
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDependencyModule.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDependencyModule.scala
@@ -1,0 +1,52 @@
+package scala.meta.internal.metals.mbt
+
+import java.net.URI
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.ArrayList
+import javax.annotation.Nullable
+
+import ch.epfl.scala.bsp4j
+
+case class MbtDependencyModule(
+    @Nullable id: String, // e.g. "com.google.guava:guava:30.0-jre"
+    @Nullable jar: String,
+    @Nullable sources: String,
+) {
+  def jarPath: Option[Path] = Option(jar).map(Paths.get(_))
+  def jarUri: Option[URI] = jarPath.map(_.toUri())
+  def jarUriString: Option[String] = jarUri.map(_.toString)
+  def sourcesUri: Option[URI] = Option(sources).map(Paths.get(_).toUri)
+  def sourcesUriString: Option[String] = sourcesUri.map(_.toString)
+  private def idParts: Array[String] = id.split(":", 3)
+  def isValid: Boolean = idParts.length == 3
+  def organization: String =
+    idParts.lift(0).getOrElse(s"INVALID_ORGANIZATION=$id")
+  def name: String =
+    idParts.lift(1).getOrElse(s"INVALID_NAME=$id")
+  def version: String =
+    idParts.lift(2).getOrElse(s"INVALID_VERSION=$id")
+
+  def asBsp: bsp4j.DependencyModule = {
+    val module = new bsp4j.DependencyModule(id, version)
+    val artifacts = new ArrayList[bsp4j.MavenDependencyModuleArtifact]()
+    jarUriString.foreach { jarUri =>
+      artifacts.add(new bsp4j.MavenDependencyModuleArtifact(jarUri))
+    }
+    sourcesUriString.foreach { sourceUri =>
+      val source = new bsp4j.MavenDependencyModuleArtifact(sourceUri)
+      source.setClassifier("sources")
+      artifacts.add(source)
+    }
+    module.setDataKind(bsp4j.DependencyModuleDataKind.MAVEN)
+    module.setData(
+      new bsp4j.MavenDependencyModule(
+        organization,
+        name,
+        version,
+        artifacts,
+      )
+    )
+    module
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtGlobMatcher.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtGlobMatcher.scala
@@ -1,0 +1,19 @@
+package scala.meta.internal.metals.mbt
+
+import java.nio.file.Path
+import java.nio.file.PathMatcher
+
+case class MbtGlobMatcher(
+    pattern: String,
+    prefix: Option[Path],
+    matcher: PathMatcher,
+) {
+  def mayContainMatchesIn(relativeDirectory: Path): Boolean =
+    prefix match {
+      case None => true
+      case Some(value) =>
+        relativeDirectory.toString.isEmpty ||
+        relativeDirectory.startsWith(value) ||
+        value.startsWith(relativeDirectory)
+    }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtNamespace.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtNamespace.scala
@@ -1,0 +1,25 @@
+package scala.meta.internal.metals.mbt
+
+import java.{util => ju}
+import javax.annotation.Nullable
+
+case class MbtNamespace(
+    @Nullable sources: ju.List[String],
+    @Nullable compilerOptions: ju.List[String],
+    @Nullable dependencyModules: ju.List[MbtDependencyModule] =
+      ju.Collections.emptyList(),
+    @Nullable scalaVersion: String,
+    @Nullable javaHome: String,
+    @Nullable dependsOn: ju.List[String] = null,
+) {
+  def getSources: ju.List[String] =
+    if (this.sources != null) this.sources else ju.Collections.emptyList()
+  def getCompilerOptions: ju.List[String] =
+    if (this.compilerOptions != null) this.compilerOptions
+    else ju.Collections.emptyList()
+  def getDependencyModules: ju.List[MbtDependencyModule] =
+    if (this.dependencyModules != null) this.dependencyModules
+    else ju.Collections.emptyList()
+  def getDependsOn: ju.List[String] =
+    if (this.dependsOn != null) this.dependsOn else ju.Collections.emptyList()
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtNamespace.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtNamespace.scala
@@ -13,13 +13,11 @@ case class MbtNamespace(
     @Nullable dependsOn: ju.List[String] = null,
 ) {
   def getSources: ju.List[String] =
-    if (this.sources != null) this.sources else ju.Collections.emptyList()
+    Option(this.sources).getOrElse(ju.Collections.emptyList())
   def getCompilerOptions: ju.List[String] =
-    if (this.compilerOptions != null) this.compilerOptions
-    else ju.Collections.emptyList()
+    Option(this.compilerOptions).getOrElse(ju.Collections.emptyList())
   def getDependencyModules: ju.List[MbtDependencyModule] =
-    if (this.dependencyModules != null) this.dependencyModules
-    else ju.Collections.emptyList()
+    Option(this.dependencyModules).getOrElse(ju.Collections.emptyList())
   def getDependsOn: ju.List[String] =
-    if (this.dependsOn != null) this.dependsOn else ju.Collections.emptyList()
+    Option(this.dependsOn).getOrElse(ju.Collections.emptyList())
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtTarget.scala
@@ -95,7 +95,7 @@ case class MbtTarget(
     target.setDisplayName(name)
     target.setBaseDirectory(baseDirectory(workspace).toURI.toString)
     target.setDataKind("scala")
-    target.setData(toGson(scalaTarget))
+    target.setData(MbtTarget.toGson(scalaTarget))
     target
   }
 
@@ -143,6 +143,10 @@ case class MbtTarget(
       dependencyModules.map(_.asBsp).asJava,
     )
 
+}
+
+object MbtTarget {
+  private val gson = new com.google.gson.Gson()
   private def toGson(value: bsp4j.ScalaBuildTarget) =
-    new com.google.gson.Gson().toJsonTree(value)
+    gson.toJsonTree(value)
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtTarget.scala
@@ -1,0 +1,148 @@
+package scala.meta.internal.metals.mbt
+
+import java.nio.file.Path
+import java.{util => ju}
+
+import scala.util.Properties
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ScalaVersionSelector
+import scala.meta.internal.metals.ScalaVersions
+import scala.meta.io.AbsolutePath
+
+import ch.epfl.scala.bsp4j
+
+case class MbtTarget(
+    name: String,
+    id: bsp4j.BuildTargetIdentifier,
+    sources: Seq[String],
+    globMatchers: Seq[MbtGlobMatcher],
+    compilerOptions: Seq[String],
+    dependencyModules: Seq[MbtDependencyModule],
+    scalaVersion: Option[String] = None,
+    javaHome: Option[String] = None,
+    dependsOn: Seq[bsp4j.BuildTargetIdentifier] = Nil,
+) {
+
+  // mbt doesn't produce any classfiles
+  private def emptyClassDirectory(workspace: AbsolutePath): AbsolutePath = {
+    workspace.resolve(".metals/mbt-out").createDirectories()
+  }
+
+  private def classpath: ju.List[String] =
+    dependencyModules.flatMap(_.jarUriString).asJava
+
+  private def baseDirectory(workspace: AbsolutePath): AbsolutePath =
+    workspace
+
+  def stableSourcePaths(workspace: AbsolutePath): Seq[AbsolutePath] =
+    sources.distinct.map(workspace.resolve)
+
+  def containsStableSource(
+      workspace: AbsolutePath,
+      path: AbsolutePath,
+  ): Boolean =
+    stableSourcePaths(workspace).exists(path.startWith)
+
+  def containsSource(workspace: AbsolutePath, path: AbsolutePath): Boolean = {
+    containsStableSource(workspace, path) ||
+    path.toRelativeInside(workspace).exists { relative =>
+      globMatchers.exists(_.matcher.matches(relative.toNIO))
+    }
+  }
+
+  def shouldScanGlobDirectory(relativeDirectory: Path): Boolean =
+    globMatchers.exists(_.mayContainMatchesIn(relativeDirectory))
+
+  private def scalaBinaryVersion(defaultScalaVersion: String): String =
+    ScalaVersions.scalaBinaryVersionFromFullVersion(
+      scalaVersion.getOrElse(defaultScalaVersion)
+    )
+
+  def buildTarget(
+      workspace: AbsolutePath,
+      scalaVersionSelector: ScalaVersionSelector,
+  ): bsp4j.BuildTarget = {
+    val capabilities = new bsp4j.BuildTargetCapabilities
+    capabilities.setCanCompile(false)
+    capabilities.setCanDebug(false)
+    capabilities.setCanRun(false)
+    capabilities.setCanTest(false)
+
+    val scalaVersion = this.scalaVersion.getOrElse(
+      scalaVersionSelector.fallbackScalaVersion(isAmmonite = false)
+    )
+    val scalaTarget = new bsp4j.ScalaBuildTarget(
+      "org.scala-lang",
+      scalaVersion,
+      scalaBinaryVersion(scalaVersion),
+      bsp4j.ScalaPlatform.JVM,
+      ju.Collections.emptyList(),
+    )
+    val jvmBt = new bsp4j.JvmBuildTarget()
+    jvmBt.setJavaHome(
+      javaHome.getOrElse(Properties.javaHome)
+    )
+    scalaTarget.setJvmBuildTarget(jvmBt)
+
+    val target = new bsp4j.BuildTarget(
+      id,
+      ju.Collections.emptyList(),
+      List("scala", "java").asJava,
+      dependsOn.asJava,
+      capabilities,
+    )
+    target.setDisplayName(name)
+    target.setBaseDirectory(baseDirectory(workspace).toURI.toString)
+    target.setDataKind("scala")
+    target.setData(toGson(scalaTarget))
+    target
+  }
+
+  def scalacOptionsItem(workspace: AbsolutePath): bsp4j.ScalacOptionsItem =
+    new bsp4j.ScalacOptionsItem(
+      id,
+      compilerOptions.asJava,
+      classpath,
+      emptyClassDirectory(workspace).toString(),
+    )
+
+  def javacOptionsItem(workspace: AbsolutePath): bsp4j.JavacOptionsItem =
+    new bsp4j.JavacOptionsItem(
+      id,
+      compilerOptions.asJava,
+      classpath,
+      emptyClassDirectory(workspace).toString(),
+    )
+
+  def sourcesItem(
+      workspace: AbsolutePath,
+      globbedSources: Seq[AbsolutePath] = Nil,
+  ): bsp4j.SourcesItem =
+    new bsp4j.SourcesItem(
+      id,
+      (stableSourcePaths(workspace) ++ globbedSources).distinct.map { path =>
+        new bsp4j.SourceItem(
+          path.toURI.toString,
+          if (path.isFile) bsp4j.SourceItemKind.FILE
+          else bsp4j.SourceItemKind.DIRECTORY,
+          false,
+        )
+      }.asJava,
+    )
+
+  def dependencySourcesItem: bsp4j.DependencySourcesItem =
+    new bsp4j.DependencySourcesItem(
+      id,
+      dependencyModules.flatMap(_.sourcesUriString).distinct.asJava,
+    )
+
+  def dependencyModulesItem: bsp4j.DependencyModulesItem =
+    new bsp4j.DependencyModulesItem(
+      id,
+      dependencyModules.map(_.asBsp).asJava,
+    )
+
+  private def toGson(value: bsp4j.ScalaBuildTarget) =
+    new com.google.gson.Gson().toJsonTree(value)
+}

--- a/tests/unit/src/main/scala/tests/Library.scala
+++ b/tests/unit/src/main/scala/tests/Library.scala
@@ -163,4 +163,25 @@ object Library {
       .asScala
       .toSeq
       .map(f => AbsolutePath(f.toPath))
+
+  /**
+   * Resolves the scala-library jar for the given Scala version.
+   * Returns the AbsolutePath to the jar file.
+   */
+  def getScalaLibraryJarPath(scalaVersion: String): AbsolutePath = {
+    val scalaLibraryDep =
+      Dependency.of("org.scala-lang", "scala-library", scalaVersion)
+    Fetch
+      .create()
+      .withDependencies(scalaLibraryDep.withTransitive(false))
+      .fetch()
+      .asScala
+      .headOption
+      .map(f => AbsolutePath(f.toPath))
+      .getOrElse(
+        throw new RuntimeException(
+          s"Could not fetch scala-library jar for version $scalaVersion"
+        )
+      )
+  }
 }

--- a/tests/unit/src/test/scala/tests/SelectBspServerSuite.scala
+++ b/tests/unit/src/test/scala/tests/SelectBspServerSuite.scala
@@ -53,4 +53,19 @@ class SelectBspServerSuite extends BaseSuite {
       |Mill
       |""".stripMargin,
   )
+
+  check(
+    "with-mbt",
+    None,
+    List(
+      name("Bloop"),
+      name("MBT"),
+      name("sbt"),
+    ),
+    """
+      |Bloop
+      |MBT
+      |sbt
+      |""".stripMargin,
+  )
 }

--- a/tests/unit/src/test/scala/tests/decompile/CfrDecompilerSuite.scala
+++ b/tests/unit/src/test/scala/tests/decompile/CfrDecompilerSuite.scala
@@ -7,27 +7,14 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.decompile.CfrDecompiler
 import scala.meta.internal.mtags.BuildInfo
-import scala.meta.io.AbsolutePath
 
-import coursierapi.Dependency
-import coursierapi.Fetch
 import tests.BaseSuite
+import tests.Library
 
 class CfrDecompilerSuite extends BaseSuite {
   test("decompile-scala-library-class") {
-    // Get scala-library jar path using coursier (similar to Library.fetch)
     val scalaVersion = BuildInfo.scalaCompilerVersion
-    val scalaLibraryDep =
-      Dependency.of("org.scala-lang", "scala-library", scalaVersion)
-
-    val scalaLibraryJar = Fetch
-      .create()
-      .withDependencies(scalaLibraryDep.withTransitive(false))
-      .fetch()
-      .asScala
-      .headOption
-      .map(f => AbsolutePath(f.toPath))
-      .getOrElse(fail("Could not fetch scala-library jar"))
+    val scalaLibraryJar = Library.getScalaLibraryJarPath(scalaVersion)
 
     // Decompile a well-known Scala class (e.g., scala.Option)
     val optionClassUri = URI.create(

--- a/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
@@ -40,7 +40,10 @@ class MbtBuildServerLspSuite
   test("two-targets-hover-definition-completion") {
     cleanWorkspace()
     val scalaLibJar =
-      Library.getScalaLibraryJarPath(BuildInfo.scalaVersion).toString()
+      Library
+        .getScalaLibraryJarPath(BuildInfo.scalaVersion)
+        .toString()
+        .replace("\\", "\\\\")
 
     val mbtJson =
       s"""{

--- a/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
@@ -1,0 +1,245 @@
+package tests.mbt
+
+import java.nio.file.Files
+
+import scala.meta.internal.metals.Configs.FallbackSourcepathConfig
+import scala.meta.internal.metals.Configs.ReferenceProviderConfig
+import scala.meta.internal.metals.Configs.WorkspaceSymbolProviderConfig
+import scala.meta.internal.metals.UserConfiguration
+
+import tests.BaseCompletionLspSuite
+import tests.BuildInfo
+import tests.Library
+import tests.TestHovers
+
+/**
+ * End-to-end checks for `.metals/mbt.json` with the built-in MBT BSP server:
+ * connection, presentation compiler hover, goto definition, and completions
+ * across two namespaces (each with multiple source files).
+ */
+class MbtBuildServerLspSuite
+    extends BaseCompletionLspSuite("mbt-build-server")
+    with TestHovers {
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(
+      fallbackScalaVersion = Some(BuildInfo.scalaVersion),
+      presentationCompilerDiagnostics = true,
+      buildOnChange = false,
+      buildOnFocus = false,
+      workspaceSymbolProvider = WorkspaceSymbolProviderConfig.mbt,
+      referenceProvider = ReferenceProviderConfig.mbt,
+      fallbackSourcepath = FallbackSourcepathConfig("all-sources"),
+    )
+
+  override def initializeGitRepo: Boolean = true
+
+  private def targetIds: Set[String] =
+    server.server.buildTargets.allBuildTargetIds.map(_.getUri).toSet
+
+  test("two-targets-hover-definition-completion") {
+    cleanWorkspace()
+    val scalaLibJar =
+      Library.getScalaLibraryJarPath(BuildInfo.scalaVersion).toString()
+
+    val mbtJson =
+      s"""{
+         |  "namespaces": {
+         |    "core": {
+         |      "sources": ["core/src/**"],
+         |      "scalaVersion": "${BuildInfo.scalaVersion}",
+         |      "dependencyModules": [
+         |        {
+         |          "id": "org.scala-lang:scala-library:${BuildInfo.scalaVersion}",
+         |          "jar": "$scalaLibJar"
+         |        }
+         |      ]
+         |    },
+         |    "extra": {
+         |      "sources": ["extra/src"],
+         |      "scalaVersion": "${BuildInfo.scalaVersion}",
+         |      "dependencyModules": [
+         |        {
+         |          "id": "org.scala-lang:scala-library:${BuildInfo.scalaVersion}",
+         |          "jar": "$scalaLibJar"
+         |        }
+         |      ],
+         |      "dependsOn": [
+         |        "core"
+         |      ]
+         |    }
+         |  }
+         |}""".stripMargin
+
+    val coreModel = "core/src/core/Model.scala"
+    val coreService = "core/src/core/Service.scala"
+    val extraHelper = "extra/src/extra/Helper.scala"
+    val extraApp = "extra/src/extra/App.scala"
+
+    for {
+      _ <- initialize(
+        s"""|/.metals/mbt.json
+            |$mbtJson
+            |/$coreModel
+            |package core
+            |
+            |import core.service.Service
+            |
+            |object Model {
+            |  def answer = Service.text
+            |}
+            |/$coreService
+            |package core.service
+            |
+            |import core.Model
+            |
+            |object Service {
+            |  def text: String = Model.answer.toString
+            |}
+            |/$extraHelper
+            |package extra
+            |
+            |object Helper {
+            |  def label: String = "ok"
+            |}
+            |/$extraApp
+            |package extra
+            |import core.Model
+            |
+            |object App {
+            |  def run() = Model.answer
+            |}
+            |""".stripMargin
+      )
+      _ = assertConnectedToBuildServer("MBT")
+      _ <- server.didOpen(coreModel)
+      _ <- server.didOpen(coreService)
+      _ <- server.didOpen(extraHelper)
+      _ <- server.didOpen(extraApp)
+      _ = assertNoDiagnostics()
+      _ <- server.assertHover(
+        coreModel,
+        """|package core
+           |
+           |import core.service.Service
+           |
+           |object Model {
+           |  def answ@@er = Service.text
+           |}""".stripMargin,
+        """|```scala
+           |def answer: String
+           |```
+           |""".stripMargin.hover,
+      )
+      _ <- server.assertDefinition(
+        coreService,
+        "Mod@@el.answer.toString",
+        s"""|$coreModel:5:8: definition
+            |object Model {
+            |       ^^^^^
+            |""".stripMargin,
+      )
+      _ <- server.didFocus(coreService)
+      _ <- assertCompletion(
+        """|package core
+           |
+           |import core.service.Service
+           |
+           |object Model {
+           |  def answer = Service.text@@
+           |}""".stripMargin,
+        "text: String",
+        filename = Some(coreModel),
+      )
+      _ <- server.assertHover(
+        extraApp,
+        """|package extra
+           |import core.Model
+           |
+           |object App {
+           |  def r@@un() = Model.answer
+           |}""".stripMargin,
+        """|```scala
+           |def run(): String
+           |```
+           |""".stripMargin.hover,
+      )
+      _ <- server.assertDefinition(
+        extraApp,
+        "Mod@@el.answer",
+        s"""|$coreModel:5:8: definition
+            |object Model {
+            |       ^^^^^
+            |""".stripMargin,
+      )
+      _ <- server.didFocus(coreService)
+      _ <- assertCompletion(
+        """|package extra
+           |import core.Model
+           |
+           |object App {
+           |  def run() = Model.answer@@
+           |}""".stripMargin,
+        "answer: String",
+        filename = Some(extraApp),
+      )
+    } yield ()
+  }
+
+  test("mbt-json-change-triggers-workspace-reload") {
+    cleanWorkspace()
+    val initialMbtJson =
+      s"""|{
+          |  "namespaces": {
+          |    "core": {
+          |      "sources": ["core/src/**"],
+          |      "scalaVersion": "${BuildInfo.scalaVersion}"
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+    val updatedMbtJson =
+      s"""|{
+          |  "namespaces": {
+          |    "core": {
+          |      "sources": ["core/src/**"],
+          |      "scalaVersion": "${BuildInfo.scalaVersion}"
+          |    },
+          |    "extra": {
+          |      "sources": ["extra/src/**"],
+          |      "scalaVersion": "${BuildInfo.scalaVersion}",
+          |      "dependsOn": ["core"]
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+
+    for {
+      _ <- initialize(
+        s"""|/.metals/mbt.json
+            |$initialMbtJson
+            |/core/src/core/Model.scala
+            |package core
+            |
+            |object Model
+            |/extra/src/extra/App.scala
+            |package extra
+            |
+            |object App
+            |""".stripMargin
+      )
+      _ = assertConnectedToBuildServer("MBT")
+      _ = assertEquals(targetIds, Set("mbt://namespace/core"))
+      _ = Files.writeString(
+        workspace.resolve(".metals").resolve("mbt.json").toNIO,
+        updatedMbtJson,
+      )
+      _ <- server.didChangeWatchedFiles(".metals/mbt.json")
+      _ = assertEquals(
+        targetIds,
+        Set("mbt://namespace/core", "mbt://namespace/extra"),
+      )
+    } yield ()
+  }
+
+}

--- a/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
@@ -175,7 +175,7 @@ class MbtBuildServerLspSuite
             |       ^^^^^
             |""".stripMargin,
       )
-      _ <- server.didFocus(coreService)
+      _ <- server.didFocus(extraApp)
       _ <- assertCompletion(
         """|package extra
            |import core.Model

--- a/tests/unit/src/test/scala/tests/mbt/MbtBuildSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtBuildSuite.scala
@@ -1,0 +1,262 @@
+package tests.mbt
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import scala.meta.internal.metals.BuildInfo
+import scala.meta.internal.metals.JsonParser.XtensionSerializableToJson
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.internal.metals.ScalaVersionSelector
+import scala.meta.internal.metals.mbt.MbtBuild
+import scala.meta.internal.metals.mbt.MbtBuildServer
+import scala.meta.io.AbsolutePath
+
+import ch.epfl.scala.bsp4j.SourceItemKind
+import ch.epfl.scala.bsp4j.SourcesParams
+import com.google.gson.GsonBuilder
+import tests.FileLayout
+
+class MbtBuildSuite extends tests.BaseSuite {
+
+  test("legacy-flat-format") {
+    val dir = Files.createTempDirectory("mbt-legacy")
+    val f = dir.resolve("mbt.json")
+    val initialContent =
+      """{
+        |  "dependencyModules": [
+        |    {
+        |      "id": "org.scala-lang:scala-library:2.13.16",
+        |      "jar": "/tmp/scala-library.jar"
+        |    }
+        |  ]
+        |}""".stripMargin
+    Files.writeString(
+      f,
+      initialContent,
+    )
+    val build = MbtBuild.fromFile(f)
+
+    val prettyGson = new GsonBuilder().setPrettyPrinting().create()
+    assertNoDiff(prettyGson.toJson(build.toJsonObject), initialContent)
+
+    assert(!build.isEmpty)
+    assertEquals(build.getNamespaces.size(), 0)
+
+    val asBsp = build.asBspModules
+    assertEquals(asBsp.getItems().size(), 1)
+    assertEquals(
+      asBsp.getItems().get(0).getTarget().getUri(),
+      MbtBuild.LegacyTargetName,
+    )
+  }
+
+  test("namespaces-format") {
+    val dir = Files.createTempDirectory("mbt-ns")
+    val f = dir.resolve("mbt.json")
+    val initialContent =
+      """|{
+         |  "dependencyModules": [],
+         |  "namespaces": {
+         |    "core": {
+         |      "sources": [
+         |        "./src"
+         |      ],
+         |      "compilerOptions": [
+         |        "-release",
+         |        "11"
+         |      ],
+         |      "dependencyModules": [
+         |        {
+         |          "id": "org.scala-lang:scala-library:2.13.16",
+         |          "jar": "/tmp/scala-library.jar"
+         |        }
+         |      ]
+         |    },
+         |    "extra": {
+         |      "sources": [
+         |        "./src/**"
+         |      ],
+         |      "dependencyModules": [
+         |        {
+         |          "id": "org.scala-lang:scala-library:2.13.16",
+         |          "jar": "/tmp/scala-library.jar"
+         |        }
+         |      ],
+         |      "dependsOn": [
+         |        "core"
+         |      ]
+         |    }
+         |  }
+         |}
+         |""".stripMargin
+    Files.writeString(
+      f,
+      initialContent,
+    )
+    val build = MbtBuild.fromFile(f)
+
+    val prettyGson = new GsonBuilder().setPrettyPrinting().create()
+    assertNoDiff(prettyGson.toJson(build.toJsonObject), initialContent)
+
+    assert(!build.isEmpty)
+    assertEquals(build.getNamespaces.size(), 2)
+
+    val targets = build.mbtTargets.map(
+      _.buildTarget(AbsolutePath(dir), ScalaVersionSelector.default)
+    )
+    assertEquals(
+      targets
+        .map(_.getId().getUri().toString)
+        .toSet,
+      Set("mbt://namespace/core", "mbt://namespace/extra"),
+    )
+    val extraTarget = targets
+      .find(_.getDisplayName == "extra")
+      .getOrElse(fail("missing extra target"))
+    assertEquals(
+      extraTarget.getDependencies.asScala.map(_.getUri).toSeq.sorted,
+      Seq("mbt://namespace/core"),
+    )
+  }
+
+  test("glob-inverse-sources") {
+    val dir = Files.createTempDirectory("mbt-glob")
+    val ws = AbsolutePath(dir)
+    val scalaPath = ws.resolve("src/main/scala/a/B.scala")
+    val javaPath = ws.resolve("src/main/scala/a/C.java")
+    Files.createDirectories(scalaPath.parent.toNIO)
+    Files.createFile(scalaPath.toNIO)
+    Files.createFile(javaPath.toNIO)
+
+    val f = dir.resolve("mbt.json")
+    Files.writeString(
+      f,
+      """|{
+         |  "namespaces": {
+         |    "app": {
+         |      "sources": ["./src/**/*.scala"],
+         |      "dependencyModules": []
+         |    }
+         |  }
+         |}
+         |""".stripMargin,
+    )
+    val build = MbtBuild.fromFile(f)
+    assertEquals(
+      build.mbtTargets
+        .filter(_.containsSource(ws, scalaPath))
+        .map(_.id)
+        .map(_.getUri)
+        .toSeq,
+      Seq("mbt://namespace/app"),
+    )
+    assertEquals(
+      build.mbtTargets.filter(_.containsSource(ws, javaPath)).length,
+      0,
+    )
+    val sourceItems = build.mbtTargets.map(_.sourcesItem(ws))
+    val appSources = sourceItems
+      .find(_.getTarget.getUri == "mbt://namespace/app")
+      .map(_.getSources.asScala.toSeq)
+      .getOrElse(fail("missing app sources"))
+    assertEquals(appSources.size, 0)
+  }
+
+  test("glob-prefixes-prune-directory-scan") {
+    val workspace = AbsolutePath(Files.createTempDirectory("prefixing-globs"))
+    FileLayout.fromString(
+      s"""|/.metals/mbt.json
+          |{
+          |  "namespaces": {
+          |    "core": {
+          |      "sources": ["core/src/**"],
+          |      "scalaVersion": "${BuildInfo.scala213}"
+          |    },
+          |    "shared": {
+          |      "sources": ["**/shared/**"],
+          |      "scalaVersion": "${BuildInfo.scala213}"
+          |    }
+          |  }
+          |}
+          |""".stripMargin,
+      root = workspace,
+    )
+
+    val targets = MbtBuild.fromWorkspace(workspace).mbtTargets
+    val core = targets.find(_.name == "core").get
+    val shared = targets.find(_.name == "shared").get
+
+    assertEquals(
+      core.globMatchers.head.prefix.map(_.toString.replace('\\', '/')),
+      Some("core/src"),
+    )
+    assert(core.shouldScanGlobDirectory(Paths.get("")))
+    assert(core.shouldScanGlobDirectory(Paths.get("core")))
+    assert(core.shouldScanGlobDirectory(Paths.get("core/src")))
+    assert(!core.shouldScanGlobDirectory(Paths.get("extra")))
+
+    assertEquals(shared.globMatchers.head.prefix, None)
+    assert(shared.shouldScanGlobDirectory(Paths.get("anywhere")))
+  }
+
+  test("build-target-sources-expands-globs") {
+    val workspace = AbsolutePath(Files.createTempDirectory("prefixing-globs"))
+    FileLayout.fromString(
+      s"""|/.metals/mbt.json
+          |{
+          |  "namespaces": {
+          |    "core": {
+          |      "sources": ["core/src/**"],
+          |      "scalaVersion": "${BuildInfo.scala213}"
+          |    }
+          |  }
+          |}
+          |/core/src/core/Model.scala
+          |package core
+          |
+          |object Model
+          |/core/src/core/Service.scala
+          |package core
+          |
+          |object Service
+          |/core/src/core/Helper.java
+          |package core;
+          |
+          |class Helper {}
+          |/core/src/core/ignored.conf
+          |value = 1
+          |""".stripMargin,
+      root = workspace,
+    )
+
+    val build = MbtBuild.fromWorkspace(workspace)
+    val server =
+      new MbtBuildServer(workspace, () => build, ScalaVersionSelector.default)
+    val targets = build.mbtTargets
+    val result =
+      server
+        .buildTargetSources(new SourcesParams(targets.map(_.id).asJava))
+        .get()
+    val coreTarget = targets.find(_.name == "core").get
+    val sourceItems =
+      result.getItems.asScala.find(_.getTarget == coreTarget.id).get
+    val sourcesByUri =
+      sourceItems.getSources.asScala.map(item => item.getUri -> item).toMap
+
+    val model = workspace.resolve("core/src/core/Model.scala").toURI.toString
+    val service =
+      workspace.resolve("core/src/core/Service.scala").toURI.toString
+    val helper = workspace.resolve("core/src/core/Helper.java").toURI.toString
+    val ignored =
+      workspace.resolve("core/src/core/ignored.conf").toURI.toString
+
+    assert(sourcesByUri.contains(model))
+    assert(sourcesByUri.contains(service))
+    assert(sourcesByUri.contains(helper))
+    assert(!sourcesByUri.contains(ignored))
+    assertEquals(sourcesByUri(model).getKind, SourceItemKind.FILE)
+    assertEquals(sourcesByUri(service).getKind, SourceItemKind.FILE)
+    assertEquals(sourcesByUri(helper).getKind, SourceItemKind.FILE)
+  }
+
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MBT (Metals Build Tool) added as a selectable BSP server with workspace auto-detection and reloads when mbt.json changes.
  * Multi-target namespaces supported: per-target sources (including glob discovery), compiler options, dependency modules, and per-target JVM/Scala classpath info.
  * Ability to reload an existing BSP session when appropriate MBT changes occur.

* **Tests**
  * New unit and integration tests validating MBT parsing, target discovery, glob handling, server behavior, and reload-on-change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->