### PR TITLE
improvement: Only digest the topelevel Bazel sources

### DIFF
--- a/metals/src/main/scala/scala/meta/internal/builds/BazelDigest.scala
+++ b/metals/src/main/scala/scala/meta/internal/builds/BazelDigest.scala
@@ -10,7 +10,7 @@ object BazelDigest extends Digestable {
       workspace: AbsolutePath,
       digest: MessageDigest,
   ): Boolean = {
-    workspace.listRecursive.forall {
+    workspace.list.forall {
       case file
           if file.isBazelRelatedPath && !file.isInBazelBspDirectory(
             workspace


### PR DESCRIPTION
In large codebases there might be thousands of files to digest. It should be fine for most cases to only digest the toplevel ones.

This was notices by one of the clients taking up a lot of memory on startup.