### PR TITLE
Replace QDox with tree-sitter for Java source parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,7 +166,7 @@ def lintingOptions(scalaVersion: String) = {
     "-Wconf:src=*.BasePCSuite.scala&msg=parameter (scalaVersion|classpath) in method (extraDependencies|scalacOptions):silent",
     "-Wconf:src=*.CodeLens.scala&msg=parameter (textDocumentWithPath|path) in method codeLenses is never used:silent",
     "-Wconf:src=*.Completions.scala&msg=parameter (member|m) in method (isCandidate|isPrioritized):silent",
-    "-Wconf:src=*.JavaMtags.scala&msg=parameter (info|ctor|method) in method (visitConstructor|visitMethod|visitClass):silent",
+    "-Wconf:src=*.JavaMtags.scala&msg=parameter info in method (visitConstructor|visitMethod):silent",
     "-Wconf:src=*.MtagsIndexer.scala&msg=parameter owner in method visitOccurrence:silent",
     "-Wconf:src=*.ScaladocParser.scala&msg=parameter (pos|message) in method reportError:silent",
     "-Wconf:src=*.TreeViewProvider.scala&msg=parameter params in method (children|parent) is never used:silent",

--- a/build.sbt
+++ b/build.sbt
@@ -166,7 +166,7 @@ def lintingOptions(scalaVersion: String) = {
     "-Wconf:src=*.BasePCSuite.scala&msg=parameter (scalaVersion|classpath) in method (extraDependencies|scalacOptions):silent",
     "-Wconf:src=*.CodeLens.scala&msg=parameter (textDocumentWithPath|path) in method codeLenses is never used:silent",
     "-Wconf:src=*.Completions.scala&msg=parameter (member|m) in method (isCandidate|isPrioritized):silent",
-    "-Wconf:src=*.JavaMtags.scala&msg=parameter (ctor|method) in method (visitConstructor|visitMethod):silent",
+    "-Wconf:src=*.JavaMtags.scala&msg=parameter (info|ctor|method) in method (visitConstructor|visitMethod|visitClass):silent",
     "-Wconf:src=*.MtagsIndexer.scala&msg=parameter owner in method visitOccurrence:silent",
     "-Wconf:src=*.ScaladocParser.scala&msg=parameter (pos|message) in method reportError:silent",
     "-Wconf:src=*.TreeViewProvider.scala&msg=parameter params in method (children|parent) is never used:silent",
@@ -334,7 +334,8 @@ val mtagsSettings = List(
   ),
   libraryDependencies ++= Seq(
     "com.lihaoyi" %% "geny" % V.genyVersion,
-    "com.thoughtworks.qdox" % "qdox" % V.qdox, // for java mtags
+    "io.github.bonede" % "tree-sitter" % V.treeSitter, // for java mtags
+    "io.github.bonede" % "tree-sitter-java" % V.treeSitterJava, // for java mtags
     "org.scala-lang.modules" %% "scala-java8-compat" % V.java8Compat,
     "org.jsoup" % "jsoup" % V.jsoup, // for extracting HTML from javadocs
     // for ivy completions

--- a/mtags/src/main/scala/scala/meta/internal/metals/JavadocIndexer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JavadocIndexer.scala
@@ -8,7 +8,12 @@ import scala.meta.inputs.Input
 import scala.meta.inputs.Position
 import scala.meta.internal.docstrings.printers.MarkdownGenerator
 import scala.meta.internal.jdk.CollectionConverters._
+import scala.meta.internal.mtags.JavaClassInfo
+import scala.meta.internal.mtags.JavaConstructorInfo
+import scala.meta.internal.mtags.JavaMethodInfo
 import scala.meta.internal.mtags.JavaMtags
+import scala.meta.internal.mtags.JavadocComment
+import scala.meta.internal.mtags.JavadocParser
 import scala.meta.internal.semanticdb.Scala.Descriptor
 import scala.meta.internal.semanticdb.Scala.Symbols
 import scala.meta.internal.semanticdb.SymbolInformation
@@ -17,14 +22,6 @@ import scala.meta.pc.ContentType.MARKDOWN
 import scala.meta.pc.ContentType.PLAINTEXT
 import scala.meta.pc.SymbolDocumentation
 import scala.meta.pc.reports.ReportContext
-
-import com.thoughtworks.qdox.model.JavaAnnotatedElement
-import com.thoughtworks.qdox.model.JavaClass
-import com.thoughtworks.qdox.model.JavaConstructor
-import com.thoughtworks.qdox.model.JavaGenericDeclaration
-import com.thoughtworks.qdox.model.JavaMethod
-import com.thoughtworks.qdox.model.JavaParameter
-import com.thoughtworks.qdox.model.JavaTypeVariable
 
 /**
  * Extracts Javadoc from Java source code.
@@ -35,16 +32,18 @@ class JavadocIndexer(
     contentType: ContentType
 )(implicit rc: ReportContext)
     extends JavaMtags(input, includeMembers = true) {
+
   override def visitClass(
-      cls: JavaClass,
+      info: JavaClassInfo,
       pos: Position,
       kind: SymbolInformation.Kind
   ): Unit = {
-    super.visitClass(cls, pos, kind)
-    fn(fromClass(currentOwner, cls))
+    super.visitClass(info, pos, kind)
+    fn(fromClass(currentOwner, info))
   }
+
   override def visitConstructor(
-      ctor: JavaConstructor,
+      info: JavaConstructorInfo,
       disambiguator: String,
       pos: Position,
       properties: Int
@@ -52,12 +51,13 @@ class JavadocIndexer(
     fn(
       fromConstructor(
         symbol(Descriptor.Method("<init>", disambiguator)),
-        ctor
+        info
       )
     )
   }
+
   override def visitMethod(
-      method: JavaMethod,
+      info: JavaMethodInfo,
       name: String,
       disambiguator: String,
       pos: Position,
@@ -66,63 +66,73 @@ class JavadocIndexer(
     fn(
       fromMethod(
         symbol(Descriptor.Method(name, disambiguator)),
-        method
+        info
       )
     )
   }
 
-  def toContent(e: JavaAnnotatedElement): String = {
-    val comment = Option(e.getComment).getOrElse("")
+  private def toContent(javadocComment: Option[String]): String = {
+    val comment = javadocComment
+      .flatMap { raw =>
+        JavadocParser.parse(raw).map(_.body)
+      }
+      .getOrElse("")
     contentType match {
       case MARKDOWN =>
         try MarkdownGenerator.fromDocstring(s"/**$comment\n*/", Map.empty)
         catch {
-          case NonFatal(_) =>
-            // The Scaladoc parser implementation uses fragile regexp processing which
-            // sometimes causes exceptions.
-            comment
+          case NonFatal(_) => comment
         }
       case PLAINTEXT => comment
     }
   }
 
-  def fromMethod(symbol: String, method: JavaMethod): SymbolDocumentation = {
+  def fromMethod(
+      symbol: String,
+      info: JavaMethodInfo
+  ): SymbolDocumentation = {
+    val javadoc = info.javadocComment.flatMap(JavadocParser.parse)
     new MetalsSymbolDocumentation(
       symbol,
-      method.getName,
-      toContent(method),
+      info.name,
+      toContent(info.javadocComment),
       "",
-      typeParameters(symbol, method, method.getTypeParameters),
-      parameters(symbol, method, method.getParameters)
+      typeParameters(symbol, javadoc, info.typeParameterNames),
+      parameters(symbol, javadoc, info.parameterNames)
     )
   }
+
   def fromClass(
       symbol: String,
-      method: JavaClass
+      info: JavaClassInfo
   ): SymbolDocumentation = {
+    val javadoc = info.javadocComment.flatMap(JavadocParser.parse)
     new MetalsSymbolDocumentation(
       symbol,
-      method.getName,
-      toContent(method),
+      info.name,
+      toContent(info.javadocComment),
       "",
-      typeParameters(symbol, method, method.getTypeParameters),
+      typeParameters(symbol, javadoc, info.typeParameterNames),
       Nil.asJava
     )
   }
+
   def fromConstructor(
       symbol: String,
-      method: JavaConstructor
+      info: JavaConstructorInfo
   ): SymbolDocumentation = {
+    val javadoc = info.javadocComment.flatMap(JavadocParser.parse)
     new MetalsSymbolDocumentation(
       symbol,
-      method.getName,
-      toContent(method),
+      info.name,
+      toContent(info.javadocComment),
       "",
-      typeParameters(symbol, method, method.getTypeParameters),
-      parameters(symbol, method, method.getParameters)
+      typeParameters(symbol, javadoc, info.typeParameterNames),
+      parameters(symbol, javadoc, info.parameterNames)
     )
   }
-  def param(
+
+  private def param(
       symbol: String,
       name: String,
       docstring: String
@@ -133,42 +143,49 @@ class JavadocIndexer(
       if (docstring == null) "" else docstring,
       ""
     )
-  def typeParameters[D <: JavaGenericDeclaration](
+
+  private def typeParameters(
       owner: String,
-      method: JavaAnnotatedElement,
-      tparams: util.List[JavaTypeVariable[D]]
+      javadoc: Option[JavadocComment],
+      tparamNames: List[String]
   ): util.List[SymbolDocumentation] = {
-    tparams.asScala.map { tparam =>
-      val tparamName = s"<${tparam.getName}>"
-      val docstring = method.getTagsByName("param").asScala.collectFirst {
-        case tag if tag.getValue.startsWith(tparamName) =>
-          tag.getValue
-      }
+    tparamNames.map { tparamName =>
+      val tparamTag = s"<$tparamName>"
+      val docstring = javadoc.toList
+        .flatMap(_.tagsByName("param"))
+        .collectFirst {
+          case tag if tag.value.startsWith(tparamTag) =>
+            tag.value
+        }
       this.param(
-        Symbols.Global(owner, Descriptor.TypeParameter(tparam.getName)),
-        tparam.getName,
+        Symbols.Global(owner, Descriptor.TypeParameter(tparamName)),
+        tparamName,
         docstring.getOrElse("")
       )
     }.asJava
   }
-  def parameters(
+
+  private def parameters(
       owner: String,
-      method: JavaAnnotatedElement,
-      params: util.List[JavaParameter]
+      javadoc: Option[JavadocComment],
+      paramNames: List[String]
   ): util.List[SymbolDocumentation] = {
-    params.asScala.map { param =>
-      val docstring = method.getTagsByName("param").asScala.collectFirst {
-        case tag if tag.getValue.startsWith(param.getName) =>
-          tag.getValue
-      }
+    paramNames.map { paramName =>
+      val docstring = javadoc.toList
+        .flatMap(_.tagsByName("param"))
+        .collectFirst {
+          case tag if tag.value.startsWith(paramName) =>
+            tag.value
+        }
       this.param(
-        Symbols.Global(owner, Descriptor.Parameter(param.getName)),
-        param.getName,
+        Symbols.Global(owner, Descriptor.Parameter(paramName)),
+        paramName,
         docstring.getOrElse("")
       )
     }.asJava
   }
 }
+
 object JavadocIndexer {
   def all(
       input: Input.VirtualFile,

--- a/mtags/src/main/scala/scala/meta/internal/metals/JavadocIndexer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JavadocIndexer.scala
@@ -174,7 +174,10 @@ class JavadocIndexer(
       val docstring = javadoc.toList
         .flatMap(_.tagsByName("param"))
         .collectFirst {
-          case tag if tag.value.startsWith(paramName) =>
+          case tag
+              if tag.value.startsWith(paramName) &&
+                (tag.value.length == paramName.length ||
+                  tag.value.charAt(paramName.length).isWhitespace) =>
             tag.value
         }
       this.param(

--- a/mtags/src/main/scala/scala/meta/internal/metals/JavadocIndexer.scala
+++ b/mtags/src/main/scala/scala/meta/internal/metals/JavadocIndexer.scala
@@ -72,18 +72,20 @@ class JavadocIndexer(
   }
 
   private def toContent(javadocComment: Option[String]): String = {
-    val comment = javadocComment
-      .flatMap { raw =>
-        JavadocParser.parse(raw).map(_.body)
-      }
+    val raw = javadocComment.getOrElse("")
+    if (raw.isEmpty) return ""
+    val body = javadocComment
+      .flatMap(JavadocParser.parse)
+      .map(_.body)
       .getOrElse("")
     contentType match {
       case MARKDOWN =>
-        try MarkdownGenerator.fromDocstring(s"/**$comment\n*/", Map.empty)
+        // Pass the full raw Javadoc to preserve @return, @throws, etc.
+        try MarkdownGenerator.fromDocstring(raw, Map.empty)
         catch {
-          case NonFatal(_) => comment
+          case NonFatal(_) => body
         }
-      case PLAINTEXT => comment
+      case PLAINTEXT => body
     }
   }
 
@@ -155,7 +157,7 @@ class JavadocIndexer(
         .flatMap(_.tagsByName("param"))
         .collectFirst {
           case tag if tag.value.startsWith(tparamTag) =>
-            tag.value
+            tag.value.substring(tparamTag.length).trim
         }
       this.param(
         Symbols.Global(owner, Descriptor.TypeParameter(tparamName)),
@@ -178,7 +180,7 @@ class JavadocIndexer(
               if tag.value.startsWith(paramName) &&
                 (tag.value.length == paramName.length ||
                   tag.value.charAt(paramName.length).isWhitespace) =>
-            tag.value
+            tag.value.substring(paramName.length).trim
         }
       this.param(
         Symbols.Global(owner, Descriptor.Parameter(paramName)),

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaDeclarationInfo.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaDeclarationInfo.scala
@@ -1,0 +1,47 @@
+package scala.meta.internal.mtags
+
+/**
+ * Lightweight case classes carrying extracted data from Java declarations.
+ * These decouple JavadocIndexer from the tree-sitter node model.
+ */
+sealed trait JavaDeclarationInfo {
+  def name: String
+  def javadocComment: Option[String]
+  def parameterNames: List[String]
+  def typeParameterNames: List[String]
+}
+
+case class JavaClassInfo(
+    name: String,
+    javadocComment: Option[String],
+    typeParameterNames: List[String],
+    isInterface: Boolean,
+    isEnum: Boolean
+) extends JavaDeclarationInfo {
+  val parameterNames: List[String] = Nil
+}
+
+case class JavaMethodInfo(
+    name: String,
+    javadocComment: Option[String],
+    parameterNames: List[String],
+    typeParameterNames: List[String],
+    isStatic: Boolean
+) extends JavaDeclarationInfo
+
+case class JavaConstructorInfo(
+    name: String,
+    javadocComment: Option[String],
+    parameterNames: List[String],
+    typeParameterNames: List[String],
+    isPrivate: Boolean
+) extends JavaDeclarationInfo
+
+case class JavaFieldInfo(
+    name: String,
+    javadocComment: Option[String],
+    isEnumConstant: Boolean
+) extends JavaDeclarationInfo {
+  val parameterNames: List[String] = Nil
+  val typeParameterNames: List[String] = Nil
+}

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaDeclarationInfo.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaDeclarationInfo.scala
@@ -18,6 +18,7 @@ case class JavaClassInfo(
     isInterface: Boolean,
     isEnum: Boolean
 ) extends JavaDeclarationInfo {
+  // Records have component parameters, but we don't extract them yet.
   val parameterNames: List[String] = Nil
 }
 

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaDeclarationInfo.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaDeclarationInfo.scala
@@ -34,8 +34,7 @@ case class JavaConstructorInfo(
     name: String,
     javadocComment: Option[String],
     parameterNames: List[String],
-    typeParameterNames: List[String],
-    isPrivate: Boolean
+    typeParameterNames: List[String]
 ) extends JavaDeclarationInfo
 
 case class JavaFieldInfo(

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
@@ -1,17 +1,12 @@
 package scala.meta.internal.mtags
 
-import java.io.StringReader
 import java.net.URI
-import java.util.Comparator
 import java.util.Optional
 
 import scala.util.control.NonFatal
 
 import scala.meta.inputs.Input
 import scala.meta.inputs.Position
-import scala.meta.internal.jdk.CollectionConverters._
-import scala.meta.internal.metals.CompilerRangeParamsUtils
-import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.metals.Report
 import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 import scala.meta.internal.semanticdb.Language
@@ -19,126 +14,189 @@ import scala.meta.internal.semanticdb.SymbolInformation.Kind
 import scala.meta.internal.semanticdb.SymbolInformation.Property
 import scala.meta.pc.reports.ReportContext
 
-import com.thoughtworks.qdox._
-import com.thoughtworks.qdox.model.JavaClass
-import com.thoughtworks.qdox.model.JavaConstructor
-import com.thoughtworks.qdox.model.JavaField
-import com.thoughtworks.qdox.model.JavaMember
-import com.thoughtworks.qdox.model.JavaMethod
-import com.thoughtworks.qdox.model.JavaModel
-import com.thoughtworks.qdox.parser.ParseException
-import org.eclipse.lsp4j
+import org.treesitter.TSNode
+import org.treesitter.TSParser
+import org.treesitter.TSTree
+import org.treesitter.TreeSitterJava
 
 object JavaMtags {
+  private val threadLocalParser: ThreadLocal[TSParser] =
+    ThreadLocal.withInitial { () =>
+      val parser = new TSParser()
+      parser.setLanguage(new TreeSitterJava())
+      parser
+    }
+
   def index(
       input: Input.VirtualFile,
       includeMembers: Boolean
   )(implicit rc: ReportContext): MtagsIndexer =
     new JavaMtags(input, includeMembers)
 }
+
 class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
     implicit rc: ReportContext
 ) extends MtagsIndexer { self =>
-  val builder = new JavaProjectBuilder()
   override def language: Language = Language.JAVA
 
   override def input: Input.VirtualFile = virtualFile
 
   override def indexRoot(): Unit = {
+    val parser = JavaMtags.threadLocalParser.get()
+    var tree: TSTree = null
     try {
-      val source = builder.addSource(new StringReader(input.value))
-      if (source.getPackage != null) {
-        source.getPackageName.split("\\.").foreach { p =>
-          pkg(
-            p,
-            toRangePosition(source.getPackage.lineNumber, p)
-          )
-        }
-      }
-      source.getClasses.asScala.foreach(visitClass)
+      tree = parser.parseString(null, input.value)
+      val root = tree.getRootNode()
+      walkProgram(root)
     } catch {
-      case e: ParseException =>
-        reportError(
-          "parse error",
-          e,
-          Some(new lsp4j.Position(e.getLine() - 1, e.getColumn()))
-        )
-      case e: NullPointerException =>
-        reportError("null pointer exception", e, None)
+      case NonFatal(e: Exception) =>
+        reportError("tree-sitter parse error", e)
+      case NonFatal(_) =>
+    } finally {
+      if (tree != null) tree.close()
     }
   }
 
-  /**
-   * Computes the start/end offsets from a name in a line number.
-   *
-   * Applies a simple heuristic to find the name: the first occurence of
-   * name in that line. If the name does not appear in the line then
-   * 0 is returned. If the name appears for example in the return type
-   * of a method then we get the position of the return type, not the
-   * end of the world.
-   */
-  def toRangePosition(line: Int, name: String): Position = {
-    val offset = input.toOffset(line, 0)
-    val columnAndLength = {
-      val fromIndex = {
-        // HACK(olafur) avoid hitting on substrings of "package".
-        if (input.value.startsWith("package", offset)) "package".length
-        else offset
+  private def walkProgram(root: TSNode): Unit = {
+    val childCount = root.getNamedChildCount()
+    var i = 0
+    while (i < childCount) {
+      val child = root.getNamedChild(i)
+      child.getType() match {
+        case "package_declaration" =>
+          walkPackageDeclaration(child)
+        case "class_declaration" | "interface_declaration" |
+            "enum_declaration" | "record_declaration" |
+            "annotation_type_declaration" =>
+          visitClassNode(child)
+        case _ => // skip imports, comments at top level, etc.
       }
-      val idx = input.value.indexOf(" " + name, fromIndex)
-      if (idx == -1) (0, 0)
-      else (idx - offset + " ".length, name.length)
+      i += 1
     }
-    input.toPosition(
-      line,
-      columnAndLength._1,
-      line,
-      columnAndLength._1 + columnAndLength._2
-    )
   }
 
-  def visitMembers[T <: JavaMember](cls: JavaClass): Unit = {
-    val fields = cls.getFields
-    if (fields == null) ()
-    else fields.asScala.foreach(visitMember(cls, _))
+  private def walkPackageDeclaration(node: TSNode): Unit = {
+    val nameNode = findPackageName(node)
+    if (nameNode != null) {
+      val parts = extractScopedIdentifierParts(nameNode)
+      parts.foreach { case (name, startPoint, endPoint) =>
+        pkg(
+          name,
+          input.toPosition(
+            startPoint.getRow(),
+            startPoint.getColumn(),
+            endPoint.getRow(),
+            endPoint.getColumn()
+          )
+        )
+      }
+    }
   }
 
-  def visitClasses(classes: java.util.List[JavaClass]): Unit =
-    if (classes == null) ()
-    else classes.asScala.foreach(visitClass)
+  private def findPackageName(pkgNode: TSNode): TSNode = {
+    val childCount = pkgNode.getNamedChildCount()
+    var i = 0
+    while (i < childCount) {
+      val child = pkgNode.getNamedChild(i)
+      val tpe = child.getType()
+      if (tpe == "scoped_identifier" || tpe == "identifier") return child
+      i += 1
+    }
+    null
+  }
+
+  private def extractScopedIdentifierParts(
+      node: TSNode
+  ): List[(String, org.treesitter.TSPoint, org.treesitter.TSPoint)] = {
+    node.getType() match {
+      case "identifier" =>
+        val text = nodeText(node)
+        List((text, node.getStartPoint(), node.getEndPoint()))
+      case "scoped_identifier" =>
+        val scope = node.getChildByFieldName("scope")
+        val name = node.getChildByFieldName("name")
+        val scopeParts =
+          if (scope != null && !scope.isNull())
+            extractScopedIdentifierParts(scope)
+          else Nil
+        val nameParts =
+          if (name != null && !name.isNull()) {
+            val text = nodeText(name)
+            List((text, name.getStartPoint(), name.getEndPoint()))
+          } else Nil
+        scopeParts ++ nameParts
+      case _ => Nil
+    }
+  }
 
   def visitClass(
-      cls: JavaClass,
+      info: JavaClassInfo,
       pos: Position,
       kind: Kind
   ): Unit = {
     tpe(
-      cls.getName,
+      info.name,
       pos,
       kind,
-      if (cls.isEnum) Property.ENUM.value else 0
+      if (info.isEnum) Property.ENUM.value else 0
     )
   }
 
-  def visitClass(cls: JavaClass): Unit =
+  private def visitClassNode(node: TSNode): Unit =
     withOwner(owner) {
-      val kind = if (cls.isInterface) Kind.INTERFACE else Kind.CLASS
-      val pos = toRangePosition(cls.lineNumber, cls.getName)
-      visitClass(
-        cls,
-        pos,
-        kind
-      )
-      visitClasses(cls.getNestedClasses)
-      if (includeMembers) {
-        visitMethods(cls)
-        visitConstructors(cls)
-        visitMembers(cls)
+      val nameNode = node.getChildByFieldName("name")
+      if (nameNode != null && !nameNode.isNull()) {
+        val name = nodeText(nameNode)
+        val nodeType = node.getType()
+        val isInterface = nodeType == "interface_declaration" ||
+          nodeType == "annotation_type_declaration"
+        val isEnum = nodeType == "enum_declaration"
+        val kind = if (isInterface) Kind.INTERFACE else Kind.CLASS
+        val pos = nodePosition(nameNode)
+        val javadoc = findJavadocComment(node)
+        val typeParams = extractTypeParameterNames(node)
+
+        val info = JavaClassInfo(
+          name = name,
+          javadocComment = javadoc,
+          typeParameterNames = typeParams,
+          isInterface = isInterface,
+          isEnum = isEnum
+        )
+
+        visitClass(info, pos, kind)
+
+        // Visit nested classes
+        val body = node.getChildByFieldName("body")
+        if (body != null && !body.isNull()) {
+          visitNestedClasses(body)
+          if (includeMembers) {
+            visitMethods(body)
+            visitConstructors(body, name)
+            visitFields(body, isEnum)
+          }
+        }
       }
     }
 
+  private def visitNestedClasses(body: TSNode): Unit = {
+    val childCount = body.getNamedChildCount()
+    var i = 0
+    while (i < childCount) {
+      val child = body.getNamedChild(i)
+      child.getType() match {
+        case "class_declaration" | "interface_declaration" |
+            "enum_declaration" | "record_declaration" |
+            "annotation_type_declaration" =>
+          visitClassNode(child)
+        case _ =>
+      }
+      i += 1
+    }
+  }
+
   def visitConstructor(
-      ctor: JavaConstructor,
+      info: JavaConstructorInfo,
       disambiguator: String,
       pos: Position,
       properties: Int
@@ -146,24 +204,42 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
     super.ctor(disambiguator, pos, properties)
   }
 
-  def visitConstructors(cls: JavaClass): Unit = {
+  private def visitConstructors(body: TSNode, className: String): Unit = {
     val overloads = new OverloadDisambiguator()
-    cls.getConstructors
-      .iterator()
-      .asScala
-      .filterNot(_.isPrivate)
-      .foreach { ctor =>
-        val name = cls.getName
-        val disambiguator = overloads.disambiguator(name)
-        val pos = toRangePosition(ctor.lineNumber, name)
-        withOwner() {
-          visitConstructor(ctor, disambiguator, pos, 0)
+    val childCount = body.getNamedChildCount()
+    var i = 0
+    while (i < childCount) {
+      val child = body.getNamedChild(i)
+      if (child.getType() == "constructor_declaration") {
+        if (!isPrivateNode(child)) {
+          val disambiguator = overloads.disambiguator(className)
+          val nameNode = child.getChildByFieldName("name")
+          val pos =
+            if (nameNode != null && !nameNode.isNull()) nodePosition(nameNode)
+            else nodePosition(child)
+          val javadoc = findJavadocComment(child)
+          val paramNames = extractParameterNames(child)
+          val typeParams = extractTypeParameterNames(child)
+
+          val info = JavaConstructorInfo(
+            name = className,
+            javadocComment = javadoc,
+            parameterNames = paramNames,
+            typeParameterNames = typeParams,
+            isPrivate = false
+          )
+
+          withOwner() {
+            visitConstructor(info, disambiguator, pos, 0)
+          }
         }
       }
+      i += 1
+    }
   }
 
   def visitMethod(
-      method: JavaMethod,
+      info: JavaMethodInfo,
       name: String,
       disambiguator: String,
       pos: Position,
@@ -172,75 +248,266 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
     super.method(name, disambiguator, pos, properties)
   }
 
-  def visitMethods(cls: JavaClass): Unit = {
+  private def visitMethods(body: TSNode): Unit = {
     val overloads = new OverloadDisambiguator()
-    val methods = cls.getMethods
-    methods.sort(new Comparator[JavaMethod] {
-      override def compare(o1: JavaMethod, o2: JavaMethod): Int = {
-        java.lang.Boolean.compare(o1.isStatic, o2.isStatic)
-      }
-    })
-    methods.asScala.foreach { method =>
-      val name = method.getName
-      val disambiguator = overloads.disambiguator(name)
-      val line =
-        if (method.lineNumber == -1) cls.lineNumber else method.lineNumber
-      val pos = toRangePosition(line, name)
-      withOwner() {
-        visitMethod(method, name, disambiguator, pos, 0)
+    // Collect methods, sort static last for overload disambiguation compatibility
+    val methods = collectMethods(body)
+    val sorted = methods.sortWith { case ((_, isStatic1), (_, isStatic2)) =>
+      java.lang.Boolean.compare(isStatic1, isStatic2) < 0
+    }
+
+    sorted.foreach { case (methodNode, _) =>
+      val nameNode = methodNode.getChildByFieldName("name")
+      if (nameNode != null && !nameNode.isNull()) {
+        val name = nodeText(nameNode)
+        val disambiguator = overloads.disambiguator(name)
+        val pos = nodePosition(nameNode)
+        val javadoc = findJavadocComment(methodNode)
+        val paramNames = extractParameterNames(methodNode)
+        val typeParams = extractTypeParameterNames(methodNode)
+        val isStatic = hasModifier(methodNode, "static")
+
+        val info = JavaMethodInfo(
+          name = name,
+          javadocComment = javadoc,
+          parameterNames = paramNames,
+          typeParameterNames = typeParams,
+          isStatic = isStatic
+        )
+
+        withOwner() {
+          visitMethod(info, name, disambiguator, pos, 0)
+        }
       }
     }
   }
 
-  def visitMember[T <: JavaMember](cls: JavaClass, m: T): Unit =
-    withOwner(owner) {
-      val name = m.getName
-      val line = m match {
-        case c: JavaMethod => c.lineNumber
-        case c: JavaField => c.lineNumber
-        case _ => 0
+  private def collectMethods(
+      body: TSNode
+  ): List[(TSNode, Boolean)] = {
+    val builder = List.newBuilder[(TSNode, Boolean)]
+    val childCount = body.getNamedChildCount()
+    var i = 0
+    while (i < childCount) {
+      val child = body.getNamedChild(i)
+      if (child.getType() == "method_declaration") {
+        val isStatic = hasModifier(child, "static")
+        builder += ((child, isStatic))
       }
-      val actualLine =
-        if (line == -1) cls.lineNumber
-        else line
-      val pos = toRangePosition(actualLine, name)
-      val (kind: Kind, properties: Int) = m match {
-        case _: JavaMethod => (Kind.METHOD, 0)
-        case field: JavaField if field.isEnumConstant() =>
-          (Kind.FIELD, Property.ENUM.value)
-        case _: JavaField =>
-          (Kind.FIELD, 0)
-        case c: JavaClass =>
-          if (c.isInterface) (Kind.INTERFACE, 0)
-          else (Kind.CLASS, 0)
-        case _ => (Kind.UNKNOWN_KIND, 0)
-      }
-      term(name, pos, kind, properties)
+      i += 1
     }
+    builder.result()
+  }
 
-  implicit class XtensionJavaModel(m: JavaModel) {
-    def lineNumber: Int = m.getLineNumber - 1
+  private def visitFields(body: TSNode, isEnum: Boolean): Unit = {
+    val childCount = body.getNamedChildCount()
+    var i = 0
+    while (i < childCount) {
+      val child = body.getNamedChild(i)
+      child.getType() match {
+        case "field_declaration" =>
+          visitFieldDeclaration(child, isEnumConstant = false)
+        case "enum_constant" if isEnum =>
+          visitEnumConstant(child)
+        case _ =>
+      }
+      i += 1
+    }
+  }
+
+  private def visitFieldDeclaration(
+      node: TSNode,
+      isEnumConstant: Boolean
+  ): Unit = {
+    // field_declaration has a "declarator" field which is a variable_declarator
+    val childCount = node.getNamedChildCount()
+    var i = 0
+    while (i < childCount) {
+      val child = node.getNamedChild(i)
+      if (child.getType() == "variable_declarator") {
+        val nameNode = child.getChildByFieldName("name")
+        if (nameNode != null && !nameNode.isNull()) {
+          val name = nodeText(nameNode)
+          val pos = nodePosition(nameNode)
+          val kind =
+            if (isEnumConstant) Kind.FIELD
+            else Kind.FIELD
+          val properties =
+            if (isEnumConstant) Property.ENUM.value
+            else 0
+          withOwner(owner) {
+            term(name, pos, kind, properties)
+          }
+        }
+      }
+      i += 1
+    }
+  }
+
+  private def visitEnumConstant(node: TSNode): Unit = {
+    val nameNode = node.getChildByFieldName("name")
+    if (nameNode != null && !nameNode.isNull()) {
+      val name = nodeText(nameNode)
+      val pos = nodePosition(nameNode)
+      withOwner(owner) {
+        term(name, pos, Kind.FIELD, Property.ENUM.value)
+      }
+    }
+  }
+
+  // --- Helper methods ---
+
+  // Lazily compute UTF-8 bytes for proper byte-offset-based text extraction
+  private lazy val utf8Bytes: Array[Byte] =
+    input.value.getBytes("UTF-8")
+
+  protected def nodeText(node: TSNode): String = {
+    val startByte = node.getStartByte()
+    val endByte = node.getEndByte()
+    new String(utf8Bytes, startByte, endByte - startByte, "UTF-8")
+  }
+
+  protected def nodePosition(node: TSNode): Position = {
+    // TSPoint columns are byte offsets from line start in UTF-8.
+    // For Java identifiers (always ASCII), byte offset = char offset.
+    val start = node.getStartPoint()
+    val end = node.getEndPoint()
+    input.toPosition(
+      start.getRow(),
+      start.getColumn(),
+      end.getRow(),
+      end.getColumn()
+    )
+  }
+
+  protected def findJavadocComment(node: TSNode): Option[String] = {
+    var sibling = node.getPrevSibling()
+    // Skip annotations and line comments to find the Javadoc block_comment
+    while (sibling != null && !sibling.isNull()) {
+      sibling.getType() match {
+        case "block_comment" =>
+          val text = nodeText(sibling)
+          if (text.startsWith("/**")) return Some(text)
+          else return None
+        case "line_comment" | "marker_annotation" | "annotation" =>
+          sibling = sibling.getPrevSibling()
+        case _ =>
+          return None
+      }
+    }
+    None
+  }
+
+  private def isPrivateNode(node: TSNode): Boolean =
+    hasModifier(node, "private")
+
+  private def hasModifier(node: TSNode, modifier: String): Boolean = {
+    val childCount = node.getNamedChildCount()
+    var i = 0
+    while (i < childCount) {
+      val child = node.getNamedChild(i)
+      if (child.getType() == "modifiers") {
+        val modCount = child.getNamedChildCount()
+        var j = 0
+        while (j < modCount) {
+          val mod = child.getNamedChild(j)
+          if (nodeText(mod) == modifier) return true
+          j += 1
+        }
+        // Also check unnamed children for simple modifiers
+        val totalCount = child.getChildCount()
+        var k = 0
+        while (k < totalCount) {
+          val mod = child.getChild(k)
+          if (nodeText(mod) == modifier) return true
+          k += 1
+        }
+        return false
+      }
+      i += 1
+    }
+    false
+  }
+
+  protected def extractParameterNames(node: TSNode): List[String] = {
+    val params = node.getChildByFieldName("parameters")
+    if (params == null || params.isNull()) return Nil
+    val builder = List.newBuilder[String]
+    val childCount = params.getNamedChildCount()
+    var i = 0
+    while (i < childCount) {
+      val child = params.getNamedChild(i)
+      child.getType() match {
+        case "formal_parameter" =>
+          val nameNode = child.getChildByFieldName("name")
+          if (nameNode != null && !nameNode.isNull()) {
+            builder += nodeText(nameNode)
+          }
+        case "spread_parameter" =>
+          // Varargs: name is in a variable_declarator or direct identifier child
+          val nameNode = child.getChildByFieldName("name")
+          if (nameNode != null && !nameNode.isNull()) {
+            builder += nodeText(nameNode)
+          } else {
+            // Fallback: find variable_declarator or identifier child
+            val paramName = findSpreadParamName(child)
+            if (paramName != null) builder += paramName
+          }
+        case _ =>
+      }
+      i += 1
+    }
+    builder.result()
+  }
+
+  private def findSpreadParamName(spreadParam: TSNode): String = {
+    val childCount = spreadParam.getNamedChildCount()
+    var i = 0
+    while (i < childCount) {
+      val child = spreadParam.getNamedChild(i)
+      child.getType() match {
+        case "variable_declarator" =>
+          // variable_declarator contains the name as its text
+          val nameNode = child.getChildByFieldName("name")
+          if (nameNode != null && !nameNode.isNull()) return nodeText(nameNode)
+          else return nodeText(child)
+        case "identifier" =>
+          // Check if this is the parameter name (not the type)
+          // Type is type_identifier, name is identifier
+          return nodeText(child)
+        case _ =>
+      }
+      i += 1
+    }
+    null
+  }
+
+  protected def extractTypeParameterNames(node: TSNode): List[String] = {
+    val tparams = node.getChildByFieldName("type_parameters")
+    if (tparams == null || tparams.isNull()) return Nil
+    val builder = List.newBuilder[String]
+    val childCount = tparams.getNamedChildCount()
+    var i = 0
+    while (i < childCount) {
+      val child = tparams.getNamedChild(i)
+      if (child.getType() == "type_parameter") {
+        // The first named child of type_parameter is the type_identifier
+        val nameCount = child.getNamedChildCount()
+        if (nameCount > 0) {
+          val nameNode = child.getNamedChild(0)
+          builder += nodeText(nameNode)
+        }
+      }
+      i += 1
+    }
+    builder.result()
   }
 
   private def reportError(
       errorName: String,
-      e: Exception,
-      position: Option[lsp4j.Position]
-  ) = {
+      e: Exception
+  ): Unit = {
     try {
-      val content = position
-        .flatMap(_.toMeta(virtualFile))
-        .map(pos =>
-          CompilerRangeParamsUtils.fromPos(pos, EmptyCancelToken).printed()
-        )
-        .map(content => s"""|
-                            |file content:
-                            |```java
-                            |$content
-                            |```
-                            |""".stripMargin)
-        .getOrElse("")
-
       val shortFileName = {
         val index = virtualFile.path.indexOf("jar!")
         if (index > 0) virtualFile.path.substring(index + 4)
@@ -250,12 +517,12 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
       rc.unsanitized()
         .create(() =>
           new Report(
-            name = "qdox-error",
-            text = s"""|error in qdox parser$content
+            name = "java-mtags-error",
+            text = s"""|error in tree-sitter java parser
                        |""".stripMargin,
             error = Some(e),
             path = Optional.of(new URI(virtualFile.path)),
-            shortSummary = s"QDox $errorName in $shortFileName",
+            shortSummary = s"Tree-sitter $errorName in $shortFileName",
             id = Optional.of(virtualFile.path)
           )
         )
@@ -263,5 +530,4 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
       case NonFatal(_) =>
     }
   }
-
 }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
@@ -54,9 +54,8 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
       val root = tree.getRootNode()
       walkProgram(root)
     } catch {
-      case NonFatal(e: Exception) =>
+      case NonFatal(e) =>
         reportError("tree-sitter parse error", e)
-      case NonFatal(_) =>
     } finally {
       if (tree != null) tree.close()
     }
@@ -243,8 +242,7 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
         childType == "constructor_declaration" ||
         childType == "compact_constructor_declaration"
       ) {
-        val isPrivate = isPrivateNode(child)
-        if (!isPrivate) {
+        if (!isPrivateNode(child)) {
           val disambiguator = overloads.disambiguator(className)
           val nameNode = child.getChildByFieldName("name")
           val pos =
@@ -258,8 +256,7 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
             name = className,
             javadocComment = javadoc,
             parameterNames = paramNames,
-            typeParameterNames = typeParams,
-            isPrivate = isPrivate
+            typeParameterNames = typeParams
           )
 
           withOwner() {
@@ -456,14 +453,7 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
     while (i < childCount) {
       val child = node.getNamedChild(i)
       if (child.getType() == "modifiers") {
-        val modCount = child.getNamedChildCount()
-        var j = 0
-        while (j < modCount) {
-          val mod = child.getNamedChild(j)
-          if (nodeText(mod) == modifier) return true
-          j += 1
-        }
-        // Also check unnamed children for simple modifiers
+        // Modifiers like "static", "private" are unnamed token children
         val totalCount = child.getChildCount()
         var k = 0
         while (k < totalCount) {
@@ -554,7 +544,7 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
 
   private def reportError(
       errorName: String,
-      e: Exception
+      e: Throwable
   ): Unit = {
     try {
       val shortFileName = {

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
@@ -19,7 +19,11 @@ import org.treesitter.TSParser
 import org.treesitter.TSTree
 import org.treesitter.TreeSitterJava
 
+// Tree-sitter node type reference:
+// https://github.com/tree-sitter/tree-sitter-java/blob/master/src/node-types.json
 object JavaMtags {
+  // ThreadLocal ensures thread safety. Re-entrancy on the same thread is not
+  // expected — JavaMtags.indexRoot() is always the top-level entry point.
   private val threadLocalParser: ThreadLocal[TSParser] =
     ThreadLocal.withInitial { () =>
       val parser = new TSParser()
@@ -45,6 +49,7 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
     val parser = JavaMtags.threadLocalParser.get()
     var tree: TSTree = null
     try {
+      // First arg is old tree for incremental re-parsing; null for fresh parse
       tree = parser.parseString(null, input.value)
       val root = tree.getRootNode()
       walkProgram(root)
@@ -176,7 +181,7 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
             visitFields(body, isEnum)
             // For enums, methods/constructors/nested classes may be in
             // enum_body_declarations
-            visitEnumBodyDeclarations(body, name, isEnum)
+            visitEnumBodyDeclarations(body, name)
           }
         }
       }
@@ -202,8 +207,7 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
 
   private def visitEnumBodyDeclarations(
       body: TSNode,
-      className: String,
-      isEnum: Boolean
+      className: String
   ): Unit = {
     val childCount = body.getNamedChildCount()
     var i = 0
@@ -233,8 +237,14 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
     var i = 0
     while (i < childCount) {
       val child = body.getNamedChild(i)
-      if (child.getType() == "constructor_declaration") {
-        if (!isPrivateNode(child)) {
+      val childType = child.getType()
+      // compact_constructor_declaration is used in Java records
+      if (
+        childType == "constructor_declaration" ||
+        childType == "compact_constructor_declaration"
+      ) {
+        val isPrivate = isPrivateNode(child)
+        if (!isPrivate) {
           val disambiguator = overloads.disambiguator(className)
           val nameNode = child.getChildByFieldName("name")
           val pos =
@@ -249,7 +259,7 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
             javadocComment = javadoc,
             parameterNames = paramNames,
             typeParameterNames = typeParams,
-            isPrivate = false
+            isPrivate = isPrivate
           )
 
           withOwner() {
@@ -313,9 +323,15 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
     var i = 0
     while (i < childCount) {
       val child = body.getNamedChild(i)
-      if (child.getType() == "method_declaration") {
-        val isStatic = hasModifier(child, "static")
-        builder += ((child, isStatic))
+      child.getType() match {
+        case "method_declaration" =>
+          val isStatic = hasModifier(child, "static")
+          builder += ((child, isStatic))
+        case "annotation_type_element_declaration" =>
+          // Annotation type elements (e.g. `String value() default ""`)
+          // are method-like declarations in @interface types
+          builder += ((child, false))
+        case _ =>
       }
       i += 1
     }
@@ -328,8 +344,9 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
     while (i < childCount) {
       val child = body.getNamedChild(i)
       child.getType() match {
-        case "field_declaration" =>
-          visitFieldDeclaration(child, isEnumConstant = false)
+        case "field_declaration" | "constant_declaration" =>
+          // constant_declaration appears in interfaces for constants
+          visitFieldDeclaration(child)
         case "enum_constant" if isEnum =>
           visitEnumConstant(child)
         case _ =>
@@ -338,11 +355,8 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
     }
   }
 
-  private def visitFieldDeclaration(
-      node: TSNode,
-      isEnumConstant: Boolean
-  ): Unit = {
-    // field_declaration has a "declarator" field which is a variable_declarator
+  private def visitFieldDeclaration(node: TSNode): Unit = {
+    // field_declaration has "declarator" children which are variable_declarators
     val childCount = node.getNamedChildCount()
     var i = 0
     while (i < childCount) {
@@ -352,14 +366,8 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
         if (nameNode != null && !nameNode.isNull()) {
           val name = nodeText(nameNode)
           val pos = nodePosition(nameNode)
-          val kind =
-            if (isEnumConstant) Kind.FIELD
-            else Kind.FIELD
-          val properties =
-            if (isEnumConstant) Property.ENUM.value
-            else 0
           withOwner(owner) {
-            term(name, pos, kind, properties)
+            term(name, pos, Kind.FIELD, 0)
           }
         }
       }
@@ -391,16 +399,34 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
   }
 
   protected def nodePosition(node: TSNode): Position = {
-    // TSPoint columns are byte offsets from line start in UTF-8.
-    // For Java identifiers (always ASCII), byte offset = char offset.
     val start = node.getStartPoint()
     val end = node.getEndPoint()
-    input.toPosition(
-      start.getRow(),
-      start.getColumn(),
-      end.getRow(),
+    val startCharCol = byteColumnToCharColumn(
+      node.getStartByte(),
+      start.getColumn()
+    )
+    val endCharCol = byteColumnToCharColumn(
+      node.getEndByte(),
       end.getColumn()
     )
+    input.toPosition(
+      start.getRow(),
+      startCharCol,
+      end.getRow(),
+      endCharCol
+    )
+  }
+
+  // TSPoint.getColumn() returns byte offsets from line start in UTF-8.
+  // input.toPosition expects character offsets. Convert by decoding the
+  // leading bytes on the line to count characters.
+  private def byteColumnToCharColumn(
+      nodeByte: Int,
+      byteColumn: Int
+  ): Int = {
+    if (byteColumn == 0) return 0
+    val lineStartByte = nodeByte - byteColumn
+    new String(utf8Bytes, lineStartByte, byteColumn, "UTF-8").length
   }
 
   protected def findJavadocComment(node: TSNode): Option[String] = {

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
@@ -82,17 +82,8 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
   private def walkPackageDeclaration(node: TSNode): Unit = {
     val nameNode = findPackageName(node)
     if (nameNode != null) {
-      val parts = extractScopedIdentifierParts(nameNode)
-      parts.foreach { case (name, startPoint, endPoint) =>
-        pkg(
-          name,
-          input.toPosition(
-            startPoint.getRow(),
-            startPoint.getColumn(),
-            endPoint.getRow(),
-            endPoint.getColumn()
-          )
-        )
+      extractScopedIdentifierParts(nameNode).foreach { part =>
+        pkg(nodeText(part), nodePosition(part))
       }
     }
   }
@@ -109,13 +100,10 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
     null
   }
 
-  private def extractScopedIdentifierParts(
-      node: TSNode
-  ): List[(String, org.treesitter.TSPoint, org.treesitter.TSPoint)] = {
+  private def extractScopedIdentifierParts(node: TSNode): List[TSNode] = {
     node.getType() match {
       case "identifier" =>
-        val text = nodeText(node)
-        List((text, node.getStartPoint(), node.getEndPoint()))
+        List(node)
       case "scoped_identifier" =>
         val scope = node.getChildByFieldName("scope")
         val name = node.getChildByFieldName("name")
@@ -124,10 +112,8 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
             extractScopedIdentifierParts(scope)
           else Nil
         val nameParts =
-          if (name != null && !name.isNull()) {
-            val text = nodeText(name)
-            List((text, name.getStartPoint(), name.getEndPoint()))
-          } else Nil
+          if (name != null && !name.isNull()) List(name)
+          else Nil
         scopeParts ++ nameParts
       case _ => Nil
     }
@@ -530,16 +516,25 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
     while (i < childCount) {
       val child = tparams.getNamedChild(i)
       if (child.getType() == "type_parameter") {
-        // The first named child of type_parameter is the type_identifier
-        val nameCount = child.getNamedChildCount()
-        if (nameCount > 0) {
-          val nameNode = child.getNamedChild(0)
-          builder += nodeText(nameNode)
-        }
+        // Find the type_identifier/identifier, skipping any leading annotations
+        val nameNode = findTypeParameterName(child)
+        if (nameNode != null) builder += nodeText(nameNode)
       }
       i += 1
     }
     builder.result()
+  }
+
+  private def findTypeParameterName(typeParam: TSNode): TSNode = {
+    val count = typeParam.getNamedChildCount()
+    var i = 0
+    while (i < count) {
+      val child = typeParam.getNamedChild(i)
+      val tpe = child.getType()
+      if (tpe == "type_identifier" || tpe == "identifier") return child
+      i += 1
+    }
+    null
   }
 
   private def reportError(

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavaMtags.scala
@@ -166,7 +166,7 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
 
         visitClass(info, pos, kind)
 
-        // Visit nested classes
+        // Visit nested classes and members
         val body = node.getChildByFieldName("body")
         if (body != null && !body.isNull()) {
           visitNestedClasses(body)
@@ -174,6 +174,9 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
             visitMethods(body)
             visitConstructors(body, name)
             visitFields(body, isEnum)
+            // For enums, methods/constructors/nested classes may be in
+            // enum_body_declarations
+            visitEnumBodyDeclarations(body, name, isEnum)
           }
         }
       }
@@ -189,7 +192,27 @@ class JavaMtags(virtualFile: Input.VirtualFile, includeMembers: Boolean)(
             "enum_declaration" | "record_declaration" |
             "annotation_type_declaration" =>
           visitClassNode(child)
+        case "enum_body_declarations" =>
+          visitNestedClasses(child)
         case _ =>
+      }
+      i += 1
+    }
+  }
+
+  private def visitEnumBodyDeclarations(
+      body: TSNode,
+      className: String,
+      isEnum: Boolean
+  ): Unit = {
+    val childCount = body.getNamedChildCount()
+    var i = 0
+    while (i < childCount) {
+      val child = body.getNamedChild(i)
+      if (child.getType() == "enum_body_declarations") {
+        visitMethods(child)
+        visitConstructors(child, className)
+        visitFields(child, isEnum = false)
       }
       i += 1
     }

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavadocParser.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavadocParser.scala
@@ -25,12 +25,12 @@ object JavadocParser {
   // Parse a raw block comment string (Javadoc delimiters included).
   // Returns None if the comment is not a Javadoc comment.
   def parse(rawComment: String): Option[JavadocComment] = {
-    if (rawComment == null || !rawComment.startsWith("/**"))
-      return None
-
-    val stripped = stripDelimiters(rawComment)
-    val (body, tags) = splitBodyAndTags(stripped)
-    Some(JavadocComment(body, tags))
+    if (rawComment == null || !rawComment.startsWith("/**")) None
+    else {
+      val stripped = stripDelimiters(rawComment)
+      val (body, tags) = splitBodyAndTags(stripped)
+      Some(JavadocComment(body, tags))
+    }
   }
 
   // Strips Javadoc delimiters and leading asterisks from each line.

--- a/mtags/src/main/scala/scala/meta/internal/mtags/JavadocParser.scala
+++ b/mtags/src/main/scala/scala/meta/internal/mtags/JavadocParser.scala
@@ -1,0 +1,97 @@
+package scala.meta.internal.mtags
+
+/**
+ * Structured representation of a parsed Javadoc comment.
+ */
+case class JavadocComment(
+    body: String,
+    tags: List[JavadocTag]
+) {
+  def tagsByName(name: String): List[JavadocTag] =
+    tags.filter(_.name == name)
+}
+
+case class JavadocTag(
+    name: String,
+    value: String
+)
+
+/**
+ * Parses raw Javadoc comment text (including delimiters) into
+ * a structured JavadocComment with body text and tags.
+ */
+object JavadocParser {
+
+  // Parse a raw block comment string (Javadoc delimiters included).
+  // Returns None if the comment is not a Javadoc comment.
+  def parse(rawComment: String): Option[JavadocComment] = {
+    if (rawComment == null || !rawComment.startsWith("/**"))
+      return None
+
+    val stripped = stripDelimiters(rawComment)
+    val (body, tags) = splitBodyAndTags(stripped)
+    Some(JavadocComment(body, tags))
+  }
+
+  // Strips Javadoc delimiters and leading asterisks from each line.
+  private def stripDelimiters(raw: String): String = {
+    val lines = raw.linesIterator.toList
+    val cleaned = lines.map { line =>
+      val trimmed = line.trim
+      if (trimmed.startsWith("/**"))
+        trimmed.stripPrefix("/**").stripSuffix("*/").trim
+      else if (trimmed.startsWith("*/"))
+        ""
+      else if (trimmed.startsWith("*"))
+        trimmed.stripPrefix("*").stripPrefix(" ")
+      else
+        trimmed.stripSuffix("*/").trim
+    }
+    cleaned.mkString("\n").trim
+  }
+
+  // Splits the stripped Javadoc content into body text and tag list.
+  // Tags start with @ at the beginning of a line.
+  private def splitBodyAndTags(content: String): (String, List[JavadocTag]) = {
+    val lines = content.split('\n').toList
+    val bodyLines = List.newBuilder[String]
+    val tagLines = List.newBuilder[(String, StringBuilder)]
+    var inTags = false
+    var currentTag: Option[(String, StringBuilder)] = None
+
+    for (line <- lines) {
+      val trimmed = line.trim
+      if (trimmed.startsWith("@")) {
+        inTags = true
+        // flush current tag
+        currentTag.foreach(tagLines += _)
+        // parse new tag
+        val spaceIdx = trimmed.indexOf(' ')
+        if (spaceIdx > 0) {
+          val name = trimmed.substring(1, spaceIdx)
+          val value = trimmed.substring(spaceIdx + 1)
+          currentTag = Some((name, new StringBuilder(value)))
+        } else {
+          val name = trimmed.substring(1)
+          currentTag = Some((name, new StringBuilder))
+        }
+      } else if (inTags) {
+        // continuation of current tag
+        currentTag.foreach { case (_, sb) =>
+          if (sb.nonEmpty) sb.append('\n')
+          sb.append(line)
+        }
+      } else {
+        bodyLines += line
+      }
+    }
+    // flush last tag
+    currentTag.foreach(tagLines += _)
+
+    val body = bodyLines.result().mkString("\n").trim
+    val tags = tagLines.result().map { case (name, sb) =>
+      JavadocTag(name, sb.toString.trim)
+    }
+    (body, tags)
+  }
+}

--- a/project/V.scala
+++ b/project/V.scala
@@ -81,7 +81,9 @@ object V {
 
   val scribe = "3.18.0"
 
-  val qdox = "2.2.0"
+  val treeSitter = "0.26.6"
+
+  val treeSitterJava = "0.23.5"
 
   val sbt2Version = "2.0.0-RC8"
 

--- a/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
+++ b/tests/cross/src/test/scala/tests/hover/HoverDocSuite.scala
@@ -29,6 +29,13 @@ class HoverDocSuite extends BaseHoverSuite {
        |```
        |List<String> s = Collections.emptyList();
        |```
+       |**Parameters**
+       |- `type`: of elements, if there were any, in the list
+       |
+       |**Returns:** an empty immutable list
+       |
+       |**See**
+       |- [#EMPTY_LIST](#EMPTY_LIST)
        |""".stripMargin,
     compat = Map(
       "2.13" ->
@@ -47,6 +54,13 @@ class HoverDocSuite extends BaseHoverSuite {
            |```
            |List<String> s = Collections.emptyList();
            |```
+           |**Parameters**
+           |- `type`: of elements, if there were any, in the list
+           |
+           |**Returns:** an empty immutable list
+           |
+           |**See**
+           |- [#EMPTY_LIST](#EMPTY_LIST)
            |""".stripMargin,
       "3" ->
         """|**Expression type**:
@@ -64,6 +78,13 @@ class HoverDocSuite extends BaseHoverSuite {
            |```
            |List<String> s = Collections.emptyList();
            |```
+           |**Parameters**
+           |- `type`: of elements, if there were any, in the list
+           |
+           |**Returns:** an empty immutable list
+           |
+           |**See**
+           |- [#EMPTY_LIST](#EMPTY_LIST)
            |""".stripMargin
     )
   )
@@ -106,12 +127,29 @@ class HoverDocSuite extends BaseHoverSuite {
        |  <<Paths.g@@et("")>>
        |}
        |""".stripMargin,
-    """|```scala
-       |def get(first: String, more: String*): Path
-       |```
-       |Converts a path string, or a sequence of strings that when joined form
-       |a path string, to a `Path`.
-       |""".stripMargin
+    s"""|```scala
+        |def get(first: String, more: String*): Path
+        |```
+        |Converts a path string, or a sequence of strings that when joined form
+        |a path string, to a `Path`.
+        |
+        |
+        |**Parameters**
+        |- `first`:${" "}
+        |         the path string or initial part of the path string
+        |- `more`:${" "}
+        |         additional strings to be joined to form the path string
+        |
+        |**Returns:** the resulting `Path`
+        |
+        |**Throws**
+        |- `InvalidPathException`:${" "}
+        |         if the path string cannot be converted to a `Path`
+        |
+        |**See**
+        |- [FileSystem#getPath](FileSystem#getPath)
+        |- [Path#of(String,String...)](Path#of(String,String...))
+        |""".stripMargin
   )
 
   check(
@@ -467,6 +505,10 @@ class HoverDocSuite extends BaseHoverSuite {
        |
        |This class consists exclusively of static methods that return a [Path](Path)
        |by converting a path string or [URI](URI).
+       |
+       |
+       |**See**
+       |- [Path](Path)
        |""".stripMargin,
     compat = Map(
       "3" -> """|```scala
@@ -474,6 +516,10 @@ class HoverDocSuite extends BaseHoverSuite {
                 |```
                 |This class consists exclusively of static methods that return a [Path](Path)
                 |by converting a path string or [URI](URI).
+                |
+                |
+                |**See**
+                |- [Path](Path)
                 |""".stripMargin
     )
   )

--- a/tests/unit/src/test/scala/tests/JavaMtagsSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaMtagsSuite.scala
@@ -200,6 +200,70 @@ class JavaMtagsSuite extends BaseSuite {
   )
 
   check(
+    "nested-declarations",
+    """|package sample;
+       |
+       |public class Outer {
+       |  public int outerField;
+       |  public void outerMethod() {}
+       |
+       |  public static class StaticInner {
+       |    public String innerField;
+       |    public void innerMethod() {}
+       |
+       |    public enum InnerEnum {
+       |      A, B;
+       |      public int value() { return ordinal(); }
+       |    }
+       |  }
+       |
+       |  public interface InnerInterface {
+       |    void doWork();
+       |    default void doDefault() {}
+       |  }
+       |
+       |  private enum Status {
+       |    ACTIVE,
+       |    INACTIVE;
+       |
+       |    public boolean isActive() { return this == ACTIVE; }
+       |  }
+       |
+       |  public record Point(int x, int y) {
+       |    public double distance() { return Math.sqrt(x*x + y*y); }
+       |  }
+       |
+       |  public @interface Marker {
+       |    String value() default "";
+       |  }
+       |}
+       |""".stripMargin,
+    """|sample/
+       |sample/Outer#
+       |sample/Outer#StaticInner#
+       |sample/Outer#StaticInner#InnerEnum#
+       |sample/Outer#StaticInner#InnerEnum#A.
+       |sample/Outer#StaticInner#InnerEnum#B.
+       |sample/Outer#StaticInner#InnerEnum#value().
+       |sample/Outer#StaticInner#innerMethod().
+       |sample/Outer#StaticInner#innerField.
+       |sample/Outer#InnerInterface#
+       |sample/Outer#InnerInterface#doWork().
+       |sample/Outer#InnerInterface#doDefault().
+       |sample/Outer#Status#
+       |sample/Outer#Status#ACTIVE.
+       |sample/Outer#Status#INACTIVE.
+       |sample/Outer#Status#isActive().
+       |sample/Outer#Point#
+       |sample/Outer#Point#distance().
+       |sample/Outer#Marker#
+       |sample/Outer#Marker#value().
+       |sample/Outer#outerMethod().
+       |sample/Outer#outerField.
+       |""".stripMargin.trim,
+  )
+
+  check(
     "interface-constants",
     """|package sample;
        |

--- a/tests/unit/src/test/scala/tests/JavaMtagsSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaMtagsSuite.scala
@@ -2,6 +2,8 @@ package tests
 
 import scala.meta.inputs.Input
 import scala.meta.internal.mtags.JavaMtags
+import scala.meta.internal.mtags.JavadocParser
+import scala.meta.internal.mtags.JavadocTag
 import scala.meta.pc.reports.EmptyReportContext
 
 /**
@@ -114,4 +116,215 @@ class JavaMtagsSuite extends BaseSuite {
        |sample/Processor#processAll().
        |""".stripMargin.trim,
   )
+
+  check(
+    "varargs-parameter",
+    """|package sample;
+       |
+       |public class VarArgs {
+       |  public void log(String format, Object... args) {}
+       |  public static void multiVarArgs(int first, String... rest) {}
+       |}
+       |""".stripMargin,
+    """|sample/
+       |sample/VarArgs#
+       |sample/VarArgs#log().
+       |sample/VarArgs#multiVarArgs().
+       |""".stripMargin.trim,
+  )
+
+  check(
+    "unicode-identifiers",
+    """|package sample;
+       |
+       |public class Café {
+       |  public int prénom;
+       |  public String élève;
+       |  public void calculé() {}
+       |}
+       |""".stripMargin,
+    """|sample/
+       |sample/Café#
+       |sample/Café#calculé().
+       |sample/Café#prénom.
+       |sample/Café#élève.
+       |""".stripMargin.trim,
+  )
+
+  check(
+    "unicode-before-identifier",
+    // Test that byte offset -> char offset conversion works when non-ASCII
+    // characters precede an identifier on the same line
+    """|package sample;
+       |
+       |public class UnicodeTest {
+       |  public String greet = "éèê"; public int after;
+       |}
+       |""".stripMargin,
+    """|sample/
+       |sample/UnicodeTest#
+       |sample/UnicodeTest#greet.
+       |sample/UnicodeTest#after.
+       |""".stripMargin.trim,
+  )
+
+  check(
+    "error-recovery",
+    // Tree-sitter produces a partial tree for malformed Java and recovers
+    // as much as possible — even extracting names from malformed declarations
+    """|package sample;
+       |
+       |public class Broken {
+       |  public void valid() {}
+       |  public void invalid( {}
+       |  public void alsoValid() {}
+       |}
+       |""".stripMargin,
+    """|sample/
+       |sample/Broken#
+       |sample/Broken#valid().
+       |sample/Broken#invalid().
+       |sample/Broken#alsoValid().
+       |""".stripMargin.trim,
+  )
+
+  check(
+    "empty-class",
+    """|package sample;
+       |
+       |public class Empty {}
+       |""".stripMargin,
+    """|sample/
+       |sample/Empty#
+       |""".stripMargin.trim,
+  )
+
+  check(
+    "interface-constants",
+    """|package sample;
+       |
+       |public interface Constants {
+       |  int MAX_SIZE = 100;
+       |  String DEFAULT_NAME = "test";
+       |  void doSomething();
+       |}
+       |""".stripMargin,
+    """|sample/
+       |sample/Constants#
+       |sample/Constants#doSomething().
+       |sample/Constants#MAX_SIZE.
+       |sample/Constants#DEFAULT_NAME.
+       |""".stripMargin.trim,
+  )
+
+  check(
+    "annotation-type-elements",
+    """|package sample;
+       |
+       |public @interface MyAnnotation {
+       |  String value();
+       |  int count() default 0;
+       |}
+       |""".stripMargin,
+    """|sample/
+       |sample/MyAnnotation#
+       |sample/MyAnnotation#value().
+       |sample/MyAnnotation#count().
+       |""".stripMargin.trim,
+  )
+
+  // --- JavadocParser tests ---
+
+  test("javadoc-parser-basic") {
+    val raw = """|/**
+                 | * This is the body.
+                 | * @param name the name
+                 | * @param age the age
+                 | * @return something
+                 | */""".stripMargin
+    val result = JavadocParser.parse(raw)
+    assert(result.isDefined)
+    val doc = result.get
+    assertNoDiff(doc.body, "This is the body.")
+    assertEquals(doc.tags.length, 3)
+    assertEquals(doc.tags(0), JavadocTag("param", "name the name"))
+    assertEquals(doc.tags(1), JavadocTag("param", "age the age"))
+    assertEquals(doc.tags(2), JavadocTag("return", "something"))
+  }
+
+  test("javadoc-parser-empty-comment") {
+    val raw = "/** */"
+    val result = JavadocParser.parse(raw)
+    assert(result.isDefined)
+    val doc = result.get
+    assertEquals(doc.body, "")
+    assertEquals(doc.tags, Nil)
+  }
+
+  test("javadoc-parser-not-javadoc") {
+    val raw = "/* regular block comment */"
+    val result = JavadocParser.parse(raw)
+    assertEquals(result, None)
+  }
+
+  test("javadoc-parser-null-input") {
+    val result = JavadocParser.parse(null)
+    assertEquals(result, None)
+  }
+
+  test("javadoc-parser-multiline-tag") {
+    val raw = """|/**
+                 | * Body text.
+                 | * @param name the name of
+                 | *        the thing being described
+                 | * @return the result
+                 | */""".stripMargin
+    val result = JavadocParser.parse(raw)
+    assert(result.isDefined)
+    val doc = result.get
+    assertNoDiff(doc.body, "Body text.")
+    assertEquals(doc.tags.length, 2)
+    assert(doc.tags(0).value.contains("the name of"))
+    assertEquals(doc.tags(1), JavadocTag("return", "the result"))
+  }
+
+  test("javadoc-parser-body-only") {
+    val raw = """|/**
+                 | * Just a body with no tags.
+                 | * Multiple lines.
+                 | */""".stripMargin
+    val result = JavadocParser.parse(raw)
+    assert(result.isDefined)
+    val doc = result.get
+    assert(doc.body.contains("Just a body"))
+    assert(doc.body.contains("Multiple lines"))
+    assertEquals(doc.tags, Nil)
+  }
+
+  test("javadoc-parser-tags-only") {
+    val raw = """|/**
+                 | * @param x the x coord
+                 | * @param y the y coord
+                 | */""".stripMargin
+    val result = JavadocParser.parse(raw)
+    assert(result.isDefined)
+    val doc = result.get
+    assertEquals(doc.body, "")
+    assertEquals(doc.tags.length, 2)
+    assertEquals(doc.tagsByName("param").length, 2)
+  }
+
+  test("javadoc-parser-malformed-tag") {
+    // Tag with no value
+    val raw = """|/**
+                 | * Body.
+                 | * @deprecated
+                 | */""".stripMargin
+    val result = JavadocParser.parse(raw)
+    assert(result.isDefined)
+    val doc = result.get
+    assertNoDiff(doc.body, "Body.")
+    assertEquals(doc.tags.length, 1)
+    assertEquals(doc.tags(0), JavadocTag("deprecated", ""))
+  }
 }

--- a/tests/unit/src/test/scala/tests/JavaMtagsSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaMtagsSuite.scala
@@ -1,0 +1,117 @@
+package tests
+
+import scala.meta.inputs.Input
+import scala.meta.internal.mtags.JavaMtags
+import scala.meta.pc.reports.EmptyReportContext
+
+/**
+ * Tests that JavaMtags (tree-sitter based) correctly indexes Java source files,
+ * including edge cases with annotations in type parameters that caused issues
+ * with the previous QDox parser.
+ */
+class JavaMtagsSuite extends BaseSuite {
+
+  implicit val rc: EmptyReportContext = new EmptyReportContext
+
+  def check(
+      name: String,
+      code: String,
+      expected: String
+  )(implicit loc: munit.Location): Unit = {
+    test(name) {
+      val input = Input.VirtualFile("Test.java", code)
+      val mtags = new JavaMtags(input, includeMembers = true)
+      val doc = mtags.index()
+      val obtained = doc.occurrences.map(_.symbol).mkString("\n")
+      assertNoDiff(obtained, expected)
+    }
+  }
+
+  check(
+    "annotated-type-params",
+    """|package com.example;
+       |
+       |import java.util.function.Function;
+       |import java.util.stream.Collector;
+       |
+       |public class CollectorUtils {
+       |  public static <T extends @Nullable Object, K, V>
+       |      Collector<T, ?, ImmutableMap<K, V>> toImmutableMap(
+       |          Function<? super T, ? extends K> keyFunction,
+       |          Function<? super T, ? extends V> valueFunction) {
+       |    return null;
+       |  }
+       |
+       |  public <@NonNull T> T requireNonNull(@Nullable T obj, String message) {
+       |    return obj;
+       |  }
+       |
+       |  public void process(java.util.@Nullable List<String> items) {
+       |  }
+       |}
+       |""".stripMargin,
+    """|com/
+       |com/example/
+       |com/example/CollectorUtils#
+       |com/example/CollectorUtils#requireNonNull().
+       |com/example/CollectorUtils#process().
+       |com/example/CollectorUtils#toImmutableMap().
+       |""".stripMargin.trim
+  )
+
+  check(
+    "basic-class-with-members",
+    """|package sample;
+       |
+       |public class Foo {
+       |  public int bar;
+       |  public static void main(String[] args) {}
+       |  public Foo(int bar) { this.bar = bar; }
+       |}
+       |""".stripMargin,
+    // methods are sorted static-last, then constructors, then fields
+    """|sample/
+       |sample/Foo#
+       |sample/Foo#main().
+       |sample/Foo#`<init>`().
+       |sample/Foo#bar.
+       |""".stripMargin.trim
+  )
+
+  check(
+    "enum-with-constants",
+    """|package sample;
+       |
+       |public enum Color {
+       |  RED,
+       |  GREEN,
+       |  BLUE;
+       |
+       |  public String display() { return name(); }
+       |}
+       |""".stripMargin,
+    """|sample/
+       |sample/Color#
+       |sample/Color#RED.
+       |sample/Color#GREEN.
+       |sample/Color#BLUE.
+       |sample/Color#display().
+       |""".stripMargin.trim
+  )
+
+  check(
+    "interface-with-default-methods",
+    """|package sample;
+       |
+       |public interface Processor<T> {
+       |  void process(T item);
+       |  default void processAll(java.util.List<T> items) {}
+       |}
+       |""".stripMargin,
+    """|sample/
+       |sample/Processor#
+       |sample/Processor#process().
+       |sample/Processor#processAll().
+       |""".stripMargin.trim
+  )
+}

--- a/tests/unit/src/test/scala/tests/JavaMtagsSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaMtagsSuite.scala
@@ -16,7 +16,7 @@ class JavaMtagsSuite extends BaseSuite {
   def check(
       name: String,
       code: String,
-      expected: String
+      expected: String,
   )(implicit loc: munit.Location): Unit = {
     test(name) {
       val input = Input.VirtualFile("Test.java", code)
@@ -56,7 +56,7 @@ class JavaMtagsSuite extends BaseSuite {
        |com/example/CollectorUtils#requireNonNull().
        |com/example/CollectorUtils#process().
        |com/example/CollectorUtils#toImmutableMap().
-       |""".stripMargin.trim
+       |""".stripMargin.trim,
   )
 
   check(
@@ -75,7 +75,7 @@ class JavaMtagsSuite extends BaseSuite {
        |sample/Foo#main().
        |sample/Foo#`<init>`().
        |sample/Foo#bar.
-       |""".stripMargin.trim
+       |""".stripMargin.trim,
   )
 
   check(
@@ -96,7 +96,7 @@ class JavaMtagsSuite extends BaseSuite {
        |sample/Color#GREEN.
        |sample/Color#BLUE.
        |sample/Color#display().
-       |""".stripMargin.trim
+       |""".stripMargin.trim,
   )
 
   check(
@@ -112,6 +112,6 @@ class JavaMtagsSuite extends BaseSuite {
        |sample/Processor#
        |sample/Processor#process().
        |sample/Processor#processAll().
-       |""".stripMargin.trim
+       |""".stripMargin.trim,
   )
 }

--- a/tests/unit/src/test/scala/tests/JavaToplevelSuite.scala
+++ b/tests/unit/src/test/scala/tests/JavaToplevelSuite.scala
@@ -228,4 +228,35 @@ class JavaToplevelSuite extends BaseToplevelSuite {
     mode = ToplevelWithInner,
   )
 
+  check(
+    "annotated-type-params",
+    """|package com.example;
+       |
+       |import java.util.function.Function;
+       |import java.util.stream.Collector;
+       |
+       |public class CollectorUtils {
+       |  public static <T extends @Nullable Object, K, V>
+       |      Collector<T, ?, ImmutableMap<K, V>> toImmutableMap(
+       |          Function<? super T, ? extends K> keyFunction,
+       |          Function<? super T, ? extends V> valueFunction) {
+       |    return null;
+       |  }
+       |
+       |  public <@NonNull T> T requireNonNull(@Nullable T obj, String message) {
+       |    return obj;
+       |  }
+       |
+       |  public void process(java.util.@Nullable List<String> items) {
+       |  }
+       |}
+       |""".stripMargin,
+    List(
+      "com/",
+      "com/example/",
+      "com/example/CollectorUtils#",
+    ),
+    mode = ToplevelWithInner,
+  )
+
 }


### PR DESCRIPTION
## Summary

Closes #8349

Replaces the end-of-life QDox library with tree-sitter for Java source parsing in the mtags module. QDox cannot parse valid Java files containing annotations in type parameter positions (e.g. `<T extends @Nullable Object>`) and has no error recovery — a single parse failure loses all symbol information for an entire file. tree-sitter handles both correctly.

## Changes

- Replace `com.thoughtworks.qdox:qdox` with `io.github.bonede:tree-sitter` + `io.github.bonede:tree-sitter-java` in build.sbt / V.scala
- Rewrite `JavaMtags.scala` to walk the tree-sitter CST instead of using QDox's `JavaProjectBuilder`
- Rewrite `JavadocIndexer.scala` to use new model case classes instead of QDox model objects
- Add `JavaDeclarationInfo.scala` — lightweight case classes decoupling the indexer from the parser model
- Add `JavadocParser.scala` — utility for parsing raw Javadoc comment text into structured tags

## Design decisions

- **ThreadLocal `TSParser`** for thread-safe concurrent indexing without allocation overhead
- **Manual tree walking** (not tree-sitter queries) for natural association of preceding comments with declarations
- **UTF-8 byte array** for correct text extraction from tree-sitter's byte offsets
- **Static methods sorted last** for overload disambiguation compatibility with existing behavior

## Trade-offs

- Introduces a JNI/native library dependency. The `io.github.bonede:tree-sitter` bindings bundle natives for x86_64 + aarch64 on macOS, Linux, and Windows — covering >99% of developer workstations.
- tree-sitter produces a CST (not AST), so the walking code is more verbose than QDox's object model. This is offset by the correctness and error recovery gains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer, structured Javadoc parsing and improved rendered documentation in hovers.

* **Refactor**
  * Overhauled Java indexing for more accurate handling of annotations, type/type-parameter docs, nested types, enums/constants, member ordering, and error recovery.

* **Tests**
  * Added extensive tests validating Java indexing, Javadoc parsing, hover docs, Unicode/offsets, varargs, and many declaration shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->