### PR TITLE
Fix issue with duplicate filenames in MBT-based PC

### DIFF
--- a/mtags/src/main/scala-2.12/scala/meta/internal/pc/classpath/MtagsPathResolver.scala
+++ b/mtags/src/main/scala-2.12/scala/meta/internal/pc/classpath/MtagsPathResolver.scala
@@ -142,7 +142,7 @@ final class MtagsPathResolver(
   @deprecated("Use resultAsURLs instead of this one", "2.11.5")
   def asURLs: List[URL] = resultAsURLs.toList
 
-  private def computeResult(): ClassPath = AggregateClassPath(
+  private def computeResult(): ClassPath = MetalsAggregateClassPath(
     containers.toIndexedSeq
   )
 }

--- a/mtags/src/main/scala-2.13/scala/meta/internal/pc/classpath/MtagsPathResolver.scala
+++ b/mtags/src/main/scala-2.13/scala/meta/internal/pc/classpath/MtagsPathResolver.scala
@@ -145,7 +145,7 @@ final class MtagsPathResolver(
   @deprecated("Use resultAsURLs instead of this one", "2.11.5")
   def asURLs: List[URL] = resultAsURLs.toList
 
-  private def computeResult(): ClassPath = AggregateClassPath(
+  private def computeResult(): ClassPath = MetalsAggregateClassPath(
     containers.toIndexedSeq
   )
 }

--- a/mtags/src/main/scala-2/scala/tools/nsc/LogicalSourcePath.scala
+++ b/mtags/src/main/scala-2/scala/tools/nsc/LogicalSourcePath.scala
@@ -4,11 +4,13 @@ package scala.tools.nsc
 
 import java.io.File
 import java.net.URL
+import java.nio.file.Files
 import java.nio.file.Path
 import java.{util => ju}
 
 import scala.jdk.CollectionConverters._
 import scala.reflect.io.AbstractFile
+import scala.reflect.io.VirtualFile
 import scala.tools.nsc.classpath._
 import scala.tools.nsc.reporters.ConsoleReporter
 import scala.tools.nsc.reporters.Reporter
@@ -48,8 +50,28 @@ class LogicalSourcePath(val dirs: Seq[File], rootPackage: LogicalPackage)
     }
   }
 
-  private def sourcesIn(pkg: LogicalPackage) = {
-    pkg.sources.map(p => SourceFileEntryImpl(AbstractFile.getFile(p)))
+  private def sourcesIn(pkg: LogicalPackage): Seq[SourceFileEntry] = {
+    val byName = pkg.sources.groupBy(p => new File(p).getName)
+    byName.flatMap { case (filename, paths) =>
+      paths.zipWithIndex.map { case (p, i) =>
+        if (i == 0) SourceFileEntryImpl(AbstractFile.getFile(p))
+        else {
+          // AggregateClassPath deduplicates SourceFileEntry by filename, so duplicate-named
+          // files in the same package (e.g. main/util/reporter.scala defined in package util
+          // and test/util/reporter.scala also defined in package util)
+          // would be silently dropped. We rename them to avoid this.
+          val ext = filename.lastIndexOf('.')
+          val uniqueName =
+            filename.substring(0, ext) + "$" + i + filename.substring(ext)
+          val vf = new VirtualFile(uniqueName)
+          val bytes = Files.readAllBytes(new File(p).toPath)
+          val os = vf.output
+          try os.write(bytes)
+          finally os.close()
+          SourceFileEntryImpl(vf)
+        }
+      }
+    }.toSeq
   }
 
   private def packagesIn(pkg: LogicalPackage, prefix: String) = {

--- a/mtags/src/main/scala-2/scala/tools/nsc/LogicalSourcePath.scala
+++ b/mtags/src/main/scala-2/scala/tools/nsc/LogicalSourcePath.scala
@@ -4,13 +4,11 @@ package scala.tools.nsc
 
 import java.io.File
 import java.net.URL
-import java.nio.file.Files
 import java.nio.file.Path
 import java.{util => ju}
 
 import scala.jdk.CollectionConverters._
 import scala.reflect.io.AbstractFile
-import scala.reflect.io.VirtualFile
 import scala.tools.nsc.classpath._
 import scala.tools.nsc.reporters.ConsoleReporter
 import scala.tools.nsc.reporters.Reporter
@@ -50,29 +48,8 @@ class LogicalSourcePath(val dirs: Seq[File], rootPackage: LogicalPackage)
     }
   }
 
