### PR TITLE
bugfix: Fix possible false positive prompt for BSP

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/SbtBuildTool.scala
@@ -511,15 +511,20 @@ object SbtBuildTool {
           args <- json("argv").arrOpt
           firstArg <- args.headOption
           javaArg <- firstArg.strOpt
-          if (javaArg.endsWith("java"))
+          // possible bug with Windows when path to java ends with /
+          javaArgEscaped =
+            if (scala.util.Properties.isWin)
+              javaArg.replace("/", "\\")
+            else javaArg
+          if (javaArg.endsWith("java") || javaArg.endsWith("java.exe"))
         } yield {
           val possibleJavaBinaries =
             JavaBinary.allPossibleJavaBinaries(userJavaHome)
           val sbtJavaHomeIsCorrect =
-            possibleJavaBinaries.exists(_.toString == javaArg)
+            possibleJavaBinaries.exists(_.toString == javaArgEscaped)
           if (!sbtJavaHomeIsCorrect) {
             scribe.debug(
-              s"Java binary used by sbt server $javaArg doesn't match the expected java home. Possible paths considered: $possibleJavaBinaries"
+              s"Java binary used by sbt server $javaArgEscaped doesn't match the expected java home. Possible paths considered: $possibleJavaBinaries"
             )
           }
           sbtJavaHomeIsCorrect


### PR DESCRIPTION
I don't think this is an issue in Metals, so let's try to just fix the prompt being shown

Should fix https://github.com/scalameta/metals/issues/8312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sbt build tool behavior on Windows when detecting the Java executable to avoid false mismatches.
  * Java path handling and comparisons now consistently normalize Windows path separators and accept both plain and .exe Java executables, resulting in clearer mismatch reporting and more reliable tool startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->