### PR TITLE
Add support for Deder build tool

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -181,6 +181,7 @@ final class BuildTools(
       SbtBuildTool.name,
       MillBuildTool.bspName,
       BazelBuildTool.bspName,
+      DederBuildTool.bspName,
     ) ++ ScalaCli.names
 
   private def customProjectRoot = userConfig().getCustomProjectRoot(workspace)

--- a/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BuildTools.scala
@@ -143,6 +143,10 @@ final class BuildTools(
     BazelBuildTool.workspaceSupportsBsp(_)
   )
   def isBazel: Boolean = bazelProject.isDefined
+  def dederProject: Option[AbsolutePath] = searchForBuildTool(
+    _.resolve(DederBuildTool.buildFile).isFile
+  )
+  def isDeder: Boolean = dederProject.isDefined
 
   def isInBsp(path: AbsolutePath): Boolean =
     path.isFile && path.parent.filename == ".bsp" &&
@@ -208,6 +212,7 @@ final class BuildTools(
       MillBuildTool(userConfig, workspace),
       ScalaCliBuildTool(workspace, workspace, userConfig),
       BazelBuildTool(userConfig, workspace),
+      DederBuildTool(userConfig, workspace),
     )
   }
 
@@ -219,6 +224,7 @@ final class BuildTools(
     if (isGradle) buf += "Gradle"
     if (isMaven) buf += "Maven"
     if (isBazel) buf += "Bazel"
+    if (isDeder) buf += "Deder"
     buf.result()
   }
 
@@ -235,6 +241,7 @@ final class BuildTools(
     millProject.foreach(buf += MillBuildTool(userConfig, _))
     scalaCliProject.foreach(buf += ScalaCliBuildTool(workspace, _, userConfig))
     bazelProject.foreach(buf += BazelBuildTool(userConfig, _))
+    dederProject.foreach(buf += DederBuildTool(userConfig, _))
     buf.addAll(customBsps)
 
     buf.result()
@@ -259,6 +266,8 @@ final class BuildTools(
       Some(MillBuildTool.name)
     else if (bazelProject.exists(BazelBuildTool.isBazelRelatedPath(_, path)))
       Some(BazelBuildTool.name)
+    else if (dederProject.exists(DederBuildTool.isDederRelatedPath(_, path)))
+      Some(DederBuildTool.name)
     else if (isInBsp(path)) {
       val name = path.filename.stripSuffix(".json")
       if (knownBsps(name) && !ScalaCli.names(name)) None
@@ -309,5 +318,6 @@ object BuildTools {
     MillBuildTool.name,
     ScalaCliBuildTool.name,
     BazelBuildTool.name,
+    DederBuildTool.name,
   )
 }

--- a/metals/src/main/scala/scala/meta/internal/builds/DederBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/DederBuildTool.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.builds
 
+import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.io.AbsolutePath
 

--- a/metals/src/main/scala/scala/meta/internal/builds/DederBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/DederBuildTool.scala
@@ -1,0 +1,36 @@
+package scala.meta.internal.builds
+
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.io.AbsolutePath
+
+case class DederBuildTool(
+    userConfig: () => UserConfiguration,
+    projectRoot: AbsolutePath,
+) extends BuildTool
+    with BuildServerProvider {
+
+  override def createBspFileArgs(
+      workspace: AbsolutePath
+  ): Option[List[String]] =
+    Option.when(workspace.resolve(DederBuildTool.buildFile).isFile)(
+      List(DederBuildTool.name, "bsp", "install")
+    )
+
+  override def digest(workspace: AbsolutePath): Option[String] =
+    DederDigest.current(projectRoot)
+
+  override def executableName: String = DederBuildTool.name
+
+  override def toString: String = "Deder"
+}
+
+object DederBuildTool {
+  val name: String = "deder"
+  val buildFile: String = "deder.pkl"
+
+  def isDederRelatedPath(
+      workspace: AbsolutePath,
+      path: AbsolutePath,
+  ): Boolean =
+    path.toNIO.startsWith(workspace.toNIO) && path.filename == buildFile
+}

--- a/metals/src/main/scala/scala/meta/internal/builds/DederBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/DederBuildTool.scala
@@ -22,11 +22,14 @@ case class DederBuildTool(
 
   override def executableName: String = DederBuildTool.name
 
+  override def buildServerName: String = DederBuildTool.bspName
+
   override def toString: String = "Deder"
 }
 
 object DederBuildTool {
   val name: String = "deder"
+  val bspName: String = "deder-bsp"
   val buildFile: String = "deder.pkl"
 
   def isDederRelatedPath(

--- a/metals/src/main/scala/scala/meta/internal/builds/DederDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/DederDigest.scala
@@ -1,0 +1,16 @@
+package scala.meta.internal.builds
+
+import java.security.MessageDigest
+
+import scala.meta.io.AbsolutePath
+
+object DederDigest extends Digestable {
+  override protected def digestWorkspace(
+      workspace: AbsolutePath,
+      digest: MessageDigest,
+  ): Boolean = {
+    val dederFile = workspace.resolve("deder.pkl")
+    if (dederFile.isFile) Digest.digestFile(dederFile, digest)
+    else true
+  }
+}

--- a/metals/src/main/scala/scala/meta/internal/builds/DederDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/DederDigest.scala
@@ -11,6 +11,6 @@ object DederDigest extends Digestable {
   ): Boolean = {
     val dederFile = workspace.resolve("deder.pkl")
     if (dederFile.isFile) Digest.digestFile(dederFile, digest)
-    else true
+    else false
   }
 }

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -483,7 +483,7 @@ class UserConfigurationSuite extends BaseSuite {
       | "target-build-tool": "invalid-tool"
       |}
     """.stripMargin,
-    "Invalid target-build-tool 'invalid-tool'. Valid values are: bazel, gradle, mill, mvn, sbt, scala-cli",
+    "Invalid target-build-tool 'invalid-tool'. Valid values are: bazel, deder, gradle, mill, mvn, sbt, scala-cli",
   )
 
   checkOK(


### PR DESCRIPTION
This adds support for [Deder build tool](https://github.com/sake92/deder) automatic import.

---
I've tested this locally, works fine.  
Tho I am not sure why I get 2 of these messages, shouldn't there be just one? (or even none if it's obvious which build tool it should use)

1:
<img width="1029" height="341" alt="Screenshot from 2026-04-30 14-35-55" src="https://github.com/user-attachments/assets/4dfc6954-1f51-4077-96d1-04ec372eca20" />

2 (switch? after I accepted to use Deder?):
<img width="1029" height="341" alt="Screenshot from 2026-04-30 14-36-09" src="https://github.com/user-attachments/assets/e9701653-b327-47f1-b552-bc94dda2c98b" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Deder build tool support: detection, project association, recognized identifier, and BSP install support.
  * Build digests now include Deder workspaces for change detection.

* **Tests**
  * Validation updated to accept "deder" as a valid build-tool value in configuration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->