### PR TITLE
Fix issue with .metals/out contents causing infinite PC crash loop

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -346,6 +346,7 @@ abstract class MetalsLspService(
       mbt.ProtobufTemplateAndTestIndexFilter,
     ),
     protobufLspConfig = () => userConfig.protobufLspConfig,
+    metalsOutDir = Some(embedded.targetDir),
   )
 
   override val mbtSymbolSearch: MbtWorkspaceSymbolProvider = mbt2

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -107,7 +107,9 @@ class MbtWorkspaceSymbolProvider(
       ProtobufVersionHistoryIndexFilter,
       ProtobufTemplateAndTestIndexFilter,
     ),
-    protobufLspConfig: () => ProtobufLspConfig = () => ProtobufLspConfig.default,
+    protobufLspConfig: () => ProtobufLspConfig = () =>
+      ProtobufLspConfig.default,
+    metalsOutDir: Option[Path] = None,
 )(implicit
     val ec: ExecutionContext = ExecutionContext.Implicits.global,
     val rc: ReportContext = LoggerReportContext,
@@ -693,28 +695,35 @@ class MbtWorkspaceSymbolProvider(
       doc: IndexedDocument,
       updateDocumentKeys: Boolean,
   ): Future[Unit] = {
-    val old = documents.put(file, doc)
-    if (old == None && updateDocumentKeys) {
-      updateDocumentsKeys(documents)
-    }
-    addDocumentToPackages(doc.semanticdbPackages, file)
-
-    if (
-      updateDocumentKeys &&
-      doc.language.isJava &&
-      javaSymbolLoader().isTurbineClasspath
-    ) {
-      doc.semanticdbPackages.headOption match {
-        case Some(pkg) =>
-          val input = file.toInputFromBuffers(buffers)
-          val packageName = pkg.stripSuffix("/").replace("/", ".")
-          val compilationUnit = doc.toSemanticdbCompilationUnit(input)
-          turbineCompiler.onDidChange(packageName, compilationUnit).ignoreValue
-        case None =>
-          Future.unit
-      }
-    } else {
+    // .metals/out contains JDK sources materialized for --patch-module; they are not workspace sources
+    if (metalsOutDir.exists(outDir => file.toNIO.startsWith(outDir))) {
       Future.unit
+    } else {
+      val old = documents.put(file, doc)
+      if (old == None && updateDocumentKeys) {
+        updateDocumentsKeys(documents)
+      }
+      addDocumentToPackages(doc.semanticdbPackages, file)
+
+      if (
+        updateDocumentKeys &&
+        doc.language.isJava &&
+        javaSymbolLoader().isTurbineClasspath
+      ) {
+        doc.semanticdbPackages.headOption match {
+          case Some(pkg) =>
+            val input = file.toInputFromBuffers(buffers)
+            val packageName = pkg.stripSuffix("/").replace("/", ".")
+            val compilationUnit = doc.toSemanticdbCompilationUnit(input)
+            turbineCompiler
+              .onDidChange(packageName, compilationUnit)
+              .ignoreValue
+          case None =>
+            Future.unit
+        }
+      } else {
+        Future.unit
+      }
     }
   }
 

--- a/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
@@ -2,6 +2,7 @@ package tests.mbt
 
 import java.nio.file.Files
 
+import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 import scala.util.Properties
 
@@ -11,13 +12,16 @@ import scala.meta.internal.metals.Configs.ReferenceProviderConfig
 import scala.meta.internal.metals.Configs.WorkspaceSymbolProviderConfig
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.mbt.MbtBuildServer
+import scala.meta.internal.mtags.ScalametaCommonEnrichments._
 
 import coursierapi.Dependency
 import coursierapi.Fetch
+import org.eclipse.lsp4j.FileChangeType
 import tests.BaseCompletionLspSuite
 import tests.BuildInfo
 import tests.Library
 import tests.TestHovers
+import tests.TestingServer
 
 /**
  * End-to-end checks for `.metals/mbt.json` with the built-in MBT BSP server:
@@ -317,4 +321,95 @@ class MbtBuildServerLspSuite
     } yield ()
   }
 
+  // Run this test with virtual document support so that JDK sources are served
+  // as src.zip! URIs. When a PC request arrives for such a URI, PruneJavaFile
+  // materializes the file to .metals/out for --patch-module. The editor then
+  // fires didChangeWatchedFiles for the new file (workspace/**/*.java glob
+  // matches it). This test verifies those events are silently dropped and the
+  // materialized file never enters the MBT index or Scala sourcepath.
+  test(
+    "metals-out-not-indexed-after-jdk-source-hover"
+      .tag(TestingServer.virtualDocTag)
+  ) {
+    cleanWorkspace()
+    val mbtJson = // namespaces might filter out the problematic file
+      s"""|{
+          |}""".stripMargin
+
+    for {
+      _ <- initialize(
+        s"""|/.metals/mbt.json
+            |$mbtJson
+            |/src/Foo.scala
+            |package example;
+            |
+            |object Foo {
+            |  def show(obj: java.lang.Object): String = {
+            |    obj.toString();
+            |  }
+            |}
+            |/src/Dummy.scala
+            |package example
+            |object Dummy {
+            |  def ok: String = ""
+            |}
+            |""".stripMargin
+      )
+      _ = assertConnectedToBuildServer("MBT")
+      _ <- server.didOpen("src/Foo.scala")
+      // Navigate to the definition of toString (a JDK method). In virtual-doc mode
+      // this returns a src.zip! URI so the editor can open the JDK source.
+      definitions <- server.definitionSubstringQuery(
+        "src/Foo.scala",
+        "    obj.toStr@@ing();",
+      )
+      srcZipLoc = definitions.find(_.getUri.contains("src.zip"))
+      // Not strictly necessary assertion here, but this is the thing that causes the issue
+      _ = assert(
+        srcZipLoc.isDefined,
+        s"Expected a src.zip! definition for String, got: $definitions",
+      )
+      // Verify PruneJavaFile actually wrote something to .metals/out.
+      metalsOut = workspace.resolve(".metals/out")
+      metalsOutFiles = metalsOut.listRecursive.filter(_.isFile).toList
+      _ = assert(
+        metalsOutFiles.nonEmpty,
+        ".metals/out should contain at least one file materialised by PruneJavaFile",
+      )
+      // Simulate the editor firing didChangeWatchedFiles for each materialised
+      // file (workspace/**/*.java glob delivers these events).
+      _ <- Future.traverse(metalsOutFiles) { f =>
+        server.didChangeWatchedFiles(
+          workspace.toNIO.relativize(f.toNIO).toString,
+          FileChangeType.Created,
+        )
+      }
+      _ <- Future.traverse(metalsOutFiles) { f =>
+        server.didChangeWatchedFiles(
+          workspace.toNIO.relativize(f.toNIO).toString
+        )
+      }
+      // Normal workspace features must still work after the spurious events.
+      _ = assertNoDiagnostics()
+      // crash appeared even after resetting the presentation compiler
+      _ <- server.server.resetPresentationCompilers()
+      _ <- server.assertHover(
+        "src/Foo.scala",
+        """|object Foo {
+           |  def show(obj: java.lang.Object): String = {
+           |    obj.toSt@@ring();
+           |  }
+           |}""".stripMargin,
+        s"""|${"def toString(): String".hover}
+            |Returns a string representation of the object.""".stripMargin,
+      )
+      _ <- server.assertHover(
+        "src/Dummy.scala",
+        """|object Dummy {
+           |  def ok: Str@@ing = ""
+           |}""".stripMargin,
+        s"""|${"type String: String".hover}""".stripMargin,
+      )
+    } yield ()
+  }
 }


### PR DESCRIPTION
When trying to navigate to a JDK symbol/source, PruneJavaFile.scala would unpack JDK sources from `*src.zip` into .metals/out. This would in turn cause didChangeWatchedFiles to be fired off by the client, in turn causing the file to be used in TurbineCompiler, be added to semanticSBPackages, etc. This would then cause the new JDK file to take part in scala's presentation compiler inputs, messing with the Symbol cache for JDK java symbols (stored in a non-resetted object), causing the crash loop after every reset.

As a fix, we filter out the .metals/out contents in MbtWorkspaceSymbolProvider. Manual tests show that the JDK symbols still show in Completions and we still get code navigation in these sources, somehow.