### PR TITLE
refactor(mcp): update KiloCode configuration metadata

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpConfig.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpConfig.scala
@@ -286,11 +286,14 @@ object KiloCodeEditor
         "Kilo",
         "kilo",
       ),
-      settingsPath = ".kilocode/",
-      serverField = "mcpServers",
+      settingsPath = ".kilo/",
+      fileNames = List("kilo.json"),
+
+      serverField = "mcp",
       additionalProperties = List(
-        "type" -> "streamable-http"
+        "type" -> "remote"
       ),
+      rootProperties = List("$schema" -> "https://app.kilo.ai/config.json"),
     )
 
 object CursorEditor

--- a/tests/unit/src/test/scala/tests/mcp/McpConfigSuite.scala
+++ b/tests/unit/src/test/scala/tests/mcp/McpConfigSuite.scala
@@ -285,7 +285,7 @@ class McpConfigSuite extends BaseSuite {
       activeClientExtensionIds = activeClientExtensionIds,
     )
     val vscodeConfigFile = projectPath.resolve(".vscode/mcp.json")
-    val kiloConfigFile = projectPath.resolve(".kilocode/mcp.json")
+    val kiloConfigFile = projectPath.resolve(".kilo/kilo.json")
     assert(vscodeConfigFile.exists, "VSCode config file should exist")
     assert(kiloConfigFile.exists, "KiloCode extension config file should exist")
     val vscodeFirstContent = vscodeConfigFile.readText
@@ -304,10 +304,11 @@ class McpConfigSuite extends BaseSuite {
     assertNoDiff(
       kiloContent,
       """{
-        |  "mcpServers": {
+        |  "$schema": "https://app.kilo.ai/config.json",
+        |  "mcp": {
         |    "test-project-metals": {
         |      "url": "http://localhost:1234/mcp",
-        |      "type": "streamable-http"
+        |      "type": "remote"
         |    }
         |  }
         |}""".stripMargin,
@@ -337,10 +338,11 @@ class McpConfigSuite extends BaseSuite {
     assertNoDiff(
       kiloSecondContent,
       """{
-        |  "mcpServers": {
+        |  "$schema": "https://app.kilo.ai/config.json",
+        |  "mcp": {
         |    "test-project-metals": {
         |      "url": "http://localhost:5678/mcp",
-        |      "type": "streamable-http"
+        |      "type": "remote"
         |    }
         |  }
         |}""".stripMargin,


### PR DESCRIPTION
Update KiloCode editor settings to use a new settings path, server field, and file name. Change the additional properties type to remote and add the JSON schema to root properties.
```
settingsPath: ".kilocode/" -> ".kilo/"
serverField: "mcpServers" -> "mcp"
fileNames: added "kilo.json"
additionalProperties: "streamable-http" -> "remote"
rootProperties: added $schema
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Kilo editor integration now uses a new config file location and name.
  * Config format updated: includes a top-level schema declaration and revised server entry structure.
  * Default server type and related properties adjusted to the new format.
  * Users with existing Kilo editor settings should review and migrate their configs as needed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalameta/metals/pull/8365)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->