### PR TITLE
Better workflow for integration tests

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -1,0 +1,77 @@
+name: Slow Integration Tests
+
+on:
+  push:
+    branches:
+      - main-v2
+  pull_request:
+    branches:
+      - main-v2
+
+jobs:
+  publish-local:
+    name: Publish artifacts to local Ivy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: sbt
+
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Publish local
+        # Keep quiet, as there are other jobs to check warnings etc.
+        run: sbt --error +publishLocal
+
+      # Upload the freshly-published artifacts so test jobs can reuse them.
+      - name: Upload local Ivy artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ivy2-local-${{ github.run_id }}
+          path: ~/.ivy2/local
+          retention-days: 1
+          if-no-files-found: error
+
+  slow-tests:
+    name: Slow integration tests for ${{ matrix.suite }}
+    needs: publish-local
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - bazel
+          - gradle
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: sbt
+
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
+
+      # This is required for some tests that create a git repo
+      - name: Configure git
+        run: |
+          git config --global user.email "ci@scalameta.org"
+          git config --global user.name "CI Bot"
+
+      - name: Restore local Ivy artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: ivy2-local-${{ github.run_id }}
+          path: ~/.ivy2/local
+
+      - name: Run tests for ${{ matrix.suite }} integration
+        run: bin/test.sh 'slow/testOnly -- tests.${{ matrix.suite }}.*'

--- a/build.sbt
+++ b/build.sbt
@@ -594,6 +594,7 @@ lazy val `semanticdb-javac` = project
 
 lazy val `mtags-java` = project
   .settings(
+    crossScalaVersions := Seq(V.scala213),
     libraryDependencies ++= pprintDebuggingDependency,
     Compile / javaOptions ++= toolchainJavaOptions,
     Compile / javacOptions ++= toolchainJavaOptions,

--- a/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/bazel/BazelMbtLspSuite.scala
@@ -563,6 +563,7 @@ class BazelMbtLspSuite
       )
       _ <- server.didOpen("lib/Parser.java")
       _ <- server.didFocus("lib/Parser.java")
+      _ <- server.waitFor(millis = 10_000)
       _ <- server.assertHover(
         "lib/Parser.java",
         s"""|package lib;


### PR DESCRIPTION
This pull request attempts to fix #8425.

The new workflow is intended to replace the jobs that run `slow/test` or `slow/testOnly`.

This workflow publishes (locally) all artifacts for all Scala versions, but these artifacts are cached and re-used for each suite of slow tests. Some publishing still happens because `slow/testOnly` invokes `publishLocal` directly for some projects, but this doesn't seem to take a long time. I will try to optimise this sometime later.

The Bazel test seems flaky, so I have added a delay before checking the hover. The Scala cross tests also seem to be flaky.