### PR TITLE
Fix: targets with empty sources missing from bazel mbt auto-import

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtBuildSupport.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtBuildSupport.scala
@@ -85,6 +85,11 @@ object BazelMbtBuildSupport {
         } {
           byBuildFile.getOrElseUpdate(p, mutable.Set.empty) += f
         }
+        // Ensure targets with no srcs (e.g. export-only targets) still produce
+        // a namespace so their dependsOn (exports) are preserved.
+        for (t <- targetLabels) {
+          byBuildFile.getOrElseUpdate(keys(t), mutable.Set.empty)
+        }
         for {
           t <- targetLabels
           p = keys(t)


### PR DESCRIPTION
E.g. problematic target: 
```
scala_library(
    name = "testing",
    visibility = ["//visibility:public"],
    exports = [
        "//some-util",
    ]
)
```
Turns out the exports are already handled correctly (put into dependsOn), so we just need to make sure taregts with empty sources are not filtered out.