### PR TITLE
Refactor symbol visibility management in DocumentSymbolProvider

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -252,6 +252,7 @@ abstract class MetalsLspService(
   protected val documentSymbolProvider = new DocumentSymbolProvider(
     trees,
     initializeParams.supportsHierarchicalDocumentSymbols,
+    () => userConfig,
   )
 
   protected val onTypeFormattingProvider =

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -611,6 +611,16 @@ object UserConfiguration {
            |and it will still generate the one matching your editor if it's also supported.
            |""".stripMargin,
       ),
+      UserConfigurationOption(
+        "symbols-view-show-all",
+        "false",
+        "true",
+        "Show all symbols in the symbols view",
+        """|When this option is enabled, the symbols view will show all symbols instead of only toplevel classes, traits, objects, and packages.
+           |This can be useful when you want to see all the available symbols in the project, but it can also make the view more cluttered and harder to navigate.
+           |""".stripMargin,
+        isBoolean = true,
+      ),
     )
 
   def listOptions: String =

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -62,6 +62,7 @@ case class UserConfiguration(
     defaultShell: Option[String] = None,
     startMcpServer: Boolean = false,
     mcpClient: Option[String] = None,
+    symbolsViewShowAll: Boolean = false,
 ) {
 
   override def toString(): String = {

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -62,7 +62,7 @@ case class UserConfiguration(
     defaultShell: Option[String] = None,
     startMcpServer: Boolean = false,
     mcpClient: Option[String] = None,
-    symbolsViewShowAll: Boolean = true,
+    symbolsViewShowAll: Boolean = false,
 ) {
 
   override def toString(): String = {

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -162,6 +162,7 @@ case class UserConfiguration(
         )
       ),
       optStringField("mcpClient", mcpClient),
+      Some(("symbolsViewShowAll", symbolsViewShowAll)),
     ).flatten.toMap.asJava
     val gson = new GsonBuilder().setPrettyPrinting().create()
     gson.toJson(fields).toString()
@@ -911,6 +912,8 @@ object UserConfiguration {
     val startMcpServer = getBooleanKey("start-mcp-server").getOrElse(false)
 
     val mcpClient = getStringKey("mcp-client")
+    val symbolsViewShowAll =
+      getBooleanKey("symbols-view-show-all").getOrElse(false)
 
     if (errors.isEmpty) {
       Right(
@@ -949,6 +952,7 @@ object UserConfiguration {
           defaultShell,
           startMcpServer,
           mcpClient,
+          symbolsViewShowAll,
         )
       )
     } else {

--- a/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/UserConfiguration.scala
@@ -62,7 +62,7 @@ case class UserConfiguration(
     defaultShell: Option[String] = None,
     startMcpServer: Boolean = false,
     mcpClient: Option[String] = None,
-    symbolsViewShowAll: Boolean = false,
+    symbolsViewShowAll: Boolean = true,
 ) {
 
   override def toString(): String = {
@@ -162,7 +162,6 @@ case class UserConfiguration(
         )
       ),
       optStringField("mcpClient", mcpClient),
-      Some(("symbolsViewShowAll", symbolsViewShowAll)),
     ).flatten.toMap.asJava
     val gson = new GsonBuilder().setPrettyPrinting().create()
     gson.toJson(fields).toString()

--- a/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
@@ -24,8 +24,6 @@ final class DocumentSymbolProvider(
     userConfig: () => UserConfiguration,
 ) {
 
-  val symbolsViewShowAll: Boolean = userConfig().symbolsViewShowAll
-
   def documentSymbols(
       path: AbsolutePath
   ): Either[util.List[DocumentSymbol], util.List[l.SymbolInformation]] = {
@@ -103,7 +101,7 @@ final class DocumentSymbolProvider(
 
     // don't show local variables, parameters, and private members in the outline view, since they are not visible outside of their enclosing class or method. This is especially important for parameters, since they can be very numerous and clutter the outline view.
     def filterSymbols(addPatF: => Unit) = {
-      if (symbolsViewShowAll) { addPatF }
+      if (userConfig().symbolsViewShowAll) { addPatF }
       else {}
     }
 

--- a/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
@@ -97,6 +97,11 @@ final class DocumentSymbolProvider(
       }
     }
 
+    // don't show local variables, parameters, and private members in the outline view, since they are not visible outside of their enclosing class or method. This is especially important for parameters, since they can be very numerous and clutter the outline view.
+    def filterSymbols(addPatF: => Unit, showOnlyTopLevel: Boolean = true) = {
+      if (showOnlyTopLevel) {} else addPatF
+    }
+
     override def apply(tree: Tree): Unit = {
       def continue(withNewOwner: Boolean = false): Unit = {
         val oldRoot = owner
@@ -209,13 +214,17 @@ final class DocumentSymbolProvider(
           )
           newOwner()
         case t: Defn.Val =>
-          addPats(
-            t.pats,
-            SymbolKind.Constant,
-            t.pos,
-            t.decltpe.fold("")(_.syntax),
+          filterSymbols(
+            {
+              addPats(
+                t.pats,
+                SymbolKind.Constant,
+                t.pos,
+                t.decltpe.fold("")(_.syntax),
+              )
+              newOwner()
+            }
           )
-          newOwner()
         case t: Term.Param =>
           addChild(
             t.name.value,
@@ -225,29 +234,41 @@ final class DocumentSymbolProvider(
             t.decltpe.fold("")(_.syntax),
           )
         case t: Decl.Val =>
-          addPats(
-            t.pats,
-            SymbolKind.Constant,
-            t.pos,
-            t.decltpe.syntax,
+          filterSymbols(
+            {
+              addPats(
+                t.pats,
+                SymbolKind.Constant,
+                t.pos,
+                t.decltpe.syntax,
+              )
+              newOwner()
+            }
           )
-          newOwner()
         case t: Defn.Var =>
-          addPats(
-            t.pats,
-            SymbolKind.Variable,
-            t.pos,
-            t.decltpe.fold("")(_.syntax),
+          filterSymbols(
+            {
+              addPats(
+                t.pats,
+                SymbolKind.Variable,
+                t.pos,
+                t.decltpe.fold("")(_.syntax),
+              )
+              newOwner()
+            }
           )
-          newOwner()
         case t: Decl.Var =>
-          addPats(
-            t.pats,
-            SymbolKind.Variable,
-            t.pos,
-            t.decltpe.syntax,
+          filterSymbols(
+            {
+              addPats(
+                t.pats,
+                SymbolKind.Variable,
+                t.pos,
+                t.decltpe.syntax,
+              )
+              newOwner()
+            }
           )
-          newOwner()
         case t: Defn.Type =>
           addChild(
             t.name.value,

--- a/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
@@ -103,7 +103,8 @@ final class DocumentSymbolProvider(
 
     // don't show local variables, parameters, and private members in the outline view, since they are not visible outside of their enclosing class or method. This is especially important for parameters, since they can be very numerous and clutter the outline view.
     def filterSymbols(addPatF: => Unit) = {
-      if (symbolsViewShowAll) {} else addPatF
+      if (symbolsViewShowAll) { addPatF }
+      else {}
     }
 
     override def apply(tree: Tree): Unit = {
@@ -230,13 +231,16 @@ final class DocumentSymbolProvider(
             }
           )
         case t: Term.Param =>
-          addChild(
-            t.name.value,
-            SymbolKind.Variable,
-            t.pos,
-            t.name.pos,
-            t.decltpe.fold("")(_.syntax),
-          )
+          filterSymbols({
+            addChild(
+              t.name.value,
+              SymbolKind.Variable,
+              t.pos,
+              t.name.pos,
+              t.decltpe.fold("")(_.syntax),
+            )
+          })
+
         case t: Decl.Val =>
           filterSymbols(
             {

--- a/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/parsing/DocumentSymbolProvider.scala
@@ -10,6 +10,7 @@ import scala.meta.trees.Origin
 import org.eclipse.lsp4j.DocumentSymbol
 import org.eclipse.lsp4j.SymbolKind
 import org.eclipse.{lsp4j => l}
+import scala.meta.internal.metals.UserConfiguration
 
 /**
  *  Retrieves all the symbols defined in a document
@@ -20,7 +21,10 @@ import org.eclipse.{lsp4j => l}
 final class DocumentSymbolProvider(
     trees: Trees,
     supportsHierarchicalDocumentSymbols: Boolean,
+    userConfig: () => UserConfiguration,
 ) {
+
+  val symbolsViewShowAll: Boolean = userConfig().symbolsViewShowAll
 
   def documentSymbols(
       path: AbsolutePath
@@ -98,8 +102,8 @@ final class DocumentSymbolProvider(
     }
 
     // don't show local variables, parameters, and private members in the outline view, since they are not visible outside of their enclosing class or method. This is especially important for parameters, since they can be very numerous and clutter the outline view.
-    def filterSymbols(addPatF: => Unit, showOnlyTopLevel: Boolean = true) = {
-      if (showOnlyTopLevel) {} else addPatF
+    def filterSymbols(addPatF: => Unit) = {
+      if (symbolsViewShowAll) {} else addPatF
     }
 
     override def apply(tree: Tree): Unit = {

--- a/tests/unit/src/test/scala/tests/DocumentSymbolSuite.scala
+++ b/tests/unit/src/test/scala/tests/DocumentSymbolSuite.scala
@@ -28,6 +28,7 @@ abstract class DocumentSymbolSuite(
           val documentSymbolProvider = new DocumentSymbolProvider(
             trees = trees,
             supportsHierarchicalDocumentSymbols = true,
+            userConfig = () => scala.meta.internal.metals.UserConfiguration(),
           )
 
           // populate buffers

--- a/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
+++ b/tests/unit/src/test/scala/tests/UserConfigurationSuite.scala
@@ -402,7 +402,8 @@ class UserConfigurationSuite extends BaseSuite {
           |enable-best-effort                           boolean                        false           Use best effort compilation for Scala 3.
           |default-shell                                string                         ""              Full path to the shell executable to be used as the default
           |start-mcp-server                             boolean                        false           Start MCP server
-          |mcp-client                                   string                         ""              MCP Client Name""".stripMargin
+          |mcp-client                                   string                         ""              MCP Client Name
+          |symbols-view-show-all                        boolean                        false           Show all symbols in the symbols view""".stripMargin
     assertNoDiff(obtained, expected)
   }
 


### PR DESCRIPTION
This pull request improves the outline view in the Metals language server by reducing clutter from local variables, parameters, and private members. The main change is introducing a filter to control which symbols are shown, ensuring only top-level symbols are displayed in the outline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control visibility of value and variable symbols in the document outline view.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalameta/metals/pull/8369)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->