### PR TITLE
[MBT] Maven: fix javac options for multi-execution compiler configs

### DIFF
--- a/maven-metals/src/main/scala/scala/meta/metals/maven/MavenCompilerConfig.scala
+++ b/maven-metals/src/main/scala/scala/meta/metals/maven/MavenCompilerConfig.scala
@@ -2,8 +2,12 @@ package scala.meta.metals.maven
 
 import java.{util => ju}
 
+import scala.jdk.CollectionConverters._
+
 import org.apache.maven.model.Plugin
+import org.apache.maven.plugin.logging.Log
 import org.apache.maven.project.MavenProject
+import org.codehaus.plexus.util.xml.Xpp3Dom
 
 private[maven] case class CompilerConfig(
     javacOptions: List[String],
@@ -16,31 +20,35 @@ private[maven] object MavenCompilerConfig {
 
   import MavenPluginSupport._
 
-  def extract(project: MavenProject, isTest: Boolean): CompilerConfig = {
+  def extract(
+      project: MavenProject,
+      isTest: Boolean,
+      log: Log = null,
+  ): CompilerConfig = {
     val plugins = effectivePlugins(project)
     val props = project.getProperties
 
     def prop(key: String): Option[String] =
       Option(props.getProperty(key)).filter(_.nonEmpty)
 
-    val javacOpts = extractJavacOptions(plugins, prop, isTest)
+    val javacConfig =
+      Option(plugins.get(JavaCompilerPlugin)).flatMap(
+        selectCompilerPluginConfiguration(_, isTest, Option(log))
+      )
+
+    val javacOpts = extractJavacOptions(javacConfig, prop, isTest)
     val (scalacOpts, scalaVer) = extractScalaOptions(plugins, isTest)
-    val procPaths = extractAnnotationProcessorPaths(plugins, project, isTest)
+    val procPaths = extractAnnotationProcessorPaths(javacConfig, project)
 
     CompilerConfig(javacOpts, scalacOpts, scalaVer, procPaths)
   }
 
   private def extractJavacOptions(
-      plugins: ju.Map[String, Plugin],
+      cfgOpt: Option[Xpp3Dom],
       prop: String => Option[String],
       isTest: Boolean,
   ): List[String] = {
     val args = List.newBuilder[String]
-
-    val cfgOpt =
-      Option(plugins.get(JavaCompilerPlugin)).flatMap(
-        compilerPluginConfiguration(_, isTest)
-      )
 
     val release =
       (if (isTest) prop("maven.compiler.testRelease") else None)
@@ -98,9 +106,13 @@ private[maven] object MavenCompilerConfig {
       def add(value: String): Unit =
         Option(value).filter(_.nonEmpty).foreach(args += _)
 
-      Option(cfg.getChild("compilerArgs")).foreach(
-        _.getChildren.foreach(arg => add(arg.getValue))
-      )
+      Option(cfg.getChild("compilerArgs")).foreach { compilerArgs =>
+        compilerArgs.getChildren
+          .map(_.getValue)
+          .filter(v => v != null && v.nonEmpty)
+          .distinct
+          .foreach(args += _)
+      }
       childText(cfg, "compilerArg").foreach(add)
       childText(cfg, "compilerArgument").foreach(add)
       Option(cfg.getChild("compilerArguments")).foreach { compilerArgs =>
@@ -116,12 +128,10 @@ private[maven] object MavenCompilerConfig {
   }
 
   private def extractAnnotationProcessorPaths(
-      plugins: ju.Map[String, Plugin],
+      cfgOpt: Option[Xpp3Dom],
       project: MavenProject,
-      isTest: Boolean,
   ): List[(String, String, String)] =
-    Option(plugins.get(JavaCompilerPlugin))
-      .flatMap(compilerPluginConfiguration(_, isTest))
+    cfgOpt
       .flatMap(cfg => Option(cfg.getChild("annotationProcessorPaths")))
       .toList
       .flatMap { paths =>
@@ -167,5 +177,35 @@ private[maven] object MavenCompilerConfig {
       (scalacArgs ++ addScalacArgs, scalaVersion)
     }
     result.getOrElse((Nil, None))
+  }
+
+  private def selectCompilerPluginConfiguration(
+      plugin: Plugin,
+      isTest: Boolean,
+      log: Option[Log],
+  ): Option[Xpp3Dom] = {
+    val goal = if (isTest) "testCompile" else "compile"
+    val defaultId = if (isTest) "default-testCompile" else "default-compile"
+    val matching = plugin.getExecutions.asScala.toList
+      .filter(compilerExecutionMatchesGoal(_, goal))
+
+    val selected = matching
+      .find(_.getId == defaultId)
+      .orElse(matching.lastOption)
+
+    selected match {
+      case Some(execution) =>
+        val skipped = matching.filter(_.getId != execution.getId).map(_.getId)
+        if (skipped.nonEmpty)
+          log.foreach(
+            _.warn(
+              s"metals-maven-plugin: using maven-compiler-plugin execution '${execution.getId}' " +
+                s"for ${if (isTest) "test" else "main"} sources; skipping ${skipped.mkString(", ")}"
+            )
+          )
+        mergedPluginConfiguration(plugin, execution)
+      case None =>
+        compilerPluginConfiguration(plugin, isTest)
+    }
   }
 }

--- a/maven-metals/src/main/scala/scala/meta/metals/maven/MavenPluginSupport.scala
+++ b/maven-metals/src/main/scala/scala/meta/metals/maven/MavenPluginSupport.scala
@@ -70,13 +70,22 @@ private[maven] object MavenPluginSupport {
       )
       .toSeq
     val goalSpecificCfgs = allExecCfgs
-      .filter { case (_, exec) => exec.getGoals.asScala.contains(goalFilter) }
+      .filter { case (_, exec) =>
+        compilerExecutionMatchesGoal(exec, goalFilter)
+      }
       .map(_._1)
     val execCfgs =
       if (goalSpecificCfgs.nonEmpty) goalSpecificCfgs
       else allExecCfgs.map(_._1)
     mergeConfigurations(execCfgs ++ pluginCfg)
   }
+
+  def compilerExecutionMatchesGoal(
+      execution: PluginExecution,
+      goal: String,
+  ): Boolean =
+    execution.getGoals.asScala.contains(goal) ||
+      execution.getId == s"default-$goal"
 
   private def mergeConfigurations(
       configurations: Seq[Xpp3Dom]

--- a/maven-metals/src/main/scala/scala/meta/metals/maven/MbtMojoImpl.scala
+++ b/maven-metals/src/main/scala/scala/meta/metals/maven/MbtMojoImpl.scala
@@ -51,8 +51,10 @@ object MbtMojoImpl {
     val namespaces = new ju.LinkedHashMap[String, NamespaceJson]()
 
     for (project <- projects) {
-      val mainConfig = MavenCompilerConfig.extract(project, isTest = false)
-      val testConfig = MavenCompilerConfig.extract(project, isTest = true)
+      val mainConfig =
+        MavenCompilerConfig.extract(project, isTest = false, log)
+      val testConfig =
+        MavenCompilerConfig.extract(project, isTest = true, log)
       val mainJavaHome =
         JavaHomeResolver
           .resolve(mainConfig.javacOptions, project, isTest = false, mojo)

--- a/maven-metals/src/test/scala/scala/meta/metals/maven/MavenCompilerConfigSuite.scala
+++ b/maven-metals/src/test/scala/scala/meta/metals/maven/MavenCompilerConfigSuite.scala
@@ -1,5 +1,7 @@
 package scala.meta.metals.maven
 
+import java.nio.file.Files
+
 import org.apache.maven.model.Build
 import org.apache.maven.model.Plugin
 import org.apache.maven.model.PluginExecution
@@ -185,6 +187,112 @@ class MavenCompilerConfigSuite extends munit.FunSuite {
     assertEquals(testConfig.scalaVersion, Some("2.13.14"))
   }
 
+  test("prefers default-compile execution over other matching executions") {
+    val workspace = Files.createTempDirectory("maven-compiler-config")
+    val src = workspace.resolve("src")
+    Files.createDirectories(src.resolve("com/example"))
+    Files.writeString(src.resolve("com/example/A.java"), "class A {}")
+    Files.writeString(src.resolve("com/example/B.java"), "class B {}")
+    Files.writeString(src.resolve("module-info.java"), "module example {}")
+
+    val project = new MavenProject()
+    project.setFile(workspace.resolve("pom.xml").toFile)
+    project.setGroupId("com.example")
+    project.setArtifactId("app")
+    project.setBuild(new Build())
+    project.addCompileSourceRoot(src.toString)
+
+    val compiler = plugin(
+      "org.apache.maven.plugins",
+      "maven-compiler-plugin",
+      node(
+        "configuration",
+        node("encoding", "UTF-8"),
+      ),
+    )
+    compiler.addExecution(
+      execution(
+        id = "default-compile",
+        goal = "",
+        node(
+          "configuration",
+          node("source", "8"),
+          node("target", "8"),
+          node("excludes", node("exclude", "module-info.java")),
+          node("compilerArg", "-Xmain"),
+        ),
+      )
+    )
+    compiler.addExecution(
+      execution(
+        id = "compile-java9",
+        goal = "compile",
+        node(
+          "configuration",
+          node("release", "9"),
+          node(
+            "compileSourceRoots",
+            node("compileSourceRoot", "${project.basedir}/src"),
+          ),
+          node("includes", node("include", "module-info.java")),
+          node("compilerArg", "--add-reads=example=ALL-UNNAMED"),
+        ),
+      )
+    )
+    project.getBuild.addPlugin(compiler)
+
+    val config = MavenCompilerConfig.extract(project, isTest = false)
+
+    assertNoDiff(
+      config.javacOptions.mkString("\n"),
+      """|-source
+         |8
+         |-target
+         |8
+         |-encoding
+         |UTF-8
+         |-Xmain""".stripMargin,
+    )
+  }
+
+  test("falls back to last matching execution when default-compile absent") {
+    val project = new MavenProject()
+    project.setGroupId("com.example")
+    project.setArtifactId("app")
+    project.setBuild(new Build())
+
+    val compiler = plugin(
+      "org.apache.maven.plugins",
+      "maven-compiler-plugin",
+      node(
+        "configuration",
+        node("source", "8"),
+        node("target", "8"),
+      ),
+    )
+    compiler.addExecution(
+      execution(
+        id = "compile-java9",
+        goal = "compile",
+        node(
+          "configuration",
+          node("release", "9"),
+          node("compilerArg", "--add-reads=example=ALL-UNNAMED"),
+        ),
+      )
+    )
+    project.getBuild.addPlugin(compiler)
+
+    val config = MavenCompilerConfig.extract(project, isTest = false)
+
+    assertNoDiff(
+      config.javacOptions.mkString("\n"),
+      """|--release
+         |9
+         |--add-reads=example=ALL-UNNAMED""".stripMargin,
+    )
+  }
+
   test("extracts annotationProcessorPaths coordinates") {
     val project = new MavenProject()
     project.setBuild(new Build())
@@ -285,7 +393,7 @@ class MavenCompilerConfigSuite extends munit.FunSuite {
   ): PluginExecution = {
     val exec = new PluginExecution()
     exec.setId(id)
-    exec.addGoal(goal)
+    if (goal.nonEmpty) exec.addGoal(goal)
     exec.setConfiguration(configuration)
     exec
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Maven compiler execution selection and prioritization, including scenarios with default executions and fallback behavior verification.

* **Refactor**  
  * Enhanced Maven compiler configuration extraction logic to improve handling and selection of multiple plugin executions.
  * Added logging support for compiler configuration processing operations.
  * Improved configuration merging behavior for goal-specific execution matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalameta/metals/pull/8428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->