### PR TITLE
bugfix: Fix actionable diagnostics coming from Scala 3 compiler

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsEnrichments.scala
@@ -944,11 +944,20 @@ object MetalsEnrichments
           DiagnosticDataDeserializer,
         )
         .create()
-      decodeJson(
-        d.getData(),
-        classOf[Either[l.TextEdit, b.ScalaDiagnostic]],
-        Some(gson),
-      )
+      d.getData() match {
+        case o: JsonObject =>
+          decodeJson(
+            o,
+            classOf[Either[l.TextEdit, b.ScalaDiagnostic]],
+            Some(gson),
+          )
+        case other =>
+          if (other != null)
+            scribe.warn(
+              s"Unexpected data type: ${d.getData().getClass().getName()}, data: ${d.getData()}"
+            )
+          None
+      }
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ScalacDiagnostic.scala
@@ -11,6 +11,17 @@ object ScalacDiagnostic {
     def unapply(d: l.Diagnostic): Option[l.TextEdit] = d.asTextEdit
   }
 
+  object Scala3Diagnostic {
+    def unapply(
+        d: l.Diagnostic
+    ): Option[Seq[l.CodeAction]] =
+      d.getData() match {
+        case list: Seq[_] =>
+          Some(list.collect { case a: l.CodeAction => a })
+        case _ => None
+      }
+  }
+
   object ScalaDiagnostic {
     def unapply(
         d: l.Diagnostic

--- a/metals/src/main/scala/scala/meta/internal/metals/codeactions/ActionableDiagnostic.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codeactions/ActionableDiagnostic.scala
@@ -75,6 +75,17 @@ class ActionableDiagnostic() extends CodeAction {
       .flatten
       .sorted
 
-    Future.successful(codeActions)
+    val scala3CodeActions = params
+      .getContext()
+      .getDiagnostics()
+      .asScala
+      .toSeq
+      .flatMap {
+        case ScalacDiagnostic.Scala3Diagnostic(actions) =>
+          actions
+        case _ => Nil
+      }
+
+    Future.successful(codeActions ++ scala3CodeActions)
   }
 }

--- a/tests/unit/src/test/scala/tests/codeactions/ActionableDiagnosticsSuite.scala
+++ b/tests/unit/src/test/scala/tests/codeactions/ActionableDiagnosticsSuite.scala
@@ -1,0 +1,22 @@
+package tests.codeactions
+
+import scala.meta.internal.metals.BuildInfo
+
+class ActionableDiagnosticsSuite
+    extends BaseCodeActionLspSuite(
+      "actionableDiagnostics"
+    ) {
+
+  check(
+    "insert-companion-object",
+    """|
+       |<<private private val x = 1>>
+       |""".stripMargin,
+    s"""|Remove repeated modifier: "private"
+        |""".stripMargin,
+    """|
+       |private  val x = 1
+       |""".stripMargin,
+    scalaVersion = BuildInfo.latestScala3Next,
+  )
+}


### PR DESCRIPTION
Since we don't have to send serialized data between the PC and Metals server Scala 3 PC actually just sends an empty Seq.

Previously, we would get exceptions whenever Seq was attached to a diagnostic coming from the compiler. Now, we properly show those diagnostics

Fixes https://github.com/scalameta/metals/issues/8347