### PR TITLE
Pass the Java home from Metals to the Gradle daemon

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -639,6 +639,8 @@ lazy val `gradle-extractor` = project
       "org.gradle" % "gradle-tooling-api" % V.gradleToolingApi,
       "com.lihaoyi" %% "upickle" % "4.3.2",
       "org.scalameta" %% "munit" % V.munit % Test,
+      "com.outr" %% "scribe" % V.scribe(scalaVersion.value),
+      "com.outr" %% "scribe-slf4j2" % V.scribe(scalaVersion.value),
     ),
     testFrameworks := List(TestFrameworks.MUnit),
   )

--- a/gradle-extractor/src/main/scala/gradleinfo/GradleInfoExtractor.scala
+++ b/gradle-extractor/src/main/scala/gradleinfo/GradleInfoExtractor.scala
@@ -5,6 +5,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 import scala.jdk.CollectionConverters._
+import scala.util.Failure
+import scala.util.Try
 import scala.util.control.NonFatal
 
 import org.gradle.tooling.GradleConnector
@@ -64,8 +66,9 @@ object GradleInfoExtractor {
     config.gradleUserHome.foreach(connector.useGradleUserHomeDir)
 
     val connection: ProjectConnection = connector.connect()
+    scribe.info("GradleInfoExtractor: Connected to the Gradle daemon")
     try {
-      val env = fetchModel(connection, classOf[BuildEnvironment], config)
+      val env = fetchModel(connection, classOf[BuildEnvironment], config).get
 
       val sourceSetsOutputFile =
         Files.createTempFile("metals-sourcesets", ".json")
@@ -77,7 +80,7 @@ object GradleInfoExtractor {
             classOf[IdeaProject],
             config,
             extraArgs = List("--init-script", initScriptFile.toString),
-          )
+          ).get
           val map = readSourceSetsMap(sourceSetsOutputFile)
           (ideaModel, map)
         } finally {
@@ -161,11 +164,45 @@ object GradleInfoExtractor {
       modelType: Class[T],
       config: ExtractorConfig,
       extraArgs: List[String] = Nil,
-  ): T = {
+  ): Try[T] = {
     val builder: ModelBuilder[T] = connection.model(modelType)
-    config.gradleJvm.foreach(builder.setJavaHome)
+    config.gradleJvm.foreach { javaHome =>
+      scribe.info(
+        s"GradleInfoExtractor: Setting Java home for the Gradle model builder: $javaHome"
+      )
+      builder.setJavaHome(javaHome)
+    }
     if (extraArgs.nonEmpty) builder.withArguments(extraArgs: _*)
-    builder.get()
+    Try {
+      builder.get()
+    }.recoverWith { case NonFatal(e) =>
+      val javaMismatchError = new StacktraceIterator(e).find { t =>
+        Option(t.getMessage()).exists(_.startsWith("Unsupported class file"))
+      }
+      /*
+       * If the model builder compiles the custom build scripts supplied by the importer
+       * with Java version that's not supported by the Gradle daemon, an exception will be thrown.
+       * This failure mode seems to be quite likely (e.g. when importing a legacy project),
+       * and the exception has a very long stack trace which is not particularly helpful.
+       * In this particular situation, we hide most of that stack trace and re-throw just the root cause.
+       */
+      javaMismatchError.foreach { _ =>
+        scribe.error(
+          """|GradleInfoExtractor: error while fetching data from the Gradle daemon.
+             |  This is very likely caused by incompatible versions of the JDK.
+             |
+             |  To mitigate this, open your workspace configuration (e.g. .vscode/settings.json)
+             |  and set "metals.java-home" to a path to a compatible JDK distribution.
+             |  See the table of compatible versions at
+             |  https://docs.gradle.org/current/userguide/compatibility.html.
+             |
+             |  (Turn on debug logging to see the full stack trace.)
+             |""".stripMargin
+        )
+        scribe.debug(e)
+      }
+      Failure[T](javaMismatchError.getOrElse(e))
+    }
   }
 
   private def extractModule(
@@ -316,5 +353,15 @@ object GradleInfoExtractor {
   private def stripJarExtension(f: File): String = {
     val n = f.getName
     if (n.endsWith(".jar")) n.dropRight(4) else n
+  }
+
+  private class StacktraceIterator(e: Throwable) extends Iterator[Throwable] {
+    var t = e
+    def hasNext: Boolean = t.getCause() != null
+
+    def next(): Throwable = {
+      t = t.getCause()
+      t
+    }
   }
 }

--- a/gradle-extractor/src/main/scala/gradleinfo/GradleInfoExtractorImpl.scala
+++ b/gradle-extractor/src/main/scala/gradleinfo/GradleInfoExtractorImpl.scala
@@ -19,9 +19,11 @@ class GradleInfoExtractorImpl extends MbtExtractor {
   override def extract(
       projectDir: Path,
       outputFile: Path,
+      jdkHome: Path,
   ): Unit = try {
     val config = ExtractorConfig(
-      projectDir = projectDir
+      projectDir = projectDir,
+      gradleJvm = Option(jdkHome).map(_.toFile()),
     )
     val report = GradleInfoExtractor.extract(config)
     val json = report.toMbtJson

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -28,7 +28,7 @@ case class GradleBuildTool(
     userConfig: () => UserConfiguration,
     override val projectRoot: AbsolutePath,
 )(implicit ec: ExecutionContext)
-    extends GradleMbtImporter(projectRoot)
+    extends GradleMbtImporter(projectRoot, userConfig)
     with BuildTool
     with BloopInstallProvider
     with VersionRecommendation

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/GradleMbtImporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/GradleMbtImporter.scala
@@ -12,6 +12,7 @@ import scala.meta.internal.builds.GradleDigest
 import scala.meta.internal.metals.Embedded
 import scala.meta.internal.metals.Time
 import scala.meta.internal.metals.Timer
+import scala.meta.internal.metals.UserConfiguration
 import scala.meta.io.AbsolutePath
 import scala.meta.mbt.MbtExtractor
 
@@ -20,7 +21,8 @@ import scala.meta.mbt.MbtExtractor
  * The extractor is downloaded on-demand using Coursier and loaded via ServiceLoader.
  */
 class GradleMbtImporter(
-    val projectRoot: AbsolutePath
+    val projectRoot: AbsolutePath,
+    userConfig: () => UserConfiguration,
 )(implicit ec: ExecutionContext)
     extends MbtImportProvider {
 
@@ -32,7 +34,14 @@ class GradleMbtImporter(
 
     val timer = new Timer(Time.system)
     val extractor = loadExtractor()
-    extractor.extract(projectRoot.toNIO, out.toNIO)
+    val toolJdkHome = userConfig().javaHome
+      .orElse(sys.env.get("JAVA_HOME"))
+      .map(AbsolutePath.apply)
+    extractor.extract(
+      projectRoot.toNIO,
+      out.toNIO,
+      toolJdkHome.map(_.toNIO).getOrElse(null),
+    )
     scribe.info(s"time: gradle-extractor extract in $timer")
   }
 

--- a/mtags-interfaces/src/main/java/scala/meta/mbt/MbtExtractor.java
+++ b/mtags-interfaces/src/main/java/scala/meta/mbt/MbtExtractor.java
@@ -17,6 +17,7 @@ public interface MbtExtractor {
    *
    * @param projectDir The root directory of the project.
    * @param outputFile The file to write the project report to.
+   * @param jdkHome The Java distribution which may be used to run the build tool.
    */
-  abstract void extract(Path projectDir, Path outputFile);
+  abstract void extract(Path projectDir, Path outputFile, Path jdkHome);
 }

--- a/tests/slow/src/test/scala/tests/gradle/GradleMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/gradle/GradleMbtLspSuite.scala
@@ -1,7 +1,5 @@
 package tests.gradle
 
-import scala.util.Properties
-
 import scala.meta.internal.metals.AutoImportBuildKind
 import scala.meta.internal.metals.Configs.JavaSymbolLoaderConfig
 import scala.meta.internal.metals.Configs.ReferenceProviderConfig
@@ -123,7 +121,7 @@ class GradleMbtLspSuite
             |        "org.typelevel:cats-core_2.13:2.13.0",
             |        "org.typelevel:cats-kernel_2.13:2.13.0"
             |      ],
-            |      "javaHome": "file://${Properties.javaHome.replace("\\", "/")}/",
+            |      "javaHome": "<javaHome-path>",
             |      "classDirectories": [
             |        "build/classes/java/main",
             |        "build/classes/scala/main"
@@ -142,7 +140,7 @@ class GradleMbtLspSuite
             |        "org.typelevel:cats-core_2.13:2.13.0",
             |        "org.typelevel:cats-kernel_2.13:2.13.0"
             |      ],
-            |      "javaHome": "file://${Properties.javaHome.replace("\\", "/")}/",
+            |      "javaHome": "<javaHome-path>",
             |      "dependsOn": [
             |        "basic"
             |      ],
@@ -256,7 +254,7 @@ class GradleMbtLspSuite
             |      "dependencyModules": [
             |        "org.jsoup:jsoup:1.21.1"
             |      ],
-            |      "javaHome": "file://${Properties.javaHome.replace("\\", "/")}/",
+            |      "javaHome": "<javaHome-path>",
             |      "classDirectories": ["<classDirectories-path>"],
             |      "projectPath": ":"
             |    },
@@ -269,7 +267,7 @@ class GradleMbtLspSuite
             |      "dependencyModules": [
             |        "org.jsoup:jsoup:1.21.1"
             |      ],
-            |      "javaHome": "file://${Properties.javaHome.replace("\\", "/")}/",
+            |      "javaHome": "<javaHome-path>",
             |      "dependsOn": [
             |        "plain-java"
             |      ],

--- a/tests/unit/src/main/scala/tests/BaseMbtSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseMbtSuite.scala
@@ -12,5 +12,9 @@ trait BaseMbtSuite {
         """"(classDirectories|testClassDirectories)":\s*\[\s*"[^"]+"\s*\]""",
         """"$1": ["<$1-path>"]""",
       )
+      .replaceAll(
+        """"(javaHome)":\s*"[^"]+"""",
+        """"$1": "<$1-path>"""",
+      )
   }
 }


### PR DESCRIPTION
In order to use the Gradle tooling API, we need to launch the Gradle model importer on a supported version of JDK (see the [compatibility table](https://docs.gradle.org/current/userguide/compatibility.html)). If the user's shell environment (`$JAVA_HOME` or `$PATH`) is pointing to an incompatible JDK, the Gradle build will crash and we won't be able to extract any data.

This PR gives the user an opportunity to set a compatible version of `$JAVA_HOME`. Actually it doesn't need to be the same version that runs the Metals server, but I decided to reuse an existing entry in `UserConfiguration` for the sake of a quick fix.

## How the error looks now
<img width="733" height="388" alt="Screenshot 2026-06-16 at 04 34 33" src="https://github.com/user-attachments/assets/c740fd45-9459-4223-8c88-2dbe477e98db" />
