### PR TITLE
bugfix: Initialize definitionIndexStrategy when initializing

### DIFF
--- a/metals-mcp/src/main/scala/scala/meta/internal/metals/mcp/StandaloneMcpService.scala
+++ b/metals-mcp/src/main/scala/scala/meta/internal/metals/mcp/StandaloneMcpService.scala
@@ -63,7 +63,8 @@ class StandaloneMcpService(
   private val time: Time = Time.system
 
   private val clientConfig: ClientConfiguration = ClientConfiguration(
-    MetalsServerConfig.default
+    MetalsServerConfig.default,
+    NoopFeatureFlagProvider,
   )
 
   private val mcpClient = new ConfiguredLanguageClient(

--- a/metals-mcp/src/main/scala/scala/meta/metals/McpMain.scala
+++ b/metals-mcp/src/main/scala/scala/meta/metals/McpMain.scala
@@ -8,6 +8,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutorService
 import scala.util.control.NonFatal
 
+import scala.meta.internal.infra.NoopFeatureFlagProvider
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.ClientConfiguration
 import scala.meta.internal.metals.MetalsServerConfig
@@ -329,7 +330,8 @@ object McpMain {
         json.addProperty(k, v)
       }
     }
-    val clientConfiguration = ClientConfiguration(MetalsServerConfig.default)
+    val clientConfiguration =
+      ClientConfiguration(MetalsServerConfig.default, NoopFeatureFlagProvider)
     UserConfiguration.fromJson(json, clientConfiguration)
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ClientConfiguration.scala
@@ -1,5 +1,8 @@
 package scala.meta.internal.metals
 
+import scala.meta.infra.FeatureFlagProvider
+import scala.meta.internal.infra.NoopFeatureFlagProvider
+import scala.meta.internal.metals.Configs.DefinitionIndexStrategy
 import scala.meta.internal.metals.Configs.GlobSyntaxConfig
 import scala.meta.internal.metals.config.DoctorFormat
 import scala.meta.internal.metals.config.StatusBarState
@@ -19,6 +22,7 @@ import org.eclipse.lsp4j.InitializeParams
 final class ClientConfiguration(
     val initialConfig: MetalsServerConfig,
     initializeParams: Option[InitializeParams],
+    featureFlags: FeatureFlagProvider,
 ) {
 
   private val clientCapabilities: Option[ClientCapabilities] =
@@ -66,6 +70,14 @@ final class ClientConfiguration(
     initializationOptions.globSyntax
       .flatMap(GlobSyntaxConfig.fromString)
       .getOrElse(initialConfig.globSyntax)
+
+  def definitionIndexStrategy(): DefinitionIndexStrategy =
+    DefinitionIndexStrategy
+      .fromConfigOrFeatureFlag(
+        initializationOptions.definitionIndexStrategy,
+        featureFlags,
+      )
+      .getOrElse(DefinitionIndexStrategy.default)
 
   def renameFileThreshold(): Int =
     initializationOptions.renameFileThreshold.getOrElse(
@@ -238,18 +250,21 @@ final class ClientConfiguration(
 }
 
 object ClientConfiguration {
-  val default: ClientConfiguration = ClientConfiguration(MetalsServerConfig())
+  val default: ClientConfiguration =
+    ClientConfiguration(MetalsServerConfig(), NoopFeatureFlagProvider)
 
   def apply(
       initialConfig: MetalsServerConfig,
       initializeParams: InitializeParams,
+      featureFlags: FeatureFlagProvider,
   ): ClientConfiguration = {
-    new ClientConfiguration(initialConfig, Some(initializeParams))
+    new ClientConfiguration(initialConfig, Some(initializeParams), featureFlags)
   }
 
   def apply(
-      initialConfig: MetalsServerConfig
+      initialConfig: MetalsServerConfig,
+      featureFlags: FeatureFlagProvider,
   ): ClientConfiguration = {
-    new ClientConfiguration(initialConfig, None)
+    new ClientConfiguration(initialConfig, None, featureFlags)
   }
 }

--- a/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Configs.scala
@@ -389,8 +389,7 @@ object Configs {
     // which fails on syntax errors. See plans/protopc.md for details.
     def default: ProtoOutlineProviderConfig = v1
     def fromConfigOrFeatureFlag(
-        value: Option[String],
-        featureFlags: FeatureFlagProvider,
+        value: Option[String]
     ): Either[String, ProtoOutlineProviderConfig] = {
       value match {
         case Some(ok @ ("v1" | "v2")) =>

--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -248,7 +248,7 @@ case class Indexer(indexProviders: IndexProviders, mbtBuild: () => MbtBuild)(
         )
         progress.message =
           s"indexing ${buildTool.importedBuild.dependencyModules.getItems().size()} dependencies"
-        if (indexProviders.userConfig.definitionIndexStrategy.isClasspath) {
+        if (indexProviders.clientConfig.definitionIndexStrategy().isClasspath) {
           usedJars ++= indexDependencyModules(
             buildTool.importedBuild.dependencyModules,
             progress,
@@ -546,7 +546,9 @@ case class Indexer(indexProviders: IndexProviders, mbtBuild: () => MbtBuild)(
       if (!path.exists) {
         scribe.warn(s"dependency missing at absolute path: $path")
       } else if (path.isJar) {
-        if (!indexProviders.userConfig.definitionIndexStrategy.isClasspath) {
+        if (
+          !indexProviders.clientConfig.definitionIndexStrategy().isClasspath
+        ) {
           usedJars += path
           if (addSourceJarSymbols(path)) cacheHits += 1
           else cacheMisses += 1

--- a/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/InitializationOptions.scala
@@ -50,6 +50,8 @@ import org.eclipse.{lsp4j => l}
  *                            the output, you can enable this to strip them.
  * @param doctorVisibilityProvider if the clients implements `metals/doctorVisibilityDidChange`
  * @param bspStatusBarProvider if the client supports `metals/status` with "bsp" status type
+ * @param definitionIndexStrategy whether definitions from dependencies should index classfiles
+ *                                or source files.
  */
 final case class InitializationOptions(
     compilerOptions: CompilerInitializationOptions,
@@ -82,6 +84,7 @@ final case class InitializationOptions(
     doctorVisibilityProvider: Option[Boolean],
     bspStatusBarProvider: Option[String],
     moduleStatusBarProvider: Option[String],
+    definitionIndexStrategy: Option[String],
 ) {
   def doctorFormat: Option[DoctorFormat.DoctorFormat] =
     doctorProvider.flatMap(DoctorFormat.fromString)
@@ -101,6 +104,7 @@ object InitializationOptions {
 
   val Default: InitializationOptions = InitializationOptions(
     CompilerInitializationOptions.default,
+    None,
     None,
     None,
     None,
@@ -188,6 +192,8 @@ object InitializationOptions {
       bspStatusBarProvider = jsonObj.getStringOption("bspStatusBarProvider"),
       moduleStatusBarProvider =
         jsonObj.getStringOption("moduleStatusBarProvider"),
+      definitionIndexStrategy =
+        jsonObj.getStringOption("definitionIndexStrategy"),
     )
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -2397,7 +2397,7 @@ abstract class MetalsLspService(
       },
       toIndexSource = path => sourceMapper.mappedTo(path).getOrElse(path),
       isClasspathDefinitionIndexEnabled = () =>
-        userConfig.definitionIndexStrategy.isClasspath,
+        clientConfig.definitionIndexStrategy().isClasspath,
       mtags = () => mtags,
     )
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -14,7 +14,6 @@ import scala.meta.internal.infra.NoopFeatureFlagProvider
 import scala.meta.internal.metals.Configs.AdditionalPcChecksConfig
 import scala.meta.internal.metals.Configs.BatchSemanticdbConfig
 import scala.meta.internal.metals.Configs.CompilerProgressConfig
-import scala.meta.internal.metals.Configs.DefinitionIndexStrategy
 import scala.meta.internal.metals.Configs.DefinitionProviderConfig
 import scala.meta.internal.metals.Configs.FallbackClasspathConfig
 import scala.meta.internal.metals.Configs.FallbackSourcepathConfig
@@ -99,8 +98,6 @@ case class UserConfiguration(
       WorkspaceSymbolProviderConfig.default,
     definitionProviders: DefinitionProviderConfig =
       DefinitionProviderConfig.default,
-    definitionIndexStrategy: DefinitionIndexStrategy =
-      DefinitionIndexStrategy.default,
     protoOutlineProvider: ProtoOutlineProviderConfig =
       ProtoOutlineProviderConfig.default,
     javaSymbolLoader: JavaSymbolLoaderConfig = JavaSymbolLoaderConfig.default,
@@ -273,12 +270,6 @@ case class UserConfiguration(
           (
             "definitionProviders",
             definitionProviders.values.asJava,
-          )
-        ),
-        Some(
-          (
-            "definitionIndexStrategy",
-            definitionIndexStrategy.value,
           )
         ),
         Some(
@@ -1358,14 +1349,6 @@ object UserConfiguration {
           featureFlags,
         ),
     ).getOrElse(WorkspaceSymbolProviderConfig.default)
-    val definitionIndexStrategy = getParsedKey(
-      "definition-index-strategy",
-      value =>
-        DefinitionIndexStrategy.fromConfigOrFeatureFlag(
-          value,
-          featureFlags,
-        ),
-    ).getOrElse(DefinitionIndexStrategy.default)
     val definitionProviders = getParsedArrayKey(
       "definition-providers",
       values =>
@@ -1378,8 +1361,7 @@ object UserConfiguration {
       "proto-outline-provider",
       value =>
         ProtoOutlineProviderConfig.fromConfigOrFeatureFlag(
-          value,
-          featureFlags,
+          value
         ),
     ).getOrElse(ProtoOutlineProviderConfig.default)
     val javaSymbolLoader = getParsedKey(
@@ -1521,7 +1503,6 @@ object UserConfiguration {
           useSourcePath,
           workspaceSymbolProvider,
           definitionProviders,
-          definitionIndexStrategy,
           protoOutlineProvider,
           javaSymbolLoader,
           javaTurbineRecompileDelay,

--- a/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/WorkspaceLspService.scala
@@ -140,6 +140,7 @@ class WorkspaceLspService(
     ClientConfiguration(
       serverInputs.initialServerConfig,
       initializeParams,
+      featureFlags,
     )
 
   private val languageClient = {

--- a/tests/unit/src/main/scala/tests/BaseLspSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseLspSuite.scala
@@ -51,7 +51,6 @@ abstract class BaseLspSuite(
       buildChangedAction = BuildChangedAction.prompt,
       fallbackScalaVersion = Some(BuildInfo.scalaVersion),
       presentationCompilerDiagnostics = false,
-      definitionIndexStrategy = Configs.DefinitionIndexStrategy.classpath,
 
       // Legacy settings that are enabled for tests only.  We  should eventually
       // update the tests to use the new defaults.

--- a/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CompletionLspSuite.scala
@@ -3,7 +3,7 @@ package tests
 import scala.concurrent.Future
 
 import scala.meta.internal.metals.Configs.DefinitionIndexStrategy
-import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.{BuildInfo => V}
 
 import munit.Location
@@ -12,8 +12,11 @@ class CompletionLspSuite extends BaseCompletionLspSuite("completion") {
 
   override def munitIgnore: Boolean = isWindows
 
-  override def userConfig: UserConfiguration = super.userConfig
-    .copy(definitionIndexStrategy = DefinitionIndexStrategy.sources)
+  override def initializationOptions: Option[InitializationOptions] = Some(
+    InitializationOptions.Default.copy(
+      definitionIndexStrategy = Some(DefinitionIndexStrategy.sources.value)
+    )
+  )
 
   test("basic-213") {
     basicTest(V.scala213)

--- a/tests/unit/src/test/scala/tests/ManualSuite.scala
+++ b/tests/unit/src/test/scala/tests/ManualSuite.scala
@@ -18,7 +18,6 @@ class ManualSuite extends BaseManualSuite {
       workspaceSymbolProvider = WorkspaceSymbolProviderConfig.mbt,
       javaSymbolLoader = JavaSymbolLoaderConfig.turbineClasspath,
       presentationCompilerDiagnostics = true,
-      definitionIndexStrategy = DefinitionIndexStrategy.classpath,
       fallbackSourcepath = FallbackSourcepathConfig.allSources,
       compilerProgress = CompilerProgressConfig.enabled,
       referenceProvider = ReferenceProviderConfig.mbt,

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -6,6 +6,7 @@ import java.util.Properties
 
 import scala.meta.infra.FeatureFlag
 import scala.meta.infra.FeatureFlagProvider
+import scala.meta.internal.infra.NoopFeatureFlagProvider
 import scala.meta.internal.metals.AutoImportBuildKind
 import scala.meta.internal.metals.BloopJvmProperties
 import scala.meta.internal.metals.ClientConfiguration
@@ -494,7 +495,6 @@ class UserConfigurationSuite extends BaseSuite {
     "mbt",
     "protobuf"
   ],
-  "definitionIndexStrategy": "classpath",
   "protoOutlineProvider": "v1",
   "javaSymbolLoader": "turbine-classpath",
   "javaTurbineRecompileDelay": "100 milliseconds",
@@ -533,7 +533,11 @@ class UserConfigurationSuite extends BaseSuite {
       Map("testExplorerProvider" -> true).asJava.toJsonObject
     )
 
-    val clientConfig = ClientConfiguration(MetalsServerConfig.default, params)
+    val clientConfig = ClientConfiguration(
+      MetalsServerConfig.default,
+      params,
+      NoopFeatureFlagProvider,
+    )
 
     val roundtrip = UserConfiguration
       .fromJson(


### PR DESCRIPTION
Previously, we would do it after initialized at which point the indexing has already happened. Now, we index according to the strategy the user wants.

The other option is to handle the change, but if someone uses non default, they will always get double indexing.

CC @olafurpg though it doesn't really change anything for feature flags. 

A side note is that I realized that even though the classpath indexing is faster it will miss features such as type member completions etc. This can easily be chosen by the user, for larger codebase they could turn on classpath, but for smaller keeup using sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the definition index strategy through initialization options.
  - Feature flags can provide the definition index strategy when no initialization option is set.
  - A default strategy is applied when no custom setting is provided.

- **Improvements**
  - Definition indexing now uses the resolved client configuration consistently across workspace, dependency, and classpath indexing.
  - Removed the definition index strategy from user configuration in favor of centralized client settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->