### PR TITLE
Gradle and Maven: improve run/debug support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -201,6 +201,7 @@ commands ++= Seq(
       "jsemanticdb/publishLocal" ::
       "turbine/publishLocal" ::
       "maven-metals/publishLocal" ::
+      "gradle-extractor/publishLocal" ::
       "semanticdb-javac/publishLocal" ::
       "semanticdb-protoc/publishLocal" ::
       s"++${V.scala213} metals/publishLocal" ::
@@ -640,6 +641,7 @@ lazy val `gradle-extractor` = project
       "com.lihaoyi" %% "upickle" % "4.3.2",
       "org.scalameta" %% "munit" % V.munit % Test,
     ),
+    testFrameworks := List(TestFrameworks.MUnit),
   )
   .settings(sharedScalacOptions)
   .dependsOn(interfaces)

--- a/gradle-extractor/src/main/scala/gradleinfo/GradleInfoExtractor.scala
+++ b/gradle-extractor/src/main/scala/gradleinfo/GradleInfoExtractor.scala
@@ -1,9 +1,11 @@
 package gradleinfo
 
 import java.io.File
+import java.nio.file.Files
 import java.nio.file.Path
 
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ModelBuilder
@@ -15,6 +17,7 @@ import org.gradle.tooling.model.idea.IdeaModule
 import org.gradle.tooling.model.idea.IdeaModuleDependency
 import org.gradle.tooling.model.idea.IdeaProject
 import org.gradle.tooling.model.idea.IdeaSingleEntryLibraryDependency
