### PR TITLE
Prevent `.bsp/.scala-build` pollution and fix Import Build command

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
@@ -229,6 +229,9 @@ class ConnectionProvider(
   def runMbtReimport(importers: List[MbtImportProvider]): Future[Unit] =
     mbtImport.runIfApproved(importers, isMbtImportInProcess).ignoreValue
 
+  def forceMbtReimport(importers: List[MbtImportProvider]): Future[Unit] =
+    mbtImport.runUnconditionally(importers, isMbtImportInProcess).ignoreValue
+
   def reloadCurrentSession(): Future[Unit] =
     bspSession match {
       case Some(session) if session.canReloadWorkspace =>
@@ -251,6 +254,27 @@ class ConnectionProvider(
     )
 
   def slowConnectToBuildServer(
+      forceImport: Boolean,
+      progress: TaskProgress,
+  ): Future[BuildChange] = {
+    def mbtImporters = buildTools.mbtImporters(shellRunner, () => userConfig)
+    if (isMbtPreferred && mbtImporters.nonEmpty) {
+      val runImport =
+        if (forceImport) forceMbtReimport(mbtImporters)
+        else runMbtReimport(mbtImporters)
+      runImport.flatMap { _ =>
+        bspSession match {
+          case Some(session) =>
+            connect(new ImportBuildAndIndex(session), progress)
+          case None =>
+            connect(CreateSession(), progress)
+        }
+      }
+    } else
+      slowConnectToStandardBuildServer(forceImport, progress)
+  }
+
+  private def slowConnectToStandardBuildServer(
       forceImport: Boolean,
       progress: TaskProgress,
   ): Future[BuildChange] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -277,6 +277,7 @@ class ProjectMetalsLspService(
   def maybeSetupScalaCli(): Future[Unit] = {
     if (
       !buildTools.isAutoConnectable()
+      && !buildTools.hasMbtImporters
       && buildTools.loadSupported().isEmpty
       && (folder.isScalaProject() || focusedDocument().exists(_.isScala))
     ) {

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/ScriptMbtImporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/ScriptMbtImporter.scala
@@ -45,7 +45,7 @@ final class ScriptMbtImporter(
     shellRunner
       .run(
         s"mbt-script: ${scriptPath.toFile.getName()}",
-        buildCommand,
+        buildCommand(workspace),
         workspace,
         redirectErrorOutput = false,
         javaHome = userConfig().javaHome,
@@ -81,13 +81,21 @@ final class ScriptMbtImporter(
       .map(AbsolutePath(_))
       .getOrElse(scriptPath)
 
-  private[importer] def buildCommand: List[String] = {
+  private[importer] def buildCommand(workspace: AbsolutePath): List[String] = {
     if (scriptPath.toFile.getName().endsWith(".mbt.sh"))
       List("sh", scriptPath.toString)
     else {
       // .mbt.scala or .mbt.java — use Scala CLI
       val launcher = userConfig().scalaCliLauncher.getOrElse("scala-cli")
-      List(launcher, "run", scriptPath.toString)
+      val scalaCliWorkspace = workspace.resolve(s".metals/scala-cli-$name")
+      List(
+        launcher,
+        "run",
+        "--server=false",
+        "--workspace",
+        scalaCliWorkspace.toString,
+        scriptPath.toString,
+      )
     }
   }
 }

--- a/tests/unit/src/test/scala/scala/meta/internal/metals/mbt/importer/ScriptMbtImporterSuite.scala
+++ b/tests/unit/src/test/scala/scala/meta/internal/metals/mbt/importer/ScriptMbtImporterSuite.scala
@@ -77,34 +77,39 @@ class ScriptMbtImporterSuite extends FunSuite {
   test("buildCommand-sh-uses-sh") {
     val dir = AbsolutePath(Files.createTempDirectory("mbt-cmd"))
     val script = makeScript(dir, "run.mbt.sh")
-    val cmd = importer(script).buildCommand
+    val cmd = importer(script).buildCommand(dir)
     assertEquals(cmd.head, "sh")
     assertEquals(cmd(1), script.toString)
   }
 
   test("buildCommand-scala-uses-scala-cli") {
     val dir = AbsolutePath(Files.createTempDirectory("mbt-cmd"))
+    val workspace = AbsolutePath(Files.createTempDirectory("mbt-cmd-ws"))
     val script = makeScript(dir, "run.mbt.scala")
-    val cmd = importer(script).buildCommand
+    val cmd = importer(script).buildCommand(workspace)
     assertEquals(cmd.head, "scala-cli")
     assertEquals(cmd(1), "run")
-    assertEquals(cmd(2), script.toString)
+    assertEquals(cmd.last, script.toString)
   }
 
   test("buildCommand-java-uses-scala-cli") {
     val dir = AbsolutePath(Files.createTempDirectory("mbt-cmd"))
+    val workspace = AbsolutePath(Files.createTempDirectory("mbt-cmd-ws"))
     val script = makeScript(dir, "run.mbt.java")
-    val cmd = importer(script).buildCommand
+    val cmd = importer(script).buildCommand(workspace)
     assertEquals(cmd.head, "scala-cli")
   }
 
   test("buildCommand-custom-scala-cli-launcher") {
     val dir = AbsolutePath(Files.createTempDirectory("mbt-cmd"))
+    val workspace = AbsolutePath(Files.createTempDirectory("mbt-cmd-ws"))
     val script = makeScript(dir, "run.mbt.scala")
     val customConfig: () => UserConfiguration =
       () => UserConfiguration(scalaCliLauncher = Some("/opt/scala-cli"))
     val cmd =
-      new ScriptMbtImporter(script, noShellRunner, customConfig).buildCommand
+      new ScriptMbtImporter(script, noShellRunner, customConfig).buildCommand(
+        workspace
+      )
     assertEquals(cmd.head, "/opt/scala-cli")
   }
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/69e842f5-6953-4521-a2b3-c725e672e214



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved build-server connection flow that prioritizes MBT workflows and supports an unconditional MBT re-import option.
  * Scripts executed with workspace-specific invocation for Scala CLI-based builds to improve isolation.

* **Bug Fixes**
  * Avoids triggering Scala CLI auto-setup when MBT importers are present, preventing conflicting setup attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->