### PR TITLE
fix: test execution over MCP

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/ProjectMetalsLspService.scala
@@ -260,6 +260,7 @@ class ProjectMetalsLspService(
     new McpTestRunner(
       debugProvider,
       buildTargets,
+      compilations,
       folder,
       () => userConfig,
       mcpSearch,

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -449,6 +449,7 @@ class DebugProvider(
         s"Found infos about: ${infos.flatten.map(_._2.symbol).mkString(", ")} test classes"
       )
       val allInfo = infos.flatten
+
       if (allInfo.isEmpty) {
         val suitesString =
           testClasses.getSuites().asScala.map(_.getClassName()).mkString(", ")
@@ -456,21 +457,30 @@ class DebugProvider(
           s"Could not get information from the compiler about $suitesString"
         )
       }
-      infos.flatten.groupBy(_._1.framework).map {
-        case (framework, testSuites) =>
+
+      // Prefer `#` over `.` to avoid synthetic companion objects
+      allInfo
+        .groupBy(_._1.fullyQualifiedName)
+        .values
+        .map { entries =>
+          val (info, pcInfo) = entries
+            .find(e => !e._2.symbol.endsWith("."))
+            .getOrElse(entries.head)
           (
-            framework,
-            testSuites.map { case (testInfo, pcInfo) =>
-              new Discovered(
-                pcInfo.symbol,
-                testInfo.fullyQualifiedName,
-                pcInfo.recursiveParents.map(_.symbolToFullyQualifiedName).toSet,
-                (pcInfo.annotations ++ pcInfo.memberDefsAnnotations).toSet,
-                isModule = pcInfo.symbol.endsWith("."),
-              )
-            },
+            info.framework,
+            new Discovered(
+              pcInfo.symbol,
+              info.fullyQualifiedName,
+              pcInfo.recursiveParents.map(_.symbolToFullyQualifiedName).toSet,
+              (pcInfo.annotations ++ pcInfo.memberDefsAnnotations).toSet,
+              isModule = pcInfo.symbol.endsWith("."),
+            ),
           )
-      }
+        }
+        .groupBy(_._1)
+        .map { case (framework, entries) =>
+          framework -> entries.map(_._2).toList
+        }
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mcp/McpTestRunner.scala
@@ -8,6 +8,7 @@ import scala.concurrent.Promise
 
 import scala.meta.internal.ansi.AnsiFilter
 import scala.meta.internal.metals.BuildTargets
+import scala.meta.internal.metals.Compilations
 import scala.meta.internal.metals.MetalsEnrichments._
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.debug.DebugProvider
@@ -22,6 +23,7 @@ import ch.epfl.scala.{bsp4j => b}
 class McpTestRunner(
     debugProvider: DebugProvider,
     buildTargets: BuildTargets,
+    compilations: Compilations,
     workspace: AbsolutePath,
     userConfig: () => UserConfiguration,
     mcpSearch: McpSymbolSearch,
@@ -54,6 +56,7 @@ class McpTestRunner(
       )
     } yield {
       for {
+        _ <- compilations.compileFile(path)
         env <- jvmTestEnv
         settings = DebugProvider.scalaTestLocalRunSettings(workspace, env)
         testSuites = new b.ScalaTestSuites(

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ZioTestFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/frameworks/ZioTestFinder.scala
@@ -117,5 +117,6 @@ object ZioTestFinder {
     "zio/test/DefaultRunnableSpec#",
     "zio/test/RunnableSpec#",
     "zio/test/ZIOSpecDefault#",
+    "zio/test/ZIOSpecAbstract#",
   )
 }


### PR DESCRIPTION
Test execution over mcp would silently fail with no output, if the class to test could not be found by the presentation compiler. This change ensures the file with the test is compiled before attempting to find the test.

In case a test lives in a class with a companion object, two `Discovered` instances were potentially created, one for the class and one for the object. Now the class is preferred over the object, such that for class based test frameworks the companion is ignored, but for module based frameworks such as ZIO test the module is uses, since no class exists.

/fixes https://github.com/scalameta/metals/issues/8276
/fixes https://github.com/scalameta/metals/issues/8138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader ZIO test framework compatibility to detect additional suite types.

* **Bug Fixes**
  * Fixed duplicate test discovery by improving deduplication logic.
  * Ensured source files are compiled before running tests to improve execution reliability.
  * Added error logging when compiler/type information is missing for test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalameta/metals/pull/8418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->