### PR TITLE
bugfix: Fix issues with file groups and possible errors in query

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/Indexer.scala
@@ -454,6 +454,7 @@ case class Indexer(indexProviders: IndexProviders, mbtBuild: () => MbtBuild)(
     val sourcesToIndex = mutable.ArrayBuffer.empty[SourceToIndex]
     for {
       (sourceItem, targets) <- data.sourceItemsToBuildTarget
+      if sourceItem.exists
       source <- sourceItem.listRecursiveOrJar
       if source.isScalaOrJava
     } {

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelQuery.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelQuery.scala
@@ -93,9 +93,10 @@ case class BazelQuery(
             )
           )
         case code =>
-          Future.failed(
-            new Exception(s"bazel-mbt: bazel query failed with exit code $code")
+          scribe.warn(
+            s"bazel-mbt: bazel query failed with exit code $code, but might be unreleated."
           )
+          Future.successful(buf.toString)
       }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelTargetsXmlDump.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelTargetsXmlDump.scala
@@ -1,16 +1,32 @@
 package scala.meta.internal.metals.mbt.importer
 
 import scala.xml.XML
+
 class BazelTargetsXmlDump(xmlDump: String) {
 
   private lazy val root = XML.loadString(xmlDump)
+
+  private lazy val filegroupSrcLabelsByTarget: Map[String, List[String]] = {
+    val targetLabels = for {
+      rule <- root \\ "rule"
+      target = (rule \ "@name").text
+      if target.nonEmpty && isFilegroupRule(rule)
+    } yield target -> labelsFromRuleAttribute(rule, Some("srcs")).toList
+    targetLabels.toMap
+  }
 
   def getLabels(attributeName: String): Map[String, List[String]] = {
     val targetLabels = for {
       rule <- root \\ "rule"
       target = (rule \ "@name").text
       if target.nonEmpty
-    } yield target -> labelsFromRuleAttribute(rule, Some(attributeName)).toList
+    } yield {
+      val labels = labelsFromRuleAttribute(rule, Some(attributeName)).toList
+      val expandedLabels =
+        if (attributeName == "srcs") expandFilegroups(labels)
+        else labels
+      target -> expandedLabels
+    }
     targetLabels.toMap
   }
 
@@ -48,6 +64,21 @@ class BazelTargetsXmlDump(xmlDump: String) {
 
   private def isExternalDep(label: String): Boolean =
     label.startsWith("@") && !label.startsWith("@@")
+
+  private def isFilegroupRule(rule: scala.xml.Node): Boolean =
+    (rule \ "@class").text == "filegroup"
+
+  private def expandFilegroups(labels: List[String]): List[String] = {
+    def expand(label: String, stack: Set[String]): List[String] =
+      filegroupSrcLabelsByTarget.get(label) match {
+        case Some(srcs) if !stack.contains(label) =>
+          srcs.flatMap(src => expand(src, stack + label))
+        case _ =>
+          List(label)
+      }
+
+    labels.flatMap(label => expand(label, Set.empty)).distinct
+  }
 
   private def reachableLabels(
       rootLabels: List[String]

--- a/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
@@ -182,6 +182,42 @@ class BazelMbtLspSuite
        |}
        |""".stripMargin
 
+  private def filegroupBazelWorkspaceLayout: String =
+    """|/.bazelproject
+       |targets:
+       |    //...
+       |
+       |/lib/BUILD
+       |load("@rules_scala//scala:scala.bzl", "scala_library")
+       |
+       |filegroup(
+       |    name = "library_sources",
+       |    srcs = [
+       |        "Library.scala",
+       |        "More.scala",
+       |    ],
+       |)
+       |
+       |scala_library(
+       |    name = "library",
+       |    srcs = [":library_sources"],
+       |)
+       |
+       |/lib/Library.scala
+       |package lib
+       |
+       |class Library {
+       |  def message: String = "hello"
+       |}
+       |
+       |/lib/More.scala
+       |package lib
+       |
+       |class More {
+       |  def library = new Library().message
+       |}
+       |""".stripMargin
+
   private def pinMaven(workspace: AbsolutePath): Unit = {
     workspace.resolve("maven_install.json").touch()
     ShellRunner.runSync(
@@ -310,6 +346,40 @@ class BazelMbtLspSuite
            |res0: Option[Int] = Some(3)
            |```
            |""".stripMargin.hover,
+      )
+    } yield ()
+  }
+
+  test("bazel-import-mbt-filegroup-srcs") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        BazelBuildLayout(
+          filegroupBazelWorkspaceLayout,
+          V.scala213,
+          bazelVersion,
+        )
+      )
+      _ <- server.headServer.connectionProvider.buildServerPromise.future
+      mbtFile = workspace.resolve(".metals/mbt.json").readText
+      _ = assertNoDiff(
+        escapeMbtFile(mbtFile),
+        s"""|{
+            |  "dependencyModules": [],
+            |  "namespaces": {
+            |    "//lib": {
+            |      "sources": [
+            |        "lib/Library.scala",
+            |        "lib/More.scala"
+            |      ],
+            |      "scalacOptions": [],
+            |      "javacOptions": [],
+            |      "dependencyModules": [],
+            |      "scalaVersion": "2.13.18",
+            |      "dependsOn": []
+            |    }
+            |  }
+            |}""".stripMargin,
       )
     } yield ()
   }


### PR DESCRIPTION
Previously, we would not find file groups. Now, we make sure to expand them.

Also, we failed if bazel query failed, but since we have keep-going we should be fine to just warn. In case of https://github.com/tensorflow/tensorflow the failures were not related to java or scala.