### PR TITLE
Upload the actual test reports and aggregate falures into a single report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,20 +52,19 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
         shell: bash
       - name: Upload heap dump if exists
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()  # This ensures the step runs even if previous steps fail
         with:
-          name: heap-dumps-${{ matrix.os }}-${{ matrix.shard }}
+          name: heap-dumps-${{ matrix.os }}-${{ matrix.shard }}-${{ github.run_id }}
           path: |
             ./**/*.hprof
           retention-days: 5
-
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-reports-${{ matrix.os }}-${{ matrix.shard }}
-          path: "**/.reports/**/*"
+          name: unit-test-reports-${{ matrix.os }}-${{ matrix.shard }}-${{ github.run_id }}
+          path: "**/target/test-reports/*.xml"
           if-no-files-found: ignore
           retention-days: 7
           compression-level: 9
@@ -171,8 +170,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-reports
-          path: "**/.reports/**/*"
+          name: integration-test-reports-${{ matrix.type }}-${{ github.run_id }}
+          path: "**/target/test-reports/*.xml"
           if-no-files-found: ignore
           retention-days: 7
           compression-level: 9

--- a/.github/workflows/test-failures-report.yml
+++ b/.github/workflows/test-failures-report.yml
@@ -23,7 +23,7 @@ jobs:
           workflow_conclusion: completed
           merge_multiple: 'true'
       - name: Test Report
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@29672c52a8220c09bd9f79b5b6cf6315f1763996
         with:
           name: Aggregated failure reports
           path: "**/target/test-reports/*.xml"

--- a/.github/workflows/test-failures-report.yml
+++ b/.github/workflows/test-failures-report.yml
@@ -1,0 +1,34 @@
+name: 'Test Failures Report'
+on:
+  workflow_run:
+    workflows: ['CI']
+    types:
+      - completed
+permissions:
+  statuses: write
+  checks: write
+  contents: write
+  pull-requests: write
+  actions: write
+jobs:
+  aggregate-test-reports:
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download reports for each test job
+        uses: dawidd6/action-download-artifact@v21
+        with:
+          workflow: ci.yml
+          workflow_conclusion: completed
+          merge_multiple: 'true'
+      - name: Test Report
+        uses: dorny/test-reporter@v3
+        with:
+          name: Aggregated failure reports
+          path: "**/target/test-reports/*.xml"
+          reporter: java-junit
+          list-suites: failed
+          list-tests: failed
+          list-files: failed
+          use-actions-summary: 'true'


### PR DESCRIPTION
The things that were previously called "test reports" are actually error logs produced by Metals. They are helpful for diagnosing test failures, but they don't correspond to failures directly.

FWIW, it seems that none of the recent CI runs have produced any Metals reports:
```
Run actions/upload-artifact@v7
No files were found with the provided path: **/.reports/**/*. No artifacts will be uploaded.
``` 
I use the latest commit of the dorny/test-reporter action because it allows showing only those test files which contain failures. This feature has not been officially released yet.
The report will look like this:
https://github.com/odisseus/github-ci-report-testing/actions/runs/27826186149?pr=2

Another small issue is partial ANSI terminal codes present in the XML output. This seems to be a bug in SBT's JUnitXmlReportPlugin.