### PR TITLE
Improved message for a missing dependency file

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -391,8 +391,7 @@ case class Indexer(indexProviders: IndexProviders)(implicit rc: ReportContext) {
     try {
       if (!path.exists) {
         scribe.warn(s"dependency missing at absolute path: $path")
-      }
-      else if (path.isJar) {
+      } else if (path.isJar) {
         usedJars += path
         addSourceJarSymbols(path)
       } else if (path.isDirectory) {

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -389,7 +389,10 @@ case class Indexer(indexProviders: IndexProviders)(implicit rc: ReportContext) {
       usedJars: mutable.HashSet[AbsolutePath],
   ): Unit = {
     try {
-      if (path.isJar && path.exists) {
+      if (!path.exists) {
+        scribe.warn(s"dependency missing at absolute path: $path")
+      }
+      else if (path.isJar) {
         usedJars += path
         addSourceJarSymbols(path)
       } else if (path.isDirectory) {


### PR DESCRIPTION
Missing JARs seem to happen often in Bazel targets. Arguably this problem should be fixed by building the classpath correctly, but I think it is still worth making the warning message more clear. This comes at no runtime cost, because the check for existence is always performed anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing dependency absolute paths now emit a clear warning to surface configuration issues.
  * Processing of dependency archives and source directories is now gated on the path actually existing, preventing incorrect handling of non-existent paths and reducing false positives in dependency indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->