+import upickle.default.read
 
 /** Configuration for a single extraction run. */
 final case class ExtractorConfig(
@@ -50,10 +53,28 @@ object GradleInfoExtractor {
     val connection: ProjectConnection = connector.connect()
     try {
       val env = fetchModel(connection, classOf[BuildEnvironment], config)
-      val idea = fetchModel(connection, classOf[IdeaProject], config)
+
+      val sourceSetsOutputFile =
+        Files.createTempFile("metals-sourcesets", ".json")
+      val initScriptFile = writeSourceSetsInitScript(sourceSetsOutputFile)
+      val (idea, sourceSetsMap) =
+        try {
+          val ideaModel = fetchModel(
+            connection,
+            classOf[IdeaProject],
+            config,
+            extraArgs = List("--init-script", initScriptFile.toString),
+          )
+          val map = readSourceSetsMap(sourceSetsOutputFile)
+          (ideaModel, map)
+        } finally {
+          Files.deleteIfExists(initScriptFile)
+          Files.deleteIfExists(sourceSetsOutputFile)
+        }
 
       val modules: Seq[ModuleReport] =
-        idea.getModules.asScala.toSeq.map(extractModule(_, config))
+        idea.getModules.asScala.toSeq
+          .map(extractModule(_, config, sourceSetsMap))
 
       ProjectReport(
         rootName = idea.getName,
@@ -65,6 +86,38 @@ object GradleInfoExtractor {
     } finally connection.close()
   }
 
+  private def writeSourceSetsInitScript(outputFile: Path): Path = {
+    val escapedPath =
+      outputFile.toString.replace("\\", "\\\\").replace("'", "\\'")
+    val script =
+      s"""|gradle.projectsEvaluated {
+          |  def result = [:]
+          |  gradle.rootProject.allprojects { project ->
+          |    def sourceSets = project.extensions.findByName('sourceSets')
+          |    if (sourceSets != null) {
+          |      def main = sourceSets.findByName('main')
+          |      if (main != null) {
+          |        result[project.path] = main.output.classesDirs.files.collect { it.absolutePath }
+          |      }
+          |    }
+          |  }
+          |  new File('$escapedPath').text = groovy.json.JsonOutput.toJson(result)
+          |}
+          |""".stripMargin
+    val initFile = Files.createTempFile("metals-sourcesets-init", ".gradle")
+    Files.writeString(initFile, script)
+    initFile
+  }
+
+  private def readSourceSetsMap(outputFile: Path): Map[String, List[String]] =
+    try {
+      if (Files.exists(outputFile) && Files.size(outputFile) > 0)
+        read[Map[String, List[String]]](Files.readString(outputFile))
+      else Map.empty
+    } catch {
+      case NonFatal(_) => Map.empty
+    }
+
   /**
    * Build a model with all per-operation Tooling API settings applied
    * (currently just the optional Java home for the daemon).
@@ -73,15 +126,18 @@ object GradleInfoExtractor {
       connection: ProjectConnection,
       modelType: Class[T],
       config: ExtractorConfig,
+      extraArgs: List[String] = Nil,
   ): T = {
     val builder: ModelBuilder[T] = connection.model(modelType)
     config.gradleJvm.foreach(builder.setJavaHome)
+    if (extraArgs.nonEmpty) builder.withArguments(extraArgs: _*)
     builder.get()
   }
 
   private def extractModule(
       m: IdeaModule,
       config: ExtractorConfig,
+      sourceSetsMap: Map[String, List[String]],
   ): ModuleReport = {
     val gradleProject = m.getGradleProject
     val projectPath = Option(gradleProject).map(_.getPath).getOrElse(":")
@@ -126,11 +182,17 @@ object GradleInfoExtractor {
     val javaTarget = javaSettings
       .flatMap(s => Option(s.getTargetBytecodeVersion))
       .map(_.toString)
-    val classDirectory =
-      Option(m.getCompilerOutput)
-        .flatMap(output => Option(output.getOutputDir))
-        .map(_.toPath)
-        .map(relativize)
+    val classDirectories: Seq[String] =
+      sourceSetsMap.get(projectPath) match {
+        case Some(dirs) if dirs.nonEmpty =>
+          dirs.map(d => relativize(java.nio.file.Paths.get(d)))
+        case _ =>
+          val ideaDir =
+            Option(m.getCompilerOutput)
+              .flatMap(output => Option(output.getOutputDir))
+              .map(_.toPath)
+          ideaDir.map(relativize).toSeq
+      }
 
     val (externalDeps, projectDeps) = classifyDependencies(m)
 
@@ -142,7 +204,7 @@ object GradleInfoExtractor {
         Option(gradleProject).flatMap(p => Option(p.getDescription)),
       javaSourceLevel = javaSource,
       javaTargetLevel = javaTarget,
-      classDirectory = classDirectory,
+      classDirectories = classDirectories,
       sourceDirectories = sourceDirs,
       testSourceDirectories = testSourceDirs,
       externalDependencies =

--- a/gradle-extractor/src/main/scala/gradleinfo/GradleInfoExtractor.scala
+++ b/gradle-extractor/src/main/scala/gradleinfo/GradleInfoExtractor.scala
@@ -126,6 +126,11 @@ object GradleInfoExtractor {
     val javaTarget = javaSettings
       .flatMap(s => Option(s.getTargetBytecodeVersion))
       .map(_.toString)
+    val classDirectory =
+      Option(m.getCompilerOutput)
+        .flatMap(output => Option(output.getOutputDir))
+        .map(_.toPath)
+        .map(relativize)
 
     val (externalDeps, projectDeps) = classifyDependencies(m)
 
@@ -137,6 +142,7 @@ object GradleInfoExtractor {
         Option(gradleProject).flatMap(p => Option(p.getDescription)),
       javaSourceLevel = javaSource,
       javaTargetLevel = javaTarget,
+      classDirectory = classDirectory,
       sourceDirectories = sourceDirs,
       testSourceDirectories = testSourceDirs,
       externalDependencies =

--- a/gradle-extractor/src/main/scala/gradleinfo/Report.scala
+++ b/gradle-extractor/src/main/scala/gradleinfo/Report.scala
@@ -42,7 +42,7 @@ final case class ModuleReport(
     description: Option[String],
     javaSourceLevel: Option[String],
     javaTargetLevel: Option[String],
-    classDirectory: Option[String],
+    classDirectories: Seq[String],
     sourceDirectories: Seq[String],
     testSourceDirectories: Seq[String],
     externalDependencies: Seq[ExternalDependency],
@@ -89,7 +89,7 @@ final case class ProjectReport(
         scalaVersion = null,
         javaHome = javaHome,
         dependsOn = if (dependsOn.nonEmpty) dependsOn else null,
-        classDirectory = m.classDirectory.orNull,
+        classDirectories = m.classDirectories,
         configurations =
           Seq(s"${MbtNamespaceJson.projectPathPrefix}${m.projectPath}"),
       )
@@ -123,7 +123,7 @@ final case class MbtNamespaceJson(
     scalaVersion: String,
     javaHome: String,
     dependsOn: Seq[String],
-    classDirectory: String,
+    classDirectories: Seq[String],
     configurations: Seq[String],
 )
 

--- a/gradle-extractor/src/main/scala/gradleinfo/Report.scala
+++ b/gradle-extractor/src/main/scala/gradleinfo/Report.scala
@@ -42,6 +42,7 @@ final case class ModuleReport(
     description: Option[String],
     javaSourceLevel: Option[String],
     javaTargetLevel: Option[String],
+    classDirectory: Option[String],
     sourceDirectories: Seq[String],
     testSourceDirectories: Seq[String],
     externalDependencies: Seq[ExternalDependency],
@@ -88,6 +89,9 @@ final case class ProjectReport(
         scalaVersion = null,
         javaHome = javaHome,
         dependsOn = if (dependsOn.nonEmpty) dependsOn else null,
+        classDirectory = m.classDirectory.orNull,
+        configurations =
+          Seq(s"${MbtNamespaceJson.projectPathPrefix}${m.projectPath}"),
       )
     }.toMap
 
@@ -119,9 +123,12 @@ final case class MbtNamespaceJson(
     scalaVersion: String,
     javaHome: String,
     dependsOn: Seq[String],
+    classDirectory: String,
+    configurations: Seq[String],
 )
 
 object MbtNamespaceJson {
+  val projectPathPrefix: String = "projectPath="
   implicit val rw: ReadWriter[MbtNamespaceJson] = macroRW
 }
 

--- a/gradle-extractor/src/main/scala/gradleinfo/Report.scala
+++ b/gradle-extractor/src/main/scala/gradleinfo/Report.scala
@@ -90,8 +90,8 @@ final case class ProjectReport(
         javaHome = javaHome,
         dependsOn = if (dependsOn.nonEmpty) dependsOn else null,
         classDirectories = m.classDirectories,
-        configurations =
-          Seq(s"${MbtNamespaceJson.projectPathPrefix}${m.projectPath}"),
+        projectPath = m.projectPath,
+        configurations = null,
       )
     }.toMap
 
@@ -124,11 +124,11 @@ final case class MbtNamespaceJson(
     javaHome: String,
     dependsOn: Seq[String],
     classDirectories: Seq[String],
+    projectPath: String,
     configurations: Seq[String],
 )
 
 object MbtNamespaceJson {
-  val projectPathPrefix: String = "projectPath="
   implicit val rw: ReadWriter[MbtNamespaceJson] = macroRW
 }
 

--- a/maven-metals/src/main/scala/scala/meta/metals/maven/MbtMojoImpl.scala
+++ b/maven-metals/src/main/scala/scala/meta/metals/maven/MbtMojoImpl.scala
@@ -213,9 +213,7 @@ object MbtMojoImpl {
         if (activeProfiles.isEmpty) null
         else
           new ju.ArrayList(
-            List(
-              s"${NamespaceJson.profilesPrefix}${activeProfiles.toList.sorted.mkString(",")}"
-            ).asJava
+            List("-P", activeProfiles.toList.sorted.mkString(",")).asJava
           )
       },
     )
@@ -361,9 +359,7 @@ private[maven] case class DepModuleEntry(
     sources: String,
 )
 
-private[maven] object NamespaceJson {
-  val profilesPrefix = "profiles="
-}
+private[maven] object NamespaceJson
 
 private[maven] case class NamespaceJson(
     sources: ju.List[String],

--- a/maven-metals/src/main/scala/scala/meta/metals/maven/MbtMojoImpl.scala
+++ b/maven-metals/src/main/scala/scala/meta/metals/maven/MbtMojoImpl.scala
@@ -201,18 +201,24 @@ object MbtMojoImpl {
         reactorByCoords,
         mojo,
       ).asJava,
-      classDirectory = {
+      classDirectories = {
         val dir =
           if (isTest) project.getBuild.getTestOutputDirectory
           else project.getBuild.getOutputDirectory
-        if (dir == null || dir.isEmpty) null else dir
+        if (dir == null || dir.isEmpty) null
+        else ju.List.of(dir)
       },
-      configurations =
-        if (activeProfiles.isEmpty) null
-        else
-          new ju.ArrayList(
-            List("-P", activeProfiles.toList.sorted.mkString(",")).asJava
-          ),
+      configurations = {
+        val projectDirEntry =
+          s"${NamespaceJson.projectDirPrefix}${project.getBasedir.getAbsolutePath}"
+        val profileEntries =
+          if (activeProfiles.isEmpty) Nil
+          else
+            List(
+              s"${NamespaceJson.profilesPrefix}${activeProfiles.toList.sorted.mkString(",")}"
+            )
+        new ju.ArrayList((projectDirEntry :: profileEntries).asJava)
+      },
     )
   }
 
@@ -356,6 +362,11 @@ private[maven] case class DepModuleEntry(
     sources: String,
 )
 
+private[maven] object NamespaceJson {
+  val projectDirPrefix = "projectDir="
+  val profilesPrefix = "profiles="
+}
+
 private[maven] case class NamespaceJson(
     sources: ju.List[String],
     scalacOptions: ju.List[String],
@@ -364,6 +375,6 @@ private[maven] case class NamespaceJson(
     scalaVersion: String,
     javaHome: String,
     dependsOn: ju.List[String],
-    classDirectory: String,
+    classDirectories: ju.List[String],
     configurations: ju.List[String],
 )

--- a/maven-metals/src/main/scala/scala/meta/metals/maven/MbtMojoImpl.scala
+++ b/maven-metals/src/main/scala/scala/meta/metals/maven/MbtMojoImpl.scala
@@ -208,16 +208,15 @@ object MbtMojoImpl {
         if (dir == null || dir.isEmpty) null
         else ju.List.of(dir)
       },
+      projectPath = project.getBasedir.getAbsolutePath,
       configurations = {
-        val projectDirEntry =
-          s"${NamespaceJson.projectDirPrefix}${project.getBasedir.getAbsolutePath}"
-        val profileEntries =
-          if (activeProfiles.isEmpty) Nil
-          else
+        if (activeProfiles.isEmpty) null
+        else
+          new ju.ArrayList(
             List(
               s"${NamespaceJson.profilesPrefix}${activeProfiles.toList.sorted.mkString(",")}"
-            )
-        new ju.ArrayList((projectDirEntry :: profileEntries).asJava)
+            ).asJava
+          )
       },
     )
   }
@@ -363,7 +362,6 @@ private[maven] case class DepModuleEntry(
 )
 
 private[maven] object NamespaceJson {
-  val projectDirPrefix = "projectDir="
   val profilesPrefix = "profiles="
 }
 
@@ -376,5 +374,6 @@ private[maven] case class NamespaceJson(
     javaHome: String,
     dependsOn: ju.List[String],
     classDirectories: ju.List[String],
+    projectPath: String,
     configurations: ju.List[String],
 )

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -151,7 +151,7 @@ case class GradleBuildTool(
     }
 
   private def gradleTask(target: MbtTarget, task: String): String =
-    GradleBuildTool.gradleProjectPath(target) match {
+    target.projectPath match {
       case Some(":") | Some("") | None => task
       case Some(path) if path.endsWith(":") => s"$path$task"
       case Some(path) => s"$path:$task"
@@ -181,8 +181,7 @@ case class GradleBuildTool(
         mainClass.getJvmOptions
       )
     val args = MbtDebugLauncher.listOrNil(mainClass.getArguments)
-    val projectPath = GradleBuildTool.gradleProjectPath(target)
-    val projectBlock = projectPath match {
+    val projectBlock = target.projectPath match {
       case Some(path) =>
         val gradlePath =
           if (path == ":" || path.isEmpty) ":"
@@ -236,13 +235,6 @@ object GradleBuildTool {
   def name = "gradle"
 
   private val metalsRunTask = "__metalsRun"
-
-  private val projectPathPrefix = "projectPath="
-
-  private def gradleProjectPath(target: MbtTarget): Option[String] =
-    target.configurations
-      .find(_.startsWith(projectPathPrefix))
-      .map(_.substring(projectPathPrefix.length))
 
   private def groovyList(values: List[String]): String =
     values.map(groovyString).mkString("[", ", ", "]")

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -10,9 +10,13 @@ import scala.util.Properties
 import scala.meta.internal.metals.BuildInfo
 import scala.meta.internal.metals.Embedded
 import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.mbt.MbtDebugLauncher
+import scala.meta.internal.metals.mbt.MbtTarget
 import scala.meta.internal.metals.mbt.importer.GradleMbtImporter
+import scala.meta.internal.mtags.MD5
 import scala.meta.io.AbsolutePath
 
+import ch.epfl.scala.bsp4j.ScalaMainClass
 import coursier.MavenRepository
 import coursier.Repositories
 import coursier.Repository
@@ -26,7 +30,8 @@ case class GradleBuildTool(
     extends GradleMbtImporter(projectRoot)
     with BuildTool
     with BloopInstallProvider
-    with VersionRecommendation {
+    with VersionRecommendation
+    with MbtDebugLauncher {
 
   private val initScriptName = "init-script.gradle"
   private val gradleBloopVersion = BuildInfo.gradleBloopVersion
@@ -96,16 +101,7 @@ case class GradleBuildTool(
       }
     }
 
-    userConfig().gradleScript match {
-      case Some(script) =>
-        script :: cmd
-      case None =>
-        val projectGradle = projectGradleLauncher
-        if (projectGradle.isFile)
-          projectGradle.toString() :: cmd
-        else
-          embeddedGradleLauncher.toString() :: cmd
-    }
+    gradleBaseCommand() ::: cmd
   }
 
   // @tgodzik This is the wrapper version we specify it as such,
@@ -119,11 +115,123 @@ case class GradleBuildTool(
 
   override def toString: String = "Gradle"
 
-  def executableName = GradleBuildTool.name
+  override def executableName = GradleBuildTool.name
+
+  override def mbtCompileCommand(
+      workspace: AbsolutePath,
+      target: MbtTarget,
+  ): List[String] =
+    gradleBaseCommand() ::: List(
+      "--console=plain",
+      gradleTask(target, "classes"),
+    )
+
+  override def mbtRunCommand(
+      workspace: AbsolutePath,
+      target: MbtTarget,
+      mainClass: ScalaMainClass,
+  ): List[String] =
+    gradleRunCommand(target, mainClass, debugAgentFlag = None)
+
+  override def mbtDebugCommand(
+      workspace: AbsolutePath,
+      target: MbtTarget,
+      mainClass: ScalaMainClass,
+      debugAgentFlag: String,
+  ): List[String] =
+    gradleRunCommand(target, mainClass, Some(debugAgentFlag))
+
+  private def gradleBaseCommand(): List[String] =
+    userConfig().gradleScript match {
+      case Some(script) => List(script)
+      case None =>
+        val projectGradle = projectGradleLauncher
+        if (projectGradle.isFile) List(projectGradle.toString())
+        else List(embeddedGradleLauncher.toString())
+    }
+
+  private def gradleTask(target: MbtTarget, task: String): String =
+    GradleBuildTool.gradleProjectPath(target) match {
+      case Some(":") | Some("") | None => task
+      case Some(path) if path.endsWith(":") => s"$path$task"
+      case Some(path) => s"$path:$task"
+    }
+
+  private def gradleRunCommand(
+      target: MbtTarget,
+      mainClass: ScalaMainClass,
+      debugAgentFlag: Option[String],
+  ): List[String] = {
+    gradleBaseCommand() ::: List(
+      "--console=plain",
+      "-q",
+      "--init-script",
+      gradleRunInitScript(mainClass, debugAgentFlag).toString,
+      gradleTask(target, GradleBuildTool.metalsRunTask),
+    )
+  }
+
+  private def gradleRunInitScript(
+      mainClass: ScalaMainClass,
+      debugAgentFlag: Option[String],
+  ): Path = {
+    val jvmOptions =
+      debugAgentFlag.toList ::: MbtDebugLauncher.listOrNil(
+        mainClass.getJvmOptions
+      )
+    val args = MbtDebugLauncher.listOrNil(mainClass.getArguments)
+    val script =
+      s"""|gradle.projectsEvaluated {
+          |  allprojects { project ->
+          |    if (project.extensions.findByName('sourceSets') != null) {
+          |      project.tasks.register('${GradleBuildTool.metalsRunTask}', JavaExec) { task ->
+          |        task.group = 'metals'
+          |        task.classpath = project.files(
+          |          project.sourceSets.main.output,
+          |          project.sourceSets.main.runtimeClasspath
+          |        )
+          |        if (task.hasProperty('mainClass')) {
+          |          task.mainClass.set(${GradleBuildTool.groovyString(mainClass.getClassName)})
+          |        } else {
+          |          task.main = ${GradleBuildTool.groovyString(mainClass.getClassName)}
+          |        }
+          |        task.jvmArgs(${GradleBuildTool.groovyList(jvmOptions)})
+          |        task.args(${GradleBuildTool.groovyList(args)})
+          |      }
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+
+    val digest = MD5.compute(script)
+    Files.write(
+      tempDir.resolve(s"${GradleBuildTool.metalsRunTask}-$digest.gradle"),
+      script.getBytes(StandardCharsets.UTF_8),
+    )
+  }
 }
 
 object GradleBuildTool {
   def name = "gradle"
+
+  private val metalsRunTask = "__metalsRun"
+
+  private val projectPathPrefix = "projectPath="
+
+  private def gradleProjectPath(target: MbtTarget): Option[String] =
+    target.configurations
+      .find(_.startsWith(projectPathPrefix))
+      .map(_.substring(projectPathPrefix.length))
+
+  private def groovyList(values: List[String]): String =
+    values.map(groovyString).mkString("[", ", ", "]")
+
+  private def groovyString(value: String): String =
+    "'" + value
+      .replace("\\", "\\\\")
+      .replace("'", "\\'")
+      .replace("\n", "\\n")
+      .replace("\r", "\\r") + "'"
 
   def isGradleRelatedPath(
       workspace: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/GradleBuildTool.scala
@@ -166,12 +166,13 @@ case class GradleBuildTool(
       "--console=plain",
       "-q",
       "--init-script",
-      gradleRunInitScript(mainClass, debugAgentFlag).toString,
+      gradleRunInitScript(target, mainClass, debugAgentFlag).toString,
       gradleTask(target, GradleBuildTool.metalsRunTask),
     )
   }
 
   private def gradleRunInitScript(
+      target: MbtTarget,
       mainClass: ScalaMainClass,
       debugAgentFlag: Option[String],
   ): Path = {
@@ -180,26 +181,46 @@ case class GradleBuildTool(
         mainClass.getJvmOptions
       )
     val args = MbtDebugLauncher.listOrNil(mainClass.getArguments)
+    val projectPath = GradleBuildTool.gradleProjectPath(target)
+    val projectBlock = projectPath match {
+      case Some(path) =>
+        val gradlePath =
+          if (path == ":" || path.isEmpty) ":"
+          else if (path.startsWith(":")) path
+          else s":$path"
+
+        val projectLookup =
+          if (gradlePath == ":") "gradle.rootProject"
+          else
+            s"gradle.rootProject.findProject(${GradleBuildTool.groovyString(gradlePath)})"
+
+        s"""|  def project = $projectLookup
+            |  if (project == null) {
+            |    throw new GradleException("Could not find Gradle project ${GradleBuildTool.groovyString(gradlePath)}")
+            |  }
+            |  def sourceSets = project.extensions.findByName('sourceSets')
+            |  def main = sourceSets?.findByName('main')
+            |  if (main == null) {
+            |    throw new GradleException("Project ${GradleBuildTool.groovyString(gradlePath)} does not have a main source set")
+            |  }
+            |  project.tasks.register('${GradleBuildTool.metalsRunTask}', JavaExec) { task ->
+            |    task.group = 'metals'
+            |    task.classpath = main.runtimeClasspath
+            |    if (task.hasProperty('mainClass')) {
+            |      task.mainClass.set(${GradleBuildTool.groovyString(mainClass.getClassName)})
+            |    } else {
+            |      task.main = ${GradleBuildTool.groovyString(mainClass.getClassName)}
+            |    }
+            |    task.jvmArgs(${GradleBuildTool.groovyList(jvmOptions)})
+            |    task.args(${GradleBuildTool.groovyList(args)})
+            |  }""".stripMargin
+      case None =>
+        s"""|  throw new GradleException("Missing Gradle project path for Metals run/debug")
+            |""".stripMargin
+    }
     val script =
       s"""|gradle.projectsEvaluated {
-          |  allprojects { project ->
-          |    if (project.extensions.findByName('sourceSets') != null) {
-          |      project.tasks.register('${GradleBuildTool.metalsRunTask}', JavaExec) { task ->
-          |        task.group = 'metals'
-          |        task.classpath = project.files(
-          |          project.sourceSets.main.output,
-          |          project.sourceSets.main.runtimeClasspath
-          |        )
-          |        if (task.hasProperty('mainClass')) {
-          |          task.mainClass.set(${GradleBuildTool.groovyString(mainClass.getClassName)})
-          |        } else {
-          |          task.main = ${GradleBuildTool.groovyString(mainClass.getClassName)}
-          |        }
-          |        task.jvmArgs(${GradleBuildTool.groovyList(jvmOptions)})
-          |        task.args(${GradleBuildTool.groovyList(args)})
-          |      }
-          |    }
-          |  }
+          |$projectBlock
           |}
           |""".stripMargin
 

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -162,17 +162,11 @@ case class MavenBuildTool(
     target.projectPath.map(p => AbsolutePath(java.nio.file.Paths.get(p)))
 
   private def mavenCliConfigurations(target: MbtTarget): List[String] =
-    target.configurations.toList.flatMap {
-      case p if p.startsWith(MavenBuildTool.profilesPrefix) =>
-        List("-P", p.substring(MavenBuildTool.profilesPrefix.length))
-      case _ => Nil
-    }
+    target.configurations.toList
 }
 
 object MavenBuildTool {
   def name = "mvn"
-
-  val profilesPrefix = "profiles="
 
   def isMavenRelatedPath(
       workspace: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -100,7 +100,7 @@ case class MavenBuildTool(
     }
     mbtMavenBaseCommand(workspace) ::: List(
       "-q"
-    ) ::: target.configurations.toList ::: List(
+    ) ::: mavenCliConfigurations(target) ::: List(
       "-pl",
       s":$artifactId",
       "--also-make",
@@ -134,8 +134,7 @@ case class MavenBuildTool(
       debugAgentFlag: Option[String],
   ): List[String] = {
     val moduleArgs =
-      target
-        .mavenModuleDirectory(workspace)
+      mavenModuleDirectory(target)
         .map(_.resolve("pom.xml"))
         .filter(_.isFile) match {
         case Some(pom) =>
@@ -152,16 +151,36 @@ case class MavenBuildTool(
       s"$jvmOpts -classpath %classpath ${mainClass.getClassName} $appArgs".trim
     mbtMavenBaseCommand(workspace) ::: List(
       "-q"
-    ) ::: target.configurations.toList ::: moduleArgs ::: List(
+    ) ::: mavenCliConfigurations(target) ::: moduleArgs ::: List(
       "exec:exec",
       "-Dexec.executable=java",
       s"-Dexec.args=$execArgs",
     )
   }
+
+  private def mavenModuleDirectory(target: MbtTarget): Option[AbsolutePath] =
+    target.configurations
+      .find(_.startsWith(MavenBuildTool.projectDirPrefix))
+      .map(c =>
+        AbsolutePath(
+          java.nio.file.Paths
+            .get(c.substring(MavenBuildTool.projectDirPrefix.length))
+        )
+      )
+
+  private def mavenCliConfigurations(target: MbtTarget): List[String] =
+    target.configurations.toList.flatMap {
+      case p if p.startsWith(MavenBuildTool.profilesPrefix) =>
+        List("-P", p.substring(MavenBuildTool.profilesPrefix.length))
+      case _ => Nil
+    }
 }
 
 object MavenBuildTool {
   def name = "mvn"
+
+  val projectDirPrefix = "projectDir="
+  val profilesPrefix = "profiles="
 
   def isMavenRelatedPath(
       workspace: AbsolutePath,

--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -159,14 +159,7 @@ case class MavenBuildTool(
   }
 
   private def mavenModuleDirectory(target: MbtTarget): Option[AbsolutePath] =
-    target.configurations
-      .find(_.startsWith(MavenBuildTool.projectDirPrefix))
-      .map(c =>
-        AbsolutePath(
-          java.nio.file.Paths
-            .get(c.substring(MavenBuildTool.projectDirPrefix.length))
-        )
-      )
+    target.projectPath.map(p => AbsolutePath(java.nio.file.Paths.get(p)))
 
   private def mavenCliConfigurations(target: MbtTarget): List[String] =
     target.configurations.toList.flatMap {
@@ -179,7 +172,6 @@ case class MavenBuildTool(
 object MavenBuildTool {
   def name = "mvn"
 
-  val projectDirPrefix = "projectDir="
   val profilesPrefix = "profiles="
 
   def isMavenRelatedPath(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuild.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuild.scala
@@ -141,7 +141,10 @@ case class MbtBuild(
 object MbtBuild {
   private val gson = new com.google.gson.Gson()
   private val gsonPretty =
-    new com.google.gson.GsonBuilder().setPrettyPrinting().create()
+    new com.google.gson.GsonBuilder()
+      .setPrettyPrinting()
+      .disableHtmlEscaping()
+      .create()
   val LegacyTargetName = "default"
 
   def toJson(build: MbtBuild): String = gsonPretty.toJson(build)

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuild.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuild.scala
@@ -108,6 +108,7 @@ case class MbtBuild(
           classDirectories = Option(namespace.classDirectories)
             .map(_.asScala.toSeq)
             .getOrElse(Nil),
+          projectPath = Option(namespace.projectPath),
           configurations = namespace.getConfigurations,
         )
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuild.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtBuild.scala
@@ -105,7 +105,9 @@ case class MbtBuild(
           scalaVersion = Option(namespace.scalaVersion),
           javaHome = Option(namespace.javaHome),
           dependsOn = dependsOnIds,
-          classDirectory = Option(namespace.classDirectory),
+          classDirectories = Option(namespace.classDirectories)
+            .map(_.asScala.toSeq)
+            .getOrElse(Nil),
           configurations = namespace.getConfigurations,
         )
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtNamespace.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtNamespace.scala
@@ -13,7 +13,7 @@ case class MbtNamespace(
     @Nullable scalaVersion: String,
     @Nullable javaHome: String,
     @Nullable dependsOn: ju.List[String] = null,
-    @Nullable classDirectory: String = null,
+    @Nullable classDirectories: ju.List[String] = null,
     @Nullable configurations: ju.List[String] = null,
 ) {
   def getSources: ju.List[String] =

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtNamespace.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtNamespace.scala
@@ -14,6 +14,7 @@ case class MbtNamespace(
     @Nullable javaHome: String,
     @Nullable dependsOn: ju.List[String] = null,
     @Nullable classDirectories: ju.List[String] = null,
+    @Nullable projectPath: String = null,
     @Nullable configurations: ju.List[String] = null,
 ) {
   def getSources: ju.List[String] =

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtTarget.scala
@@ -27,6 +27,7 @@ case class MbtTarget(
     javaHome: Option[String] = None,
     dependsOn: Seq[bsp4j.BuildTargetIdentifier] = Nil,
     classDirectories: Seq[String] = Nil,
+    projectPath: Option[String] = None,
     configurations: Seq[String] = Nil,
 ) {
 

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtTarget.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtTarget.scala
@@ -26,7 +26,7 @@ case class MbtTarget(
     scalaVersion: Option[String] = None,
     javaHome: Option[String] = None,
     dependsOn: Seq[bsp4j.BuildTargetIdentifier] = Nil,
-    classDirectory: Option[String] = None,
+    classDirectories: Seq[String] = Nil,
     configurations: Seq[String] = Nil,
 ) {
 
@@ -131,24 +131,11 @@ case class MbtTarget(
   def runClassDirectories(
       workspace: AbsolutePath,
       buildToolName: String,
-  ): List[AbsolutePath] = {
-    classDirectory.map(resolveClassDir(workspace, _)) match {
-      case Some(dir) => List(dir)
-      case None =>
-        MbtTarget.conventionalClassDirectories(workspace, buildToolName)
-    }
-  }
-
-  def mavenModuleDirectory(workspace: AbsolutePath): Option[AbsolutePath] =
-    classDirectory
-      .map(resolveClassDir(workspace, _))
-      .flatMap { output =>
-        Iterator
-          .iterate(output.parent)(_.parent)
-          .takeWhile(p => p != workspace && p.toNIO.startsWith(workspace.toNIO))
-          .filterNot(dir => dir.filename == "target" || dir.filename == "build")
-          .find(dir => dir.resolve("pom.xml").isFile)
-      }
+  ): List[AbsolutePath] =
+    if (classDirectories.nonEmpty)
+      classDirectories.map(resolveClassDir(workspace, _)).toList
+    else
+      MbtTarget.conventionalClassDirectories(workspace, buildToolName)
 
   private def resolveClassDir(
       workspace: AbsolutePath,

--- a/tests/slow/src/test/scala/tests/gradle/GradleMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/gradle/GradleMbtLspSuite.scala
@@ -130,9 +130,7 @@ class GradleMbtLspSuite
             |        "build/classes/java/main",
             |        "build/classes/scala/main"
             |      ],
-            |      "configurations": [
-            |        "projectPath=:"
-            |      ]
+            |      "projectPath": ":"
             |    }
             |  }
             |}
@@ -243,9 +241,7 @@ class GradleMbtLspSuite
             |      "classDirectories": [
             |        "build/classes/java/main"
             |      ],
-            |      "configurations": [
-            |        "projectPath=:"
-            |      ]
+            |      "projectPath": ":"
             |    }
             |  }
             |}

--- a/tests/slow/src/test/scala/tests/gradle/GradleMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/gradle/GradleMbtLspSuite.scala
@@ -126,6 +126,10 @@ class GradleMbtLspSuite
             |        "org.typelevel:cats-kernel_2.13:2.13.0"
             |      ],
             |      "javaHome": "file://${Properties.javaHome.replace("\\", "/")}/",
+            |      "classDirectories": [
+            |        "build/classes/java/main",
+            |        "build/classes/scala/main"
+            |      ],
             |      "configurations": [
             |        "projectPath=:"
             |      ]
@@ -236,6 +240,9 @@ class GradleMbtLspSuite
             |        "org.jsoup:jsoup:1.21.1"
             |      ],
             |      "javaHome": "file://${Properties.javaHome.replace("\\", "/")}/",
+            |      "classDirectories": [
+            |        "build/classes/java/main"
+            |      ],
             |      "configurations": [
             |        "projectPath=:"
             |      ]

--- a/tests/slow/src/test/scala/tests/gradle/GradleMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/gradle/GradleMbtLspSuite.scala
@@ -125,7 +125,10 @@ class GradleMbtLspSuite
             |        "org.typelevel:cats-core_2.13:2.13.0",
             |        "org.typelevel:cats-kernel_2.13:2.13.0"
             |      ],
-            |      "javaHome": "file://${Properties.javaHome.replace("\\", "/")}/"
+            |      "javaHome": "file://${Properties.javaHome.replace("\\", "/")}/",
+            |      "configurations": [
+            |        "projectPath=:"
+            |      ]
             |    }
             |  }
             |}
@@ -232,7 +235,10 @@ class GradleMbtLspSuite
             |      "dependencyModules": [
             |        "org.jsoup:jsoup:1.21.1"
             |      ],
-            |      "javaHome": "file://${Properties.javaHome.replace("\\", "/")}/"
+            |      "javaHome": "file://${Properties.javaHome.replace("\\", "/")}/",
+            |      "configurations": [
+            |        "projectPath=:"
+            |      ]
             |    }
             |  }
             |}
@@ -258,6 +264,50 @@ class GradleMbtLspSuite
            |public java.lang.String title()
            |```
            |Get the string contents of the document's `title` element.
+           |""".stripMargin,
+      )
+    } yield ()
+  }
+
+  test("code-lens-java-main") {
+    client.selectedServer = Messages.ChooseBuildServer.mbt
+    cleanWorkspace()
+    for {
+      _ <- initialize(
+        s"""|/build.gradle
+            |plugins {
+            |    id 'java'
+            |}
+            |repositories {
+            |    mavenCentral()
+            |}
+            |/src/main/java/a/Main.java
+            |package a;
+            |
+            |public class Main {
+            |  public static void main(String[] args) {
+            |    System.out.println("Hello!");
+            |  }
+            |}
+            |""".stripMargin
+      )
+      _ <- server.headServer.connectionProvider.buildServerPromise.future
+      _ <- server.didOpen("src/main/java/a/Main.java")
+      obtained <- server
+        .codeLensesText("src/main/java/a/Main.java")(maxRetries = 4)
+        .recover { case _: NoSuchElementException =>
+          server.textContents("src/main/java/a/Main.java")
+        }
+      _ = assertNoDiff(
+        obtained,
+        """|package a;
+           |
+           |public class Main {
+           |<<run>><<debug>>
+           |  public static void main(String[] args) {
+           |    System.out.println("Hello!");
+           |  }
+           |}
            |""".stripMargin,
       )
     } yield ()

--- a/tests/unit/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/unit/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -35,7 +35,7 @@ class GradleBuildToolSuite extends BaseSuite {
       scalacOptions = Nil,
       javacOptions = Nil,
       dependencyModules = Nil,
-      configurations = Seq(s"projectPath=$gradleProjectPath"),
+      projectPath = Some(gradleProjectPath),
     )
 
   test("gradle-mbt-compile-command") {

--- a/tests/unit/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/unit/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -1,0 +1,156 @@
+package tests
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters._
+
+import scala.meta.internal.builds.GradleBuildTool
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.mbt.MbtTarget
+import scala.meta.io.AbsolutePath
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier
+import ch.epfl.scala.bsp4j.ScalaMainClass
+
+class GradleBuildToolSuite extends BaseSuite {
+
+  private def gradleBuildTool(workspace: AbsolutePath): GradleBuildTool = {
+    implicit val ec: ExecutionContext = ExecutionContext.global
+    val config = UserConfiguration.default.copy(gradleScript = Some("gradle"))
+    GradleBuildTool(() => config, workspace)
+  }
+
+  private def mbtTarget(
+      name: String,
+      sources: Seq[String] = Seq("src/main/java"),
+      gradleProjectPath: String = ":",
+  ): MbtTarget =
+    MbtTarget(
+      name = name,
+      id = new BuildTargetIdentifier(s"mbt://namespace/$name"),
+      sources = sources,
+      globMatchers = Nil,
+      scalacOptions = Nil,
+      javacOptions = Nil,
+      dependencyModules = Nil,
+      configurations = Seq(s"projectPath=$gradleProjectPath"),
+    )
+
+  test("gradle-mbt-compile-command") {
+    val workspace = AbsolutePath(Files.createTempDirectory("gradle-mbt"))
+
+    assertEquals(
+      gradleBuildTool(workspace)
+        .mbtCompileCommand(workspace, mbtTarget("app")),
+      List("gradle", "--console=plain", "classes"),
+    )
+  }
+
+  test("gradle-mbt-run-command-uses-init-script") {
+    val workspace = AbsolutePath(Files.createTempDirectory("gradle-mbt"))
+    val mainClass = new ScalaMainClass(
+      "a.Main",
+      List("Bar").asJava,
+      List("-Dproperty=Foo").asJava,
+    )
+
+    val command =
+      gradleBuildTool(workspace)
+        .mbtRunCommand(
+          workspace,
+          mbtTarget("app"),
+          mainClass,
+        )
+
+    assertEquals(
+      command.take(2),
+      List("gradle", "--console=plain"),
+    )
+    assert(command.contains("--init-script"))
+    assert(!command.contains("-x"))
+    assertEquals(command.last, "__metalsRun")
+    val script =
+      Files.readString(Paths.get(command(command.indexOf("--init-script") + 1)))
+    assert(script.contains("project.tasks.register('__metalsRun', JavaExec)"))
+    assert(script.contains("project.sourceSets.main.output"))
+    assert(script.contains("project.sourceSets.main.runtimeClasspath"))
+    assert(script.contains("task.mainClass.set('a.Main')"))
+    assert(script.contains("task.jvmArgs(['-Dproperty=Foo'])"))
+    assert(script.contains("task.args(['Bar'])"))
+  }
+
+  test("gradle-mbt-debug-command-uses-debug-agent") {
+    val workspace = AbsolutePath(Files.createTempDirectory("gradle-mbt"))
+    val mainClass = new ScalaMainClass("a.Main", Nil.asJava, Nil.asJava)
+
+    val command =
+      gradleBuildTool(workspace)
+        .mbtDebugCommand(
+          workspace,
+          mbtTarget("app"),
+          mainClass,
+          "debug-agent",
+        )
+
+    assertEquals(
+      command.take(2),
+      List("gradle", "--console=plain"),
+    )
+    assert(command.contains("--init-script"))
+    assert(!command.contains("-x"))
+    assertEquals(command.last, "__metalsRun")
+    val script =
+      Files.readString(Paths.get(command(command.indexOf("--init-script") + 1)))
+    assert(script.contains("task.jvmArgs(['debug-agent'])"))
+    assert(script.contains("task.args([])"))
+  }
+
+  test("gradle-mbt-run-command-uses-subproject-task-path") {
+    val workspace = AbsolutePath(Files.createTempDirectory("gradle-mbt"))
+    val mainClass = new ScalaMainClass("a.Main", Nil.asJava, Nil.asJava)
+
+    val command =
+      gradleBuildTool(workspace)
+        .mbtRunCommand(
+          workspace,
+          mbtTarget("app", gradleProjectPath = ":app"),
+          mainClass,
+        )
+
+    assertEquals(command.last, ":app:__metalsRun")
+  }
+
+  test("gradle-mbt-compile-command-uses-nested-subproject-path") {
+    val workspace = AbsolutePath(Files.createTempDirectory("gradle-mbt"))
+
+    val command =
+      gradleBuildTool(workspace)
+        .mbtCompileCommand(
+          workspace,
+          mbtTarget("bar", gradleProjectPath = ":foo:bar"),
+        )
+
+    assertEquals(command.last, ":foo:bar:classes")
+  }
+
+  test("gradle-mbt-run-command-escapes-special-groovy-chars") {
+    val workspace = AbsolutePath(Files.createTempDirectory("gradle-mbt"))
+    val mainClass = new ScalaMainClass(
+      "a.Main",
+      List("it's", "line1\nline2").asJava,
+      List("-Dpath=C:\\foo").asJava,
+    )
+
+    val command =
+      gradleBuildTool(workspace)
+        .mbtRunCommand(workspace, mbtTarget("app"), mainClass)
+
+    val script =
+      Files.readString(Paths.get(command(command.indexOf("--init-script") + 1)))
+    assert(script.contains("'it\\'s'"))
+    assert(script.contains("'line1\\nline2'"))
+    assert(script.contains("'-Dpath=C:\\\\foo'"))
+  }
+}

--- a/tests/unit/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/unit/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -74,8 +74,7 @@ class GradleBuildToolSuite extends BaseSuite {
     val script =
       Files.readString(Paths.get(command(command.indexOf("--init-script") + 1)))
     assert(script.contains("project.tasks.register('__metalsRun', JavaExec)"))
-    assert(script.contains("project.sourceSets.main.output"))
-    assert(script.contains("project.sourceSets.main.runtimeClasspath"))
+    assert(script.contains("main.runtimeClasspath"))
     assert(script.contains("task.mainClass.set('a.Main')"))
     assert(script.contains("task.jvmArgs(['-Dproperty=Foo'])"))
     assert(script.contains("task.args(['Bar'])"))

--- a/tests/unit/src/test/scala/tests/MavenBuildToolSuite.scala
+++ b/tests/unit/src/test/scala/tests/MavenBuildToolSuite.scala
@@ -5,6 +5,8 @@ import java.nio.file.Files
 import scala.concurrent.ExecutionContext
 
 import scala.meta.internal.builds.MavenBuildTool
+import scala.meta.internal.builds.MavenBuildTool.profilesPrefix
+import scala.meta.internal.builds.MavenBuildTool.projectDirPrefix
 import scala.meta.internal.builds.ShellRunner
 import scala.meta.internal.metals.EmptyWorkDoneProgress
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -33,6 +35,7 @@ class MavenBuildToolSuite extends BaseSuite {
       name: String,
       classDirectory: String,
       configurations: Seq[String] = Nil,
+      projectDir: Option[AbsolutePath] = None,
   ): MbtTarget =
     MbtTarget(
       name = name,
@@ -42,8 +45,9 @@ class MavenBuildToolSuite extends BaseSuite {
       scalacOptions = Nil,
       javacOptions = Nil,
       dependencyModules = Nil,
-      classDirectory = Some(classDirectory),
-      configurations = configurations,
+      classDirectories = Seq(classDirectory),
+      configurations =
+        configurations ++ projectDir.map(d => s"${projectDirPrefix}$d"),
     )
 
   test("maven-mbt-compile-command") {
@@ -51,7 +55,7 @@ class MavenBuildToolSuite extends BaseSuite {
     val target = mbtTarget(
       "com.example:app:1.0.0",
       "target/classes",
-      configurations = Seq("-P", "dev,ci"),
+      configurations = Seq(s"${profilesPrefix}dev,ci"),
     )
 
     assertEquals(
@@ -98,7 +102,11 @@ class MavenBuildToolSuite extends BaseSuite {
     assertEquals(
       mavenBuildTool(workspace).mbtDebugCommand(
         workspace,
-        mbtTarget("com.example:app:1.0.0", "app/target/classes"),
+        mbtTarget(
+          "com.example:app:1.0.0",
+          "app/target/classes",
+          projectDir = Some(workspace.resolve("app")),
+        ),
         mainClass,
         "debug-agent",
       ),

--- a/tests/unit/src/test/scala/tests/MavenBuildToolSuite.scala
+++ b/tests/unit/src/test/scala/tests/MavenBuildToolSuite.scala
@@ -6,7 +6,6 @@ import scala.concurrent.ExecutionContext
 
 import scala.meta.internal.builds.MavenBuildTool
 import scala.meta.internal.builds.MavenBuildTool.profilesPrefix
-import scala.meta.internal.builds.MavenBuildTool.projectDirPrefix
 import scala.meta.internal.builds.ShellRunner
 import scala.meta.internal.metals.EmptyWorkDoneProgress
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -46,8 +45,8 @@ class MavenBuildToolSuite extends BaseSuite {
       javacOptions = Nil,
       dependencyModules = Nil,
       classDirectories = Seq(classDirectory),
-      configurations =
-        configurations ++ projectDir.map(d => s"${projectDirPrefix}$d"),
+      projectPath = projectDir.map(_.toString),
+      configurations = configurations,
     )
 
   test("maven-mbt-compile-command") {

--- a/tests/unit/src/test/scala/tests/MavenBuildToolSuite.scala
+++ b/tests/unit/src/test/scala/tests/MavenBuildToolSuite.scala
@@ -5,7 +5,6 @@ import java.nio.file.Files
 import scala.concurrent.ExecutionContext
 
 import scala.meta.internal.builds.MavenBuildTool
-import scala.meta.internal.builds.MavenBuildTool.profilesPrefix
 import scala.meta.internal.builds.ShellRunner
 import scala.meta.internal.metals.EmptyWorkDoneProgress
 import scala.meta.internal.metals.MetalsEnrichments._
@@ -54,7 +53,7 @@ class MavenBuildToolSuite extends BaseSuite {
     val target = mbtTarget(
       "com.example:app:1.0.0",
       "target/classes",
-      configurations = Seq(s"${profilesPrefix}dev,ci"),
+      configurations = Seq("-P", "dev,ci"),
     )
 
     assertEquals(


### PR DESCRIPTION
> Instead of BSP, we want to use the build tools directly. This is the first approach so it might not work perfectly yet. @tgodzik 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced run and debug support for Gradle and Maven with improved classpath resolution
  * Added support for multiple class directories per module
  * Code lens for Java main method execution

* **Bug Fixes**
  * Improved class directory detection using source-set output directories instead of compiler output

* **Tests**
  * Added comprehensive test coverage for Gradle and Maven build commands
  * Updated test expectations to validate new configuration metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalameta/metals/pull/8413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->