-  private def sourcesIn(pkg: LogicalPackage): Seq[SourceFileEntry] = {
-    val byName = pkg.sources.groupBy(p => new File(p).getName)
-    byName.flatMap { case (filename, paths) =>
-      paths.zipWithIndex.map { case (p, i) =>
-        if (i == 0) SourceFileEntryImpl(AbstractFile.getFile(p))
-        else {
-          // AggregateClassPath deduplicates SourceFileEntry by filename, so duplicate-named
-          // files in the same package (e.g. main/util/reporter.scala defined in package util
-          // and test/util/reporter.scala also defined in package util)
-          // would be silently dropped. We rename them to avoid this.
-          val ext = filename.lastIndexOf('.')
-          val uniqueName =
-            filename.substring(0, ext) + "$" + i + filename.substring(ext)
-          val vf = new VirtualFile(uniqueName)
-          val bytes = Files.readAllBytes(new File(p).toPath)
-          val os = vf.output
-          try os.write(bytes)
-          finally os.close()
-          SourceFileEntryImpl(vf)
-        }
-      }
-    }.toSeq
-  }
+  private def sourcesIn(pkg: LogicalPackage): Seq[SourceFileEntry] =
+    pkg.sources.map(p => SourceFileEntryImpl(AbstractFile.getFile(p)))
 
   private def packagesIn(pkg: LogicalPackage, prefix: String) = {
     val pre = if (prefix.isEmpty) prefix else s"$prefix."

--- a/mtags/src/main/scala-2/scala/tools/nsc/classpath/MetalsAggregateClassPath.scala
+++ b/mtags/src/main/scala-2/scala/tools/nsc/classpath/MetalsAggregateClassPath.scala
@@ -1,0 +1,54 @@
+package scala.tools.nsc.classpath
+
+import scala.collection.mutable.ArrayBuffer
+import scala.tools.nsc.util.ClassPath
+import scala.tools.nsc.util.ClassRepresentation
+
+/**
+ * A variant of AggregateClassPath that does not deduplicate source file entries
+ * by basename. This allows the presentation compiler to see multiple source files
+ * with the same basename in the same package (e.g. main/util/Utils.scala and
+ * test/util/Utils.scala both in package util), which can occur in MBT-based builds
+ * where multiple source roots contribute to a single logical package.
+ */
+final class MetalsAggregateClassPath(_aggregates: Seq[ClassPath])
+    extends AggregateClassPath(_aggregates) {
+
+  override private[nsc] def sources(
+      inPackage: PackageName
+  ): Seq[SourceFileEntry] =
+    aggregates.flatMap(_.sources(inPackage))
+
+  override private[nsc] def list(inPackage: PackageName): ClassPathEntries = {
+    val pkgs = packages(inPackage)
+    val classEntries = classes(inPackage)
+    val sourceEntries = sources(inPackage)
+
+    // Build a name → class map for merging class+source pairs.
+    val classMap = classEntries.iterator.map(c => c.name -> c).toMap
+    val mergedClassNames = new java.util.HashSet[String]()
+    val result = new ArrayBuffer[ClassRepresentation]()
+
+    // Add sources first. When a class entry exists for the same name, merge once;
+    // subsequent sources with the same name are kept as standalone SourceFileEntries.
+    for (s <- sourceEntries) {
+      classMap.get(s.name) match {
+        case Some(c) if mergedClassNames.add(s.name) =>
+          result += ClassAndSourceFilesEntry(c.file, s.file)
+        case _ =>
+          result += s
+      }
+    }
+    // Add class entries that had no matching source.
+    for (c <- classEntries if !mergedClassNames.contains(c.name)) {
+      result += c
+    }
+
+    ClassPathEntries(pkgs, if (result.isEmpty) Nil else result.toIndexedSeq)
+  }
+}
+
+object MetalsAggregateClassPath {
+  def apply(aggregates: Seq[ClassPath]): ClassPath =
+    new MetalsAggregateClassPath(aggregates)
+}

--- a/mtags/src/main/scala-2/scala/tools/nsc/classpath/MetalsAggregateClassPath.scala
+++ b/mtags/src/main/scala-2/scala/tools/nsc/classpath/MetalsAggregateClassPath.scala
@@ -1,8 +1,10 @@
 package scala.tools.nsc.classpath
 
 import scala.collection.mutable.ArrayBuffer
+import scala.reflect.internal.FatalError
 import scala.tools.nsc.util.ClassPath
 import scala.tools.nsc.util.ClassRepresentation
+import scala.tools.nsc.util.EfficientClassPath
 
 /**
  * A variant of AggregateClassPath that does not deduplicate source file entries
@@ -19,32 +21,76 @@ final class MetalsAggregateClassPath(_aggregates: Seq[ClassPath])
   ): Seq[SourceFileEntry] =
     aggregates.flatMap(_.sources(inPackage))
 
+  // The same as in AggregateClassPath, except it now uses mergeWithDuplicateSources
   override private[nsc] def list(inPackage: PackageName): ClassPathEntries = {
-    val pkgs = packages(inPackage)
-    val classEntries = classes(inPackage)
-    val sourceEntries = sources(inPackage)
+    val packages: java.util.HashSet[PackageEntry] =
+      new java.util.HashSet[PackageEntry]()
+    val classesAndSourcesBuffer = new ArrayBuffer[ClassRepresentation]()
+    val onPackage: PackageEntry => Unit = packages.add(_)
+    val onClassesAndSources: ClassRepresentation => Unit =
+      classesAndSourcesBuffer += _
 
-    // Build a name → class map for merging class+source pairs.
-    val classMap = classEntries.iterator.map(c => c.name -> c).toMap
-    val mergedClassNames = new java.util.HashSet[String]()
-    val result = new ArrayBuffer[ClassRepresentation]()
-
-    // Add sources first. When a class entry exists for the same name, merge once;
-    // subsequent sources with the same name are kept as standalone SourceFileEntries.
-    for (s <- sourceEntries) {
-      classMap.get(s.name) match {
-        case Some(c) if mergedClassNames.add(s.name) =>
-          result += ClassAndSourceFilesEntry(c.file, s.file)
-        case _ =>
-          result += s
+    aggregates.foreach { cp =>
+      try {
+        cp match {
+          case ecp: EfficientClassPath =>
+            ecp.list(inPackage, onPackage, onClassesAndSources)
+          case _ =>
+            val entries = cp.list(inPackage)
+            entries._1.foreach(entry => packages.add(entry))
+            classesAndSourcesBuffer ++= entries._2
+        }
+      } catch {
+        case ex: java.io.IOException =>
+          val e = FatalError(ex.getMessage)
+          e.initCause(ex)
+          throw e
       }
     }
-    // Add class entries that had no matching source.
-    for (c <- classEntries if !mergedClassNames.contains(c.name)) {
-      result += c
+
+    val distinctPackages: Seq[PackageEntry] =
+      if (packages.isEmpty) Nil
+      else
+        packages.toArray(new Array[PackageEntry](packages.size())).toIndexedSeq
+    val mergedClassesAndSources = mergeWithDuplicateSources(
+      classesAndSourcesBuffer
+    )
+    ClassPathEntries(distinctPackages, mergedClassesAndSources)
+  }
+
+  // Like AggregateClassPath.mergeClassesAndSources
+  // but keeps all source entries with the same name
+  private def mergeWithDuplicateSources(
+      entries: ArrayBuffer[ClassRepresentation]
+  ): Seq[ClassRepresentation] = {
+    var count = 0
+    val indices =
+      new java.util.HashMap[String, Int]((entries.size * 1.25).toInt)
+    val mergedEntries = new ArrayBuffer[ClassRepresentation](entries.size)
+
+    for (entry <- entries) {
+      val name = entry.name
+      if (indices.containsKey(name)) {
+        val index = indices.get(name)
+        val existing = mergedEntries(index)
+
+        if (existing.binary.isEmpty && entry.binary.isDefined)
+          mergedEntries(index) =
+            ClassAndSourceFilesEntry(entry.binary.get, existing.source.get)
+        else if (existing.source.isEmpty && entry.source.isDefined)
+          mergedEntries(index) =
+            ClassAndSourceFilesEntry(existing.binary.get, entry.source.get)
+        else if (entry.source.isDefined)
+          // added in the reimplementation here, to not filter out duplicate sources
+          mergedEntries += entry
+      } else {
+        indices.put(name, count)
+        mergedEntries += entry
+        count += 1
+      }
     }
 
-    ClassPathEntries(pkgs, if (result.isEmpty) Nil else result.toIndexedSeq)
+    if (mergedEntries.isEmpty) Nil else mergedEntries.toIndexedSeq
   }
 }
 

--- a/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtBuildServerLspSuite.scala
@@ -528,4 +528,84 @@ class MbtBuildServerLspSuite
       )
     } yield ()
   }
+
+  test("mbt-duplicate-source-filenames-in-same-package") {
+    cleanWorkspace()
+    val mbtJson =
+      s"""|{
+          |  "namespaces": {
+          |    "core": {
+          |      "sources": ["main/src/**", "test/src/**"],
+          |      "scalaVersion": "${BuildInfo.scalaVersion}"
+          |    }
+          |  }
+          |}""".stripMargin
+
+    val appFile = "main/src/app/App.scala"
+
+    for {
+      _ <- initialize(
+        s"""|/.metals/mbt.json
+            |$mbtJson
+            |/main/src/util/Utils.scala
+            |package util
+            |
+            |object MainUtils {
+            |  val value: String = "main"
+            |}
+            |/test/src/util/Utils.scala
+            |package util
+            |
+            |object TestUtils {
+            |  val value: String = "test"
+            |}
+            |/$appFile
+            |package app
+            |
+            |import util.MainUtils
+            |import util.TestUtils
+            |
+            |object App {
+            |  def runMain: String = MainUtils.value
+            |  def runTest: String = TestUtils.value
+            |}
+            |""".stripMargin
+      )
+      _ = assertConnectedToBuildServer("MBT")
+      _ <- server.didOpen(appFile)
+      _ = assertNoDiagnostics()
+      _ <- server.assertHover(
+        appFile,
+        """|package app
+           |
+           |import util.MainUtils
+           |import util.TestUtils
+           |
+           |object App {
+           |  def runMain: String = MainUtils.val@@ue
+           |  def runTest: String = TestUtils.value
+           |}""".stripMargin,
+        """|```scala
+           |val value: String
+           |```
+           |""".stripMargin.hover,
+      )
+      _ <- server.assertHover(
+        appFile,
+        """|package app
+           |
+           |import util.MainUtils
+           |import util.TestUtils
+           |
+           |object App {
+           |  def runMain: String = MainUtils.value
+           |  def runTest: String = TestUtils.val@@ue
+           |}""".stripMargin,
+        """|```scala
+           |val value: String
+           |```
+           |""".stripMargin.hover,
+      )
+    } yield ()
+  }
 }


### PR DESCRIPTION
The presentation compiler puts the scala sources into AggregateClassPath object, which appears to be indexed by `(package, file_basename)` (slight simplification here), so when we compile main/util/reporter.scala with test/util/reporter.scala (where both are actually put into the same package, just come from different modules/targets), the compiler loses track of one of those. We fix it by <s>renaming the virtual file.</s> reimplementing the problematic parts of AggregateClassPath.

This previously wasn't an issue, since before metals V2, we would not compile multiple sources at once, instead relying on classfiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced classpath handling to better support projects with duplicate source filenames across different directories, ensuring accurate resolution and preventing conflicts.

* **Tests**
  * Added end-to-end test validating correct behavior for duplicate-named source files in the same package across multiple source roots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->