### PR TITLE
improvement: Optimize main classes detection in MBT

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/MetalsLspService.scala
@@ -1722,9 +1722,7 @@ abstract class MetalsLspService(
     fileDecoderProvider.decodedFileContents(uri)
 
   def discoverTestSuites(uri: Option[String]): Future[List[BuildTargetUpdate]] =
-    Future {
-      testProvider.discoverTests(uri.map(_.toAbsolutePath))
-    }
+    testProvider.discoverTests(uri.map(_.toAbsolutePath))
 
   def runScalafix(uri: String): Future[ApplyWorkspaceEditResponse] =
     scalafixProvider

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -111,27 +111,36 @@ final class RunTestCodeLens(
       // although hasDebug is already available in BSP capabilities
       // see https://github.com/build-server-protocol/build-server-protocol/pull/161
       // most of the bsp servers such as bloop and sbt might not support it.
-    } yield requestJvmEnvironment(buildTargetId, isJVM).map { _ =>
-      val classes = buildTargetClasses.classesOf(buildTargetId)
-      val syntheticLenses =
-        if (!path.isWorksheet)
-          syntheticCodeLenses(
-            textDocument,
-            buildTargetId,
-            classes,
-            isJVM,
-          )
-        else Nil
-      val regularLenses =
-        codeLenses(
-          textDocument,
-          buildTargetId,
-          classes,
-          distance,
-          path,
-          isJVM,
-        )
-      syntheticLenses ++ regularLenses
+    } yield {
+      // First confirm any candidate main classes for this file.
+      // This is needed for MBT build servers where main classes are discovered lazily.
+      val confirmCandidates =
+        buildTargetClasses.confirmMbtMainClassCandidates(path, buildTargetId)
+
+      confirmCandidates.flatMap { _ =>
+        requestJvmEnvironment(buildTargetId, isJVM).map { _ =>
+          val classes = buildTargetClasses.classesOf(buildTargetId)
+          val syntheticLenses =
+            if (!path.isWorksheet)
+              syntheticCodeLenses(
+                textDocument,
+                buildTargetId,
+                classes,
+                isJVM,
+              )
+            else Nil
+          val regularLenses =
+            codeLenses(
+              textDocument,
+              buildTargetId,
+              classes,
+              distance,
+              path,
+              isJVM,
+            )
+          syntheticLenses ++ regularLenses
+        }
+      }
     }
     Future.sequence(lenses).map(_.flatten)
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/codelenses/RunTestCodeLens.scala
@@ -112,34 +112,38 @@ final class RunTestCodeLens(
       // see https://github.com/build-server-protocol/build-server-protocol/pull/161
       // most of the bsp servers such as bloop and sbt might not support it.
     } yield {
-      // First confirm any candidate main classes for this file.
-      // This is needed for MBT build servers where main classes are discovered lazily.
-      val confirmCandidates =
+      // First confirm any candidate main and test classes for this file.
+      // This is needed for MBT build servers where classes are discovered lazily.
+      val confirmMainCandidates =
         buildTargetClasses.confirmMbtMainClassCandidates(path, buildTargetId)
+      val confirmTestCandidates =
+        buildTargetClasses.confirmMbtTestClassCandidates(path, buildTargetId)
 
-      confirmCandidates.flatMap { _ =>
-        requestJvmEnvironment(buildTargetId, isJVM).map { _ =>
-          val classes = buildTargetClasses.classesOf(buildTargetId)
-          val syntheticLenses =
-            if (!path.isWorksheet)
-              syntheticCodeLenses(
-                textDocument,
-                buildTargetId,
-                classes,
-                isJVM,
-              )
-            else Nil
-          val regularLenses =
-            codeLenses(
+      for {
+        _ <- confirmMainCandidates
+        _ <- confirmTestCandidates
+        _ <- requestJvmEnvironment(buildTargetId, isJVM)
+      } yield {
+        val classes = buildTargetClasses.classesOf(buildTargetId)
+        val syntheticLenses =
+          if (!path.isWorksheet)
+            syntheticCodeLenses(
               textDocument,
               buildTargetId,
               classes,
-              distance,
-              path,
               isJVM,
             )
-          syntheticLenses ++ regularLenses
-        }
+          else Nil
+        val regularLenses =
+          codeLenses(
+            textDocument,
+            buildTargetId,
+            classes,
+            distance,
+            path,
+            isJVM,
+          )
+        syntheticLenses ++ regularLenses
       }
     }
     Future.sequence(lenses).map(_.flatten)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -707,6 +707,10 @@ final class BuildTargetClasses(
           EmptyCancelToken,
           Duration.ofSeconds(15),
         )
+        .recover { case e =>
+          scribe.error(s"Error parsing semanticdb text documents: $e", e)
+          TextDocuments(documents = Seq.empty)
+        }
         .map { documents =>
           documents.documents.foreach { doc =>
             processMbtSemanticdb(doc.uri.toAbsolutePath, doc, targetIds)
@@ -797,6 +801,10 @@ final class BuildTargetClasses(
           EmptyCancelToken,
           Duration.ofSeconds(15),
         )
+        .recover { case e =>
+          scribe.error(s"Error parsing semanticdb text documents: $e", e)
+          TextDocuments(documents = Seq.empty)
+        }
         .map { documents =>
           documents.documents.foreach { doc =>
             val docPath = doc.uri.toAbsolutePath
@@ -839,6 +847,10 @@ final class BuildTargetClasses(
           EmptyCancelToken,
           Duration.ofSeconds(15),
         )
+        .recover { case e =>
+          scribe.error(s"Error parsing semanticdb text documents: $e", e)
+          TextDocuments(documents = Seq.empty)
+        }
         .flatMap { documents =>
           Future
             .sequence(

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -19,7 +19,6 @@ import scala.meta.internal.metals.SemanticdbFeatureProvider
 import scala.meta.internal.metals.debug.BuildTargetClasses.Classes
 import scala.meta.internal.metals.debug.BuildTargetClasses.TestSymbolInfo
 import scala.meta.internal.metals.mbt.MbtBuildServer
-import scala.meta.internal.metals.mbt.MbtPossibleReferencesParams
 import scala.meta.internal.metals.mbt.MbtWorkspaceSymbolProvider
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.semanticdb.ClassSignature
@@ -600,50 +599,91 @@ final class BuildTargetClasses(
     }
   }
 
+  /**
+   * Populates candidate main classes from the MBT index WITHOUT loading semanticdb.
+   * The candidates are stored in `candidateMainClasses` and will be confirmed
+   * lazily when:
+   * - A file is opened (for code lenses)
+   * - User runs test from config and uses discovery
+   *
+   * This optimization avoids the expensive semanticdb loading at startup.
+   */
   private def populateMbtMainClasses(
       classes: Map[b.BuildTargetIdentifier, Classes],
       targets: Seq[b.BuildTargetIdentifier],
-  ): Future[Unit] = {
+  ): Future[Unit] = Future {
     mbt() match {
       case None =>
         scribe.warn("mbt-run: MBT workspace symbol provider is not available.")
-        Future.unit
       case Some(mbtProvider) =>
         val targetSet = targets.toSet
-        val pathsFromMainSymbols =
-          mbtProvider
-            .queryWorkspaceSymbol("main")
-            .flatMap(info => Option(info.getLocation()))
-            .map { loc =>
-              AbsolutePath.fromAbsoluteUri(URI.create(loc.getUri()))
-            }
-        val pathsFromReferences =
-          mbtProvider.possibleReferences(
-            MbtPossibleReferencesParams(
-              references = Seq("scala/main#", "scala/App#")
+
+        val candidates = mbtProvider.candidateMainClasses(path =>
+          path.isScalaOrJava &&
+            buildTargets.inverseSourcesAll(path).exists(targetSet)
+        )
+        // Group candidates by path
+        val candidatesByPath = candidates
+          .groupBy(_.path)
+          .view
+          .mapValues(
+            _.map(c =>
+              BuildTargetClasses.MainClassCandidate(c.path, c.candidateSymbol)
             )
           )
-        val candidatePaths =
-          filterMbtCandidatePaths(
-            pathsFromMainSymbols ++ pathsFromReferences,
-            targetSet,
-          )
+          .toMap
 
-        foreachMbtSemanticdbDocument(candidatePaths) { doc =>
-          val targetIds =
-            buildTargets
-              .inverseSourcesAll(doc.uri.toAbsolutePath)
-              .filter(targetSet)
-          if (targetIds.nonEmpty) {
-            val mainClasses = extractMbtMainClasses(doc)
-            for {
-              target <- targetIds
-              (symbol, mc) <- mainClasses
-            } {
-              classes(target).mainClasses.put(symbol, mc)
-            }
+        // Store candidates in the appropriate target classes
+        for {
+          (path, pathCandidates) <- candidatesByPath
+          targetId <- buildTargets.inverseSourcesAll(path).filter(targetSet)
+        } {
+          val existingCandidates =
+            classes(targetId).candidateMainClasses.getOrElse(path, Seq.empty)
+          classes(targetId).candidateMainClasses
+            .put(path, existingCandidates ++ pathCandidates)
+        }
+
+        scribe.debug(
+          s"mbt-run: stored ${candidates.size} main class candidates from ${candidatesByPath.size} files"
+        )
+        Future.unit
+    }
+  }
+
+  /**
+   * Confirms candidate main classes for a specific file by loading semanticdb.
+   * This should be called when:
+   * - A file is opened (for code lenses)
+   * - User runs test from config and uses discovery
+   *
+   * @param path The file path to confirm candidates for
+   * @param targetId Optional target to limit confirmation to
+   * @return Future that completes when confirmation is done
+   */
+  def confirmMbtMainClassCandidates(
+      path: AbsolutePath,
+      targetId: b.BuildTargetIdentifier,
+  ): Future[Unit] = {
+    val targetIds = Seq(targetId)
+
+    val hasCandidates = targetIds.exists { tid =>
+      index.get(tid).exists(_.candidateMainClasses.contains(path))
+    }
+
+    if (!hasCandidates) {
+      Future.unit
+    } else {
+      compilers()
+        .batchSemanticdbTextDocuments(
+          Seq(path),
+          EmptyCancelToken,
+          Duration.ofSeconds(15),
+        )
+        .map { documents =>
+          documents.documents.foreach { doc =>
+            processMbtSemanticdb(doc.uri.toAbsolutePath, doc, targetIds)
           }
-          Future.unit
         }
     }
   }
@@ -681,6 +721,83 @@ final class BuildTargetClasses(
             .flatMap { documents =>
               Future.sequence(documents.documents.map(f)).map(_ => ())
             }
+        }
+    }
+  }
+
+  private def processMbtSemanticdb(
+      docPath: AbsolutePath,
+      doc: TextDocument,
+      targetIds: Seq[b.BuildTargetIdentifier],
+  ): Unit = {
+    for {
+      tid <- targetIds
+      classes <- index.get(tid)
+    } {
+      // Remove candidates for this path
+      classes.candidateMainClasses.remove(docPath)
+
+      // Extract and store confirmed main classes
+      val mainClasses = extractMbtMainClasses(doc)
+      for ((symbol, mc) <- mainClasses) {
+        classes.mainClasses.put(symbol, mc)
+      }
+    }
+  }
+
+  /**
+   * Confirms candidate main classes for specific targets, optionally filtering by class name.
+   * This is more targeted than confirming all candidates and avoids unnecessary semanticdb loading.
+   *
+   * @param targetIds The build targets to confirm candidates for
+   * @param mainClassName Optional main class name filter. If provided, only candidates that
+   *                      might match this class name will be confirmed.
+   * @return Future that completes when confirmation is done
+   */
+  def confirmMbtMainClassCandidatesForTargets(
+      targetIds: Seq[b.BuildTargetIdentifier],
+      mainClassName: Option[String] = None,
+  ): Future[Unit] = {
+    // Collect candidate paths from the specified targets
+    val candidatePaths = for {
+      tid <- targetIds
+      classes <- index.get(tid).toSeq
+      (path, candidates) <- classes.candidateMainClasses.toSeq
+      // If a main class name is provided, filter candidates that might match
+      if mainClassName.forall { className =>
+        val normalizedClassName = className.replace(".", "/")
+        candidates.exists { candidate =>
+          val candidateSymbol = candidate.candidateSymbol
+          // Check if the candidate symbol might match the requested class name
+          candidateSymbol.contains(normalizedClassName) ||
+          candidateSymbol
+            .stripSuffix("#")
+            .stripSuffix(".")
+            .endsWith(normalizedClassName)
+        }
+      }
+    } yield path
+    val distinctPaths = candidatePaths.distinct
+
+    if (distinctPaths.isEmpty) {
+      Future.unit
+    } else {
+      compilers()
+        .batchSemanticdbTextDocuments(
+          distinctPaths,
+          EmptyCancelToken,
+          Duration.ofSeconds(15),
+        )
+        .map { documents =>
+          documents.documents.foreach { doc =>
+            val docPath = doc.uri.toAbsolutePath
+            val docTargetIds = buildTargets.inverseSourcesAll(docPath)
+            processMbtSemanticdb(
+              docPath,
+              doc,
+              docTargetIds.filter(targetIds.contains),
+            )
+          }
         }
     }
   }
@@ -885,9 +1002,27 @@ object BuildTargetClasses {
       framework: TestFramework,
   )
 
+  /**
+   * Represents a candidate main class that has been discovered from the MBT index
+   * without loading semanticdb. The candidate needs to be confirmed before being
+   * added to mainClasses.
+   */
+  final case class MainClassCandidate(
+      path: AbsolutePath,
+      candidateSymbol: String,
+  )
+
   final class Classes {
     val mainClasses = new TrieMap[Symbol, b.ScalaMainClass]()
     val testClasses = new TrieMap[Symbol, TestSymbolInfo]()
+
+    /**
+     * Candidate main classes discovered from the MBT index without semanticdb.
+     * These are unconfirmed and need semanticdb verification before use.
+     * Key is the file path, value is the list of candidate symbols in that file.
+     */
+    val candidateMainClasses =
+      new TrieMap[AbsolutePath, Seq[MainClassCandidate]]()
 
     def isEmpty: Boolean = mainClasses.isEmpty && testClasses.isEmpty
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -701,28 +701,17 @@ final class BuildTargetClasses(
     if (!hasCandidates) {
       Future.unit
     } else {
-      compilers()
-        .batchSemanticdbTextDocuments(
-          Seq(path),
-          EmptyCancelToken,
-          Duration.ofSeconds(15),
-        )
-        .recover { case e =>
-          scribe.error(s"Error parsing semanticdb text documents: $e", e)
-          TextDocuments(documents = Seq.empty)
+      foreachMbtSemanticdbDocument(Seq(path)) { doc =>
+        Future {
+          processMbtSemanticdb(doc.uri.toAbsolutePath, doc, targetIds)
         }
-        .map { documents =>
-          documents.documents.foreach { doc =>
-            processMbtSemanticdb(doc.uri.toAbsolutePath, doc, targetIds)
-          }
-        }
+      }
     }
   }
 
   private def foreachMbtSemanticdbDocument(
       candidatePaths: Seq[AbsolutePath]
   )(f: TextDocument => Future[Unit]): Future[Unit] = {
-    // TODO batch by build target? run parallel?
     candidatePaths.grouped(MbtSemanticdbBatchSize).foldLeft(Future.unit) {
       case (previous, batch) =>
         previous.flatMap { _ =>
@@ -795,27 +784,17 @@ final class BuildTargetClasses(
     if (distinctPaths.isEmpty) {
       Future.unit
     } else {
-      compilers()
-        .batchSemanticdbTextDocuments(
-          distinctPaths,
-          EmptyCancelToken,
-          Duration.ofSeconds(15),
-        )
-        .recover { case e =>
-          scribe.error(s"Error parsing semanticdb text documents: $e", e)
-          TextDocuments(documents = Seq.empty)
+      foreachMbtSemanticdbDocument(distinctPaths) { doc =>
+        Future {
+          val docPath = doc.uri.toAbsolutePath
+          val docTargetIds = buildTargets.inverseSourcesAll(docPath)
+          processMbtSemanticdb(
+            docPath,
+            doc,
+            docTargetIds.filter(targetIds.contains),
+          )
         }
-        .map { documents =>
-          documents.documents.foreach { doc =>
-            val docPath = doc.uri.toAbsolutePath
-            val docTargetIds = buildTargets.inverseSourcesAll(docPath)
-            processMbtSemanticdb(
-              docPath,
-              doc,
-              docTargetIds.filter(targetIds.contains),
-            )
-          }
-        }
+      }
     }
   }
 
@@ -841,25 +820,9 @@ final class BuildTargetClasses(
     if (!hasCandidates) {
       Future.unit
     } else {
-      compilers()
-        .batchSemanticdbTextDocuments(
-          Seq(path),
-          EmptyCancelToken,
-          Duration.ofSeconds(15),
-        )
-        .recover { case e =>
-          scribe.error(s"Error parsing semanticdb text documents: $e", e)
-          TextDocuments(documents = Seq.empty)
-        }
-        .flatMap { documents =>
-          Future
-            .sequence(
-              documents.documents.map { doc =>
-                processMbtTestSemanticdb(doc.uri.toAbsolutePath, doc, targetIds)
-              }
-            )
-            .map(_ => ())
-        }
+      foreachMbtSemanticdbDocument(Seq(path)) { doc =>
+        processMbtTestSemanticdb(doc.uri.toAbsolutePath, doc, targetIds)
+      }
     }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClasses.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.metals.debug
 
-import java.net.URI
 import java.time.Duration
 
 import scala.collection.concurrent.TrieMap
@@ -125,6 +124,32 @@ final class BuildTargetClasses(
         .find(_.fullyQualifiedName == name)
         .map(_.fullyQualifiedName)
     )
+
+  def resolveCandidateTestClass(
+      name: String,
+      target: Option[String],
+  ): Future[Unit] = {
+    // Find targets that have candidates that might match this class name
+    val normalizedClassName = name.replace(".", "/")
+    val targetId =
+      target.flatMap(buildTargets.findByDisplayNameOrUri(_).map(_.getId))
+    val requestedTargets = targetId
+      .map(targetId => index.get(targetId).toList.map(targetId -> _))
+      .getOrElse(index.toList)
+    val targetsWithMatchingCandidates = requestedTargets.flatMap {
+      case (targetId, classes) =>
+        val hasMatchingCandidate = classes.candidateTestClasses.values.flatten
+          .exists(_.candidateSymbol.contains(normalizedClassName))
+        if (hasMatchingCandidate) Some(targetId) else None
+    }
+
+    if (targetsWithMatchingCandidates.isEmpty) {
+      Future.unit
+    } else {
+      confirmMbtTestClassCandidatesForTargets(targetsWithMatchingCandidates)
+    }
+
+  }
 
   def getTestClasses(
       name: String,
@@ -547,55 +572,58 @@ final class BuildTargetClasses(
     }
   }
 
+  /**
+   * Populates candidate test classes from the MBT index WITHOUT loading semanticdb.
+   * The candidates are stored in `candidateTestClasses` and will be confirmed
+   * lazily when:
+   * - A file is opened (for code lenses or test explorer)
+   * - User explicitly requests test discovery (test explorer opened)
+   *
+   * This optimization avoids the expensive semanticdb loading at startup.
+   */
   private def populateMbtTestClasses(
       classes: Map[b.BuildTargetIdentifier, Classes],
       targets: Seq[b.BuildTargetIdentifier],
-  ): Future[Unit] = {
+  ): Future[Unit] = Future {
     mbt() match {
       case None =>
         scribe.warn("mbt-test: MBT workspace symbol provider is not available.")
-        Future.unit
       case Some(mbtProvider) =>
         val targetSet = targets.toSet
-        val candidatePaths =
-          filterMbtCandidatePaths(
-            mbtProvider.possibleReferences(
-              MbtPossibleReferencesParams(
-                references = TestFrameworkSymbolRegistry.annotationSymbols,
-                implementations = TestFrameworkSymbolRegistry.baseParentSymbols,
-              )
-            ),
-            targetSet,
-          )
 
-        foreachMbtSemanticdbDocument(candidatePaths) { doc =>
-          val path = doc.uri.toAbsolutePath
-          extractTestClassesFromDocument(doc, path).map { testClasses =>
-            cacheExtractedTestClasses(
-              classes,
-              targetSet,
-              path,
-              testClasses,
+        val candidates = mbtProvider.candidateTestClasses(
+          filterPath = path =>
+            path.isScalaOrJava &&
+              buildTargets.inverseSourcesAll(path).exists(targetSet),
+          annotationSymbols = TestFrameworkSymbolRegistry.annotationSymbols,
+          baseParentSymbols = TestFrameworkSymbolRegistry.baseParentSymbols,
+        )
+
+        // Group candidates by path
+        val candidatesByPath = candidates
+          .groupBy(_.path)
+          .view
+          .mapValues(
+            _.map(c =>
+              BuildTargetClasses.TestClassCandidate(c.path, c.candidateSymbol)
             )
-          }
-        }
-    }
-  }
+          )
+          .toMap
 
-  private def cacheExtractedTestClasses(
-      classes: Map[b.BuildTargetIdentifier, Classes],
-      targetSet: Set[b.BuildTargetIdentifier],
-      path: AbsolutePath,
-      testClasses: List[(String, TestSymbolInfo)],
-  ): Unit = {
-    val targetIds = buildTargets.inverseSourcesAll(path).filter(targetSet)
-    if (targetIds.nonEmpty) {
-      for {
-        target <- targetIds
-        (symbol, testInfo) <- testClasses
-      } {
-        classes(target).testClasses.put(symbol, testInfo)
-      }
+        // Store candidates in the appropriate target classes
+        for {
+          (path, pathCandidates) <- candidatesByPath
+          targetId <- buildTargets.inverseSourcesAll(path).filter(targetSet)
+        } {
+          val existingCandidates =
+            classes(targetId).candidateTestClasses.getOrElse(path, Seq.empty)
+          classes(targetId).candidateTestClasses
+            .put(path, existingCandidates ++ pathCandidates)
+        }
+
+        scribe.debug(
+          s"mbt-test: stored ${candidates.size} test class candidates from ${candidatesByPath.size} files"
+        )
     }
   }
 
@@ -647,7 +675,6 @@ final class BuildTargetClasses(
         scribe.debug(
           s"mbt-run: stored ${candidates.size} main class candidates from ${candidatesByPath.size} files"
         )
-        Future.unit
     }
   }
 
@@ -687,18 +714,6 @@ final class BuildTargetClasses(
         }
     }
   }
-
-  private def filterMbtCandidatePaths(
-      paths: Iterable[AbsolutePath],
-      targetSet: Set[b.BuildTargetIdentifier],
-  ): Seq[AbsolutePath] =
-    paths
-      .filter(path =>
-        path.isScalaOrJava &&
-          buildTargets.inverseSourcesAll(path).exists(targetSet)
-      )
-      .toSeq
-      .distinct
 
   private def foreachMbtSemanticdbDocument(
       candidatePaths: Seq[AbsolutePath]
@@ -767,13 +782,7 @@ final class BuildTargetClasses(
       if mainClassName.forall { className =>
         val normalizedClassName = className.replace(".", "/")
         candidates.exists { candidate =>
-          val candidateSymbol = candidate.candidateSymbol
-          // Check if the candidate symbol might match the requested class name
-          candidateSymbol.contains(normalizedClassName) ||
-          candidateSymbol
-            .stripSuffix("#")
-            .stripSuffix(".")
-            .endsWith(normalizedClassName)
+          candidate.candidateSymbol.contains(normalizedClassName)
         }
       }
     } yield path
@@ -799,6 +808,104 @@ final class BuildTargetClasses(
             )
           }
         }
+    }
+  }
+
+  /**
+   * Confirms candidate test classes for a specific file by loading semanticdb.
+   * This should be called when:
+   * - A file is opened (for code lenses or test explorer)
+   * - User explicitly requests test discovery
+   *
+   * @param path The file path to confirm candidates for
+   * @param targetId The target to limit confirmation to
+   * @return Future that completes when confirmation is done
+   */
+  def confirmMbtTestClassCandidates(
+      path: AbsolutePath,
+      targetId: b.BuildTargetIdentifier,
+  ): Future[Unit] = {
+    val targetIds = Seq(targetId)
+
+    val hasCandidates = targetIds.exists { tid =>
+      index.get(tid).exists(_.candidateTestClasses.contains(path))
+    }
+    if (!hasCandidates) {
+      Future.unit
+    } else {
+      compilers()
+        .batchSemanticdbTextDocuments(
+          Seq(path),
+          EmptyCancelToken,
+          Duration.ofSeconds(15),
+        )
+        .flatMap { documents =>
+          Future
+            .sequence(
+              documents.documents.map { doc =>
+                processMbtTestSemanticdb(doc.uri.toAbsolutePath, doc, targetIds)
+              }
+            )
+            .map(_ => ())
+        }
+    }
+  }
+
+  /**
+   * Confirms candidate test classes for specific targets.
+   * This is useful when the user opens the test explorer and wants to discover all tests.
+   *
+   * @param targetIds The build targets to confirm candidates for
+   * @return Future that completes when confirmation is done
+   */
+  def confirmMbtTestClassCandidatesForTargets(
+      targetIds: Seq[b.BuildTargetIdentifier]
+  ): Future[Unit] = {
+    // Collect candidate paths from the specified targets
+    val candidatePaths = for {
+      tid <- targetIds
+      classes <- index.get(tid).toSeq
+      (path, _) <- classes.candidateTestClasses.toSeq
+    } yield path
+    val distinctPaths = candidatePaths.distinct
+
+    if (distinctPaths.isEmpty) {
+      Future.unit
+    } else {
+      foreachMbtSemanticdbDocument(distinctPaths) { doc =>
+        val docPath = doc.uri.toAbsolutePath
+        val docTargetIds = buildTargets.inverseSourcesAll(docPath)
+        processMbtTestSemanticdb(
+          docPath,
+          doc,
+          docTargetIds.filter(targetIds.contains),
+        )
+      }
+    }
+  }
+
+  /**
+   * Processes semanticdb to extract and store confirmed test classes.
+   * Also removes candidates for the processed path.
+   */
+  private def processMbtTestSemanticdb(
+      docPath: AbsolutePath,
+      doc: TextDocument,
+      targetIds: Seq[b.BuildTargetIdentifier],
+  ): Future[Unit] = {
+    extractTestClassesFromDocument(doc, docPath).map { testClasses =>
+      for {
+        tid <- targetIds
+        classes <- index.get(tid)
+      } {
+        // Remove candidates for this path
+        classes.candidateTestClasses.remove(docPath)
+
+        // Extract and store confirmed test classes
+        for ((symbol, testInfo) <- testClasses) {
+          classes.testClasses.put(symbol, testInfo)
+        }
+      }
     }
   }
 
@@ -1012,6 +1119,16 @@ object BuildTargetClasses {
       candidateSymbol: String,
   )
 
+  /**
+   * Represents a candidate test class that has been discovered from the MBT index
+   * without loading semanticdb. The candidate needs to be confirmed before being
+   * added to testClasses.
+   */
+  final case class TestClassCandidate(
+      path: AbsolutePath,
+      candidateSymbol: String,
+  )
+
   final class Classes {
     val mainClasses = new TrieMap[Symbol, b.ScalaMainClass]()
     val testClasses = new TrieMap[Symbol, TestSymbolInfo]()
@@ -1023,6 +1140,14 @@ object BuildTargetClasses {
      */
     val candidateMainClasses =
       new TrieMap[AbsolutePath, Seq[MainClassCandidate]]()
+
+    /**
+     * Candidate test classes discovered from the MBT index without semanticdb.
+     * These are unconfirmed and need semanticdb verification before use.
+     * Key is the file path, value is the list of candidate symbols in that file.
+     */
+    val candidateTestClasses =
+      new TrieMap[AbsolutePath, Seq[TestClassCandidate]]()
 
     def isEmpty: Boolean = mainClasses.isEmpty && testClasses.isEmpty
   }

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
@@ -31,8 +31,10 @@ class BuildTargetClassesFinder(
   ): Future[Try[List[(b.ScalaMainClass, b.BuildTarget)]]] = {
     val targetId =
       buildTarget.flatMap(buildTargets.findByDisplayNameOrUri(_).map(_.getId))
+    val targetIds =
+      targetId.fold(buildTargets.allBuildTargetIds)(id => List(id))
     buildTargetClasses
-      .confirmMbtMainClassCandidatesForTargets(targetId.toSeq, Some(className))
+      .confirmMbtMainClassCandidatesForTargets(targetIds, Some(className))
       .map { _ =>
         val classes = buildTargetClasses.findMainClassByName(className)
         findClassAndBuildTarget(

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/BuildTargetClassesFinder.scala
@@ -1,5 +1,7 @@
 package scala.meta.internal.metals.debug
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 import scala.util.Failure
 import scala.util.Success
@@ -21,56 +23,71 @@ class BuildTargetClassesFinder(
     index: OnDemandSymbolIndex,
 ) {
 
-  // In case of success returns non-empty list
   def findMainClassAndItsBuildTarget(
       className: String,
       buildTarget: Option[String],
-  ): Try[List[(b.ScalaMainClass, b.BuildTarget)]] = {
-    findClassAndBuildTarget(
-      className,
-      buildTarget,
-      buildTargetClasses.findMainClassByName(_),
-      buildTargetClasses
-        .classesOf(_)
-        .mainClasses
-        .values,
-      { (clazz: b.ScalaMainClass) => clazz.getClassName },
-    ).recoverWith { case ex =>
-      val found = ex match {
-        // We check whether there is a main in dependencies that is not reported via BSP
-        case ClassNotFoundInBuildTargetException(className, target) =>
-          revertToDependencies(
-            className,
-            buildTargets.findByDisplayNameOrUri(target),
-          )
-        case _: NoMainClassFoundException =>
-          revertToDependencies(className, buildTarget = None)
-        case _ => Nil
+  )(implicit
+      ec: ExecutionContext
+  ): Future[Try[List[(b.ScalaMainClass, b.BuildTarget)]]] = {
+    val targetId =
+      buildTarget.flatMap(buildTargets.findByDisplayNameOrUri(_).map(_.getId))
+    buildTargetClasses
+      .confirmMbtMainClassCandidatesForTargets(targetId.toSeq, Some(className))
+      .map { _ =>
+        val classes = buildTargetClasses.findMainClassByName(className)
+        findClassAndBuildTarget(
+          className,
+          buildTarget,
+          classes,
+          buildTargetClasses
+            .classesOf(_)
+            .mainClasses
+            .values,
+          { (clazz: b.ScalaMainClass) => clazz.getClassName },
+        ).recoverWith { case ex =>
+          val found = ex match {
+            // We check whether there is a main in dependencies that is not reported via BSP
+            case ClassNotFoundInBuildTargetException(className, target) =>
+              revertToDependencies(
+                className,
+                buildTargets.findByDisplayNameOrUri(target),
+              )
+            case _: NoMainClassFoundException =>
+              revertToDependencies(className, buildTarget = None)
+            case _ => Nil
+          }
+          found match {
+            case Nil => Failure(ex)
+            case deps => Success(deps)
+          }
+        }
       }
-      found match {
-        case Nil => Failure(ex)
-        case deps => Success(deps)
-      }
-    }
   }
 
   // In case of success returns non-empty list
   def findTestClassAndItsBuildTarget(
       className: String,
       buildTarget: Option[String],
-  ): Try[List[(String, b.BuildTarget)]] =
-    findClassAndBuildTarget[String](
-      className,
-      buildTarget,
-      buildTargetClasses.findTestClassByName(_),
-      id =>
-        buildTargetClasses
-          .classesOf(id)
-          .testClasses
-          .values
-          .map(_.fullyQualifiedName),
-      clazz => clazz,
-    )
+  )(implicit
+      ec: ExecutionContext
+  ): Future[Try[List[(String, b.BuildTarget)]]] = {
+    buildTargetClasses.resolveCandidateTestClass(className, buildTarget).map {
+      _ =>
+        val classes = buildTargetClasses.findTestClassByName(className)
+        findClassAndBuildTarget[String](
+          className,
+          buildTarget,
+          classes,
+          id =>
+            buildTargetClasses
+              .classesOf(id)
+              .testClasses
+              .values
+              .map(_.fullyQualifiedName),
+          clazz => clazz,
+        )
+    }
+  }
 
   private def revertToDependencies(
       className: String,
@@ -99,22 +116,25 @@ class BuildTargetClassesFinder(
   private def findClassAndBuildTarget[A](
       className: String,
       buildTarget: Option[String],
-      findClassesByName: String => List[(A, b.BuildTargetIdentifier)],
+      classes: List[(A, b.BuildTargetIdentifier)],
       classesByBuildTarget: b.BuildTargetIdentifier => Iterable[A],
       getClassName: A => String,
   ): Try[List[(A, b.BuildTarget)]] =
     buildTarget.fold {
-      val classes =
-        findClassesByName(className)
-          .collect { case (clazz, BuildTargetIdOf(buildTarget)) =>
-            (clazz, buildTarget)
-          }
-          .sortBy { case (_, target) =>
-            buildTargets.buildTargetsOrder(target.getId())
-          }
-          .reverse
-      if (classes.nonEmpty) Success(classes)
-      else Failure(new NoMainClassFoundException(className))
+      if (classes.nonEmpty) {
+        Success(
+          classes
+            .collect { case (clazz, BuildTargetIdOf(buildTarget)) =>
+              (clazz, buildTarget)
+            }
+            .sortBy { case (_, target) =>
+              buildTargets.buildTargetsOrder(target.getId())
+            }
+            .reverse
+        )
+      } else {
+        Failure(new NoMainClassFoundException(className))
+      }
     } { targetName =>
       buildTargets
         .findByDisplayNameOrUri(targetName)

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugDiscovery.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugDiscovery.scala
@@ -187,17 +187,22 @@ class DebugDiscovery(
       path: AbsolutePath,
       position: Position,
   ): Future[b.DebugSessionParams] = {
-    val semanticDocOpt =
-      semanticdbs()
-        .textDocument(path)
-        .documentIncludingStale
+    // First confirm any candidate main classes for this file
+    buildTargetClasses
+      .confirmMbtMainClassCandidates(path, buildTarget)
+      .flatMap { _ =>
+        val semanticDocOpt =
+          semanticdbs()
+            .textDocument(path)
+            .documentIncludingStale
 
-    semanticDocOpt match {
-      case Some(textDocument) =>
-        findClosestRunnableTarget(textDocument, buildTarget, path, position)
-      case None =>
-        Future.failed(SemanticDbNotFoundException)
-    }
+        semanticDocOpt match {
+          case Some(textDocument) =>
+            findClosestRunnableTarget(textDocument, buildTarget, path, position)
+          case None =>
+            Future.failed(SemanticDbNotFoundException)
+        }
+      }
   }
 
   sealed trait Distance
@@ -444,12 +449,29 @@ class DebugDiscovery(
       params: DebugDiscoveryParams,
       classes: List[(b.BuildTargetIdentifier, b.ScalaMainClass)],
   ): Future[b.DebugSessionParams] = {
-    val targetToMainClasses =
-      classes.groupBy(_._1).view.mapValues(_.map(_._2)).toMap
-    findMainToRun(
-      targetToMainClasses,
-      params,
-    )
+    // Get the target IDs from the classes list
+    val targetIds = classes.map(_._1).distinct
+
+    // Confirm candidate main classes for the specific targets, filtered by class name if provided
+    buildTargetClasses
+      .confirmMbtMainClassCandidatesForTargets(
+        targetIds,
+        Option(params.mainClass),
+      )
+      .flatMap { _ =>
+        // Re-fetch the classes after confirmation in case new ones were added
+        val updatedClasses = targetIds.flatMap { targetId =>
+          mainClasses(targetId).values.map(mc => (targetId, mc))
+        }
+        val finalClasses =
+          if (updatedClasses.nonEmpty) updatedClasses else classes
+        val targetToMainClasses =
+          finalClasses.groupBy(_._1).view.mapValues(_.map(_._2)).toMap
+        findMainToRun(
+          targetToMainClasses,
+          params,
+        )
+      }
   }
 
   private def testFile(
@@ -504,28 +526,33 @@ class DebugDiscovery(
       params: DebugDiscoveryParams,
       path: AbsolutePath,
   ): Future[b.DebugSessionParams] = {
-    semanticdbs()
-      .textDocument(path)
-      .documentIncludingStale
-      .fold[Future[b.DebugSessionParams]] {
-        Future.failed(SemanticDbNotFoundException)
-      } { textDocument =>
-        val classes = buildTargetClasses.classesOf(buildTarget)
-        lazy val tests = for {
-          symbolInfo <- textDocument.symbols
-          symbol = symbolInfo.symbol
-          testSymbolInfo <- classes.testClasses.get(symbol)
-        } yield testSymbolInfo.fullyQualifiedName
-        val mainWithFallback = findMainClasses(textDocument, classes)
-        if (mainWithFallback.nonEmpty) {
-          findMainToRun(Map(buildTarget -> mainWithFallback.toList), params)
-        } else if (tests.nonEmpty) {
-          val suiteSelections =
-            tests.map(new b.ScalaTestSuiteSelection(_, Nil.asJava)).toList
-          createScalaTestSuites(buildTarget, suiteSelections, params)
-        } else {
-          Future.failed(NoRunOptionException)
-        }
+    // First confirm any candidate main classes for this file
+    buildTargetClasses
+      .confirmMbtMainClassCandidates(path, buildTarget)
+      .flatMap { _ =>
+        semanticdbs()
+          .textDocument(path)
+          .documentIncludingStale
+          .fold[Future[b.DebugSessionParams]] {
+            Future.failed(SemanticDbNotFoundException)
+          } { textDocument =>
+            val classes = buildTargetClasses.classesOf(buildTarget)
+            lazy val tests = for {
+              symbolInfo <- textDocument.symbols
+              symbol = symbolInfo.symbol
+              testSymbolInfo <- classes.testClasses.get(symbol)
+            } yield testSymbolInfo.fullyQualifiedName
+            val mainWithFallback = findMainClasses(textDocument, classes)
+            if (mainWithFallback.nonEmpty) {
+              findMainToRun(Map(buildTarget -> mainWithFallback.toList), params)
+            } else if (tests.nonEmpty) {
+              val suiteSelections =
+                tests.map(new b.ScalaTestSuiteSelection(_, Nil.asJava)).toList
+              createScalaTestSuites(buildTarget, suiteSelections, params)
+            } else {
+              Future.failed(NoRunOptionException)
+            }
+          }
       }
   }
 

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugDiscovery.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugDiscovery.scala
@@ -4,9 +4,7 @@ import java.util.Collections.singletonList
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.util.Failure
 import scala.util.Success
-import scala.util.Try
 
 import scala.meta.internal.metals.BuildTargets
 import scala.meta.internal.metals.DebugDiscoveryParams
@@ -70,7 +68,7 @@ class DebugDiscovery(
 
   private def validate(
       params: DebugDiscoveryParams
-  ): Try[ValidRunType.Value] = {
+  ): Future[ValidRunType.Value] = {
 
     val runType = RunType.fromString(params.runType)
     val pathOpt = Option(params.path).map(_.toAbsolutePath)
@@ -80,28 +78,43 @@ class DebugDiscovery(
         .map(_.getId())
     }
 
+    // Check if there are test classes or pending candidates (for lazy MBT discovery)
+    def hasTestsOrCandidates(target: b.BuildTargetIdentifier): Boolean = {
+      val classes = buildTargetClasses.classesOf(target)
+      classes.testClasses.nonEmpty || classes.candidateTestClasses.nonEmpty
+    }
+
+    def hasTestsOrCandidatesForPath(
+        target: b.BuildTargetIdentifier,
+        path: AbsolutePath,
+    ): Boolean = {
+      val classes = buildTargetClasses.classesOf(target)
+      classes.testClasses.nonEmpty ||
+      classes.candidateTestClasses.contains(path)
+    }
+
     (runType, buildTarget, pathOpt) match {
       case (_, Some(buildTarget), _)
           if buildClient.buildHasErrors(buildTarget) =>
-        Failure(WorkspaceErrorsException)
+        Future.failed(WorkspaceErrorsException)
       case (_, None, Some(path)) =>
-        Failure(BuildTargetNotFoundForPathException(path))
+        Future.failed(BuildTargetNotFoundForPathException(path))
       case (None, _, _) =>
-        Failure(RunType.UnknownRunTypeException(params.runType))
+        Future.failed(RunType.UnknownRunTypeException(params.runType))
       case (Some(TestFile), Some(target), Some(path))
-          if testClasses(target).isEmpty =>
-        Failure(
+          if !hasTestsOrCandidatesForPath(target, path) =>
+        Future.failed(
           NoTestsFoundException("file", path.toString())
         )
       case (Some(TestFile | TestTarget), Some(target), _)
-          if testClasses(target).isEmpty =>
-        Failure(
+          if !hasTestsOrCandidates(target) =>
+        Future.failed(
           NoTestsFoundException("build target", displayName(target))
         )
       case (Some(TestTarget | RunClosest), None, _) =>
-        Failure(NoBuildTargetSpecified)
+        Future.failed(NoBuildTargetSpecified)
       case (Some(tpe @ (TestFile | RunOrTestFile | RunClosest)), _, None) =>
-        Failure(UndefinedPathException(tpe))
+        Future.failed(UndefinedPathException(tpe))
       case (Some(Run), target, _) =>
         val targetIds = target match {
           case None => buildTargets.allBuildTargetIds
@@ -114,10 +127,14 @@ class DebugDiscovery(
                 main,
                 buildTarget.map(displayName),
               )
-              .map(found =>
-                ValidRunType.Run(found.map { case (mainClass, target) =>
-                  target.getId() -> mainClass
-                })
+              .flatMap(classes =>
+                Future
+                  .fromTry(classes)
+                  .map(found =>
+                    ValidRunType.Run(found.map { case (mainClass, target) =>
+                      target.getId() -> mainClass
+                    })
+                  )
               )
 
           case None =>
@@ -127,27 +144,29 @@ class DebugDiscovery(
             if (classes.isEmpty) {
               target match {
                 case None =>
-                  Failure(NothingToRun)
+                  Future.failed(NothingToRun)
                 case Some(targetId) =>
-                  Failure(
+                  Future.failed(
                     BuildTargetContainsNoMainException(displayName(targetId))
                   )
               }
             } else {
-              Success(ValidRunType.Run(classes))
+              Future.successful(ValidRunType.Run(classes))
             }
         }
       case (Some(RunOrTestFile), Some(target), Some(path)) =>
-        Success(ValidRunType.RunOrTestFile(target, path))
+        Future.successful(ValidRunType.RunOrTestFile(target, path))
       case (Some(TestFile), Some(target), Some(path)) =>
-        Success(ValidRunType.TestFile(target, path))
+        Future.successful(ValidRunType.TestFile(target, path))
       case (Some(TestTarget), Some(target), _) =>
-        Success(ValidRunType.TestTarget(target))
+        Future.successful(ValidRunType.TestTarget(target))
       case (Some(RunClosest), Some(target), Some(path)) =>
         if (params.position == null) {
-          Failure(UndefinedPositionException(RunClosest))
+          Future.failed(UndefinedPositionException(RunClosest))
         } else {
-          Success(ValidRunType.RunClosest(target, path, params.position))
+          Future.successful(
+            ValidRunType.RunClosest(target, path, params.position)
+          )
         }
     }
   }
@@ -161,7 +180,7 @@ class DebugDiscovery(
   def debugDiscovery(
       params: DebugDiscoveryParams
   ): Future[b.DebugSessionParams] = {
-    val validated = Future.fromTry(validate(params))
+    val validated = validate(params)
 
     validated.flatMap {
       case ValidRunType.Run(classes) =>
@@ -220,27 +239,28 @@ class DebugDiscovery(
   ): Future[b.DebugSessionParams] = {
     val classes = buildTargetClasses.classesOf(buildTarget)
     val mains = findMainClasses(textDocument, classes)
-    val allTestCases = discoverTestCases(path)
+    discoverTestCases(path)
+      .flatMap { allTestCases =>
+        val allDistances: Seq[Distance] =
+          calculateMainDistances(textDocument, mains, classes, position) ++
+            calculateTestCaseDistances(allTestCases, position) ++
+            calculateTestSuiteDistances(textDocument, allTestCases, position)
 
-    val allDistances: Seq[Distance] =
-      calculateMainDistances(textDocument, mains, classes, position) ++
-        calculateTestCaseDistances(allTestCases, position) ++
-        calculateTestSuiteDistances(textDocument, allTestCases, position)
-
-    findClosestTarget(allDistances) match {
-      case Some(MainDistance(_, mainClass)) =>
-        createMainParams(
-          DebugDiscoveryParams(path.toURI.toString, "run"),
-          mainClass,
-          buildTarget,
-        )
-      case Some(TestSuiteDistance(_, suiteFqn)) =>
-        createTestSuiteParams(buildTarget, suiteFqn)
-      case Some(TestCaseDistance(_, testName, suiteFqn)) =>
-        createTestCaseParams(buildTarget, suiteFqn, testName)
-      case None =>
-        Future.failed(NoRunOptionException)
-    }
+        findClosestTarget(allDistances) match {
+          case Some(MainDistance(_, mainClass)) =>
+            createMainParams(
+              DebugDiscoveryParams(path.toURI.toString, "run"),
+              mainClass,
+              buildTarget,
+            )
+          case Some(TestSuiteDistance(_, suiteFqn)) =>
+            createTestSuiteParams(buildTarget, suiteFqn)
+          case Some(TestCaseDistance(_, testName, suiteFqn)) =>
+            createTestCaseParams(buildTarget, suiteFqn, testName)
+          case None =>
+            Future.failed(NoRunOptionException)
+        }
+      }
   }
 
   private def findMainClasses(
@@ -266,17 +286,19 @@ class DebugDiscovery(
 
   private def discoverTestCases(
       path: AbsolutePath
-  ): List[(String, List[TestCaseEntry])] = {
+  ): Future[List[(String, List[TestCaseEntry])]] = {
     import scala.jdk.CollectionConverters._
     import scala.meta.internal.metals.testProvider.TestExplorerEvent.AddTestCases
 
     val testUpdates = testProvider.discoverTests(Some(path))
-    testUpdates
-      .flatMap(_.events.asScala)
-      .collect { case AddTestCases(fqn, _, testCases) =>
-        (fqn, testCases.asScala.toList)
-      }
-      .toList
+    testUpdates.map { updates =>
+      updates
+        .flatMap(_.events.asScala)
+        .collect { case AddTestCases(fqn, _, testCases) =>
+          (fqn, testCases.asScala.toList)
+        }
+        .toList
+    }
   }
 
   private def calculateMainDistances(
@@ -478,82 +500,95 @@ class DebugDiscovery(
       path: AbsolutePath,
       target: b.BuildTargetIdentifier,
   ): Future[b.DebugSessionParams] =
-    semanticdbs()
-      .textDocument(path)
-      .documentIncludingStale
-      .fold[Future[Seq[BuildTargetClasses.FullyQualifiedClassName]]] {
-        Future.failed(SemanticDbNotFoundException)
-      } { textDocument =>
-        Future {
-          for {
-            symbolInfo <- textDocument.symbols
-            symbol = symbolInfo.symbol
-            testSymbolInfo <- testClasses(target).get(symbol)
-          } yield testSymbolInfo.fullyQualifiedName
-        }
-      }
-      .map { tests =>
-        val params = new b.DebugSessionParams(
-          singletonList(target)
-        )
-        params.setDataKind(
-          b.TestParamsDataKind.SCALA_TEST_SUITES
-        )
-        params.setData(tests.asJava.toJson)
-        params
+    // First confirm any candidate test classes for this file
+    buildTargetClasses
+      .confirmMbtTestClassCandidates(path, target)
+      .flatMap { _ =>
+        semanticdbs()
+          .textDocument(path)
+          .documentIncludingStale
+          .fold[Future[Seq[BuildTargetClasses.FullyQualifiedClassName]]] {
+            Future.failed(SemanticDbNotFoundException)
+          } { textDocument =>
+            Future {
+              for {
+                symbolInfo <- textDocument.symbols
+                symbol = symbolInfo.symbol
+                testSymbolInfo <- testClasses(target).get(symbol)
+              } yield testSymbolInfo.fullyQualifiedName
+            }
+          }
+          .map { tests =>
+            val params = new b.DebugSessionParams(
+              singletonList(target)
+            )
+            params.setDataKind(
+              b.TestParamsDataKind.SCALA_TEST_SUITES
+            )
+            params.setData(tests.asJava.toJson)
+            params
+          }
       }
 
   private def testTarget(
       target: b.BuildTargetIdentifier
   ): Future[b.DebugSessionParams] = {
-    Future {
-      val params = new b.DebugSessionParams(
-        singletonList(target)
-      )
-      params.setDataKind(b.TestParamsDataKind.SCALA_TEST_SUITES)
-      params.setData(
-        testClasses(target).values
-          .map(_.fullyQualifiedName)
-          .toList
-          .asJava
-          .toJson
-      )
-      params
-    }
+    // First confirm all candidate test classes for this target
+    buildTargetClasses
+      .confirmMbtTestClassCandidatesForTargets(Seq(target))
+      .map { _ =>
+        val params = new b.DebugSessionParams(
+          singletonList(target)
+        )
+        params.setDataKind(b.TestParamsDataKind.SCALA_TEST_SUITES)
+        params.setData(
+          testClasses(target).values
+            .map(_.fullyQualifiedName)
+            .toList
+            .asJava
+            .toJson
+        )
+        params
+      }
   }
   private def runOrTestFile(
       buildTarget: b.BuildTargetIdentifier,
       params: DebugDiscoveryParams,
       path: AbsolutePath,
   ): Future[b.DebugSessionParams] = {
-    // First confirm any candidate main classes for this file
-    buildTargetClasses
-      .confirmMbtMainClassCandidates(path, buildTarget)
-      .flatMap { _ =>
-        semanticdbs()
-          .textDocument(path)
-          .documentIncludingStale
-          .fold[Future[b.DebugSessionParams]] {
-            Future.failed(SemanticDbNotFoundException)
-          } { textDocument =>
-            val classes = buildTargetClasses.classesOf(buildTarget)
-            lazy val tests = for {
-              symbolInfo <- textDocument.symbols
-              symbol = symbolInfo.symbol
-              testSymbolInfo <- classes.testClasses.get(symbol)
-            } yield testSymbolInfo.fullyQualifiedName
-            val mainWithFallback = findMainClasses(textDocument, classes)
-            if (mainWithFallback.nonEmpty) {
-              findMainToRun(Map(buildTarget -> mainWithFallback.toList), params)
-            } else if (tests.nonEmpty) {
-              val suiteSelections =
-                tests.map(new b.ScalaTestSuiteSelection(_, Nil.asJava)).toList
-              createScalaTestSuites(buildTarget, suiteSelections, params)
-            } else {
-              Future.failed(NoRunOptionException)
-            }
+    // First confirm any candidate main and test classes for this file
+    val confirmMainCandidates =
+      buildTargetClasses.confirmMbtMainClassCandidates(path, buildTarget)
+    val confirmTestCandidates =
+      buildTargetClasses.confirmMbtTestClassCandidates(path, buildTarget)
+
+    for {
+      _ <- confirmMainCandidates
+      _ <- confirmTestCandidates
+      result <- semanticdbs()
+        .textDocument(path)
+        .documentIncludingStale
+        .fold[Future[b.DebugSessionParams]] {
+          Future.failed(SemanticDbNotFoundException)
+        } { textDocument =>
+          val classes = buildTargetClasses.classesOf(buildTarget)
+          lazy val tests = for {
+            symbolInfo <- textDocument.symbols
+            symbol = symbolInfo.symbol
+            testSymbolInfo <- classes.testClasses.get(symbol)
+          } yield testSymbolInfo.fullyQualifiedName
+          val mainWithFallback = findMainClasses(textDocument, classes)
+          if (mainWithFallback.nonEmpty) {
+            findMainToRun(Map(buildTarget -> mainWithFallback.toList), params)
+          } else if (tests.nonEmpty) {
+            val suiteSelections =
+              tests.map(new b.ScalaTestSuiteSelection(_, Nil.asJava)).toList
+            createScalaTestSuites(buildTarget, suiteSelections, params)
+          } else {
+            Future.failed(NoRunOptionException)
           }
-      }
+        }
+    } yield result
   }
 
   private def findMainToRun(

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -519,7 +519,7 @@ class DebugProvider(
 
   def findMainClassAndItsBuildTarget(
       params: DebugUnresolvedMainClassParams
-  ): Try[List[(ScalaMainClass, b.BuildTarget)]] =
+  ): Future[Try[List[(ScalaMainClass, b.BuildTarget)]]] =
     buildTargetClassesFinder
       .findMainClassAndItsBuildTarget(
         params.mainClass,
@@ -564,7 +564,7 @@ class DebugProvider(
 
   def findTestClassAndItsBuildTarget(
       params: DebugUnresolvedTestClassParams
-  ): Try[List[(String, b.BuildTarget)]] =
+  )(implicit ec: ExecutionContext): Future[Try[List[(String, b.BuildTarget)]]] =
     buildTargetClassesFinder
       .findTestClassAndItsBuildTarget(
         params.testClass,
@@ -772,8 +772,8 @@ class DebugProvider(
     }
   }
 
-  def retryAfterRebuild[A](previousResult: Try[A], f: () => Try[A])(implicit
-      ec: ExecutionContext
+  def retryAfterRebuild[A](previousResult: Try[A], f: () => Future[Try[A]])(
+      implicit ec: ExecutionContext
   ): Future[Try[A]] =
     previousResult match {
       case Failure(ClassNotFoundInBuildTargetException(_, buildTarget)) =>
@@ -782,14 +782,14 @@ class DebugProvider(
         for {
           _ <- compilations.compileTargets(target)
           _ <- buildTargetClasses.rebuildIndex(target)
-          result <- Future(f())
+          result <- f()
         } yield result
       case Failure(_: NoMainClassFoundException) =>
         val activeTargetIds = buildTargets.activeBuildTargetIds
         for {
           _ <- compilations.compileTargets(activeTargetIds)
           _ <- buildTargetClasses.rebuildIndex(activeTargetIds)
-          result <- Future(f())
+          result <- f()
         } yield result
       case result => Future.successful(result)
     }
@@ -927,15 +927,12 @@ object DebugProvider {
       ec: ExecutionContext
   ) {
     private val searchPromise = Promise[Try[A]]()
-    protected def search(): Try[A]
+    protected def search(): Future[Try[A]]
     protected def dapSessionParams(res: A): Future[DebugSessionParams]
     def createDapSession(args: A): Future[DebugSession] =
       dapSessionParams(args).flatMap(debugProvider.asSession(_))
     def searchResult: Future[(Try[A], ClassSearch[A])] = {
-      Future {
-        val resolved = search()
-        searchPromise.trySuccess(resolved)
-      }
+      search().map(resolved => searchPromise.trySuccess(resolved))
       searchPromise.future.map(e => (e, this))
     }
     def retrySearchResult: Future[(Try[A], ClassSearch[A])] =
@@ -952,8 +949,9 @@ object DebugProvider {
         debugProvider
       ) {
     override protected def search()
-        : Try[List[(ScalaMainClass, b.BuildTarget)]] =
+        : Future[Try[List[(ScalaMainClass, b.BuildTarget)]]] =
       debugProvider.findMainClassAndItsBuildTarget(params)
+
     override protected def dapSessionParams(
         res: List[(ScalaMainClass, b.BuildTarget)]
     ): Future[DebugSessionParams] =
@@ -965,7 +963,8 @@ object DebugProvider {
       params: DebugUnresolvedTestClassParams,
   )(implicit ec: ExecutionContext)
       extends ClassSearch[List[(String, b.BuildTarget)]](debugProvider) {
-    override protected def search(): Try[List[(String, b.BuildTarget)]] =
+    override protected def search()
+        : Future[Try[List[(String, b.BuildTarget)]]] =
       debugProvider.findTestClassAndItsBuildTarget(params)
     override protected def dapSessionParams(
         res: List[(String, b.BuildTarget)]

--- a/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/debug/DebugProvider.scala
@@ -932,7 +932,10 @@ object DebugProvider {
     def createDapSession(args: A): Future[DebugSession] =
       dapSessionParams(args).flatMap(debugProvider.asSession(_))
     def searchResult: Future[(Try[A], ClassSearch[A])] = {
-      search().map(resolved => searchPromise.trySuccess(resolved))
+      search().onComplete {
+        case Success(resolved) => searchPromise.trySuccess(resolved)
+        case Failure(err) => searchPromise.trySuccess(Failure(err))
+      }
       searchPromise.future.map(e => (e, this))
     }
     def retrySearchResult: Future[(Try[A], ClassSearch[A])] =

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtDebugSessionStarter.scala
@@ -28,7 +28,7 @@ class MbtDebugSessionStarter(
     buildTool: MbtDebugLauncher,
     userJavaHome: () => Option[String],
     workDoneProgress: BaseWorkDoneProgress,
-    debuggeeGracePeriodSeconds: Long = 5L,
+    debuggeeGracePeriodSeconds: Long = 60L,
 )(implicit ec: ExecutionContext) {
 
   def start(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -31,6 +31,7 @@ import scala.meta.inputs.Input
 import scala.meta.internal.infra.NoopMonitoringClient
 import scala.meta.internal.jmbt.Mbt
 import scala.meta.internal.jpc.SourceJavaFileObject
+import scala.meta.internal.jsemanticdb.Semanticdb
 import scala.meta.internal.metals.BaseFallbackClasspaths
 import scala.meta.internal.metals.BaseWorkDoneProgress
 import scala.meta.internal.metals.Buffers
@@ -542,6 +543,105 @@ class MbtWorkspaceSymbolProvider(
    */
   def findProtoRpcDefinition(methodSymbol: String): List[l.Location] = {
     protobufWorkspace.findProtoRpcDefinition(methodSymbol, documents)
+  }
+
+  /**
+   * Holds candidate main class information extracted from the MBT index.
+   * This is used for lazy main class discovery without loading semanticdb.
+   *
+   * @param path The file path containing the potential main class
+   * @param candidateSymbol The symbol that suggests this might be a main class.
+   *                        For Java/Scala main methods, this is the class symbol (e.g., "com/example/Main#").
+   *                        For @main annotated methods, this is the method symbol.
+   *                        For App extending classes, this is the class symbol.
+   */
+  case class MbtMainClassCandidate(
+      path: AbsolutePath,
+      candidateSymbol: String,
+  )
+
+  /**
+   * Extracts potential main class candidates from the MBT index without loading semanticdb.
+   * Returns candidates that need to be confirmed via semanticdb before use.
+   *
+   * Candidates are identified by:
+   * 1. Symbols ending in "#main()." or ".main()." (Java/Scala main methods)
+   * 2. Files referencing "scala/main#" (@main annotation)
+   * 3. Files referencing "scala/App#" (App trait extension)
+   */
+  def candidateMainClasses(
+      filterPath: AbsolutePath => Boolean
+  ): Seq[MbtMainClassCandidate] = {
+    val candidates =
+      scala.collection.mutable.ArrayBuffer.empty[MbtMainClassCandidate]
+    val javaMain = "#main()."
+    val scalaMain = ".main()."
+    val mainAnnotRef = FingerprintedCharSequence.fuzzyReference("scala/main#")
+    val appRef = FingerprintedCharSequence.fuzzyReference("scala/App#")
+    val pathsFromMainSymbols =
+      queryWorkspaceSymbol("main")
+        .flatMap(info => Option(info.getLocation()))
+        .map(_.getUri.toAbsolutePath)
+    val pathsFromReferences =
+      possibleReferences(
+        MbtPossibleReferencesParams(
+          references = Seq(mainAnnotRef.value.toString, appRef.value.toString)
+        )
+      )
+    for {
+      path <- pathsFromMainSymbols.distinct
+      if filterPath(path)
+      doc <- documents.get(path).toList
+    } {
+
+      // Check for main method symbols in the document
+      for (symbolInfo <- doc.symbols) {
+        val symbol = symbolInfo.getSymbol()
+        // Java main method pattern: com/example/Main#main().
+        if (symbol.endsWith(javaMain)) {
+          val classSymbol = symbol.stripSuffix("main().")
+          candidates += MbtMainClassCandidate(path, classSymbol)
+        }
+        // Scala main method pattern: com/example/Main.main().
+        else if (symbol.endsWith(scalaMain)) {
+          val objectSymbol = symbol.stripSuffix("main().")
+          candidates += MbtMainClassCandidate(path, objectSymbol)
+        }
+      }
+    }
+
+    for {
+      path <- pathsFromReferences
+      if filterPath(path)
+      doc <- documents.get(path).toList
+    } {
+      // Check bloom filter for @main annotation reference
+      if (doc.bloomFilter.mightContain(mainAnnotRef)) {
+        // For @main annotated methods, we need to find method symbols
+        // that could be annotated. We'll add all method symbols as candidates.
+        for (symbolInfo <- doc.symbols) {
+          val symbol = symbolInfo.getSymbol()
+          val kind = symbolInfo.getKind()
+          // Methods that could have @main annotation
+          if (kind == Semanticdb.SymbolInformation.Kind.METHOD) {
+            candidates += MbtMainClassCandidate(path, symbol)
+          }
+        }
+      }
+      // For App extension, we add class/object symbols as candidates
+      for (symbolInfo <- doc.symbols) {
+        val symbol = symbolInfo.getSymbol()
+        val kind = symbolInfo.getKind()
+        if (
+          kind == Semanticdb.SymbolInformation.Kind.OBJECT &&
+          Symbol(symbol).isToplevel
+        ) {
+          candidates += MbtMainClassCandidate(path, symbol)
+        }
+
+      }
+    }
+    candidates.toSeq
   }
 
   def possibleReferences(

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -644,6 +644,70 @@ class MbtWorkspaceSymbolProvider(
     candidates.toSeq
   }
 
+  /**
+   * Holds candidate test class information extracted from the MBT index.
+   * This is used for lazy test class discovery without loading semanticdb.
+   *
+   * @param path The file path containing the potential test class
+   * @param candidateSymbol The symbol that suggests this might be a test class.
+   *                        For annotated tests (JUnit, TestNG), this is the class symbol.
+   *                        For framework-extending tests, this is the class symbol.
+   */
+  case class MbtTestClassCandidate(
+      path: AbsolutePath,
+      candidateSymbol: String,
+  )
+
+  /**
+   * Extracts potential test class candidates from the MBT index without loading semanticdb.
+   * Returns candidates that need to be confirmed via semanticdb before use.
+   *
+   * Candidates are identified by:
+   * 1. Files referencing JUnit/TestNG annotation symbols (e.g., "org/junit/Test#")
+   * 2. Files referencing base parent classes of test frameworks (e.g., "munit/FunSuite#")
+   *
+   * @param filterPath A function to filter which paths should be included
+   * @param annotationSymbols JUnit/TestNG annotation symbols to search for
+   * @param baseParentSymbols Base parent class symbols for ScalaTest, MUnit, Weaver, ZIO Test
+   */
+  def candidateTestClasses(
+      filterPath: AbsolutePath => Boolean,
+      annotationSymbols: Seq[String],
+      baseParentSymbols: Seq[String],
+  ): Seq[MbtTestClassCandidate] = {
+    val candidates =
+      scala.collection.mutable.ArrayBuffer.empty[MbtTestClassCandidate]
+
+    val pathsFromReferences = possibleReferences(
+      MbtPossibleReferencesParams(
+        references = annotationSymbols,
+        implementations = baseParentSymbols,
+      )
+    )
+
+    for {
+      path <- pathsFromReferences
+      if filterPath(path)
+      doc <- documents.get(path).toList
+    } {
+      // Add all class/object symbols as potential test class candidates
+      for (symbolInfo <- doc.symbols) {
+        val symbol = symbolInfo.getSymbol()
+        val kind = symbolInfo.getKind()
+        // Classes and objects that could be test suites
+        if (
+          kind == Semanticdb.SymbolInformation.Kind.CLASS ||
+          kind == Semanticdb.SymbolInformation.Kind.OBJECT
+        ) {
+          if (Symbol(symbol).isToplevel) {
+            candidates += MbtTestClassCandidate(path, symbol)
+          }
+        }
+      }
+    }
+    candidates.toSeq
+  }
+
   def possibleReferences(
       params: MbtPossibleReferencesParams
   ): Set[AbsolutePath] = {

--- a/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/mbt/MbtWorkspaceSymbolProvider.scala
@@ -50,6 +50,7 @@ import scala.meta.internal.metals.Sleeper
 import scala.meta.internal.metals.Time
 import scala.meta.internal.metals.Timer
 import scala.meta.internal.metals.WorkspaceSymbolQuery
+import scala.meta.internal.metals.debug.BuildTargetClasses
 import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.Symbol
 import scala.meta.internal.tokenizers.UnexpectedInputEndException
@@ -546,21 +547,6 @@ class MbtWorkspaceSymbolProvider(
   }
 
   /**
-   * Holds candidate main class information extracted from the MBT index.
-   * This is used for lazy main class discovery without loading semanticdb.
-   *
-   * @param path The file path containing the potential main class
-   * @param candidateSymbol The symbol that suggests this might be a main class.
-   *                        For Java/Scala main methods, this is the class symbol (e.g., "com/example/Main#").
-   *                        For @main annotated methods, this is the method symbol.
-   *                        For App extending classes, this is the class symbol.
-   */
-  case class MbtMainClassCandidate(
-      path: AbsolutePath,
-      candidateSymbol: String,
-  )
-
-  /**
    * Extracts potential main class candidates from the MBT index without loading semanticdb.
    * Returns candidates that need to be confirmed via semanticdb before use.
    *
@@ -571,9 +557,10 @@ class MbtWorkspaceSymbolProvider(
    */
   def candidateMainClasses(
       filterPath: AbsolutePath => Boolean
-  ): Seq[MbtMainClassCandidate] = {
+  ): Seq[BuildTargetClasses.MainClassCandidate] = {
     val candidates =
-      scala.collection.mutable.ArrayBuffer.empty[MbtMainClassCandidate]
+      scala.collection.mutable.ArrayBuffer
+        .empty[BuildTargetClasses.MainClassCandidate]
     val javaMain = "#main()."
     val scalaMain = ".main()."
     val mainAnnotRef = FingerprintedCharSequence.fuzzyReference("scala/main#")
@@ -600,12 +587,15 @@ class MbtWorkspaceSymbolProvider(
         // Java main method pattern: com/example/Main#main().
         if (symbol.endsWith(javaMain)) {
           val classSymbol = symbol.stripSuffix("main().")
-          candidates += MbtMainClassCandidate(path, classSymbol)
+          candidates += BuildTargetClasses.MainClassCandidate(path, classSymbol)
         }
         // Scala main method pattern: com/example/Main.main().
         else if (symbol.endsWith(scalaMain)) {
           val objectSymbol = symbol.stripSuffix("main().")
-          candidates += MbtMainClassCandidate(path, objectSymbol)
+          candidates += BuildTargetClasses.MainClassCandidate(
+            path,
+            objectSymbol,
+          )
         }
       }
     }
@@ -624,7 +614,7 @@ class MbtWorkspaceSymbolProvider(
           val kind = symbolInfo.getKind()
           // Methods that could have @main annotation
           if (kind == Semanticdb.SymbolInformation.Kind.METHOD) {
-            candidates += MbtMainClassCandidate(path, symbol)
+            candidates += BuildTargetClasses.MainClassCandidate(path, symbol)
           }
         }
       }
@@ -636,27 +626,13 @@ class MbtWorkspaceSymbolProvider(
           kind == Semanticdb.SymbolInformation.Kind.OBJECT &&
           Symbol(symbol).isToplevel
         ) {
-          candidates += MbtMainClassCandidate(path, symbol)
+          candidates += BuildTargetClasses.MainClassCandidate(path, symbol)
         }
 
       }
     }
     candidates.toSeq
   }
-
-  /**
-   * Holds candidate test class information extracted from the MBT index.
-   * This is used for lazy test class discovery without loading semanticdb.
-   *
-   * @param path The file path containing the potential test class
-   * @param candidateSymbol The symbol that suggests this might be a test class.
-   *                        For annotated tests (JUnit, TestNG), this is the class symbol.
-   *                        For framework-extending tests, this is the class symbol.
-   */
-  case class MbtTestClassCandidate(
-      path: AbsolutePath,
-      candidateSymbol: String,
-  )
 
   /**
    * Extracts potential test class candidates from the MBT index without loading semanticdb.
@@ -674,9 +650,10 @@ class MbtWorkspaceSymbolProvider(
       filterPath: AbsolutePath => Boolean,
       annotationSymbols: Seq[String],
       baseParentSymbols: Seq[String],
-  ): Seq[MbtTestClassCandidate] = {
+  ): Seq[BuildTargetClasses.TestClassCandidate] = {
     val candidates =
-      scala.collection.mutable.ArrayBuffer.empty[MbtTestClassCandidate]
+      scala.collection.mutable.ArrayBuffer
+        .empty[BuildTargetClasses.TestClassCandidate]
 
     val pathsFromReferences = possibleReferences(
       MbtPossibleReferencesParams(
@@ -700,7 +677,7 @@ class MbtWorkspaceSymbolProvider(
           kind == Semanticdb.SymbolInformation.Kind.OBJECT
         ) {
           if (Symbol(symbol).isToplevel) {
-            candidates += MbtTestClassCandidate(path, symbol)
+            candidates += BuildTargetClasses.TestClassCandidate(path, symbol)
           }
         }
       }

--- a/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
+++ b/metals/src/main/scala/scala/meta/internal/metals/testProvider/TestSuitesProvider.scala
@@ -172,13 +172,31 @@ final class TestSuitesProvider(
 
   /**
    * Check if opened file contains test suite and update test cases if yes.
+   * For MBT build servers, this also confirms any pending test class candidates.
    */
-  def didOpen(file: AbsolutePath): Future[Unit] =
-    if (isExplorerEnabled && index.contains(file)) Future {
-      val buildTargetUpdates = getTestCasesForPath(file, None)
-      updateClientIfNonEmpty(buildTargetUpdates)
+  def didOpen(file: AbsolutePath): Future[Unit] = {
+    if (!isExplorerEnabled) {
+      Future.unit
+    } else {
+      // First confirm any candidate test classes for this file (MBT lazy discovery)
+      discoverMbtTestsForPath(file).map { _ =>
+        if (index.contains(file)) {
+          val buildTargetUpdates = getTestCasesForPath(file, None)
+          updateClientIfNonEmpty(buildTargetUpdates)
+        }
+      }
     }
-    else Future.unit
+  }
+
+  private def discoverMbtTestsForPath(
+      path: AbsolutePath
+  ): Future[Unit] = {
+    val targetIds = buildTargets.inverseSourcesAll(path)
+    val confirmFutures = targetIds.map { targetId =>
+      buildTargetClasses.confirmMbtTestClassCandidates(path, targetId)
+    }
+    Future.sequence(confirmFutures).flatMap(_ => doRefreshTestSuites())
+  }
 
   /**
    * Discover tests:
@@ -187,17 +205,55 @@ final class TestSuitesProvider(
    */
   def discoverTests(
       path: Option[AbsolutePath]
-  ): List[BuildTargetUpdate] = {
+  ): Future[List[BuildTargetUpdate]] = {
     path match {
-      case Some(path0) => getTestCasesForPath(path0, None)
+      case Some(path0) =>
+        discoverMbtTestsForPath(path0)
+          .map { _ =>
+            getTestCasesForPath(path0, None)
+          }
       case None =>
-        index.allSuites.map { case (buildTarget, entries) =>
+        val result = index.allSuites.map { case (buildTarget, entries) =>
           buildTargetUpdate(
             buildTarget,
             entries.map(_.suiteDetails.asAddEvent).toList,
           )
         }.toList
+        Future.successful(result)
     }
+  }
+
+  /**
+   * Discovers all test suites by confirming any pending test class candidates.
+   * This is intended to be called when the test explorer is opened, triggering
+   * a full discovery of all test classes that were lazily indexed.
+   *
+   * For MBT build servers, test classes are discovered lazily from the index
+   * without loading semanticdb at startup. This method confirms all candidates
+   * and updates the test suites index.
+   *
+   * @return Future that completes when discovery is done, containing the updated test suites
+   */
+  def discoverAllTestSuites(): Future[List[BuildTargetUpdate]] = {
+    val targetIds = buildTargets.allBuildTargetIds.toList
+      .filter { id =>
+        buildTargets
+          .scalaTarget(id)
+          .forall(_.scalaInfo.getPlatform == ScalaPlatform.JVM)
+      }
+      .flatMap(buildTargets.info)
+      .filterNot(_.isSbtBuild)
+      .map(_.getId)
+
+    // First confirm all candidate test classes
+    buildTargetClasses
+      .confirmMbtTestClassCandidatesForTargets(targetIds)
+      .flatMap { _ =>
+        // Then refresh the test suites
+        refreshTestSuites(()).flatMap { _ =>
+          discoverTests(None)
+        }
+      }
   }
 
   /**
@@ -392,14 +448,12 @@ final class TestSuitesProvider(
 
     val deletedSuites = removeStaleTestSuites(symbolsPerTarget)
     val addedEntries = getTestEntries(symbolsPerTarget)
-
     // update cached suites with currently discovered
     addedEntries.foreach { case (_, entries) =>
       entries.foreach(index.put(_))
     }
 
     if (isCodeLensEnabled) client.refreshModel()
-
     if (isExplorerEnabled) {
       val addedTestCases = addedEntries.mapValues {
         _.flatMap { entry =>
@@ -413,7 +467,6 @@ final class TestSuitesProvider(
 
       val addedSuites =
         addedEntries.mapValues(_.map(_.suiteDetails.asAddEvent)).toMap
-
       val buildTargetUpdates =
         getBuildTargetUpdates(
           deletedSuites = deletedSuites,

--- a/tests/slow/src/test/scala/tests/gradle/GradleLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/gradle/GradleLspSuite.scala
@@ -303,14 +303,9 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
       _ <- server.server.buildServerPromise.future
       _ = client.progressParams.clear() // restart
       _ <- server.executeCommand(ServerCommands.ImportBuild)
-      _ = assertNoDiff(
-        client.beginProgressMessages
-          .replaceAll("Discovering main classes and tests\n", ""),
-        List(
-          "Import",
-          progressMessage,
-          Messages.importingBuild,
-        ).mkString("\n"),
+      _ = assertNotContains(
+        client.beginProgressMessages,
+        Messages.ImportProjectFailed.getMessage,
       )
     } yield ()
   }

--- a/tests/slow/src/test/scala/tests/gradle/GradleLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/gradle/GradleLspSuite.scala
@@ -304,7 +304,8 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
       _ = client.progressParams.clear() // restart
       _ <- server.executeCommand(ServerCommands.ImportBuild)
       _ = assertNoDiff(
-        client.beginProgressMessages,
+        client.beginProgressMessages
+          .replaceAll("Discovering main classes and tests\n", ""),
         List(
           "Import",
           progressMessage,

--- a/tests/slow/src/test/scala/tests/gradle/GradleLspSuite.scala
+++ b/tests/slow/src/test/scala/tests/gradle/GradleLspSuite.scala
@@ -309,7 +309,6 @@ class GradleLspSuite extends BaseImportSuite("gradle-import") {
           "Import",
           progressMessage,
           Messages.importingBuild,
-          "Discovering main classes and tests",
         ).mkString("\n"),
       )
     } yield ()

--- a/tests/unit/src/test/scala/tests/mbt/MbtRunDebugLspSuite.scala
+++ b/tests/unit/src/test/scala/tests/mbt/MbtRunDebugLspSuite.scala
@@ -5,6 +5,7 @@ import scala.concurrent.Future
 import scala.meta.internal.metals.AutoImportBuildKind
 import scala.meta.internal.metals.Configs.ReferenceProviderConfig
 import scala.meta.internal.metals.Configs.WorkspaceSymbolProviderConfig
+import scala.meta.internal.metals.InitializationOptions
 import scala.meta.internal.metals.TestUserInterfaceKind
 import scala.meta.internal.metals.UserConfiguration
 import scala.meta.internal.metals.mbt.MbtBuildServer
@@ -15,6 +16,12 @@ import tests.MbtJsonBuilder
 
 class MbtRunDebugLspSuite extends BaseCodeLensLspSuite("mbt-run-debug") {
 
+  override protected def initializationOptions: Some[InitializationOptions] =
+    Some(
+      InitializationOptions.Default
+        .copy(testExplorerProvider = Some(true), debuggingProvider = Some(true))
+    )
+
   override def userConfig: UserConfiguration =
     super.userConfig.copy(
       buildOnChange = false,
@@ -23,7 +30,7 @@ class MbtRunDebugLspSuite extends BaseCodeLensLspSuite("mbt-run-debug") {
       referenceProvider = ReferenceProviderConfig.mbt,
       preferredBuildServer = Some(MbtBuildServer.name),
       automaticImportBuild = AutoImportBuildKind.All,
-      testUserInterface = TestUserInterfaceKind.CodeLenses,
+      testUserInterface = TestUserInterfaceKind.TestExplorer,
     )
 
   override def initializeGitRepo: Boolean = true
@@ -126,6 +133,11 @@ class MbtRunDebugLspSuite extends BaseCodeLensLspSuite("mbt-run-debug") {
       _ = assertConnectedToBuildServer("MBT")
       _ <- server.didOpen("src/MunitTest.scala")
       _ <- server.discoverTestSuites(List("src/MunitTest.scala"))
+      _ <- server.didChangeConfiguration(
+        userConfig
+          .copy(testUserInterface = TestUserInterfaceKind.CodeLenses)
+          .toString()
+      )
       _ <- assertCodeLenses(
         "src/MunitTest.scala",
         """|package example
@@ -172,6 +184,11 @@ class MbtRunDebugLspSuite extends BaseCodeLensLspSuite("mbt-run-debug") {
       _ = assertConnectedToBuildServer("MBT")
       _ <- server.didOpen("src/JunitTest.java")
       _ <- server.discoverTestSuites(List("src/JunitTest.java"))
+      _ <- server.didChangeConfiguration(
+        userConfig
+          .copy(testUserInterface = TestUserInterfaceKind.CodeLenses)
+          .toString()
+      )
       _ <- assertCodeLenses(
         "src/JunitTest.java",
         """|package example;


### PR DESCRIPTION
Instead of checking all the files up front we only gather the ones that can potentially contain main classes.

We only check when:
- code lenses are generated for the current file
- we run a main class specified by the user, we then try to match that main class to any of the candidates and then if matched we load semanticdb and do the analysis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lazy MBT-based discovery for main/test classes for faster, on-demand test detection.
  * Improved test explorer integration and more reliable run/test/debug actions (better confirmation of runnable candidates).

* **Bug Fixes**
  * Increased debug session grace period to reduce startup failures.

* **Chores**
  * Asynchronous refactors to improve responsiveness of discovery and debug flows.

* **Tests**
  * Updated test suites and expectations to align with new discovery and UI defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->