### PR TITLE
[MBT] Use mvnw by default if available

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/MavenBuildTool.scala
@@ -50,20 +50,7 @@ case class MavenBuildTool(
   }
 
   override def mavenBaseCommand(): List[String] =
-    userConfig().mavenScript match {
-      case Some(script) => List(script)
-      case None =>
-        writeProperties()
-        List(
-          JavaBinary(userConfig().javaHome),
-          "-Dfile.encoding=UTF-8",
-          s"-Dmaven.multiModuleProjectDirectory=$projectRoot",
-          s"-Dmaven.home=$tempDir",
-          "-cp",
-          embeddedMavenLauncher.toString(),
-          "org.apache.maven.wrapper.MavenWrapperMain",
-        )
-    }
+    mbtMavenBaseCommand(projectRoot)
 
   override def isBuildRelated(path: AbsolutePath): Boolean =
     MavenBuildTool.isMavenRelatedPath(projectRoot, path)
@@ -88,7 +75,21 @@ case class MavenBuildTool(
 
   private def mbtMavenBaseCommand(workspace: AbsolutePath): List[String] =
     if (hasMvnw(workspace)) List(s"./$mvnwName")
-    else mavenBaseCommand()
+    else
+      userConfig().mavenScript match {
+        case Some(script) => List(script)
+        case None =>
+          writeProperties()
+          List(
+            JavaBinary(userConfig().javaHome),
+            "-Dfile.encoding=UTF-8",
+            s"-Dmaven.multiModuleProjectDirectory=$projectRoot",
+            s"-Dmaven.home=$tempDir",
+            "-cp",
+            embeddedMavenLauncher.toString(),
+            "org.apache.maven.wrapper.MavenWrapperMain",
+          )
+      }
 
   override def mbtCompileCommand(
       workspace: AbsolutePath,

--- a/tests/unit/src/test/scala/tests/MavenBuildToolSuite.scala
+++ b/tests/unit/src/test/scala/tests/MavenBuildToolSuite.scala
@@ -3,6 +3,7 @@ package tests
 import java.nio.file.Files
 
 import scala.concurrent.ExecutionContext
+import scala.util.Properties
 
 import scala.meta.internal.builds.MavenBuildTool
 import scala.meta.internal.builds.ShellRunner
@@ -62,6 +63,18 @@ class MavenBuildToolSuite extends BaseSuite {
         "mvn", "-q", "-P", "dev,ci", "-pl", ":app", "--also-make", "install",
         "-DskipTests", "-Denforcer.skip=true",
       ),
+    )
+  }
+
+  test("maven-base-command-uses-project-wrapper") {
+    val workspace = AbsolutePath(Files.createTempDirectory("maven-mbt"))
+    val mvnwName = if (Properties.isWin) "mvnw.cmd" else "mvnw"
+    val mvnw = workspace.resolve(mvnwName)
+    mvnw.writeText("#!/bin/sh\n")
+
+    assertEquals(
+      mavenBuildTool(workspace).mavenBaseCommand(),
+      List(s"./$mvnwName"),
     )
   }
 


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/8422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Maven build tool to prioritize and use local Maven wrappers (mvnw) when present, with automatic fallback to configured Maven scripts or embedded wrappers when unavailable.

* **Tests**
  * Added unit test for Maven wrapper detection in project builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalameta/metals/pull/8423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->