### PR TITLE
feature: Allow running in Bazel

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
+++ b/metals/src/main/scala/scala/meta/internal/bsp/BspServers.scala
@@ -59,7 +59,7 @@ final class BspServers(
     workDoneProgress: WorkDoneProgress,
     scalaVersionSelector: ScalaVersionSelector,
     hasMbtImporters: () => Boolean = () => false,
-    mbtDebugStarter: Option[MbtDebugSessionStarter] = None,
+    mbtDebugStarter: () => Option[MbtDebugSessionStarter] = () => None,
 )(implicit ec: ExecutionContextExecutorService) {
   private def customProjectRoot =
     userConfig().getCustomProjectRoot(mainWorkspace)
@@ -188,7 +188,7 @@ final class BspServers(
         workDoneProgress,
         scalaVersionSelector,
         userConfig,
-        debugStarter = mbtDebugStarter,
+        debugStarter = mbtDebugStarter(),
       )
     } else {
       BuildServerConnection.fromSockets(

--- a/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelBuildTool.scala
@@ -8,9 +8,12 @@ import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.Tables
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.clients.language.MetalsLanguageClient
+import scala.meta.internal.metals.mbt.MbtDebugLauncher
+import scala.meta.internal.metals.mbt.MbtTarget
 import scala.meta.internal.metals.mbt.importer.BazelMbtImporter
 import scala.meta.io.AbsolutePath
 
+import ch.epfl.scala.bsp4j.ScalaMainClass
 import coursier.Dependency
 
 case class BazelBuildTool(
@@ -29,7 +32,8 @@ case class BazelBuildTool(
     )(ec)
     with BuildTool
     with BuildServerProvider
-    with VersionRecommendation {
+    with VersionRecommendation
+    with MbtDebugLauncher {
 
   override def digest(workspace: AbsolutePath): Option[String] = {
     BazelDigest.current(projectRoot)
@@ -80,6 +84,55 @@ case class BazelBuildTool(
       case _ =>
     }
   }
+
+  override def mbtCompileCommand(
+      workspace: AbsolutePath,
+      target: MbtTarget,
+  ): List[String] =
+    List("bazel", "build") ::: bazelBuildTargets(target)
+
+  override def mbtRunCommand(
+      workspace: AbsolutePath,
+      target: MbtTarget,
+      mainClass: ScalaMainClass,
+  ): List[String] =
+    mbtRunCommand(target, mainClass, debugAgentFlag = None)
+
+  override def mbtDebugCommand(
+      workspace: AbsolutePath,
+      target: MbtTarget,
+      mainClass: ScalaMainClass,
+      debugAgentFlag: String,
+  ): List[String] =
+    mbtRunCommand(target, mainClass, debugAgentFlag = Some(debugAgentFlag))
+
+  private def mbtRunCommand(
+      target: MbtTarget,
+      mainClass: ScalaMainClass,
+      debugAgentFlag: Option[String],
+  ): List[String] = {
+    val jvmFlags =
+      debugAgentFlag.toList ::: MbtDebugLauncher
+        .listOrNil(mainClass.getJvmOptions)
+    val appArgs = MbtDebugLauncher.listOrNil(mainClass.getArguments)
+    List(
+      "bazel",
+      "run",
+      "--ui_event_filters=-info,-stderr",
+      "--noshow_progress",
+      bazelRunTarget(target),
+      "--",
+    ) ::: jvmFlags.map(flag => s"--jvm_flag=$flag") ::: appArgs
+  }
+
+  private def bazelBuildTargets(target: MbtTarget): List[String] =
+    target.configurations.toList match {
+      case Nil => List(target.name)
+      case targets => targets
+    }
+
+  private def bazelRunTarget(target: MbtTarget): String =
+    target.configurations.headOption.getOrElse(target.name)
 
 }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ConnectionProvider.scala
@@ -69,7 +69,7 @@ class ConnectionProvider(
     indexProviders: IndexProviders,
     syncStatusReporter: SyncStatusReporter,
     mbtBuild: () => MbtBuild,
-    mbtDebugStarter: Option[MbtDebugSessionStarter] = None,
+    mbtDebugStarter: () => Option[MbtDebugSessionStarter] = () => None,
 )(implicit ec: ExecutionContextExecutorService, rc: ReportContext)
     extends Indexer(indexProviders, mbtBuild)
     with Cancelable {

--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -202,7 +202,7 @@ class ProjectMetalsLspService(
     sh,
   )
 
-  private val mbtDebugStarter =
+  private def mbtDebugStarter =
     buildTools.current().collectFirst { case buildTool: MbtDebugLauncher =>
       new MbtDebugSessionStarter(
         debugProvider.debugConfigCreator,
@@ -235,7 +235,7 @@ class ProjectMetalsLspService(
       this,
       syncStatusReporter,
       () => mbtBuild,
-      mbtDebugStarter = mbtDebugStarter,
+      mbtDebugStarter = () => mbtDebugStarter,
     )
     provider.buildServerPromise.future.onComplete(_ => moduleStatus.refresh())
     provider

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtBuildSupport.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtBuildSupport.scala
@@ -37,6 +37,8 @@ object BazelMbtBuildSupport {
       javacOptionsByTarget: Map[String, List[String]],
       directDepRules: Map[String, List[String]],
       externalDepsByTarget: Map[String, List[String]],
+      runTargets: Set[String],
+      classDirectoriesByTarget: Map[String, String],
       dependencyModules: Seq[MbtDependencyModule],
       scalaVersion: Option[String],
   ): MbtBuild = {
@@ -67,6 +69,15 @@ object BazelMbtBuildSupport {
           granularity,
           targetLabels,
           externalDepsByTarget,
+          keys,
+        )
+      val runTargetsByNs =
+        computeRunTargets(granularity, targetLabels, runTargets, keys)
+      val classDirectoriesByNs =
+        computeClassDirectories(
+          targetLabels,
+          runTargetsByNs,
+          classDirectoriesByTarget,
           keys,
         )
       val srcFilesByTarget = srcsByTarget.map { case (k, v) =>
@@ -121,6 +132,8 @@ object BazelMbtBuildSupport {
             javacOptionsByBuildFile.getOrElse(namespace, Nil),
             dependsByNs.getOrElse(namespace, Set.empty),
             externalDepsByNs.getOrElse(namespace, Set.empty),
+            runTargetsByNs.getOrElse(namespace, Set.empty),
+            classDirectoriesByNs.get(namespace),
             scalaVersion,
           )
         }
@@ -136,6 +149,8 @@ object BazelMbtBuildSupport {
           Nil,
           Set.empty,
           allExtDeps,
+          runTargetsByNs.getOrElse(workspaceNamespaceName, Set.empty),
+          classDirectoriesByNs.get(workspaceNamespaceName),
           scalaVersion,
         )
       }
@@ -232,6 +247,43 @@ object BazelMbtBuildSupport {
     }
   }
 
+  private def computeRunTargets(
+      granularity: BazelMbtNamespaceMode,
+      targetLabels: List[String],
+      runTargets: Set[String],
+      keys: Map[String, String],
+  ): Map[String, Set[String]] = {
+    val outgoing = mutable.Map.empty[String, mutable.Set[String]]
+    for {
+      target <- targetLabels
+      if runTargets(target)
+    } {
+      val nsKey =
+        if (granularity == BazelMbtNamespaceMode.Workspace)
+          workspaceNamespaceName
+        else keys(target)
+      outgoing.getOrElseUpdate(nsKey, mutable.Set.empty) += target
+    }
+    outgoing.map { case (k, v) => k -> v.toSet }.toMap
+  }
+
+  private def computeClassDirectories(
+      targetLabels: List[String],
+      runTargetsByNs: Map[String, Set[String]],
+      classDirectoriesByTarget: Map[String, String],
+      keys: Map[String, String],
+  ): Map[String, String] =
+    keys.values.toSet.flatMap { (namespace: String) =>
+      val preferredTargets = runTargetsByNs.getOrElse(namespace, Set.empty)
+      val fallbackTargets =
+        targetLabels.filter(target => keys(target) == namespace)
+      val candidates = preferredTargets.toSeq.sorted ++ fallbackTargets
+      candidates
+        .flatMap(classDirectoriesByTarget.get)
+        .headOption
+        .map(dir => namespace -> dir)
+    }.toMap
+
   private def putNamespace(
       namespaces: ju.Map[String, MbtNamespace],
       name: String,
@@ -240,18 +292,24 @@ object BazelMbtBuildSupport {
       javacOptions: Seq[String],
       dependsOn: Set[String],
       dependencyModuleIds: Set[String],
+      runTargets: Set[String],
+      classDirectory: Option[String],
       scalaVersion: Option[String],
   ): Unit = {
+    val sortedRunTargets =
+      if (runTargets.isEmpty) null else runTargets.toSeq.sorted.asJava
     namespaces.put(
       name,
       new MbtNamespace(
-        sources.toSeq.sorted.asJava,
-        scalacOptions.distinct.asJava,
-        javacOptions.distinct.asJava,
-        dependencyModuleIds.toSeq.sorted.asJava,
-        scalaVersion.orNull,
-        null,
-        dependsOn.toSeq.sorted.asJava,
+        sources = sources.toSeq.sorted.asJava,
+        scalacOptions = scalacOptions.distinct.asJava,
+        javacOptions = javacOptions.distinct.asJava,
+        dependencyModules = dependencyModuleIds.toSeq.sorted.asJava,
+        scalaVersion = scalaVersion.orNull,
+        javaHome = null,
+        dependsOn = dependsOn.toSeq.sorted.asJava,
+        classDirectories = classDirectory.toList.asJava,
+        configurations = sortedRunTargets,
       ),
     )
   }
@@ -270,6 +328,8 @@ object BazelMbtBuildSupport {
       Nil,
       Set.empty,
       dependencyModuleIds,
+      Set.empty,
+      None,
       scalaVersion,
     )
     m

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtImporter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelMbtImporter.scala
@@ -51,6 +51,7 @@ abstract class BazelMbtImporter(
     val patterns = BazelProjectViewTargets.patterns(projectRoot)
     for {
       outputBase <- queryOutputBase()
+      bazelBin <- queryBazelBin()
       repositoryName = BazelMavenJsonImporter
         .extractRepositoryNameFromBazelConfig(projectRoot)
       _ = scribe.info(s"bazel-mbt: found repository name: $repositoryName")
@@ -72,6 +73,18 @@ abstract class BazelMbtImporter(
       srcs = targetsXmlDump.getLabels("srcs")
       scalacOptions = targetsXmlDump.getStrings("scalacopts")
       javacOptions = targetsXmlDump.getStrings("javacopts")
+      runTargets = targets
+        .filter(target =>
+          targetsXmlDump.ruleClassesByTarget
+            .get(target)
+            .exists(isRunnableRule)
+        )
+        .toSet
+      classDirectories = classDirectoriesForRunTargets(
+        bazelBin,
+        runTargets,
+        targetsXmlDump.ruleOutputsByTarget,
+      )
       deps = queryDeps(targets.toSet, targets, targetsXmlDump)
       externalDeps = targetsXmlDump.externalDepsByTarget(targets)
       externalDepModules = matchExternalDepsToModules(
@@ -92,6 +105,8 @@ abstract class BazelMbtImporter(
         javacOptions,
         deps,
         externalDepModules,
+        runTargets,
+        classDirectories,
         dependencyModules,
         effectiveScalaVersion,
       )
@@ -101,6 +116,32 @@ abstract class BazelMbtImporter(
 
   private def asLines(output: String) =
     output.linesIterator.map(_.trim).filter(_.nonEmpty).toList
+
+  private def isRunnableRule(ruleClass: String): Boolean =
+    ruleClass == "scala_binary" || ruleClass == "java_binary"
+
+  private def classDirectoriesForRunTargets(
+      bazelBin: Option[Path],
+      runTargets: Set[String],
+      ruleOutputsByTarget: Map[String, List[String]],
+  ): Map[String, String] =
+    bazelBin.toList.flatMap { bin =>
+      for {
+        target <- runTargets.toList
+        output <- ruleOutputsByTarget
+          .getOrElse(target, Nil)
+          .find(isClassJarOutput)
+        relative <- BazelMbtBuildSupport.fileLabelToWorkspaceRelativePath(
+          output
+        )
+      } yield target -> bin.resolve(relative).toString
+    }.toMap
+
+  private def isClassJarOutput(label: String): Boolean =
+    label.endsWith(".jar") &&
+      !label.endsWith("-src.jar") &&
+      !label.endsWith("_deploy.jar") &&
+      !label.endsWith("_deploy-src.jar")
 
   private def selectedNamespaceMode(): Future[BazelMbtNamespaceMode] =
     rememberedNamespaceMode match {
@@ -220,11 +261,19 @@ abstract class BazelMbtImporter(
   }
 
   private def queryOutputBase(): Future[Option[Path]] = {
+    queryBazelInfo("output_base")
+  }
+
+  private def queryBazelBin(): Future[Option[Path]] = {
+    queryBazelInfo("bazel-bin")
+  }
+
+  private def queryBazelInfo(key: String): Future[Option[Path]] = {
     val buf = new StringBuilder()
     shellRunner
       .run(
         "bazel-info",
-        List("bazel", "info", "output_base"),
+        List("bazel", "info", key),
         projectRoot,
         redirectErrorOutput = false,
         javaHome = userConfig().javaHome,

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelTargetsXmlDump.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/importer/BazelTargetsXmlDump.scala
@@ -39,6 +39,32 @@ class BazelTargetsXmlDump(xmlDump: String) {
     targetLabels.toMap
   }
 
+  lazy val ruleClassesByTarget: Map[String, String] = {
+    val targetLabels = for {
+      rule <- root \\ "rule"
+      target = (rule \ "@name").text
+      ruleClass = (rule \ "@class").text
+      if target.nonEmpty && ruleClass.nonEmpty
+    } yield target -> ruleClass
+    targetLabels.toMap
+  }
+
+  lazy val ruleOutputsByTarget: Map[String, List[String]] = {
+    val targetLabels = for {
+      rule <- root \\ "rule"
+      target = (rule \ "@name").text
+      if target.nonEmpty
+    } yield {
+      val outputs = for {
+        output <- rule \ "rule-output"
+        value = (output \ "@name").text
+        if value.nonEmpty
+      } yield value
+      target -> outputs.toList
+    }
+    targetLabels.toMap
+  }
+
   lazy val depsByTarget: Map[String, List[String]] = {
     val targetLabels = for {
       rule <- root \\ "rule"

--- a/tests/slow/src/test/scala/tests/bazel/BazelDapMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelDapMbtLspSuite.scala
@@ -1,0 +1,100 @@
+package tests.bazel
+
+import scala.jdk.CollectionConverters._
+
+import scala.meta.internal.metals.AutoImportBuildKind
+import scala.meta.internal.metals.Configs.JavaSymbolLoaderConfig
+import scala.meta.internal.metals.Configs.ReferenceProviderConfig
+import scala.meta.internal.metals.Configs.WorkspaceSymbolProviderConfig
+import scala.meta.internal.metals.Messages
+import scala.meta.internal.metals.UserConfiguration
+import scala.meta.internal.metals.mbt.MbtBuildServer
+import scala.meta.internal.metals.{BuildInfo => V}
+
+import ch.epfl.scala.bsp4j.DebugSessionParamsDataKind
+import ch.epfl.scala.bsp4j.ScalaMainClass
+import tests.BaseDapSuite
+import tests.BazelBuildLayout
+import tests.BazelMbtTestInitializer
+
+class BazelDapMbtLspSuite
+    extends BaseDapSuite(
+      "bazel-mbt-dap",
+      BazelMbtTestInitializer,
+      BazelBuildLayout,
+    ) {
+
+  private val bazelVersion = "8.2.1"
+
+  override def userConfig: UserConfiguration =
+    super.userConfig.copy(
+      presentationCompilerDiagnostics = true,
+      buildOnChange = false,
+      buildOnFocus = false,
+      workspaceSymbolProvider = WorkspaceSymbolProviderConfig.mbt,
+      javaSymbolLoader = JavaSymbolLoaderConfig.turbineClasspath,
+      referenceProvider = ReferenceProviderConfig.mbt,
+      preferredBuildServer = Some(MbtBuildServer.name),
+      automaticImportBuild = AutoImportBuildKind.All,
+    )
+
+  override def initializeGitRepo: Boolean = true
+
+  private def bazelWorkspaceLayout: String =
+    """|/.bazelproject
+       |targets:
+       |    //...
+       |
+       |/app/BUILD
+       |java_binary(
+       |    name = "main",
+       |    srcs = ["Main.java"],
+       |    main_class = "app.Main",
+       |)
+       |
+       |/app/Main.java
+       |package app;
+       |
+       |public class Main {
+       |  public static void main(String[] args) {
+       |    String foo = System.getProperty("property", "");
+       |    String bar = args.length > 0 ? args[0] : "";
+       |    System.out.print(foo + bar);
+       |    System.exit(0);
+       |  }
+       |}
+       |""".stripMargin
+
+  test("bazel-mbt-debug-session") {
+    client.selectedServer = Messages.ChooseBuildServer.mbt
+    cleanWorkspace()
+
+    val mainClass = new ScalaMainClass(
+      "app.Main",
+      List("Bar").asJava,
+      List("-Dproperty=Foo").asJava,
+    )
+
+    for {
+      _ <- initialize(
+        BazelBuildLayout(
+          bazelWorkspaceLayout,
+          V.scala213,
+          bazelVersion,
+        )
+      )
+      _ <- server.headServer.connectionProvider.buildServerPromise.future
+      _ <- server.didOpen("app/Main.java")
+      debugger <- server.startDebugging(
+        "//app",
+        DebugSessionParamsDataKind.SCALA_MAIN_CLASS,
+        mainClass,
+      )
+      _ <- debugger.initialize
+      _ <- debugger.launch
+      _ <- debugger.configurationDone
+      _ <- debugger.shutdown
+      output <- debugger.allOutput
+    } yield assertContains(output, "FooBar")
+  }
+}

--- a/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
@@ -274,7 +274,8 @@ class BazelMbtLspSuite
             |        "org.typelevel:cats-kernel_2.13:2.13.0"
             |      ],
             |      "scalaVersion": "2.13.16",
-            |      "dependsOn": []
+            |      "dependsOn": [],
+            |      "classDirectories": []
             |    },
             |    "//app": {
             |      "sources": [
@@ -291,6 +292,10 @@ class BazelMbtLspSuite
             |      "scalaVersion": "2.13.16",
             |      "dependsOn": [
             |        "//core"
+            |      ],
+            |      "classDirectories": ["<classDirectories-path>"],
+            |      "configurations": [
+            |        "//app:hello"
             |      ]
             |    }
             |  }
@@ -372,7 +377,8 @@ class BazelMbtLspSuite
             |      "javacOptions": [],
             |      "dependencyModules": [],
             |      "scalaVersion": "2.13.18",
-            |      "dependsOn": []
+            |      "dependsOn": [],
+            |      "classDirectories": []
             |    }
             |  }
             |}""".stripMargin,
@@ -437,7 +443,8 @@ class BazelMbtLspSuite
             |        "org.typelevel:cats-kernel_2.13:2.13.0"
             |      ],
             |      "scalaVersion": "2.13.16",
-            |      "dependsOn": []
+            |      "dependsOn": [],
+            |      "classDirectories": []
             |    }
             |  }
             |}""".stripMargin,
@@ -530,7 +537,8 @@ class BazelMbtLspSuite
             |        "org.jsoup:jsoup:1.21.1"
             |      ],
             |      "scalaVersion": "2.13.18",
-            |      "dependsOn": []
+            |      "dependsOn": [],
+            |      "classDirectories": []
             |    },
             |    "//app": {
             |      "sources": [
@@ -544,6 +552,10 @@ class BazelMbtLspSuite
             |      "scalaVersion": "2.13.18",
             |      "dependsOn": [
             |        "//lib"
+            |      ],
+            |      "classDirectories": ["<classDirectories-path>"],
+            |      "configurations": [
+            |        "//app:main"
             |      ]
             |    }
             |  }
@@ -631,7 +643,11 @@ class BazelMbtLspSuite
             |        "org.typelevel:cats-kernel_2.13:2.13.0"
             |      ],
             |      "scalaVersion": "2.13.16",
-            |      "dependsOn": []
+            |      "dependsOn": [],
+            |      "classDirectories": ["<classDirectories-path>"],
+            |      "configurations": [
+            |        "//app:hello"
+            |      ]
             |    }
             |  }
             |}""".stripMargin,

--- a/tests/slow/src/test/scala/tests/gradle/GradleMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/gradle/GradleMbtLspSuite.scala
@@ -238,9 +238,7 @@ class GradleMbtLspSuite
             |        "org.jsoup:jsoup:1.21.1"
             |      ],
             |      "javaHome": "file://${Properties.javaHome.replace("\\", "/")}/",
-            |      "classDirectories": [
-            |        "build/classes/java/main"
-            |      ],
+            |      "classDirectories": ["<classDirectories-path>"],
             |      "projectPath": ":"
             |    }
             |  }

--- a/tests/unit/src/main/scala/tests/BaseMbtSuite.scala
+++ b/tests/unit/src/main/scala/tests/BaseMbtSuite.scala
@@ -3,9 +3,14 @@ package tests
 trait BaseMbtSuite {
   protected def escapeMbtFile(mbtFile: String): String = {
 
-    mbtFile.replaceAll(
-      """"(jar|sources)":\s*"[^"]+"""",
-      """"$1": "<$1-path>"""",
-    )
+    mbtFile
+      .replaceAll(
+        """"(jar|sources)":\s*"[^"]+"""",
+        """"$1": "<$1-path>"""",
+      )
+      .replaceAll(
+        """"(classDirectories|testClassDirectories)":\s*\[\s*"[^"]+"\s*\]""",
+        """"$1": ["<$1-path>"]""",
+      )
   }
 }


### PR DESCRIPTION
Instead of BSP, we want to use the build tools directly. This is the first approach so it might not work perfectly yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Bazel build tool support with explicit compile, run, and debug commands via MBT integration.
  * Improved detection and handling of runnable Bazel targets (scala_binary/java_binary) with class directory mapping.

* **Tests**
  * Added new debug session test suite for Bazel+MBT configuration, validating debugging workflows for Bazel projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalameta/metals/pull/8414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->