### PR TITLE
bugfix: Fix duplicate lenses

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -89,10 +89,10 @@ final class RunTestCodeLens(
       buffers.tokenEditDistance(path, textDocument.text, scalaVersionSelector)
     val targetIds = buildTargets
       .inverseSourcesAll(path)
-      .flatMap(buildTargets.allInverseDependencies)
       .distinct
-    val lenses = for {
-      buildTargetId <- targetIds
+
+    val firstLegitimateTargetId = for {
+      buildTargetId <- targetIds.iterator
       buildTarget <- buildTargets.info(buildTargetId)
       capabilities = buildTarget.getCapabilities
       if Option(capabilities.getCanDebug).exists(_.booleanValue) ||
@@ -101,6 +101,10 @@ final class RunTestCodeLens(
       isJVM = buildTarget.asScalaBuildTarget.forall(
         _.getPlatform == b.ScalaPlatform.JVM
       )
+    } yield (buildTargetId, isJVM)
+
+    val lenses = for {
+      (buildTargetId, isJVM) <- firstLegitimateTargetId.headOption.toSeq
       // although hasDebug is already available in BSP capabilities
       // see https://github.com/build-server-protocol/build-server-protocol/pull/161
       // most of the bsp servers such as bloop and sbt might not support it.

--- a/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/CodeLensLspSuite.scala
@@ -146,6 +146,7 @@ class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
       )
     } yield ()
   }
+
   test("run-java") {
     cleanWorkspace()
     for {
@@ -171,6 +172,53 @@ class CodeLensLspSuite extends BaseCodeLensLspSuite("codeLenses") {
       _ <- assertCodeLenses(
         "a/src/main/java/Main.java",
         """|package foo.bar;
+           |
+           |public class Main {
+           |<<run>><<debug>>
+           |  public static void main(String[] args){
+           |    System.out.println("Hello from Java!");
+           |  }
+           |}
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("run-java-depends") {
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        """|/metals.json
+           |{
+           |  "a": { },
+           |  "b": { "dependsOn": ["a"] }
+           |}
+           |
+           |/a/src/main/java/Main.java
+           |package a;
+           |
+           |public class Main {
+           |  public static void main(String[] args){
+           |    System.out.println("Hello from Java!");
+           |  }
+           |}
+           |
+           |/b/src/main/java/Main.java
+           |package b;
+           |
+           |public class Main {
+           |  public static void main(String[] args){
+           |    System.out.println("Hello from Java!");
+           |  }
+           |}
+           |""".stripMargin
+      )
+      _ <- server.didOpen(
+        "a/src/main/java/Main.java"
+      ) // compile `a` to populate its cache
+      _ <- assertCodeLenses(
+        "a/src/main/java/Main.java",
+        """|package a;
            |
            |public class Main {
            |<<run>><<debug>>


### PR DESCRIPTION
This change never really made sense, but my guess is that it was due to some targets containing the same path but not all being  runnable. Without the reproduction this is my best guess.

Fixes https://github.com/scalameta/metals/issues/8389