### PR TITLE
bugfix: Don't calcualte semanticdb for unopened files that do not belong to any target

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,11 @@ Global / resolvers += "scala-integration" at
 // Make sure to bump up this version when we merge with upstream.
 val forkBaseVersion = "1.6.0"
 
+val currentVersion = "2.0.0"
+
 def localSnapshotVersion = sys.env.getOrElse(
   "METALS_VERSION",
-  s"$forkBaseVersion-${sys.env.getOrElse("METALS_VERSION_SUFFIX", "SNAPSHOT")}",
+  s"$currentVersion-${sys.env.getOrElse("METALS_VERSION_SUFFIX", "SNAPSHOT")}",
 )
 def isCI = System.getenv("CI") != null
 def isTest = System.getenv("METALS_TEST") != null

--- a/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InteractiveSemanticdbs.scala
@@ -81,7 +81,9 @@ final class InteractiveSemanticdbs(
           source.isMill || // mill files
           source.isProtoFilename || // protobuf files (no semanticdb-scalac)
           source.isWorksheet || // worksheets
-          doesNotBelongToBuildTarget || // standalone files
+          doesNotBelongToBuildTarget && buffers.contains(
+            source
+          ) || // standalone files that are opened
           scalaCliServers.loadedExactly(source) || // scala-cli single files
           sourceText.exists(
             _.startsWith(Shebang.shebang)


### PR DESCRIPTION


We don't use interactive semanticdb for unopene files and can calculated them when needed. Currently if too many change at the same time (save-expect in metals repo), we will quickly go OOM