### PR TITLE
Removed transitive dependencies which broke the build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1016,7 +1016,7 @@ lazy val metalsDependencies = project
       // not available for Scala 2.13.13
       // "org.typelevel" % "kind-projector" % V.kindProjector cross CrossVersion.full,
       "com.olegpy" %% "better-monadic-for" % V.betterMonadicFor,
-      "com.lihaoyi" % "mill-contrib-testng" % V.mill,
+      "com.lihaoyi" % "mill-contrib-testng" % V.mill intransitive (),
       "org.virtuslab.scala-cli" % "cli_3" % V.scalaCli intransitive (),
       "ch.epfl.scala" % "bloop-maven-plugin" % V.mavenBloop,
       "ch.epfl.scala" %% "gradle-bloop" % V.gradleBloop,


### PR DESCRIPTION
`com.lihaoyi:mill-contrib-testng:1.0.3` depends transitively on `com.lihaoyi:unroll-annotation_3:0.2.0`. This clashes with `com.lihaoyi:unroll-annotation_2.13:0.1.12`, which is used everywhere in the project.