### PR TITLE
fix: bazel 8 dirs not being matched in mbt-importer

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMavenJsonImporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMavenJsonImporter.scala
@@ -757,7 +757,7 @@ object BazelMavenJsonImporter {
       jarName: String,
   ): Option[AbsolutePath] = {
     Try {
-      val entries = extDir.list
+      val entries: List[AbsolutePath] = extDir.list.toList
 
       // Look for directory matching Bazel 7.x pattern: rules_jvm_external~{version}~maven~{artifactDir}
       val bazel7Dir = entries.find { entry =>
@@ -823,12 +823,6 @@ object BazelMavenJsonImporter {
           }
         }.toList
 
-        if (candidateRepositories.nonEmpty) {
-          scribe.debug(
-            s"bzlmod maven repositories: ${candidateRepositories.map(_.filename).mkString(", ")}"
-          )
-        }
-
         val repositoryRelativePaths = relativePaths.flatMap { path =>
           bzlmodRepositoryNames.flatMap { repo =>
             Seq(
@@ -839,17 +833,21 @@ object BazelMavenJsonImporter {
           }
         }.distinct
 
-        candidateRepositories
-          .flatMap { repo =>
-            repositoryRelativePaths
-              .map(path => repo.resolve(path))
-              .find(_.exists)
-          }
-          .headOption
-          .map { path =>
-            scribe.debug(s"Found Bzlmod maven JAR: $path")
-            path
-          }
+        val found = candidateRepositories.flatMap { repo =>
+          repositoryRelativePaths
+            .map(path => repo.resolve(path))
+            .find(_.exists)
+        }.headOption
+
+        if (candidateRepositories.nonEmpty && found.isEmpty) {
+          scribe.warn(
+            s"JAR not found in central maven repos " +
+              s"${candidateRepositories.map(_.filename).mkString(", ")}; " +
+              s"tried: [${repositoryRelativePaths.mkString(", ")}]"
+          )
+        }
+
+        found
       }.getOrElse(None)
     }
   }


### PR DESCRIPTION
The Iterator returned by extDir.list would be used up by trying to find bazel 7 path matches, so it never got to check the Bazel 8 ones. I also allowed myself to add some logs that ended up being especially helpful for figuring out what's going on (previously we would only log successes, but I feel like "misses" are more helpful).  