### PR TITLE
feat(bazel): forward-port 13 Bazel build tool improvements from main

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
@@ -20,14 +20,7 @@ case class BazelBuildTool(
   }
 
   def createBspFileArgs(workspace: AbsolutePath): Option[List[String]] =
-    Option.when(workspaceSupportsBsp)(composeArgs())
-
-  def workspaceSupportsBsp: Boolean = {
-    projectRoot.list.exists {
-      case file if file.filename == "WORKSPACE" => true
-      case _ => false
-    }
-  }
+    Option.when(BazelBuildTool.workspaceSupportsBsp(projectRoot))(composeArgs())
 
   private def composeArgs(): List[String] = {
     val classpathSeparator = java.io.File.pathSeparator
@@ -42,11 +35,11 @@ case class BazelBuildTool(
     ) ++ BazelBuildTool.projectViewArgs(projectRoot)
   }
 
-  override def minimumVersion: String = "3.0.0"
+  override def minimumVersion: String = "5.0.0"
 
   override def recommendedVersion: String = version
 
-  override def version: String = BazelBuildTool.version
+  override def version: String = BazelBuildTool.resolveBazelVersion(projectRoot)
 
   override def toString: String = "bazel"
 
@@ -60,7 +53,7 @@ case class BazelBuildTool(
       currentVersion: String,
       workspace: AbsolutePath,
   ): Boolean = {
-    currentVersion != BazelBuildTool.version
+    currentVersion != BazelBuildTool.bspVersion
   }
 
   override def ensurePrerequisites(workspace: AbsolutePath): Unit = {
@@ -77,33 +70,50 @@ case class BazelBuildTool(
 object BazelBuildTool {
   val name: String = "bazel"
   val bspName: String = "bazelbsp"
-  val version: String = "3.2.0-20240629-e3d8bdf-NIGHTLY"
+  val bspVersion: String = "4.0.3"
+  val defaultBazelVersion = "8.2.1"
+
+  def resolveBazelVersion(projectRoot: AbsolutePath): String = {
+    val bazelVersionFile = projectRoot.resolve(".bazelversion")
+    if (bazelVersionFile.exists && bazelVersionFile.isFile) {
+      val version = bazelVersionFile.readText.trim()
+      if (version.nonEmpty) version else defaultBazelVersion
+    } else {
+      defaultBazelVersion
+    }
+  }
+
+  def getScalaRulesName(projectRoot: AbsolutePath): Option[String] = {
+    ScalaRulesetFinderHeuristic(projectRoot).guessRulesetName()
+  }
 
   val mainClass = "org.jetbrains.bsp.bazel.install.Install"
 
   val dependency: Dependency = Dependency.of(
-    "org.jetbrains.bsp",
+    "org.virtuslab",
     "bazel-bsp",
-    version,
+    bspVersion,
   )
 
   private def hasProjectView(dir: AbsolutePath): Option[AbsolutePath] =
-    dir.list.find(_.filename.endsWith(".bazelproject"))
+    Some(dir.resolve(".bazelproject"))
+      .filter(_.isFile)
+      .orElse(dir.list.find(_.filename.endsWith(".bazelproject")))
 
-  val fallbackProjectView: String = {
-    """|targets:
-       |    //...
-       |
-       |build_manual_targets: false
-       |
-       |derive_targets_from_directories: false
-       |
-       |enabled_rules:
-       |    io_bazel_rules_scala
-       |    rules_java
-       |    rules_jvm
-       |
-       |""".stripMargin
+  def enabledRules(projectRoot: AbsolutePath): List[String] = {
+    val scalaRules = getScalaRulesName(projectRoot)
+    List(scalaRules.getOrElse("rules_scala"), "rules_java", "rules_jvm")
+  }
+
+  def fallbackProjectView: String = {
+    s"""|targets:
+        |    //...
+        |
+        |build_manual_targets: false
+        |
+        |derive_targets_from_directories: false
+        |
+        |""".stripMargin
   }
 
   def existingProjectView(
@@ -124,9 +134,16 @@ object BazelBuildTool {
         List("-p", projectView.toRelative(projectRoot).toString())
       case None =>
         List(
-          "-t", "//...", "-enabled-rules", "io_bazel_rules_scala", "rules_java",
-          "rules_jvm",
+          "-t",
+          "//...",
         )
+    }
+  }
+
+  def workspaceSupportsBsp(projectRoot: AbsolutePath): Boolean = {
+    val bzlProjectRootFiles = Set("WORKSPACE", "MODULE.bazel")
+    projectRoot.list.exists { file =>
+      bzlProjectRootFiles.contains(file.filename)
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/builds/ScalaRulesetFinderHeuristic.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/ScalaRulesetFinderHeuristic.scala
@@ -1,0 +1,61 @@
+package scala.meta.internal.builds
+
+import scala.util.matching.UnanchoredRegex
+
+import scala.meta.internal.metals.MetalsEnrichments._
+import scala.meta.io.AbsolutePath
+
+class ScalaRulesetFinderHeuristic private (
+    workspaceFile: Option[AbsolutePath],
+    moduleFile: Option[AbsolutePath],
+) {
+  private lazy val workspaceFileContent = workspaceFile.flatMap(_.readTextOpt)
+  private lazy val moduleFileContent = moduleFile.flatMap(_.readTextOpt)
+
+  def guessRulesetName(): Option[String] = {
+    import ScalaRulesetFinderHeuristic._
+    // First try the module file, because it is the default since Bazel 7
+    val fromModuleFile = moduleFileContent.collect {
+      // The name of the repo that contains the module from which we load the "scala_config" extension
+      case useExtensionPattern(repoName) => repoName
+      // The name of the module which looks like it might contain Scala rules
+      case rulesScalaDepPattern(moduleName)
+          if moduleName.contains("rules_scala") =>
+        moduleName
+      // If there are no better clues, try finding a name that's typically used in examples on the Web
+      case commonlyUsedRepoNames(name) => name
+    }
+    // If the module file doesn't exist or doesn't contain any clues, try the workspace file
+    fromModuleFile.orElse(workspaceFileContent.collect {
+      // The name of the repo from which we load the "scala_config" repository rule
+      case loadRepoPattern(repoName) => repoName
+      // If there are no better clues, try finding a name that's typically used in examples on the Web
+      case commonlyUsedRepoNames(name) => name
+    })
+  }
+}
+
+object ScalaRulesetFinderHeuristic {
+  // Copied from com.google.devtools.build.lib.cmdlineRepositoryName at https://github.com/bazelbuild/bazel
+  private val repoNameCapturingGroup = "([a-zA-Z0-9][-.\\w]*)"
+  private val moduleNameCapturingGroup = "([a-z](?:[a-z0-9._-]*[a-z0-9])?)"
+
+  // These patterns are made public for the sake of testing.
+  val useExtensionPattern: UnanchoredRegex =
+    ("""use_extension\s*\(\s*"@""" + repoNameCapturingGroup + """//(?:\S+)"\s*,\s*"scala_config"""").r.unanchored
+  val rulesScalaDepPattern: UnanchoredRegex =
+    ("""bazel_dep\s*\(name\s*=\s*"""" + moduleNameCapturingGroup + "\"").r.unanchored
+  val loadRepoPattern: UnanchoredRegex =
+    ("""load\s*\(\s*"@""" + repoNameCapturingGroup + """//(?:\S+)"\s*,\s*"scala_config"""").r.unanchored
+  val commonlyUsedRepoNames: UnanchoredRegex =
+    "@((?:io_bazel_)?rules_scala)".r.unanchored
+
+  def apply(workspace: AbsolutePath): ScalaRulesetFinderHeuristic = {
+    val workspaceFile = (for {
+      fileName <- List("WORKSPACE.bazel", "WORKSPACE")
+      file = workspace.resolve(fileName) if file.isFile
+    } yield file).headOption
+    val moduleFile = Some(workspace.resolve("MODULE.bazel")).filter(_.isFile)
+    new ScalaRulesetFinderHeuristic(workspaceFile, moduleFile)
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/BuildServerConnection.scala
@@ -741,6 +741,10 @@ object BuildServerConnection {
       enableBestEffortMode: Boolean,
   )
 
+  final case class InitializeBuildData(
+      enabledRules: Array[String]
+  )
+
   private def extractSyncModes(
       result: InitializeBuildResult
   ): Option[List[SyncMode]] = {
@@ -780,12 +784,28 @@ object BuildServerConnection {
       serverName: String,
       config: MetalsServerConfig,
   ): InitializeBuildResult = {
-    val extraParams = BspExtraBuildParams(
-      BuildInfo.javaSemanticdbVersion,
-      BuildInfo.scalametaVersion,
-      BuildInfo.supportedScala2Versions.asJava,
-      config.enableBestEffort,
-    )
+    val isBazel = serverName == BazelBuildTool.bspName
+    val gson = new Gson
+    val (data, dataKind) =
+      if (isBazel)
+        (
+          gson.toJsonTree(
+            InitializeBuildData(BazelBuildTool.enabledRules(workspace).toArray)
+          ),
+          "bazel-data-kind",
+        )
+      else
+        (
+          gson.toJsonTree(
+            BspExtraBuildParams(
+              BuildInfo.javaSemanticdbVersion,
+              BuildInfo.scalametaVersion,
+              BuildInfo.supportedScala2Versions.asJava,
+              config.enableBestEffort,
+            )
+          ),
+          "bloop-data-kind",
+        )
 
     val capabilities = new BuildClientCapabilities(
       List("scala", "java").asJava
@@ -800,9 +820,8 @@ object BuildServerConnection {
         capabilities,
       )
 
-      val gson = new Gson
-      val data = gson.toJsonTree(extraParams)
       params.setData(data)
+      params.setDataKind(dataKind)
       params
     }
     // Block on the `build/initialize` request because it should respond instantly by Bloop

--- a/tests/slow/src/test/scala/tests/bazel/BazelLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelLspSuite.scala
@@ -348,7 +348,7 @@ class BazelLspSuite
            |                   ^
            |""".stripMargin,
       )
-      _ = assertContains(jsonFile, BazelBuildTool.version)
+      _ = assertContains(jsonFile, BazelBuildTool.bspVersion)
     } yield ()
   }
 

--- a/tests/unit/src/test/resources/bazel/example.MODULE.bazel
+++ b/tests/unit/src/test/resources/bazel/example.MODULE.bazel
@@ -1,0 +1,65 @@
+"""Bazel module ./test/shell/test_examples.sh tests"""
+
+module(name = "overridden_artifacts")
+
+bazel_dep(name = "dummy-scala_rules.2")
+local_path_override(
+    module_name = "rules_scala",
+    path = "fake/path",
+)
+
+bazel_dep(name = "latest_dependencies", dev_dependency = True)
+local_path_override(
+    module_name = "latest_dependencies",
+    path = "fake/path/deps/latest",
+)
+
+scala_config = use_extension(
+    "@dummy-scala_rules.2//scala/extensions:config.bzl",
+    "scala_config",
+)
+scala_config.settings(
+    scala_version = "3.3.7",
+)
+
+scala_deps = use_extension(
+    "@dummy-scala_rules.2//scala/extensions:deps.bzl",
+    "scala_deps",
+    dev_dependency = True,
+)
+scala_deps.settings(
+    fetch_sources = False,
+)
+scala_deps.scala()
+
+# Deliberately set for Scala 3.3 and 2.13 versions less than the most
+# recently supported. See the `scala_version` setting at the top of
+# `third_party/repositories/scala_{2_13,3_3}.bzl`.
+scala_deps.overridden_artifact(
+    name = "io_bazel_rules_scala_scala_library",
+    artifact = "org.scala-lang:scala3-library_3:3.3.4",
+    sha256 = "d95184acfcd814da2e051378e4962c653f4b468f4086452ab427af030482bd3c",
+)
+scala_deps.overridden_artifact(
+    name = "io_bazel_rules_scala_scala_compiler",
+    artifact = "org.scala-lang:scala3-compiler_3:3.3.4",
+    sha256 = "2cca65fdb92e2cc393786cae61b4f7bcb9032ad4be61f9cebae1dca72997e52f",
+    # These are _not_ strictly required in this case, but we want to test that
+    # nothing breaks when they're specified.
+    deps = [
+        "@io_bazel_rules_scala_scala_asm",
+        "@io_bazel_rules_scala_scala_interfaces",
+        "@io_bazel_rules_scala_scala_library",
+        "@io_bazel_rules_scala_scala_tasty_core",
+        "@org_jline_jline_reader",
+        "@org_jline_jline_terminal",
+        "@org_jline_jline_terminal_jni",
+        "@org_scala_sbt_compiler_interface",
+    ],
+)
+scala_deps.overridden_artifact(
+    name = "io_bazel_rules_scala_scala_library_2",
+    artifact = "org.scala-lang:scala-library:2.13.14",
+    sha256 = "43e0ca1583df1966eaf02f0fbddcfb3784b995dd06bfc907209347758ce4b7e3",
+)
+scala_deps.scalatest()

--- a/tests/unit/src/test/resources/bazel/example.WORKSPACE.bazel
+++ b/tests/unit/src/test/resources/bazel/example.WORKSPACE.bazel
@@ -1,0 +1,101 @@
+workspace(name = "overridden_artifacts")
+
+local_repository(
+    name = "dummy-scala_rules",
+    path = "fake/path",
+)
+
+load("@dummy-scala_rules//scala:latest_deps.bzl", "rules_scala_dependencies")
+
+rules_scala_dependencies()
+
+load("@platforms//host:extension.bzl", "host_platform_repo")
+
+host_platform_repo(name = "host_platform")
+
+register_toolchains("@rules_scala_protoc_toolchains//...:all")
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
+load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
+
+rules_java_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+load("@rules_java//java:repositories.bzl", "rules_java_toolchains")
+
+rules_java_toolchains()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+
+rules_proto_dependencies()
+
+load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
+
+rules_proto_setup()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
+rules_proto_toolchains()
+
+load("@dummy-scala_rules//protoc:toolchains.bzl", "scala_protoc_toolchains")
+
+scala_protoc_toolchains(name = "rules_scala_protoc_toolchains")
+
+load("@dummy-scala_rules//:scala_config.bzl", "scala_config")
+
+scala_config(scala_version = "3.3.7")
+
+load(
+    "@dummy-scala_rules//scala:toolchains.bzl",
+    "scala_register_toolchains",
+    "scala_toolchains",
+)
+
+scala_toolchains(
+    # Deliberately set for Scala 3.3 and 2.13 versions less than the most
+    # recently supported. See the `scala_version` setting at the top of
+    # `third_party/repositories/scala_{2_13,3_3}.bzl`.
+    overridden_artifacts = {
+        "io_bazel_rules_scala_scala_library": {
+            "artifact": "org.scala-lang:scala3-library_3:3.3.4",
+            "sha256": "d95184acfcd814da2e051378e4962c653f4b468f4086452ab427af030482bd3c",
+        },
+        "io_bazel_rules_scala_scala_compiler": {
+            "artifact": "org.scala-lang:scala3-compiler_3:3.3.4",
+            "sha256": "2cca65fdb92e2cc393786cae61b4f7bcb9032ad4be61f9cebae1dca72997e52f",
+            # These are _not_ strictly required in this case, but we want to
+            # test that nothing breaks when they're specified.
+            "deps": [
+                "@io_bazel_rules_scala_scala_asm",
+                "@io_bazel_rules_scala_scala_interfaces",
+                "@io_bazel_rules_scala_scala_library",
+                "@io_bazel_rules_scala_scala_tasty_core",
+                "@org_jline_jline_reader",
+                "@org_jline_jline_terminal",
+                "@org_jline_jline_terminal_jni",
+                "@org_scala_sbt_compiler_interface",
+            ],
+        },
+        "io_bazel_rules_scala_scala_library_2": {
+            "artifact": "org.scala-lang:scala-library:2.13.14",
+            "sha256": "43e0ca1583df1966eaf02f0fbddcfb3784b995dd06bfc907209347758ce4b7e3",
+        },
+    },
+    scalatest = True,
+)
+
+scala_register_toolchains()

--- a/tests/unit/src/test/scala/tests/bazel/ScalaRulesetFinderHeuristicTest.scala
+++ b/tests/unit/src/test/scala/tests/bazel/ScalaRulesetFinderHeuristicTest.scala
@@ -1,0 +1,42 @@
+package tests.bazel
+
+import java.nio.file.Files
+
+import scala.meta.internal.builds.ScalaRulesetFinderHeuristic
+import scala.meta.io.AbsolutePath
+
+import tests.BaseSuite
+import tests.BuildInfo
+
+class ScalaRulesetFinderHeuristicTest extends BaseSuite {
+
+  test("workspace file patterns") {
+    val tmp = AbsolutePath(Files.createTempDirectory("workspace file patterns"))
+
+    copyFiles(tmp)("example.WORKSPACE.bazel" -> "WORKSPACE.bazel")
+    val finder = ScalaRulesetFinderHeuristic(tmp)
+    assertNoDiff(finder.guessRulesetName().get, "dummy-scala_rules")
+  }
+
+  test("module file patterns") {
+    val tmp = AbsolutePath(Files.createTempDirectory("module file patterns"))
+
+    copyFiles(tmp)(
+      "example.WORKSPACE.bazel" -> "WORKSPACE.bazel",
+      "example.MODULE.bazel" -> "MODULE.bazel",
+    )
+    val finder = ScalaRulesetFinderHeuristic(tmp)
+    assertNoDiff(finder.guessRulesetName().get, "dummy-scala_rules.2")
+  }
+
+  private def copyFiles(
+      workDir: AbsolutePath
+  )(mappings: (String, String)*): Unit = {
+    val testResources =
+      AbsolutePath(BuildInfo.testResourceDirectory).resolve("bazel")
+    mappings.foreach { case (from, to) =>
+      Files.copy(testResources.resolve(from).toNIO, workDir.resolve(to).toNIO)
+    }
+  }
+
+}


### PR DESCRIPTION
Forward-ports a squashed range of 13 commits (up to main@ffabfea36b2) into main-v2, centred on `BazelBuildTool.scala`.

## Main commits forward-ported

In reverse chronological order (newest first):

| SHA | PR | Title |
| --- | --- | --- |
| `8008cc6afd8` | #8270 | Better heuristic for guessing the name of the Scala rule set |
| `e70ead3d3f9` | #8265 | bugfix: Detect rules name instead of assuming a specific version |
| `57c8e9e13e3` | #8169 | chore: Bump Bloop and Bazel BSP |
| `bf987346bab` | #8042 | chore: Send enabled rules in initialize params |
| `0f703465d65` | #8041 | chore: Update bazel-bsp to 4.0.2 |
| `08dfae77636` | #7947 | bugfix: Use coursierapi to make sure credentials are used |
| `7abd8aed871` | #7769 | feature: Implement test discovery for Bazel |
| `e665821a81f` | #7817 | bugfix: Don't use bsp version as Bazel fallback version |
| `800dbe13b73` | #7753 | improvement: Fix issues with Bazel 8 |
| `a5fde340869` | #7698 | update: Bump Bazel BSP to 4.0.1 |
| `43866172bce` | #7640 | fix: detect bzl workspace for both WORKSPACE and MODULE.bazel files |
| `c9f074fac10` | #7617 | feat: use org.virtuslab.bazel-bsp 4.0.0-M3 |
| `e7012116684` | — | prefer `.bazelproject` as the Bazel BSP root |

Applied as a squash rather than individual cherry-picks due to conflicts with main-v2's `coursierapi.Dependency` usage.

## Context

 I use metals v2 with bazel frequently and I noticed that v2 branch don't have many of the bazel improvements such as https://github.com/scalameta/metals/pull/8270, which motivated me to make the PR.